### PR TITLE
fix(core)!: remove deprecated simpleName option from library generators

### DIFF
--- a/docs/generated/packages/angular/generators/library.json
+++ b/docs/generated/packages/angular/generators/library.json
@@ -44,12 +44,6 @@
         "default": false,
         "x-priority": "internal"
       },
-      "simpleName": {
-        "description": "Don't include the directory in the name of the module or standalone component entry of the library.",
-        "type": "boolean",
-        "default": false,
-        "x-deprecated": "Use the --name option to provide the exact name instead. This option will be removed in Nx 22."
-      },
       "addModuleSpec": {
         "description": "Add a module spec file.",
         "type": "boolean",

--- a/docs/generated/packages/js/generators/library.json
+++ b/docs/generated/packages/js/generators/library.json
@@ -127,12 +127,6 @@
         "description": "Generate a library with a minimal setup. No README.md generated.",
         "default": false
       },
-      "simpleName": {
-        "description": "Don't include the directory in the generated file name.",
-        "type": "boolean",
-        "default": false,
-        "x-deprecated": "Use the --name option to provide the exact name instead. This option will be removed in Nx 22."
-      },
       "useProjectJson": {
         "type": "boolean",
         "description": "Use a `project.json` configuration file instead of inlining the Nx configuration in the `package.json` file."

--- a/docs/generated/packages/nest/generators/library.json
+++ b/docs/generated/packages/nest/generators/library.json
@@ -129,12 +129,6 @@
         "default": false,
         "x-priority": "internal"
       },
-      "simpleName": {
-        "description": "Don't include the directory in the name of the module of the library.",
-        "type": "boolean",
-        "default": false,
-        "x-deprecated": "Use the --name option to provide the exact name instead. This option will be removed in Nx 22."
-      },
       "useProjectJson": {
         "type": "boolean",
         "description": "Use a `project.json` configuration file instead of inlining the Nx configuration in the `package.json` file."

--- a/docs/generated/packages/react/generators/library.json
+++ b/docs/generated/packages/react/generators/library.json
@@ -180,12 +180,6 @@
         "type": "boolean",
         "default": false
       },
