### PR TITLE
docs(nx-dev): update CTA variants

### DIFF
--- a/astro-docs/markdoc.config.mjs
+++ b/astro-docs/markdoc.config.mjs
@@ -27,7 +27,13 @@ export default defineMarkdocConfig({
           type: 'String',
           required: false,
           default: 'default',
-          matches: ['default', 'gradient', 'inverted', 'gradient-alt'],
+          matches: [
+            'default',
+            'gradient',
+            'inverted',
+            'gradient-alt',
+            'simple',
+          ],
         },
         size: {
           type: 'String',

--- a/astro-docs/src/content/docs/getting-started/Tutorials/angular-monorepo-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/angular-monorepo-tutorial.mdoc
@@ -23,9 +23,9 @@ This tutorial requires a [GitHub account](https://github.com) to demonstrate the
 
 ### Step 1: Creating a new Nx Angular workspace
 
-Let's create your workspace. The setup process takes about 2 minutes and will configure Angular, testing, and CI/CD automatically.
+Let's [create your workspace](https://cloud.nx.app/create-nx-workspace/angular/github) with our Angular preset to get started quickly.
 
-{% call_to_action variant="default" title="Create Angular Workspace in 2 Minutes ⚡" url="https://cloud.nx.app/create-nx-workspace/angular/github" description="Skip the setup hassle - Get coding instantly with pre-configured CI/CD" /%}
+{% call_to_action variant="default" title="Create Angular Workspace" url="https://cloud.nx.app/create-nx-workspace/angular/github" /%}
 
 ### Step 2: Verify Your Setup
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/gradle-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/gradle-tutorial.mdoc
@@ -126,9 +126,9 @@ Finally, commit and push all the changes to GitHub and proceed with finishing yo
 
 > Nx Cloud provides self-healing CI, remote caching and many other features. [Learn more about Nx Cloud features](/docs/features/ci-features).
 
-Click the link printing in your terminal, or you can connect your existing workspace to Nx Cloud:
+Click the link printing in your terminal, or you can [finish setup in Nx Cloud](https://cloud.nx.app/setup/connect-workspace/github/select)
 
-{% call_to_action variant="gradient-alt" title="Finish Nx Cloud Setup ☁️" url="https://cloud.nx.app/setup/connect-workspace/github/select" description="Nx Cloud needs to be setup to complete the tutorial" /%}
+{% call_to_action variant="simple" title="Finish Nx Cloud Setup" url="https://cloud.nx.app/setup/connect-workspace/github/select" /%}
 
 ### Verify your setup
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/react-monorepo-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/react-monorepo-tutorial.mdoc
@@ -23,9 +23,9 @@ This tutorial requires a [GitHub account](https://github.com) to demonstrate the
 
 ### Step 1: Creating a new Nx React workspace
 
-Let's create your workspace. The setup process takes about 2 minutes and will configure React, testing, and CI/CD automatically.
+Let's [create your workspace](https://cloud.nx.app/create-nx-workspace/react/github) with our React preset to get started quickly.
 
-{% call_to_action variant="inverted" title="Start Building React Apps 10x Faster →" url="https://cloud.nx.app/create-nx-workspace/react/github" description="Zero-config setup with caching, testing, and CI ready out of the box" /%}
+{% call_to_action variant="simple" title="Create Workspace" url="https://cloud.nx.app/create-nx-workspace/react/github" /%}
 
 ### Step 2: Verify Your Setup
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/typescript-packages-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/typescript-packages-tutorial.mdoc
@@ -21,11 +21,11 @@ What you'll learn:
 This tutorial requires a [GitHub account](https://github.com) to demonstrate the full value of **Nx** - including task running, caching, and CI integration.
 {% /aside %}
 
-### Step 1: Creating a new Nx TypeScript workspace
+### Step 1: Creating a new Nx TypeScript workspace (required)
 
-Let's create your workspace. The setup process takes about 2 minutes and will configure TypeScript, testing, and CI/CD automatically.
+Let's [create your workspace](https://cloud.nx.app/create-nx-workspace/typescript/github) with our TypeScript preset to get started quickly.
 
-{% call_to_action variant="gradient" title="Join 1M+ Developers Using Nx Cloud 🚀" url="https://cloud.nx.app/create-nx-workspace/typescript/github" description="Transform your TypeScript workflow - Setup takes less than 2 minutes" /%}
+{% call_to_action variant="simple" title="Create TypeScript Workspace" url="https://cloud.nx.app/create-nx-workspace/typescript/github" /%}
 
 ### Step 2: Verify Your Setup
 

--- a/docs/shared/tutorials/angular-monorepo.md
+++ b/docs/shared/tutorials/angular-monorepo.md
@@ -23,9 +23,9 @@ This tutorial requires a [GitHub account](https://github.com) to demonstrate the
 
 ### Step 1: Creating a new Nx Angular workspace
 
-Let's create your workspace. The setup process takes about 2 minutes and will configure Angular, testing, and CI/CD automatically.
+Let's [create your workspace](https://cloud.nx.app/create-nx-workspace/angular/github) with our Angular preset to get started quickly.
 
-{% call-to-action variant="default" title="Create Angular Workspace in 2 Minutes ⚡" url="https://cloud.nx.app/create-nx-workspace/angular/github" description="Skip the setup hassle - Get coding instantly with pre-configured CI/CD" /%}
+{% call-to-action variant="default" title="Create Angular Workspace" url="https://cloud.nx.app/create-nx-workspace/angular/github" /%}
 
 ### Step 2: Verify Your Setup
 

--- a/docs/shared/tutorials/gradle.md
+++ b/docs/shared/tutorials/gradle.md
@@ -126,9 +126,9 @@ Finally, commit and push all the changes to GitHub and proceed with finishing yo
 
 > Nx Cloud provides self-healing CI, remote caching and many other features. [Learn more about Nx Cloud features](/ci/features).
 
-Click the link printing in your terminal, or you can connect your existing workspace to Nx Cloud:
+Click the link printing in your terminal, or you can [finish setup in Nx Cloud](https://cloud.nx.app/setup/connect-workspace/github/select)
 
-{% call-to-action variant="gradient-alt" title="Finish Nx Cloud Setup ☁️" url="https://cloud.nx.app/setup/connect-workspace/github/select" description="Nx Cloud needs to be setup to complete the tutorial" /%}
+{% call-to-action variant="simple" title="Finish Nx Cloud Setup" url="https://cloud.nx.app/setup/connect-workspace/github/select" /%}
 
 ### Verify your setup
 

--- a/docs/shared/tutorials/react-monorepo.md
+++ b/docs/shared/tutorials/react-monorepo.md
@@ -23,9 +23,9 @@ This tutorial requires a [GitHub account](https://github.com) to demonstrate the
 
 ### Step 1: Creating a new Nx React workspace
 
-Let's create your workspace. The setup process takes about 2 minutes and will configure React, testing, and CI/CD automatically.
+Let's [create your workspace](https://cloud.nx.app/create-nx-workspace/react/github) with our React preset to get started quickly.
 
-{% call-to-action variant="inverted" title="Start Building React Apps 10x Faster →" url="https://cloud.nx.app/create-nx-workspace/react/github" description="Zero-config setup with caching, testing, and CI ready out of the box" /%}
+{% call-to-action variant="simple" title="Create Workspace" url="https://cloud.nx.app/create-nx-workspace/react/github" /%}
 
 ### Step 2: Verify Your Setup
 

--- a/docs/shared/tutorials/typescript-packages.md
+++ b/docs/shared/tutorials/typescript-packages.md
@@ -21,11 +21,11 @@ What you'll learn:
 This tutorial requires a [GitHub account](https://github.com) to demonstrate the full value of **Nx** - including task running, caching, and CI integration.
 {% /callout %}
 
-### Step 1: Creating a new Nx TypeScript workspace
+### Step 1: Creating a new Nx TypeScript workspace (required)
 
-Let's create your workspace. The setup process takes about 2 minutes and will configure TypeScript, testing, and CI/CD automatically.
+Let's [create your workspace](https://cloud.nx.app/create-nx-workspace/typescript/github) with our TypeScript preset to get started quickly.
 
-{% call-to-action variant="gradient" title="Join 1M+ Developers Using Nx Cloud 🚀" url="https://cloud.nx.app/create-nx-workspace/typescript/github" description="Transform your TypeScript workflow - Setup takes less than 2 minutes" /%}
+{% call-to-action variant="simple" title="Create TypeScript Workspace" url="https://cloud.nx.app/create-nx-workspace/typescript/github" /%}
 
 ### Step 2: Verify Your Setup
 

--- a/nx-dev/ui-markdoc/src/lib/tags/call-to-action.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/call-to-action.component.tsx
@@ -47,6 +47,12 @@ const variantClasses: Record<
     hoverText: 'hover:text-blue-100 dark:hover:text-sky-200 text-white',
     expandBg: 'group-hover:w-full',
   },
+  simple: {
+    container: 'bg-blue-600 dark:bg-blue-600',
+    accent: 'bg-transparent',
+    hoverText: 'text-white',
+    expandBg: '',
+  },
 };
 
 export type CallToActionProps = {
@@ -55,7 +61,7 @@ export type CallToActionProps = {
   description?: string;
   icon?: string;
   size?: 'sm' | 'md' | 'lg';
-  variant?: 'default' | 'gradient' | 'inverted' | 'gradient-alt';
+  variant?: 'default' | 'gradient' | 'inverted' | 'gradient-alt' | 'simple';
 };
 
 export function CallToAction({
@@ -68,6 +74,26 @@ export function CallToAction({
 }: CallToActionProps): JSX.Element {
   const iconClasses = iconSizeClasses[size];
   const colorClasses = variantClasses?.[variant] ?? variantClasses['default'];
+
+  if (variant === 'simple') {
+    return (
+      <div className="not-content not-prose mx-auto my-12 flex justify-center">
+        <a
+          href={url}
+          target="_blank"
+          rel="noreferrer"
+          className={classNames(
+            colorClasses.container,
+            colorClasses.hoverText,
+            'inline-flex items-center gap-2 rounded-md px-6 py-3 font-medium no-underline shadow-sm'
+          )}
+        >
+          {title}
+          <ChevronRightIcon className="h-5 w-5" />
+        </a>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/nx-dev/ui-markdoc/src/lib/tags/call-to-action.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/tags/call-to-action.schema.ts
@@ -29,7 +29,7 @@ export const callToAction: Schema = {
       type: 'String',
       required: false,
       default: 'default',
-      matches: ['default', 'gradient', 'inverted', 'gradient-alt'],
+      matches: ['default', 'gradient', 'inverted', 'gradient-alt', 'simple'],
     },
     size: {
       // 'Size of the call to action.  Defaults to "sm".',


### PR DESCRIPTION
add `simple` variant to CTA markdoc component and make CTA in tutorials to the point. 