### PR TITLE
feat(testing): support inferring atomized tasks for cypress component tests

### DIFF
--- a/astro-docs/src/content/docs/technologies/test-tools/cypress/Guides/cypress-component-testing.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/cypress/Guides/cypress-component-testing.mdoc
@@ -72,6 +72,42 @@ With, `nx component-test your-lib --watch` Cypress will start in headed mode. Wh
 
 Running Cypress with `--watch` is a great way to iterate on your components since cypress will rerun your tests as you make those changes validating the new behavior.
 
+## Splitting Component Testing Tasks by File
+
+{% aside type="note" title="Available since Nx 21.6.1" %}
+Splitting component testing tasks by file is available since Nx 21.6.1.
+{% /aside %}
+
+Nx provides powerful features for [distributing tasks in CI](/docs/features/ci-features/distribute-task-execution), including [splitting tasks by file](/docs/features/ci-features/split-e2e-tasks) (also known as atomization). The `@nx/cypress` plugin facilitates this for Cypress projects, allowing you to run your tests more efficiently in your Continuous Integration (CI) environment.
+
+To enable component testing task splitting, set the `ciComponentTestingTargetName` option of the `@nx/cypress/plugin` in your `nx.json` file. It will look something like this:
+
+```json {% meta="{10}" %}
+// nx.json
+{
+  "plugins": [
+    {
+      "plugin": "@nx/cypress/plugin",
+      "options": {
+        "targetName": "e2e",
+        "ciTargetName": "e2e-ci",
+        "componentTestingTargetName": "component-test",
+        "ciComponentTestingTargetName": "component-test-ci",
+        "openTargetName": "open-cypress"
+      }
+    }
+  ]
+}
+```
+
+The plugin will infer the `component-test-ci` task, which depends on individual component testing tasks for each file. You can then replace the `component-test` task with the `component-test-ci` task in your CI configuration to run your tests in a distributed fashion:
+
+```diff {% meta="lang='yaml'" %}
+// .github/workflows/ci.yaml
+-     - run: pnpm exec nx affected -t lint test build component-test
++     - run: pnpm exec nx affected -t lint test build component-test-ci
+```
+
 ## More Information
 
 You can read more on component testing in the [Cypress documentation](https://docs.cypress.io/guides/component-testing/writing-your-first-component-test).

--- a/astro-docs/src/content/docs/technologies/test-tools/cypress/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/cypress/introduction.mdoc
@@ -78,6 +78,7 @@ The `@nx/cypress/plugin` is configured in the `plugins` array in `nx.json`.
         "targetName": "e2e",
         "ciTargetName": "e2e-ci",
         "componentTestingTargetName": "component-test",
+        "ciComponentTestingTargetName": "component-test-ci",
         "openTargetName": "open-cypress"
       }
     }
