### PR TITLE
fix(remix): @nx/remix/package.json export typo fixed #32810

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -47,7 +47,7 @@
   },
   "exports": {
     ".": {
-      "defautl": "./index.js",
+      "default": "./index.js",
       "types": "./index.d.ts"
     },
     "./package.json": "./package.json",


### PR DESCRIPTION

## Current Behavior
Error on install in node_modules folder.
 [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /Volumes/ssd/user/Dev/project/node_modules/@nx/remix/package.json
      at exportsNotFound (node:internal/modules/esm/resolve:313:10)

## Expected Behavior
Can install without error.

## Related Issue(s)
* [@nx/remix package.json is broken due to export misspelling](https://github.com/nrwl/nx/issues/32810)

Fixes #32810 