### PR TITLE
cleanup(devkit): move the ignore object creation to nx

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,6 @@
     "http-server": "14.1.0",
     "husky": "^9.1.5",
     "identity-obj-proxy": "3.0.0",
-    "ignore": "^5.0.4",
     "immer": "^9.0.6",
     "import-fresh": "^3.1.0",
     "injection-js": "^2.4.0",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -29,7 +29,6 @@
   "homepage": "https://nx.dev",
   "dependencies": {
     "ejs": "^3.1.7",
-    "ignore": "^5.0.4",
     "tslib": "^2.3.0",
     "semver": "^7.5.3",
     "yargs-parser": "21.1.1",

--- a/packages/devkit/src/generators/visit-not-ignored-files.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.ts
@@ -1,5 +1,5 @@
 import type { Tree } from 'nx/src/devkit-exports';
-import ignore from 'ignore';
+import { getIgnoreObjectForTree } from 'nx/src/devkit-internals';
 import { join, relative, sep } from 'path';
 
 /**
@@ -10,17 +10,7 @@ export function visitNotIgnoredFiles(
   dirPath: string = tree.root,
   visitor: (path: string) => void
 ): void {
-  // TODO (v17): use packages/nx/src/utils/ignore.ts
-  let ig: ReturnType<typeof ignore>;
-  if (tree.exists('.gitignore')) {
-    ig = ignore();
-    ig.add('.git');
-    ig.add(tree.read('.gitignore', 'utf-8'));
-  }
-  if (tree.exists('.nxignore')) {
-    ig ??= ignore();
-    ig.add(tree.read('.nxignore', 'utf-8'));
-  }
+  const ig = getIgnoreObjectForTree(tree);
   dirPath = normalizePathRelativeToRoot(dirPath, tree.root);
   if (dirPath !== '' && ig?.ignores(dirPath)) {
     return;

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -52,7 +52,7 @@
     "figures": "3.2.0",
     "flat": "^5.0.2",
     "front-matter": "^4.0.2",
-    "ignore": "^5.0.4",
+    "ignore": "^7.0.5",
     "jest-diff": "^30.0.2",
     "jsonc-parser": "3.2.0",
     "lines-and-columns": "2.0.3",

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-monorepo.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-monorepo.ts
@@ -1,6 +1,6 @@
 import { prompt } from 'enquirer';
 import { readdirSync, readFileSync, statSync } from 'fs';
-import ignore from 'ignore';
+import ignore = require('ignore');
 import { join, relative } from 'path';
 import { InitArgs } from '../init-v1';
 import { readJsonFile } from '../../../utils/fileutils';

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -16,6 +16,7 @@ export {
   readProjectConfigurationsFromRootMap,
   findMatchingConfigFiles,
 } from './project-graph/utils/project-configuration-utils';
+export { getIgnoreObjectForTree } from './utils/ignore';
 export { splitTarget } from './utils/split-target';
 export { combineOptionsForExecutor } from './utils/params';
 export { sortObjectByKeys } from './utils/object-sort';

--- a/packages/nx/src/migrations/update-17-0-0/move-cache-directory.ts
+++ b/packages/nx/src/migrations/update-17-0-0/move-cache-directory.ts
@@ -1,5 +1,5 @@
 import { Tree } from '../../generators/tree';
-import ignore from 'ignore';
+import ignore = require('ignore');
 
 export default function moveCacheDirectory(tree: Tree) {
   // If nx.json doesn't exist the repo can't utilize

--- a/packages/nx/src/migrations/update-21-1-0/add-gitignore-entry.ts
+++ b/packages/nx/src/migrations/update-21-1-0/add-gitignore-entry.ts
@@ -1,5 +1,5 @@
 import { Tree } from '../../generators/tree';
-import ignore from 'ignore';
+import ignore = require('ignore');
 
 export default async function addGitignoreEntry(tree: Tree) {
   if (!tree.exists('nx.json')) {

--- a/packages/nx/src/project-graph/file-utils.spec.ts
+++ b/packages/nx/src/project-graph/file-utils.spec.ts
@@ -5,7 +5,7 @@ import {
 } from './file-utils';
 import * as fs from 'fs';
 import { JsonDiffType } from '../utils/json-diff';
-import ignore from 'ignore';
+import ignore = require('ignore');
 
 describe('calculateFileChanges', () => {
   it('should return a whole file change by default for files that exist', () => {

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -1,6 +1,7 @@
-import ignore from 'ignore';
+import ignore = require('ignore');
 import { readFileIfExisting } from './fileutils';
 import { workspaceRoot } from './workspace-root';
+import { Tree } from '../generators/tree';
 
 export function getIgnoreObject(
   root: string = workspaceRoot
@@ -8,5 +9,20 @@ export function getIgnoreObject(
   const ig = ignore();
   ig.add(readFileIfExisting(`${root}/.gitignore`));
   ig.add(readFileIfExisting(`${root}/.nxignore`));
+  return ig;
+}
+
+export function getIgnoreObjectForTree(tree: Tree) {
+  let ig: ReturnType<typeof ignore>;
+  if (tree.exists('.gitignore')) {
+    ig = ignore();
+    ig.add('.git');
+    ig.add(tree.read('.gitignore', 'utf-8'));
+  }
+  if (tree.exists('.nxignore')) {
+    ig ??= ignore();
+    ig.add(tree.read('.nxignore', 'utf-8'));
+  }
+
   return ig;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -772,9 +772,6 @@ importers:
       identity-obj-proxy:
         specifier: 3.0.0
         version: 3.0.0
-      ignore:
-        specifier: ^5.0.4
-        version: 5.3.2
       immer:
         specifier: ^9.0.6
         version: 9.0.21
@@ -2706,9 +2703,6 @@ importers:
       enquirer:
         specifier: ~2.3.6
         version: 2.3.6
-      ignore:
-        specifier: ^5.0.4
-        version: 5.3.2
       minimatch:
         specifier: 9.0.3
         version: 9.0.3
@@ -3298,8 +3292,8 @@ importers:
         specifier: ^4.0.2
         version: 4.0.2
       ignore:
-        specifier: ^5.0.4
-        version: 5.3.2
+        specifier: ^7.0.5
+        version: 7.0.5
       jest-diff:
         specifier: ^30.0.2
         version: 30.0.2


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Devkit creates the ignore object using the `ignore` package. Nx also creates the ignore object.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Only `nx` creates the ignore object using the `ignore` package. Devkit utilizes a util from nx.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
