### PR TITLE
fix(core): do not add `cache_outputs` foreign key to `task_details` when `NX_DISABLE_DB=true`

### DIFF
--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -75,7 +75,7 @@ export class DbCache {
     workspaceRoot,
     cacheDir,
     getDbConnection(),
-    undefined,
+    process.env.NX_DISABLE_DB !== 'true',
     resolveMaxCacheSize(this.nxJson)
   );
 


### PR DESCRIPTION
## Current Behavior

The `cache_outputs` table is always created with a foreign key to the `task_details` table. When `NX_DISABLE_DB=true` is set, the `task_details` table is not created, and this results in an error when trying to insert any records in the `cache_outputs` table.

## Expected Behavior

When `NX_DISABLE_DB=true` is set, the `cache_outputs` table should not have a foreign key to the non-existent `task_details` table.

## Related Issue(s)

Fixes #32208 
