### PR TITLE
fix(release): process project dependents in other release groups despite group filter #31273

### DIFF
--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -193,43 +193,40 @@ describe('nx release - independent projects', () => {
         `release version 999.9.9-package.3 -p ${pkg3}`
       );
       expect(versionPkg3Output).toMatchInlineSnapshot(`
+NX   Your filter "{project-name}" matched the following projects:
 
-          NX   Your filter "{project-name}" matched the following projects:
-
-          - {project-name}
-
-
-          NX   Running release version for project: {project-name}
-
-        {project-name} 📄 Resolved the current version as 999.9.9-package.2 from manifest: {project-name}/package.json
-        {project-name} ✍️  Updated 1 dependency in manifest: {project-name}/package.json
-        {project-name} ❓ Applied semver relative bump "patch", because a dependency was bumped, to get new version 999.9.9
-        {project-name} ✍️  New version 999.9.9 written to manifest: {project-name}/package.json
-        {project-name} ✍️  Updated 1 dependency in manifest: {project-name}/package.json
-
-          NX   Running release version for project: {project-name}
-
-          {project-name} 📄 Resolved the current version as 0.0.0 from manifest: {project-name}/package.json
-          {project-name} ❓ Applied explicit semver value "999.9.9-package.3", from the given specifier, to get new version 999.9.9-package.3
-          {project-name} ✍️  New version 999.9.9-package.3 written to manifest: {project-name}/package.json
+- {project-name}
 
 
-          "name": "@proj/{project-name}",
-          -   "version": "0.0.0",
-          +   "version": "999.9.9-package.3",
-          "exports": {
+NX   Running release version for project: {project-name}
+
+{project-name} 📄 Resolved the current version as 999.9.9-package.2 from manifest: {project-name}/package.json
+{project-name} ❓ Applied semver relative bump "patch", because a dependency was bumped, to get new version 999.9.9
+{project-name} ✍️  New version 999.9.9 written to manifest: {project-name}/package.json
+
+NX   Running release version for project: {project-name}
+
+{project-name} 📄 Resolved the current version as 0.0.0 from manifest: {project-name}/package.json
+{project-name} ❓ Applied explicit semver value "999.9.9-package.3", from the given specifier, to get new version 999.9.9-package.3
+{project-name} ✍️  New version 999.9.9-package.3 written to manifest: {project-name}/package.json
 
 
-          "name": "@proj/{project-name}",
-          -   "version": "999.9.9-package.2",
-          +   "version": "999.9.9",
-          "exports": {
+"name": "@proj/{project-name}",
+-   "version": "0.0.0",
++   "version": "999.9.9-package.3",
+"exports": {
 
 
-          NX   Updating {package-manager} lock file
+"name": "@proj/{project-name}",
+-   "version": "999.9.9-package.2",
++   "version": "999.9.9",
+"exports": {
 
 
-          NX   Staging changed files with git
+NX   Updating {package-manager} lock file
+
+
+NX   Staging changed files with git
 
 
         `);

--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -61,7 +61,7 @@ expect.addSnapshotSerializer({
   },
 });
 
-describe('debug nx release - independent projects', () => {
+describe('nx release - independent projects', () => {
   let pkg1: string;
   let pkg2: string;
   let pkg3: string;
@@ -201,9 +201,11 @@ describe('debug nx release - independent projects', () => {
 
           NX   Running release version for project: {project-name}
 
-          {project-name} 📄 Resolved the current version as 999.9.9-package.2 from manifest: {project-name}/package.json
-          {project-name} ❓ Applied semver relative bump "patch", because a dependency was bumped, to get new version 999.9.9
-          {project-name} ✍️  New version 999.9.9 written to manifest: {project-name}/package.json
+        {project-name} 📄 Resolved the current version as 999.9.9-package.2 from manifest: {project-name}/package.json
+        {project-name} ✍️  Updated 1 dependency in manifest: {project-name}/package.json
+        {project-name} ❓ Applied semver relative bump "patch", because a dependency was bumped, to get new version 999.9.9
+        {project-name} ✍️  New version 999.9.9 written to manifest: {project-name}/package.json
+        {project-name} ✍️  Updated 1 dependency in manifest: {project-name}/package.json
 
           NX   Running release version for project: {project-name}
 

--- a/packages/nx/src/command-line/release/version/release-group-processor.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.ts
@@ -1768,10 +1768,18 @@ Valid values are: ${validReleaseVersionPrefixes
       return false;
     }
 
-    for (const dependents of this.projectToDependents.values()) {
-      if (dependents.has(project)) {
-        this.cachedIsDependentUpdate.set(project, true);
-        return true;
+    // Check if the project depends on any project in the filtered release groups
+    const dependencies = this.projectToDependencies.get(project);
+    if (dependencies) {
+      for (const dependency of dependencies) {
+        if (
+          this.releaseGroups.some((group) =>
+            group.projects.includes(dependency)
+          )
+        ) {
+          this.cachedIsDependentUpdate.set(project, true);
+          return true;
+        }
       }
     }
     this.cachedIsDependentUpdate.set(project, false);


### PR DESCRIPTION
## Current Behavior

When using the --groups filter with nx release, projects in other release groups that depend on
projects in the filtered group are not properly updated, even when updateDependents is set to
auto. This causes dependency version mismatches when releasing a subset of release groups.

## Expected Behavior

When releasing with a --groups filter and updateDependents: 'auto', all dependent projects
across all release groups should have their dependencies updated to match the new versions of
the filtered projects being released. This ensures dependency consistency across the entire
workspace.

## Related Issue(s)

Fixes #31273