### PR TITLE
fix(nx-dev): implement client-side routing for documentation URLs

### DIFF
--- a/nx-dev/nx-dev/pages/changelog.tsx
+++ b/nx-dev/nx-dev/pages/changelog.tsx
@@ -255,7 +255,11 @@ export default function Changelog(props: ChangeLogProps): JSX.Element {
               All the Nx goodies in one page, sorted by release. See our{' '}
               <Link
                 className="underline"
-                href="/reference/releases"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/reference/releases'
+                    : '/reference/releases'
+                }
                 prefetch={false}
               >
                 release page

--- a/nx-dev/nx-dev/pages/plugin-registry.tsx
+++ b/nx-dev/nx-dev/pages/plugin-registry.tsx
@@ -132,7 +132,11 @@ export default function Browse(props: BrowseProps): JSX.Element {
                     Are you a plugin author? You can{' '}
                     <a
                       className="underline"
-                      href="/extending-nx/recipes/publish-plugin#list-your-nx-plugin"
+                      href={
+                        process.env.NEXT_PUBLIC_ASTRO_URL
+                          ? '/docs/extending-nx/recipes/publish-plugin#list-your-nx-plugin'
+                          : '/extending-nx/recipes/publish-plugin#list-your-nx-plugin'
+                      }
                     >
                       add your plugin to the registry
                     </a>{' '}

--- a/nx-dev/ui-ai-landing-page/src/lib/call-to-action.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/call-to-action.tsx
@@ -62,7 +62,11 @@ export function CallToAction(): ReactElement {
         </h2>
         <div className="mt-10 flex items-center justify-center gap-x-6">
           <Link
-            href="/features/enhance-AI#setting-up-nx-mcp"
+            href={
+              process.env.NEXT_PUBLIC_ASTRO_URL
+                ? '/docs/features/enhance-ai#setting-up-nx-mcp'
+                : '/features/enhance-AI#setting-up-nx-mcp'
+            }
             title="Get started with Nx AI integration"
             prefetch={false}
             className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"

--- a/nx-dev/ui-ai-landing-page/src/lib/hero.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/hero.tsx
@@ -493,7 +493,11 @@ export function Hero(): JSX.Element {
               className="mt-8 flex justify-start"
             >
               <ButtonLink
-                href="/features/enhance-AI#setting-up-nx-mcp"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/features/enhance-ai#setting-up-nx-mcp'
+                    : '/features/enhance-AI#setting-up-nx-mcp'
+                }
                 variant="primary"
                 size="default"
                 title="Enhance your AI assistant"

--- a/nx-dev/ui-ai-landing-page/src/lib/new/ai-hero.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/new/ai-hero.tsx
@@ -25,7 +25,11 @@ export function AiHero(): ReactElement {
           </SectionHeading>
           <div className="mt-6">
             <ButtonLink
-              href="/getting-started/ai-integration"
+              href={
+                process.env.NEXT_PUBLIC_ASTRO_URL
+                  ? '/docs/getting-started/ai-setup'
+                  : '/getting-started/ai-integration'
+              }
               title="Nx AI Integration"
               variant="primary"
               size="small"

--- a/nx-dev/ui-ai-landing-page/src/lib/new/while-running-ci.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/new/while-running-ci.tsx
@@ -18,7 +18,11 @@ const features: FeatureCardProps[] = [
         </p>
         <div className="mt-4">
           <Link
-            href="/ci/features/flaky-tasks"
+            href={
+              process.env.NEXT_PUBLIC_ASTRO_URL
+                ? '/docs/features/ci-features/flaky-tasks'
+                : '/ci/features/flaky-tasks'
+            }
             title="How to identify and rerun flaky tasks"
             className="text-sm/6 font-semibold"
           >
@@ -72,7 +76,11 @@ const features: FeatureCardProps[] = [
         </p>
         <div className="mt-4">
           <Link
-            href="/ci/features/dynamic-agents"
+            href={
+              process.env.NEXT_PUBLIC_ASTRO_URL
+                ? '/docs/features/ci-features/dynamic-agents'
+                : '/ci/features/dynamic-agents'
+            }
             title="How to setup dynamic agents"
             className="text-sm/6 font-semibold"
           >

--- a/nx-dev/ui-cloud/src/lib/pricing.tsx
+++ b/nx-dev/ui-cloud/src/lib/pricing.tsx
@@ -116,7 +116,11 @@ export function Pricing(): ReactElement {
                     <span>
                       Remote caching with{' '}
                       <Link
-                        href="/ci/features/remote-cache"
+                        href={
+                          process.env.NEXT_PUBLIC_ASTRO_URL
+                            ? '/docs/features/ci-features/remote-cache'
+                            : '/ci/features/remote-cache'
+                        }
                         target="_blank"
                         title="Learn how Nx Replay easily reduces CI execution time"
                         onClick={() =>
@@ -140,7 +144,11 @@ export function Pricing(): ReactElement {
                     <span>
                       Distributed task execution with{' '}
                       <Link
-                        href="/ci/features/distribute-task-execution"
+                        href={
+                          process.env.NEXT_PUBLIC_ASTRO_URL
+                            ? '/docs/features/ci-features/distribute-task-execution'
+                            : '/ci/features/distribute-task-execution'
+                        }
                         target="_blank"
                         title="Learn how Nx Agents easily scale your CI pipelines"
                         onClick={() =>
@@ -409,7 +417,11 @@ export function Pricing(): ReactElement {
             <p className="text-sm font-medium opacity-80">
               See{' '}
               <Link
-                href="/ci/reference/credits-pricing"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/reference'
+                    : '/ci/reference/credits-pricing'
+                }
                 className="font-semibold underline"
               >
                 Credit Pricing

--- a/nx-dev/ui-common/src/lib/footer.tsx
+++ b/nx-dev/ui-common/src/lib/footer.tsx
@@ -12,8 +12,13 @@ const navigation = {
   ],
   nxCloud: [
     { name: 'App', href: 'https://cloud.nx.app' },
-    { name: 'Docs', href: '/ci/features' },
-    { name: 'Pricing', href: '/pricing' },
+    {
+      name: 'Docs',
+      href: process.env.NEXT_PUBLIC_ASTRO_URL
+        ? '/docs/features/ci-features'
+        : '/ci/features',
+    },
+    { name: 'Pricing', href: '/nx-cloud#plans' },
     { name: 'Terms', href: 'https://cloud.nx.app/terms' },
   ],
   solutions: [

--- a/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
@@ -100,7 +100,9 @@ export function DocumentationHeader({
     { name: 'Nx', href: docsUrl, current: isNx },
     {
       name: 'CI',
-      href: '/ci/features',
+      href: process.env.NEXT_PUBLIC_ASTRO_URL
+        ? '/docs/features/ci-features'
+        : '/ci/features',
       current: isCI,
     },
     {
@@ -110,7 +112,9 @@ export function DocumentationHeader({
     },
     {
       name: 'Plugins',
-      href: '/plugin-registry',
+      href: process.env.NEXT_PUBLIC_ASTRO_URL
+        ? '/docs/plugin-registry'
+        : '/plugin-registry',
       current: isPlugins,
     },
     {

--- a/nx-dev/ui-common/src/lib/sidebar.tsx
+++ b/nx-dev/ui-common/src/lib/sidebar.tsx
@@ -319,7 +319,9 @@ export function SidebarMobile({
       },
       {
         name: 'CI',
-        href: '/ci/features',
+        href: process.env.NEXT_PUBLIC_ASTRO_URL
+          ? '/docs/features/ci-features'
+          : '/ci/features',
         current: isCI,
       },
       {

--- a/nx-dev/ui-community/src/lib/connect-with-us.tsx
+++ b/nx-dev/ui-community/src/lib/connect-with-us.tsx
@@ -20,7 +20,11 @@ export function ConnectWithUs(): JSX.Element {
           <p className="py-4">
             Looking for community plugins? Find them listed in the{' '}
             <Link
-              href="/plugin-registry"
+              href={
+                process.env.NEXT_PUBLIC_ASTRO_URL
+                  ? '/docs/plugin-registry'
+                  : '/plugin-registry'
+              }
               className="font-semibold underline"
               prefetch={false}
             >

--- a/nx-dev/ui-contact/src/lib/contact-links.tsx
+++ b/nx-dev/ui-contact/src/lib/contact-links.tsx
@@ -55,7 +55,11 @@ export function ContactLinks(): JSX.Element {
             Get an overview of Nx's features, integrations, and how to use them.
           </p>
           <Link
-            href="/getting-started/intro"
+            href={
+              process.env.NEXT_PUBLIC_ASTRO_URL
+                ? '/docs/getting-started/intro'
+                : '/getting-started/intro'
+            }
             title="Nx documentation"
             className="mt-2 flex items-center gap-2 text-sm text-slate-500 transition hover:text-slate-800 dark:hover:text-slate-400"
             prefetch={false}

--- a/nx-dev/ui-enterprise/src/lib/scale-your-organization.tsx
+++ b/nx-dev/ui-enterprise/src/lib/scale-your-organization.tsx
@@ -156,7 +156,11 @@ export function ScaleYourOrganization(): ReactElement {
                     <ul className="mt-6 space-y-2 pl-4">
                       <li>
                         <Link
-                          href="/ci/recipes/enterprise/conformance/configure-conformance-rules-in-nx-cloud"
+                          href={
+                            process.env.NEXT_PUBLIC_ASTRO_URL
+                              ? '/docs/enterprise/powerpack/configure-conformance-rules-in-nx-cloud'
+                              : '/ci/recipes/enterprise/conformance/configure-conformance-rules-in-nx-cloud'
+                          }
                           prefetch={false}
                           title="Configure Conformance Rules"
                           className="text-sm/6 font-semibold"
@@ -167,7 +171,11 @@ export function ScaleYourOrganization(): ReactElement {
                       </li>
                       <li>
                         <Link
-                          href="/ci/recipes/enterprise/conformance/publish-conformance-rules-to-nx-cloud"
+                          href={
+                            process.env.NEXT_PUBLIC_ASTRO_URL
+                              ? '/docs/enterprise/powerpack/publish-conformance-rules-to-nx-cloud'
+                              : '/ci/recipes/enterprise/conformance/publish-conformance-rules-to-nx-cloud'
+                          }
                           prefetch={false}
                           title="Publish Conformance Rules"
                           className="text-sm/6 font-semibold"

--- a/nx-dev/ui-enterprise/src/lib/solutions/engineering/all-speed-no-stress.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/engineering/all-speed-no-stress.tsx
@@ -23,7 +23,11 @@ const features = [
         </p>
         <div className="mt-4">
           <Link
-            href="/ci/features/remote-cache"
+            href={
+              process.env.NEXT_PUBLIC_ASTRO_URL
+                ? '/docs/features/ci-features/remote-cache'
+                : '/ci/features/remote-cache'
+            }
             title="Learn more about Nx Replay"
             className="text-sm/6 font-semibold"
           >

--- a/nx-dev/ui-enterprise/src/lib/solutions/engineering/developer-experience-that-works-for-you.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/engineering/developer-experience-that-works-for-you.tsx
@@ -58,7 +58,11 @@ const features = [
         </p>
         <div className="mt-4">
           <Link
-            href="/features/enhance-AI"
+            href={
+              process.env.NEXT_PUBLIC_ASTRO_URL
+                ? '/docs/features/enhance-ai'
+                : '/features/enhance-AI'
+            }
             title="Learn about Enhancing your LLM"
             className="text-sm/6 font-semibold"
           >

--- a/nx-dev/ui-enterprise/src/lib/solutions/leadership/build-a-modern-engineering-organization.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/leadership/build-a-modern-engineering-organization.tsx
@@ -19,7 +19,11 @@ const features = [
         </p>
         <div className="mt-4">
           <Link
-            href="/features/enhance-AI"
+            href={
+              process.env.NEXT_PUBLIC_ASTRO_URL
+                ? '/docs/features/enhance-ai'
+                : '/features/enhance-AI'
+            }
             title="Learn about our Enhancing your LLM"
             className="text-sm/6 font-semibold"
           >

--- a/nx-dev/ui-enterprise/src/lib/solutions/management/keep-teams-aligned.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/management/keep-teams-aligned.tsx
@@ -59,7 +59,11 @@ const features = [
         </p>
         <div className="mt-4">
           <Link
-            href="/features/enhance-AI"
+            href={
+              process.env.NEXT_PUBLIC_ASTRO_URL
+                ? '/docs/features/enhance-ai'
+                : '/features/enhance-AI'
+            }
             title="Learn about Enhancing your LLM"
             className="text-sm/6 font-semibold"
           >

--- a/nx-dev/ui-gradle/src/lib/features.tsx
+++ b/nx-dev/ui-gradle/src/lib/features.tsx
@@ -18,7 +18,11 @@ export function Features(): ReactElement {
         <FeatureCard
           title="Task Caching"
           description="Cache task results locally and remotely, avoiding redundant builds and speeding up your development workflow."
-          href="/features/cache-task-results"
+          href={
+            process.env.NEXT_PUBLIC_ASTRO_URL
+              ? '/docs/features/cache-task-results'
+              : '/features/cache-task-results'
+          }
           icon={
             <svg
               className="h-6 w-6"

--- a/nx-dev/ui-home/src/lib/features/features-while-coding.tsx
+++ b/nx-dev/ui-home/src/lib/features/features-while-coding.tsx
@@ -28,21 +28,33 @@ export function FeaturesWhileCoding(): ReactElement {
               Drop Nx into any codebase and it automatically understands your
               project structure,{' '}
               <TextLink
-                href="/features/run-tasks?utm_medium=website&utm_campaign=homepage_links&utm_content=features"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/features/run-tasks?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                    : '/features/run-tasks?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                }
                 className="decoration-2"
               >
                 executing tasks efficiently
               </TextLink>{' '}
               with intelligent{' '}
               <TextLink
-                href="/features/cache-task-results?utm_medium=website&utm_campaign=homepage_links&utm_content=features"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/features/cache-task-results?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                    : '/features/cache-task-results?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                }
                 className="decoration-2"
               >
                 caching
               </TextLink>{' '}
               and a clean{' '}
               <TextLink
-                href="/recipes/running-tasks/terminal-ui?utm_medium=website&utm_campaign=homepage_links&utm_content=features"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/guides/tasks--caching/terminal-ui?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                    : '/recipes/running-tasks/terminal-ui?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                }
                 className="decoration-2"
               >
                 terminal interface
@@ -51,7 +63,11 @@ export function FeaturesWhileCoding(): ReactElement {
             </p>
             <p>
               <TextLink
-                href="/concepts/nx-plugins?utm_medium=website&utm_campaign=homepage_links&utm_content=features"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/concepts/nx-plugins?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                    : '/concepts/nx-plugins?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                }
                 className="decoration-2"
               >
                 Nx plugins
@@ -63,7 +79,11 @@ export function FeaturesWhileCoding(): ReactElement {
             <p>
               Your{' '}
               <TextLink
-                href="/features/enhance-AI?utm_medium=website&utm_campaign=homepage_links&utm_content=features"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/features/enhance-ai?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                    : '/features/enhance-AI?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                }
                 className="decoration-2"
               >
                 AI coding assistant
@@ -75,7 +95,11 @@ export function FeaturesWhileCoding(): ReactElement {
 
             <div className="mt-10 flex gap-x-6">
               <Link
-                href="/getting-started/intro?utm_medium=website&utm_campaign=homepage_links&utm_content=features"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/getting-started/intro?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                    : '/getting-started/intro?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                }
                 title="Find out about Nx"
                 prefetch={false}
                 className="group font-semibold leading-6 text-slate-950 dark:text-white"

--- a/nx-dev/ui-home/src/lib/features/features-while-running-ci.tsx
+++ b/nx-dev/ui-home/src/lib/features/features-while-running-ci.tsx
@@ -28,21 +28,33 @@ export function FeaturesWhileRunningCI(): ReactElement {
               Nx works with your CI provider to compress the entire validation
               process.{' '}
               <TextLink
-                href="/ci/features/remote-cache?utm_medium=website&utm_campaign=homepage_links&utm_content=features"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/features/ci-features/remote-cache?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                    : '/ci/features/remote-cache?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                }
                 className="decoration-2"
               >
                 Remote cache
               </TextLink>{' '}
               and{' '}
               <TextLink
-                href="/ci/features/distribute-task-execution?utm_medium=website&utm_campaign=homepage_links&utm_content=features"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/features/ci-features/distribute-task-execution?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                    : '/ci/features/distribute-task-execution?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                }
                 className="decoration-2"
               >
                 automatic task distribution
               </TextLink>{' '}
               speed up CI, while{' '}
               <TextLink
-                href="/ci/features/self-healing-ci?utm_medium=website&utm_campaign=homepage_links&utm_content=features"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/features/ci-features/self-healing-ci?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                    : '/ci/features/self-healing-ci?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                }
                 className="decoration-2"
               >
                 self-healing systems

--- a/nx-dev/ui-home/src/lib/features/features-while-scaling-your-organization.tsx
+++ b/nx-dev/ui-home/src/lib/features/features-while-scaling-your-organization.tsx
@@ -26,7 +26,11 @@ export function FeaturesWhileScalingYourOrganization(): ReactElement {
             <p>
               Nx defines{' '}
               <TextLink
-                href="/features/enforce-module-boundaries"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/features/enforce-module-boundaries'
+                    : '/features/enforce-module-boundaries'
+                }
                 className="decoration-2"
               >
                 clear project boundaries
@@ -34,14 +38,22 @@ export function FeaturesWhileScalingYourOrganization(): ReactElement {
               and leverages monorepo concepts—shared tooling, atomic changes,
               and coordinated releases—so code stays easy to maintain.{' '}
               <TextLink
-                href="/nx-enterprise/powerpack/owners"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/enterprise/powerpack/owners'
+                    : '/nx-enterprise/powerpack/owners'
+                }
                 className="decoration-2"
               >
                 Ownership
               </TextLink>{' '}
               is defined at the project level, while{' '}
               <TextLink
-                href="/nx-enterprise/powerpack/conformance"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/enterprise/powerpack/conformance'
+                    : '/nx-enterprise/powerpack/conformance'
+                }
                 className="decoration-2"
               >
                 conformance rules
@@ -50,16 +62,34 @@ export function FeaturesWhileScalingYourOrganization(): ReactElement {
               <strong>entire codebase</strong>.
             </p>
             <p>
-              <TextLink href="/plugin-registry" className="decoration-2">
+              <TextLink
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/plugin-registry'
+                    : '/plugin-registry'
+                }
+                className="decoration-2"
+              >
                 Nx plugins
               </TextLink>{' '}
               and{' '}
-              <TextLink href="/features/generate-code" className="decoration-2">
+              <TextLink
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/features/generate-code'
+                    : '/features/generate-code'
+                }
+                className="decoration-2"
+              >
                 code generation
               </TextLink>{' '}
               standardize best practices and eliminate duplication, while{' '}
               <TextLink
-                href="/features/automate-updating-dependencies"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/features/automate-updating-dependencies'
+                    : '/features/automate-updating-dependencies'
+                }
                 className="decoration-2"
               >
                 automated updates

--- a/nx-dev/ui-home/src/lib/features/features.tsx
+++ b/nx-dev/ui-home/src/lib/features/features.tsx
@@ -15,7 +15,13 @@ export function Features(): ReactElement {
         </SectionHeading>
         <SectionHeading as="p" variant="subtitle" className="mt-6">
           Whether you're a startup shipping fast or managing enterprise{' '}
-          <TextLink href="/concepts/decisions/why-monorepos?utm_medium=website&utm_campaign=homepage_links&utm_content=features">
+          <TextLink
+            href={
+              process.env.NEXT_PUBLIC_ASTRO_URL
+                ? '/docs/concepts/decisions/why-monorepos?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                : '/concepts/decisions/why-monorepos?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+            }
+          >
             monorepos
           </TextLink>{' '}
           with thousands of projects, Nx lets you focus on what matters and

--- a/nx-dev/ui-powerpack/src/lib/get-started.tsx
+++ b/nx-dev/ui-powerpack/src/lib/get-started.tsx
@@ -139,14 +139,22 @@ export function GetStarted(): ReactElement {
                 <p className="mt-2">
                   Install Powerpack plugins such as{' '}
                   <TextLink
-                    href="/nx-enterprise/powerpack/conformance"
+                    href={
+                      process.env.NEXT_PUBLIC_ASTRO_URL
+                        ? '/docs/enterprise/powerpack/conformance'
+                        : '/nx-enterprise/powerpack/conformance'
+                    }
                     title="Workspace conformance"
                   >
                     workspace conformance
                   </TextLink>
                   , and{' '}
                   <TextLink
-                    href="/nx-enterprise/powerpack/owners"
+                    href={
+                      process.env.NEXT_PUBLIC_ASTRO_URL
+                        ? '/docs/enterprise/powerpack/owners'
+                        : '/nx-enterprise/powerpack/owners'
+                    }
                     title="Codeowners for monorepos"
                   >
                     Codeowners for monorepos

--- a/nx-dev/ui-powerpack/src/lib/powerpack-features.tsx
+++ b/nx-dev/ui-powerpack/src/lib/powerpack-features.tsx
@@ -78,7 +78,7 @@ export function PowerpackFeatures(): ReactElement {
                 storage, offering a flexible, self-managed solution for faster
                 builds. Nx Powerpack self-hosted cache storage is{' '}
                 <TextLink
-                  href="/nx-enterprise/powerpack/free-licenses-and-trials"
+                  href={process.env.NEXT_PUBLIC_ASTRO_URL ? "/docs/enterprise/powerpack/free-licenses-and-trials" : "/nx-enterprise/powerpack/free-licenses-and-trials"}
                   title="Get a Powerpack license"
                 >
                   free for small teams
@@ -87,7 +87,7 @@ export function PowerpackFeatures(): ReactElement {
               </p>
               <div className="mt-16">
                 <ButtonLink
-                  href="/nx-enterprise/powerpack/custom-caching"
+                  href={process.env.NEXT_PUBLIC_ASTRO_URL ? "/docs/enterprise/powerpack/custom-caching" : "/nx-enterprise/powerpack/custom-caching"}
                   title="Learn more about self-hosted cache storage"
                   variant="secondary"
                   size="default"
@@ -128,7 +128,11 @@ export function PowerpackFeatures(): ReactElement {
             </div>
             <div className="flex">
               <ButtonLink
-                href="/nx-enterprise/powerpack/owners"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/enterprise/powerpack/owners'
+                    : '/nx-enterprise/powerpack/owners'
+                }
                 title="Learn more about codeowners"
                 variant="secondary"
                 size="default"
@@ -168,7 +172,11 @@ export function PowerpackFeatures(): ReactElement {
             </div>
             <div className="flex">
               <ButtonLink
-                href="/nx-enterprise/powerpack/conformance"
+                href={
+                  process.env.NEXT_PUBLIC_ASTRO_URL
+                    ? '/docs/enterprise/powerpack/conformance'
+                    : '/nx-enterprise/powerpack/conformance'
+                }
                 title="Learn how to set up conformance rules"
                 variant="secondary"
                 size="default"

--- a/nx-dev/ui-pricing/src/lib/plans-display.tsx
+++ b/nx-dev/ui-pricing/src/lib/plans-display.tsx
@@ -110,7 +110,11 @@ export function PlansDisplay(): ReactElement {
                     <span>
                       Remote caching with{' '}
                       <Link
-                        href="/ci/features/remote-cache"
+                        href={
+                          process.env.NEXT_PUBLIC_ASTRO_URL
+                            ? '/docs/features/ci-features/remote-cache'
+                            : '/ci/features/remote-cache'
+                        }
                         target="_blank"
                         title="Learn how Nx Replay easily reduces CI execution time"
                         onClick={() =>
@@ -134,7 +138,11 @@ export function PlansDisplay(): ReactElement {
                     <span>
                       Distributed task execution with{' '}
                       <Link
-                        href="/ci/features/distribute-task-execution"
+                        href={
+                          process.env.NEXT_PUBLIC_ASTRO_URL
+                            ? '/docs/features/ci-features/distribute-task-execution'
+                            : '/ci/features/distribute-task-execution'
+                        }
                         target="_blank"
                         title="Learn how Nx Agents easily scale your CI pipelines"
                         onClick={() =>

--- a/nx-dev/ui-react/src/lib/feature-sections.tsx
+++ b/nx-dev/ui-react/src/lib/feature-sections.tsx
@@ -20,7 +20,11 @@ export function FeatureSections(): ReactElement {
             imageSrc="/images/enterprise/nx-affected.avif"
             alt="Nx Affected: Run tasks only on affected projects"
             tag="Affected"
-            href="/ci/features/affected"
+            href={
+              process.env.NEXT_PUBLIC_ASTRO_URL
+                ? '/docs/ci/features/affected'
+                : '/ci/features/affected'
+            }
           />
 
           {/* Remote Caching Section */}
@@ -30,7 +34,11 @@ export function FeatureSections(): ReactElement {
             imageSrc="/images/enterprise/nx-replay.avif"
             alt="Nx Replay: Remote caching"
             tag="Nx Replay"
-            href="/features/cache-task-results"
+            href={
+              process.env.NEXT_PUBLIC_ASTRO_URL
+                ? '/docs/features/cache-task-results'
+                : '/features/cache-task-results'
+            }
           />
 
           {/* Distribution Section */}
@@ -40,7 +48,11 @@ export function FeatureSections(): ReactElement {
             imageSrc="/images/enterprise/nx-agents.avif"
             alt="Nx Agents: Task distribution"
             tag="Nx Agents"
-            href="/ci/features/distribute-task-execution"
+            href={
+              process.env.NEXT_PUBLIC_ASTRO_URL
+                ? '/docs/ci/features/distribute-task-execution'
+                : '/ci/features/distribute-task-execution'
+            }
           />
 
           {/* Atomizer Section */}
@@ -50,7 +62,11 @@ export function FeatureSections(): ReactElement {
             imageSrc="/images/enterprise/nx-atomizer.avif"
             alt="Nx Atomizer: Split large test tasks"
             tag="Atomizer"
-            href="/ci/features/split-e2e-tasks"
+            href={
+              process.env.NEXT_PUBLIC_ASTRO_URL
+                ? '/docs/ci/features/split-e2e-tasks'
+                : '/ci/features/split-e2e-tasks'
+            }
           />
 
           {/* Flaky Test Retries Section */}

--- a/nx-dev/ui-react/src/lib/features.tsx
+++ b/nx-dev/ui-react/src/lib/features.tsx
@@ -18,7 +18,11 @@ export function Features(): ReactElement {
         <FeatureCard
           title="Task Caching"
           description="Cache task results locally and remotely, avoiding redundant builds and speeding up your development workflow."
-          href="/features/cache-task-results"
+          href={
+            process.env.NEXT_PUBLIC_ASTRO_URL
+              ? '/docs/features/cache-task-results'
+              : '/features/cache-task-results'
+          }
           icon={
             <svg
               className="h-6 w-6"
@@ -46,7 +50,11 @@ export function Features(): ReactElement {
         <FeatureCard
           title="Distributed Task Execution"
           description="Run your project tasks across multiple machines, dramatically reducing build times for large repositories."
-          href="/ci/features/distribute-task-execution"
+          href={
+            process.env.NEXT_PUBLIC_ASTRO_URL
+              ? '/docs/features/ci-features/distribute-task-execution'
+              : '/ci/features/distribute-task-execution'
+          }
           icon={
             <svg
               className="h-6 w-6"
@@ -86,7 +94,11 @@ export function Features(): ReactElement {
         <FeatureCard
           title="Affected Targets"
           description="Run tasks only on projects affected by your changes, saving time and computing resources."
-          href="/ci/features/affected"
+          href={
+            process.env.NEXT_PUBLIC_ASTRO_URL
+              ? '/docs/ci/features/affected'
+              : '/ci/features/affected'
+          }
           icon={
             <svg
               className="h-6 w-6"
@@ -114,7 +126,11 @@ export function Features(): ReactElement {
         <FeatureCard
           title="Project Graph"
           description="Nx automatically infers your project graph from project's configuration, providing visualization and dependency analysis."
-          href="/features/explore-graph"
+          href={
+            process.env.NEXT_PUBLIC_ASTRO_URL
+              ? '/docs/features/explore-graph'
+              : '/features/explore-graph'
+          }
           icon={
             <svg
               className="h-6 w-6"
@@ -160,7 +176,11 @@ export function Features(): ReactElement {
         <FeatureCard
           title="Split E2E Tests"
           description="Automatically split your E2E tests for faster parallel execution in CI environments with Atomizer."
-          href="/ci/features/split-e2e-tasks"
+          href={
+            process.env.NEXT_PUBLIC_ASTRO_URL
+              ? '/docs/ci/features/split-e2e-tasks'
+              : '/ci/features/split-e2e-tasks'
+          }
           icon={
             <svg
               className="h-6 w-6"
@@ -202,7 +222,11 @@ export function Features(): ReactElement {
         <FeatureCard
           title="Zero Configuration"
           description="Add Nx to your existing monorepo in minutes."
-          href="/recipes/adopting-nx/adding-to-monorepo"
+          href={
+            process.env.NEXT_PUBLIC_ASTRO_URL
+              ? '/docs/recipes/adopting-nx/adding-to-monorepo'
+              : '/recipes/adopting-nx/adding-to-monorepo'
+          }
           icon={
             <svg
               className="h-6 w-6"

--- a/nx-dev/ui-react/src/lib/hero.tsx
+++ b/nx-dev/ui-react/src/lib/hero.tsx
@@ -39,7 +39,11 @@ export function Hero(): ReactElement {
 
         <div className="mt-10 flex flex-col items-center justify-center gap-6 sm:flex-row">
           <ButtonLink
-            href="/getting-started/tutorials/react-monorepo-tutorial"
+            href={
+              process.env.NEXT_PUBLIC_ASTRO_URL
+                ? '/docs/getting-started/tutorials/react-monorepo-tutorial'
+                : '/getting-started/tutorials/react-monorepo-tutorial'
+            }
             variant="primary"
             size="default"
             title="Get Started"

--- a/nx-dev/ui-remote-cache/src/lib/faq.tsx
+++ b/nx-dev/ui-remote-cache/src/lib/faq.tsx
@@ -67,7 +67,11 @@ export function Faq(): ReactElement {
           thus giving you the flexibility to adapt it to your custom
           authentication requirements.{' '}
           <Link
-            href="/recipes/running-tasks/self-hosted-caching#build-your-own-caching-server"
+            href={
+              process.env.NEXT_PUBLIC_ASTRO_URL
+                ? '/docs/guides/tasks--caching/self-hosted-caching#build-your-own-caching-server'
+                : '/recipes/running-tasks/self-hosted-caching#build-your-own-caching-server'
+            }
             title="Learn more"
             prefetch={false}
             className="font-semibold"

--- a/nx-dev/ui-remote-cache/src/lib/remote-cache-solutions.tsx
+++ b/nx-dev/ui-remote-cache/src/lib/remote-cache-solutions.tsx
@@ -168,7 +168,11 @@ export function RemoteCacheSolutions(): ReactElement {
                 </p>
                 <div className="my-8">
                   <ButtonLink
-                    href="/recipes/running-tasks/self-hosted-caching"
+                    href={
+                      process.env.NEXT_PUBLIC_ASTRO_URL
+                        ? '/docs/guides/tasks--caching/self-hosted-caching'
+                        : '/recipes/running-tasks/self-hosted-caching'
+                    }
                     aria-describedby="official-plugins"
                     title="Free official remote cache plugins"
                     size="default"
@@ -256,7 +260,11 @@ export function RemoteCacheSolutions(): ReactElement {
 
                 <div className="mt-8">
                   <ButtonLink
-                    href="/recipes/running-tasks/self-hosted-caching#build-your-own-caching-server"
+                    href={
+                      process.env.NEXT_PUBLIC_ASTRO_URL
+                        ? '/docs/guides/tasks--caching/self-hosted-caching#build-your-own-caching-server'
+                        : '/recipes/running-tasks/self-hosted-caching#build-your-own-caching-server'
+                    }
                     aria-describedby="open-api"
                     title="Remote cache api specs"
                     size="default"


### PR DESCRIPTION
Update all documentation links in nx-dev UI components to conditionally use the new /docs
structure when NEXT_PUBLIC_ASTRO_URL is set. This prevents landing on the old docs page due to the lack of redirect support in Next.js' `<Link>` when used with pages router.

Note: Blog pages are not updated in `docs/blog` because blog is using app router which supports redirects. For example, on https://canary.nx.dev/blog/nx-self-healing-ci the link at the end for `Nx AI Docs` point to https://canary.nx.dev/features/enhance-AI and is correctly redirected to https://canary.nx.dev/docs/features/enhance-ai.

## Logic

- When NEXT_PUBLIC_ASTRO_URL is set: links point to /docs/* URLs
- When NEXT_PUBLIC_ASTRO_URL is not set: links use legacy URLs (current production behavior)

## Pages and components updated

### Pages router pages and components

These are critical since pages router does not support redirects in next config.

  - Homepage (/) components
  - AI Page (/ai) components
  - Enterprise Page (/enterprise) components
  - NX Cloud (/nx-cloud) components
  - Pricing (/pricing) components
  - Community (/community) components
  - Contact (/contact) components
  - Powerpack (/powerpack) components
  - Gradle pages components
  - Common UI components (footer, headers, sidebar)
  - Solution pages (engineering, leadership, management)
  - Changelog (/changelog)

### App router pages

These pages would have worked regardless since app router supports redirects in next config.

  - React Page (/react):
    - ui-react/src/lib/hero.tsx - 1 link
    - ui-react/src/lib/features.tsx - 4 links
    - ui-react/src/lib/feature-sections.tsx - 3 links
  - Powerpack Page (/powerpack):
    - ui-powerpack/src/lib/powerpack-features.tsx - 2 links
  - Remote Cache Page (/remote-cache):
    - ui-remote-cache/src/lib/remote-cache-solutions.tsx - 2 links
    - ui-remote-cache/src/lib/faq.tsx - 1 link

---

Verified with NEXT_PUBLIC_ASTRO_URL=https://canary.nx.dev:
- All links now point to /docs URLs (no 308 redirects)
- Old URLs still redirect for backward compatibility
- Pages load successfully with updated links

Fixes DOC-184