### PR TITLE
 feat(core): add inline-tui view mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2420,6 +2420,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "static_assertions",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_dep_graph",

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -67,6 +67,7 @@ xxhash-rust = { version = '0.8.5', features = ['xxh3', 'xxh64'] }
 vt100-ctt = { git = "https://github.com/JamesHenry/vt100-rust", rev = "b15dc3b0f7db94167a9c584f1d403899c0cc871d" }
 serde = "1.0.219"
 serde_json = "1.0.140"
+static_assertions = "1.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "psapi", "shellapi"] }
@@ -81,7 +82,7 @@ crossterm = { version = "0.29.0", features = ["event-stream", "use-dev-tty"] }
 portable-pty = { git = "https://github.com/cammisuli/wezterm", rev = "b538ee29e1e89eeb4832fb35ae095564dce34c29" }
 ignore-files = "2.1.0"
 fs4 = "0.12.0"
-ratatui = { version = "0.29", features = ["scrolling-regions"] }
+ratatui = { version = "0.29" }
 reqwest = { version = "0.12.22", default-features = false, features = [
     "rustls-tls-native-roots",
 ] }

--- a/packages/nx/src/native/tui/action.rs
+++ b/packages/nx/src/native/tui/action.rs
@@ -1,6 +1,6 @@
 use crate::native::tasks::types::{Task, TaskResult};
 
-use super::{app::Focus, components::tasks_list::TaskStatus};
+use super::{app::Focus, components::tasks_list::TaskStatus, lifecycle::TuiMode};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Action {
@@ -37,4 +37,5 @@ pub enum Action {
     ConsoleMessengerAvailable(bool),
     EndCommand,
     ShowHint(String),
+    SwitchMode(TuiMode),
 }

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -1,8 +1,8 @@
 use color_eyre::eyre::Result;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use hashbrown::HashSet;
 use napi::bindgen_prelude::External;
 use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction};
+use parking_lot::Mutex;
 use ratatui::layout::{Alignment, Rect, Size};
 use ratatui::style::Modifier;
 use ratatui::style::Style;
@@ -11,7 +11,7 @@ use ratatui::widgets::Paragraph;
 use std::collections::HashMap;
 use std::io;
 use std::io::Write;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, trace};
@@ -21,7 +21,7 @@ use crate::native::tui::escape_sequences::EscapeSequence;
 use crate::native::tui::tui::Tui;
 use crate::native::{
     pseudo_terminal::pseudo_terminal::{ParserArc, WriterArc},
-    tasks::types::{Task, TaskGraph, TaskResult},
+    tasks::types::{Task, TaskResult},
 };
 
 use super::action::Action;
