### PR TITLE
docs(nx-dev): respect NEXT_PUBLIC_NO_INDEX variable for app router

### DIFF
--- a/nx-dev/nx-dev/app/layout.tsx
+++ b/nx-dev/nx-dev/app/layout.tsx
@@ -45,6 +45,17 @@ export const metadata: Metadata = {
       'application/atom+xml': '/blog/atom.xml',
     },
   },
+  // Add robots directive when NEXT_PUBLIC_NO_INDEX is set
+  ...(process.env.NEXT_PUBLIC_NO_INDEX === 'true' && {
+    robots: {
+      index: false,
+      follow: false,
+      googleBot: {
+        index: false,
+        follow: false,
+      },
+    },
+  }),
 };
 
 // Viewport settings for the entire site


### PR DESCRIPTION
We already have `NEXT_PUBLIC_NO_INDEX` supported in pages router, so canary.nx.dev does not get indexed. However, we missed this in the app router, so `/blog` is not setting `noindex` in preview environments.