### PR TITLE
fix(bundling): postcss-cli-resources should handle relative urls #32582

### DIFF
--- a/packages/angular-rspack/src/lib/utils/postcss-cli-resources.ts
+++ b/packages/angular-rspack/src/lib/utils/postcss-cli-resources.ts
@@ -8,7 +8,6 @@
 
 import { interpolateName } from 'loader-utils';
 import * as path from 'node:path';
-import * as url from 'node:url';
 import type { Declaration, Plugin } from 'postcss';
 import { assertIsError } from './misc-helpers';
 
@@ -96,7 +95,7 @@ export default function (options?: PostcssCliResourcesOptions): Plugin {
       inputUrl = inputUrl.slice(1);
     }
 
-    const normalizedUrl = inputUrl.replace(/\\/g, '/');
+    const normalizedUrl = path.resolve(context, inputUrl.replace(/\\/g, '/'));
     const parsedUrl = new URL(normalizedUrl, 'file:///');
     const { pathname, hash, search } = parsedUrl;
     const resolver = (file: string, base: string) =>

--- a/packages/rspack/src/plugins/utils/plugins/postcss-cli-resources.ts
+++ b/packages/rspack/src/plugins/utils/plugins/postcss-cli-resources.ts
@@ -1,7 +1,6 @@
 import { interpolateName } from 'loader-utils';
 import * as path from 'path';
 import type { Declaration } from 'postcss';
-import * as url from 'node:url';
 import type { LoaderContext } from '@rspack/core';
 
 function wrapUrl(url: string): string {
@@ -94,7 +93,7 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
       resourceCache.set(cacheKey, outputUrl);
       return outputUrl;
     }
-    const normalizedUrl = inputUrl.replace(/\\/g, '/');
+    const normalizedUrl = path.resolve(context, inputUrl.replace(/\\/g, '/'));
     const parsedUrl = new URL(normalizedUrl, 'file:///');
     const { pathname, hash, search } = parsedUrl;
     const resolver = (file: string, base: string) =>

--- a/packages/webpack/src/utils/webpack/plugins/postcss-cli-resources.ts
+++ b/packages/webpack/src/utils/webpack/plugins/postcss-cli-resources.ts
@@ -1,7 +1,6 @@
 import { interpolateName } from 'loader-utils';
 import * as path from 'path';
 import type { Declaration } from 'postcss';
-import * as url from 'node:url';
 import { LoaderContext } from 'webpack';
 
 function wrapUrl(url: string): string {
@@ -94,7 +93,7 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
       resourceCache.set(cacheKey, outputUrl);
       return outputUrl;
     }
-    const normalizedUrl = inputUrl.replace(/\\/g, '/');
+    const normalizedUrl = path.resolve(context, inputUrl.replace(/\\/g, '/'));
     const parsedUrl = new URL(normalizedUrl, 'file:///');
     const { pathname, hash, search } = parsedUrl;
     const resolver = (file: string, base: string) =>


### PR DESCRIPTION
## Current Behavior
Relative urls are not being handled correctly in the `postcss-cli-resources` Plugins for Webpack and Rspack after switching to use WHATWG URL in favour of the deprecated `url.parse()` method.

## Expected Behavior
Ensure relatives are handled appropriately by resolving them based on the context of the current resource being loaded.

## Related Issue(s)

Fixes #32582
