### PR TITLE
docs(misc): add API docs for nx, workspace, web, plugin

### DIFF
--- a/astro-docs/src/content/docs/reference/Deprecated/affected-graph.mdoc
+++ b/astro-docs/src/content/docs/reference/Deprecated/affected-graph.mdoc
@@ -1,6 +1,8 @@
 ---
 title: 'affected:graph - CLI command'
 description: 'Graph dependencies affected by changes'
+sidebar:
+  hidden: true
 ---
 
 

--- a/astro-docs/src/content/docs/reference/Deprecated/angular-schematics-builders.mdoc
+++ b/astro-docs/src/content/docs/reference/Deprecated/angular-schematics-builders.mdoc
@@ -1,6 +1,8 @@
 ---
 title: 'Angular Schematics and Builders'
 description: 'Learn about the deprecation of Angular schematics and builders in Nx 17, and how to handle interoperability between Nx and Angular CLI tools.'
+sidebar:
+  hidden: true
 ---
 
 

--- a/astro-docs/src/content/docs/reference/Deprecated/as-provided-vs-derived.mdoc
+++ b/astro-docs/src/content/docs/reference/Deprecated/as-provided-vs-derived.mdoc
@@ -1,6 +1,8 @@
 ---
 title: 'As Provided vs. Derived Generator Path Options'
 description: 'Learn about the transition from derived to as-provided path options in Nx generators, improving transparency and predictability in code generation.'
+sidebar:
+  hidden: true
 ---
 
 

--- a/astro-docs/src/content/docs/reference/Deprecated/cacheable-operations.mdoc
+++ b/astro-docs/src/content/docs/reference/Deprecated/cacheable-operations.mdoc
@@ -1,6 +1,8 @@
 ---
 title: 'Cacheable Operations'
 description: 'Learn about the transition from cacheableOperations array to the cache property in Nx 17 for defining which tasks are cacheable.'
+sidebar:
+  hidden: true
 ---
 
 

--- a/astro-docs/src/content/docs/reference/Deprecated/custom-tasks-runner.mdoc
+++ b/astro-docs/src/content/docs/reference/Deprecated/custom-tasks-runner.mdoc
@@ -1,6 +1,8 @@
 ---
 title: 'Deprecating Custom Tasks Runner'
 description: 'Learn about the transition from Custom Tasks Runner to the new plugin-based API in Nx, including pre and post task execution hooks and self-hosted remote cache options.'
+sidebar:
+  hidden: true
 ---
 
 

--- a/astro-docs/src/content/docs/reference/Deprecated/global-implicit-dependencies.mdoc
+++ b/astro-docs/src/content/docs/reference/Deprecated/global-implicit-dependencies.mdoc
@@ -1,6 +1,8 @@
 ---
 title: 'Global Implicit Dependencies'
 description: 'Learn about the transition from global implicit dependencies to inputs and namedInputs in Nx, and how to properly configure project dependencies on global files.'
+sidebar:
+  hidden: true
 ---
 
 

--- a/astro-docs/src/content/docs/reference/Deprecated/integrated-vs-package-based.mdoc
+++ b/astro-docs/src/content/docs/reference/Deprecated/integrated-vs-package-based.mdoc
@@ -1,6 +1,8 @@
 ---
 title: 'Integrated Repos vs. Package-Based Repos vs. Standalone Apps'
 description: 'Understand the historical differences between integrated, package-based, and standalone repositories in Nx, and how to choose the right approach for your needs.'
+sidebar:
+  hidden: true
 ---
 
 {% aside type="note" title="" %}

--- a/astro-docs/src/content/docs/reference/Deprecated/legacy-cache.mdoc
+++ b/astro-docs/src/content/docs/reference/Deprecated/legacy-cache.mdoc
@@ -1,6 +1,8 @@
 ---
 title: 'Legacy Cache'
 description: 'Learn about the transition from legacy file system cache to the new database cache in Nx 21, including migration options for custom task runners and shared caches.'
+sidebar:
+  hidden: true
 ---
 
 

--- a/astro-docs/src/content/docs/reference/Deprecated/npm-scope.mdoc
+++ b/astro-docs/src/content/docs/reference/Deprecated/npm-scope.mdoc
@@ -1,6 +1,8 @@
 ---
 title: 'NPM Scope'
 description: 'Learn about the deprecation of npmScope property in nx.json and how to properly configure organization prefixes using package.json name property.'
