### PR TITLE
chore(web): ensure readme is published

### DIFF
--- a/packages/web/project.json
+++ b/packages/web/project.json
@@ -4,7 +4,10 @@
   "sourceRoot": "packages/web",
   "projectType": "library",
   "targets": {
-    "build": {},
+    "build": {
+      "outputs": ["{workspaceRoot}/dist/packages/web/README.md"],
+      "command": "node ./scripts/copy-readme.js web"
+    },
     "legacy-post-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {


### PR DESCRIPTION
## Current Behavior
The `README.md` file for `@nx/web` is currently not copied into the publish directory for release.

## Expected Behavior
Ensure the `README.md` file is copied into the publish directory.

## Related Issue(s)

Fixes NXC-3055
