### PR TITLE
chore(repo): pin actions to shas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           filter: tree:0
@@ -41,7 +41,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
 
       - name: Set SHAs
-        uses: nrwl/nx-set-shas@v4
+        uses: nrwl/nx-set-shas@1859e66a83ac9be0dceecbd9a023702e27ac47f4 # v4.3.3
         with:
           main-branch-name: 'master'
 
@@ -54,43 +54,30 @@ jobs:
           sudo apt-get install -y ca-certificates lsof libvips-dev libglib2.0-dev libgirepository1.0-dev
 
       - name: Install Chrome
-        uses: browser-actions/setup-chrome@v1
+        uses: browser-actions/setup-chrome@2dbff04819ebbfd5c974947148805a825b8a07fd # v2.1.0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
         name: Install pnpm
         with:
           version: 10.11.1
           run_install: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: 'pnpm'
 
-      - name: Cache Rust toolchain and cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a # v1
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: temurin
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4.4.3
 
       - name: Install project dependencies
         run: |
@@ -150,7 +137,7 @@ jobs:
         if: always()
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           filter: tree:0
@@ -160,7 +147,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
 
       - name: Restore Homebrew packages
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: |
             /opt/homebrew
@@ -265,39 +252,26 @@ jobs:
           ls -la ~/Library/Logs/CoreSimulator/ || echo "No simulator logs found"
 
       - name: Save Homebrew Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: |
             /opt/homebrew
             ~/Library/Caches/Homebrew
           key: nrwl-nx-homebrew-packages
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
         name: Install pnpm
         with:
           version: 10.11.1
           run_install: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: 'pnpm'
 
-      - name: Cache Rust toolchain and cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a # v1
 
       - name: Install project dependencies
         run: |
@@ -305,7 +279,7 @@ jobs:
           pnpm playwright install --with-deps
 
       - name: Set SHAs
