### PR TITLE
fix(misc): add typescript output to the eslint ignore when needed

### DIFF
--- a/packages/expo/src/generators/application/application.spec.ts
+++ b/packages/expo/src/generators/application/application.spec.ts
@@ -148,6 +148,36 @@ describe('app', () => {
     expect(packageJson.devDependencies['jest-expo']).toBeUndefined();
   });
 
+  it('should not ignore "out-tsc" from eslint', async () => {
+    await expoApplicationGenerator(appTree, {
+      directory: 'my-app',
+      linter: 'eslint',
+      e2eTestRunner: 'none',
+      js: false,
+      unitTestRunner: 'none',
+      skipFormat: true,
+    });
+
+    const eslintConfig = readJson(appTree, 'my-app/.eslintrc.json');
+    expect(eslintConfig.ignorePatterns).not.toContain('**/out-tsc');
+  });
+
+  it('should not ignore "out-tsc" from eslint with flat config', async () => {
+    appTree.write('eslint.config.mjs', 'export default [];');
+
+    await expoApplicationGenerator(appTree, {
+      directory: 'my-app',
+      linter: 'eslint',
+      e2eTestRunner: 'none',
+      js: false,
+      unitTestRunner: 'none',
+      skipFormat: true,
+    });
+
+    const eslintConfig = appTree.read('my-app/eslint.config.mjs', 'utf-8');
+    expect(eslintConfig).not.toContain('**/out-tsc');
+  });
+
   describe('detox', () => {
     it('should create e2e app with directory', async () => {
       await expoApplicationGenerator(appTree, {
@@ -569,6 +599,36 @@ describe('app', () => {
         }
       `);
       expect(readJson(tree, 'my-app-e2e/package.json').nx).toBeUndefined();
+    });
+
+    it('should ignore "out-tsc" from eslint', async () => {
+      await expoApplicationGenerator(tree, {
+        directory: 'my-app',
+        linter: 'eslint',
+        e2eTestRunner: 'none',
+        js: false,
+        unitTestRunner: 'none',
+        skipFormat: true,
+      });
+
+      const eslintConfig = readJson(tree, 'my-app/.eslintrc.json');
+      expect(eslintConfig.ignorePatterns).toContain('**/out-tsc');
+    });
+
+    it('should ignore "out-tsc" from eslint with flat config', async () => {
+      tree.write('eslint.config.mjs', 'export default [];');
+
+      await expoApplicationGenerator(tree, {
+        directory: 'my-app',
+        linter: 'eslint',
+        e2eTestRunner: 'none',
+        js: false,
+        unitTestRunner: 'none',
+        skipFormat: true,
+      });
+
+      const eslintConfig = tree.read('my-app/eslint.config.mjs', 'utf-8');
+      expect(eslintConfig).toContain('**/out-tsc');
     });
   });
 });

--- a/packages/expo/src/utils/add-linting.ts
+++ b/packages/expo/src/utils/add-linting.ts
@@ -25,6 +25,7 @@ interface NormalizedSchema {
   skipPackageJson?: boolean;
   addPlugin?: boolean;
   buildable?: boolean;
+  isTsSolutionSetup?: boolean;
 }
 
 export async function addLinting(host: Tree, options: NormalizedSchema) {
@@ -101,6 +102,7 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
       'web-build',
       'cache',
       'dist',
+      ...(options.isTsSolutionSetup ? ['**/out-tsc'] : []),
     ]);
   }
 

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -810,6 +810,36 @@ describe('lib', () => {
           }
         `);
       });
+
+      it('should not ignore "out-tsc" from eslint', async () => {
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          directory: 'my-lib',
+          linter: 'eslint',
+          bundler: 'none',
+          unitTestRunner: 'none',
+          skipFormat: true,
+        });
+
+        const eslintConfig = readJson(tree, 'my-lib/.eslintrc.json');
+        expect(eslintConfig.ignorePatterns).not.toContain('**/out-tsc');
+      });
+
+      it('should not ignore "out-tsc" from eslint with flat config', async () => {
+        tree.write('eslint.config.mjs', 'export default [];');
+
+        await libraryGenerator(tree, {
+          ...defaultOptions,
+          directory: 'my-lib',
+          linter: 'eslint',
+          bundler: 'none',
+          unitTestRunner: 'none',
+          skipFormat: true,
+        });
+
+        const eslintConfig = tree.read('my-lib/eslint.config.mjs', 'utf-8');
+        expect(eslintConfig).not.toContain('**/out-tsc');
+      });
     });
   });
 
