### PR TITLE
fix(rspack): mark svgr support as deprecated

### DIFF
--- a/packages/rspack/src/plugins/nx-react-rspack-plugin/nx-react-rspack-plugin.ts
+++ b/packages/rspack/src/plugins/nx-react-rspack-plugin/nx-react-rspack-plugin.ts
@@ -2,7 +2,15 @@ import type { Compiler } from '@rspack/core';
 import { applyReactConfig } from '../utils/apply-react-config';
 
 export class NxReactRspackPlugin {
-  constructor(private options: { svgr?: boolean } = {}) {}
+  constructor(
+    private options: {
+      /**
+       * @deprecated SVGR support is deprecated and will be removed in Nx 23.
+       * TODO(v23): Remove SVGR support
+       */
+      svgr?: boolean;
+    } = {}
+  ) {}
 
   apply(compiler: Compiler) {
     applyReactConfig(this.options, compiler.options);

--- a/packages/rspack/src/plugins/utils/apply-react-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-react-config.ts
@@ -1,6 +1,8 @@
 import { Configuration, RspackOptionsNormalized } from '@rspack/core';
+import { logger } from '@nx/devkit';
 import { SvgrOptions } from './models';
 
+// TODO(v23): Remove SVGR support
 export function applyReactConfig(
   options: { svgr?: boolean | SvgrOptions },
   config: Partial<RspackOptionsNormalized | Configuration> = {}
@@ -10,6 +12,13 @@ export function applyReactConfig(
   addHotReload(config);
 
   if (options.svgr !== false || typeof options.svgr === 'object') {
+    // Log deprecation warning when SVGR is used
+    if (options.svgr === true || typeof options.svgr === 'object') {
+      logger.warn(
+        'SVGR support is deprecated and will be removed in Nx 23. Please consider using alternative SVG handling methods.'
+      );
+    }
+
     removeSvgLoaderIfPresent(config);
 
     const defaultSvgrOptions = {

--- a/packages/rspack/src/plugins/utils/models.ts
+++ b/packages/rspack/src/plugins/utils/models.ts
@@ -2,6 +2,10 @@ import type { DevTool, Mode } from '@rspack/core';
 import type { ProjectGraph } from '@nx/devkit';
 import type { AssetGlob } from '@nx/js/src/utils/assets/assets';
 
+/**
+ * @deprecated SVGR support is deprecated and will be removed in Nx 23.
+ * TODO(v23): Remove SVGR support
+ */
 export interface SvgrOptions {
   svgo?: boolean;
   titleProp?: boolean;

--- a/packages/rspack/src/utils/with-react.ts
+++ b/packages/rspack/src/utils/with-react.ts
@@ -5,6 +5,10 @@ import { applyReactConfig } from '../plugins/utils/apply-react-config';
 import { SvgrOptions } from '../plugins/utils/models';
 
 export interface WithReactOptions extends WithWebOptions {
+  /**
+   * @deprecated SVGR support is deprecated and will be removed in Nx 23.
+   * TODO(v23): Remove SVGR support
+   */
   svgr?: boolean | SvgrOptions;
 }
 


### PR DESCRIPTION
## Current Behavior
`svgr` support has been deprecated in `webpack` for some time, but it was never marked as deprecated for `rspack`.

## Expected Behavior
Mark `svgr` support as deprecated with aim for removal in v23
