### PR TITLE
docs(linter): show flat config in docs

### DIFF
--- a/astro-docs/src/content/docs/concepts/Decisions/project-dependency-rules.mdoc
+++ b/astro-docs/src/content/docs/concepts/Decisions/project-dependency-rules.mdoc
@@ -114,7 +114,7 @@ export { formatCurrency } from './src/format-currency';
 
 In order to enforce the dependency constraints that were listed for each type, you can add the following rule in your ESLint configuration:
 
-{% tabs %}
+{% tabs syncKey="eslint-config-preference" %}
 {% tabitem label="Flat Config" %}
 
 ```javascript

--- a/astro-docs/src/content/docs/concepts/Decisions/project-dependency-rules.mdoc
+++ b/astro-docs/src/content/docs/concepts/Decisions/project-dependency-rules.mdoc
@@ -112,9 +112,59 @@ export { formatCurrency } from './src/format-currency';
 
 ## Enforce Project Dependency Rules
 
-In order to enforce the dependency constraints that were listed for each type, you can add the following rule in the root `.eslintrc.json` file:
+In order to enforce the dependency constraints that were listed for each type, you can add the following rule in your ESLint configuration:
 
-```json title="/.eslintrc.json"
+{% tabs %}
+{% tabitem label="Flat Config" %}
+
+```javascript
+// eslint.config.mjs
+import nx from '@nx/eslint-plugin';
+
+export default [
+  ...nx.configs['flat/base'],
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
+  {
+    ignores: ['**/dist'],
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      '@nx/enforce-module-boundaries': [
+        'error',
+        {
+          allow: [],
+          depConstraints: [
+            {
+              sourceTag: 'type:feature',
+              onlyDependOnLibsWithTags: [
+                'type:feature',
+                'type:ui',
+                'type:util',
+              ],
+            },
+            {
+              sourceTag: 'type:ui',
+              onlyDependOnLibsWithTags: ['type:ui', 'type:util'],
+            },
+            {
+              sourceTag: 'type:util',
+              onlyDependOnLibsWithTags: ['type:util'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+```
+
+{% /tabitem %}
+{% tabitem label="Legacy (.eslintrc.json)" %}
+
+```json
+// .eslintrc.json
 {
   "root": true,
   "ignorePatterns": ["**/*"],
@@ -152,6 +202,9 @@ In order to enforce the dependency constraints that were listed for each type, y
   ]
 }
 ```
+
+{% /tabitem %}
+{% /tabs %}
 
 ## Other Types
 

--- a/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
+++ b/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
@@ -107,7 +107,35 @@ For JavaScript/TypeScript projects, configure the `@nx/enforce-module-boundaries
 nx add @nx/eslint-plugin @nx/devkit
 ```
 
-Update your root `.eslintrc.json` file:
+And configure the rule in your ESLint configuration:
+
+{% tabs %}
+{% tabitem label="Flat Config" %}
+
+```javascript
+// eslint.config.mjs
+import nx from '@nx/eslint-plugin';
+
+export default [
+  ...nx.configs['flat/base'],
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      '@nx/enforce-module-boundaries': [
+        'error',
+        {
+          /* options */
+        },
+      ],
+    },
+  },
+];
+```
+
+{% /tabitem %}
+{% tabitem label="Legacy (.eslintrc.json)" %}
 
 ```jsonc
 // .eslintrc.json
@@ -140,6 +168,9 @@ Update your root `.eslintrc.json` file:
   // ... more ESLint config here
 }
 ```
+
+{% /tabitem %}
+{% /tabs %}
 
 If you violate the constraints, you will get an error when linting:
 

--- a/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
+++ b/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
@@ -98,7 +98,7 @@ First, use your project configuration (in `project.json` or `package.json`) to a
 
 Once you have tagged your projects, configure the dependency constraints based on your chosen approach:
 
-{% tabs %}
+{% tabs syncKey="eslint-config-preference" %}
 {% tabitem label="ESLint" %}
 
 For JavaScript/TypeScript projects, configure the `@nx/enforce-module-boundaries` ESLint rule:
@@ -109,7 +109,7 @@ nx add @nx/eslint-plugin @nx/devkit
 
 And configure the rule in your ESLint configuration:
 
