### PR TITLE
docs(misc): fix JSON parsing for project details with escaped quotes

### DIFF
--- a/astro-docs/src/content/docs/concepts/CI Concepts/reduce-waste.mdoc
+++ b/astro-docs/src/content/docs/concepts/CI Concepts/reduce-waste.mdoc
@@ -19,6 +19,8 @@ If we look at these two trivial examples, you can see that the repository with m
 {% cards smCols=2 mdCols=2 lgCols=2 %}
 
 {% graph title="One Project" height="200px" %}
+
+```json
 {
   "hash": "85fd0561bd88f0bcd8703a9e9369592e2805f390d04982fb2401e700dc9ebc59",
   "projects": [
@@ -41,10 +43,13 @@ If we look at these two trivial examples, you can see that the repository with m
   "groupByFolder": false,
   "exclude": []
 }
+```
 
 {% /graph %}
 
 {% graph title="Four Projects" height="200px" %}
+
+```json
 {
   "hash": "85fd0561bd88f0bcd8703a9e9369592e2805f390d04982fb2401e700dc9ebc59",
   "projects": [
@@ -89,6 +94,8 @@ If we look at these two trivial examples, you can see that the repository with m
   "groupByFolder": false,
   "exclude": []
 }
+```
+
 {% /graph %}
 
 {% /cards %}
@@ -104,6 +111,8 @@ Consider the following example repo structures.
 {% cards mdCols=3 lgCols=3 %}
 
 {% graph title="Stacked" height="200px" %}
+
+```json
 {
   "hash": "85fd0561bd88f0bcd8703a9e9369592e2805f390d04982fb2401e700dc9ebc59",
   "projects": [
@@ -140,9 +149,12 @@ Consider the following example repo structures.
   "groupByFolder": false,
   "exclude": []
 }
+```
 {% /graph %}
 
 {% graph title="Grouped" height="200px" %}
+
+```json
 {
   "hash": "85fd0561bd88f0bcd8703a9e9369592e2805f390d04982fb2401e700dc9ebc59",
   "projects": [
@@ -179,10 +191,13 @@ Consider the following example repo structures.
   "groupByFolder": false,
   "exclude": []
 }
+```
 
 {% /graph %}
 
 {% graph title="Flat" height="200px" %}
+
+```json
 {
   "hash": "85fd0561bd88f0bcd8703a9e9369592e2805f390d04982fb2401e700dc9ebc59",
   "projects": [
@@ -219,6 +234,8 @@ Consider the following example repo structures.
   "groupByFolder": false,
   "exclude": []
 }
+```
+
 {% /graph %}
 
 {% /cards %}
@@ -290,6 +307,8 @@ Take a look at the example below. The projects are setup in the suboptimal stack
 
 {% cards smCols=2 mdCols=2 lgCols=2 %}
 {% graph title="First CI Run" height="200px" %}
+
+```json
 {
   "hash": "85fd0561bd88f0bcd8703a9e9369592e2805f390d04982fb2401e700dc9ebc59",
   "projects": [
@@ -326,9 +345,13 @@ Take a look at the example below. The projects are setup in the suboptimal stack
   "groupByFolder": false,
   "exclude": []
 }
+```
+
 {% /graph %}
 
 {% graph title="Second CI Run (project2 Changed)" height="200px" %}
+
+```json
 {
   "hash": "85fd0561bd88f0bcd8703a9e9369592e2805f390d04982fb2401e700dc9ebc59",
   "projects": [
@@ -365,6 +388,8 @@ Take a look at the example below. The projects are setup in the suboptimal stack
   "groupByFolder": false,
   "exclude": []
 }
+```
+
 {% /graph %}
 
 {% /cards %}

--- a/astro-docs/src/content/docs/concepts/mental-model.mdoc
+++ b/astro-docs/src/content/docs/concepts/mental-model.mdoc
@@ -45,6 +45,8 @@ For instance `nx test lib` creates a task graph with a single node:
 
 {% graph height="100px" type="task" %}
 
+
+```json
 {
   "projects": [
     {
@@ -77,6 +79,7 @@ For instance `nx test lib` creates a task graph with a single node:
       "dependencies": {}
   }
 }
+```
 
 {% /graph %}
 
