### PR TITLE
feat(core): add --check=all flag to configure-ai-agents

### DIFF
--- a/docs/generated/cli/configure-ai-agents.md
+++ b/docs/generated/cli/configure-ai-agents.md
@@ -17,11 +17,11 @@ Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`
 
 ## Options
 
-| Option          | Type                                             | Description                                                                                                          |
-| --------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `--agents`      | `claude`, `codex`, `copilot`, `cursor`, `gemini` | List of AI agents to set up.                                                                                         |
-| `--check`       | boolean                                          | Check if any configured agents are out of date and need to be updated. Does not make any changes. (Default: `false`) |
-| `--help`        | boolean                                          | Show help.                                                                                                           |
-| `--interactive` | boolean                                          | When false disables interactive input prompts for options. (Default: `true`)                                         |
-| `--verbose`     | boolean                                          | Prints additional information about the commands (e.g., stack traces).                                               |
-| `--version`     | boolean                                          | Show version number.                                                                                                 |
+| Option          | Type                                             | Description                                                                                                                                                                            |
+| --------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--agents`      | `claude`, `codex`, `copilot`, `cursor`, `gemini` | List of AI agents to set up.                                                                                                                                                           |
+| `--check`       | `outdated`, `all`                                | Check agent configurations. Use --check or --check=outdated to check only configured agents, or --check=all to include unconfigured/partial configurations. Does not make any changes. |
+| `--help`        | boolean                                          | Show help.                                                                                                                                                                             |
+| `--interactive` | boolean                                          | When false disables interactive input prompts for options. (Default: `true`)                                                                                                           |
+| `--verbose`     | boolean                                          | Prints additional information about the commands (e.g., stack traces).                                                                                                                 |
+| `--version`     | boolean                                          | Show version number.                                                                                                                                                                   |

--- a/docs/generated/packages/nx/documents/configure-ai-agents.md
+++ b/docs/generated/packages/nx/documents/configure-ai-agents.md
@@ -17,11 +17,11 @@ Install `nx` globally to invoke the command directly using `nx`, or use `npx nx`
 
 ## Options
 
