### PR TITLE
feat(docker): ensure docker:build dependsOn build

### DIFF
--- a/packages/docker/src/plugins/plugin.spec.ts
+++ b/packages/docker/src/plugins/plugin.spec.ts
@@ -63,6 +63,10 @@ describe('@nx/docker', () => {
                 "targets": {
                   "docker:build": {
                     "command": "docker build .",
+                    "dependsOn": [
+                      "build",
+                      "^build",
+                    ],
                     "inputs": [
                       "production",
                       "^production",
@@ -170,6 +174,10 @@ describe('@nx/docker', () => {
                 "targets": {
                   "docker:build": {
                     "command": "docker build .",
+                    "dependsOn": [
+                      "build",
+                      "^build",
+                    ],
                     "inputs": [
                       "default",
                       "^default",
@@ -273,6 +281,10 @@ describe('@nx/docker', () => {
                 "targets": {
                   "build-docker": {
                     "command": "docker build .",
+                    "dependsOn": [
+                      "build",
+                      "^build",
+                    ],
                     "inputs": [
                       "production",
                       "^production",
@@ -373,6 +385,10 @@ describe('@nx/docker', () => {
                 "targets": {
                   "docker:build": {
                     "command": "docker build .",
+                    "dependsOn": [
+                      "build",
+                      "^build",
+                    ],
                     "inputs": [
                       "production",
                       "^production",
@@ -530,6 +546,10 @@ describe('@nx/docker', () => {
                 "targets": {
                   "docker:build": {
                     "command": "docker build .",
+                    "dependsOn": [
+                      "build",
+                      "^build",
+                    ],
                     "inputs": [
                       "production",
                       "^production",

--- a/packages/docker/src/plugins/plugin.ts
+++ b/packages/docker/src/plugins/plugin.ts
@@ -124,6 +124,7 @@ async function createDockerTargets(
   };
 
   targets[options.buildTarget] = {
+    dependsOn: ['build', '^build'],
     command: `docker build .`,
     options: {
       cwd: projectRoot,


### PR DESCRIPTION
## Current Behavior
The inferred `docker:build` target does not depend on the build target.
Given that most `docker build` commands rely on the initial application itself to be built first, it makes sense to depend on the build target.

## Expected Behavior
`docker:build` dependsOn `build`
