### PR TITLE
cleanup(core): do not detect the terminal theme unnecessarily when running native tests

### DIFF
--- a/packages/nx/src/native/tui/theme.rs
+++ b/packages/nx/src/native/tui/theme.rs
@@ -4,6 +4,7 @@
 // This is the only file we should use the `ratatui::style::Color` type in
 use ratatui::style::Color;
 use std::sync::LazyLock;
+#[cfg(not(test))]
 use terminal_colorsaurus::{ColorScheme, QueryOptions, color_scheme};
 use tracing::debug;
 
@@ -65,10 +66,20 @@ impl Theme {
     /// NOTE: This requires raw mode access and might not work correctly once the TUI is fully running.
     /// It should ideally be called once during initialization.
     fn is_dark_mode() -> bool {
-        match color_scheme(QueryOptions::default()) {
-            Ok(ColorScheme::Dark) => true,
-            Ok(ColorScheme::Light) => false,
-            Err(_) => true, // Default to dark mode if detection fails
+        // Tests don't really need to detect the theme, default to dark mode
+        // to avoid sending OSC queries
+        #[cfg(test)]
+        {
+            return true;
+        }
+
+        #[cfg(not(test))]
+        {
+            match color_scheme(QueryOptions::default()) {
+                Ok(ColorScheme::Dark) => true,
+                Ok(ColorScheme::Light) => false,
+                Err(_) => true, // Default to dark mode if detection fails
+            }
         }
     }
 }


### PR DESCRIPTION
## Current Behavior

When running `pnpm nx test-native nx`, OSC (Operating System Command) escape sequences appear after the test completes, displaying as random characters like `10;rgb:f8f8/f8f8/f2f2` and `11;rgb:0000/2b2b/3636`.

## Expected Behavior

Test execution should complete cleanly without any escape sequences appearing in the terminal.

## Root Cause

The issue occurs because:
1. Tests in `tasks_list.rs` create `TasksList` components for testing UI functionality
2. `TasksList` accesses the `THEME` static for styling (e.g., `THEME.secondary_fg`)
3. `THEME` is a `LazyLock` that initializes by calling `is_dark_mode()`
4. `is_dark_mode()` uses `terminal_colorsaurus::color_scheme()` which sends OSC queries to detect terminal colors
5. The test process often exits before the terminal responds, leaving orphaned responses that appear as escape sequences

## Solution

Added compile-time conditional compilation to skip terminal color detection during tests:
- `#[cfg(test)]`: Returns `true` (dark mode) without sending OSC queries. Tests run in virtual buffers and don't need the terminal theme. It's also less deterministic to have tests relying on the terminal theme.
- `#[cfg(not(test))]`: Performs normal terminal detection for production use

This approach:
- ✅ Eliminates OSC sequences during test execution
- ✅ Preserves normal color detection in production
- ✅ Provides deterministic test behavior regardless of terminal theme
- ✅ Improves test performance by avoiding I/O operations