@@ -36,32 +36,30 @@ use super::components::layout_manager::{
 use super::components::task_selection_manager::{SelectionMode, TaskSelectionManager};
 use super::components::tasks_list::{TaskStatus, TasksList};
 use super::components::terminal_pane::{TerminalPane, TerminalPaneData, TerminalPaneState};
-use super::config::TuiConfig;
 use super::graph_utils::{get_task_count, is_task_continuous};
-use super::lifecycle::RunMode;
+use super::lifecycle::{RunMode, TuiMode};
 use super::pty::PtyInstance;
 use super::theme::THEME;
 use super::tui;
-use super::utils::normalize_newlines;
+use super::utils::{normalize_newlines, write_output_to_pty};
 use crate::native::ide::nx_console::messaging::NxConsoleMessageConnection;
 use crate::native::tui::graph_utils::get_failed_dependencies;
+use crate::native::tui::tui_core::{AutoExitDecision, QuitDecision, TuiCore};
+use crate::native::tui::tui_state::TuiState;
 use crate::native::utils::time::current_timestamp_millis;
 
 /// Duration before status messages in terminal panes are automatically cleared
 const STATUS_MESSAGE_DURATION: std::time::Duration = std::time::Duration::from_secs(3);
 
 pub struct App {
+    // === Shared Core ===
+    /// Shared core functionality (state management, callbacks, etc.)
+    core: TuiCore,
+
+    // === Full-Screen UI State ===
     pub components: Vec<Box<dyn Component>>,
-    pub quit_at: Option<std::time::Instant>,
     focus: Focus,
-    run_mode: RunMode,
     previous_focus: Focus,
-    done_callback: Option<ThreadsafeFunction<(), ErrorStrategy::Fatal>>,
-    forced_shutdown_callback: Option<ThreadsafeFunction<(), ErrorStrategy::Fatal>>,
-    tui_config: TuiConfig,
-    // We track whether the user has interacted with the app to determine if we should show perform any auto-exit at all
-    user_has_interacted: bool,
-    is_forced_shutdown: bool,
     layout_manager: LayoutManager,
     // Cached frame area used for layout calculations, only updated on terminal resize
     frame_area: Option<Rect>,
@@ -71,19 +69,12 @@ pub struct App {
     dependency_view_states: [Option<DependencyViewState>; 2],
     spacebar_mode: bool,
     pane_tasks: [Option<String>; 2], // Tasks assigned to panes 1 and 2 (0-indexed)
-    action_tx: Option<UnboundedSender<Action>>,
     resize_debounce_timer: Option<u128>, // Timer for debouncing resize events
-    // task id -> pty instance
-    pty_instances: HashMap<String, Arc<PtyInstance>>,
     selection_manager: Arc<Mutex<TaskSelectionManager>>,
-    pinned_tasks: Vec<String>,
-    task_graph: TaskGraph,
-    task_status_map: HashMap<String, TaskStatus>, // App owns task status
-    incomplete_task_count: usize,                 // Count of tasks that are not yet complete
     debug_mode: bool,
     debug_state: TuiWidgetState,
-    console_messenger: Option<NxConsoleMessageConnection>,
-    estimated_task_timings: HashMap<String, i64>,
+    /// Flag to indicate this App was restored from a mode switch and should skip init pane setup
+    restored_from_mode_switch: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -96,27 +87,59 @@ pub enum Focus {
 }
 
 impl App {
-    pub fn new(
-        tasks: Vec<Task>,
-        initiating_tasks: HashSet<String>,
-        run_mode: RunMode,
-        pinned_tasks: Vec<String>,
-        tui_config: TuiConfig,
-        title_text: String,
-        task_graph: TaskGraph,
-    ) -> Result<Self> {
-        let task_count = get_task_count(&task_graph);
+    /// Create a new App with existing shared state (for mode switching)
+    ///
+    /// This constructor is used when switching from inline mode to full-screen mode,
+    /// allowing state to be preserved during the transition.
+    pub fn with_state(state: Arc<Mutex<TuiState>>, _tui_mode: TuiMode) -> Result<Self> {
         let selection_manager = Arc::new(Mutex::new(TaskSelectionManager::new(5)));
 
-        let initial_focus = Focus::TaskList;
+        // Get data from shared state to initialize UI components
+        let (
+            tasks,
+            initiating_tasks,
+            run_mode,
+            _,
+            title_text,
+            task_count,
+            task_status_map,
+            task_start_times,
+            task_end_times,
+            // UI state for restoration
+            saved_pane_tasks,
+            saved_spacebar_mode,
+            saved_focused_pane,
+            saved_selected_task,
+        ) = {
+            let state_lock = state.lock();
+            (
+                state_lock.tasks().clone(),
+                state_lock.initiating_tasks().clone(),
+                state_lock.run_mode(),
+                state_lock.pinned_tasks().clone(),
+                state_lock.title_text().to_string(),
+                get_task_count(state_lock.task_graph()),
+                state_lock.get_task_status_map().clone(),
+                state_lock.get_task_start_times().clone(),
+                state_lock.get_task_end_times().clone(),
+                // Get saved UI state
+                state_lock.get_ui_pane_tasks().clone(),
+                state_lock.get_ui_spacebar_mode(),
+                state_lock.get_ui_focused_pane(),
+                state_lock.get_ui_selected_task().cloned(),
+            )
+        };
 
-        // Initialize task status map - App owns this now
-        let mut task_status_map = HashMap::new();
-        for task in &tasks {
-            task_status_map.insert(task.id.clone(), TaskStatus::NotStarted);
-        }
+        // Determine initial focus based on saved state
+        let initial_focus = match saved_focused_pane {
+            Some(pane_idx) if saved_pane_tasks[pane_idx].is_some() => {
+                Focus::MultipleOutput(pane_idx)
+            }
+            _ if saved_pane_tasks[0].is_some() || saved_pane_tasks[1].is_some() => Focus::TaskList,
+            _ => Focus::TaskList,
+        };
 
-        let tasks_list = TasksList::new(
+        let mut tasks_list = TasksList::new(
             tasks.clone(),
             initiating_tasks,
             run_mode,
@@ -124,6 +147,21 @@ impl App {
             title_text,
             selection_manager.clone(),
         );
+
+        // Sync task status from shared state (important for mode switching)
+        // TasksList::new creates TaskItems with NotStarted status, but we need
+        // to restore the actual status from TuiState
+        for (task_id, status) in task_status_map {
+            tasks_list.update_task_status(task_id.clone(), status);
+
+            // Also sync timing data for this task
+            let start_time = task_start_times.get(&task_id).copied();
+            let end_time = task_end_times.get(&task_id).copied();
+            if start_time.is_some() || end_time.is_some() {
+                tasks_list.set_task_timing(task_id, start_time, end_time);
+            }
+        }
+
         let help_popup = HelpPopup::new();
         let countdown_popup = CountdownPopup::new();
         let hint_popup = HintPopup::new();
@@ -137,61 +175,94 @@ impl App {
 
         let main_terminal_pane_data = TerminalPaneData::new();
 
-        // All tasks start as NotStarted, so all are incomplete
-        let incomplete_task_count = task_status_map.len();
+        // Create layout manager and configure based on saved state
+        let mut layout_manager = LayoutManager::new_with_run_mode(task_count, run_mode);
+
+        // Restore pane arrangement based on saved pane tasks
+        let has_pane0 = saved_pane_tasks[0].is_some();
+        let has_pane1 = saved_pane_tasks[1].is_some();
+        if has_pane0 && has_pane1 {
+            layout_manager.set_pane_arrangement(PaneArrangement::Double);
+        } else if has_pane0 || has_pane1 || saved_spacebar_mode {
+            layout_manager.set_pane_arrangement(PaneArrangement::Single);
+        }
+
+        // Restore selection in selection_manager
+        if let Some(ref selected) = saved_selected_task {
+            selection_manager.lock().select_task(selected.clone());
+        }
+
+        // Check if we're restoring from a mode switch (has saved UI state)
+        let has_restored_state = saved_pane_tasks[0].is_some()
+            || saved_pane_tasks[1].is_some()
+            || saved_spacebar_mode
+            || saved_selected_task.is_some();
+
+        tracing::trace!(
+            "App::with_state - restored panes: [{:?}, {:?}], focus: {:?}, spacebar: {}, selected: {:?}",
+            saved_pane_tasks[0],
+            saved_pane_tasks[1],
+            initial_focus,
+            saved_spacebar_mode,
+            saved_selected_task
+        );
 
         Ok(Self {
-            run_mode,
+            core: TuiCore::new(state),
             components,
-            pinned_tasks,
-            quit_at: None,
             focus: initial_focus,
             previous_focus: Focus::TaskList,
-            done_callback: None,
-            forced_shutdown_callback: None,
-            tui_config,
-            user_has_interacted: false,
-            is_forced_shutdown: false,
-            layout_manager: LayoutManager::new_with_run_mode(task_count, run_mode),
+            layout_manager,
             frame_area: None,
             layout_areas: None,
             terminal_pane_data: [main_terminal_pane_data, TerminalPaneData::new()],
             dependency_view_states: [None, None],
-            spacebar_mode: false,
-            pane_tasks: [None, None],
-            action_tx: None,
+            spacebar_mode: saved_spacebar_mode,
+            pane_tasks: saved_pane_tasks,
             resize_debounce_timer: None,
-            pty_instances: HashMap::new(),
             selection_manager,
-            task_graph,
-            task_status_map,
-            incomplete_task_count,
             debug_mode: false,
             debug_state: TuiWidgetState::default().set_default_display_level(LevelFilter::Debug),
-            console_messenger: None,
-            estimated_task_timings: HashMap::new(),
+            restored_from_mode_switch: has_restored_state,
         })
     }
 
+    /// Get the shared state Arc (for mode switching)
+    pub fn get_state(&self) -> Arc<Mutex<TuiState>> {
+        self.core.state().clone()
+    }
+
     pub fn register_action_handler(&mut self, tx: UnboundedSender<Action>) -> Result<()> {
-        self.action_tx = Some(tx);
+        self.core.register_action_handler(tx);
         Ok(())
     }
 
     pub fn init(&mut self, _area: Size) -> Result<()> {
+        // If we're restoring from a mode switch, skip the pinned tasks initialization
+        // because we've already restored the pane state from TuiState
+        if self.restored_from_mode_switch {
+            debug!("App::init - Skipping pinned task setup, restored from mode switch");
+            return Ok(());
+        }
+
         // Iterate over the pinned tasks and assign them to the terminal panes (up to the maximum of 2), focusing the first one as well
-        let pinned_tasks = self.pinned_tasks.clone();
+        let (pinned_tasks, run_mode, task_count) = {
+            let state = self.core.state().lock();
+            (
+                state.pinned_tasks().clone(),
+                state.run_mode(),
+                get_task_count(state.task_graph()),
+            )
+        };
+
         for (idx, task) in pinned_tasks.iter().enumerate() {
             if idx < 2 {
-                self.selection_manager
-                    .lock()
-                    .unwrap()
-                    .select_task(task.clone());
+                self.selection_manager.lock().select_task(task.clone());
 
                 if pinned_tasks.len() == 1 && idx == 0 {
-                    self.display_and_focus_current_task_in_terminal_pane(match self.run_mode {
+                    self.display_and_focus_current_task_in_terminal_pane(match run_mode {
                         RunMode::RunMany => true,
-                        RunMode::RunOne if get_task_count(&self.task_graph) == 1 => false,
+                        RunMode::RunOne if task_count == 1 => false,
                         RunMode::RunOne => true,
                     });
                 } else {
@@ -207,17 +278,15 @@ impl App {
     }
 
     pub fn start_tasks(&mut self, tasks: Vec<Task>) {
-        // Update App's task status map when tasks start
-        for task in &tasks {
-            self.task_status_map
-                .insert(task.id.clone(), TaskStatus::InProgress);
-        }
-
+        // Use TuiCore to record timing and update status
+        // This ensures task_start_times are recorded properly
+        self.core.start_tasks(&tasks);
         self.dispatch_action(Action::StartTasks(tasks));
     }
 
     pub fn update_task_status(&mut self, task_id: String, status: TaskStatus) {
-        self.task_status_map.insert(task_id.clone(), status);
+        // Update the task status map in shared state first
+        self.core.update_task_status(task_id.clone(), status);
 
         // Auto-switch pane to failed dependency when a task becomes skipped
         if status == TaskStatus::Skipped {
@@ -227,24 +296,25 @@ impl App {
         self.dispatch_action(Action::UpdateTaskStatus(task_id.clone(), status));
 
         // Update terminal progress indicator only when task reaches a completed state
-        if self.is_status_complete(status) {
-            self.incomplete_task_count = self.incomplete_task_count.saturating_sub(1);
+        if Self::is_status_complete(status) {
             self.update_terminal_progress();
         }
     }
 
-    /// Get task status efficiently from App's own HashMap
+    /// Get task status efficiently from shared state HashMap
     pub fn get_task_status(&self, task_id: &str) -> Option<TaskStatus> {
-        self.task_status_map.get(task_id).copied()
+        let state = self.core.state().lock();
+        state.get_task_status(task_id)
     }
 
-    /// Get task continuous flag efficiently from task graph
+    /// Get task continuous flag efficiently from task graph in shared state
     pub fn is_task_continuous(&self, task_id: &str) -> bool {
-        is_task_continuous(&self.task_graph, task_id)
+        let state = self.core.state().lock();
+        is_task_continuous(state.task_graph(), task_id)
     }
 
     /// Check if a task status is considered complete
-    fn is_status_complete(&self, status: TaskStatus) -> bool {
+    fn is_status_complete(status: TaskStatus) -> bool {
         !matches!(
             status,
             TaskStatus::NotStarted | TaskStatus::InProgress | TaskStatus::Shared
@@ -253,22 +323,34 @@ impl App {
 
     pub fn print_task_terminal_output(&mut self, task_id: String, output: String) {
         // Check if a PTY instance already exists for this task
-        if let Some(pty) = self.pty_instances.get(&task_id) {
-            // Hide cursor in the output to avoid confusion
-            Self::write_escape_sequence_to_parser(pty, crossterm::cursor::Hide);
-        } else {
-            // Tasks run within a pseudo-terminal always have a pty instance and do not need a new one
-            // Tasks not run within a pseudo-terminal need a new pty instance to print output
-            let pty = PtyInstance::non_interactive();
-
-            // Add ANSI escape sequence to hide cursor at the end of output, it would be confusing to have it visible when a task is a cache hit
-            let output_with_hidden_cursor = format!("{}\x1b[?25l", output);
-            Self::write_output_to_parser(&pty, output_with_hidden_cursor);
-
-            self.register_pty_instance(&task_id, pty);
-            // Ensure the pty instances get resized appropriately
-            let _ = self.debounce_pty_resize();
+        // If so, it already has all the output from the task execution
+        if self
+            .core
+            .state()
+            .lock()
+            .get_pty_instance(&task_id)
+            .is_some()
+        {
+            // If the task is continuous, ensure the pty instances get resized appropriately
+            if self.is_task_continuous(&task_id) {
+                let _ = self.debounce_pty_resize();
+            }
+            return;
         }
+
+        // Tasks run within a pseudo-terminal always have a pty instance and do not need a new one
+        // Tasks not run within a pseudo-terminal need a new pty instance to print output
+        let (rows, cols) = self.calculate_pty_dimensions_for_mode();
+        let pty = PtyInstance::non_interactive_with_dimensions(rows, cols);
+
+        // Add ANSI escape sequence to hide cursor at the end of output,
+        // it would be confusing to have it visible when a task is a cache hit
+        let output_with_hidden_cursor = format!("{}\x1b[?25l", output);
+        write_output_to_pty(&pty, &output_with_hidden_cursor);
+
+        self.register_pty_instance(&task_id, pty);
+        // Ensure the pty instances get resized appropriately
+        let _ = self.debounce_pty_resize();
 
         // If the task is continuous, ensure the pty instances get resized appropriately
         if self.is_task_continuous(&task_id) {
@@ -279,63 +361,67 @@ impl App {
     pub fn end_tasks(&mut self, task_results: Vec<TaskResult>) {
         // When tasks finish ensure that pty instances are resized appropriately as they may be actively displaying output when they finish
         let _ = self.debounce_pty_resize();
+
+        // Use TuiCore to record end timing and update status
+        // This ensures task_end_times are recorded properly
+        self.core.end_tasks(&task_results);
+
         self.dispatch_action(Action::EndTasks(task_results));
     }
 
     // Show countdown popup for the configured duration (making sure the help popup is not open first)
     pub fn end_command(&mut self) {
-        self.console_messenger
+        let state = self.core.state().lock();
+        state
+            .get_console_messenger()
             .as_ref()
             .and_then(|c| c.end_running_tasks());
+        drop(state);
 
         self.dispatch_action(Action::EndCommand);
     }
 
     // Internal method to handle Action::EndCommand
     fn handle_end_command(&mut self) {
-        // If the user has interacted with the app or auto-exit is disabled, do nothing
-        if self.user_has_interacted || !self.tui_config.auto_exit.should_exit_automatically() {
-            return;
-        }
-
-        let failed_task_names = self.get_failed_task_names();
-        // If there are more than 1 failed tasks, do not auto-exit
-        if failed_task_names.len() > 1 {
-            // If there are no visible panes (e.g. run one would have a pane open by default), focus the first failed task
-            if !self.has_visible_panes() {
-                self.selection_manager
-                    .lock()
-                    .unwrap()
-                    .select_task(failed_task_names.first().unwrap().clone());
-
-                // Display the task logs but keep focus on the task list to allow the user to navigate the failed tasks
-                self.toggle_output_visibility();
+        // Use TuiCore to determine auto-exit behavior
+        match self.core.get_auto_exit_decision() {
+            AutoExitDecision::Stay => {
+                // User interacted or auto-exit disabled - do nothing
             }
-            return;
-        }
+            AutoExitDecision::StayWithFailures(failed_task_names) => {
+                // Multiple failures - show them to user
+                // If there are no visible panes, focus the first failed task
+                if !self.has_visible_panes() {
+                    self.selection_manager
+                        .lock()
+                        .select_task(failed_task_names.first().unwrap().clone());
 
-        if get_task_count(&self.task_graph) > 1 {
-            self.begin_exit_countdown()
-        } else {
-            self.quit();
+                    // Display the task logs but keep focus on the task list
+                    self.toggle_output_visibility();
+                }
+            }
+            AutoExitDecision::ShowCountdown => {
+                self.begin_exit_countdown();
+            }
+            AutoExitDecision::ExitImmediately => {
+                self.quit();
+            }
         }
     }
 
     fn quit(&mut self) {
-        App::clear_terminal_progress();
-        self.quit_at = Some(std::time::Instant::now());
+        self.core.quit_immediately();
     }
 
     fn begin_exit_countdown(&mut self) {
-        let countdown_duration = self.tui_config.auto_exit.countdown_seconds();
-        // If countdown is disabled, exit immediately
-        if countdown_duration.is_none() {
+        // Use TuiCore to get countdown duration
+        let Some(countdown_duration) = self.core.get_countdown_duration() else {
+            // Countdown is disabled, exit immediately
             self.quit();
             return;
-        }
+        };
 
-        // Otherwise, show the countdown popup for the configured duration
-        let countdown_duration = countdown_duration.unwrap() as u64;
+        // Show the countdown popup for the configured duration
         if let Some(countdown_popup) = self
             .components
             .iter_mut()
@@ -343,9 +429,8 @@ impl App {
         {
             countdown_popup.start_countdown(countdown_duration);
             self.update_focus(Focus::CountdownPopup);
-            self.quit_at = Some(
-                std::time::Instant::now() + std::time::Duration::from_secs(countdown_duration),
-            );
+            self.core
+                .schedule_quit(std::time::Duration::from_secs(countdown_duration));
         }
     }
 
@@ -355,15 +440,15 @@ impl App {
         task_id: String,
         parser_and_writer: External<(ParserArc, WriterArc)>,
     ) {
-        debug!("Registering interactive task: {task_id}");
+        debug!("Registering interactive task: {}", task_id);
         let pty =
             PtyInstance::interactive(parser_and_writer.0.clone(), parser_and_writer.1.clone());
-        self.register_running_task(task_id, pty)
+        self.register_running_task(task_id, pty);
     }
 
     pub fn register_running_non_interactive_task(&mut self, task_id: String) {
-        debug!("Registering non-interactive task: {task_id}");
-        let pty = PtyInstance::non_interactive();
+        let (rows, cols) = self.calculate_pty_dimensions_for_mode();
+        let pty = PtyInstance::non_interactive_with_dimensions(rows, cols);
         self.register_pty_instance(&task_id, pty);
         self.update_task_status(task_id.clone(), TaskStatus::InProgress);
         // Ensure the pty instances get resized appropriately
@@ -376,9 +461,9 @@ impl App {
     }
 
     pub fn append_task_output(&mut self, task_id: String, output: String) {
-        let pty = self
-            .pty_instances
-            .get_mut(&task_id)
+        let state = self.core.state().lock();
+        let pty = state
+            .get_pty_instance(&task_id)
             .unwrap_or_else(|| panic!("{} has not been registered yet.", task_id));
         pty.process_output(output.as_bytes());
     }
@@ -390,8 +475,8 @@ impl App {
     ) -> Result<bool> {
         match event {
             tui::Event::Quit => {
-                let _ = action_tx.send(Action::Quit);
-                return Ok(true);
+                self.core.state().lock().quit_immediately();
+                return Ok(false);
             }
             tui::Event::Tick => {
                 let _ = action_tx.send(Action::Tick);
@@ -418,7 +503,7 @@ impl App {
                 // the running task, not the app itself
                 if !self.is_interactive_mode() {
                     // Record that the user has interacted with the app
-                    self.user_has_interacted = true;
+                    self.core.mark_user_interacted();
                 }
 
                 // Handle Ctrl+C to quit, unless we're in interactive mode and the focus is on a terminal pane
@@ -427,14 +512,9 @@ impl App {
                     && !(matches!(self.focus, Focus::MultipleOutput(_))
                         && self.is_interactive_mode())
                 {
-                    self.console_messenger
-                        .as_ref()
-                        .and_then(|c| c.end_running_tasks());
-
-                    self.is_forced_shutdown = true;
-                    // Quit immediately
-                    self.quit_at = Some(std::time::Instant::now());
-                    return Ok(true);
+                    // Use TuiCore to handle Ctrl+C (end command, set forced shutdown, quit)
+                    self.core.handle_ctrl_c();
+                    return Ok(false);
                 }
 
                 if matches!(self.focus, Focus::MultipleOutput(_)) && self.is_interactive_mode() {
@@ -454,6 +534,15 @@ impl App {
 
                 if matches!(key.code, KeyCode::F(12)) {
                     self.dispatch_action(Action::ToggleDebugMode);
+                    return Ok(false);
+                }
+
+                // F11 toggles between full-screen and inline mode
+                // Don't allow mode switch during countdown (user is about to quit)
+                if matches!(key.code, KeyCode::F(11))
+                    && !matches!(self.focus, Focus::CountdownPopup)
+                {
+                    self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
                     return Ok(false);
                 }
 
@@ -495,14 +584,14 @@ impl App {
                             KeyCode::Char('q') => {
                                 // Quit immediately
                                 trace!("Confirming shutdown");
-                                self.quit_at = Some(std::time::Instant::now());
-                                return Ok(true);
+                                self.core.state().lock().quit_immediately();
+                                return Ok(false);
                             }
                             KeyCode::Char('c') if key.modifiers == KeyModifiers::CONTROL => {
                                 // Quit immediately
                                 trace!("Confirming shutdown");
-                                self.quit_at = Some(std::time::Instant::now());
-                                return Ok(true);
+                                self.core.state().lock().quit_immediately();
+                                return Ok(false);
                             }
                             KeyCode::Up | KeyCode::Char('k') if countdown_popup.is_scrollable() => {
                                 countdown_popup.scroll_up();
@@ -516,7 +605,7 @@ impl App {
                             }
                             _ => {
                                 countdown_popup.cancel_countdown();
-                                self.quit_at = None;
+                                self.core.state().lock().cancel_quit();
                                 self.update_focus(self.previous_focus);
                             }
                         }
@@ -548,27 +637,8 @@ impl App {
                 {
                     // Handle Q to trigger countdown or immediate exit, depending on the tasks
                     if !tasks_list.filter_mode && key.code == KeyCode::Char('q') {
-                        // Check if all tasks are in a completed state using the task status map
-                        let all_tasks_completed = self.task_status_map.values().all(|status| {
-                            matches!(
-                                status,
-                                TaskStatus::Success
-                                    | TaskStatus::Failure
-                                    | TaskStatus::Skipped
-                                    | TaskStatus::LocalCache
-                                    | TaskStatus::LocalCacheKeptExisting
-                                    | TaskStatus::RemoteCache
-                                    | TaskStatus::Stopped // Consider stopped continuous tasks as completed for exit purposes
-                            )
-                        });
-
-                        if all_tasks_completed {
-                            // If all tasks are done, quit immediately like Ctrl+C
-                            self.is_forced_shutdown = true;
-                            self.quit_at = Some(std::time::Instant::now());
-                        } else {
-                            // Otherwise, start the exit countdown to give the user the chance to change their mind in case of an accidental keypress
-                            self.is_forced_shutdown = true;
+                        // Use TuiCore to handle quit request (sets forced_shutdown, checks completion)
+                        if self.core.handle_quit_request() == QuitDecision::StartCountdown {
                             self.begin_exit_countdown();
                         }
                         return Ok(false);
@@ -668,6 +738,16 @@ impl App {
                                     KeyCode::Char('m') => {
                                         if let Some(area) = self.frame_area {
                                             self.toggle_layout_mode(area);
+                                        }
+                                    }
+                                    // If focused on a specific terminal pane, and not interactive, enter should
+                                    // swap to inline tui mode focusing that task
+                                    KeyCode::Enter => {
+                                        // dispatch action to switch to inline mode with focused task
+                                        if let Focus::MultipleOutput(_pane_idx) = self.focus {
+                                            self.dispatch_action(Action::SwitchMode(
+                                                TuiMode::Inline,
+                                            ));
                                         }
                                     }
                                     _ => {
@@ -834,19 +914,27 @@ impl App {
         }
         match &action {
             Action::StartCommand(_) => {
-                self.console_messenger
+                let state = self.core.state().lock();
+                state
+                    .get_console_messenger()
                     .as_ref()
                     .and_then(|c| c.start_running_tasks());
             }
             Action::Tick => {
-                self.console_messenger.as_ref().and_then(|messenger| {
-                    self.components
-                        .iter()
-                        .find_map(|c| c.as_any().downcast_ref::<TasksList>())
-                        .and_then(|tasks_list| {
-                            messenger.update_running_tasks(&tasks_list.tasks, &self.pty_instances)
-                        })
-                });
+                let state = self.core.state().lock();
+                state
+                    .get_console_messenger()
+                    .as_ref()
+                    .and_then(|messenger| {
+                        self.components
+                            .iter()
+                            .find_map(|c| c.as_any().downcast_ref::<TasksList>())
+                            .and_then(|tasks_list| {
+                                let pty_instances = state.get_pty_instances();
+                                messenger.update_running_tasks(&tasks_list.tasks, &pty_instances)
+                            })
+                    });
+                drop(state);
 
                 // Auto-dismiss hint popup after duration elapsed
                 if let Some(hint_popup) = self
@@ -874,11 +962,11 @@ impl App {
             }
             // Quit immediately
             Action::Quit => {
-                self.quit_at = Some(std::time::Instant::now());
+                self.core.state().lock().quit_immediately();
             }
             // Cancel quitting
             Action::CancelQuit => {
-                self.quit_at = None;
+                self.core.state().lock().cancel_quit();
                 self.update_focus(self.previous_focus);
             }
             Action::Resize(w, h) => {
@@ -898,10 +986,12 @@ impl App {
             Action::Render => {
                 tui.draw(|f| {
                     let area = f.area();
+
                     // Cache the frame area if it's never been set before (will be updated in subsequent resize events if necessary)
                     if self.frame_area.is_none() {
                         self.frame_area = Some(area);
                     }
+
                     // Determine the required layout areas for the tasks list and terminal panes using the LayoutManager
                     if self.layout_areas.is_none() {
                         self.recalculate_layout_areas();
@@ -1002,10 +1092,6 @@ impl App {
                         }
                     }
 
-                    // Calculate minimal view context once for all panes
-                    let is_minimal =
-                        self.is_task_list_hidden() && get_task_count(&self.task_graph) == 1;
-
                     // Clone terminal pane areas upfront to avoid borrow conflicts with self
                     // This is a small vec (at most 2 elements), so the clone cost is minimal
                     let terminal_panes: Vec<Rect> = layout_areas.terminal_panes.clone();
@@ -1018,7 +1104,6 @@ impl App {
                         let task = self
                             .selection_manager
                             .lock()
-                            .unwrap()
                             .get_selected_task_name()
                             .cloned();
                         [task, None]
@@ -1066,7 +1151,6 @@ impl App {
                                         pane_idx,
                                         pane_area,
                                         task_name.clone(),
-                                        is_minimal,
                                         is_focused,
                                     );
                                 } else {
@@ -1075,7 +1159,6 @@ impl App {
                                         pane_idx,
                                         pane_area,
                                         task_name.clone(),
-                                        is_minimal,
                                         is_focused,
                                         is_next_tab_target,
                                     );
@@ -1113,7 +1196,8 @@ impl App {
                 .ok();
             }
             Action::SendConsoleMessage(msg) => {
-                if let Some(connection) = &self.console_messenger {
+                let state = self.core.state().lock();
+                if let Some(connection) = state.get_console_messenger() {
                     connection.send_terminal_string(msg);
                 } else {
                     trace!("No console connection available");
@@ -1124,7 +1208,8 @@ impl App {
             }
             Action::ShowHint(message) => {
                 // Only show hints if not suppressed by config
-                if !self.tui_config.suppress_hints {
+                let suppress_hints = self.core.state().lock().tui_config().suppress_hints;
+                if !suppress_hints {
                     if let Some(hint_popup) = self
                         .components
                         .iter_mut()
@@ -1146,38 +1231,33 @@ impl App {
         }
     }
 
+    #[cfg(not(test))]
     pub fn set_done_callback(
         &mut self,
         done_callback: ThreadsafeFunction<(), ErrorStrategy::Fatal>,
     ) {
-        self.done_callback = Some(done_callback);
+        self.core.state().lock().set_done_callback(done_callback);
     }
 
+    #[cfg(not(test))]
     pub fn set_forced_shutdown_callback(
         &mut self,
         forced_shutdown_callback: ThreadsafeFunction<(), ErrorStrategy::Fatal>,
     ) {
-        self.forced_shutdown_callback = Some(forced_shutdown_callback);
+        self.core
+            .state()
+            .lock()
+            .set_forced_shutdown_callback(forced_shutdown_callback);
     }
 
     pub fn call_done_callback(&self) {
-        if self.is_forced_shutdown {
-            if let Some(cb) = &self.forced_shutdown_callback {
-                cb.call(
-                    (),
-                    napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking,
-                );
-            }
-        }
-        if let Some(cb) = &self.done_callback {
-            cb.call(
-                (),
-                napi::threadsafe_function::ThreadsafeFunctionCallMode::Blocking,
-            );
-        }
+        self.core.state().lock().call_done_callback();
     }
 
     pub fn set_cloud_message(&mut self, message: Option<String>) {
+        // Store in state (for mode switching persistence)
+        self.core.state().lock().set_cloud_message(message.clone());
+        // Dispatch to TasksList component for UI rendering
         if let Some(message) = message {
             self.dispatch_action(Action::UpdateCloudMessage(message));
         }
@@ -1185,11 +1265,7 @@ impl App {
 
     /// Dispatches an action to the action tx for other components to handle however they see fit
     fn dispatch_action(&self, action: Action) {
-        if let Some(tx) = &self.action_tx {
-            tx.send(action).unwrap_or_else(|e| {
-                debug!("Failed to dispatch action: {}", e);
-            });
-        }
+        self.core.dispatch_action(action);
     }
 
     fn recalculate_layout_areas(&mut self) {
@@ -1201,20 +1277,6 @@ impl App {
     /// Checks if the current view has any visible output panes.
     fn has_visible_panes(&self) -> bool {
         self.pane_tasks.iter().any(|t| t.is_some())
-    }
-
-    /// Returns the names of tasks that have failed.
-    fn get_failed_task_names(&self) -> Vec<String> {
-        self.task_status_map
-            .iter()
-            .filter_map(|(task_name, status)| {
-                if *status == TaskStatus::Failure {
-                    Some(task_name.clone())
-                } else {
-                    None
-                }
-            })
-            .collect()
     }
 
     /// Clears PTY reference and related state for a specific pane
@@ -1247,12 +1309,7 @@ impl App {
             .set_task_list_visibility(TaskListVisibility::Visible);
 
         // Extract task name first to end the immutable borrow
-        let task_name = match self
-            .selection_manager
-            .lock()
-            .unwrap()
-            .get_selected_task_name()
-        {
+        let task_name = match self.selection_manager.lock().get_selected_task_name() {
             Some(name) => name.clone(),
             None => return,
         };
@@ -1283,7 +1340,6 @@ impl App {
         };
         self.selection_manager
             .lock()
-            .unwrap()
             .set_selection_mode(selection_mode_override.unwrap_or(selection_mode));
 
         if spacebar_mode {
@@ -1431,12 +1487,7 @@ impl App {
 
     fn assign_current_task_to_pane(&mut self, pane_idx: usize) {
         // Extract task name first to end the immutable borrow
-        let task_name = match self
-            .selection_manager
-            .lock()
-            .unwrap()
-            .get_selected_task_name()
-        {
+        let task_name = match self.selection_manager.lock().get_selected_task_name() {
             Some(name) => name.clone(),
             None => return,
         };
@@ -1540,7 +1591,6 @@ impl App {
             let relevant_pane_task: Option<String> = if self.spacebar_mode {
                 self.selection_manager
                     .lock()
-                    .unwrap()
                     .get_selected_task_name()
                     .cloned()
             } else {
@@ -1609,47 +1659,51 @@ impl App {
 
     /// Actually processes the resize event by updating PTY dimensions.
     fn handle_pty_resize(&mut self) -> io::Result<()> {
-        if self.layout_areas.is_none() {
-            return Ok(());
-        }
-
-        let mut needs_sort = false;
-
-        for (pane_idx, pane_area) in self
-            .layout_areas
-            .as_ref()
-            .unwrap()
-            .terminal_panes
-            .iter()
-            .enumerate()
+        // Always use fullscreen mode logic
         {
-            let terminal_pane_data = &mut self.terminal_pane_data[pane_idx];
-            if let Some(pty) = terminal_pane_data.pty.as_ref() {
-                let (pty_height, pty_width) = TerminalPane::calculate_pty_dimensions(*pane_area);
+            if self.layout_areas.is_none() {
+                return Ok(());
+            }
 
-                // Get current dimensions before resize
-                let (current_rows, current_cols) = pty.get_dimensions();
+            let mut needs_sort = false;
 
-                // Skip resize if dimensions haven't actually changed
-                if current_rows == pty_height && current_cols == pty_width {
-                    continue;
-                }
+            for (pane_idx, pane_area) in self
+                .layout_areas
+                .as_ref()
+                .unwrap()
+                .terminal_panes
+                .iter()
+                .enumerate()
+            {
+                let terminal_pane_data = &mut self.terminal_pane_data[pane_idx];
+                if let Some(pty) = terminal_pane_data.pty.as_ref() {
+                    let (pty_height, pty_width) =
+                        TerminalPane::calculate_pty_dimensions(*pane_area);
 
-                // With shared dimensions, we only need to call resize once per PTY instance
-                // The shared Arc<RwLock<(u16, u16)>> ensures all references see the update
-                let mut pty_clone = pty.as_ref().clone();
-                pty_clone.resize(pty_height, pty_width)?;
+                    // Get current dimensions before resize
+                    let (current_rows, current_cols) = pty.get_dimensions();
 
-                // If dimensions changed, mark for sort
-                if current_rows != pty_height {
-                    needs_sort = true;
+                    // Skip resize if dimensions haven't actually changed
+                    if current_rows == pty_height && current_cols == pty_width {
+                        continue;
+                    }
+
+                    // With shared dimensions, we only need to call resize once per PTY instance
+                    // The shared Arc<RwLock<(u16, u16)>> ensures all references see the update
+                    let mut pty_clone = pty.as_ref().clone();
+                    pty_clone.resize(pty_height, pty_width)?;
+
+                    // If dimensions changed, mark for sort
+                    if current_rows != pty_height {
+                        needs_sort = true;
+                    }
                 }
             }
-        }
 
-        // Sort tasks if needed after all resizing is complete
-        if needs_sort {
-            self.dispatch_action(Action::SortTasks);
+            // Sort tasks if needed after all resizing is complete
+            if needs_sort {
+                self.dispatch_action(Action::SortTasks);
+            }
         }
 
         Ok(())
@@ -1660,10 +1714,18 @@ impl App {
     }
 
     fn register_pty_instance(&mut self, task_id: &str, pty: PtyInstance) {
-        // Access the contents of the External
+        // Wrap in Arc
         let pty = Arc::new(pty);
+        self.core
+            .state()
+            .lock()
+            .register_pty_instance(task_id.to_string(), pty);
+    }
 
-        self.pty_instances.insert(task_id.to_string(), pty);
+    /// Calculate appropriate PTY dimensions based on the current TUI mode
+    fn calculate_pty_dimensions_for_mode(&self) -> (u16, u16) {
+        // For fullscreen mode, use reasonable defaults that will be resized later by terminal panes
+        (24, 80)
     }
 
     // Writes the given output to the given parser, used for the case where a task is a cache hit, or when it is run outside of the rust pseudo-terminal
@@ -1732,14 +1794,8 @@ impl App {
     }
 
     pub fn set_console_messenger(&mut self, messenger: NxConsoleMessageConnection) {
-        self.console_messenger = Some(messenger);
-        if self
-            .console_messenger
-            .as_ref()
-            .is_some_and(|c| c.is_connected())
-        {
-            self.dispatch_action(Action::ConsoleMessengerAvailable(true));
-        }
+        self.core.state().lock().set_console_messenger(messenger);
+        self.dispatch_action(Action::ConsoleMessengerAvailable(true));
     }
 
     /// Renders the dependency view for a pending task in the specified pane
@@ -1749,7 +1805,6 @@ impl App {
         pane_idx: usize,
         pane_area: Rect,
         task_name: String,
-        is_minimal: bool,
         is_focused: bool,
     ) {
         // Calculate values that were previously passed in
@@ -1778,21 +1833,26 @@ impl App {
         } else {
             // Different task or no existing state - create a new one
             // This ensures we get fresh dependency analysis when task becomes SKIPPED
+            let state = self.core.state().lock();
+            let task_graph = state.task_graph();
             let new_state = DependencyViewState::new(
                 task_name.clone(),
                 task_status,
-                &self.task_graph,
+                task_graph,
                 is_focused,
                 throbber_counter,
                 pane_area,
             );
+            drop(state);
             self.dependency_view_states[pane_idx] = Some(new_state);
         }
 
         // No need to update status in DependencyViewState - we pass the full map to the widget
         if let Some(dep_state) = &mut self.dependency_view_states[pane_idx] {
-            let dependency_view =
-                DependencyView::new(&self.task_status_map, &self.task_graph, is_minimal);
+            let state = self.core.state().lock();
+            let task_status_map = state.get_task_status_map();
+            let task_graph = state.task_graph();
+            let dependency_view = DependencyView::new(task_status_map, task_graph);
             f.render_stateful_widget(dependency_view, pane_area, dep_state);
         }
     }
@@ -1804,7 +1864,6 @@ impl App {
         pane_idx: usize,
         pane_area: Rect,
         task_name: String,
-        is_minimal: bool,
         is_focused: bool,
         is_next_tab_target: bool,
     ) {
@@ -1813,7 +1872,8 @@ impl App {
             .get_task_status(&task_name)
             .unwrap_or(TaskStatus::NotStarted);
         let task_continuous = self.is_task_continuous(&task_name);
-        let has_pty = self.pty_instances.contains_key(&task_name);
+        let state = self.core.state().lock();
+        let has_pty = state.get_pty_instance(&task_name).is_some();
 
         let terminal_pane_data = &mut self.terminal_pane_data[pane_idx];
         terminal_pane_data.is_continuous = task_continuous;
@@ -1823,7 +1883,7 @@ impl App {
         }
 
         if has_pty {
-            if let Some(pty) = self.pty_instances.get(&task_name) {
+            if let Some(pty) = state.get_pty_instance(&task_name) {
                 terminal_pane_data.can_be_interactive = in_progress && pty.can_be_interactive();
                 terminal_pane_data.pty = Some(pty.clone());
 
@@ -1851,31 +1911,32 @@ impl App {
             .unwrap_or((None, None));
 
         // Get estimated duration from app's estimated_task_timings
-        let estimated_duration = self.estimated_task_timings.get(&task_name).copied();
+        let estimated_duration = state.estimated_task_timings().get(&task_name).copied();
+        let has_console_messenger = state.get_console_messenger().is_some();
+        drop(state);
 
-        let mut state = TerminalPaneState::new(
+        let mut pane_state = TerminalPaneState::new(
             task_name,
             task_status,
             task_continuous,
             is_focused,
             has_pty,
             is_next_tab_target,
-            self.console_messenger.is_some(),
+            has_console_messenger,
             estimated_duration,
             start_time,
             end_time,
         );
 
         let terminal_pane = TerminalPane::new()
-            .minimal(is_minimal)
             .pty_data(terminal_pane_data)
             .continuous(task_continuous);
 
-        f.render_stateful_widget(terminal_pane, pane_area, &mut state);
+        f.render_stateful_widget(terminal_pane, pane_area, &mut pane_state);
     }
 
     pub fn set_estimated_task_timings(&mut self, timings: HashMap<String, i64>) {
-        self.estimated_task_timings = timings;
+        self.core.state().lock().set_estimated_task_timings(timings);
     }
 
     /// Handles automatic pane switching when a task becomes skipped.
@@ -1924,7 +1985,8 @@ impl App {
         self.dependency_view_states[pane_idx] = None;
 
         // Assign the PTY for the new task to this pane if available
-        if let Some(pty_instance) = self.pty_instances.get(&task_id) {
+        let state = self.core.state().lock();
+        if let Some(pty_instance) = state.get_pty_instance(&task_id) {
             self.terminal_pane_data[pane_idx].pty = Some(pty_instance.clone());
 
             // Immediately resize PTY to match the current terminal pane dimensions
@@ -1939,7 +2001,8 @@ impl App {
         }
 
         // Update the selection manager to prevent conflicts with manual selection
-        if let Ok(mut selection_manager) = self.selection_manager.lock() {
+        {
+            let mut selection_manager = self.selection_manager.lock();
             selection_manager.select_task(task_id);
         }
     }
@@ -1949,21 +2012,24 @@ impl App {
     /// Returns the task name of the first dependency that failed, causing this task to be skipped.
     /// This is used for automatic pane switching to show the root cause of failures.
     fn get_first_failed_dependency(&self, task_name: &str) -> Option<String> {
+        let state = self.core.state().lock();
         let failed_deps =
-            get_failed_dependencies(task_name, &self.task_graph, &self.task_status_map);
+            get_failed_dependencies(task_name, state.task_graph(), state.get_task_status_map());
         failed_deps.into_iter().next()
     }
 
     /// Updates the terminal progress indicator (OSC 9;4).
     /// Shows percentage of tasks that are complete (anything except NotStarted, InProgress, or Shared).
     fn update_terminal_progress(&self) {
-        let total_tasks = self.task_status_map.len();
+        let state = self.core.state().lock();
+        let total_tasks = state.get_task_status_map().len();
         if total_tasks == 0 {
             return;
         }
 
-        // Use cached incomplete task count instead of recalculating
-        let completed_tasks = total_tasks - self.incomplete_task_count;
+        let completed_tasks = state.get_completed_task_count();
+        drop(state); // Release lock before I/O
+
         let percentage = (completed_tasks * 100) / total_tasks;
 
         // Write OSC 9;4 escape sequence to stderr (less likely to conflict with TUI rendering)
@@ -1980,5 +2046,155 @@ impl App {
         // State 0 = hide progress (using ST terminator for compatibility)
         let _ = io::stderr().write_all(b"\x1b]9;4;0;0\x1b\\");
         let _ = io::stderr().flush();
+    }
+}
+
+// === TuiApp Trait Implementation ===
+
+use crate::native::tui::tui_app::TuiApp;
+
+impl TuiApp for App {
+    // === Core Access ===
+
+    fn core(&self) -> &TuiCore {
+        &self.core
+    }
+
+    fn core_mut(&mut self) -> &mut TuiCore {
+        &mut self.core
+    }
+
+    // === Event Handling (delegates to App methods) ===
+
+    fn handle_event(
+        &mut self,
+        event: tui::Event,
+        action_tx: &UnboundedSender<Action>,
+    ) -> Result<bool> {
+        self.handle_event(event, action_tx)
+    }
+
+    fn handle_action(
+        &mut self,
+        tui: &mut tui::Tui,
+        action: Action,
+        action_tx: &UnboundedSender<Action>,
+    ) {
+        self.handle_action(tui, action, action_tx);
+    }
+
+    // === Mode Identification ===
+
+    fn get_tui_mode(&self) -> TuiMode {
+        TuiMode::FullScreen
+    }
+
+    // === Initialization ===
+
+    fn init(&mut self, area: Size) -> Result<()> {
+        self.init(area)
+    }
+
+    // === Task Lifecycle (App has custom UI logic, so override defaults) ===
+
+    fn start_command(&mut self, thread_count: Option<u32>) {
+        App::start_command(self, thread_count);
+    }
+
+    // === Task Lifecycle (hooks for trait defaults) ===
+
+    fn on_tasks_started(&mut self, tasks: &[Task]) {
+        self.dispatch_action(Action::StartTasks(tasks.to_vec()));
+    }
+
+    fn on_tasks_ended(&mut self, task_results: &[TaskResult]) {
+        // Resize PTYs when tasks finish (they may still be displaying output)
+        let _ = self.debounce_pty_resize();
+        self.dispatch_action(Action::EndTasks(task_results.to_vec()));
+    }
+
+    // start_tasks and end_tasks use trait defaults which call hooks above
+
+    fn update_task_status(&mut self, task_id: String, status: TaskStatus) {
+        App::update_task_status(self, task_id, status);
+    }
+
+    fn end_command(&mut self) {
+        App::end_command(self);
+    }
+
+    // === PTY Registration (hooks for trait defaults) ===
+
+    fn calculate_pty_dimensions(&self) -> (u16, u16) {
+        self.calculate_pty_dimensions_for_mode()
+    }
+
+    fn on_pty_registered(&mut self, task_id: &str) {
+        // Update task status and trigger resize debounce
+        self.update_task_status(task_id.to_string(), TaskStatus::InProgress);
+        let _ = self.debounce_pty_resize();
+    }
+
+    // Override print_task_terminal_output for App-specific continuous task handling
+    fn print_task_terminal_output(&mut self, task_id: String, output: String) {
+        // Call the inherent method which has continuous task handling
+        App::print_task_terminal_output(self, task_id, output);
+    }
+
+    // Override append_task_output because App has different behavior (panics if not registered)
+    fn append_task_output(&mut self, task_id: String, output: String) {
+        App::append_task_output(self, task_id, output);
+    }
+
+    // `should_quit` uses default implementation from trait
+
+    fn get_selected_task_name(&self) -> Option<String> {
+        self.selection_manager
+            .lock()
+            .get_selected_task_name()
+            .cloned()
+    }
+
+    fn get_focused_pane_task(&self) -> Option<String> {
+        // If focus is on a terminal pane, return that pane's task
+        // In spacebar mode, return the selected task (it follows selection)
+        // Otherwise return the pinned task from that pane
+        match self.focus {
+            Focus::MultipleOutput(pane_idx) => {
+                if self.spacebar_mode {
+                    self.selection_manager
+                        .lock()
+                        .get_selected_task_name()
+                        .cloned()
+                } else {
+                    self.pane_tasks[pane_idx].clone()
+                }
+            }
+            _ => {
+                // Focus is on task list - return None to let the caller
+                // fall back to get_selected_task_name() for the user's selection
+                None
+            }
+        }
+    }
+
+    fn save_ui_state_for_mode_switch(&self) {
+        let focused_pane = match self.focus {
+            Focus::MultipleOutput(pane_idx) => Some(pane_idx),
+            _ => None,
+        };
+
+        let selected_task = self
+            .selection_manager
+            .lock()
+            .get_selected_task_name()
+            .cloned();
+
+        self.core.state().lock().save_ui_state(
+            self.pane_tasks.clone(),
+            self.spacebar_mode,
+            focused_pane,
+            selected_task,
+        );
     }
 }

--- a/packages/nx/src/native/tui/components/dependency_view.rs
+++ b/packages/nx/src/native/tui/components/dependency_view.rs
@@ -174,19 +174,13 @@ impl DependencyViewState {
 pub struct DependencyView<'a> {
     status_map: &'a HashMap<String, TaskStatus>,
     task_graph: &'a TaskGraph,
-    is_minimal: bool,
 }
 
 impl<'a> DependencyView<'a> {
-    pub fn new(
-        status_map: &'a HashMap<String, TaskStatus>,
-        task_graph: &'a TaskGraph,
-        is_minimal: bool,
-    ) -> Self {
+    pub fn new(status_map: &'a HashMap<String, TaskStatus>, task_graph: &'a TaskGraph) -> Self {
         Self {
             status_map,
             task_graph,
-            is_minimal,
         }
     }
 
@@ -522,23 +516,17 @@ impl<'a> StatefulWidget for DependencyView<'a> {
             ),
         ];
 
-        let block = if self.is_minimal {
-            Block::default()
-                .borders(Borders::NONE)
-                .padding(Padding::new(2, 2, 1, 1))
-        } else {
-            Block::default()
-                .title(title)
-                .title_alignment(Alignment::Left)
-                .borders(Borders::ALL)
-                .border_type(if state.is_focused {
-                    BorderType::Thick
-                } else {
-                    BorderType::Plain
-                })
-                .border_style(border_style)
-                .padding(Padding::new(2, 2, 1, 1))
-        };
+        let block = Block::default()
+            .title(title)
+            .title_alignment(Alignment::Left)
+            .borders(Borders::ALL)
+            .border_type(if state.is_focused {
+                BorderType::Thick
+            } else {
+                BorderType::Plain
+            })
+            .border_style(border_style)
+            .padding(Padding::new(2, 2, 1, 1));
 
         let inner_area = block.inner(area);
         block.render(area, buf);

--- a/packages/nx/src/native/tui/components/layout_manager.rs
+++ b/packages/nx/src/native/tui/components/layout_manager.rs
@@ -110,11 +110,7 @@ impl LayoutManager {
             min_horizontal_width: 120, // Minimum width for horizontal layout to be viable
             min_vertical_height: 30,   // Minimum height for vertical layout to be viable
             pane_arrangement: PaneArrangement::None,
-            task_list_visibility: if task_count > 1 {
-                TaskListVisibility::Visible
-            } else {
-                TaskListVisibility::Hidden
-            },
+            task_list_visibility: TaskListVisibility::Visible,
             task_count,
             horizontal_padding: 2, // Default horizontal padding of 2 characters
             vertical_padding: 1,   // Default vertical padding of 1 character
@@ -124,8 +120,6 @@ impl LayoutManager {
     pub fn new_with_run_mode(task_count: usize, run_mode: RunMode) -> Self {
         let mut layout_manager = Self::new(task_count);
         layout_manager.set_task_list_visibility(match run_mode {
-            // nx run task with no dependent tasks
-            RunMode::RunOne if task_count == 1 => TaskListVisibility::Hidden,
             // nx run task with dependent tasks
             RunMode::RunOne => TaskListVisibility::Visible,
             RunMode::RunMany => TaskListVisibility::Visible,

--- a/packages/nx/src/native/tui/inline_app.rs
+++ b/packages/nx/src/native/tui/inline_app.rs
@@ -1,0 +1,1714 @@
+use arboard::Clipboard;
+use color_eyre::eyre::Result;
+use crossterm::event::{KeyCode, KeyModifiers};
+use hashbrown::HashSet;
+use napi::bindgen_prelude::External;
+use parking_lot::Mutex;
+use ratatui::layout::{Constraint, Direction, Layout, Size};
+use ratatui::style::Modifier;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::Paragraph;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::mpsc::UnboundedSender;
+use tracing::debug;
+
+/// Duration before status messages are automatically cleared
+const STATUS_MESSAGE_DURATION: std::time::Duration = std::time::Duration::from_secs(3);
+
+use crate::native::tui::utils::{
+    calculate_actual_duration_ms, format_duration_with_estimate, get_task_status_style,
+};
+use crate::native::{
+    pseudo_terminal::pseudo_terminal::{ParserArc, WriterArc},
+    tasks::types::{Task, TaskGraph},
+};
+
+use super::action::Action;
+use super::components::countdown_popup::CountdownPopup;
+use super::components::tasks_list::TaskStatus;
+use super::config::TuiConfig;
+use super::lifecycle::{RunMode, TuiMode};
+use super::pty::PtyInstance;
+use super::tui;
+use super::tui_app::TuiApp;
+use super::tui_core::{AutoExitDecision, QuitDecision, TuiCore};
+use super::tui_state::TuiState;
+use super::utils::get_task_status_icon;
+
+/// Simplified TUI application for inline viewport mode
+///
+/// InlineApp displays task execution in a compact inline format within the terminal,
+/// showing only the currently running task's output. Unlike the full-screen App,
+/// it has no interactive navigation and minimal UI elements.
+///
+/// # Design Philosophy
+///
+/// - **Single Task Focus**: Only shows output for the currently running task
+/// - **No Navigation**: No arrow keys, tabs, or focus management
+/// - **Simple Quit**: Only q, ESC, and Ctrl+C to quit
+/// - **Scrollback Above**: Completed task output scrolls above the viewport
+/// - **Shared State**: Uses Arc<Mutex<TuiState>> to enable mode switching
+///
+/// # State Management
+///
+/// All task execution state (tasks, status, PTY instances, timing, callbacks)
+/// is stored in the shared TuiState. InlineApp only maintains UI-specific state
+/// like scrollback tracking and render counters.
+pub struct InlineApp {
+    // === Shared Core ===
+    /// Shared core functionality (state management, callbacks, etc.)
+    core: TuiCore,
+
+    // === Inline UI State ===
+    /// The task whose output should be displayed (required for inline mode)
+    /// This is set during mode switching or defaults to the first running task
+    selected_task: Option<String>,
+    /// Countdown popup for auto-exit (shared with full-screen mode)
+    countdown_popup: CountdownPopup,
+    /// Whether we're in interactive mode (forwarding keys to PTY)
+    is_interactive: bool,
+
+    // === Scrollback Rendering ===
+    /// Track scrollback line count per task for incremental rendering
+    task_scrollback_lines: HashMap<String, usize>,
+    /// Track last rendered scrollback lines per task for buffered rendering
+    task_last_rendered_scrollback: HashMap<String, usize>,
+    /// Counter for buffering scrollback renders (render every 20th iteration)
+    scrollback_render_counter: u32,
+    /// Total lines inserted above TUI (for cleanup on exit)
+    total_inserted_lines: u32,
+    /// Status message to display in the bottom chrome (e.g., "Output copied")
+    status_message: Option<(String, Instant)>,
+}
+
+impl InlineApp {
+    /// Create new inline app with fresh state
+    ///
+    /// This constructor creates a new TuiState and wraps it in Arc<Mutex<>>.
+    /// Use this when starting a new task execution session.
+    ///
+    /// # Arguments
+    ///
+    /// * `tasks` - All tasks to be executed
+    /// * `initiating_tasks` - Tasks that were explicitly requested
+    /// * `run_mode` - Whether this is run-one or run-many
+    /// * `pinned_tasks` - Tasks that should always be visible (unused in inline mode)
+    /// * `tui_config` - TUI configuration (auto-exit, etc.)
+    /// * `title_text` - Title to display in status bar
+    /// * `task_graph` - Task dependency graph
+    pub fn new(
+        tasks: Vec<Task>,
+        initiating_tasks: HashSet<String>,
+        run_mode: RunMode,
+        pinned_tasks: Vec<String>,
+        tui_config: TuiConfig,
+        title_text: String,
+        task_graph: TaskGraph,
+    ) -> Result<Self> {
+        let state = Arc::new(Mutex::new(TuiState::new(
+            tasks,
+            initiating_tasks,
+            run_mode,
+            pinned_tasks,
+            tui_config,
+            title_text,
+            task_graph,
+            HashMap::new(), // estimated_task_timings - will be set later via set_estimated_task_timings()
+        )));
+
+        Ok(Self {
+            core: TuiCore::new(state),
+            selected_task: None, // Will auto-select first running task on render
+            countdown_popup: CountdownPopup::new(),
+            is_interactive: false,
+            task_scrollback_lines: HashMap::new(),
+            task_last_rendered_scrollback: HashMap::new(),
+            scrollback_render_counter: 0,
+            total_inserted_lines: 0,
+            status_message: None,
+        })
+    }
+
+    /// Create inline app with existing shared state
+    ///
+    /// This constructor is used for mode switching, allowing an InlineApp to be
+    /// created from the same TuiState that was used by a full-screen App.
+    /// The UI state (scrollback, render counters) is reset, but task execution
+    /// state is preserved.
+    ///
+    /// # Arguments
+    ///
+    /// * `state` - Existing shared TuiState from another app instance
+    /// * `selected_task` - Optional task to display (from full-screen selection)
+    pub fn with_state(state: Arc<Mutex<TuiState>>, selected_task: Option<String>) -> Result<Self> {
+        Ok(Self {
+            core: TuiCore::new(state),
+            selected_task, // Use the provided selection from mode switch
+            countdown_popup: CountdownPopup::new(),
+            is_interactive: false, // Always start non-interactive when switching modes
+            // Reset all scrollback tracking when mode switching
+            // PTYs will be resized in init(), which changes scrollback calculations
+            task_scrollback_lines: HashMap::new(),
+            task_last_rendered_scrollback: HashMap::new(),
+            // Start at 19 so the first render (increment to 20) will trigger scrollback rendering
+            // This ensures existing PTY content from full-screen mode is immediately displayed
+            scrollback_render_counter: 19,
+            total_inserted_lines: 0,
+            status_message: None,
+        })
+    }
+
+    /// Get reference to the shared state (for mode switching)
+    ///
+    /// Returns an Arc clone, which is cheap (just increments ref count).
+    pub fn get_state(&self) -> Arc<Mutex<TuiState>> {
+        self.core.state().clone()
+    }
+
+    // === Helper Methods ===
+
+    /// Immediately set quit flag in shared state
+    fn quit_immediately(&mut self) {
+        self.core.quit_immediately();
+    }
+
+    /// Get the task ID of the currently running task (if any)
+    fn get_current_running_task(&self) -> Option<String> {
+        self.core.state().lock().get_current_running_task()
+    }
+
+    /// Internal method to handle Action::EndCommand
+    fn handle_end_command(&mut self) {
+        // Use TuiCore to determine auto-exit behavior
+        match self.core.get_auto_exit_decision() {
+            AutoExitDecision::Stay | AutoExitDecision::StayWithFailures(_) => {
+                // User interacted, auto-exit disabled, or failures present - do nothing
+            }
+            AutoExitDecision::ShowCountdown => {
+                self.begin_exit_countdown();
+            }
+            AutoExitDecision::ExitImmediately => {
+                self.quit();
+            }
+        }
+    }
+
+    fn quit(&mut self) {
+        self.quit_immediately();
+    }
+
+    fn begin_exit_countdown(&mut self) {
+        let Some(countdown_duration) = self.core.get_countdown_duration() else {
+            self.quit();
+            return;
+        };
+
+        self.countdown_popup.start_countdown(countdown_duration);
+        self.core
+            .schedule_quit(std::time::Duration::from_secs(countdown_duration));
+    }
+
+    /// Resize all PTY instances to match current inline dimensions
+    ///
+    /// Called when switching to inline mode via init().
+    /// This ensures PTY output fits the available space, pushing excess content
+    /// into scrollback.
+    fn resize_all_ptys(&mut self) {
+        let (rows, cols) = self.calculate_pty_dimensions();
+
+        let mut state = self.core.state().lock();
+
+        // Collect task IDs to avoid holding immutable borrow during mutation
+        let task_ids: Vec<String> = state.get_pty_instances().keys().cloned().collect();
+
+        // Resize each PTY instance by replacing the Arc
+        for task_id in task_ids {
+            if let Some(pty_arc) = state.get_pty_instance(&task_id) {
+                let (current_rows, current_cols) = pty_arc.get_dimensions();
+
+                // Only resize if dimensions actually changed
+                if current_rows != rows || current_cols != cols {
+                    tracing::trace!(
+                        "InlineApp resizing PTY for {} from {}x{} to {}x{}",
+                        task_id,
+                        current_cols,
+                        current_rows,
+                        cols,
+                        rows
+                    );
+
+                    // Clone the PTY instance, resize it, and replace the Arc
+                    let mut pty_clone = pty_arc.as_ref().clone();
+                    if let Ok(()) = pty_clone.resize(rows, cols) {
+                        state.register_pty_instance(task_id, Arc::new(pty_clone));
+                    }
+                }
+            }
+        }
+    }
+
+    fn dispatch_action(&self, action: Action) {
+        self.core.dispatch_action(action);
+    }
+
+    // === Interactive Mode Methods ===
+    // can_be_interactive() uses the trait default implementation from TuiApp
+
+    /// Enter interactive mode
+    fn enter_interactive_mode(&mut self) {
+        self.is_interactive = true;
+        debug!("Entered interactive mode");
+    }
+
+    /// Exit interactive mode
+    fn exit_interactive_mode(&mut self) {
+        self.is_interactive = false;
+        debug!("Exited interactive mode");
+    }
+
+    /// Show a hint message in the status bar (replaces hint popup in inline mode)
+    fn show_hint(&mut self, message: impl Into<String>) {
+        // Check if hints are suppressed
+        let suppress_hints = self.core.state().lock().tui_config().suppress_hints;
+        if !suppress_hints {
+            self.status_message = Some((message.into(), Instant::now()));
+        }
+    }
+
+    /// Handle keyboard input in interactive mode - forward to PTY
+    fn handle_interactive_key(&mut self, key: crossterm::event::KeyEvent) -> Result<()> {
+        let current_task = self
+            .selected_task
+            .clone()
+            .or_else(|| self.get_current_running_task());
+
+        let Some(task_id) = current_task else {
+            return Ok(());
+        };
+
+        let state = self.core.state().lock();
+        let Some(pty) = state.get_pty_instance(&task_id) else {
+            return Ok(());
+        };
+
+        // Clone the PTY to work with it outside the lock
+        let mut pty_clone = pty.as_ref().clone();
+        drop(state);
+
+        match key.code {
+            KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                // Convert Ctrl+letter to ASCII control code (Ctrl+A = 0x01, Ctrl+C = 0x03, etc.)
+                let ascii_code = (c as u8).wrapping_sub(0x60);
+                debug!("Sending control code: {:?}", &[ascii_code]);
+                pty_clone.write_input(&[ascii_code])?;
+            }
+            KeyCode::Char(c) => {
+                pty_clone.write_input(c.to_string().as_bytes())?;
+            }
+            KeyCode::Up | KeyCode::Down => {
+                pty_clone.handle_arrow_keys(key);
+            }
+            KeyCode::Enter => {
+                pty_clone.write_input(b"\r")?;
+            }
+            KeyCode::Esc => {
+                pty_clone.write_input(&[0x1b])?;
+            }
+            KeyCode::Backspace => {
+                pty_clone.write_input(&[0x7f])?;
+            }
+            KeyCode::Tab => {
+                pty_clone.write_input(b"\t")?;
+            }
+            KeyCode::Left => {
+                pty_clone.write_input(b"\x1b[D")?;
+            }
+            KeyCode::Right => {
+                pty_clone.write_input(b"\x1b[C")?;
+            }
+            KeyCode::Home => {
+                pty_clone.write_input(b"\x1b[H")?;
+            }
+            KeyCode::End => {
+                pty_clone.write_input(b"\x1b[F")?;
+            }
+            KeyCode::Delete => {
+                pty_clone.write_input(b"\x1b[3~")?;
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+}
+
+impl TuiApp for InlineApp {
+    // === Core Access ===
+
+    fn core(&self) -> &TuiCore {
+        &self.core
+    }
+
+    fn core_mut(&mut self) -> &mut TuiCore {
+        &mut self.core
+    }
+
+    // === Event Handling ===
+
+    fn handle_event(
+        &mut self,
+        event: tui::Event,
+        action_tx: &UnboundedSender<Action>,
+    ) -> Result<bool> {
+        match event {
+            tui::Event::Quit => {
+                self.quit_immediately();
+                return Ok(false);
+            }
+            tui::Event::Key(key) => {
+                // If countdown popup is visible, handle countdown-specific keys
+                if self.countdown_popup.is_visible() {
+                    match key.code {
+                        KeyCode::Char('q') => {
+                            // Quit immediately on 'q' when countdown is active
+                            self.quit_immediately();
+                            return Ok(false);
+                        }
+                        KeyCode::Char('c') if key.modifiers == KeyModifiers::CONTROL => {
+                            // Quit immediately on Ctrl+C
+                            self.quit_immediately();
+                            return Ok(false);
+                        }
+                        KeyCode::Up | KeyCode::Char('k')
+                            if self.countdown_popup.is_scrollable() =>
+                        {
+                            // Scroll up in countdown popup if scrollable
+                            self.countdown_popup.scroll_up();
+                            return Ok(false);
+                        }
+                        KeyCode::Down | KeyCode::Char('j')
+                            if self.countdown_popup.is_scrollable() =>
+                        {
+                            // Scroll down in countdown popup if scrollable
+                            self.countdown_popup.scroll_down();
+                            return Ok(false);
+                        }
+                        _ => {
+                            // Any other key cancels the countdown
+                            self.countdown_popup.cancel_countdown();
+                            self.core.cancel_quit();
+                            return Ok(false);
+                        }
+                    }
+                }
+
+                // === Interactive Mode Handling ===
+                // When in interactive mode, Ctrl+Z exits, all other keys go to PTY
+                if self.is_interactive {
+                    // Ctrl+Z exits interactive mode
+                    if matches!(key.code, KeyCode::Char('z'))
+                        && key.modifiers == KeyModifiers::CONTROL
+                    {
+                        self.exit_interactive_mode();
+                        return Ok(false);
+                    }
+
+                    // Forward all other keys to the PTY
+                    self.handle_interactive_key(key).ok();
+                    return Ok(false);
+                }
+
+                // === Non-Interactive Mode Handling ===
+
+                // 'i' enters interactive mode if task supports it
+                if matches!(key.code, KeyCode::Char('i')) && key.modifiers.is_empty() {
+                    if self.can_be_interactive() {
+                        self.enter_interactive_mode();
+                    } else {
+                        self.show_hint("This task does not support interactive mode. Only in-progress tasks that accept input can be interactive.");
+                    }
+                    return Ok(false);
+                }
+
+                if matches!(key.code, KeyCode::Char('q')) && key.modifiers.is_empty() {
+                    // Use TuiCore to handle quit request (sets forced_shutdown, checks completion)
+                    if self.core.handle_quit_request() == QuitDecision::StartCountdown {
+                        self.begin_exit_countdown();
+                    }
+                    return Ok(false);
+                }
+
+                if matches!(key.code, KeyCode::Char('c')) && key.modifiers == KeyModifiers::CONTROL
+                {
+                    // Use TuiCore to handle Ctrl+C (end command, set forced shutdown, quit)
+                    self.core.handle_ctrl_c();
+                    return Ok(false);
+                }
+
+                if matches!(key.code, KeyCode::F(12)) {
+                    // Toggle debug mode on F12
+                    self.dispatch_action(Action::ToggleDebugMode);
+                    return Ok(false);
+                }
+
+                // F11 toggles between inline and full-screen mode
+                if matches!(key.code, KeyCode::F(11)) {
+                    self.dispatch_action(Action::SwitchMode(TuiMode::FullScreen));
+                    return Ok(false);
+                }
+
+                // ESC switches to full-screen mode (not quit like in countdown popup)
+                if matches!(key.code, KeyCode::Esc) {
+                    self.dispatch_action(Action::SwitchMode(TuiMode::FullScreen));
+                    return Ok(false);
+                }
+
+                // Handle 'c' for copying terminal output to clipboard (same as full-screen mode)
+                if matches!(key.code, KeyCode::Char('c')) && key.modifiers.is_empty() {
+                    // Get the task to display (selected or first running)
+                    let current_task = self
+                        .selected_task
+                        .clone()
+                        .or_else(|| self.get_current_running_task());
+
+                    if let Some(task_id) = current_task {
+                        let state = self.core.state().lock();
+                        if let Some(pty) = state.get_pty_instance(&task_id) {
+                            if let Some(screen) = pty.get_screen() {
+                                // Unformatted output (no ANSI escape codes)
+                                let output = screen.all_contents();
+                                drop(state); // Release lock before clipboard operations
+                                if let Ok(mut clipboard) = Clipboard::new() {
+                                    if clipboard.set_text(output).is_ok() {
+                                        // Show status message in bottom chrome
+                                        self.status_message =
+                                            Some((String::from("Output copied"), Instant::now()));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    return Ok(false);
+                }
+
+                let unhandled_key_message = if self.can_be_interactive() {
+                    "This key is not handled by the TUI. To send input to the terminal, press 'i' to enter interactive mode."
+                } else {
+                    "This key is not handled by the TUI."
+                };
+
+                self.show_hint(unhandled_key_message);
+                return Ok(false);
+            }
+            tui::Event::Render => action_tx.send(Action::Render)?,
+            tui::Event::Tick => action_tx.send(Action::Tick)?,
+            tui::Event::Resize(w, h) => action_tx.send(Action::Resize(w, h))?,
+            _ => {} // Ignore mouse events, etc.
+        }
+        Ok(false)
+    }
+
+    fn handle_action(
+        &mut self,
+        tui: &mut tui::Tui,
+        action: Action,
+        _action_tx: &UnboundedSender<Action>,
+    ) {
+        match action {
+            Action::Tick => {
+                // Clear expired status messages
+                if let Some((_, shown_at)) = &self.status_message {
+                    if shown_at.elapsed() > STATUS_MESSAGE_DURATION {
+                        self.status_message = None;
+                    }
+                }
+            }
+            Action::Render => {
+                // Render scrollback content above the TUI using insert_before
+                self.render_scrollback_above_tui(tui);
+
+                // Draw the inline TUI layout
+                tui.draw(|f| {
+                    let area = f.area();
+                    self.render_inline_layout(f, area);
+                })
+                .ok();
+            }
+            Action::Quit => {
+                self.quit_immediately();
+            }
+            Action::StartCommand(_) => {
+                // Notify console messenger if connected
+                let state = self.core.state().lock();
+                if let Some(messenger) = state.get_console_messenger() {
+                    messenger.start_running_tasks();
+                }
+            }
+            Action::EndCommand => {
+                self.handle_end_command();
+            }
+            Action::ShowHint(message) => {
+                // In inline mode, show hints in the status bar instead of a popup
+                self.show_hint(message);
+            }
+            _ => {} // Ignore other actions (including Resize - ratatui doesn't handle it properly for inline viewports)
+        }
+    }
+
+    // === Mode Identification ===
+
+    fn get_tui_mode(&self) -> TuiMode {
+        TuiMode::Inline
+    }
+
+    // === Initialization ===
+
+    fn init(&mut self, _area: Size) -> Result<()> {
+        // Resize all existing PTYs to inline dimensions
+        // This is critical when switching from full-screen mode
+        self.resize_all_ptys();
+        Ok(())
+    }
+
+    // === Task Lifecycle (hooks for trait defaults) ===
+
+    fn on_tasks_started(&mut self, tasks: &[Task]) {
+        // Auto-select the first task to display its output
+        if let Some(first_task) = tasks.first() {
+            self.selected_task = Some(first_task.id.clone());
+        }
+    }
+
+    // start_tasks uses trait default which calls on_tasks_started
+
+    // === PTY Registration (hooks for trait defaults) ===
+
+    fn calculate_pty_dimensions(&self) -> (u16, u16) {
+        // Get terminal size
+        if let Ok((cols, rows)) = crossterm::terminal::size() {
+            // Reserves 2 rows at the bottom - one for the inline chrome,
+            // one for space between terminal output and chrome.
+            let content_height = rows.saturating_sub(2);
+            (content_height, cols)
+        } else {
+            // Fallback to reasonable defaults
+            debug!("Failed to get terminal size, using default PTY dimensions");
+            (20, 80)
+        }
+    }
+
+    fn on_pty_registered(&mut self, task_id: &str) {
+        // Initialize scrollback tracking for inline mode
+        self.task_scrollback_lines.insert(task_id.to_string(), 0);
+        self.task_last_rendered_scrollback
+            .insert(task_id.to_string(), 0);
+    }
+
+    /// Override to resize interactive PTYs to inline dimensions
+    ///
+    /// Inline mode needs smaller PTYs to fit the compact viewport,
+    /// unlike full-screen mode where interactive PTYs use their own dimensions.
+    fn register_running_interactive_task(
+        &mut self,
+        task_id: String,
+        parser_and_writer: External<(ParserArc, WriterArc)>,
+    ) {
+        let mut pty =
+            PtyInstance::interactive(parser_and_writer.0.clone(), parser_and_writer.1.clone());
+
+        // Resize PTY to inline dimensions (mode-specific)
+        let (rows, cols) = self.calculate_pty_dimensions();
+        pty.resize(rows, cols).ok();
+
+        let pty = Arc::new(pty);
+        self.state()
+            .lock()
+            .register_pty_instance(task_id.clone(), pty);
+
+        // Call mode-specific hook
+        self.on_pty_registered(&task_id);
+    }
+
+    // Other PTY registration methods use trait defaults
+
+    // === Mode-specific overrides ===
+
+    fn get_selected_task_name(&self) -> Option<String> {
+        // Include fallback to first running task for inline mode
+        // This ensures can_be_interactive and other trait methods work correctly
+        self.selected_task
+            .clone()
+            .or_else(|| self.get_current_running_task())
+    }
+
+    fn update_task_status(&mut self, task_id: String, status: TaskStatus) {
+        debug!("Updating task '{}' status to {:?}", task_id, status);
+        self.core.update_task_status(task_id, status);
+        let can_be_interactive = self.can_be_interactive();
+        if !can_be_interactive && self.is_interactive {
+            // Exit interactive mode if the selected task can no longer be interactive
+            self.is_interactive = false;
+        }
+    }
+
+    fn end_tasks(&mut self, task_results: Vec<crate::native::tasks::types::TaskResult>) {
+        debug!(
+            "Ending tasks in InlineApp - {:?}. Selected task: {:?}",
+            task_results
+                .clone()
+                .iter()
+                .map(|t| &t.task.id)
+                .collect::<Vec<_>>(),
+            self.selected_task
+        );
+        self.core.end_tasks(&task_results);
+        if task_results
+            .iter()
+            .find(|t| {
+                self.selected_task
+                    .as_ref()
+                    .map_or(false, |id| id == &t.task.id)
+            })
+            .is_some()
+        {
+            // If the selected task has completed, exit interactive mode
+            self.is_interactive = false;
+        }
+    }
+}
+
+// === Private Rendering Methods ===
+impl InlineApp {
+    fn render_scrollback_above_tui(&mut self, tui: &mut tui::Tui) {
+        self.scrollback_render_counter += 1;
+
+        // Only render scrollback every 20th iteration to batch updates for VSCode
+        if self.scrollback_render_counter % 20 != 0 {
+            return;
+        }
+
+        // Get the task to display (selected or first running)
+        let current_task = self
+            .selected_task
+            .clone()
+            .or_else(|| self.get_current_running_task());
+
+        if let Some(current_task) = current_task {
+            let state = self.core.state().lock();
+            if let Some(pty) = state.get_pty_instance(&current_task) {
+                let pty = pty.clone();
+                drop(state);
+
+                // Get last rendered scrollback line count for this task
+                let last_rendered_lines = self
+                    .task_last_rendered_scrollback
+                    .get(&current_task)
+                    .copied()
+                    .unwrap_or(0);
+
+                // Get buffered scrollback content since last render
+                let buffered_scrollback_lines =
+                    pty.get_buffered_scrollback_content_for_inline(last_rendered_lines);
+
+                // Update tracking for next buffered render
+                let current_scrollback_lines = pty.get_scrollback_line_count();
+
+                self.task_scrollback_lines
+                    .insert(current_task.clone(), current_scrollback_lines);
+
+                // Render buffered scrollback above TUI using terminal.insert_before
+                // Render in batches to avoid overwhelming the terminal
+                if !buffered_scrollback_lines.is_empty() {
+                    const MAX_LINES_PER_RENDER: usize = 250;
+
+                    // Calculate how many lines to render this cycle
+                    let lines_to_render = buffered_scrollback_lines.len().min(MAX_LINES_PER_RENDER);
+                    let batch = &buffered_scrollback_lines[0..lines_to_render];
+
+                    use crate::native::tui::theme::THEME;
+                    use ratatui::style::Style;
+                    use ratatui::text::Line;
+                    use ratatui::widgets::Paragraph;
+
+                    let height = lines_to_render as u16;
+
+                    // Call insert_before on the dereferenced Terminal
+                    // This only works with inline viewport
+                    if let Ok(()) = tui.insert_before(height, |buf| {
+                        // Convert batched scrollback lines to ratatui Lines
+                        let lines: Vec<Line> =
+                            batch.iter().map(|line| Line::from(line.as_str())).collect();
+
+                        // Create a paragraph with the buffered scrollback content
+                        let paragraph =
+                            Paragraph::new(lines).style(Style::default().fg(THEME.secondary_fg));
+
+                        // Render using the Widget trait
+                        use ratatui::widgets::Widget;
+                        paragraph.render(buf.area, buf);
+                    }) {
+                        // Track total lines inserted for cleanup on exit
+                        self.total_inserted_lines += height as u32;
+
+                        // Update last rendered count to reflect what we actually rendered
+                        // This is incremental - we only advance by the batch size
+                        let new_last_rendered = last_rendered_lines + lines_to_render;
+                        self.task_last_rendered_scrollback
+                            .insert(current_task.clone(), new_last_rendered);
+
+                        tracing::trace!(
+                            "render_scrollback_above_tui: Updated last_rendered from {} to {} (remaining: {})",
+                            last_rendered_lines,
+                            new_last_rendered,
+                            current_scrollback_lines - new_last_rendered
+                        );
+                    } else {
+                        tracing::error!(
+                            "insert_before failed - method may not exist on this terminal type"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn render_inline_layout(&mut self, f: &mut ratatui::Frame, area: ratatui::layout::Rect) {
+        use ratatui::layout::{Constraint, Direction, Layout};
+
+        // Put terminal content at the top, status/progress at bottom
+        // Minimize UI elements to maximize terminal output space
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Fill(1), // Terminal output (at least 10 lines, takes remaining space)
+                Constraint::Length(1), // Status bar (compact: 3 lines with border)
+            ])
+            .split(area);
+
+        // Render main content section (terminal at top)
+        self.render_inline_main_content(f, chunks[0]);
+
+        // Render status section below
+        self.render_inline_status(f, chunks[1]);
+
+        // Render countdown popup as overlay if visible
+        if self.countdown_popup.is_visible() {
+            self.countdown_popup.render(f, area);
+        }
+    }
+
+    fn render_inline_status(&self, f: &mut ratatui::Frame, area: ratatui::layout::Rect) {
+        use crate::native::tui::theme::THEME;
+        use ratatui::style::Style;
+
+        // Get current task and its status for color coding
+        let current_task = self
+            .selected_task
+            .clone()
+            .or_else(|| self.get_current_running_task());
+
+        let (task_name, status, status_style, duration_text) =
+            if let Some(ref task_id) = current_task {
+                let state = self.core.state().lock();
+                let status = state
+                    .get_task_status(task_id)
+                    .unwrap_or(TaskStatus::NotStarted);
+
+                // Get timing information and format duration using shared utility
+                // Now both are in milliseconds since epoch
+                let (start_time, end_time) = state.get_task_timing(task_id);
+                let estimated_ms = state.estimated_task_timings().get(task_id).copied();
+                drop(state);
+
+                let actual_ms = calculate_actual_duration_ms(status, start_time, end_time);
+                let duration = actual_ms
+                    .map(|actual_ms| format_duration_with_estimate(actual_ms, estimated_ms));
+
+                (
+                    task_id.clone(),
+                    status,
+                    get_task_status_style(status),
+                    duration,
+                )
+            } else {
+                (
+                    String::from("Idle"),
+                    TaskStatus::NotStarted,
+                    get_task_status_style(TaskStatus::NotStarted),
+                    None,
+                )
+            };
+
+        // Get cloud message from state (using trait default implementation)
+        let cloud_message = TuiApp::get_cloud_message(self);
+
+        // Get status message (e.g., "Output copied")
+        let status_msg = self.status_message.as_ref().map(|(msg, _)| msg.as_str());
+
+        // Check if we can show interactive mode indicator
+        let can_interact = self.can_be_interactive();
+        let show_interactive_hint = status == TaskStatus::InProgress && can_interact;
+
+        // Calculate sizes for layout elements
+        // Left side: " NX" (3) + icon (2) + task_name + some padding
+        let left_fixed_size = 6; // " NX" + icon spacing
+        let task_name_len = task_name.len();
+
+        // Right side elements (in order of priority - highest priority items are always shown)
+        let status_msg_size = status_msg.map(|m| m.len() + 2).unwrap_or(0); // "Output copied " with padding
+        let esc_hint_size = 9; // "exit: esc" - always shown
+        let duration_size = duration_text.as_ref().map(|d| d.len() + 4).unwrap_or(3); // duration or "??"
+        let interactive_size = if show_interactive_hint {
+            if self.is_interactive { 22 } else { 12 } // "INTERACTIVE <ctrl>+z " or "interact: i "
+        } else {
+            0
+        };
+        let cloud_size = cloud_message.as_ref().map(|m| m.len() + 1).unwrap_or(0);
+
+        // Calculate available width and determine what fits
+        let total_width = area.width as usize;
+        let min_task_display = 10; // Minimum chars to show for task name
+
+        // Required elements: left side + status msg (if present) + esc hint + duration
+        let required_size = left_fixed_size
+            + task_name_len.min(min_task_display)
+            + status_msg_size
+            + esc_hint_size
+            + duration_size;
+
+        // Determine if we have space for optional elements
+        let available_for_optional = total_width.saturating_sub(required_size);
+        let show_cloud = cloud_size > 0 && available_for_optional >= cloud_size + interactive_size;
+        let show_interactive = interactive_size > 0 && available_for_optional >= interactive_size;
+
+        // Calculate actual right side size based on what we'll show
+        let right_size = if status_msg_size > 0 {
+            status_msg_size
+        } else {
+            esc_hint_size
+                + duration_size
+                + if show_interactive {
+                    interactive_size
+                } else {
+                    0
+                }
+                + if show_cloud { cloud_size } else { 0 }
+        };
+
+        let chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Fill(10),               // Left: task info
+                Constraint::Min(right_size as u16), // Right: esc + optional elements + duration
+            ])
+            .split(area);
+
+        // Build left side: NX logo + status icon + task name
+        let left_spans = vec![
+            Span::styled(" NX", status_style.add_modifier(Modifier::BOLD)),
+            get_task_status_icon(status, 1),
+            Span::styled(task_name.clone(), status_style),
+        ];
+
+        f.render_widget(Paragraph::new(Line::from(left_spans)), chunks[0]);
+
+        // Build right side: status msg + esc hint + interactive hint (if space) + cloud message (if space) + duration
+        let mut right_spans = Vec::new();
+
+        // Show status message (high priority - e.g., "Output copied")
+        if let Some(msg) = status_msg {
+            right_spans.push(Span::styled(
+                format!("{} ", msg),
+                Style::default().fg(THEME.info),
+            ));
+        } else {
+            // Show cloud message only if there's space
+            if show_cloud {
+                if let Some(ref message) = cloud_message {
+                    right_spans.push(Span::styled(
+                        format!("{} ", message),
+                        Style::default().fg(THEME.info),
+                    ));
+                }
+            }
+
+            // ESC hint - always shown
+            right_spans.push(Span::styled("exit: esc", Style::default().fg(THEME.info)));
+            right_spans.push(Span::styled(" ", Style::default().fg(THEME.secondary_fg)));
+
+            // Show interactive mode indicator if there's space
+            if show_interactive && show_interactive_hint {
+                if self.is_interactive {
+                    // In interactive mode: show how to exit
+                    right_spans.push(Span::styled(
+                        "INTERACTIVE ",
+                        Style::default().fg(THEME.primary_fg),
+                    ));
+                    right_spans.push(Span::styled("<ctrl>+z ", Style::default().fg(THEME.info)));
+                } else {
+                    // Not in interactive mode: show how to enter
+                    right_spans.push(Span::styled("interact: i", Style::default().fg(THEME.info)));
+                }
+            }
+
+            if let Some(ref duration) = duration_text {
+                right_spans.push(Span::styled(" - ", Style::default().fg(THEME.secondary_fg)));
+                right_spans.push(Span::styled(
+                    duration.clone(),
+                    Style::default().fg(THEME.secondary_fg),
+                ));
+            }
+        }
+        f.render_widget(Paragraph::new(Line::from(right_spans)), chunks[1]);
+    }
+
+    fn render_inline_main_content(&mut self, f: &mut ratatui::Frame, area: ratatui::layout::Rect) {
+        // Show selected task output if available, otherwise first running task
+        let current_task = self
+            .selected_task
+            .clone()
+            .or_else(|| self.get_current_running_task());
+
+        if let Some(current_task) = current_task {
+            let state = self.core.state().lock();
+            if let Some(pty) = state.get_pty_instance(&current_task) {
+                let pty = pty.clone();
+                drop(state);
+                self.render_inline_task_output(f, area, &pty);
+                return;
+            }
+        }
+
+        // Fallback: show a message indicating no task is running
+        use crate::native::tui::theme::THEME;
+        use ratatui::layout::Alignment;
+        use ratatui::style::Style;
+        use ratatui::widgets::{Block, Borders, Paragraph};
+
+        let message = Paragraph::new(" Waiting for tasks to start... ")
+            .style(Style::default().fg(THEME.secondary_fg))
+            .alignment(Alignment::Center)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Output ")
+                    .border_style(Style::default().fg(THEME.secondary_fg)),
+            );
+
+        f.render_widget(message, area);
+    }
+
+    fn render_inline_task_output(
+        &mut self,
+        f: &mut ratatui::Frame,
+        area: ratatui::layout::Rect,
+        pty: &Arc<PtyInstance>,
+    ) {
+        use crate::native::tui::theme::THEME;
+        use ratatui::style::Style;
+        use ratatui::widgets::Block;
+        use tui_term::widget::PseudoTerminal;
+
+        // Scrollback is handled separately via terminal.insert_before
+        // Just render the current terminal screen here
+        if let Some(screen) = pty.get_screen() {
+            let block = Block::default()
+                .borders(ratatui::widgets::Borders::NONE)
+                .border_style(Style::default().fg(THEME.primary_fg));
+
+            // Use PseudoTerminal with block
+            let pseudo_term = PseudoTerminal::new(&*screen).block(block);
+            f.render_widget(pseudo_term, area);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::tasks::types::{TaskResult, TaskTarget};
+    use crate::native::tui::config;
+    use crossterm::event::KeyEvent;
+    use tokio::sync::mpsc;
+
+    fn create_test_task(id: &str) -> Task {
+        Task {
+            id: id.to_string(),
+            target: TaskTarget {
+                project: id.to_string(),
+                target: "build".to_string(),
+                configuration: None,
+            },
+            outputs: vec![],
+            project_root: Some(format!("/tmp/{}", id)),
+            start_time: None,
+            end_time: None,
+            continuous: None,
+        }
+    }
+
+    fn create_test_inline_app() -> InlineApp {
+        let tasks = vec![create_test_task("app1"), create_test_task("app2")];
+        let initiating_tasks = HashSet::from([String::from("app1")]);
+        let task_graph = TaskGraph {
+            tasks: HashMap::new(),
+            dependencies: HashMap::new(),
+            continuous_dependencies: HashMap::new(),
+            roots: vec![],
+        };
+
+        let cli_args = config::TuiCliArgs {
+            targets: vec![],
+            tui_auto_exit: None,
+        };
+
+        InlineApp::new(
+            tasks,
+            initiating_tasks,
+            RunMode::RunMany,
+            vec![],
+            config::TuiConfig::new(None, None, &cli_args),
+            String::from("Test"),
+            task_graph,
+        )
+        .unwrap()
+    }
+
+    // === Construction Tests ===
+
+    #[test]
+    fn test_inline_app_creation_with_new() {
+        let app = create_test_inline_app();
+
+        // Verify state is initialized
+        let state_ref = app.get_state();
+        let state = state_ref.lock();
+        assert_eq!(state.tasks().len(), 2);
+        assert_eq!(state.title_text(), "Test");
+
+        // Verify UI state is initialized
+        drop(state); // Release lock
+        assert_eq!(app.scrollback_render_counter, 0);
+        assert_eq!(app.total_inserted_lines, 0);
+    }
+
+    #[test]
+    fn test_inline_app_creation_with_state() {
+        // Create existing state
+        let existing_tasks = vec![create_test_task("existing")];
+        let existing_graph = TaskGraph {
+            tasks: HashMap::new(),
+            dependencies: HashMap::new(),
+            continuous_dependencies: HashMap::new(),
+            roots: vec![],
+        };
+        let cli_args = config::TuiCliArgs {
+            targets: vec![],
+            tui_auto_exit: None,
+        };
+
+        let existing_state = Arc::new(Mutex::new(TuiState::new(
+            existing_tasks,
+            HashSet::new(),
+            RunMode::RunMany,
+            vec![],
+            config::TuiConfig::new(None, None, &cli_args),
+            String::from("Existing"),
+            existing_graph,
+            HashMap::new(),
+        )));
+
+        // Create app with existing state
+        let app = InlineApp::with_state(existing_state.clone(), None).unwrap();
+
+        // Verify it uses the same state
+        assert!(Arc::ptr_eq(&app.get_state(), &existing_state));
+
+        // Verify state contents are preserved
+        let state_ref = app.get_state();
+        let state = state_ref.lock();
+        assert_eq!(state.tasks().len(), 1);
+        assert_eq!(state.title_text(), "Existing");
+    }
+
+    // === Event Handling Tests ===
+
+    #[test]
+    fn test_q_key_starts_countdown_when_tasks_not_complete() {
+        let mut app = create_test_inline_app();
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        // Tasks are NotStarted, so 'q' should start countdown, not quit immediately
+        let event = tui::Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
+        let result = app.handle_event(event, &tx).unwrap();
+
+        // Return value is always false (quit is time-based)
+        assert!(!result);
+
+        // Countdown popup should be visible
+        assert!(app.countdown_popup.is_visible());
+    }
+
+    #[test]
+    fn test_q_key_quits_immediately_when_all_tasks_complete() {
+        let mut app = create_test_inline_app();
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        // Mark all tasks as completed
+        app.update_task_status(String::from("app1"), TaskStatus::Success);
+        app.update_task_status(String::from("app2"), TaskStatus::Success);
+
+        let event = tui::Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
+        let result = app.handle_event(event, &tx).unwrap();
+
+        // Return value is always false (quit is time-based)
+        assert!(!result);
+
+        // Should quit immediately via time-based mechanism
+        assert!(app.should_quit());
+    }
+
+    #[test]
+    fn test_esc_key_dispatches_switch_mode_action() {
+        // ESC in inline mode dispatches SwitchMode action to switch to fullscreen
+        let mut app = create_test_inline_app();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        // Register action handler so dispatch_action works
+        app.register_action_handler(tx.clone()).unwrap();
+
+        let event = tui::Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        let result = app.handle_event(event, &tx).unwrap();
+
+        // Should not quit
+        assert!(!result);
+        assert!(!app.should_quit());
+
+        // Should dispatch SwitchMode(FullScreen) action
+        let action = rx.try_recv().unwrap();
+        assert!(matches!(action, Action::SwitchMode(TuiMode::FullScreen)));
+    }
+
+    #[test]
+    fn test_f11_key_dispatches_switch_mode_action() {
+        // F11 in inline mode dispatches SwitchMode action to switch to fullscreen
+        let mut app = create_test_inline_app();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        // Register action handler so dispatch_action works
+        app.register_action_handler(tx.clone()).unwrap();
+
+        let event = tui::Event::Key(KeyEvent::new(KeyCode::F(11), KeyModifiers::NONE));
+        let result = app.handle_event(event, &tx).unwrap();
+
+        // Should not quit
+        assert!(!result);
+        assert!(!app.should_quit());
+
+        // Should dispatch SwitchMode(FullScreen) action
+        let action = rx.try_recv().unwrap();
+        assert!(matches!(action, Action::SwitchMode(TuiMode::FullScreen)));
+    }
+
+    #[test]
+    fn test_quit_on_ctrl_c() {
+        let mut app = create_test_inline_app();
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let event = tui::Event::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+        let result = app.handle_event(event, &tx).unwrap();
+
+        // Return value is always false (quit is time-based)
+        assert!(!result);
+
+        // Should quit immediately via time-based mechanism
+        assert!(app.should_quit());
+    }
+
+    #[test]
+    fn test_ignore_navigation_keys() {
+        let mut app = create_test_inline_app();
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        // These should all be ignored
+        let keys = vec![
+            KeyCode::Up,
+            KeyCode::Down,
+            KeyCode::Left,
+            KeyCode::Right,
+            KeyCode::Enter,
+            KeyCode::Tab,
+            KeyCode::Char('j'),
+            KeyCode::Char('k'),
+        ];
+
+        for key in keys {
+            let event = tui::Event::Key(KeyEvent::new(key, KeyModifiers::NONE));
+            let result = app.handle_event(event, &tx).unwrap();
+
+            // Should NOT quit
+            assert!(!result);
+        }
+    }
+
+    #[test]
+    fn test_handle_render_event() {
+        let mut app = create_test_inline_app();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let event = tui::Event::Render;
+        let result = app.handle_event(event, &tx).unwrap();
+
+        // Should not quit
+        assert!(!result);
+
+        // Should forward Action::Render
+        let action = rx.try_recv().unwrap();
+        assert!(matches!(action, Action::Render));
+    }
+
+    #[test]
+    fn test_handle_tick_event() {
+        let mut app = create_test_inline_app();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let event = tui::Event::Tick;
+        let result = app.handle_event(event, &tx).unwrap();
+
+        assert!(!result);
+
+        let action = rx.try_recv().unwrap();
+        assert!(matches!(action, Action::Tick));
+    }
+
+    // === PTY Registration Tests ===
+
+    #[test]
+    fn test_register_pty_initializes_scrollback() {
+        let mut app = create_test_inline_app();
+
+        // Register non-interactive PTY (simpler test)
+        app.register_running_non_interactive_task(String::from("app1"));
+
+        // Verify scrollback tracking initialized
+        assert_eq!(app.task_scrollback_lines.get("app1"), Some(&0));
+        assert_eq!(app.task_last_rendered_scrollback.get("app1"), Some(&0));
+
+        // Verify PTY registered in state
+        let state_ref = app.get_state();
+        let state = state_ref.lock();
+        assert!(state.get_pty_instance("app1").is_some());
+    }
+
+    #[test]
+    fn test_calculate_pty_dimensions() {
+        let app = create_test_inline_app();
+        let (rows, cols) = app.calculate_pty_dimensions();
+
+        // Should return reasonable dimensions (either from terminal or fallback)
+        assert!(rows > 0, "rows should be positive");
+        assert!(cols > 0, "cols should be positive");
+    }
+
+    // === Task Lifecycle Tests ===
+
+    #[test]
+    fn test_start_tasks() {
+        let mut app = create_test_inline_app();
+
+        let tasks = vec![create_test_task("app1")];
+        app.start_tasks(tasks);
+
+        // Verify status updated in state
+        let state_ref = app.get_state();
+        let state = state_ref.lock();
+        assert_eq!(state.get_task_status("app1"), Some(TaskStatus::InProgress));
+    }
+
+    #[test]
+    fn test_update_task_status() {
+        let mut app = create_test_inline_app();
+
+        app.update_task_status(String::from("app1"), TaskStatus::Success);
+
+        let state_ref = app.get_state();
+        let state = state_ref.lock();
+        assert_eq!(state.get_task_status("app1"), Some(TaskStatus::Success));
+    }
+
+    #[test]
+    fn test_end_tasks() {
+        let mut app = create_test_inline_app();
+
+        // Start task first
+        app.start_tasks(vec![create_test_task("app1")]);
+
+        // End task
+        let results = vec![TaskResult {
+            task: create_test_task("app1"),
+            status: String::from("success"),
+            code: 0,
+            terminal_output: None,
+        }];
+        app.end_tasks(results);
+
+        // Verify timing recorded
+        let state_ref = app.get_state();
+        let state = state_ref.lock();
+        let (start, end) = state.get_task_timing("app1");
+        assert!(start.is_some());
+        assert!(end.is_some());
+    }
+
+    // === Helper Method Tests ===
+
+    #[test]
+    fn test_get_current_running_task() {
+        let mut app = create_test_inline_app();
+
+        // No running tasks initially
+        assert!(app.get_current_running_task().is_none());
+
+        // Start a task
+        app.update_task_status(String::from("app1"), TaskStatus::InProgress);
+
+        // Should find running task
+        assert_eq!(app.get_current_running_task(), Some(String::from("app1")));
+    }
+
+    #[test]
+    fn test_quit_immediately() {
+        let mut app = create_test_inline_app();
+
+        assert!(!app.should_quit());
+
+        app.quit_immediately();
+
+        assert!(app.should_quit());
+    }
+
+    // === TuiApp Trait Implementation Tests ===
+
+    #[test]
+    fn test_get_tui_mode() {
+        let app = create_test_inline_app();
+        // TuiMode doesn't implement PartialEq, so just verify it returns a value
+        let _ = app.get_tui_mode();
+        // Mode is correct by construction (always returns TuiMode::Inline)
+    }
+
+    #[test]
+    fn test_register_action_handler() {
+        let mut app = create_test_inline_app();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        app.register_action_handler(tx.clone()).unwrap();
+
+        // Verify action dispatch works after registration
+        app.dispatch_action(Action::Tick);
+        let action = rx.try_recv().unwrap();
+        assert!(matches!(action, Action::Tick));
+    }
+
+    // === State Access Tests ===
+
+    #[test]
+    fn test_get_state() {
+        let app = create_test_inline_app();
+        let state_ref = app.get_state();
+
+        // Verify we can access state
+        let state = state_ref.lock();
+        assert_eq!(state.tasks().len(), 2);
+    }
+
+    // === Interactive Mode Tests ===
+
+    #[test]
+    fn test_interactive_mode_starts_false() {
+        let app = create_test_inline_app();
+        // Interactive mode should start as false
+        assert!(!app.is_interactive);
+    }
+
+    #[test]
+    fn test_can_be_interactive_returns_false_without_interactive_task() {
+        let app = create_test_inline_app();
+        // Without a registered interactive PTY, can_be_interactive should be false
+        assert!(!app.can_be_interactive());
+    }
+
+    #[test]
+    fn test_enter_and_exit_interactive_mode() {
+        let mut app = create_test_inline_app();
+
+        // Start in non-interactive mode
+        assert!(!app.is_interactive);
+
+        // Enter interactive mode
+        app.enter_interactive_mode();
+        assert!(app.is_interactive);
+
+        // Exit interactive mode
+        app.exit_interactive_mode();
+        assert!(!app.is_interactive);
+    }
+
+    #[test]
+    fn test_i_key_does_nothing_without_interactive_task() {
+        let mut app = create_test_inline_app();
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        // Press 'i' without an interactive task
+        let event = tui::Event::Key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
+        app.handle_event(event, &tx).unwrap();
+
+        // Should remain non-interactive
+        assert!(!app.is_interactive);
+    }
+
+    #[test]
+    fn test_ctrl_z_exits_interactive_mode() {
+        let mut app = create_test_inline_app();
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        // Manually enter interactive mode
+        app.enter_interactive_mode();
+        assert!(app.is_interactive);
+
+        // Press Ctrl+Z
+        let event = tui::Event::Key(KeyEvent::new(KeyCode::Char('z'), KeyModifiers::CONTROL));
+        app.handle_event(event, &tx).unwrap();
+
+        // Should exit interactive mode
+        assert!(!app.is_interactive);
+    }
+
+    #[test]
+    fn test_interactive_mode_captures_regular_keys() {
+        let mut app = create_test_inline_app();
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        // Enter interactive mode
+        app.enter_interactive_mode();
+
+        // These keys should be captured (not trigger quit)
+        let keys = vec![
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE),
+        ];
+
+        for key in keys {
+            let event = tui::Event::Key(key);
+            app.handle_event(event, &tx).unwrap();
+            // Should not quit
+            assert!(!app.should_quit());
+        }
+    }
+
+    #[test]
+    fn test_with_state_starts_non_interactive() {
+        // Create existing state
+        let tasks = vec![create_test_task("app1")];
+        let task_graph = TaskGraph {
+            tasks: HashMap::new(),
+            dependencies: HashMap::new(),
+            continuous_dependencies: HashMap::new(),
+            roots: vec![],
+        };
+        let cli_args = config::TuiCliArgs {
+            targets: vec![],
+            tui_auto_exit: None,
+        };
+
+        let state = Arc::new(Mutex::new(TuiState::new(
+            tasks,
+            HashSet::new(),
+            RunMode::RunMany,
+            vec![],
+            config::TuiConfig::new(None, None, &cli_args),
+            String::from("Test"),
+            task_graph,
+            HashMap::new(),
+        )));
+
+        // Create app with existing state (simulating mode switch)
+        let app = InlineApp::with_state(state, None).unwrap();
+
+        // Should start non-interactive
+        assert!(!app.is_interactive);
+    }
+
+    // === Edge Case Tests ===
+
+    #[test]
+    fn test_multiple_quit_calls() {
+        let mut app = create_test_inline_app();
+
+        // Multiple quit calls should not panic
+        app.quit_immediately();
+        app.quit_immediately();
+        app.quit_immediately();
+
+        assert!(app.should_quit());
+    }
+
+    #[test]
+    fn test_pty_registration_same_task_twice() {
+        let mut app = create_test_inline_app();
+
+        // Register same task twice
+        app.register_running_non_interactive_task(String::from("app1"));
+        app.register_running_non_interactive_task(String::from("app1"));
+
+        // Should overwrite, not panic
+        let state_ref = app.get_state();
+        let state = state_ref.lock();
+        assert!(state.get_pty_instance("app1").is_some());
+    }
+
+    #[test]
+    fn test_update_status_for_nonexistent_task() {
+        let mut app = create_test_inline_app();
+
+        // Should not panic
+        app.update_task_status(String::from("nonexistent"), TaskStatus::Success);
+
+        // Status should be recorded anyway
+        let state_ref = app.get_state();
+        let state = state_ref.lock();
+        assert_eq!(
+            state.get_task_status("nonexistent"),
+            Some(TaskStatus::Success)
+        );
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use crate::native::tasks::types::{TaskResult, TaskTarget};
+    use crate::native::tui::config;
+
+    fn create_test_task(id: &str) -> Task {
+        Task {
+            id: id.to_string(),
+            target: TaskTarget {
+                project: id.to_string(),
+                target: "build".to_string(),
+                configuration: None,
+            },
+            outputs: vec![],
+            project_root: Some(format!("/tmp/{}", id)),
+            start_time: None,
+            end_time: None,
+            continuous: None,
+        }
+    }
+
+    fn create_test_inline_app() -> InlineApp {
+        let tasks = vec![create_test_task("app1"), create_test_task("app2")];
+        let initiating_tasks = HashSet::from([String::from("app1")]);
+        let task_graph = TaskGraph {
+            tasks: HashMap::new(),
+            dependencies: HashMap::new(),
+            continuous_dependencies: HashMap::new(),
+            roots: vec![],
+        };
+
+        let cli_args = config::TuiCliArgs {
+            targets: vec![],
+            tui_auto_exit: None,
+        };
+
+        InlineApp::new(
+            tasks,
+            initiating_tasks,
+            RunMode::RunMany,
+            vec![],
+            config::TuiConfig::new(None, None, &cli_args),
+            String::from("Test"),
+            task_graph,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_full_task_lifecycle() {
+        let mut app = create_test_inline_app();
+
+        // Start command
+        app.start_command(None);
+
+        // Start tasks
+        let tasks = vec![create_test_task("app1")];
+        app.start_tasks(tasks);
+
+        // Register PTY
+        app.register_running_non_interactive_task(String::from("app1"));
+
+        // Update to success
+        app.update_task_status(String::from("app1"), TaskStatus::Success);
+
+        // End tasks
+        app.end_tasks(vec![TaskResult {
+            task: create_test_task("app1"),
+            status: String::from("success"),
+            code: 0,
+            terminal_output: None,
+        }]);
+
+        // End command
+        app.end_command();
+
+        // Verify final state
+        let state_ref = app.get_state();
+        let state = state_ref.lock();
+        assert_eq!(state.get_task_status("app1"), Some(TaskStatus::Success));
+        assert!(state.get_pty_instance("app1").is_some());
+    }
+
+    #[test]
+    fn test_shared_state_between_apps() {
+        // Create shared state
+        let tasks = vec![create_test_task("shared")];
+        let task_graph = TaskGraph {
+            tasks: HashMap::new(),
+            dependencies: HashMap::new(),
+            continuous_dependencies: HashMap::new(),
+            roots: vec![],
+        };
+        let cli_args = config::TuiCliArgs {
+            targets: vec![],
+            tui_auto_exit: None,
+        };
+
+        let state = Arc::new(Mutex::new(TuiState::new(
+            tasks,
+            HashSet::new(),
+            RunMode::RunMany,
+            vec![],
+            config::TuiConfig::new(None, None, &cli_args),
+            String::from("Shared"),
+            task_graph,
+            HashMap::new(),
+        )));
+
+        // Create two apps with same state
+        let mut app1 = InlineApp::with_state(state.clone(), None).unwrap();
+        let app2 = InlineApp::with_state(state.clone(), None).unwrap();
+
+        // Modify through app1
+        app1.update_task_status(String::from("shared"), TaskStatus::Success);
+
+        // Verify visible through app2
+        assert!(!app2.should_quit()); // Can access state without issues
+        let state2_ref = app2.get_state();
+        let state2 = state2_ref.lock();
+        assert_eq!(state2.get_task_status("shared"), Some(TaskStatus::Success));
+    }
+}

--- a/packages/nx/src/native/tui/mod.rs
+++ b/packages/nx/src/native/tui/mod.rs
@@ -4,6 +4,7 @@ pub mod components;
 pub mod config;
 pub mod escape_sequences;
 pub mod graph_utils;
+pub mod inline_app;
 pub mod lifecycle;
 pub mod pty;
 pub mod scroll_momentum;
@@ -11,4 +12,12 @@ pub mod status_icons;
 pub mod theme;
 #[allow(clippy::module_inception)]
 pub mod tui;
+pub mod tui_app;
+pub mod tui_core;
+pub mod tui_state;
 pub mod utils;
+
+pub use inline_app::InlineApp;
+pub use tui_app::TuiApp;
+pub use tui_core::TuiCore;
+pub use tui_state::TuiState;

--- a/packages/nx/src/native/tui/tui_app.rs
+++ b/packages/nx/src/native/tui/tui_app.rs
@@ -1,0 +1,484 @@
+use color_eyre::eyre::Result;
+use napi::bindgen_prelude::External;
+#[cfg(not(test))]
+use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction};
+use parking_lot::Mutex;
+use ratatui::layout::Size;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::mpsc::UnboundedSender;
+use tracing::debug;
+
+use crate::native::ide::nx_console::messaging::NxConsoleMessageConnection;
+use crate::native::{
+    pseudo_terminal::pseudo_terminal::{ParserArc, WriterArc},
+    tasks::types::{Task, TaskResult},
+};
+
+use super::action::Action;
+use super::components::tasks_list::TaskStatus;
+use super::lifecycle::TuiMode;
+use super::pty::PtyInstance;
+use super::tui;
+use super::tui_core::TuiCore;
+use super::tui_state::TuiState;
+#[cfg(not(test))]
+use super::tui_state::{DoneCallback, ForcedShutdownCallback};
+use super::utils::write_output_to_pty;
+
+/// Common trait for both full-screen and inline TUI implementations
+///
+/// This allows lifecycle.rs to handle both modes uniformly through a common interface.
+/// Both `App` (full-screen) and `InlineApp` (inline) will implement this trait.
+///
+/// # Thread Safety
+///
+/// Implementations of this trait must be `Send` to work in async contexts.
+///
+/// # Shared State
+///
+/// Both implementations should use `Arc<Mutex<TuiState>>` for shared state,
+/// allowing state to be transferred between modes during mode switching.
+pub trait TuiApp: Send {
+    // === Core Access ===
+    //
+    // These accessor methods enable default implementations that delegate to TuiCore.
+    // Implementors must provide these to get the default behavior.
+
+    /// Get immutable reference to the TuiCore
+    ///
+    /// This enables default implementations for methods that only read from core.
+    fn core(&self) -> &TuiCore;
+
+    /// Get mutable reference to the TuiCore
+    ///
+    /// This enables default implementations for methods that need to modify core.
+    fn core_mut(&mut self) -> &mut TuiCore;
+
+    /// Get reference to the shared state Arc
+    ///
+    /// This enables default implementations to access state directly
+    /// without going through TuiCore, reducing indirection for simple operations.
+    fn state(&self) -> &Arc<Mutex<TuiState>> {
+        self.core().state()
+    }
+
+    // === Event Handling ===
+
+    /// Handle a terminal event (keyboard, mouse, resize, etc.)
+    ///
+    /// Returns `Ok(true)` if the event was handled, `Ok(false)` if it should be ignored.
+    ///
+    /// # Arguments
+    ///
+    /// * `event` - The terminal event to handle
+    /// * `action_tx` - Channel for sending actions to the event loop
+    fn handle_event(
+        &mut self,
+        event: tui::Event,
+        action_tx: &UnboundedSender<Action>,
+    ) -> Result<bool>;
+
+    /// Handle an action from the action channel
+    ///
+    /// # Arguments
+    ///
+    /// * `tui` - The TUI instance for rendering
+    /// * `action` - The action to handle
+    /// * `action_tx` - Channel for sending additional actions
+    fn handle_action(
+        &mut self,
+        tui: &mut tui::Tui,
+        action: Action,
+        action_tx: &UnboundedSender<Action>,
+    );
+
+    // === Action Channel ===
+
+    /// Register the action channel sender with this app
+    ///
+    /// Default implementation delegates to TuiCore.
+    fn register_action_handler(&mut self, tx: UnboundedSender<Action>) -> Result<()> {
+        self.core_mut().register_action_handler(tx);
+        Ok(())
+    }
+
+    // === Mode Identification ===
+
+    /// Get the TUI mode for this app (FullScreen or Inline)
+    ///
+    /// This is used to identify which mode is currently active.
+    fn get_tui_mode(&self) -> TuiMode;
+
+    // === Initialization ===
+
+    /// Initialize the app with the given terminal area size
+    ///
+    /// Called once when the app is first created, before the event loop starts.
+    ///
+    /// # Arguments
+    ///
+    /// * `area` - The initial terminal size
+    fn init(&mut self, area: Size) -> Result<()>;
+
+    // === Task Lifecycle ===
+    //
+    // Task lifecycle uses hooks for mode-specific behavior:
+    // - `on_tasks_started()` - called after tasks are recorded in TuiCore
+    // - `on_tasks_ended()` - called after task results are recorded
+
+    /// Called when a command starts (before any tasks run)
+    ///
+    /// Default implementation notifies console messenger if connected.
+    ///
+    /// # Arguments
+    ///
+    /// * `thread_count` - Number of threads available for task execution
+    fn start_command(&mut self, _thread_count: Option<u32>) {
+        // Default: notify console messenger if connected
+        let state = self.core().state().lock();
+        if let Some(messenger) = state.get_console_messenger() {
+            messenger.start_running_tasks();
+        }
+    }
+
+    /// Hook called after tasks are started
+    ///
+    /// Override to perform mode-specific post-start logic:
+    /// - Full-screen: dispatch StartTasks action
+    /// - Inline: auto-select first task
+    ///
+    /// Default implementation does nothing.
+    fn on_tasks_started(&mut self, _tasks: &[Task]) {
+        // Default: no-op
+    }
+
+    /// Hook called after tasks are ended
+    ///
+    /// Override to perform mode-specific post-end logic:
+    /// - Full-screen: dispatch EndTasks action, debounce resize
+    ///
+    /// Default implementation does nothing.
+    fn on_tasks_ended(&mut self, _task_results: &[TaskResult]) {
+        // Default: no-op
+    }
+
+    /// Called when tasks begin execution
+    ///
+    /// Default implementation records timing in TuiCore and calls hook.
+    ///
+    /// # Arguments
+    ///
+    /// * `tasks` - List of tasks that will be executed
+    fn start_tasks(&mut self, tasks: Vec<Task>) {
+        self.core().start_tasks(&tasks);
+        self.on_tasks_started(&tasks);
+    }
+
+    /// Update the status of a specific task
+    ///
+    /// Default implementation delegates to TuiCore.
+    ///
+    /// # Arguments
+    ///
+    /// * `task_id` - The task identifier
+    /// * `status` - The new status for the task
+    fn update_task_status(&mut self, task_id: String, status: TaskStatus) {
+        self.core().update_task_status(task_id, status);
+    }
+
+    /// Called when tasks finish execution
+    ///
+    /// Default implementation records timing in TuiCore and calls hook.
+    ///
+    /// # Arguments
+    ///
+    /// * `task_results` - Results of all completed tasks
+    fn end_tasks(&mut self, task_results: Vec<TaskResult>) {
+        self.core().end_tasks(&task_results);
+        self.on_tasks_ended(&task_results);
+    }
+
+    /// Called when the entire command finishes
+    ///
+    /// Default implementation delegates to TuiCore and dispatches EndCommand action.
+    fn end_command(&mut self) {
+        self.core().end_command();
+        self.core().dispatch_action(Action::EndCommand);
+    }
+
+    // === PTY Registration ===
+    //
+    // PTY registration uses the Template Method pattern:
+    // - `calculate_pty_dimensions()` is mode-specific (required)
+    // - `on_pty_registered()` is an optional hook for post-registration logic
+    // - Registration methods have default implementations using these hooks
+
+    /// Calculate PTY dimensions for this mode
+    ///
+    /// This is mode-specific because:
+    /// - Full-screen mode: calculates based on terminal pane split
+    /// - Inline mode: calculates for minimal UI overhead
+    ///
+    /// Returns (rows, cols) for the PTY.
+    fn calculate_pty_dimensions(&self) -> (u16, u16);
+
+    /// Hook called after a PTY is registered
+    ///
+    /// Override this to perform mode-specific post-registration logic:
+    /// - Full-screen: debounce PTY resize, update status
+    /// - Inline: initialize scrollback tracking
+    ///
+    /// Default implementation does nothing.
+    fn on_pty_registered(&mut self, _task_id: &str) {
+        // Default: no-op
+    }
+
+    /// Register a running interactive task with its PTY parser and writer
+    ///
+    /// Default implementation creates a PTY, registers it, and calls the hook.
+    /// Interactive PTYs are NOT resized because they handle dimensions through
+    /// the parser/writer. Override if mode-specific resizing is needed.
+    ///
+    /// # Arguments
+    ///
+    /// * `task_id` - The task identifier
+    /// * `parser_and_writer` - External reference to PTY parser and writer
+    fn register_running_interactive_task(
+        &mut self,
+        task_id: String,
+        parser_and_writer: External<(ParserArc, WriterArc)>,
+    ) {
+        // Interactive PTYs don't need dimension calculation - they use parser/writer dimensions
+        let pty =
+            PtyInstance::interactive(parser_and_writer.0.clone(), parser_and_writer.1.clone());
+
+        let pty = Arc::new(pty);
+        self.state()
+            .lock()
+            .register_pty_instance(task_id.clone(), pty);
+
+        // Call mode-specific hook
+        self.on_pty_registered(&task_id);
+    }
+
+    /// Register a running non-interactive task
+    ///
+    /// Default implementation creates a PTY with mode-specific dimensions,
+    /// registers it, and calls the hook.
+    ///
+    /// # Arguments
+    ///
+    /// * `task_id` - The task identifier
+    fn register_running_non_interactive_task(&mut self, task_id: String) {
+        let (rows, cols) = self.calculate_pty_dimensions();
+        let pty = PtyInstance::non_interactive_with_dimensions(rows, cols);
+
+        let pty = Arc::new(pty);
+        self.state()
+            .lock()
+            .register_pty_instance(task_id.clone(), pty);
+
+        // Call mode-specific hook
+        self.on_pty_registered(&task_id);
+    }
+
+    /// Print terminal output for a specific task
+    ///
+    /// This method is called after tasks complete. If a PTY already exists,
+    /// it means the task ran interactively and the PTY already has all output.
+    /// Only tasks that didn't run in a pseudo-terminal need a new PTY.
+    ///
+    /// # Arguments
+    ///
+    /// * `task_id` - The task identifier
+    /// * `output` - The output string to print
+    fn print_task_terminal_output(&mut self, task_id: String, output: String) {
+        // Check if a PTY instance already exists for this task
+        // If so, it already has all the output from the task execution
+        if self.state().lock().get_pty_instance(&task_id).is_some() {
+            return;
+        }
+
+        // Tasks not run within a pseudo-terminal need a new pty instance
+        let (rows, cols) = self.calculate_pty_dimensions();
+        let pty = PtyInstance::non_interactive_with_dimensions(rows, cols);
+
+        // Add ANSI escape sequence to hide cursor at the end of output,
+        // it would be confusing to have it visible when a task is a cache hit
+        let output_with_hidden_cursor = format!("{}\x1b[?25l", output);
+        write_output_to_pty(&pty, &output_with_hidden_cursor);
+
+        // Register the PTY instance in shared state
+        let pty = Arc::new(pty);
+        self.state()
+            .lock()
+            .register_pty_instance(task_id.clone(), pty);
+
+        // Call mode-specific hook
+        self.on_pty_registered(&task_id);
+    }
+
+    /// Append output to a task's output buffer
+    ///
+    /// Default implementation delegates to print_task_terminal_output.
+    ///
+    /// # Arguments
+    ///
+    /// * `task_id` - The task identifier
+    /// * `output` - The output string to append
+    fn append_task_output(&mut self, task_id: String, output: String) {
+        self.print_task_terminal_output(task_id, output);
+    }
+
+    // === Callback Management ===
+    //
+    // These methods are only available in non-test builds because they use
+    // NAPI ThreadsafeFunction which requires Node.js runtime symbols.
+
+    /// Set the callback to be invoked when all tasks are complete
+    ///
+    /// Default implementation stores the callback directly in TuiState.
+    ///
+    /// # Arguments
+    ///
+    /// * `callback` - The threadsafe callback function
+    #[cfg(not(test))]
+    fn set_done_callback(&mut self, callback: DoneCallback) {
+        self.state().lock().set_done_callback(callback);
+    }
+
+    /// Set the callback to be invoked on forced shutdown
+    ///
+    /// Default implementation stores the callback directly in TuiState.
+    ///
+    /// # Arguments
+    ///
+    /// * `callback` - The threadsafe callback function
+    #[cfg(not(test))]
+    fn set_forced_shutdown_callback(&mut self, callback: ForcedShutdownCallback) {
+        self.state().lock().set_forced_shutdown_callback(callback);
+    }
+
+    /// Call the done callback (if set)
+    ///
+    /// Default implementation calls the callback directly from TuiState.
+    fn call_done_callback(&self) {
+        self.state().lock().call_done_callback();
+    }
+
+    // === Misc ===
+
+    /// Set a message from Nx Cloud to display
+    ///
+    /// Default implementation stores the message directly in TuiState.
+    /// Mode-specific implementations can override to also dispatch actions for UI updates.
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - Optional cloud message to display
+    fn set_cloud_message(&mut self, message: Option<String>) {
+        self.state().lock().set_cloud_message(message);
+    }
+
+    fn get_cloud_message(&self) -> Option<String> {
+        self.state()
+            .lock()
+            .get_cloud_message()
+            .map(|s| s.to_string())
+    }
+
+    /// Set the console messenger for IDE integration
+    ///
+    /// Default implementation stores the messenger directly in TuiState.
+    ///
+    /// # Arguments
+    ///
+    /// * `messenger` - The console messenger connection
+    fn set_console_messenger(&mut self, messenger: NxConsoleMessageConnection) {
+        self.state().lock().set_console_messenger(messenger);
+    }
+
+    /// Set estimated timings for tasks (used for progress indication)
+    ///
+    /// Default implementation stores timings directly in TuiState.
+    ///
+    /// # Arguments
+    ///
+    /// * `timings` - Map of task IDs to estimated duration in milliseconds
+    fn set_estimated_task_timings(&mut self, timings: HashMap<String, i64>) {
+        self.state().lock().set_estimated_task_timings(timings);
+    }
+
+    // === Quit Check ===
+
+    /// Check if the app should quit
+    ///
+    /// Default implementation checks the quit state directly in TuiState.
+    ///
+    /// Returns `true` if the app should exit the event loop.
+    fn should_quit(&self) -> bool {
+        self.state().lock().should_quit()
+    }
+
+    /// Get the currently selected/focused task name (for mode switching)
+    ///
+    /// No default implementation - this is mode-specific.
+    ///
+    /// Returns the name of the task that should be displayed when switching to inline mode.
+    /// For full-screen mode, this is the selected task from the task list.
+    /// For inline mode, this is the task currently being displayed.
+    fn get_selected_task_name(&self) -> Option<String>;
+
+    /// Get the task that is currently focused in a terminal pane (for mode switching)
+    ///
+    /// Default implementation returns None (no panes in inline mode).
+    /// Full-screen mode overrides this to return the task in the focused pane.
+    ///
+    /// This is used when switching to inline mode to preserve which task output was being viewed.
+    fn get_focused_pane_task(&self) -> Option<String> {
+        None
+    }
+
+    /// Check if the currently selected/focused task can be interactive
+    ///
+    /// A task can be interactive if:
+    /// 1. It exists (selected or focused)
+    /// 2. It is currently in progress
+    /// 3. Its PTY has a writer (was created as an interactive task)
+    ///
+    /// Default implementation checks the selected task from `get_selected_task_name()`.
+    fn can_be_interactive(&self) -> bool {
+        let task_id = self.get_selected_task_name();
+
+        if let Some(task_id) = task_id {
+            let state = self.state().lock();
+            // Check if task is in progress and has an interactive PTY
+            let is_in_progress = state.get_task_status(&task_id) == Some(TaskStatus::InProgress);
+            let has_writer = state
+                .get_pty_instance(&task_id)
+                .map(|pty| pty.can_be_interactive())
+                .unwrap_or(false);
+            is_in_progress && has_writer
+        } else {
+            false
+        }
+    }
+
+    /// Save UI state before switching to inline mode
+    ///
+    /// Default implementation is a no-op.
+    /// Full-screen mode overrides this to save pane_tasks, focus, spacebar_mode.
+    fn save_ui_state_for_mode_switch(&self) {
+        // Default: no-op for inline mode
+    }
+
+    /// Get the shared state Arc (for mode switching)
+    ///
+    /// Default implementation clones the Arc directly from the state accessor.
+    ///
+    /// Returns a clone of the Arc<Mutex<TuiState>>, which is cheap (just increments ref count).
+    fn get_shared_state(&self) -> Arc<Mutex<TuiState>> {
+        self.state().clone()
+    }
+}

--- a/packages/nx/src/native/tui/tui_core.rs
+++ b/packages/nx/src/native/tui/tui_core.rs
@@ -1,0 +1,304 @@
+//! Shared core functionality for TUI implementations
+//!
+//! `TuiCore` provides common functionality that is shared between the full-screen
+//! `App` and the inline `InlineApp`. This follows the composition over inheritance
+//! pattern - both apps embed a `TuiCore` and delegate common operations to it.
+//!
+//! # Architecture
+//!
+//! The TUI uses a layered architecture:
+//! 1. **TuiState** - Lowest level, holds all state (callbacks, timings, PTYs, etc.)
+//! 2. **TuiCore** - Middle layer, orchestrates complex operations involving state
+//! 3. **TuiApp trait** - Top layer, provides uniform interface with mode-specific hooks
+//!
+//! # What TuiCore Handles
+//!
+//! - Task lifecycle (start, update status, end) with timing
+//! - Quit management (schedule, cancel, immediate)
+//! - Action dispatch
+//! - Quit decision logic (auto-exit, countdown)
+//!
+//! # What TuiApp Trait Defaults Handle
+//!
+//! Simple state operations are handled by trait default implementations that
+//! access TuiState directly via `state().lock()`:
+//! - Callback registration (done, forced shutdown)
+//! - Configuration (console messenger, estimated timings)
+//! - PTY registration (with mode-specific hooks)
+//!
+//! This reduces TuiCore's responsibility and eliminates unnecessary delegation.
+
+use parking_lot::Mutex;
+use std::sync::Arc;
+use tokio::sync::mpsc::UnboundedSender;
+
+use crate::native::tasks::types::{Task, TaskResult};
+
+use super::action::Action;
+use super::components::tasks_list::TaskStatus;
+use super::tui_state::TuiState;
+
+/// Shared core functionality for TUI implementations
+///
+/// This struct contains the common state and operations that both full-screen
+/// and inline TUI modes need. By extracting this into a separate struct, we:
+///
+/// 1. Avoid code duplication between App and InlineApp
+/// 2. Ensure consistent behavior for core operations
+/// 3. Make it easier to add new TUI modes in the future
+///
+/// # Usage
+///
+/// Both `App` and `InlineApp` embed a `TuiCore` and delegate common operations:
+///
+/// ```ignore
+/// struct App {
+///     core: TuiCore,
+///     // app-specific fields...
+/// }
+///
+/// impl App {
+///     fn update_task_status(&mut self, task_id: String, status: TaskStatus) {
+///         self.core.update_task_status(task_id, status);
+///     }
+/// }
+/// ```
+pub struct TuiCore {
+    /// Shared state (can be transferred between modes)
+    state: Arc<Mutex<TuiState>>,
+
+    /// Action channel sender for dispatching actions
+    action_tx: Option<UnboundedSender<Action>>,
+}
+
+impl TuiCore {
+    /// Create a new TuiCore with the given shared state
+    pub fn new(state: Arc<Mutex<TuiState>>) -> Self {
+        Self {
+            state,
+            action_tx: None,
+        }
+    }
+
+    /// Get a reference to the shared state
+    pub fn state(&self) -> &Arc<Mutex<TuiState>> {
+        &self.state
+    }
+
+    /// Register the action channel sender
+    pub fn register_action_handler(&mut self, tx: UnboundedSender<Action>) {
+        self.action_tx = Some(tx);
+    }
+
+    /// Dispatch an action if the action channel is registered
+    pub fn dispatch_action(&self, action: Action) {
+        if let Some(tx) = &self.action_tx {
+            tx.send(action).ok();
+        }
+    }
+
+    // === Task Lifecycle Methods ===
+
+    /// Start tasks - records start times and updates status to InProgress
+    pub fn start_tasks(&self, tasks: &[Task]) {
+        let mut state = self.state.lock();
+        for task in tasks {
+            state.record_task_start(task.id.clone());
+            state.update_task_status(task.id.clone(), TaskStatus::InProgress);
+        }
+    }
+
+    /// Update task status with automatic timing recording
+    pub fn update_task_status(&self, task_id: String, status: TaskStatus) {
+        let mut state = self.state.lock();
+
+        // Record start time when task transitions to InProgress
+        if status == TaskStatus::InProgress && state.get_task_timing(&task_id).0.is_none() {
+            state.record_task_start(task_id.clone());
+        }
+
+        state.update_task_status(task_id, status);
+    }
+
+    /// End tasks - records end times and updates status based on result
+    pub fn end_tasks(&self, task_results: &[TaskResult]) {
+        let mut state = self.state.lock();
+        for result in task_results {
+            state.record_task_end(result.task.id.clone());
+            let status = if result.code == 0 {
+                TaskStatus::Success
+            } else {
+                TaskStatus::Failure
+            };
+            state.update_task_status(result.task.id.clone(), status);
+        }
+    }
+
+    /// End command - notifies console messenger if connected
+    pub fn end_command(&self) {
+        let state = self.state.lock();
+        state
+            .get_console_messenger()
+            .as_ref()
+            .and_then(|c| c.end_running_tasks());
+    }
+
+    // === Quit Management ===
+
+    /// Quit immediately
+    pub fn quit_immediately(&self) {
+        self.state.lock().quit_immediately();
+    }
+
+    /// Schedule quit after delay
+    pub fn schedule_quit(&self, delay: std::time::Duration) {
+        self.state.lock().schedule_quit(delay);
+    }
+
+    /// Cancel scheduled quit
+    pub fn cancel_quit(&self) {
+        self.state.lock().cancel_quit();
+    }
+
+    /// Set forced shutdown flag
+    pub fn set_forced_shutdown(&self, forced: bool) {
+        self.state.lock().set_forced_shutdown(forced);
+    }
+
+    /// Mark that user has interacted with the TUI
+    pub fn mark_user_interacted(&self) {
+        self.state.lock().mark_user_interacted();
+    }
+
+    // === Task Status Queries ===
+
+    /// Check if all tasks are in a completed state
+    ///
+    /// Returns true if every task has reached a terminal state (success, failure,
+    /// skipped, cache hit, or stopped). This is used for determining quit behavior.
+    pub fn are_all_tasks_completed(&self) -> bool {
+        let state = self.state.lock();
+        state.get_task_status_map().values().all(|status| {
+            matches!(
+                status,
+                TaskStatus::Success
+                    | TaskStatus::Failure
+                    | TaskStatus::Skipped
+                    | TaskStatus::LocalCache
+                    | TaskStatus::LocalCacheKeptExisting
+                    | TaskStatus::RemoteCache
+                    | TaskStatus::Stopped // Consider stopped continuous tasks as completed
+            )
+        })
+    }
+
+    /// Get names of tasks that have failed
+    pub fn get_failed_task_names(&self) -> Vec<String> {
+        self.state.lock().get_failed_task_names()
+    }
+
+    /// Get task count from task graph
+    pub fn get_task_count(&self) -> usize {
+        use crate::native::tui::graph_utils::get_task_count;
+        let state = self.state.lock();
+        get_task_count(state.task_graph())
+    }
+
+    // === Quit Decision Logic ===
+
+    /// Handle 'q' key quit request
+    ///
+    /// Returns `QuitDecision` indicating what action to take:
+    /// - `QuitImmediately` if all tasks are completed
+    /// - `StartCountdown` if tasks are still running
+    ///
+    /// Both cases set forced_shutdown flag.
+    pub fn handle_quit_request(&self) -> QuitDecision {
+        self.set_forced_shutdown(true);
+
+        if self.are_all_tasks_completed() {
+            self.quit_immediately();
+            QuitDecision::QuitImmediately
+        } else {
+            QuitDecision::StartCountdown
+        }
+    }
+
+    /// Handle Ctrl+C forced quit
+    ///
+    /// Notifies console messenger, sets forced shutdown, and quits immediately.
+    pub fn handle_ctrl_c(&self) {
+        self.end_command();
+        self.set_forced_shutdown(true);
+        self.quit_immediately();
+    }
+
+    /// Get countdown duration from config, or None if auto-exit is disabled
+    pub fn get_countdown_duration(&self) -> Option<u64> {
+        self.state
+            .lock()
+            .tui_config()
+            .auto_exit
+            .countdown_seconds()
+            .map(|d| d as u64)
+    }
+
+    /// Determine what to do when command ends (auto-exit logic)
+    ///
+    /// Returns `AutoExitDecision` based on:
+    /// - Whether user has interacted
+    /// - Whether auto-exit is enabled in config
+    /// - Number of failed tasks
+    /// - Total task count
+    pub fn get_auto_exit_decision(&self) -> AutoExitDecision {
+        let state = self.state.lock();
+        let user_has_interacted = state.has_user_interacted();
+        let should_exit_automatically = state.tui_config().auto_exit.should_exit_automatically();
+        let task_count = {
+            use crate::native::tui::graph_utils::get_task_count;
+            get_task_count(state.task_graph())
+        };
+        drop(state);
+
+        // User interacted or auto-exit disabled - don't exit
+        if user_has_interacted || !should_exit_automatically {
+            return AutoExitDecision::Stay;
+        }
+
+        let failed_task_names = self.get_failed_task_names();
+
+        // Multiple failures - don't auto-exit (let user inspect)
+        if failed_task_names.len() > 1 {
+            return AutoExitDecision::StayWithFailures(failed_task_names);
+        }
+
+        // Single task - exit immediately, multiple tasks - show countdown
+        if task_count > 1 {
+            AutoExitDecision::ShowCountdown
+        } else {
+            AutoExitDecision::ExitImmediately
+        }
+    }
+}
+
+/// Decision for handling quit request (q key)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QuitDecision {
+    /// All tasks completed, quit immediately
+    QuitImmediately,
+    /// Tasks still running, show countdown first
+    StartCountdown,
+}
+
+/// Decision for auto-exit behavior when command ends
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AutoExitDecision {
+    /// Stay in TUI (user interacted or auto-exit disabled)
+    Stay,
+    /// Stay but with multiple failures (may want to show them)
+    StayWithFailures(Vec<String>),
+    /// Show countdown before exiting
+    ShowCountdown,
+    /// Exit immediately (single task completed)
+    ExitImmediately,
+}

--- a/packages/nx/src/native/tui/tui_state.rs
+++ b/packages/nx/src/native/tui/tui_state.rs
@@ -1,0 +1,867 @@
+use hashbrown::HashSet;
+#[cfg(not(test))]
+use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::native::ide::nx_console::messaging::NxConsoleMessageConnection;
+use crate::native::tasks::types::{Task, TaskGraph};
+use crate::native::utils::time::current_timestamp_millis;
+
+// Re-export for backward compatibility with places that use TuiState timing
+
+use super::components::tasks_list::TaskStatus;
+use super::config::TuiConfig;
+use super::lifecycle::RunMode;
+use super::pty::PtyInstance;
+
+// In test mode, use a stub type instead of the real NAPI ThreadsafeFunction.
+// This is necessary because ThreadsafeFunction requires NAPI symbols that are
+// only available when running in Node.js, not in standalone Rust test binaries.
+#[cfg(test)]
+pub type DoneCallback = ();
+#[cfg(test)]
+pub type ForcedShutdownCallback = ();
+
+#[cfg(not(test))]
+pub type DoneCallback = ThreadsafeFunction<(), ErrorStrategy::Fatal>;
+#[cfg(not(test))]
+pub type ForcedShutdownCallback = ThreadsafeFunction<(), ErrorStrategy::Fatal>;
+
+/// Shared state that can be transferred between TUI modes
+/// This is the "source of truth" for task execution state
+///
+/// Note: This struct is NOT Clone. Access only via Arc<Mutex<TuiState>>
+pub struct TuiState {
+    // === Core Task Data ===
+    tasks: Vec<Task>,
+    task_status_map: HashMap<String, TaskStatus>,
+    task_graph: TaskGraph,
+    initiating_tasks: HashSet<String>,
+
+    // === PTY Management ===
+    pty_instances: HashMap<String, Arc<PtyInstance>>,
+
+    // === Task Timing (all in milliseconds since epoch) ===
+    task_start_times: HashMap<String, i64>,
+    task_end_times: HashMap<String, i64>,
+    estimated_task_timings: HashMap<String, i64>,
+
+    // === Configuration ===
+    run_mode: RunMode,
+    tui_config: TuiConfig,
+    pinned_tasks: Vec<String>,
+    title_text: String,
+
+    // === Callbacks ===
+    // In test mode these are () which is zero-sized and has no Drop impl
+    done_callback: Option<DoneCallback>,
+    forced_shutdown_callback: Option<ForcedShutdownCallback>,
+
+    // === Console Messaging ===
+    console_messenger: Option<NxConsoleMessageConnection>,
+
+    // === Quit State ===
+    quit_at: Option<Instant>,
+    is_forced_shutdown: bool,
+    user_has_interacted: bool,
+
+    // === Cloud Message ===
+    cloud_message: Option<String>,
+
+    // === UI State (for mode switching persistence) ===
+    /// Tasks assigned to terminal panes [pane0, pane1]
+    ui_pane_tasks: [Option<String>; 2],
+    /// Whether spacebar (follow) mode is active
+    ui_spacebar_mode: bool,
+    /// Index of focused pane (None = task list, Some(0) = pane 0, Some(1) = pane 1)
+    ui_focused_pane: Option<usize>,
+    /// Currently selected task in the task list
+    ui_selected_task: Option<String>,
+}
+
+impl TuiState {
+    /// Create a new TuiState with the given tasks and configuration
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        tasks: Vec<Task>,
+        initiating_tasks: HashSet<String>,
+        run_mode: RunMode,
+        pinned_tasks: Vec<String>,
+        tui_config: TuiConfig,
+        title_text: String,
+        task_graph: TaskGraph,
+        estimated_task_timings: HashMap<String, i64>,
+    ) -> Self {
+        // Initialize task status map with NotStarted for all tasks
+        let mut task_status_map = HashMap::new();
+        for task in &tasks {
+            task_status_map.insert(task.id.clone(), TaskStatus::NotStarted);
+        }
+
+        Self {
+            tasks,
+            task_status_map,
+            task_graph,
+            initiating_tasks,
+            pty_instances: HashMap::new(),
+            task_start_times: HashMap::new(),
+            task_end_times: HashMap::new(),
+            estimated_task_timings,
+            run_mode,
+            tui_config,
+            pinned_tasks,
+            title_text,
+            done_callback: None,
+            forced_shutdown_callback: None,
+            console_messenger: None,
+            quit_at: None,
+            is_forced_shutdown: false,
+            user_has_interacted: false,
+            cloud_message: None,
+            ui_pane_tasks: [None, None],
+            ui_spacebar_mode: false,
+            ui_focused_pane: None,
+            ui_selected_task: None,
+        }
+    }
+
+    // === Task Status Methods ===
+
+    /// Update the status of a task
+    pub fn update_task_status(&mut self, task_id: String, status: TaskStatus) {
+        self.task_status_map.insert(task_id, status);
+    }
+
+    /// Get the status of a task
+    pub fn get_task_status(&self, task_id: &str) -> Option<TaskStatus> {
+        self.task_status_map.get(task_id).copied()
+    }
+
+    /// Get a reference to the entire task status map
+    pub fn get_task_status_map(&self) -> &HashMap<String, TaskStatus> {
+        &self.task_status_map
+    }
+
+    /// Get the task ID of the first currently running task (if any)
+    ///
+    /// This is useful for inline mode which shows output for the current running task.
+    /// In multi-task scenarios, this returns an arbitrary running task.
+    pub fn get_current_running_task(&self) -> Option<String> {
+        self.task_status_map
+            .iter()
+            .find(|(_, status)| **status == TaskStatus::InProgress)
+            .map(|(id, _)| id.clone())
+    }
+
+    /// Get count of completed tasks (any terminal state)
+    ///
+    /// Counts tasks with status: Success, Failure, Skipped, LocalCache,
+    /// LocalCacheKeptExisting, RemoteCache
+    pub fn get_completed_task_count(&self) -> usize {
+        self.task_status_map
+            .values()
+            .filter(|status| {
+                matches!(
+                    status,
+                    TaskStatus::Success
+                        | TaskStatus::Failure
+                        | TaskStatus::Skipped
+                        | TaskStatus::LocalCache
+                        | TaskStatus::LocalCacheKeptExisting
+                        | TaskStatus::RemoteCache
+                )
+            })
+            .count()
+    }
+
+    /// Get names of tasks that failed
+    pub fn get_failed_task_names(&self) -> Vec<String> {
+        self.task_status_map
+            .iter()
+            .filter(|(_, status)| **status == TaskStatus::Failure)
+            .map(|(id, _)| id.clone())
+            .collect()
+    }
+
+    // === PTY Management Methods ===
+
+    /// Register a PTY instance for a task
+    pub fn register_pty_instance(&mut self, task_id: String, pty: Arc<PtyInstance>) {
+        self.pty_instances.insert(task_id, pty);
+    }
+
+    /// Get a PTY instance for a task
+    pub fn get_pty_instance(&self, task_id: &str) -> Option<Arc<PtyInstance>> {
+        self.pty_instances.get(task_id).cloned()
+    }
+
+    /// Get a reference to all PTY instances
+    pub fn get_pty_instances(&self) -> &HashMap<String, Arc<PtyInstance>> {
+        &self.pty_instances
+    }
+
+    /// Get a mutable reference to all PTY instances
+    /// Used for resizing PTYs when switching modes
+    pub fn get_pty_instances_mut(&mut self) -> &mut HashMap<String, Arc<PtyInstance>> {
+        &mut self.pty_instances
+    }
+
+    // === Task Timing Methods ===
+
+    /// Record the start time of a task (in milliseconds since epoch)
+    pub fn record_task_start(&mut self, task_id: String) {
+        self.task_start_times
+            .insert(task_id, current_timestamp_millis());
+    }
+
+    /// Record the end time of a task (in milliseconds since epoch)
+    pub fn record_task_end(&mut self, task_id: String) {
+        self.task_end_times
+            .insert(task_id, current_timestamp_millis());
+    }
+
+    /// Get the start and end times of a task (in milliseconds since epoch)
+    pub fn get_task_timing(&self, task_id: &str) -> (Option<i64>, Option<i64>) {
+        (
+            self.task_start_times.get(task_id).copied(),
+            self.task_end_times.get(task_id).copied(),
+        )
+    }
+
+    /// Get all task start times (for mode switching sync)
+    pub fn get_task_start_times(&self) -> &HashMap<String, i64> {
+        &self.task_start_times
+    }
+
+    /// Get all task end times (for mode switching sync)
+    pub fn get_task_end_times(&self) -> &HashMap<String, i64> {
+        &self.task_end_times
+    }
+
+    /// Set estimated task timings
+    pub fn set_estimated_task_timings(&mut self, timings: HashMap<String, i64>) {
+        self.estimated_task_timings = timings;
+    }
+
+    /// Get estimated task timings
+    pub fn estimated_task_timings(&self) -> &HashMap<String, i64> {
+        &self.estimated_task_timings
+    }
+
+    // === Quit Management Methods ===
+
+    /// Check if the application should quit
+    pub fn should_quit(&self) -> bool {
+        if let Some(quit_at) = self.quit_at {
+            Instant::now() >= quit_at
+        } else {
+            false
+        }
+    }
+
+    /// Schedule a quit after a delay
+    /// If called multiple times, the last call wins
+    pub fn schedule_quit(&mut self, delay: Duration) {
+        self.quit_at = Some(Instant::now() + delay);
+    }
+
+    /// Quit immediately (sets quit time to now)
+    pub fn quit_immediately(&mut self) {
+        self.quit_at = Some(Instant::now());
+    }
+
+    /// Cancel a scheduled quit
+    pub fn cancel_quit(&mut self) {
+        self.quit_at = None;
+    }
+
+    // === Callback Methods ===
+    //
+    // These methods are only available in non-test builds because they require
+    // NAPI symbols that are provided by Node.js at runtime.
+
+    /// Set the done callback
+    #[cfg(not(test))]
+    pub fn set_done_callback(&mut self, callback: DoneCallback) {
+        self.done_callback = Some(callback);
+    }
+
+    /// Set the forced shutdown callback
+    #[cfg(not(test))]
+    pub fn set_forced_shutdown_callback(&mut self, callback: ForcedShutdownCallback) {
+        self.forced_shutdown_callback = Some(callback);
+    }
+
+    /// Call the done callback if it exists
+    /// Can be called multiple times safely
+    /// If is_forced_shutdown is true, also calls the forced_shutdown_callback first
+    #[cfg(not(test))]
+    pub fn call_done_callback(&self) {
+        // Call forced shutdown callback first if this was a forced shutdown
+        if self.is_forced_shutdown {
+            if let Some(callback) = &self.forced_shutdown_callback {
+                callback.call((), ThreadsafeFunctionCallMode::Blocking);
+            }
+        }
+        // Then call the regular done callback
+        if let Some(callback) = &self.done_callback {
+            callback.call((), ThreadsafeFunctionCallMode::Blocking);
+        }
+    }
+
+    /// Call the forced shutdown callback if it exists (standalone, without done callback)
+    #[cfg(not(test))]
+    pub fn call_forced_shutdown_callback(&self) {
+        if let Some(callback) = &self.forced_shutdown_callback {
+            callback.call((), ThreadsafeFunctionCallMode::Blocking);
+        }
+    }
+
+    // Test-mode stubs for callback methods
+    #[cfg(test)]
+    pub fn call_done_callback(&self) {
+        // No-op in test mode
+    }
+
+    #[cfg(test)]
+    pub fn call_forced_shutdown_callback(&self) {
+        // No-op in test mode
+    }
+
+    // === Console Messenger Methods ===
+
+    /// Set the console messenger
+    pub fn set_console_messenger(&mut self, messenger: NxConsoleMessageConnection) {
+        self.console_messenger = Some(messenger);
+    }
+
+    /// Get a reference to the console messenger
+    pub fn get_console_messenger(&self) -> Option<&NxConsoleMessageConnection> {
+        self.console_messenger.as_ref()
+    }
+
+    // === Read-Only Accessors ===
+
+    /// Get a reference to all tasks
+    pub fn tasks(&self) -> &Vec<Task> {
+        &self.tasks
+    }
+
+    /// Get a reference to the task graph
+    pub fn task_graph(&self) -> &TaskGraph {
+        &self.task_graph
+    }
+
+    /// Get the run mode
+    pub fn run_mode(&self) -> RunMode {
+        self.run_mode
+    }
+
+    /// Get a reference to the TUI config
+    pub fn tui_config(&self) -> &TuiConfig {
+        &self.tui_config
+    }
+
+    /// Get a reference to pinned tasks
+    pub fn pinned_tasks(&self) -> &Vec<String> {
+        &self.pinned_tasks
+    }
+
+    /// Get the title text
+    pub fn title_text(&self) -> &str {
+        &self.title_text
+    }
+
+    /// Get a reference to initiating tasks
+    pub fn initiating_tasks(&self) -> &HashSet<String> {
+        &self.initiating_tasks
+    }
+
+    // === User Interaction Methods ===
+
+    /// Mark that the user has interacted with the TUI
+    pub fn mark_user_interacted(&mut self) {
+        self.user_has_interacted = true;
+    }
+
+    /// Check if the user has interacted with the TUI
+    pub fn has_user_interacted(&self) -> bool {
+        self.user_has_interacted
+    }
+
+    // === Forced Shutdown Methods ===
+
+    /// Set the forced shutdown flag
+    pub fn set_forced_shutdown(&mut self, forced: bool) {
+        self.is_forced_shutdown = forced;
+    }
+
+    /// Check if this is a forced shutdown
+    pub fn is_forced_shutdown(&self) -> bool {
+        self.is_forced_shutdown
+    }
+
+    // === Cloud Message Methods ===
+
+    /// Set the cloud message to display
+    pub fn set_cloud_message(&mut self, message: Option<String>) {
+        self.cloud_message = message;
+    }
+
+    /// Get the cloud message (if any)
+    pub fn get_cloud_message(&self) -> Option<&str> {
+        self.cloud_message.as_deref()
+    }
+
+    // === UI State Methods (for mode switching persistence) ===
+
+    /// Save the UI state from full-screen mode for later restoration
+    pub fn save_ui_state(
+        &mut self,
+        pane_tasks: [Option<String>; 2],
+        spacebar_mode: bool,
+        focused_pane: Option<usize>,
+        selected_task: Option<String>,
+    ) {
+        self.ui_pane_tasks = pane_tasks;
+        self.ui_spacebar_mode = spacebar_mode;
+        self.ui_focused_pane = focused_pane;
+        self.ui_selected_task = selected_task;
+    }
+
+    /// Get the saved pane tasks
+    pub fn get_ui_pane_tasks(&self) -> &[Option<String>; 2] {
+        &self.ui_pane_tasks
+    }
+
+    /// Get whether spacebar mode was active
+    pub fn get_ui_spacebar_mode(&self) -> bool {
+        self.ui_spacebar_mode
+    }
+
+    /// Get the focused pane index (None = task list)
+    pub fn get_ui_focused_pane(&self) -> Option<usize> {
+        self.ui_focused_pane
+    }
+
+    /// Get the saved selected task from the task list
+    pub fn get_ui_selected_task(&self) -> Option<&String> {
+        self.ui_selected_task.as_ref()
+    }
+
+    /// Get the task that should be shown in inline mode
+    /// Priority: focused pane task > first pane task > selected task
+    pub fn get_focused_task(&self) -> Option<String> {
+        // If we have a focused pane, use that pane's task
+        if let Some(pane_idx) = self.ui_focused_pane {
+            if let Some(task) = &self.ui_pane_tasks[pane_idx] {
+                return Some(task.clone());
+            }
+        }
+        // Otherwise try the first pane
+        if let Some(task) = &self.ui_pane_tasks[0] {
+            return Some(task.clone());
+        }
+        // No pane tasks available
+        None
+    }
+}
+
+// Compile-time verification that TuiState is Send
+// This ensures it can be safely shared across thread boundaries via Arc<Mutex<>>
+static_assertions::assert_impl_all!(TuiState: Send);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::native::tasks::types::TaskTarget;
+    use crate::native::tui::config;
+
+    fn create_test_task(id: &str) -> Task {
+        Task {
+            id: id.to_string(),
+            target: TaskTarget {
+                project: id.to_string(),
+                target: "build".to_string(),
+                configuration: None,
+            },
+            outputs: vec![],
+            project_root: Some(format!("/tmp/{}", id)),
+            start_time: None,
+            end_time: None,
+            continuous: None,
+        }
+    }
+
+    fn create_test_state() -> TuiState {
+        let tasks = vec![create_test_task("app1"), create_test_task("app2")];
+        let initiating_tasks = HashSet::from([String::from("app1")]);
+        let task_graph = TaskGraph {
+            tasks: HashMap::new(),
+            dependencies: HashMap::new(),
+            continuous_dependencies: HashMap::new(),
+            roots: vec![],
+        };
+
+        let cli_args = config::TuiCliArgs {
+            targets: vec![],
+            tui_auto_exit: None,
+        };
+
+        TuiState::new(
+            tasks,
+            initiating_tasks,
+            RunMode::RunMany,
+            vec![],
+            config::TuiConfig::new(None, None, &cli_args),
+            String::from("Test"),
+            task_graph,
+            HashMap::new(),
+        )
+    }
+
+    // === Task Status Tests ===
+
+    #[test]
+    fn test_task_status_updates() {
+        let mut state = create_test_state();
+
+        // Initial status should be NotStarted
+        assert_eq!(state.get_task_status("app1"), Some(TaskStatus::NotStarted));
+
+        // Update status
+        state.update_task_status(String::from("app1"), TaskStatus::InProgress);
+
+        // Verify status updated
+        assert_eq!(state.get_task_status("app1"), Some(TaskStatus::InProgress));
+    }
+
+    #[test]
+    fn test_task_status_nonexistent() {
+        let state = create_test_state();
+        assert_eq!(state.get_task_status("nonexistent"), None);
+    }
+
+    #[test]
+    fn test_get_task_status_map() {
+        let mut state = create_test_state();
+        state.update_task_status(String::from("app1"), TaskStatus::Success);
+        state.update_task_status(String::from("app2"), TaskStatus::InProgress);
+
+        let map = state.get_task_status_map();
+        assert_eq!(map.get("app1"), Some(&TaskStatus::Success));
+        assert_eq!(map.get("app2"), Some(&TaskStatus::InProgress));
+    }
+
+    // === PTY Management Tests ===
+
+    #[test]
+    fn test_pty_registration() {
+        let mut state = create_test_state();
+
+        // Create mock PTY instance
+        let pty = Arc::new(PtyInstance::non_interactive_with_dimensions(24, 80));
+
+        // Register PTY
+        state.register_pty_instance(String::from("app1"), pty.clone());
+
+        // Verify PTY is retrievable
+        let retrieved = state.get_pty_instance("app1");
+        assert!(retrieved.is_some());
+        assert!(Arc::ptr_eq(&pty, &retrieved.unwrap()));
+    }
+
+    #[test]
+    fn test_pty_instance_nonexistent() {
+        let state = create_test_state();
+        assert!(state.get_pty_instance("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_multiple_pty_registrations() {
+        let mut state = create_test_state();
+
+        let pty1 = Arc::new(PtyInstance::non_interactive_with_dimensions(24, 80));
+        let pty2 = Arc::new(PtyInstance::non_interactive_with_dimensions(30, 120));
+
+        state.register_pty_instance(String::from("app1"), pty1.clone());
+        state.register_pty_instance(String::from("app2"), pty2.clone());
+
+        let instances = state.get_pty_instances();
+        assert_eq!(instances.len(), 2);
+        assert!(instances.contains_key("app1"));
+        assert!(instances.contains_key("app2"));
+    }
+
+    // === Quit Management Tests ===
+
+    #[test]
+    fn test_schedule_quit_not_reached() {
+        let mut state = create_test_state();
+
+        // Schedule quit in 1 second
+        state.schedule_quit(Duration::from_secs(1));
+
+        // Should not quit immediately
+        assert!(!state.should_quit());
+    }
+
+    #[test]
+    fn test_schedule_quit_reached() {
+        let mut state = create_test_state();
+
+        // Schedule quit in 10ms
+        state.schedule_quit(Duration::from_millis(10));
+
+        // Wait for timeout
+        std::thread::sleep(Duration::from_millis(50));
+
+        // Should quit now
+        assert!(state.should_quit());
+    }
+
+    #[test]
+    fn test_quit_immediately() {
+        let mut state = create_test_state();
+
+        // Quit immediately
+        state.quit_immediately();
+
+        // Should quit right away
+        assert!(state.should_quit());
+    }
+
+    #[test]
+    fn test_cancel_quit() {
+        let mut state = create_test_state();
+
+        // Schedule quit
+        state.schedule_quit(Duration::from_millis(10));
+
+        // Cancel before timeout
+        state.cancel_quit();
+
+        // Wait past original timeout
+        std::thread::sleep(Duration::from_millis(50));
+
+        // Should NOT quit (was cancelled)
+        assert!(!state.should_quit());
+    }
+
+    #[test]
+    fn test_schedule_quit_overwrite() {
+        let mut state = create_test_state();
+
+        // Schedule quit in 1 second
+        state.schedule_quit(Duration::from_secs(1));
+
+        // Immediately overwrite with shorter delay
+        state.schedule_quit(Duration::from_millis(10));
+
+        // Wait for short delay
+        std::thread::sleep(Duration::from_millis(50));
+
+        // Should quit (last schedule wins)
+        assert!(state.should_quit());
+    }
+
+    // === Task Timing Tests ===
+
+    #[test]
+    fn test_task_timing() {
+        use crate::native::utils::time::current_timestamp_millis;
+
+        let mut state = create_test_state();
+
+        // Record start
+        let before_start = current_timestamp_millis();
+        state.record_task_start(String::from("app1"));
+        let after_start = current_timestamp_millis();
+
+        // Small delay
+        std::thread::sleep(Duration::from_millis(10));
+
+        // Record end
+        let before_end = current_timestamp_millis();
+        state.record_task_end(String::from("app1"));
+        let after_end = current_timestamp_millis();
+
+        // Verify timings
+        let (start, end) = state.get_task_timing("app1");
+        assert!(start.is_some());
+        assert!(end.is_some());
+
+        let start = start.unwrap();
+        let end = end.unwrap();
+
+        // Verify start is in expected range (millis)
+        assert!(start >= before_start && start <= after_start);
+
+        // Verify end is in expected range (millis)
+        assert!(end >= before_end && end <= after_end);
+
+        // Verify end is after start
+        assert!(end > start);
+    }
+
+    #[test]
+    fn test_task_timing_nonexistent() {
+        let state = create_test_state();
+        let (start, end) = state.get_task_timing("nonexistent");
+        assert!(start.is_none());
+        assert!(end.is_none());
+    }
+
+    #[test]
+    fn test_get_task_start_and_end_times() {
+        let mut state = create_test_state();
+
+        state.record_task_start(String::from("app1"));
+        state.record_task_end(String::from("app1"));
+
+        let start_times = state.get_task_start_times();
+        let end_times = state.get_task_end_times();
+
+        assert!(start_times.contains_key("app1"));
+        assert!(end_times.contains_key("app1"));
+    }
+
+    // === User Interaction Tests ===
+
+    #[test]
+    fn test_user_interaction_tracking() {
+        let mut state = create_test_state();
+
+        // Initially false
+        assert!(!state.has_user_interacted());
+
+        // Mark as interacted
+        state.mark_user_interacted();
+
+        // Now true
+        assert!(state.has_user_interacted());
+    }
+
+    // === Forced Shutdown Tests ===
+
+    #[test]
+    fn test_forced_shutdown_tracking() {
+        let mut state = create_test_state();
+
+        // Initially false
+        assert!(!state.is_forced_shutdown());
+
+        // Set forced shutdown
+        state.set_forced_shutdown(true);
+
+        // Now true
+        assert!(state.is_forced_shutdown());
+
+        // Can unset
+        state.set_forced_shutdown(false);
+        assert!(!state.is_forced_shutdown());
+    }
+
+    // === Read-Only Accessor Tests ===
+
+    #[test]
+    fn test_read_only_accessors() {
+        let state = create_test_state();
+
+        // Verify all accessors work
+        assert_eq!(state.tasks().len(), 2);
+        // run_mode() accessor works (value checked during construction)
+        let _ = state.run_mode();
+        assert!(state.pinned_tasks().is_empty());
+        assert_eq!(state.title_text(), "Test");
+        assert_eq!(state.initiating_tasks().len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use crate::native::tasks::types::TaskTarget;
+    use crate::native::tui::config;
+
+    #[test]
+    fn test_shared_state_across_threads() {
+        use parking_lot::Mutex;
+        use std::sync::Arc;
+
+        let state = Arc::new(Mutex::new(create_test_state()));
+
+        let state_clone = state.clone();
+        let handle = std::thread::spawn(move || {
+            let mut s = state_clone.lock();
+            s.update_task_status(String::from("app1"), TaskStatus::Success);
+        });
+
+        handle.join().unwrap();
+
+        // Verify change is visible
+        let s = state.lock();
+        assert_eq!(s.get_task_status("app1"), Some(TaskStatus::Success));
+    }
+
+    #[test]
+    fn test_cheap_arc_clone() {
+        use parking_lot::Mutex;
+        use std::sync::Arc;
+
+        let state = Arc::new(Mutex::new(create_test_state()));
+
+        // Clone should be cheap (just incrementing ref count)
+        let clone1 = state.clone();
+        let clone2 = state.clone();
+
+        // All should point to same data
+        assert!(Arc::ptr_eq(&state, &clone1));
+        assert!(Arc::ptr_eq(&state, &clone2));
+    }
+
+    fn create_test_state() -> TuiState {
+        let tasks = vec![create_test_task("app1"), create_test_task("app2")];
+        let initiating_tasks = HashSet::from([String::from("app1")]);
+        let task_graph = TaskGraph {
+            tasks: HashMap::new(),
+            dependencies: HashMap::new(),
+            continuous_dependencies: HashMap::new(),
+            roots: vec![],
+        };
+
+        let cli_args = config::TuiCliArgs {
+            targets: vec![],
+            tui_auto_exit: None,
+        };
+
+        TuiState::new(
+            tasks,
+            initiating_tasks,
+            RunMode::RunMany,
+            vec![],
+            config::TuiConfig::new(None, None, &cli_args),
+            String::from("Test"),
+            task_graph,
+            HashMap::new(),
+        )
+    }
+
+    fn create_test_task(id: &str) -> Task {
+        Task {
+            id: id.to_string(),
+            target: TaskTarget {
+                project: id.to_string(),
+                target: "build".to_string(),
+                configuration: None,
+            },
+            outputs: vec![],
+            project_root: Some(format!("/tmp/{}", id)),
+            start_time: None,
+            end_time: None,
+            continuous: None,
+        }
+    }
+}

--- a/packages/nx/src/native/tui/utils.rs
+++ b/packages/nx/src/native/tui/utils.rs
@@ -31,6 +31,64 @@ pub fn format_live_duration(start_ms: i64) -> String {
     format_duration(current_ms.saturating_sub(start_ms))
 }
 
+/// Formats a duration with an optional estimated time.
+///
+/// Returns a string in the format "{actual} ({estimated} avg)" if estimated is provided,
+/// otherwise just "{actual}".
+///
+/// This is the shared formatting pattern used by both the terminal pane and inline app
+/// for displaying task durations.
+pub fn format_duration_with_estimate(actual_ms: i64, estimated_ms: Option<i64>) -> String {
+    let actual_formatted = format_duration(actual_ms);
+    if let Some(estimated) = estimated_ms {
+        let estimated_formatted = format_duration(estimated);
+        format!("{} ({} avg)", actual_formatted, estimated_formatted)
+    } else {
+        actual_formatted
+    }
+}
+
+/// Calculate actual duration in milliseconds from epoch-based timing.
+///
+/// This handles the different cases:
+/// - For in-progress tasks: duration from start to now
+/// - For completed tasks: duration from start to end
+/// - For other states: None
+///
+/// # Arguments
+///
+/// * `status` - The task's current status
+/// * `start_time` - Task start time in milliseconds since epoch
+/// * `end_time` - Task end time in milliseconds since epoch (for completed tasks)
+///
+/// # Returns
+///
+/// The duration in milliseconds, or None if duration cannot be calculated.
+pub fn calculate_actual_duration_ms(
+    status: TaskStatus,
+    start_time: Option<i64>,
+    end_time: Option<i64>,
+) -> Option<i64> {
+    let start = start_time?;
+    match status {
+        TaskStatus::InProgress => {
+            // For in-progress tasks, calculate duration from start to now
+            let now = current_timestamp_millis();
+            Some(now - start)
+        }
+        TaskStatus::Success
+        | TaskStatus::Failure
+        | TaskStatus::LocalCache
+        | TaskStatus::LocalCacheKeptExisting
+        | TaskStatus::RemoteCache => {
+            // For completed tasks, calculate duration from start to end
+            let end = end_time?;
+            Some(end - start)
+        }
+        _ => None,
+    }
+}
+
 /// Ensures that all newlines in the output are properly handled by converting
 /// lone \n to \r\n sequences. This mimics terminal driver behavior.
 pub fn normalize_newlines(input: &[u8]) -> Vec<u8> {
@@ -47,6 +105,104 @@ pub fn normalize_newlines(input: &[u8]) -> Vec<u8> {
         i += 1;
     }
     output
+}
+
+use super::pty::PtyInstance;
+
+/// ANSI escape sequence to hide the cursor
+/// This is appended to output to prevent a confusing blinking cursor
+/// when viewing cache hits or completed task output.
+const HIDE_CURSOR_ESCAPE: &str = "\x1b[?25l";
+
+/// Writes output to a PTY instance, normalizing newlines and hiding the cursor.
+///
+/// This is the common implementation used by both App and InlineApp for
+/// processing terminal output from tasks.
+///
+/// # Arguments
+///
+/// * `pty` - The PTY instance to write output to
+/// * `output` - The raw output string to process
+pub fn write_output_to_pty(pty: &PtyInstance, output: &str) {
+    let output_with_hidden_cursor = format!("{}{}", output, HIDE_CURSOR_ESCAPE);
+    let normalized_output = normalize_newlines(output_with_hidden_cursor.as_bytes());
+    pty.process_output(&normalized_output);
+}
+
+use super::theme::THEME;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Span;
+
+/// Returns the base style (with foreground color) for a given task status.
+///
+/// This provides consistent color coding across different TUI components:
+/// - Success/Cache: Green
+/// - Failure: Red
+/// - Skipped: Yellow/Warning
+/// - InProgress/Shared: Blue/Info
+/// - NotStarted/Stopped: Gray/Secondary
+pub fn get_task_status_style(status: TaskStatus) -> Style {
+    Style::default().fg(match status {
+        TaskStatus::Success
+        | TaskStatus::LocalCacheKeptExisting
+        | TaskStatus::LocalCache
+        | TaskStatus::RemoteCache => THEME.success,
+        TaskStatus::Failure => THEME.error,
+        TaskStatus::Skipped => THEME.warning,
+        TaskStatus::InProgress | TaskStatus::Shared => THEME.info,
+        TaskStatus::NotStarted | TaskStatus::Stopped => THEME.secondary_fg,
+    })
+}
+
+/// Returns a styled icon Span for a given task status.
+///
+/// Icons:
+/// - ✔ for success/cache states
+/// - ✖ for failure
+/// - ⏭ for skipped
+/// - ● for in progress/shared
+/// - ◼ for stopped
+/// - · for not started
+pub fn get_task_status_icon(status: TaskStatus, padding: usize) -> Span<'static> {
+    match status {
+        TaskStatus::Success
+        | TaskStatus::LocalCacheKeptExisting
+        | TaskStatus::LocalCache
+        | TaskStatus::RemoteCache => Span::styled(
+            pad_symbol("✔", padding),
+            Style::default()
+                .fg(THEME.success)
+                .add_modifier(Modifier::BOLD),
+        ),
+        TaskStatus::Failure => Span::styled(
+            pad_symbol("✖", padding),
+            Style::default()
+                .fg(THEME.error)
+                .add_modifier(Modifier::BOLD),
+        ),
+        TaskStatus::Skipped => Span::styled(
+            pad_symbol("⏭", padding),
+            Style::default()
+                .fg(THEME.warning)
+                .add_modifier(Modifier::BOLD),
+        ),
+        TaskStatus::InProgress | TaskStatus::Shared => Span::styled(
+            pad_symbol("●", padding),
+            Style::default().fg(THEME.info).add_modifier(Modifier::BOLD),
+        ),
+        TaskStatus::Stopped => Span::styled(
+            pad_symbol("◼", padding),
+            Style::default()
+                .fg(THEME.secondary_fg)
+                .add_modifier(Modifier::BOLD),
+        ),
+        TaskStatus::NotStarted => Span::styled(
+            pad_symbol("·", padding),
+            Style::default()
+                .fg(THEME.secondary_fg)
+                .add_modifier(Modifier::BOLD),
+        ),
+    }
 }
 
 /// Sorts a list of TaskItems with a stable, total ordering.
@@ -127,6 +283,10 @@ pub fn sort_task_items(tasks: &mut [TaskItem], highlighted_names: &HashSet<Strin
         // For all other cases or as a tiebreaker, sort by name
         a.name.cmp(&b.name)
     });
+}
+
+fn pad_symbol(symbol: &str, padding: usize) -> String {
+    format!("{:^width$}", symbol, width = padding * 2 + 1)
 }
 
 #[cfg(test)]
@@ -497,7 +657,7 @@ mod tests {
             let b = &tasks[i];
 
             // Map status to category for comparison
-            let status_to_category = |status: &TaskStatus, name: &str| -> u8 {
+            let status_to_category = |status: &TaskStatus, _: &str| -> u8 {
                 // In this test we're using an empty highlighted list
                 match status {
                     TaskStatus::InProgress | TaskStatus::Shared => 0,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21846,6 +21846,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.11.0:


### PR DESCRIPTION
## Current Behavior
When running single tasks we have a "minimal" tui, but that minimal tui still makes it really hard / impossible to use some of the terminals built in features... like:

- Find (can only find what's currently rendered by tui)
- Text select + copy (can only select what's rendered to screen, copied text includes the frame around the tui / scrollbar)

## Expected Behavior
When running single tasks we can use an inline viewport to render some tui widgets at the bottom of the viewport, and terminal output can be printed above.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
