### PR TITLE
docs(misc): add CTA buttons to header matching Next.js implementation

### DIFF
--- a/astro-docs/src/components/layout/Header.astro
+++ b/astro-docs/src/components/layout/Header.astro
@@ -175,10 +175,31 @@ const currentVersion = versions.find(v => v.current);
 		{shouldRenderSearch && <Search />}
 	</div>
 	<div class="hidden md:flex items-center gap-4 print:hidden">
-		<div class="flex items-center gap-4">
+		<!-- CTA Buttons - Hide on screens smaller than xl (1280px) -->
+		<div class="hidden xl:flex items-center gap-2">
+			<a 
+				href="https://nx.dev/contact"
+				class="inline-flex items-center justify-center px-2.5 py-1.5 text-sm font-medium rounded-md transition no-underline border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 shadow-sm"
+				title="Contact Us"
+			>
+				Contact
+			</a>
+			<a 
+				href="https://cloud.nx.app?utm_source=nx-dev&utm_medium=header"
+				target="_blank"
+				rel="noopener noreferrer"
+				class="inline-flex items-center justify-center px-2.5 py-1.5 text-sm font-medium rounded-md transition no-underline bg-blue-500 dark:bg-sky-500 text-white hover:bg-blue-600 dark:hover:bg-sky-600 shadow-sm"
+				title="Login to Nx Cloud"
+			>
+				Login
+			</a>
+		</div>
+		<!-- Social Icons - Hide on screens smaller than 2xl (1536px) -->
+		<div class="hidden 2xl:flex items-center gap-4">
 			<SocialIcons />
 		</div>
 		<div class="after:content-[''] after:h-8 after:border-l after:border-slate-200 dark:after:border-slate-700"></div>
+		<!-- Theme Switcher - Always visible (highest priority) -->
 		<ThemeSelect />
 	</div>
 </div>

--- a/astro-docs/src/components/layout/PageFrame.astro
+++ b/astro-docs/src/components/layout/PageFrame.astro
@@ -15,6 +15,27 @@ const { hasSidebar } = Astro.locals.starlightRoute;
         <div id="starlight__sidebar" class="sidebar-pane">
           <div class="sidebar-content sl-flex">
             <slot name="sidebar" />
+            <!-- CTA Buttons for Mobile Menu - Show when not in header (below xl breakpoint) -->
+            <div class="mobile-cta-buttons xl:hidden mt-auto pt-4 pb-4 border-t border-slate-800 dark:border-slate-700">
+              <div class="flex flex-col gap-2">
+                <a 
+                  href="https://nx.dev/contact"
+                  class="w-full inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition no-underline border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 shadow-sm"
+                  title="Contact Us"
+                >
+                  Contact
+                </a>
+                <a 
+                  href="https://cloud.nx.app?utm_source=nx-dev&utm_medium=header"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="w-full inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition no-underline bg-blue-500 dark:bg-sky-500 text-white hover:bg-blue-600 dark:hover:bg-sky-600 shadow-sm"
+                  title="Login to Nx Cloud"
+                >
+                  Login
+                </a>
+              </div>
+            </div>
           </div>
         </div>
       </nav>


### PR DESCRIPTION
The astro-docs header lacks the CTA buttons (Contact and Login) that are present in the Next.js version, missing important navigation elements for user engagement.

Added Contact and Login buttons to the astro-docs header with responsive design:
- Desktop (≥1280px): CTA buttons visible in header
- Mobile (<1280px): CTA buttons appear in mobile menu at bottom
- Proper element priority to prevent overflow: Theme switcher (always visible) > CTAs > Social icons
- Visual ordering: CTA buttons, social icons, divider, theme switcher

https://www.loom.com/share/34feb737d11342b19f3ef2df0174a5dc?fromJoinRequest=true

Closes DOC-142