@@ -2475,6 +2505,40 @@ describe('lib', () => {
       expect(
         readJson(tree, 'my-lib/package.json').exports['.']
       ).not.toHaveProperty('@proj/source');
+    });
+
+    it('should ignore "out-tsc" from eslint', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        directory: 'my-lib',
+        linter: 'eslint',
+        bundler: 'none',
+        unitTestRunner: 'none',
+        addPlugin: true,
+        useProjectJson: false,
+        skipFormat: true,
+      });
+
+      const eslintConfig = readJson(tree, 'my-lib/.eslintrc.json');
+      expect(eslintConfig.ignorePatterns).toContain('**/out-tsc');
+    });
+
+    it('should ignore "out-tsc" from eslint with flat config', async () => {
+      tree.write('eslint.config.mjs', 'export default [];');
+
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        directory: 'my-lib',
+        linter: 'eslint',
+        bundler: 'none',
+        unitTestRunner: 'none',
+        addPlugin: true,
+        useProjectJson: false,
+        skipFormat: true,
+      });
+
+      const eslintConfig = tree.read('my-lib/eslint.config.mjs', 'utf-8');
+      expect(eslintConfig).toContain('**/out-tsc');
     });
   });
 });

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -406,6 +406,7 @@ export type AddLintOptions = Pick<
   | 'rootProject'
   | 'bundler'
   | 'addPlugin'
+  | 'isUsingTsSolutionConfig'
 >;
 
 export async function addLint(
@@ -433,6 +434,7 @@ export async function addLint(
     lintConfigHasOverride,
     isEslintConfigSupported,
     updateOverrideInLintConfig,
+    addIgnoresToLintConfig,
     // nx-ignore-next-line
   } = require('@nx/eslint/src/generators/utils/eslint-file');
 
@@ -511,6 +513,12 @@ export async function addLint(
       }
     );
   }
+
+  // Add out-tsc ignore pattern when using TS solution setup
+  if (options.isUsingTsSolutionConfig) {
+    addIgnoresToLintConfig(tree, options.projectRoot, ['**/out-tsc']);
+  }
+
   return task;
 }
 

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -803,6 +803,30 @@ describe('app', () => {
         ]);
       });
     });
