### PR TITLE
chore(nx-dev): update active contributors

### DIFF
--- a/nx-dev/ui-cloud/src/lib/pricing.tsx
+++ b/nx-dev/ui-cloud/src/lib/pricing.tsx
@@ -289,7 +289,7 @@ export function Pricing(): ReactElement {
               </ul>
               <p className="mt-4 text-xs text-slate-500">
                 ¹Any person or actor that has triggered a CI Pipeline Execution
-                within the current billing cycle. Up to 30 active contributors.
+                within the current billing cycle. Up to 50 active contributors.
               </p>
             </div>
 


### PR DESCRIPTION
Increased the maximum number of active contributors mentioned in the pricing description from 30 to 50 in the `Pricing` component (`nx-dev/ui-cloud/src/lib/pricing.tsx`).