### PR TITLE
feat(gradle): use project configurations to determine project dependencies

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectDependencyUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectDependencyUtils.kt
@@ -4,6 +4,8 @@ import dev.nx.gradle.data.Dependency
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.internal.artifacts.result.DefaultResolvedDependencyResult
+import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
 
 private val dependencyCache = mutableMapOf<Project, Set<Dependency>>()
 
@@ -38,25 +40,31 @@ private fun dependenciesFromConfiguration(
     val dependencies = mutableSetOf<Dependency>()
     
     try {
-        conf.dependencies.forEach { dependency ->
-            if (dependency is ProjectDependency) {
-                val dependentProject = dependency.dependencyProject
-                
+        conf.incoming.resolutionResult.allDependencies.forEach { dependency ->
+            if (dependency is DefaultResolvedDependencyResult) {
+                val requested = dependency.requested
+                if(requested is DefaultProjectComponentSelector) {
+                    val dependentProject = project.findProject( requested.toIdentifier().projectPath)
+
+                    if (dependentProject != null &&
+                        dependentProject.projectDir.exists() &&
+                        dependentProject.buildFile.exists()) {
+
+                        val targetPath = dependentProject.projectDir.absolutePath
+
+                        dependencies.add(
+                            Dependency(
+                                source = sourcePath,
+                                target = targetPath,
+                                sourceFile = sourceFilePath
+                            )
+                        )
+                    }
+                }
+
                 // Only add dependency if the target project has a valid project directory
                 // and exists as an actual Gradle project in the repository
-                if (dependentProject.projectDir.exists() && 
-                    dependentProject.buildFile.exists()) {
-                    
-                    val targetPath = dependentProject.projectDir.absolutePath
-                    
-                    dependencies.add(
-                        Dependency(
-                            source = sourcePath,
-                            target = targetPath,
-                            sourceFile = sourceFilePath
-                        )
-                    )
-                }
+
             }
         }
     } catch (e: Exception) {

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectDependencyUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectDependencyUtils.kt
@@ -2,6 +2,8 @@ package dev.nx.gradle.utils
 
 import dev.nx.gradle.data.Dependency
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ProjectDependency
 
 private val dependencyCache = mutableMapOf<Project, Set<Dependency>>()
 
@@ -14,23 +16,53 @@ fun getDependenciesForProject(project: Project): MutableSet<Dependency> {
 private fun buildDependenciesForProject(project: Project): Set<Dependency> {
   val dependencies = mutableSetOf<Dependency>()
 
-  // Include subprojects manually
-  project.subprojects.forEach { childProject ->
-    val buildFilePath = if (project.buildFile.exists()) project.buildFile.path else null
-    if (buildFilePath != null) {
-      dependencies.add(
-          Dependency(project.projectDir.path, childProject.projectDir.path, buildFilePath))
-    }
-  }
+    val sourcePath = project.projectDir.absolutePath
+    val sourceFilePath = project.buildFile.takeIf { it.exists() }?.absolutePath ?: ""
 
-  // Include included builds manually
-  project.gradle.includedBuilds.forEach { includedBuild ->
-    val buildFilePath = if (project.buildFile.exists()) project.buildFile.path else null
-    if (buildFilePath != null) {
-      dependencies.add(
-          Dependency(project.projectDir.path, includedBuild.projectDir.path, buildFilePath))
-    }
-  }
+    // Resolve every resolvable configuration (generic)
+    project.configurations
+        .matching { it.isCanBeResolved }
+        .forEach { conf ->
+            dependencies += dependenciesFromConfiguration(project, conf, sourcePath, sourceFilePath)
+        }
 
-  return dependencies
+    return dependencies
+}
+
+private fun dependenciesFromConfiguration(
+    project: Project,
+    conf: Configuration,
+    sourcePath: String,
+    sourceFilePath: String
+): Set<Dependency> {
+    val dependencies = mutableSetOf<Dependency>()
+    
+    try {
+        conf.dependencies.forEach { dependency ->
+            if (dependency is ProjectDependency) {
+                val dependentProject = dependency.dependencyProject
+                
+                // Only add dependency if the target project has a valid project directory
+                // and exists as an actual Gradle project in the repository
+                if (dependentProject.projectDir.exists() && 
+                    dependentProject.buildFile.exists()) {
+                    
+                    val targetPath = dependentProject.projectDir.absolutePath
+                    
+                    dependencies.add(
+                        Dependency(
+                            source = sourcePath,
+                            target = targetPath,
+                            sourceFile = sourceFilePath
+                        )
+                    )
+                }
+            }
+        }
+    } catch (e: Exception) {
+        // Log the error but don't fail the build
+        project.logger.debug("Error processing configuration ${conf.name}: ${e.message}")
+    }
+    
+    return dependencies
 }

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectDependencyUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectDependencyUtils.kt
@@ -2,75 +2,58 @@ package dev.nx.gradle.utils
 
 import dev.nx.gradle.data.Dependency
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.internal.artifacts.result.DefaultResolvedDependencyResult
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
 
 private val dependencyCache = mutableMapOf<Project, Set<Dependency>>()
 
 fun getDependenciesForProject(project: Project): MutableSet<Dependency> {
-  return dependencyCache
-      .getOrPut(project) { buildDependenciesForProject(project) }
-      .toMutableSet() // Return a new mutable copy to prevent modifying the cached set
+    return dependencyCache
+        .getOrPut(project) { buildDependenciesForProject(project) }
+        .toMutableSet() // Return a new mutable copy to prevent modifying the cached set
 }
 
 private fun buildDependenciesForProject(project: Project): Set<Dependency> {
-  val dependencies = mutableSetOf<Dependency>()
+    val dependencies = mutableSetOf<Dependency>()
 
     val sourcePath = project.projectDir.absolutePath
     val sourceFilePath = project.buildFile.takeIf { it.exists() }?.absolutePath ?: ""
 
-    // Resolve every resolvable configuration (generic)
     project.configurations
         .matching { it.isCanBeResolved }
         .forEach { conf ->
-            dependencies += dependenciesFromConfiguration(project, conf, sourcePath, sourceFilePath)
-        }
+            try {
+                conf.incoming.resolutionResult.allDependencies.forEach { dependency ->
+                    if (dependency is DefaultResolvedDependencyResult) {
+                        val requested = dependency.requested
+                        if (requested is DefaultProjectComponentSelector) {
+                            val dependentProject =
+                                project.findProject(requested.toIdentifier().projectPath)
 
-    return dependencies
-}
+                            if (
+                                dependentProject != null &&
+                                    dependentProject.projectDir.exists() &&
+                                    dependentProject.buildFile.exists()
+                            ) {
 
-private fun dependenciesFromConfiguration(
-    project: Project,
-    conf: Configuration,
-    sourcePath: String,
-    sourceFilePath: String
-): Set<Dependency> {
-    val dependencies = mutableSetOf<Dependency>()
-    
-    try {
-        conf.incoming.resolutionResult.allDependencies.forEach { dependency ->
-            if (dependency is DefaultResolvedDependencyResult) {
-                val requested = dependency.requested
-                if(requested is DefaultProjectComponentSelector) {
-                    val dependentProject = project.findProject( requested.toIdentifier().projectPath)
+                                val targetPath = dependentProject.projectDir.absolutePath
 
-                    if (dependentProject != null &&
-                        dependentProject.projectDir.exists() &&
-                        dependentProject.buildFile.exists()) {
-
-                        val targetPath = dependentProject.projectDir.absolutePath
-
-                        dependencies.add(
-                            Dependency(
-                                source = sourcePath,
-                                target = targetPath,
-                                sourceFile = sourceFilePath
-                            )
-                        )
+                                dependencies.add(
+                                    Dependency(
+                                        source = sourcePath,
+                                        target = targetPath,
+                                        sourceFile = sourceFilePath,
+                                    )
+                                )
+                            }
+                        }
                     }
                 }
-
-                // Only add dependency if the target project has a valid project directory
-                // and exists as an actual Gradle project in the repository
-
+            } catch (e: Exception) {
+                // Log the error but don't fail the build
+                project.logger.debug("Error processing configuration ${conf.name}: ${e.message}")
             }
         }
-    } catch (e: Exception) {
-        // Log the error but don't fail the build
-        project.logger.debug("Error processing configuration ${conf.name}: ${e.message}")
-    }
-    
+
     return dependencies
 }

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectDependencyUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectDependencyUtils.kt
@@ -2,8 +2,10 @@ package dev.nx.gradle.utils
 
 import dev.nx.gradle.data.Dependency
 import org.gradle.api.Project
-import org.gradle.api.internal.artifacts.result.DefaultResolvedDependencyResult
-import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
+
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.artifacts.component.ProjectComponentSelector
+
 
 private val dependencyCache = mutableMapOf<Project, Set<Dependency>>()
 
@@ -24,11 +26,11 @@ private fun buildDependenciesForProject(project: Project): Set<Dependency> {
         .forEach { conf ->
             try {
                 conf.incoming.resolutionResult.allDependencies.forEach { dependency ->
-                    if (dependency is DefaultResolvedDependencyResult) {
+                    if (dependency is ResolvedDependencyResult) {
                         val requested = dependency.requested
-                        if (requested is DefaultProjectComponentSelector) {
+                        if (requested is ProjectComponentSelector) {
                             val dependentProject =
-                                project.findProject(requested.toIdentifier().projectPath)
+                                project.findProject(requested.projectPath)
 
                             if (
                                 dependentProject != null &&

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectDependencyUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectDependencyUtils.kt
@@ -2,60 +2,54 @@ package dev.nx.gradle.utils
 
 import dev.nx.gradle.data.Dependency
 import org.gradle.api.Project
-
-import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.artifacts.component.ProjectComponentSelector
-
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
 
 private val dependencyCache = mutableMapOf<Project, Set<Dependency>>()
 
 fun getDependenciesForProject(project: Project): MutableSet<Dependency> {
-    return dependencyCache
-        .getOrPut(project) { buildDependenciesForProject(project) }
-        .toMutableSet() // Return a new mutable copy to prevent modifying the cached set
+  return dependencyCache
+      .getOrPut(project) { buildDependenciesForProject(project) }
+      .toMutableSet() // Return a new mutable copy to prevent modifying the cached set
 }
 
 private fun buildDependenciesForProject(project: Project): Set<Dependency> {
-    val dependencies = mutableSetOf<Dependency>()
+  val dependencies = mutableSetOf<Dependency>()
 
-    val sourcePath = project.projectDir.absolutePath
-    val sourceFilePath = project.buildFile.takeIf { it.exists() }?.absolutePath ?: ""
+  val sourcePath = project.projectDir.absolutePath
+  val sourceFilePath = project.buildFile.takeIf { it.exists() }?.absolutePath ?: ""
 
-    project.configurations
-        .matching { it.isCanBeResolved }
-        .forEach { conf ->
-            try {
-                conf.incoming.resolutionResult.allDependencies.forEach { dependency ->
-                    if (dependency is ResolvedDependencyResult) {
-                        val requested = dependency.requested
-                        if (requested is ProjectComponentSelector) {
-                            val dependentProject =
-                                project.findProject(requested.projectPath)
+  project.configurations
+      .matching { it.isCanBeResolved }
+      .forEach { conf ->
+        try {
+          conf.incoming.resolutionResult.allDependencies.forEach { dependency ->
+            if (dependency is ResolvedDependencyResult) {
+              val requested = dependency.requested
+              if (requested is ProjectComponentSelector) {
+                val dependentProject = project.findProject(requested.projectPath)
 
-                            if (
-                                dependentProject != null &&
-                                    dependentProject.projectDir.exists() &&
-                                    dependentProject.buildFile.exists()
-                            ) {
+                if (dependentProject != null &&
+                    dependentProject.projectDir.exists() &&
+                    dependentProject.buildFile.exists()) {
 
-                                val targetPath = dependentProject.projectDir.absolutePath
+                  val targetPath = dependentProject.projectDir.absolutePath
 
-                                dependencies.add(
-                                    Dependency(
-                                        source = sourcePath,
-                                        target = targetPath,
-                                        sourceFile = sourceFilePath,
-                                    )
-                                )
-                            }
-                        }
-                    }
+                  dependencies.add(
+                      Dependency(
+                          source = sourcePath,
+                          target = targetPath,
+                          sourceFile = sourceFilePath,
+                      ))
                 }
-            } catch (e: Exception) {
-                // Log the error but don't fail the build
-                project.logger.debug("Error processing configuration ${conf.name}: ${e.message}")
+              }
             }
+          }
+        } catch (e: Exception) {
+          // Log the error but don't fail the build
+          project.logger.debug("Error processing configuration ${conf.name}: ${e.message}")
         }
+      }
 
-    return dependencies
+  return dependencies
 }


### PR DESCRIPTION
## Current Behavior
gradle dependencies are hardcoded to included builds & subprojects

## Expected Behavior
we use project configurations to determine dependencies like the tooling api does

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
