### PR TITLE
feat(core)!: remove CreateNodes v1 types for Nx 22

### DIFF
--- a/packages/angular/src/generators/convert-to-rspack/convert-to-rspack.ts
+++ b/packages/angular/src/generators/convert-to-rspack/convert-to-rspack.ts
@@ -522,7 +522,6 @@ export async function convertToRspack(
         // which webpack tasks wouldn't have
         const namedInputs = getNamedInputs(project.root, {
           nxJsonConfiguration: nxJson,
-          configFiles: [],
           workspaceRoot,
         });
 

--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -37,7 +37,6 @@ describe('@nx/cypress/plugin', () => {
         },
       },
       workspaceRoot: tempFs.tempDir,
-      configFiles: [],
     };
 
     process.chdir(tempFs.tempDir);

--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContext } from '@nx/devkit';
+import { CreateNodesContextV2 } from '@nx/devkit';
 import { defineConfig } from 'cypress';
 
 import { createNodesV2 } from './plugin';
@@ -9,7 +9,7 @@ import { nxE2EPreset } from '../../plugins/cypress-preset';
 
 describe('@nx/cypress/plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   let tempFs: TempFs;
   let cwd = process.cwd();
   let originalCacheProjectGraph: string | undefined;

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -1,12 +1,10 @@
 import {
-  type CreateNodes,
   type CreateNodesContext,
   createNodesFromFiles,
   type CreateNodesV2,
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
-  logger,
   normalizePath,
   type NxJsonConfiguration,
   type ProjectConfiguration,
@@ -61,7 +59,7 @@ const defaultPatterns = {
 
 const pmc = getPackageManagerCommand();
 
-export const createNodesV2: CreateNodesV2<CypressPluginOptions> = [
+export const createNodes: CreateNodesV2<CypressPluginOptions> = [
   cypressConfigGlob,
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
@@ -84,19 +82,7 @@ export const createNodesV2: CreateNodesV2<CypressPluginOptions> = [
   },
 ];
 
-/**
- * @deprecated This is replaced with {@link createNodesV2}. Update your plugin to export its own `createNodesV2` function that wraps this one instead.
- * This function will change to the v2 function in Nx 20.
- */
-export const createNodes: CreateNodes<CypressPluginOptions> = [
-  cypressConfigGlob,
-  (configFile, options, context) => {
-    logger.warn(
-      '`createNodes` is deprecated. Update your plugin to utilize createNodesV2 instead. In Nx 20, this will change to the createNodesV2 API.'
-    );
-    return createNodesInternal(configFile, options, context, {});
-  },
-];
+export const createNodesV2 = createNodes;
 
 async function createNodesInternal(
   configFilePath: string,

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -1,5 +1,5 @@
 import {
-  type CreateNodesContext,
+  type CreateNodesContextV2,
   createNodesFromFiles,
   type CreateNodesV2,
   detectPackageManager,
@@ -87,7 +87,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFilePath: string,
   options: CypressPluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   targetsCache: CypressTargets
 ) {
   options = normalizeOptions(options);
@@ -243,7 +243,7 @@ async function buildCypressTargets(
   configFilePath: string,
   projectRoot: string,
   options: CypressPluginOptions,
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ): Promise<CypressTargets> {
   const cypressConfig = await loadConfigFile(
     join(context.workspaceRoot, configFilePath)

--- a/packages/detox/src/plugins/plugin.ts
+++ b/packages/detox/src/plugins/plugin.ts
@@ -1,5 +1,5 @@
 import {
-  CreateNodesContext,
+  CreateNodesContextV2,
   createNodesFromFiles,
   CreateNodesResult,
   CreateNodesV2,
@@ -75,7 +75,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFile: string,
   options: DetoxPluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   targetsCache: Record<
     string,
     Record<string, TargetConfiguration<DetoxPluginOptions>>
@@ -105,7 +105,7 @@ async function createNodesInternal(
 function buildDetoxTargets(
   projectRoot: string,
   options: DetoxPluginOptions,
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ) {
   const namedInputs = getNamedInputs(projectRoot, context);
 

--- a/packages/detox/src/plugins/plugin.ts
+++ b/packages/detox/src/plugins/plugin.ts
@@ -1,5 +1,4 @@
 import {
-  CreateNodes,
   CreateNodesContext,
   createNodesFromFiles,
   CreateNodesResult,
@@ -50,7 +49,7 @@ function writeTargetsToCache(
   });
 }
 
-export const createNodesV2: CreateNodesV2<DetoxPluginOptions> = [
+export const createNodes: CreateNodesV2<DetoxPluginOptions> = [
   '**/{detox.config,.detoxrc}.{json,js}',
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
@@ -71,25 +70,7 @@ export const createNodesV2: CreateNodesV2<DetoxPluginOptions> = [
   },
 ];
 
-export const createNodes: CreateNodes<DetoxPluginOptions> = [
-  '**/{detox.config,.detoxrc}.{json,js}',
-  async (configFilePath, options, context) => {
-    const optionsHash = hashObject(options);
-    const cachePath = join(workspaceDataDirectory, `detox-${optionsHash}.hash`);
-
-    const targetsCache = readTargetsCache(cachePath);
-    const result = await createNodesInternal(
-      configFilePath,
-      options,
-      context,
-      targetsCache
-    );
-
-    writeTargetsToCache(cachePath, targetsCache);
-
-    return result;
-  },
-];
+export const createNodesV2 = createNodes;
 
 async function createNodesInternal(
   configFile: string,

--- a/packages/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator.ts
+++ b/packages/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator.ts
@@ -10,7 +10,6 @@ import {
   readProjectConfiguration,
   updateNxJson,
   updateProjectConfiguration,
-  type CreateNodes,
   type CreateNodesV2,
   type ExpandedPluginConfiguration,
   type NxJsonConfiguration,
@@ -62,7 +61,7 @@ class ExecutorToPluginMigrator<T> {
   #nxJson: NxJsonConfiguration;
   #targetDefaultsForExecutor: Partial<TargetConfiguration>;
   #targetAndProjectsToMigrate: Map<string, Set<string>>;
-  #createNodes?: CreateNodes<T>;
+  #createNodes?: CreateNodesV2<T>;
   #createNodesV2?: CreateNodesV2<T>;
   #createNodesResultsForTargets: Map<string, ConfigurationResult>;
   #skippedProjects: Set<string>;
@@ -74,7 +73,7 @@ class ExecutorToPluginMigrator<T> {
     pluginPath: string,
     pluginOptionsBuilder: PluginOptionsBuilder<T>,
     postTargetTransformer: PostTargetTransformer,
-    createNodes?: CreateNodes<T>,
+    createNodes?: CreateNodesV2<T>,
     createNodesV2?: CreateNodesV2<T>,
     specificProjectToMigrate?: string,
     filters?: {
@@ -381,7 +380,7 @@ export async function migrateProjectExecutorsToPluginV1<T>(
   tree: Tree,
   projectGraph: ProjectGraph,
   pluginPath: string,
-  createNodes: CreateNodes<T>,
+  createNodes: CreateNodesV2<T>,
   defaultPluginOptions: T,
   migrations: Array<{
     executors: string[];
@@ -410,7 +409,7 @@ async function migrateProjects<T>(
   tree: Tree,
   projectGraph: ProjectGraph,
   pluginPath: string,
-  createNodes: CreateNodes<T>,
+  createNodes: CreateNodesV2<T>,
   createNodesV2: CreateNodesV2<T>,
   defaultPluginOptions: T,
   migrations: Array<{
@@ -487,7 +486,7 @@ async function addPluginRegistrations<T>(
   tree: Tree,
   projects: Map<string, Record<string, string>>,
   pluginPath: string,
-  createNodes: CreateNodes | undefined,
+  createNodes: CreateNodesV2 | undefined,
   createNodesV2: CreateNodesV2 | undefined,
   defaultPluginOptions: T,
   projectGraph: ProjectGraph
@@ -590,7 +589,7 @@ async function getCreateNodesResultsForPlugin(
   tree: Tree,
   pluginConfiguration: ExpandedPluginConfiguration,
   pluginPath: string,
-  createNodes: CreateNodes | undefined,
+  createNodes: CreateNodesV2 | undefined,
   createNodesV2: CreateNodesV2 | undefined,
   nxJson: NxJsonConfiguration
 ): Promise<ConfigurationResult> {

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -1,5 +1,4 @@
 import {
-  type CreateNodes,
   type CreateNodesV2,
   type PluginConfiguration,
   type Tree,
@@ -45,7 +44,7 @@ export async function addE2eCiTargetDefaults(
   }
 
   const resolvedE2ePlugin: {
-    createNodes?: CreateNodes;
+    createNodes?: CreateNodesV2;
     createNodesV2?: CreateNodesV2;
   } = await import(e2ePlugin);
   const e2ePluginGlob =

--- a/packages/devkit/src/utils/add-plugin.ts
+++ b/packages/devkit/src/utils/add-plugin.ts
@@ -4,7 +4,6 @@ import type { ConfigurationResult } from 'nx/src/project-graph/utils/project-con
 import * as yargs from 'yargs-parser';
 
 import {
-  CreateNodes,
   CreateNodesV2,
   ProjectConfiguration,
   ProjectGraph,
@@ -64,7 +63,7 @@ export async function addPluginV1<PluginOptions>(
   tree: Tree,
   graph: ProjectGraph,
   pluginName: string,
-  createNodesTuple: CreateNodes<PluginOptions>,
+  createNodesTuple: CreateNodesV2<PluginOptions>,
   options: Partial<
     Record<keyof PluginOptions, PluginOptions[keyof PluginOptions][]>
   >,

--- a/packages/devkit/src/utils/calculate-hash-for-create-nodes.ts
+++ b/packages/devkit/src/utils/calculate-hash-for-create-nodes.ts
@@ -1,9 +1,5 @@
 import { join } from 'path';
-import {
-  CreateNodesContext,
-  CreateNodesContextV2,
-  hashArray,
-} from 'nx/src/devkit-exports';
+import { CreateNodesContextV2, hashArray } from 'nx/src/devkit-exports';
 
 import {
   hashMultiGlobWithWorkspaceContext,
@@ -14,7 +10,7 @@ import {
 export async function calculateHashForCreateNodes(
   projectRoot: string,
   options: object,
-  context: CreateNodesContext | CreateNodesContextV2,
+  context: CreateNodesContextV2,
   additionalGlobs: string[] = []
 ): Promise<string> {
   return hashArray([
@@ -29,7 +25,7 @@ export async function calculateHashForCreateNodes(
 export async function calculateHashesForCreateNodes(
   projectRoots: string[],
   options: object,
-  context: CreateNodesContext | CreateNodesContextV2,
+  context: CreateNodesContextV2,
   additionalGlobs: string[][] = []
 ): Promise<string[]> {
   if (

--- a/packages/devkit/src/utils/find-plugin-for-config-file.ts
+++ b/packages/devkit/src/utils/find-plugin-for-config-file.ts
@@ -2,7 +2,6 @@ import {
   type Tree,
   type PluginConfiguration,
   readNxJson,
-  CreateNodes,
   CreateNodesV2,
 } from 'nx/src/devkit-exports';
 import { findMatchingConfigFiles } from 'nx/src/devkit-internals';
@@ -31,7 +30,7 @@ export async function findPluginForConfigFile(
 
     if (plugin.include || plugin.exclude) {
       const resolvedPlugin: {
-        createNodes?: CreateNodes;
+        createNodes?: CreateNodesV2;
         createNodesV2?: CreateNodesV2;
       } = await import(pluginName);
       const pluginGlob =

--- a/packages/devkit/src/utils/get-named-inputs.ts
+++ b/packages/devkit/src/utils/get-named-inputs.ts
@@ -5,7 +5,6 @@ import type { PackageJson } from 'nx/src/utils/package-json';
 import type { InputDefinition } from 'nx/src/config/workspace-json-project-json';
 
 import {
-  CreateNodesContext,
   CreateNodesContextV2,
   ProjectConfiguration,
   readJsonFile,
@@ -16,7 +15,7 @@ import {
  */
 export function getNamedInputs(
   directory: string,
-  context: CreateNodesContext | CreateNodesContextV2
+  context: CreateNodesContextV2
 ): { [inputName: string]: (string | InputDefinition)[] } {
   const projectJsonPath = join(directory, 'project.json');
   const projectJson: ProjectConfiguration = existsSync(projectJsonPath)

--- a/packages/devkit/src/utils/replace-project-configuration-with-plugin.spec.ts
+++ b/packages/devkit/src/utils/replace-project-configuration-with-plugin.spec.ts
@@ -1,6 +1,6 @@
 import {
   addProjectConfiguration,
-  CreateNodes,
+  CreateNodesV2,
   readProjectConfiguration,
   Tree,
 } from 'nx/src/devkit-exports';
@@ -10,36 +10,40 @@ import { replaceProjectConfigurationsWithPlugin } from './replace-project-config
 
 describe('replaceProjectConfigurationsWithPlugin', () => {
   let tree: Tree;
-  let createNodes: CreateNodes;
+  let createNodes: CreateNodesV2;
 
   beforeEach(async () => {
     tree = createTreeWithEmptyWorkspace();
     tree.write('proj/file.txt', '');
     createNodes = [
       'proj/file.txt',
-      () => ({
-        projects: {
-          proj: {
-            root: 'proj',
-            targets: {
-              build: {
-                executor: 'nx:run-commands',
-                dependsOn: ['^build-base'],
-                inputs: ['default', '^default'],
-                outputs: ['{options.output}', '{projectRoot}/outputs'],
-                options: {
-                  configFile: 'file.txt',
-                },
-                configurations: {
-                  production: {
-                    configFile: 'file.prod.txt',
+      (configFiles) =>
+        configFiles.map((configFile) => [
+          configFile,
+          {
+            projects: {
+              proj: {
+                root: 'proj',
+                targets: {
+                  build: {
+                    executor: 'nx:run-commands',
+                    dependsOn: ['^build-base'],
+                    inputs: ['default', '^default'],
+                    outputs: ['{options.output}', '{projectRoot}/outputs'],
+                    options: {
+                      configFile: 'file.txt',
+                    },
+                    configurations: {
+                      production: {
+                        configFile: 'file.prod.txt',
+                      },
+                    },
                   },
                 },
               },
             },
           },
-        },
-      }),
+        ]),
     ];
   });
 

--- a/packages/docker/src/plugins/plugin.spec.ts
+++ b/packages/docker/src/plugins/plugin.spec.ts
@@ -25,7 +25,6 @@ describe('@nx/docker', () => {
         },
       },
       workspaceRoot: tempFs.tempDir,
-      configFiles: [],
     };
   });
 

--- a/packages/docker/src/plugins/plugin.spec.ts
+++ b/packages/docker/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContext } from '@nx/devkit';
+import { CreateNodesContextV2 } from '@nx/devkit';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { createNodesV2 } from './plugin';
 
@@ -9,7 +9,7 @@ jest.mock('nx/src/utils/cache-directory', () => ({
 
 describe('@nx/docker', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   let tempFs: TempFs;
   let cwd: string;
 

--- a/packages/docker/src/plugins/plugin.ts
+++ b/packages/docker/src/plugins/plugin.ts
@@ -5,7 +5,7 @@ import {
   createNodesFromFiles,
   readJsonFile,
   writeJsonFile,
-  CreateNodesContext,
+  CreateNodesContextV2,
 } from '@nx/devkit';
 import { calculateHashesForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { hashObject } from 'nx/src/hasher/file-hasher';
@@ -80,7 +80,7 @@ async function createNodesInternal(
   configFilePath: string,
   hash: string,
   normalizedOptions: NormalizedDockerPluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   targetsCache: Record<string, DockerTargets>
 ) {
   const projectRoot = dirname(configFilePath);
@@ -107,7 +107,7 @@ async function createNodesInternal(
 async function createDockerTargets(
   projectRoot: string,
   options: NormalizedDockerPluginOptions,
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ) {
   const imageRef = projectRoot.replace(/^[\\/]/, '').replace(/[\\/\s]+/g, '-');
 

--- a/packages/eslint/src/plugins/plugin.ts
+++ b/packages/eslint/src/plugins/plugin.ts
@@ -76,7 +76,7 @@ function writeTargetsToCache(
 const internalCreateNodes = async (
   configFilePath: string,
   options: EslintPluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   projectsCache: Record<string, CreateNodesResult['projects']>
 ): Promise<CreateNodesResult> => {
   options = normalizeOptions(options);

--- a/packages/eslint/src/plugins/plugin.ts
+++ b/packages/eslint/src/plugins/plugin.ts
@@ -1,13 +1,10 @@
 import {
-  CreateNodes,
-  CreateNodesContext,
   CreateNodesContextV2,
   createNodesFromFiles,
   CreateNodesResult,
   CreateNodesV2,
   detectPackageManager,
   getPackageManagerCommand,
-  logger,
   readJsonFile,
   TargetConfiguration,
   writeJsonFile,
@@ -263,7 +260,7 @@ const internalCreateNodesV2 = async (
   };
 };
 
-export const createNodesV2: CreateNodesV2<EslintPluginOptions> = [
+export const createNodes: CreateNodesV2<EslintPluginOptions> = [
   ESLINT_CONFIG_GLOB_V2,
   async (configFiles, options, context) => {
     options = normalizeOptions(options);
@@ -327,15 +324,7 @@ export const createNodesV2: CreateNodesV2<EslintPluginOptions> = [
   },
 ];
 
-export const createNodes: CreateNodes<EslintPluginOptions> = [
-  ESLINT_CONFIG_GLOB_V1,
-  (configFilePath, options, context) => {
-    logger.warn(
-      '`createNodes` is deprecated. Update your plugin to utilize createNodesV2 instead. In Nx 20, this will change to the createNodesV2 API.'
-    );
-    return internalCreateNodes(configFilePath, options, context, {});
-  },
-];
+export const createNodesV2 = createNodes;
 
 function splitConfigFiles(configFiles: readonly string[]): {
   eslintConfigFiles: string[];
@@ -391,7 +380,7 @@ function groupProjectRootsByEslintRoots(
 async function collectLintableFilesByProjectRoot(
   projectRoots: string[],
   options: EslintPluginOptions,
-  context: CreateNodesContext | CreateNodesContextV2
+  context: CreateNodesContextV2
 ): Promise<Map<string, string[]>> {
   const lintableFilesPerProjectRoot = new Map<string, string[]>();
 
@@ -437,7 +426,7 @@ function getProjectUsingESLintConfig(
   projectRoot: string,
   eslintVersion: string,
   options: EslintPluginOptions,
-  context: CreateNodesContext | CreateNodesContextV2
+  context: CreateNodesContextV2
 ): CreateNodesResult['projects'][string] | null {
   const rootEslintConfig = [
     baseEsLintConfigFile,

--- a/packages/expo/plugins/plugin.ts
+++ b/packages/expo/plugins/plugin.ts
@@ -1,12 +1,10 @@
 import {
-  CreateNodes,
   CreateNodesContext,
   createNodesFromFiles,
   CreateNodesResult,
   CreateNodesV2,
   detectPackageManager,
   getPackageManagerCommand,
-  logger,
   NxJsonConfiguration,
   readJsonFile,
   TargetConfiguration,
@@ -57,7 +55,7 @@ function writeTargetsToCache(
   });
 }
 
-export const createNodesV2: CreateNodesV2<ExpoPluginOptions> = [
+export const createNodes: CreateNodesV2<ExpoPluginOptions> = [
   '**/app.{json,config.js,config.ts}',
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
@@ -78,20 +76,7 @@ export const createNodesV2: CreateNodesV2<ExpoPluginOptions> = [
   },
 ];
 
-export const createNodes: CreateNodes<ExpoPluginOptions> = [
-  '**/app.{json,config.js,config.ts}',
-  async (configFilePath, options, context) => {
-    logger.warn(
-      '`createNodes` is deprecated. Update your plugin to utilize createNodesV2 instead. In Nx 20, this will change to the createNodesV2 API.'
-    );
-
-    const optionsHash = hashObject(options);
-    const cachePath = join(workspaceDataDirectory, `expo-${optionsHash}.hash`);
-    const targetsCache = readTargetsCache(cachePath);
-
-    return createNodesInternal(configFilePath, options, context, targetsCache);
-  },
-];
+export const createNodesV2 = createNodes;
 
 async function createNodesInternal(
   configFile: string,

--- a/packages/expo/plugins/plugin.ts
+++ b/packages/expo/plugins/plugin.ts
@@ -1,5 +1,5 @@
 import {
-  CreateNodesContext,
+  CreateNodesContextV2,
   createNodesFromFiles,
   CreateNodesResult,
   CreateNodesV2,
@@ -81,7 +81,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFile: string,
   options: ExpoPluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   targetsCache: Record<
     string,
     Record<string, TargetConfiguration<ExpoPluginOptions>>
@@ -133,7 +133,7 @@ async function createNodesInternal(
 function buildExpoTargets(
   projectRoot: string,
   options: ExpoPluginOptions,
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ) {
   const namedInputs = getNamedInputs(projectRoot, context);
 
@@ -193,7 +193,7 @@ function buildExpoTargets(
 
 function getAppConfig(
   configFilePath: string,
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ): Promise<any> {
   const resolvedPath = join(context.workspaceRoot, configFilePath);
 

--- a/packages/gradle/plugin-v1.spec.ts
+++ b/packages/gradle/plugin-v1.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContext } from '@nx/devkit';
+import { CreateNodesContextV2 } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { createNodesV2 } from './plugin-v1';
 import { type GradleReport } from './src/plugin-v1/utils/get-gradle-report';
@@ -14,7 +14,7 @@ jest.mock('./src/plugin-v1/utils/get-gradle-report', () => {
 
 describe('@nx/gradle/plugin-v1', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   let tempFs: TempFs;
 
   beforeEach(async () => {

--- a/packages/gradle/plugin-v1.spec.ts
+++ b/packages/gradle/plugin-v1.spec.ts
@@ -47,7 +47,6 @@ describe('@nx/gradle/plugin-v1', () => {
         },
       },
       workspaceRoot: tempFs.tempDir,
-      configFiles: [],
     };
     tempFs.createFileSync('package.json', JSON.stringify({ name: 'repo' }));
     tempFs.createFileSync(

--- a/packages/gradle/plugin.spec.ts
+++ b/packages/gradle/plugin.spec.ts
@@ -33,7 +33,6 @@ describe('@nx/gradle/plugin', () => {
         },
       },
       workspaceRoot: tempFs.tempDir,
-      configFiles: [],
     };
     tempFs.createFileSync('package.json', JSON.stringify({ name: 'repo' }));
     tempFs.createFileSync(

--- a/packages/gradle/plugin.spec.ts
+++ b/packages/gradle/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContext, readJsonFile } from '@nx/devkit';
+import { CreateNodesContextV2, readJsonFile } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { createNodesV2 } from './plugin';
 import { type ProjectGraphReport } from './src/plugin/utils/get-project-graph-from-gradle-plugin';
@@ -17,7 +17,7 @@ jest.mock('./src/plugin/utils/get-project-graph-from-gradle-plugin', () => {
 
 describe('@nx/gradle/plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   let tempFs: TempFs;
 
   beforeEach(async () => {

--- a/packages/gradle/src/plugin-v1/nodes.spec.ts
+++ b/packages/gradle/src/plugin-v1/nodes.spec.ts
@@ -58,7 +58,6 @@ describe('@nx/gradle/plugin-v1/nodes', () => {
         },
       },
       workspaceRoot: tempFs.tempDir,
-      configFiles: [],
     };
 
     await tempFs.createFiles({

--- a/packages/gradle/src/plugin-v1/nodes.spec.ts
+++ b/packages/gradle/src/plugin-v1/nodes.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContext } from '@nx/devkit';
+import { CreateNodesContextV2 } from '@nx/devkit';
 
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { type GradleReport } from './utils/get-gradle-report';
@@ -16,7 +16,7 @@ import { createNodesV2 } from './nodes';
 
 describe('@nx/gradle/plugin-v1/nodes', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   let tempFs: TempFs;
   let cwd: string;
 

--- a/packages/gradle/src/plugin-v1/nodes.ts
+++ b/packages/gradle/src/plugin-v1/nodes.ts
@@ -1,7 +1,7 @@
 import {
   CreateNodes,
   CreateNodesV2,
-  CreateNodesContext,
+  CreateNodesContextV2,
   ProjectConfiguration,
   TargetConfiguration,
   createNodesFromFiles,
@@ -117,7 +117,7 @@ export const makeCreateNodesForGradleConfigFile =
   async (
     gradleFilePath,
     options: GradlePluginOptions | undefined,
-    context: CreateNodesContext
+    context: CreateNodesContextV2
   ) => {
     const projectRoot = dirname(gradleFilePath);
     options = normalizeOptions(options);
@@ -168,7 +168,7 @@ async function createGradleProject(
   gradleReport: GradleReport,
   gradleFilePath: string,
   options: GradlePluginOptions | undefined,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   testFiles = []
 ) {
   try {
@@ -244,7 +244,7 @@ async function createGradleProject(
 async function createGradleTargets(
   tasks: GradleTask[],
   options: GradlePluginOptions | undefined,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   outputDirs: Map<string, string>,
   gradleProject: string,
   gradleBuildFilePath: string,
@@ -320,7 +320,7 @@ async function createGradleTargets(
 }
 
 function createInputsMap(
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ): Record<string, TargetConfiguration['inputs']> {
   const namedInputs = context.nxJsonConfiguration.namedInputs;
   return {

--- a/packages/gradle/src/plugin-v1/nodes.ts
+++ b/packages/gradle/src/plugin-v1/nodes.ts
@@ -1,5 +1,4 @@
 import {
-  CreateNodes,
   CreateNodesV2,
   CreateNodesContextV2,
   ProjectConfiguration,
@@ -7,7 +6,6 @@ import {
   createNodesFromFiles,
   readJsonFile,
   writeJsonFile,
-  CreateNodesFunction,
   logger,
 } from '@nx/devkit';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
@@ -149,20 +147,7 @@ export const makeCreateNodesForGradleConfigFile =
  @deprecated This is replaced with {@link createNodesV2}. Update your plugin to export its own `createNodesV2` function that wraps this one instead.
   This function will change to the v2 function in Nx 20.
  */
-export const createNodes: CreateNodes<GradlePluginOptions> = [
-  gradleConfigGlob,
-  async (buildFile, options, context) => {
-    logger.warn(
-      '`createNodes` is deprecated. Update your plugin to utilize createNodesV2 instead. In Nx 20, this will change to the createNodesV2 API.'
-    );
-    const { gradlewFiles } = splitConfigFiles(context.configFiles);
-    await populateGradleReport(context.workspaceRoot, gradlewFiles);
-    const gradleReport = getCurrentGradleReport();
-    const internalCreateNodes =
-      makeCreateNodesForGradleConfigFile(gradleReport);
-    return await internalCreateNodes(buildFile, options, context);
-  },
-];
+export const createNodes = createNodesV2;
 
 async function createGradleProject(
   gradleReport: GradleReport,

--- a/packages/gradle/src/plugin-v1/nodes.ts
+++ b/packages/gradle/src/plugin-v1/nodes.ts
@@ -111,7 +111,7 @@ export const makeCreateNodesForGradleConfigFile =
     gradleReport: GradleReport,
     targetsCache: GradleTargets = {},
     gradleProjectRootToTestFilesMap: Record<string, string[]> = {}
-  ): CreateNodesFunction =>
+  ) =>
   async (
     gradleFilePath,
     options: GradlePluginOptions | undefined,

--- a/packages/gradle/src/plugin/nodes.spec.ts
+++ b/packages/gradle/src/plugin/nodes.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContext, readJsonFile } from '@nx/devkit';
+import { CreateNodesContextV2, readJsonFile } from '@nx/devkit';
 import { join } from 'path';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { type ProjectGraphReport } from './utils/get-project-graph-from-gradle-plugin';
@@ -18,7 +18,7 @@ import { createNodesV2 } from './nodes';
 
 describe('@nx/gradle/plugin/nodes', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   let tempFs: TempFs;
   let cwd: string;
 

--- a/packages/gradle/src/plugin/nodes.spec.ts
+++ b/packages/gradle/src/plugin/nodes.spec.ts
@@ -37,7 +37,6 @@ describe('@nx/gradle/plugin/nodes', () => {
         },
       },
       workspaceRoot: tempFs.tempDir,
-      configFiles: [],
     };
 
     await tempFs.createFiles({

--- a/packages/gradle/src/plugin/nodes.ts
+++ b/packages/gradle/src/plugin/nodes.ts
@@ -5,7 +5,6 @@ import {
   createNodesFromFiles,
   readJsonFile,
   writeJsonFile,
-  CreateNodesFunction,
   workspaceRoot,
   ProjectGraphExternalNode,
   normalizePath,

--- a/packages/gradle/src/plugin/nodes.ts
+++ b/packages/gradle/src/plugin/nodes.ts
@@ -81,7 +81,7 @@ export const makeCreateNodesForGradleConfigFile =
     projects: Record<string, Partial<ProjectConfiguration>>,
     projectsCache: GradleTargets = {},
     externalNodes: Record<string, ProjectGraphExternalNode> = {}
-  ): CreateNodesFunction =>
+  ) =>
   async (
     gradleFilePath,
     options: GradlePluginOptions | undefined,

--- a/packages/gradle/src/plugin/nodes.ts
+++ b/packages/gradle/src/plugin/nodes.ts
@@ -1,6 +1,6 @@
 import {
   CreateNodesV2,
-  CreateNodesContext,
+  CreateNodesContextV2,
   ProjectConfiguration,
   createNodesFromFiles,
   readJsonFile,
@@ -86,7 +86,7 @@ export const makeCreateNodesForGradleConfigFile =
   async (
     gradleFilePath,
     options: GradlePluginOptions | undefined,
-    context: CreateNodesContext
+    context: CreateNodesContextV2
   ) => {
     // Vercel does not allow JAVA_VERSION to be set, skip on Vercel
     if (process.env.VERCEL) return {};

--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContext } from '@nx/devkit';
+import { CreateNodesContextV2 } from '@nx/devkit';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { join } from 'path';
 import { createNodesV2 } from './plugin';
@@ -10,7 +10,7 @@ jest.mock('nx/src/utils/cache-directory', () => ({
 
 describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   let tempFs: TempFs;
   let cwd: string;
 
@@ -870,7 +870,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
   });
 });
 
-function mockJestConfig(config: any, context: CreateNodesContext) {
+function mockJestConfig(config: any, context: CreateNodesContextV2) {
   jest.mock(join(context.workspaceRoot, 'proj/jest.config.js'), () => config, {
     virtual: true,
   });

--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -26,7 +26,6 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
         },
       },
       workspaceRoot: tempFs.tempDir,
-      configFiles: [],
     };
 
     await tempFs.createFiles({

--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { detectPackageManager, type CreateNodesContext } from '@nx/devkit';
+import { detectPackageManager, type CreateNodesContextV2 } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import picomatch = require('picomatch');
 import { mkdirSync, rmdirSync } from 'node:fs';
@@ -13,13 +13,14 @@ jest.mock('nx/src/utils/cache-directory', () => ({
 }));
 
 describe(`Plugin: ${PLUGIN_NAME}`, () => {
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   let cwd = process.cwd();
   let tempFs: TempFs;
   let originalCacheProjectGraph: string | undefined;
   let lockFileName: string;
+  let configFiles: string[];
 
-  beforeEach(() => {
+  beforeEach(async () => {
     mkdirSync('tmp/project-graph-cache', { recursive: true });
     tempFs = new TempFs('typescript-plugin');
     context = {
@@ -30,13 +31,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         },
       },
       workspaceRoot: tempFs.tempDir,
-      configFiles: [],
     };
     process.chdir(tempFs.tempDir);
     originalCacheProjectGraph = process.env.NX_CACHE_PROJECT_GRAPH;
     process.env.NX_CACHE_PROJECT_GRAPH = 'false';
     lockFileName = getLockFileName(detectPackageManager(context.workspaceRoot));
-    applyFilesToTempFsAndContext(tempFs, context, { [lockFileName]: '' });
+    await applyFilesToTempFsAndContext(tempFs, context, {
+      [lockFileName]: '',
+    });
   });
 
   afterEach(() => {
@@ -48,40 +50,40 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
   });
 
   it('should handle missing lock file', async () => {
-    await applyFilesToTempFsAndContext(tempFs, context, {
+    configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
       'libs/my-lib/tsconfig.json': JSON.stringify({ files: [] }),
       'libs/my-lib/package.json': `{}`,
     });
     tempFs.removeFileSync(lockFileName);
 
     await expect(
-      invokeCreateNodesOnMatchingFiles(context, {})
+      invokeCreateNodesOnMatchingFiles(configFiles, context, {})
     ).resolves.not.toThrow();
   });
 
   it('should not create nodes for root tsconfig.json files', async () => {
-    await applyFilesToTempFsAndContext(tempFs, context, {
+    configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
       'package.json': `{}`,
       'project.json': `{}`,
       'tsconfig.json': `{}`,
       'src/index.ts': `console.log('Hello World!');`,
     });
-    expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+    expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
       .toMatchInlineSnapshot(`
       {
         "projects": {},
-      }
+      } 
     `);
   });
 
   describe('typecheck target', () => {
     it('should create a node with a typecheck target for a project level tsconfig.json file by default (when there is a sibling package.json or project.json)', async () => {
       // Sibling package.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': JSON.stringify({ files: [] }),
         'libs/my-lib/package.json': `{}`,
       });
-      expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+      expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
         .toMatchInlineSnapshot(`
         {
           "projects": {
@@ -126,11 +128,11 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // Sibling project.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': JSON.stringify({ files: [] }),
         'libs/my-lib/project.json': `{}`,
       });
-      expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+      expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
         .toMatchInlineSnapshot(`
         {
           "projects": {
@@ -175,14 +177,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // Other tsconfigs present
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': JSON.stringify({ files: [] }),
         'libs/my-lib/tsconfig.lib.json': `{}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
         'libs/my-lib/tsconfig.spec.json': `{}`,
         'libs/my-lib/project.json': `{}`,
       });
-      expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+      expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
         .toMatchInlineSnapshot(`
         {
           "projects": {
@@ -229,12 +231,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     it('should create a node with a typecheck target with "--verbose" flag when the "verboseOutput" plugin option is true', async () => {
       // Sibling package.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': JSON.stringify({ files: [] }),
         'libs/my-lib/package.json': `{}`,
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, { verboseOutput: true })
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
+          verboseOutput: true,
+        })
       ).toMatchInlineSnapshot(`
         {
           "projects": {
@@ -279,12 +283,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // Sibling project.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': JSON.stringify({ files: [] }),
         'libs/my-lib/project.json': `{}`,
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, { verboseOutput: true })
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
+          verboseOutput: true,
+        })
       ).toMatchInlineSnapshot(`
         {
           "projects": {
@@ -329,7 +335,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // Other tsconfigs present
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': JSON.stringify({ files: [] }),
         'libs/my-lib/tsconfig.lib.json': `{}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
@@ -337,7 +343,9 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         'libs/my-lib/project.json': `{}`,
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, { verboseOutput: true })
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
+          verboseOutput: true,
+        })
       ).toMatchInlineSnapshot(`
         {
           "projects": {
@@ -384,12 +392,12 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     it('should not create typecheck target for a project level tsconfig.json file if set to false in plugin options', async () => {
       // Sibling package.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/package.json': `{}`,
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
         })
       ).toMatchInlineSnapshot(`
@@ -403,12 +411,12 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // Sibling project.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/project.json': `{}`,
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
         })
       ).toMatchInlineSnapshot(`
@@ -424,14 +432,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     it('should not invoke `tsc --build` when `noEmit` is set in the tsconfig.json file', async () => {
       // set directly in tsconfig.json file
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': JSON.stringify({
           compilerOptions: { noEmit: true },
           files: [],
         }),
         'libs/my-lib/package.json': `{}`,
       });
-      expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+      expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
         .toMatchInlineSnapshot(`
         {
           "projects": {
@@ -476,7 +484,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // set in extended tsconfig file
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'tsconfig.base.json': JSON.stringify({
           compilerOptions: { noEmit: true },
         }),
@@ -486,7 +494,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         }),
         'libs/my-lib/package.json': `{}`,
       });
-      expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+      expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
         .toMatchInlineSnapshot(`
         {
           "projects": {
@@ -532,7 +540,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should not invoke `tsc --build` when `noEmit` is set in any of the referenced tsconfig.json files', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': JSON.stringify({
           files: [],
           references: [{ path: './tsconfig.lib.json' }],
@@ -543,7 +551,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         }),
         'libs/my-lib/package.json': `{}`,
       });
-      expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+      expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
         .toMatchInlineSnapshot(`
         {
           "projects": {
@@ -589,7 +597,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should handle ts project references pointing to non-existing files and not throw', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': JSON.stringify({
           references: [{ path: '../my-lib-2' }],
         }),
@@ -597,12 +605,12 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       await expect(
-        invokeCreateNodesOnMatchingFiles(context, {})
+        invokeCreateNodesOnMatchingFiles(configFiles, context, {})
       ).resolves.not.toThrow();
     });
 
     it('should not infer typecheck target when nx.addTypecheckTarget is false in tsconfig.json', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': JSON.stringify({
           nx: { addTypecheckTarget: false },
         }),
@@ -614,7 +622,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       await expect(
-        invokeCreateNodesOnMatchingFiles(context, {
+        invokeCreateNodesOnMatchingFiles(configFiles, context, {
           build: {
             configName: 'tsconfig.lib.json',
           },
@@ -668,7 +676,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     describe('inputs', () => {
       it('should add the config file and the `include` and `exclude` patterns', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             include: ['src/**/*.ts'],
             exclude: ['src/**/foo.ts'],
@@ -677,7 +685,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           }),
           'libs/my-lib/package.json': `{}`,
         });
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -729,7 +737,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add the config file and the `include` and `exclude` patterns using the "${configDir}" template', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             include: ['${configDir}/src/**/*.ts'],
             exclude: ['${configDir}/src/**/foo.ts'],
@@ -738,7 +746,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           }),
           'libs/my-lib/package.json': `{}`,
         });
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -790,7 +798,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should normalize and add directories in `include` with the ts extensions', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             include: ['src'],
             // set this to keep outputs smaller
@@ -799,7 +807,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{}`,
         });
 
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -856,7 +864,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should normalize and add directories in `include` with the ts and js extensions when `allowJs` is true', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             include: ['src'],
             // set this to keep outputs smaller
@@ -865,7 +873,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{}`,
         });
 
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -926,7 +934,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should normalize and add directories in `include` with the ts and json extensions when `resolveJsonModule` is true', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             include: ['src'],
             // set this to keep outputs smaller
@@ -938,7 +946,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{}`,
         });
 
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -996,7 +1004,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should normalize and add directories in `include` with the ts, js and json extensions when `allowJs` and `resolveJsonModule` are true', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             include: ['src'],
             // set this to keep outputs smaller
@@ -1009,7 +1017,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{}`,
         });
 
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -1071,7 +1079,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add extended config files', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'tsconfig.base.json': JSON.stringify({
             exclude: ['node_modules', 'tmp'],
           }),
@@ -1086,7 +1094,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           }),
           'libs/my-lib/package.json': `{}`,
         });
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -1141,7 +1149,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add extended config files when there are multiple extended config files', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'tsconfig.base.json': JSON.stringify({
             exclude: ['node_modules', 'tmp'],
           }),
@@ -1158,7 +1166,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           }),
           'libs/my-lib/package.json': `{}`,
         });
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -1214,7 +1222,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add extended config files supporting node.js style resolution and local workspace packages', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'tsconfig.base.json': JSON.stringify({
             extends: '@tsconfig/strictest/tsconfig.json', // should be resolved and the package name should be included in inputs as an external dependency
             exclude: ['node_modules', 'tmp'],
@@ -1244,7 +1252,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'dir'
         );
 
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -1300,7 +1308,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add files from internal project references', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             include: ['src/**/*.ts'],
             exclude: ['src/**/*.spec.ts'], // should be ignored because a referenced internal project includes this same pattern
@@ -1343,7 +1351,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
             include: ['**/*.ts'], // different pattern that should not be included because it's an external project
           }),
         });
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -1446,7 +1454,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should normalize and add directories in `include` from internal project references', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             files: [],
             include: [],
@@ -1474,7 +1482,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{}`,
         });
 
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -1539,7 +1547,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
       it('should only add exclude paths that are not part of other tsconfig files include paths', async () => {
         // exact match
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             references: [
               { path: './tsconfig.lib.json' },
@@ -1557,7 +1565,11 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{}`,
         });
 
-        let result = await invokeCreateNodesOnMatchingFiles(context, {});
+        let result = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          {}
+        );
         expect(result.projects['libs/my-lib'].targets.typecheck.inputs)
           .toMatchInlineSnapshot(`
           [
@@ -1572,7 +1584,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // other file include pattern is a subset of exclude pattern
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             references: [
               { path: './tsconfig.lib.json' },
@@ -1589,7 +1601,11 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           }),
           'libs/my-lib/package.json': `{}`,
         });
-        result = await invokeCreateNodesOnMatchingFiles(context, {});
+        result = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          {}
+        );
         expect(result.projects['libs/my-lib'].targets.typecheck.inputs)
           .toMatchInlineSnapshot(`
           [
@@ -1604,7 +1620,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // exclude pattern is a subset of other file include pattern
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             references: [
               { path: './tsconfig.lib.json' },
@@ -1621,7 +1637,11 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           }),
           'libs/my-lib/package.json': `{}`,
         });
-        result = await invokeCreateNodesOnMatchingFiles(context, {});
+        result = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          {}
+        );
         expect(result.projects['libs/my-lib'].targets.typecheck.inputs)
           .toMatchInlineSnapshot(`
           [
@@ -1636,7 +1656,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // handles mismatches with leading `./`
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             references: [
               { path: './tsconfig.lib.json' },
@@ -1653,7 +1673,11 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           }),
           'libs/my-lib/package.json': `{}`,
         });
-        result = await invokeCreateNodesOnMatchingFiles(context, {});
+        result = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          {}
+        );
         expect(result.projects['libs/my-lib'].targets.typecheck.inputs)
           .toMatchInlineSnapshot(`
           [
@@ -1668,7 +1692,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // no matching pattern in the exclude list
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             references: [
               { path: './tsconfig.lib.json' },
@@ -1688,7 +1712,11 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           }),
           'libs/my-lib/package.json': `{}`,
         });
-        result = await invokeCreateNodesOnMatchingFiles(context, {});
+        result = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          {}
+        );
         expect(result.projects['libs/my-lib'].targets.typecheck.inputs)
           .toMatchInlineSnapshot(`
           [
@@ -1705,11 +1733,11 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should fall back to named inputs when not using include', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({ files: ['main.ts'] }),
           'libs/my-lib/package.json': `{}`,
         });
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -1771,14 +1799,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     describe('outputs', () => {
       it('should add the `outFile`', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             compilerOptions: { outFile: '../../dist/libs/my-lib/index.js' },
             files: ['main.ts'],
           }),
           'libs/my-lib/package.json': `{}`,
         });
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -1830,14 +1858,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add the `outDir`', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             compilerOptions: { outDir: '../../dist/libs/my-lib' },
             files: ['main.ts'],
           }),
           'libs/my-lib/package.json': `{}`,
         });
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -1886,7 +1914,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should include tsbuildinfo file when outDir and rootDir at both set', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             files: [],
             references: [{ path: './tsconfig.lib.json' }],
@@ -1899,7 +1927,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         });
 
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             build: {
               configName: 'tsconfig.lib.json',
             },
@@ -1988,13 +2016,13 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add the inline output files when `outDir` is not defined', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             files: ['main.ts'],
           }),
           'libs/my-lib/package.json': `{}`,
         });
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -2054,7 +2082,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should collect outputs from all internal project references', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             files: [],
             references: [
@@ -2093,7 +2121,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
             },
           }),
         });
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -2196,7 +2224,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
       it('should respect the "tsBuildInfoFile" option', async () => {
         // outFile
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             compilerOptions: {
               outFile: '../../dist/libs/my-lib/index.js',
@@ -2206,7 +2234,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           }),
           'libs/my-lib/package.json': `{}`,
         });
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -2257,7 +2285,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // no outFile & no outDir
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             compilerOptions: {
               tsBuildInfoFile: '../../dist/libs/my-lib/my-lib.tsbuildinfo',
@@ -2266,7 +2294,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           }),
           'libs/my-lib/package.json': `{}`,
         });
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -2326,7 +2354,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should set the "tsBuildInfoFile" option when outside of the "outDir"', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             compilerOptions: {
               outDir: 'dist',
@@ -2337,7 +2365,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{}`,
         });
 
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -2386,7 +2414,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should not set the "tsBuildInfoFile" option when contained in the "outDir"', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             compilerOptions: {
               outDir: 'dist',
@@ -2397,7 +2425,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{}`,
         });
 
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -2446,14 +2474,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should support the "${configDir}" template', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
             compilerOptions: { outDir: '${configDir}/dist' },
             files: ['main.ts'],
           }),
           'libs/my-lib/package.json': `{}`,
         });
-        expect(await invokeCreateNodesOnMatchingFiles(context, {}))
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
           .toMatchInlineSnapshot(`
           {
             "projects": {
@@ -2506,14 +2534,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
   describe('build target', () => {
     it('should not create a node with a build target for a project level tsconfig files by default', async () => {
       // Sibling package.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
         'libs/my-lib/package.json': `{}`,
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           // Reduce noise in build snapshots by disabling default typecheck target
           typecheck: false,
         })
@@ -2528,14 +2556,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // Sibling project.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
         'libs/my-lib/project.json': `{}`,
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           // Reduce noise in build snapshots by disabling default typecheck target
           typecheck: false,
         })
@@ -2552,14 +2580,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     it('should not create build target for a project level tsconfig.json file if set to false in plugin options', async () => {
       // Sibling package.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
         'libs/my-lib/package.json': `{}`,
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           // Reduce noise in build snapshots by disabling default typecheck target
           typecheck: false,
           build: false,
@@ -2575,14 +2603,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // Sibling project.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
         'libs/my-lib/project.json': `{}`,
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           // Reduce noise in build snapshots by disabling default typecheck target
           typecheck: false,
           build: false,
@@ -2600,7 +2628,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     it('should not create build target when the entry points point to source files', async () => {
       // Sibling package.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/package.json': JSON.stringify({
@@ -2612,7 +2640,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         }),
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           // Reduce noise in build snapshots by disabling default typecheck target
           typecheck: false,
           build: true,
@@ -2630,7 +2658,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     it('should create build target when the entry points point to dist files', async () => {
       // Sibling package.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/package.json': JSON.stringify({
@@ -2645,7 +2673,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         }),
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           // Reduce noise in build snapshots by disabling default typecheck target
           typecheck: false,
           build: true,
@@ -2698,7 +2726,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     it('should create a node with a build target when enabled, for a project level tsconfig.lib.json build file by default', async () => {
       // Sibling package.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
@@ -2717,7 +2745,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         }),
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           // Reduce noise in build snapshots by disabling default typecheck target
           typecheck: false,
           build: true, // shorthand for apply with default options
@@ -2780,14 +2808,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // Sibling project.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
         'libs/my-lib/project.json': `{}`,
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           // Reduce noise in build snapshots by disabling default typecheck target
           typecheck: false,
           build: {}, // apply with default options
@@ -2840,7 +2868,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     it('should create a node with a build target with "--verbose" flag when the "verboseOutput" plugin option is true', async () => {
       // Sibling package.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
@@ -2859,7 +2887,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         }),
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           // Reduce noise in build snapshots by disabling default typecheck target
           typecheck: false,
           build: true, // shorthand for apply with default options
@@ -2923,14 +2951,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
 
       // Sibling project.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
         'libs/my-lib/project.json': `{}`,
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           // Reduce noise in build snapshots by disabling default typecheck target
           typecheck: false,
           build: {}, // apply with default options
@@ -2984,14 +3012,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     it('should create a node with a build target when enabled, using a custom configured target name', async () => {
       // Sibling package.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/tsconfig.build.json': `{}`,
         'libs/my-lib/package.json': `{ "main": "dist/index.js" }`,
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           // Reduce noise in build snapshots by disabling default typecheck target
           typecheck: false,
           build: {
@@ -3046,14 +3074,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     it('should create a node with a build target when enabled, using a custom configured tsconfig file', async () => {
       // Sibling project.json
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': `{}`,
         'libs/my-lib/tsconfig.lib.json': `{}`,
         'libs/my-lib/tsconfig.build.json': `{"compilerOptions": {"outDir": "dist"}}`,
         'libs/my-lib/project.json': `{}`,
       });
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           // Reduce noise in build snapshots by disabling default typecheck target
           typecheck: false,
           build: {
@@ -3107,7 +3135,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should handle ts project references pointing to non-existing files and not throw', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': JSON.stringify({
           references: [{ path: '../my-lib-2' }],
         }),
@@ -3116,7 +3144,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       await expect(
-        invokeCreateNodesOnMatchingFiles(context, {
+        invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         })
@@ -3125,7 +3153,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     describe('inputs', () => {
       it('should add the config file and the `include` and `exclude` patterns', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
               outDir: 'dist',
@@ -3137,7 +3165,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
         });
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -3191,7 +3219,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add the config file and the `include` and `exclude` patterns using the "${configDir}" template', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
               outDir: 'dist',
@@ -3203,7 +3231,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{"main": "./dist/index.js"}`,
         });
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -3257,7 +3285,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should normalize and add directories in `include` with the ts extensions', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: { outDir: 'dist' },
             include: ['src'],
@@ -3267,7 +3295,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         });
 
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -3326,7 +3354,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should normalize and add directories in `include` with the ts and js extensions when `allowJs` is true', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: { outDir: 'dist', allowJs: true },
             include: ['src'],
@@ -3336,7 +3364,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         });
 
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -3399,7 +3427,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should normalize and add directories in `include` with the ts and json extensions when `resolveJsonModule` is true', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: { outDir: 'dist', resolveJsonModule: true },
             include: ['src'],
@@ -3409,7 +3437,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         });
 
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -3469,7 +3497,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should normalize and add directories in `include` with the ts, js and json extensions when `allowJs` and `resolveJsonModule` are true', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
               outDir: 'dist',
@@ -3483,7 +3511,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         });
 
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -3547,7 +3575,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should be able to extended config files', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'tsconfig.base.json': JSON.stringify({
             exclude: ['node_modules', 'tmp'],
           }),
@@ -3565,7 +3593,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
         });
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -3622,7 +3650,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add extended config files when there are multiple extended config files', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'tsconfig.base.json': JSON.stringify({
             exclude: ['node_modules', 'tmp'],
           }),
@@ -3640,7 +3668,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
         });
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -3698,7 +3726,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add extended config files supporting node.js style resolution and local workspace packages', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'tsconfig.base.json': JSON.stringify({
             extends: '@tsconfig/strictest/tsconfig.json', // should be resolved and the package name should be included in inputs as an external dependency
             exclude: ['node_modules', 'tmp'],
@@ -3731,7 +3759,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         );
 
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -3789,7 +3817,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add files from internal project references', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: { outDir: 'dist' },
@@ -3811,7 +3839,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{"main": "dist/index.js"}`, // Should be defined so that the project is considered buildable
         });
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -3869,7 +3897,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should normalize and add directories in `include` from internal project references', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: { outDir: 'dist' },
@@ -3888,7 +3916,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         });
 
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -3952,7 +3980,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
       it('should only add exclude paths that are not part of other tsconfig files include paths', async () => {
         // exact match
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: { outDir: 'dist' }, // outDir is required to determine if the project is buildable
@@ -3966,10 +3994,14 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{"main": "dist/index.js" }`,
         });
 
-        let result = await invokeCreateNodesOnMatchingFiles(context, {
-          typecheck: false,
-          build: true,
-        });
+        let result = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          {
+            typecheck: false,
+            build: true,
+          }
+        );
         expect(result.projects['libs/my-lib'].targets.build.inputs)
           .toMatchInlineSnapshot(`
           [
@@ -3984,7 +4016,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // other file include pattern is a subset of exclude pattern
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: { outDir: 'dist' },
@@ -3997,7 +4029,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           }),
           'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
         });
-        result = await invokeCreateNodesOnMatchingFiles(context, {
+        result = await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         });
@@ -4015,7 +4047,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // exclude pattern is a subset of other file include pattern
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: { outDir: 'dist' }, // outDir is required to determine if the project is buildable
@@ -4028,7 +4060,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           }),
           'libs/my-lib/package.json': `{"main": "dist/index.js" }`, // Should be defined so that the project is considered buildable
         });
-        result = await invokeCreateNodesOnMatchingFiles(context, {
+        result = await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         });
@@ -4046,7 +4078,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // handles mismatches with leading `./`
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: { outDir: 'dist' },
@@ -4059,7 +4091,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           }),
           'libs/my-lib/package.json': `{"main": "dist/index.js" }`,
         });
-        result = await invokeCreateNodesOnMatchingFiles(context, {
+        result = await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         });
@@ -4077,7 +4109,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // no matching pattern in the exclude list
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: { outDir: 'dist' },
@@ -4093,7 +4125,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           }),
           'libs/my-lib/package.json': `{"main": "dist/index.js" }`,
         });
-        result = await invokeCreateNodesOnMatchingFiles(context, {
+        result = await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         });
@@ -4113,7 +4145,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should fall back to named inputs when not using include', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: { outDir: 'dist' },
             files: ['main.ts'],
@@ -4122,7 +4154,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
         });
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -4175,7 +4207,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
     describe('outputs', () => {
       it('should add the `outFile`', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
               outFile: '../../dist/libs/my-lib/index.js',
@@ -4186,7 +4218,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{}`,
         });
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -4241,7 +4273,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add the `outDir`', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
               outDir: '../../dist/libs/my-lib',
@@ -4252,7 +4284,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{"main": "../../dist/libs/my-lib/index.js"}`,
         });
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -4303,7 +4335,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should add the inline output files when `outDir` is not defined', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             files: ['main.ts'],
           }),
@@ -4311,7 +4343,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{}`,
         });
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -4374,7 +4406,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should collect outputs from all internal project references', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
@@ -4392,7 +4424,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{"main": "../../dist/libs/my-lib/lib.js"}`,
         });
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -4452,7 +4484,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
       it('should respect the "tsBuildInfoFile" option', async () => {
         // outFile
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
@@ -4464,7 +4496,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{"main": "../../dist/libs/my-lib/index.js"}`,
         });
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -4518,7 +4550,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
 
         // no outFile & no outDir
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': '{}',
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
@@ -4529,7 +4561,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{"main": "dist/libs/my-lib/index.js"}`,
         });
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -4592,7 +4624,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should set the "tsBuildInfoFile" option when outside of the "outDir"', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
               outDir: 'dist',
@@ -4605,7 +4637,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         });
 
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -4657,7 +4689,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should not set the "tsBuildInfoFile" option when contained in the "outDir"', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
               outDir: 'dist',
@@ -4670,7 +4702,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         });
 
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -4721,7 +4753,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       it('should support the "${configDir}" template', async () => {
-        await applyFilesToTempFsAndContext(tempFs, context, {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
             compilerOptions: {
               outDir: '${configDir}/dist',
@@ -4732,7 +4764,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
           'libs/my-lib/package.json': `{"main": "./dist/index.js"}`,
         });
         expect(
-          await invokeCreateNodesOnMatchingFiles(context, {
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
             typecheck: false,
             build: true,
           })
@@ -4786,7 +4818,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
   describe('isValidPackageJsonBuildConfig', () => {
     it('should consider a package buildable when main points to transpiled output outside source folder', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',
         'libs/my-lib/tsconfig.lib.json': JSON.stringify({
           compilerOptions: { outDir: 'src' },
@@ -4799,7 +4831,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         })
@@ -4852,7 +4884,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should consider a package buildable when main points to transpiled output with include patterns', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',
         'libs/my-lib/tsconfig.lib.json': JSON.stringify({
           compilerOptions: { outDir: 'lib' },
@@ -4865,7 +4897,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         })
@@ -4918,7 +4950,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should not consider a package buildable when main points to source file', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',
         'libs/my-lib/tsconfig.lib.json': JSON.stringify({
           compilerOptions: { outDir: 'dist' },
@@ -4931,7 +4963,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         })
@@ -4947,7 +4979,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should consider a package buildable when main points to source file when skipBuildCheck is true', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',
         'libs/my-lib/tsconfig.lib.json': JSON.stringify({
           compilerOptions: { outDir: 'dist' },
@@ -4960,7 +4992,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: {
             skipBuildCheck: true,
@@ -5015,7 +5047,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should handle relative paths correctly when main points to transpiled output', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',
         'libs/my-lib/tsconfig.lib.json': JSON.stringify({
           compilerOptions: { outDir: '../build/my-lib' },
@@ -5028,7 +5060,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         })
@@ -5081,7 +5113,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should handle absolute paths correctly when main points to transpiled output', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',
         'libs/my-lib/tsconfig.lib.json': JSON.stringify({
           compilerOptions: { outDir: 'dist' },
@@ -5094,7 +5126,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         })
@@ -5147,7 +5179,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should not consider package buildable when absolute path points to source file', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',
         'libs/my-lib/tsconfig.lib.json': JSON.stringify({
           compilerOptions: { outDir: 'dist' },
@@ -5160,7 +5192,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         })
@@ -5176,7 +5208,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should handle glob patterns with ** and single *', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',
         'libs/my-lib/tsconfig.lib.json': JSON.stringify({
           compilerOptions: { outDir: 'compiled' },
@@ -5190,7 +5222,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         })
@@ -5244,7 +5276,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should consider package buildable when outDir is outside project and main export points to outDir', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',
         'libs/my-lib/tsconfig.lib.json': JSON.stringify({
           compilerOptions: { outDir: '../../../external-build' },
@@ -5257,7 +5289,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         })
@@ -5310,7 +5342,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should consider package buildable when outDir is within project and main points to file inside outDir', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',
         'libs/my-lib/tsconfig.lib.json': JSON.stringify({
           compilerOptions: { outDir: 'dist' },
@@ -5323,7 +5355,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         })
@@ -5376,7 +5408,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should not consider package buildable when outDir is within project but main points to source file', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',
         'libs/my-lib/tsconfig.lib.json': JSON.stringify({
           compilerOptions: { outDir: 'dist' },
@@ -5389,7 +5421,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         })
@@ -5405,7 +5437,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should consider package buildable when main points to JS build output', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',
         'libs/my-lib/tsconfig.lib.json': JSON.stringify({
           compilerOptions: { outDir: 'build' },
@@ -5418,7 +5450,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         })
@@ -5469,7 +5501,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should not consider package buildable when main points to TS source file', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',
         'libs/my-lib/tsconfig.lib.json': JSON.stringify({
           compilerOptions: { outDir: 'build' },
@@ -5481,7 +5513,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         })
@@ -5497,7 +5529,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should consider package buildable when main points to build output even with TS extension', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',
         'libs/my-lib/tsconfig.lib.json': JSON.stringify({
           compilerOptions: { outDir: 'build' },
@@ -5510,7 +5542,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         })
@@ -5561,7 +5593,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should not consider package buildable when main matches include pattern', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',
         'libs/my-lib/tsconfig.lib.json': JSON.stringify({
           compilerOptions: {},
@@ -5574,7 +5606,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         })
@@ -5590,7 +5622,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     });
 
     it('should consider package buildable when main does not match include pattern', async () => {
-      await applyFilesToTempFsAndContext(tempFs, context, {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
         'libs/my-lib/tsconfig.json': '{}',
         'libs/my-lib/tsconfig.lib.json': JSON.stringify({
           compilerOptions: {},
@@ -5604,7 +5636,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       });
 
       expect(
-        await invokeCreateNodesOnMatchingFiles(context, {
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
           typecheck: false,
           build: true,
         })
@@ -5672,27 +5704,24 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
 async function applyFilesToTempFsAndContext(
   tempFs: TempFs,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   fileSys: Record<string, string>
-) {
+): Promise<string[]> {
   await tempFs.createFiles(fileSys);
-  // @ts-expect-error update otherwise readonly property for testing
-  context.configFiles = Object.keys(fileSys).filter((file) =>
+  const configFiles = Object.keys(fileSys).filter((file) =>
     picomatch(createNodesV2[0], { dot: true })(file)
   );
   setupWorkspaceContext(tempFs.tempDir);
+  return configFiles;
 }
 
 async function invokeCreateNodesOnMatchingFiles(
-  context: CreateNodesContext,
+  configFiles: string[],
+  context: CreateNodesContextV2,
   pluginOptions: TscPluginOptions
 ) {
   const aggregateProjects: Record<string, any> = {};
-  const results = await createNodesV2[1](
-    context.configFiles,
-    pluginOptions,
-    context
-  );
+  const results = await createNodesV2[1](configFiles, pluginOptions, context);
   for (const [, nodes] of results) {
     for (const [projectName, project] of Object.entries(nodes.projects ?? {})) {
       if (aggregateProjects[projectName]) {

--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -72,7 +72,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       .toMatchInlineSnapshot(`
       {
         "projects": {},
-      } 
+      }
     `);
   });
 

--- a/packages/next/src/plugins/plugin.spec.ts
+++ b/packages/next/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContext } from '@nx/devkit';
+import { CreateNodesContextV2 } from '@nx/devkit';
 import type { NextConfig } from 'next';
 
 import { createNodesV2 } from './plugin';
@@ -6,7 +6,7 @@ import { TempFs } from '@nx/devkit/internal-testing-utils';
 
 describe('@nx/next/plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
 
   describe('root projects', () => {
     beforeEach(async () => {

--- a/packages/next/src/plugins/plugin.spec.ts
+++ b/packages/next/src/plugins/plugin.spec.ts
@@ -18,7 +18,6 @@ describe('@nx/next/plugin', () => {
           },
         },
         workspaceRoot: '',
-        configFiles: [],
       };
     });
 
@@ -54,7 +53,6 @@ describe('@nx/next/plugin', () => {
           },
         },
         workspaceRoot: tempFs.tempDir,
-        configFiles: [],
       };
 
       tempFs.createFileSync(

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -264,7 +264,7 @@ async function getOutputs(projectRoot, nextConfig) {
 
 function getNextConfig(
   configFilePath: string,
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ): Promise<any> {
   const resolvedPath = join(context.workspaceRoot, configFilePath);
 

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -1,6 +1,6 @@
 import {
   CreateDependencies,
-  CreateNodesContext,
+  CreateNodesContextV2,
   createNodesFromFiles,
   CreateNodesV2,
   detectPackageManager,
@@ -94,7 +94,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFilePath: string,
   options: NextPluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   targetsCache: Record<
     string,
     Record<string, TargetConfiguration<NextPluginOptions>>
@@ -142,7 +142,7 @@ async function buildNextTargets(
   nextConfigPath: string,
   projectRoot: string,
   options: NextPluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   isTsSolutionSetup: boolean
 ) {
   const nextConfig = await getNextConfig(nextConfigPath, context);

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -1,12 +1,10 @@
 import {
   CreateDependencies,
-  CreateNodes,
   CreateNodesContext,
   createNodesFromFiles,
   CreateNodesV2,
   detectPackageManager,
   getPackageManagerCommand,
-  logger,
   NxJsonConfiguration,
   readJsonFile,
   TargetConfiguration,
@@ -63,7 +61,7 @@ export const createDependencies: CreateDependencies = () => {
   return [];
 };
 
-export const createNodesV2: CreateNodesV2<NextPluginOptions> = [
+export const createNodes: CreateNodesV2<NextPluginOptions> = [
   nextConfigBlob,
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
@@ -91,33 +89,7 @@ export const createNodesV2: CreateNodesV2<NextPluginOptions> = [
   },
 ];
 
-/**
- * @deprecated This is replaced with {@link createNodesV2}. Update your plugin to export its own `createNodesV2` function that wraps this one instead.
- * This function will change to the v2 function in Nx 21.
- */
-export const createNodes: CreateNodes<NextPluginOptions> = [
-  nextConfigBlob,
-  async (configFilePath, options, context) => {
-    logger.warn(
-      '`createNodes` is deprecated. Update your plugin to utilize createNodesV2 instead. In Nx 21, this will change to the createNodesV2 API.'
-    );
-
-    const optionsHash = hashObject(options);
-    const cachePath = join(workspaceDataDirectory, `next-${optionsHash}.json`);
-    const targetsCache = readTargetsCache(cachePath);
-    const isTsSolutionSetup = isUsingTsSolutionSetup();
-
-    const result = await createNodesInternal(
-      configFilePath,
-      options,
-      context,
-      targetsCache,
-      isTsSolutionSetup
-    );
-    writeTargetsToCache(cachePath, targetsCache);
-    return result;
-  },
-];
+export const createNodesV2 = createNodes;
 
 async function createNodesInternal(
   configFilePath: string,

--- a/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -1,9 +1,12 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`@nx/nuxt/plugin not root project should create nodes 1`] = `
-{
-  "projects": {
-    "my-app": {
+[
+  [
+    "my-app/nuxt.config.ts",
+    {
+      "projects": {
+        "my-app": {
       "root": "my-app",
       "targets": {
         "acme-build-static": {
@@ -87,13 +90,18 @@ exports[`@nx/nuxt/plugin not root project should create nodes 1`] = `
       },
     },
   },
-}
+    },
+  ],
+]
 `;
 
 exports[`@nx/nuxt/plugin root project should create nodes 1`] = `
-{
-  "projects": {
-    ".": {
+[
+  [
+    "nuxt.config.ts",
+    {
+      "projects": {
+        ".": {
       "root": ".",
       "targets": {
         "build": {
@@ -177,5 +185,7 @@ exports[`@nx/nuxt/plugin root project should create nodes 1`] = `
       },
     },
   },
-}
+    },
+  ],
+]
 `;

--- a/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -7,89 +7,89 @@ exports[`@nx/nuxt/plugin not root project should create nodes 1`] = `
     {
       "projects": {
         "my-app": {
-      "root": "my-app",
-      "targets": {
-        "acme-build-static": {
-          "cache": true,
-          "command": "nuxt build --prerender",
-          "dependsOn": [
-            "^acme-build-static",
-          ],
-          "inputs": [
-            "production",
-            "^production",
-            {
-              "externalDependencies": [
-                "nuxt",
+          "root": "my-app",
+          "targets": {
+            "acme-build-static": {
+              "cache": true,
+              "command": "nuxt build --prerender",
+              "dependsOn": [
+                "^acme-build-static",
+              ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "nuxt",
+                  ],
+                },
+              ],
+              "options": {
+                "cwd": "my-app",
+              },
+              "outputs": [
+                "{workspaceRoot}/dist/my-app/.nuxt",
+                "{projectRoot}/.output",
               ],
             },
-          ],
-          "options": {
-            "cwd": "my-app",
-          },
-          "outputs": [
-            "{workspaceRoot}/dist/my-app/.nuxt",
-            "{projectRoot}/.output",
-          ],
-        },
-        "acme-serve-static": {
-          "continuous": true,
-          "dependsOn": [
-            "acme-build-static",
-          ],
-          "executor": "@nx/web:file-server",
-          "options": {
-            "buildTarget": "acme-build-static",
-            "port": 4200,
-            "spa": false,
-            "staticFilePath": "{projectRoot}/dist",
-          },
-        },
-        "build-deps": {
-          "dependsOn": [
-            "^build",
-          ],
-        },
-        "build-something": {
-          "cache": true,
-          "command": "nuxt build",
-          "dependsOn": [
-            "^build-something",
-          ],
-          "inputs": [
-            "production",
-            "^production",
-            {
-              "externalDependencies": [
-                "nuxt",
+            "acme-serve-static": {
+              "continuous": true,
+              "dependsOn": [
+                "acme-build-static",
+              ],
+              "executor": "@nx/web:file-server",
+              "options": {
+                "buildTarget": "acme-build-static",
+                "port": 4200,
+                "spa": false,
+                "staticFilePath": "{projectRoot}/dist",
+              },
+            },
+            "build-deps": {
+              "dependsOn": [
+                "^build",
               ],
             },
-          ],
-          "options": {
-            "cwd": "my-app",
+            "build-something": {
+              "cache": true,
+              "command": "nuxt build",
+              "dependsOn": [
+                "^build-something",
+              ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "nuxt",
+                  ],
+                },
+              ],
+              "options": {
+                "cwd": "my-app",
+              },
+              "outputs": [
+                "{workspaceRoot}/dist/my-app/.nuxt",
+                "{projectRoot}/.output",
+              ],
+            },
+            "my-serve": {
+              "command": "nuxt dev",
+              "continuous": true,
+              "options": {
+                "cwd": "my-app",
+              },
+            },
+            "watch-deps": {
+              "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+              "continuous": true,
+              "dependsOn": [
+                "build-deps",
+              ],
+            },
           },
-          "outputs": [
-            "{workspaceRoot}/dist/my-app/.nuxt",
-            "{projectRoot}/.output",
-          ],
-        },
-        "my-serve": {
-          "command": "nuxt dev",
-          "continuous": true,
-          "options": {
-            "cwd": "my-app",
-          },
-        },
-        "watch-deps": {
-          "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
-          "continuous": true,
-          "dependsOn": [
-            "build-deps",
-          ],
         },
       },
-    },
-  },
     },
   ],
 ]
@@ -102,89 +102,89 @@ exports[`@nx/nuxt/plugin root project should create nodes 1`] = `
     {
       "projects": {
         ".": {
-      "root": ".",
-      "targets": {
-        "build": {
-          "cache": true,
-          "command": "nuxt build",
-          "dependsOn": [
-            "^build",
-          ],
-          "inputs": [
-            "production",
-            "^production",
-            {
-              "externalDependencies": [
-                "nuxt",
+          "root": ".",
+          "targets": {
+            "build": {
+              "cache": true,
+              "command": "nuxt build",
+              "dependsOn": [
+                "^build",
+              ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "nuxt",
+                  ],
+                },
+              ],
+              "options": {
+                "cwd": ".",
+              },
+              "outputs": [
+                "dist/my-app/.nuxt",
+                "{projectRoot}/.output",
               ],
             },
-          ],
-          "options": {
-            "cwd": ".",
-          },
-          "outputs": [
-            "dist/my-app/.nuxt",
-            "{projectRoot}/.output",
-          ],
-        },
-        "build-deps": {
-          "dependsOn": [
-            "^build",
-          ],
-        },
-        "build-static": {
-          "cache": true,
-          "command": "nuxt build --prerender",
-          "dependsOn": [
-            "^build-static",
-          ],
-          "inputs": [
-            "production",
-            "^production",
-            {
-              "externalDependencies": [
-                "nuxt",
+            "build-deps": {
+              "dependsOn": [
+                "^build",
               ],
             },
-          ],
-          "options": {
-            "cwd": ".",
+            "build-static": {
+              "cache": true,
+              "command": "nuxt build --prerender",
+              "dependsOn": [
+                "^build-static",
+              ],
+              "inputs": [
+                "production",
+                "^production",
+                {
+                  "externalDependencies": [
+                    "nuxt",
+                  ],
+                },
+              ],
+              "options": {
+                "cwd": ".",
+              },
+              "outputs": [
+                "dist/my-app/.nuxt",
+                "{projectRoot}/.output",
+              ],
+            },
+            "serve": {
+              "command": "nuxt dev",
+              "continuous": true,
+              "options": {
+                "cwd": ".",
+              },
+            },
+            "serve-static": {
+              "continuous": true,
+              "dependsOn": [
+                "build-static",
+              ],
+              "executor": "@nx/web:file-server",
+              "options": {
+                "buildTarget": "build-static",
+                "port": 4200,
+                "spa": false,
+                "staticFilePath": "{projectRoot}/dist",
+              },
+            },
+            "watch-deps": {
+              "command": "npx nx watch --projects nuxt --includeDependentProjects -- npx nx build-deps nuxt",
+              "continuous": true,
+              "dependsOn": [
+                "build-deps",
+              ],
+            },
           },
-          "outputs": [
-            "dist/my-app/.nuxt",
-            "{projectRoot}/.output",
-          ],
-        },
-        "serve": {
-          "command": "nuxt dev",
-          "continuous": true,
-          "options": {
-            "cwd": ".",
-          },
-        },
-        "serve-static": {
-          "continuous": true,
-          "dependsOn": [
-            "build-static",
-          ],
-          "executor": "@nx/web:file-server",
-          "options": {
-            "buildTarget": "build-static",
-            "port": 4200,
-            "spa": false,
-            "staticFilePath": "{projectRoot}/dist",
-          },
-        },
-        "watch-deps": {
-          "command": "npx nx watch --projects nuxt --includeDependentProjects -- npx nx build-deps nuxt",
-          "continuous": true,
-          "dependsOn": [
-            "build-deps",
-          ],
         },
       },
-    },
-  },
     },
   ],
 ]

--- a/packages/nuxt/src/plugins/plugin.spec.ts
+++ b/packages/nuxt/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContext } from '@nx/devkit';
+import { CreateNodesContextV2 } from '@nx/devkit';
 import { createNodes } from './plugin';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 
@@ -19,7 +19,7 @@ jest.mock('../utils/executor-utils', () => ({
 }));
 describe('@nx/nuxt/plugin', () => {
   let createNodesFunction = createNodes[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
 
   describe('root project', () => {
     beforeEach(async () => {

--- a/packages/nuxt/src/plugins/plugin.spec.ts
+++ b/packages/nuxt/src/plugins/plugin.spec.ts
@@ -38,7 +38,6 @@ describe('@nx/nuxt/plugin', () => {
           },
         },
         workspaceRoot: '',
-        configFiles: [],
       };
     });
 
@@ -48,7 +47,7 @@ describe('@nx/nuxt/plugin', () => {
 
     it('should create nodes', async () => {
       const nodes = await createNodesFunction(
-        'nuxt.config.ts',
+        ['nuxt.config.ts'],
         {
           buildTargetName: 'build',
           serveTargetName: 'serve',
@@ -73,7 +72,6 @@ describe('@nx/nuxt/plugin', () => {
           },
         },
         workspaceRoot: tempFs.tempDir,
-        configFiles: [],
       };
 
       tempFs.createFileSync(
@@ -89,7 +87,7 @@ describe('@nx/nuxt/plugin', () => {
 
     it('should create nodes', async () => {
       const nodes = await createNodesFunction(
-        'my-app/nuxt.config.ts',
+        ['my-app/nuxt.config.ts'],
         {
           buildTargetName: 'build-something',
           serveTargetName: 'my-serve',

--- a/packages/nuxt/src/plugins/plugin.ts
+++ b/packages/nuxt/src/plugins/plugin.ts
@@ -1,7 +1,7 @@
 import type { NuxtOptions } from '@nuxt/schema';
 import {
   CreateDependencies,
-  CreateNodesContext,
+  CreateNodesContextV2,
   createNodesFromFiles,
   CreateNodesV2,
   detectPackageManager,
@@ -70,7 +70,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFilePath: string,
   options: NuxtPluginOptions,
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ) {
   const projectRoot = dirname(configFilePath);
   // Do not create a project if package.json and project.json isn't there.
@@ -111,7 +111,7 @@ async function buildNuxtTargets(
   configFilePath: string,
   projectRoot: string,
   options: NuxtPluginOptions,
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ) {
   const nuxtConfig: {
     buildDir: string;
@@ -236,7 +236,7 @@ function buildStaticTarget(
 
 async function getInfoFromNuxtConfig(
   configFilePath: string,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   projectRoot: string
 ): Promise<{
   buildDir: string;

--- a/packages/nuxt/src/plugins/plugin.ts
+++ b/packages/nuxt/src/plugins/plugin.ts
@@ -1,7 +1,6 @@
 import type { NuxtOptions } from '@nuxt/schema';
 import {
   CreateDependencies,
-  CreateNodes,
   CreateNodesContext,
   createNodesFromFiles,
   CreateNodesV2,
@@ -51,12 +50,12 @@ export interface NuxtPluginOptions {
   watchDepsTargetName?: string;
 }
 
-export const createNodesV2: CreateNodesV2<NuxtPluginOptions> = [
+export const createNodes: CreateNodesV2<NuxtPluginOptions> = [
   '**/nuxt.config.{js,ts,mjs,mts,cjs,cts}',
   async (files, options, context) => {
     //TODO(@nrwl/nx-vue-reviewers): This should batch hashing like our other plugins.
     const result = await createNodesFromFiles(
-      createNodes[1],
+      createNodesInternal,
       files,
       options,
       context
@@ -66,44 +65,47 @@ export const createNodesV2: CreateNodesV2<NuxtPluginOptions> = [
   },
 ];
 
-export const createNodes: CreateNodes<NuxtPluginOptions> = [
-  '**/nuxt.config.{js,ts,mjs,mts,cjs,cts}',
-  async (configFilePath, options, context) => {
-    const projectRoot = dirname(configFilePath);
-    // Do not create a project if package.json and project.json isn't there.
-    const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
-    if (
-      !siblingFiles.includes('package.json') &&
-      !siblingFiles.includes('project.json')
-    ) {
-      return {};
-    }
+export const createNodesV2 = createNodes;
 
-    options = normalizeOptions(options);
+async function createNodesInternal(
+  configFilePath: string,
+  options: NuxtPluginOptions,
+  context: CreateNodesContext
+) {
+  const projectRoot = dirname(configFilePath);
+  // Do not create a project if package.json and project.json isn't there.
+  const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
+  if (
+    !siblingFiles.includes('package.json') &&
+    !siblingFiles.includes('project.json')
+  ) {
+    return {};
+  }
 
-    const hash = await calculateHashForCreateNodes(
-      projectRoot,
-      options,
-      context,
-      [getLockFileName(detectPackageManager(context.workspaceRoot))]
-    );
-    targetsCache[hash] ??= await buildNuxtTargets(
-      configFilePath,
-      projectRoot,
-      options,
-      context
-    );
+  options = normalizeOptions(options);
 
-    return {
-      projects: {
-        [projectRoot]: {
-          root: projectRoot,
-          targets: targetsCache[hash],
-        },
+  const hash = await calculateHashForCreateNodes(
+    projectRoot,
+    options,
+    context,
+    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+  );
+  targetsCache[hash] ??= await buildNuxtTargets(
+    configFilePath,
+    projectRoot,
+    options,
+    context
+  );
+
+  return {
+    projects: {
+      [projectRoot]: {
+        root: projectRoot,
+        targets: targetsCache[hash],
       },
-    };
-  },
-];
+    },
+  };
+}
 
 async function buildNuxtTargets(
   configFilePath: string,

--- a/packages/nx/src/adapter/angular-json.ts
+++ b/packages/nx/src/adapter/angular-json.ts
@@ -2,29 +2,26 @@ import { existsSync } from 'fs';
 import * as path from 'path';
 import { readJsonFile } from '../utils/fileutils';
 import { ProjectsConfigurations } from '../config/workspace-json-project-json';
-import { NxPluginV2 } from '../project-graph/plugins';
+import { CreateNodesV2, NxPluginV2 } from '../project-graph/plugins';
 
 export const NX_ANGULAR_JSON_PLUGIN_NAME = 'nx-angular-json-plugin';
 
-export const NxAngularJsonPlugin: NxPluginV2 = {
-  name: NX_ANGULAR_JSON_PLUGIN_NAME,
-  createNodes: [
-    'angular.json',
-    (f, _, ctx) => ({
-      projects: readAngularJson(ctx.workspaceRoot),
-    }),
-  ],
-  createNodesV2: [
-    'angular.json',
-    (f, _, ctx) => [
-      [
-        'angular.json',
-        {
-          projects: readAngularJson(ctx.workspaceRoot),
-        },
-      ],
+const createNodes: CreateNodesV2 = [
+  'angular.json',
+  (f, _, ctx) => [
+    [
+      'angular.json',
+      {
+        projects: readAngularJson(ctx.workspaceRoot),
+      },
     ],
   ],
+];
+
+export const NxAngularJsonPlugin: NxPluginV2 = {
+  name: NX_ANGULAR_JSON_PLUGIN_NAME,
+  createNodes,
+  createNodesV2: createNodes,
 };
 
 export default NxAngularJsonPlugin;

--- a/packages/nx/src/devkit-exports.ts
+++ b/packages/nx/src/devkit-exports.ts
@@ -45,10 +45,7 @@ export { workspaceLayout } from './config/configuration';
 export type {
   NxPlugin,
   NxPluginV2,
-  CreateNodes,
-  CreateNodesFunction,
   CreateNodesResult,
-  CreateNodesContext,
   CreateNodesContextV2,
   CreateNodesFunctionV2,
   CreateNodesResultV2,

--- a/packages/nx/src/plugins/js/lock-file/lock-file.ts
+++ b/packages/nx/src/plugins/js/lock-file/lock-file.ts
@@ -13,7 +13,7 @@ import {
 } from '../../../config/project-graph';
 import {
   CreateDependenciesContext,
-  CreateNodesContext,
+  CreateNodesContextV2,
 } from '../../../project-graph/plugins';
 import { RawProjectGraphDependency } from '../../../project-graph/project-graph-builder';
 import { readJsonFile } from '../../../utils/fileutils';
@@ -73,7 +73,7 @@ export function getLockFileNodes(
   packageManager: PackageManager,
   contents: string,
   lockFileHash: string,
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ): Record<string, ProjectGraphExternalNode> {
   try {
     if (packageManager === 'yarn') {

--- a/packages/nx/src/plugins/package-json/create-nodes.spec.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.spec.ts
@@ -6,7 +6,6 @@ import { createNodeFromPackageJson, createNodesV2 } from './create-nodes';
 describe('nx package.json workspaces plugin', () => {
   const context = {
     workspaceRoot: '/root',
-    configFiles: [],
     nxJsonConfiguration: {},
   };
 
@@ -255,7 +254,6 @@ describe('nx package.json workspaces plugin', () => {
 
       const context = {
         workspaceRoot: '/root',
-        configFiles: [],
         nxJsonConfiguration: {},
       };
 
@@ -359,7 +357,6 @@ describe('nx package.json workspaces plugin', () => {
 
       const context = {
         workspaceRoot: '/root',
-        configFiles: [],
         nxJsonConfiguration: {},
       };
 

--- a/packages/nx/src/plugins/project-json/build-nodes/project-json.spec.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/project-json.spec.ts
@@ -3,11 +3,11 @@ import * as memfs from 'memfs';
 import '../../../internal-testing-utils/mock-fs';
 
 import { ProjectJsonProjectsPlugin } from './project-json';
-import { CreateNodesContext } from '../../../project-graph/plugins';
+import { CreateNodesContextV2 } from '../../../project-graph/plugins';
 const { createNodesV2 } = ProjectJsonProjectsPlugin;
 
 describe('nx project.json plugin', () => {
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   beforeEach(() => {
     context = {
       nxJsonConfiguration: {},

--- a/packages/nx/src/plugins/project-json/build-nodes/project-json.spec.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/project-json.spec.ts
@@ -12,7 +12,6 @@ describe('nx project.json plugin', () => {
     context = {
       nxJsonConfiguration: {},
       workspaceRoot: '/root',
-      configFiles: [],
     };
   });
 

--- a/packages/nx/src/project-graph/plugins/public-api.ts
+++ b/packages/nx/src/project-graph/plugins/public-api.ts
@@ -13,30 +13,10 @@ import type { NxJsonConfiguration } from '../../config/nx-json';
 import type { RawProjectGraphDependency } from '../project-graph-builder';
 import type { TaskResults } from '../../tasks-runner/life-cycle';
 
-/**
- * Context for {@link CreateNodesFunction}
- */
-export interface CreateNodesContext extends CreateNodesContextV2 {
-  /**
-   * The subset of configuration files which match the createNodes pattern
-   */
-  readonly configFiles: readonly string[];
-}
-
 export interface CreateNodesContextV2 {
   readonly nxJsonConfiguration: NxJsonConfiguration;
   readonly workspaceRoot: string;
 }
-
-/**
- * A function which parses a configuration file into a set of nodes.
- * Used for creating nodes for the {@link ProjectGraph}
- */
-export type CreateNodesFunction<T = unknown> = (
-  projectConfigurationFile: string,
-  options: T | undefined,
-  context: CreateNodesContext
-) => CreateNodesResult | Promise<CreateNodesResult>;
 
 export type CreateNodesResultV2 = Array<
   readonly [configFileSource: string, result: CreateNodesResult]
@@ -61,24 +41,6 @@ export interface CreateNodesResult {
    */
   externalNodes?: Record<string, ProjectGraphExternalNode>;
 }
-
-/**
- * A pair of file patterns and {@link CreateNodesFunction}
- *
- * Nx 19.2+: Both original `CreateNodes` and `CreateNodesV2` are supported. Nx will only invoke `CreateNodesV2` if it is present.
- * Nx 21.X : The `CreateNodesV2` will be the only supported API. This typing will still exist, but be identical to `CreateNodesV2`.
-             Nx **will not** invoke the original `plugin.createNodes` callback. This should give plugin authors a window to transition.
-             Plugin authors should update their plugin's `createNodes` function to align with `CreateNodesV2` / the updated `CreateNodes`.
-             The plugin should contain something like: `export createNodes = createNodesV2;` during this period. This will allow the plugin
-             to maintain compatibility with Nx 19.2 and up.
- * Nx 22.X : The `CreateNodesV2` typing will be removed, as it has replaced `CreateNodes`.
- *
- * @deprecated Use {@link CreateNodesV2} instead. CreateNodesV2 will replace this API. Read more about the transition above.
- */
-export type CreateNodes<T = unknown> = readonly [
-  projectFilePattern: string,
-  createNodesFunction: CreateNodesFunction<T>
-];
 
 /**
  * A pair of file patterns and {@link CreateNodesFunctionV2}
@@ -155,16 +117,12 @@ export type NxPluginV2<TOptions = unknown> = {
   /**
    * Provides a file pattern and function that retrieves configuration info from
    * those files. e.g. { '**\/*.csproj': buildProjectsFromCsProjFile }
-   *
-   * @deprecated Use {@link createNodesV2} instead. In Nx 21 support for calling createNodes with a single file for the first argument will be removed.
    */
-  createNodes?: CreateNodes<TOptions>;
+  createNodes?: CreateNodesV2<TOptions>;
 
   /**
    * Provides a file pattern and function that retrieves configuration info from
    * those files. e.g. { '**\/*.csproj': buildProjectsFromCsProjFiles }
-   *
-   * In Nx 21 {@link createNodes} will be replaced with this property. In Nx 22, this property will be removed.
    */
   createNodesV2?: CreateNodesV2<TOptions>;
 

--- a/packages/nx/src/project-graph/plugins/utils.ts
+++ b/packages/nx/src/project-graph/plugins/utils.ts
@@ -1,14 +1,10 @@
-import {
-  CreateNodesContext,
-  CreateNodesContextV2,
-  CreateNodesResult,
-} from './public-api';
+import { CreateNodesContextV2, CreateNodesResult } from './public-api';
 import { AggregateCreateNodesError } from '../error-types';
 export async function createNodesFromFiles<T = unknown>(
   createNodes: (
     projectConfigurationFile: string,
     options: T | undefined,
-    context: CreateNodesContext,
+    context: CreateNodesContextV2 & { configFiles: readonly string[] },
     idx: number
   ) => CreateNodesResult | Promise<CreateNodesResult>,
   configFiles: readonly string[],

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -26,7 +26,6 @@ describe('@nx/playwright/plugin', () => {
         },
       },
       workspaceRoot: tempFs.tempDir,
-      configFiles: [],
     };
 
     process.chdir(tempFs.tempDir);

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContext } from '@nx/devkit';
+import { CreateNodesContextV2 } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { PlaywrightTestConfig } from '@playwright/test';
 import { join } from 'node:path';
@@ -6,7 +6,7 @@ import { createNodesV2 } from './plugin';
 
 describe('@nx/playwright/plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   let tempFs: TempFs;
   let cwd = process.cwd();
   let originalCacheProjectGraph: string | undefined;

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -1,12 +1,10 @@
 import {
-  type CreateNodes,
-  type CreateNodesContext,
   createNodesFromFiles,
+  type CreateNodesContextV2,
   type CreateNodesV2,
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
-  logger,
   normalizePath,
   type ProjectConfiguration,
   readJsonFile,
@@ -62,7 +60,7 @@ function writeTargetsToCache(
 }
 
 const playwrightConfigGlob = '**/playwright.config.{js,ts,cjs,cts,mjs,mts}';
-export const createNodesV2: CreateNodesV2<PlaywrightPluginOptions> = [
+export const createNodes: CreateNodesV2<PlaywrightPluginOptions> = [
   playwrightConfigGlob,
   async (configFilePaths, options, context) => {
     const optionsHash = hashObject(options);
@@ -85,24 +83,12 @@ export const createNodesV2: CreateNodesV2<PlaywrightPluginOptions> = [
   },
 ];
 
-/**
- * @deprecated This is replaced with {@link createNodesV2}. Update your plugin to export its own `createNodesV2` function that wraps this one instead.
- * This function will change to the v2 function in Nx 20.
- */
-export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
-  playwrightConfigGlob,
-  async (configFile, options, context) => {
-    logger.warn(
-      '`createNodes` is deprecated. Update your plugin to utilize createNodesV2 instead. In Nx 20, this will change to the createNodesV2 API.'
-    );
-    return createNodesInternal(configFile, options, context, {});
-  },
-];
+export const createNodesV2 = createNodes;
 
 async function createNodesInternal(
   configFilePath: string,
   options: PlaywrightPluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   targetsCache: Record<string, PlaywrightTargets>
 ) {
   const projectRoot = dirname(configFilePath);
@@ -151,7 +137,7 @@ async function buildPlaywrightTargets(
   configFilePath: string,
   projectRoot: string,
   options: NormalizedOptions,
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ): Promise<PlaywrightTargets> {
   // Playwright forbids importing the `@playwright/test` module twice. This would affect running the tests,
   // but we're just reading the config so let's delete the variable they are using to detect this.
@@ -384,7 +370,7 @@ async function buildPlaywrightTargets(
 }
 
 async function getAllTestFiles(opts: {
-  context: CreateNodesContext;
+  context: CreateNodesContextV2;
   path: string;
   config: PlaywrightTestConfig;
 }) {

--- a/packages/react-native/plugins/plugin.ts
+++ b/packages/react-native/plugins/plugin.ts
@@ -1,5 +1,5 @@
 import {
-  CreateNodesContext,
+  CreateNodesContextV2,
   createNodesFromFiles,
   CreateNodesResult,
   CreateNodesV2,
@@ -83,7 +83,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFile: string,
   options: ReactNativePluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   targetsCache: Record<
     string,
     Record<string, TargetConfiguration<ReactNativePluginOptions>>

--- a/packages/react-native/plugins/plugin.ts
+++ b/packages/react-native/plugins/plugin.ts
@@ -1,5 +1,4 @@
 import {
-  CreateNodes,
   CreateNodesContext,
   createNodesFromFiles,
   CreateNodesResult,
@@ -55,7 +54,7 @@ function writeTargetsToCache(
   });
 }
 
-export const createNodesV2: CreateNodesV2<ReactNativePluginOptions> = [
+export const createNodes: CreateNodesV2<ReactNativePluginOptions> = [
   '**/app.{json,config.js,config.ts}',
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
@@ -79,28 +78,7 @@ export const createNodesV2: CreateNodesV2<ReactNativePluginOptions> = [
   },
 ];
 
-export const createNodes: CreateNodes<ReactNativePluginOptions> = [
-  '**/app.{json,config.js,config.ts}',
-  async (configFilePath, options, context) => {
-    const optionsHash = hashObject(options);
-    const cachePath = join(
-      workspaceDataDirectory,
-      `react-native-${optionsHash}.hash`
-    );
-
-    const targetsCache = readTargetsCache(cachePath);
-    const result = await createNodesInternal(
-      configFilePath,
-      options,
-      context,
-      targetsCache
-    );
-
-    writeTargetsToCache(cachePath, targetsCache);
-
-    return result;
-  },
-];
+export const createNodesV2 = createNodes;
 
 async function createNodesInternal(
   configFile: string,

--- a/packages/react-native/plugins/plugin.ts
+++ b/packages/react-native/plugins/plugin.ts
@@ -135,7 +135,7 @@ async function createNodesInternal(
 function buildReactNativeTargets(
   projectRoot: string,
   options: ReactNativePluginOptions,
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ) {
   const namedInputs = getNamedInputs(projectRoot, context);
 
@@ -196,7 +196,7 @@ function buildReactNativeTargets(
 
 function getAppConfig(
   configFilePath: string,
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ): Promise<any> {
   const resolvedPath = join(context.workspaceRoot, configFilePath);
 

--- a/packages/react/src/plugins/router-plugin.spec.ts
+++ b/packages/react/src/plugins/router-plugin.spec.ts
@@ -38,7 +38,6 @@ describe('@nx/react/react-router-plugin', () => {
           },
         },
         workspaceRoot: tempFs.tempDir,
-        configFiles: [],
       };
 
       await tempFs.createFiles({

--- a/packages/react/src/plugins/router-plugin.spec.ts
+++ b/packages/react/src/plugins/router-plugin.spec.ts
@@ -1,4 +1,4 @@
-import { type CreateNodesContext } from '@nx/devkit';
+import { type CreateNodesContextV2 } from '@nx/devkit';
 import { createNodesV2 } from './router-plugin';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
@@ -16,7 +16,7 @@ jest.mock('@nx/js/src/utils/typescript/ts-solution-setup', () => ({
 
 describe('@nx/react/react-router-plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   let tempFs: TempFs;
   let cwd: string;
 
@@ -87,7 +87,7 @@ describe('@nx/react/react-router-plugin', () => {
     });
   });
 
-  function mockConfig(path: string, config, context: CreateNodesContext) {
+  function mockConfig(path: string, config, context: CreateNodesContextV2) {
     jest.mock(join(context.workspaceRoot, path), () => config, {
       virtual: true,
     });

--- a/packages/react/src/plugins/router-plugin.ts
+++ b/packages/react/src/plugins/router-plugin.ts
@@ -9,7 +9,6 @@ import {
   getPackageManagerCommand,
   joinPathFragments,
   type ProjectConfiguration,
-  type CreateNodesContextV2,
 } from '@nx/devkit';
 
 import { dirname, join } from 'path';

--- a/packages/react/src/plugins/router-plugin.ts
+++ b/packages/react/src/plugins/router-plugin.ts
@@ -1,6 +1,6 @@
 import {
   type CreateNodesV2,
-  type CreateNodesContext,
+  type CreateNodesContextV2,
   detectPackageManager,
   readJsonFile,
   type TargetConfiguration,
@@ -150,7 +150,7 @@ async function buildReactRouterTargets(
   configFilePath: string,
   projectRoot: string,
   options: ReactRouterPluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   siblingFiles: string[],
   isUsingTsSolutionSetup: boolean
 ): Promise<ReactRouterTargets> {
@@ -362,7 +362,7 @@ function normalizeOptions(options: ReactRouterPluginOptions) {
 
 function checkIfConfigFileShouldBeProject(
   projectRoot: string,
-  context: CreateNodesContext | CreateNodesContextV2
+  context: CreateNodesContextV2
 ): boolean {
   // Do not create a project if package.json and project.json isn't there.
   const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));

--- a/packages/remix/src/plugins/plugin.spec.ts
+++ b/packages/remix/src/plugins/plugin.spec.ts
@@ -57,7 +57,6 @@ describe('@nx/remix/plugin', () => {
             },
           },
           workspaceRoot: tempFs.tempDir,
-          configFiles: [],
         };
         tempFs.createFileSync(
           'package.json',
@@ -117,7 +116,6 @@ module.exports = {
             },
           },
           workspaceRoot: tempFs.tempDir,
-          configFiles: [],
         };
 
         tempFs.createFileSync(
@@ -298,7 +296,6 @@ module.exports = {
             },
           },
           workspaceRoot: tempFs.tempDir,
-          configFiles: [],
         };
         tempFs.createFileSync(
           'package.json',
@@ -365,7 +362,6 @@ module.exports = {
             },
           },
           workspaceRoot: tempFs.tempDir,
-          configFiles: [],
         };
 
         tempFs.createFileSync(

--- a/packages/remix/src/plugins/plugin.spec.ts
+++ b/packages/remix/src/plugins/plugin.spec.ts
@@ -1,5 +1,5 @@
 import {
-  type CreateNodesContext,
+  type CreateNodesContextV2,
   detectPackageManager,
   joinPathFragments,
 } from '@nx/devkit';
@@ -22,7 +22,7 @@ jest.mock('@nx/js/src/utils/typescript/ts-solution-setup', () => ({
 
 describe('@nx/remix/plugin', () => {
   let createNodesFunction = createNodes[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   let cwd = process.cwd();
 
   beforeEach(() => {

--- a/packages/remix/src/plugins/plugin.ts
+++ b/packages/remix/src/plugins/plugin.ts
@@ -2,7 +2,7 @@ import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { hashObject } from 'nx/src/hasher/file-hasher';
 import {
   type CreateDependencies,
-  type CreateNodesContext,
+  type CreateNodesContextV2,
   createNodesFromFiles,
   CreateNodesV2,
   detectPackageManager,
@@ -91,7 +91,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFilePath: string,
   options: RemixPluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   targetsCache: Record<string, RemixTargets>,
   isUsingTsSolutionSetup: boolean
 ) {
@@ -154,7 +154,7 @@ async function buildRemixTargets(
   configFilePath: string,
   projectRoot: string,
   options: RemixPluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   siblingFiles: string[],
   remixCompiler: RemixCompiler,
   isUsingTsSolutionSetup: boolean

--- a/packages/remix/src/plugins/plugin.ts
+++ b/packages/remix/src/plugins/plugin.ts
@@ -2,14 +2,12 @@ import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { hashObject } from 'nx/src/hasher/file-hasher';
 import {
   type CreateDependencies,
-  type CreateNodes,
   type CreateNodesContext,
   createNodesFromFiles,
   CreateNodesV2,
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
-  logger,
   ProjectConfiguration,
   readJsonFile,
   type TargetConfiguration,
@@ -62,7 +60,7 @@ export const createDependencies: CreateDependencies = () => {
 
 const remixConfigGlob = '**/{remix,vite}.config.{js,cjs,mjs,ts,cts,mts}';
 
-export const createNodesV2: CreateNodesV2<RemixPluginOptions> = [
+export const createNodes: CreateNodesV2<RemixPluginOptions> = [
   remixConfigGlob,
   async (configFilePaths, options, context) => {
     const optionsHash = hashObject(options);
@@ -88,21 +86,7 @@ export const createNodesV2: CreateNodesV2<RemixPluginOptions> = [
   },
 ];
 
-export const createNodes: CreateNodes<RemixPluginOptions> = [
-  remixConfigGlob,
-  async (configFilePath, options, context) => {
-    logger.warn(
-      '`createNodes` is deprecated. Update your plugin to utilize createNodesV2 instead. In Nx 20, this will change to the createNodesV2 API.'
-    );
-    return createNodesInternal(
-      configFilePath,
-      options,
-      context,
-      {},
-      _isUsingTsSolutionSetup()
-    );
-  },
-];
+export const createNodesV2 = createNodes;
 
 async function createNodesInternal(
   configFilePath: string,

--- a/packages/rollup/src/plugins/plugin.spec.ts
+++ b/packages/rollup/src/plugins/plugin.spec.ts
@@ -46,7 +46,6 @@ describe('@nx/rollup/plugin', () => {
           },
         },
         workspaceRoot: tempFs.tempDir,
-        configFiles: [],
       };
       const rollupConfigOptions = {
         options: [
@@ -114,7 +113,6 @@ describe('@nx/rollup/plugin', () => {
           },
         },
         workspaceRoot: tempFs.tempDir,
-        configFiles: [],
       };
       const rollupConfigOptions = {
         options: [

--- a/packages/rollup/src/plugins/plugin.spec.ts
+++ b/packages/rollup/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { type CreateNodesContext } from '@nx/devkit';
+import { type CreateNodesContextV2 } from '@nx/devkit';
 import { createNodesV2 } from './plugin';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 
@@ -25,7 +25,7 @@ jest.mock('@nx/js/src/utils/typescript/ts-solution-setup', () => ({
 
 describe('@nx/rollup/plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   let cwd = process.cwd();
 
   describe.each(['js', 'ts'])('root project', (extname) => {

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -3,7 +3,7 @@ import { basename, dirname, join } from 'path';
 import { existsSync, readdirSync } from 'fs';
 import {
   type CreateDependencies,
-  CreateNodesContext,
+  CreateNodesContextV2,
   createNodesFromFiles,
   CreateNodesV2,
   detectPackageManager,
@@ -88,7 +88,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFilePath: string,
   options: Required<RollupPluginOptions>,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   targetsCache: Record<string, Record<string, TargetConfiguration>>,
   isTsSolutionSetup: boolean
 ) {
@@ -133,7 +133,7 @@ async function buildRollupTarget(
   configFilePath: string,
   projectRoot: string,
   options: RollupPluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   isTsSolutionSetup: boolean
 ): Promise<Record<string, TargetConfiguration>> {
   let loadConfigFile: (

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -3,14 +3,12 @@ import { basename, dirname, join } from 'path';
 import { existsSync, readdirSync } from 'fs';
 import {
   type CreateDependencies,
-  type CreateNodes,
   CreateNodesContext,
   createNodesFromFiles,
   CreateNodesV2,
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
-  logger,
   readJsonFile,
   type TargetConfiguration,
   writeJsonFile,
@@ -53,23 +51,7 @@ export interface RollupPluginOptions {
 
 const rollupConfigGlob = '**/rollup.config.{js,cjs,mjs,ts,cts,mts}';
 
-export const createNodes: CreateNodes<RollupPluginOptions> = [
-  rollupConfigGlob,
-  async (configFilePath, options, context) => {
-    logger.warn(
-      '`createNodes` is deprecated. Update your plugin to utilize createNodesV2 instead. In Nx 20, this will change to the createNodesV2 API.'
-    );
-    return createNodesInternal(
-      configFilePath,
-      normalizeOptions(options),
-      context,
-      {},
-      isUsingTsSolutionSetup()
-    );
-  },
-];
-
-export const createNodesV2: CreateNodesV2<RollupPluginOptions> = [
+export const createNodes: CreateNodesV2<RollupPluginOptions> = [
   rollupConfigGlob,
   async (configFilePaths, options, context) => {
     const normalizedOptions = normalizeOptions(options);
@@ -100,6 +82,8 @@ export const createNodesV2: CreateNodesV2<RollupPluginOptions> = [
     }
   },
 ];
+
+export const createNodesV2 = createNodes;
 
 async function createNodesInternal(
   configFilePath: string,

--- a/packages/rsbuild/src/plugins/plugin.spec.ts
+++ b/packages/rsbuild/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { type CreateNodesContext } from '@nx/devkit';
+import { type CreateNodesContextV2 } from '@nx/devkit';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { createNodesV2 } from './plugin';
@@ -18,7 +18,7 @@ jest.mock('@nx/js/src/utils/typescript/ts-solution-setup', () => ({
 
 describe('@nx/rsbuild', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   let tempFs: TempFs;
 
   beforeEach(() => {

--- a/packages/rsbuild/src/plugins/plugin.spec.ts
+++ b/packages/rsbuild/src/plugins/plugin.spec.ts
@@ -25,7 +25,6 @@ describe('@nx/rsbuild', () => {
     (isUsingTsSolutionSetup as jest.Mock).mockReturnValue(false);
     tempFs = new TempFs('rsbuild-test');
     context = {
-      configFiles: [],
       nxJsonConfiguration: {
         namedInputs: {
           default: ['{projectRoot}/**/*'],

--- a/packages/rsbuild/src/plugins/plugin.ts
+++ b/packages/rsbuild/src/plugins/plugin.ts
@@ -4,7 +4,7 @@ import {
   readJsonFile,
   writeJsonFile,
   CreateNodesV2,
-  CreateNodesContext,
+  CreateNodesContextV2,
   createNodesFromFiles,
   joinPathFragments,
   getPackageManagerCommand,
@@ -82,7 +82,7 @@ export const createNodesV2: CreateNodesV2<RsbuildPluginOptions> = [
 async function createNodesInternal(
   configFilePath: string,
   options: RsbuildPluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   targetsCache: Record<string, RsbuildTargets>,
   isUsingTsSolutionSetup: boolean
 ) {
@@ -135,7 +135,7 @@ async function createRsbuildTargets(
   options: RsbuildPluginOptions,
   tsConfigFiles: string[],
   isUsingTsSolutionSetup: boolean,
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ): Promise<RsbuildTargets> {
   const absoluteConfigFilePath = joinPathFragments(
     context.workspaceRoot,

--- a/packages/rspack/src/plugins/plugin.spec.ts
+++ b/packages/rspack/src/plugins/plugin.spec.ts
@@ -18,7 +18,6 @@ describe('@nx/rspack', () => {
     (isUsingTsSolutionSetup as jest.Mock).mockReturnValue(false);
     tempFs = new TempFs('rspack-test');
     context = {
-      configFiles: [],
       nxJsonConfiguration: {
         namedInputs: {
           default: ['{projectRoot}/**/*'],

--- a/packages/rspack/src/plugins/plugin.spec.ts
+++ b/packages/rspack/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { type CreateNodesContext } from '@nx/devkit';
+import { type CreateNodesContextV2 } from '@nx/devkit';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { createNodesV2 } from './plugin';
@@ -10,7 +10,7 @@ jest.mock('@nx/js/src/utils/typescript/ts-solution-setup', () => ({
 
 describe('@nx/rspack', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   let tempFs: TempFs;
   let originalCacheProjectGraph = process.env.NX_CACHE_PROJECT_GRAPH;
 

--- a/packages/rspack/src/plugins/plugin.ts
+++ b/packages/rspack/src/plugins/plugin.ts
@@ -1,6 +1,6 @@
 import {
   CreateDependencies,
-  CreateNodesContext,
+  CreateNodesContextV2,
   createNodesFromFiles,
   CreateNodesV2,
   detectPackageManager,
@@ -90,7 +90,7 @@ export const createNodesV2: CreateNodesV2<RspackPluginOptions> = [
 async function createNodesInternal(
   configFilePath: string,
   options: RspackPluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   targetsCache: Record<string, RspackTargets>,
   isTsSolutionSetup: boolean
 ) {
@@ -156,7 +156,7 @@ async function createRspackTargets(
   configFilePath: string,
   projectRoot: string,
   options: RspackPluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   isTsSolutionSetup: boolean
 ): Promise<RspackTargets> {
   const namedInputs = getNamedInputs(projectRoot, context);

--- a/packages/storybook/src/plugins/plugin.spec.ts
+++ b/packages/storybook/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContext } from '@nx/devkit';
+import { CreateNodesContextV2 } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import type { StorybookConfig } from 'storybook/internal/types';
 import { join } from 'node:path';
@@ -6,7 +6,7 @@ import { createNodesV2 } from './plugin';
 
 describe('@nx/storybook/plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   let tempFs: TempFs;
 
   beforeEach(async () => {

--- a/packages/storybook/src/plugins/plugin.spec.ts
+++ b/packages/storybook/src/plugins/plugin.spec.ts
@@ -19,7 +19,6 @@ describe('@nx/storybook/plugin', () => {
         },
       },
       workspaceRoot: tempFs.tempDir,
-      configFiles: [],
     };
     tempFs.createFileSync('package.json', JSON.stringify({ name: 'repo' }));
     tempFs.createFileSync(

--- a/packages/storybook/src/plugins/plugin.ts
+++ b/packages/storybook/src/plugins/plugin.ts
@@ -1,12 +1,10 @@
 import {
   CreateDependencies,
-  CreateNodes,
   CreateNodesContext,
   createNodesFromFiles,
   CreateNodesV2,
   detectPackageManager,
   joinPathFragments,
-  logger,
   parseJson,
   readJsonFile,
   TargetConfiguration,
@@ -52,7 +50,7 @@ export const createDependencies: CreateDependencies = () => {
 
 const storybookConfigGlob = '**/.storybook/main.{js,ts,mjs,mts,cjs,cts}';
 
-export const createNodesV2: CreateNodesV2<StorybookPluginOptions> = [
+export const createNodes: CreateNodesV2<StorybookPluginOptions> = [
   storybookConfigGlob,
   async (configFilePaths, options, context) => {
     const normalizedOptions = normalizeOptions(options);
@@ -82,20 +80,7 @@ export const createNodesV2: CreateNodesV2<StorybookPluginOptions> = [
   },
 ];
 
-export const createNodes: CreateNodes<StorybookPluginOptions> = [
-  storybookConfigGlob,
-  (configFilePath, options, context) => {
-    logger.warn(
-      '`createNodes` is deprecated. Update your plugin to utilize createNodesV2 instead. In Nx 20, this will change to the createNodesV2 API.'
-    );
-    return createNodesInternal(
-      configFilePath,
-      normalizeOptions(options),
-      context,
-      {}
-    );
-  },
-];
+export const createNodesV2 = createNodes;
 
 async function createNodesInternal(
   configFilePath: string,

--- a/packages/storybook/src/plugins/plugin.ts
+++ b/packages/storybook/src/plugins/plugin.ts
@@ -313,7 +313,7 @@ function serveStaticTarget(
 
 async function getStorybookFramework(
   configFilePath: string,
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ): Promise<string | undefined> {
   const resolvedPath = join(context.workspaceRoot, configFilePath);
   const mainTsJs = readFileSync(resolvedPath, 'utf-8');
@@ -370,7 +370,7 @@ function parseFrameworkName(mainTsJs: string) {
 
 async function getStorybookFullyResolvedFramework(
   configFilePath: string,
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ): Promise<string> {
   const resolvedPath = join(context.workspaceRoot, configFilePath);
   const { framework } = await loadConfigFile<StorybookConfig>(resolvedPath);

--- a/packages/storybook/src/plugins/plugin.ts
+++ b/packages/storybook/src/plugins/plugin.ts
@@ -1,6 +1,6 @@
 import {
   CreateDependencies,
-  CreateNodesContext,
+  CreateNodesContextV2,
   createNodesFromFiles,
   CreateNodesV2,
   detectPackageManager,
@@ -85,7 +85,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFilePath: string,
   options: Required<StorybookPluginOptions>,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   targetsCache: Record<string, Record<string, TargetConfiguration>>
 ) {
   let projectRoot = '';
@@ -141,7 +141,7 @@ async function buildStorybookTargets(
   configFilePath: string,
   projectRoot: string,
   options: StorybookPluginOptions,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   projectName: string
 ) {
   const buildOutputs = getOutputs();

--- a/packages/vite/src/plugins/plugin-vitest.spec.ts
+++ b/packages/vite/src/plugins/plugin-vitest.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContext } from '@nx/devkit';
+import { CreateNodesContextV2 } from '@nx/devkit';
 import { createNodesV2 } from './plugin';
 
 // Mock fs to provide stable test environment
@@ -53,7 +53,7 @@ jest.mock('../utils/executor-utils', () => ({
 
 describe('@nx/vite/plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   describe('root project', () => {
     beforeEach(async () => {
       context = {

--- a/packages/vite/src/plugins/plugin-vitest.spec.ts
+++ b/packages/vite/src/plugins/plugin-vitest.spec.ts
@@ -57,7 +57,6 @@ describe('@nx/vite/plugin', () => {
   describe('root project', () => {
     beforeEach(async () => {
       context = {
-        configFiles: [],
         nxJsonConfiguration: {
           targetDefaults: {},
           namedInputs: {

--- a/packages/vite/src/plugins/plugin-with-test.spec.ts
+++ b/packages/vite/src/plugins/plugin-with-test.spec.ts
@@ -19,7 +19,6 @@ describe('@nx/vite/plugin with test node', () => {
   describe('root project', () => {
     beforeEach(async () => {
       context = {
-        configFiles: [],
         nxJsonConfiguration: {
           // These defaults should be overridden by plugin
           targetDefaults: {

--- a/packages/vite/src/plugins/plugin-with-test.spec.ts
+++ b/packages/vite/src/plugins/plugin-with-test.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContext } from '@nx/devkit';
+import { CreateNodesContextV2 } from '@nx/devkit';
 import { createNodes, createNodesV2 } from './plugin';
 
 // This will only create test targets since no build targets are defined in vite.config.ts
@@ -15,7 +15,7 @@ jest.mock('../utils/executor-utils', () => ({
 
 describe('@nx/vite/plugin with test node', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   describe('root project', () => {
     beforeEach(async () => {
       context = {

--- a/packages/vite/src/plugins/plugin.spec.ts
+++ b/packages/vite/src/plugins/plugin.spec.ts
@@ -28,7 +28,6 @@ describe('@nx/vite/plugin', () => {
     beforeEach(async () => {
       tempFs = new TempFs('vite-plugin-tests');
       context = {
-        configFiles: [],
         nxJsonConfiguration: {
           // These defaults should be overridden by plugin
           targetDefaults: {
@@ -247,7 +246,6 @@ describe('@nx/vite/plugin', () => {
     beforeEach(() => {
       tempFs = new TempFs('test');
       context = {
-        configFiles: [],
         nxJsonConfiguration: {
           namedInputs: {
             default: ['{projectRoot}/**/*'],
@@ -334,7 +332,6 @@ describe('@nx/vite/plugin', () => {
         }),
       }),
         (context = {
-          configFiles: [],
           nxJsonConfiguration: {
             namedInputs: {
               default: ['{projectRoot}/**/*'],
@@ -378,7 +375,6 @@ describe('@nx/vite/plugin', () => {
         }),
       }),
         (context = {
-          configFiles: [],
           nxJsonConfiguration: {
             namedInputs: {
               default: ['{projectRoot}/**/*'],

--- a/packages/vite/src/plugins/plugin.spec.ts
+++ b/packages/vite/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContext } from '@nx/devkit';
+import { CreateNodesContextV2 } from '@nx/devkit';
 import { createNodesV2 } from './plugin';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { loadViteDynamicImport } from '../utils/executor-utils';
@@ -17,7 +17,7 @@ jest.mock('@nx/js/src/utils/typescript/ts-solution-setup', () => ({
 
 describe('@nx/vite/plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
 
   beforeEach(() => {
     (isUsingTsSolutionSetup as jest.Mock).mockReturnValue(false);

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -1,6 +1,5 @@
 import {
   CreateDependencies,
-  CreateNodesContext,
   CreateNodesContextV2,
   createNodesFromFiles,
   CreateNodesV2,
@@ -182,7 +181,7 @@ async function buildViteTargets(
   tsConfigFiles: string[],
   hasReactRouterConfig: boolean,
   isUsingTsSolutionSetup: boolean,
-  context: CreateNodesContext
+  context: CreateNodesContextV2
 ): Promise<ViteTargets> {
   const absoluteConfigFilePath = joinPathFragments(
     context.workspaceRoot,
@@ -571,7 +570,7 @@ function normalizeOptions(options: VitePluginOptions): VitePluginOptions {
 
 function checkIfConfigFileShouldBeProject(
   projectRoot: string,
-  context: CreateNodesContext | CreateNodesContextV2
+  context: CreateNodesContextV2
 ): boolean {
   // Do not create a project if package.json and project.json isn't there.
   const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));

--- a/packages/webpack/src/plugins/plugin.spec.ts
+++ b/packages/webpack/src/plugins/plugin.spec.ts
@@ -32,7 +32,6 @@ describe('@nx/webpack/plugin', () => {
         },
       },
       workspaceRoot: tempFs.tempDir,
-      configFiles: [],
     };
 
     tempFs.createFileSync(

--- a/packages/webpack/src/plugins/plugin.spec.ts
+++ b/packages/webpack/src/plugins/plugin.spec.ts
@@ -11,14 +11,14 @@ jest.mock('@nx/js/src/utils/typescript/ts-solution-setup', () => ({
   isUsingTsSolutionSetup: jest.fn(() => false),
 }));
 
-import { CreateNodesContext } from '@nx/devkit';
+import { CreateNodesContextV2 } from '@nx/devkit';
 import { createNodesV2 } from './plugin';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { join } from 'path';
 
 describe('@nx/webpack/plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContext;
+  let context: CreateNodesContextV2;
   let tempFs: TempFs;
 
   beforeEach(() => {

--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -1,6 +1,6 @@
 import {
   CreateDependencies,
-  CreateNodesContext,
+  CreateNodesContextV2,
   createNodesFromFiles,
   CreateNodesResult,
   CreateNodesV2,
@@ -93,7 +93,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFilePath: string,
   options: Required<WebpackPluginOptions>,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   targetsCache: Record<string, WebpackTargets>,
   isTsSolutionSetup: boolean
 ): Promise<CreateNodesResult> {
@@ -140,7 +140,7 @@ async function createWebpackTargets(
   configFilePath: string,
   projectRoot: string,
   options: Required<WebpackPluginOptions>,
-  context: CreateNodesContext,
+  context: CreateNodesContextV2,
   isTsSolutionSetup: boolean
 ): Promise<WebpackTargets> {
   const namedInputs = getNamedInputs(projectRoot, context);

--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -1,13 +1,11 @@
 import {
   CreateDependencies,
-  CreateNodes,
   CreateNodesContext,
   createNodesFromFiles,
   CreateNodesResult,
   CreateNodesV2,
   detectPackageManager,
   getPackageManagerCommand,
-  logger,
   ProjectConfiguration,
   readJsonFile,
   TargetConfiguration,
@@ -59,7 +57,7 @@ export const createDependencies: CreateDependencies = () => {
 
 const webpackConfigGlob = '**/webpack.config.{js,ts,mjs,cjs}';
 
-export const createNodesV2: CreateNodesV2<WebpackPluginOptions> = [
+export const createNodes: CreateNodesV2<WebpackPluginOptions> = [
   webpackConfigGlob,
   async (configFilePaths, options, context) => {
     const optionsHash = hashObject(options);
@@ -90,22 +88,7 @@ export const createNodesV2: CreateNodesV2<WebpackPluginOptions> = [
   },
 ];
 
-export const createNodes: CreateNodes<WebpackPluginOptions> = [
-  webpackConfigGlob,
-  async (configFilePath, options, context) => {
-    logger.warn(
-      '`createNodes` is deprecated. Update your plugin to utilize createNodesV2 instead. In Nx 20, this will change to the createNodesV2 API.'
-    );
-    const normalizedOptions = normalizeOptions(options);
-    return createNodesInternal(
-      configFilePath,
-      normalizedOptions,
-      context,
-      {},
-      isUsingTsSolutionSetup()
-    );
-  },
-];
+export const createNodesV2 = createNodes;
 
 async function createNodesInternal(
   configFilePath: string,


### PR DESCRIPTION
Remove the old CreateNodes v1 signature and related types from the public API.
This standardizes on CreateNodesV2 as the primary interface.

Related to Nx 22 createNodes v2 compatibility work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com><!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