-{% tabs %}
+{% tabs syncKey="eslint-config-preference" %}
 {% tabitem label="Flat Config" %}
 
 ```javascript

--- a/astro-docs/src/content/docs/guides/Enforce Module Boundaries/ban-external-imports.mdoc
+++ b/astro-docs/src/content/docs/guides/Enforce Module Boundaries/ban-external-imports.mdoc
@@ -10,7 +10,7 @@ You may want to constrain what external packages a project may import. For examp
 
 A common example of this is for backend projects that use NestJS and frontend projects that use Angular. Both frameworks contain a class named `Injectable`. It's very easy for a developer to import the wrong one by mistake, especially when using auto-import in an IDE. To prevent this, add tags to define the type of project to distinguish between backend and frontend projects. Each tag should define its own list of banned external imports.
 
-{% tabs %}
+{% tabs syncKey="eslint-config-preference" %}
 {% tabitem label="Flat Config" %}
 
 ```javascript
@@ -86,7 +86,7 @@ export default [
 
 Another common example is ensuring that util libraries stay framework-free by banning imports from these frameworks. You can use wildcard `*` to match multiple projects e.g. `react*` would match `react`, but also `react-dom`, `react-native` etc. You can also have multiple wildcards e.g. `*react*` would match any package with word `react` in it's name. A workspace using React would have a configuration like this.
 
-{% tabs %}
+{% tabs syncKey="eslint-config-preference" %}
 {% tabitem label="Flat Config" %}
 
 ```javascript
@@ -154,7 +154,7 @@ export default [
 If you need a more restrictive approach, you can use the `allowedExternalImports` option to ensure that a project only imports from a specific set of packages.
 This is useful if you want to enforce separation of concerns _(e.g. keeping your domain logic clean from infrastructure concerns, or ui libraries clean from data access concerns)_ or keep some parts of your codebase framework-free or library-free.
 
-{% tabs %}
+{% tabs syncKey="eslint-config-preference" %}
 {% tabitem label="Flat Config" %}
 
 ```javascript

--- a/astro-docs/src/content/docs/guides/Enforce Module Boundaries/ban-external-imports.mdoc
+++ b/astro-docs/src/content/docs/guides/Enforce Module Boundaries/ban-external-imports.mdoc
@@ -10,6 +10,47 @@ You may want to constrain what external packages a project may import. For examp
 
 A common example of this is for backend projects that use NestJS and frontend projects that use Angular. Both frameworks contain a class named `Injectable`. It's very easy for a developer to import the wrong one by mistake, especially when using auto-import in an IDE. To prevent this, add tags to define the type of project to distinguish between backend and frontend projects. Each tag should define its own list of banned external imports.
 
+{% tabs %}
+{% tabitem label="Flat Config" %}
+
+```javascript
+// eslint.config.mjs
+import nx from '@nx/eslint-plugin';
+
+export default [
+  ...nx.configs['flat/base'],
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      '@nx/enforce-module-boundaries': [
+        'error',
+        {
+          allow: [],
+          // update depConstraints based on your tags
+          depConstraints: [
+            // projects tagged with "frontend" can't import from "@nestjs/common"
+            {
+              sourceTag: 'frontend',
+              bannedExternalImports: ['@nestjs/common'],
+            },
+            // projects tagged with "backend" can't import from "@angular/core"
+            {
+              sourceTag: 'backend',
+              bannedExternalImports: ['@angular/core'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+```
+
+{% /tabitem %}
+{% tabitem label="Legacy (.eslintrc.json)" %}
+
 ```jsonc
 // .eslintrc.json
 {
@@ -40,7 +81,46 @@ A common example of this is for backend projects that use NestJS and frontend pr
 }
 ```
 
+{% /tabitem %}
+{% /tabs %}
+
 Another common example is ensuring that util libraries stay framework-free by banning imports from these frameworks. You can use wildcard `*` to match multiple projects e.g. `react*` would match `react`, but also `react-dom`, `react-native` etc. You can also have multiple wildcards e.g. `*react*` would match any package with word `react` in it's name. A workspace using React would have a configuration like this.
+
+{% tabs %}
+{% tabitem label="Flat Config" %}
+
+```javascript
+// eslint.config.mjs
+import nx from '@nx/eslint-plugin';
+
+export default [
+  ...nx.configs['flat/base'],
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      '@nx/enforce-module-boundaries': [
+        'error',
+        {
+          allow: [],
+          // update depConstraints based on your tags
+          depConstraints: [
+            // projects tagged with "type:util" can't import from "react" or related projects
+            {
+              sourceTag: 'type:util',
+              bannedExternalImports: ['*react*'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+```
+
+{% /tabitem %}
+{% tabitem label="Legacy (.eslintrc.json)" %}
 
 ```jsonc
 // .eslintrc.json
@@ -66,10 +146,63 @@ Another common example is ensuring that util libraries stay framework-free by ba
 }
 ```
 
+{% /tabitem %}
+{% /tabs %}
+
 ## Allowlist external imports with `allowedExternalImports`
 
 If you need a more restrictive approach, you can use the `allowedExternalImports` option to ensure that a project only imports from a specific set of packages.
 This is useful if you want to enforce separation of concerns _(e.g. keeping your domain logic clean from infrastructure concerns, or ui libraries clean from data access concerns)_ or keep some parts of your codebase framework-free or library-free.
+
+{% tabs %}
+{% tabitem label="Flat Config" %}
+
+```javascript
+// eslint.config.mjs
+import nx from '@nx/eslint-plugin';
+
+export default [
+  ...nx.configs['flat/base'],
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      '@nx/enforce-module-boundaries': [
+        'error',
+        {
+          allow: [],
+          // update depConstraints based on your tags
+          depConstraints: [
+            // limiting the dependencies of util libraries to the bare minimum
+            // projects tagged with "type:util" can only import from "date-fns"
+            {
+              sourceTag: 'type:util',
+              allowedExternalImports: ['date-fns'],
+            },
+            // ui libraries clean from data access concerns
+            // projects tagged with "type:ui" can only import packages matching "@angular/*" except "@angular/common/http"
+            {
+              sourceTag: 'type:ui',
+              allowedExternalImports: ['@angular/*'],
+              bannedExternalImports: ['@angular/common/http'],
+            },
+            // keeping the domain logic clean from infrastructure concerns
+            // projects tagged with "type:core" can't import any external packages.
+            {
+              sourceTag: 'type:core',
+              allowedExternalImports: [],
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+```
+
+{% /tabitem %}
+{% tabitem label="Legacy (.eslintrc.json)" %}
 
 ```jsonc
 // .eslintrc.json
@@ -90,7 +223,7 @@ This is useful if you want to enforce separation of concerns _(e.g. keeping your
           "allowedExternalImports": ["date-fns"]
         },
         // ui libraries clean from data access concerns
-        // projects tagged with "type:ui" can only import pacages matching "@angular/*" except "@angular/common/http"
+        // projects tagged with "type:ui" can only import packages matching "@angular/*" except "@angular/common/http"
         {
           "sourceTag": "type:ui",
           "allowedExternalImports": ["@angular/*"],
@@ -105,4 +238,8 @@ This is useful if you want to enforce separation of concerns _(e.g. keeping your
       ]
     }
   ]
+}
 ```
+
+{% /tabitem %}
+{% /tabs %}

--- a/astro-docs/src/content/docs/guides/Enforce Module Boundaries/tag-multiple-dimensions.mdoc
+++ b/astro-docs/src/content/docs/guides/Enforce Module Boundaries/tag-multiple-dimensions.mdoc
@@ -85,7 +85,71 @@ We can now restrict projects within the same group to depend on each other based
 - `ui` can only depend on other `ui`
 - everyone can depend on `util` including `util` itself
 
+{% tabs %}
+{% tabitem label="Flat Config" %}
+
+```javascript
+// eslint.config.mjs
+import nx from '@nx/eslint-plugin';
+
+export default [
+  ...nx.configs['flat/base'],
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      '@nx/enforce-module-boundaries': [
+        'error',
+        {
+          allow: [],
+          // update depConstraints based on your tags
+          depConstraints: [
+            {
+              sourceTag: 'scope:shared',
+              onlyDependOnLibsWithTags: ['scope:shared'],
+            },
+            {
+              sourceTag: 'scope:admin',
+              onlyDependOnLibsWithTags: ['scope:shared', 'scope:admin'],
+            },
+            {
+              sourceTag: 'scope:client',
+              onlyDependOnLibsWithTags: ['scope:shared', 'scope:client'],
+            },
+            {
+              sourceTag: 'type:app',
+              onlyDependOnLibsWithTags: [
+                'type:feature',
+                'type:ui',
+                'type:util',
+              ],
+            },
+            {
+              sourceTag: 'type:feature',
+              onlyDependOnLibsWithTags: ['type:ui', 'type:util'],
+            },
+            {
+              sourceTag: 'type:ui',
+              onlyDependOnLibsWithTags: ['type:ui', 'type:util'],
+            },
+            {
+              sourceTag: 'type:util',
+              onlyDependOnLibsWithTags: ['type:util'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+```
+
+{% /tabitem %}
+{% tabitem label="Legacy (.eslintrc.json)" %}
+
 ```jsonc
+// .eslintrc.json
 {
   // ... more ESLint config here
 
@@ -132,13 +196,64 @@ We can now restrict projects within the same group to depend on each other based
 }
 ```
 
+{% /tabitem %}
+{% /tabs %}
+
 There are no limits to the number of tags, but as you add more tags the complexity of your dependency constraints rises exponentially. It's always good to draw a diagram and carefully plan the boundaries.
 
 ## Matching multiple source tags
 
 Matching just a single source tag is sometimes not enough for solving complex restrictions. To avoid creating ad-hoc tags that are only meant for specific constraints, you can also combine multiple tags with `allSourceTags`. Each tag in the array must be matched for a constraint to be applied:
 
+{% tabs %}
+{% tabitem label="Flat Config" %}
+
+```javascript
+// eslint.config.mjs
+import nx from '@nx/eslint-plugin';
+
+export default [
+  ...nx.configs['flat/base'],
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      '@nx/enforce-module-boundaries': [
+        'error',
+        {
+          allow: [],
+          // update depConstraints based on your tags
+          depConstraints: [
+            {
+              // this constraint applies to all "admin" projects
+              sourceTag: 'scope:admin',
+              onlyDependOnLibsWithTags: ['scope:shared', 'scope:admin'],
+            },
+            {
+              sourceTag: 'type:ui',
+              onlyDependOnLibsWithTags: ['type:ui', 'type:util'],
+            },
+            {
+              // we don't want our admin ui components to depend on anything except utilities,
+              // and we also want to ban router imports
+              allSourceTags: ['scope:admin', 'type:ui'],
+              onlyDependOnLibsWithTags: ['type:util'],
+              bannedExternalImports: ['*router*'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+```
+
+{% /tabitem %}
+{% tabitem label="Legacy (.eslintrc.json)" %}
+
 ```jsonc
+// .eslintrc.json
 {
   // ... more ESLint config here
 
@@ -172,6 +287,9 @@ Matching just a single source tag is sometimes not enough for solving complex re
   // ... more ESLint config here
 }
 ```
+
+{% /tabitem %}
+{% /tabs %}
 
 ## Further reading
 

--- a/astro-docs/src/content/docs/guides/Enforce Module Boundaries/tag-multiple-dimensions.mdoc
+++ b/astro-docs/src/content/docs/guides/Enforce Module Boundaries/tag-multiple-dimensions.mdoc
@@ -85,7 +85,7 @@ We can now restrict projects within the same group to depend on each other based
 - `ui` can only depend on other `ui`
 - everyone can depend on `util` including `util` itself
 
-{% tabs %}
+{% tabs syncKey="eslint-config-preference" %}
 {% tabitem label="Flat Config" %}
 
 ```javascript
@@ -205,7 +205,7 @@ There are no limits to the number of tags, but as you add more tags the complexi
 
 Matching just a single source tag is sometimes not enough for solving complex restrictions. To avoid creating ad-hoc tags that are only meant for specific constraints, you can also combine multiple tags with `allSourceTags`. Each tag in the array must be matched for a constraint to be applied:
 
-{% tabs %}
+{% tabs syncKey="eslint-config-preference" %}
 {% tabitem label="Flat Config" %}
 
 ```javascript

--- a/astro-docs/src/content/docs/technologies/eslint/Guides/eslint.mdoc
+++ b/astro-docs/src/content/docs/technologies/eslint/Guides/eslint.mdoc
@@ -12,7 +12,7 @@ By default, Nx sets up your ESLint configs with performance in mind - we want yo
 
 Let's take an example of an ESLint config that Nx might generate for you out of the box for a Next.js project called `tuskdesk`:
 
-{% tabs %}
+{% tabs syncKey="eslint-config-preference" %}
 {% tabitem label="Flat Config" %}
 
 ```javascript
@@ -78,7 +78,7 @@ Here we do _not_ have `parserOptions.project`, which is appropriate because we a
 
 If we now come in and add a rule which does require type information, for example `@typescript-eslint/await-thenable`, our config will look as follows:
 
-{% tabs %}
+{% tabs syncKey="eslint-config-preference" %}
 {% tabitem label="Flat Config" %}
 
 ```javascript
@@ -163,7 +163,7 @@ Linting "tuskdesk"...
 
 The solution is to update our config once more, this time to set `parserOptions.project` to appropriately point at our various tsconfig.json files which belong to our project:
 
-{% tabs %}
+{% tabs syncKey="eslint-config-preference" %}
 {% tabitem label="Flat Config" %}
 
 ```javascript

--- a/astro-docs/src/content/docs/technologies/eslint/Guides/eslint.mdoc
+++ b/astro-docs/src/content/docs/technologies/eslint/Guides/eslint.mdoc
@@ -12,6 +12,43 @@ By default, Nx sets up your ESLint configs with performance in mind - we want yo
 
 Let's take an example of an ESLint config that Nx might generate for you out of the box for a Next.js project called `tuskdesk`:
 
+{% tabs %}
+{% tabitem label="Flat Config" %}
+
+```javascript
+// apps/tuskdesk/eslint.config.mjs
+import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+import nxPlugin from '@nx/eslint-plugin';
+import reactPlugin from '@nx/react/eslint-plugin';
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+});
+
+export default [
+  ...reactPlugin,
+  ...compat.config({ extends: ['../../eslint.config.mjs'] }),
+  { ignores: ['!**/*'] },
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {},
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {},
+  },
+  {
+    files: ['**/*.js', '**/*.jsx'],
+    rules: {},
+  },
+];
+```
+
+{% /tabitem %}
+{% tabitem label="Legacy (.eslintrc.json)" %}
+
 ```jsonc
 // apps/tuskdesk/.eslintrc.json
 {
@@ -34,11 +71,54 @@ Let's take an example of an ESLint config that Nx might generate for you out of 
 }
 ```
 
+{% /tabitem %}
+{% /tabs %}
+
 Here we do _not_ have `parserOptions.project`, which is appropriate because we are not leveraging any rules which require type information.
 
 If we now come in and add a rule which does require type information, for example `@typescript-eslint/await-thenable`, our config will look as follows:
 
-```jsonc {% meta="{6-8}" %}
+{% tabs %}
+{% tabitem label="Flat Config" %}
+
+```javascript
+// apps/tuskdesk/eslint.config.mjs
+import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+import nxPlugin from '@nx/eslint-plugin';
+import reactPlugin from '@nx/react/eslint-plugin';
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+});
+
+export default [
+  ...reactPlugin,
+  ...compat.config({ extends: ['../../eslint.config.mjs'] }),
+  { ignores: ['!**/*'] },
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      // This rule requires the TypeScript type checker to be present when it runs
+      '@typescript-eslint/await-thenable': 'error',
+    },
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {},
+  },
+  {
+    files: ['**/*.js', '**/*.jsx'],
+    rules: {},
+  },
+];
+```
+
+{% /tabitem %}
+{% tabitem label="Legacy (.eslintrc.json)" %}
+
+```jsonc
 // apps/tuskdesk/.eslintrc.json
 {
   "extends": ["plugin:@nx/react", "../../.eslintrc.json"],
@@ -63,6 +143,9 @@ If we now come in and add a rule which does require type information, for exampl
 }
 ```
 
