### PR TITLE
fix(core): move from execFile to exec for windows support

### DIFF
--- a/packages/nx/src/utils/provenance.ts
+++ b/packages/nx/src/utils/provenance.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { join } from 'path';
 import { promisify } from 'util';
 import { readJsonFile } from './fileutils';
@@ -21,11 +21,10 @@ export async function ensurePackageHasProvenance(
     return;
   }
 
-  const execFileAsync = promisify(execFile);
+  const execAsync = promisify(exec);
   try {
-    const result = await execFileAsync(
-      platform() === 'win32' ? 'npm.cmd' : 'npm',
-      ['view', `${packageName}@${packageVersion}`, '--json', '--silent'],
+    const result = await execAsync(
+      `npm view ${packageName}@${packageVersion} --json --silent`,
       {
         timeout: 20000,
       }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
provenance checks fail on latest on windows because `npm.cmd` is only executable with a shell. That removes the entire security aspect of using `execFile` so we just go back to `exec`.

## Expected Behavior
provenance checks shouldn't fail on windows.

## Related Issue(s)

Fixes #32713 
