### PR TITLE
docs(storybook): fix incorrect version references in storybook v9 docs

### DIFF
--- a/packages/storybook/docs/migrate-9-generator-examples.md
+++ b/packages/storybook/docs/migrate-9-generator-examples.md
@@ -3,9 +3,9 @@ title: Storybook 9 Migration Generator Examples
 description: This page contains examples for the @nx/storybook:migrate-9 generator.
 ---
 
-Storybook 9 is a major release that brings a lot of new features and improvements. You can read more about it in the [Storybook 9.0.0 release article](https://storybook.js.org/blog/storybook-9). Apart from the new features and improvements it introduces, it also brings some breaking changes. You can read more about them in the [Storybook 9 migration docs](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#from-version-7x-to-800) and the [Storybook 9.0.0 migration guide](https://storybook.js.org/docs/react/migration-guide).
+Storybook 9 is a major release that brings a lot of new features and improvements. You can read more about it in the [Storybook 9.0.0 release article](https://storybook.js.org/blog/storybook-9). Apart from the new features and improvements it introduces, it also brings some breaking changes. You can read more about them in the [Storybook 9 migration docs](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#from-version-8x-to-900) and the [Storybook 9.0.0 migration guide](https://storybook.js.org/docs/react/migration-guide).
 
-You can now migrate your existing Nx workspace with Storybook configuration to use Storybook version 8. To help you, Nx offers the `@nx/storybook:migrate-9` generator. This generator will help you migrate your existing Storybook setup to version 8.
+You can now migrate your existing Nx workspace with Storybook configuration to use Storybook version 9. To help you, Nx offers the `@nx/storybook:migrate-9` generator. This generator will help you migrate your existing Storybook setup to version 9.
 
 ## How to use it
 
@@ -41,7 +41,7 @@ Once the generator finishes, and the Storybook CLI automigration scripts have ru
 
 #### Full example for Angular projects
 
-Here is an example of a project-level `.storybook/main.js|ts` file for an Angular project that has been migrated to Storybook version 8:
+Here is an example of a project-level `.storybook/main.js|ts` file for an Angular project that has been migrated to Storybook version 9:
 
 ```ts title="apps/my-angular-app/.storybook/main.js"
 const config = {
@@ -58,7 +58,7 @@ export default config;
 
 #### Full example for React projects with Vite
 
-Here is an example of a project-level `.storybook/main.js|ts` file for a React project using Vite that has been migrated to Storybook version 8:
+Here is an example of a project-level `.storybook/main.js|ts` file for a React project using Vite that has been migrated to Storybook version 9:
 
 ```ts title="apps/my-react-app/.storybook/main.js"
 const config = {


### PR DESCRIPTION
### Summary:
This PR updates the Nx documentation for the Storybook migration generator to ensure clear and accurate guidance for migrating to Storybook version 9. It replaces outdated references to version 8, corrects migration links, and updates example configurations for Angular and React (Vite) projects to reflect Storybook v9. These improvements help users follow the correct steps and avoid confusion when upgrading their workspace to the latest major release.

### Key Updates:

- Updated all migration documentation links and text to target Storybook v9 resources.
- Corrected example .storybook/main.js|ts file descriptions for Angular and React projects to reference version 9. [[1]](diffhunk://#diff-2bd0403b5cc6e0c92d83a89400b36d55ad50eb0f82688aa976ecb3c93ff69eceL44-R44) [[2]](diffhunk://#diff-2bd0403b5cc6e0c92d83a89400b36d55ad50eb0f82688aa976ecb3c93ff69eceL61-R61)
- Ensured users will be directed to the right guides and migration steps for a smoother upgrade experience.

### Type of Change:
Documentation only; no changes to code or functionality.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
N/A - Docs update

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
N/A - Docs update

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
N/A 

