### PR TITLE
docs(misc): mobile menu icon respects theme color

### DIFF
--- a/astro-docs/src/styles/global.css
+++ b/astro-docs/src/styles/global.css
@@ -329,6 +329,28 @@ pre {
     --sl-color-border-badge: theme('colors.slate.700');
     --sl-color-text-badge: theme('colors.slate.400');
   }
+
+  starlight-menu-button button {
+    color: theme('colors.slate.600');
+    background-color: transparent;
+    box-shadow: none;
+  }
+
+  [data-theme='dark'] starlight-menu-button button {
+    color: theme('colors.slate.200');
+    background-color: transparent;
+    box-shadow: none;
+  }
+
+  starlight-menu-button button[aria-expanded='true'] {
+    background-color: theme('colors.white');
+    box-shadow: none;
+  }
+
+  [data-theme='dark'] starlight-menu-button button[aria-expanded='true'] {
+    background-color: theme('colors.slate.900');
+    box-shadow: none;
+  }
 } /* end component layer */
 
 /* Additional custom styles can be added here */


### PR DESCRIPTION
The mobile menu icon (hamburger menu) in astro-docs does not properly respect the theme color, making it hard to see in dark mode.

The mobile menu icon should be visible in both light and dark themes with appropriate colors, transparent background, and no box shadow.

<img width="633" height="431" alt="image" src="https://github.com/user-attachments/assets/30e170d7-4eac-4933-84ab-7f3150747721" />

<img width="632" height="375" alt="image" src="https://github.com/user-attachments/assets/ad095dc9-8c9c-4b26-b13a-8cfabdd9ba99" />
<img width="597" height="430" alt="image" src="https://github.com/user-attachments/assets/25caf367-aa10-4ddb-b08a-5ebaa662addc" />
<img width="596" height="391" alt="image" src="https://github.com/user-attachments/assets/6dc566b7-3559-45a6-a4a8-c21a8121143e" />


Fixes DOC-169