### PR TITLE
docs(core): align remote cache docs with implementation

### DIFF
--- a/astro-docs/src/content/docs/guides/Tasks & Caching/self-hosted-caching.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/self-hosted-caching.mdoc
@@ -91,7 +91,7 @@ You can implement your server in any programming language or framework, as long 
           }
         ],
         "responses": {
-          "202": {
+          "200": {
             "description": "Successfully uploaded the output"
           },
           "401": {


### PR DESCRIPTION
Fix docs so it aligns with remote cache implementation.
## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #32870 
