### PR TITLE
fix(nx-dev): provide message to check previous docs w/ empty migrations

### DIFF
--- a/astro-docs/src/plugins/plugin.loader.ts
+++ b/astro-docs/src/plugins/plugin.loader.ts
@@ -219,7 +219,10 @@ export async function generateAllPluginDocs(
 
       // Process migrations
       const migrations = parseMigrations(pluginPath);
-      if (migrations && migrations.size > 0) {
+      // parseMigrations will return null if the plugin doesn't define migration.json
+      // if there are not migrations then getMigrationsMarkdown will render a custom message
+      // to check previous Nx version docs
+      if (migrations) {
         const markdown = getMigrationsMarkdown(pluginName, migrations);
         const slug = getPluginSlug(pluginName, 'migrations');
         if (slug) {

--- a/astro-docs/src/plugins/utils/generate-plugin-markdown.ts
+++ b/astro-docs/src/plugins/utils/generate-plugin-markdown.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync } from 'fs';
+import { NX_VERSION } from '@nx/devkit';
 import { getExampleForSchema } from './get-schema-example-content';
 import {
   getPropertyDefault,
@@ -76,8 +77,24 @@ export function getMigrationsMarkdown(
 ): string {
   const packageName = `@nx/${pluginName}`;
 
-  let markdown = `
-  The ${packageName} plugin provides various migrations to help you migrate to newer versions of ${pluginName} projects within your Nx workspace.
+  let markdown = ``;
+  if (items.size === 0) {
+    markdown += `No migrations found for \`${packageName}\`.
+Nx only retains migrations for the last 2 major versions of Nx.
+It's possible migrations existed in previous verions of \`${packageName}\`.\n\n`;
+    if (NX_VERSION) {
+      const majorVersion = Number(NX_VERSION.split('.')[0]);
+      const previousMajor = majorVersion - 1;
+      const twoMajorsAgo = previousMajor - 1;
+      markdown += `You can check the previous docs for [Nx v${previousMajor}](https://${previousMajor}.nx.dev/docs) or [Nx v${twoMajorsAgo}](https://${twoMajorsAgo}.nx.dev/docs).`;
+    } else {
+      markdown += `You can check previous versions of Nx documentations by using the version selector at the top of the page.`;
+    }
+
+    // early exit since there aren't any migration items to process anyway;
+    return markdown;
+  }
+  markdown += `The ${packageName} plugin provides various migrations to help you migrate to newer versions of ${pluginName} projects within your Nx workspace.
 Below is a complete reference for all available migrations.
 `;
 

--- a/astro-docs/src/plugins/utils/generate-plugin-markdown.ts
+++ b/astro-docs/src/plugins/utils/generate-plugin-markdown.ts
@@ -81,7 +81,7 @@ export function getMigrationsMarkdown(
   if (items.size === 0) {
     markdown += `No migrations found for \`${packageName}\`.
 Nx only retains migrations for the last 2 major versions of Nx.
-It's possible migrations existed in previous verions of \`${packageName}\`.\n\n`;
+It's possible migrations existed in previous versions of \`${packageName}\`.\n\n`;
     if (NX_VERSION) {
       const majorVersion = Number(NX_VERSION.split('.')[0]);
       const previousMajor = majorVersion - 1;


### PR DESCRIPTION
Since Nx only keeps the last 2 majors listed in a plugins migration.json, it's possible migrations can be defined and a valid link, but a new nx version will removed those migrations now causing the page to 404 a link that previously worked. 

instead of 404-ing when plugin migrations delete old versions of migrations we provide a message stating that there are no migrations, but you can check the previous versions of the docs to check if the migration you need is listed here. 

We still will not include the migrations link in the sidebar when the migration.json does not contain any migrations.

Example:
<img width="780" height="425" alt="image" src="https://github.com/user-attachments/assets/de27c4f7-1442-44e6-9005-970450cabe1e" />


Fixes DOC-251
