### PR TITLE
chore(repo): run pnpm install after setup-node so `resolve-required-data` job can cache correctly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,16 +40,13 @@ jobs:
       # Default checkout on the triggering branch so that the latest publish-resolve-data.js script is available
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
-        with:
-          version: ${{ env.PNPM_VERSION }}
-
       - name: Setup node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
+          package-manager-cache: false
 
       - name: Resolve and set checkout and version data to use for release
         id: script


### PR DESCRIPTION
Fix publish pipeline by running `pnpm install` when using `setup-node`.