### PR TITLE
docs(nx-dev): require description for doc pages

### DIFF
--- a/astro-docs/src/content.config.ts
+++ b/astro-docs/src/content.config.ts
@@ -15,20 +15,27 @@ const searchSchema = z.object({
   filter: z.string().optional(),
 });
 
-const baseSchema = z
+const customDocsSchema = z
   .object({
     title: z.string(),
+    description: z.string(),
+  })
+  .and(searchSchema);
+
+const baseSchema = z
+  .object({
     /**
      * Slug should be from the root route without any prefix requirements i.e. `/docs`
      **/
     slug: z.string(),
   })
-  .and(searchSchema);
+  .and(customDocsSchema);
+
 // Default docs collection handled by Starlight
 const docs = defineCollection({
   loader: docsLoader(),
   schema: docsSchema({
-    extend: searchSchema,
+    extend: customDocsSchema,
   }),
 });
 

--- a/astro-docs/src/content/docs/concepts/CI Concepts/ai-features.mdoc
+++ b/astro-docs/src/content/docs/concepts/CI Concepts/ai-features.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Nx Cloud AI
+description: Enable and configure AI-powered features in Nx Cloud to enhance your development workflow
 sidebar:
   order: 100
 filter: 'type:Concepts'

--- a/astro-docs/src/content/docs/concepts/CI Concepts/building-blocks-fast-ci.mdoc
+++ b/astro-docs/src/content/docs/concepts/CI Concepts/building-blocks-fast-ci.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Building Blocks of Fast CI
+description: Learn how Nx features combine to create optimized CI pipelines through fast tools, reduced waste, and efficient task distribution
 filter: 'type:Concepts'
 ---
 

--- a/astro-docs/src/content/docs/concepts/CI Concepts/cache-security.mdoc
+++ b/astro-docs/src/content/docs/concepts/CI Concepts/cache-security.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Cache Security
+description: Best practices for securing your remote cache and preventing cache poisoning in Nx Cloud
 filter: 'type:Concepts'
 ---
 

--- a/astro-docs/src/content/docs/concepts/CI Concepts/heartbeat-and-manual-shutdown-handling.mdoc
+++ b/astro-docs/src/content/docs/concepts/CI Concepts/heartbeat-and-manual-shutdown-handling.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Heartbeat and Main Job Completion Handling
+description: How Nx Cloud tracks main job completion and manages agent shutdown through the heartbeat process
 filter: 'type:Concepts'
 ---
 

--- a/astro-docs/src/content/docs/concepts/CI Concepts/parallelization-distribution.mdoc
+++ b/astro-docs/src/content/docs/concepts/CI Concepts/parallelization-distribution.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Parallelization and Distribution
+description: Understanding task parallelization strategies and distributed task execution with Nx Agents
 filter: 'type:Concepts'
 ---
 

--- a/astro-docs/src/content/docs/concepts/CI Concepts/reduce-waste.mdoc
+++ b/astro-docs/src/content/docs/concepts/CI Concepts/reduce-waste.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Reduce Wasted Time in CI
+description: How the affected command and remote caching eliminate wasted time in CI pipelines
 filter: 'type:Concepts'
 ---
 

--- a/astro-docs/src/content/docs/enterprise/Powerpack/configure-conformance-rules-in-nx-cloud.mdoc
+++ b/astro-docs/src/content/docs/enterprise/Powerpack/configure-conformance-rules-in-nx-cloud.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Configure Conformance Rules in Nx Cloud
+description: Configure and manage Nx Conformance rules across workspaces using the Nx Cloud UI
 filter: 'type:Features'
 ---
 

--- a/astro-docs/src/content/docs/enterprise/Powerpack/publish-conformance-rules-to-nx-cloud.mdoc
+++ b/astro-docs/src/content/docs/enterprise/Powerpack/publish-conformance-rules-to-nx-cloud.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Publish Conformance Rules to Nx Cloud
+description: Create and publish custom Nx Conformance rules to your Nx Cloud organization
 filter: 'type:Guides'
 ---
 

--- a/astro-docs/src/content/docs/enterprise/Single Tenant/auth-bitbucket-data-center.mdoc
+++ b/astro-docs/src/content/docs/enterprise/Single Tenant/auth-bitbucket-data-center.mdoc
@@ -1,5 +1,6 @@
 ---
 title: BitBucket Data Center Auth
