### PR TITLE
fix(nx-dev): improve default zoom level of graph nodes in docs

### DIFF
--- a/astro-docs/markdoc.config.mjs
+++ b/astro-docs/markdoc.config.mjs
@@ -423,14 +423,5 @@ export default defineMarkdocConfig({
         },
       },
     },
-    side_by_side: {
-      render: component('./src/components/markdoc/SideBySide.astro'),
-      attributes: {
-        align: {
-          type: 'String',
-          default: 'center',
-        },
-      },
-    },
   },
 });

--- a/astro-docs/src/components/markdoc/SideBySide.astro
+++ b/astro-docs/src/components/markdoc/SideBySide.astro
@@ -1,3 +1,0 @@
-<div class="not-content grid grid-auto-col md:grid-flow-row md:grid-cols-2 gap-4">
-  <slot />
-</div>

--- a/astro-docs/src/content/docs/concepts/CI Concepts/reduce-waste.mdoc
+++ b/astro-docs/src/content/docs/concepts/CI Concepts/reduce-waste.mdoc
@@ -18,8 +18,6 @@ How much benefit you gain from this is different for each repository, but there 
 
 If we look at these two trivial examples, you can see that the repository with more projects gains more value from the affected command.
 
-{% cards smCols=2 mdCols=2 lgCols=2 %}
-
 {% graph title="One Project" height="200px" %}
 
 ```json
@@ -100,8 +98,6 @@ If we look at these two trivial examples, you can see that the repository with m
 
 {% /graph %}
 
-{% /cards %}
-
 In the one project example, every PR will affect the entire repository. In the four project example, modifying one project only affects 25% of the repository. For the one project repository `nx affected -t build` is identical to `nx run-many -t build`, whereas for the four project repository, `nx affected -t build` cuts out the 75% of wasted work.
 
 With this principle in mind, you can add more applications to the repository to gain the [benefits of a monorepo](https://monorepo.tools) without suffering an exponential increase in CI execution time. This principle also encourages splitting projects into multiple projects in order to have a faster CI pipeline for the existing applications.
@@ -110,9 +106,7 @@ With this principle in mind, you can add more applications to the repository to 
 
 Consider the following example repo structures.
 
-{% cards mdCols=3 lgCols=3 %}
-
-{% graph title="Stacked" height="200px" %}
+{% graph title="Stacked" height="350px" %}
 
 ```json
 {
@@ -241,8 +235,6 @@ Consider the following example repo structures.
 
 {% /graph %}
 
-{% /cards %}
-
 If we assume that each project has an independent 50% chance of being modified on a given PR, we can calculate the expected average number of affected projects. Intuitively, the flat structure should have less affected projects than the stacked structure and the grouped structure should fall somewhere in between. That is, in fact, the case.
 
 If we don't use the `nx affected` command in CI, no matter how our repo is structured, the expected number of projects run in CI will be 3 - all of them.
@@ -308,8 +300,7 @@ The first time CI runs for a particular PR, affected is doing most of the work t
 
 Take a look at the example below. The projects are setup in the suboptimal stacked arrangement from before. On the first CI run, `project3` was modified, so every project is affected. Then the developer realizes that `project2` should be changed as well and pushes a new commit. For the second CI run, every project is still affected when compared against the `main` branch, but `project3` hasn't changed between the first CI run and the second, so the cache from the first CI run can be used instead of re-running that task. `project2` tasks need to be re-run since it was modified and `project1` tasks need to be re-run since it depends on a project that was modified.
 
-{% cards smCols=2 mdCols=2 lgCols=2 %}
-{% graph title="First CI Run" height="200px" %}
+{% graph title="First CI Run" height="300px" %}
 
 ```json
 {
@@ -352,7 +343,7 @@ Take a look at the example below. The projects are setup in the suboptimal stack
 
 {% /graph %}
 
-{% graph title="Second CI Run (project2 Changed)" height="200px" %}
+{% graph title="Second CI Run (project2 Changed)" height="300px" %}
 
 ```json
 {
@@ -394,8 +385,6 @@ Take a look at the example below. The projects are setup in the suboptimal stack
 ```
 
 {% /graph %}
-
-{% /cards %}
 
 ### Caching Provides More Value When There are More Projects and a Flatter Structure
 

--- a/astro-docs/src/content/docs/concepts/mental-model.mdoc
+++ b/astro-docs/src/content/docs/concepts/mental-model.mdoc
@@ -344,7 +344,7 @@ instance, Nx:
 
 As your workspace grows, the task graph looks more like this:
 
-{% graph height="400px" type="task"%}
+{% graph height="200px" type="task"%}
 
 ```json
 {

--- a/astro-docs/src/content/docs/concepts/mental-model.mdoc
+++ b/astro-docs/src/content/docs/concepts/mental-model.mdoc
@@ -86,15 +86,9 @@ A task is an invocation of a target. If you invoke the same target twice, you cr
 Nx uses the [project graph](#the-project-graph), but the task graph and project graph aren't isomorphic, meaning they
 aren't directly connected. In the case above, `app1` and `app2` depend on `lib`, but
 running `nx run-many -t test -p app1 app2 lib`, the created task graph will look like this:
-{% side_by_side %}
 
-**Project Graph**
+**Project Graph:**
 
-**Task Graph**
-
-{% /side_by_side %}
-
-{% side_by_side %}
 {% graph height="200px" type="project" %}
 
 ```json
@@ -131,6 +125,8 @@ running `nx run-many -t test -p app1 app2 lib`, the created task graph will look
 ```
 
 {% /graph %}
+
+**Task Graph:**
 
 {% graph height="200px" type="task"%}
 
@@ -168,7 +164,6 @@ running `nx run-many -t test -p app1 app2 lib`, the created task graph will look
 ```
 
 {% /graph %}
-{% /side_by_side %}
 
 Even though the apps depend on `lib`, testing `app1` doesn't depend on the testing `lib`. This means that the two tasks
 can
@@ -192,15 +187,8 @@ Let's look at the test target relying on its dependencies.
 
 With this, running the same test command creates the following task graph:
 
-{% side_by_side %}
+**Project Graph:**
 
-**Project Graph**
-
-**Task Graph**
-
-{% /side_by_side %}
-
-{% side_by_side %}
 {% graph height="200px" type="project" %}
 
 ```json
@@ -238,6 +226,8 @@ With this, running the same test command creates the following task graph:
 
 {% /graph %}
 
+**Task Graph:**
+
 {% graph height="200px" type="task" %}
 
 ```json
@@ -274,7 +264,6 @@ With this, running the same test command creates the following task graph:
 ```
 
 {% /graph %}
-{% /side_by_side %}
 
 This often makes more sense for builds, where to build `app1`, you want to build `lib` first. You can also define
 similar

--- a/astro-docs/src/content/docs/concepts/sync-generators.mdoc
+++ b/astro-docs/src/content/docs/concepts/sync-generators.mdoc
@@ -105,9 +105,9 @@ Global sync generators are not associated with a particular task and are execute
 
 Nx processes the file system in order to [create the project graph](/docs/features/explore-graph) which is used to run tasks in the correct order and determine project dependencies. Sync generators allow you to also go the other direction and use the project graph to update the file system.
 
-{% side_by_side %}
+**File System:**
 
-```text title="File System"
+```text
 └─ myorg
    ├─ apps
    │  ├─ app1
@@ -117,6 +117,8 @@ Nx processes the file system in order to [create the project graph](/docs/featur
    ├─ nx.json
    └─ package.json
 ```
+
+**Project Graph:**
 
 {% graph title="Project Graph" height="200px" type="project" %}
 
@@ -183,7 +185,6 @@ Nx processes the file system in order to [create the project graph](/docs/featur
 ```
 
 {% /graph %}
-{% /side_by_side %}
 
 The ability to update the file system from the project graph makes it possible to use the Nx project graph to change the behavior of other tools that are not part of the Nx ecosystem.
 

--- a/astro-docs/src/content/docs/features/explore-graph.mdoc
+++ b/astro-docs/src/content/docs/features/explore-graph.mdoc
@@ -307,7 +307,7 @@ Composite nodes represent a set of projects in the same folder and can be expand
 
 Try playing around with a [fully interactive graph on a sample repo](https://nrwl-nx-examples-dep-graph.netlify.app/?focus=cart) or look at the more limited example below:
 
-{% side_by_side %}
+**Project View:**
 
 {% graph height="450px" title="Project View" %}
 
@@ -424,6 +424,8 @@ Try playing around with a [fully interactive graph on a sample repo](https://nrw
 
 {% /graph %}
 
+**Composite View (Nx 20+):**
+
 {% graph height="450px" title="Composite View (Nx 20+)" %}
 
 ```json
@@ -538,8 +540,6 @@ Try playing around with a [fully interactive graph on a sample repo](https://nrw
 ```
 
 {% /graph %}
-
-{% /side_by_side %}
 
 ### Export Project Graph to JSON
 

--- a/astro-docs/src/content/docs/features/maintain-typescript-monorepos.mdoc
+++ b/astro-docs/src/content/docs/features/maintain-typescript-monorepos.mdoc
@@ -19,9 +19,7 @@ Whenever possible, Nx will detect the existing configuration settings of other t
 
 ### Project Detection with Workspaces
 
-If your repository is using package manager workspaces, Nx will use those settings to find all the [projects](/docs/reference/project-configuration) in your repository. So you don't need to define a project for your package manager and separately identify the project for Nx. The `workspaces` configuration on the left allows Nx to detect the project graph on the right.
-
-{% side_by_side align="top" %}
+If your repository is using package manager workspaces, Nx will use those settings to find all the [projects](/docs/reference/project-configuration) in your repository. So you don't need to define a project for your package manager and separately identify the project for Nx. The `workspaces` configuration allows Nx to detect the project graph.
 
 ```json
 // package.json
@@ -83,17 +81,13 @@ If your repository is using package manager workspaces, Nx will use those settin
 
 {% /graph %}
 
-{% /side_by_side %}
-
 ### Inferred Tasks with Tooling Plugins
 
 Nx provides [plugins](/docs/concepts/nx-plugins) for tools that run tasks, like Vite, TypeScript, Playwright or Jest. These plugins can automatically [infer the Nx-specific task configuration](/docs/concepts/inferred-tasks) based on the tooling configuration files that already exist.
 
-In the example below, because the `/apps/cart/vite.config.ts` file exists, Nx knows that the `cart` project can run a `build` task using Vite. If you expand the `build` task on the right, you can also see that Nx configured the output directory for the [cache](/docs/features/cache-task-results) to match the `build.outDir` provided in the Vite configuration file.
+In the example below, because the `/apps/cart/vite.config.ts` file exists, Nx knows that the `cart` project can run a `build` task using Vite. If you expand the `build` task, you can also see that Nx configured the output directory for the [cache](/docs/features/cache-task-results) to match the `build.outDir` provided in the Vite configuration file.
 
 With inferred tasks, you can keep your tooling configuration file as the one source of truth for that tool's configuration, instead of adding an extra layer of configuration on top.
-
-{% side_by_side align="top" %}
 
 ```ts
 // /apps/cart/vite.config.ts
@@ -184,8 +178,6 @@ export default defineConfig({
 
 {% /project_details %}
 
-{% /side_by_side %}
-
 ## Enhance Tools for Monorepos
 
 Nx does not just reduce its own configuration burden, it also improves the functionality of your existing tools so that they work better in a monorepo context.
@@ -195,8 +187,6 @@ Nx does not just reduce its own configuration burden, it also improves the funct
 TypeScript provides a feature called [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html) that allows the TypeScript compiler to build and typecheck each project independently. When each project is typechecked, the TypeScript compiler will output an intermediate `*.tsbuildinfo` file that can be used by other projects instead of re-typechecking all dependencies. This feature can provide [significant performance improvements](/docs/concepts/typescript-project-linking#typescript-project-references-performance-benefits), particularly in a large monorepo.
 
 The main downside of this feature is that you have to manually define each project's references (dependencies) in the appropriate `tsconfig.*.json` file. This process is tedious to set up and very difficult to maintain as the repository changes over time. Nx can help by using a [sync generator](/docs/concepts/sync-generators) to automatically update the references defined in the `tsconfig.json` files based on the project graph it already knows about.
-
-{% side_by_side align="top" %}
 
 {% graph height="200px" title="Project View" %}
 
@@ -275,8 +265,6 @@ The main downside of this feature is that you have to manually define each proje
   ]
 }
 ```
-
-{% /side_by_side %}
 
 Later, if someone adds another dependency to the `cart` app and then runs the `build` task, Nx will detect that the project references are out of sync and ask if the references should be updated.
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/gradle-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/gradle-tutorial.mdoc
@@ -156,7 +156,7 @@ visually is vital to understanding how your code is structured and how Nx and Gr
 nx graph
 ```
 
-{% graph title="Gradle Projects" height="200px" %}
+{% graph title="Gradle Projects" height="300px" %}
 
 ```json
 {

--- a/nx-dev/ui-markdoc/src/lib/graphs/project-graph.tsx
+++ b/nx-dev/ui-markdoc/src/lib/graphs/project-graph.tsx
@@ -81,6 +81,9 @@ function NxDevProjectGraphInner({
     });
 
     send({ type: 'showAll' });
+    // make sure the graph sized to fix into the box
+    const el = orchestrator['renderer'].cy.elements();
+    orchestrator['renderer'].cy.fit(el, 1).center().resize();
   }, [orchestrator]);
 
   return (

--- a/nx-dev/ui-markdoc/src/lib/graphs/task-graph.tsx
+++ b/nx-dev/ui-markdoc/src/lib/graphs/task-graph.tsx
@@ -70,6 +70,10 @@ export function NxDevTaskGraphInner({
         ),
       }
     );
+
+    // make sure the graph sized to fix into the box
+    const el = orchestrator['renderer'].cy.elements();
+    orchestrator['renderer'].cy.fit(el, 10).center().resize();
   }, [orchestrator]);
 
   return (


### PR DESCRIPTION
- remove side_by_side and the usage of cards grid for graph views
- re-center project/task graphs on render to better fit into view
  -  also updating the height of a few usages of the graph for when there was a tall stack of nodes to better fit
  - NOTE: we can still apply custom node styles if we want, but since the complaint was just the default render size bc zoom level, I decided to just resize the view for the elements.

before: 
![wm_2025-09-30T16-49-08@2x](https://github.com/user-attachments/assets/fb740063-6cff-4892-b164-e0a5cc168a8a)


after: 
![wm_2025-09-30T16-48-41@2x](https://github.com/user-attachments/assets/c2d54dd2-13bf-45bb-b8c0-153fb277526a)


fixes: DOC-248