+{% /tabitem %}
+{% /tabs %}
+
 Now if we try and run `nx lint tuskdesk` we will get an error
 
 ```{% title="nx lint tuskdesk" frame="terminal" %}
@@ -80,7 +163,53 @@ Linting "tuskdesk"...
 
 The solution is to update our config once more, this time to set `parserOptions.project` to appropriately point at our various tsconfig.json files which belong to our project:
 
-```jsonc {% meta="{7-10}" %}
+{% tabs %}
+{% tabitem label="Flat Config" %}
+
+```javascript
+// apps/tuskdesk/eslint.config.mjs
+import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+import nxPlugin from '@nx/eslint-plugin';
+import reactPlugin from '@nx/react/eslint-plugin';
+import tseslint from 'typescript-eslint';
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+});
+
+export default [
+  ...reactPlugin,
+  ...compat.config({ extends: ['../../eslint.config.mjs'] }),
+  { ignores: ['!**/*'] },
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    languageOptions: {
+      // We set parserOptions.project for the project to allow TypeScript to create the type-checker behind the scenes when we run linting
+      parserOptions: {
+        project: ['apps/tuskdesk/tsconfig.*?.json'],
+      },
+    },
+    rules: {
+      '@typescript-eslint/await-thenable': 'error',
+    },
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    rules: {},
+  },
+  {
+    files: ['**/*.js', '**/*.jsx'],
+    rules: {},
+  },
+];
+```
+
+{% /tabitem %}
+{% tabitem label="Legacy (.eslintrc.json)" %}
+
+```jsonc
 // apps/tuskdesk/.eslintrc.json
 {
   "extends": ["plugin:@nx/react", "../../.eslintrc.json"],
@@ -107,6 +236,9 @@ The solution is to update our config once more, this time to set `parserOptions.
   ]
 }
 ```
+
+{% /tabitem %}
+{% /tabs %}
 
 And that's it! Now any rules requiring type information will run correctly when we run `nx lint tuskdesk`.
 

--- a/astro-docs/src/content/docs/technologies/eslint/eslint-plugin/Guides/dependency-checks.mdoc
+++ b/astro-docs/src/content/docs/technologies/eslint/eslint-plugin/Guides/dependency-checks.mdoc
@@ -24,6 +24,34 @@ Library generators from `@nx` packages will configure this rule automatically wh
 
 To set it up manually for existing libraries, you need to add the `dependency-checks` rule to your project's ESLint configuration:
 
+{% tabs %}
+{% tabitem label="Flat Config" %}
+
+```javascript
+// <your-project-root>/eslint.config.mjs
+import nxPlugin from '@nx/eslint-plugin';
+import jsoncParser from 'jsonc-eslint-parser';
+
+export default [
+  ...nxPlugin.configs['flat/base'],
+  ...nxPlugin.configs['flat/typescript'],
+  ...nxPlugin.configs['flat/javascript'],
+  {
+    files: ['**/*.json'],
+    languageOptions: {
+      parser: jsoncParser,
+    },
+    rules: {
+      '@nx/dependency-checks': 'error',
+    },
+  },
+  // ... more ESLint config here
+];
+```
+
+{% /tabitem %}
+{% tabitem label="Legacy (.eslintrc.json)" %}
+
 ```jsonc
 // <your-project-root>/.eslintrc.json
 {
@@ -40,6 +68,9 @@ To set it up manually for existing libraries, you need to add the `dependency-ch
   ]
 }
 ```
+
+{% /tabitem %}
+{% /tabs %}
 
 Additionally, you need to adjust your `lintFilePatterns` to include the project's `package.json` file::
 
@@ -67,6 +98,37 @@ Additionally, you need to adjust your `lintFilePatterns` to include the project'
 
 Sometimes we intentionally want to add or remove a dependency from our `package.json` despite what the rule suggests. We can use the rule's options to override default behavior:
 
+{% tabs %}
+{% tabitem label="Flat Config" %}
+
+```javascript
+// eslint.config.mjs
+export default [
+  // ... other config
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          buildTargets: ['build', 'custom-build'], // add non standard build target names
+          checkMissingDependencies: true, // toggle to disable
+          checkObsoleteDependencies: true, // toggle to disable
+          checkVersionMismatches: true, // toggle to disable
+          ignoredDependencies: ['lodash'], // these libs will be omitted from checks
+          ignoredFiles: ['webpack.config.js', 'eslint.config.mjs'], // list of files that should be skipped for check
+          includeTransitiveDependencies: true, // collect dependencies transitively from children
+          useLocalPathsForWorkspaceDependencies: true, // toggle to disable
+        },
+      ],
+    },
+  },
+];
+```
+
+{% /tabitem %}
+{% tabitem label="Legacy (.eslintrc.json)" %}
+
 ```jsonc
 // .eslintrc.json
 {
@@ -78,13 +140,16 @@ Sometimes we intentionally want to add or remove a dependency from our `package.
       "checkObsoleteDependencies": true, // toggle to disable
       "checkVersionMismatches": true, // toggle to disable
       "ignoredDependencies": ["lodash"], // these libs will be omitted from checks
-      "ignoredFiles": ["webpack.config.js", "eslint.config.cjs"], // list of files that should be skipped for check
+      "ignoredFiles": ["webpack.config.js", "eslint.config.mjs"], // list of files that should be skipped for check
       "includeTransitiveDependencies": true, // collect dependencies transitively from children
       "useLocalPathsForWorkspaceDependencies": true // toggle to disable
     }
   ]
 }
 ```
+
+{% /tabitem %}
+{% /tabs %}
 
 ## Options
 

--- a/astro-docs/src/content/docs/technologies/eslint/eslint-plugin/Guides/dependency-checks.mdoc
+++ b/astro-docs/src/content/docs/technologies/eslint/eslint-plugin/Guides/dependency-checks.mdoc
@@ -24,7 +24,7 @@ Library generators from `@nx` packages will configure this rule automatically wh
 
 To set it up manually for existing libraries, you need to add the `dependency-checks` rule to your project's ESLint configuration:
 
-{% tabs %}
+{% tabs syncKey="eslint-config-preference" %}
 {% tabitem label="Flat Config" %}
 
 ```javascript
