### PR TITLE
fix(misc): remove unnecessary `bust` property from plugin hashes

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -363,9 +363,6 @@ async function getConfigFileHash(
     lockFileHash,
     optionsHash,
     ...(packageJson ? [hashObject(packageJson)] : []),
-    // change this to bust the cache when making changes that would yield
-    // different results for the same hash
-    hashObject({ bust: 3 }),
   ]);
 }
 

--- a/packages/nx/src/plugins/package-json/create-nodes.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.ts
@@ -16,6 +16,7 @@ import {
   readTargetsFromPackageJson,
 } from '../../utils/package-json';
 import { joinPathFragments } from '../../utils/path';
+import { nxVersion } from '../../utils/versions';
 import {
   createNodesFromFiles,
   CreateNodesV2,
@@ -144,9 +145,7 @@ export function createNodeFromPackageJson(
     ...json,
     root: projectRoot,
     isInPackageManagerWorkspaces,
-    // change this to bust the cache when making changes that result in different
-    // results for the same hash
-    bust: 1,
+    nxVersion,
   });
 
   const cached = cache[hash];


### PR DESCRIPTION
Remove the manually maintained and unnecessary `bust` property from plugin hashes.