### PR TITLE
feat(release)!: match nx affected behavior to determine relevant conventional commits

### DIFF
--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -1000,7 +1000,7 @@ describe('debug nx release - independent projects', () => {
             'g'
           )
         ).length
-      ).toEqual(1);
+      ).toEqual(2);
       expect(
         releaseOutput.match(
           new RegExp(
@@ -1012,6 +1012,15 @@ describe('debug nx release - independent projects', () => {
       expect(
         releaseOutput.match(
           new RegExp(`- \\*\\*${pkg1}:\\*\\* new feature 1`, 'g')
+        ).length
+      ).toEqual(1);
+
+      expect(
+        releaseOutput.match(
+          new RegExp(
+            `New version 1\\.6\\.0 written to manifest: my-pkg-2\\d*`,
+            'g'
+          )
         ).length
       ).toEqual(1);
 

--- a/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
+++ b/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
@@ -4,7 +4,7 @@ import { ProjectGraph } from '../../../config/project-graph';
 import { NxReleaseConfig } from '../config/config';
 import { SemverBumpType } from '../version/version-actions';
 import { getGitDiff, parseCommits } from './git';
-import { determineSemverChange } from './semver';
+import { determineSemverChange, SemverSpecifier } from './semver';
 import { getCommitsRelevantToProjects } from './shared';
 
 export async function resolveSemverSpecifierFromConventionalCommits(
@@ -12,7 +12,8 @@ export async function resolveSemverSpecifierFromConventionalCommits(
   projectGraph: ProjectGraph,
   projectNames: string[],
   conventionalCommitsConfig: NxReleaseConfig['conventionalCommits']
-): Promise<string | null> {
+): // Map of projectName to semver bump type
+Promise<Map<string, SemverSpecifier | null>> {
   const commits = await getGitDiff(from);
   const parsedCommits = parseCommits(commits);
   const relevantCommits = await getCommitsRelevantToProjects(

--- a/packages/nx/src/command-line/release/utils/semver.spec.ts
+++ b/packages/nx/src/command-line/release/utils/semver.spec.ts
@@ -1,7 +1,11 @@
 import { NxReleaseConfig } from '../config/config';
 import { DEFAULT_CONVENTIONAL_COMMITS_CONFIG } from '../config/conventional-commits';
 import { GitCommit } from './git';
-import { deriveNewSemverVersion, determineSemverChange } from './semver';
+import {
+  deriveNewSemverVersion,
+  determineSemverChange,
+  SemverSpecifier,
+} from './semver';
 
 describe('semver', () => {
   describe('deriveNewSemverVersion()', () => {
@@ -119,46 +123,98 @@ describe('semver', () => {
     it('should return the highest bump level of all commits', () => {
       expect(
         determineSemverChange(
-          [fixCommit, featNonBreakingCommit, choreCommit],
+          new Map([
+            [
+              'default',
+              [
+                { commit: fixCommit, isProjectScopedCommit: false },
+                {
+                  commit: featNonBreakingCommit,
+                  isProjectScopedCommit: false,
+                },
+                { commit: choreCommit, isProjectScopedCommit: false },
+              ],
+            ],
+          ]),
           config
-        )
-      ).toEqual('minor');
+        ).get('default')
+      ).toEqual(SemverSpecifier.MINOR);
     });
 
     it('should return major if any commits are breaking', () => {
       expect(
         determineSemverChange(
-          [fixCommit, featBreakingCommit, featNonBreakingCommit, choreCommit],
+          new Map([
+            [
+              'default',
+              [
+                { commit: fixCommit, isProjectScopedCommit: true },
+                { commit: featBreakingCommit, isProjectScopedCommit: true },
+                { commit: featNonBreakingCommit, isProjectScopedCommit: true },
+                { commit: choreCommit, isProjectScopedCommit: true },
+              ],
+            ],
+          ]),
           config
-        )
-      ).toEqual('major');
+        ).get('default')
+      ).toEqual(SemverSpecifier.MAJOR);
     });
 
     it('should return major if any commits (including unknown types) are breaking', () => {
       expect(
         determineSemverChange(
-          [
-            fixCommit,
-            unknownTypeBreakingCommit,
-            featNonBreakingCommit,
-            choreCommit,
-          ],
+          new Map([
+            [
+              'default',
+              [
+                { commit: fixCommit, isProjectScopedCommit: true },
+                {
+                  commit: unknownTypeBreakingCommit,
+                  isProjectScopedCommit: true,
+                },
+                { commit: featNonBreakingCommit, isProjectScopedCommit: true },
+                { commit: choreCommit, isProjectScopedCommit: true },
+              ],
+            ],
+          ]),
           config
-        )
-      ).toEqual('major');
+        ).get('default')
+      ).toEqual(SemverSpecifier.MAJOR);
     });
 
     it('should return patch when given only patch commits, ignoring unknown types', () => {
       expect(
         determineSemverChange(
-          [fixCommit, choreCommit, unknownTypeCommit],
+          new Map([
+            [
+              'default',
+              [
+                { commit: fixCommit, isProjectScopedCommit: true },
+                {
+                  commit: choreCommit,
+                  isProjectScopedCommit: true,
+                },
+                { commit: unknownTypeCommit, isProjectScopedCommit: true },
+              ],
+            ],
+          ]),
           config
-        )
-      ).toEqual('patch');
+        ).get('default')
+      ).toEqual(SemverSpecifier.PATCH);
     });
 
     it('should return null when given only unknown type commits', () => {
-      expect(determineSemverChange([unknownTypeCommit], config)).toEqual(null);
+      expect(
+        determineSemverChange(
+          new Map([
+            [
+              'default',
+              [{ commit: unknownTypeCommit, isProjectScopedCommit: true }],
+            ],
+          ]),
+          config
+        ).get('default')
+      ).toEqual(null);
     });
   });
 });

--- a/packages/nx/src/command-line/release/utils/semver.ts
+++ b/packages/nx/src/command-line/release/utils/semver.ts
@@ -7,6 +7,18 @@ import { RELEASE_TYPES, ReleaseType, inc, valid } from 'semver';
 import { NxReleaseConfig } from '../config/config';
 import { GitCommit } from './git';
 
+export const enum SemverSpecifier {
+  MAJOR = 3,
+  MINOR = 2,
+  PATCH = 1,
+}
+
+export const SemverSpecifierType = {
+  3: 'major',
+  2: 'minor',
+  1: 'patch',
+};
+
 export function isRelativeVersionKeyword(val: string): val is ReleaseType {
   return RELEASE_TYPES.includes(val as ReleaseType);
 }
@@ -17,34 +29,39 @@ export function isValidSemverSpecifier(specifier: string): boolean {
   );
 }
 
-/**
- * TODO: We would be able to make the logging for the conventional commits use-case
- * for fixed release groups more clear/precise if we passed through which project
- * the conventional commits were detected for.
- *
- * It would then flow up through deriveSpecifierFromConventionalCommits back to
- * ReleaseGroupProcessor.
- */
 // https://github.com/unjs/changelogen/blob/main/src/semver.ts
 export function determineSemverChange(
-  commits: GitCommit[],
+  relevantCommits: Map<
+    string,
+    { commit: GitCommit; isProjectScopedCommit: boolean }[]
+  >, // <projectName, commits>
   config: NxReleaseConfig['conventionalCommits']
-): 'patch' | 'minor' | 'major' | null {
-  let [hasMajor, hasMinor, hasPatch] = [false, false, false];
-  for (const commit of commits) {
-    const semverType = config.types[commit.type]?.semverBump;
-    if (semverType === 'major' || commit.isBreaking) {
-      hasMajor = true;
-    } else if (semverType === 'minor') {
-      hasMinor = true;
-    } else if (semverType === 'patch') {
-      hasPatch = true;
-    } else if (semverType === 'none' || !semverType) {
-      // do not report a change
+): Map<string, SemverSpecifier | null> {
+  const semverChangePerProject: Map<string, SemverSpecifier | null> = new Map();
+  for (const [projectName, relevantCommit] of relevantCommits) {
+    let highestChange: SemverSpecifier | null = null;
+
+    for (const { commit, isProjectScopedCommit } of relevantCommit) {
+      if (!isProjectScopedCommit) {
+        // commit is relevant to the project, but not directly, report minor change
+        highestChange = Math.max(SemverSpecifier.MINOR, highestChange ?? 0);
+        continue;
+      }
+      const semverType = config.types[commit.type]?.semverBump;
+      if (semverType === 'major' || commit.isBreaking) {
+        highestChange = Math.max(SemverSpecifier.MAJOR, highestChange ?? 0);
+        break; // Major is highest priority, no need to check more commits
+      } else if (semverType === 'minor') {
+        highestChange = Math.max(SemverSpecifier.MINOR, highestChange ?? 0);
+      } else if (semverType === 'patch') {
+        highestChange = Math.max(SemverSpecifier.PATCH, highestChange ?? 0);
+      }
     }
+
+    semverChangePerProject.set(projectName, highestChange);
   }
 
-  return hasMajor ? 'major' : hasMinor ? 'minor' : hasPatch ? 'patch' : null;
+  return semverChangePerProject;
 }
 
 export function deriveNewSemverVersion(

--- a/packages/nx/src/command-line/release/utils/shared.ts
+++ b/packages/nx/src/command-line/release/utils/shared.ts
@@ -356,8 +356,6 @@ Promise<Map<string, { commit: GitCommit; isProjectScopedCommit: boolean }[]>> {
     // Convert affectedFiles to FileChange[] format
     const touchedFiles = commit.affectedFiles.map((f) => ({
       file: f,
-      ext: extname(f),
-      hash: '', // Not needed for affected detection
       getChanges: () => [new WholeFileChange()],
     }));
 

--- a/packages/nx/src/command-line/release/version/derive-specifier-from-conventional-commits.ts
+++ b/packages/nx/src/command-line/release/version/derive-specifier-from-conventional-commits.ts
@@ -8,6 +8,7 @@ import { getFirstGitCommit, getLatestGitTagForPattern } from '../utils/git';
 import { resolveSemverSpecifierFromConventionalCommits } from '../utils/resolve-semver-specifier';
 import { ProjectLogger } from './project-logger';
 import { SemverBumpType } from './version-actions';
+import { SemverSpecifier, SemverSpecifierType } from '../utils/semver';
 
 export async function deriveSpecifierFromConventionalCommits(
   nxReleaseConfig: NxReleaseConfig,
@@ -49,12 +50,28 @@ export async function deriveSpecifierFromConventionalCommits(
     );
   }
 
-  let specifier = await resolveSemverSpecifierFromConventionalCommits(
-    previousVersionRef,
-    projectGraph,
-    affectedProjects,
-    nxReleaseConfig.conventionalCommits
-  );
+  const projectToSpecifiers =
+    await resolveSemverSpecifierFromConventionalCommits(
+      previousVersionRef,
+      projectGraph,
+      affectedProjects,
+      nxReleaseConfig.conventionalCommits
+    );
+
+  const getHighestSemverChange = (
+    semverSpecifiersItr: MapIterator<SemverSpecifier>
+  ) => {
+    const semverSpecifiers = Array.from(semverSpecifiersItr);
+    return semverSpecifiers.sort((a, b) => b - a)[0];
+  };
+
+  const semverSpecifier =
+    releaseGroup.projectsRelationship === 'independent'
+      ? projectToSpecifiers.get(projectGraphNode.name)
+      : getHighestSemverChange(projectToSpecifiers.values());
+
+  let specifier =
+    semverSpecifier === null ? null : SemverSpecifierType[semverSpecifier];
 
   if (!specifier) {
     projectLogger.buffer(


### PR DESCRIPTION
## Current Behavior
Nx Release currently only checks for commits with affected files changed under the root of projects configured for release.
However, changes to other files may affect and invalidate these projects also.

## Expected Behavior
Reuse Nx's affected logic to determine when commits contain changes that affect the projects configured for release.

BREAKING CHANGE: More files are now being used to determine relevant commits, meaning there is higher chance for projects to receive version bumps 