+sidebar:
+  hidden: true
 ---
 
 

--- a/astro-docs/src/content/docs/reference/Deprecated/print-affected.mdoc
+++ b/astro-docs/src/content/docs/reference/Deprecated/print-affected.mdoc
@@ -1,6 +1,8 @@
 ---
 title: 'print-affected - CLI command'
 description: 'Prints information about the projects and targets affected by changes'
+sidebar:
+  hidden: true
 ---
 
 

--- a/astro-docs/src/content/docs/reference/Deprecated/rescope.mdoc
+++ b/astro-docs/src/content/docs/reference/Deprecated/rescope.mdoc
@@ -1,6 +1,8 @@
 ---
 title: 'Rescoping Packages from @nrwl to @nx'
 description: 'Learn about the transition of official Nx plugins from @nrwl to @nx npm scope, and how to update your dependencies accordingly.'
+sidebar:
+  hidden: true
 ---
 
 

--- a/astro-docs/src/content/docs/reference/Deprecated/runtime-cache-inputs.mdoc
+++ b/astro-docs/src/content/docs/reference/Deprecated/runtime-cache-inputs.mdoc
@@ -1,6 +1,8 @@
 ---
 title: 'Runtime Cache Inputs'
 description: 'Learn about the transition from runtimeCacheInputs in tasksRunnerOptions to the new inputs and namedInputs configuration for runtime cache inputs.'
+sidebar:
+  hidden: true
 ---
 
 

--- a/astro-docs/src/content/docs/reference/Deprecated/v1-nx-plugin-api.mdoc
+++ b/astro-docs/src/content/docs/reference/Deprecated/v1-nx-plugin-api.mdoc
@@ -1,6 +1,8 @@
 ---
 title: 'Extending the Project Graph (v1 API)'
 description: 'Learn about the deprecated v1 API for extending the Nx project graph through project inference and project graph plugins.'
+sidebar:
+  hidden: true
 ---
 
 

--- a/astro-docs/src/content/docs/reference/Deprecated/workspace-executors.mdoc
+++ b/astro-docs/src/content/docs/reference/Deprecated/workspace-executors.mdoc
@@ -1,6 +1,8 @@
 ---
 title: 'Workspace Executors'
 description: 'Learn how to migrate from workspace executors to local executors in Nx plugins for better build process management.'
+sidebar:
+  hidden: true
 ---
 
 

--- a/astro-docs/src/content/docs/reference/Deprecated/workspace-generators.mdoc
+++ b/astro-docs/src/content/docs/reference/Deprecated/workspace-generators.mdoc
@@ -1,6 +1,8 @@
 ---
 title: 'Workspace Generators'
 description: 'Learn how to migrate from workspace generators to local generators in Nx plugins for better code generation management.'
+sidebar:
+  hidden: true
 ---
 
 

--- a/astro-docs/src/content/docs/reference/Deprecated/workspace-json.mdoc
+++ b/astro-docs/src/content/docs/reference/Deprecated/workspace-json.mdoc
@@ -1,6 +1,8 @@
 ---
 title: 'workspace.json'
 description: 'Learn about the deprecation of workspace.json in Nx and how to migrate to project.json files for better project configuration management.'
+sidebar:
+  hidden: true
 ---
 
 

