### PR TITLE
docs(misc): minor styling fixes

### DIFF
--- a/astro-docs/src/styles/global.css
+++ b/astro-docs/src/styles/global.css
@@ -194,6 +194,14 @@ pre {
     border-radius: var(--radius-lg);
   }
 
+  aside a {
+    color: var(--sl-color-accent);
+  }
+
+  aside a:hover {
+    color: var(--sl-color-accent-high);
+  }
+
   /* Align TOC with sidebar styling */
   starlight-toc ul {
     line-height: var(--leading-relaxed);
@@ -356,9 +364,15 @@ pre {
 /* Additional custom styles can be added here */
 
 /* For deepdive callouts that are still used, need to space out content */
-.callout div:not(:last-child),
+.callout div:not(:last-child):not(.ec-line),
 .callout p:not(:last-child) {
   @apply mb-4;
+}
+.callout a {
+  color: var(--sl-color-accent);
+}
+.callout a:hover {
+  color: var(--sl-color-accent-high);
 }
 
 /* Align top with breadcrumbs */
@@ -386,7 +400,7 @@ h6:hover .anchor-link {
 }
 
 .anchor-link:hover {
-  color: var(--sl-color-accent);
+  color: var(--sl-color-accent-high);
 }
 
 .right-sidebar {
@@ -405,7 +419,7 @@ table code {
   word-wrap: break-word;
 }
 
-/* Fix tab alignment */
 [role='tablist'] {
-  align-items: end;
+  font-size: var(--text-sm);
+  align-items: end; /* Fix tab alignment */
 }


### PR DESCRIPTION
This PR fixes a few styling issues

## Anchor links colors being consistent inside asides:
https://github.com/user-attachments/assets/13ba7892-50ee-4429-b9f5-8587f65869de

## Mobile login border color on light theme (make it lighter and same as other border colors):
<img width="325" height="279" alt="Screenshot 2025-09-24 at 10 34 56 AM" src="https://github.com/user-attachments/assets/b2ca3246-5a11-491c-8240-68a0e4430c81" />

## Decrease font size for tabs:
<img width="676" height="319" alt="Screenshot 2025-09-24 at 10 38 38 AM" src="https://github.com/user-attachments/assets/5a7dc828-f049-4b25-9b28-144969fd810f" />

## Remove extra margin-bottom for code lines in asides:
Before:

<img width="743" height="387" alt="image" src="https://github.com/user-attachments/assets/55312f0a-acc5-48e2-bcb2-3370d00ed05f" />

After:
<img width="828" height="467" alt="image" src="https://github.com/user-attachments/assets/537f688a-61cf-444a-a512-84c611b80c43" />


Closes #DOC-227 #DOC-225