### PR TITLE
chore(repo): prevent conflicts when more than one process runs `npx playwright install`

### DIFF
--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -2,8 +2,6 @@ import { output, PackageManager, ProjectConfiguration } from '@nx/devkit';
 import { packageInstall, tmpProjPath } from './create-project-utils';
 import {
   detectPackageManager,
-  ensureCypressInstallation,
-  ensurePlaywrightBrowsersInstallation,
   getNpmMajorVersion,
   getPnpmVersion,
   getPublishedVersion,
@@ -11,6 +9,10 @@ import {
   getYarnMajorVersion,
   isVerboseE2ERun,
 } from './get-env-info';
+import {
+  ensureCypressInstallation,
+  ensurePlaywrightBrowsersInstallation,
+} from './ensure-browser-installation';
 import { TargetConfiguration } from '@nx/devkit';
 import { ChildProcess, exec, execSync, ExecSyncOptions } from 'child_process';
 import { join } from 'path';

--- a/e2e/utils/ensure-browser-installation.ts
+++ b/e2e/utils/ensure-browser-installation.ts
@@ -1,0 +1,220 @@
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync, openSync, closeSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { tmpProjPath } from './create-project-utils';
+import { e2eConsoleLogger } from './log-utils';
+import { isVerbose } from './get-env-info';
+
+// Helper files to prevent multiple `npx playwright install` on the same machine.
+// Doing so will cause `apt` to fail on Linux machines.
+const LOCK_DIR = join(tmpdir(), 'nx-e2e-locks');
+const PLAYWRIGHT_LOCK_FILE = join(LOCK_DIR, 'playwright-install.lock');
+const PLAYWRIGHT_STATUS_FILE = join(LOCK_DIR, 'playwright-install.status');
+const LOCK_TIMEOUT_MS = 5 * 60 * 1000;
+const POLL_INTERVAL_MS = 1000;
+const MAX_WAIT_MS = 3 * 60 * 1000;
+
+interface InstallStatus {
+  status: 'installing' | 'success' | 'failed';
+  pid: number;
+  timestamp: number;
+  error?: string;
+}
+
+function ensureLockDir() {
+  if (!existsSync(LOCK_DIR)) {
+    mkdirSync(LOCK_DIR, { recursive: true });
+  }
+}
+
+function isLockStale(lockPath: string): boolean {
+  try {
+    const stats = statSync(lockPath);
+    const age = Date.now() - stats.mtimeMs;
+    return age > LOCK_TIMEOUT_MS;
+  } catch {
+    return true; // If we can't read it, consider it stale
+  }
+}
+
+function acquireLock(lockFile: string, statusFile: string): boolean {
+  ensureLockDir();
+
+  // Check if lock is stale and clean it up
+  if (existsSync(lockFile) && isLockStale(lockFile)) {
+    e2eConsoleLogger('Cleaning up stale browser installation lock');
+    try {
+      unlinkSync(lockFile);
+      if (existsSync(statusFile)) {
+        unlinkSync(statusFile);
+      }
+    } catch (err) {
+      // Someone else might have cleaned it up
+    }
+  }
+
+  try {
+    // Atomic operation - fails if file exists
+    const fd = openSync(lockFile, 'wx');
+    closeSync(fd);
+
+    // Write initial status
+    const status: InstallStatus = {
+      status: 'installing',
+      pid: process.pid,
+      timestamp: Date.now(),
+    };
+    writeFileSync(statusFile, JSON.stringify(status));
+
+    return true;
+  } catch (err) {
+    if (err.code === 'EEXIST') {
+      return false; // Lock already held
+    }
+    throw err; // Unexpected error
+  }
+}
+
+function releaseLock(
+  lockFile: string,
+  statusFile: string,
+  success: boolean,
+  error?: string
+) {
+  try {
+    const status: InstallStatus = {
+      status: success ? 'success' : 'failed',
+      pid: process.pid,
+      timestamp: Date.now(),
+      error: error,
+    };
+    writeFileSync(statusFile, JSON.stringify(status));
+  } finally {
+    try {
+      unlinkSync(lockFile);
+    } catch {
+      // Best effort
+    }
+  }
+}
+
+function readInstallStatus(statusFile: string): InstallStatus | null {
+  try {
+    if (!existsSync(statusFile)) {
+      return null;
+    }
+    const content = readFileSync(statusFile, 'utf-8');
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+async function waitForInstallation(
+  lockFile: string,
+  statusFile: string,
+  toolName: string
+): Promise<void> {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < MAX_WAIT_MS) {
+    // Check if lock is released
+    if (!existsSync(lockFile)) {
+      const status = readInstallStatus(statusFile);
+
+      if (status?.status === 'success') {
+        e2eConsoleLogger(
+          `${toolName} browsers installed by process ${status.pid}`
+        );
+        return;
+      }
+
+      if (status?.status === 'failed') {
+        const errorMsg = `${toolName} browser installation failed in process ${status.pid}: ${
+          status.error || 'Unknown error'
+        }`;
+        e2eConsoleLogger(errorMsg);
+        throw new Error(errorMsg);
+      }
+    }
+
+    // Wait before polling again
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+
+  throw new Error(
+    `Timeout waiting for ${toolName} browser installation to complete`
+  );
+}
+
+export function ensureCypressInstallation() {
+  let cypressVerified = true;
+  try {
+    const r = execSync('npx cypress verify', {
+      stdio: isVerbose() ? 'inherit' : 'pipe',
+      encoding: 'utf-8',
+      cwd: tmpProjPath(),
+    });
+    if (r.indexOf('Verified Cypress!') === -1) {
+      cypressVerified = false;
+    }
+  } catch {
+    cypressVerified = false;
+  } finally {
+    if (!cypressVerified) {
+      e2eConsoleLogger('Cypress was not verified. Installing Cypress now.');
+      execSync('npx cypress install', {
+        stdio: isVerbose() ? 'inherit' : 'pipe',
+        encoding: 'utf-8',
+        cwd: tmpProjPath(),
+      });
+    }
+  }
+}
+
+export async function ensurePlaywrightBrowsersInstallation() {
+  // Try to acquire lock
+  if (acquireLock(PLAYWRIGHT_LOCK_FILE, PLAYWRIGHT_STATUS_FILE)) {
+    // We got the lock - we're responsible for installation
+    e2eConsoleLogger(
+      `Process ${process.pid} acquired lock, installing Playwright browsers...`
+    );
+
+    const playwrightInstallArgs =
+      process.env.PLAYWRIGHT_INSTALL_ARGS || '--with-deps';
+
+    try {
+      execSync(`npx playwright install ${playwrightInstallArgs}`, {
+        stdio: isVerbose() ? 'inherit' : 'pipe',
+        encoding: 'utf-8',
+        cwd: tmpProjPath(),
+      });
+
+      const version = execSync('npx playwright --version').toString().trim();
+
+      e2eConsoleLogger(`Playwright browsers ${version} installed successfully.`);
+
+      releaseLock(PLAYWRIGHT_LOCK_FILE, PLAYWRIGHT_STATUS_FILE, true);
+    } catch (error) {
+      e2eConsoleLogger('Failed to install Playwright browsers:', error);
+      releaseLock(
+        PLAYWRIGHT_LOCK_FILE,
+        PLAYWRIGHT_STATUS_FILE,
+        false,
+        error.message
+      );
+      throw error;
+    }
+  } else {
+    // Lock is held by another process - wait for it
+    e2eConsoleLogger(
+      `Process ${process.pid} waiting for Playwright browser installation...`
+    );
+    await waitForInstallation(
+      PLAYWRIGHT_LOCK_FILE,
+      PLAYWRIGHT_STATUS_FILE,
+      'Playwright'
+    );
+  }
+}

--- a/e2e/utils/get-env-info.ts
+++ b/e2e/utils/get-env-info.ts
@@ -134,72 +134,11 @@ export const packageManagerLockFile = {
   })(),
 };
 
-export function ensureCypressInstallation() {
-  let cypressVerified = true;
-  try {
-    const r = execSync('npx cypress verify', {
-      stdio: isVerbose() ? 'inherit' : 'pipe',
-      encoding: 'utf-8',
-      cwd: tmpProjPath(),
-    });
-    if (r.indexOf('Verified Cypress!') === -1) {
-      cypressVerified = false;
-    }
-  } catch {
-    cypressVerified = false;
-  } finally {
-    if (!cypressVerified) {
-      e2eConsoleLogger('Cypress was not verified. Installing Cypress now.');
-      execSync('npx cypress install', {
-        stdio: isVerbose() ? 'inherit' : 'pipe',
-        encoding: 'utf-8',
-        cwd: tmpProjPath(),
-      });
-    }
-  }
-}
-
-export function ensurePlaywrightBrowsersInstallation() {
-  // Lightweight check: try to get Playwright browser path
-  try {
-    const browserPath = execSync('npx playwright install --dry-run', {
-      stdio: 'pipe',
-      encoding: 'utf-8',
-      cwd: tmpProjPath(),
-    });
-
-    // If browsers are up to date, skip installation
-    if (browserPath.includes('browser binaries are up to date')) {
-      e2eConsoleLogger('Playwright browsers already installed locally');
-      return;
-    }
-  } catch {
-    // If dry-run fails, browsers likely need installation
-  }
-
-  // Only install browsers for local development
-  const playwrightInstallArgs =
-    process.env.PLAYWRIGHT_INSTALL_ARGS || '--with-deps';
-
-  e2eConsoleLogger('Installing Playwright browsers for local development...');
-
-  try {
-    execSync(`npx playwright install ${playwrightInstallArgs}`, {
-      stdio: isVerbose() ? 'inherit' : 'pipe',
-      encoding: 'utf-8',
-      cwd: tmpProjPath(),
-    });
-
-    e2eConsoleLogger(
-      `Playwright browsers ${execSync('npx playwright --version')
-        .toString()
-        .trim()} installed.`
-    );
-  } catch (error) {
-    e2eConsoleLogger('Failed to install Playwright browsers:', error);
-    throw error;
-  }
-}
+// Re-export browser installation utilities from ensure-browser-installation.ts
+export {
+  ensureCypressInstallation,
+  ensurePlaywrightBrowsersInstallation,
+} from './ensure-browser-installation';
 
 export function getStrippedEnvironmentVariables() {
   return Object.fromEntries(


### PR DESCRIPTION
The install command will fail on Linux machines due to `apt` command only allowing one invocation at a time. This PR solves this by writing lock and status files to coordinate between potentially many tests on the same machine.