### PR TITLE
fix(gradle): skip targets on Netlify since the Java version is too old

### DIFF
--- a/packages/gradle/src/plugin/nodes.ts
+++ b/packages/gradle/src/plugin/nodes.ts
@@ -88,11 +88,11 @@ export const makeCreateNodesForGradleConfigFile =
     options: GradlePluginOptions | undefined,
     context: CreateNodesContext
   ) => {
-    if (process.env.VERCEL) {
-      // Vercel does not allow JAVA_VERSION to be set
-      // skip on Vercel
-      return {};
-    }
+    // Vercel does not allow JAVA_VERSION to be set, skip on Vercel
+    if (process.env.VERCEL) return {};
+
+    // Netlify only supports Java 8 but we require 17, skip on Netlify
+    if (process.env.NETLIFY) return {};
 
     const projectRoot = dirname(gradleFilePath);
     options = normalizeOptions(options);


### PR DESCRIPTION
Building on Netlify fails.

```
3:03:48 PM: FAILURE: Build failed with an exception.
3:03:48 PM: * What went wrong:
3:03:48 PM: A problem occurred configuring root project 'nx'.
3:03:48 PM: > Could not resolve all artifacts for configuration 'classpath'.
3:03:48 PM:    > Could not resolve dev.nx.gradle:project-graph:0.1.7.
3:03:48 PM:      Required by:
3:03:48 PM:          root project : > dev.nx.gradle.project-graph:dev.nx.gradle.project-graph.gradle.plugin:0.1.7
3:03:48 PM:       > Dependency requires at least JVM runtime version 17. This build uses a Java 8 JVM.
3:03:48 PM:    > Could not resolve com.ncorti.ktfmt.gradle:plugin:0.24.0.
3:03:48 PM:      Required by:
3:03:48 PM:          root project : > com.ncorti.ktfmt.gradle:com.ncorti.ktfmt.gradle.gradle.plugin:0.24.0
3:03:48 PM:       > Dependency requires at least JVM runtime version 17. This build uses a Java 8 JVM.
3:03:48 PM: * Try:
3:03:48 PM: > Run this build using a Java 17 or newer JVM.
3:03:48 PM: > Run with --stacktrace option to get the stack trace.
3:03:48 PM: > Run with --debug option to get more log output.
3:03:48 PM: > Run with --scan to get full insights.
3:03:48 PM: > Get more help at https://help.gradle.org.
3:03:48 PM: BUILD FAILED in 30s
```

## Current Behavior
Gradle plugin needs Java 17, but Netlify uses 8.

## Expected Behavior
Skip targets on Netlify just like on Vercel.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #NXC-3175
