### PR TITLE
fix(core): tweak messaging if vscode / cursor aren't installed

### DIFF
--- a/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
+++ b/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
@@ -1,6 +1,7 @@
 import { prompt } from 'enquirer';
 import { output } from '../../utils/output';
 import { ensurePackageHasProvenance } from '../../utils/provenance';
+import * as chalk from 'chalk';
 
 import {
   Agent,
@@ -65,12 +66,31 @@ export async function configureAiAgentsHandlerImpl(
   } = await getAgentConfigurations(normalizedOptions.agents, workspaceRoot);
 
   if (disabledAgents.length > 0) {
+    const commandNames = disabledAgents.map((a) => {
+      if (a === 'cursor') return '"cursor"';
+      if (a === 'copilot') return '"code"/"code-insiders"';
+      return a;
+    });
+
+    const agentNames = disabledAgents.map((a) => agentDisplayMap[a]).join(', ');
+
+    const pluralS = disabledAgents.length > 1 ? 's' : '';
+    const title =
+      commandNames.length === 1
+        ? `${commandNames[0]} command not available. Ignoring ${agentNames} agent${pluralS}.`
+        : `CLI commands ${commandNames
+            .map((c) => `${c}`)
+            .join(
+              ', '
+            )} not available. Ignoring ${agentNames} agent${pluralS}.`;
+
     output.log({
-      title: `Ignoring agent${
-        disabledAgents.length > 1 ? 's' : ''
-      } ${disabledAgents
-        .map((a) => agentDisplayMap[a])
-        .join(', ')} because editor is not available.`,
+      title,
+      bodyLines: [
+        chalk.dim(
+          'To manually configure the Nx MCP in your editor, install Nx Console (https://nx.dev/getting-started/editor-setup)'
+        ),
+      ],
     });
   }
 

--- a/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
+++ b/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
@@ -72,17 +72,12 @@ export async function configureAiAgentsHandlerImpl(
       return a;
     });
 
-    const agentNames = disabledAgents.map((a) => agentDisplayMap[a]).join(', ');
-
-    const pluralS = disabledAgents.length > 1 ? 's' : '';
     const title =
       commandNames.length === 1
-        ? `${commandNames[0]} command not available. Ignoring ${agentNames} agent${pluralS}.`
+        ? `${commandNames[0]} command not available.`
         : `CLI commands ${commandNames
             .map((c) => `${c}`)
-            .join(
-              ', '
-            )} not available. Ignoring ${agentNames} agent${pluralS}.`;
+            .join('/')} not available.`;
 
     output.log({
       title,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
The messaging can be confusing if vscode/cursor are installed but not added to PATH.

## Expected Behavior
The messaging is clearer.
