### PR TITLE
feat(react): keep deprecated @nx/react/bundle-rollup module since there is not a replacement when using @nx/rollup:rollup executor

### DIFF
--- a/packages/react/plugins/bundle-rollup.ts
+++ b/packages/react/plugins/bundle-rollup.ts
@@ -1,6 +1,5 @@
 import * as rollup from 'rollup';
 
-// TODO(v22): Remove this in Nx 22 and migrate to explicit rollup.config.cjs files.
 /**
  * @deprecated Use `withNx` function from `@nx/rollup/with-nx` in your rollup.config.cjs file instead. Use `nx g @nx/rollup:convert-to-inferred` to generate the rollup.config.cjs file if it does not exist.
  */


### PR DESCRIPTION
There isn't a replacement for `bundle-rollup` since the rollup executor does not support isolated configs. This module ensures that existing projects will continue to work.