+description: Configure authentication for Nx Cloud using BitBucket Data Center on-premise
 filter: 'type:Guides'
 ---
 

--- a/astro-docs/src/content/docs/enterprise/Single Tenant/auth-bitbucket.mdoc
+++ b/astro-docs/src/content/docs/enterprise/Single Tenant/auth-bitbucket.mdoc
@@ -1,5 +1,6 @@
 ---
 title: BitBucket Cloud Auth
+description: Configure authentication for Nx Cloud using BitBucket Cloud OAuth
 filter: 'type:Guides'
 ---
 

--- a/astro-docs/src/content/docs/enterprise/Single Tenant/auth-github.mdoc
+++ b/astro-docs/src/content/docs/enterprise/Single Tenant/auth-github.mdoc
@@ -1,5 +1,6 @@
 ---
 title: GitHub Auth
+description: Configure authentication for Nx Cloud using a GitHub OAuth app
 filter: 'type:Guides'
 ---
 

--- a/astro-docs/src/content/docs/enterprise/Single Tenant/auth-gitlab.mdoc
+++ b/astro-docs/src/content/docs/enterprise/Single Tenant/auth-gitlab.mdoc
@@ -1,5 +1,6 @@
 ---
 title: GitLab Auth
+description: Configure authentication for Nx Cloud using a GitLab app
 filter: 'type:Guides'
 ---
 

--- a/astro-docs/src/content/docs/enterprise/Single Tenant/auth-saml.mdoc
+++ b/astro-docs/src/content/docs/enterprise/Single Tenant/auth-saml.mdoc
@@ -1,5 +1,6 @@
 ---
 title: SAML Auth
+description: Configure SAML authentication for Nx Cloud Enterprise with Azure AD or Okta
 filter: 'type:Guides'
 ---
 

--- a/astro-docs/src/content/docs/enterprise/Single Tenant/custom-github-app.mdoc
+++ b/astro-docs/src/content/docs/enterprise/Single Tenant/custom-github-app.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Custom GitHub App
+description: Create and configure a custom GitHub App for Nx Cloud Enterprise integration
 filter: 'type:Guides'
 ---
 

--- a/astro-docs/src/content/docs/enterprise/Single Tenant/overview.mdoc
+++ b/astro-docs/src/content/docs/enterprise/Single Tenant/overview.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Single Tenant Nx Cloud Hosting
+description: Nx Cloud Enterprise hosting options including multi-tenant and single tenant instances
 sidebar:
   order: 5
 filter: 'type:Features'

--- a/astro-docs/src/content/docs/features/CI Features/dynamic-agents.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/dynamic-agents.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Dynamically Allocate Agents
+description: Configure Nx Agents to dynamically scale based on PR size for cost-effective CI
 sidebar:
   order: 14
 filter: 'type:Features'

--- a/astro-docs/src/content/docs/features/CI Features/explain-with-ai.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/explain-with-ai.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Explain with AI
+description: Get AI-powered explanations and resolution steps for failed tasks in Nx Cloud
 sidebar:
   order: 17
   badge: beta

--- a/astro-docs/src/content/docs/features/CI Features/flaky-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/flaky-tasks.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Identify and Re-run Flaky Tasks
+description: Automatically detect and re-run flaky tasks in CI with Nx Cloud
 sidebar:
   order: 16
 filter: 'type:Features'

--- a/astro-docs/src/content/docs/features/CI Features/github-integration.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/github-integration.mdoc
@@ -1,5 +1,6 @@
 ---
 title: GitHub Integration
+description: Connect Nx Cloud with GitHub for seamless onboarding, PR insights, and access control
 sidebar:
   order: 18
 filter: 'type:Features'

--- a/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Automatically Split Slow Tasks by File (Atomizer)
+description: Automatically split large test tasks into individual file-level tasks for parallel execution
 keywords: [split tasks, atomizer]
 sidebar:
   label: Automatically Split Slow Tasks

--- a/astro-docs/src/content/docs/guides/Nx Cloud/access-tokens.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/access-tokens.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Nx CLI and CI Access Tokens
+description: Configure read-only and read-write CI access tokens for secure remote cache access
 sidebar:
   label: CI Access Tokens
 filter: 'type:Guides'

