### PR TITLE
fix(core): handle uninstalled nx console case in autoinstall logic

### DIFF
--- a/packages/nx/src/utils/nx-console-prompt.ts
+++ b/packages/nx/src/utils/nx-console-prompt.ts
@@ -13,6 +13,15 @@ export async function ensureNxConsoleInstalled() {
 
   const canInstallConsole = canInstallNxConsole();
 
+  // If user previously opted in but extension is not installed,
+  // they must have manually uninstalled it - respect that choice
+  if (setting === true && canInstallConsole) {
+    // User had auto-install enabled but extension is missing
+    // This means they manually uninstalled it
+    preferences.setAutoInstallPreference(false);
+    return;
+  }
+
   // Noop
   if (!canInstallConsole) {
     return;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Once you opt in to installing nx console from the CLI, it will be installed again and again even after you uninstall it.

## Expected Behavior
If you uninstall Nx Console manually, we will respect that and update the setting to false.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
