### PR TITLE
docs(testing): update task splitting docs to be more generic rather t…han just for e2e tasks

### DIFF
--- a/astro-docs/src/components/layout/Breadcrumbs.astro
+++ b/astro-docs/src/components/layout/Breadcrumbs.astro
@@ -18,8 +18,9 @@ type Crumb = {
 }
 
 function findDocByPath (path: string) {
-  return allDocs.find(d => d.id === `${path}.mdoc`)
-      ?? allDocs.find(d => d.id === `${path}/index.mdoc`);
+  path = path.replace(/^docs\//, '');
+  return allDocs.find(d => d.id === `${path}`)
+      ?? allDocs.find(d => d.id === `${path}/index`);
 }
 
 function createNameFromSegment(segment: string): string {

--- a/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
@@ -1,8 +1,8 @@
 ---
-title: Automatically Split E2E Tasks by File (Atomizer)
+title: Automatically Split Slow Tasks by File (Atomizer)
 keywords: [split tasks, atomizer]
 sidebar:
-  label: Automatically Split E2E Tasks
+  label: Automatically Split Slow Tasks
   order: 15
 filter: 'type:Features'
 ---
@@ -12,18 +12,18 @@ src="https://youtu.be/0YxcxIR7QU0"
 title="10x Faster e2e Tests!"
 width="100%" /%}
 
-End-to-end (e2e) tests are often large, monolithic tasks that can take a considerable amount of time to execute. As a result, teams often push them to a nightly or even weekly build rather than running them for each PR. This approach is suboptimal as it increases the risk of merging problematic PRs.
+Certain tasks like end-to-end (e2e) tests, integration tests, or large unit test suites can be large, monolithic tasks that take a considerable amount of time to execute. As a result, teams often push them to a nightly or even weekly build rather than running them for each PR. This approach is suboptimal as it increases the risk of merging problematic PRs.
 
-Manually splitting large e2e test projects can be complex and require ongoing maintenance. Nx's Atomizer solves this by **automatically generating runnable targets for e2e tests for each spec file**. Instead of one large e2e task, you get multiple smaller e2e tasks that can be run individually. This allows for:
+Manually splitting these slow tasks can be complex and require ongoing maintenance. Nx's Atomizer solves this by **automatically generating runnable targets for each test file**. For example, a task that takes 10 minutes can be split and distributed as five 2-minute tasks per agent. This allows for:
 
 - parallelization across multiple machines with [Nx Agents](/docs/features/ci-features/distribute-task-execution)
 - faster [flakiness detection & retries](/docs/features/ci-features/flaky-tasks) by isolating and re-running only the failed tests
 
-## Enable Automated e2e Task Splitting
+## Enable Automated Task Splitting
 
 ### Step 1: Connect to Nx Cloud
 
-To use **automated e2e task splitting**, you need to connect your workspace to Nx Cloud (if you haven't already).
+To use **automated task splitting**, you need to connect your workspace to Nx Cloud (if you haven't already).
 
 ```shell {% frame="none" %}
 npx nx@latest connect
@@ -79,18 +79,18 @@ If you upgraded Nx from an older version, ensure that [inferred tasks](/docs/con
 }
 ```
 
-## Update an Existing e2e Project to use Automated Task Splitting
+## Update an Existing Project to use Automated Task Splitting
 
-If you are already using the `@nx/cypress`, `@nx/playwright`, or `@nx/jest` plugin, you need to manually add the appropriate configuration to the `plugins` array of `nx.json`. Follow the instructions for the plugin you are using:
+If you are already using the `@nx/cypress`, `@nx/playwright`, `@nx/jest`, or `@nx/gradle` plugin, you need to manually add the appropriate configuration to the `plugins` array of `nx.json`. Follow the instructions for the plugin you are using:
 
 - [Configure Cypress Task Splitting](/docs/technologies/test-tools/cypress/introduction#nxcypress-configuration)
 - [Configure Playwright Task Splitting](/docs/technologies/test-tools/playwright/introduction#nxplaywright-configuration)
 - [Configure Jest Task Splitting](/docs/technologies/test-tools/jest/introduction#splitting-e2e-tests)
-- [Configure Gradle Testing Task Splitting](/docs/technologies/java/introduction#splitting-tests)
+- [Configure Gradle Testing Task Splitting](/docs/technologies/java/introduction#test-distribution)
 
 ## Verify Automated Task Splitting Works
 
-Run the following command to open the project detail view for the e2e project:
+Run the following command to open the project detail view for your test project:
 
 {% tabs %}
 {% tabitem label="CLI" %}
@@ -417,19 +417,19 @@ nx show project my-project-e2e
 {% /tabitem %}
 {% /tabs %}
 
-If you configured Nx Atomizer properly, you'll see that there are tasks named `e2e`, `e2e-ci` and a task for each e2e test file.
+If you configured Nx Atomizer properly, you'll see that there are tasks named `e2e`, `e2e-ci` (or similar for other test types) and a task for each test file.
 
-During local development, you’ll want to continue using `e2e` as it is more efficient on a single machine.
+During local development, you'll want to continue using the base task (e.g., `e2e`, `test`) as it is more efficient on a single machine.
 
 ```shell {% frame="none" %}
 nx e2e my-project-e2e
 ```
 
-The `e2e-ci` task truly shines when configured and run on CI.
+The `-ci` variant task truly shines when configured and run on CI.
 
 ## Configure Automated Task Splitting on CI
 
-Update your CI pipeline to run `e2e-ci`, which will automatically run all the inferred tasks for the individual e2e test files. Here's an example of a GitHub Actions workflow:
+Update your CI pipeline to run the `-ci` variant task (e.g., `e2e-ci`, `test-ci`), which will automatically run all the inferred tasks for the individual test files. Here's an example of a GitHub Actions workflow:
 
 ```yaml {% meta="{17,27}" %}
 // .github/workflows/ci.yml

--- a/docs/blog/2025-03-17-modern-angular-testing-with-nx.md
+++ b/docs/blog/2025-03-17-modern-angular-testing-with-nx.md
@@ -103,7 +103,7 @@ Fortunately, Nx has a solution that does not require complicated pipeline files 
 
 If you view the `my-app-e2e` project (`npx nx show project my-app-e2e`), you will notice that there is an `e2e-ci` target, with additional targets created for each test file. This is the task splitting feature that `@nx/playwright` enables. Whereas the `e2e` target runs the full Playwright suite, the `e2e-ci` task runs additional tasks created from test files.
 
-When run on a single machine, `e2e-ci` will be slower because it starts multiple Playwright processes, which is why we only allow it to run through distribution. To [enable distribution](/ci/features/split-e2e-tasks#enable-automated-e2e-task-splitting), you must connect your workspace to [Nx Cloud](/nx-cloud). This is easily done with the `connect` command.
+When run on a single machine, `e2e-ci` will be slower because it starts multiple Playwright processes, which is why we only allow it to run through distribution. To [enable distribution](/ci/features/split-e2e-tasks#enable-automated-task-splitting), you must connect your workspace to [Nx Cloud](/nx-cloud). This is easily done with the `connect` command.
 
 ```shell
 npx nx@latest connect

--- a/docs/nx-cloud/features/split-e2e-tasks.md
+++ b/docs/nx-cloud/features/split-e2e-tasks.md
@@ -2,25 +2,25 @@
 keywords: [split tasks, atomizer]
 ---
 
-# Automatically Split E2E Tasks by File (Atomizer)
+# Automatically Split Slow Tasks by File (Atomizer)
 
 {% youtube
 src="https://youtu.be/0YxcxIR7QU0"
 title="10x Faster e2e Tests!"
 width="100%" /%}
 
-End-to-end (e2e) tests are often large, monolithic tasks that can take a considerable amount of time to execute. As a result, teams often push them to a nightly or even weekly build rather than running them for each PR. This approach is suboptimal as it increases the risk of merging problematic PRs.
+Certain tasks like end-to-end (e2e) tests, integration tests, or large unit test suites can be large, monolithic tasks that take a considerable amount of time to execute. As a result, teams often push them to a nightly or even weekly build rather than running them for each PR. This approach is suboptimal as it increases the risk of merging problematic PRs.
 
-Manually splitting large e2e test projects can be complex and require ongoing maintenance. Nx's Atomizer solves this by **automatically generating runnable targets for e2e tests for each spec file**. Instead of one large e2e task, you get multiple smaller e2e tasks that can be run individually. This allows for:
+Manually splitting these slow tasks can be complex and require ongoing maintenance. Nx's Atomizer solves this by **automatically generating runnable targets for each test file**. For example, a task that takes 10 minutes can be split and distributed as five 2-minute tasks per agent. This allows for:
 
 - parallelization across multiple machines with [Nx Agents](/ci/features/distribute-task-execution)
 - faster [flakiness detection & retries](/ci/features/flaky-tasks) by isolating and re-running only the failed tests
 
-## Enable Automated e2e Task Splitting
+## Enable Automated Task Splitting
 
 ### Step 1: Connect to Nx Cloud
 
-To use **automated e2e task splitting**, you need to connect your workspace to Nx Cloud (if you haven't already).
+To use **automated task splitting**, you need to connect your workspace to Nx Cloud (if you haven't already).
 
 ```shell
 npx nx@latest connect
@@ -75,18 +75,18 @@ If you upgraded Nx from an older version, ensure that [inferred tasks](/concepts
 }
 ```
 
-## Update an Existing e2e Project to use Automated Task Splitting
+## Update an Existing Project to use Automated Task Splitting
 
-If you are already using the `@nx/cypress`, `@nx/playwright`, or `@nx/jest` plugin, you need to manually add the appropriate configuration to the `plugins` array of `nx.json`. Follow the instructions for the plugin you are using:
+If you are already using the `@nx/cypress`, `@nx/playwright`, `@nx/jest`, or `@nx/gradle` plugin, you need to manually add the appropriate configuration to the `plugins` array of `nx.json`. Follow the instructions for the plugin you are using:
 
 - [Configure Cypress Task Splitting](/technologies/test-tools/cypress/introduction#nxcypress-configuration)
 - [Configure Playwright Task Splitting](/technologies/test-tools/playwright/introduction#nxplaywright-configuration)
 - [Configure Jest Task Splitting](/technologies/test-tools/jest/introduction#splitting-e2e-tests)
-- [Configure Gradle Testing Task Splitting](/technologies/java/introduction#splitting-tests)
+- [Configure Gradle Testing Task Splitting](/technologies/java/introduction#test-distribution)
 
 ## Verify Automated Task Splitting Works
 
-Run the following command to open the project detail view for the e2e project:
+Run the following command to open the project detail view for your test project:
 
 {% tabs %}
 {% tab label="CLI" %}
@@ -413,19 +413,19 @@ nx show project my-project-e2e
 {% /tab %}
 {% /tabs %}
 
-If you configured Nx Atomizer properly, you'll see that there are tasks named `e2e`, `e2e-ci` and a task for each e2e test file.
+If you configured Nx Atomizer properly, you'll see that there are tasks named `e2e`, `e2e-ci` (or similar for other test types) and a task for each test file.
 
-During local development, you’ll want to continue using `e2e` as it is more efficient on a single machine.
+During local development, you'll want to continue using the base task (e.g., `e2e`, `test`) as it is more efficient on a single machine.
 
 ```shell
 nx e2e my-project-e2e
 ```
 
-The `e2e-ci` task truly shines when configured and run on CI.
+The `-ci` variant task truly shines when configured and run on CI.
 
 ## Configure Automated Task Splitting on CI
 
-Update your CI pipeline to run `e2e-ci`, which will automatically run all the inferred tasks for the individual e2e test files. Here's an example of a GitHub Actions workflow:
+Update your CI pipeline to run the `-ci` variant task (e.g., `e2e-ci`, `test-ci`), which will automatically run all the inferred tasks for the individual test files. Here's an example of a GitHub Actions workflow:
 
 ```yaml {% fileName=".github/workflows/ci.yml" highlightLines=[15,25] %}
 name: CI


### PR DESCRIPTION
Update language on task splitting docs. Fix broken anchor link for Java/Gradle test distribution.