### PR TITLE
feat(testing): forward `e2e-ci` task options to their atomized tasks

### DIFF
--- a/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
@@ -206,12 +206,14 @@ nx show project my-project-e2e
             {
               "target": "e2e-ci--src/e2e/app.cy.ts",
               "projects": "self",
-              "params": "forward"
+              "params": "forward",
+              "options": "forward"
             },
             {
               "target": "e2e-ci--src/e2e/login.cy.ts",
               "projects": "self",
-              "params": "forward"
+              "params": "forward",
+              "options": "forward"
             }
           ],
           "options": {},

--- a/docs/nx-cloud/features/split-e2e-tasks.md
+++ b/docs/nx-cloud/features/split-e2e-tasks.md
@@ -203,12 +203,14 @@ nx show project my-project-e2e
             {
               "target": "e2e-ci--src/e2e/app.cy.ts",
               "projects": "self",
-              "params": "forward"
+              "params": "forward",
+              "options": "forward"
             },
             {
               "target": "e2e-ci--src/e2e/login.cy.ts",
               "projects": "self",
-              "params": "forward"
+              "params": "forward",
+              "options": "forward"
             }
           ],
           "options": {},

--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -366,6 +366,7 @@ describe('@nx/cypress/plugin', () => {
                     "cache": true,
                     "dependsOn": [
                       {
+                        "options": "forward",
                         "params": "forward",
                         "projects": "self",
                         "target": "e2e-ci--src/test.cy.ts",
@@ -570,6 +571,7 @@ describe('@nx/cypress/plugin', () => {
                     "cache": true,
                     "dependsOn": [
                       {
+                        "options": "forward",
                         "params": "forward",
                         "projects": "self",
                         "target": "e2e-ci--src/test.cy.ts",
@@ -776,6 +778,7 @@ describe('@nx/cypress/plugin', () => {
                     "cache": true,
                     "dependsOn": [
                       {
+                        "options": "forward",
                         "params": "forward",
                         "projects": "self",
                         "target": "e2e-ci--src/test.cy.ts",
@@ -970,11 +973,13 @@ describe('@nx/cypress/plugin', () => {
                     "cache": true,
                     "dependsOn": [
                       {
+                        "options": "forward",
                         "params": "forward",
                         "projects": "self",
                         "target": "component-test-ci--src/test-2.cy.ts",
                       },
                       {
+                        "options": "forward",
                         "params": "forward",
                         "projects": "self",
                         "target": "component-test-ci--src/test.cy.ts",

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -118,12 +118,7 @@ async function createNodesInternal(
 
   const hash = await calculateHashForCreateNodes(
     projectRoot,
-    {
-      ...options,
-      // change this to bust the cache when making changes that would yield
-      // different results for the same hash
-      bust: 1,
-    },
+    options,
     context,
     [getLockFileName(detectPackageManager(context.workspaceRoot))]
   );

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -118,7 +118,12 @@ async function createNodesInternal(
 
   const hash = await calculateHashForCreateNodes(
     projectRoot,
-    options,
+    {
+      ...options,
+      // change this to bust the cache when making changes that would yield
+      // different results for the same hash
+      bust: 1,
+    },
     context,
     [getLockFileName(detectPackageManager(context.workspaceRoot))]
   );
@@ -411,6 +416,7 @@ async function buildCypressTargets(
           target: targetName,
           projects: 'self',
           params: 'forward',
+          options: 'forward',
         });
 
         if (ciWebServerCommandTask) {
@@ -553,6 +559,7 @@ async function buildCypressTargets(
           target: targetName,
           projects: 'self',
           params: 'forward',
+          options: 'forward',
         });
       }
 

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -198,9 +198,14 @@ export interface TargetDependencyConfig {
   target: string;
 
   /**
-   * Configuration for params handling.
+   * Whether to forward CLI params to the dependency target.
    */
   params?: 'ignore' | 'forward';
+
+  /**
+   * Whether to forward task options to the dependency target.
+   */
+  options?: 'ignore' | 'forward';
 }
 
 export type InputDefinition =

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -357,11 +357,13 @@ describe('@nx/playwright/plugin', () => {
         "cache": true,
         "dependsOn": [
           {
+            "options": "forward",
             "params": "forward",
             "projects": "self",
             "target": "e2e-ci--tests/run-me-2.spec.ts",
           },
           {
+            "options": "forward",
             "params": "forward",
             "projects": "self",
             "target": "e2e-ci--tests/run-me.spec.ts",
@@ -533,11 +535,13 @@ describe('@nx/playwright/plugin', () => {
         "cache": true,
         "dependsOn": [
           {
+            "options": "forward",
             "params": "forward",
             "projects": "self",
             "target": "e2e-ci--tests/run-me-2.spec.ts",
           },
           {
+            "options": "forward",
             "params": "forward",
             "projects": "self",
             "target": "e2e-ci--tests/run-me.spec.ts",
@@ -769,11 +773,13 @@ describe('@nx/playwright/plugin', () => {
         "cache": true,
         "dependsOn": [
           {
+            "options": "forward",
             "params": "forward",
             "projects": "self",
             "target": "e2e-ci--tests/run-me-2.spec.ts",
           },
           {
+            "options": "forward",
             "params": "forward",
             "projects": "self",
             "target": "e2e-ci--tests/run-me.spec.ts",
@@ -989,11 +995,13 @@ describe('@nx/playwright/plugin', () => {
         "cache": true,
         "dependsOn": [
           {
+            "options": "forward",
             "params": "forward",
             "projects": "self",
             "target": "e2e-ci--tests/run-me-2.spec.ts",
           },
           {
+            "options": "forward",
             "params": "forward",
             "projects": "self",
             "target": "e2e-ci--tests/run-me.spec.ts",

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -123,6 +123,9 @@ async function createNodesInternal(
     {
       ...normalizedOptions,
       CI: process.env.CI,
+      // change this to bust the cache when making changes that would yield
+      // different results for the same hash
+      bust: 1,
     },
     context,
     [getLockFileName(detectPackageManager(context.workspaceRoot))]
@@ -321,6 +324,7 @@ async function buildPlaywrightTargets(
         target: targetName,
         projects: 'self',
         params: 'forward',
+        options: 'forward',
       });
     }
 

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -123,9 +123,6 @@ async function createNodesInternal(
     {
       ...normalizedOptions,
       CI: process.env.CI,
-      // change this to bust the cache when making changes that would yield
-      // different results for the same hash
-      bust: 1,
     },
     context,
     [getLockFileName(detectPackageManager(context.workspaceRoot))]


### PR DESCRIPTION
## Current Behavior

Options configured in the `e2e-ci` tasks are not forwarded to their atomized tasks.

## Expected Behavior

Options configured in the `e2e-ci` tasks can be forwarded to their atomized tasks.

The `@nx/cypress/plugin` and `@nx/playwright/plugin` plugins will infer their `e2e-ci` dependencies to atomized tasks with `"options": "forward"`.