### PR TITLE
feat(nx-plugin): add createNodes generator

### DIFF
--- a/docs/generated/manifests/menus.json
+++ b/docs/generated/manifests/menus.json
@@ -6172,6 +6172,14 @@
                         "disableCollapsible": false
                       },
                       {
+                        "id": "create-nodes",
+                        "path": "/reference/core-api/plugin/generators/create-nodes",
+                        "name": "create-nodes",
+                        "children": [],
+                        "isExternal": false,
+                        "disableCollapsible": false
+                      },
+                      {
                         "id": "plugin-lint-checks",
                         "path": "/reference/core-api/plugin/generators/plugin-lint-checks",
                         "name": "plugin-lint-checks",

--- a/docs/generated/manifests/new-nx-api.json
+++ b/docs/generated/manifests/new-nx-api.json
@@ -3837,6 +3837,15 @@
         "path": "/reference/core-api/plugin/generators/executor",
         "type": "generator"
       },
+      "/reference/core-api/plugin/generators/create-nodes": {
+        "description": "Create an Inference Plugin (createNodes) for an Nx Plugin.",
+        "file": "generated/packages/plugin/generators/create-nodes.json",
+        "hidden": false,
+        "name": "create-nodes",
+        "originalFilePath": "/packages/plugin/src/generators/create-nodes/schema.json",
+        "path": "/reference/core-api/plugin/generators/create-nodes",
+        "type": "generator"
+      },
       "/reference/core-api/plugin/generators/plugin-lint-checks": {
         "description": "Adds linting configuration to validate common json files for nx plugins.",
         "file": "generated/packages/plugin/generators/plugin-lint-checks.json",

--- a/docs/generated/packages-metadata.json
+++ b/docs/generated/packages-metadata.json
@@ -4180,6 +4180,15 @@
         "type": "generator"
       },
       {
+        "description": "Create an Inference Plugin (createNodes) for an Nx Plugin.",
+        "file": "generated/packages/plugin/generators/create-nodes.json",
+        "hidden": false,
+        "name": "create-nodes",
+        "originalFilePath": "/packages/plugin/src/generators/create-nodes/schema.json",
+        "path": "plugin/generators/create-nodes",
+        "type": "generator"
+      },
+      {
         "description": "Adds linting configuration to validate common json files for nx plugins.",
         "file": "generated/packages/plugin/generators/plugin-lint-checks.json",
         "hidden": false,

--- a/docs/generated/packages/plugin/generators/create-nodes.json
+++ b/docs/generated/packages/plugin/generators/create-nodes.json
@@ -1,0 +1,54 @@
+{
+  "name": "create-nodes",
+  "factory": "./src/generators/create-nodes/create-nodes",
+  "schema": {
+    "$schema": "https://json-schema.org/schema",
+    "cli": "nx",
+    "$id": "NxPluginCreateNodes",
+    "title": "Create an Inference Plugin (createNodes) for an Nx Plugin",
+    "description": "Create an Inference Plugin (createNodes) for an Nx Plugin.",
+    "type": "object",
+    "properties": {
+      "path": {
+        "type": "string",
+        "description": "The file path to the plugin. Relative to the current working directory.",
+        "x-prompt": "What is the plugin file path?",
+        "$default": { "$source": "argv", "index": 0 },
+        "x-priority": "important"
+      },
+      "name": { "type": "string", "description": "The plugin name." },
+      "targetName": {
+        "type": "string",
+        "description": "The default name for the target created by this plugin.",
+        "default": "echo",
+        "x-priority": "important"
+      },
+      "configFile": {
+        "type": "string",
+        "description": "The configuration file glob pattern to match (e.g., '**/my-config.json').",
+        "default": "**/.my-plugin-config.json",
+        "x-priority": "important"
+      },
+      "skipReadme": {
+        "type": "boolean",
+        "default": false,
+        "description": "Do not create or update README.md with plugin documentation."
+      },
+      "skipFormat": {
+        "type": "boolean",
+        "description": "Skip formatting files.",
+        "default": false,
+        "x-priority": "internal"
+      }
+    },
+    "required": ["path"],
+    "additionalProperties": false,
+    "presets": []
+  },
+  "description": "Create an Inference Plugin (createNodes) for an Nx Plugin.",
+  "implementation": "/packages/plugin/src/generators/create-nodes/create-nodes.ts",
+  "aliases": [],
+  "hidden": false,
+  "path": "/packages/plugin/src/generators/create-nodes/schema.json",
+  "type": "generator"
+}

--- a/docs/generated/packages/plugin/generators/plugin.json
+++ b/docs/generated/packages/plugin/generators/plugin.json
@@ -96,6 +96,12 @@
       "useProjectJson": {
         "type": "boolean",
         "description": "Use a `project.json` configuration file instead of inlining the Nx configuration in the `package.json` file."
+      },
+      "includeCreateNodes": {
+        "type": "boolean",
+        "description": "Generate an Inference Plugin (createNodes) example with the plugin.",
+        "default": true,
+        "x-priority": "important"
       }
     },
     "required": ["directory"],

