### PR TITLE
fix(react): only add react router plugin when using react router #32525

### DIFF
--- a/docs/generated/packages/react/generators/init.json
+++ b/docs/generated/packages/react/generators/init.json
@@ -24,6 +24,12 @@
         "x-priority": "internal",
         "description": "Keep existing dependencies versions",
         "default": false
+      },
+      "useReactRouterPlugin": {
+        "type": "boolean",
+        "x-priority": "internal",
+        "description": "Add the @nx/react/router-plugin to the nx.json plugins array. Only use this if using React Router for SSR/RSC.",
+        "default": false
       }
     },
     "required": [],

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -115,6 +115,7 @@ export async function applicationGeneratorInternal(
   const initTask = await reactInitGenerator(tree, {
     ...options,
     skipFormat: true,
+    useReactRouterPlugin: options.useReactRouter,
   });
   tasks.push(initTask);
 

--- a/packages/react/src/generators/init/init.spec.ts
+++ b/packages/react/src/generators/init/init.spec.ts
@@ -1,4 +1,4 @@
-import { readJson, Tree } from '@nx/devkit';
+import { readJson, readNxJson, Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import reactInitGenerator from './init';
 
@@ -15,5 +15,50 @@ describe('init', () => {
     expect(packageJson.dependencies['react']).toBeDefined();
     expect(packageJson.dependencies['react-dom']).toBeDefined();
     expect(packageJson.devDependencies['@nx/react']).toBeDefined();
+  });
+
+  it('should NOT add react-router plugin when useReactRouterPlugin is false', async () => {
+    await reactInitGenerator(tree, {
+      skipFormat: true,
+      addPlugin: true,
+      useReactRouterPlugin: false,
+    });
+    const nxJson = readNxJson(tree);
+    const hasRouterPlugin = nxJson.plugins?.some(
+      (p) =>
+        (typeof p === 'string' && p === '@nx/react/router-plugin') ||
+        (typeof p === 'object' && p.plugin === '@nx/react/router-plugin')
+    );
+    expect(hasRouterPlugin).toBeFalsy();
+  });
+
+  it('should add react-router plugin when useReactRouterPlugin is true', async () => {
+    await reactInitGenerator(tree, {
+      skipFormat: true,
+      addPlugin: true,
+      useReactRouterPlugin: true,
+    });
+    const nxJson = readNxJson(tree);
+    const hasRouterPlugin = nxJson.plugins?.some(
+      (p) =>
+        (typeof p === 'string' && p === '@nx/react/router-plugin') ||
+        (typeof p === 'object' && p.plugin === '@nx/react/router-plugin')
+    );
+    expect(hasRouterPlugin).toBeTruthy();
+  });
+
+  it('should NOT add react-router plugin when addPlugin is false even if useReactRouterPlugin is true', async () => {
+    await reactInitGenerator(tree, {
+      skipFormat: true,
+      addPlugin: false,
+      useReactRouterPlugin: true,
+    });
+    const nxJson = readNxJson(tree);
+    const hasRouterPlugin = nxJson.plugins?.some(
+      (p) =>
+        (typeof p === 'string' && p === '@nx/react/router-plugin') ||
+        (typeof p === 'object' && p.plugin === '@nx/react/router-plugin')
+    );
+    expect(hasRouterPlugin).toBeFalsy();
   });
 });

--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -41,7 +41,7 @@ export async function reactInitGenerator(tree: Tree, schema: InitSchema) {
     process.env.NX_ADD_PLUGINS !== 'false' &&
     nxJson.useInferencePlugins !== false;
 
-  if (schema.addPlugin) {
+  if (schema.useReactRouterPlugin && schema.addPlugin) {
     await addPlugin(
       tree,
       await createProjectGraphAsync(),

--- a/packages/react/src/generators/init/schema.d.ts
+++ b/packages/react/src/generators/init/schema.d.ts
@@ -4,4 +4,5 @@ export interface InitSchema {
   keepExistingVersions?: boolean;
   updatePackageScripts?: boolean;
   addPlugin?: boolean;
+  useReactRouterPlugin?: boolean;
 }

--- a/packages/react/src/generators/init/schema.json
+++ b/packages/react/src/generators/init/schema.json
@@ -21,6 +21,12 @@
       "x-priority": "internal",
       "description": "Keep existing dependencies versions",
       "default": false
+    },
+    "useReactRouterPlugin": {
+      "type": "boolean",
+      "x-priority": "internal",
+      "description": "Add the @nx/react/router-plugin to the nx.json plugins array. Only use this if using React Router for SSR/RSC.",
+      "default": false
     }
   },
   "required": []

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -92,6 +92,7 @@ export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
   const initTask = await initGenerator(host, {
     ...options,
     skipFormat: true,
+    useReactRouterPlugin: false,
   });
   tasks.push(initTask);
 


### PR DESCRIPTION
## Current Behavior

  The React init generator unconditionally adds the @nx/react/router-plugin to the nx.json plugins
   array whenever addPlugin is true. This causes the React Router plugin to be added even for
  React applications that don't use React Router, which is unnecessary and can lead to unwanted
  behavior.

## Expected Behavior

  The React Router plugin should only be added to nx.json when:
  1. The React application is actually using React Router (specifically for SSR/RSC scenarios)
  2. The addPlugin option is true

  This ensures that:
  - Applications without React Router don't get the plugin unnecessarily
  - Applications with React Router for SSR/RSC get the plugin automatically when created with the
  --useReactRouter flag
  - Libraries never get the React Router plugin as they don't need it

## Related Issue(s)

  Fixes #32525