-      "simpleName": {
-        "description": "Don't include the directory in the name of the module of the library.",
-        "type": "boolean",
-        "default": false,
-        "x-deprecated": "Use the --name option to provide the exact name instead. This option will be removed in Nx 22."
-      },
       "useProjectJson": {
         "type": "boolean",
         "description": "Use a `project.json` configuration file instead of inlining the Nx configuration in the `package.json` file."

--- a/packages/angular/src/generators/library/lib/normalize-options.ts
+++ b/packages/angular/src/generators/library/lib/normalize-options.ts
@@ -21,7 +21,6 @@ export async function normalizeOptions(
     buildable: false,
     linter: 'eslint',
     publishable: false,
-    simpleName: false,
     skipFormat: false,
     unitTestRunner: UnitTestRunner.Jest,
     // Publishable libs cannot use `full` yet, so if its false then use the passed value or default to `full`
@@ -45,9 +44,7 @@ export async function normalizeOptions(
     importPath: options.importPath,
   });
 
-  const fileName = options.simpleName
-    ? projectNames.projectSimpleName
-    : projectNames.projectFileName;
+  const fileName = projectNames.projectFileName;
 
   const moduleName = `${names(fileName).className}Module`;
   const parsedTags = options.tags

--- a/packages/angular/src/generators/library/lib/normalized-schema.ts
+++ b/packages/angular/src/generators/library/lib/normalized-schema.ts
@@ -7,7 +7,6 @@ export interface NormalizedSchema {
     name?: string;
     addTailwind?: boolean;
     skipFormat?: boolean;
-    simpleName?: boolean;
     addModuleSpec?: boolean;
     sourceDir?: string;
     buildable?: boolean;

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -48,13 +48,6 @@ export async function libraryGenerator(
     );
   }
 
-  if (schema.simpleName !== undefined && schema.simpleName !== false) {
-    // TODO(v22): Remove simpleName as user should be using name.
-    logger.warn(
-      `The "--simpleName" option is deprecated and will be removed in Nx 22. Please use the "--name" option to provide the exact name you want for the library.`
-    );
-  }
-
   if (schema.addTailwind && !schema.buildable && !schema.publishable) {
     throw new Error(
       `To use "--addTailwind" option, you have to set either "--buildable" or "--publishable".`

--- a/packages/angular/src/generators/library/schema.d.ts
+++ b/packages/angular/src/generators/library/schema.d.ts
@@ -6,7 +6,6 @@ export interface Schema {
   name?: string;
   addTailwind?: boolean;
   skipFormat?: boolean;
-  simpleName?: boolean;
   addModuleSpec?: boolean;
   sourceDir?: string;
   buildable?: boolean;

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -44,12 +44,6 @@
       "default": false,
       "x-priority": "internal"
     },
-    "simpleName": {
-      "description": "Don't include the directory in the name of the module or standalone component entry of the library.",
-      "type": "boolean",
-      "default": false,
-      "x-deprecated": "Use the --name option to provide the exact name instead. This option will be removed in Nx 22."
-    },
     "addModuleSpec": {
       "description": "Add a module spec file.",
       "type": "boolean",

--- a/packages/angular/src/generators/move/move.spec.ts
+++ b/packages/angular/src/generators/move/move.spec.ts
@@ -37,7 +37,6 @@ describe('@nx/angular:move', () => {
       buildable: false,
       linter: 'eslint',
       publishable: false,
-      simpleName: true,
       skipFormat: true,
       unitTestRunner: UnitTestRunner.Jest,
       standalone: false,
@@ -133,7 +132,6 @@ describe('@nx/angular:move', () => {
         buildable: false,
         linter: 'eslint',
         publishable: false,
-        simpleName: true,
         skipFormat: true,
         unitTestRunner: UnitTestRunner.Jest,
       });
@@ -260,7 +258,6 @@ describe('@nx/angular:move', () => {
         buildable: false,
         linter: 'eslint',
         publishable: false,
-        simpleName: true,
         skipFormat: true,
         unitTestRunner: UnitTestRunner.Jest,
       });
@@ -343,7 +340,6 @@ describe('@nx/angular:move', () => {
         buildable: false,
         linter: 'eslint',
         publishable: false,
-        simpleName: true,
         skipFormat: true,
         unitTestRunner: UnitTestRunner.Jest,
         standalone: false,

--- a/packages/angular/src/generators/utils/testing.ts
+++ b/packages/angular/src/generators/utils/testing.ts
@@ -60,7 +60,6 @@ export async function createStorybookTestWorkspaceForLib(
     buildable: false,
     linter: 'eslint',
     publishable: false,
-    simpleName: false,
     skipFormat: true,
     unitTestRunner: UnitTestRunner.Jest,
     standalone: false,

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1742,22 +1742,6 @@ describe('lib', () => {
     });
   });
 
-  describe('--simpleName', () => {
-    it('should generate a simple name', async () => {
-      await libraryGenerator(tree, {
-        ...defaultOptions,
-        name: 'my-lib',
-        simpleName: true,
-        directory: 'web/my-lib',
-      });
-
-      expect(tree.read('web/my-lib/src/index.ts', 'utf-8')).toContain(
-        `export * from './lib/my-lib';`
-      );
-      expect(tree.exists('web/my-lib/src/lib/my-lib.ts')).toBeTruthy();
-    });
-  });
-
   describe('--testEnvironment', () => {
     it('should generate a vite config with testEnvironment set to node', async () => {
       await libraryGenerator(tree, {

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -107,13 +107,6 @@ export async function libraryGeneratorInternal(
   );
   const options = await normalizeOptions(tree, schema);
 
-  if (schema.simpleName !== undefined && schema.simpleName !== false) {
-    // TODO(v22): Remove simpleName as user should be using name.
-    logger.warn(
-      `The "--simpleName" option is deprecated and will be removed in Nx 22. Please use the "--name" option to provide the exact name you want for the library.`
-    );
-  }
-
   createFiles(tree, options);
 
   await configureProject(tree, options);
@@ -895,11 +888,7 @@ async function normalizeOptions(
     rootProject: options.rootProject,
   });
   options.rootProject = projectRoot === '.';
-  const fileName = names(
-    options.simpleName
-      ? projectNames.projectSimpleName
-      : projectNames.projectFileName
-  ).fileName;
+  const fileName = names(projectNames.projectFileName).fileName;
 
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())

--- a/packages/js/src/generators/library/schema.d.ts
+++ b/packages/js/src/generators/library/schema.d.ts
@@ -30,7 +30,6 @@ export interface LibraryGeneratorSchema {
   skipTypeCheck?: boolean;
   minimal?: boolean;
   rootProject?: boolean;
-  simpleName?: boolean;
   addPlugin?: boolean;
   useProjectJson?: boolean;
   useTscExecutor?: boolean;

--- a/packages/js/src/generators/library/schema.json
+++ b/packages/js/src/generators/library/schema.json
@@ -127,12 +127,6 @@
       "description": "Generate a library with a minimal setup. No README.md generated.",
       "default": false
     },
-    "simpleName": {
-      "description": "Don't include the directory in the generated file name.",
-      "type": "boolean",
-      "default": false,
-      "x-deprecated": "Use the --name option to provide the exact name instead. This option will be removed in Nx 22."
-    },
     "useProjectJson": {
       "type": "boolean",
       "description": "Use a `project.json` configuration file instead of inlining the Nx configuration in the `package.json` file."

--- a/packages/nest/src/generators/library/lib/normalize-options.ts
+++ b/packages/nest/src/generators/library/lib/normalize-options.ts
@@ -34,9 +34,7 @@ export async function normalizeOptions(
 
   options.addPlugin ??= addPlugin;
 
-  const fileName = options.simpleName
-    ? projectNames.projectSimpleName
-    : projectNames.projectFileName;
+  const fileName = projectNames.projectFileName;
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())
     : [];

--- a/packages/nest/src/generators/library/library.ts
+++ b/packages/nest/src/generators/library/library.ts
@@ -39,13 +39,6 @@ export async function libraryGeneratorInternal(
 ): Promise<GeneratorCallback> {
   const options = await normalizeOptions(tree, rawOptions);
 
-  if (rawOptions.simpleName !== undefined && rawOptions.simpleName !== false) {
-    // TODO(v22): Remove simpleName as user should be using name.
-    logger.warn(
-      `The "--simpleName" option is deprecated and will be removed in Nx 22. Please use the "--name" option to provide the exact name you want for the library.`
-    );
-  }
-
   const jsLibraryTask = await jsLibraryGenerator(
     tree,
     toJsLibraryGeneratorOptions(options)

--- a/packages/nest/src/generators/library/schema.d.ts
+++ b/packages/nest/src/generators/library/schema.d.ts
@@ -30,7 +30,6 @@ export interface LibraryGeneratorOptions {
   unitTestRunner?: UnitTestRunner;
   setParserOptionsProject?: boolean;
   skipPackageJson?: boolean;
-  simpleName?: boolean;
   addPlugin?: boolean;
   isUsingTsSolutionsConfig?: boolean;
   useProjectJson?: boolean;

--- a/packages/nest/src/generators/library/schema.json
+++ b/packages/nest/src/generators/library/schema.json
@@ -129,12 +129,6 @@
       "default": false,
       "x-priority": "internal"
     },
-    "simpleName": {
-      "description": "Don't include the directory in the name of the module of the library.",
-      "type": "boolean",
-      "default": false,
-      "x-deprecated": "Use the --name option to provide the exact name instead. This option will be removed in Nx 22."
-    },
     "useProjectJson": {
       "type": "boolean",
       "description": "Use a `project.json` configuration file instead of inlining the Nx configuration in the `package.json` file."

--- a/packages/react/src/generators/library/lib/normalize-options.ts
+++ b/packages/react/src/generators/library/lib/normalize-options.ts
@@ -43,9 +43,7 @@ export async function normalizeOptions(
 
   options.addPlugin ??= addPlugin;
 
-  const fileName = options.simpleName
-    ? projectNames.projectSimpleName
-    : projectNames.projectFileName;
+  const fileName = projectNames.projectFileName;
 
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -78,13 +78,6 @@ export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
     );
   }
 
-  if (schema.simpleName !== undefined && schema.simpleName !== false) {
-    // TODO(v22): Remove simpleName as user should be using name.
-    logger.warn(
-      `The "--simpleName" option is deprecated and will be removed in Nx 22. Please use the "--name" option to provide the exact name you want for the library.`
-    );
-  }
-
   if (!options.component) {
     options.style = 'none';
   }

--- a/packages/react/src/generators/library/schema.d.ts
+++ b/packages/react/src/generators/library/schema.d.ts
@@ -25,7 +25,6 @@ export interface Schema {
   tags?: string;
   unitTestRunner?: 'jest' | 'vitest' | 'none';
   minimal?: boolean;
-  simpleName?: boolean;
   addPlugin?: boolean;
   useProjectJson?: boolean;
 }

--- a/packages/react/src/generators/library/schema.json
+++ b/packages/react/src/generators/library/schema.json
@@ -186,12 +186,6 @@
       "type": "boolean",
       "default": false
     },
-    "simpleName": {
-      "description": "Don't include the directory in the name of the module of the library.",
-      "type": "boolean",
-      "default": false,
-      "x-deprecated": "Use the --name option to provide the exact name instead. This option will be removed in Nx 22."
-    },
     "useProjectJson": {
       "type": "boolean",
       "description": "Use a `project.json` configuration file instead of inlining the Nx configuration in the `package.json` file."


### PR DESCRIPTION
The deprecated simpleName option has been removed from the library generators for Angular, React, Nest, and JS packages. Use the --name option to provide the exact name for the library.

BREAKING CHANGE: simpleName option is no longer supported in library generators

Closes NXC-3107, NXC-3098, NXC-3093, NXC-3111