### PR TITLE
fix(core): spinner shows correct plugin count during project graph creation

### DIFF
--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -348,7 +348,7 @@ async function updateProjectGraphWithPlugins(
   }
 
   spinner = new DelayedSpinner(
-    `Creating project graph dependencies with ${plugins.length} plugins`
+    `Creating project graph dependencies with ${createDependencyPlugins.length} plugins`
   );
 
   await Promise.all(
@@ -468,29 +468,30 @@ export async function applyProjectMetadata(
     }
   }
 
+  const createMetadataPlugins = plugins.filter(
+    (plugin) => plugin.createMetadata
+  );
   spinner = new DelayedSpinner(
-    `Creating project metadata with ${plugins.length} plugins`
+    `Creating project metadata with ${createMetadataPlugins.length} plugins`
   );
 
-  const promises = plugins.map(async (plugin) => {
-    if (plugin.createMetadata) {
-      performance.mark(`${plugin.name}:createMetadata - start`);
-      inProgressPlugins.add(plugin.name);
-      try {
-        const metadata = await plugin.createMetadata(graph, context);
-        results.push({ metadata, pluginName: plugin.name });
-      } catch (e) {
-        errors.push(new CreateMetadataError(e, plugin.name));
-      } finally {
-        inProgressPlugins.delete(plugin.name);
-        updateSpinner();
-        performance.mark(`${plugin.name}:createMetadata - end`);
-        performance.measure(
-          `${plugin.name}:createMetadata`,
-          `${plugin.name}:createMetadata - start`,
-          `${plugin.name}:createMetadata - end`
-        );
-      }
+  const promises = createMetadataPlugins.map(async (plugin) => {
+    performance.mark(`${plugin.name}:createMetadata - start`);
+    inProgressPlugins.add(plugin.name);
+    try {
+      const metadata = await plugin.createMetadata(graph, context);
+      results.push({ metadata, pluginName: plugin.name });
+    } catch (e) {
+      errors.push(new CreateMetadataError(e, plugin.name));
+    } finally {
+      inProgressPlugins.delete(plugin.name);
+      updateSpinner();
+      performance.mark(`${plugin.name}:createMetadata - end`);
+      performance.measure(
+        `${plugin.name}:createMetadata`,
+        `${plugin.name}:createMetadata - start`,
+        `${plugin.name}:createMetadata - end`
+      );
     }
   });
 

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -375,8 +375,11 @@ export async function createProjectConfigurationsWithPlugins(
     }
   }
 
+  const createNodesPlugins = plugins.filter(
+    (plugin) => plugin.createNodes?.[0]
+  );
   spinner = new DelayedSpinner(
-    `Creating project graph nodes with ${plugins.length} plugins`
+    `Creating project graph nodes with ${createNodesPlugins.length} plugins`
   );
 
   const results: Promise<
@@ -404,12 +407,8 @@ export async function createProjectConfigurationsWithPlugins(
       exclude,
       name: pluginName,
     },
-  ] of plugins.entries()) {
-    const [pattern, createNodes] = createNodesTuple ?? [];
-
-    if (!pattern) {
-      continue;
-    }
+  ] of createNodesPlugins.entries()) {
+    const [pattern, createNodes] = createNodesTuple;
 
     const matchingConfigFiles: string[] = findMatchingConfigFiles(
       projectFiles[index],


### PR DESCRIPTION
## Current Behavior

The spinners shown during project graph creation display incorrect plugin counts. They show the total number of registered plugins instead of the actual number of plugins being processed for each specific phase.

For example, if there are 10 total plugins but only 3 have `createDependencies`, the spinner would incorrectly show "Creating project graph dependencies with 10 plugins" instead of "Creating project graph dependencies with 3 plugins".

## Expected Behavior

Spinners should show accurate counts reflecting the actual number of plugins being executed for each phase of project graph creation.

## Related Issue(s)

This fixes a misleading user experience where users see progress indicators that don't match the actual work being performed.

## Changes Made

### 1. Dependencies Phase
- Use `createDependencyPlugins.length` instead of `plugins.length` for spinner count

### 2. Metadata Phase  
- Filter plugins once for `createMetadata` capability
- Use filtered count for spinner
- Eliminate double filtering by using filtered array directly in processing

### 3. Create Nodes Phase
- Filter plugins once for `createNodes[0]` pattern existence
- Use filtered count for spinner
- Eliminate redundant pattern check in loop

## Benefits

- **Accurate Progress**: Users see correct plugin counts during each phase
- **Better Performance**: Eliminated redundant filtering operations
- **Consistent Code**: All three phases now follow the same pattern of filter-once-use-everywhere