### PR TITLE
chore(repo): fix slack notifcation to use mention_users

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -450,7 +450,7 @@ jobs:
           notification_title: '📦 Publish Pending Review'
           message_format: ${{ format('Version `{0}` is being published to NPM - manual review is required', needs.resolve-required-data.outputs.version) }}
           footer: '<{run_url}|View Workflow Run>'
-          mention_groups: 'U9NPA6C90' # Jason
+          mention_users: 'U9NPA6C90' # Jason
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 


### PR DESCRIPTION
It was incorrectly using `mention_groups` but should be `mention_users`.