### PR TITLE
fix(core): check if daemon process is actually alive before trying to kill it

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -746,11 +746,13 @@ export class DaemonClient {
         process.kill(pid, 'SIGTERM');
       }
     } catch (err) {
-      output.error({
-        title:
-          err?.message ||
-          'Something unexpected went wrong when stopping the daemon server',
-      });
+      if ((err as any).code !== 'ESRCH') {
+        output.error({
+          title:
+            err?.message ||
+            'Something unexpected went wrong when stopping the daemon server',
+        });
+      }
     }
 
     removeSocketDir();


### PR DESCRIPTION
## Current Behavior
If the daemon shuts down, and the user tries to run `nx reset`, an ESRCH error is thrown since the pid in server-process.json doesn't match up to a process

## Expected Behavior
We check if the process is alive before terminating it

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