@@ -85,7 +86,15 @@ The `@nx/cypress/plugin` is configured in the `plugins` array in `nx.json`.
 }
 ```
 
-The `targetName`, `ciTargetName`, `componentTestingTargetName`, and `open-cypress` options control the names of the inferred Cypress tasks. The default names are `e2e`, `e2e-ci`, `component-test`, and `open-cypress`.
+The options shown above control the names of the inferred Cypress tasks. The following table shows the default values for each option:
+
+| Option                         | Default                                       |
+| ------------------------------ | --------------------------------------------- |
+| `targetName`                   | `"e2e"`                                       |
+| `ciTargetName`                 | `"e2e-ci"`                                    |
+| `componentTestingTargetName`   | `"component-test"`                            |
+| `ciComponentTestingTargetName` | `undefined` (task is not inferred by default) |
+| `openTargetName`               | `"open-cypress"`                              |
 
 ### Splitting E2E tasks by file
 
@@ -117,6 +126,32 @@ export default defineConfig({
 {% aside type="note" title="Using setupNodeEvents function" %}
 If you use the `setupNodeEvents` function in your Cypress configuration, make sure to invoke the same function that is returned by `nxE2EPreset`. See the recipe on [using `setupNodeEvents` with Cypress preset](/docs/technologies/test-tools/cypress/guides/cypress-setup-node-events) for more details.
 {% /aside %}
+
+### Splitting Component Testing Tasks by File
+
+{% aside type="note" title="Available since Nx 21.6.1" %}
+Splitting component testing tasks by file is available since Nx 21.6.1.
+{% /aside %}
+
+The `@nx/cypress/plugin` can also automatically split your component testing tasks by file. To enable it, set the `ciComponentTestingTargetName` option of the `@nx/cypress/plugin` in your `nx.json` file. It will look something like this:
+
+```json {% meta="{10}" %}
+// nx.json
+{
+  "plugins": [
+    {
+      "plugin": "@nx/cypress/plugin",
+      "options": {
+        "targetName": "e2e",
+        "ciTargetName": "e2e-ci",
+        "componentTestingTargetName": "component-test",
+        "ciComponentTestingTargetName": "component-test-ci",
+        "openTargetName": "open-cypress"
+      }
+    }
+  ]
+}
+```
 
 ## E2E Testing
 

--- a/docs/generated/packages/cypress/documents/overview.md
+++ b/docs/generated/packages/cypress/documents/overview.md
@@ -77,6 +77,7 @@ The `@nx/cypress/plugin` is configured in the `plugins` array in `nx.json`.
         "targetName": "e2e",
         "ciTargetName": "e2e-ci",
         "componentTestingTargetName": "component-test",
+        "ciComponentTestingTargetName": "component-test-ci",
         "openTargetName": "open-cypress"
       }
     }
@@ -84,7 +85,15 @@ The `@nx/cypress/plugin` is configured in the `plugins` array in `nx.json`.
 }
 ```
 
-The `targetName`, `ciTargetName`, `componentTestingTargetName`, and `open-cypress` options control the names of the inferred Cypress tasks. The default names are `e2e`, `e2e-ci`, `component-test`, and `open-cypress`.
+The options shown above control the names of the inferred Cypress tasks. The following table shows the default values for each option:
+
+| Option                         | Default                                       |
+| ------------------------------ | --------------------------------------------- |
+| `targetName`                   | `"e2e"`                                       |
+| `ciTargetName`                 | `"e2e-ci"`                                    |
+| `componentTestingTargetName`   | `"component-test"`                            |
+| `ciComponentTestingTargetName` | `undefined` (task is not inferred by default) |
+| `openTargetName`               | `"open-cypress"`                              |
 
 ### Splitting E2E tasks by file
 