--- a/astro-docs/src/content/docs/reference/nodejs-typescript-compatibility.mdoc
+++ b/astro-docs/src/content/docs/reference/nodejs-typescript-compatibility.mdoc
@@ -1,0 +1,35 @@
+---
+title: Node.js and TypeScript Compatibility
+description: A reference outlining Nx's support policy and current compatibility matrix for Node.js and TypeScript.
+---
+
+## Node.js Compatibility Matrix
+
+Below is a reference table that matches the most recent major versions of Nx to the versions of Node.js that they officially support, and are tested against.
+
+Nx's policy is to support the LTS versions (i.e. actively maintained even numbered versions) of Node.js, but we will only remove support for older versions in a major version of Nx to avoid unexpected disruption. We may add support for newer LTS versions in a minor version of Nx as long as it would not break existing projects.
+
+> _Note: Other versions of Node.js **may** still work without issue for these versions of Nx. Those include versions which are already EOL, or odd version numbers (e.g. 23), which Node.js actively
+> discourages using in production._
+
+| Nx Version      | Node Version             |
+| --------------- | ------------------------ |
+| 21.x (current)  | 24.x, ^22.12.0, ^20.19.0 |
+| 20.x (previous) | 22.x, 20.x, 18.x         |
+| 19.x            | 22.x, 20.x, 18.x         |
+| 18.x            | 20.x, 18.x               |
+
+We intentionally do not include an `"engines"` field in the `package.json` file for Nx in order to allow for user flexibility, but this page should be considered the official compatibility matrix.
+
+## TypeScript Compatibility
+
+Unlike Node.js, TypeScript's policy is not to follow semver conventions around breaking changes only coming in major versions, despite using version numbers that are semver-like. Just like with Node.js, though, we will only remove support for older versions of TypeScript in a major version of Nx to avoid unexpected disruption. We may add support for newer versions in a minor version of Nx as long as it would not break existing projects.
+
+| Nx Version      | TypeScript Version |
+| --------------- | ------------------ |
+| 21.x (current)  | >= 5.4.2 < 5.9.0   |
+| 20.x (previous) | ~5.4.2             |
+| 19.x            | ~5.4.2             |
+| 18.x            | ~5.4.2             |
+
+This page will be updated from time to time to reflect the latest versions of Node.js and TypeScript that are supported. If you encounter issues with Nx, please make sure you are using a supported version of Node.js and TypeScript before filing an issue.

--- a/astro-docs/src/pages/reference/nx/[...slug].astro
+++ b/astro-docs/src/pages/reference/nx/[...slug].astro
@@ -1,0 +1,43 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import { getCollection, render } from 'astro:content';
+
+export async function getStaticPaths() {
+  const pluginDocs = await getCollection(
+    'nx-reference-packages',
+    (entry) => entry.data.packageType ==='nx'
+  );
+
+  const paths = pluginDocs.map((doc) => {
+    return {
+      params: {
+        slug: doc.data.slug.split('reference/nx')[1],
+      },
+      props: {
+        doc,
+      }
+    };
+  });
+
+  return paths;
+}
+
+const { doc } = Astro.props;
+const { Content, headings } = await render(doc);
+const pluginName = doc.data.packageType;
+const docType = doc.data.docType;
+
+
+// Capitalize the doc type for display
+const docTypeDisplay = docType.charAt(0).toUpperCase() + docType.slice(1);
+---
+
+<StarlightPage
+  frontmatter={{
+    title: doc.data.title,
+    description: doc.data.description,
+  }}
+  headings={headings || []}
+>
+  <Content />
+</StarlightPage>

--- a/astro-docs/src/pages/reference/nx/index.astro
+++ b/astro-docs/src/pages/reference/nx/index.astro
@@ -1,0 +1,30 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+import { getEntry } from 'astro:content';
+
+const doc = await getEntry('nx-reference-packages', 'nx-overview')!;
+---
+
+<StarlightPage
+  frontmatter={{
+    title: doc.data.title,
+    description:doc.data.description,
+    tableOfContents: false
+  }}
+  headings={[]}
+>
+  <p>{doc.data.description}</p>
+  {doc.data.features!.length === 0 ? (
+    <p class="mt-4">No features available.</p>
+  ) : (
+  <CardGrid>
+    {doc.data.features!.map((feature) => (
+      <LinkCard
+        href={`/docs/reference/${doc.data.packageType}/${feature}`}
+        title={feature}
+      />
+    ))}
+  </CardGrid>
+  )}
+</StarlightPage>

--- a/astro-docs/src/pages/reference/plugin/[...slug].astro
+++ b/astro-docs/src/pages/reference/plugin/[...slug].astro
@@ -1,0 +1,43 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import { getCollection, render } from 'astro:content';
+
+export async function getStaticPaths() {
+  const pluginDocs = await getCollection(
+    'nx-reference-packages',
+    (entry) => entry.data.packageType ==='plugin'
+  );
+
+  const paths = pluginDocs.map((doc) => {
+    return {
+      params: {
+        slug: doc.data.slug.split('reference/plugin')[1],
+      },
+      props: {
+        doc,
+      }
+    };
+  });
+
+  return paths;
+}
+
+const { doc } = Astro.props;
+const { Content, headings } = await render(doc);
+const pluginName = doc.data.packageType;
+const docType = doc.data.docType;
+
+
+// Capitalize the doc type for display
+const docTypeDisplay = docType.charAt(0).toUpperCase() + docType.slice(1);
+---
+
+<StarlightPage
+  frontmatter={{
+    title: doc.data.title,
+    description: doc.data.description,
+  }}
+  headings={headings || []}
+>
+  <Content />
+</StarlightPage>

