### PR TITLE
fix(nest): setup tsconfig to use decorators #30749

### DIFF
--- a/packages/nest/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/nest/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`lib --testEnvironment should set target jest testEnvironment to jsdom 1`] = `
 "export default {

--- a/packages/nest/src/generators/library/lib/update-tsconfig.ts
+++ b/packages/nest/src/generators/library/lib/update-tsconfig.ts
@@ -7,6 +7,10 @@ export function updateTsConfig(tree: Tree, options: NormalizedOptions): void {
 
   return updateJson(tree, `${project.root}/tsconfig.lib.json`, (json) => {
     json.compilerOptions.target = options.target;
+    // NestJS requires decorators to be enabled for dependency injection
+    json.compilerOptions.experimentalDecorators = true;
+    json.compilerOptions.emitDecoratorMetadata = true;
+
     if (options.strict) {
       json.compilerOptions = {
         ...json.compilerOptions,

--- a/packages/nest/src/generators/library/library.spec.ts
+++ b/packages/nest/src/generators/library/library.spec.ts
@@ -274,6 +274,16 @@ describe('lib', () => {
       const tsconfigJson = readJson(tree, `my-lib/tsconfig.lib.json`);
       expect(tsconfigJson.compilerOptions.target).toEqual('es2021');
     });
+
+    it('should enable decorators in tsconfig.lib.json for NestJS support', async () => {
+      await libraryGenerator(tree, {
+        directory: 'my-lib',
+      });
+
+      const tsconfigJson = readJson(tree, `my-lib/tsconfig.lib.json`);
+      expect(tsconfigJson.compilerOptions.experimentalDecorators).toBe(true);
+      expect(tsconfigJson.compilerOptions.emitDecoratorMetadata).toBe(true);
+    });
   });
 
   describe('--skipFormat', () => {
@@ -440,6 +450,8 @@ describe('lib', () => {
           "compilerOptions": {
             "baseUrl": ".",
             "emitDeclarationOnly": true,
+            "emitDecoratorMetadata": true,
+            "experimentalDecorators": true,
             "forceConsistentCasingInFileNames": true,
             "importHelpers": true,
             "module": "nodenext",


### PR DESCRIPTION
## Current Behavior
NestJS libraries using decorators in constructor, or otherwise, are causing TS errors due to missing configuration for decorators.

## Expected Behavior
Ensure decorator config settings are set in `tsconfig.lib.json`.

## Related Issue(s)

Fixes #30749
