### PR TITLE
feat(gradle): pass in project directory

### DIFF
--- a/packages/gradle/src/plugin/utils/get-project-graph-lines.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-lines.ts
@@ -16,9 +16,13 @@ export async function getNxProjectGraphLines(
   let nxProjectGraphBuffer: Buffer;
 
   const gradlePluginOptionsArgs =
-    Object.entries(gradlePluginOptions ?? {})?.map(
-      ([key, value]) => `-P${key}=${value}`
-    ) ?? [];
+    Object.entries(gradlePluginOptions ?? {})
+      ?.filter(([key]) => key !== 'projectDirectory')
+      ?.map(([key, value]) => `-P${key}=${value}`) ?? [];
+
+  const projectDirArg = gradlePluginOptions?.projectDirectory
+    ? [`--project-dir`, gradlePluginOptions.projectDirectory]
+    : [];
 
   try {
     nxProjectGraphBuffer = await execGradleAsync(gradlewFile, [
@@ -29,6 +33,7 @@ export async function getNxProjectGraphLines(
       '--build-cache', // enable build cache
       '--warning-mode',
       'none',
+      ...projectDirArg,
       ...gradlePluginOptionsArgs,
       `-PworkspaceRoot=${workspaceRoot}`,
       process.env.NX_VERBOSE_LOGGING ? '--info' : '',

--- a/packages/gradle/src/plugin/utils/gradle-plugin-options.ts
+++ b/packages/gradle/src/plugin/utils/gradle-plugin-options.ts
@@ -3,6 +3,7 @@ export interface GradlePluginOptions {
   ciTestTargetName?: string;
   ciIntTestTargetName?: string;
   [taskTargetName: string]: string | undefined | boolean;
+  projectDirectory?: string;
 }
 
 export function normalizeOptions(


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently we assume that in your monorepo, there exists a gradle project at the root of the workspace. This assumption creates errors if you have all gradle related projects in a nested subdirectory.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Allow gradle project directory to be configured in the gradle plugin options, which can then be used by the gradle plugin to generate project graphs even for non-root gradle projects.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #NXC-3147
