### PR TITLE
fix(nx-dev): watch for theme changes for project/task graph components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ packages/angular-rspack/README.md
 packages/angular-rspack-compiler/README.md
 
 test-output
+test-results

--- a/astro-docs/e2e/theme-switching.spec.ts
+++ b/astro-docs/e2e/theme-switching.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+
+test('should apply system theme by default', async ({ page }) => {
+  await page.goto('/docs/getting-started/intro');
+
+  await expect(
+    page.getByRole('heading', { name: 'What is Nx?' })
+  ).toBeVisible();
+
+  const themeSelector = page.getByRole('combobox', {
+    name: /theme/i,
+  });
+
+  await expect(themeSelector).toBeVisible();
+
+  await expect(themeSelector).toHaveValue('auto');
+
+  const dataTheme = await page.evaluate(
+    () => document.documentElement.dataset.theme
+  );
+  // The data-theme should be either 'light' or 'dark' based on system preference
+  // It won't be 'auto' on the document element
+  expect(['light', 'dark']).toContain(dataTheme);
+});
+
+test('should switch to between light and dark theme', async ({ page }) => {
+  await page.goto('/docs/getting-started/intro');
+
+  await expect(
+    page.getByRole('heading', { name: 'What is Nx?' })
+  ).toBeVisible();
+
+  const themeSelector = page.getByRole('combobox', {
+    name: /theme/i,
+  });
+
+  await test.step('light theme renders', async () => {
+    await expect(themeSelector).toBeVisible();
+
+    await themeSelector.selectOption('light');
+
+    await expect(themeSelector).toHaveValue('light');
+
+    const dataTheme = await page.evaluate(
+      () => document.documentElement.dataset.theme
+    );
+    expect(dataTheme).toBe('light');
+  });
+
+  await test.step('dark theme renders', async () => {
+    await themeSelector.selectOption('dark');
+
+    await expect(themeSelector).toHaveValue('dark');
+
+    const dataTheme = await page.evaluate(
+      () => document.documentElement.dataset.theme
+    );
+    expect(dataTheme).toBe('dark');
+  });
+
+  await test.step('switch back to auto', async () => {
+    await themeSelector.selectOption('auto');
+
+    await expect(themeSelector).toHaveValue('auto');
+
+    const dataTheme = await page.evaluate(
+      () => document.documentElement.dataset.theme
+    );
+    expect(['light', 'dark']).toContain(dataTheme);
+  });
+});

--- a/nx-dev/ui-markdoc/src/lib/graphs/project-graph.tsx
+++ b/nx-dev/ui-markdoc/src/lib/graphs/project-graph.tsx
@@ -10,7 +10,7 @@ import {
   NxGraphProjectGraphProvider,
   useProjectGraphContext,
 } from '@nx/graph/projects';