--- a/astro-docs/src/pages/reference/plugin/index.astro
+++ b/astro-docs/src/pages/reference/plugin/index.astro
@@ -1,0 +1,30 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+import { getEntry } from 'astro:content';
+
+const doc = await getEntry('nx-reference-packages', 'plugin-overview')!;
+---
+
+<StarlightPage
+  frontmatter={{
+    title: doc.data.title,
+    description:doc.data.description,
+    tableOfContents: false
+  }}
+  headings={[]}
+>
+  <p>{doc.data.description}</p>
+  {doc.data.features!.length === 0 ? (
+    <p class="mt-4">No features available.</p>
+  ) : (
+  <CardGrid>
+    {doc.data.features!.map((feature) => (
+      <LinkCard
+        href={`/docs/reference/${doc.data.packageType}/${feature}`}
+        title={feature}
+      />
+    ))}
+  </CardGrid>
+  )}
+</StarlightPage>

--- a/astro-docs/src/pages/reference/web/[...slug].astro
+++ b/astro-docs/src/pages/reference/web/[...slug].astro
@@ -1,0 +1,43 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import { getCollection, render } from 'astro:content';
+
+export async function getStaticPaths() {
+  const pluginDocs = await getCollection(
+    'nx-reference-packages',
+    (entry) => entry.data.packageType ==='web'
+  );
+
+  const paths = pluginDocs.map((doc) => {
+    return {
+      params: {
+        slug: doc.data.slug.split('reference/web')[1],
+      },
+      props: {
+        doc,
+      }
+    };
+  });
+
+  return paths;
+}
+
+const { doc } = Astro.props;
+const { Content, headings } = await render(doc);
+const pluginName = doc.data.packageType;
+const docType = doc.data.docType;
+
+
+// Capitalize the doc type for display
+const docTypeDisplay = docType.charAt(0).toUpperCase() + docType.slice(1);
+---
+
+<StarlightPage
+  frontmatter={{
+    title: doc.data.title,
+    description: doc.data.description,
+  }}
+  headings={headings || []}
+>
+  <Content />
+</StarlightPage>

--- a/astro-docs/src/pages/reference/web/index.astro
+++ b/astro-docs/src/pages/reference/web/index.astro
@@ -1,0 +1,30 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+import { getEntry } from 'astro:content';
+
+const doc = await getEntry('nx-reference-packages', 'web-overview')!;
+---
+
+<StarlightPage
+  frontmatter={{
+    title: doc.data.title,
+    description:doc.data.description,
+    tableOfContents: false
+  }}
+  headings={[]}
+>
+  <p>{doc.data.description}</p>
+  {doc.data.features!.length === 0 ? (
+    <p class="mt-4">No features available.</p>
+  ) : (
+  <CardGrid>
+    {doc.data.features!.map((feature) => (
+      <LinkCard
+        href={`/docs/reference/${doc.data.packageType}/${feature}`}
+        title={feature}
+      />
+    ))}
+  </CardGrid>
+  )}
+</StarlightPage>

--- a/astro-docs/src/pages/reference/workspace/[...slug].astro
+++ b/astro-docs/src/pages/reference/workspace/[...slug].astro
@@ -1,0 +1,43 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import { getCollection, render } from 'astro:content';
+
+export async function getStaticPaths() {
+  const pluginDocs = await getCollection(
+    'nx-reference-packages',
+    (entry) => entry.data.packageType ==='workspace'
+  );
+
+  const paths = pluginDocs.map((doc) => {
+    return {
+      params: {
+        slug: doc.data.slug.split('reference/workspace')[1],
+      },
+      props: {
+        doc,
+      }
+    };
+  });
+
+  return paths;
+}
+
+const { doc } = Astro.props;
+const { Content, headings } = await render(doc);
+const pluginName = doc.data.packageType;
+const docType = doc.data.docType;
+
+
+// Capitalize the doc type for display
+const docTypeDisplay = docType.charAt(0).toUpperCase() + docType.slice(1);
+---
+
+<StarlightPage
+  frontmatter={{
+    title: doc.data.title,
+    description: doc.data.description,
+  }}
+  headings={headings || []}
+>
+  <Content />
+</StarlightPage>

