### PR TITLE
chore(repo): enable astro-docs validate-links to be autofixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           main-branch-name: 'master'
 
       - name: Start CI Run
-        run: npx nx-cloud@next start-ci-run --fix-tasks="!*check-commit*" --auto-apply-fixes="*format:check*,*documentation*" --distribute-on="./.nx/workflows/dynamic-changesets.yaml" --stop-agents-after="e2e"
+        run: npx nx-cloud@next start-ci-run --fix-tasks="!*check-commit*" --auto-apply-fixes="*format:check*,*astro-docs:validate-links*" --distribute-on="./.nx/workflows/dynamic-changesets.yaml" --stop-agents-after="e2e"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
adds the `astro-docs:validate-links` to be auto-fixed by [self-healing CI](https://nx.dev/docs/features/ci-features/self-healing-ci)