+
+    it('should not ignore "out-tsc" from eslint', async () => {
+      await applicationGenerator(tree, {
+        directory: 'myapp',
+        style: 'css',
+        skipFormat: true,
+      });
+
+      const eslintConfig = readJson(tree, 'myapp/.eslintrc.json');
+      expect(eslintConfig.ignorePatterns).not.toContain('**/out-tsc');
+    });
+
+    it('should not ignore "out-tsc" from eslint with flat config', async () => {
+      tree.write('eslint.config.mjs', 'export default [];');
+
+      await applicationGenerator(tree, {
+        directory: 'myapp',
+        style: 'css',
+        skipFormat: true,
+      });
+
+      const eslintConfig = tree.read('myapp/eslint.config.mjs', 'utf-8');
+      expect(eslintConfig).not.toContain('**/out-tsc');
+    });
   });
 
   describe('--js', () => {
@@ -1079,6 +1103,30 @@ describe('app', () => {
         }
       `);
       expect(readJson(tree, 'myapp-e2e/package.json').nx).toBeUndefined();
+    });
+
+    it('should ignore "out-tsc" from eslint', async () => {
+      await applicationGenerator(tree, {
+        directory: 'myapp',
+        style: 'css',
+        skipFormat: true,
+      });
+
+      const eslintConfig = readJson(tree, 'myapp/.eslintrc.json');
+      expect(eslintConfig.ignorePatterns).toContain('**/out-tsc');
+    });
+
+    it('should ignore "out-tsc" from eslint with flat config', async () => {
+      tree.write('eslint.config.mjs', 'export default [];');
+
+      await applicationGenerator(tree, {
+        directory: 'myapp',
+        style: 'css',
+        skipFormat: true,
+      });
+
+      const eslintConfig = tree.read('myapp/eslint.config.mjs', 'utf-8');
+      expect(eslintConfig).toContain('**/out-tsc');
     });
   });
 

--- a/packages/next/src/generators/application/lib/add-linting.ts
+++ b/packages/next/src/generators/application/lib/add-linting.ts
@@ -91,7 +91,10 @@ export async function addLinting(
         },
       })
     );
-    addIgnoresToLintConfig(host, options.appProjectRoot, ['.next/**/*']);
+    addIgnoresToLintConfig(host, options.appProjectRoot, [
+      '.next/**/*',
+      ...(options.isTsSolutionSetup ? ['**/out-tsc'] : []),
+    ]);
   }
 
   if (!options.skipPackageJson) {

--- a/packages/react-native/src/generators/application/application.spec.ts
+++ b/packages/react-native/src/generators/application/application.spec.ts
@@ -128,6 +128,40 @@ describe('app', () => {
     expect(tsconfig.extends).toEqual('../tsconfig.json');
   });
 
+  it('should not ignore "out-tsc" from eslint', async () => {
+    await reactNativeApplicationGenerator(appTree, {
+      name: 'my-app',
+      directory: 'my-app',
+      linter: 'eslint',
+      e2eTestRunner: 'none',
+      install: false,
+      unitTestRunner: 'none',
+      bundler: 'webpack',
+      skipFormat: true,
+    });
+
+    const eslintConfig = readJson(appTree, 'my-app/.eslintrc.json');
+    expect(eslintConfig.ignorePatterns).not.toContain('**/out-tsc');
+  });
+
+  it('should not ignore "out-tsc" from eslint with flat config', async () => {
+    appTree.write('eslint.config.mjs', 'export default [];');
+
+    await reactNativeApplicationGenerator(appTree, {
+      name: 'my-app',
+      directory: 'my-app',
+      linter: 'eslint',
+      e2eTestRunner: 'none',
+      install: false,
+      unitTestRunner: 'none',
+      bundler: 'webpack',
+      skipFormat: true,
+    });
+
+    const eslintConfig = appTree.read('my-app/eslint.config.mjs', 'utf-8');
+    expect(eslintConfig).not.toContain('**/out-tsc');
+  });
+
   describe('detox', () => {
     it('should create e2e app with directory', async () => {
       await reactNativeApplicationGenerator(appTree, {
@@ -485,6 +519,42 @@ describe('app', () => {
         }
       `);
       expect(readJson(tree, 'my-app-e2e/package.json').nx).toBeUndefined();
+    });
+
+    it('should ignore "out-tsc" from eslint', async () => {
+      await reactNativeApplicationGenerator(tree, {
+        directory: 'my-app',
+        linter: 'eslint',
+        e2eTestRunner: 'none',
+        install: false,
+        unitTestRunner: 'none',
+        bundler: 'webpack',
+        addPlugin: true,
+        useProjectJson: false,
+        skipFormat: true,
+      });
+
+      const eslintConfig = readJson(tree, 'my-app/.eslintrc.json');
+      expect(eslintConfig.ignorePatterns).toContain('**/out-tsc');
+    });
+
+    it('should ignore "out-tsc" from eslint with flat config', async () => {
+      tree.write('eslint.config.mjs', 'export default [];');
+
+      await reactNativeApplicationGenerator(tree, {
+        directory: 'my-app',
+        linter: 'eslint',
+        e2eTestRunner: 'none',
+        install: false,
+        unitTestRunner: 'none',
+        bundler: 'webpack',
+        addPlugin: true,
+        useProjectJson: false,
+        skipFormat: true,
+      });
+
+      const eslintConfig = tree.read('my-app/eslint.config.mjs', 'utf-8');
+      expect(eslintConfig).toContain('**/out-tsc');
     });
   });
 });

