### PR TITLE
fix(bundling): ensure tsconfig options are respected with rollup-typescript-plugin

### DIFF
--- a/e2e/release/project.json
+++ b/e2e/release/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "e2e/release",
   "projectType": "application",
-  "implicitDependencies": ["nx", "js"],
+  "implicitDependencies": ["nx", "js", "rollup"],
   "// targets": "to see all targets run: nx show project e2e-release --web",
   "targets": {}
 }

--- a/e2e/remix/src/remix-ts-solution.test.ts
+++ b/e2e/remix/src/remix-ts-solution.test.ts
@@ -7,14 +7,14 @@ import {
 } from '@nx/e2e-utils';
 
 describe('Remix - TS solution setup', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     newProject({
       packages: ['@nx/remix'],
       preset: 'ts',
     });
   });
 
-  afterAll(() => {
+  afterEach(() => {
     cleanupProject();
   });
 

--- a/packages/rollup/src/plugins/with-nx/with-nx.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx.ts
@@ -279,12 +279,11 @@ export function withNx(
               tsconfig: tsConfigPath,
               compilerOptions: {
                 ...tsCompilerOptions,
+                composite: false,
                 outDir: rollupOutputDir,
                 declarationDir: rollupOutputDir,
+                noEmitOnError: !options.skipTypeCheck,
               },
-              declaration: true,
-              declarationMap: !!options.sourceMap,
-              noEmitOnError: !options.skipTypeCheck,
             });
           })(),
       typeDefinitions({


### PR DESCRIPTION
## Current Behavior
The configuration of the `@rollup/typescript-plugin` is incorrect and overrides options provided by tsconfig.
It also doesn't respect options from the tsconfig file.

## Expected Behavior
Ensure tsconfig options are respected and not implicitly overriden.
