### PR TITLE
fix(bundling): postcss-cli-resources should handle relative deploy url #32714

### DIFF
--- a/packages/angular-rspack/src/lib/utils/postcss-cli-resources.ts
+++ b/packages/angular-rspack/src/lib/utils/postcss-cli-resources.ts
@@ -24,6 +24,16 @@ function wrapUrl(url: string): string {
   return `url(${wrappedUrl})`;
 }
 
+function resolveUrl(from: string, to: string) {
+  const resolvedUrl = new URL(to, new URL(from, 'resolve://'));
+  if (resolvedUrl.protocol === 'resolve:') {
+    // `from` is a relative URL.
+    const { pathname, search, hash } = resolvedUrl;
+    return pathname + search + hash;
+  }
+  return resolvedUrl.toString();
+}
+
 export interface PostcssCliResourcesOptions {
   baseHref?: string;
   deployUrl?: string;
@@ -149,7 +159,7 @@ export default function (options?: PostcssCliResourcesOptions): Plugin {
         }
 
         if (deployUrl && !extracted) {
-          outputUrl = new URL(outputUrl, deployUrl).href;
+          outputUrl = resolveUrl(deployUrl, outputUrl);
         }
 
         resourceCache.set(cacheKey, outputUrl);

--- a/packages/rspack/src/plugins/utils/plugins/postcss-cli-resources.ts
+++ b/packages/rspack/src/plugins/utils/plugins/postcss-cli-resources.ts
@@ -14,6 +14,16 @@ function wrapUrl(url: string): string {
   return `url(${wrappedUrl})`;
 }
 
+function resolveUrl(from: string, to: string) {
+  const resolvedUrl = new URL(to, new URL(from, 'resolve://'));
+  if (resolvedUrl.protocol === 'resolve:') {
+    // `from` is a relative URL.
+    const { pathname, search, hash } = resolvedUrl;
+    return pathname + search + hash;
+  }
+  return resolvedUrl.toString();
+}
+
 export interface PostcssCliResourcesOptions {
   baseHref?: string;
   deployUrl?: string;
@@ -130,7 +140,7 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
         }
         const loaderOptions: any = loader.loaders[loader.loaderIndex].options;
         if (deployUrl && loaderOptions.ident !== 'extracted') {
-          outputUrl = new URL(outputUrl, deployUrl).href;
+          outputUrl = resolveUrl(deployUrl, outputUrl);
         }
         resourceCache.set(cacheKey, outputUrl);
         resolve(outputUrl);

--- a/packages/webpack/src/utils/webpack/plugins/postcss-cli-resources.ts
+++ b/packages/webpack/src/utils/webpack/plugins/postcss-cli-resources.ts
@@ -14,6 +14,16 @@ function wrapUrl(url: string): string {
   return `url(${wrappedUrl})`;
 }
 
+function resolveUrl(from: string, to: string) {
+  const resolvedUrl = new URL(to, new URL(from, 'resolve://'));
+  if (resolvedUrl.protocol === 'resolve:') {
+    // `from` is a relative URL.
+    const { pathname, search, hash } = resolvedUrl;
+    return pathname + search + hash;
+  }
+  return resolvedUrl.toString();
+}
+
 export interface PostcssCliResourcesOptions {
   baseHref?: string;
   deployUrl?: string;
@@ -130,7 +140,7 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
         }
         const loaderOptions: any = loader.loaders[loader.loaderIndex].options;
         if (deployUrl && loaderOptions.ident !== 'extracted') {
-          outputUrl = new URL(outputUrl, deployUrl).href;
+          outputUrl = resolveUrl(deployUrl, outputUrl);
         }
         resourceCache.set(cacheKey, outputUrl);
         resolve(outputUrl);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Relative deploy URL is not being handled correctly in the postcss-cli-resources Plugins for Webpack and Rspack after switching to use WHATWG URL in favour of the url.resolve() method.

## Expected Behavior
Ensure the relative deploy URL is properly resolved when using relative paths

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #32714
