### PR TITLE
feat(docker): support inferring additional args for targets with interpolation support

### DIFF
--- a/astro-docs/src/content/docs/technologies/build-tools/docker/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/docker/introduction.mdoc
@@ -58,6 +58,129 @@ The `@nx/docker` plugin is configured in the `plugins` array in `nx.json`.
 
 The `buildTarget` and `runTarget` options control the names of the inferred Docker tasks. The default names are `docker:build` and `docker:run`.
 
+### Advanced Plugin Configuration
+
+The `buildTarget` and `runTarget` options can be configured as objects to provide additional customization beyond just naming the targets. This allows you to pass custom arguments, set environment variables, and use pattern interpolation.
+
+```json
+// nx.json
+{
+  "plugins": [
+    {
+      "plugin": "@nx/docker",
+      "options": {
+        "buildTarget": {
+          "name": "docker:build",
+          "args": [
+            "--platform",
+            "linux/amd64,linux/arm64",
+            "--label",
+            "project={projectName}"
+          ],
+          "env": {
+            "DOCKER_BUILDKIT": "1"
+          },
+          "envFile": ".env.docker",
+          "cwd": "{projectRoot}/docker"
+        },
+        "runTarget": {
+          "name": "docker:run",
+          "args": ["--rm"],
+          "env": {
+            "NODE_ENV": "production"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Configuration Properties
+
+When using the object format, the following properties are available:
+
+- **`name`** (string, required): The name of the inferred target
+- **`args`** (string[], optional): Additional arguments to pass to the Docker command. Supports pattern interpolation.
+- **`env`** (object, optional): Environment variables to set when running the Docker command. Values support pattern interpolation.
+- **`envFile`** (string, optional): Path to an environment file to load
+- **`cwd`** (string, optional): Working directory for the command. Supports pattern interpolation.
+
+#### Pattern Interpolation
+
+All string values in the configuration support pattern interpolation using the following tokens:
+
+- **`{projectName}`** - The name of the project from `project.json` or `package.json`
+- **`{projectRoot}`** - The root directory of the project (e.g., `apps/api`)
+- **`{imageRef}`** - The default image reference derived from the project root (e.g., `apps-api`)
+- **`{currentDate}`** - Current date in ISO format (e.g., `2025-01-30T14:30:00.000Z`)
+- **`{currentDate|FORMAT}`** - Current date with custom formatting (e.g., `{currentDate|YYYY.MM.DD}` → `2025.01.30`)
+- **`{commitSha}`** - Full Git commit SHA
+- **`{shortCommitSha}`** - First 7 characters of the commit SHA
+- **`{env.VAR_NAME}`** - Environment variable values (e.g., `{env.BUILD_NUMBER}`)
+
+Date formatting supports these tokens: `YYYY` (year), `YY` (2-digit year), `MM` (month), `DD` (day), `HH` (hours), `mm` (minutes), `ss` (seconds).
+
+#### Example: Multi-Platform Build with Metadata
+
+Here's a practical example that builds Docker images for multiple platforms and includes build metadata:
+
+```json
+// nx.json
+{
+  "plugins": [
+    {
+      "plugin": "@nx/docker",
+      "options": {
+        "buildTarget": {
+          "name": "build",
+          "args": [
+            "--platform",
+            "linux/amd64,linux/arm64",
+            "--label",
+            "org.opencontainers.image.title={projectName}",
+            "--label",
+            "org.opencontainers.image.source={projectRoot}",
+            "--label",
+            "org.opencontainers.image.revision={commitSha}",
+            "--label",
+            "org.opencontainers.image.created={currentDate}",
+            "--build-arg",
+            "BUILD_DATE={currentDate|YYYY-MM-DD}",
+            "--build-arg",
+            "VERSION={env.VERSION}",
+            "--tag",
+            "{imageRef}:{currentDate|YYMMDD}.{shortCommitSha}"
+          ],
+          "env": {
+            "DOCKER_BUILDKIT": "1",
+            "IMAGE_NAME": "{imageRef}"
+          }
+        },
+        "runTarget": {
+          "name": "run",
+          "args": [
+            "--rm",
+            "--publish",
+            "3000:3000",
+            "--env",
+            "NODE_ENV=production"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+This configuration:
+
+- Builds for both AMD64 and ARM64 architectures
+- Adds OpenContainers metadata labels with project information
+- Tags images with a calendar version and commit SHA (e.g., `my-app:250130.abc1234`)
+- Enables Docker BuildKit for improved build performance
+- Injects build arguments and environment variables from the CI/CD pipeline
+
 ## Using Nx Release to Publish Docker Images
 
 The `@nx/docker` plugin provides a `nx-release-publish` target for publishing docker images to a registry.

--- a/packages/docker/src/plugins/plugin.spec.ts
+++ b/packages/docker/src/plugins/plugin.spec.ts
@@ -1,11 +1,14 @@
 import { CreateNodesContextV2 } from '@nx/devkit';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { createNodesV2 } from './plugin';
+import * as gitUtils from 'nx/src/utils/git-utils';
 
 jest.mock('nx/src/utils/cache-directory', () => ({
   ...jest.requireActual('nx/src/utils/cache-directory'),
   workspaceDataDirectory: 'tmp/project-graph-cache',
 }));
+
+jest.mock('nx/src/utils/git-utils');
 
 describe('@nx/docker', () => {
   let createNodesFunction = createNodesV2[1];
@@ -13,7 +16,17 @@ describe('@nx/docker', () => {
   let tempFs: TempFs;
   let cwd: string;
 
+  const mockGetLatestCommitSha =
+    gitUtils.getLatestCommitSha as jest.MockedFunction<
+      typeof gitUtils.getLatestCommitSha
+    >;
+
   beforeEach(async () => {
+    jest.clearAllMocks();
+    mockGetLatestCommitSha.mockReturnValue(
+      'abc123456789def0123456789abcdef012345678'
+    );
+
     tempFs = new TempFs('test');
     cwd = process.cwd();
     process.chdir(tempFs.tempDir);
@@ -686,6 +699,29 @@ describe('@nx/docker', () => {
       expect(Object.keys(targets)).toContain('custom-build');
       expect(Object.keys(targets)).toContain('docker:run'); // default value
     });
+
+    it('should accept object for buildTarget', async () => {
+      await tempFs.createFiles({
+        'proj/Dockerfile': 'FROM node:18',
+        'proj/project.json': '{}',
+      });
+
+      const results = await createNodesFunction(
+        ['proj/Dockerfile'],
+        {
+          buildTarget: {
+            name: 'custom-build',
+            args: ['--platform', 'linux/amd64'],
+          },
+        },
+        context
+      );
+
+      const targets = results[0][1].projects['proj'].targets;
+      expect(Object.keys(targets)).toContain('custom-build');
+      expect(targets['custom-build'].options.args).toContain('--platform');
+      expect(targets['custom-build'].options.args).toContain('linux/amd64');
+    });
   });
 
   describe('dependency handling', () => {
@@ -706,6 +742,280 @@ describe('@nx/docker', () => {
 
       const targets = results[0][1].projects['proj'].targets;
       expect(targets['run'].dependsOn).toEqual(['build']);
+    });
+
+    it('should set run target to depend on custom build target name', async () => {
+      await tempFs.createFiles({
+        'proj/Dockerfile': 'FROM node:18',
+        'proj/project.json': '{}',
+      });
+
+      const results = await createNodesFunction(
+        ['proj/Dockerfile'],
+        {
+          buildTarget: { name: 'custom-build' },
+          runTarget: { name: 'custom-run' },
+        },
+        context
+      );
+
+      const targets = results[0][1].projects['proj'].targets;
+      expect(targets['custom-run'].dependsOn).toEqual(['custom-build']);
+    });
+  });
+
+  describe('pattern interpolation', () => {
+    it('should interpolate imageRef in args', async () => {
+      await tempFs.createFiles({
+        'proj/Dockerfile': 'FROM node:18',
+        'proj/project.json': '{}',
+      });
+
+      const results = await createNodesFunction(
+        ['proj/Dockerfile'],
+        {
+          buildTarget: {
+            name: 'build',
+            args: ['--tag', '{imageRef}:latest'],
+          },
+        },
+        context
+      );
+
+      const targets = results[0][1].projects['proj'].targets;
+      expect(targets['build'].options.args).toContain('proj:latest');
+    });
+
+    it('should interpolate projectName from project.json', async () => {
+      await tempFs.createFiles({
+        'proj/Dockerfile': 'FROM node:18',
+        'proj/project.json': JSON.stringify({ name: 'my-project' }),
+      });
+
+      const results = await createNodesFunction(
+        ['proj/Dockerfile'],
+        {
+          buildTarget: {
+            name: 'build',
+            args: ['--label', 'project={projectName}'],
+          },
+        },
+        context
+      );
+
+      const targets = results[0][1].projects['proj'].targets;
+      expect(targets['build'].options.args).toContain('--label');
+      expect(targets['build'].options.args).toContain('project=my-project');
+    });
+
+    it('should interpolate projectName from package.json', async () => {
+      await tempFs.createFiles({
+        'proj/Dockerfile': 'FROM node:18',
+        'proj/package.json': JSON.stringify({ name: '@org/my-package' }),
+      });
+
+      const results = await createNodesFunction(
+        ['proj/Dockerfile'],
+        {
+          buildTarget: {
+            name: 'build',
+            args: ['--label', 'package={projectName}'],
+          },
+        },
+        context
+      );
+
+      const targets = results[0][1].projects['proj'].targets;
+      expect(targets['build'].options.args).toContain('--label');
+      expect(targets['build'].options.args).toContain(
+        'package=@org/my-package'
+      );
+    });
+
+    it('should prefer project.json name over package.json', async () => {
+      await tempFs.createFiles({
+        'proj/Dockerfile': 'FROM node:18',
+        'proj/project.json': JSON.stringify({ name: 'project-name' }),
+        'proj/package.json': JSON.stringify({ name: 'package-name' }),
+      });
+
+      const results = await createNodesFunction(
+        ['proj/Dockerfile'],
+        {
+          buildTarget: {
+            name: 'build',
+            args: ['--label', 'name={projectName}'],
+          },
+        },
+        context
+      );
+
+      const targets = results[0][1].projects['proj'].targets;
+      expect(targets['build'].options.args).toContain('--label');
+      expect(targets['build'].options.args).toContain('name=project-name');
+    });
+
+    it('should interpolate projectRoot', async () => {
+      await tempFs.createFiles({
+        'apps/api/Dockerfile': 'FROM node:18',
+        'apps/api/project.json': '{}',
+      });
+
+      const results = await createNodesFunction(
+        ['apps/api/Dockerfile'],
+        {
+          buildTarget: {
+            name: 'build',
+            args: ['--label', 'root={projectRoot}'],
+          },
+        },
+        context
+      );
+
+      const targets = results[0][1].projects['apps/api'].targets;
+      expect(targets['build'].options.args).toContain('--label');
+      expect(targets['build'].options.args).toContain('root=apps/api');
+    });
+
+    it('should interpolate multiple tokens in single arg', async () => {
+      await tempFs.createFiles({
+        'proj/Dockerfile': 'FROM node:18',
+        'proj/project.json': JSON.stringify({ name: 'my-app' }),
+      });
+
+      const results = await createNodesFunction(
+        ['proj/Dockerfile'],
+        {
+          buildTarget: {
+            name: 'build',
+            args: ['--tag', '{projectName}:{imageRef}'],
+          },
+        },
+        context
+      );
+
+      const targets = results[0][1].projects['proj'].targets;
+      expect(targets['build'].options.args).toContain('my-app:proj');
+    });
+
+    it('should interpolate env variables', async () => {
+      await tempFs.createFiles({
+        'proj/Dockerfile': 'FROM node:18',
+        'proj/project.json': '{}',
+      });
+
+      const results = await createNodesFunction(
+        ['proj/Dockerfile'],
+        {
+          buildTarget: {
+            name: 'build',
+            env: {
+              IMAGE_NAME: '{imageRef}',
+              PROJECT_NAME: '{projectName}',
+            },
+          },
+        },
+        context
+      );
+
+      const targets = results[0][1].projects['proj'].targets;
+      expect(targets['build'].options.env).toEqual({
+        IMAGE_NAME: 'proj',
+        PROJECT_NAME: 'proj',
+      });
+    });
+
+    it('should interpolate cwd', async () => {
+      await tempFs.createFiles({
+        'apps/api/Dockerfile': 'FROM node:18',
+        'apps/api/project.json': '{}',
+      });
+
+      const results = await createNodesFunction(
+        ['apps/api/Dockerfile'],
+        {
+          buildTarget: {
+            name: 'build',
+            cwd: '{projectRoot}/dist',
+          },
+        },
+        context
+      );
+
+      const targets = results[0][1].projects['apps/api'].targets;
+      expect(targets['build'].options.cwd).toBe('apps/api/dist');
+    });
+  });
+
+  describe('options merging', () => {
+    it('should merge custom args with default args', async () => {
+      await tempFs.createFiles({
+        'proj/Dockerfile': 'FROM node:18',
+        'proj/project.json': '{}',
+      });
+
+      const results = await createNodesFunction(
+        ['proj/Dockerfile'],
+        {
+          buildTarget: {
+            name: 'build',
+            args: ['--platform', 'linux/amd64', '--no-cache'],
+          },
+        },
+        context
+      );
+
+      const targets = results[0][1].projects['proj'].targets;
+      expect(targets['build'].options.args).toContain('--tag proj');
+      expect(targets['build'].options.args).toContain('--platform');
+      expect(targets['build'].options.args).toContain('linux/amd64');
+      expect(targets['build'].options.args).toContain('--no-cache');
+    });
+
+    it('should apply env options to target', async () => {
+      await tempFs.createFiles({
+        'proj/Dockerfile': 'FROM node:18',
+        'proj/project.json': '{}',
+      });
+
+      const results = await createNodesFunction(
+        ['proj/Dockerfile'],
+        {
+          buildTarget: {
+            name: 'build',
+            env: {
+              DOCKER_BUILDKIT: '1',
+            },
+          },
+        },
+        context
+      );
+
+      const targets = results[0][1].projects['proj'].targets;
+      expect(targets['build'].options.env).toEqual({
+        DOCKER_BUILDKIT: '1',
+      });
+    });
+
+    it('should apply envFile option to target', async () => {
+      await tempFs.createFiles({
+        'proj/Dockerfile': 'FROM node:18',
+        'proj/project.json': '{}',
+      });
+
+      const results = await createNodesFunction(
+        ['proj/Dockerfile'],
+        {
+          buildTarget: {
+            name: 'build',
+            envFile: '.env.docker',
+          },
+        },
+        context
+      );
+
+      const targets = results[0][1].projects['proj'].targets;
+      expect(targets['build'].options.envFile).toBe('.env.docker');
     });
   });
 });

--- a/packages/docker/src/utils/interpolate-pattern.spec.ts
+++ b/packages/docker/src/utils/interpolate-pattern.spec.ts
@@ -1,0 +1,232 @@
+import { interpolatePattern, interpolateObject } from './interpolate-pattern';
+
+describe('interpolate-pattern', () => {
+  describe('interpolatePattern', () => {
+    it('should interpolate simple tokens', () => {
+      const result = interpolatePattern('{projectName}', {
+        projectName: 'my-app',
+      });
+      expect(result).toBe('my-app');
+    });
+
+    it('should interpolate multiple tokens', () => {
+      const result = interpolatePattern('{projectName}-{version}', {
+        projectName: 'my-app',
+        version: '1.0.0',
+      });
+      expect(result).toBe('my-app-1.0.0');
+    });
+
+    it('should keep unknown tokens unchanged', () => {
+      const result = interpolatePattern('{unknownToken}', {
+        projectName: 'my-app',
+      });
+      expect(result).toBe('{unknownToken}');
+    });
+
+    it('should handle empty pattern', () => {
+      const result = interpolatePattern('', {
+        projectName: 'my-app',
+      });
+      expect(result).toBe('');
+    });
+
+    it('should handle pattern without tokens', () => {
+      const result = interpolatePattern('1.2.3', {
+        projectName: 'my-app',
+      });
+      expect(result).toBe('1.2.3');
+    });
+
+    it('should handle missing token values', () => {
+      const result = interpolatePattern('{projectName}', {});
+      expect(result).toBe('{projectName}');
+    });
+
+    describe('date formatting', () => {
+      it('should interpolate currentDate with ISO format by default', () => {
+        const testDate = new Date('2024-01-15T10:30:45.000Z');
+        const result = interpolatePattern('{currentDate}', {
+          currentDate: testDate,
+        });
+        expect(result).toBe('2024-01-15T10:30:45.000Z');
+      });
+
+      it('should interpolate currentDate with custom format YYYY.MM.DD', () => {
+        const testDate = new Date('2024-01-15T10:30:45.000Z');
+        const result = interpolatePattern('{currentDate|YYYY.MM.DD}', {
+          currentDate: testDate,
+        });
+        expect(result).toBe('2024.01.15');
+      });
+
+      it('should interpolate currentDate with custom format YY.MM.DD', () => {
+        const testDate = new Date('2024-01-15T10:30:45.000Z');
+        const result = interpolatePattern('{currentDate|YY.MM.DD}', {
+          currentDate: testDate,
+        });
+        expect(result).toBe('24.01.15');
+      });
+
+      it('should interpolate currentDate with time format HH:mm:ss', () => {
+        const testDate = new Date('2024-01-15T10:30:45.000Z');
+        const result = interpolatePattern('{currentDate|HH:mm:ss}', {
+          currentDate: testDate,
+        });
+        expect(result).toBe('10:30:45');
+      });
+
+      it('should pad single digit values correctly', () => {
+        const testDate = new Date('2024-01-05T03:07:09.000Z');
+        const result = interpolatePattern('{currentDate|YYYY-MM-DD HH:mm:ss}', {
+          currentDate: testDate,
+        });
+        expect(result).toBe('2024-01-05 03:07:09');
+      });
+    });
+
+    describe('environment variable interpolation', () => {
+      const originalEnv = process.env;
+
+      beforeEach(() => {
+        process.env = { ...originalEnv };
+      });
+
+      afterEach(() => {
+        process.env = originalEnv;
+      });
+
+      it('should interpolate environment variables', () => {
+        process.env.BUILD_NUMBER = '123';
+        const result = interpolatePattern('build-{env.BUILD_NUMBER}', {});
+        expect(result).toBe('build-123');
+      });
+
+      it('should handle multiple environment variables', () => {
+        process.env.STAGE = 'QA';
+        process.env.BUILD_NUMBER = '456';
+        const result = interpolatePattern(
+          'build-{env.STAGE}.{env.BUILD_NUMBER}',
+          {}
+        );
+        expect(result).toBe('build-QA.456');
+      });
+
+      it('should keep unknown environment variables as-is', () => {
+        const result = interpolatePattern('build-{env.NON_EXISTENT_VAR}', {});
+        expect(result).toBe('build-{env.NON_EXISTENT_VAR}');
+      });
+
+      it('should combine environment variables with other tokens', () => {
+        process.env.TASK = 'builder';
+        const result = interpolatePattern('{projectName}-{env.TASK}', {
+          projectName: 'api',
+        });
+        expect(result).toBe('api-builder');
+      });
+
+      it('should handle empty environment variable values', () => {
+        process.env.EMPTY_VAR = '';
+        const result = interpolatePattern('prefix-{env.EMPTY_VAR}-suffix', {});
+        expect(result).toBe('prefix--suffix');
+      });
+    });
+  });
+
+  describe('interpolateObject', () => {
+    it('should interpolate strings in objects', () => {
+      const result = interpolateObject(
+        {
+          name: '{projectName}',
+          version: '1.0.0',
+        },
+        { projectName: 'my-app' }
+      );
+      expect(result).toEqual({
+        name: 'my-app',
+        version: '1.0.0',
+      });
+    });
+
+    it('should interpolate strings in arrays', () => {
+      const result = interpolateObject(
+        ['--tag', '{imageRef}', '--build-arg', 'VERSION={version}'],
+        { imageRef: 'my-app:latest', version: '1.0.0' }
+      );
+      expect(result).toEqual([
+        '--tag',
+        'my-app:latest',
+        '--build-arg',
+        'VERSION=1.0.0',
+      ]);
+    });
+
+    it('should interpolate nested objects', () => {
+      const result = interpolateObject(
+        {
+          build: {
+            args: ['--tag', '{imageRef}'],
+            env: {
+              APP_NAME: '{projectName}',
+            },
+          },
+        },
+        { imageRef: 'my-app:latest', projectName: 'my-app' }
+      );
+      expect(result).toEqual({
+        build: {
+          args: ['--tag', 'my-app:latest'],
+          env: {
+            APP_NAME: 'my-app',
+          },
+        },
+      });
+    });
+
+    it('should preserve non-string values', () => {
+      const result = interpolateObject(
+        {
+          name: '{projectName}',
+          port: 3000,
+          enabled: true,
+          config: null,
+        },
+        { projectName: 'my-app' }
+      );
+      expect(result).toEqual({
+        name: 'my-app',
+        port: 3000,
+        enabled: true,
+        config: null,
+      });
+    });
+
+    it('should handle arrays of objects', () => {
+      const result = interpolateObject(
+        [
+          { name: '{projectName}-web', port: 3000 },
+          { name: '{projectName}-api', port: 8080 },
+        ],
+        { projectName: 'my-app' }
+      );
+      expect(result).toEqual([
+        { name: 'my-app-web', port: 3000 },
+        { name: 'my-app-api', port: 8080 },
+      ]);
+    });
+
+    it('should return primitive values unchanged', () => {
+      expect(interpolateObject('simple string', {})).toBe('simple string');
+      expect(interpolateObject(123, {})).toBe(123);
+      expect(interpolateObject(true, {})).toBe(true);
+      expect(interpolateObject(null, {})).toBe(null);
+    });
+
+    it('should interpolate string primitives', () => {
+      const result = interpolateObject('{projectName}-app', {
+        projectName: 'my',
+      });
+      expect(result).toBe('my-app');
+    });
+  });
+});

--- a/packages/docker/src/utils/interpolate-pattern.ts
+++ b/packages/docker/src/utils/interpolate-pattern.ts
@@ -1,0 +1,93 @@
+const tokenRegex = /\{(env\.([^}]+)|([^|{}]+)(?:\|([^{}]+))?)\}/g;
+
+function formatDate(date: Date, format: string) {
+  const year = String(date.getUTCFullYear());
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const hours = String(date.getUTCHours()).padStart(2, '0');
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+  const seconds = String(date.getUTCSeconds()).padStart(2, '0');
+
+  return format
+    .replace(/YYYY/g, year)
+    .replace(/YY/g, year.slice(-2))
+    .replace(/MM/g, month)
+    .replace(/DD/g, day)
+    .replace(/HH/g, hours)
+    .replace(/mm/g, minutes)
+    .replace(/ss/g, seconds);
+}
+
+/**
+ * Interpolates pattern tokens in a string.
+ *
+ * Supported tokens:
+ * - {tokenName} - Simple token replacement
+ * - {currentDate} - Current date in ISO format
+ * - {currentDate|FORMAT} - Current date with custom format (YYYY, YY, MM, DD, HH, mm, ss)
+ * - {env.VAR_NAME} - Environment variable value
+ *
+ * @param pattern - String containing tokens to interpolate
+ * @param tokens - Record of token values
+ * @returns Interpolated string
+ */
+export function interpolatePattern(
+  pattern: string,
+  tokens: Record<string, any>
+): string {
+  return pattern.replace(
+    tokenRegex,
+    (match, fullMatch, envVarName, identifier, format) => {
+      // Handle environment variables
+      if (envVarName) {
+        const envValue = process.env[envVarName];
+        return envValue !== undefined ? envValue : match;
+      }
+
+      // Handle other tokens
+      const value = tokens[identifier];
+
+      if (value === undefined) {
+        return match; // Keep original token if no data
+      }
+
+      // Handle date formatting
+      if (identifier === 'currentDate') {
+        if (format) {
+          return formatDate(value, format);
+        } else {
+          return (value as Date).toISOString();
+        }
+      }
+
+      return value;
+    }
+  );
+}
+
+/**
+ * Recursively interpolates pattern tokens in all string values within an object or array.
+ *
+ * @param obj - Object or array to process
+ * @param tokens - Record of token values
+ * @returns New object/array with interpolated values
+ */
+export function interpolateObject<T>(obj: T, tokens: Record<string, any>): T {
+  if (typeof obj === 'string') {
+    return interpolatePattern(obj, tokens) as T;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => interpolateObject(item, tokens)) as T;
+  }
+
+  if (obj !== null && typeof obj === 'object') {
+    const result: any = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[key] = interpolateObject(value, tokens);
+    }
+    return result;
+  }
+
+  return obj;
+}


### PR DESCRIPTION
## Current Behavior
Currently, when configuring the `@nx/docker` plugin, we only set the target name and a basic command.
The intention was that targetDefaults might be able to be used to configure additional args, but this falls short in some places.


## Expected Behavior
Allow setting additional args when configuring the `@nx/docker` plugin that supports interpolated values, similar to `versionSchemes`.

This will allow additional flexibility when setting up the docker build command such as:

```json
{
  "plugin": "@nx/docker",
  "options": {
     "buildTarget": {
       "name": "docker:build",
       "args": ["-t {projectName}"]
     }
  }
}
```

This means that we can use `nx run-many -t docker:build` and it will successfully add the name of the projects into the tag.

This is one example, other examples include being able to set individual Docker Layer Caching where each registry needs a unique name.

