### PR TITLE
fix(core): detect vscode insiders as separate editor

### DIFF
--- a/packages/nx/src/native/ide/install.rs
+++ b/packages/nx/src/native/ide/install.rs
@@ -177,6 +177,17 @@ pub fn get_install_command() -> Option<&'static str> {
                 Some("code")
             }
         }
+        SupportedEditor::VSCodeInsiders => {
+            debug!("Installing Nx Console extension for VS Code Insiders");
+            #[cfg(target_os = "windows")]
+            {
+                Some("code-insiders.cmd")
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                Some("code-insiders")
+            }
+        }
         SupportedEditor::Cursor => {
             debug!("Installing Nx Console extension for Cursor");
             if cfg!(target_os = "windows") {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
right now nx checks the installation state for vscode for both vscode & vscode insiders

## Expected Behavior
They should be handled separately as they have separate sets of installed extensions.