-import { resolveTheme } from './resolve-theme';
+import { useThemeSync } from './resolve-theme';
 import {
   NxGraphCompositeProjectNodePanelContent,
   NxGraphCompositeProjectNodePanelHeader,
@@ -59,12 +59,12 @@ function NxDevProjectGraphInner({
     ElementData.ProjectNode | ElementData.CompositeProjectNode
   >(eventBus);
 
-  useEffect(() => {
+  useThemeSync(theme, (resolvedTheme) => {
     sendRendererConfigEvent({
       type: 'themeChange',
-      theme: resolveTheme(theme),
+      theme: resolvedTheme,
     });
-  }, [theme]);
+  });
 
   useEffect(() => {
     if (!orchestrator) return;

--- a/nx-dev/ui-markdoc/src/lib/graphs/resolve-theme.ts
+++ b/nx-dev/ui-markdoc/src/lib/graphs/resolve-theme.ts
@@ -1,10 +1,74 @@
 import type { RenderTheme } from '@nx/graph';
+import { useEffect, useState } from 'react';
 
 export function resolveTheme(theme: RenderTheme | 'system'): RenderTheme {
-  if (theme !== 'system') {
-    return theme;
+  // Astro theme switcher sets this data attr when
+  // user manually changes theme or on first render
+  const astroTheme = document.documentElement.dataset.theme;
+
+  if (astroTheme === 'light' || astroTheme === 'dark') {
+    return astroTheme as RenderTheme;
   }
 
-  const darkMedia = window.matchMedia('(prefers-color-scheme: dark)');
-  return darkMedia.matches ? 'dark' : 'light';
+  if (astroTheme === 'auto' || !astroTheme || theme === 'system') {
+    const prefersDark = window.matchMedia(
+      '(prefers-color-scheme: dark)'
+    ).matches;
+    return prefersDark ? 'dark' : 'light';
+  }
+
+  return theme === 'dark' || theme === 'light' ? theme : 'light';
+}
+
+/**
+ * Hook to track theme changes from both Astro theme switcher and system preference
+ */
+export function useThemeSync(
+  fallbackTheme: RenderTheme | 'system' = 'system',
+  onThemeChange?: (theme: RenderTheme) => void
+): RenderTheme {
+  const [currentTheme, setCurrentTheme] = useState<RenderTheme>(() => {
+    if (typeof window === 'undefined') return 'light';
+    return resolveTheme(fallbackTheme);
+  });
+
+  useEffect(() => {
+    const updateTheme = () => {
+      const newTheme = resolveTheme(fallbackTheme);
+      setCurrentTheme(newTheme);
+      onThemeChange?.(newTheme);
+    };
+
+    updateTheme();
+
+    // Listen for changes to the document's theme attribute astro theme switcher sets
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (
+          mutation.type === 'attributes' &&
+          mutation.attributeName === 'data-theme'
+        ) {
+          updateTheme();
+        }
+      });
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+
+    // Listen for system theme preference changes
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleSystemThemeChange = () => updateTheme();
+
+    mediaQuery.addEventListener('change', handleSystemThemeChange);
+
+    return () => {
+      observer.disconnect();
+      mediaQuery.removeEventListener('change', handleSystemThemeChange);
+    };
+  }, [fallbackTheme, onThemeChange]);
+
+  return currentTheme;
 }

--- a/nx-dev/ui-markdoc/src/lib/graphs/task-graph.tsx
+++ b/nx-dev/ui-markdoc/src/lib/graphs/task-graph.tsx
@@ -5,7 +5,7 @@ import { TaskGraph } from 'nx/src/config/task-graph';
 import { useEffect, useMemo } from 'react';
 import { RenderTheme } from '@nx/graph';
 import { NxGraphTaskGraphProvider, useTaskGraphContext } from '@nx/graph/tasks';
-import { resolveTheme } from './resolve-theme';
+import { useThemeSync } from './resolve-theme';
 import {
   NxGraphElementPanel,
   NxGraphTaskNodePanelContent,
@@ -49,12 +49,12 @@ export function NxDevTaskGraphInner({
 
   const [element] = useElementPanel(eventBus);
 
-  useEffect(() => {
+  useThemeSync(theme, (resolvedTheme) => {
     sendRendererConfigEvent({
       type: 'themeChange',
-      theme: resolveTheme(theme),
+      theme: resolvedTheme,
     });
-  }, [theme]);
+  });
 
   useEffect(() => {
     if (!orchestrator) return;

--- a/nx-dev/ui-markdoc/src/lib/tags/graph.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/graph.component.tsx
@@ -102,9 +102,11 @@ export function Graph({
 
   return parsedProps ? (
     <div className="not-content mt-4 w-full place-content-center overflow-hidden rounded-md ring-1 ring-slate-200 dark:ring-slate-700">
-      <div className="relative flex justify-center border-b border-slate-200 bg-slate-100/50 p-2 font-bold dark:border-slate-700 dark:bg-slate-700/50">
-        {title}
-      </div>
+      {title ? (
+        <div className="relative flex justify-center border-b border-slate-200 bg-slate-100/50 p-2 font-bold dark:border-slate-700 dark:bg-slate-700/50">
+          {title}
+        </div>
+      ) : null}
 
       <div style={{ height }}>
         {type === 'project' ? (


### PR DESCRIPTION
markdoc graph components were not updating the theme if the user changed their theme preference causing contrast issues with graph content.
now the graph components will update the selected them when the system theme or pages theme changes

also do not render title bar if no title is provided

fixes: DOC-237