-| Option          | Type                                             | Description                                                                                                          |
-| --------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
-| `--agents`      | `claude`, `codex`, `copilot`, `cursor`, `gemini` | List of AI agents to set up.                                                                                         |
-| `--check`       | boolean                                          | Check if any configured agents are out of date and need to be updated. Does not make any changes. (Default: `false`) |
-| `--help`        | boolean                                          | Show help.                                                                                                           |
-| `--interactive` | boolean                                          | When false disables interactive input prompts for options. (Default: `true`)                                         |
-| `--verbose`     | boolean                                          | Prints additional information about the commands (e.g., stack traces).                                               |
-| `--version`     | boolean                                          | Show version number.                                                                                                 |
+| Option          | Type                                             | Description                                                                                                                                                                            |
+| --------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--agents`      | `claude`, `codex`, `copilot`, `cursor`, `gemini` | List of AI agents to set up.                                                                                                                                                           |
+| `--check`       | `outdated`, `all`                                | Check agent configurations. Use --check or --check=outdated to check only configured agents, or --check=all to include unconfigured/partial configurations. Does not make any changes. |
+| `--help`        | boolean                                          | Show help.                                                                                                                                                                             |
+| `--interactive` | boolean                                          | When false disables interactive input prompts for options. (Default: `true`)                                                                                                           |
+| `--verbose`     | boolean                                          | Prints additional information about the commands (e.g., stack traces).                                                                                                                 |
+| `--version`     | boolean                                          | Show version number.                                                                                                                                                                   |

--- a/e2e/nx/src/configure-ai-agents.test.ts
+++ b/e2e/nx/src/configure-ai-agents.test.ts
@@ -84,8 +84,9 @@ describe('configure-ai-agents', () => {
       const output = runCLI(
         `configure-ai-agents --agents claude --check=outdated`
       );
-      // Should exit 0 because partially configured agents are ignored in outdated mode
-      expect(output).toContain('All configured AI agents are up to date');
+      // Should exit 0 because partially configured agents are not considered "fully configured"
+      // so outdated mode reports no agents configured
+      expect(output).toContain('No AI agents are configured');
     });
 
     it('should exit 1 with outdated agents', () => {
@@ -118,9 +119,8 @@ describe('configure-ai-agents', () => {
       let didThrow = false;
       try {
         runCLI(`configure-ai-agents --agents claude --check=all`);
-      } catch (e) {
+      } catch {
         didThrow = true;
-        expect(e.toString()).toContain('not fully configured or up to date');
       }
       expect(didThrow).toBe(true);
     });
@@ -132,13 +132,12 @@ describe('configure-ai-agents', () => {
       let didThrow = false;
       try {
         runCLI(`configure-ai-agents --agents claude --check=all`);
-      } catch (e) {
+      } catch {
         didThrow = true;
-        expect(e.toString()).toContain('not fully configured or up to date');
       }
       expect(didThrow).toBe(true);
 
-      // Restore full configuration
+      // Restore full configuration for next tests
       runCLI(`configure-ai-agents --agents claude --no-interactive`);
     });
 
@@ -150,17 +149,19 @@ describe('configure-ai-agents', () => {
       let didThrow = false;
       try {
         runCLI(`configure-ai-agents --agents claude --check=all`);
-      } catch (e) {
+      } catch {
         didThrow = true;
-        expect(e.toString()).toContain('not fully configured or up to date');
       }
       expect(didThrow).toBe(true);
 
-      // Restore
+      // Restore for next test
       runCLI(`configure-ai-agents --agents claude --no-interactive`);
     });
 
     it('should exit 0 with fully configured and up-to-date agents', () => {
+      // Ensure clean state
+      runCLI(`configure-ai-agents --agents claude --no-interactive`);
+
       const output = runCLI(`configure-ai-agents --agents claude --check=all`);
       expect(output).toContain(
         'All selected AI agents are fully configured and up to date'

--- a/e2e/nx/src/configure-ai-agents.test.ts
+++ b/e2e/nx/src/configure-ai-agents.test.ts
@@ -2,6 +2,7 @@ import {
   cleanupProject,
   newProject,
   readFile,
+  removeFile,
   runCLI,
   updateFile,
 } from '@nx/e2e-utils';
@@ -43,5 +44,127 @@ describe('configure-ai-agents', () => {
     runCLI(`configure-ai-agents --agents claude --no-interactive`);
 
     expect(readFile('CLAUDE.md')).not.toContain('nx_workspace_outdated');
+  });
+
+  describe('--check (backward compatible, defaults to outdated mode)', () => {
+    beforeAll(() => {
+      // Clean up previous tests
+      removeFile('CLAUDE.md');
+      removeFile('.mcp.json');
+    });
+
+    it('should exit 0 with no configured agents', () => {
+      const output = runCLI(`configure-ai-agents --agents claude --check`);
+      expect(output).toContain('No AI agents are configured');
+    });
+
+    it('should exit 0 with up-to-date agents', () => {
+      runCLI(`configure-ai-agents --agents claude --no-interactive`);
+
+      const output = runCLI(`configure-ai-agents --agents claude --check`);
+      expect(output).toContain('All configured AI agents are up to date');
+    });
+  });
+
+  describe('--check=outdated (explicit outdated mode)', () => {
+    it('should exit 0 with no configured agents', () => {
+      removeFile('CLAUDE.md');
+      removeFile('.mcp.json');
+
+      const output = runCLI(
+        `configure-ai-agents --agents claude --check=outdated`
+      );
+      expect(output).toContain('No AI agents are configured');
+    });
+
+    it('should exit 0 with partially configured agents (ignores partial configs)', () => {
+      runCLI(`configure-ai-agents --agents claude --no-interactive`);
+      removeFile('.mcp.json');
+
+      const output = runCLI(
+        `configure-ai-agents --agents claude --check=outdated`
+      );
+      // Should exit 0 because partially configured agents are ignored in outdated mode
+      expect(output).toContain('All configured AI agents are up to date');
+    });
+
+    it('should exit 1 with outdated agents', () => {
+      // Restore full configuration
+      runCLI(`configure-ai-agents --agents claude --no-interactive`);
+
+      // Make it outdated
+      updateFile('CLAUDE.md', (content: string) =>
+        content.replace('nx_workspace', 'nx_workspace_outdated')
+      );
+
+      let didThrow = false;
+      try {
+        runCLI(`configure-ai-agents --agents claude --check=outdated`);
+      } catch {
+        didThrow = true;
+      }
+      expect(didThrow).toBe(true);
+
+      // Restore for next tests
+      runCLI(`configure-ai-agents --agents claude --no-interactive`);
+    });
+  });
+
+  describe('--check=all (comprehensive check)', () => {
+    it('should exit 1 on clean workspace with no configured agents', () => {
+      removeFile('CLAUDE.md');
+      removeFile('.mcp.json');
+
+      let didThrow = false;
+      try {
+        runCLI(`configure-ai-agents --agents claude --check=all`);
+      } catch (e) {
+        didThrow = true;
+        expect(e.toString()).toContain('not fully configured or up to date');
+      }
+      expect(didThrow).toBe(true);
+    });
+
+    it('should exit 1 with partially configured agents', () => {
+      runCLI(`configure-ai-agents --agents claude --no-interactive`);
+      removeFile('.mcp.json');
+
+      let didThrow = false;
+      try {
+        runCLI(`configure-ai-agents --agents claude --check=all`);
+      } catch (e) {
+        didThrow = true;
+        expect(e.toString()).toContain('not fully configured or up to date');
+      }
+      expect(didThrow).toBe(true);
+
+      // Restore full configuration
+      runCLI(`configure-ai-agents --agents claude --no-interactive`);
+    });
+
+    it('should exit 1 with outdated agents', () => {
+      updateFile('CLAUDE.md', (content: string) =>
+        content.replace('nx_workspace', 'nx_workspace_outdated')
+      );
+
+      let didThrow = false;
+      try {
+        runCLI(`configure-ai-agents --agents claude --check=all`);
+      } catch (e) {
+        didThrow = true;
+        expect(e.toString()).toContain('not fully configured or up to date');
+      }
+      expect(didThrow).toBe(true);
+
+      // Restore
+      runCLI(`configure-ai-agents --agents claude --no-interactive`);
+    });
+
+    it('should exit 0 with fully configured and up-to-date agents', () => {
+      const output = runCLI(`configure-ai-agents --agents claude --check=all`);
+      expect(output).toContain(
+        'All selected AI agents are fully configured and up to date'
+      );
+    });
   });
 });

--- a/packages/nx/src/command-line/configure-ai-agents/command-object.ts
+++ b/packages/nx/src/command-line/configure-ai-agents/command-object.ts
@@ -5,7 +5,7 @@ export interface ConfigureAiAgentsOptions {
   agents?: string[];
   interactive?: boolean;
   verbose?: boolean;
-  check?: false | 'outdated' | 'all';
+  check?: boolean | 'outdated' | 'all';
 }
 
 export const yargsConfigureAiAgentsCommand: CommandModule<

--- a/packages/nx/src/command-line/configure-ai-agents/command-object.ts
+++ b/packages/nx/src/command-line/configure-ai-agents/command-object.ts
@@ -5,7 +5,7 @@ export interface ConfigureAiAgentsOptions {
   agents?: string[];
   interactive?: boolean;
   verbose?: boolean;
-  check?: boolean;
+  check?: false | 'outdated' | 'all';
 }
 
 export const yargsConfigureAiAgentsCommand: CommandModule<
@@ -29,10 +29,20 @@ export const yargsConfigureAiAgentsCommand: CommandModule<
         default: true,
       })
       .option('check', {
-        type: 'boolean',
+        type: 'string',
         description:
-          'Check if any configured agents are out of date and need to be updated. Does not make any changes.',
-        default: false,
+          'Check agent configurations. Use --check or --check=outdated to check only configured agents, or --check=all to include unconfigured/partial configurations. Does not make any changes.',
+        coerce: (value: string) => {
+          // --check (no value)
+          if (value === '') return 'outdated';
+          // --check=true
+          if (value === 'true') return 'outdated';
+          // --no-check or --check=false
+          if (value === 'false') return false;
+          // --check=all or --check=outdated
+          return value;
+        },
+        choices: ['outdated', 'all'],
       })
       .example(
         '$0 configure-ai-agents',
@@ -47,9 +57,13 @@ export const yargsConfigureAiAgentsCommand: CommandModule<
         'Checks if any configured agents are out of date and need to be updated'
       )
       .example(
+        '$0 configure-ai-agents --check=all',
+        'Checks if any agents are not configured, out of date or partially configured'
+      )
+      .example(
         '$0 configure-ai-agents --agents claude gemini --no-interactive',
         'Configures and updates Claude and Gemini AI agents without prompts'
-      ),
+      ) as any, // because of the coerce function
   handler: async (args) => {
     await (
       await import('./configure-ai-agents')

--- a/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
+++ b/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
@@ -100,39 +100,71 @@ export async function configureAiAgentsHandlerImpl(
     process.exit(1);
   }
 
-  if (options.check) {
-    if (fullyConfiguredAgents.length === 0) {
-      output.log({
-        title: 'No AI agents are configured',
-        bodyLines: [
-          'You can configure AI agents by running `nx configure-ai-agents`.',
-        ],
-      });
-      process.exit(0);
-    }
+  // important for wording
+  const usingAllAgents =
+    normalizedOptions.agents.length === supportedAgents.length;
 
+  if (options.check) {
     const outOfDateAgents = fullyConfiguredAgents.filter((a) => a?.outdated);
 
-    if (outOfDateAgents.length === 0) {
-      output.success({
-        title: 'All configured AI agents are up to date',
-        bodyLines: fullyConfiguredAgents.map((a) => `- ${a.displayName}`),
-      });
-      process.exit(0);
-    } else {
-      output.log({
-        title: 'The following AI agents are out of date:',
+    // only error if something is fully configured but outdated
+    if (options.check === 'outdated') {
+      if (fullyConfiguredAgents.length === 0) {
+        output.log({
+          title: 'No AI agents are configured',
+          bodyLines: [
+            'You can configure AI agents by running `nx configure-ai-agents`.',
+          ],
+        });
+        process.exit(0);
+      }
+
+      if (outOfDateAgents.length === 0) {
+        output.success({
+          title: 'All configured AI agents are up to date',
+          bodyLines: fullyConfiguredAgents.map((a) => `- ${a.displayName}`),
+        });
+        process.exit(0);
+      } else {
+        output.log({
+          title: 'The following AI agents are out of date:',
+          bodyLines: [
+            ...outOfDateAgents.map((a) => {
+              const rulesPath = a.rulesPath;
+              const displayPath = rulesPath.startsWith(workspaceRoot)
+                ? relative(workspaceRoot, rulesPath)
+                : rulesPath;
+              return `- ${a.displayName} (${displayPath})`;
+            }),
+            '',
+            'You can update them by running `nx configure-ai-agents`.',
+          ],
+        });
+        process.exit(1);
+      }
+      // error on any partial, outdated or non-configured agent
+    } else if (options.check === 'all') {
+      if (
+        partiallyConfiguredAgents.length === 0 &&
+        outOfDateAgents.length === 0 &&
+        nonConfiguredAgents.length === 0
+      ) {
+        output.success({
+          title: `All ${
+            !usingAllAgents ? 'selected' : 'supported'
+          } AI agents are fully configured and up to date`,
+          bodyLines: fullyConfiguredAgents.map((a) => `- ${a.displayName}`),
+        });
+        process.exit(0);
+      }
+
+      output.error({
+        title: 'The following agents are not fully configured or up to date:',
         bodyLines: [
-          ...outOfDateAgents.map((a) => {
-            const rulesPath = a.rulesPath;
-            const displayPath = rulesPath.startsWith(workspaceRoot)
-              ? relative(workspaceRoot, rulesPath)
-              : rulesPath;
-            return `- ${a.displayName} (${displayPath})`;
-          }),
-          '',
-          'You can update them by running `nx configure-ai-agents`.',
-        ],
+          ...partiallyConfiguredAgents,
+          ...outOfDateAgents,
+          ...nonConfiguredAgents,
+        ].map((a) => getAgentChoiceForPrompt(a).message),
       });
       process.exit(1);
     }
@@ -164,8 +196,6 @@ export async function configureAiAgentsHandlerImpl(
   });
 
   if (allAgentChoices.length === 0) {
-    const usingAllAgents =
-      normalizedOptions.agents.length === supportedAgents.length;
     output.success({
       title: `No new agents to configure. All ${
         !usingAllAgents ? 'selected' : 'supported'

--- a/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
+++ b/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
@@ -104,11 +104,11 @@ export async function configureAiAgentsHandlerImpl(
   const usingAllAgents =
     normalizedOptions.agents.length === supportedAgents.length;
 
-  if (options.check) {
+  if (normalizedOptions.check) {
     const outOfDateAgents = fullyConfiguredAgents.filter((a) => a?.outdated);
 
     // only error if something is fully configured but outdated
-    if (options.check === 'outdated') {
+    if (normalizedOptions.check === 'outdated') {
       if (fullyConfiguredAgents.length === 0) {
         output.log({
           title: 'No AI agents are configured',
@@ -143,7 +143,7 @@ export async function configureAiAgentsHandlerImpl(
         process.exit(1);
       }
       // error on any partial, outdated or non-configured agent
-    } else if (options.check === 'all') {
+    } else if (normalizedOptions.check === 'all') {
       if (
         partiallyConfiguredAgents.length === 0 &&
         outOfDateAgents.length === 0 &&
@@ -344,9 +344,11 @@ function normalizeOptions(
   const agents = (options.agents ?? supportedAgents).filter((a) =>
     supportedAgents.includes(a as Agent)
   ) as Agent[];
+  // it used to be just --check which was implicitly 'outdated'
+  const check = (options.check === true ? 'outdated' : options.check) ?? false;
   return {
     ...options,
     agents,
-    check: options.check ?? false,
+    check,
   };
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
It's only possible to check if any agent configurations are outdated, but not if any agents could use some configuring.

## Expected Behavior
The `--check=all` flag allows you to check if any agent is not fully configured and up to date.
