### PR TITLE
docs(nx-dev): add Algolia search to blog index when Astro docs are enabled

### DIFF
--- a/nx-dev/feature-search/src/lib/algolia-search.tsx
+++ b/nx-dev/feature-search/src/lib/algolia-search.tsx
@@ -32,8 +32,10 @@ function Hit({
 
 export function AlgoliaSearch({
   tiny = false,
+  blogOnly = false,
 }: {
   tiny?: boolean;
+  blogOnly?: boolean;
 }): JSX.Element {
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
@@ -139,12 +141,14 @@ export function AlgoliaSearch({
         createPortal(
           <DocSearchModal
             searchParameters={{
-              facetFilters: ['language:en'],
+              facetFilters: blogOnly
+                ? ['language:en', 'hierarchy.lvl0:Nx | Blog']
+                : ['language:en'],
               hitsPerPage: 100,
               distinct: true,
             }}
             initialQuery={initialQuery}
-            placeholder="Search the docs"
+            placeholder={blogOnly ? 'Search blog posts' : 'Search the docs'}
             initialScrollY={window.scrollY}
             onClose={handleClose}
             indexName={`${process.env.NEXT_PUBLIC_SEARCH_INDEX}`}

--- a/nx-dev/ui-blog/package.json
+++ b/nx-dev/ui-blog/package.json
@@ -7,6 +7,7 @@
   "types": "./src/index.ts",
   "dependencies": {
     "@nx/nx-dev-data-access-documents": "workspace:*",
+    "@nx/nx-dev-feature-search": "workspace:*",
     "@nx/nx-dev-ui-icons": "workspace:*",
     "@nx/nx-dev-ui-primitives": "workspace:*",
     "@nx/nx-dev-ui-common": "workspace:*",

--- a/nx-dev/ui-blog/src/lib/blog-container.tsx
+++ b/nx-dev/ui-blog/src/lib/blog-container.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { AlgoliaSearch } from '@nx/nx-dev-feature-search';
 import { BlogPostDataEntry } from '@nx/nx-dev-data-access-documents/node-only';
 import { MoreBlogs } from './more-blogs';
 import { FeaturedBlogs } from './featured-blogs';
@@ -73,25 +74,52 @@ export function BlogContainer({ blogPosts, tags }: BlogContainerProps) {
   return (
     <main id="main" role="main" className="w-full py-8">
       <div className="mx-auto mb-8 w-full max-w-[1088px] px-8">
-        <div className="mb-12 mt-20 flex items-center justify-between">
-          <header>
-            <h1
-              id="blog-title"
-              className="text-xl font-semibold tracking-tight text-slate-900 md:text-2xl dark:text-slate-100"
-            >
-              {selectedFilterHeading}
-            </h1>
-          </header>
-          <div className="flex items-center justify-end md:justify-start">
-            <Filters
-              blogs={blogPosts}
-              filters={filters}
-              initialSelectedFilter={initialSelectedFilter}
-              setFilteredList={setFilteredList}
-              setSelectedFilterHeading={setSelectedFilterHeading}
-            />
+        {process.env.NEXT_PUBLIC_ASTRO_URL ? (
+          <>
+            <header className="mb-8 mt-20">
+              <h1
+                id="blog-title"
+                className="text-xl font-semibold tracking-tight text-slate-900 md:text-2xl dark:text-slate-100"
+              >
+                {selectedFilterHeading}
+              </h1>
+            </header>
+            <div className="mb-12 flex items-center justify-between">
+              <div className="flex items-center">
+                <Filters
+                  blogs={blogPosts}
+                  filters={filters}
+                  initialSelectedFilter={initialSelectedFilter}
+                  setFilteredList={setFilteredList}
+                  setSelectedFilterHeading={setSelectedFilterHeading}
+                />
+              </div>
+              <div className="flex w-48 items-center justify-end md:justify-start">
+                <AlgoliaSearch blogOnly={true} />
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className="mb-12 mt-20 flex items-center justify-between">
+            <header>
+              <h1
+                id="blog-title"
+                className="text-xl font-semibold tracking-tight text-slate-900 md:text-2xl dark:text-slate-100"
+              >
+                {selectedFilterHeading}
+              </h1>
+            </header>
+            <div className="flex items-center justify-end md:justify-start">
+              <Filters
+                blogs={blogPosts}
+                filters={filters}
+                initialSelectedFilter={initialSelectedFilter}
+                setFilteredList={setFilteredList}
+                setSelectedFilterHeading={setSelectedFilterHeading}
+              />
+            </div>
           </div>
-        </div>
+        )}
         <FeaturedBlogs blogs={firstFiveBlogs} />
         {!!remainingBlogs.length && (
           <>

--- a/nx-dev/ui-blog/src/lib/filters.tsx
+++ b/nx-dev/ui-blog/src/lib/filters.tsx
@@ -72,7 +72,10 @@ export function Filters({
   return (
     <>
       {/* DESKTOP */}
-      <ul className="hidden gap-1.5 lg:flex" aria-label="Filter blog posts">
+      <ul
+        className="hidden gap-1.5 text-sm lg:flex"
+        aria-label="Filter blog posts"
+      >
         {filters
           .filter((filter) => filter.value !== selectedFilter)
           .map((filter) => (

--- a/nx-dev/ui-blog/tsconfig.json
+++ b/nx-dev/ui-blog/tsconfig.json
@@ -26,6 +26,9 @@
       "path": "../ui-icons"
     },
     {
+      "path": "../feature-search"
+    },
+    {
       "path": "../data-access-documents"
     },
     {

--- a/nx-dev/ui-blog/tsconfig.lib.json
+++ b/nx-dev/ui-blog/tsconfig.lib.json
@@ -20,6 +20,9 @@
       "path": "../ui-icons/tsconfig.lib.json"
     },
     {
+      "path": "../feature-search/tsconfig.lib.json"
+    },
+    {
       "path": "../data-access-documents/tsconfig.lib.json"
     }
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1972,6 +1972,9 @@ importers:
       '@nx/nx-dev-data-access-documents':
         specifier: workspace:*
         version: link:../data-access-documents
+      '@nx/nx-dev-feature-search':
+        specifier: workspace:*
+        version: link:../feature-search
       '@nx/nx-dev-ui-common':
         specifier: workspace:*
         version: link:../ui-common
@@ -32646,6 +32649,7 @@ snapshots:
   '@nx/nx-dev-ui-blog@file:nx-dev/ui-blog':
     dependencies:
       '@nx/nx-dev-data-access-documents': link:nx-dev/data-access-documents
+      '@nx/nx-dev-feature-search': link:nx-dev/feature-search
       '@nx/nx-dev-ui-common': link:nx-dev/ui-common
       '@nx/nx-dev-ui-icons': link:nx-dev/ui-icons
       '@nx/nx-dev-ui-markdoc': link:nx-dev/ui-markdoc


### PR DESCRIPTION
When NEXT_PUBLIC_ASTRO_URL is set, the blog index now includes a dedicated search box that filters results to only blog posts. This ensures blog search functionality is maintained when the main docs search is moved to the Astro site.

Blog index page has no search functionality when Astro docs are enabled, making it difficult to find specific blog posts.

Blog index page displays a search box that searches only within blog posts (using Algolia facet filter for 'Nx | Blog') when Astro docs are enabled, preserving the ability to search blog content.

Without astro docs:

<img width="1162" height="733" alt="Screenshot 2025-09-19 at 2 26 34 PM" src="https://github.com/user-attachments/assets/a499fb03-ecc6-4a4f-9303-2198e32f9a77" />

With astro docs:

<img width="1143" height="784" alt="Screenshot 2025-09-19 at 2 27 42 PM" src="https://github.com/user-attachments/assets/4d0bfa7e-0ca6-4694-bba0-fc5e63d1b140" />

https://github.com/user-attachments/assets/fe96bc49-dafe-4bc6-9b89-578f29f93cf7



Fixes DOC-221