### PR TITLE
chore(repo): revert gradle v2 plugin

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -286,12 +286,6 @@
         "serveStaticTargetName": "serve-static"
       }
     },
-    {
-      "plugin": "@nx/gradle",
-      "options": {
-        "testTargetName": "test-kt"
-      }
-    },
     "@nx/enterprise-cloud",
     {
       "plugin": "@nx/storybook/plugin",

--- a/packages/gradle/batch-runner/project.json
+++ b/packages/gradle/batch-runner/project.json
@@ -3,5 +3,35 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/gradle/batch-runner/src",
   "projectType": "library",
-  "tags": []
+  "tags": [],
+  "targets": {
+    "assemble": {
+      "executor": "@nx/gradle:gradle",
+      "options": {
+        "taskName": "batch-runner:assemble"
+      },
+      "inputs": [
+        "{projectRoot}/src/**",
+        "{projectRoot}/build.gradle.kts",
+        "{projectRoot}/settings.gradle.kts"
+      ],
+      "outputs": ["{projectRoot}/build"],
+      "cache": true
+    },
+    "test": {
+      "command": "./gradlew :batch-runner:test",
+      "options": {
+        "args": []
+      },
+      "cache": true
+    },
+    "lint": {
+      "command": "./gradlew :batch-runner:ktfmtCheck",
+      "cache": true
+    },
+    "format": {
+      "command": "./gradlew :batch-runner:ktfmtFormat",
+      "cache": true
+    }
+  }
 }

--- a/packages/gradle/project-graph/project.json
+++ b/packages/gradle/project-graph/project.json
@@ -2,6 +2,26 @@
   "name": "gradle-project-graph",
   "$schema": "node_modules/nx/schemas/project-schema.json",
   "targets": {
+    "test": {
+      "command": "./gradlew :project-graph:test",
+      "options": {
+        "args": []
+      },
+      "cache": true
+    },
+    "lint": {
+      "command": "./gradlew :project-graph:ktfmtCheck",
+      "cache": true
+    },
+    "format": {
+      "command": "./gradlew :project-graph:ktfmtFormat",
+      "cache": true
+    },
+    "publish-staging": {
+      "command": "./gradlew :project-graph:publish",
+      "cache": true,
+      "outputs": ["{projectRoot}/build/staging"]
+    },
     "zip-staging": {
       "command": "zip -r ../deployment.zip .",
       "options": {


### PR DESCRIPTION
Reverting gradle v2 plugin from Nx due to issues with publish pipelines not being able to handle the new changes. Will re-apply once the kinks in publish are ironed out.