@@ -96,6 +99,7 @@ running `nx run-many -t test -p app1 app2 lib`, the created task graph will look
 {% side_by_side %}
 {% graph height="200px" type="project" %}
 
+```json
 {
   "projects": [
     {
@@ -128,11 +132,13 @@ running `nx run-many -t test -p app1 app2 lib`, the created task graph will look
       "dependencies": {}
   }
 }
+```
 
 {% /graph %}
 
 {% graph height="200px" type="task"%}
 
+```json
 {
   "projects": [
     {
@@ -165,6 +171,7 @@ running `nx run-many -t test -p app1 app2 lib`, the created task graph will look
       "dependencies": {}
   }
 }
+```
 
 {% /graph %}
 {% /side_by_side %}
@@ -202,6 +209,7 @@ With this, running the same test command creates the following task graph:
 {% side_by_side %}
 {% graph height="200px" type="project" %}
 
+```json
 {
   "projects": [
     {
@@ -234,11 +242,13 @@ With this, running the same test command creates the following task graph:
       "dependencies": {}
   }
 }
+```
 
 {% /graph %}
 
 {% graph height="200px" type="task" %}
 
+```json
 {
   "projects": [
     {
@@ -271,6 +281,7 @@ With this, running the same test command creates the following task graph:
       "dependencies": {}
   }
 }
+```
 
 {% /graph %}
 {% /side_by_side %}
@@ -356,6 +367,7 @@ As your workspace grows, the task graph looks more like this:
 
 {% graph height="400px" type="task"%}
 
+```json
 {
   "projects": [
     {
@@ -388,6 +400,7 @@ As your workspace grows, the task graph looks more like this:
       "dependencies": {}
   }
 }
+```
 
 {% /graph %}
 

--- a/astro-docs/src/content/docs/concepts/sync-generators.mdoc
+++ b/astro-docs/src/content/docs/concepts/sync-generators.mdoc
@@ -56,6 +56,8 @@ nx show project <name>
 The above command opens up the project details view, and the registered sync generators are under the **Sync Generators** for each target. Most sync generators are inferred when using an [inference plugin](/docs/concepts/inferred-tasks). For example, the `@nx/js/typescript` plugin registers the `@nx/js:typescript-sync` generator on `build` and `typecheck` targets.
 
 {% project_details title="Project Details View" expandedTargets=["build"] %}
+
+```json
 {
   "project": {
     "name": "foo",
@@ -86,6 +88,8 @@ The above command opens up the project details view, and the registered sync gen
     "targets.build": ["packages/foo/tsconfig.ts", "@nx/js/typescript"]
   }
 }
+```
+
 {% /project_details %}
 
 Task sync generators can be thought of like the `dependsOn` property, but for generators instead of task dependencies.
