### PR TITLE
chore(repo): try to read and print out the error log file when e2e tests fail during CNW

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 
+# bust 1
+
 on:
   push:
     branches:

--- a/e2e/detox/src/detox.test.ts
+++ b/e2e/detox/src/detox.test.ts
@@ -7,6 +7,7 @@ import {
   updateJson,
 } from '@nx/e2e-utils';
 
+// bump 1
 describe('@nx/detox', () => {
   let project: string;
   let reactNativeAppName: string;

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -371,7 +371,21 @@ export function runCreateWorkspace(
 
     return create;
   } catch (e) {
-    logError(`Original command: ${command}`, `${e.stdout}\n\n${e.stderr}`);
+    let errorDetails = `${e.stdout}\n\n${e.stderr}`;
+
+    // Try to find and read the error.log file mentioned in the output
+    const logFileMatch = errorDetails.match(/Log file: (.+)/);
+    if (logFileMatch) {
+      const logFilePath = logFileMatch[1];
+      try {
+        const errorLogContent = readFileSync(logFilePath, 'utf-8');
+        errorDetails += `\n\nError log contents (${logFilePath}):\n${errorLogContent}`;
+      } catch (readError) {
+        errorDetails += `\n\nFailed to read error log at ${logFilePath}: ${readError.message}`;
+      }
+    }
+
+    logError(`Original command: ${command}`, errorDetails);
     throw e;
   }
 }
@@ -422,7 +436,21 @@ export function runCreatePlugin(
 
     return create;
   } catch (e) {
-    logError(`Original command: ${command}`, `${e.stdout}\n\n${e.stderr}`);
+    let errorDetails = `${e.stdout}\n\n${e.stderr}`;
+
+    // Try to find and read the error.log file mentioned in the output
+    const logFileMatch = errorDetails.match(/Log file: (.+)/);
+    if (logFileMatch) {
+      const logFilePath = logFileMatch[1];
+      try {
+        const errorLogContent = readFileSync(logFilePath, 'utf-8');
+        errorDetails += `\n\nError log contents (${logFilePath}):\n${errorLogContent}`;
+      } catch (readError) {
+        errorDetails += `\n\nFailed to read error log at ${logFilePath}: ${readError.message}`;
+      }
+    }
+
+    logError(`Original command: ${command}`, errorDetails);
     throw e;
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -320,7 +320,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 1,
+  "bust": 2,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true

--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -67,6 +67,9 @@
         "production",
         "^production",
         {
+          "runtime": "node -e 'console.log(process.platform)'"
+        },
+        {
           "dependentTasksOutputFiles": "**/*.node"
         }
       ],

--- a/scripts/copy-local-native.js
+++ b/scripts/copy-local-native.js
@@ -7,7 +7,7 @@ const p = process.argv[2];
 
 const nativeFiles = glob.globSync(`packages/${p}/**/*.{node,wasm,js,mjs,cjs}`);
 
-console.log({ nativeFiles });
+console.log(JSON.stringify({ nativeFiles }, null, 2));
 
 nativeFiles.forEach((file) => {
   const destFile = `dist/${file}`;


### PR DESCRIPTION
We're not able to debug e2e-macos failures in CI. More logs would help.