-        uses: nrwl/nx-set-shas@v4
+        uses: nrwl/nx-set-shas@1859e66a83ac9be0dceecbd9a023702e27ac47f4 # v4.3.3
         with:
           main-branch-name: 'master'
 

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -45,19 +45,19 @@ jobs:
     name: Cache install (${{ matrix.os }}, node v${{ matrix.node_version }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           filter: tree:0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
         name: Install pnpm
         with:
           version: 10.11.1
           run_install: false
 
       - name: Set node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: ${{ matrix.node_version }}
           cache: 'pnpm'
@@ -67,7 +67,7 @@ jobs:
         run: echo "path=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ${{ steps.pnpm-cache.outputs.path }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
@@ -91,7 +91,7 @@ jobs:
 
       - name: Cache Homebrew
         if: ${{ matrix.os == 'macos-latest' }}
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           lookup-only: true
           path: ${{ steps.homebrew-cache-dir-path.outputs.dir }}
@@ -101,7 +101,7 @@ jobs:
 
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           lookup-only: true
           path: '${{ github.workspace }}/.cypress'
@@ -120,7 +120,7 @@ jobs:
       matrix: ${{ steps.process-json.outputs.MATRIX }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           filter: tree:0
@@ -146,7 +146,7 @@ jobs:
     name: ${{ matrix.os_name }}/${{ matrix.package_manager }}/${{ matrix.node_version }} ${{ join(matrix.project) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           filter: tree:0
@@ -154,14 +154,14 @@ jobs:
       - name: Prepare dir for output
         run: mkdir -p outputs
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
         name: Install pnpm
         with:
           version: 10.11.1
           run_install: false
 
       - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: ${{ matrix.node_version }}
           cache: 'pnpm'
@@ -179,7 +179,7 @@ jobs:
   
       - name: Install bun
         if: ${{ matrix.os != 'windows-latest' }}
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
         with:
           bun-version: latest
 
@@ -207,7 +207,7 @@ jobs:
 
       - name: Cache Homebrew
         if: ${{ matrix.os == 'macos-latest' }}
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ${{ steps.homebrew-cache-dir-path.outputs.dir }}
           key: brew-${{ matrix.node_version }}
@@ -216,7 +216,7 @@ jobs:
 
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: '${{ github.workspace }}/.cypress'
           key: ${{ runner.os }}-cypress
@@ -397,7 +397,7 @@ jobs:
           echo "$matrix" > 'outputs/matrix.json'
 
       - name: Upload matrix config
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ always() }}
         with:
           name: ${{ matrix.os_name}}-${{ matrix.node_version}}-${{ matrix.package_manager}}-${{ matrix.project }}
@@ -407,7 +407,7 @@ jobs:
 
       - name: Setup tmate session
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled && failure() }}
-        uses: mxschmitt/action-tmate@v3.8
+        uses: mxschmitt/action-tmate@1fb8b1023602bf1fd0e2994d7f1e93015cb5bbec # v3.22
         timeout-minutes: 15
         with:
           sudo: ${{ matrix.os != 'windows-latest' }} # disable sudo for windows debugging
@@ -425,7 +425,7 @@ jobs:
       has_golden_failures: ${{ steps.process-json.outputs.has_golden_failures }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           filter: tree:0
@@ -434,7 +434,7 @@ jobs:
         run: mkdir -p outputs
 
       - name: Load outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           path: outputs
 
@@ -457,7 +457,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Send notification
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v11
         with:
           status: 'failure'
           message_format: '${{ needs.process-result.outputs.message }}'
@@ -475,7 +475,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Send notification
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v11
         with:
           status: 'success'
           message_format: '${{ needs.process-result.outputs.message }}'
@@ -492,7 +492,7 @@ jobs:
     name: Report duration per package manager
     steps:
       - name: Send notification
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v11
         with:
           status: 'skipped'
           message_format: '${{ needs.process-result.outputs.pm_duration }}'
@@ -508,7 +508,7 @@ jobs:
     name: Report duration per project
     steps:
       - name: Send notification
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v11
         with:
           status: 'skipped'
           message_format: '${{ needs.process-result.outputs.proj_duration }}'

--- a/.github/workflows/generate-embeddings.yml
+++ b/.github/workflows/generate-embeddings.yml
@@ -14,15 +14,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '20.19.0'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
         id: pnpm-install
         with:
           version: 10.11.1
@@ -35,7 +35,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Setup pnpm cache
-        uses: actions/cache@v3
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -16,21 +16,21 @@ jobs:
     name: Report status
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
         with:
           version: 10.11.1
 
       - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '20.19.0'
           cache: 'pnpm'
 
       - name: Cache node_modules
         id: cache-modules
-        uses: actions/cache@v3
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           lookup-only: true
           path: '**/node_modules'
@@ -41,11 +41,12 @@ jobs:
 
       - name: Download artifact
         id: download-artifact
-        uses: dawidd6/action-download-artifact@v2 # Needed since we are downloading artifact from a different workflow run, official actions/download-artifact doesn't support this.
+        uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e # v2 # Needed since we are downloading artifact from a different workflow run, official actions/download-artifact doesn't support this.
         with:
           name: cached-issue-data
           path: ${{ github.workspace }}/scripts/issues-scraper/cached
           search_artifacts: true
+          allow_forks: false
         continue-on-error: true
 
       - name: Collect Issue Data
@@ -54,14 +55,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cached-issue-data
           path: ./scripts/issues-scraper/cached/data.json
 
       - name: Send GitHub Action trigger data to Slack workflow
         id: slack
-        uses: slackapi/slack-github-action@v1.23.0
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           payload: ${{ steps.collect.outputs.SLACK_MESSAGE }}
         env:

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ github.repository_owner == 'nrwl' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v4
+      - uses: dessant/lock-threads@7de207be1d3ce97a9abe6ff1306222982d1ca9f9 # v5.0.1
         id: lockthreads
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
         with:
           version: 10.11.1 # Aligned with root package.json (pnpm/action-setup will helpfully error if out of sync)
 
@@ -30,7 +30,7 @@ jobs:
     name: Report status
     steps:
       - name: Send notification
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v11
         with:
           status: ${{ needs.audit.result }}
           message_format: '{emoji} Audit has {status_message}'

--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -12,16 +12,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           # Ensure's validate-pr-title.js is the copy from master
           ref: master
-          
+
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
+        name: Install pnpm
+        with:
+          version: 10.11.1
+          run_install: false
+
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
-          
+          cache: 'pnpm'
+
       - name: Validate PR title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,11 +28,6 @@ jobs:
   # - release:
   #   - We are running a full release which is based on the tag that triggered the release event, we can use default
   #     ref resolution in actions/checkout. The exact version will be generated within scripts/nx-release.ts.
-  #
-  # - workflow_dispatch:
-  #   - We are either running a dry-run on the current branch, in which case the version will be statica and we can use
-  #     default ref resolution in actions/checkout, or we are creating a PR release for the given PR number, in which case
-  #     we should generate an applicable version number within publish-resolve-data.js and use a custom ref of the PR branch name.
   resolve-required-data:
     name: Resolve Required Data
     if: ${{ github.repository_owner == 'nrwl' }}
@@ -40,20 +35,17 @@ jobs:
     outputs:
       version: ${{ steps.script.outputs.version }}
       dry_run_flag: ${{ steps.script.outputs.dry_run_flag }}
-      success_comment: ${{ steps.script.outputs.success_comment }}
       publish_branch: ${{ steps.script.outputs.publish_branch }}
-      ref: ${{ steps.script.outputs.ref }}
-      repo: ${{ steps.script.outputs.repo }}
     steps:
       # Default checkout on the triggering branch so that the latest publish-resolve-data.js script is available
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
@@ -61,7 +53,7 @@ jobs:
 
       - name: Resolve and set checkout and version data to use for release
         id: script
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           PR_NUMBER: ${{ github.event.inputs.pr }}
         with:
@@ -69,36 +61,6 @@ jobs:
           script: |
             const script = require('${{ github.workspace }}/scripts/publish-resolve-data.js');
             await script({ github, context, core });
-
-      - name: (PR Release Only) Check out latest master
-        if: ${{ steps.script.outputs.ref != '' }}
-        uses: actions/checkout@v4
-        with:
-          # Check out the latest master branch to get its copy of nx-release.ts
-          repository: nrwl/nx
-          ref: master
-          path: latest-master-checkout
-
-      - name: (PR Release Only) Check out PR branch
-        if: ${{ steps.script.outputs.ref != '' }}
-        uses: actions/checkout@v4
-        with:
-          # Check out the PR branch to get its copy of nx-release.ts
-          repository: ${{ steps.script.outputs.repo }}
-          ref: ${{ steps.script.outputs.ref }}
-          path: pr-branch-checkout
-
-      - name: (PR Release Only) Ensure that nx-release.ts has not changed in the PR being released
-        if: ${{ steps.script.outputs.ref != '' }}
-        env:
-          FILE_TO_COMPARE: "scripts/nx-release.ts"
-        run: |
-          if ! cmp -s "latest-master-checkout/${{ env.FILE_TO_COMPARE }}" "pr-branch-checkout/${{ env.FILE_TO_COMPARE }}"; then
-            echo "🛑 Error: The file ${{ env.FILE_TO_COMPARE }} is different on the ${{ steps.script.outputs.ref }} branch on ${{ steps.script.outputs.repo }} vs latest master on nrwl/nx, cancelling workflow. If you did not modify the file, then you likely just need to rebase/merge latest master."
-            exit 1
-          else
-            echo "✅ The file ${{ env.FILE_TO_COMPARE }} is identical between the ${{ steps.script.outputs.ref }} branch on ${{ steps.script.outputs.repo }} and latest master on nrwl/nx."
-          fi
 
   build:
     needs: [ resolve-required-data ]
@@ -253,17 +215,14 @@ jobs:
     name: stable - ${{ matrix.settings.target }} - node@22.16.0
     runs-on: ${{ matrix.settings.host }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ needs.resolve-required-data.outputs.repo }}
-          ref: ${{ needs.resolve-required-data.outputs.ref }}
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         if: ${{ !matrix.settings.docker }}
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -271,13 +230,13 @@ jobs:
           cache: 'pnpm'
 
       - name: Install
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a # v1
         if: ${{ !matrix.settings.docker }}
         with:
           targets: ${{ matrix.settings.target }}
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: |
             ~/.cargo/registry/index/
@@ -287,7 +246,7 @@ jobs:
             target/
           key: ${{ matrix.settings.target }}-cargo-registry
 
-      - uses: goto-bus-stop/setup-zig@v2
+      - uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1
         if: ${{ matrix.settings.target == 'armv7-unknown-linux-gnueabihf' }}
         with:
           version: 0.10.0
@@ -308,7 +267,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Setup node x86
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         if: matrix.settings.target == 'i686-pc-windows-msvc'
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -317,7 +276,7 @@ jobs:
           architecture: x86
 
       - name: Build in docker
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
         if: ${{ matrix.settings.docker }}
         with:
           image: ${{ matrix.settings.docker }}
@@ -330,7 +289,7 @@ jobs:
         shell: bash
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: bindings-${{ matrix.settings.target }}
           path: |
@@ -345,14 +304,11 @@ jobs:
     name: Build FreeBSD
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ needs.resolve-required-data.outputs.repo }}
-          ref: ${{ needs.resolve-required-data.outputs.ref }}
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Build
         id: build