@@ -115,6 +124,31 @@ export default defineConfig({
 {% callout type="note" title="Using setupNodeEvents function" %}
 If you use the `setupNodeEvents` function in your Cypress configuration, make sure to invoke the same function that is returned by `nxE2EPreset`. See the recipe on [using `setupNodeEvents` with Cypress preset](/technologies/test-tools/cypress/recipes/cypress-setup-node-events) for more details.
 {% /callout %}
+
+### Splitting Component Testing Tasks by File
+
+{% callout type="note" title="Available since Nx 21.6.1" %}
+Splitting component testing tasks by file is available since Nx 21.6.1.
+{% /callout %}
+
+The `@nx/cypress/plugin` can also automatically split your component testing tasks by file. To enable it, set the `ciComponentTestingTargetName` option of the `@nx/cypress/plugin` in your `nx.json` file. It will look something like this:
+
+```json {% fileName="nx.json" highlightLines=[9] %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/cypress/plugin",
+      "options": {
+        "targetName": "e2e",
+        "ciTargetName": "e2e-ci",
+        "componentTestingTargetName": "component-test",
+        "ciComponentTestingTargetName": "component-test-ci",
+        "openTargetName": "open-cypress"
+      }
+    }
+  ]
+}
+```
 
 ## E2E Testing
 

--- a/docs/shared/packages/cypress/cypress-component-testing.md
+++ b/docs/shared/packages/cypress/cypress-component-testing.md
@@ -71,6 +71,42 @@ With, `nx component-test your-lib --watch` Cypress will start in headed mode. Wh
 
 Running Cypress with `--watch` is a great way to iterate on your components since cypress will rerun your tests as you make those changes validating the new behavior.
 
+## Splitting Component Testing Tasks by File
+
+{% callout type="note" title="Available since Nx 21.6.1" %}
+Splitting component testing tasks by file is available since Nx 21.6.1.
+{% /callout %}
+
+Nx provides powerful features for [distributing tasks in CI](/ci/features/distribute-task-execution), including [splitting tasks by file](/ci/features/split-e2e-tasks) (also known as atomization). The `@nx/cypress` plugin facilitates this for Cypress projects, allowing you to run your tests more efficiently in your Continuous Integration (CI) environment.
+
+To enable component testing task splitting, set the `ciComponentTestingTargetName` option of the `@nx/cypress/plugin` in your `nx.json` file. It will look something like this:
+
+```json {% fileName="nx.json" highlightLines=[9] %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/cypress/plugin",
+      "options": {
+        "targetName": "e2e",
+        "ciTargetName": "e2e-ci",
+        "componentTestingTargetName": "component-test",
+        "ciComponentTestingTargetName": "component-test-ci",
+        "openTargetName": "open-cypress"
+      }
+    }
+  ]
+}
+```
+
+The plugin will infer the `component-test-ci` task, which depends on individual component testing tasks for each file. You can then replace the `component-test` task with the `component-test-ci` task in your CI configuration to run your tests in a distributed fashion:
+
+```diff {% fileName=".github/workflows/ci.yaml" %}
+-     - run: pnpm exec nx affected -t lint test build component-test
++     - run: pnpm exec nx affected -t lint test build component-test-ci
+```
+
+You can read more about the Atomizer feature [here](/ci/features/split-e2e-tasks).
+
 ## More Information
 
 You can read more on component testing in the [Cypress documentation](https://docs.cypress.io/guides/component-testing/writing-your-first-component-test).

--- a/docs/shared/packages/cypress/cypress-plugin.md
+++ b/docs/shared/packages/cypress/cypress-plugin.md
@@ -77,6 +77,7 @@ The `@nx/cypress/plugin` is configured in the `plugins` array in `nx.json`.
         "targetName": "e2e",
         "ciTargetName": "e2e-ci",
         "componentTestingTargetName": "component-test",
+        "ciComponentTestingTargetName": "component-test-ci",
         "openTargetName": "open-cypress"
       }
     }
@@ -84,7 +85,15 @@ The `@nx/cypress/plugin` is configured in the `plugins` array in `nx.json`.
 }
 ```
 
-The `targetName`, `ciTargetName`, `componentTestingTargetName`, and `open-cypress` options control the names of the inferred Cypress tasks. The default names are `e2e`, `e2e-ci`, `component-test`, and `open-cypress`.
+The options shown above control the names of the inferred Cypress tasks. The following table shows the default values for each option:
+
+| Option                         | Default                                       |
+| ------------------------------ | --------------------------------------------- |
+| `targetName`                   | `"e2e"`                                       |
+| `ciTargetName`                 | `"e2e-ci"`                                    |
+| `componentTestingTargetName`   | `"component-test"`                            |
+| `ciComponentTestingTargetName` | `undefined` (task is not inferred by default) |
+| `openTargetName`               | `"open-cypress"`                              |
 
 ### Splitting E2E tasks by file
 
@@ -115,6 +124,31 @@ export default defineConfig({
 {% callout type="note" title="Using setupNodeEvents function" %}
 If you use the `setupNodeEvents` function in your Cypress configuration, make sure to invoke the same function that is returned by `nxE2EPreset`. See the recipe on [using `setupNodeEvents` with Cypress preset](/technologies/test-tools/cypress/recipes/cypress-setup-node-events) for more details.
 {% /callout %}
+
+### Splitting Component Testing Tasks by File
+
+{% callout type="note" title="Available since Nx 21.6.1" %}
+Splitting component testing tasks by file is available since Nx 21.6.1.
+{% /callout %}
+
+The `@nx/cypress/plugin` can also automatically split your component testing tasks by file. To enable it, set the `ciComponentTestingTargetName` option of the `@nx/cypress/plugin` in your `nx.json` file. It will look something like this:
+
+```json {% fileName="nx.json" highlightLines=[9] %}
+{
+  "plugins": [
+    {
+      "plugin": "@nx/cypress/plugin",
+      "options": {
+        "targetName": "e2e",
+        "ciTargetName": "e2e-ci",
+        "componentTestingTargetName": "component-test",
+        "ciComponentTestingTargetName": "component-test-ci",
+        "openTargetName": "open-cypress"
+      }
+    }
+  ]
+}
+```
 
 ## E2E Testing
 

--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -885,6 +885,243 @@ describe('@nx/cypress/plugin', () => {
     `);
   });
 
