### PR TITLE
fix(core): do not shutdown daemon for project graph errors

### DIFF
--- a/packages/nx/src/daemon/server/shutdown-utils.ts
+++ b/packages/nx/src/daemon/server/shutdown-utils.ts
@@ -113,10 +113,10 @@ export async function respondWithErrorAndExit(
   description: string,
   error: Error
 ) {
-  const normalizedError =
-    error instanceof DaemonProjectGraphError
-      ? ProjectGraphError.fromDaemonProjectGraphError(error)
-      : error;
+  const isProjectGraphError = error instanceof DaemonProjectGraphError;
+  const normalizedError = isProjectGraphError
+    ? ProjectGraphError.fromDaemonProjectGraphError(error)
+    : error;
 
   // print some extra stuff in the error message
   serverLogger.requestLog(
@@ -128,5 +128,9 @@ export async function respondWithErrorAndExit(
 
   // Respond with the original error
   await respondToClient(socket, serializeResult(error, null, null), null);
-  process.exit(1);
+
+  // Project Graph errors are okay. Restarting the daemon won't help with this.
+  if (!isProjectGraphError) {
+    process.exit(1);
+  }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

All errors.. even Project Graph errors cause the daemon to shutdown. This meant that showing partial graphs in the graph application no longer worked.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Shutting down the daemon won't help for project graph errors. In this case, we should not shutdown the daemon. And showing partial project graphs will work again.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
