### PR TITLE
feat(release)!: process non-release dependencies of release projects

### DIFF
--- a/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
+++ b/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
@@ -11,6 +11,7 @@ export async function resolveSemverSpecifierFromConventionalCommits(
   from: string,
   projectGraph: ProjectGraph,
   projectNames: string[],
+  projectToDependencies: Map<string, Set<string>>,
   conventionalCommitsConfig: NxReleaseConfig['conventionalCommits']
 ): // Map of projectName to semver bump type
 Promise<Map<string, SemverSpecifier | null>> {
@@ -19,7 +20,8 @@ Promise<Map<string, SemverSpecifier | null>> {
   const relevantCommits = await getCommitsRelevantToProjects(
     projectGraph,
     parsedCommits,
-    projectNames
+    projectNames,
+    projectToDependencies
   );
   return determineSemverChange(relevantCommits, conventionalCommitsConfig);
 }

--- a/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
+++ b/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
@@ -11,7 +11,6 @@ export async function resolveSemverSpecifierFromConventionalCommits(
   from: string,
   projectGraph: ProjectGraph,
   projectNames: string[],
-  projectToDependencies: Map<string, Set<string>>,
   conventionalCommitsConfig: NxReleaseConfig['conventionalCommits']
 ): // Map of projectName to semver bump type
 Promise<Map<string, SemverSpecifier | null>> {
@@ -20,8 +19,7 @@ Promise<Map<string, SemverSpecifier | null>> {
   const relevantCommits = await getCommitsRelevantToProjects(
     projectGraph,
     parsedCommits,
-    projectNames,
-    projectToDependencies
+    projectNames
   );
   return determineSemverChange(relevantCommits, conventionalCommitsConfig);
 }

--- a/packages/nx/src/command-line/release/utils/shared.ts
+++ b/packages/nx/src/command-line/release/utils/shared.ts
@@ -1,6 +1,5 @@
 import * as chalk from 'chalk';
 import { prerelease } from 'semver';
-import { extname } from 'path';
 import { ProjectGraph } from '../../../config/project-graph';
 import { interpolate } from '../../../tasks-runner/utils';
 import { output } from '../../../utils/output';

--- a/packages/nx/src/command-line/release/version/release-group-processor.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.ts
@@ -1106,7 +1106,6 @@ export class ReleaseGroupProcessor {
         projectLogger,
         releaseGroup,
         projectGraphNode,
-        this.projectToDependencies,
         !!semver.prerelease(currentVersion ?? ''),
         this.cachedLatestMatchingGitTag.get(projectName),
         cachedFinalConfigForProject.fallbackCurrentVersionResolver,

--- a/packages/nx/src/command-line/release/version/release-group-processor.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.ts
@@ -1106,6 +1106,7 @@ export class ReleaseGroupProcessor {
         projectLogger,
         releaseGroup,
         projectGraphNode,
+        this.projectToDependencies,
         !!semver.prerelease(currentVersion ?? ''),
         this.cachedLatestMatchingGitTag.get(projectName),
         cachedFinalConfigForProject.fallbackCurrentVersionResolver,
@@ -1702,11 +1703,6 @@ Valid values are: ${validReleaseVersionPrefixes
       );
 
       for (const dep of deps) {
-        // Skip dependencies not covered by nx release
-        if (!this.allProjectsConfiguredForNxRelease.has(dep.target)) {
-          continue;
-        }
-
         // Add this dependency to the project's dependencies
         this.projectToDependencies.get(projectName)!.add(dep.target);
 


### PR DESCRIPTION
## Current Behavior
When processing projects within Nx Release, only projects that are also configured within Nx Release are considered when determining dependencies of projects.


## Expected Behavior
All dependencies of projects within Nx Release, whether they are included in the Nx Release Config or not, should be added.

BREAKING CHANGE: All dependencies of projects within Nx Release Config are considered and processed now when determining version bumps and changelog generation.