+  it('should infer atomized tasks for component testing when "ciComponentTestingTargetName" is provided', async () => {
+    mockCypressConfig(
+      defineConfig({
+        component: {
+          videosFolder: './dist/videos',
+          screenshotsFolder: './dist/screenshots',
+          devServer: {
+            framework: 'react',
+            bundler: 'webpack',
+          },
+        },
+      })
+    );
+    // add a second test file to see multiple atomized tasks are created
+    await tempFs.createFiles({ 'src/test-2.cy.ts': '' });
+
+    const nodes = await createNodesFunction(
+      ['cypress.config.js'],
+      {
+        componentTestingTargetName: 'component-test',
+        ciComponentTestingTargetName: 'component-test-ci',
+      },
+      context
+    );
+
+    expect(nodes).toMatchInlineSnapshot(`
+      [
+        [
+          "cypress.config.js",
+          {
+            "projects": {
+              ".": {
+                "metadata": {
+                  "targetGroups": {
+                    "Component Testing (CI)": [
+                      "component-test-ci--src/test-2.cy.ts",
+                      "component-test-ci--src/test.cy.ts",
+                      "component-test-ci",
+                    ],
+                  },
+                },
+                "projectType": "application",
+                "targets": {
+                  "component-test": {
+                    "cache": true,
+                    "command": "cypress run --component",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "cypress",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Runs Cypress Component Tests",
+                      "help": {
+                        "command": "npx cypress run --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--headed",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "options": {
+                      "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
+                    },
+                    "outputs": [
+                      "{projectRoot}/dist/videos",
+                      "{projectRoot}/dist/screenshots",
+                    ],
+                  },
+                  "component-test-ci": {
+                    "cache": true,
+                    "dependsOn": [
+                      {
+                        "params": "forward",
+                        "projects": "self",
+                        "target": "component-test-ci--src/test-2.cy.ts",
+                      },
+                      {
+                        "params": "forward",
+                        "projects": "self",
+                        "target": "component-test-ci--src/test.cy.ts",
+                      },
+                    ],
+                    "executor": "nx:noop",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "cypress",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Runs Cypress Component Tests in CI",
+                      "help": {
+                        "command": "npx cypress run --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--headed",
+                          ],
+                        },
+                      },
+                      "nonAtomizedTarget": "component-test",
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "outputs": [
+                      "{projectRoot}/dist/videos",
+                      "{projectRoot}/dist/screenshots",
+                    ],
+                  },
+                  "component-test-ci--src/test-2.cy.ts": {
+                    "cache": true,
+                    "command": "cypress run --component --spec src/test-2.cy.ts --config="{\\"component\\":{\\"videosFolder\\":\\"dist/videos/src-test-2-cy-ts\\",\\"screenshotsFolder\\":\\"dist/screenshots/src-test-2-cy-ts\\"}}"",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "cypress",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Runs Cypress Component Tests for src/test-2.cy.ts in CI",
+                      "help": {
+                        "command": "npx cypress run --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--headed",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "options": {
+                      "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
+                    },
+                    "outputs": [
+                      "{projectRoot}/dist/videos/src-test-2-cy-ts",
+                      "{projectRoot}/dist/screenshots/src-test-2-cy-ts",
+                    ],
+                    "parallelism": false,
+                  },
+                  "component-test-ci--src/test.cy.ts": {
+                    "cache": true,
+                    "command": "cypress run --component --spec src/test.cy.ts --config="{\\"component\\":{\\"videosFolder\\":\\"dist/videos/src-test-cy-ts\\",\\"screenshotsFolder\\":\\"dist/screenshots/src-test-cy-ts\\"}}"",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "cypress",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Runs Cypress Component Tests for src/test.cy.ts in CI",
+                      "help": {
+                        "command": "npx cypress run --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--headed",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "options": {
+                      "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
+                    },
+                    "outputs": [
+                      "{projectRoot}/dist/videos/src-test-cy-ts",
+                      "{projectRoot}/dist/screenshots/src-test-cy-ts",
+                    ],
+                    "parallelism": false,
+                  },
+                  "open-cypress": {
+                    "command": "cypress open",
+                    "metadata": {
+                      "description": "Opens Cypress",
+                      "help": {
+                        "command": "npx cypress open --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--e2e",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "options": {
+                      "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      ]
+    `);
+  });
+
   function mockCypressConfig(cypressConfig: Cypress.ConfigOptions) {
     // This isn't JS, but all that really matters here
     // is that the hash is different after updating the

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -1,38 +1,36 @@
 import {
-  CreateNodes,
-  CreateNodesContext,
+  type CreateNodes,
+  type CreateNodesContext,
   createNodesFromFiles,
-  CreateNodesV2,
+  type CreateNodesV2,
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
   logger,
   normalizePath,
-  NxJsonConfiguration,
-  ProjectConfiguration,
+  type NxJsonConfiguration,
+  type ProjectConfiguration,
   readJsonFile,
-  TargetConfiguration,
+  type TargetConfiguration,
   writeJsonFile,
 } from '@nx/devkit';
-import { dirname, join, relative } from 'path';
-
-import { getLockFileName } from '@nx/js';
-
-import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
-import { existsSync, readdirSync } from 'fs';
-
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
-import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
-import { NX_PLUGIN_OPTIONS } from '../utils/constants';
 import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
+import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
+import { getLockFileName } from '@nx/js';
+import { readdirSync } from 'fs';
 import { hashObject } from 'nx/src/devkit-internals';
+import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { globWithWorkspaceContext } from 'nx/src/utils/workspace-context';
+import { dirname, join, relative } from 'path';
+import { NX_PLUGIN_OPTIONS } from '../utils/constants';
 
 export interface CypressPluginOptions {
   ciTargetName?: string;
   targetName?: string;
   openTargetName?: string;
   componentTestingTargetName?: string;
+  ciComponentTestingTargetName?: string;
 }
 
 function readTargetsCache(cachePath: string): Record<string, CypressTargets> {
@@ -50,6 +48,16 @@ function writeTargetsToCache(cachePath: string, results: CypressTargets) {
 }
 
 const cypressConfigGlob = '**/cypress.config.{js,ts,mjs,cjs}';
+const defaultPatterns = {
+  e2e: {
+    specPattern: 'cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
+    excludeSpecPattern: '*.hot-update.js',
+  },
+  component: {
+    specPattern: '**/*.cy.{js,jsx,ts,tsx}',
+    excludeSpecPattern: ['/snapshots/*', '/image_snapshots/*'],
+  },
+};
 
 const pmc = getPackageManagerCommand();
 
@@ -327,21 +335,13 @@ async function buildCypressTargets(
 
     const ciWebServerCommand: string = pluginPresetOptions?.ciWebServerCommand;
     if (ciWebServerCommand) {
-      const specPatterns = Array.isArray(cypressConfig.e2e.specPattern)
-        ? cypressConfig.e2e.specPattern.map((p) => join(projectRoot, p))
-        : [join(projectRoot, cypressConfig.e2e.specPattern)];
-
-      const excludeSpecPatterns: string[] = !cypressConfig.e2e
-        .excludeSpecPattern
-        ? cypressConfig.e2e.excludeSpecPattern
-        : Array.isArray(cypressConfig.e2e.excludeSpecPattern)
-        ? cypressConfig.e2e.excludeSpecPattern.map((p) => join(projectRoot, p))
-        : [join(projectRoot, cypressConfig.e2e.excludeSpecPattern)];
-      const specFiles = await globWithWorkspaceContext(
-        context.workspaceRoot,
-        specPatterns,
-        excludeSpecPatterns
-      );
+      const { specFiles, specPatterns, excludeSpecPatterns } =
+        await getSpecFilesAndPatternsForTestType(
+          cypressConfig,
+          'e2e',
+          context.workspaceRoot,
+          projectRoot
+        );
 
       const ciBaseUrl = pluginPresetOptions?.ciBaseUrl;
 
@@ -453,6 +453,9 @@ async function buildCypressTargets(
   }
 
   if ('component' in cypressConfig) {
+    const inputs = getInputs(namedInputs);
+    const outputs = getOutputs(projectRoot, cypressConfig, 'component');
+
     // This will not override the e2e target if it is the same
     targets[options.componentTestingTargetName] ??= {
       command: `cypress run --component`,
@@ -461,8 +464,8 @@ async function buildCypressTargets(
         env: { TS_NODE_COMPILER_OPTIONS: tsNodeCompilerOptions },
       },
       cache: true,
-      inputs: getInputs(namedInputs),
-      outputs: getOutputs(projectRoot, cypressConfig, 'component'),
+      inputs,
+      outputs,
       metadata: {
         technologies: ['cypress'],
         description: 'Runs Cypress Component Tests',
@@ -474,6 +477,106 @@ async function buildCypressTargets(
         },
       },
     };
+
+    if (options.ciComponentTestingTargetName) {
+      const { specFiles, specPatterns, excludeSpecPatterns } =
+        await getSpecFilesAndPatternsForTestType(
+          cypressConfig,
+          'component',
+          context.workspaceRoot,
+          projectRoot
+        );
+
+      const dependsOn: TargetConfiguration['dependsOn'] = [];
+      const groupName = 'Component Testing (CI)';
+      metadata ??= {};
+      metadata.targetGroups ??= {};
+      metadata.targetGroups[groupName] ??= [];
+      const ctCiTargetGroup = metadata.targetGroups[groupName];
+
+      for (const file of specFiles) {
+        const relativeSpecFilePath = normalizePath(relative(projectRoot, file));
+
+        if (relativeSpecFilePath.includes('../')) {
+          throw new Error(
+            '@nx/cypress/plugin attempted to run tests outside of the project root. This is not supported and should not happen. Please open an issue at https://github.com/nrwl/nx/issues/new/choose with the following information:\n\n' +
+              `\n\n${JSON.stringify(
+                {
+                  projectRoot,
+                  relativeSpecFilePath,
+                  specFiles,
+                  context,
+                  excludeSpecPatterns,
+                  specPatterns,
+                },
+                null,
+                2
+              )}`
+          );
+        }
+
+        const targetName =
+          options.ciComponentTestingTargetName + '--' + relativeSpecFilePath;
+        const outputSubfolder = relativeSpecFilePath
+          .replace(/[\/\\]/g, '-')
+          .replace(/\./g, '-');
+
+        ctCiTargetGroup.push(targetName);
+        targets[targetName] = {
+          outputs: getTargetOutputs(outputs, outputSubfolder),
+          inputs,
+          cache: true,
+          command: `cypress run --component --spec ${relativeSpecFilePath} --config=${getTargetConfig(
+            cypressConfig,
+            outputSubfolder
+          )}`,
+          options: {
+            cwd: projectRoot,
+            env: { TS_NODE_COMPILER_OPTIONS: tsNodeCompilerOptions },
+          },
+          // Cypress handles starting the server, there's no separate server
+          // target we can use as continuous, so we need to disable parallelism
+          // to avoid port conflicts
+          parallelism: false,
+          metadata: {
+            technologies: ['cypress'],
+            description: `Runs Cypress Component Tests for ${relativeSpecFilePath} in CI`,
+            help: {
+              command: `${pmc.exec} cypress run --help`,
+              example: {
+                args: ['--dev', '--headed'],
+              },
+            },
+          },
+        };
+        dependsOn.push({
+          target: targetName,
+          projects: 'self',
+          params: 'forward',
+        });
+      }
+
+      targets[options.ciComponentTestingTargetName] = {
+        executor: 'nx:noop',
+        cache: true,
+        inputs,
+        outputs,
+        dependsOn,
+        metadata: {
+          technologies: ['cypress'],
+          description: 'Runs Cypress Component Tests in CI',
+          nonAtomizedTarget: options.componentTestingTargetName,
+          help: {
+            command: `${pmc.exec} cypress run --help`,
+            example: {
+              args: ['--dev', '--headed'],
+            },
+          },
+        },
+      };
+
+      ctCiTargetGroup.push(options.ciComponentTestingTargetName);
+    }
   }
 
   targets[options.openTargetName] = {
@@ -503,6 +606,8 @@ function normalizeOptions(options: CypressPluginOptions): CypressPluginOptions {
   options.openTargetName ??= 'open-cypress';
   options.componentTestingTargetName ??= 'component-test';
   options.ciTargetName ??= 'e2e-ci';
+  // must be explicitly provided to opt-in to atomized component testing
+  options.ciComponentTestingTargetName;
   return options;
 }
 
@@ -541,4 +646,36 @@ function parseTaskFromCommand(command: string): {
   }
 
   return null;
+}
+
+async function getSpecFilesAndPatternsForTestType(
+  cypressConfig: any,
+  testType: 'e2e' | 'component',
+  workspaceRoot: string,
+  projectRoot: string
+): Promise<{
+  specFiles: string[];
+  specPatterns: string[];
+  excludeSpecPatterns: string[];
+}> {
+  const specPattern =
+    cypressConfig[testType].specPattern ??
+    defaultPatterns[testType].specPattern;
+  const specPatterns = Array.isArray(specPattern)
+    ? specPattern.map((p) => join(projectRoot, p))
+    : [join(projectRoot, specPattern)];
+
+  const excludeSpecPattern =
+    cypressConfig[testType].excludeSpecPattern ??
+    defaultPatterns[testType].excludeSpecPattern;
+  const excludeSpecPatterns: string[] = Array.isArray(excludeSpecPattern)
+    ? excludeSpecPattern.map((p) => join(projectRoot, p))
+    : [join(projectRoot, excludeSpecPattern)];
+  const specFiles = await globWithWorkspaceContext(
+    workspaceRoot,
+    specPatterns,
+    excludeSpecPatterns
+  );
+
+  return { specFiles, specPatterns, excludeSpecPatterns };
 }


### PR DESCRIPTION
## Current Behavior

There's no way to distribute Cypress Component Tests.

## Expected Behavior

Cypress Component Tests can be distributed.

Users can choose to infer individual tasks per Cypress Component Test files that can be distributed across Nx Agents using DTE, by setting the `ciComponentTestingTargetName` option for the `@nx/cypress/plugin`:

```json
// nx.json
{
  ...
  "plugins": [
    {
      "plugin": "@nx/cypress/plugin",
      "options": {
        ...
        "componentTestingTargetName": "component-test",
        "ciComponentTestingTargetName": "component-test-ci"
      }
    },
    ...
  ]
}
```