### PR TITLE
fix(core): filter task duration estimation by successful tasks only

### DIFF
--- a/packages/nx/src/native/tasks/task_history.rs
+++ b/packages/nx/src/native/tasks/task_history.rs
@@ -53,6 +53,7 @@ impl NxTaskHistory {
                 FOREIGN KEY (hash) REFERENCES task_details (hash)
             );
             CREATE INDEX IF NOT EXISTS hash_idx ON task_history (hash);
+            CREATE INDEX IF NOT EXISTS status_idx ON task_history (status);
             COMMIT;
             ",
             )
@@ -133,7 +134,7 @@ impl NxTaskHistory {
                     AVG(end - start) AS duration
                     FROM task_history
                         JOIN task_details ON task_history.hash = task_details.hash
-                    WHERE target_string in rarray(?1)
+                    WHERE target_string in rarray(?1) AND status = 'success'
                     GROUP BY target_string
                 ",
             )?


### PR DESCRIPTION
## Current Behavior

Task duration estimation includes all task runs regardless of their status (success, failure, cancelled), which can lead to inaccurate timing predictions.

## Expected Behavior

Task duration estimation should only consider successful task runs to provide more accurate timing estimates for future task execution planning.

## Related Issue(s)

Fixes inaccurate task duration estimation by filtering out failed/cancelled tasks from the calculation.

## Changes Made

- Modified SQL query in `get_estimated_task_timings` to filter by `status = 'success'`
- Added database index on `status` column to improve query performance
- Updated both the WHERE clause condition and table schema initialization