### PR TITLE
feat(bundling)!: change default useLegacyTypescriptPlugin to false for v22

### DIFF
--- a/docs/generated/packages/rollup/executors/rollup.json
+++ b/docs/generated/packages/rollup/executors/rollup.json
@@ -167,7 +167,7 @@
       "useLegacyTypescriptPlugin": {
         "type": "boolean",
         "description": "Use rollup-plugin-typescript2 instead of @rollup/plugin-typescript.",
-        "default": true
+        "default": false
       }
     },
     "required": ["tsConfig", "main", "outputPath"],

--- a/e2e/rollup/src/rollup-legacy.test.ts
+++ b/e2e/rollup/src/rollup-legacy.test.ts
@@ -147,6 +147,13 @@ describe('Rollup Plugin', () => {
     runCLI(
       `generate @nx/js:lib ${jsLib} --directory=libs/${jsLib} --bundler rollup`
     );
+
+    // Update project to use legacy TypeScript plugin for this legacy test
+    updateJson(join('libs', jsLib, 'project.json'), (config) => {
+      config.targets.build.options.useLegacyTypescriptPlugin = true;
+      return config;
+    });
+
     updateFile(
       `libs/${jsLib}/rollup.config.cjs`,
       `module.exports = {
@@ -191,6 +198,13 @@ describe('Rollup Plugin', () => {
     runCLI(
       `generate @nx/js:lib ${jsLib} --directory=libs/${jsLib} --bundler rollup --verbose`
     );
+
+    // Update project to use legacy TypeScript plugin for this legacy test
+    updateJson(join('libs', jsLib, 'project.json'), (config) => {
+      config.targets.build.options.useLegacyTypescriptPlugin = true;
+      return config;
+    });
+
     updateFile(
       `libs/${jsLib}/rollup.config.cjs`,
       `module.exports = (config) => [{

--- a/e2e/rollup/src/rollup.test.ts
+++ b/e2e/rollup/src/rollup.test.ts
@@ -235,6 +235,64 @@ export default config;
   });
 
   describe('useLegacyTypescriptPlugin', () => {
+    it('should use @rollup/plugin-typescript by default when useLegacyTypescriptPlugin is not specified', async () => {
+      const myPkg = uniq('my-pkg');
+      runCLI(
+        `generate @nx/js:lib ${myPkg} --directory=libs/${myPkg} --bundler=rollup --no-interactive`
+      );
+      updateFile(
+        `libs/${myPkg}/src/index.ts`,
+        `export const hello = 'default';\n`
+      );
+
+      // Change TypeScript plugin build target to avoid conflict with Rollup
+      updateJson('nx.json', (nxJson) => {
+        nxJson.plugins.forEach((plugin) => {
+          if (
+            plugin.plugin === '@nx/js/typescript' &&
+            plugin.include?.includes(`libs/${myPkg}/*`)
+          ) {
+            if (plugin.options?.build?.targetName === 'build') {
+              plugin.options.build.targetName = 'tsc:build';
+            }
+          }
+        });
+        return nxJson;
+      });
+
+      // Use default config without specifying useLegacyTypescriptPlugin
+      updateFile(
+        `libs/${myPkg}/rollup.config.cjs`,
+        `
+        const { withNx } = require('@nx/rollup/with-nx');
+        module.exports = withNx({
+          outputPath: '../../dist/libs/${myPkg}',
+          main: './src/index.ts',
+          tsConfig: './tsconfig.lib.json',
+          compiler: 'tsc',
+          format: ['cjs', 'esm']
+        });
+      `
+      );
+
+      // Build should succeed with the official @rollup/plugin-typescript (new default)
+      rmDist();
+      const output = runCLI(`build ${myPkg} --verbose`);
+
+      // Verify build succeeded
+      expect(output).toContain('Successfully ran target build');
+      // By default (without the flag), it should use @rollup/plugin-typescript
+      checkFilesExist(`dist/libs/${myPkg}/index.cjs.js`);
+      checkFilesExist(`dist/libs/${myPkg}/index.esm.js`);
+      checkFilesExist(`dist/libs/${myPkg}/index.d.ts`);
+
+      // Verify the output works
+      const result = runCommand(
+        `node -e "console.log(require('./dist/libs/${myPkg}/index.cjs.js').hello)"`
+      );
+      expect(result.trim()).toBe('default');
+    });
+
     it('should use @rollup/plugin-typescript when useLegacyTypescriptPlugin is false', async () => {
       const myPkg = uniq('my-pkg');
       runCLI(
@@ -337,6 +395,8 @@ export default config;
 
       // Verify build succeeded
       expect(output).toContain('Successfully ran target build');
+      // Note: The deprecation warning is shown but may not be captured in the test output
+      // The important thing is that the build succeeds with the legacy plugin when explicitly set
       checkFilesExist(`dist/libs/${myPkg}/index.cjs.js`);
       checkFilesExist(`dist/libs/${myPkg}/index.esm.js`);
       checkFilesExist(`dist/libs/${myPkg}/index.d.ts`);

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -159,7 +159,7 @@
     "useLegacyTypescriptPlugin": {
       "type": "boolean",
       "description": "Use rollup-plugin-typescript2 instead of @rollup/plugin-typescript.",
-      "default": true
+      "default": false
     }
   },
   "required": ["tsConfig", "main", "outputPath"],

--- a/packages/rollup/src/plugins/with-nx/with-nx.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx.ts
@@ -250,14 +250,14 @@ export function withNx(
       image(),
       json(),
       // TypeScript compilation and declaration generation
-      // TODO(v22): Change default value of useLegacyTypescriptPlugin to false for Nx 22
-      options.useLegacyTypescriptPlugin !== false
+      options.useLegacyTypescriptPlugin === true
         ? (() => {
             // TODO(v23): Remove in Nx 23
             // Show deprecation warning
             logger.warn(
-              `rollup-plugin-typescript2 usage is deprecated and will be removed in Nx 23. ` +
-                `Set 'useLegacyTypescriptPlugin: false' to use the official @rollup/plugin-typescript.`
+              `rollup-plugin-typescript2 is deprecated and will be removed in Nx 23. ` +
+                `You are explicitly using it with 'useLegacyTypescriptPlugin: true'. ` +
+                `Consider removing this option to use the official @rollup/plugin-typescript.`
             );
 
             return require('rollup-plugin-typescript2')({


### PR DESCRIPTION
The default TypeScript plugin for Rollup has changed from rollup-plugin-typescript2 to @rollup/plugin-typescript. To continue using the legacy plugin, explicitly set useLegacyTypescriptPlugin: true in your configuration.

Resolves NXC-3094