-        uses: cross-platform-actions/action@v0.25.0
+        uses: cross-platform-actions/action@462ed697694d2ac9aa49e1225f395f7bb6dd49fe # v0.29.0
         env:
           DEBUG: napi:*
           RUSTUP_IO_THREADS: 1
@@ -397,7 +353,7 @@ jobs:
             echo "COMPLETE"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: bindings-freebsd
           path: |
@@ -420,17 +376,14 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ${{ needs.resolve-required-data.outputs.repo }}
-          ref: ${{ needs.resolve-required-data.outputs.ref }}
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
         with:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
@@ -444,7 +397,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           path: artifacts
 
@@ -478,22 +431,6 @@ jobs:
         if: ${{ !github.event.release.prerelease && github.event_name == 'release' }}
         run: npx ts-node -P ./scripts/tsconfig.scripts.json  ./scripts/release-docs.ts
 
-      - name: (PR Release Only) Create comment for successful PR release
-        if: success() && github.event.inputs.pr
-        uses: actions/github-script@v7
-        env:
-          SUCCESS_COMMENT: ${{ needs.resolve-required-data.outputs.success_comment }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const successComment = JSON.parse(process.env.SUCCESS_COMMENT);
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{ github.event.inputs.pr }},
-              body: successComment
-            });
-
   pr_failure_comment:
     # Run this job if it is a PR release, running on the nrwl origin, and any of the required jobs failed
     if: ${{ github.repository_owner == 'nrwl' && github.event.inputs.pr && always() && contains(needs.*.result, 'failure') }}
