### PR TITLE
fix(core): kill child process correctly when run-script executor process is killed and not using pseudoterminal

### DIFF
--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -1027,7 +1027,7 @@ export class TaskOrchestrator {
       ...Array.from(this.runningContinuousTasks).map(async ([taskId, t]) => {
         try {
           await t.kill();
-          this.options.lifeCycle.setTaskStatus(
+          this.options.lifeCycle.setTaskStatus?.(
             taskId,
             NativeTaskStatus.Stopped
           );
@@ -1063,7 +1063,7 @@ export class TaskOrchestrator {
         const runningTask = this.runningContinuousTasks.get(taskId);
         if (runningTask) {
           runningTask.kill();
-          this.options.lifeCycle.setTaskStatus(
+          this.options.lifeCycle.setTaskStatus?.(
             taskId,
             NativeTaskStatus.Stopped
           );


### PR DESCRIPTION
## Current Behavior

When running an npm script through nx and not using the PseudoTerminal, child processes might not be killed when the `nx:run-script` executor is killed.

## Expected Behavior

When running an npm script through nx and not using the PseudoTerminal, child processes should be killed when the `nx:run-script` executor is killed.