### PR TITLE
chore(repo): fixup rust setup action after pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a # v1
+        with:
+          rustflags: ''
 
       - name: Setup Java
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
@@ -272,6 +274,8 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a # v1
+        with:
+          rustflags: ''
 
       - name: Install project dependencies
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -233,7 +233,8 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a # v1
         if: ${{ !matrix.settings.docker }}
         with:
-          targets: ${{ matrix.settings.target }}
+          target: ${{ matrix.settings.target }}
+          rustflags: ''
 
       - name: Cache cargo
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4


### PR DESCRIPTION
This pull request makes minor updates to the GitHub Actions workflow configuration for Rust toolchain installation. The main change is the addition of an explicit (empty) `rustflags` parameter to the `actions-rust-lang/setup-rust-toolchain` steps in both the CI and publish workflows, and a correction of the `targets` parameter to `target` in the publish workflow.

* CI workflow updates:
  * Added `rustflags: ''` to the Rust toolchain setup steps in `.github/workflows/ci.yml` to ensure no custom Rust flags are set during installation. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR72-R73) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR277-R278)

* Publish workflow updates:
  * Changed `targets` to `target` and added `rustflags: ''` for the Rust toolchain setup in `.github/workflows/publish.yml` to fix parameter usage and clarify Rust flags.

