### PR TITLE
fix(nx-dev): update credit pricing link to new docs page

### DIFF
--- a/nx-dev/ui-cloud/src/lib/pricing.tsx
+++ b/nx-dev/ui-cloud/src/lib/pricing.tsx
@@ -419,7 +419,7 @@ export function Pricing(): ReactElement {
               <Link
                 href={
                   process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/reference'
+                    ? '/docs/reference/nx-cloud/credits-pricing'
                     : '/ci/reference/credits-pricing'
                 }
                 className="font-semibold underline"


### PR DESCRIPTION
fix bad link to the credit pricing page from next site -> astro docs

Fixes DOC-245
