### PR TITLE
docs(nx-dev): update self-healing ci supported vcs providers

### DIFF
--- a/astro-docs/src/content/docs/features/CI Features/self-healing-ci.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/self-healing-ci.mdoc
@@ -20,6 +20,9 @@ Nx Cloud Self-Healing CI is an **AI-powered system that automatically detects, a
 
 ## Enable Self-Healing CI
 
+{% aside title="VCS Integration Support" type="note" %}
+Currently, your Nx Cloud workspace needs to have the [GitHub VCS integration enabled](/docs/guides/nx-cloud/source-control-integration) to use self-healing ci. We are working on support more VCS providers!
+{% /aside %}
 To enable Self-Healing CI in your workspace, you'll need to connect to Nx Cloud and configure your CI pipeline.
 
 If you haven't already connected to Nx Cloud, run the following command:

--- a/astro-docs/src/content/docs/features/CI Features/self-healing-ci.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/self-healing-ci.mdoc
@@ -21,7 +21,7 @@ Nx Cloud Self-Healing CI is an **AI-powered system that automatically detects, a
 ## Enable Self-Healing CI
 
 {% aside title="VCS Integration Support" type="note" %}
-Currently, your Nx Cloud workspace needs to have the [GitHub VCS integration enabled](/docs/guides/nx-cloud/source-control-integration) to use self-healing ci. We are working on support more VCS providers!
+Currently, your Nx Cloud workspace needs to have the [GitHub VCS integration enabled](/docs/guides/nx-cloud/source-control-integration) to use self-healing ci. We are working on supporting more VCS providers!
 {% /aside %}
 To enable Self-Healing CI in your workspace, you'll need to connect to Nx Cloud and configure your CI pipeline.
 

--- a/docs/shared/features/self-healing-ci.md
+++ b/docs/shared/features/self-healing-ci.md
@@ -20,6 +20,10 @@ Nx Cloud Self-Healing CI is an **AI-powered system that automatically detects, a
 
 ## Enable Self-Healing CI
 
+{% callout title="VCS Integration Support" type="note" %}
+Currently, your Nx Cloud workspace needs to have the [GitHub VCS integration enabled](/ci/recipes/source-control-integration/github) to use self-healing ci. We are working on support more VCS providers!
+{% /callout %}
+
 To enable Self-Healing CI in your workspace, you'll need to connect to Nx Cloud and configure your CI pipeline.
 
 If you haven't already connected to Nx Cloud, run the following command:

--- a/docs/shared/features/self-healing-ci.md
+++ b/docs/shared/features/self-healing-ci.md
@@ -21,7 +21,7 @@ Nx Cloud Self-Healing CI is an **AI-powered system that automatically detects, a
 ## Enable Self-Healing CI
 
 {% callout title="VCS Integration Support" type="note" %}
-Currently, your Nx Cloud workspace needs to have the [GitHub VCS integration enabled](/ci/recipes/source-control-integration/github) to use self-healing ci. We are working on support more VCS providers!
+Currently, your Nx Cloud workspace needs to have the [GitHub VCS integration enabled](/ci/recipes/source-control-integration/github) to use self-healing ci. We are working on supporting more VCS providers!
 {% /callout %}
 
 To enable Self-Healing CI in your workspace, you'll need to connect to Nx Cloud and configure your CI pipeline.


### PR DESCRIPTION
clarify gh vcs required right now, with other providers coming soon. 