### PR TITLE
feat(release)!: release graph aware filtering, updateDependents can now be "always"

### DIFF
--- a/astro-docs/src/content/docs/features/manage-releases.mdoc
+++ b/astro-docs/src/content/docs/features/manage-releases.mdoc
@@ -105,13 +105,15 @@ import * as yargs from 'yargs';
     })
     .parseAsync();
 
-  const { workspaceVersion, projectsVersionData } = await releaseVersion({
-    specifier: options.version,
-    dryRun: options.dryRun,
-    verbose: options.verbose,
-  });
+  const { workspaceVersion, projectsVersionData, releaseGraph } =
+    await releaseVersion({
+      specifier: options.version,
+      dryRun: options.dryRun,
+      verbose: options.verbose,
+    });
 
   await releaseChangelog({
+    releaseGraph, // Re-use the existing release graph to avoid recomputing in each subcommand
     versionData: projectsVersionData,
     version: workspaceVersion,
     dryRun: options.dryRun,
@@ -120,6 +122,7 @@ import * as yargs from 'yargs';
 
   // publishResults contains a map of project names and their exit codes
   const publishResults = await releasePublish({
+    releaseGraph, // Re-use the existing release graph to avoid recomputing in each subcommand
     dryRun: options.dryRun,
     verbose: options.verbose,
     // You can optionally pass through the version data (e.g. if you are using a custom publish executor that needs to be aware of versions)

--- a/docs/shared/features/manage-releases.md
+++ b/docs/shared/features/manage-releases.md
@@ -102,13 +102,15 @@ import * as yargs from 'yargs';
     })
     .parseAsync();
 
-  const { workspaceVersion, projectsVersionData } = await releaseVersion({
-    specifier: options.version,
-    dryRun: options.dryRun,
-    verbose: options.verbose,
-  });
+  const { workspaceVersion, projectsVersionData, releaseGraph } =
+    await releaseVersion({
+      specifier: options.version,
+      dryRun: options.dryRun,
+      verbose: options.verbose,
+    });
 
   await releaseChangelog({
+    releaseGraph, // Re-use the existing release graph to avoid recomputing in each subcommand
     versionData: projectsVersionData,
     version: workspaceVersion,
     dryRun: options.dryRun,
@@ -117,6 +119,7 @@ import * as yargs from 'yargs';
 
   // publishResults contains a map of project names and their exit codes
   const publishResults = await releasePublish({
+    releaseGraph, // Re-use the existing release graph to avoid recomputing in each subcommand
     dryRun: options.dryRun,
     verbose: options.verbose,
     // You can optionally pass through the version data (e.g. if you are using a custom publish executor that needs to be aware of versions)

--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -2,20 +2,18 @@ import { joinPathFragments, NxJsonConfiguration } from '@nx/devkit';
 import {
   cleanupProject,
   exists,
-  getSelectedPackageManager,
   getPackageManagerCommand,
+  getSelectedPackageManager,
   newProject,
   readFile,
   runCLI,
   runCommand,
-  runCommandAsync,
   tmpProjPath,
   uniq,
   updateJson,
-  removeFile,
 } from '@nx/e2e-utils';
 import { execSync } from 'child_process';
-import { setupWorkspaces, prepareAndInstallDependencies } from './utils';
+import { prepareAndInstallDependencies, setupWorkspaces } from './utils';
 
 expect.addSnapshotSerializer({
   serialize(str: string) {
@@ -680,7 +678,7 @@ describe('nx release - independent projects', () => {
                   integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                   total files:   4
 
-                  Would publish to http://localhost:4873 with tag "latest", but [dry-run] was set
+                  Would publish to ${e2eRegistryUrl} with tag "latest", but [dry-run] was set
 
 
 
@@ -729,7 +727,7 @@ describe('nx release - independent projects', () => {
                   integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                   total files:   4
 
-                  Would publish to http://localhost:4873 with tag "latest", but [dry-run] was set
+                  Would publish to ${e2eRegistryUrl} with tag "latest", but [dry-run] was set
 
 
 
@@ -766,7 +764,7 @@ describe('nx release - independent projects', () => {
                   integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                   total files:   4
 
-                  Would publish to http://localhost:4873 with tag "latest", but [dry-run] was set
+                  Would publish to ${e2eRegistryUrl} with tag "latest", but [dry-run] was set
 
 
 
@@ -811,7 +809,7 @@ describe('nx release - independent projects', () => {
                   integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                   total files:   4
 
-                  Would publish to http://localhost:4873 with tag "latest", but [dry-run] was set
+                  Would publish to ${e2eRegistryUrl} with tag "latest", but [dry-run] was set
 
                   > nx run {project-name}:nx-release-publish
 
@@ -833,7 +831,7 @@ describe('nx release - independent projects', () => {
                   integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                   total files:   4
 
-                  Would publish to http://localhost:4873 with tag "latest", but [dry-run] was set
+                  Would publish to ${e2eRegistryUrl} with tag "latest", but [dry-run] was set
 
 
 
@@ -875,7 +873,7 @@ describe('nx release - independent projects', () => {
                   integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                   total files:   4
 
-                  Would publish to http://localhost:4873 with tag "latest", but [dry-run] was set
+                  Would publish to ${e2eRegistryUrl} with tag "latest", but [dry-run] was set
 
 
 
@@ -1002,7 +1000,7 @@ describe('nx release - independent projects', () => {
             'g'
           )
         ).length
-      ).toEqual(2);
+      ).toEqual(1);
       expect(
         releaseOutput.match(
           new RegExp(
@@ -1020,11 +1018,11 @@ describe('nx release - independent projects', () => {
       expect(
         releaseOutput.match(
           new RegExp(
-            `New version 1\\.6\\.0 written to manifest: my-pkg-2\\d*`,
+            `New version 1\\.5\\.1 written to manifest: my-pkg-2\\d*`,
             'g'
           )
         ).length
-      ).toEqual(1);
+      ).toEqual(2);
 
       expect(
         releaseOutput.match(
@@ -1033,7 +1031,7 @@ describe('nx release - independent projects', () => {
             'g'
           )
         ).length
-      ).toEqual(1);
+      ).toEqual(2);
       expect(
         releaseOutput.match(
           new RegExp(

--- a/e2e/release/src/pre-version-command.test.ts
+++ b/e2e/release/src/pre-version-command.test.ts
@@ -63,7 +63,7 @@ describe('nx release pre-version command', () => {
 
     // command should fail because @nx/js:library configures the manifestRootsToUpdate to be ['dist/{project-name}'], which doesn't exist yet
     expect(result1).toContain(
-      `NX   The project "${pkg1}" does not have a package.json file available in ./dist/${pkg1}`
+      `NX   The project "${pkg1}" does not have a package.json file available in dist/${pkg1}`
     );
 
     updateJson(`nx.json`, (json) => {

--- a/e2e/release/src/version-plans.test.ts
+++ b/e2e/release/src/version-plans.test.ts
@@ -493,13 +493,14 @@ const yargs = require('yargs');
     })
     .parseAsync();
 
-  const { workspaceVersion, projectsVersionData } = await releaseVersion({
+  const { workspaceVersion, projectsVersionData, releaseGraph } = await releaseVersion({
     specifier: options.version,
     dryRun: options.dryRun,
     verbose: options.verbose,
   });
 
   await releaseChangelog({
+    releaseGraph,
     versionData: projectsVersionData,
     version: workspaceVersion,
     dryRun: options.dryRun,
@@ -507,6 +508,7 @@ const yargs = require('yargs');
   });
 
   const publishProjectsResult = await releasePublish({
+    releaseGraph,
     dryRun: options.dryRun,
     verbose: options.verbose,
   });

--- a/packages/docker/src/release/version-utils.ts
+++ b/packages/docker/src/release/version-utils.ts
@@ -3,7 +3,7 @@ import { writeFileSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { prompt } from 'enquirer';
 import type { ProjectGraphProjectNode } from '@nx/devkit';
-import type { FinalConfigForProject } from 'nx/src/command-line/release/version/release-group-processor';
+import type { FinalConfigForProject } from 'nx/src/command-line/release/utils/release-graph';
 import { interpolateVersionPattern } from './version-pattern-utils';
 
 const DEFAULT_VERSION_SCHEMES = {

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -843,9 +843,9 @@
         },
         "updateDependents": {
           "type": "string",
-          "enum": ["never", "auto"],
+          "enum": ["never", "auto", "always"],
           "default": "auto",
-          "description": "When versioning independent projects, this controls whether to update their dependents (i.e. the things that depend on them). 'never' means no dependents will be updated (unless they happen to be versioned directly as well). 'auto' is the default and will cause dependents to be updated (a patch version bump) when a dependency is versioned."
+          "description": "When versioning independent projects, this controls whether to update their dependents (i.e. the things that depend on them). 'never' means no dependents will be updated (unless they happen to be versioned directly as well). 'auto' is the default and will cause dependents to be updated (a patch version bump) when a dependency is versioned, as long as a group or projects filter is not applied that does not include them. 'always' will cause dependents to be updated (a patch version bump) when a dependency is versioned, even if they are not included in the group or projects filter."
         },
         "logUnchangedProjects": {
           "type": "boolean",

--- a/packages/nx/src/command-line/release/command-object.ts
+++ b/packages/nx/src/command-line/release/command-object.ts
@@ -1,17 +1,18 @@
-import { Argv, CommandModule, showHelp } from 'yargs';
+import { type Argv, type CommandModule, showHelp } from 'yargs';
 import { logger } from '../../utils/logger';
 import {
-  OutputStyle,
-  RunManyOptions,
+  type OutputStyle,
+  type RunManyOptions,
   parseCSV,
+  readParallelFromArgsAndEnv,
   withAffectedOptions,
   withOutputStyleOption,
   withOverrides,
   withRunManyOptions,
   withVerbose,
-  readParallelFromArgsAndEnv,
 } from '../yargs-utils/shared-options';
-import { VersionData } from './utils/shared';
+import type { ReleaseGraph } from './utils/release-graph';
+import type { VersionData } from './utils/shared';
 
 // Implemented by every command and subcommand
 export interface BaseNxReleaseArgs {
@@ -52,6 +53,8 @@ export type VersionOptions = NxReleaseArgs &
     preid?: string;
     stageChanges?: boolean;
     versionActionsOptionsOverrides?: Record<string, unknown>;
+    // This will only be set if using the `nx release` top level command, or orchestrating via the programmatic API
+    releaseGraph?: ReleaseGraph;
   };
 
 export type ChangelogOptions = NxReleaseArgs &
@@ -65,6 +68,8 @@ export type ChangelogOptions = NxReleaseArgs &
     from?: string;
     interactive?: string;
     createRelease?: false | 'github' | 'gitlab';
+    // This will only be set if using the `nx release` top level command, or orchestrating via the programmatic API
+    releaseGraph?: ReleaseGraph;
   };
 
 export type PublishOptions = NxReleaseArgs &
@@ -75,6 +80,8 @@ export type PublishOptions = NxReleaseArgs &
     otp?: number;
     // This will only be set if using the `nx release` top level command, or orchestrating via the programmatic API
     versionData?: VersionData;
+    // This will only be set if using the `nx release` top level command, or orchestrating via the programmatic API
+    releaseGraph?: ReleaseGraph;
   };
 
 export type PlanOptions = NxReleaseArgs & {

--- a/packages/nx/src/command-line/release/config/version-plans.ts
+++ b/packages/nx/src/command-line/release/config/version-plans.ts
@@ -266,7 +266,10 @@ export async function setResolvedVersionPlansOnGroups(
                 );
               }
             } else {
-              existingPlan.triggeredByProjects.push(key);
+              // Avoid duplicates when releaseGraph is reused and version plans are resolved multiple times
+              if (!existingPlan.triggeredByProjects.includes(key)) {
+                existingPlan.triggeredByProjects.push(key);
+              }
             }
           } else {
             groupForProject.resolvedVersionPlans.push(<GroupVersionPlan>{

--- a/packages/nx/src/command-line/release/utils/release-graph.spec.ts
+++ b/packages/nx/src/command-line/release/utils/release-graph.spec.ts
@@ -1,0 +1,1086 @@
+let mockDeriveSpecifierFromConventionalCommits = jest.fn();
+let mockDeriveSpecifierFromVersionPlan = jest.fn();
+let mockResolveVersionActionsForProject = jest.fn();
+
+jest.doMock('../version/derive-specifier-from-conventional-commits', () => ({
+  deriveSpecifierFromConventionalCommits:
+    mockDeriveSpecifierFromConventionalCommits,
+}));
+
+jest.doMock('../version/version-actions', () => ({
+  ...jest.requireActual('../version/version-actions'),
+  deriveSpecifierFromVersionPlan: mockDeriveSpecifierFromVersionPlan,
+  resolveVersionActionsForProject: mockResolveVersionActionsForProject,
+}));
+
+jest.doMock('../version/project-logger', () => ({
+  ...jest.requireActual('../version/project-logger'),
+  ProjectLogger: class ProjectLogger {
+    buffer() {}
+    flush() {}
+  },
+}));
+
+let mockResolveCurrentVersion = jest.fn();
+jest.doMock('../version/resolve-current-version', () => ({
+  resolveCurrentVersion: mockResolveCurrentVersion,
+}));
+
+import { createTreeWithEmptyWorkspace } from '../../../generators/testing-utils/create-tree-with-empty-workspace';
+import type { Tree } from '../../../generators/tree';
+import {
+  createNxReleaseConfigAndPopulateWorkspace,
+  mockResolveVersionActionsForProjectImplementation,
+} from '../version/test-utils';
+import { createReleaseGraph } from './release-graph';
+
+process.env.NX_DAEMON = 'false';
+
+describe('ReleaseGraph', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    mockResolveVersionActionsForProject.mockImplementation(
+      mockResolveVersionActionsForProjectImplementation
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+  });
+
+  describe('basic graph construction', () => {
+    it('should build graph for a simple fixed release group with no dependencies', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          __default__ ({ "projectsRelationship": "fixed" }):
+            - projectA@1.0.0 [js]
+            - projectB@1.0.0 [js]
+            - projectC@1.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+            },
+          },
+          mockResolveCurrentVersion
+        );
+
+      const graph = await createReleaseGraph({
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters,
+        firstRelease: false,
+        preid: undefined,
+        verbose: false,
+      });
+
+      expect(graph.allProjectsConfiguredForNxRelease.size).toBe(3);
+      expect(graph.allProjectsToProcess.size).toBe(3);
+      expect(graph.getReleaseGroupForProject('projectA')?.name).toBe(
+        '__default__'
+      );
+      expect(graph.sortedReleaseGroups).toEqual(['__default__']);
+    });
+
+    it('should build graph with dependency relationships', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          __default__ ({ "projectsRelationship": "independent" }):
+            - projectA@1.0.0 [js]
+              -> depends on projectB
+            - projectB@2.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+            },
+          },
+          mockResolveCurrentVersion
+        );
+
+      const graph = await createReleaseGraph({
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters,
+        firstRelease: false,
+        preid: undefined,
+        verbose: false,
+      });
+
+      expect(graph.getProjectDependencies('projectA').has('projectB')).toBe(
+        true
+      );
+      expect(graph.getProjectDependents('projectB').has('projectA')).toBe(true);
+    });
+  });
+
+  describe('filtering - fixed release groups', () => {
+    // TODO: Maybe this should not error as it is perhaps just a logical extension of expanding the filtered group based on dependents (which all other projects in the fixed release group implicitly _kind of_ are)
+    it('should ERROR when filtering to subset of projects in a fixed group', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          __default__ ({ "projectsRelationship": "fixed" }):
+            - projectA@1.0.0 [js]
+            - projectB@1.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+            },
+          },
+          mockResolveCurrentVersion,
+          {
+            projects: ['projectB'], // Try to filter to only projectB in a fixed group
+          }
+        );
+
+      await expect(
+        createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        })
+      ).rejects.toThrow(
+        /Cannot filter to a subset of projects within fixed release group/
+      );
+    });
+
+    // TODO: test would be redundant if we change the one above to not error
+    it('should NOT error when manually filtering to ALL projects in a fixed group', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          __default__ ({ "projectsRelationship": "fixed" }):
+            - projectA@1.0.0 [js]
+            - projectB@1.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+            },
+          },
+          mockResolveCurrentVersion,
+          {
+            projects: ['projectA', 'projectB'],
+          }
+        );
+
+      const graph = await createReleaseGraph({
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters,
+        firstRelease: false,
+        preid: undefined,
+        verbose: false,
+      });
+
+      expect(graph.allProjectsToProcess.size).toBe(2);
+      expect(graph.isProjectToProcess('projectA')).toBe(true);
+      expect(graph.isProjectToProcess('projectB')).toBe(true);
+    });
+  });
+
+  describe('filtering - independent release groups with updateDependents', () => {
+    describe('scenario: projectA depends on projectB, filter by [projectB]', () => {
+      it('should include ONLY projectB when updateDependents=never (projectA should NOT be included)', async () => {
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
+            __default__ ({ "projectsRelationship": "independent" }):
+              - projectA@1.0.0 [js]
+                -> depends on projectB
+              - projectB@2.0.0 [js]
+          `,
+            {
+              version: {
+                conventionalCommits: true,
+                updateDependents: 'never',
+              },
+            },
+            mockResolveCurrentVersion,
+            {
+              projects: ['projectB'],
+            }
+          );
+
+        const graph = await createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        });
+
+        // Only projectB should be processed
+        expect(graph.allProjectsConfiguredForNxRelease.size).toBe(2);
+        expect(graph.allProjectsToProcess.size).toBe(1);
+        expect(graph.isProjectToProcess('projectB')).toBe(true);
+        expect(graph.isProjectToProcess('projectA')).toBe(false);
+      });
+
+      it('should include BOTH projectA and projectB when updateDependents=auto (same release group)', async () => {
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
+            __default__ ({ "projectsRelationship": "independent" }):
+              - projectA@1.0.0 [js]
+                -> depends on projectB
+              - projectB@2.0.0 [js]
+          `,
+            {
+              version: {
+                conventionalCommits: true,
+                // updateDependents defaults to 'auto'
+              },
+            },
+            mockResolveCurrentVersion,
+            {
+              projects: ['projectB'], // filtering to only projectB with updateDependents=auto
+            }
+          );
+
+        const graph = await createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        });
+
+        // Both projects should be processed (same release group with auto)
+        expect(graph.allProjectsConfiguredForNxRelease.size).toBe(2);
+        expect(graph.allProjectsToProcess.size).toBe(2);
+        expect(graph.isProjectToProcess('projectB')).toBe(true);
+        expect(graph.isProjectToProcess('projectA')).toBe(true);
+      });
+
+      it('should include BOTH projectA and projectB when updateDependents=always', async () => {
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
+            __default__ ({ "projectsRelationship": "independent" }):
+              - projectA@1.0.0 [js]
+                -> depends on projectB
+              - projectB@2.0.0 [js]
+          `,
+            {
+              version: {
+                conventionalCommits: true,
+                updateDependents: 'always', // Explicitly set to 'always'
+              },
+            },
+            mockResolveCurrentVersion,
+            {
+              projects: ['projectB'], // filtering to only projectB with updateDependents=always
+            }
+          );
+
+        const graph = await createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        });
+
+        // Both projects should be processed because A depends on B and updateDependents is always
+        expect(graph.allProjectsConfiguredForNxRelease.size).toBe(2);
+        expect(graph.allProjectsToProcess.size).toBe(2);
+        expect(graph.isProjectToProcess('projectB')).toBe(true);
+        expect(graph.isProjectToProcess('projectA')).toBe(true);
+      });
+    });
+
+    describe('scenario: projectA depends on projectB, filter by [projectA]', () => {
+      it('should include ONLY projectA regardless of updateDependents (projectA has no dependents)', async () => {
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
+            __default__ ({ "projectsRelationship": "independent" }):
+              - projectA@1.0.0 [js]
+                -> depends on projectB
+              - projectB@2.0.0 [js]
+          `,
+            {
+              version: {
+                conventionalCommits: true,
+                updateDependents: 'auto',
+              },
+            },
+            mockResolveCurrentVersion,
+            {
+              projects: ['projectA'],
+            }
+          );
+
+        const graph = await createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        });
+
+        // Only projectA should be processed (it has no dependents)
+        expect(graph.allProjectsConfiguredForNxRelease.size).toBe(2);
+        expect(graph.allProjectsToProcess.size).toBe(1);
+        expect(graph.isProjectToProcess('projectA')).toBe(true);
+        expect(graph.isProjectToProcess('projectB')).toBe(false);
+      });
+    });
+
+    describe('transitive dependencies', () => {
+      it('should include all transitive dependents when updateDependents=auto within same group (C -> B -> A, filter [A])', async () => {
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
+            __default__ ({ "projectsRelationship": "independent" }):
+              - projectC@1.0.0 [js]
+                -> depends on projectB
+              - projectB@2.0.0 [js]
+                -> depends on projectA
+              - projectA@3.0.0 [js]
+          `,
+            {
+              version: {
+                conventionalCommits: true,
+                updateDependents: 'auto',
+              },
+            },
+            mockResolveCurrentVersion,
+            {
+              projects: ['projectA'], // filtering to only projectA with updateDependents=auto
+            }
+          );
+
+        const graph = await createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        });
+
+        // All three should be included (same release group with auto)
+        expect(graph.allProjectsConfiguredForNxRelease.size).toBe(3);
+        expect(graph.allProjectsToProcess.size).toBe(3);
+        expect(graph.isProjectToProcess('projectA')).toBe(true);
+        expect(graph.isProjectToProcess('projectB')).toBe(true);
+        expect(graph.isProjectToProcess('projectC')).toBe(true);
+      });
+
+      it('should include all transitive dependents when updateDependents=always (C -> B -> A, filter [A])', async () => {
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
+            __default__ ({ "projectsRelationship": "independent" }):
+              - projectC@1.0.0 [js]
+                -> depends on projectB
+              - projectB@2.0.0 [js]
+                -> depends on projectA
+              - projectA@3.0.0 [js]
+          `,
+            {
+              version: {
+                conventionalCommits: true,
+                updateDependents: 'always', // Explicitly set to 'always'
+              },
+            },
+            mockResolveCurrentVersion,
+            {
+              projects: ['projectA'], // filtering to only projectA with updateDependents=always
+            }
+          );
+
+        const graph = await createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        });
+
+        // All three should be included due to transitive dependency chain
+        expect(graph.allProjectsConfiguredForNxRelease.size).toBe(3);
+        expect(graph.allProjectsToProcess.size).toBe(3);
+        expect(graph.isProjectToProcess('projectA')).toBe(true);
+        expect(graph.isProjectToProcess('projectB')).toBe(true);
+        expect(graph.isProjectToProcess('projectC')).toBe(true);
+      });
+
+      it('should include ONLY filtered project when updateDependents=never (C -> B -> A, filter [A])', async () => {
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
+            __default__ ({ "projectsRelationship": "independent" }):
+              - projectC@1.0.0 [js]
+                -> depends on projectB
+              - projectB@2.0.0 [js]
+                -> depends on projectA
+              - projectA@3.0.0 [js]
+          `,
+            {
+              version: {
+                conventionalCommits: true,
+                updateDependents: 'never',
+              },
+            },
+            mockResolveCurrentVersion,
+            {
+              projects: ['projectA'],
+            }
+          );
+
+        const graph = await createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        });
+
+        // Only projectA should be processed
+        expect(graph.allProjectsConfiguredForNxRelease.size).toBe(3);
+        expect(graph.allProjectsToProcess.size).toBe(1);
+        expect(graph.isProjectToProcess('projectA')).toBe(true);
+        expect(graph.isProjectToProcess('projectB')).toBe(false);
+        expect(graph.isProjectToProcess('projectC')).toBe(false);
+      });
+    });
+  });
+
+  describe('multiple release groups', () => {
+    it('should handle cross-group dependencies with proper topological ordering', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          group1 ({ "projectsRelationship": "fixed" }):
+            - pkg-a@1.0.0 [js]
+              -> depends on pkg-c
+            - pkg-b@1.0.0 [js]
+          group2 ({ "projectsRelationship": "fixed" }):
+            - pkg-c@2.0.0 [js]
+            - pkg-d@2.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+            },
+          },
+          mockResolveCurrentVersion
+        );
+
+      const graph = await createReleaseGraph({
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters,
+        firstRelease: false,
+        preid: undefined,
+        verbose: false,
+      });
+
+      // All projects should be processed
+      expect(graph.allProjectsConfiguredForNxRelease.size).toBe(4);
+      expect(graph.allProjectsToProcess.size).toBe(4);
+
+      // Verify cross-group dependency
+      expect(graph.getProjectDependencies('pkg-a').has('pkg-c')).toBe(true);
+
+      // Verify group2 comes before group1 in topological sort
+      const indexGroup1 = graph.sortedReleaseGroups.indexOf('group1');
+      const indexGroup2 = graph.sortedReleaseGroups.indexOf('group2');
+      expect(indexGroup2).toBeLessThan(indexGroup1);
+    });
+
+    describe('updateDependents across groups', () => {
+      it('should NOT propagate through groups when all have updateDependents=auto (group1 -> group2 -> group3, filter group3)', async () => {
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
+            group1 ({ "projectsRelationship": "independent" }):
+              - pkg-a@1.0.0 [js]
+                -> depends on pkg-c
+              - pkg-b@1.0.0 [js]
+            group2 ({ "projectsRelationship": "independent" }):
+              - pkg-c@2.0.0 [js]
+                -> depends on pkg-e
+              - pkg-d@2.0.0 [js]
+            group3 ({ "projectsRelationship": "independent" }):
+              - pkg-e@3.0.0 [js]
+              - pkg-f@3.0.0 [js]
+          `,
+            {
+              version: {
+                conventionalCommits: true,
+                updateDependents: 'auto', // All groups have auto
+              },
+            },
+            mockResolveCurrentVersion,
+            {
+              projects: ['pkg-e'], // Filter to only pkg-e
+            }
+          );
+
+        const graph = await createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        });
+
+        // Only pkg-e should be included (auto does NOT include dependents outside filter)
+        expect(graph.allProjectsConfiguredForNxRelease.size).toBe(6);
+        expect(graph.allProjectsToProcess.size).toBe(1);
+        expect(graph.isProjectToProcess('pkg-e')).toBe(true);
+        expect(graph.isProjectToProcess('pkg-c')).toBe(false); // NOT included with auto
+        expect(graph.isProjectToProcess('pkg-a')).toBe(false); // NOT included with auto
+        expect(graph.isProjectToProcess('pkg-b')).toBe(false); // No dependency chain
+        expect(graph.isProjectToProcess('pkg-d')).toBe(false); // No dependency chain
+        expect(graph.isProjectToProcess('pkg-f')).toBe(false); // Not included in projects filter and the group is independent
+      });
+
+      it('should propagate through all groups when all have updateDependents=always (group1 -> group2 -> group3, filter group3)', async () => {
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
+            group1 ({ "projectsRelationship": "independent" }):
+              - pkg-a@1.0.0 [js]
+                -> depends on pkg-c
+              - pkg-b@1.0.0 [js]
+            group2 ({ "projectsRelationship": "independent" }):
+              - pkg-c@2.0.0 [js]
+                -> depends on pkg-e
+              - pkg-d@2.0.0 [js]
+            group3 ({ "projectsRelationship": "independent" }):
+              - pkg-e@3.0.0 [js]
+              - pkg-f@3.0.0 [js]
+          `,
+            {
+              version: {
+                conventionalCommits: true,
+                updateDependents: 'always', // All groups have always
+              },
+            },
+            mockResolveCurrentVersion,
+            {
+              projects: ['pkg-e'], // Filter to only pkg-e
+            }
+          );
+
+        const graph = await createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        });
+
+        // All dependencies should be included: pkg-e, pkg-c (depends on pkg-e), pkg-a (depends on pkg-c)
+        expect(graph.allProjectsConfiguredForNxRelease.size).toBe(6);
+        expect(graph.allProjectsToProcess.size).toBe(3);
+        expect(graph.isProjectToProcess('pkg-e')).toBe(true);
+        expect(graph.isProjectToProcess('pkg-c')).toBe(true); // Included via always
+        expect(graph.isProjectToProcess('pkg-a')).toBe(true); // Included via always
+        expect(graph.isProjectToProcess('pkg-b')).toBe(false); // No dependency chain
+        expect(graph.isProjectToProcess('pkg-d')).toBe(false); // No dependency chain
+        expect(graph.isProjectToProcess('pkg-f')).toBe(false); // Not included in projects filter and the group is independent
+      });
+    });
+
+    describe('groups filter', () => {
+      it('should filter to only specified groups', async () => {
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
+            group1 ({ "projectsRelationship": "fixed" }):
+              - pkg-a@1.0.0 [js]
+              - pkg-b@1.0.0 [js]
+            group2 ({ "projectsRelationship": "fixed" }):
+              - pkg-c@2.0.0 [js]
+              - pkg-d@2.0.0 [js]
+          `,
+            {
+              version: {
+                conventionalCommits: true,
+              },
+            },
+            mockResolveCurrentVersion,
+            {
+              groups: ['group1'], // Filter to only group1
+            }
+          );
+
+        const graph = await createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        });
+
+        // Only group1 projects should be processed
+        expect(graph.allProjectsConfiguredForNxRelease.size).toBe(4);
+        expect(graph.allProjectsToProcess.size).toBe(2);
+        expect(graph.isProjectToProcess('pkg-a')).toBe(true);
+        expect(graph.isProjectToProcess('pkg-b')).toBe(true);
+        expect(graph.isProjectToProcess('pkg-c')).toBe(false);
+        expect(graph.isProjectToProcess('pkg-d')).toBe(false);
+
+        // Only group1 should be in sortedReleaseGroups
+        expect(graph.sortedReleaseGroups.length).toBe(1);
+        expect(graph.sortedReleaseGroups).toContain('group1');
+      });
+
+      it('should NOT include dependent groups when filtering by group with updateDependents=auto (group1 -> group2, filter group2)', async () => {
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
+            group1 ({ "projectsRelationship": "independent" }):
+              - pkg-a@1.0.0 [js]
+                -> depends on pkg-c
+              - pkg-b@1.0.0 [js]
+            group2 ({ "projectsRelationship": "independent" }):
+              - pkg-c@2.0.0 [js]
+              - pkg-d@2.0.0 [js]
+          `,
+            {
+              version: {
+                conventionalCommits: true,
+                updateDependents: 'auto',
+              },
+            },
+            mockResolveCurrentVersion,
+            {
+              groups: ['group2'], // Filter to only group2
+            }
+          );
+
+        const graph = await createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        });
+
+        // Only group2 projects (auto does NOT include dependents outside filter)
+        expect(graph.allProjectsConfiguredForNxRelease.size).toBe(4);
+        expect(graph.allProjectsToProcess.size).toBe(2);
+        expect(graph.isProjectToProcess('pkg-c')).toBe(true);
+        expect(graph.isProjectToProcess('pkg-d')).toBe(true);
+        expect(graph.isProjectToProcess('pkg-a')).toBe(false); // NOT included with auto
+        expect(graph.isProjectToProcess('pkg-b')).toBe(false); // No dependency
+      });
+
+      it('should include dependent groups when filtering by group with updateDependents=always (group1 -> group2, filter group2)', async () => {
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
+            group1 ({ "projectsRelationship": "independent" }):
+              - pkg-a@1.0.0 [js]
+                -> depends on pkg-c
+              - pkg-b@1.0.0 [js]
+            group2 ({ "projectsRelationship": "independent" }):
+              - pkg-c@2.0.0 [js]
+              - pkg-d@2.0.0 [js]
+          `,
+            {
+              version: {
+                conventionalCommits: true,
+                updateDependents: 'always', // Explicitly set to 'always'
+              },
+            },
+            mockResolveCurrentVersion,
+            {
+              groups: ['group2'], // Filter to only group2
+            }
+          );
+
+        const graph = await createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        });
+
+        // group2 projects plus pkg-a from group1 (depends on pkg-c)
+        expect(graph.allProjectsConfiguredForNxRelease.size).toBe(4);
+        expect(graph.allProjectsToProcess.size).toBe(3);
+        expect(graph.isProjectToProcess('pkg-c')).toBe(true);
+        expect(graph.isProjectToProcess('pkg-d')).toBe(true);
+        expect(graph.isProjectToProcess('pkg-a')).toBe(true); // Included via updateDependents=always
+        expect(graph.isProjectToProcess('pkg-b')).toBe(false); // No dependency
+      });
+
+      it('should NOT include dependent groups when filtering by group with updateDependents=never (group1 -> group2, filter group2)', async () => {
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
+            group1 ({ "projectsRelationship": "independent" }):
+              - pkg-a@1.0.0 [js]
+                -> depends on pkg-c
+              - pkg-b@1.0.0 [js]
+            group2 ({ "projectsRelationship": "independent" }):
+              - pkg-c@2.0.0 [js]
+              - pkg-d@2.0.0 [js]
+          `,
+            {
+              version: {
+                conventionalCommits: true,
+                updateDependents: 'never',
+              },
+            },
+            mockResolveCurrentVersion,
+            {
+              groups: ['group2'], // Filter to only group2
+            }
+          );
+
+        const graph = await createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        });
+
+        // Only group2 projects should be processed
+        expect(graph.allProjectsConfiguredForNxRelease.size).toBe(4);
+        expect(graph.allProjectsToProcess.size).toBe(2);
+        expect(graph.isProjectToProcess('pkg-c')).toBe(true);
+        expect(graph.isProjectToProcess('pkg-d')).toBe(true);
+        expect(graph.isProjectToProcess('pkg-a')).toBe(false); // Blocked by updateDependents=never
+        expect(graph.isProjectToProcess('pkg-b')).toBe(false);
+      });
+
+      it('should filter to multiple groups', async () => {
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
+            group1 ({ "projectsRelationship": "fixed" }):
+              - pkg-a@1.0.0 [js]
+            group2 ({ "projectsRelationship": "fixed" }):
+              - pkg-b@2.0.0 [js]
+            group3 ({ "projectsRelationship": "fixed" }):
+              - pkg-c@3.0.0 [js]
+          `,
+            {
+              version: {
+                conventionalCommits: true,
+              },
+            },
+            mockResolveCurrentVersion,
+            {
+              groups: ['group1', 'group3'], // Filter to group1 and group3, exclude group2
+            }
+          );
+
+        const graph = await createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        });
+
+        // Only group1 and group3 projects
+        expect(graph.allProjectsConfiguredForNxRelease.size).toBe(3);
+        expect(graph.allProjectsToProcess.size).toBe(2);
+        expect(graph.isProjectToProcess('pkg-a')).toBe(true);
+        expect(graph.isProjectToProcess('pkg-b')).toBe(false);
+        expect(graph.isProjectToProcess('pkg-c')).toBe(true);
+
+        // Only group1 and group3 in sorted groups
+        expect(graph.sortedReleaseGroups).toContain('group1');
+        expect(graph.sortedReleaseGroups).toContain('group3');
+        expect(graph.sortedReleaseGroups).not.toContain('group2');
+      });
+    });
+
+    describe('complex cross-group scenarios', () => {
+      it('should NOT propagate across groups when all have auto (group1[auto] -> group2[auto] -> group3[auto])', async () => {
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
+            group1 ({ "projectsRelationship": "independent" }):
+              - pkg-a@1.0.0 [js]
+                -> depends on pkg-c
+            group2 ({ "projectsRelationship": "independent" }):
+              - pkg-c@2.0.0 [js]
+                -> depends on pkg-e
+            group3 ({ "projectsRelationship": "independent" }):
+              - pkg-e@3.0.0 [js]
+          `,
+            {
+              version: {
+                conventionalCommits: true,
+                updateDependents: 'auto', // All groups have auto
+              },
+            },
+            mockResolveCurrentVersion,
+            {
+              projects: ['pkg-e'], // Start from group3
+            }
+          );
+
+        const graph = await createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        });
+
+        // Only pkg-e should be processed (auto does NOT propagate)
+        expect(graph.isProjectToProcess('pkg-e')).toBe(true); // Filtered
+        expect(graph.isProjectToProcess('pkg-c')).toBe(false); // NOT included with auto
+        expect(graph.isProjectToProcess('pkg-a')).toBe(false); // NOT included with auto
+
+        // Only group3 should be in the sorted list
+        expect(graph.sortedReleaseGroups).toContain('group3');
+        expect(graph.sortedReleaseGroups).not.toContain('group2');
+        expect(graph.sortedReleaseGroups).not.toContain('group1');
+      });
+
+      it('should handle transitive dependencies across 3 groups when all have always (group1[always] -> group2[always] -> group3[always])', async () => {
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
+            group1 ({ "projectsRelationship": "independent" }):
+              - pkg-a@1.0.0 [js]
+                -> depends on pkg-c
+            group2 ({ "projectsRelationship": "independent" }):
+              - pkg-c@2.0.0 [js]
+                -> depends on pkg-e
+            group3 ({ "projectsRelationship": "independent" }):
+              - pkg-e@3.0.0 [js]
+          `,
+            {
+              version: {
+                conventionalCommits: true,
+                updateDependents: 'always', // All groups have always
+              },
+            },
+            mockResolveCurrentVersion,
+            {
+              projects: ['pkg-e'], // Start from group3
+            }
+          );
+
+        const graph = await createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        });
+
+        // Full propagation through all groups
+        expect(graph.isProjectToProcess('pkg-e')).toBe(true); // Filtered
+        expect(graph.isProjectToProcess('pkg-c')).toBe(true); // Included via always
+        expect(graph.isProjectToProcess('pkg-a')).toBe(true); // Included via always
+
+        // Verify all 3 groups are in the sorted list
+        expect(graph.sortedReleaseGroups).toContain('group1');
+        expect(graph.sortedReleaseGroups).toContain('group2');
+        expect(graph.sortedReleaseGroups).toContain('group3');
+
+        // Verify topological ordering: group3 -> group2 -> group1
+        const idx1 = graph.sortedReleaseGroups.indexOf('group1');
+        const idx2 = graph.sortedReleaseGroups.indexOf('group2');
+        const idx3 = graph.sortedReleaseGroups.indexOf('group3');
+        expect(idx3).toBeLessThan(idx2);
+        expect(idx2).toBeLessThan(idx1);
+      });
+    });
+  });
+
+  describe('filter log', () => {
+    it('should generate filter log for projects filter', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          __default__ ({ "projectsRelationship": "independent" }):
+            - projectA@1.0.0 [js]
+            - projectB@2.0.0 [js]
+            - projectC@3.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+            },
+          },
+          mockResolveCurrentVersion,
+          {
+            projects: ['projectA', 'projectB'],
+          }
+        );
+
+      const graph = await createReleaseGraph({
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters,
+        firstRelease: false,
+        preid: undefined,
+        verbose: false,
+      });
+
+      expect(graph.filterLog).toBeDefined();
+      expect(graph.filterLog?.title).toContain('projectA,projectB');
+      expect(graph.filterLog?.bodyLines).toContain('- projectA');
+      expect(graph.filterLog?.bodyLines).toContain('- projectB');
+    });
+
+    it('should not generate filter log when no filters applied', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          __default__ ({ "projectsRelationship": "fixed" }):
+            - projectA@1.0.0 [js]
+            - projectB@2.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+            },
+          },
+          mockResolveCurrentVersion
+        );
+
+      const graph = await createReleaseGraph({
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters,
+        firstRelease: false,
+        preid: undefined,
+        verbose: false,
+      });
+
+      expect(graph.filterLog).toBeNull();
+    });
+  });
+
+  describe('validate', () => {
+    it('should error when projects in release groups outside of the filtered groups do not have valid manifestsToUpdate IF they are required to be processed because of dependencies to groups included in the filtered groups', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+            group1 ({ "projectsRelationship": "fixed" }):
+              - pkg-a@1.0.0 [js]
+                -> depends on pkg-c
+              - pkg-b@1.0.0 [js]
+            group2 ({ "projectsRelationship": "fixed" }):
+              - pkg-c@2.0.0 [js]
+              - pkg-d@2.0.0 [js]
+          `,
+          {
+            version: {
+              conventionalCommits: true,
+              manifestRootsToUpdate: ['{projectRoot}'],
+            },
+          },
+          mockResolveCurrentVersion,
+          {
+            // Only release group2 (but group1 has a dependency on group2)
+            groups: ['group2'],
+          }
+        );
+
+      // Delete the package.json for pkg-c which is outside of the filtered groups. This test is asserting that this DOES throw an error.
+      tree.delete('pkg-c/package.json');
+
+      const releaseGraph = await createReleaseGraph({
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters,
+        firstRelease: false,
+        preid: undefined,
+        verbose: false,
+      });
+
+      await expect(releaseGraph.validate(tree)).rejects
+        .toThrowErrorMatchingInlineSnapshot(`
+        "The project "pkg-c" does not have a package.json file available in pkg-c/
+
+        To fix this you will either need to add a package.json file at that location, or configure "release" within your nx.json to exclude "pkg-c" from the current release group, or amend the "release.version.manifestRootsToUpdate" configuration to point to where the relevant manifest should be.
+
+        It is also possible that the project is being processed because of a dependency relationship between what you are directly versioning and the project/release group, in which case you will need to amend your filters to include all relevant projects and release groups."
+      `);
+    });
+  });
+});

--- a/packages/nx/src/command-line/release/utils/release-graph.ts
+++ b/packages/nx/src/command-line/release/utils/release-graph.ts
@@ -1,0 +1,1031 @@
+import type {
+  NxReleaseDockerConfiguration,
+  NxReleaseVersionConfiguration,
+} from '../../../config/nx-json';
+import type {
+  ProjectGraph,
+  ProjectGraphProjectNode,
+} from '../../../config/project-graph';
+import type { Tree } from '../../../generators/tree';
+import {
+  IMPLICIT_DEFAULT_RELEASE_GROUP,
+  type NxReleaseConfig,
+} from '../config/config';
+import type { ReleaseGroupWithName } from '../config/filter-release-groups';
+import { ProjectLogger } from '../version/project-logger';
+import { resolveCurrentVersion } from '../version/resolve-current-version';
+import { topologicalSort } from '../version/topological-sort';
+import {
+  NOOP_VERSION_ACTIONS,
+  resolveVersionActionsForProject,
+  type AfterAllProjectsVersioned,
+  type VersionActions,
+} from '../version/version-actions';
+import { getLatestGitTagForPattern } from './git';
+import { shouldSkipVersionActions, type VersionDataEntry } from './shared';
+
+/**
+ * Final configuration for a project after applying release group and project level overrides
+ */
+export interface FinalConfigForProject {
+  specifierSource: NxReleaseVersionConfiguration['specifierSource'];
+  currentVersionResolver: NxReleaseVersionConfiguration['currentVersionResolver'];
+  currentVersionResolverMetadata: NxReleaseVersionConfiguration['currentVersionResolverMetadata'];
+  fallbackCurrentVersionResolver: NxReleaseVersionConfiguration['fallbackCurrentVersionResolver'];
+  versionPrefix: NxReleaseVersionConfiguration['versionPrefix'];
+  preserveLocalDependencyProtocols: NxReleaseVersionConfiguration['preserveLocalDependencyProtocols'];
+  preserveMatchingDependencyRanges: NxReleaseVersionConfiguration['preserveMatchingDependencyRanges'];
+  versionActionsOptions: NxReleaseVersionConfiguration['versionActionsOptions'];
+  manifestRootsToUpdate: Array<
+    Exclude<
+      NxReleaseVersionConfiguration['manifestRootsToUpdate'][number],
+      string
+    >
+  >;
+  dockerOptions: NxReleaseDockerConfiguration & {
+    groupPreVersionCommand?: string;
+  };
+}
+
+interface GroupNode {
+  group: ReleaseGroupWithName;
+  dependencies: Set<string>;
+  dependents: Set<string>;
+}
+
+export interface CreateReleaseGraphOptions {
+  tree: Tree;
+  projectGraph: ProjectGraph;
+  nxReleaseConfig: NxReleaseConfig;
+  filters: {
+    projects?: string[];
+    groups?: string[];
+  };
+  firstRelease: boolean;
+  preid?: string;
+  verbose: boolean;
+  /**
+   * Current version resolution is not needed for publishing, so in cases where the publish subcommand needs to build a release graph,
+   * we allow it to skip this step.
+   */
+  skipVersionResolution?: boolean;
+  versionActionsOptionsOverrides?: Record<string, unknown>;
+}
+
+export const validReleaseVersionPrefixes = ['auto', '', '~', '^', '='] as const;
+
+/**
+ * The complete release graph containing all relationships, caches, and computed data
+ * necessary for efficient release operations across versioning, changelog, and publishing.
+ *
+ * This class encapsulates the complex dependency graph between projects and release groups,
+ * providing convenient methods for querying relationships and accessing cached data.
+ */
+export class ReleaseGraph {
+  readonly projectToReleaseGroup = new Map<string, ReleaseGroupWithName>();
+  readonly projectToDependents = new Map<string, Set<string>>();
+  readonly projectToDependencies = new Map<string, Set<string>>();
+  readonly projectToUpdateDependentsSetting = new Map<
+    string,
+    'auto' | 'always' | 'never'
+  >();
+  readonly groupGraph = new Map<string, GroupNode>();
+  sortedReleaseGroups: string[] = [];
+  readonly sortedProjects = new Map<string, string[]>();
+  readonly allProjectsConfiguredForNxRelease = new Set<string>();
+  allProjectsToProcess = new Set<string>();
+  readonly finalConfigsByProject = new Map<string, FinalConfigForProject>();
+  readonly projectsToVersionActions = new Map<string, VersionActions>();
+  readonly uniqueAfterAllProjectsVersioned = new Map<
+    string,
+    AfterAllProjectsVersioned
+  >();
+  readonly projectLoggers = new Map<string, ProjectLogger>();
+  readonly cachedCurrentVersions = new Map<string, string | null>();
+  readonly cachedLatestMatchingGitTag = new Map<
+    string,
+    Awaited<ReturnType<typeof getLatestGitTagForPattern>>
+  >();
+  readonly currentVersionsPerFixedReleaseGroup = new Map<
+    string,
+    {
+      currentVersion: string;
+      originatingProjectName: string;
+      logText: string;
+    }
+  >();
+  readonly originalDependentProjectsPerProject = new Map<
+    string,
+    VersionDataEntry['dependentProjects']
+  >();
+  readonly releaseGroupToFilteredProjects = new Map<
+    ReleaseGroupWithName,
+    Set<string>
+  >();
+  private originalFilteredProjects = new Set<string>();
+
+  /**
+   * User-friendly log describing what the filter matched.
+   * Null if no filters were applied.
+   */
+  filterLog: { title: string; bodyLines: string[] } | null = null;
+
+  constructor(
+    public releaseGroups: ReleaseGroupWithName[],
+    public readonly filters: {
+      projects?: string[];
+      groups?: string[];
+    }
+  ) {}
+
+  /**
+   * Initialize the graph by building all relationships and caches
+   * @internal - Called by createReleaseGraph(), not meant for external use
+   */
+  async init(options: CreateReleaseGraphOptions): Promise<void> {
+    // Step 1: Setup project to release group mapping
+    this.setupProjectReleaseGroupMapping();
+
+    // Step 2: Apply initial filtering to determine base set of projects and groups to process
+    this.applyInitialFiltering();
+
+    // Step 3: Setup projects to process and resolve version actions
+    await this.setupProjectsToProcess(options);
+
+    // Step 4: Precompute dependency relationships
+    await this.precomputeDependencyRelationships(
+      options.tree,
+      options.projectGraph
+    );
+
+    // Step 5: Apply dependency-aware filtering based on updateDependents
+    this.applyDependencyAwareFiltering();
+
+    // Step 5: Build the group graph structure
+    this.buildGroupGraphStructure();
+
+    // Step 6: Resolve current versions for all projects to process (unless explicitly skipped)
+    if (!options.skipVersionResolution) {
+      await this.resolveCurrentVersionsForProjects(
+        options.tree,
+        options.projectGraph,
+        options.preid ?? ''
+      );
+    }
+
+    // Step 7: Build dependency relationships between groups
+    this.buildGroupDependencyGraph();
+
+    // Step 8: Topologically sort groups and projects
+    this.sortedReleaseGroups = this.topologicallySortReleaseGroups();
+    for (const group of this.releaseGroups) {
+      this.sortedProjects.set(
+        group.name,
+        this.topologicallySortProjects(group)
+      );
+    }
+
+    // Step 9: Populate dependent projects data
+    await this.populateDependentProjectsData(
+      options.tree,
+      options.projectGraph
+    );
+  }
+
+  /**
+   * Setup mapping from project to release group and cache updateDependents settings
+   */
+  private setupProjectReleaseGroupMapping(): void {
+    for (const group of this.releaseGroups) {
+      for (const project of group.projects) {
+        this.projectToReleaseGroup.set(project, group);
+
+        const updateDependents =
+          (group.version as NxReleaseVersionConfiguration)?.updateDependents ||
+          'auto';
+        this.projectToUpdateDependentsSetting.set(project, updateDependents);
+      }
+    }
+  }
+
+  /**
+   * Apply initial filtering to construct releaseGroupToFilteredProjects based on filters.
+   * This determines the base set of projects and groups before considering dependencies.
+   */
+  private applyInitialFiltering(): void {
+    const matchedReleaseGroups: ReleaseGroupWithName[] = [];
+
+    for (const releaseGroup of this.releaseGroups) {
+      // If group filter is applied and this group doesn't match, skip it entirely
+      if (
+        this.filters.groups?.length &&
+        !this.filters.groups.includes(releaseGroup.name)
+      ) {
+        continue;
+      }
+
+      // If filtering by groups (not projects), include ALL projects in the matched group
+      if (this.filters.groups?.length && !this.filters.projects?.length) {
+        this.releaseGroupToFilteredProjects.set(
+          releaseGroup,
+          new Set(releaseGroup.projects)
+        );
+        matchedReleaseGroups.push(releaseGroup);
+        continue;
+      }
+
+      // If filtering by projects, filter down to matching projects
+      const filteredProjects = new Set<string>();
+      for (const project of releaseGroup.projects) {
+        if (
+          this.filters.projects?.length &&
+          !this.filters.projects.includes(project)
+        ) {
+          continue;
+        }
+        filteredProjects.add(project);
+      }
+
+      // If no filters applied or group has matching projects, include it
+      if (filteredProjects.size > 0 || !this.hasAnyFilters()) {
+        const projectsToInclude =
+          filteredProjects.size > 0
+            ? filteredProjects
+            : new Set(releaseGroup.projects);
+        this.releaseGroupToFilteredProjects.set(
+          releaseGroup,
+          projectsToInclude
+        );
+        matchedReleaseGroups.push(releaseGroup);
+      }
+    }
+
+    // Update this.releaseGroups to only include matched groups
+    if (this.hasAnyFilters()) {
+      this.releaseGroups = matchedReleaseGroups;
+    }
+  }
+
+  /**
+   * Check if any filters are applied
+   */
+  private hasAnyFilters(): boolean {
+    return !!(this.filters.projects?.length || this.filters.groups?.length);
+  }
+
+  /**
+   * Setup projects to process and resolve version actions
+   */
+  private async setupProjectsToProcess(
+    options: CreateReleaseGraphOptions
+  ): Promise<void> {
+    const {
+      tree,
+      projectGraph,
+      nxReleaseConfig,
+      filters,
+      firstRelease,
+      versionActionsOptionsOverrides,
+    } = options;
+    let projectsToProcess = new Set<string>();
+    const resolveVersionActionsForProjectCallbacks = [];
+
+    // Precompute all projects in nx release config
+    for (const [groupName, group] of Object.entries(nxReleaseConfig.groups)) {
+      for (const project of group.projects) {
+        this.allProjectsConfiguredForNxRelease.add(project);
+        this.projectLoggers.set(project, new ProjectLogger(project));
+
+        if (filters.groups?.includes(groupName)) {
+          projectsToProcess.add(project);
+        } else if (filters.projects?.includes(project)) {
+          projectsToProcess.add(project);
+        }
+
+        const projectGraphNode = projectGraph.nodes[project];
+
+        const releaseGroup = this.projectToReleaseGroup.get(project);
+
+        const finalConfigForProject = ReleaseGraph.resolveFinalConfigForProject(
+          releaseGroup,
+          projectGraphNode,
+          firstRelease,
+          versionActionsOptionsOverrides
+        );
+        this.finalConfigsByProject.set(project, finalConfigForProject);
+
+        resolveVersionActionsForProjectCallbacks.push(async () => {
+          const {
+            versionActionsPath,
+            versionActions,
+            afterAllProjectsVersioned,
+          } = await resolveVersionActionsForProject(
+            tree,
+            releaseGroup,
+            projectGraphNode,
+            finalConfigForProject
+          );
+          if (!this.uniqueAfterAllProjectsVersioned.has(versionActionsPath)) {
+            this.uniqueAfterAllProjectsVersioned.set(
+              versionActionsPath,
+              afterAllProjectsVersioned
+            );
+          }
+          let versionActionsToUse = versionActions;
+          const shouldSkip = shouldSkipVersionActions(
+            finalConfigForProject.dockerOptions,
+            project
+          );
+
+          if (shouldSkip) {
+            versionActionsToUse = new NOOP_VERSION_ACTIONS(
+              releaseGroup,
+              projectGraphNode,
+              finalConfigForProject
+            );
+          }
+          this.projectsToVersionActions.set(project, versionActionsToUse);
+        });
+      }
+    }
+
+    if (!filters.groups?.length && !filters.projects?.length) {
+      projectsToProcess = this.allProjectsConfiguredForNxRelease;
+    }
+
+    if (projectsToProcess.size === 0) {
+      throw new Error(
+        'No projects are set to be processed, please report this as a bug on https://github.com/nrwl/nx/issues'
+      );
+    }
+
+    this.allProjectsToProcess = new Set(projectsToProcess);
+
+    for (const cb of resolveVersionActionsForProjectCallbacks) {
+      await cb();
+    }
+  }
+
+  /**
+   * Precompute dependency relationships between all projects
+   */
+  private async precomputeDependencyRelationships(
+    tree: Tree,
+    projectGraph: ProjectGraph
+  ): Promise<void> {
+    for (const projectName of this.allProjectsConfiguredForNxRelease) {
+      const versionActions = this.projectsToVersionActions.get(projectName);
+
+      if (!this.projectToDependencies.has(projectName)) {
+        this.projectToDependencies.set(projectName, new Set());
+      }
+
+      const deps = await versionActions.readDependencies(tree, projectGraph);
+
+      for (const dep of deps) {
+        if (!this.allProjectsConfiguredForNxRelease.has(dep.target)) {
+          continue;
+        }
+
+        this.projectToDependencies.get(projectName)!.add(dep.target);
+
+        if (!this.projectToDependents.has(dep.target)) {
+          this.projectToDependents.set(dep.target, new Set());
+        }
+        this.projectToDependents.get(dep.target)!.add(projectName);
+      }
+    }
+  }
+
+  /**
+   * Apply dependency-aware filtering that considers updateDependents configuration.
+   * This includes transitive dependents when updateDependents='auto'.
+   */
+  private applyDependencyAwareFiltering(): void {
+    // Track the original filtered projects before adding dependents
+    this.originalFilteredProjects = new Set(this.allProjectsToProcess);
+
+    if (!this.hasAnyFilters()) {
+      // No filtering applied, nothing to do
+      return;
+    }
+
+    // Validate filtering against fixed release groups
+    this.validateFilterAgainstFixedGroups();
+
+    // Find all dependents that need to be included based on updateDependents setting
+    this.findDependentsToProcess();
+
+    // Generate user-friendly filter log
+    this.generateFilterLog();
+  }
+
+  /**
+   * Validate that the filter doesn't try to isolate projects in fixed release groups
+   */
+  private validateFilterAgainstFixedGroups(): void {
+    if (!this.filters.projects?.length) {
+      // Group filtering doesn't have this issue
+      return;
+    }
+
+    for (const releaseGroup of this.releaseGroups) {
+      if (releaseGroup.projectsRelationship !== 'fixed') {
+        continue;
+      }
+
+      const filteredProjectsInGroup = releaseGroup.projects.filter((p) =>
+        this.releaseGroupToFilteredProjects.get(releaseGroup)?.has(p)
+      );
+
+      if (
+        filteredProjectsInGroup.length > 0 &&
+        filteredProjectsInGroup.length < releaseGroup.projects.length
+      ) {
+        throw new Error(
+          `Cannot filter to a subset of projects within fixed release group "${releaseGroup.name}". ` +
+            `Filtered projects: [${filteredProjectsInGroup.join(', ')}], ` +
+            `All projects in group: [${releaseGroup.projects.join(', ')}]. ` +
+            `Either filter to all projects in the group, use --groups to filter by group, or change the group to "independent".`
+        );
+      }
+    }
+  }
+
+  /**
+   * Find dependents that should be included in processing based on updateDependents configuration
+   */
+  private findDependentsToProcess(): void {
+    const projectsToProcess = Array.from(this.allProjectsToProcess);
+    const allTrackedDependents = new Set<string>();
+    const dependentsToProcess = new Set<string>();
+    const additionalGroups = new Map<string, ReleaseGroupWithName>();
+
+    // BFS traversal to find all transitive dependents
+    let currentLevel = [...projectsToProcess];
+
+    while (currentLevel.length > 0) {
+      const nextLevel: string[] = [];
+
+      const dependents = this.getAllNonImplicitDependents(currentLevel);
+
+      for (const dep of dependents) {
+        if (
+          allTrackedDependents.has(dep) ||
+          this.allProjectsToProcess.has(dep)
+        ) {
+          continue;
+        }
+
+        allTrackedDependents.add(dep);
+
+        // Check if this dependent should be included based on updateDependents settings
+        const depUpdateDependentsSetting =
+          this.projectToUpdateDependentsSetting.get(dep);
+
+        // Only include if dependent has 'always' or 'auto' (not 'never')
+        if (depUpdateDependentsSetting !== 'never') {
+          // Find which project(s) in currentLevel this dependent depends on
+          const shouldIncludeDependent = currentLevel.some((proj) => {
+            const projUpdateSetting =
+              this.projectToUpdateDependentsSetting.get(proj);
+            const projDependents = this.getProjectDependents(proj);
+
+            if (!projDependents.has(dep)) {
+              return false;
+            }
+
+            // Always include if updateDependents is 'always'
+            if (projUpdateSetting === 'always') {
+              return true;
+            }
+
+            // For 'auto', include if in the same release group to match historical behavior
+            if (projUpdateSetting === 'auto') {
+              const projGroup = this.getReleaseGroupForProject(proj);
+              const depGroup = this.getReleaseGroupForProject(dep);
+              return projGroup && depGroup && projGroup.name === depGroup.name;
+            }
+
+            return false;
+          });
+
+          if (shouldIncludeDependent) {
+            dependentsToProcess.add(dep);
+
+            // Track the release group of this dependent
+            const depGroup = this.getReleaseGroupForProject(dep);
+            if (depGroup) {
+              // Check if this group is already in our list by name
+              const groupAlreadyExists = this.releaseGroups.some(
+                (g) => g.name === depGroup.name
+              );
+              if (!groupAlreadyExists) {
+                additionalGroups.set(depGroup.name, depGroup);
+              }
+            }
+          }
+        }
+
+        nextLevel.push(dep);
+      }
+
+      currentLevel = nextLevel;
+    }
+
+    dependentsToProcess.forEach((dep) => this.allProjectsToProcess.add(dep));
+
+    // Add any additional groups and their filtered projects
+    additionalGroups.forEach((group) => {
+      // When adding groups due to dependents, clear version plans to avoid duplication
+      // Version plans should only be processed for groups that were explicitly included
+      const groupForDependents = {
+        ...group,
+        versionPlans: false,
+        resolvedVersionPlans: false,
+      } as const;
+      this.releaseGroups.push(groupForDependents);
+      // Add the projects from this group that are actually being processed
+      const projectsInGroup = new Set(
+        group.projects.filter((p) => dependentsToProcess.has(p))
+      );
+      this.releaseGroupToFilteredProjects.set(
+        groupForDependents,
+        projectsInGroup
+      );
+    });
+  }
+
+  /**
+   * Generate user-friendly log describing what the filter matched
+   */
+  private generateFilterLog(): void {
+    if (this.filters.projects?.length) {
+      // Projects filter - only show the originally filtered projects to match old behavior
+      const matchedProjects = Array.from(this.originalFilteredProjects);
+      this.filterLog = {
+        title: `Your filter "${this.filters.projects.join(
+          ','
+        )}" matched the following projects:`,
+        bodyLines: matchedProjects.map((p) => {
+          const releaseGroupForProject = this.projectToReleaseGroup.get(p);
+          if (
+            !releaseGroupForProject ||
+            releaseGroupForProject.name === IMPLICIT_DEFAULT_RELEASE_GROUP
+          ) {
+            return `- ${p}`;
+          }
+          return `- ${p} (release group "${releaseGroupForProject.name}")`;
+        }),
+      };
+    }
+    // TODO: add groups filter log
+  }
+
+  /**
+   * Build the group graph structure
+   */
+  private buildGroupGraphStructure(): void {
+    for (const group of this.releaseGroups) {
+      // Don't overwrite if already exists (may have been added during filtering)
+      if (!this.groupGraph.has(group.name)) {
+        this.groupGraph.set(group.name, {
+          group,
+          dependencies: new Set(),
+          dependents: new Set(),
+        });
+      }
+    }
+  }
+
+  /**
+   * Resolve current versions for all projects that will be processed
+   */
+  private async resolveCurrentVersionsForProjects(
+    tree: Tree,
+    projectGraph: ProjectGraph,
+    preid: string
+  ): Promise<void> {
+    for (const [, releaseGroupNode] of this.groupGraph) {
+      for (const projectName of releaseGroupNode.group.projects) {
+        const projectGraphNode = projectGraph.nodes[projectName];
+
+        if (!this.allProjectsToProcess.has(projectName)) {
+          continue;
+        }
+
+        const versionActions = this.projectsToVersionActions.get(projectName)!;
+        const finalConfigForProject =
+          this.finalConfigsByProject.get(projectName)!;
+
+        let latestMatchingGitTag:
+          | Awaited<ReturnType<typeof getLatestGitTagForPattern>>
+          | undefined;
+        const releaseTagPattern = releaseGroupNode.group.releaseTagPattern;
+
+        if (finalConfigForProject.currentVersionResolver === 'git-tag') {
+          latestMatchingGitTag = await getLatestGitTagForPattern(
+            releaseTagPattern,
+            {
+              projectName: projectGraphNode.name,
+            },
+            {
+              checkAllBranchesWhen:
+                releaseGroupNode.group.releaseTagPatternCheckAllBranchesWhen,
+              preid: preid,
+              releaseTagPatternRequireSemver:
+                releaseGroupNode.group.releaseTagPatternRequireSemver,
+              releaseTagPatternStrictPreid:
+                releaseGroupNode.group.releaseTagPatternStrictPreid,
+            }
+          );
+          this.cachedLatestMatchingGitTag.set(
+            projectName,
+            latestMatchingGitTag
+          );
+        }
+
+        const currentVersion = await resolveCurrentVersion(
+          tree,
+          projectGraphNode,
+          releaseGroupNode.group,
+          versionActions,
+          this.projectLoggers.get(projectName)!,
+          this.currentVersionsPerFixedReleaseGroup,
+          finalConfigForProject,
+          releaseTagPattern,
+          latestMatchingGitTag
+        );
+        this.cachedCurrentVersions.set(projectName, currentVersion);
+      }
+    }
+  }
+
+  /**
+   * Build dependency relationships between release groups
+   */
+  private buildGroupDependencyGraph(): void {
+    for (const [releaseGroupName, releaseGroupNode] of this.groupGraph) {
+      for (const projectName of releaseGroupNode.group.projects) {
+        const projectDeps = this.getProjectDependencies(projectName);
+        for (const dep of projectDeps) {
+          const dependencyGroup = this.getReleaseGroupNameForProject(dep);
+          if (dependencyGroup && dependencyGroup !== releaseGroupName) {
+            releaseGroupNode.dependencies.add(dependencyGroup);
+
+            // Only add to dependents if the dependency group exists in the graph
+            // (it may have been filtered out due to user filters)
+            const dependencyGroupNode = this.groupGraph.get(dependencyGroup);
+            if (dependencyGroupNode) {
+              dependencyGroupNode.dependents.add(releaseGroupName);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Topologically sort release groups
+   */
+  private topologicallySortReleaseGroups(): string[] {
+    const groupNames = Array.from(this.groupGraph.keys());
+
+    const getGroupDependencies = (groupName: string): string[] => {
+      const groupNode = this.groupGraph.get(groupName);
+      if (!groupNode) {
+        return [];
+      }
+      return Array.from(groupNode.dependencies);
+    };
+
+    return topologicalSort(groupNames, getGroupDependencies);
+  }
+
+  /**
+   * Topologically sort projects within a release group
+   */
+  private topologicallySortProjects(
+    releaseGroup: ReleaseGroupWithName
+  ): string[] {
+    const projects = releaseGroup.projects.filter((p) =>
+      this.allProjectsToProcess.has(p)
+    );
+
+    const getProjectDependenciesInSameGroup = (project: string): string[] => {
+      const deps = this.getProjectDependencies(project);
+      return Array.from(deps).filter(
+        (dep) =>
+          this.getReleaseGroupNameForProject(dep) === releaseGroup.name &&
+          this.allProjectsToProcess.has(dep)
+      );
+    };
+
+    return topologicalSort(projects, getProjectDependenciesInSameGroup);
+  }
+
+  private async populateDependentProjectsData(
+    tree: Tree,
+    projectGraph: ProjectGraph
+  ): Promise<void> {
+    // Populate detailed dependent projects data for all projects being processed
+    for (const projectName of this.allProjectsToProcess) {
+      const dependentProjectNames = Array.from(
+        this.getProjectDependents(projectName)
+      ).filter((dep) => this.allProjectsConfiguredForNxRelease.has(dep));
+
+      const dependentProjectsData: VersionDataEntry['dependentProjects'] = [];
+
+      for (const dependentProjectName of dependentProjectNames) {
+        const versionActions =
+          this.projectsToVersionActions.get(dependentProjectName)!;
+        const { currentVersion, dependencyCollection } =
+          await versionActions.readCurrentVersionOfDependency(
+            tree,
+            projectGraph,
+            projectName
+          );
+        dependentProjectsData.push({
+          source: dependentProjectName,
+          target: projectName,
+          type: 'static',
+          dependencyCollection,
+          rawVersionSpec: currentVersion,
+        });
+      }
+
+      this.originalDependentProjectsPerProject.set(
+        projectName,
+        dependentProjectsData
+      );
+    }
+  }
+
+  /**
+   * Get all non-implicit dependents for a set of projects
+   */
+  private getAllNonImplicitDependents(projects: string[]): string[] {
+    return projects
+      .flatMap((project) => Array.from(this.getProjectDependents(project)))
+      .filter((dep) => !this.allProjectsToProcess.has(dep));
+  }
+
+  /**
+   * Resolve final configuration for a project
+   *
+   * NOTE: We are providing ultimate fallback values via ?? here mainly just to keep TypeScript happy.
+   * All default values should have been applied by this point by config.ts but the types can't know
+   * that for sure at this point.
+   */
+  private static resolveFinalConfigForProject(
+    releaseGroup: ReleaseGroupWithName,
+    projectGraphNode: ProjectGraphProjectNode,
+    firstRelease: boolean,
+    versionActionsOptionsOverrides?: Record<string, unknown>
+  ): FinalConfigForProject {
+    const releaseGroupVersionConfig = releaseGroup.version as
+      | NxReleaseVersionConfiguration
+      | undefined;
+    const projectVersionConfig = projectGraphNode.data.release?.version as
+      | NxReleaseVersionConfiguration
+      | undefined;
+    const projectDockerConfig = projectGraphNode.data.release?.docker;
+
+    /**
+     * specifierSource
+     *
+     * If the user has provided a specifier, it always takes precedence,
+     * so the effective specifier source is 'prompt', regardless of what
+     * the project or release group config says.
+     */
+    const specifierSource =
+      projectVersionConfig?.specifierSource ??
+      releaseGroupVersionConfig?.specifierSource ??
+      'prompt';
+
+    /**
+     * versionPrefix, defaults to auto
+     */
+    const versionPrefix =
+      projectVersionConfig?.versionPrefix ??
+      releaseGroupVersionConfig?.versionPrefix ??
+      'auto';
+    if (versionPrefix && !validReleaseVersionPrefixes.includes(versionPrefix)) {
+      throw new Error(
+        `Invalid value for versionPrefix: "${versionPrefix}"
+
+Valid values are: ${validReleaseVersionPrefixes
+          .map((s) => `"${s}"`)
+          .join(', ')}`
+      );
+    }
+
+    /**
+     * Merge docker options configured in project with release group config,
+     * project level configuration should take precedence
+     */
+    const dockerOptions: NxReleaseDockerConfiguration & {
+      groupPreVersionCommand?: string;
+    } = Object.assign(
+      {},
+      releaseGroup.docker || {},
+      projectDockerConfig || {}
+    ) as NxReleaseDockerConfiguration & {
+      groupPreVersionCommand?: string;
+    };
+
+    /**
+     * currentVersionResolver, defaults to disk
+     */
+    let currentVersionResolver =
+      projectVersionConfig?.currentVersionResolver ??
+      releaseGroupVersionConfig?.currentVersionResolver ??
+      'disk';
+
+    // Check if this project should skip version actions based on docker configuration
+    const shouldSkip = shouldSkipVersionActions(
+      dockerOptions,
+      projectGraphNode.name
+    );
+
+    if (shouldSkip) {
+      // If the project skips version actions, it doesn't need to resolve a current version
+      currentVersionResolver = 'none';
+    } else if (
+      specifierSource === 'conventional-commits' &&
+      currentVersionResolver !== 'git-tag'
+    ) {
+      throw new Error(
+        `Invalid currentVersionResolver "${currentVersionResolver}" provided for project "${projectGraphNode.name}". Must be "git-tag" when "specifierSource" is "conventional-commits"`
+      );
+    }
+
+    /**
+     * currentVersionResolverMetadata, defaults to {}
+     */
+    const currentVersionResolverMetadata =
+      projectVersionConfig?.currentVersionResolverMetadata ??
+      releaseGroupVersionConfig?.currentVersionResolverMetadata ??
+      {};
+
+    /**
+     * preserveLocalDependencyProtocols
+     *
+     * This was false by default in legacy versioning, but is true by default now.
+     */
+    const preserveLocalDependencyProtocols =
+      projectVersionConfig?.preserveLocalDependencyProtocols ??
+      releaseGroupVersionConfig?.preserveLocalDependencyProtocols ??
+      true;
+
+    /**
+     * preserveMatchingDependencyRanges
+     *
+     * This was false by default until v22, but is true by default now.
+     */
+    const preserveMatchingDependencyRanges =
+      projectVersionConfig?.preserveMatchingDependencyRanges ??
+      releaseGroupVersionConfig?.preserveMatchingDependencyRanges ??
+      true;
+
+    /**
+     * fallbackCurrentVersionResolver, defaults to disk when performing a first release, otherwise undefined
+     */
+    const fallbackCurrentVersionResolver =
+      projectVersionConfig?.fallbackCurrentVersionResolver ??
+      releaseGroupVersionConfig?.fallbackCurrentVersionResolver ??
+      (firstRelease ? 'disk' : undefined);
+
+    /**
+     * versionActionsOptions, defaults to {}
+     */
+    let versionActionsOptions =
+      projectVersionConfig?.versionActionsOptions ??
+      releaseGroupVersionConfig?.versionActionsOptions ??
+      {};
+    // Apply any optional overrides that may be passed in from the programmatic API
+    versionActionsOptions = {
+      ...versionActionsOptions,
+      ...(versionActionsOptionsOverrides ?? {}),
+    };
+
+    const manifestRootsToUpdate = (
+      projectVersionConfig?.manifestRootsToUpdate ??
+      releaseGroupVersionConfig?.manifestRootsToUpdate ??
+      []
+    ).map((manifestRoot) => {
+      if (typeof manifestRoot === 'string') {
+        return {
+          path: manifestRoot,
+          // Apply the project level preserveLocalDependencyProtocols setting that was already resolved
+          preserveLocalDependencyProtocols,
+        };
+      }
+      return manifestRoot;
+    });
+
+    return {
+      specifierSource,
+      currentVersionResolver,
+      currentVersionResolverMetadata,
+      fallbackCurrentVersionResolver,
+      versionPrefix,
+      preserveLocalDependencyProtocols,
+      preserveMatchingDependencyRanges,
+      versionActionsOptions,
+      manifestRootsToUpdate,
+      dockerOptions,
+    };
+  }
+
+  /**
+   * Get the release group for a given project
+   */
+  getReleaseGroupForProject(
+    projectName: string
+  ): ReleaseGroupWithName | undefined {
+    return this.projectToReleaseGroup.get(projectName);
+  }
+
+  /**
+   * Get the release group name for a given project
+   */
+  getReleaseGroupNameForProject(projectName: string): string | null {
+    const group = this.projectToReleaseGroup.get(projectName);
+    return group ? group.name : null;
+  }
+
+  /**
+   * Get the dependencies of a project
+   */
+  getProjectDependencies(projectName: string): Set<string> {
+    return this.projectToDependencies.get(projectName) || new Set();
+  }
+
+  /**
+   * Get the dependents of a project (projects that depend on it)
+   */
+  getProjectDependents(projectName: string): Set<string> {
+    return this.projectToDependents.get(projectName) || new Set();
+  }
+
+  /**
+   * Get the version actions for a project
+   */
+  getVersionActionsForProject(projectName: string): VersionActions | undefined {
+    return this.projectsToVersionActions.get(projectName);
+  }
+
+  /**
+   * Check if a project will be processed
+   */
+  isProjectToProcess(projectName: string): boolean {
+    return this.allProjectsToProcess.has(projectName);
+  }
+
+  /**
+   * Runs validation on resolved VersionActions instances. E.g. check that manifest files exist for all projects that will be processed.
+   * This should be called after preVersionCommand has run, as those commands may create manifest files that are needed for versioning.
+   */
+  async validate(tree: Tree): Promise<void> {
+    const validationPromises: Promise<void>[] = [];
+
+    for (const projectName of this.allProjectsToProcess) {
+      const versionActions = this.projectsToVersionActions.get(projectName);
+      if (versionActions) {
+        validationPromises.push(versionActions.validate(tree));
+      }
+    }
+
+    // Validate in parallel
+    await Promise.all(validationPromises);
+  }
+}
+
+/**
+ * Creates a complete release graph by analyzing all release groups, projects, and their relationships.
+ *
+ * This function builds the graph structure, applies filtering logic that considers dependencies
+ * and updateDependents configuration, and caches all necessary data.
+ *
+ * The returned graph can be reused across versioning, changelog, and publishing operations.
+ */
+export async function createReleaseGraph(
+  options: CreateReleaseGraphOptions
+): Promise<ReleaseGraph> {
+  // Construct ReleaseGroupWithName objects from nxReleaseConfig
+  const releaseGroups: ReleaseGroupWithName[] = Object.entries(
+    options.nxReleaseConfig.groups
+  ).map(([name, group]) => {
+    return {
+      ...group,
+      name,
+      resolvedVersionPlans: group.versionPlans ? [] : false,
+    };
+  });
+
+  const graph = new ReleaseGraph(releaseGroups, options.filters);
+  await graph.init(options);
+
+  return graph;
+}

--- a/packages/nx/src/command-line/release/utils/semver.spec.ts
+++ b/packages/nx/src/command-line/release/utils/semver.spec.ts
@@ -127,6 +127,27 @@ describe('semver', () => {
             [
               'default',
               [
+                { commit: fixCommit, isProjectScopedCommit: true },
+                {
+                  commit: featNonBreakingCommit,
+                  isProjectScopedCommit: true,
+                },
+                { commit: choreCommit, isProjectScopedCommit: true },
+              ],
+            ],
+          ]),
+          config
+        ).get('default')
+      ).toEqual(SemverSpecifier.MINOR);
+    });
+
+    it('should return a patch bump level if none of the commits are project scoped', () => {
+      expect(
+        determineSemverChange(
+          new Map([
+            [
+              'default',
+              [
                 { commit: fixCommit, isProjectScopedCommit: false },
                 {
                   commit: featNonBreakingCommit,
@@ -138,7 +159,7 @@ describe('semver', () => {
           ]),
           config
         ).get('default')
-      ).toEqual(SemverSpecifier.MINOR);
+      ).toEqual(SemverSpecifier.PATCH);
     });
 
     it('should return major if any commits are breaking', () => {

--- a/packages/nx/src/command-line/release/utils/semver.ts
+++ b/packages/nx/src/command-line/release/utils/semver.ts
@@ -29,12 +29,11 @@ export function isValidSemverSpecifier(specifier: string): boolean {
   );
 }
 
-// https://github.com/unjs/changelogen/blob/main/src/semver.ts
 export function determineSemverChange(
   relevantCommits: Map<
     string,
     { commit: GitCommit; isProjectScopedCommit: boolean }[]
-  >, // <projectName, commits>
+  >,
   config: NxReleaseConfig['conventionalCommits']
 ): Map<string, SemverSpecifier | null> {
   const semverChangePerProject: Map<string, SemverSpecifier | null> = new Map();
@@ -43,8 +42,8 @@ export function determineSemverChange(
 
     for (const { commit, isProjectScopedCommit } of relevantCommit) {
       if (!isProjectScopedCommit) {
-        // commit is relevant to the project, but not directly, report minor change
-        highestChange = Math.max(SemverSpecifier.MINOR, highestChange ?? 0);
+        // commit is relevant to the project, but not directly, report patch change to match side-effectful bump behavior in update dependents in release-group-processor
+        highestChange = Math.max(SemverSpecifier.PATCH, highestChange ?? 0);
         continue;
       }
       const semverType = config.types[commit.type]?.semverBump;

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -6,6 +6,7 @@ import {
   NxReleaseVersionConfiguration,
   readNxJson,
 } from '../../config/nx-json';
+import { LARGE_BUFFER } from '../../executors/run-commands/run-commands.impl';
 import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
 import { FsTree, Tree, flushChanges } from '../../generators/tree';
 import { createProjectFileMapUsingProjectGraph } from '../../project-graph/file-map-utils';
@@ -20,10 +21,7 @@ import {
   handleNxReleaseConfigError,
 } from './config/config';
 import { deepMergeJson } from './config/deep-merge-json';
-import {
-  ReleaseGroupWithName,
-  filterReleaseGroups,
-} from './config/filter-release-groups';
+import { ReleaseGroupWithName } from './config/filter-release-groups';
 import {
   readRawVersionPlans,
   setResolvedVersionPlansOnGroups,
@@ -31,6 +29,7 @@ import {
 import { gitAdd, gitPush, gitTag } from './utils/git';
 import { printDiff } from './utils/print-changes';
 import { printConfigAndExit } from './utils/print-config';
+import { ReleaseGraph, createReleaseGraph } from './utils/release-graph';
 import { resolveNxJsonConfigErrorMessage } from './utils/resolve-nx-json-error-message';
 import {
   VersionData,
@@ -39,15 +38,9 @@ import {
   createGitTagValues,
   handleDuplicateGitTags,
 } from './utils/shared';
+import { validateResolvedVersionPlansAgainstFilter } from './utils/version-plan-utils';
 import { ReleaseGroupProcessor } from './version/release-group-processor';
 import { SemverBumpType } from './version/version-actions';
-import { validateResolvedVersionPlansAgainstFilter } from './utils/version-plan-utils';
-
-const LARGE_BUFFER = 1024 * 1000000;
-
-// Reexport some utils for use in plugin release-version generator implementations
-
-export const validReleaseVersionPrefixes = ['auto', '', '~', '^', '='] as const;
 
 export interface NxReleaseVersionResult {
   /**
@@ -62,6 +55,11 @@ export interface NxReleaseVersionResult {
    */
   workspaceVersion: (string | null) | undefined;
   projectsVersionData: VersionData;
+  /**
+   * The release graph that was built or reused during this operation.
+   * This can be passed to subsequent operations (changelog, publish) to avoid recomputing.
+   */
+  releaseGraph: ReleaseGraph;
 }
 
 export const releaseVersionCLIHandler = (args: VersionOptions) =>
@@ -122,33 +120,38 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
       process.exit(1);
     }
 
-    const {
-      error: filterError,
-      filterLog,
-      releaseGroups,
-      releaseGroupToFilteredProjects,
-    } = filterReleaseGroups(
-      projectGraph,
-      nxReleaseConfig,
-      args.projects,
-      args.groups
-    );
-    if (filterError) {
-      output.error(filterError);
-      process.exit(1);
-    }
+    const tree = new FsTree(workspaceRoot, args.verbose);
+
+    // Use pre-built release graph if provided, otherwise create a new one
+    const releaseGraph: ReleaseGraph =
+      args.releaseGraph ||
+      (await createReleaseGraph({
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters: {
+          projects: args.projects,
+          groups: args.groups,
+        },
+        firstRelease: args.firstRelease,
+        verbose: args.verbose,
+        preid: args.preid,
+        versionActionsOptionsOverrides: args.versionActionsOptionsOverrides,
+      }));
+
+    // Display filter log if filters were applied
     if (
-      filterLog &&
+      releaseGraph.filterLog &&
       process.env.NX_RELEASE_INTERNAL_SUPPRESS_FILTER_LOG !== 'true'
     ) {
-      output.note(filterLog);
+      output.note(releaseGraph.filterLog);
     }
 
     if (!args.specifier) {
       const rawVersionPlans = await readRawVersionPlans();
       await setResolvedVersionPlansOnGroups(
         rawVersionPlans,
-        releaseGroups,
+        releaseGraph.releaseGroups,
         Object.keys(projectGraph.nodes),
         args.verbose
       );
@@ -156,15 +159,18 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
       // Validate version plans against the filter after resolution
       const versionPlanValidationError =
         validateResolvedVersionPlansAgainstFilter(
-          releaseGroups,
-          releaseGroupToFilteredProjects
+          releaseGraph.releaseGroups,
+          releaseGraph.releaseGroupToFilteredProjects
         );
       if (versionPlanValidationError) {
         output.error(versionPlanValidationError);
         process.exit(1);
       }
     } else {
-      if (args.verbose && releaseGroups.some((g) => !!g.versionPlans)) {
+      if (
+        args.verbose &&
+        releaseGraph.releaseGroups.some((g) => !!g.versionPlans)
+      ) {
         console.log(
           `Skipping version plan discovery as a specifier was provided`
         );
@@ -186,8 +192,16 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
 
     /**
      * Run any configured pre-version command for the selected release groups
+     * in topological order
      */
-    for (const releaseGroup of releaseGroups) {
+    for (const groupName of releaseGraph.sortedReleaseGroups) {
+      const releaseGroup = releaseGraph.releaseGroups.find(
+        (g) => g.name === groupName
+      );
+      if (!releaseGroup) {
+        // Release group was filtered out, skip
+        continue;
+      }
       runPreVersionCommand(
         releaseGroup.version?.groupPreVersionCommand,
         {
@@ -198,7 +212,11 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
       );
     }
 
-    const tree = new FsTree(workspaceRoot, args.verbose);
+    /**
+     * Validate the resolved data for the release graph, e.g. that manifest files exist for all projects that will be processed.
+     * This happens after preVersionCommands run, as those commands may create manifest files needed for versioning.
+     */
+    await releaseGraph.validate(tree);
 
     const commitMessage: string | undefined =
       args.gitCommitMessage || nxReleaseConfig.version.git.commitMessage;
@@ -214,8 +232,7 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
       tree,
       projectGraph,
       nxReleaseConfig,
-      releaseGroups,
-      releaseGroupToFilteredProjects,
+      releaseGraph,
       {
         dryRun: args.dryRun,
         verbose: args.verbose,
@@ -231,7 +248,6 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
     );
 
     try {
-      await processor.init();
       await processor.processGroups();
 
       // Delete processed version plan files if applicable
@@ -280,8 +296,16 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
 
     /**
      * Run any configured docker pre-version command for the selected release groups
+     * in topological order (dependencies before dependents)
      */
-    for (const releaseGroup of releaseGroups) {
+    for (const groupName of releaseGraph.sortedReleaseGroups) {
+      const releaseGroup = releaseGraph.releaseGroups.find(
+        (g) => g.name === groupName
+      );
+      if (!releaseGroup) {
+        // Release group was filtered out, skip
+        continue;
+      }
       if (releaseGroup.docker?.groupPreVersionCommand) {
         runPreVersionCommand(
           releaseGroup.docker.groupPreVersionCommand,
@@ -296,7 +320,10 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
     }
 
     // TODO(colum): Remove when Docker support is no longer experimental
-    if (nxReleaseConfig.docker || releaseGroups.some((rg) => rg.docker)) {
+    if (
+      nxReleaseConfig.docker ||
+      releaseGraph.releaseGroups.some((rg) => rg.docker)
+    ) {
       output.warn({
         title: 'Warning',
         bodyLines: [
@@ -315,8 +342,8 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
     const gitTagValues: string[] =
       args.gitTag ?? nxReleaseConfig.version.git.tag
         ? createGitTagValues(
-            releaseGroups,
-            releaseGroupToFilteredProjects,
+            releaseGraph.releaseGroups,
+            releaseGraph.releaseGroupToFilteredProjects,
             versionData
           )
         : [];
@@ -324,11 +351,11 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
 
     // Only applicable when there is a single release group with a fixed relationship
     let workspaceVersion: string | null | undefined = undefined;
-    if (releaseGroups.length === 1) {
-      const releaseGroup = releaseGroups[0];
+    if (releaseGraph.releaseGroups.length === 1) {
+      const releaseGroup = releaseGraph.releaseGroups[0];
       if (releaseGroup.projectsRelationship === 'fixed') {
         const releaseGroupProjectNames = Array.from(
-          releaseGroupToFilteredProjects.get(releaseGroup)
+          releaseGraph.releaseGroupToFilteredProjects.get(releaseGroup)
         );
         workspaceVersion = versionData[releaseGroupProjectNames[0]].newVersion; // all projects have the same version so we can just grab the first
       }
@@ -345,6 +372,7 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
       return {
         workspaceVersion,
         projectsVersionData: versionData,
+        releaseGraph,
       };
     }
 
@@ -355,8 +383,8 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
         isDryRun: !!args.dryRun,
         isVerbose: !!args.verbose,
         gitCommitMessages: createCommitMessageValues(
-          releaseGroups,
-          releaseGroupToFilteredProjects,
+          releaseGraph.releaseGroups,
+          releaseGraph.releaseGroupToFilteredProjects,
           versionData,
           commitMessage
         ),
@@ -403,6 +431,7 @@ export function createAPI(overrideReleaseConfig: NxReleaseConfiguration) {
     return {
       workspaceVersion,
       projectsVersionData: versionData,
+      releaseGraph,
     };
   };
 }

--- a/packages/nx/src/command-line/release/version/multiple-release-groups.spec.ts
+++ b/packages/nx/src/command-line/release/version/multiple-release-groups.spec.ts
@@ -7,7 +7,8 @@ jest.doMock('./derive-specifier-from-conventional-commits', () => ({
     mockDeriveSpecifierFromConventionalCommits,
 }));
 
-jest.doMock('./version-actions', () => ({
+// Use jest.mock (hoisted) to ensure it's set up before any imports
+jest.mock('./version-actions', () => ({
   ...jest.requireActual('./version-actions'),
   deriveSpecifierFromVersionPlan: mockDeriveSpecifierFromVersionPlan,
   resolveVersionActionsForProject: mockResolveVersionActionsForProject,
@@ -31,12 +32,9 @@ import { createTreeWithEmptyWorkspace } from '../../../generators/testing-utils/
 import type { Tree } from '../../../generators/tree';
 import {
   createNxReleaseConfigAndPopulateWorkspace,
+  createTestReleaseGroupProcessor,
   mockResolveVersionActionsForProjectImplementation,
 } from './test-utils';
-
-const { ReleaseGroupProcessor } = require('./release-group-processor') as {
-  ReleaseGroupProcessor: typeof import('./release-group-processor').ReleaseGroupProcessor;
-};
 
 // Using the daemon in unit tests would cause jest to never exit
 process.env.NX_DAEMON = 'false';
@@ -55,15 +53,10 @@ describe('Multiple Release Groups', () => {
 
   describe('Two unrelated groups, both fixed relationship, just JS', () => {
     it('should correctly version projects using mocked conventional commits', async () => {
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        `
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
             group1 ({ "projectsRelationship": "fixed" }):
               - pkg-a@1.0.0 [js]
               - pkg-b@1.0.0 [js]
@@ -73,13 +66,13 @@ describe('Multiple Release Groups', () => {
               - pkg-d@2.0.0 [js]
                 -> depends on pkg-c
           `,
-        {
-          version: {
-            conventionalCommits: true,
+          {
+            version: {
+              conventionalCommits: true,
+            },
           },
-        },
-        mockResolveCurrentVersion
-      );
+          mockResolveCurrentVersion
+        );
 
       mockDeriveSpecifierFromConventionalCommits.mockImplementation(
         (_, __, ___, ____, { name: projectName }) => {
@@ -93,22 +86,12 @@ describe('Multiple Release Groups', () => {
         }
       );
 
-      const processor = new ReleaseGroupProcessor(
+      const processor = await createTestReleaseGroupProcessor(
         tree,
         projectGraph,
         nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        {
-          dryRun: false,
-          verbose: false,
-          firstRelease: false,
-          preid: undefined,
-          filters,
-        }
+        filters
       );
-
-      await processor.init();
       await processor.processGroups();
 
       // Called for each project
@@ -153,15 +136,10 @@ describe('Multiple Release Groups', () => {
 
   describe('Two unrelated groups, both independent relationship, just JS', () => {
     it('should correctly version projects using mocked conventional commits', async () => {
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        `
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
             group1 ({ "projectsRelationship": "independent" }):
               - pkg-a@1.0.0 [js]
               - pkg-b@1.1.0 [js]
@@ -171,13 +149,13 @@ describe('Multiple Release Groups', () => {
               - pkg-d@2.1.0 [js]
                 -> depends on pkg-c
           `,
-        {
-          version: {
-            conventionalCommits: true,
+          {
+            version: {
+              conventionalCommits: true,
+            },
           },
-        },
-        mockResolveCurrentVersion
-      );
+          mockResolveCurrentVersion
+        );
 
       mockDeriveSpecifierFromConventionalCommits.mockImplementation(
         (_, __, ___, ____, { name: projectName }) => {
@@ -189,22 +167,12 @@ describe('Multiple Release Groups', () => {
         }
       );
 
-      const processor = new ReleaseGroupProcessor(
+      const processor = await createTestReleaseGroupProcessor(
         tree,
         projectGraph,
         nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        {
-          dryRun: false,
-          verbose: false,
-          firstRelease: false,
-          preid: undefined,
-          filters,
-        }
+        filters
       );
-
-      await processor.init();
       await processor.processGroups();
 
       // Called for each project
@@ -250,15 +218,10 @@ describe('Multiple Release Groups', () => {
 
   describe('Two unrelated groups, one fixed one independent, just JS', () => {
     it('should correctly version projects using mocked conventional commits', async () => {
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        `
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
             group1 ({ "projectsRelationship": "fixed" }):
               - pkg-a@1.0.0 [js]
               - pkg-b@1.0.0 [js]
@@ -268,13 +231,13 @@ describe('Multiple Release Groups', () => {
               - pkg-d@2.1.0 [js]
                 -> depends on pkg-c
           `,
-        {
-          version: {
-            conventionalCommits: true,
+          {
+            version: {
+              conventionalCommits: true,
+            },
           },
-        },
-        mockResolveCurrentVersion
-      );
+          mockResolveCurrentVersion
+        );
 
       mockDeriveSpecifierFromConventionalCommits.mockImplementation(
         (_, __, ___, ____, { name: projectName }) => {
@@ -286,22 +249,12 @@ describe('Multiple Release Groups', () => {
         }
       );
 
-      const processor = new ReleaseGroupProcessor(
+      const processor = await createTestReleaseGroupProcessor(
         tree,
         projectGraph,
         nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        {
-          dryRun: false,
-          verbose: false,
-          firstRelease: false,
-          preid: undefined,
-          filters,
-        }
+        filters
       );
-
-      await processor.init();
       await processor.processGroups();
 
       // Called for each project
@@ -346,15 +299,10 @@ describe('Multiple Release Groups', () => {
 
   describe('Two related groups, both fixed relationship, just JS', () => {
     it('should correctly version projects across group boundaries', async () => {
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        `
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
             group1 ({ "projectsRelationship": "fixed" }):
               - pkg-a@1.0.0 [js]
                 -> depends on pkg-c
@@ -363,13 +311,13 @@ describe('Multiple Release Groups', () => {
               - pkg-c@2.0.0 [js]
               - pkg-d@2.0.0 [js]
           `,
-        {
-          version: {
-            conventionalCommits: true,
+          {
+            version: {
+              conventionalCommits: true,
+            },
           },
-        },
-        mockResolveCurrentVersion
-      );
+          mockResolveCurrentVersion
+        );
 
       mockDeriveSpecifierFromConventionalCommits.mockImplementation(
         (_, __, ___, ____, { name: projectName }) => {
@@ -380,22 +328,12 @@ describe('Multiple Release Groups', () => {
         }
       );
 
-      const processor = new ReleaseGroupProcessor(
+      const processor = await createTestReleaseGroupProcessor(
         tree,
         projectGraph,
         nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        {
-          dryRun: false,
-          verbose: false,
-          firstRelease: false,
-          preid: undefined,
-          filters,
-        }
+        filters
       );
-
-      await processor.init();
       await processor.processGroups();
 
       expect(mockResolveVersionActionsForProject).toHaveBeenCalledTimes(4);
@@ -436,15 +374,10 @@ describe('Multiple Release Groups', () => {
 
   describe('Three related groups, all fixed relationship, just JS', () => {
     it('should correctly version projects across transitive group boundaries', async () => {
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        `
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
             group1 ({ "projectsRelationship": "fixed" }):
               - pkg-a@1.0.0 [js]
                 -> depends on pkg-c
@@ -457,13 +390,13 @@ describe('Multiple Release Groups', () => {
               - pkg-e@3.0.0 [js]
               - pkg-f@3.0.0 [js]
           `,
-        {
-          version: {
-            conventionalCommits: true,
+          {
+            version: {
+              conventionalCommits: true,
+            },
           },
-        },
-        mockResolveCurrentVersion
-      );
+          mockResolveCurrentVersion
+        );
 
       mockDeriveSpecifierFromConventionalCommits.mockImplementation(
         (_, __, ___, ____, { name: projectName }) => {
@@ -475,22 +408,12 @@ describe('Multiple Release Groups', () => {
         }
       );
 
-      const processor = new ReleaseGroupProcessor(
+      const processor = await createTestReleaseGroupProcessor(
         tree,
         projectGraph,
         nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        {
-          dryRun: false,
-          verbose: false,
-          firstRelease: false,
-          preid: undefined,
-          filters,
-        }
+        filters
       );
-
-      await processor.init();
       await processor.processGroups();
 
       expect(mockResolveVersionActionsForProject).toHaveBeenCalledTimes(6);
@@ -566,22 +489,17 @@ describe('Multiple Release Groups', () => {
     `;
 
     it('should correctly version projects across group boundaries', async () => {
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        graphDefinition,
-        {
-          version: {
-            conventionalCommits: true,
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          graphDefinition,
+          {
+            version: {
+              conventionalCommits: true,
+            },
           },
-        },
-        mockResolveCurrentVersion
-      );
+          mockResolveCurrentVersion
+        );
 
       mockDeriveSpecifierFromConventionalCommits.mockImplementation(
         (_, __, ___, ____, { name: projectName }) => {
@@ -597,22 +515,12 @@ describe('Multiple Release Groups', () => {
         }
       );
 
-      const processor = new ReleaseGroupProcessor(
+      const processor = await createTestReleaseGroupProcessor(
         tree,
         projectGraph,
         nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        {
-          dryRun: false,
-          verbose: false,
-          firstRelease: false,
-          preid: undefined,
-          filters,
-        }
+        filters
       );
-
-      await processor.init();
       await processor.processGroups();
 
       expect(mockResolveVersionActionsForProject).toHaveBeenCalledTimes(4);
@@ -651,22 +559,17 @@ describe('Multiple Release Groups', () => {
     });
 
     it('should pick an appropriate overall version across group boundaries when a project is influenced by both a direct specifier and a dependency bump', async () => {
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        graphDefinition,
-        {
-          version: {
-            conventionalCommits: true,
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          graphDefinition,
+          {
+            version: {
+              conventionalCommits: true,
+            },
           },
-        },
-        mockResolveCurrentVersion
-      );
+          mockResolveCurrentVersion
+        );
 
       mockDeriveSpecifierFromConventionalCommits.mockImplementation(
         (_, __, ___, ____, { name: projectName }) => {
@@ -682,22 +585,12 @@ describe('Multiple Release Groups', () => {
         }
       );
 
-      const processor = new ReleaseGroupProcessor(
+      const processor = await createTestReleaseGroupProcessor(
         tree,
         projectGraph,
         nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        {
-          dryRun: false,
-          verbose: false,
-          firstRelease: false,
-          preid: undefined,
-          filters,
-        }
+        filters
       );
-
-      await processor.init();
       await processor.processGroups();
 
       expect(mockResolveVersionActionsForProject).toHaveBeenCalledTimes(4);
@@ -739,15 +632,10 @@ describe('Multiple Release Groups', () => {
   describe('Mixed JS and Rust projects within groups', () => {
     describe('Two unrelated groups, both fixed relationship, mixed JS and Rust', () => {
       it('should correctly version projects using mocked conventional commits', async () => {
-        const {
-          nxReleaseConfig,
-          projectGraph,
-          releaseGroups,
-          releaseGroupToFilteredProjects,
-          filters,
-        } = await createNxReleaseConfigAndPopulateWorkspace(
-          tree,
-          `
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
               group1 ({ "projectsRelationship": "fixed" }):
                 - pkg-a@1.0.0 [js]
                 - pkg-b@1.0.0 [rust]
@@ -755,13 +643,13 @@ describe('Multiple Release Groups', () => {
                 - pkg-c@2.0.0 [rust]
                 - pkg-d@2.0.0 [js]
             `,
-          {
-            version: {
-              conventionalCommits: true,
+            {
+              version: {
+                conventionalCommits: true,
+              },
             },
-          },
-          mockResolveCurrentVersion
-        );
+            mockResolveCurrentVersion
+          );
 
         mockDeriveSpecifierFromConventionalCommits.mockImplementation(
           (_, __, ___, ____, { name: projectName }) => {
@@ -773,22 +661,12 @@ describe('Multiple Release Groups', () => {
           }
         );
 
-        const processor = new ReleaseGroupProcessor(
+        const processor = await createTestReleaseGroupProcessor(
           tree,
           projectGraph,
           nxReleaseConfig,
-          releaseGroups,
-          releaseGroupToFilteredProjects,
-          {
-            dryRun: false,
-            verbose: false,
-            firstRelease: false,
-            preid: undefined,
-            filters,
-          }
+          filters
         );
-
-        await processor.init();
         await processor.processGroups();
 
         // Called for each project
@@ -827,15 +705,10 @@ describe('Multiple Release Groups', () => {
 
     describe('Two unrelated groups, both independent relationship, mixed JS and Rust', () => {
       it('should correctly version projects using mocked conventional commits', async () => {
-        const {
-          nxReleaseConfig,
-          projectGraph,
-          releaseGroups,
-          releaseGroupToFilteredProjects,
-          filters,
-        } = await createNxReleaseConfigAndPopulateWorkspace(
-          tree,
-          `
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
               group1 ({ "projectsRelationship": "independent" }):
                 - pkg-a@1.0.0 [js]
                 - pkg-b@1.1.0 [rust]
@@ -843,13 +716,13 @@ describe('Multiple Release Groups', () => {
                 - pkg-c@2.0.0 [rust]
                 - pkg-d@2.1.0 [js]
             `,
-          {
-            version: {
-              conventionalCommits: true,
+            {
+              version: {
+                conventionalCommits: true,
+              },
             },
-          },
-          mockResolveCurrentVersion
-        );
+            mockResolveCurrentVersion
+          );
 
         mockDeriveSpecifierFromConventionalCommits.mockImplementation(
           (_, __, ___, ____, { name: projectName }) => {
@@ -861,22 +734,12 @@ describe('Multiple Release Groups', () => {
           }
         );
 
-        const processor = new ReleaseGroupProcessor(
+        const processor = await createTestReleaseGroupProcessor(
           tree,
           projectGraph,
           nxReleaseConfig,
-          releaseGroups,
-          releaseGroupToFilteredProjects,
-          {
-            dryRun: false,
-            verbose: false,
-            firstRelease: false,
-            preid: undefined,
-            filters,
-          }
+          filters
         );
-
-        await processor.init();
         await processor.processGroups();
 
         // Called for each project
@@ -915,15 +778,10 @@ describe('Multiple Release Groups', () => {
 
     describe('Two related groups, both fixed relationship, mixed JS and Rust', () => {
       it('should correctly version projects across group boundaries', async () => {
-        const {
-          nxReleaseConfig,
-          projectGraph,
-          releaseGroups,
-          releaseGroupToFilteredProjects,
-          filters,
-        } = await createNxReleaseConfigAndPopulateWorkspace(
-          tree,
-          `
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
               group1 ({ "projectsRelationship": "fixed" }):
                 - pkg-a@1.0.0 [js]
                 - pkg-b@1.0.0 [rust]
@@ -932,13 +790,13 @@ describe('Multiple Release Groups', () => {
                 - pkg-c@2.0.0 [rust]
                 - pkg-d@2.0.0 [js]
             `,
-          {
-            version: {
-              conventionalCommits: true,
+            {
+              version: {
+                conventionalCommits: true,
+              },
             },
-          },
-          mockResolveCurrentVersion
-        );
+            mockResolveCurrentVersion
+          );
 
         mockDeriveSpecifierFromConventionalCommits.mockImplementation(
           (_, __, ___, ____, { name: projectName }) => {
@@ -954,22 +812,12 @@ describe('Multiple Release Groups', () => {
           }
         );
 
-        const processor = new ReleaseGroupProcessor(
+        const processor = await createTestReleaseGroupProcessor(
           tree,
           projectGraph,
           nxReleaseConfig,
-          releaseGroups,
-          releaseGroupToFilteredProjects,
-          {
-            dryRun: false,
-            verbose: false,
-            firstRelease: false,
-            preid: undefined,
-            filters,
-          }
+          filters
         );
-
-        await processor.init();
         await processor.processGroups();
 
         // Called for each project
@@ -1012,32 +860,27 @@ describe('Multiple Release Groups', () => {
 
   describe('groups filter', () => {
     it('should not error if projects in release groups outside of the filtered groups do not have valid manifestsToUpdate', async () => {
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        `
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
             group1 ({ "projectsRelationship": "fixed" }):
               - pkg-a@1.0.0 [js]
             group2 ({ "projectsRelationship": "fixed" }):
               - pkg-c@2.0.0 [js]
           `,
-        {
-          version: {
-            conventionalCommits: true,
-            manifestRootsToUpdate: ['{projectRoot}'],
+          {
+            version: {
+              conventionalCommits: true,
+              manifestRootsToUpdate: ['{projectRoot}'],
+            },
           },
-        },
-        mockResolveCurrentVersion,
-        {
-          // Only release group1
-          groups: ['group1'],
-        }
-      );
+          mockResolveCurrentVersion,
+          {
+            // Only release group1
+            groups: ['group1'],
+          }
+        );
 
       // Delete the package.json for pkg-c which is outside of the filtered groups. This test is asserting that this does NOT throw an error.
       tree.delete('pkg-c/package.json');
@@ -1049,22 +892,12 @@ describe('Multiple Release Groups', () => {
         }
       );
 
-      const processor = new ReleaseGroupProcessor(
+      const processor = await createTestReleaseGroupProcessor(
         tree,
         projectGraph,
         nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        {
-          dryRun: false,
-          verbose: false,
-          firstRelease: false,
-          preid: undefined,
-          filters,
-        }
+        filters
       );
-
-      await processor.init();
       await processor.processGroups();
 
       // Called for each project
@@ -1076,72 +909,6 @@ describe('Multiple Release Groups', () => {
           "version": "1.1.0"
         }
         "
-      `);
-    });
-
-    it('should error when projects in release groups outside of the filtered groups do not have valid manifestsToUpdate IF they are required to be processed because of dependencies to groups included in the filtered groups', async () => {
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        `
-            group1 ({ "projectsRelationship": "fixed" }):
-              - pkg-a@1.0.0 [js]
-                -> depends on pkg-c
-              - pkg-b@1.0.0 [js]
-            group2 ({ "projectsRelationship": "fixed" }):
-              - pkg-c@2.0.0 [js]
-              - pkg-d@2.0.0 [js]
-          `,
-        {
-          version: {
-            conventionalCommits: true,
-            manifestRootsToUpdate: ['{projectRoot}'],
-          },
-        },
-        mockResolveCurrentVersion,
-        {
-          // Only release group2 (but group1 has a dependency on group2)
-          groups: ['group2'],
-        }
-      );
-
-      // Delete the package.json for pkg-c which is outside of the filtered groups. This test is asserting that this DOES throw an error.
-      tree.delete('pkg-c/package.json');
-
-      mockDeriveSpecifierFromConventionalCommits.mockImplementation(
-        (_, __, ___, ____, { name: projectName }) => {
-          if (projectName === 'pkg-c') return 'patch';
-          return 'none';
-        }
-      );
-
-      const processor = new ReleaseGroupProcessor(
-        tree,
-        projectGraph,
-        nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        {
-          dryRun: false,
-          verbose: false,
-          firstRelease: false,
-          preid: undefined,
-          filters,
-        }
-      );
-
-      await expect(processor.init()).rejects
-        .toThrowErrorMatchingInlineSnapshot(`
-        "The project "pkg-c" does not have a package.json file available in ./pkg-c.
-
-        To fix this you will either need to add a package.json file at that location, or configure "release" within your nx.json to exclude "pkg-c" from the current release group, or amend the "release.version.manifestRootsToUpdate" configuration to point to where the relevant manifest should be.
-
-        It is also possible that the project is being processed because of a dependency relationship between what you are directly versioning and the project/release group, in which case you will need to amend your filters to include all relevant projects and release groups."
       `);
     });
   });

--- a/packages/nx/src/command-line/release/version/release-group-processor.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.ts
@@ -1,64 +1,27 @@
 import * as semver from 'semver';
-import {
-  ManifestRootToUpdate,
-  NxReleaseDockerConfiguration,
-  NxReleaseVersionConfiguration,
-} from '../../../config/nx-json';
+import { NxReleaseVersionConfiguration } from '../../../config/nx-json';
 import {
   ProjectGraph,
   ProjectGraphProjectNode,
 } from '../../../config/project-graph';
 import { Tree } from '../../../generators/tree';
+import { workspaceRoot } from '../../../utils/workspace-root';
 import {
   IMPLICIT_DEFAULT_RELEASE_GROUP,
   type NxReleaseConfig,
 } from '../config/config';
-import { workspaceRoot } from '../../../utils/workspace-root';
 import type { ReleaseGroupWithName } from '../config/filter-release-groups';
-import { getLatestGitTagForPattern } from '../utils/git';
+import { FinalConfigForProject, ReleaseGraph } from '../utils/release-graph';
 import { resolveSemverSpecifierFromPrompt } from '../utils/resolve-semver-specifier';
 import type { VersionData, VersionDataEntry } from '../utils/shared';
-import { shouldSkipVersionActions } from '../utils/shared';
-import { validReleaseVersionPrefixes } from '../version';
 import { deriveSpecifierFromConventionalCommits } from './derive-specifier-from-conventional-commits';
 import { deriveSpecifierFromVersionPlan } from './deriver-specifier-from-version-plans';
 import { ProjectLogger } from './project-logger';
-import { resolveCurrentVersion } from './resolve-current-version';
-import { topologicalSort } from './topological-sort';
 import {
-  AfterAllProjectsVersioned,
-  resolveVersionActionsForProject,
+  NOOP_VERSION_ACTIONS,
   SemverBumpType,
   VersionActions,
-  NOOP_VERSION_ACTIONS,
 } from './version-actions';
-
-/**
- * The final configuration for a project after applying release group and project level overrides,
- * as well as default values. This will be passed to the relevant version actions implementation,
- * and referenced throughout the versioning process.
- */
-export interface FinalConfigForProject {
-  specifierSource: NxReleaseVersionConfiguration['specifierSource'];
-  currentVersionResolver: NxReleaseVersionConfiguration['currentVersionResolver'];
-  currentVersionResolverMetadata: NxReleaseVersionConfiguration['currentVersionResolverMetadata'];
-  fallbackCurrentVersionResolver: NxReleaseVersionConfiguration['fallbackCurrentVersionResolver'];
-  versionPrefix: NxReleaseVersionConfiguration['versionPrefix'];
-  preserveLocalDependencyProtocols: NxReleaseVersionConfiguration['preserveLocalDependencyProtocols'];
-  preserveMatchingDependencyRanges: NxReleaseVersionConfiguration['preserveMatchingDependencyRanges'];
-  versionActionsOptions: NxReleaseVersionConfiguration['versionActionsOptions'];
-  // Consistently expanded to the object form for easier processing in VersionActions
-  manifestRootsToUpdate: Array<Exclude<ManifestRootToUpdate, string>>;
-  dockerOptions: NxReleaseDockerConfiguration & {
-    groupPreVersionCommand?: string;
-  };
-}
-
-interface GroupNode {
-  group: ReleaseGroupWithName;
-  dependencies: Set<string>;
-  dependents: Set<string>;
-}
 
 // Any semver version string such as "1.2.3" or "1.2.3-beta.1"
 type SemverVersion = string;
@@ -100,13 +63,6 @@ interface ReleaseGroupProcessorOptions {
 
 export class ReleaseGroupProcessor {
   /**
-   * Stores the relationships between release groups, including their dependencies
-   * and dependents. This is used for determining processing order and propagating
-   * version changes between related groups.
-   */
-  private groupGraph: Map<string, GroupNode> = new Map();
-
-  /**
    * Tracks which release groups have already been processed to avoid
    * processing them multiple times. Used during the group traversal.
    */
@@ -120,32 +76,6 @@ export class ReleaseGroupProcessor {
   private bumpedProjects: Set<string> = new Set();
 
   /**
-   * Cache of release groups sorted in topological order to ensure dependencies
-   * are processed before dependents. Computed once and reused throughout processing.
-   */
-  private sortedReleaseGroups: string[] = [];
-
-  /**
-   * Maps each release group to its projects sorted in topological order.
-   * Ensures projects are processed after their dependencies within each group.
-   */
-  private sortedProjects: Map<string, string[]> = new Map();
-
-  /**
-   * Track the unique afterAllProjectsVersioned functions involved in the current versioning process,
-   * so that we can ensure they are only invoked once per versioning execution.
-   */
-  private uniqueAfterAllProjectsVersioned: Map<
-    string,
-    AfterAllProjectsVersioned
-  > = new Map();
-
-  /**
-   * Track the versionActions for each project so that we can invoke certain instance methods.
-   */
-  private projectsToVersionActions: Map<string, VersionActions> = new Map();
-
-  /**
    * versionData that will ultimately be returned to the nx release version handler by getVersionData()
    */
   private versionData: Map<
@@ -154,78 +84,10 @@ export class ReleaseGroupProcessor {
   > = new Map();
 
   /**
-   * Set of all projects that are configured in the nx release config.
-   * Used to validate dependencies and identify projects that should be updated.
-   */
-  private allProjectsConfiguredForNxRelease: Set<string> = new Set();
-
-  /**
-   * Set of projects that will be processed in the current run.
-   * This is potentially a subset of allProjectsConfiguredForNxRelease based on filters
-   * and dependency relationships.
-   */
-  private allProjectsToProcess: Set<string> = new Set();
-
-  /**
    * If the user provided a specifier at the time of versioning we store it here so that it can take priority
    * over any configuration.
    */
   private userGivenSpecifier: string | undefined;
-
-  /**
-   * Caches the current version of each project to avoid repeated disk/registry/git tag lookups.
-   * Often used during new version calculation. Will be null if the current version resolver is set to 'none'.
-   */
-  private cachedCurrentVersions: Map<
-    string, // project name
-    string | null // current version
-  > = new Map();
-
-  /**
-   * Caches git tag information for projects that resolve their version from git tags.
-   * This avoids performing expensive git operations multiple times for the same project.
-   */
-  private cachedLatestMatchingGitTag: Map<
-    string, // project name
-    Awaited<ReturnType<typeof getLatestGitTagForPattern>>
-  > = new Map();
-
-  /**
-   * Temporary storage for dependent project names while building the dependency graph.
-   * This is used as an intermediate step before creating the full dependent projects data.
-   */
-  private tmpCachedDependentProjects: Map<
-    string, // project name
-    string[] // dependent project names
-  > = new Map();
-
-  /**
-   * Resolve the data regarding dependent projects for each project upfront so that it remains accurate
-   * even after updates are applied to manifests.
-   */
-  private originalDependentProjectsPerProject: Map<
-    string, // project name
-    VersionDataEntry['dependentProjects']
-  > = new Map();
-
-  /**
-   * In the case of fixed release groups that are configured to resolve the current version from a registry
-   * or a git tag, it would be a waste of time and resources to resolve the current version for each individual
-   * project, therefore we maintain a cache of the current version for each applicable fixed release group here.
-   */
-  private currentVersionsPerFixedReleaseGroup: Map<
-    string, // release group name
-    {
-      currentVersion: string;
-      originatingProjectName: string;
-      logText: string;
-    }
-  > = new Map();
-
-  /**
-   * Cache of project loggers for each project.
-   */
-  private projectLoggers: Map<string, ProjectLogger> = new Map();
 
   /**
    * Track any version plan files that have been processed so that we can delete them after versioning is complete,
@@ -233,49 +95,11 @@ export class ReleaseGroupProcessor {
    */
   private processedVersionPlanFiles = new Set<string>();
 
-  /**
-   * Certain configuration options can be overridden at the project level, and otherwise fall back to the release group level.
-   * Many also have a specific default value if nothing is set at either level. To avoid applying this hierarchy for each project
-   * every time such a configuration option is needed, we cache the result per project here.
-   */
-  private finalConfigsByProject: Map<string, FinalConfigForProject> = new Map();
-
-  /**
-   * Maps each project to its release group for quick O(1) lookups.
-   * This avoids having to scan through all release groups to find a project.
-   */
-  private projectToReleaseGroup: Map<string, ReleaseGroupWithName> = new Map();
-
-  /**
-   * Maps each project to its dependents (projects that depend on it).
-   * This is the inverse of the projectToDependencies map and enables
-   * efficient lookup of dependent projects for propagating version changes.
-   */
-  private projectToDependents: Map<string, Set<string>> = new Map();
-
-  /**
-   * Maps each project to its dependencies (projects it depends on).
-   * Used for building dependency graphs and determining processing order.
-   */
-  private projectToDependencies: Map<string, Set<string>> = new Map();
-
-  /**
-   * Caches the updateDependents setting for each project to avoid repeated
-   * lookups and calculations. This determines if dependent projects should
-   * be automatically updated when a dependency changes.
-   */
-  private projectToUpdateDependentsSetting: Map<string, 'auto' | 'never'> =
-    new Map();
-
   constructor(
     private tree: Tree,
     private projectGraph: ProjectGraph,
     private nxReleaseConfig: NxReleaseConfig,
-    private releaseGroups: ReleaseGroupWithName[],
-    private releaseGroupToFilteredProjects: Map<
-      ReleaseGroupWithName,
-      Set<string>
-    >,
+    private releaseGraph: ReleaseGraph,
     private options: ReleaseGroupProcessorOptions
   ) {
     /**
@@ -295,364 +119,25 @@ export class ReleaseGroupProcessor {
     } else {
       this.userGivenSpecifier = options.userGivenSpecifier;
     }
-  }
 
-  /**
-   * Initialize the processor by building the group graph and preparing for processing.
-   * This method must be called before processGroups().
-   */
-  async init(): Promise<void> {
-    // Precompute project to release group mapping for O(1) lookups
-    this.setupProjectReleaseGroupMapping();
-
-    // Setup projects to process and resolve version actions
-    await this.setupProjectsToProcess();
-
-    // Precompute dependency relationships
-    await this.precomputeDependencyRelationships();
-
-    // Process dependency graph to find dependents to process
-    this.findDependentsToProcess();
-
-    // Build the group graph structure
-    for (const group of this.releaseGroups) {
-      this.groupGraph.set(group.name, {
-        group,
-        dependencies: new Set(),
-        dependents: new Set(),
+    // Ensure that there is an entry in versionData for each project being processed
+    for (const projectName of this.releaseGraph.allProjectsToProcess) {
+      this.versionData.set(projectName, {
+        currentVersion: this.getCurrentCachedVersionForProject(projectName),
+        newVersion: null,
+        dockerVersion: null,
+        dependentProjects: this.getOriginalDependentProjects(projectName),
       });
-    }
-
-    // Process each project within each release group
-    for (const [, releaseGroupNode] of this.groupGraph) {
-      for (const projectName of releaseGroupNode.group.projects) {
-        const projectGraphNode = this.projectGraph.nodes[projectName];
-
-        // Check if the project has been filtered out of explicit versioning before continuing any further
-        if (!this.allProjectsToProcess.has(projectName)) {
-          continue;
-        }
-
-        const versionActions = this.getVersionActionsForProject(projectName);
-        const finalConfigForProject =
-          this.getFinalConfigForProject(projectName);
-
-        let latestMatchingGitTag:
-          | Awaited<ReturnType<typeof getLatestGitTagForPattern>>
-          | undefined;
-        const releaseTagPattern = releaseGroupNode.group.releaseTagPattern;
-        // Cache the last matching git tag for relevant projects
-        if (finalConfigForProject.currentVersionResolver === 'git-tag') {
-          latestMatchingGitTag = await getLatestGitTagForPattern(
-            releaseTagPattern,
-            {
-              projectName: projectGraphNode.name,
-            },
-            {
-              checkAllBranchesWhen:
-                releaseGroupNode.group.releaseTagPatternCheckAllBranchesWhen,
-              preid: this.options.preid,
-              releaseTagPatternRequireSemver:
-                releaseGroupNode.group.releaseTagPatternRequireSemver,
-              releaseTagPatternStrictPreid:
-                releaseGroupNode.group.releaseTagPatternStrictPreid,
-            }
-          );
-          this.cachedLatestMatchingGitTag.set(
-            projectName,
-            latestMatchingGitTag
-          );
-        }
-
-        // Cache the current version for the project
-        const currentVersion = await resolveCurrentVersion(
-          this.tree,
-          projectGraphNode,
-          releaseGroupNode.group,
-          versionActions,
-          this.projectLoggers.get(projectName)!,
-          this.currentVersionsPerFixedReleaseGroup,
-          finalConfigForProject,
-          releaseTagPattern,
-          latestMatchingGitTag
-        );
-        this.cachedCurrentVersions.set(projectName, currentVersion);
-      }
-
-      // Ensure that there is an entry in versionData for each project being processed, even if they don't end up being bumped
-      for (const projectName of this.allProjectsToProcess) {
-        this.versionData.set(projectName, {
-          currentVersion: this.getCurrentCachedVersionForProject(projectName),
-          newVersion: null,
-          dockerVersion: null,
-          dependentProjects: this.getOriginalDependentProjects(projectName),
-        });
-      }
-    }
-
-    // Build the dependency relationships between groups
-    this.buildGroupDependencyGraph();
-
-    // Topologically sort the release groups and projects for efficient processing
-    this.sortedReleaseGroups = this.topologicallySortReleaseGroups();
-
-    // Sort projects within each release group
-    for (const group of this.releaseGroups) {
-      this.sortedProjects.set(
-        group.name,
-        this.topologicallySortProjects(group)
-      );
-    }
-
-    // Populate the dependent projects data
-    await this.populateDependentProjectsData();
-  }
-
-  /**
-   * Setup mapping from project to release group and cache updateDependents settings
-   */
-  private setupProjectReleaseGroupMapping(): void {
-    for (const group of this.releaseGroups) {
-      for (const project of group.projects) {
-        this.projectToReleaseGroup.set(project, group);
-
-        // Cache updateDependents setting relevant for each project
-        const updateDependents =
-          ((group.version as NxReleaseVersionConfiguration)
-            ?.updateDependents as 'auto' | 'never') || 'auto';
-        this.projectToUpdateDependentsSetting.set(project, updateDependents);
-      }
-    }
-  }
-
-  /**
-   * Determine which projects should be processed and resolve their version actions
-   */
-  private async setupProjectsToProcess(): Promise<void> {
-    // Track the projects being directly versioned
-    let projectsToProcess = new Set<string>();
-
-    const resolveVersionActionsForProjectCallbacks = [];
-
-    // Precompute all projects in nx release config
-    for (const [groupName, group] of Object.entries(
-      this.nxReleaseConfig.groups
-    )) {
-      for (const project of group.projects) {
-        this.allProjectsConfiguredForNxRelease.add(project);
-        // Create a project logger for the project
-        this.projectLoggers.set(project, new ProjectLogger(project));
-
-        // If group filtering is applied and the current group is captured by the filter, add the project to the projectsToProcess
-        if (this.options.filters.groups?.includes(groupName)) {
-          projectsToProcess.add(project);
-          // Otherwise, if project filtering is applied and the current project is captured by the filter, add the project to the projectsToProcess
-        } else if (this.options.filters.projects?.includes(project)) {
-          projectsToProcess.add(project);
-        }
-
-        const projectGraphNode = this.projectGraph.nodes[project];
-
-        /**
-         * Try and resolve a cached ReleaseGroupWithName for the project. It may not be present
-         * if the user filtered by group and excluded this parent group from direct versioning,
-         * so fallback to the release group config and apply the name manually.
-         */
-        let releaseGroup = this.projectToReleaseGroup.get(project);
-        if (!releaseGroup) {
-          releaseGroup = {
-            ...group,
-            name: groupName,
-            resolvedVersionPlans: false,
-          };
-        }
-
-        // Resolve the final configuration for the project
-        const finalConfigForProject = this.resolveFinalConfigForProject(
-          releaseGroup,
-          projectGraphNode
-        );
-        this.finalConfigsByProject.set(project, finalConfigForProject);
-
-        /**
-         * For our versionActions validation to accurate, we need to wait until the full allProjectsToProcess
-         * set is populated so that all dependencies, including those across release groups, are included.
-         *
-         * In order to save us fully traversing the graph again to arrive at this project level, schedule a callback
-         * to resolve the versionActions for the project only once we have all the projects to process.
-         */
-        resolveVersionActionsForProjectCallbacks.push(async () => {
-          const {
-            versionActionsPath,
-            versionActions,
-            afterAllProjectsVersioned,
-          } = await resolveVersionActionsForProject(
-            this.tree,
-            releaseGroup,
-            projectGraphNode,
-            finalConfigForProject,
-            // Will be fully populated by the time this callback is executed
-            this.allProjectsToProcess.has(project)
-          );
-          if (!this.uniqueAfterAllProjectsVersioned.has(versionActionsPath)) {
-            this.uniqueAfterAllProjectsVersioned.set(
-              versionActionsPath,
-              afterAllProjectsVersioned
-            );
-          }
-          let versionActionsToUse = versionActions;
-          // Check if this project should skip version actions based on docker configuration
-          const shouldSkip = shouldSkipVersionActions(
-            finalConfigForProject.dockerOptions,
-            project
-          );
-
-          if (shouldSkip) {
-            versionActionsToUse = new NOOP_VERSION_ACTIONS(
-              releaseGroup,
-              projectGraphNode,
-              finalConfigForProject
-            ) as VersionActions;
-          }
-          this.projectsToVersionActions.set(project, versionActionsToUse);
-        });
-      }
-    }
-
-    // If no filters are applied, process all projects
-    if (
-      !this.options.filters.groups?.length &&
-      !this.options.filters.projects?.length
-    ) {
-      projectsToProcess = this.allProjectsConfiguredForNxRelease;
-    }
-
-    // If no projects are set to be processed, throw an error. This should be impossible because the filter validation in version.ts should have already caught this
-    if (projectsToProcess.size === 0) {
-      throw new Error(
-        'No projects are set to be processed, please report this as a bug on https://github.com/nrwl/nx/issues'
-      );
-    }
-
-    this.allProjectsToProcess = new Set(projectsToProcess);
-
-    // Execute all the callbacks to resolve the version actions for the projects
-    for (const cb of resolveVersionActionsForProjectCallbacks) {
-      await cb();
-    }
-  }
-
-  /**
-   * Find all dependents that should be processed due to dependency updates
-   */
-  private findDependentsToProcess(): void {
-    const projectsToProcess = Array.from(this.allProjectsToProcess);
-    const allTrackedDependents = new Set<string>();
-    const dependentsToProcess = new Set<string>();
-
-    // BFS traversal of dependency graph to find all transitive dependents
-    let currentLevel = [...projectsToProcess];
-
-    while (currentLevel.length > 0) {
-      const nextLevel: string[] = [];
-
-      // Get all dependents for the current level at once
-      const dependents = this.getAllNonImplicitDependents(currentLevel);
-
-      // Process each dependent
-      for (const dep of dependents) {
-        // Skip if we've already seen this dependent or it's already in projectsToProcess
-        if (
-          allTrackedDependents.has(dep) ||
-          this.allProjectsToProcess.has(dep)
-        ) {
-          continue;
-        }
-
-        // Track that we've seen this dependent
-        allTrackedDependents.add(dep);
-
-        // If both the dependent and its dependency have updateDependents='auto',
-        // add the dependent to the projects to process
-        if (this.hasAutoUpdateDependents(dep)) {
-          // Check if any of its dependencies in the current level have auto update
-          const hasDependencyWithAutoUpdate = currentLevel.some(
-            (proj) =>
-              this.hasAutoUpdateDependents(proj) &&
-              this.getProjectDependents(proj).has(dep)
-          );
-
-          if (hasDependencyWithAutoUpdate) {
-            dependentsToProcess.add(dep);
-          }
-        }
-
-        // Add to next level for traversal
-        nextLevel.push(dep);
-      }
-
-      // Move to next level
-      currentLevel = nextLevel;
-    }
-
-    // Add all dependents that should be processed to allProjectsToProcess
-    dependentsToProcess.forEach((dep) => this.allProjectsToProcess.add(dep));
-  }
-
-  private buildGroupDependencyGraph(): void {
-    for (const [releaseGroupName, releaseGroupNode] of this.groupGraph) {
-      for (const projectName of releaseGroupNode.group.projects) {
-        const projectDeps = this.getProjectDependencies(projectName);
-        for (const dep of projectDeps) {
-          const dependencyGroup = this.getReleaseGroupNameForProject(dep);
-          if (dependencyGroup && dependencyGroup !== releaseGroupName) {
-            releaseGroupNode.dependencies.add(dependencyGroup);
-            this.groupGraph
-              .get(dependencyGroup)!
-              .dependents.add(releaseGroupName);
-          }
-        }
-      }
-    }
-  }
-
-  private async populateDependentProjectsData(): Promise<void> {
-    for (const [projectName, dependentProjectNames] of this
-      .tmpCachedDependentProjects) {
-      const dependentProjectsData: VersionDataEntry['dependentProjects'] = [];
-
-      for (const dependentProjectName of dependentProjectNames) {
-        const versionActions =
-          this.getVersionActionsForProject(dependentProjectName);
-        const { currentVersion, dependencyCollection } =
-          await versionActions.readCurrentVersionOfDependency(
-            this.tree,
-            this.projectGraph,
-            projectName
-          );
-        dependentProjectsData.push({
-          source: dependentProjectName,
-          target: projectName,
-          type: 'static',
-          dependencyCollection,
-          rawVersionSpec: currentVersion,
-        });
-      }
-
-      this.originalDependentProjectsPerProject.set(
-        projectName,
-        dependentProjectsData
-      );
     }
   }
 
   getReleaseGroupNameForProject(projectName: string): string | null {
-    const group = this.projectToReleaseGroup.get(projectName);
+    const group = this.releaseGraph.projectToReleaseGroup.get(projectName);
     return group ? group.name : null;
   }
 
   getNextGroup(): string | null {
-    for (const [groupName, groupNode] of this.groupGraph) {
+    for (const [groupName, groupNode] of this.releaseGraph.groupGraph) {
       if (
         !this.processedGroups.has(groupName) &&
         Array.from(groupNode.dependencies).every((dep) =>
@@ -668,22 +153,23 @@ export class ReleaseGroupProcessor {
   async processGroups(): Promise<string[]> {
     const processOrder: string[] = [];
 
-    // Use the topologically sorted groups instead of getNextGroup
-    for (const nextGroup of this.sortedReleaseGroups) {
+    // Use the topologically sorted groups
+    for (const nextGroup of this.releaseGraph.sortedReleaseGroups) {
       // Skip groups that have already been processed (could happen with circular dependencies)
       if (this.processedGroups.has(nextGroup)) {
         continue;
       }
 
       const allDependenciesProcessed = Array.from(
-        this.groupGraph.get(nextGroup)!.dependencies
+        this.releaseGraph.groupGraph.get(nextGroup)!.dependencies
       ).every((dep) => this.processedGroups.has(dep));
 
       if (!allDependenciesProcessed) {
         // If we encounter a group whose dependencies aren't all processed,
         // it means there's a circular dependency that our topological sort broke.
         // We need to process any unprocessed dependencies first.
-        for (const dep of this.groupGraph.get(nextGroup)!.dependencies) {
+        for (const dep of this.releaseGraph.groupGraph.get(nextGroup)!
+          .dependencies) {
           if (!this.processedGroups.has(dep)) {
             await this.processGroup(dep);
             this.processedGroups.add(dep);
@@ -701,7 +187,7 @@ export class ReleaseGroupProcessor {
   }
 
   flushAllProjectLoggers() {
-    for (const projectLogger of this.projectLoggers.values()) {
+    for (const projectLogger of this.releaseGraph.projectLoggers.values()) {
       projectLogger.flush();
     }
   }
@@ -736,7 +222,7 @@ export class ReleaseGroupProcessor {
     const changedFiles = new Set<string>();
     const deletedFiles = new Set<string>();
 
-    for (const [, afterAllProjectsVersioned] of this
+    for (const [, afterAllProjectsVersioned] of this.releaseGraph
       .uniqueAfterAllProjectsVersioned) {
       const {
         changedFiles: changedFilesForVersionActions,
@@ -767,7 +253,8 @@ export class ReleaseGroupProcessor {
   ) {
     const dockerProjects = new Map<string, FinalConfigForProject>();
     for (const project of this.versionData.keys()) {
-      const finalConfigForProject = this.finalConfigsByProject.get(project);
+      const finalConfigForProject =
+        this.releaseGraph.finalConfigsByProject.get(project);
       if (Object.keys(finalConfigForProject.dockerOptions).length === 0) {
         continue;
       }
@@ -820,8 +307,8 @@ export class ReleaseGroupProcessor {
   }
 
   private async processGroup(releaseGroupName: string): Promise<void> {
-    const groupNode = this.groupGraph.get(releaseGroupName)!;
-    const bumped = await this.bumpVersions(groupNode.group);
+    const groupNode = this.releaseGraph.groupGraph.get(releaseGroupName)!;
+    await this.bumpVersions(groupNode.group);
 
     // Flush the project loggers for the group
     for (const project of groupNode.group.projects) {
@@ -861,7 +348,8 @@ export class ReleaseGroupProcessor {
       let bumpedByDependency = false;
 
       // Use sorted projects to check for dependencies in processed groups
-      const sortedProjects = this.sortedProjects.get(releaseGroup.name) || [];
+      const sortedProjects =
+        this.releaseGraph.sortedProjects.get(releaseGroup.name) || [];
 
       // Iterate through each project in the release group in topological order
       for (const project of sortedProjects) {
@@ -950,7 +438,8 @@ export class ReleaseGroupProcessor {
 
     // Use sorted projects for processing projects in the right order
     const sortedProjects =
-      this.sortedProjects.get(releaseGroup.name) || releaseGroup.projects;
+      this.releaseGraph.sortedProjects.get(releaseGroup.name) ||
+      releaseGroup.projects;
 
     // First, update versions for all projects in the fixed group in topological order
     for (const project of sortedProjects) {
@@ -1002,7 +491,7 @@ export class ReleaseGroupProcessor {
     releaseGroup: ReleaseGroupWithName
   ): Promise<boolean> {
     const releaseGroupFilteredProjects =
-      this.releaseGroupToFilteredProjects.get(releaseGroup);
+      this.releaseGraph.releaseGroupToFilteredProjects.get(releaseGroup);
 
     let bumped = false;
     const projectBumpTypes = new Map<
@@ -1015,8 +504,8 @@ export class ReleaseGroupProcessor {
     >();
     const projectsToUpdate = new Set<string>();
 
-    // First pass: Determine bump types
-    for (const project of this.allProjectsToProcess) {
+    // First pass: Determine bump types (only for projects in this release group)
+    for (const project of releaseGroupFilteredProjects) {
       const {
         newVersionInput: bumpType,
         newVersionInputReason: bumpTypeReason,
@@ -1034,7 +523,8 @@ export class ReleaseGroupProcessor {
 
     // Second pass: Update versions using topologically sorted projects
     // This ensures dependencies are processed before dependents
-    const sortedProjects = this.sortedProjects.get(releaseGroup.name) || [];
+    const sortedProjects =
+      this.releaseGraph.sortedProjects.get(releaseGroup.name) || [];
 
     // Process projects in topological order
     for (const project of sortedProjects) {
@@ -1107,7 +597,7 @@ export class ReleaseGroupProcessor {
         releaseGroup,
         projectGraphNode,
         !!semver.prerelease(currentVersion ?? ''),
-        this.cachedLatestMatchingGitTag.get(projectName),
+        this.releaseGraph.cachedLatestMatchingGitTag.get(projectName),
         cachedFinalConfigForProject.fallbackCurrentVersionResolver,
         this.options.preid
       );
@@ -1191,7 +681,8 @@ export class ReleaseGroupProcessor {
   }
 
   private getVersionActionsForProject(projectName: string): VersionActions {
-    const versionActions = this.projectsToVersionActions.get(projectName);
+    const versionActions =
+      this.releaseGraph.projectsToVersionActions.get(projectName);
     if (!versionActions) {
       throw new Error(
         `No versionActions found for project ${projectName}, please report this as a bug on https://github.com/nrwl/nx/issues`
@@ -1200,18 +691,8 @@ export class ReleaseGroupProcessor {
     return versionActions;
   }
 
-  private getFinalConfigForProject(projectName: string): FinalConfigForProject {
-    const finalConfig = this.finalConfigsByProject.get(projectName);
-    if (!finalConfig) {
-      throw new Error(
-        `No final config found for project ${projectName}, please report this as a bug on https://github.com/nrwl/nx/issues`
-      );
-    }
-    return finalConfig;
-  }
-
   private getProjectLoggerForProject(projectName: string): ProjectLogger {
-    const projectLogger = this.projectLoggers.get(projectName);
+    const projectLogger = this.releaseGraph.projectLoggers.get(projectName);
     if (!projectLogger) {
       throw new Error(
         `No project logger found for project ${projectName}, please report this as a bug on https://github.com/nrwl/nx/issues`
@@ -1223,174 +704,20 @@ export class ReleaseGroupProcessor {
   private getCurrentCachedVersionForProject(
     projectName: string
   ): string | null {
-    return this.cachedCurrentVersions.get(projectName);
+    return this.releaseGraph.cachedCurrentVersions.get(projectName);
   }
 
   private getCachedFinalConfigForProject(
     projectName: string
   ): NxReleaseVersionConfiguration {
-    const cachedFinalConfig = this.finalConfigsByProject.get(projectName);
+    const cachedFinalConfig =
+      this.releaseGraph.finalConfigsByProject.get(projectName);
     if (!cachedFinalConfig) {
       throw new Error(
         `Unexpected error: No cached config found for project ${projectName}, please report this as a bug on https://github.com/nrwl/nx/issues`
       );
     }
     return cachedFinalConfig;
-  }
-
-  /**
-   * Apply project and release group precedence and default values, as well as validate the final configuration,
-   * ready to be cached.
-   */
-  private resolveFinalConfigForProject(
-    releaseGroup: ReleaseGroupWithName,
-    projectGraphNode: ProjectGraphProjectNode
-  ): FinalConfigForProject {
-    const releaseGroupVersionConfig = releaseGroup.version as
-      | NxReleaseVersionConfiguration
-      | undefined;
-    const projectVersionConfig = projectGraphNode.data.release?.version as
-      | NxReleaseVersionConfiguration
-      | undefined;
-    const projectDockerConfig = projectGraphNode.data.release?.docker as
-      | NxReleaseDockerConfiguration
-      | undefined;
-
-    /**
-     * specifierSource
-     *
-     * If the user has provided a specifier, it always takes precedence,
-     * so the effective specifier source is 'prompt', regardless of what
-     * the project or release group config says.
-     */
-    const specifierSource = this.userGivenSpecifier
-      ? 'prompt'
-      : projectVersionConfig?.specifierSource ??
-        releaseGroupVersionConfig?.specifierSource ??
-        'prompt';
-
-    /**
-     * versionPrefix, defaults to auto
-     */
-    const versionPrefix =
-      projectVersionConfig?.versionPrefix ??
-      releaseGroupVersionConfig?.versionPrefix ??
-      'auto';
-    if (versionPrefix && !validReleaseVersionPrefixes.includes(versionPrefix)) {
-      throw new Error(
-        `Invalid value for versionPrefix: "${versionPrefix}"
-
-Valid values are: ${validReleaseVersionPrefixes
-          .map((s) => `"${s}"`)
-          .join(', ')}`
-      );
-    }
-
-    // Merge docker options configured in project with release group config
-    // Project level configuration should take preference
-    const dockerOptions = {
-      ...(releaseGroup.docker ?? {}),
-      ...(projectDockerConfig ?? {}),
-    };
-
-    /**
-     * currentVersionResolver, defaults to disk
-     */
-    let currentVersionResolver =
-      projectVersionConfig?.currentVersionResolver ??
-      releaseGroupVersionConfig?.currentVersionResolver ??
-      'disk';
-
-    // Check if this project should skip version actions based on docker configuration
-    const shouldSkip = shouldSkipVersionActions(
-      dockerOptions,
-      projectGraphNode.name
-    );
-
-    if (shouldSkip) {
-      // If the project skips version actions, it doesn't need to resolve a current version
-      currentVersionResolver = 'none';
-    } else if (
-      specifierSource === 'conventional-commits' &&
-      currentVersionResolver !== 'git-tag'
-    ) {
-      throw new Error(
-        `Invalid currentVersionResolver "${currentVersionResolver}" provided for project "${projectGraphNode.name}". Must be "git-tag" when "specifierSource" is "conventional-commits"`
-      );
-    }
-
-    /**
-     * currentVersionResolverMetadata, defaults to {}
-     */
-    const currentVersionResolverMetadata =
-      projectVersionConfig?.currentVersionResolverMetadata ??
-      releaseGroupVersionConfig?.currentVersionResolverMetadata ??
-      {};
-
-    /**
-     * preserveLocalDependencyProtocols
-     *
-     * This was false by default in legacy versioning, but is true by default now.
-     */
-    const preserveLocalDependencyProtocols =
-      projectVersionConfig?.preserveLocalDependencyProtocols ??
-      releaseGroupVersionConfig?.preserveLocalDependencyProtocols ??
-      true;
-
-    const preserveMatchingDependencyRanges =
-      projectVersionConfig?.preserveMatchingDependencyRanges ??
-      releaseGroupVersionConfig?.preserveMatchingDependencyRanges ??
-      true;
-
-    /**
-     * fallbackCurrentVersionResolver, defaults to disk when performing a first release, otherwise undefined
-     */
-    const fallbackCurrentVersionResolver =
-      projectVersionConfig?.fallbackCurrentVersionResolver ??
-      releaseGroupVersionConfig?.fallbackCurrentVersionResolver ??
-      // Always fall back to disk if this is the first release
-      (this.options.firstRelease ? 'disk' : undefined);
-
-    /**
-     * versionActionsOptions, defaults to {}
-     */
-    let versionActionsOptions =
-      projectVersionConfig?.versionActionsOptions ??
-      releaseGroupVersionConfig?.versionActionsOptions ??
-      {};
-    // Apply any optional overrides that may be passed in from the programmatic API
-    versionActionsOptions = {
-      ...versionActionsOptions,
-      ...(this.options.versionActionsOptionsOverrides ?? {}),
-    };
-
-    const manifestRootsToUpdate = (
-      projectVersionConfig?.manifestRootsToUpdate ??
-      releaseGroupVersionConfig?.manifestRootsToUpdate ??
-      []
-    ).map((manifestRoot) => {
-      if (typeof manifestRoot === 'string') {
-        return {
-          path: manifestRoot,
-          // Apply the project level preserveLocalDependencyProtocols setting that was already resolved
-          preserveLocalDependencyProtocols,
-        };
-      }
-      return manifestRoot;
-    });
-
-    return {
-      specifierSource,
-      currentVersionResolver,
-      currentVersionResolverMetadata,
-      fallbackCurrentVersionResolver,
-      versionPrefix,
-      preserveLocalDependencyProtocols,
-      preserveMatchingDependencyRanges,
-      versionActionsOptions,
-      manifestRootsToUpdate,
-      dockerOptions,
-    };
   }
 
   private async calculateNewVersion(
@@ -1416,7 +743,7 @@ Valid values are: ${validReleaseVersionPrefixes
   private async updateDependenciesForProject(
     projectName: string
   ): Promise<void> {
-    if (!this.allProjectsToProcess.has(projectName)) {
+    if (!this.releaseGraph.allProjectsToProcess.has(projectName)) {
       throw new Error(
         `Unable to find ${projectName} in allProjectsToProcess, please report this as a bug on https://github.com/nrwl/nx/issues`
       );
@@ -1431,7 +758,7 @@ Valid values are: ${validReleaseVersionPrefixes
 
     for (const dep of dependencies) {
       if (
-        this.allProjectsToProcess.has(dep.target) &&
+        this.releaseGraph.allProjectsToProcess.has(dep.target) &&
         this.bumpedProjects.has(dep.target)
       ) {
         const targetVersionData = this.versionData.get(dep.target);
@@ -1529,25 +856,30 @@ Valid values are: ${validReleaseVersionPrefixes
       return;
     }
 
-    const releaseGroup = this.groupGraph.get(releaseGroupName)!.group;
+    const releaseGroup =
+      this.releaseGraph.groupGraph.get(releaseGroupName)!.group;
     const releaseGroupVersionConfig =
       releaseGroup.version as NxReleaseVersionConfiguration;
 
     // Get updateDependents from the release group level config
     const updateDependents =
-      (releaseGroupVersionConfig?.updateDependents as 'auto' | 'never') ||
-      'auto';
+      (releaseGroupVersionConfig?.updateDependents as
+        | 'auto'
+        | 'always'
+        | 'never') || 'auto';
 
-    // Only update dependencies for dependents if the group's updateDependents is 'auto'
-    if (updateDependents === 'auto') {
+    // Only update dependencies for dependents if the group's updateDependents is 'auto' or 'always'
+    if (updateDependents === 'auto' || updateDependents === 'always') {
       const dependents = this.getNonImplicitDependentsForProject(projectName);
-      await this.updateDependenciesForDependents(dependents);
+      // Only process dependents that are actually being processed
+      const dependentsToProcess = dependents.filter((dep) =>
+        this.releaseGraph.allProjectsToProcess.has(dep)
+      );
 
-      for (const dependent of dependents) {
-        if (
-          this.allProjectsToProcess.has(dependent) &&
-          !this.bumpedProjects.has(dependent)
-        ) {
+      await this.updateDependenciesForDependents(dependentsToProcess);
+
+      for (const dependent of dependentsToProcess) {
+        if (!this.bumpedProjects.has(dependent)) {
           await this.bumpVersionForProject(
             dependent,
             'patch',
@@ -1571,7 +903,7 @@ Valid values are: ${validReleaseVersionPrefixes
     dependents: string[]
   ): Promise<void> {
     for (const dependent of dependents) {
-      if (!this.allProjectsToProcess.has(dependent)) {
+      if (!this.releaseGraph.allProjectsToProcess.has(dependent)) {
         throw new Error(
           `Unable to find project "${dependent}" in allProjectsToProcess, please report this as a bug on https://github.com/nrwl/nx/issues`
         );
@@ -1583,15 +915,18 @@ Valid values are: ${validReleaseVersionPrefixes
   private getOriginalDependentProjects(
     project: string
   ): VersionDataEntry['dependentProjects'] {
-    return this.originalDependentProjectsPerProject.get(project) || [];
+    return (
+      this.releaseGraph.originalDependentProjectsPerProject.get(project) || []
+    );
   }
 
   private async getFixedReleaseGroupBumpType(
     releaseGroupName: string
   ): Promise<SemverBumpType | SemverVersion> {
-    const releaseGroup = this.groupGraph.get(releaseGroupName)!.group;
+    const releaseGroup =
+      this.releaseGraph.groupGraph.get(releaseGroupName)!.group;
     const releaseGroupFilteredProjects =
-      this.releaseGroupToFilteredProjects.get(releaseGroup);
+      this.releaseGraph.releaseGroupToFilteredProjects.get(releaseGroup);
     if (releaseGroupFilteredProjects.size === 0) {
       return 'none';
     }
@@ -1618,107 +953,11 @@ Valid values are: ${validReleaseVersionPrefixes
   }
 
   private getProjectDependents(project: string): Set<string> {
-    return this.projectToDependents.get(project) || new Set();
-  }
-
-  private getAllNonImplicitDependents(projects: string[]): string[] {
-    return projects
-      .flatMap((project) => {
-        const dependentProjectNames =
-          this.getNonImplicitDependentsForProject(project);
-        this.tmpCachedDependentProjects.set(project, dependentProjectNames);
-        return dependentProjectNames;
-      })
-      .filter((dep) => !this.allProjectsToProcess.has(dep));
+    return this.releaseGraph.projectToDependents.get(project) || new Set();
   }
 
   private getNonImplicitDependentsForProject(project: string): string[] {
     // Use the cached dependents for O(1) lookup instead of O(n) scan
     return Array.from(this.getProjectDependents(project));
-  }
-
-  private hasAutoUpdateDependents(projectName: string): boolean {
-    return this.projectToUpdateDependentsSetting.get(projectName) === 'auto';
-  }
-
-  private topologicallySortReleaseGroups(): string[] {
-    // Get all release group names
-    const groupNames = Array.from(this.groupGraph.keys());
-
-    // Function to get dependencies of a group
-    const getGroupDependencies = (groupName: string): string[] => {
-      const groupNode = this.groupGraph.get(groupName);
-      if (!groupNode) {
-        return [];
-      }
-      return Array.from(groupNode.dependencies);
-    };
-
-    // Perform topological sort
-    return topologicalSort(groupNames, getGroupDependencies);
-  }
-
-  private topologicallySortProjects(
-    releaseGroup: ReleaseGroupWithName
-  ): string[] {
-    // For fixed relationship groups, the order doesn't matter since all projects will
-    // be versioned identically, but we still sort them for consistency
-    const projects = releaseGroup.projects.filter((p) =>
-      // Only include projects that are in allProjectsToProcess
-      this.allProjectsToProcess.has(p)
-    );
-
-    // Function to get dependencies of a project that are in the same release group
-    const getProjectDependenciesInSameGroup = (project: string): string[] => {
-      const deps = this.getProjectDependencies(project);
-      // Only include dependencies that are in the same release group and in allProjectsToProcess
-      return Array.from(deps).filter(
-        (dep) =>
-          this.getReleaseGroupNameForProject(dep) === releaseGroup.name &&
-          this.allProjectsToProcess.has(dep)
-      );
-    };
-
-    // Perform topological sort
-    return topologicalSort(projects, getProjectDependenciesInSameGroup);
-  }
-
-  /**
-   * Precompute project -> dependents/dependencies relationships for O(1) lookups
-   */
-  private async precomputeDependencyRelationships(): Promise<void> {
-    for (const projectName of this.allProjectsConfiguredForNxRelease) {
-      const versionActions = this.projectsToVersionActions.get(projectName);
-
-      // Create a new set for this project's dependencies
-      if (!this.projectToDependencies.has(projectName)) {
-        this.projectToDependencies.set(projectName, new Set());
-      }
-
-      const deps = await versionActions.readDependencies(
-        this.tree,
-        this.projectGraph
-      );
-
-      for (const dep of deps) {
-        // Skip dependencies not covered by nx release
-        if (!this.allProjectsConfiguredForNxRelease.has(dep.target)) {
-          continue;
-        }
-
-        // Add this dependency to the project's dependencies
-        this.projectToDependencies.get(projectName)!.add(dep.target);
-
-        // Add this project as a dependent of the target
-        if (!this.projectToDependents.has(dep.target)) {
-          this.projectToDependents.set(dep.target, new Set());
-        }
-        this.projectToDependents.get(dep.target)!.add(projectName);
-      }
-    }
-  }
-
-  private getProjectDependencies(project: string): Set<string> {
-    return this.projectToDependencies.get(project) || new Set();
   }
 }

--- a/packages/nx/src/command-line/release/version/release-version.spec.ts
+++ b/packages/nx/src/command-line/release/version/release-version.spec.ts
@@ -9,12 +9,11 @@ import {
   writeJson,
 } from '../../../generators/utils/json';
 import { output } from '../../../utils/output';
-import { NxReleaseConfig } from '../config/config';
-import { ReleaseGroupWithName } from '../config/filter-release-groups';
+import type { NxReleaseConfig } from '../config/config';
 import { VersionData } from '../utils/shared';
-import { ReleaseGroupProcessor } from './release-group-processor';
 import {
   createNxReleaseConfigAndPopulateWorkspace,
+  createTestReleaseGroupProcessor,
   mockResolveVersionActionsForProjectImplementation,
 } from './test-utils';
 import { SemverBumpType } from './version-actions';
@@ -97,16 +96,12 @@ async function releaseVersionGeneratorForTest(
   {
     nxReleaseConfig,
     projectGraph,
-    releaseGroups,
-    releaseGroupToFilteredProjects,
     userGivenSpecifier,
     filters,
     preid,
   }: {
     nxReleaseConfig: NxReleaseConfig;
     projectGraph: ProjectGraph;
-    releaseGroups: ReleaseGroupWithName[];
-    releaseGroupToFilteredProjects: Map<ReleaseGroupWithName, Set<string>>;
     userGivenSpecifier: SemverBumpType | undefined;
     filters?: {
       projects?: string[];
@@ -115,24 +110,19 @@ async function releaseVersionGeneratorForTest(
     preid?: string;
   }
 ): Promise<ReleaseVersionGeneratorResult> {
-  const processor = new ReleaseGroupProcessor(
-    tree,
-    projectGraph,
-    nxReleaseConfig,
-    releaseGroups,
-    releaseGroupToFilteredProjects,
-    {
-      dryRun: false,
-      verbose: false,
-      firstRelease: false,
-      preid,
-      userGivenSpecifier,
-      filters,
-    }
-  );
-
   try {
-    await processor.init();
+    const processor = await createTestReleaseGroupProcessor(
+      tree,
+      projectGraph,
+      nxReleaseConfig,
+      filters || {},
+      {
+        firstRelease: false,
+        preid,
+        userGivenSpecifier,
+      }
+    );
+
     await processor.processGroups();
 
     return {
@@ -143,15 +133,12 @@ async function releaseVersionGeneratorForTest(
          */
         return processor.afterAllProjectsVersioned(
           (nxReleaseConfig.version as NxReleaseVersionConfiguration)
-            .versionActionsOptions
+            .versionActionsOptions ?? {}
         );
       },
       data: processor.getVersionData(),
     };
   } catch (e: any) {
-    // Flush any pending logs before printing the error to make troubleshooting easier
-    processor.flushAllProjectLoggers();
-
     if (process.env.NX_VERBOSE_LOGGING === 'true') {
       output.error({
         title: e.message,
@@ -194,15 +181,10 @@ describe('releaseVersionGenerator (ported tests)', () => {
   });
 
   it('should return a versionData object', async () => {
-    const {
-      nxReleaseConfig,
-      projectGraph,
-      releaseGroups,
-      releaseGroupToFilteredProjects,
-      filters,
-    } = await createNxReleaseConfigAndPopulateWorkspace(
-      tree,
-      `
+    const { nxReleaseConfig, projectGraph, filters } =
+      await createNxReleaseConfigAndPopulateWorkspace(
+        tree,
+        `
           __default__ ({ "projectsRelationship": "fixed" }):
             - my-lib@0.0.1 [js]
             - project-with-dependency-on-my-pkg@0.0.1 [js]
@@ -210,12 +192,12 @@ describe('releaseVersionGenerator (ported tests)', () => {
             - project-with-devDependency-on-my-pkg@0.0.1 [js]
               -> depends on my-lib {devDependencies}
         `,
-      {
-        version: {
-          specifierSource: 'prompt',
-        },
-      }
-    );
+        {
+          version: {
+            specifierSource: 'prompt',
+          },
+        }
+      );
 
     expect(
       await releaseVersionGeneratorForTest(tree, {
@@ -223,8 +205,6 @@ describe('releaseVersionGenerator (ported tests)', () => {
         projectGraph,
         filters,
         userGivenSpecifier: 'major',
-        releaseGroups,
-        releaseGroupToFilteredProjects,
       })
     ).toMatchInlineSnapshot(`
       {
@@ -269,15 +249,10 @@ describe('releaseVersionGenerator (ported tests)', () => {
     it(`should exit with code one and print guidance when not all of the given projects are appropriate for JS versioning`, async () => {
       stubProcessExit = true;
 
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        `
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
             __default__ ({ "projectsRelationship": "fixed" }):
               - my-lib@0.0.1 [js]
               - project-with-dependency-on-my-pkg@0.0.1 [js]
@@ -285,12 +260,12 @@ describe('releaseVersionGenerator (ported tests)', () => {
               - project-with-devDependency-on-my-pkg@0.0.1 [js]
                 -> depends on my-lib {devDependencies}
           `,
-        {
-          version: {
-            specifierSource: 'prompt',
-          },
-        }
-      );
+          {
+            version: {
+              specifierSource: 'prompt',
+            },
+          }
+        );
 
       tree.delete('my-lib/package.json');
 
@@ -302,14 +277,12 @@ describe('releaseVersionGenerator (ported tests)', () => {
         nxReleaseConfig,
         projectGraph,
         filters,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
         userGivenSpecifier: 'major',
       });
 
       expect(outputSpy).toHaveBeenCalledWith({
         title: expect.stringContaining(
-          'The project "my-lib" does not have a package.json file available in ./my-lib'
+          'The project "my-lib" does not have a package.json file available in my-lib'
         ),
       });
 
@@ -322,15 +295,10 @@ describe('releaseVersionGenerator (ported tests)', () => {
 
   describe('package with mixed "prod" and "dev" dependencies', () => {
     it('should update local dependencies only where it needs to', async () => {
-      const {
-        projectGraph,
-        nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        `
+      const { projectGraph, nxReleaseConfig, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
             __default__ ({ "projectsRelationship": "fixed" }):
               - my-app@0.0.1 [js]
                 -> depends on my-lib-1
@@ -338,17 +306,15 @@ describe('releaseVersionGenerator (ported tests)', () => {
               - my-lib-1@0.0.1 [js]
               - my-lib-2@0.0.1 [js]
           `,
-        {
-          version: {
-            specifierSource: 'prompt',
-          },
-        }
-      );
+          {
+            version: {
+              specifierSource: 'prompt',
+            },
+          }
+        );
 
       await releaseVersionGeneratorForTest(tree, {
         nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
         filters,
         projectGraph,
         userGivenSpecifier: 'major',
@@ -371,15 +337,10 @@ describe('releaseVersionGenerator (ported tests)', () => {
 
   describe('fixed release group', () => {
     it(`should work with semver keywords and exact semver versions`, async () => {
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        `
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
             __default__ ({ "projectsRelationship": "fixed" }):
               - my-lib@0.0.1 [js]
               - project-with-dependency-on-my-pkg@0.0.1 [js]
@@ -387,12 +348,12 @@ describe('releaseVersionGenerator (ported tests)', () => {
               - project-with-devDependency-on-my-pkg@0.0.1 [js]
                 -> depends on my-lib {devDependencies}
           `,
-        {
-          version: {
-            specifierSource: 'prompt',
-          },
-        }
-      );
+          {
+            version: {
+              specifierSource: 'prompt',
+            },
+          }
+        );
 
       expect(readJson(tree, 'my-lib/package.json').version).toEqual('0.0.1');
 
@@ -401,8 +362,6 @@ describe('releaseVersionGenerator (ported tests)', () => {
         projectGraph,
         filters,
         userGivenSpecifier: 'major',
-        releaseGroups,
-        releaseGroupToFilteredProjects,
       });
       expect(readJson(tree, 'my-lib/package.json').version).toEqual('1.0.0');
 
@@ -411,8 +370,6 @@ describe('releaseVersionGenerator (ported tests)', () => {
         projectGraph,
         filters,
         userGivenSpecifier: 'minor',
-        releaseGroups,
-        releaseGroupToFilteredProjects,
       });
       expect(readJson(tree, 'my-lib/package.json').version).toEqual('1.1.0');
 
@@ -421,8 +378,6 @@ describe('releaseVersionGenerator (ported tests)', () => {
         projectGraph,
         filters,
         userGivenSpecifier: 'patch',
-        releaseGroups,
-        releaseGroupToFilteredProjects,
       });
       expect(readJson(tree, 'my-lib/package.json').version).toEqual('1.1.1');
 
@@ -431,22 +386,15 @@ describe('releaseVersionGenerator (ported tests)', () => {
         projectGraph,
         filters,
         userGivenSpecifier: '1.2.3' as SemverBumpType,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
       });
       expect(readJson(tree, 'my-lib/package.json').version).toEqual('1.2.3');
     });
 
     it(`should apply the updated version to the projects, including updating dependents`, async () => {
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        `
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
             __default__ ({ "projectsRelationship": "fixed" }):
               - my-lib@0.0.1 [js]
               - project-with-dependency-on-my-pkg@0.0.1 [js]
@@ -454,20 +402,18 @@ describe('releaseVersionGenerator (ported tests)', () => {
               - project-with-devDependency-on-my-pkg@0.0.1 [js]
                 -> depends on my-lib {devDependencies}
           `,
-        {
-          version: {
-            specifierSource: 'prompt',
-          },
-        }
-      );
+          {
+            version: {
+              specifierSource: 'prompt',
+            },
+          }
+        );
 
       await releaseVersionGeneratorForTest(tree, {
         nxReleaseConfig,
         projectGraph,
         filters,
         userGivenSpecifier: 'major',
-        releaseGroups,
-        releaseGroupToFilteredProjects,
       });
 
       expect(readJson(tree, 'my-lib/package.json')).toMatchInlineSnapshot(`
@@ -515,15 +461,10 @@ describe('releaseVersionGenerator (ported tests)', () => {
           .mockReturnValueOnce(Promise.resolve({ specifier: 'custom' }))
           .mockReturnValueOnce(Promise.resolve({ specifier: '1.2.3' }));
 
-        const {
-          nxReleaseConfig,
-          projectGraph,
-          releaseGroups,
-          releaseGroupToFilteredProjects,
-          filters,
-        } = await createNxReleaseConfigAndPopulateWorkspace(
-          tree,
-          `
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
               __default__ ({ "projectsRelationship": "independent" }):
                 - my-lib@0.0.1 [js]
                 - project-with-dependency-on-my-pkg@0.0.1 [js]
@@ -531,20 +472,18 @@ describe('releaseVersionGenerator (ported tests)', () => {
                 - project-with-devDependency-on-my-pkg@0.0.1 [js]
                   -> depends on my-lib {devDependencies}
             `,
-          {
-            version: {
-              specifierSource: 'prompt',
-            },
-          }
-        );
+            {
+              version: {
+                specifierSource: 'prompt',
+              },
+            }
+          );
 
         await releaseVersionGeneratorForTest(tree, {
           nxReleaseConfig,
           projectGraph,
           filters,
           userGivenSpecifier: undefined,
-          releaseGroups,
-          releaseGroupToFilteredProjects,
         });
 
         expect(readJson(tree, 'my-lib/package.json')).toMatchInlineSnapshot(`
@@ -577,15 +516,10 @@ describe('releaseVersionGenerator (ported tests)', () => {
         `);
       });
       it(`should respect an explicit user CLI specifier for all, even when projects are independent, and apply the version updates across all manifest files`, async () => {
-        const {
-          nxReleaseConfig,
-          projectGraph,
-          releaseGroups,
-          releaseGroupToFilteredProjects,
-          filters,
-        } = await createNxReleaseConfigAndPopulateWorkspace(
-          tree,
-          `
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            `
               __default__ ({ "projectsRelationship": "independent" }):
                 - my-lib@0.0.1 [js]
                 - project-with-dependency-on-my-pkg@0.0.1 [js]
@@ -593,20 +527,18 @@ describe('releaseVersionGenerator (ported tests)', () => {
                 - project-with-devDependency-on-my-pkg@0.0.1 [js]
                   -> depends on my-lib {devDependencies}
             `,
-          {
-            version: {
-              specifierSource: 'prompt',
-            },
-          }
-        );
+            {
+              version: {
+                specifierSource: 'prompt',
+              },
+            }
+          );
 
         await releaseVersionGeneratorForTest(tree, {
           nxReleaseConfig,
           projectGraph,
           filters,
           userGivenSpecifier: '4.5.6' as SemverBumpType,
-          releaseGroups,
-          releaseGroupToFilteredProjects,
         });
 
         expect(readJson(tree, 'my-lib/package.json')).toMatchInlineSnapshot(`
@@ -641,15 +573,10 @@ describe('releaseVersionGenerator (ported tests)', () => {
 
       describe('updateDependentsOptions', () => {
         it(`should update dependents even when filtering to a subset of projects which do not include those dependents, by default`, async () => {
-          const {
-            nxReleaseConfig,
-            projectGraph,
-            releaseGroups,
-            releaseGroupToFilteredProjects,
-            filters,
-          } = await createNxReleaseConfigAndPopulateWorkspace(
-            tree,
-            `
+          const { nxReleaseConfig, projectGraph, filters } =
+            await createNxReleaseConfigAndPopulateWorkspace(
+              tree,
+              `
                 __default__ ({ "projectsRelationship": "independent" }):
                   - my-lib@0.0.1 [js]
                   - project-with-dependency-on-my-pkg@0.0.1 [js]
@@ -657,18 +584,18 @@ describe('releaseVersionGenerator (ported tests)', () => {
                   - project-with-devDependency-on-my-pkg@0.0.1 [js]
                     -> depends on my-lib {devDependencies}
               `,
-            {
-              version: {
-                specifierSource: 'prompt',
-                // No value for updateDependents, should default to 'auto'
+              {
+                version: {
+                  specifierSource: 'prompt',
+                  // No value for updateDependents, should default to 'auto'
+                },
               },
-            },
-            undefined,
-            {
-              // version only my-lib
-              projects: ['my-lib'],
-            }
-          );
+              undefined,
+              {
+                // version only my-lib
+                projects: ['my-lib'],
+              }
+            );
 
           expect(readJson(tree, 'my-lib/package.json').version).toEqual(
             '0.0.1'
@@ -701,8 +628,6 @@ describe('releaseVersionGenerator (ported tests)', () => {
             projectGraph,
             filters,
             userGivenSpecifier: '9.9.9' as SemverBumpType,
-            releaseGroups,
-            releaseGroupToFilteredProjects,
           });
 
           expect(readJson(tree, 'my-lib/package.json')).toMatchInlineSnapshot(`
@@ -737,15 +662,10 @@ describe('releaseVersionGenerator (ported tests)', () => {
         });
 
         it(`should not update dependents when filtering to a subset of projects by default, if "updateDependents" is set to "never"`, async () => {
-          const {
-            nxReleaseConfig,
-            projectGraph,
-            releaseGroups,
-            releaseGroupToFilteredProjects,
-            filters,
-          } = await createNxReleaseConfigAndPopulateWorkspace(
-            tree,
-            `
+          const { nxReleaseConfig, projectGraph, filters } =
+            await createNxReleaseConfigAndPopulateWorkspace(
+              tree,
+              `
                 __default__ ({ "projectsRelationship": "independent" }):
                   - my-lib@0.0.1 [js]
                   - project-with-dependency-on-my-pkg@0.0.1 [js]
@@ -753,25 +673,23 @@ describe('releaseVersionGenerator (ported tests)', () => {
                   - project-with-devDependency-on-my-pkg@0.0.1 [js]
                     -> depends on my-lib {devDependencies}
               `,
-            {
-              version: {
-                specifierSource: 'prompt',
-                updateDependents: 'never',
+              {
+                version: {
+                  specifierSource: 'prompt',
+                  updateDependents: 'never',
+                },
               },
-            },
-            undefined,
-            {
-              projects: ['my-lib'],
-            }
-          );
+              undefined,
+              {
+                projects: ['my-lib'],
+              }
+            );
 
           await releaseVersionGeneratorForTest(tree, {
             nxReleaseConfig,
             projectGraph,
             filters,
             userGivenSpecifier: '9.9.9' as SemverBumpType,
-            releaseGroups,
-            releaseGroupToFilteredProjects,
           });
 
           expect(readJson(tree, 'my-lib/package.json')).toMatchInlineSnapshot(`
@@ -806,15 +724,10 @@ describe('releaseVersionGenerator (ported tests)', () => {
         });
 
         it(`should update dependents even when filtering to a subset of projects which do not include those dependents, if "updateDependents" is "auto"`, async () => {
-          const {
-            nxReleaseConfig,
-            projectGraph,
-            releaseGroups,
-            releaseGroupToFilteredProjects,
-            filters,
-          } = await createNxReleaseConfigAndPopulateWorkspace(
-            tree,
-            `
+          const { nxReleaseConfig, projectGraph, filters } =
+            await createNxReleaseConfigAndPopulateWorkspace(
+              tree,
+              `
                 __default__ ({ "projectsRelationship": "independent" }):
                   - my-lib@0.0.1 [js]
                   - project-with-dependency-on-my-pkg@0.0.1 [js]
@@ -822,25 +735,23 @@ describe('releaseVersionGenerator (ported tests)', () => {
                   - project-with-devDependency-on-my-pkg@0.0.1 [js]
                     -> depends on my-lib {devDependencies}
               `,
-            {
-              version: {
-                specifierSource: 'prompt',
-                updateDependents: 'auto',
+              {
+                version: {
+                  specifierSource: 'prompt',
+                  updateDependents: 'auto',
+                },
               },
-            },
-            undefined,
-            {
-              projects: ['my-lib'],
-            }
-          );
+              undefined,
+              {
+                projects: ['my-lib'],
+              }
+            );
 
           await releaseVersionGeneratorForTest(tree, {
             nxReleaseConfig,
             filters,
             projectGraph,
             userGivenSpecifier: '9.9.9' as SemverBumpType,
-            releaseGroups,
-            releaseGroupToFilteredProjects,
           });
 
           expect(readJson(tree, 'my-lib/package.json')).toMatchInlineSnapshot(`
@@ -875,15 +786,10 @@ describe('releaseVersionGenerator (ported tests)', () => {
         });
 
         it('should update dependents with a prepatch when creating a pre-release version', async () => {
-          const {
-            nxReleaseConfig,
-            projectGraph,
-            releaseGroups,
-            releaseGroupToFilteredProjects,
-            filters,
-          } = await createNxReleaseConfigAndPopulateWorkspace(
-            tree,
-            `
+          const { nxReleaseConfig, projectGraph, filters } =
+            await createNxReleaseConfigAndPopulateWorkspace(
+              tree,
+              `
                 __default__ ({ "projectsRelationship": "independent" }):
                   - my-lib@0.0.1 [js]
                   - project-with-dependency-on-my-pkg@0.0.1 [js]
@@ -891,12 +797,12 @@ describe('releaseVersionGenerator (ported tests)', () => {
                   - project-with-devDependency-on-my-pkg@0.0.1 [js]
                     -> depends on my-lib {devDependencies}
               `,
-            {
-              version: {
-                specifierSource: 'prompt',
-              },
-            }
-          );
+              {
+                version: {
+                  specifierSource: 'prompt',
+                },
+              }
+            );
 
           expect(readJson(tree, 'my-lib/package.json').version).toEqual(
             '0.0.1'
@@ -915,8 +821,6 @@ describe('releaseVersionGenerator (ported tests)', () => {
             filters,
             projectGraph,
             userGivenSpecifier: 'prepatch' as SemverBumpType,
-            releaseGroups,
-            releaseGroupToFilteredProjects,
             preid: 'alpha',
           });
 
@@ -956,15 +860,10 @@ describe('releaseVersionGenerator (ported tests)', () => {
 
   describe('leading v in version', () => {
     it(`should strip a leading v from the provided specifier`, async () => {
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        `
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
             __default__ ({ "projectsRelationship": "fixed" }):
               - my-lib@0.0.1 [js]
               - project-with-dependency-on-my-pkg@0.0.1 [js]
@@ -972,20 +871,18 @@ describe('releaseVersionGenerator (ported tests)', () => {
               - project-with-devDependency-on-my-pkg@0.0.1 [js]
                 -> depends on my-lib {devDependencies}
           `,
-        {
-          version: {
-            specifierSource: 'prompt',
-          },
-        }
-      );
+          {
+            version: {
+              specifierSource: 'prompt',
+            },
+          }
+        );
 
       await releaseVersionGeneratorForTest(tree, {
         nxReleaseConfig,
         projectGraph,
         filters,
         userGivenSpecifier: 'v8.8.8' as SemverBumpType,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
       });
 
       expect(readJson(tree, 'my-lib/package.json')).toMatchInlineSnapshot(`
@@ -1057,23 +954,14 @@ describe('releaseVersionGenerator (ported tests)', () => {
     }
 
     it('should work with an empty prefix', async () => {
-      const {
-        projectGraph,
-        nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        graphDefinition,
-        {
+      const { projectGraph, nxReleaseConfig, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(tree, graphDefinition, {
           version: {
             specifierSource: 'prompt',
             versionPrefix: '',
             preserveMatchingDependencyRanges: false,
           },
-        }
-      );
+        });
 
       // Manually set different version prefixes
       setDifferentVersionPrefixes(tree);
@@ -1082,8 +970,6 @@ describe('releaseVersionGenerator (ported tests)', () => {
         nxReleaseConfig,
         projectGraph,
         filters,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
         userGivenSpecifier: '9.9.9' as SemverBumpType,
       });
 
@@ -1132,23 +1018,14 @@ describe('releaseVersionGenerator (ported tests)', () => {
     });
 
     it('should work with a ^ prefix', async () => {
-      const {
-        projectGraph,
-        nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        graphDefinition,
-        {
+      const { projectGraph, nxReleaseConfig, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(tree, graphDefinition, {
           version: {
             specifierSource: 'prompt',
             versionPrefix: '^',
             preserveMatchingDependencyRanges: false,
           },
-        }
-      );
+        });
 
       // Manually set different version prefixes
       setDifferentVersionPrefixes(tree);
@@ -1157,8 +1034,6 @@ describe('releaseVersionGenerator (ported tests)', () => {
         nxReleaseConfig,
         projectGraph,
         filters,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
         userGivenSpecifier: '9.9.9' as SemverBumpType,
       });
 
@@ -1207,23 +1082,14 @@ describe('releaseVersionGenerator (ported tests)', () => {
     });
 
     it('should work with a ~ prefix', async () => {
-      const {
-        projectGraph,
-        nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        graphDefinition,
-        {
+      const { projectGraph, nxReleaseConfig, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(tree, graphDefinition, {
           version: {
             specifierSource: 'prompt',
             versionPrefix: '~',
             preserveMatchingDependencyRanges: false,
           },
-        }
-      );
+        });
 
       // Manually set different version prefixes
       setDifferentVersionPrefixes(tree);
@@ -1232,8 +1098,6 @@ describe('releaseVersionGenerator (ported tests)', () => {
         nxReleaseConfig,
         projectGraph,
         filters,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
         userGivenSpecifier: '9.9.9' as SemverBumpType,
       });
 
@@ -1282,23 +1146,14 @@ describe('releaseVersionGenerator (ported tests)', () => {
     });
 
     it('should respect any existing prefix when explicitly set to "auto"', async () => {
-      const {
-        projectGraph,
-        nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        graphDefinition,
-        {
+      const { projectGraph, nxReleaseConfig, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(tree, graphDefinition, {
           version: {
             specifierSource: 'prompt',
             versionPrefix: 'auto',
             preserveMatchingDependencyRanges: false,
           },
-        }
-      );
+        });
 
       // Manually set different version prefixes
       setDifferentVersionPrefixes(tree);
@@ -1307,8 +1162,6 @@ describe('releaseVersionGenerator (ported tests)', () => {
         nxReleaseConfig,
         projectGraph,
         filters,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
         userGivenSpecifier: '9.9.9' as SemverBumpType,
       });
 
@@ -1357,24 +1210,15 @@ describe('releaseVersionGenerator (ported tests)', () => {
     });
 
     it('should use the behavior of "auto" by default', async () => {
-      const {
-        projectGraph,
-        nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        graphDefinition,
-        {
+      const { projectGraph, nxReleaseConfig, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(tree, graphDefinition, {
           version: {
             specifierSource: 'prompt',
             // No value, should default to "auto"
             versionPrefix: undefined,
             preserveMatchingDependencyRanges: false,
           },
-        }
-      );
+        });
 
       // Manually set different version prefixes
       setDifferentVersionPrefixes(tree);
@@ -1383,8 +1227,6 @@ describe('releaseVersionGenerator (ported tests)', () => {
         nxReleaseConfig,
         projectGraph,
         filters,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
         userGivenSpecifier: '9.9.9' as SemverBumpType,
       });
 
@@ -1435,22 +1277,13 @@ describe('releaseVersionGenerator (ported tests)', () => {
     it(`should exit with code one and print guidance for invalid prefix values`, async () => {
       stubProcessExit = true;
 
-      const {
-        projectGraph,
-        nxReleaseConfig,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        graphDefinition,
-        {
+      const { projectGraph, nxReleaseConfig, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(tree, graphDefinition, {
           version: {
             specifierSource: 'prompt',
             versionPrefix: '$' as any,
           },
-        }
-      );
+        });
 
       const outputSpy = jest
         .spyOn(output, 'error')
@@ -1462,8 +1295,6 @@ describe('releaseVersionGenerator (ported tests)', () => {
         nxReleaseConfig,
         projectGraph,
         filters,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
         userGivenSpecifier: 'major' as SemverBumpType,
       });
 
@@ -1482,15 +1313,10 @@ Valid values are: "auto", "", "~", "^", "="`,
 
   describe('transitive updateDependents', () => {
     it('should not update transitive dependents when updateDependents is set to "never" and the transitive dependents are not in the same batch', async () => {
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        `
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
               __default__ ({ "projectsRelationship": "independent" }):
                 - my-lib@0.0.1 [js]
                 - project-with-dependency-on-my-lib@0.0.1 [js]
@@ -1498,24 +1324,22 @@ Valid values are: "auto", "", "~", "^", "="`,
                 - project-with-transitive-dependency-on-my-lib@0.0.1 [js]
                   -> depends on project-with-dependency-on-my-lib
             `,
-        {
-          version: {
-            updateDependents: 'never',
+          {
+            version: {
+              updateDependents: 'never',
+            },
           },
-        },
-        undefined,
-        {
-          projects: ['my-lib'],
-        }
-      );
+          undefined,
+          {
+            projects: ['my-lib'],
+          }
+        );
 
       const result = await releaseVersionGeneratorForTest(tree, {
         nxReleaseConfig,
         projectGraph,
         filters,
         userGivenSpecifier: '9.9.9' as SemverBumpType,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
       });
 
       expect(result).toMatchInlineSnapshot(`
@@ -1574,15 +1398,10 @@ Valid values are: "auto", "", "~", "^", "="`,
     });
 
     it('should always update transitive dependents when updateDependents is set to "auto"', async () => {
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        `
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
               __default__ ({ "projectsRelationship": "independent" }):
                 - my-lib@0.0.1 [js]
                 - project-with-dependency-on-my-lib@0.0.1 [js]
@@ -1590,25 +1409,23 @@ Valid values are: "auto", "", "~", "^", "="`,
                 - project-with-transitive-dependency-on-my-lib@0.0.1 [js]
                   -> depends on ^project-with-dependency-on-my-lib {devDependencies}
             `,
-        {
-          version: {
-            updateDependents: 'auto',
-            preserveMatchingDependencyRanges: false,
+          {
+            version: {
+              updateDependents: 'auto',
+              preserveMatchingDependencyRanges: false,
+            },
           },
-        },
-        undefined,
-        {
-          projects: ['my-lib'],
-        }
-      );
+          undefined,
+          {
+            projects: ['my-lib'],
+          }
+        );
 
       const result = await releaseVersionGeneratorForTest(tree, {
         nxReleaseConfig,
         projectGraph,
         filters,
         userGivenSpecifier: '9.9.9' as SemverBumpType,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
       });
 
       expect(result).toMatchInlineSnapshot(`
@@ -1697,26 +1514,21 @@ Valid values are: "auto", "", "~", "^", "="`,
 
     describe("updateDependents: 'never'", () => {
       it('should allow versioning of circular dependencies when not all projects are included in the current batch', async () => {
-        const {
-          nxReleaseConfig,
-          projectGraph,
-          releaseGroups,
-          releaseGroupToFilteredProjects,
-          filters,
-        } = await createNxReleaseConfigAndPopulateWorkspace(
-          tree,
-          circularGraphDefinition,
-          {
-            version: {
-              updateDependents: 'never',
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            circularGraphDefinition,
+            {
+              version: {
+                updateDependents: 'never',
+              },
             },
-          },
-          undefined,
-          {
-            // version only package-a
-            projects: ['package-a'],
-          }
-        );
+            undefined,
+            {
+              // version only package-a
+              projects: ['package-a'],
+            }
+          );
 
         expect(readJson(tree, 'package-a/package.json')).toMatchInlineSnapshot(`
         {
@@ -1740,8 +1552,6 @@ Valid values are: "auto", "", "~", "^", "="`,
         expect(
           await releaseVersionGeneratorForTest(tree, {
             nxReleaseConfig,
-            releaseGroups,
-            releaseGroupToFilteredProjects,
             filters,
             projectGraph,
             userGivenSpecifier: '2.0.0' as SemverBumpType,
@@ -1796,26 +1606,21 @@ Valid values are: "auto", "", "~", "^", "="`,
       });
 
       it('should allow versioning of circular dependencies when all projects are included in the current batch', async () => {
-        const {
-          nxReleaseConfig,
-          projectGraph,
-          releaseGroups,
-          releaseGroupToFilteredProjects,
-          filters,
-        } = await createNxReleaseConfigAndPopulateWorkspace(
-          tree,
-          circularGraphDefinition,
-          {
-            version: {
-              updateDependents: 'never',
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            circularGraphDefinition,
+            {
+              version: {
+                updateDependents: 'never',
+              },
             },
-          },
-          undefined,
-          {
-            // version both packages
-            projects: ['package-a', 'package-b'],
-          }
-        );
+            undefined,
+            {
+              // version both packages
+              projects: ['package-a', 'package-b'],
+            }
+          );
 
         expect(readJson(tree, 'package-a/package.json')).toMatchInlineSnapshot(`
         {
@@ -1839,8 +1644,6 @@ Valid values are: "auto", "", "~", "^", "="`,
         expect(
           await releaseVersionGeneratorForTest(tree, {
             nxReleaseConfig,
-            releaseGroups,
-            releaseGroupToFilteredProjects,
             filters,
             projectGraph,
             userGivenSpecifier: '2.0.0' as SemverBumpType,
@@ -1904,26 +1707,21 @@ Valid values are: "auto", "", "~", "^", "="`,
 
     describe("updateDependents: 'auto'", () => {
       it('should allow versioning of circular dependencies when not all projects are included in the current batch', async () => {
-        const {
-          nxReleaseConfig,
-          projectGraph,
-          releaseGroups,
-          releaseGroupToFilteredProjects,
-          filters,
-        } = await createNxReleaseConfigAndPopulateWorkspace(
-          tree,
-          circularGraphDefinition,
-          {
-            version: {
-              updateDependents: 'auto',
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            circularGraphDefinition,
+            {
+              version: {
+                updateDependents: 'auto',
+              },
             },
-          },
-          undefined,
-          {
-            // version only package-a
-            projects: ['package-a'],
-          }
-        );
+            undefined,
+            {
+              // version only package-a
+              projects: ['package-a'],
+            }
+          );
 
         expect(readJson(tree, 'package-a/package.json')).toMatchInlineSnapshot(`
         {
@@ -1947,8 +1745,6 @@ Valid values are: "auto", "", "~", "^", "="`,
         expect(
           await releaseVersionGeneratorForTest(tree, {
             nxReleaseConfig,
-            releaseGroups,
-            releaseGroupToFilteredProjects,
             filters,
             projectGraph,
             userGivenSpecifier: '2.0.0' as SemverBumpType,
@@ -2010,26 +1806,21 @@ Valid values are: "auto", "", "~", "^", "="`,
       });
 
       it('should allow versioning of circular dependencies when all projects are included in the current batch', async () => {
-        const {
-          nxReleaseConfig,
-          projectGraph,
-          releaseGroups,
-          releaseGroupToFilteredProjects,
-          filters,
-        } = await createNxReleaseConfigAndPopulateWorkspace(
-          tree,
-          circularGraphDefinition,
-          {
-            version: {
-              updateDependents: 'auto',
+        const { nxReleaseConfig, projectGraph, filters } =
+          await createNxReleaseConfigAndPopulateWorkspace(
+            tree,
+            circularGraphDefinition,
+            {
+              version: {
+                updateDependents: 'auto',
+              },
             },
-          },
-          undefined,
-          {
-            // version both packages
-            projects: ['package-a', 'package-b'],
-          }
-        );
+            undefined,
+            {
+              // version both packages
+              projects: ['package-a', 'package-b'],
+            }
+          );
 
         expect(readJson(tree, 'package-a/package.json')).toMatchInlineSnapshot(`
           {
@@ -2053,8 +1844,6 @@ Valid values are: "auto", "", "~", "^", "="`,
         expect(
           await releaseVersionGeneratorForTest(tree, {
             nxReleaseConfig,
-            releaseGroups,
-            releaseGroupToFilteredProjects,
             filters,
             projectGraph,
             userGivenSpecifier: '2.0.0' as SemverBumpType,
@@ -2119,40 +1908,33 @@ Valid values are: "auto", "", "~", "^", "="`,
 
   describe('preserveLocalDependencyProtocols', () => {
     it('should preserve local `workspace:` references when preserveLocalDependencyProtocols is true', async () => {
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        `
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
             __default__ ({ "projectsRelationship": "independent" }):
               - package-a@1.0.0 [js]
                 -> depends on package-b(workspace:*)
               - package-b@1.0.0 [js]
             `,
-        {
-          version: {
-            specifierSource: 'prompt',
-            preserveLocalDependencyProtocols: true,
+          {
+            version: {
+              specifierSource: 'prompt',
+              preserveLocalDependencyProtocols: true,
+            },
           },
-        },
-        undefined,
-        {
-          // version only package-b
-          projects: ['package-b'],
-        }
-      );
+          undefined,
+          {
+            // version only package-b
+            projects: ['package-b'],
+          }
+        );
 
       expect(
         await releaseVersionGeneratorForTest(tree, {
           nxReleaseConfig,
           projectGraph,
           filters,
-          releaseGroups,
-          releaseGroupToFilteredProjects,
           userGivenSpecifier: '2.0.0' as SemverBumpType,
         })
       ).toMatchInlineSnapshot(`
@@ -2200,40 +1982,33 @@ Valid values are: "auto", "", "~", "^", "="`,
     });
 
     it('should preserve local `file:` references when preserveLocalDependencyProtocols is true', async () => {
-      const {
-        nxReleaseConfig,
-        projectGraph,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
-        filters,
-      } = await createNxReleaseConfigAndPopulateWorkspace(
-        tree,
-        `
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
             __default__ ({ "projectsRelationship": "independent" }):
               - package-a@1.0.0 [js]
                 -> depends on package-b(file:../package-b)
               - package-b@1.0.0 [js]
             `,
-        {
-          version: {
-            specifierSource: 'prompt',
-            preserveLocalDependencyProtocols: true,
+          {
+            version: {
+              specifierSource: 'prompt',
+              preserveLocalDependencyProtocols: true,
+            },
           },
-        },
-        undefined,
-        {
-          // version only package-b
-          projects: ['package-b'],
-        }
-      );
+          undefined,
+          {
+            // version only package-b
+            projects: ['package-b'],
+          }
+        );
 
       expect(
         await releaseVersionGeneratorForTest(tree, {
           nxReleaseConfig,
           projectGraph,
           filters,
-          releaseGroups,
-          releaseGroupToFilteredProjects,
           userGivenSpecifier: '2.0.0' as SemverBumpType,
         })
       ).toMatchInlineSnapshot(`
@@ -2282,15 +2057,10 @@ Valid values are: "auto", "", "~", "^", "="`,
   });
 
   it('should not double patch transitive dependents that are already direct dependents', async () => {
-    const {
-      nxReleaseConfig,
-      projectGraph,
-      releaseGroups,
-      releaseGroupToFilteredProjects,
-      filters,
-    } = await createNxReleaseConfigAndPopulateWorkspace(
-      tree,
-      `
+    const { nxReleaseConfig, projectGraph, filters } =
+      await createNxReleaseConfigAndPopulateWorkspace(
+        tree,
+        `
         __default__ ({ "projectsRelationship": "independent" }):
           - core@1.0.0 [js:@slateui/core]
           - buttons@1.0.0 [js:@slateui/buttons]
@@ -2299,16 +2069,16 @@ Valid values are: "auto", "", "~", "^", "="`,
             -> depends on core
             -> depends on buttons
       `,
-      {
-        version: {
-          specifierSource: 'prompt',
+        {
+          version: {
+            specifierSource: 'prompt',
+          },
         },
-      },
-      undefined,
-      {
-        projects: ['core'],
-      }
-    );
+        undefined,
+        {
+          projects: ['core'],
+        }
+      );
 
     expect(readJson(tree, 'core/package.json')).toMatchInlineSnapshot(`
       {
@@ -2343,8 +2113,6 @@ Valid values are: "auto", "", "~", "^", "="`,
         nxReleaseConfig,
         projectGraph,
         filters,
-        releaseGroups,
-        releaseGroupToFilteredProjects,
         // Bump core to 2.0.0, which will cause buttons and forms to be patched to 1.0.1
         // This prevents a regression against an issue where forms would end up being patched twice to 1.0.2 in this scenario
         userGivenSpecifier: '2.0.0' as SemverBumpType,
@@ -2456,15 +2224,10 @@ Valid values are: "auto", "", "~", "^", "="`,
             }
           );
 
-          const {
-            nxReleaseConfig,
-            projectGraph,
-            releaseGroups,
-            releaseGroupToFilteredProjects,
-            filters,
-          } = await createNxReleaseConfigAndPopulateWorkspace(
-            tree,
-            `
+          const { nxReleaseConfig, projectGraph, filters } =
+            await createNxReleaseConfigAndPopulateWorkspace(
+              tree,
+              `
               myReleaseGroup ({ "projectsRelationship": "independent" }):
                 - my-lib@0.0.1 [js]
                 - root[.]@0.0.1 [js]
@@ -2473,22 +2236,20 @@ Valid values are: "auto", "", "~", "^", "="`,
                 - project-with-devDependency-on-my-pkg@0.0.1 [js]
                   -> depends on my-lib {devDependencies}
             `,
-            {
-              version: {
-                manifestRootsToUpdate: ['dist/{projectRoot}'],
-                currentVersionResolver: 'disk',
+              {
+                version: {
+                  manifestRootsToUpdate: ['dist/{projectRoot}'],
+                  currentVersionResolver: 'disk',
+                },
               },
-            },
-            undefined
-          );
+              undefined
+            );
 
           expect(
             await releaseVersionGeneratorForTest(tree, {
               nxReleaseConfig,
               projectGraph,
               filters,
-              releaseGroups,
-              releaseGroupToFilteredProjects,
               userGivenSpecifier: 'patch',
             })
           ).toMatchInlineSnapshot(`
@@ -2541,15 +2302,10 @@ Valid values are: "auto", "", "~", "^", "="`,
             version: '0.0.1',
           });
 
-          const {
-            nxReleaseConfig,
-            projectGraph,
-            releaseGroups,
-            releaseGroupToFilteredProjects,
-            filters,
-          } = await createNxReleaseConfigAndPopulateWorkspace(
-            tree,
-            `
+          const { nxReleaseConfig, projectGraph, filters } =
+            await createNxReleaseConfigAndPopulateWorkspace(
+              tree,
+              `
               myReleaseGroup ({ "projectsRelationship": "independent" }):
                 - depends-on-my-lib@0.0.1 [js]
                   -> depends on my-lib
@@ -2558,27 +2314,25 @@ Valid values are: "auto", "", "~", "^", "="`,
                 - root[.]@0.0.1 [js:@proj/source]
                 - my-lib-2@0.0.1 [js]
             `,
-            {
-              version: {
-                manifestRootsToUpdate: ['dist/{projectRoot}'],
-                currentVersionResolver: 'disk',
+              {
+                version: {
+                  manifestRootsToUpdate: ['dist/{projectRoot}'],
+                  currentVersionResolver: 'disk',
+                },
               },
-            },
-            undefined,
-            {
-              // depends-on-my-lib will get its dependencies updated in package.json because my-lib is being versioned
-              // this will happen regardless of if depends-on-my-lib should be versioned
-              projects: ['my-lib', 'my-lib-2'],
-            }
-          );
+              undefined,
+              {
+                // depends-on-my-lib will get its dependencies updated in package.json because my-lib is being versioned
+                // this will happen regardless of if depends-on-my-lib should be versioned
+                projects: ['my-lib', 'my-lib-2'],
+              }
+            );
 
           expect(
             await releaseVersionGeneratorForTest(tree, {
               nxReleaseConfig,
               projectGraph,
               filters,
-              releaseGroups,
-              releaseGroupToFilteredProjects,
               userGivenSpecifier: 'patch',
             })
           ).toMatchInlineSnapshot(`

--- a/packages/nx/src/command-line/release/version/resolve-current-version.spec.ts
+++ b/packages/nx/src/command-line/release/version/resolve-current-version.spec.ts
@@ -3,7 +3,7 @@ import { createTreeWithEmptyWorkspace } from '../../../generators/testing-utils/
 import type { Tree } from '../../../generators/tree';
 import { ReleaseGroupWithName } from '../config/filter-release-groups';
 import { ProjectLogger } from './project-logger';
-import type { FinalConfigForProject } from './release-group-processor';
+import type { FinalConfigForProject } from '../utils/release-graph';
 import { resolveCurrentVersion } from './resolve-current-version';
 import { VersionActions } from './version-actions';
 
@@ -108,7 +108,7 @@ describe('resolveCurrentVersion', () => {
         new TestProjectLogger(projectGraphNode.name),
         new Map(),
         finalConfigForProject,
-        undefined
+        ''
       );
       expect(currentVersion).toBe('1.2.3');
     });
@@ -146,7 +146,7 @@ describe('resolveCurrentVersion', () => {
         new TestProjectLogger(projectGraphNode.name),
         new Map(),
         finalConfigForProject,
-        undefined
+        ''
       );
       expect(currentVersion).toBe('1.2.3');
     });
@@ -215,7 +215,7 @@ describe('resolveCurrentVersion', () => {
           new TestProjectLogger(projectGraphNode.name),
           new Map(),
           finalConfigForProject,
-          undefined
+          ''
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"For project "test", the "currentVersionResolver" is set to "disk" but it is using "versionActions" of type "TestVersionActionsWithoutManifest". This is invalid because "TestVersionActionsWithoutManifest" does not support a manifest file. You should use a different "currentVersionResolver" or use a different "versionActions" implementation that supports a manifest file"`

--- a/packages/nx/src/command-line/release/version/resolve-current-version.ts
+++ b/packages/nx/src/command-line/release/version/resolve-current-version.ts
@@ -7,7 +7,7 @@ import type { Tree } from '../../../generators/tree';
 import type { ReleaseGroupWithName } from '../config/filter-release-groups';
 import { getLatestGitTagForPattern } from '../utils/git';
 import { ProjectLogger } from './project-logger';
-import type { FinalConfigForProject } from './release-group-processor';
+import type { FinalConfigForProject } from '../utils/release-graph';
 import { VersionActions } from './version-actions';
 
 export async function resolveCurrentVersion(
@@ -109,7 +109,7 @@ export async function resolveCurrentVersionFromDisk(
         projectGraphNode.name
       }" does not have a ${versionActions.validManifestFilenames.join(
         ' or '
-      )} file available in ./${projectGraphNode.data.root}.
+      )} file available in ${projectGraphNode.data.root}
 
 To fix this you will either need to add a ${versionActions.validManifestFilenames.join(
         ' or '

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -1,8 +1,7 @@
-import { existsSync } from 'fs';
-import { dirname, join } from 'path';
-
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import type { ChangelogRenderOptions } from '../../release/changelog-renderer';
-import type { validReleaseVersionPrefixes } from '../command-line/release/version';
+import type { validReleaseVersionPrefixes } from '../command-line/release/utils/release-graph';
 import { readJsonFile } from '../utils/fileutils';
 import type { PackageManager } from '../utils/package-manager';
 import { workspaceRoot } from '../utils/workspace-root';
@@ -167,10 +166,12 @@ export interface NxReleaseVersionConfiguration {
   deleteVersionPlans?: boolean;
   /**
    * When versioning independent projects, this controls whether to update their dependents (i.e. the things that depend on them).
-   * 'never' means no dependents will be updated (unless they happen to be versioned directly as well).
-   * 'auto' is the default and will cause dependents to be updated (a patch version bump) when a dependency is versioned.
+   * - 'never' means no dependents will be updated (unless they happen to be versioned directly as well).
+   * - 'auto' is the default and will cause dependents to be updated (a patch version bump) when a dependency is versioned, as long as a
+   *   group or projects filter is not applied that does not include them.
+   * - 'always' will cause dependents to be updated (a patch version bump) when a dependency is versioned, even if they are not included in the group or projects filter.
    */
-  updateDependents?: 'auto' | 'never';
+  updateDependents?: 'auto' | 'always' | 'never';
   /**
    * Whether to log projects that have not changed during versioning.
    */


### PR DESCRIPTION
When release groups changed to become more flexible and powerful, with `updateDependents` tracing across any number of transitive release groups, the logic for filtering (e.g. `--projects` and `--groups` on the CLI) was never updated to reflect this new dynamism and complexity.

Now in this PR, release graph construction has been fully separated out from the release-group-processor. It now lives in the new `ReleaseGraph`. This is also now where filtering takes place so that the filters can be fully graph aware.

There is additionally a new `always` option available for `updateDependents` in addition to `auto` and `never` which are unchanged. `always` means that a project's dependents will be updated wherever they may live in the graph, regardless of whether or not they were directly included within a project or graph filter. We feel that this is what people want most of the time so this is also going to become the default in a follow up breaking change PR. In order to be easier to review, and to increase confidence in this refactor, this PR does not yet make that change to leave as many tests as possible untouched (other than utilities changing).

BREAKING CHANGE: The signature of `init()` on `VersionActions` has changed, it no longer accepts a second argument. Validation of the manifest files, if any, now takes place via a separate method (`validate()`) call after construction of the new `ReleaseGraph`. For the most part, users do not need custom `VersionActions` so only a small percentage of consumers should be impacted.

Fixes https://github.com/nrwl/nx/issues/31273