--- a/astro-docs/src/pages/reference/workspace/index.astro
+++ b/astro-docs/src/pages/reference/workspace/index.astro
@@ -1,0 +1,30 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+import { getEntry } from 'astro:content';
+
+const doc = await getEntry('nx-reference-packages', 'workspace-overview')!;
+---
+
+<StarlightPage
+  frontmatter={{
+    title: doc.data.title,
+    description:doc.data.description,
+    tableOfContents: false
+  }}
+  headings={[]}
+>
+  <p>{doc.data.description}</p>
+  {doc.data.features!.length === 0 ? (
+    <p class="mt-4">No features available.</p>
+  ) : (
+  <CardGrid>
+    {doc.data.features!.map((feature) => (
+      <LinkCard
+        href={`/docs/reference/${doc.data.packageType}/${feature}`}
+        title={feature}
+      />
+    ))}
+  </CardGrid>
+  )}
+</StarlightPage>

--- a/astro-docs/src/plugins/sidebar-reference-updater.middleware.ts
+++ b/astro-docs/src/plugins/sidebar-reference-updater.middleware.ts
@@ -35,13 +35,36 @@ export const onRequest = defineRouteMiddleware(async (context) => {
   }
 
   const devkitSection = await getDevKitSection(context.locals.starlightRoute);
+  const nxSection = await getNxPackageSection(
+    'nx',
+    context.locals.starlightRoute
+  );
+  const webSection = await getNxPackageSection(
+    'web',
+    context.locals.starlightRoute
+  );
+  const workspaceSection = await getNxPackageSection(
+    'workspace',
+    context.locals.starlightRoute
+  );
+  const pluginSection = await getNxPackageSection(
+    'plugin',
+    context.locals.starlightRoute
+  );
 
   const commandSection = await getCommandsSection(
     context.locals.starlightRoute
   );
 
   // Apply sorting to reference entries
-  const newEntries = [...commandSection, devkitSection];
+  const newEntries = [
+    ...commandSection,
+    nxSection,
+    devkitSection,
+    webSection,
+    workspaceSection,
+    pluginSection,
+  ] as Array<SidebarGroup | SidebarLink>;
   refSection.entries = sortReferenceEntries(
     refSection.entries as (SidebarGroup | SidebarLink)[],
     newEntries,
@@ -123,6 +146,77 @@ async function getDevKitSection({ entry }: StarlightRouteData) {
   return devkitSection;
 }
 
+async function getNxPackageSection(
+  packageName: 'nx' | 'web' | 'workspace' | 'plugin',
+  { entry }: StarlightRouteData
+) {
+  const docTypes = ['overview', 'generators', 'executors', 'migrations'];
+  const docIds = docTypes.map((type) => `${packageName}-${type}`);
+
+  const docs = await getEntries<'nx-reference-packages'>(
+    docIds.map((id) => ({ collection: 'nx-reference-packages' as const, id }))
+  );
+
+  const overviewDoc = docs.find((d) => d?.id === `${packageName}-overview`);
+  if (!overviewDoc) {
+    const label =
+      packageName === 'nx'
+        ? 'Nx'
+        : packageName.charAt(0).toUpperCase() + packageName.slice(1);
+    return {
+      type: 'group',
+      label,
+      entries: [],
+      collapsed: true,
+      badge: undefined,
+    };
+  }
+
+  const packageOverview: SidebarLink = {
+    type: 'link',
+    label: 'Overview',
+    href: `/docs/reference/${packageName}`,
+    badge: undefined,
+    isCurrent: entry.slug === `reference/${packageName}`,
+    attrs: {},
+  };
+
+  const packageRoutes = docs
+    .filter((d) => {
+      // Skip if it's the overview doc
+      if (d?.id === `${packageName}-overview`) return false;
+      // Skip if data or slug is missing
+      if (!d?.data?.slug) return false;
+      // Ensure slug is a string and not undefined
+      if (typeof d.data.slug !== 'string') return false;
+      return true;
+    })
+    .map(
+      (record): SidebarLink => ({
+        type: 'link',
+        label: record.data.title || 'Untitled',
+        href: `/docs/${record.data.slug}`,
+        badge: undefined,
+        isCurrent: entry.slug === record.data.slug,
+        attrs: {},
+      })
+    );
+
+  const label =
+    packageName === 'nx'
+      ? 'Nx'
+      : packageName.charAt(0).toUpperCase() + packageName.slice(1);
+  const packageSection: SidebarGroup = {
+    type: 'group',
+    label,
+    entries: [packageOverview, ...packageRoutes],
+    collapsed: !entry.slug.startsWith(`reference/${packageName}`),
+    badge: undefined,
+  };
+
+  return packageSection;
+}
+
 async function getCommandsSection({ entry }: StarlightRouteData) {
   const docs = await getEntries<'nx-reference-packages'>([
     { collection: 'nx-reference-packages', id: 'nx-cli' },
@@ -184,5 +278,13 @@ function sortReferenceEntries(
 const desiredSectionOrder = [
   'Nx Commands', // auto generated
   'Cloud Commands', // mdoc file
+  'Nx configuration',
+  'Project Configuration',
+  'Inputs and Named Inputs',
+  '.nxignore',
+  'Environment Variables',
+  'Glossary',
+  'Releases',
+  'Node.js and TypeScript Compatibility',
   'create-nx-workspace', // auto generated
 ];

--- a/nx-dev/nx-dev/redirect-rules-docs-to-astro.js
+++ b/nx-dev/nx-dev/redirect-rules-docs-to-astro.js
@@ -115,7 +115,7 @@ const docsToAstroRedirects = {
     '/docs/concepts/decisions/project-dependency-rules',
   '/concepts/decisions/folder-structure':
     '/docs/concepts/decisions/folder-structure',
-  '/concepts/nx-daemon': '/docs/concepts', // TODO: missing
+  '/concepts/nx-daemon': '/docs/concepts/nx-daemon',
 
   // ========== EXTENDING-NX ==========
   '/extending-nx': '/docs/extending-nx',
@@ -385,10 +385,10 @@ const docsToAstroRedirects = {
   '/reference/core-api/shared-fs-cache/generators':
     '/docs/reference/remote-cache-plugins/shared-fs-cache/generators',
   '/reference/core-api': '/docs/reference',
-  '/reference/core-api/nx': '/docs/reference', // TODO: missing
-  '/reference/core-api/workspace': '/docs/reference', // TODO: missing
-  '/reference/core-api/plugin': '/docs/reference', // TODO: missing
-  '/reference/core-api/web': '/docs/reference', // TODO: missing
+  '/reference/core-api/nx': '/reference/nx',
+  '/reference/core-api/workspace': '/reference/workspace',
+  '/reference/core-api/plugin': '/reference/plugin',
+  '/reference/core-api/web': '/reference/web',
   '/reference/core-api/create-nx-workspace':
     '/docs/reference/create-nx-workspace',
   '/reference/core-api/devkit/documents': '/docs/reference/devkit',
@@ -686,9 +686,9 @@ const docsToAstroRedirects = {
     '/docs/reference/devkit/writeJson',
   '/reference/core-api/devkit/documents/writeJsonFile':
     '/docs/reference/devkit/writeJsonFile',
-  '/reference/core-api/devkit/executors': '/docs/reference/devkit', // TODO: missing (but this was an empty page anyway
-  '/reference/core-api/devkit/generators': '/docs/reference/devkit', // TODO: missing (but this was an empty page anyway
-  '/reference/core-api/devkit/migrations': '/docs/reference/devkit', // TODO: missing (but this was an empty page anyway
+  '/reference/core-api/devkit/executors': '/docs/reference/devkit', // missing (but this was an empty page anyway
+  '/reference/core-api/devkit/generators': '/docs/reference/devkit', // missing (but this was an empty page anyway
+  '/reference/core-api/devkit/migrations': '/docs/reference/devkit', // missing (but this was an empty page anyway
   '/reference/core-api/nx/documents': '/docs/reference/nx-commands', // these were just list of CLI commands
   '/reference/core-api/nx/documents/create-nx-workspace':
     'https://canary.nx.dev/docs/reference/create-nx-workspace',
@@ -724,50 +724,69 @@ const docsToAstroRedirects = {
   '/reference/core-api/nx/documents/record': '/docs/reference/nx-commands',
   '/reference/core-api/nx/documents/start-ci-run':
     '/docs/reference/nx-commands',
-  '/reference/core-api/nx/executors': '/docs/reference', // TODO: missing
-  '/reference/core-api/nx/executors/noop': '/docs/reference', // TODO: missing
-  '/reference/core-api/nx/executors/run-commands': '/docs/reference', // TODO: missing
-  '/reference/core-api/nx/executors/run-script': '/docs/reference', // TODO: missing
-  '/reference/core-api/nx/generators': '/docs/reference/benchmarks/caching', // TODO: missing
-  '/reference/core-api/nx/generators/connect-to-nx-cloud': '/docs/reference', // TODO: missing
-  '/reference/core-api/nx/migrations': '/docs/reference', // TODO: missing
-  '/reference/core-api/plugin/executors': '/docs/reference', // TODO: missing
-  '/reference/core-api/plugin/generators': '/docs/reference', // TODO: missing
-  '/reference/core-api/plugin/generators/plugin': '/docs/reference', // TODO: missing
-  '/reference/core-api/plugin/generators/create-package': '/docs/reference', // TODO: missing
-  '/reference/core-api/plugin/generators/e2e-project': '/docs/reference', // TODO: missing
-  '/reference/core-api/plugin/generators/migration': '/docs/reference', // TODO: missing
-  '/reference/core-api/plugin/generators/generator': '/docs/reference', // TODO: missing
-  '/reference/core-api/plugin/generators/executor': '/docs/reference', // TODO: missing
-  '/reference/core-api/plugin/generators/plugin-lint-checks': '/docs/reference', // TODO: missing
-  '/reference/core-api/plugin/generators/preset': '/docs/reference', // TODO: missing
-  '/reference/core-api/plugin/migrations': '/docs/reference', // TODO: missing
-  '/reference/core-api/web/executors': '/docs/reference', // TODO: missing
-  '/reference/core-api/web/executors/file-server': '/docs/reference', // TODO: missing
-  '/reference/core-api/web/generators': '/docs/reference', // TODO: missing
-  '/reference/core-api/web/generators/init': '/docs/reference', // TODO: missing
-  '/reference/core-api/web/generators/application': '/docs/reference', // TODO: missing
-  '/reference/core-api/web/generators/static-config': '/docs/reference', // TODO: missing
-  '/reference/core-api/web/migrations': '/docs/reference', // TODO: missing
-  '/reference/core-api/workspace/documents': '/docs/reference', // TODO: missing
+  '/reference/core-api/nx/executors': '/reference/nx/executors',
+  '/reference/core-api/nx/executors/noop': '/reference/nx/executors',
+  '/reference/core-api/nx/executors/run-commands': '/reference/nx/executors',
+  '/reference/core-api/nx/executors/run-script': '/reference/nx/executors',
+  '/reference/core-api/nx/generators': '/reference/nx/generators',
+  '/reference/core-api/nx/generators/connect-to-nx-cloud':
+    '/reference/nx/generators',
+  '/reference/core-api/nx/migrations': '/reference/nx/migrations',
+  '/reference/core-api/plugin/executors': '/reference/plugin/executors',
+  '/reference/core-api/plugin/generators': '/reference/plugin/generators',
+  '/reference/core-api/plugin/generators/plugin':
+    '/reference/plugin/generators',
+  '/reference/core-api/plugin/generators/create-package':
+    '/reference/plugin/generators',
+  '/reference/core-api/plugin/generators/e2e-project':
+    '/reference/plugin/generators',
+  '/reference/core-api/plugin/generators/migration':
+    '/reference/plugin/generators',
+  '/reference/core-api/plugin/generators/generator':
+    '/reference/plugin/generators',
+  '/reference/core-api/plugin/generators/executor':
+    '/reference/plugin/generators',
+  '/reference/core-api/plugin/generators/plugin-lint-checks':
+    '/reference/plugin/generators',
+  '/reference/core-api/plugin/generators/preset':
+    '/reference/plugin/generators',
+  '/reference/core-api/plugin/migrations': '/reference/plugin/migrations',
+  '/reference/core-api/web/executors': '/reference/web/executors',
+  '/reference/core-api/web/executors/file-server': '/reference/web/executors',
+  '/reference/core-api/web/generators': '/reference/web/generators',
+  '/reference/core-api/web/generators/init': '/reference/web/generators',
+  '/reference/core-api/web/generators/application': '/reference/web/generators',
+  '/reference/core-api/web/generators/static-config':
+    '/reference/web/generators',
+  '/reference/core-api/web/migrations': '/reference/web/migrations',
+  '/reference/core-api/workspace/documents': '/reference/workspace',
   '/reference/core-api/workspace/documents/nx-nodejs-typescript-version-matrix':
-    '/docs/reference', // TODO: missing
-  '/reference/core-api/workspace/executors': '/docs/reference', // TODO: missing
-  '/reference/core-api/workspace/executors/counter': '/docs/reference', // TODO: missing
-  '/reference/core-api/workspace/generators': '/docs/reference', // TODO: missing
-  '/reference/core-api/workspace/generators/preset': '/docs/reference', // TODO: missing
-  '/reference/core-api/workspace/generators/move': '/docs/reference', // TODO: missing
-  '/reference/core-api/workspace/generators/remove': '/docs/reference', // TODO: missing
+    '/docs/reference/nodejs-typescript-compatibility',
+  '/reference/core-api/workspace/executors': '/reference/workspace/executors',
+  '/reference/core-api/workspace/executors/counter':
+    '/reference/workspace/executors',
+  '/reference/core-api/workspace/generators': '/reference/workspace/generators',
+  '/reference/core-api/workspace/generators/preset':
+    '/reference/workspace/generators',
+  '/reference/core-api/workspace/generators/move':
+    '/reference/workspace/generators',
+  '/reference/core-api/workspace/generators/remove':
+    '/reference/workspace/generators',
   '/reference/core-api/workspace/generators/convert-to-monorepo':
-    '/docs/reference', // TODO: missing
-  '/reference/core-api/workspace/generators/new': '/docs/reference', // TODO: missing
-  '/reference/core-api/workspace/generators/run-commands': '/docs/reference', // TODO: missing
+    '/reference/workspace/generators',
+  '/reference/core-api/workspace/generators/new':
+    '/reference/workspace/generators',
+  '/reference/core-api/workspace/generators/run-commands':
+    '/reference/workspace/generators',
   '/reference/core-api/workspace/generators/fix-configuration':
-    '/docs/reference', // TODO: missing
-  '/reference/core-api/workspace/generators/npm-package': '/docs/reference', // TODO: missing
-  '/reference/core-api/workspace/generators/ci-workflow': '/docs/reference', // TODO: missing
-  '/reference/core-api/workspace/generators/infer-targets': '/docs/reference', // TODO: missing
-  '/reference/core-api/workspace/migrations': '/docs/reference', // TODO: missing
+    '/reference/workspace/generators',
+  '/reference/core-api/workspace/generators/npm-package':
+    '/reference/workspace/generators',
+  '/reference/core-api/workspace/generators/ci-workflow':
+    '/reference/workspace/generators',
+  '/reference/core-api/workspace/generators/infer-targets':
+    '/reference/workspace/generators',
+  '/reference/core-api/workspace/migrations': '/reference/workspace/migrations',
   '/reference/core-api/azure-cache/executors':
     '/docs/reference/remote-cache-plugins/azure-cache/overview', // this was empty
   '/reference/core-api/azure-cache/generators':


### PR DESCRIPTION
This PR adds the missing API docs for nx, workspace, web, and plugin.

## What's changed

- Added missing plugins to `astro-docs/src/pages/references/`
- Update sidebar with new API docs
- Hide deprecated docs from sidebar (these should not be shown)
- Redirects are updated with the new API docs

<img width="1379" height="1210" alt="image" src="https://github.com/user-attachments/assets/e590a74a-d427-4c6c-b253-a96af9d2c7b3" />


<img width="1382" height="1207" alt="image" src="https://github.com/user-attachments/assets/3c607cd3-9acd-4461-8c8f-9395228951d3" />

<img width="1363" height="1205" alt="image" src="https://github.com/user-attachments/assets/4de36af2-9e58-4579-bca1-4e2a792ab79b" />


Closes #DOC-205