@@ -502,7 +439,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create comment for failed PR release
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # This script is intentionally kept inline (and e.g. not generated in publish-resolve-data.js)

--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -19,7 +19,7 @@ jobs:
       # This handles issues that need more info
       - name: stale-more-info-needed
         id: stale-more-info-needed
-        uses: actions/stale@v9.0.0
+        uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 7
@@ -37,7 +37,7 @@ jobs:
       # This handles PRs that need to be rebased
       - name: stale-needs-rebase
         id: stale-needs-rebase
-        uses: actions/stale@v9.0.0
+        uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 7
@@ -56,7 +56,7 @@ jobs:
       # This handles issues that do not have a repro
       - name: stale-repro-needed
         id: stale-repro-needed
-        uses: actions/stale@v9.0.0
+        uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 7
@@ -75,7 +75,7 @@ jobs:
 
       - name: stale-retry-with-latest
         id: stale-retry-with-latest
-        uses: actions/stale@v9.0.0
+        uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 7
@@ -95,7 +95,7 @@ jobs:
       # This handles issues are really old and were made with a previous major
       - name: stale-bug
         id: stale-bug
-        uses: actions/stale@v9.0.0
+        uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 180

--- a/scripts/publish-resolve-data.js
+++ b/scripts/publish-resolve-data.js
@@ -10,10 +10,7 @@
  * @typedef {{
  *   version: string;
  *   dry_run_flag: DryRunFlag;
- *   success_comment: string;
  *   publish_branch: string;
- *   repo: string;
- *   ref: string;
  * }} PublishResolveData
  *
  * Partial from https://github.com/actions/toolkit/blob/c6b487124a61d7dc6c7bd6ea0208368af3513a6e/packages/github/src/context.ts
