### PR TITLE
docs(misc): mark docs pages as noindex when using Astro docs

### DIFF
--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -82,6 +82,8 @@ export function DocViewer({
           vm.description ??
           'Get to green PRs in half the time. Nx optimizes your builds, scales your CI, and fixes failed PRs. Built for developers and AI agents.'
         }
+        noindex={!!process.env.NEXT_PUBLIC_ASTRO_URL}
+        nofollow={!!process.env.NEXT_PUBLIC_ASTRO_URL}
         openGraph={{
           url: 'https://nx.dev' + currentPath,
           title: vm.title,

--- a/nx-dev/nx-dev/pages/plugin-registry.tsx
+++ b/nx-dev/nx-dev/pages/plugin-registry.tsx
@@ -84,6 +84,8 @@ export default function Browse(props: BrowseProps): JSX.Element {
       <NextSeo
         title="Nx Plugin Registry"
         description="Nx Plugins enhance the developer experience in you workspace to make your life simpler. Browse the list of available Nx Plugins."
+        noindex={!!process.env.NEXT_PUBLIC_ASTRO_URL}
+        nofollow={!!process.env.NEXT_PUBLIC_ASTRO_URL}
         openGraph={{
           url: 'https://nx.dev' + router.asPath,
           title: 'Nx Plugin Registry',


### PR DESCRIPTION
If new docs are enabled, then mark the old ones as `noindex`. They should already be redirected to new docs as well, but this helps anything missed.