### PR TITLE
feat(docker): add env var for providing docker registry

### DIFF
--- a/astro-docs/src/content/docs/guides/Nx Release/release-docker-images.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/release-docker-images.mdoc
@@ -142,6 +142,15 @@ Or if you don't have a `package.json` (e.g. for non-JS projects), set it in `pro
 
 You should replace `acme` with your organization or username for the Docker registry that you are logged into.
 
+{% aside title="Docker Registry Override" type="info" %}
+The `release.docker.registryUrl` option can be used to override the Docker registry URL. This is useful if you want to push to a private registry like GitHub Container Registry.
+
+If you need even more control during CI/CD pipelines, for example if you target different registries for different environments, you can use the `NX_DOCKER_REGISTRY` environment variable.
+Note that the value you set this to will need to include the `repositoryName` as well. e.g. `NX_DOCKER_REGISTRY=ghcr.io/acme/api`.
+
+Versioning will continue to work as normal.
+{% /aside %}
+
 ## Your First Docker Release
 
 Dry run your first Docker release with calendar versioning:

--- a/astro-docs/src/content/docs/guides/Nx Release/release-docker-images.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/release-docker-images.mdoc
@@ -142,11 +142,11 @@ Or if you don't have a `package.json` (e.g. for non-JS projects), set it in `pro
 
 You should replace `acme` with your organization or username for the Docker registry that you are logged into.
 
-{% aside title="Docker Registry Override" type="info" %}
+{% aside title="Docker Image Reference Override" type="note" %}
 The `release.docker.registryUrl` option can be used to override the Docker registry URL. This is useful if you want to push to a private registry like GitHub Container Registry.
 
-If you need even more control during CI/CD pipelines, for example if you target different registries for different environments, you can use the `NX_DOCKER_REGISTRY` environment variable.
-Note that the value you set this to will need to include the `repositoryName` as well. e.g. `NX_DOCKER_REGISTRY=ghcr.io/acme/api`.
+If you need even more control during CI/CD pipelines, for example if you target different registries for different environments, you can use the `NX_DOCKER_IMAGE_REF` environment variable.
+Note that the value you set this to will need to include the `repositoryName` as well. e.g. `NX_DOCKER_IMAGE_REF=ghcr.io/acme/api:2508.16.1`.
 
 Versioning will continue to work as normal.
 {% /aside %}

--- a/docs/shared/recipes/nx-release/release-docker-images.md
+++ b/docs/shared/recipes/nx-release/release-docker-images.md
@@ -139,6 +139,15 @@ Or if you don't have a `package.json` (e.g. for non-JS projects), set it in `pro
 
 You should replace `acme` with your organization or username for the Docker registry that you are logged into.
 
+{% callout title="Docker Registry Override" type="info" %}
+The `release.docker.registryUrl` option can be used to override the Docker registry URL. This is useful if you want to push to a private registry like GitHub Container Registry.
+
+If you need even more control during CI/CD pipelines, for example if you target different registries for different environments, you can use the `NX_DOCKER_REGISTRY` environment variable.
+Note that the value you set this to will need to include the `repositoryName` as well. e.g. `NX_DOCKER_REGISTRY=ghcr.io/acme/api`.
+
+Versioning will continue to work as normal.
+{% /callout %}
+
 ## Your First Docker Release
 
 Dry run your first Docker release with calendar versioning:

--- a/docs/shared/recipes/nx-release/release-docker-images.md
+++ b/docs/shared/recipes/nx-release/release-docker-images.md
@@ -139,11 +139,11 @@ Or if you don't have a `package.json` (e.g. for non-JS projects), set it in `pro
 
 You should replace `acme` with your organization or username for the Docker registry that you are logged into.
 
-{% callout title="Docker Registry Override" type="info" %}
+{% callout title="Docker Image Reference Override" type="note" %}
 The `release.docker.registryUrl` option can be used to override the Docker registry URL. This is useful if you want to push to a private registry like GitHub Container Registry.
 
-If you need even more control during CI/CD pipelines, for example if you target different registries for different environments, you can use the `NX_DOCKER_REGISTRY` environment variable.
-Note that the value you set this to will need to include the `repositoryName` as well. e.g. `NX_DOCKER_REGISTRY=ghcr.io/acme/api`.
+If you need even more control during CI/CD pipelines, for example if you target different registries for different environments, you can use the `NX_DOCKER_IMAGE_REF` environment variable.
+Note that the value you set this to will need to include the `repositoryName` and `version`. e.g. `NX_DOCKER_IMAGE_REF=ghcr.io/acme/api:2508.16.1`.
 
 Versioning will continue to work as normal.
 {% /callout %}

--- a/packages/docker/src/release/version-utils.ts
+++ b/packages/docker/src/release/version-utils.ts
@@ -63,7 +63,7 @@ export async function handleDockerVersion(
   );
 
   return {
-    newVersion,
+    newVersion: newVersion || (process.env.NX_DOCKER_IMAGE_REF?.split(':')[1] || null),
     logs,
   };
 }