--- a/astro-docs/src/content/docs/guides/Nx Cloud/encryption.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/encryption.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Enable End to End Encryption
+description: Configure end-to-end encryption for task artifacts in Nx Cloud remote cache
 filter: 'type:Guides'
 ---
 

--- a/astro-docs/src/content/docs/guides/Nx Cloud/google-auth.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/google-auth.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Connecting Nx Cloud to your existing Google identity provider
+description: Use Google Identity or Google Workspaces for Nx Cloud authentication and access control
 filter: 'type:Guides'
 sidebar:
   label: Authenticate with Google Identity

--- a/astro-docs/src/content/docs/guides/Nx Cloud/personal-access-tokens.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/personal-access-tokens.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Nx Cloud and Personal Access Tokens
+description: Provision and manage personal access tokens for secure Nx Cloud authentication
 sidebar:
   label: Personal Access Tokens
 filter: 'type:Guides'

--- a/astro-docs/src/content/docs/reference/Nx Cloud/assignment-rules.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/assignment-rules.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Assignment Rules
+description: Control which tasks run on which agents using assignment rules with Nx Agents or manual DTE
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/reference/Nx Cloud/credits-pricing.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/credits-pricing.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Nx Cloud Credit Pricing Reference
+description: Pricing information for Nx Cloud credits and agent resource classes
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/reference/Nx Cloud/custom-images.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/custom-images.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Custom images for Nx Agents
+description: Create and configure custom Docker images for Nx Agents
 sidebar:
   label: Custom Images
 filter: 'type:References'

--- a/astro-docs/src/content/docs/reference/Nx Cloud/custom-steps.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/custom-steps.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Creating Custom Steps
+description: Define and use custom workflow steps in Nx Cloud launch templates
 sidebar:
   label: Custom Steps
 filter: 'type:References'

--- a/astro-docs/src/content/docs/reference/Powerpack/conformance/Generators.mdoc
+++ b/astro-docs/src/content/docs/reference/Powerpack/conformance/Generators.mdoc
@@ -1,5 +1,6 @@
 ---
 title: '@nx/conformance - Generators'
+description: Generators for Nx Conformance
 sidebar:
   label: Generators
 filter: 'type:References'

--- a/astro-docs/src/content/docs/reference/Powerpack/owners/Generators.mdoc
+++ b/astro-docs/src/content/docs/reference/Powerpack/owners/Generators.mdoc
@@ -1,5 +1,6 @@
 ---
 title: '@nx/owners - Generators'
+description: Generators for Nx Powerpack Owners configuration
 sidebar:
   label: Generators
 weight: .5

--- a/astro-docs/src/content/docs/reference/Remote Cache Plugins/shared-fs-cache/Generators.mdoc
+++ b/astro-docs/src/content/docs/reference/Remote Cache Plugins/shared-fs-cache/Generators.mdoc
@@ -1,5 +1,6 @@
 ---
 title: '@nx/shared-fs-cache - Generators'
+description: Generator for the shared filesystem cache plugin
 sidebar:
   label: Generators
 weight: .5

--- a/astro-docs/src/content/docs/troubleshooting/ci-execution-failed.mdoc
+++ b/astro-docs/src/content/docs/troubleshooting/ci-execution-failed.mdoc
@@ -1,5 +1,6 @@
 ---
 title: Understanding "CI Execution Failed"
+description: Common causes and solutions for CI execution failures in Nx Cloud
 sidebar:
   label: CI Execution Failed
 filter: 'type:References'

--- a/astro-docs/src/plugins/utils/devkit-generation.ts
+++ b/astro-docs/src/plugins/utils/devkit-generation.ts
@@ -143,6 +143,7 @@ export async function loadDevkitPackage(
         category: mappedCategory,
         weight: 1.0,
         filter: 'type:References',
+        description: `${title} Devkit documentation`,
       },
     };
 


### PR DESCRIPTION
add description to all docs and make required to make index views not render differently

<img width="804" height="669" alt="image" src="https://github.com/user-attachments/assets/4ecf6a24-13b7-4223-bcd3-c3db50007740" />


closes: DOC-246