### PR TITLE
docs(misc): improve conformance documentation discoverability

### DIFF
--- a/astro-docs/src/content/docs/enterprise/Powerpack/conformance.mdoc
+++ b/astro-docs/src/content/docs/enterprise/Powerpack/conformance.mdoc
@@ -11,11 +11,17 @@ filter: 'type:Guides'
 
 The [`@nx/conformance`](/docs/reference/core-api/conformance) plugin allows [Nx Powerpack](https://nx.dev/powerpack) and [Nx Enterprise](https://nx.dev/enterprise) users to write and apply rules for your entire workspace that help with **consistency**, **maintainability**, **reliability** and **security**. Powerpack is available for Nx version 19.8 and higher.
 
-The conformance plugin allows you to **encode your own organization's standards** so that they can be enforced automatically. Conformance rules can also **complement linting tools** by enforcing that those tools are configured in the recommended way. The rules are written in TypeScript but can be **applied to any language in the codebase** or focus entirely on configuration files.
+## Why Conformance?
+
+Large organizations struggle with maintaining consistency across teams and projects. Manual audits don't scale and developers can't remember every standard. Conformance provides **automated governance** that catches issues before they reach production and enforces policies without manual intervention.
+
+## What Does Conformance Do?
+
+The `@nx/conformance` plugin lets you write custom rules in TypeScript that enforce your organization's standards across **any language or technology** in your codebase. Rules can complement existing linting tools by verifying proper configuration, or enforce entirely new policies around security, architecture, or documentation requirements.
 
 The plugin also provides the following pre-written rules:
 
-- **Enforce Project Boundaries**: Similar to the Nx [ESLint Enforce Module Boundaries rule](/docs/features/enforce-module-boundaries), but enforces the boundaries on every project dependency, not just those created from TypeScript imports or `package.json` dependencies.
+- **Enforce Project Boundaries**: Similar to the Nx [ESLint Enforce Module Boundaries rule](/docs/technologies/eslint/eslint-plugin/guides/enforce-module-boundaries), but enforces the boundaries on every project dependency, not just those created from TypeScript imports or `package.json` dependencies.
 - **Ensure Owners**: Require every project to have an owner defined for the [`@nx/owners` plugin](/docs/reference/core-api/owners)
 
 ## Setup
@@ -113,3 +119,11 @@ Simply add an appropriate invocation of the `nx-cloud conformance:check` command
 ```
 
 Learn more about [publishing](/docs/enterprise/powerpack/publish-conformance-rules-to-nx-cloud) and [configuring conformance rules in Nx Cloud](/docs/enterprise/powerpack/configure-conformance-rules-in-nx-cloud).
+
+## Learn More
+
+- [Conformance Plugin API Reference](/docs/reference/powerpack/conformance/overview) - Detailed documentation on configuration options and provided rules
+- [Create a Custom Conformance Rule](/docs/reference/powerpack/conformance/create-conformance-rule) - Step-by-step guide to writing your own rules
+- [Publish Conformance Rules to Nx Cloud](/docs/enterprise/powerpack/publish-conformance-rules-to-nx-cloud) - Share rules across your organization
+- [Configure Conformance Rules in Nx Cloud](/docs/enterprise/powerpack/configure-conformance-rules-in-nx-cloud) - Manage rules via the Nx Cloud dashboard
+- [Blog: Automating Consistency with Nx Cloud Conformance](https://nx.dev/blog/nx-cloud-conformance-automate-consistency) - Learn about the philosophy and benefits of conformance

--- a/astro-docs/src/content/docs/enterprise/polygraph.mdoc
+++ b/astro-docs/src/content/docs/enterprise/polygraph.mdoc
@@ -63,7 +63,7 @@ You can setup notifications for teams, so they're always kept in the loop
 
 ![Conformance notifications](../../../assets/enterprise/polygraph/conformance-notifications.avif)
 
-Ready to write your first conformance rule? [See our conformance rule guide](/docs/enterprise/powerpack/configure-conformance-rules-in-nx-cloud) to start.
+Ready to write your first conformance rule? [See our conformance guide](/docs/enterprise/powerpack/conformance) to start.
 
 ## Custom Workflows
 
@@ -82,7 +82,7 @@ Custom workflows enable proactive monitoring and automated compliance checking, 
 
 Gain quick visibility across your organization's repositories without needing to migrate each repository as an Nx Workspace.
 Easily onboard any repository as a **metadata-only** to immediately start contributing to the [Workspace Graph](#workspace-graph).
-Metadata-only workspaces can still leverage [custom workflows](/docs/enterprise/polygraph#custom-workflows) and [conformance rules](/docs/enterprise/powerpack/configure-conformance-rules-in-nx-cloud).
+Metadata-only workspaces can still leverage [custom workflows](/docs/enterprise/polygraph#custom-workflows) and [conformance rules](/docs/enterprise/powerpack/conformance).
 
 Read more about [onboarding a workspace as metadata-only](/docs/enterprise/metadata-only-workspace).
 

--- a/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
+++ b/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
@@ -1,6 +1,6 @@
 ---
 title: 'Enforce Module Boundaries'
-description: 'Learn how to use Nx module boundaries to maintain a clean architecture by controlling dependencies between projects using tags and ESLint rules.'
+description: 'Learn how to use Nx module boundaries to maintain a clean architecture by controlling dependencies between projects using tags and dependency constraints.'
 sidebar:
   order: 8
 filter: 'type:Features'
@@ -8,40 +8,22 @@ filter: 'type:Features'
 
 If you partition your code into well-defined cohesive units, even a small organization will end up with a dozen apps and dozens or hundreds of libs. If all of them can depend on each other freely, chaos will ensue, and the workspace will become unmanageable.
 
-To help with that Nx uses code analysis to make sure projects can only depend on each other's well-defined public API. It also allows you to declaratively impose constraints on how projects can depend on each other.
+To help with that, Nx provides powerful mechanisms to enforce architectural boundaries and ensure projects can only depend on each other according to your organization's rules. You can declaratively define constraints using project tags and enforce them automatically.
 
 {% youtube
 src="https://www.youtube.com/embed/q0en5vlOsWY"
 title="Applying Module Boundaries"
 /%}
 
-## Project APIs
+## How to Enforce Boundaries
 
-Nx provides an `enforce-module-boundaries` eslint rule that enforces the public API of projects in the repo. Each project defines its public API in an `index.ts` (or `index.js`) file. If another project tries to import a variable from a file deep within a different project, an error will be thrown during linting.
+Nx offers two complementary approaches to enforce module boundaries:
 
-To set up the lint rule, install these dependencies:
+**ESLint Integration** - For JavaScript/TypeScript projects, enforce boundaries on code imports using the `@nx/enforce-module-boundaries` ESLint rule. This checks TypeScript imports and `package.json` dependencies during linting.
 
-```shell {% frame="none" %}
-nx add @nx/eslint-plugin @nx/devkit
-```
+**Language-Agnostic Conformance** - For any project type (e.g. Java, Python, PHP, JavaScript, etc.), use the [Conformance plugin's Enforce Project Boundaries rule](/docs/enterprise/powerpack/conformance). This rule checks dependencies in the Nx graph during `nx conformance:check`. Requires [Nx Powerpack or Enterprise](https://nx.dev/enterprise).
 
-And configure the rule in your root `.eslintrc.json` file:
-
-```jsonc
-// .eslintrc.json
-{
-  "plugins": ["@nx"],
-  // ...
-  "rules": {
-    "@nx/enforce-module-boundaries": [
-      "error",
-      {
-        /* options */
-      }
-    ]
-  }
-}
-```
+Both approaches use the same tag-based constraint system described below.
 
 ## Tags
 
@@ -112,9 +94,20 @@ First, use your project configuration (in `project.json` or `package.json`) to a
 {% /tabitem %}
 {% /tabs %}
 
-Next, you should update your root lint configuration:
+## Configure Boundary Rules
 
-- If you are using **ESLint** you should look for an existing rule entry in your root `.eslintrc.json` called `@nx/enforce-module-boundaries` and you should update the `depConstraints`:
+Once you have tagged your projects, configure the dependency constraints based on your chosen approach:
+
+{% tabs %}
+{% tabitem label="ESLint" %}
+
+For JavaScript/TypeScript projects, configure the `@nx/enforce-module-boundaries` ESLint rule:
+
+```shell {% frame="none" %}
+nx add @nx/eslint-plugin @nx/devkit
+```
+
+Update your root `.eslintrc.json` file:
 
 ```jsonc
 // .eslintrc.json
@@ -148,16 +141,70 @@ Next, you should update your root lint configuration:
 }
 ```
 
-With these constraints in place, `scope:client` projects can only depend on projects with `scope:client` or `scope:shared`. And `scope:admin` projects can only depend on projects with `scope:admin` or `scope:shared`. So `scope:client` and `scope:admin` cannot depend on each other.
-
-Projects without any tags cannot depend on any other projects. If you try to violate the constraints, you will get an error when linting:
+If you violate the constraints, you will get an error when linting:
 
 ```plaintext
 A project tagged with "scope:admin" can only depend on projects
 tagged with "scoped:shared" or "scope:admin".
 ```
 
-The exception to this rule is by explicitly allowing all tags (see below).
+Read more about [ESLint rule options](/docs/technologies/eslint/eslint-plugin/guides/enforce-module-boundaries).
+
+{% /tabitem %}
+{% tabitem label="Conformance" %}
+
+For any project type or to enforce boundaries on the complete dependency graph, use the Conformance plugin:
+
+```shell {% frame="none" %}
+nx add @nx/conformance
+```
+
+Configure rules in your `nx.json`:
+
+```jsonc
+// nx.json
+{
+  "conformance": {
+    "rules": [
+      {
+        "rule": "@nx/conformance/enforce-project-boundaries",
+        "options": {
+          "depConstraints": [
+            {
+              "sourceTag": "scope:shared",
+              "onlyDependOnProjectsWithTags": ["scope:shared"]
+            },
+            {
+              "sourceTag": "scope:admin",
+              "onlyDependOnProjectsWithTags": ["scope:shared", "scope:admin"]
+            },
+            {
+              "sourceTag": "scope:client",
+              "onlyDependOnProjectsWithTags": ["scope:shared", "scope:client"]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+Run conformance checks in CI:
+
+```yaml
+- name: Enforce all conformance rules
+  run: npx nx conformance:check
+```
+
+Learn more about [Conformance rules](/docs/enterprise/powerpack/conformance).
+
+{% /tabitem %}
+{% /tabs %}
+
+With these constraints in place, `scope:client` projects can only depend on projects with `scope:client` or `scope:shared`. And `scope:admin` projects can only depend on projects with `scope:admin` or `scope:shared`. So `scope:client` and `scope:admin` cannot depend on each other.
+
+Projects without any tags cannot depend on any other projects. The exception to this rule is by explicitly allowing all tags (see below).
 
 ### Tag formats
 

--- a/astro-docs/src/content/docs/reference/Powerpack/conformance/overview.mdoc
+++ b/astro-docs/src/content/docs/reference/Powerpack/conformance/overview.mdoc
@@ -91,7 +91,7 @@ The following rules are provided by Nx along with the `@nx/conformance` plugin.
 
 ### Enforce Project Boundaries
 
-This rule is similar to the Nx [ESLint Enforce Module Boundaries rule](/docs/features/enforce-module-boundaries), but enforces the boundaries on every project dependency, not just those created from TypeScript imports or `package.json` dependencies.
+This rule is similar to the Nx [ESLint Enforce Module Boundaries rule](/docs/technologies/eslint/eslint-plugin/guides/enforce-module-boundaries), but enforces the boundaries on every project dependency, not just those created from TypeScript imports or `package.json` dependencies.
 
 Set the `rule` property to: `@nx/conformance/enforce-project-boundaries`
 

--- a/astro-docs/src/content/docs/technologies/eslint/eslint-plugin/Guides/enforce-module-boundaries.mdoc
+++ b/astro-docs/src/content/docs/technologies/eslint/eslint-plugin/Guides/enforce-module-boundaries.mdoc
@@ -9,6 +9,10 @@ filter: 'type:Guides'
 The `@nx/enforce-module-boundaries` ESLint rule enables you to define strict rules for accessing resources between
 different projects in the repository. Enforcing strict boundaries helps to prevent unplanned cross-dependencies.
 
+{% aside type="note" %}
+This rule requires ESLint and only works for JavaScript/TypeScript projects. For language-agnostic boundary enforcement across all project dependencies, see the [Conformance plugin's Enforce Project Boundaries rule](/docs/enterprise/powerpack/conformance).
+{% /aside %}
+
 ## Usage
 
 You can use the `enforce-module-boundaries` rule by adding it to your ESLint rules configuration:

--- a/nx-dev/ui-enterprise/src/lib/scale-your-organization.tsx
+++ b/nx-dev/ui-enterprise/src/lib/scale-your-organization.tsx
@@ -158,29 +158,14 @@ export function ScaleYourOrganization(): ReactElement {
                         <Link
                           href={
                             process.env.NEXT_PUBLIC_ASTRO_URL
-                              ? '/docs/enterprise/powerpack/configure-conformance-rules-in-nx-cloud'
-                              : '/ci/recipes/enterprise/conformance/configure-conformance-rules-in-nx-cloud'
+                              ? '/docs/reference/powerpack/conformance/overview'
+                              : '/ci/recipes/enterprise/conformance'
                           }
                           prefetch={false}
-                          title="Configure Conformance Rules"
+                          title="Learn More About Conformance"
                           className="text-sm/6 font-semibold"
                         >
-                          Configure Conformance Rules{' '}
-                          <span aria-hidden="true">→</span>
-                        </Link>
-                      </li>
-                      <li>
-                        <Link
-                          href={
-                            process.env.NEXT_PUBLIC_ASTRO_URL
-                              ? '/docs/enterprise/powerpack/publish-conformance-rules-to-nx-cloud'
-                              : '/ci/recipes/enterprise/conformance/publish-conformance-rules-to-nx-cloud'
-                          }
-                          prefetch={false}
-                          title="Publish Conformance Rules"
-                          className="text-sm/6 font-semibold"
-                        >
-                          Publish Conformance Rules{' '}
+                          Learn More About Conformance
                           <span aria-hidden="true">→</span>
                         </Link>
                       </li>


### PR DESCRIPTION
This PR updates our module boundary feature/rule pages such that:
- It is clear that the feature is for both JS/TS projects (ESLint) and any language (conformance)
- Update links to the ESLint rule from feature page to the actual ESLint rule page (since feature covers both ESLint and Conformance now)
- Add a "Why" section to the conformance overview page

The conformance page (`docs/enterprise/powerpack/conformance`) is meant to be the main landing page that we send to users. Also updates the Enterprise page so link to the overview page.

<img width="1024" height="459" alt="image" src="https://github.com/user-attachments/assets/c24f110d-cc44-41c8-b448-56d4a246a7b6" />

## Updated Pages

- /docs/features/enforce-module-boundaries
- /docs/enterprise/powerpack/conformance
- /docs/technologies/eslint/eslint-plugin/guides/enforce-module-boundaries
- /docs/reference/powerpack/conformance/overview
- /docs/enterprise/polygraph#conformance
- /enterprise

## Notes
The `/docs/enterprise/powerpack/conformance` and `/docs/reference/powerpack/conformance/overview` have some overlaps, where the latter documents all the API options. We should look at cleaning both the conformance and owners reference pages such that they are just API docs.

## Related Issue(s)
Closes DOC-206