--- a/docs/shared/reference/sitemap.md
+++ b/docs/shared/reference/sitemap.md
@@ -745,6 +745,7 @@
           - [migration](/reference/core-api/plugin/generators/migration)
           - [generator](/reference/core-api/plugin/generators/generator)
           - [executor](/reference/core-api/plugin/generators/executor)
+          - [create-nodes](/reference/core-api/plugin/generators/create-nodes)
           - [plugin-lint-checks](/reference/core-api/plugin/generators/plugin-lint-checks)
           - [preset](/reference/core-api/plugin/generators/preset)
       - [web](/reference/core-api/web)

--- a/packages/plugin/generators.json
+++ b/packages/plugin/generators.json
@@ -33,6 +33,11 @@
       "schema": "./src/generators/executor/schema.json",
       "description": "Create an executor for an Nx Plugin."
     },
+    "create-nodes": {
+      "factory": "./src/generators/create-nodes/create-nodes",
+      "schema": "./src/generators/create-nodes/schema.json",
+      "description": "Create an Inference Plugin (createNodes) for an Nx Plugin."
+    },
     "plugin-lint-checks": {
       "factory": "./src/generators/lint-checks/generator",
       "schema": "./src/generators/lint-checks/schema.json",

--- a/packages/plugin/src/generators/create-nodes/create-nodes.spec.ts
+++ b/packages/plugin/src/generators/create-nodes/create-nodes.spec.ts
@@ -87,17 +87,6 @@ describe('create-nodes generator', () => {
     expect(readmeContent).not.toContain('## What is an Inference Plugin?');
   });
 
-  it('should skip test file when unitTestRunner is none', async () => {
-    await createNodesGenerator(tree, {
-      name: 'my-plugin',
-      path: 'my-plugin/src/plugins/my-plugin/plugin',
-    });
-
-    expect(
-      tree.exists('my-plugin/src/plugins/my-plugin/plugin.ts')
-    ).toBeTruthy();
-  });
-
   it('should use custom targetName', async () => {
     await createNodesGenerator(tree, {
       name: 'my-plugin',

--- a/packages/plugin/src/generators/create-nodes/create-nodes.spec.ts
+++ b/packages/plugin/src/generators/create-nodes/create-nodes.spec.ts
@@ -1,0 +1,142 @@
+import 'nx/src/internal-testing-utils/mock-project-graph';
+
+import { Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { pluginGenerator } from '../plugin/plugin';
+import { createNodesGenerator } from './create-nodes';
+import { setCwd } from '@nx/devkit/internal-testing-utils';
+
+describe('create-nodes generator', () => {
+  let tree: Tree;
+  let projectName: string;
+
+  beforeEach(async () => {
+    projectName = 'my-plugin';
+    tree = createTreeWithEmptyWorkspace();
+    setCwd('');
+    await pluginGenerator(tree, {
+      directory: projectName,
+      unitTestRunner: 'jest',
+      linter: 'eslint',
+      compiler: 'tsc',
+      includeCreateNodes: false,
+    });
+  });
+
+  it('should generate files', async () => {
+    await createNodesGenerator(tree, {
+      name: 'my-plugin',
+      path: 'my-plugin/src/plugins/my-plugin/plugin',
+    });
+
+    expect(
+      tree.exists('my-plugin/src/plugins/my-plugin/plugin.ts')
+    ).toBeTruthy();
+  });
+
+  it('should create README when it does not exist', async () => {
+    await createNodesGenerator(tree, {
+      name: 'my-plugin',
+      path: 'my-plugin/src/plugins/my-plugin/plugin',
+    });
+
+    const readmePath = 'my-plugin/README.md';
+    expect(tree.exists(readmePath)).toBeTruthy();
+
+    const readmeContent = tree.read(readmePath, 'utf-8');
+    expect(readmeContent).toContain('## What is an Inference Plugin?');
+    expect(readmeContent).toContain('## How This Plugin Works');
+  });
+
+  it('should append to existing README without duplicating content', async () => {
+    const readmePath = 'my-plugin/README.md';
+    tree.write(readmePath, '# My Plugin\n\nExisting content');
+
+    await createNodesGenerator(tree, {
+      name: 'my-plugin',
+      path: 'my-plugin/src/plugins/my-plugin/plugin',
+    });
+
+    const readmeContent = tree.read(readmePath, 'utf-8');
+    expect(readmeContent).toContain('# My Plugin');
+    expect(readmeContent).toContain('Existing content');
+    expect(readmeContent).toContain('## What is an Inference Plugin?');
+
+    // Run generator again to ensure no duplication
+    await createNodesGenerator(tree, {
+      name: 'another-plugin',
+      path: 'my-plugin/src/plugins/another-plugin/plugin',
+    });
+
+    const updatedContent = tree.read(readmePath, 'utf-8');
+    const matches = updatedContent.match(/## What is an Inference Plugin\?/g);
+    expect(matches?.length).toBe(1);
+  });
+
+  it('should skip README when skipReadme is true', async () => {
+    await createNodesGenerator(tree, {
+      name: 'my-plugin',
+      path: 'my-plugin/src/plugins/my-plugin/plugin',
+      skipReadme: true,
+    });
+
+    // README exists from plugin generator, but should not contain our inference plugin content
+    const readmePath = 'my-plugin/README.md';
+    expect(tree.exists(readmePath)).toBeTruthy();
+    const readmeContent = tree.read(readmePath, 'utf-8');
+    expect(readmeContent).not.toContain('## What is an Inference Plugin?');
+  });
+
+  it('should skip test file when unitTestRunner is none', async () => {
+    await createNodesGenerator(tree, {
+      name: 'my-plugin',
+      path: 'my-plugin/src/plugins/my-plugin/plugin',
+    });
+
+    expect(
+      tree.exists('my-plugin/src/plugins/my-plugin/plugin.ts')
+    ).toBeTruthy();
+  });
+
+  it('should use custom targetName', async () => {
+    await createNodesGenerator(tree, {
+      name: 'my-plugin',
+      path: 'my-plugin/src/plugins/my-plugin/plugin',
+      targetName: 'custom-target',
+    });
+
+    const pluginContent = tree.read(
+      'my-plugin/src/plugins/my-plugin/plugin.ts',
+      'utf-8'
+    );
+    expect(pluginContent).toContain(
+      "targetName: options.targetName ?? 'custom-target'"
+    );
+    expect(pluginContent).toContain("@default 'custom-target'");
+  });
+
+  it('should use custom configFile pattern', async () => {
+    await createNodesGenerator(tree, {
+      name: 'my-plugin',
+      path: 'my-plugin/src/plugins/my-plugin/plugin',
+      configFile: '**/custom.config.json',
+    });
+
+    const pluginContent = tree.read(
+      'my-plugin/src/plugins/my-plugin/plugin.ts',
+      'utf-8'
+    );
+    expect(pluginContent).toContain("'**/custom.config.json'");
+  });
+
+  it('should handle path with file extension', async () => {
+    await createNodesGenerator(tree, {
+      name: 'my-plugin',
+      path: 'my-plugin/src/plugins/my-plugin/plugin.ts',
+    });
+
+    expect(
+      tree.exists('my-plugin/src/plugins/my-plugin/plugin.ts')
+    ).toBeTruthy();
+  });
+});

--- a/packages/plugin/src/generators/create-nodes/create-nodes.ts
+++ b/packages/plugin/src/generators/create-nodes/create-nodes.ts
@@ -1,0 +1,152 @@
+import {
+  formatFiles,
+  generateFiles,
+  joinPathFragments,
+  names,
+  readJson,
+  readProjectConfiguration,
+  Tree,
+} from '@nx/devkit';
+import { determineArtifactNameAndDirectoryOptions } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';
+import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { join } from 'path';
+import { PackageJson } from 'nx/src/utils/package-json';
+import type { CreateNodesGeneratorSchema } from './schema';
+
+interface NormalizedSchema extends CreateNodesGeneratorSchema {
+  className: string;
+  propertyName: string;
+  projectRoot: string;
+  projectSourceRoot: string;
+  fileName: string;
+  directory: string;
+  project: string;
+  isTsSolutionSetup: boolean;
+  importPath: string;
+}
+
+function addFiles(host: Tree, options: NormalizedSchema) {
+  generateFiles(host, join(__dirname, './files/plugin'), options.directory, {
+    ...options,
+  });
+}
+
+function addReadmeFile(host: Tree, options: NormalizedSchema) {
+  if (options.skipReadme) {
+    return;
+  }
+
+  const readmePath = joinPathFragments(options.projectRoot, 'README.md');
+  const readmeExists = host.exists(readmePath);
+
+  if (!readmeExists) {
+    // Create new README
+    generateFiles(host, join(__dirname, './files'), options.projectRoot, {
+      ...options,
+      tmpl: '',
+    });
+  } else {
+    // Append to existing README
+    const existingContent = host.read(readmePath, 'utf-8');
+    const separator = '\n\n---\n\n';
+
+    // Check if the content already exists to avoid duplicates
+    if (existingContent.includes('## What is an Inference Plugin?')) {
+      return;
+    }
+
+    // Generate to a temp directory to get the processed content
+    const tempDir = '.nx-temp-readme';
+    generateFiles(host, join(__dirname, './files'), tempDir, {
+      ...options,
+      tmpl: '',
+    });
+
+    const tempReadmePath = joinPathFragments(tempDir, 'README.md');
+    const newContent = host.read(tempReadmePath, 'utf-8');
+
+    // Clean up temp directory
+    host.delete(tempDir);
+
+    // Append to existing README
+    host.write(readmePath, existingContent + separator + newContent);
+  }
+}
+
+async function normalizeOptions(
+  tree: Tree,
+  options: CreateNodesGeneratorSchema
+): Promise<NormalizedSchema> {
+  const {
+    artifactName: name,
+    directory: initialDirectory,
+    fileName,
+    project,
+  } = await determineArtifactNameAndDirectoryOptions(tree, {
+    path: options.path,
+    name: options.name,
+    allowedFileExtensions: ['ts'],
+    fileExtension: 'ts',
+  });
+
+  // Check if the path looks like a directory path (doesn't end with a filename)
+  // If so, include the artifact name as a subdirectory
+  let directory = initialDirectory;
+  const normalizedPath = options.path.replace(/^\.?\//, '').replace(/\/$/, '');
+  const pathSegments = normalizedPath.split('/');
+  const lastSegment = pathSegments[pathSegments.length - 1];
+
+  // If the last segment doesn't end with a known file extension and matches the artifact name,
+  // it's likely a directory path, so we should create a subdirectory
+  const knownFileExtensions = ['.ts', '.js', '.jsx', '.tsx'];
+  const hasKnownFileExtension = knownFileExtensions.some((ext) =>
+    lastSegment.endsWith(ext)
+  );
+  if (!hasKnownFileExtension && lastSegment === name) {
+    directory = joinPathFragments(initialDirectory, name);
+  }
+
+  const { className, propertyName } = names(name);
+
+  const { root: projectRoot, sourceRoot: projectSourceRoot } =
+    readProjectConfiguration(tree, project);
+
+  // Get the import path from package.json
+  const packageJson = readJson<PackageJson>(
+    tree,
+    joinPathFragments(projectRoot, 'package.json')
+  );
+  const importPath = packageJson.name;
+
+  return {
+    ...options,
+    fileName,
+    project,
+    directory,
+    name,
+    className,
+    propertyName,
+    projectRoot,
+    projectSourceRoot: projectSourceRoot ?? join(projectRoot, 'src'),
+    isTsSolutionSetup: isUsingTsSolutionSetup(tree),
+    targetName: options.targetName ?? 'echo',
+    configFile: options.configFile ?? '**/.my-plugin-config.json',
+    importPath,
+  };
+}
+
+export async function createNodesGenerator(
+  tree: Tree,
+  schema: CreateNodesGeneratorSchema
+) {
+  const options = await normalizeOptions(tree, schema);
+
+  addFiles(tree, options);
+  addReadmeFile(tree, options);
+
+  if (!options.skipFormat) {
+    await formatFiles(tree);
+  }
+}
+
+export default createNodesGenerator;

--- a/packages/plugin/src/generators/create-nodes/files/README.md.template
+++ b/packages/plugin/src/generators/create-nodes/files/README.md.template
@@ -1,0 +1,77 @@
+# <%= className %> Plugin
+
+This directory contains an Inference plugin (createNodes) for Nx.
+
+## What is an Inference Plugin?
+
+Inference plugins (also known as createNodes plugins) are Nx's modern approach to automatically inferring project configuration and targets from your workspace. Instead of manually maintaining `project.json` or `package.json` configurations, Inference plugins automatically detect configuration files and generate the appropriate Nx targets.
+
+## How This Plugin Works
+
+This plugin looks for `<%= configFile %>` files in your workspace and automatically creates Nx targets for those projects.
+
+**Generated Targets:**
+- `<%= targetName %>`: Runs the <%= className %> command
+
+## Usage
+
+### 1. Register the Plugin
+
+Add this plugin to your `nx.json`:
+
+```json
+{
+  "plugins": [
+    {
+      "plugin": "<%= importPath %>",
+      "options": {
+        "targetName": "<%= targetName %>"
+      }
+    }
+  ]
+}
+```
+
+### 2. Add Configuration Files
+
+Create a `<%= configFile.replace("**/", "") %>` file in any project directory:
+
+```json
+{}
+```
+
+### 3. Run the Target
+
+Once registered, you can run the generated target:
+
+```bash
+nx <%= targetName %> <project-name>
+```
+
+Or run it for all projects:
+
+```bash
+nx run-many -t <%= targetName %>
+```
+
+## Plugin Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `targetName` | `string` | `<%= targetName %>` | The name of the target to create |
+
+## Customization
+
+You can customize the plugin by modifying the `<%= fileName %>.ts` file:
+
+- Change the glob pattern to match different configuration files
+- Modify the target configuration
+- Add additional targets
+- Customize caching behavior
+- Add custom inputs/outputs
+
+## Learn More
+
+- [Nx Inference Plugins Documentation](https://nx.dev/concepts/inferred-tasks)
+- [Creating Nx Plugins](https://nx.dev/extending-nx/intro/getting-started)
+- [Plugin API Reference](https://nx.dev/extending-nx/recipes/create-nodes)

--- a/packages/plugin/src/generators/create-nodes/files/plugin/__fileName__.ts.template
+++ b/packages/plugin/src/generators/create-nodes/files/plugin/__fileName__.ts.template
@@ -37,7 +37,7 @@ function writeTargetsCache(
   cachePath: string,
   results?: Record<string, <%= className %>Targets>
 ) {
-  writeJsonFile(cachePath, results);
+  writeJsonFile(cachePath, results ?? {});
 }
 
 /**
@@ -70,6 +70,7 @@ const configGlob = '<%= configFile %>';
 export const createNodesV2: CreateNodesV2<<%= className %>PluginOptions> = [
   configGlob,
   async (configFilePaths, options, context) => {
+    options ??= {} as <%= className %>PluginOptions;
     const optionsHash = hashObject(options);
     const cachePath = join(
       workspaceDataDirectory,
@@ -79,7 +80,7 @@ export const createNodesV2: CreateNodesV2<<%= className %>PluginOptions> = [
 
     try {
       return await createNodesFromFiles(
-        (configFile, options, context) =>
+        (configFile, _, context) =>
           createNodesInternal(configFile, options, context, targetsCache),
         configFilePaths,
         options,

--- a/packages/plugin/src/generators/create-nodes/files/plugin/__fileName__.ts.template
+++ b/packages/plugin/src/generators/create-nodes/files/plugin/__fileName__.ts.template
@@ -1,0 +1,179 @@
+import {
+  CreateNodesV2,
+  CreateNodesContext,
+  createNodesFromFiles,
+  type TargetConfiguration,
+  readJsonFile,
+  writeJsonFile,
+} from '@nx/devkit';
+import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
+import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
+import { hashObject } from 'nx/src/hasher/file-hasher';
+import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
+import { existsSync, readdirSync } from 'fs';
+import { dirname, join } from 'path';
+
+/**
+ * Plugin options for the <%= className %> plugin.
+ */
+export interface <%= className %>PluginOptions {
+  /**
+   * The name of the target to create.
+   * @default '<%= targetName %>'
+   */
+  targetName: string;
+}
+
+type <%= className %>Targets = Pick<
+  ReturnType<typeof createTargets>,
+  'targets' | 'metadata'
+>;
+
+function readTargetsCache(cachePath: string): Record<string, <%= className %>Targets> {
+  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
+}
+
+function writeTargetsCache(
+  cachePath: string,
+  results?: Record<string, <%= className %>Targets>
+) {
+  writeJsonFile(cachePath, results);
+}
+
+/**
+ * The glob pattern for the configuration file.
+ * Update this to match your plugin's configuration file.
+ */
+const configGlob = '<%= configFile %>';
+
+/**
+ * Inference plugin for <%= className %>.
+ *
+ * This plugin automatically creates targets for projects that have a
+ * configuration file matching the glob pattern defined in `configGlob`.
+ *
+ * @example
+ * ```json
+ * // In nx.json
+ * {
+ *   "plugins": [
+ *     {
+ *       "plugin": "<%= importPath %>",
+ *       "options": {
+ *         "targetName": "<%= targetName %>"
+ *       }
+ *     }
+ *   ]
+ * }
+ * ```
+ */
+export const createNodesV2: CreateNodesV2<<%= className %>PluginOptions> = [
+  configGlob,
+  async (configFilePaths, options, context) => {
+    const optionsHash = hashObject(options);
+    const cachePath = join(
+      workspaceDataDirectory,
+      `<%= fileName %>-${optionsHash}.hash`
+    );
+    const targetsCache = readTargetsCache(cachePath);
+
+    try {
+      return await createNodesFromFiles(
+        (configFile, options, context) =>
+          createNodesInternal(configFile, options, context, targetsCache),
+        configFilePaths,
+        options,
+        context
+      );
+    } finally {
+      writeTargetsCache(cachePath, targetsCache);
+    }
+  },
+];
+
+async function createNodesInternal(
+  configFilePath: string,
+  options: <%= className %>PluginOptions,
+  context: CreateNodesContext,
+  targetsCache: Record<string, <%= className %>Targets>
+) {
+  const projectRoot = dirname(configFilePath);
+
+  // Only create a project if package.json or project.json exists
+  const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
+  if (
+    !siblingFiles.includes('package.json') &&
+    !siblingFiles.includes('project.json')
+  ) {
+    return {};
+  }
+
+  const normalizedOptions = normalizeOptions(options);
+
+  const hash = await calculateHashForCreateNodes(
+    projectRoot,
+    normalizedOptions,
+    context
+  );
+
+  targetsCache[hash] ??= createTargets(
+    projectRoot,
+    normalizedOptions,
+    context
+  );
+
+  const { targets, metadata } = targetsCache[hash];
+
+  return {
+    projects: {
+      [projectRoot]: {
+        root: projectRoot,
+        targets,
+        metadata,
+      },
+    },
+  };
+}
+
+function createTargets(
+  projectRoot: string,
+  options: <%= className %>PluginOptions,
+  context: CreateNodesContext
+) {
+  const namedInputs = getNamedInputs(projectRoot, context);
+
+  const targets: Record<string, TargetConfiguration> = {};
+
+  // Create the main target
+  targets[options.targetName] = {
+    command: `echo "Hello from <%= className %>!"`,
+    options: { cwd: projectRoot },
+    cache: true,
+    inputs: [
+      ...('production' in namedInputs
+        ? ['production', '^production']
+        : ['default', '^default']),
+    ],
+    metadata: {
+      technologies: ['<%= fileName %>'],
+      description: 'Run <%= className %> target',
+      help: {
+        command: 'echo "Hello from <%= className %>!"',
+        example: {
+          args: [],
+        },
+      },
+    },
+  };
+
+  return { targets, metadata: {} };
+}
+
+function normalizeOptions(
+  options: <%= className %>PluginOptions
+): <%= className %>PluginOptions {
+  return {
+    ...options,
+    targetName: options.targetName ?? '<%= targetName %>',
+  };
+}

--- a/packages/plugin/src/generators/create-nodes/schema.d.ts
+++ b/packages/plugin/src/generators/create-nodes/schema.d.ts
@@ -1,0 +1,8 @@
+export interface CreateNodesGeneratorSchema {
+  path: string;
+  name?: string;
+  targetName?: string;
+  configFile?: string;
+  skipReadme?: boolean;
+  skipFormat?: boolean;
+}

--- a/packages/plugin/src/generators/create-nodes/schema.json
+++ b/packages/plugin/src/generators/create-nodes/schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "cli": "nx",
+  "$id": "NxPluginCreateNodes",
+  "title": "Create an Inference Plugin (createNodes) for an Nx Plugin",
+  "description": "Create an Inference Plugin (createNodes) for an Nx Plugin.",
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string",
+      "description": "The file path to the plugin. Relative to the current working directory.",
+      "x-prompt": "What is the plugin file path?",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-priority": "important"
+    },
+    "name": {
+      "type": "string",
+      "description": "The plugin name."
+    },
+    "targetName": {
+      "type": "string",
+      "description": "The default name for the target created by this plugin.",
+      "default": "echo",
+      "x-priority": "important"
+    },
+    "configFile": {
+      "type": "string",
+      "description": "The configuration file glob pattern to match (e.g., '**/my-config.json').",
+      "default": "**/.my-plugin-config.json",
+      "x-priority": "important"
+    },
+    "skipReadme": {
+      "type": "boolean",
+      "default": false,
+      "description": "Do not create or update README.md with plugin documentation."
+    },
+    "skipFormat": {
+      "type": "boolean",
+      "description": "Skip formatting files.",
+      "default": false,
+      "x-priority": "internal"
+    }
+  },
+  "required": ["path"],
+  "additionalProperties": false
+}

--- a/packages/plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/plugin/src/generators/plugin/plugin.spec.ts
@@ -442,6 +442,8 @@ describe('NxPlugin Plugin Generator', () => {
       expect(readJson(tree, 'my-plugin/package.json')).toMatchInlineSnapshot(`
         {
           "dependencies": {
+            "@nx/devkit": "0.0.1",
+            "nx": "0.0.1",
             "tslib": "^2.3.0",
           },
           "exports": {

--- a/packages/plugin/src/generators/plugin/plugin.ts
+++ b/packages/plugin/src/generators/plugin/plugin.ts
@@ -21,6 +21,7 @@ import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-se
 import * as path from 'path';
 import { e2eProjectGenerator } from '../e2e-project/e2e';
 import pluginLintCheckGenerator from '../lint-checks/generator';
+import { createNodesGenerator } from '../create-nodes/create-nodes';
 import type { Schema } from './schema';
 import { NormalizedSchema, normalizeOptions } from './utils/normalize-schema';
 
@@ -165,6 +166,20 @@ export async function pluginGeneratorInternal(host: Tree, schema: Schema) {
 
   if (options.linter === 'eslint' && !options.skipLintChecks) {
     await pluginLintCheckGenerator(host, { projectName: options.projectName });
+  }
+
+  if (schema.includeCreateNodes !== false) {
+    await createNodesGenerator(host, {
+      name: options.projectName,
+      path: joinPathFragments(
+        options.projectRoot,
+        'src/plugins',
+        options.projectName,
+        'plugin'
+      ),
+      unitTestRunner: options.unitTestRunner,
+      skipFormat: true,
+    });
   }
 
   if (!options.skipFormat) {

--- a/packages/plugin/src/generators/plugin/plugin.ts
+++ b/packages/plugin/src/generators/plugin/plugin.ts
@@ -177,7 +177,6 @@ export async function pluginGeneratorInternal(host: Tree, schema: Schema) {
         options.projectName,
         'plugin'
       ),
-      unitTestRunner: options.unitTestRunner,
       skipFormat: true,
     });
   }

--- a/packages/plugin/src/generators/plugin/schema.d.ts
+++ b/packages/plugin/src/generators/plugin/schema.d.ts
@@ -17,4 +17,5 @@ export interface Schema {
   publishable?: boolean;
   useProjectJson?: boolean;
   addPlugin?: boolean;
+  includeCreateNodes?: boolean;
 }

--- a/packages/plugin/src/generators/plugin/schema.json
+++ b/packages/plugin/src/generators/plugin/schema.json
@@ -96,6 +96,12 @@
     "useProjectJson": {
       "type": "boolean",
       "description": "Use a `project.json` configuration file instead of inlining the Nx configuration in the `package.json` file."
+    },
+    "includeCreateNodes": {
+      "type": "boolean",
+      "description": "Generate an Inference Plugin (createNodes) example with the plugin.",
+      "default": true,
+      "x-priority": "important"
     }
   },
   "required": ["directory"]


### PR DESCRIPTION
## Current Behavior
There is not currently a generator for creating an Inference Plugin in the `@nx/plugin` package.

## Expected Behavior
Add a generator for creating an Inference Plugin.

It can be invoked with `nx g @nx/plugin:create-nodes`.
The `@nx/plugin:plugin` generator will also create an Inference Plugin by default.
