### PR TITLE
fix(core): display prettier valid errors

### DIFF
--- a/packages/nx/src/command-line/format/format.ts
+++ b/packages/nx/src/command-line/format/format.ts
@@ -240,12 +240,17 @@ async function check(patterns: string[]): Promise<string[]> {
 
   const prettierPath = getPrettierPath();
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     exec(
       `node "${prettierPath}" --list-different ${patterns.join(' ')}`,
       { encoding: 'utf-8', windowsHide: false },
       (error, stdout) => {
         if (error) {
+          // The command failed because Prettier threw an error.
+          if (stdout.length === 0) {
+            reject(error);
+          }
+
           // The command failed so there are files with different formatting. Prettier writes them to stdout, newline separated.
           resolve(stdout.trim().split('\n'));
         } else {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
When running `nx format:check`, if there is an error, it is considered as files not formatted correctly
But if Prettier is throwing a real error, it is not diplayed. We just see an empty result without information

For example:

Format check failing with empty result
```
nx format:check


```

But when running the command, we can see the error:
```
node "/node_modules/prettier/bin/prettier.cjs" --list-different "packages/lib/.spec.swcrc" 
packages/lib/.spec.swcrc
[error] No parser could be inferred for file "/packages/lib/.spec.swcrc".
```

## Expected Behavior
I should see the prettier error to understand why it is failing

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
