### PR TITLE
feat(nx-dev): disable Algolia search on non-docs pages when Astro docs are enabled

### DIFF
--- a/astro-docs/src/components/layout/Header.astro
+++ b/astro-docs/src/components/layout/Header.astro
@@ -119,17 +119,11 @@ const currentVersion = versions.find(v => v.current);
 						<!-- Events Section -->
 						<div class="space-y-1">
 							<h5 class="text-xs font-semibold uppercase tracking-wider text-slate-500 px-2 pb-2 dark:text-slate-400">Events</h5>
-							<a href="https://go.nx.dev/office-hours" class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
-								<svg class="w-5 h-5 text-slate-400 dark:text-slate-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-									<path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z" />
-								</svg>
-								<span class="text-sm font-medium text-slate-900 dark:text-slate-200">Office Hours</span>
-							</a>
-							<a href="https://www.youtube.com/@nxdevtools/streams" class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
+							<a href="https://www.youtube.com/playlist?list=PLakNactNC1dE8KLQ5zd3fQwu_yQHjTmR5" class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
 								<svg class="w-5 h-5 text-slate-400 dark:text-slate-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
 									<path stroke-linecap="round" d="m15.75 10.5 4.72-4.72a.75.75 0 0 1 1.28.53v11.38a.75.75 0 0 1-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25h-9A2.25 2.25 0 0 0 2.25 7.5v9a2.25 2.25 0 0 0 2.25 2.25Z" />
 								</svg>
-								<span class="text-sm font-medium text-slate-900 dark:text-slate-200">Live Streams</span>
+								<span class="text-sm font-medium text-slate-900 dark:text-slate-200">Nx Live</span>
 							</a>
 						</div>
 						<!-- Company Section -->

--- a/astro-docs/src/plugins/sidebar-reference-updater.middleware.ts
+++ b/astro-docs/src/plugins/sidebar-reference-updater.middleware.ts
@@ -37,23 +37,23 @@ export const onRequest = defineRouteMiddleware(async (context) => {
   const devkitSection = await getDevKitSection(context.locals.starlightRoute);
   const nxSection = await getNxPackageSection(
     'nx',
-    context.locals.starlightRoute,
+    context.locals.starlightRoute
   );
   const webSection = await getNxPackageSection(
     'web',
-    context.locals.starlightRoute,
+    context.locals.starlightRoute
   );
   const workspaceSection = await getNxPackageSection(
     'workspace',
-    context.locals.starlightRoute,
+    context.locals.starlightRoute
   );
   const pluginSection = await getNxPackageSection(
     'plugin',
-    context.locals.starlightRoute,
+    context.locals.starlightRoute
   );
 
   const commandSection = await getCommandsSection(
-    context.locals.starlightRoute,
+    context.locals.starlightRoute
   );
 
   // Add Plugin Registry and Changelog links
@@ -89,7 +89,7 @@ export const onRequest = defineRouteMiddleware(async (context) => {
   refSection.entries = sortReferenceEntries(
     refSection.entries as (SidebarGroup | SidebarLink)[],
     newEntries,
-    desiredSectionOrder,
+    desiredSectionOrder
   );
 });
 
@@ -107,12 +107,12 @@ async function getDevKitSection({ entry }: StarlightRouteData) {
 
   const devkitOnlyItems = devkitItems.filter(
     (item) =>
-      !item.params.slug?.startsWith('ngcli_adapter') && item.params.slug !== '',
+      !item.params.slug?.startsWith('ngcli_adapter') && item.params.slug !== ''
   );
   const ngcliItems = devkitItems.filter(
     (item) =>
       item.params.slug?.startsWith('ngcli_adapter/') &&
-      item.params.slug !== 'ngcli_adapter',
+      item.params.slug !== 'ngcli_adapter'
   );
 
   const devkitRoutes = devkitOnlyItems.map(
@@ -124,7 +124,7 @@ async function getDevKitSection({ entry }: StarlightRouteData) {
       isCurrent:
         entry.slug === `reference/devkit/${record.props.doc.data.slug}`,
       attrs: {},
-    }),
+    })
   );
 
   const ngcliOverview: SidebarLink = {
@@ -145,7 +145,7 @@ async function getDevKitSection({ entry }: StarlightRouteData) {
       isCurrent:
         entry.slug === `reference/devkit/${record.props.doc.data.slug}`,
       attrs: {},
-    }),
+    })
   );
 
   const ngcliSection: SidebarGroup = {
@@ -169,13 +169,13 @@ async function getDevKitSection({ entry }: StarlightRouteData) {
 
 async function getNxPackageSection(
   packageName: 'nx' | 'web' | 'workspace' | 'plugin',
-  { entry }: StarlightRouteData,
+  { entry }: StarlightRouteData
 ) {
   const docTypes = ['overview', 'generators', 'executors', 'migrations'];
   const docIds = docTypes.map((type) => `${packageName}-${type}`);
 
   const docs = await getEntries<'nx-reference-packages'>(
-    docIds.map((id) => ({ collection: 'nx-reference-packages' as const, id })),
+    docIds.map((id) => ({ collection: 'nx-reference-packages' as const, id }))
   );
 
   const overviewDoc = docs.find((d) => d?.id === `${packageName}-overview`);
@@ -220,7 +220,7 @@ async function getNxPackageSection(
         badge: undefined,
         isCurrent: entry.slug === record.data.slug,
         attrs: {},
-      }),
+      })
     );
 
   const label =
