### PR TITLE
chore(repo): disable duplicated typecheck targets if the project already uses tsc to build

### DIFF
--- a/e2e/utils/tsconfig.json
+++ b/e2e/utils/tsconfig.json
@@ -24,5 +24,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "typecheckTargetName": null
+  }
 }

--- a/nx.json
+++ b/nx.json
@@ -220,12 +220,20 @@
     },
     {
       "plugin": "@nx/js/typescript",
-      "exclude": ["examples/angular-rspack/**/*"],
+      "exclude": ["examples/angular-rspack/**/*", "nx-dev/**/*", "e2e/**/*"],
       "options": {
         "typecheck": true,
         "build": {
           "targetName": "build-base"
         }
+      }
+    },
+    {
+      "plugin": "@nx/js/typescript",
+      "include": ["e2e/**/*"],
+      "options": {
+        "typecheck": true,
+        "build": false
       }
     },
     {

--- a/packages/angular-rspack-compiler/tsconfig.json
+++ b/packages/angular-rspack-compiler/tsconfig.json
@@ -13,5 +13,8 @@
     {
       "path": "./tsconfig.spec.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/angular-rspack/tsconfig.json
+++ b/packages/angular-rspack/tsconfig.json
@@ -15,5 +15,8 @@
     {
       "path": "./tsconfig.spec.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -46,5 +46,8 @@
     {
       "path": "./tsconfig.spec.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/create-nx-plugin/tsconfig.json
+++ b/packages/create-nx-plugin/tsconfig.json
@@ -12,5 +12,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/create-nx-workspace/tsconfig.json
+++ b/packages/create-nx-workspace/tsconfig.json
@@ -10,5 +10,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/cypress/tsconfig.json
+++ b/packages/cypress/tsconfig.json
@@ -21,5 +21,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/detox/tsconfig.json
+++ b/packages/detox/tsconfig.json
@@ -24,5 +24,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/devkit/tsconfig.json
+++ b/packages/devkit/tsconfig.json
@@ -12,5 +12,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/docker/tsconfig.json
+++ b/packages/docker/tsconfig.json
@@ -15,5 +15,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/esbuild/tsconfig.json
+++ b/packages/esbuild/tsconfig.json
@@ -18,5 +18,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -17,5 +17,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/eslint/tsconfig.json
+++ b/packages/eslint/tsconfig.json
@@ -18,5 +18,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/expo/tsconfig.json
+++ b/packages/expo/tsconfig.json
@@ -24,5 +24,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/express/tsconfig.json
+++ b/packages/express/tsconfig.json
@@ -18,5 +18,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/gradle/tsconfig.json
+++ b/packages/gradle/tsconfig.json
@@ -13,5 +13,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/jest/tsconfig.json
+++ b/packages/jest/tsconfig.json
@@ -21,5 +21,8 @@
     {
       "path": "./tsconfig.spec.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/js/tsconfig.json
+++ b/packages/js/tsconfig.json
@@ -18,5 +18,8 @@
     {
       "path": "./tsconfig.spec.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/module-federation/tsconfig.json
+++ b/packages/module-federation/tsconfig.json
@@ -21,5 +21,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/nest/tsconfig.json
+++ b/packages/nest/tsconfig.json
@@ -21,5 +21,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -30,5 +30,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -27,5 +27,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/nuxt/tsconfig.json
+++ b/packages/nuxt/tsconfig.json
@@ -27,5 +27,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/nx/tsconfig.json
+++ b/packages/nx/tsconfig.json
@@ -6,5 +6,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/playwright/tsconfig.json
+++ b/packages/playwright/tsconfig.json
@@ -21,5 +21,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/plugin/tsconfig.json
+++ b/packages/plugin/tsconfig.json
@@ -24,5 +24,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/react-native/tsconfig.json
+++ b/packages/react-native/tsconfig.json
@@ -24,5 +24,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -33,5 +33,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/remix/tsconfig.json
+++ b/packages/remix/tsconfig.json
@@ -21,5 +21,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/rollup/tsconfig.json
+++ b/packages/rollup/tsconfig.json
@@ -18,5 +18,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/rsbuild/tsconfig.json
+++ b/packages/rsbuild/tsconfig.json
@@ -18,5 +18,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/rspack/tsconfig.json
+++ b/packages/rspack/tsconfig.json
@@ -27,5 +27,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/storybook/tsconfig.json
+++ b/packages/storybook/tsconfig.json
@@ -24,5 +24,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/vite/tsconfig.json
+++ b/packages/vite/tsconfig.json
@@ -18,5 +18,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -27,5 +27,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -18,5 +18,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/webpack/tsconfig.json
+++ b/packages/webpack/tsconfig.json
@@ -18,5 +18,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/packages/workspace/tsconfig.json
+++ b/packages/workspace/tsconfig.json
@@ -18,5 +18,8 @@
     {
       "path": "./tsconfig.spec.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/tools/update-repos/tsconfig.json
+++ b/tools/update-repos/tsconfig.json
@@ -9,5 +9,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/tools/workspace-plugin/tsconfig.json
+++ b/tools/workspace-plugin/tsconfig.json
@@ -27,5 +27,8 @@
     {
       "path": "./tsconfig.spec.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }

--- a/typedoc-theme/tsconfig.json
+++ b/typedoc-theme/tsconfig.json
@@ -6,5 +6,8 @@
     {
       "path": "./tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "addTypecheckTarget": false
+  }
 }


### PR DESCRIPTION
This PR removes redundant `typecheck` targets from projects already building with `tsc`.

- Add `addTypecheckTarget: false` to projects using `tsc` as `build-base`.
- Exclude `e2e` and `nx-dev` projects from having `tsc` build inferred but leave the `typecheck` target

Note:	angular-rspack and angular-rspack-compiler has an issue where `@nx/vite/plugin` is inferring the typecheck target. We may want to check `addTypecheckTarget` for that plugin as well.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->
Closes NXC-3208