### PR TITLE
docs(misc): update header menu items per Linear task DOC-209

### DIFF
--- a/astro-docs/src/plugins/sidebar-reference-updater.middleware.ts
+++ b/astro-docs/src/plugins/sidebar-reference-updater.middleware.ts
@@ -56,9 +56,30 @@ export const onRequest = defineRouteMiddleware(async (context) => {
     context.locals.starlightRoute
   );
 
+  // Add Plugin Registry and Changelog links
+  const pluginRegistryLink: SidebarLink = {
+    type: 'link',
+    label: 'Plugin Registry',
+    href: '/docs/plugin-registry',
+    badge: undefined,
+    isCurrent: context.locals.starlightRoute.entry.slug === 'plugin-registry',
+    attrs: {},
+  };
+
+  const changelogLink: SidebarLink = {
+    type: 'link',
+    label: 'Changelog',
+    href: '/changelog',
+    badge: undefined,
+    isCurrent: false, // This is on Next.js
+    attrs: {},
+  };
+
   // Apply sorting to reference entries
   const newEntries = [
     ...commandSection,
+    pluginRegistryLink,
+    changelogLink,
     nxSection,
     devkitSection,
     webSection,
@@ -284,6 +305,8 @@ const desiredSectionOrder = [
   '.nxignore',
   'Environment Variables',
   'Glossary',
+  'Plugin Registry',
+  'Changelog',
   'Releases',
   'Node.js and TypeScript Compatibility',
   'create-nx-workspace', // auto generated

--- a/astro-docs/src/plugins/sidebar-reference-updater.middleware.ts
+++ b/astro-docs/src/plugins/sidebar-reference-updater.middleware.ts
@@ -69,7 +69,7 @@ export const onRequest = defineRouteMiddleware(async (context) => {
   const changelogLink: SidebarLink = {
     type: 'link',
     label: 'Changelog',
-    href: '/changelog',
+    href: `${process.env.NX_DEV_URL ?? 'https://nx.dev'}/changelog`,
     badge: undefined,
     isCurrent: false, // This is on Next.js
     attrs: {},
@@ -305,9 +305,9 @@ const desiredSectionOrder = [
   '.nxignore',
   'Environment Variables',
   'Glossary',
-  'Plugin Registry',
-  'Changelog',
   'Releases',
+  'Changelog',
   'Node.js and TypeScript Compatibility',
+  'Plugin Registry',
   'create-nx-workspace', // auto generated
 ];

--- a/nx-dev/ui-common/src/lib/headers/menu-items.ts
+++ b/nx-dev/ui-common/src/lib/headers/menu-items.ts
@@ -156,7 +156,9 @@ export const learnItems: MenuItem[] = [
   {
     name: 'Step by step tutorials',
     description: null,
-    href: '/docs/getting-started/tutorials',
+    href: process.env.NEXT_PUBLIC_ASTRO_URL
+      ? '/docs/getting-started/tutorials'
+      : '/getting-started/tutorials',
     icon: AcademicCapIcon,
     isNew: false,
     isHighlight: false,
@@ -212,9 +214,9 @@ export const learnItems: MenuItem[] = [
 ];
 export const eventItems: MenuItem[] = [
   {
-    name: 'Live Streams',
+    name: 'Nx Live',
     description: null,
-    href: 'https://www.youtube.com/@nxdevtools/streams',
+    href: 'https://www.youtube.com/playlist?list=PLakNactNC1dE8KLQ5zd3fQwu_yQHjTmR5',
     icon: VideoCameraIcon,
     isNew: false,
     isHighlight: false,

--- a/nx-dev/ui-common/src/lib/headers/menu-items.ts
+++ b/nx-dev/ui-common/src/lib/headers/menu-items.ts
@@ -156,16 +156,8 @@ export const learnItems: MenuItem[] = [
   {
     name: 'Step by step tutorials',
     description: null,
-    href: '/getting-started/intro#learn-nx',
+    href: '/docs/getting-started/tutorials',
     icon: AcademicCapIcon,
-    isNew: false,
-    isHighlight: false,
-  },
-  {
-    name: 'Code examples for your stack',
-    description: null,
-    href: '/showcase/example-repos',
-    icon: CodeBracketIcon,
     isNew: false,
     isHighlight: false,
   },
@@ -219,14 +211,6 @@ export const learnItems: MenuItem[] = [
   },
 ];
 export const eventItems: MenuItem[] = [
-  {
-    name: 'Office Hours',
-    description: null,
-    href: 'https://go.nx.dev/office-hours',
-    icon: DiscordIcon,
-    isNew: false,
-    isHighlight: false,
-  },
   {
     name: 'Live Streams',
     description: null,


### PR DESCRIPTION
This PR fixes the header links so they don't point to old Next.js docs. Also cleaned up outdated links.

<img width="805" height="671" alt="Screenshot 2025-09-16 at 4 06 11 PM" src="https://github.com/user-attachments/assets/78123e6b-3421-4a0d-b114-0e43bc70356e" />


The sidebar is also updated to include links to Changelog and Plugin Registry.
<img width="2672" height="1527" alt="Screenshot 2025-09-16 at 4 06 03 PM" src="https://github.com/user-attachments/assets/dd097a40-666c-49d6-8a9b-9cf63523eb2f" />


## Related Issue(s)
Fixes DOC-209