### PR TITLE
chore(core): update CI to node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 24.9
           cache: 'pnpm'
 
       - name: Install Rust
@@ -269,7 +269,7 @@ jobs:
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 24.9
           cache: 'pnpm'
 
       - name: Install Rust

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -14,8 +14,21 @@ launch-templates:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
 
+      - name: Install Node
+        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-node/main.yaml'
+        inputs:
+          node_version: '24.9'
+
       - name: Check Node Version
         script: node --version
+
+      - name: Set NODE_OPTIONS for Node 24
+        script: |
+          if [ -n "$NODE_OPTIONS" ]; then
+            echo "NODE_OPTIONS=$NODE_OPTIONS --no-experimental-strip-types" >> $NX_CLOUD_ENV
+          else
+            echo "NODE_OPTIONS=--no-experimental-strip-types" >> $NX_CLOUD_ENV
+          fi
 
       - name: Cache restore
         uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/cache/main.yaml'
@@ -95,8 +108,21 @@ launch-templates:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
 
+      - name: Install Node
+        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-node/main.yaml'
+        inputs:
+          node_version: '24.9'
+
       - name: Check Node Version
         script: node --version
+
+      - name: Set NODE_OPTIONS for Node 24
+        script: |
+          if [ -n "$NODE_OPTIONS" ]; then
+            echo "NODE_OPTIONS=$NODE_OPTIONS --no-experimental-strip-types" >> $NX_CLOUD_ENV
+          else
+            echo "NODE_OPTIONS=--no-experimental-strip-types" >> $NX_CLOUD_ENV
+          fi
 
       - name: Cache restore
         uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/cache/main.yaml'

--- a/e2e/release/src/custom-registries.test.ts
+++ b/e2e/release/src/custom-registries.test.ts
@@ -1,6 +1,5 @@
 import { NxJsonConfiguration, ProjectConfiguration } from '@nx/devkit';
 import {
-  cleanupProject,
   createFile,
   killProcessAndPorts,
   newProject,
@@ -20,16 +19,28 @@ describe('nx release - custom npm registries', () => {
   const scope = 'scope';
   let previousPackageManager: string;
 
+  let e2eRegistryHost: string;
+
   beforeAll(async () => {
     previousPackageManager = process.env.SELECTED_PM;
     // We are testing some more advanced scoped registry features that only npm has within this file
     process.env.SELECTED_PM = 'npm';
+
     newProject({
       packages: ['@nx/js'],
     });
+
+    // Get the e2e registry URL and parse it for auth token setup AFTER project is created
+    const e2eRegistryUrl = execSync('npm config get registry')
+      .toString()
+      .trim();
+    // Remove http:// or https:// and trailing slash to get just //host:port format for npm config
+    e2eRegistryHost = e2eRegistryUrl
+      .replace(/^https?:\/\//, '//')
+      .replace(/\/$/, '');
   }, 60000);
+
   afterAll(() => {
-    cleanupProject();
     process.env.SELECTED_PM = previousPackageManager;
   });
 
@@ -45,11 +56,25 @@ describe('nx release - custom npm registries', () => {
       .toString()
       .trim();
 
+    const e2eRegistryHost = e2eRegistryUrl
+      .replace(/^https?:\/\//, '//')
+      .replace(/\/$/, '');
+
     const npmrcEntries = [
       `@${scope}:registry=http://scoped-registry.com`,
       'tag=next',
       // We can't test overriding the default registry in this file since our e2e tests override it anyway.
       // Instead, we'll just assert that the e2e registry is used anytime we expect the default registry
+      '',
+      // Add auth tokens for all registries (required for NPM 11)
+      `${e2eRegistryHost}/:_authToken=test-auth-token`,
+      '//publish-config-registry.com/:_authToken=test-auth-token',
+      '//default-override-registy.com/:_authToken=test-auth-token',
+      '//scope-override-registry.com/:_authToken=test-auth-token',
+      '//scope-override-arg-registry.com/:_authToken=test-auth-token',
+      '//default-override-arg-registry.com/:_authToken=test-auth-token',
+      '//ignored-registry.com/:_authToken=test-auth-token',
+      '//scoped-registry.com/:_authToken=test-auth-token',
     ];
     createFile('.npmrc', npmrcEntries.join('\n'));
 
@@ -212,6 +237,11 @@ describe('nx release - custom npm registries', () => {
       `@${scope}:registry=${customRegistryUrl}`,
       `registry=http://ignored-registry.com`,
       'tag=next',
+      '',
+      // Add auth tokens for all registries (required for NPM 11)
+      `//localhost:${verdaccioPort}/:_authToken=test-auth-token`,
+      `${e2eRegistryHost}/:_authToken=test-auth-token`,
+      '//ignored-registry.com/:_authToken=test-auth-token',
     ];
     updateFile('.npmrc', npmrcEntries2.join('\n'));
 
@@ -339,7 +369,7 @@ describe('nx release - custom npm registries', () => {
         )
       ).length
     ).toBe(1);
-  }, 600000);
+  }, 1_000_000);
 
   function newPackage(
     name: string,

--- a/e2e/release/src/preserve-local-dependency-protocols.test.ts
+++ b/e2e/release/src/preserve-local-dependency-protocols.test.ts
@@ -67,6 +67,8 @@ describe('nx release preserve local dependency protocols', () => {
     previousPackageManager = process.env.SELECTED_PM;
     // This is the verdaccio instance that the e2e tests themselves are working from
     e2eRegistryUrl = execSync('npm config get registry').toString().trim();
+    // Ignore NPM warnings as to not affect snapshots
+    execSync('npm config set loglevel error');
   });
 
   afterEach(() => cleanupProject());

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -1290,8 +1290,10 @@ describe('TargetProjectLocator', () => {
 
 describe('isBuiltinModuleImport()', () => {
   const withExclusions = builtinModules
-    .concat(builtinModules.filter((a) => true).map((s) => 'node:' + s))
-    .concat(['node:test', 'node:sqlite', 'node:test']);
+    .concat(
+      builtinModules.map((s) => (s.startsWith('node:') ? s : 'node:' + s))
+    )
+    .concat(['node:test', 'node:sqlite']);
 
   it.each(withExclusions)(
     `should return true for %s builtin module`,


### PR DESCRIPTION
- Update CI workflows to use Node 24
- Update Nx Cloud agents to use Node 24
- Configure NODE_OPTIONS with --no-experimental-strip-types flag to avoid config transpile errors
- Fixes for tests