@@ -43,10 +40,7 @@ module.exports = async ({ github, context, core }) => {
   // Set the outputs to be consumed in later steps
   core.setOutput('version', data.version);
   core.setOutput('dry_run_flag', data.dry_run_flag);
-  core.setOutput('success_comment', JSON.stringify(data.success_comment)); // Escape the multi-line string
   core.setOutput('publish_branch', data.publish_branch);
-  core.setOutput('ref', data.ref);
-  core.setOutput('repo', data.repo);
 };
 
 /**
@@ -59,9 +53,6 @@ module.exports = async ({ github, context, core }) => {
  */
 async function getPublishResolveData({ github, context }) {
   // We use empty strings as default values so that we can let the `actions/checkout` action apply its default resolution
-  const DEFAULT_REF = '';
-  const DEFAULT_REPO = '';
-
   /**
    * "The short ref name of the branch or tag that triggered the workflow run. This value matches the branch or tag name shown
    * on GitHub. For example, feature-branch-1."
@@ -85,11 +76,7 @@ async function getPublishResolveData({ github, context }) {
       const data = {
         version: 'canary',
         dry_run_flag: DRY_RUN_DISABLED,
-        success_comment: '',
         publish_branch: DEFAULT_PUBLISH_BRANCH,
-        // In this case the default checkout logic should use the default (master) branch
-        repo: DEFAULT_REPO,
-        ref: DEFAULT_REF,
       };
       console.log('"schedule" trigger detected', { data });
       return data;
@@ -99,81 +86,9 @@ async function getPublishResolveData({ github, context }) {
       const data = {
         version: refName,
         dry_run_flag: DRY_RUN_DISABLED,
-        success_comment: '',
         publish_branch: DEFAULT_PUBLISH_BRANCH,
-        // In this case the default checkout logic should use the tag that triggered the release event
-        ref: DEFAULT_REF,
-        repo: DEFAULT_REPO,
       };
       console.log('"release" trigger detected', { data });
-      return data;
-    }
-
-    case 'workflow_dispatch': {
-      const prNumber = process.env.PR_NUMBER;
-
-      if (!prNumber) {
-        const data = {
-          version: '0.0.0-dry-run.0',
-          dry_run_flag: DRY_RUN_ENABLED,
-          success_comment: '',
-          publish_branch: DEFAULT_PUBLISH_BRANCH,
-          // In this case the default checkout logic should use the branch/tag selected when triggering the workflow
-          repo: DEFAULT_REPO,
-          ref: DEFAULT_REF,
-        };
-        console.log(
-          '"workflow_dispatch" trigger detected, no PR number provided',
-          { data }
-        );
-        return data;
-      }
-
-      const pr = await github.rest.pulls.get({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        pull_number: Number(prNumber),
-      });
-      if (!pr?.data?.head?.repo) {
-        throw new Error(
-          `The PR data for PR number ${prNumber} is missing the head branch information`
-        );
-      }
-
-      const fullSHA = pr.data.head.sha;
-      const shortSHA = fullSHA.slice(0, 7);
-      const version = `0.0.0-pr-${prNumber}-${shortSHA}`;
-      const repo = pr.data.head.repo.full_name;
-      const ref = pr.data.head.ref;
-
-      const data = {
-        version,
-        dry_run_flag: DRY_RUN_DISABLED,
-        success_comment: getSuccessCommentForPR({
-          context,
-          version,
-          repo,
-          ref,
-          pr_short_sha: shortSHA,
-          pr_full_sha: fullSHA,
-        }),
-        // Custom publish branch name for PRs
-        publish_branch: `publish/pr-${prNumber}`,
-        // In this case we instruct the checkout action what repo and ref to use
-        repo,
-        ref,
-      };
-      console.log(
-        `"workflow_dispatch" trigger detected, PR number ${prNumber} provided`,
-        { data }
-      );
-
-      console.log(`Owner: ${context.repo.owner}`);
-      console.log(`Repo: ${context.repo.repo}`);
-      console.log(`Fork repo:`, pr.data.head.repo.full_name);
-      console.log(`Fetched PR details: ${pr.data.head.ref}`);
-      console.log(`Full PR SHA: ${pr.data.head.sha}`);
-
       return data;
     }
 


### PR DESCRIPTION
This PR pins our publish actions to specific SHAs, and removes unused logic tied to the previous PR release support.

Note: `dtolnay/rust-toolchain` cannot be pinned since will treat the SHA as the Rust version. e.g. `@abc` will try to install Rust version `abc`, which is invalid.