@@ -115,6 +119,7 @@ Nx processes the file system in order to [create the project graph](/docs/featur
 
 {% graph title="Project Graph" height="200px" type="project" %}
 
+```json
 {
   "projects": [
     {
@@ -174,6 +179,7 @@ Nx processes the file system in order to [create the project graph](/docs/featur
   "groupByFolder": false,
   "exclude": []
 }
+```
 
 {% /graph %}
 {% /side_by_side %}

--- a/astro-docs/src/content/docs/concepts/task-pipeline-configuration.mdoc
+++ b/astro-docs/src/content/docs/concepts/task-pipeline-configuration.mdoc
@@ -11,6 +11,7 @@ As you can see in the graph visualization below, the `myreactapp` project depend
 
 {% graph height="450px" %}
 
+```json
 {
   "projects": [
     {
@@ -53,6 +54,7 @@ As you can see in the graph visualization below, the `myreactapp` project depend
   "focus": null,
   "groupByFolder": false
 }
+```
 
 {% /graph %}
 

--- a/astro-docs/src/content/docs/features/CI Features/affected.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/affected.mdoc
@@ -16,6 +16,7 @@ This drastically improves the speed of your CI and reduces the amount of compute
 
 {% graph title="Making a change in lib10 only affects a sub-part of the project graph (shown in purple)" height="400px" %}
 
+```json
 {
   "projects": [
     {
@@ -200,6 +201,7 @@ This drastically improves the speed of your CI and reduces the amount of compute
   },
   "affectedProjectIds": ["lib10", "lib4", "lib5", "app2"]
 }
+```
 
 {% /graph %}
 

--- a/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
@@ -104,6 +104,7 @@ nx show project my-project-e2e
 
 {% project_details title="Project Details View" %}
 
+```json
 {
   "project": {
     "name": "admin-e2e",
@@ -409,6 +410,7 @@ nx show project my-project-e2e
     ]
   }
 }
+```
 
 {% /project_details %}
 

--- a/astro-docs/src/content/docs/features/explore-graph.mdoc
+++ b/astro-docs/src/content/docs/features/explore-graph.mdoc
@@ -374,6 +374,7 @@ Try playing around with a [fully interactive graph on a sample repo](https://nrw
 
 {% graph height="450px" title="Project View" %}
 
+```json
 {
   "composite": false,
   "projects": [
@@ -482,11 +483,13 @@ Try playing around with a [fully interactive graph on a sample repo](https://nrw
   "exclude": [],
   "enableTooltips": false
 }
+```
 
 {% /graph %}
 
 {% graph height="450px" title="Composite View (Nx 20+)" %}
 
+```json
 {
   "composite": true,
   "projects": [
@@ -595,6 +598,7 @@ Try playing around with a [fully interactive graph on a sample repo](https://nrw
   "exclude": [],
   "enableTooltips": false
 }
+```
 
 {% /graph %}
 

--- a/astro-docs/src/content/docs/features/maintain-typescript-monorepos.mdoc
+++ b/astro-docs/src/content/docs/features/maintain-typescript-monorepos.mdoc
@@ -31,6 +31,7 @@ If your repository is using package manager workspaces, Nx will use those settin
 
 {% graph height="200px" title="Project View" %}
 
+```json
 {
   "composite": false,
   "projects": [
@@ -77,6 +78,7 @@ If your repository is using package manager workspaces, Nx will use those settin
   "exclude": [],
   "enableTooltips": false
 }
+```
 
 {% /graph %}
 
@@ -115,6 +117,7 @@ export default defineConfig({
 
 {% project_details %}
 
+```json
 {
   "project": {
     "name": "cart",
@@ -176,6 +179,7 @@ export default defineConfig({
     "tags": ["apps/cart/project.json", "nx/core/project-json"]
   }
 }
+```
 
 {% /project_details %}
 
@@ -195,6 +199,7 @@ The main downside of this feature is that you have to manually define each proje
 
 {% graph height="200px" title="Project View" %}
 
+```json
 {
   "composite": false,
   "projects": [
@@ -241,6 +246,7 @@ The main downside of this feature is that you have to manually define each proje
   "exclude": [],
   "enableTooltips": false
 }
+```
 
 {% /graph %}
 

--- a/astro-docs/src/content/docs/features/run-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/run-tasks.mdoc
@@ -161,6 +161,7 @@ Nx can automatically detect the dependencies between projects (see [project grap
 
 {% graph height="450px" %}
 
+```json
 {
   "projects": [
     {
@@ -203,6 +204,7 @@ Nx can automatically detect the dependencies between projects (see [project grap
   "focus": null,
   "groupByFolder": false
 }
+```
 
 {% /graph %}
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/angular-monorepo-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/angular-monorepo-tutorial.mdoc
@@ -146,6 +146,7 @@ npx nx show project demo
 
 {% project_details title="Project Details View (Simplified)" %}
 
+```json
 {
   "project": {
     "name": "demo",
@@ -211,6 +212,7 @@ npx nx show project demo
     "tags": ["apps/demo/project.json", "nx/core/project-json"]
   }
 }
+```
 
 {% /project_details %}
 
@@ -417,6 +419,7 @@ You should be able to see something similar to the following in your browser.
 
 {% graph height="450px" %}
 
+```json
 {
   "projects": [
     {
@@ -442,6 +445,7 @@ You should be able to see something similar to the following in your browser.
   "focus": null,
   "groupByFolder": false
 }
+```
 
 {% /graph %}
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/gradle-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/gradle-tutorial.mdoc
@@ -157,6 +157,7 @@ nx graph
 
 {% graph title="Gradle Projects" height="200px" %}
 
+```json
 {
   "hash": "ad0ea8f7ae85c873d6478c31b51a95c54115a49844d62a5b3972232ac82137d0",
   "projects": [
@@ -1117,6 +1118,8 @@ nx graph
   "exclude": [],
   "isPartial": false
 }
+```
+
 {% /graph %}
 
 ## Running Tasks
@@ -1134,6 +1137,7 @@ nx show project application
 
 {% project_details title="Project Details View" expandedTargets=["build"] height="520px" %}
 
+```json
 {
   "project": {
     "name": "application",
@@ -2363,6 +2367,8 @@ nx show project application
     ]
   }
 }
+```
+
 {% /project_details %}
 
 The Nx command to run the `build` task for the `application` project is:

--- a/astro-docs/src/content/docs/getting-started/Tutorials/react-monorepo-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/react-monorepo-tutorial.mdoc
@@ -123,6 +123,7 @@ npx nx show project demo
 
 {% project_details title="Project Details View (Simplified)" %}
 
+```json
 {
   "project": {
     "name": "@acme/demo",
@@ -178,6 +179,7 @@ npx nx show project demo
     "tags": ["apps/demo/project.json", "nx/core/project-json"]
   }
 }
+```
 
 {% /project_details %}
 
@@ -391,6 +393,7 @@ You should be able to see something similar to the following in your browser.
 
 {% graph height="450px" %}
 
+```json
 {
   "projects": [
     {
@@ -418,6 +421,7 @@ You should be able to see something similar to the following in your browser.
   "focus": null,
   "groupByFolder": false
 }
+```
 
 {% /graph %}
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/typescript-packages-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/typescript-packages-tutorial.mdoc
@@ -209,6 +209,7 @@ npx nx show project animal
 
 {% project_details title="Project Details View (Simplified)" %}
 
+```json
 {
   "project": {
     "name": "@acme/animal",
@@ -329,6 +330,7 @@ npx nx show project animal
     "tags": ["packages/animal/project.json", "nx/core/project-json"]
   }
 }
+```
 
 {% /project_details %}
 
@@ -449,6 +451,7 @@ You should be able to see something similar to the following in your browser.
 
 {% graph height="450px" %}
 
+```json
 {
   "projects": [
     {
@@ -487,6 +490,7 @@ You should be able to see something similar to the following in your browser.
   "focus": null,
   "groupByFolder": false
 }
+```
 
 {% /graph %}
 

--- a/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-existing-project.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-existing-project.mdoc
@@ -119,6 +119,7 @@ nx show project my-workspace --web
 
 {% project_details title="Project Details View" %}
 
+```json
 {
   "project": {
     "name": "my-workspace",
@@ -246,6 +247,7 @@ nx show project my-workspace --web
     ]
   }
 }
+```
 
 {% /project_details %}
 

--- a/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-monorepo.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-monorepo.mdoc
@@ -117,6 +117,7 @@ nx show project my-workspace --web
 
 {% project_details title="Project Details View" %}
 
+```json
 {
   "project": {
     "name": "my-workspace",
@@ -244,6 +245,7 @@ nx show project my-workspace --web
     ]
   }
 }
+```
 
 {% /project_details %}
 

--- a/astro-docs/src/content/docs/guides/Tasks & Caching/configure-inputs.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/configure-inputs.mdoc
@@ -16,6 +16,7 @@ Throughout this recipe, the following project structure of a simple workspace wi
 
 {% graph height="450px" %}
 
+```json
 {
   "projects": [
     {
@@ -44,6 +45,7 @@ Throughout this recipe, the following project structure of a simple workspace wi
   "focus": null,
   "groupByFolder": false
 }
+```
 
 {% /graph %}
 

--- a/astro-docs/src/content/docs/guides/Tasks & Caching/convert-to-inferred.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/convert-to-inferred.mdoc
@@ -71,6 +71,7 @@ For example, if we migrated the `@nx/vite` plugin for a single app (i.e. `nx g @
 
 {% project_details title="Test" height="100px" %}
 
+```json
 {
   "project": {
     "name": "demo",
@@ -102,6 +103,7 @@ For example, if we migrated the `@nx/vite` plugin for a single app (i.e. `nx g @
     "targets.build": ["apps/demo/vite.config.ts", "@nx/vite"]
   }
 }
+```
 
 {% /project_details %}
 

--- a/astro-docs/src/content/docs/guides/Tasks & Caching/pass-args-to-commands.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/pass-args-to-commands.mdoc
@@ -22,6 +22,7 @@ And the following [final configuration](/docs/reference/project-configuration):
 
 {% project_details title="Project Details View" %}
 
+```json
 {
   "project": {
     "name": "my-app",
@@ -154,6 +155,7 @@ And the following [final configuration](/docs/reference/project-configuration):
     "tags": ["apps/my-app/project.json", "nx/core/project-json"]
   }
 }
+```
 
 {% /project_details %}
 

--- a/astro-docs/src/content/docs/guides/Tasks & Caching/workspace-watching.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/workspace-watching.mdoc
@@ -11,6 +11,7 @@ Imagine the following project graph with these projects:
 
 {% graph height="450px" %}
 
+```json
 {
   "projects": [
     {
@@ -74,6 +75,7 @@ Imagine the following project graph with these projects:
   "groupByFolder": false,
   "exclude": []
 }
+```
 
 {% /graph %}
 

--- a/astro-docs/src/content/docs/guides/Tips-n-Tricks/identify-dependencies-between-folders.mdoc
+++ b/astro-docs/src/content/docs/guides/Tips-n-Tricks/identify-dependencies-between-folders.mdoc
@@ -39,6 +39,7 @@ Here is a graph that was created when doing this exercise on the [Angular Jump S
 
 {% graph height="450px" %}
 
+```json
 {
   "hash": "9713539543f19c5299e56715e78c576a40b91056b9cbb4e42118780cfcd22b5e",
   "projects": [
@@ -151,6 +152,7 @@ Here is a graph that was created when doing this exercise on the [Angular Jump S
   "groupByFolder": false,
   "exclude": []
 }
+```
 
 {% /graph %}
 

--- a/astro-docs/src/content/docs/reference/project-configuration.mdoc
+++ b/astro-docs/src/content/docs/reference/project-configuration.mdoc
@@ -21,6 +21,8 @@ nx show project myproject --web
 
 {% project_details title="Project Details View" %}
 
+
+```json
 {
   "project": {
     "name": "demo",
@@ -58,6 +60,7 @@ nx show project myproject --web
     "targets.build": ["packages/demo/vite.config.ts", "@nx/vite"]
   }
 }
+```
 
 {% /project_details %}
 

--- a/astro-docs/src/content/docs/technologies/angular/Guides/nx-and-angular.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/Guides/nx-and-angular.mdoc
@@ -287,6 +287,7 @@ As you start modularizing your Angular workspace, Nx can visualize it using the 
 
 {% graph height="450px" %}
 
+```json
 {
   "hash": "58420bb4002bb9b6914bdeb7808c77a591a089fc82aaee11e656d73b2735e3fa",
   "projects": [
@@ -388,6 +389,7 @@ As you start modularizing your Angular workspace, Nx can visualize it using the 
   "exclude": [],
   "enableTooltips": true
 }
+```
 
 {% /graph %}
 

--- a/nx-dev/ui-markdoc/src/lib/tags/graph.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/graph.component.tsx
@@ -2,6 +2,7 @@
 import { useTheme } from '@nx/nx-dev-ui-theme';
 import dynamic from 'next/dynamic';
 import { ReactElement, useEffect, useState } from 'react';
+import { parseAstroHtmlWrappedJson } from '../utils/parse-astro-html-wrapped-json';
 
 export function Loading() {
   return (
@@ -40,15 +41,6 @@ function getInitialPropsForAstro(children: ReactElement) {
   } catch {
     return null;
   }
-}
-
-function parseAstroHtmlWrappedJson(htmlString: string) {
-  const cleanedString = htmlString
-    .trim()
-    .replace(/^<\w>|<\/\w>$/g, '')
-    .trim()
-    .replace(/&quot;/g, '"');
-  return JSON.parse(cleanedString);
 }
 
 export type GraphProps = {

--- a/nx-dev/ui-markdoc/src/lib/tags/project-details.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/project-details.component.tsx
@@ -12,6 +12,7 @@ import {
   ExpandedTargetsProvider,
 } from '@nx/graph-internal-ui-project-details';
 import { twMerge } from 'tailwind-merge';
+import { parseAstroHtmlWrappedJson } from '../utils/parse-astro-html-wrapped-json';
 
 export function Loading() {
   return (
@@ -34,15 +35,6 @@ function getInitialPropsForAstro(children: ReactElement) {
   } catch {
     return null;
   }
-}
-
-function parseAstroHtmlWrappedJson(htmlString: string) {
-  const cleanedString = htmlString
-    .trim()
-    .replace(/^<\w>|<\/\w>$/g, '')
-    .trim()
-    .replace(/&quot;/g, '"');
-  return JSON.parse(cleanedString);
 }
 
 export type ProjectDetailsProps = {

--- a/nx-dev/ui-markdoc/src/lib/utils/parse-astro-html-wrapped-json.spec.ts
+++ b/nx-dev/ui-markdoc/src/lib/utils/parse-astro-html-wrapped-json.spec.ts
@@ -1,0 +1,167 @@
+import { parseAstroHtmlWrappedJson } from './parse-astro-html-wrapped-json';
+
+describe('parseAstroHtmlWrappedJson', () => {
+  describe('with data-code attribute', () => {
+    it('should parse JSON with escaped quotes in command field', () => {
+      const htmlString = `<div class="expressive-code">
+        <button data-code="{&#x22;project&#x22;: {&#x22;name&#x22;: &#x22;test&#x22;, &#x22;command&#x22;: &#x22;\\&#x22;hello\\&#x22;&#x22;}}" />
+      </div>`;
+
+      const result = parseAstroHtmlWrappedJson(htmlString);
+
+      expect(result).toEqual({
+        project: {
+          name: 'test',
+          command: '"hello"',
+        },
+      });
+    });
+
+    it('should handle various HTML entity encodings', () => {
+      const htmlString = `<button data-code="{&quot;test&quot;: &quot;value&quot;, &#x22;&amp;key&amp;&#x22;: &#x22;&lt;test&gt;&#x22;, &#x22;&#39;single&#39;&#x22;: &#x22;&#x27;quote&#x27;&#x22;}" />`;
+
+      const result = parseAstroHtmlWrappedJson(htmlString);
+
+      expect(result).toEqual({
+        test: 'value',
+        '&key&': '<test>',
+        "'single'": "'quote'",
+      });
+    });
+
+    it('should handle complex nested JSON with escaped quotes', () => {
+      const htmlString = `<div data-code="{&#x22;project&#x22;: {&#x22;targets&#x22;: {&#x22;e2e-ci--src/e2e/login.cy.ts&#x22;: {&#x22;options&#x22;: {&#x22;command&#x22;: &#x22;cypress run --env webServerCommand=\\&#x22;nx run admin:serve-static\\&#x22; --spec src/e2e/login.cy.ts&#x22;}}}}}" />`;
+
+      const result = parseAstroHtmlWrappedJson(htmlString);
+
+      expect(result).toEqual({
+        project: {
+          targets: {
+            'e2e-ci--src/e2e/login.cy.ts': {
+              options: {
+                command:
+                  'cypress run --env webServerCommand="nx run admin:serve-static" --spec src/e2e/login.cy.ts',
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it('should remove Unicode replacement characters (U+FFFD)', () => {
+      const htmlString = `<button data-code="{&#x22;test&#x22;: &#x22;value�with�replacement�chars&#x22;}" />`;
+
+      const result = parseAstroHtmlWrappedJson(htmlString);
+
+      expect(result).toEqual({
+        test: 'valuewithreplacementchars',
+      });
+    });
+
+    it('should handle backslash encoding', () => {
+      const htmlString = `<button data-code="{&#x22;path&#x22;: &#x22;C:&#x5C;&#x5C;Users&#x5C;&#x5C;test&#x22;}" />`;
+
+      const result = parseAstroHtmlWrappedJson(htmlString);
+
+      expect(result).toEqual({
+        path: 'C:\\Users\\test',
+      });
+    });
+
+    it('should handle non-breaking spaces', () => {
+      const htmlString = `<button data-code="{&#x22;text&#x22;: &#x22;hello&nbsp;world&#x22;}" />`;
+
+      const result = parseAstroHtmlWrappedJson(htmlString);
+
+      expect(result).toEqual({
+        text: 'hello world',
+      });
+    });
+
+    it('should handle all HTML entity variations for quotes', () => {
+      const variations = [
+        `<button data-code="{&quot;test&quot;: &quot;named&quot;}" />`,
+        `<button data-code="{&#34;test&#34;: &#34;decimal&#34;}" />`,
+        `<button data-code="{&#x22;test&#x22;: &#x22;hexadecimal&#x22;}" />`,
+      ];
+
+      variations.forEach((html, index) => {
+        const result = parseAstroHtmlWrappedJson(html);
+        expect(result.test).toBeDefined();
+      });
+    });
+  });
+
+  describe('fallback parsing (without data-code)', () => {
+    it('should parse simple JSON without HTML wrapper', () => {
+      const jsonString = '{"test": "value"}';
+
+      const result = parseAstroHtmlWrappedJson(jsonString);
+
+      expect(result).toEqual({
+        test: 'value',
+      });
+    });
+
+    it('should handle HTML entity encoding in fallback mode', () => {
+      const jsonString = '{&quot;test&quot;: &quot;value&quot;}';
+
+      const result = parseAstroHtmlWrappedJson(jsonString);
+
+      expect(result).toEqual({
+        test: 'value',
+      });
+    });
+
+    it('should strip single-letter HTML tags', () => {
+      const jsonString = '<p>{"test": "value"}</p>';
+
+      const result = parseAstroHtmlWrappedJson(jsonString);
+
+      expect(result).toEqual({
+        test: 'value',
+      });
+    });
+  });
+
+  describe('real-world examples', () => {
+    it('should handle the actual Cypress atomizer output structure', () => {
+      const htmlString = `<div class="expressive-code"><button data-code="{&#x22;project&#x22;: {&#x22;name&#x22;: &#x22;admin-e2e&#x22;, &#x22;data&#x22;: {&#x22;targets&#x22;: {&#x22;e2e-ci--src/e2e/login.cy.ts&#x22;: {&#x22;outputs&#x22;: [], &#x22;inputs&#x22;: [], &#x22;options&#x22;: {&#x22;command&#x22;: &#x22;\\&#x22;hello\\&#x22;&#x22;}, &#x22;executor&#x22;: &#x22;nx:run-commands&#x22;}}, &#x22;name&#x22;: &#x22;admin-e2e&#x22;}}, &#x22;sourceMap&#x22;: {}}" /></div>`;
+
+      const result = parseAstroHtmlWrappedJson(htmlString);
+
+      expect(result).toEqual({
+        project: {
+          name: 'admin-e2e',
+          data: {
+            targets: {
+              'e2e-ci--src/e2e/login.cy.ts': {
+                outputs: [],
+                inputs: [],
+                options: {
+                  command: '"hello"',
+                },
+                executor: 'nx:run-commands',
+              },
+            },
+            name: 'admin-e2e',
+          },
+        },
+        sourceMap: {},
+      });
+    });
+
+    it('should handle complex Cypress commands with nested quotes', () => {
+      const htmlString = `<div data-code="{&#x22;options&#x22;: {&#x22;command&#x22;: &#x22;cypress run --env webServerCommand=\\&#x22;nx run admin:serve-static\\&#x22; --spec src/e2e/app.cy.ts&#x22;}}" />`;
+
+      const result = parseAstroHtmlWrappedJson(htmlString);
+
+      expect(result).toEqual({
+        options: {
+          command:
+            'cypress run --env webServerCommand="nx run admin:serve-static" --spec src/e2e/app.cy.ts',
+        },
+      });
+    });
+  });
+});

--- a/nx-dev/ui-markdoc/src/lib/utils/parse-astro-html-wrapped-json.ts
+++ b/nx-dev/ui-markdoc/src/lib/utils/parse-astro-html-wrapped-json.ts
@@ -1,0 +1,50 @@
+/**
+ * Parses JSON from HTML string, handling data-code attributes and HTML entities
+ * This is used by Astro components to extract JSON from code fences
+ */
+export function parseAstroHtmlWrappedJson(htmlString: string): any {
+  // If code fence is used like "```json" then try to parse the data-code attribute for the JSON object.
+  if (htmlString.includes('data-code=')) {
+    // Use regex to extract data-code attribute value (works on both client and server)
+    // The quotes inside are already HTML-encoded as &quot; so this regex is safe
+    const dataCodeMatch = htmlString.match(/data-code="([^"]*)"/);
+    if (dataCodeMatch && dataCodeMatch[1]) {
+      const dataCode = dataCodeMatch[1];
+      const cleanedJson = dataCode
+        // Handle all variations of quote encoding (named, decimal, hexadecimal)
+        .replace(/(&quot;|&quote;|&#34;|&#x22;)/g, '"')
+        // Handle apostrophe/single quote
+        .replace(/(&apos;|&#39;|&#x27;)/g, "'")
+        // Handle ampersand
+        .replace(/(&amp;|&#38;|&#x26;)/g, '&')
+        // Handle less than
+        .replace(/(&lt;|&#60;|&#x3C;)/g, '<')
+        // Handle greater than
+        .replace(/(&gt;|&#62;|&#x3E;)/g, '>')
+        // Handle non-breaking space
+        .replace(/(&nbsp;|&#160;|&#xA0;)/g, ' ')
+        // Handle backslash (might be encoded)
+        .replace(/(&#92;|&#x5C;)/g, '\\')
+        // Remove all Unicode replacement characters and other non-printable characters
+        .replace(
+          /[\uFFFD\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g,
+          ''
+        )
+        // Also remove any remaining control characters except newline, tab, and carriage return
+        .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
+      try {
+        return JSON.parse(cleanedJson);
+      } catch (e) {
+        console.error('Failed to parse data-code JSON:', e);
+      }
+    }
+  }
+
+  // Fallback to original parsing method
+  const cleanedString = htmlString
+    .trim()
+    .replace(/^<\w>|<\/\w>$/g, '')
+    .trim()
+    .replace(/&quot;/g, '"');
+  return JSON.parse(cleanedString);
+}


### PR DESCRIPTION
Fixed the `parseAstroHtmlWrappedJson` function used by PDV and graph tag components to render code fence properly.

The problem was that inner HTML with code fence caused escaped double-quotes (`\"`) to be improperly handled. By the time we read the HTML via React props, the escape character is already done (`\`). Thus, use code fence to let Starlight render the full block, and then parse out the JSON object from the `[data-code]` attribute on the div.

For example, previously this would fail:

```
{% project_details %}
{ "foo": "\"bar\"" }
{% /project_details %}
```

That doesn't work because the HTML is just ""bar"", which is invalid. But changing the above to this works:

````
{% project_details %}
```json
{ "foo": "\"bar\"" }
```
{% /project_details %}
````

This works because you get something like `data-code="&quot;foo&quot;: &quot;\&quot;bar\&quot;&quot;"` set on the `div`. So we can use regexp to match everything within that attribute and parse it out as JSON once we convert some entities.

Check the [`nx-dev/ui-markdoc/src/lib/utils/parse-astro-html-wrapped-json.ts`](https://github.com/nrwl/nx/pull/32778/files#diff-c3d8e90b624e30217beaa44c46a16b9053533cf9a8542a4f7301ccaf3dbdab58) file for the full logic.

Also added JSON code fences to all graph tags in mdoc files to ensure proper parsing.

<img width="709" height="866" alt="Screenshot 2025-09-18 at 3 41 26 PM" src="https://github.com/user-attachments/assets/fdae86a6-929a-4a1f-82fe-7d4052de5db5" />

Closes #DOC-217