### PR TITLE
fix(js): adjusted stdout and stderr handling to support the latest @swc/cli version

### DIFF
--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -211,8 +211,8 @@ export async function* compileSwcWatch(
             );
           }
         } else if (type === 'stderr' && !data.includes('Successfully')) {
-          process.stderr.write(err);
-          if (err.includes('Debugger attached.')) {
+          process.stderr.write(data);
+          if (data.includes('Debugger attached.')) {
             return;
           }
           next(getResult(false));

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -141,6 +141,7 @@ export async function* compileSwcWatch(
   return yield* createAsyncIterable<{ success: boolean; outfile: string }>(
     async ({ next, done }) => {
       let processOnExit: () => void;
+      let handleCallback: () => void;
       let stdoutOnData: () => void;
       let stderrOnData: () => void;
       let watcherOnExit: () => void;
@@ -158,64 +159,72 @@ export async function* compileSwcWatch(
         process.off('exit', processOnExit);
       };
 
-      stdoutOnData = async (data?: string) => {
-        process.stdout.write(data);
-        if (!data.startsWith('Watching')) {
-          const swcStatus = data.includes('Successfully');
-
-          if (initialPostCompile) {
-            await postCompilationCallback();
-            initialPostCompile = false;
+      handleCallback = async (type: string, data?: string) => {
+        if (type === 'stdout' || data.includes('Successfully')) {
+          process.stdout.write(data);
+          if (!data.startsWith('Watching')) {
+            const swcStatus = data.includes('Successfully');
+  
+            if (initialPostCompile) {
+              await postCompilationCallback();
+              initialPostCompile = false;
+            }
+  
+            if (
+              normalizedOptions.skipTypeCheck ||
+              normalizedOptions.isTsSolutionSetup
+            ) {
+              next(getResult(swcStatus));
+              return;
+            }
+  
+            if (!typeCheckOptions) {
+              typeCheckOptions = getTypeCheckOptions(normalizedOptions);
+            }
+  
+            const delayed = delay(5000);
+            next(
+              getResult(
+                await Promise.race([
+                  delayed
+                    .start()
+                    .then(() => ({ tscStatus: false, type: 'timeout' })),
+                  runTypeCheck(typeCheckOptions).then(({ errors, warnings }) => {
+                    const hasErrors = errors.length > 0;
+                    if (hasErrors) {
+                      printDiagnostics(errors, warnings);
+                    }
+                    return {
+                      tscStatus: !hasErrors,
+                      type: 'tsc',
+                    };
+                  }),
+                ]).then(({ type, tscStatus }) => {
+                  if (type === 'tsc') {
+                    delayed.cancel();
+                    return tscStatus && swcStatus;
+                  }
+  
+                  return swcStatus;
+                })
+              )
+            );
           }
-
-          if (
-            normalizedOptions.skipTypeCheck ||
-            normalizedOptions.isTsSolutionSetup
-          ) {
-            next(getResult(swcStatus));
+        } else if (type === 'stderr' && !data.includes('Successfully')) {
+          process.stderr.write(err);
+          if (err.includes('Debugger attached.')) {
             return;
           }
-
-          if (!typeCheckOptions) {
-            typeCheckOptions = getTypeCheckOptions(normalizedOptions);
-          }
-
-          const delayed = delay(5000);
-          next(
-            getResult(
-              await Promise.race([
-                delayed
-                  .start()
-                  .then(() => ({ tscStatus: false, type: 'timeout' })),
-                runTypeCheck(typeCheckOptions).then(({ errors, warnings }) => {
-                  const hasErrors = errors.length > 0;
-                  if (hasErrors) {
-                    printDiagnostics(errors, warnings);
-                  }
-                  return {
-                    tscStatus: !hasErrors,
-                    type: 'tsc',
-                  };
-                }),
-              ]).then(({ type, tscStatus }) => {
-                if (type === 'tsc') {
-                  delayed.cancel();
-                  return tscStatus && swcStatus;
-                }
-
-                return swcStatus;
-              })
-            )
-          );
+          next(getResult(false));
         }
+      }
+      
+      stdoutOnData = async (data?: string) => {
+        handleCallback('stdout', data);
       };
 
       stderrOnData = (err?: any) => {
-        process.stderr.write(err);
-        if (err.includes('Debugger attached.')) {
-          return;
-        }
-        next(getResult(false));
+        handleCallback('stderr', err);
       };
 
       watcherOnExit = () => {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Due to this PR https://github.com/swc-project/pkgs/pull/53 at SWC, it is not possible to use the latest version of @swc/cli in NX.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
stdout and stderr are now handled more precisely, allowing you to update to the latest version of @swc/cli.