--- a/packages/docker/src/release/version-utils.ts
+++ b/packages/docker/src/release/version-utils.ts
@@ -63,7 +63,8 @@ export async function handleDockerVersion(
   );
 
   return {
-    newVersion: newVersion || (process.env.NX_DOCKER_IMAGE_REF?.split(':')[1] || null),
+    newVersion:
+      newVersion || process.env.NX_DOCKER_IMAGE_REF?.split(':')[1] || null,
     logs,
   };
 }

--- a/packages/docker/src/release/version-utils.ts
+++ b/packages/docker/src/release/version-utils.ts
@@ -25,34 +25,43 @@ export async function handleDockerVersion(
   dockerVersionScheme?: string,
   dockerVersion?: string
 ) {
+  // If the full docker image reference is provided, use it directly
+  const nxDockerImageRefEnvOverride =
+    process.env.NX_DOCKER_IMAGE_REF?.trim() || undefined;
   // If an explicit dockerVersion is provided, use it directly
-  let newVersion: string;
-  if (dockerVersion) {
-    newVersion = dockerVersion;
-  } else {
-    const availableVersionSchemes =
-      finalConfigForProject.dockerOptions.versionSchemes ??
-      DEFAULT_VERSION_SCHEMES;
-    const versionScheme =
-      dockerVersionScheme && dockerVersionScheme in availableVersionSchemes
-        ? dockerVersionScheme
-        : await promptForNewVersion(
-            availableVersionSchemes,
-            projectGraphNode.name
-          );
-    newVersion = calculateNewVersion(
-      projectGraphNode.name,
-      versionScheme,
-      availableVersionSchemes
-    );
+  let newVersion: string | undefined;
+
+  if (!nxDockerImageRefEnvOverride) {
+    if (dockerVersion) {
+      newVersion = dockerVersion;
+    } else {
+      const availableVersionSchemes =
+        finalConfigForProject.dockerOptions.versionSchemes ??
+        DEFAULT_VERSION_SCHEMES;
+      const versionScheme =
+        dockerVersionScheme && dockerVersionScheme in availableVersionSchemes
+          ? dockerVersionScheme
+          : await promptForNewVersion(
+              availableVersionSchemes,
+              projectGraphNode.name
+            );
+      newVersion = calculateNewVersion(
+        projectGraphNode.name,
+        versionScheme,
+        availableVersionSchemes
+      );
+    }
   }
+
   const logs = updateProjectVersion(
     newVersion,
+    nxDockerImageRefEnvOverride,
     workspaceRoot,
     projectGraphNode.data.root,
     finalConfigForProject.dockerOptions.repositoryName,
     finalConfigForProject.dockerOptions.registryUrl
   );
+
   return {
     newVersion,
     logs,
@@ -96,20 +105,18 @@ function calculateNewVersion(
 }
 
 function updateProjectVersion(
-  newVersion: string,
+  newVersion: string | undefined,
+  nxDockerImageRefEnvOverride: string | undefined,
   workspaceRoot: string,
   projectRoot: string,
   repositoryName?: string,
   registry?: string
 ): string[] {
   const isDryRun = process.env.NX_DRY_RUN && process.env.NX_DRY_RUN !== 'false';
-  const nxDockerRegistryEnvOverride =
-    process.env.NX_DOCKER_REGISTRY?.trim() || undefined;
   const imageRef = getDefaultImageReference(projectRoot);
-  const newImageRef =
-    nxDockerRegistryEnvOverride ??
-    getImageReference(projectRoot, repositoryName, registry);
-  const fullImageRef = `${newImageRef}:${newVersion}`;
+  const newImageRef = getImageReference(projectRoot, repositoryName, registry);
+  const fullImageRef =
+    nxDockerImageRefEnvOverride ?? `${newImageRef}:${newVersion}`;
   if (!isDryRun) {
     execSync(`docker tag ${imageRef} ${fullImageRef}`);
   }

--- a/packages/docker/src/release/version-utils.ts
+++ b/packages/docker/src/release/version-utils.ts
@@ -103,8 +103,12 @@ function updateProjectVersion(
   registry?: string
 ): string[] {
   const isDryRun = process.env.NX_DRY_RUN && process.env.NX_DRY_RUN !== 'false';
+  const nxDockerRegistryEnvOverride =
+    process.env.NX_DOCKER_REGISTRY?.trim() || undefined;
   const imageRef = getDefaultImageReference(projectRoot);
-  const newImageRef = getImageReference(projectRoot, repositoryName, registry);
+  const newImageRef =
+    nxDockerRegistryEnvOverride ??
+    getImageReference(projectRoot, repositoryName, registry);
   const fullImageRef = `${newImageRef}:${newVersion}`;
   if (!isDryRun) {
     execSync(`docker tag ${imageRef} ${fullImageRef}`);


### PR DESCRIPTION
## Current Behavior
There is no method for overriding the repo config for Container Registry and Repository Name per environment.

## Expected Behavior
Allow an environment variable `NX_DOCKER_IMAGE_REF` to be set to modify the full image reference