--- a/packages/react-native/src/utils/add-linting.ts
+++ b/packages/react-native/src/utils/add-linting.ts
@@ -25,6 +25,7 @@ interface NormalizedSchema {
   skipPackageJson?: boolean;
   addPlugin?: boolean;
   buildable?: boolean;
+  isTsSolutionSetup?: boolean;
 }
 
 export async function addLinting(host: Tree, options: NormalizedSchema) {
@@ -101,6 +102,7 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
       'public',
       '.cache',
       'node_modules',
+      ...(options.isTsSolutionSetup ? ['**/out-tsc'] : []),
     ]);
   }
 

--- a/packages/react/src/generators/library/lib/add-linting.ts
+++ b/packages/react/src/generators/library/lib/add-linting.ts
@@ -11,6 +11,7 @@ import { NormalizedSchema } from '../schema';
 import { extraEslintDependencies } from '../../../utils/lint';
 import {
   addExtendsToLintConfig,
+  addIgnoresToLintConfig,
   addOverrideToLintConfig,
   addPredefinedConfigToFlatLintConfig,
   isEslintConfigSupported,
@@ -56,6 +57,11 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
           }
         );
         tasks.push(addExtendsTask);
+      }
+
+      // Add out-tsc ignore pattern when using TS solution setup
+      if (options.isUsingTsSolutionConfig) {
+        addIgnoresToLintConfig(host, options.projectRoot, ['**/out-tsc']);
       }
     }
 

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -947,6 +947,36 @@ module.exports = withNx(
     }
   );
 