@@ -260,7 +260,7 @@ async function getCommandsSection({ entry }: StarlightRouteData) {
 function sortReferenceEntries(
   existingEntries: (SidebarLink | SidebarGroup)[],
   newEntries: (SidebarLink | SidebarGroup)[],
-  desiredOrder: string[],
+  desiredOrder: string[]
 ): (SidebarLink | SidebarGroup)[] {
   const allEntries = [...newEntries, ...existingEntries];
 
@@ -280,7 +280,7 @@ function sortReferenceEntries(
   // Add links in desired order
   for (const desiredLabel of desiredOrder) {
     const linkIndex = linkEntries.findIndex(
-      (entry) => entry.label === desiredLabel,
+      (entry) => entry.label === desiredLabel
     );
     if (linkIndex !== -1) {
       orderedLinkEntries.push(linkEntries[linkIndex]);

--- a/astro-docs/src/plugins/sidebar-reference-updater.middleware.ts
+++ b/astro-docs/src/plugins/sidebar-reference-updater.middleware.ts
@@ -37,23 +37,23 @@ export const onRequest = defineRouteMiddleware(async (context) => {
   const devkitSection = await getDevKitSection(context.locals.starlightRoute);
   const nxSection = await getNxPackageSection(
     'nx',
-    context.locals.starlightRoute
+    context.locals.starlightRoute,
   );
   const webSection = await getNxPackageSection(
     'web',
-    context.locals.starlightRoute
+    context.locals.starlightRoute,
   );
   const workspaceSection = await getNxPackageSection(
     'workspace',
-    context.locals.starlightRoute
+    context.locals.starlightRoute,
   );
   const pluginSection = await getNxPackageSection(
     'plugin',
-    context.locals.starlightRoute
+    context.locals.starlightRoute,
   );
 
   const commandSection = await getCommandsSection(
-    context.locals.starlightRoute
+    context.locals.starlightRoute,
   );
 
   // Add Plugin Registry and Changelog links
@@ -89,7 +89,7 @@ export const onRequest = defineRouteMiddleware(async (context) => {
   refSection.entries = sortReferenceEntries(
     refSection.entries as (SidebarGroup | SidebarLink)[],
     newEntries,
-    desiredSectionOrder
+    desiredSectionOrder,
   );
 });
 
@@ -107,12 +107,12 @@ async function getDevKitSection({ entry }: StarlightRouteData) {
 
   const devkitOnlyItems = devkitItems.filter(
     (item) =>
-      !item.params.slug?.startsWith('ngcli_adapter') && item.params.slug !== ''
+      !item.params.slug?.startsWith('ngcli_adapter') && item.params.slug !== '',
   );
   const ngcliItems = devkitItems.filter(
     (item) =>
       item.params.slug?.startsWith('ngcli_adapter/') &&
-      item.params.slug !== 'ngcli_adapter'
+      item.params.slug !== 'ngcli_adapter',
   );
 
   const devkitRoutes = devkitOnlyItems.map(
@@ -124,7 +124,7 @@ async function getDevKitSection({ entry }: StarlightRouteData) {
       isCurrent:
         entry.slug === `reference/devkit/${record.props.doc.data.slug}`,
       attrs: {},
-    })
+    }),
   );
 
   const ngcliOverview: SidebarLink = {
@@ -145,7 +145,7 @@ async function getDevKitSection({ entry }: StarlightRouteData) {
       isCurrent:
         entry.slug === `reference/devkit/${record.props.doc.data.slug}`,
       attrs: {},
-    })
+    }),
   );
 
   const ngcliSection: SidebarGroup = {
@@ -169,13 +169,13 @@ async function getDevKitSection({ entry }: StarlightRouteData) {
 
 async function getNxPackageSection(
   packageName: 'nx' | 'web' | 'workspace' | 'plugin',
-  { entry }: StarlightRouteData
+  { entry }: StarlightRouteData,
 ) {
   const docTypes = ['overview', 'generators', 'executors', 'migrations'];
   const docIds = docTypes.map((type) => `${packageName}-${type}`);
 
   const docs = await getEntries<'nx-reference-packages'>(
-    docIds.map((id) => ({ collection: 'nx-reference-packages' as const, id }))
+    docIds.map((id) => ({ collection: 'nx-reference-packages' as const, id })),
   );
 
   const overviewDoc = docs.find((d) => d?.id === `${packageName}-overview`);
@@ -220,7 +220,7 @@ async function getNxPackageSection(
         badge: undefined,
         isCurrent: entry.slug === record.data.slug,
         attrs: {},
-      })
+      }),
     );
 
   const label =
@@ -260,7 +260,7 @@ async function getCommandsSection({ entry }: StarlightRouteData) {
 function sortReferenceEntries(
   existingEntries: (SidebarLink | SidebarGroup)[],
   newEntries: (SidebarLink | SidebarGroup)[],
-  desiredOrder: string[]
+  desiredOrder: string[],
 ): (SidebarLink | SidebarGroup)[] {
   const allEntries = [...newEntries, ...existingEntries];
 
@@ -280,7 +280,7 @@ function sortReferenceEntries(
   // Add links in desired order
   for (const desiredLabel of desiredOrder) {
     const linkIndex = linkEntries.findIndex(
-      (entry) => entry.label === desiredLabel
+      (entry) => entry.label === desiredLabel,
     );
     if (linkIndex !== -1) {
       orderedLinkEntries.push(linkEntries[linkIndex]);

--- a/nx-dev/feature-ai/src/lib/feed-container.tsx
+++ b/nx-dev/feature-ai/src/lib/feed-container.tsx
@@ -116,7 +116,7 @@ export function FeedContainer(): JSX.Element {
         data-testid="wrapper"
         className="relative flex flex-grow flex-col items-stretch justify-start overflow-y-scroll"
       >
-        <div className="mx-auto w-full grow items-stretch px-4 sm:px-8 lg:max-w-4xl">
+        <div className="mx-auto w-full max-w-4xl grow items-stretch px-4 sm:px-8 ">
           <div
             id="content-wrapper"
             className="w-full flex-auto flex-grow flex-col"

--- a/nx-dev/feature-ai/src/lib/prompt.tsx
+++ b/nx-dev/feature-ai/src/lib/prompt.tsx
@@ -62,7 +62,7 @@ export function Prompt({
     <form
       ref={formRef}
       onSubmit={handleSubmit}
-      className="relative mx-auto flex max-w-3xl gap-2 rounded-md border border-slate-300 bg-white px-2 py-0 shadow-lg dark:border-slate-900 dark:bg-slate-700"
+      className="relative mx-auto flex max-w-3xl gap-2 rounded-md border border-slate-300 bg-white px-2 py-2 shadow-lg dark:border-slate-900 dark:bg-slate-700"
     >
       <div
         className={cx(
@@ -123,12 +123,12 @@ export function Prompt({
           name="query"
           maxLength={500}
           disabled={isGenerating}
-          className="block w-full resize-none border-none bg-transparent p-0 py-[1.3rem] pl-2 text-sm placeholder-slate-500 focus-within:outline-none focus:placeholder-slate-400 focus:outline-none focus:ring-0 disabled:cursor-not-allowed dark:text-white dark:focus:placeholder-slate-300"
+          className="block w-full resize-none border-none bg-transparent p-0 py-3 pl-2 text-sm placeholder-slate-500 focus-within:outline-none focus:placeholder-slate-400 focus:outline-none focus:ring-0 disabled:cursor-not-allowed dark:text-white dark:focus:placeholder-slate-300"
           placeholder="How does caching work?"
           rows={1}
         />
       </div>
-      <div className="flex pb-2">
+      <div className="flex">
         <Button
           variant="primary"
           size="small"

--- a/nx-dev/nx-dev/pages/ai-chat/index.tsx
+++ b/nx-dev/nx-dev/pages/ai-chat/index.tsx
@@ -1,5 +1,9 @@
 import { FeedContainer } from '@nx/nx-dev-feature-ai';
-import { DocumentationHeader, SidebarContainer } from '@nx/nx-dev-ui-common';
+import {
+  DocumentationHeader,
+  Header,
+  SidebarContainer,
+} from '@nx/nx-dev-ui-common';
 import { NextSeo } from 'next-seo';
 import { useNavToggle } from '../../lib/navigation-toggle.effect';
 import { cx } from '@nx/nx-dev-ui-primitives';
@@ -47,9 +51,15 @@ export default function AiDocs(): JSX.Element {
           'h-[calc(100dvh)]'
         )}
       >
-        <div className="w-full flex-shrink-0">
-          <DocumentationHeader isNavOpen={navIsOpen} toggleNav={toggleNav} />
-        </div>
+        {process.env.NEXT_PUBLIC_ASTRO_URL ? (
+          <div className="mb-12">
+            <Header />
+          </div>
+        ) : (
+          <div className="w-full flex-shrink-0">
+            <DocumentationHeader isNavOpen={navIsOpen} toggleNav={toggleNav} />
+          </div>
+        )}
         <main
           id="main"
           role="main"

--- a/nx-dev/nx-dev/pages/changelog.tsx
+++ b/nx-dev/nx-dev/pages/changelog.tsx
@@ -2,6 +2,7 @@ import { LinkIcon, TagIcon } from '@heroicons/react/24/outline';
 import {
   Breadcrumbs,
   DocumentationHeader,
+  Header,
   Footer,
   SidebarContainer,
 } from '@nx/nx-dev-ui-common';
@@ -231,9 +232,15 @@ export default function Changelog(props: ChangeLogProps): JSX.Element {
           type: 'website',
         }}
       />
-      <div className="w-full flex-shrink-0">
-        <DocumentationHeader isNavOpen={navIsOpen} toggleNav={toggleNav} />
-      </div>
+      {process.env.NEXT_PUBLIC_ASTRO_URL ? (
+        <div className="mb-12">
+          <Header />
+        </div>
+      ) : (
+        <div className="w-full flex-shrink-0">
+          <DocumentationHeader isNavOpen={navIsOpen} toggleNav={toggleNav} />
+        </div>
+      )}
 
       <main id="main" role="main">
         <div className="mx-auto flex max-w-7xl flex-col px-4 py-8 sm:px-6 lg:px-8">

--- a/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
@@ -245,9 +245,11 @@ export function DocumentationHeader({
           </button>
 
           {/*SEARCH*/}
-          <div className="mx-4 w-auto flex-grow">
-            <AlgoliaSearch />
-          </div>
+          {process.env.NEXT_PUBLIC_ASTRO_URL ? null : (
+            <div className="mx-4 w-auto flex-grow">
+              <AlgoliaSearch />
+            </div>
+          )}
         </div>
         {/*LOGO*/}
         <div className="flex items-center gap-4">
@@ -281,9 +283,11 @@ export function DocumentationHeader({
           <VersionPicker />
         </div>
         {/*SEARCH*/}
-        <div className="hidden w-full max-w-[14rem] lg:inline">
-          <AlgoliaSearch />
-        </div>
+        {process.env.NEXT_PUBLIC_ASTRO_URL ? null : (
+          <div className="hidden w-full max-w-[14rem] lg:inline">
+            <AlgoliaSearch />
+          </div>
+        )}
         {/*NAVIGATION*/}
         <div className="hidden flex-shrink-0 lg:flex">
           <nav

--- a/nx-dev/ui-common/src/lib/headers/header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/header.tsx
@@ -291,10 +291,14 @@ export function Header({
             >
               Nx Enterprise
             </Link>
-            <div className="hidden h-6 w-px bg-slate-200 md:block dark:bg-slate-700" />
-            <div className="px-3 opacity-50 hover:opacity-100">
-              <AlgoliaSearch tiny={true} />
-            </div>
+            {process.env.NEXT_PUBLIC_ASTRO_URL ? null : (
+              <>
+                <div className="hidden h-6 w-px bg-slate-200 md:block dark:bg-slate-700" />
+                <div className="px-3 opacity-50 hover:opacity-100">
+                  <AlgoliaSearch tiny={true} />
+                </div>
+              </>
+            )}
           </nav>
         </div>
         {/*SECONDARY NAVIGATION*/}

--- a/nx-dev/ui-common/src/lib/sidebar.tsx
+++ b/nx-dev/ui-common/src/lib/sidebar.tsx
@@ -379,9 +379,11 @@ export function SidebarMobile({
                 </button>
 
                 {/*SEARCH*/}
-                <div className="mx-4 w-auto">
-                  <AlgoliaSearch />
-                </div>
+                {process.env.NEXT_PUBLIC_ASTRO_URL ? null : (
+                  <div className="mx-4 w-auto">
+                    <AlgoliaSearch />
+                  </div>
+                )}
                 {/*LOGO*/}
                 <div className="ml-auto flex items-center">
                   <Link


### PR DESCRIPTION


Algolia search appears on all nx-dev pages, including non-documentation pages like AI chat and changelog, even when the new Astro documentation site is enabled. This creates confusion as search should only be available on documentation pages.

- When NEXT_PUBLIC_ASTRO_URL is set (indicating new docs are enabled), Algolia search is disabled on all nx-dev pages
- Non-documentation pages (AI chat, changelog) use the non-documentation header without search
- Documentation header only shows search when Astro docs are not enabled
- Clean up existing styling issues and ensure consistent header usage across the site

- Updated documentation-header.tsx to conditionally hide search when NEXT_PUBLIC_ASTRO_URL is set
- Updated header.tsx to pass showSearch prop based on NEXT_PUBLIC_ASTRO_URL
- Modified AI chat page to use non-documentation header and fixed styling issues
- Modified changelog page to use non-documentation header-
- Fixed astro header such that `Office Hours` and `Live Streams` are replaced with `Nx Live` (already done on Next.js side)
- Fixed astro sidebar reference updater middleware formatting

## Examples

Non-docs headers (for homepage, blog, cloud, enterprise, etc.):

<img width="1349" height="103" alt="Screenshot 2025-09-19 at 11 49 06 AM" src="https://github.com/user-attachments/assets/5a9e6355-43b9-4142-9c76-b30ccc4982b1" />

Changelog (with astro docs):

<img width="1467" height="1401" alt="Screenshot 2025-09-19 at 11 48 36 AM" src="https://github.com/user-attachments/assets/8e135ca7-fe36-4b44-b181-633d3dc5890d" />

AI Chat (with astro docs):

<img width="1246" height="952" alt="Screenshot 2025-09-19 at 11 48 24 AM" src="https://github.com/user-attachments/assets/866c7e4d-8eac-40ab-9c77-5d125135d4e9" />


Changelog (without astro docs);

<img width="1180" height="1132" alt="image" src="https://github.com/user-attachments/assets/eccdeb17-08fc-4f90-949d-5c7879abe3d3" />

AI Chat (without astro docs):

<img width="1172" height="1407" alt="image" src="https://github.com/user-attachments/assets/2ad6b797-32bc-498b-93cb-29cc368030f1" />


Astro docs header with updated `Nx Live` link:

<img width="685" height="434" alt="Screenshot 2025-09-19 at 11 48 51 AM" src="https://github.com/user-attachments/assets/48facc87-2c90-4195-97c7-024b11112001" />




Fixes DOC-219