### PR TITLE
chore(core): nx plugin submission @frontenderz/backstage-insights

### DIFF
--- a/astro-docs/src/content/approved-community-plugins.json
+++ b/astro-docs/src/content/approved-community-plugins.json
@@ -553,5 +553,10 @@
     "name": "@berenddeboer/nx-knip",
     "description": "A self-inferring Nx plugin for using knip to find and fix unused dependencies, exports and files",
     "url": "https://github.com/berenddeboer/nx-plugins/tree/main/packages/nx-knip"
+  },
+  {
+    "name": "@frontenderz/backstage-insights",
+    "description": "An Nx plugin to generate a Backstage software catalog from your monorepo, including components, dependencies, and ownership.",
+    "url": "https://github.com/frontenderz/frontenderz-nx-plugins/tree/main/packages/backstage-insights"
   }
 ]


### PR DESCRIPTION
# Community Plugin Submission

## @frontenderz/backstage-insights

A powerful Nx Plugin that automates the discovery of your monorepo's components and ownership, generating a valid and interconnected software catalog for [Backstage](https://backstage.io/).

This tool acts as the essential bridge between the technical, graph-based reality of your Nx workspace and the socio-technical, entity-based model of Backstage.

The "Why?" - The Problem We Solve
By default, Backstage can register any Git repository as a single entity in its catalog. For a large Nx monorepo where many teams collaborate, this creates a critical visibility gap. Registering the repository only tells you that it exists; it reveals nothing about the dozens or hundreds of applications and libraries inside it—what they are, who owns them, or how they relate to each other.

This plugin solves that problem.

It treats your Nx workspace as the single source of truth, scanning its project graph to make the implicit architecture of your monorepo explicit for Backstage. It generates a detailed, up-to-date catalog of every component and its owner, giving you a granular, high-fidelity view of your frontend landscape directly in your developer portal.