+  it('should not ignore "out-tsc" from eslint', async () => {
+    await libraryGenerator(tree, {
+      ...defaultSchema,
+      directory: 'libs/mylib',
+      linter: 'eslint',
+      bundler: 'none',
+      unitTestRunner: 'none',
+      skipFormat: true,
+    });
+
+    const eslintConfig = readJson(tree, 'libs/mylib/.eslintrc.json');
+    expect(eslintConfig.ignorePatterns).not.toContain('**/out-tsc');
+  });
+
+  it('should not ignore "out-tsc" from eslint with flat config', async () => {
+    tree.write('eslint.config.mjs', 'export default [];');
+
+    await libraryGenerator(tree, {
+      ...defaultSchema,
+      directory: 'libs/mylib',
+      linter: 'eslint',
+      bundler: 'none',
+      unitTestRunner: 'none',
+      skipFormat: true,
+    });
+
+    const eslintConfig = tree.read('libs/mylib/eslint.config.mjs', 'utf-8');
+    expect(eslintConfig).not.toContain('**/out-tsc');
+  });
+
   describe('TS solution setup', () => {
     beforeEach(() => {
       tree = createTreeWithEmptyWorkspace();
@@ -1386,6 +1416,38 @@ module.exports = withNx(
         }
       `);
       expect(readJson(tree, 'libs/mylib/package.json').nx).toBeUndefined();
+    });
+
+    it('should ignore "out-tsc" from eslint', async () => {
+      await libraryGenerator(tree, {
+        ...defaultSchema,
+        directory: 'libs/mylib',
+        linter: 'eslint',
+        bundler: 'none',
+        unitTestRunner: 'none',
+        useProjectJson: false,
+        skipFormat: true,
+      });
+
+      const eslintConfig = readJson(tree, 'libs/mylib/.eslintrc.json');
+      expect(eslintConfig.ignorePatterns).toContain('**/out-tsc');
+    });
+
+    it('should ignore "out-tsc" from eslint with flat config', async () => {
+      tree.write('eslint.config.mjs', 'export default [];');
+
+      await libraryGenerator(tree, {
+        ...defaultSchema,
+        directory: 'libs/mylib',
+        linter: 'eslint',
+        bundler: 'none',
+        unitTestRunner: 'none',
+        useProjectJson: false,
+        skipFormat: true,
+      });
+
+      const eslintConfig = tree.read('libs/mylib/eslint.config.mjs', 'utf-8');
+      expect(eslintConfig).toContain('**/out-tsc');
     });
   });
 });

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -469,6 +469,38 @@ describe('app', () => {
     expect(tree.read('my-app/.eslintrc.json', 'utf-8')).toMatchSnapshot();
   });
 
+  it('should not ignore "out-tsc" from eslint', async () => {
+    await applicationGenerator(tree, {
+      directory: 'myapp',
+      linter: 'eslint',
+      style: 'none',
+      bundler: 'vite',
+      unitTestRunner: 'none',
+      e2eTestRunner: 'none',
+      skipFormat: true,
+    });
+
+    const eslintConfig = readJson(tree, 'myapp/.eslintrc.json');
+    expect(eslintConfig.ignorePatterns).not.toContain('**/out-tsc');
+  });
+
+  it('should not ignore "out-tsc" from eslint with flat config', async () => {
+    tree.write('eslint.config.mjs', 'export default [];');
+
+    await applicationGenerator(tree, {
+      directory: 'myapp',
+      linter: 'eslint',
+      style: 'none',
+      bundler: 'vite',
+      unitTestRunner: 'none',
+      e2eTestRunner: 'none',
+      skipFormat: true,
+    });
+
+    const eslintConfig = tree.read('myapp/eslint.config.mjs', 'utf-8');
+    expect(eslintConfig).not.toContain('**/out-tsc');
+  });
+
   describe('--prefix', () => {
     it('should use the prefix in the index.html', async () => {
       await applicationGenerator(tree, {
@@ -1009,6 +1041,42 @@ describe('app', () => {
         }
       `);
       expect(readJson(tree, 'apps/myapp-e2e/package.json').nx).toBeUndefined();
+    });
+
+    it('should ignore "out-tsc" from eslint', async () => {
+      await applicationGenerator(tree, {
+        directory: 'apps/myapp',
+        linter: 'eslint',
+        style: 'none',
+        bundler: 'vite',
+        unitTestRunner: 'none',
+        e2eTestRunner: 'none',
+        addPlugin: true,
+        useProjectJson: false,
+        skipFormat: true,
+      });
+
+      const eslintConfig = readJson(tree, 'apps/myapp/.eslintrc.json');
+      expect(eslintConfig.ignorePatterns).toContain('**/out-tsc');
+    });
+
+    it('should ignore "out-tsc" from eslint with flat config', async () => {
+      tree.write('eslint.config.mjs', 'export default [];');
+
+      await applicationGenerator(tree, {
+        directory: 'apps/myapp',
+        linter: 'eslint',
+        style: 'none',
+        bundler: 'vite',
+        unitTestRunner: 'none',
+        e2eTestRunner: 'none',
+        addPlugin: true,
+        useProjectJson: false,
+        skipFormat: true,
+      });
+
+      const eslintConfig = tree.read('apps/myapp/eslint.config.mjs', 'utf-8');
+      expect(eslintConfig).toContain('**/out-tsc');
     });
   });
 });

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -340,6 +340,14 @@ export async function applicationGeneratorInternal(host: Tree, schema: Schema) {
       addPlugin: options.addPlugin,
     });
     tasks.push(lintTask);
+
+    // Add out-tsc ignore pattern when using TS solution setup
+    if (options.isUsingTsSolutionConfig) {
+      const { addIgnoresToLintConfig } = await import(
+        '@nx/eslint/src/generators/utils/eslint-file'
+      );
+      addIgnoresToLintConfig(host, options.appProjectRoot, ['**/out-tsc']);
+    }
   }
 
   if (options.bundler === 'vite') {


### PR DESCRIPTION
## Current Behavior

When generating workspaces or projects with ESLint and using the TS solution setup, the generated `out-tsc` directory for TS output is not ignored in the ESLint configuration. This results in the lint task processing and potentially reporting errors from that directory.

## Expected Behavior

When generating workspaces or projects with ESLint and using the TS solution setup, the generated `out-tsc` directory for TS output should be ignored in the ESLint configuration.