### PR TITLE
docs(misc): fix tab alignment on mobile devices

### DIFF
--- a/astro-docs/src/styles/global.css
+++ b/astro-docs/src/styles/global.css
@@ -382,3 +382,8 @@ iframe[src*='youtube'] {
 table code {
   word-wrap: break-word;
 }
+
+/* Fix tab alignment */
+[role="tablist"] {
+  align-items: end;
+}

--- a/astro-docs/src/styles/global.css
+++ b/astro-docs/src/styles/global.css
@@ -384,6 +384,6 @@ table code {
 }
 
 /* Fix tab alignment */
-[role="tablist"] {
+[role='tablist'] {
   align-items: end;
 }


### PR DESCRIPTION
Tabs were not aligning properly on mobile, causing visual inconsistencies. Added align-items: end to tablist elements to ensure proper vertical alignment.

<img width="528" height="614" alt="image" src="https://github.com/user-attachments/assets/b9a1d9b3-c051-43ac-9454-21b16c7f21b5" />


Fixes DOC-168