@@ -98,7 +98,7 @@ Additionally, you need to adjust your `lintFilePatterns` to include the project'
 
 Sometimes we intentionally want to add or remove a dependency from our `package.json` despite what the rule suggests. We can use the rule's options to override default behavior:
 
-{% tabs %}
+{% tabs syncKey="eslint-config-preference" %}
 {% tabitem label="Flat Config" %}
 
 ```javascript

--- a/astro-docs/src/content/docs/technologies/eslint/eslint-plugin/Guides/enforce-module-boundaries.mdoc
+++ b/astro-docs/src/content/docs/technologies/eslint/eslint-plugin/Guides/enforce-module-boundaries.mdoc
@@ -17,7 +17,7 @@ This rule requires ESLint and only works for JavaScript/TypeScript projects. For
 
 You can use the `enforce-module-boundaries` rule by adding it to your ESLint rules configuration:
 
-{% tabs %}
+{% tabs syncKey="eslint-config-preference" %}
 {% tabitem label="Flat Config" %}
 
 ```javascript

--- a/astro-docs/src/content/docs/technologies/eslint/eslint-plugin/Guides/enforce-module-boundaries.mdoc
+++ b/astro-docs/src/content/docs/technologies/eslint/eslint-plugin/Guides/enforce-module-boundaries.mdoc
@@ -17,7 +17,36 @@ This rule requires ESLint and only works for JavaScript/TypeScript projects. For
 
 You can use the `enforce-module-boundaries` rule by adding it to your ESLint rules configuration:
 
+{% tabs %}
+{% tabitem label="Flat Config" %}
+
+```javascript
+// eslint.config.mjs
+import nxPlugin from '@nx/eslint-plugin';
+
+export default [
+  ...nxPlugin.configs['flat/base'],
+  ...nxPlugin.configs['flat/typescript'],
+  ...nxPlugin.configs['flat/javascript'],
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    rules: {
+      '@nx/enforce-module-boundaries': [
+        'error',
+        {
+          // ...rule specific configuration
+        },
+      ],
+    },
+  },
+];
+```
+
+{% /tabitem %}
+{% tabitem label="Legacy (.eslintrc.json)" %}
+
 ```jsonc
+// .eslintrc.json
 {
   // ... more ESLint config here
   "overrides": [
@@ -36,6 +65,9 @@ You can use the `enforce-module-boundaries` rule by adding it to your ESLint rul
   ]
 }
 ```
+
+{% /tabitem %}
+{% /tabs %}
 
 ## Options
 


### PR DESCRIPTION
We show legacy eslintrc format that's been deprecated and shouldn't be used anymore. We still want to document the legacy format in case users haven't switched yet.