### PR TITLE
fix(core): ensure nx is published with the correct dependency version for the native packages

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3383,6 +3383,26 @@ importers:
         specifier: '*'
         version: 21.6.2
 
+  packages/nx/native-packages/darwin-arm64: {}
+
+  packages/nx/native-packages/darwin-x64: {}
+
+  packages/nx/native-packages/freebsd-x64: {}
+
+  packages/nx/native-packages/linux-arm-gnueabihf: {}
+
+  packages/nx/native-packages/linux-arm64-gnu: {}
+
+  packages/nx/native-packages/linux-arm64-musl: {}
+
+  packages/nx/native-packages/linux-x64-gnu: {}
+
+  packages/nx/native-packages/linux-x64-musl: {}
+
+  packages/nx/native-packages/win32-arm64-msvc: {}
+
+  packages/nx/native-packages/win32-x64-msvc: {}
+
   packages/playwright:
     dependencies:
       '@nx/devkit':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,4 @@ packages:
   - 'typedoc-theme'
   - 'astro-docs'
   - 'examples/*/*'
+  - 'packages/nx/native-packages/*'


### PR DESCRIPTION
## Current Behavior

The `nx` package is being published with the native package dependencies using an invalid version range `"*"`.

## Expected Behavior

The `nx` package should be published with the native package dependencies pointing to the same version as the `nx` package.

A recent change to `nx release` requires workspace packages to be identified as such when deciding to replace the version.

## Related Issue(s)

Fixes #32898 