### PR TITLE
feat(vite): add buildable libs support for vitest  

### DIFF
--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -1,26 +1,25 @@
 import {
   createProjectGraphAsync,
   joinPathFragments,
-  stripIndents,
   workspaceRoot,
 } from '@nx/devkit';
-import { copyFileSync, existsSync } from 'node:fs';
-import { join, relative, resolve } from 'node:path';
-import {
-  loadConfig,
-  createMatchPath,
-  MatchPath,
-  ConfigLoaderSuccessResult,
-} from 'tsconfig-paths';
 import {
   calculateProjectBuildableDependencies,
   createTmpTsConfig,
 } from '@nx/js/src/utils/buildable-libs-utils';
-import { Plugin } from 'vite';
-import { nxViteBuildCoordinationPlugin } from './nx-vite-build-coordination.plugin';
-import { findFile } from '../src/utils/nx-tsconfig-paths-find-file';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { copyFileSync, existsSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import {
+  ConfigLoaderSuccessResult,
+  createMatchPath,
+  loadConfig,
+  MatchPath,
+} from 'tsconfig-paths';
+import { Plugin } from 'vite';
+import { findFile } from '../src/utils/nx-tsconfig-paths-find-file';
 import { getProjectTsConfigPath } from '../src/utils/options-utils';
+import { nxViteBuildCoordinationPlugin } from './nx-vite-build-coordination.plugin';
 
 export interface nxViteTsPathsOptions {
   /**
@@ -95,11 +94,7 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
 
       if (!foundTsConfigPath) return;
 
-      if (
-        !options.buildLibsFromSource &&
-        !global.NX_GRAPH_CREATION &&
-        config.mode !== 'test'
-      ) {
+      if (!options.buildLibsFromSource && !global.NX_GRAPH_CREATION) {
         const projectGraph = await createProjectGraphAsync({
           exitOnError: false,
           resetDaemonClient: true,
@@ -107,7 +102,8 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
         // When using incremental building and the serve target is called
         // we need to get the deps for the 'build' target instead.
         const depsBuildTarget =
-          process.env.NX_TASK_TARGET_TARGET === 'serve'
+          process.env.NX_TASK_TARGET_TARGET === 'serve' ||
+          process.env.NX_TASK_TARGET_TARGET === 'test'
             ? 'build'
             : process.env.NX_TASK_TARGET_TARGET;
         const { dependencies } = calculateProjectBuildableDependencies(
@@ -118,16 +114,23 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
           depsBuildTarget,
           process.env.NX_TASK_TARGET_CONFIGURATION
         );
-        // This tsconfig is used via the Vite ts paths plugin.
-        // It can be also used by other user-defined Vite plugins (e.g. for creating type declaration files).
-        foundTsConfigPath = createTmpTsConfig(
-          foundTsConfigPath,
-          workspaceRoot,
-          relative(workspaceRoot, projectRoot),
-          dependencies,
-          true
-        );
 
+        if (process.env.NX_GENERATED_TSCONFIG_PATH) {
+          // This is needed for vitest browser mode because it runs two vite dev servers
+          // so we want to reuse the same tsconfig file for both servers
+          foundTsConfigPath = process.env.NX_GENERATED_TSCONFIG_PATH;
+        } else {
+          // This tsconfig is used via the Vite ts paths plugin.
+          // It can be also used by other user-defined Vite plugins (e.g. for creating type declaration files).
+          foundTsConfigPath = createTmpTsConfig(
+            foundTsConfigPath,
+            workspaceRoot,
+            relative(workspaceRoot, projectRoot),
+            dependencies,
+            true
+          );
+          process.env.NX_GENERATED_TSCONFIG_PATH = foundTsConfigPath;
+        }
         if (config.command === 'serve') {
           const buildableLibraryDependencies = dependencies
             .filter((dep) => dep.node.type === 'lib')


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
In the vite nxTsConfigPaths plugin, when using `buildLibsFromSource: false`, it has no effect when running vitest. 

This is an issue especially in large nx projects when running vitest browser mode because it has a potential to load all the files from the entire project using the vite dev server (if no modules mocking is being used). 

This increases the amount of time vitest runs substantially.

Plus, there is no way for vite plugin authors to reuse the same generated tsconfig file (the one generated by nx that points to the `dist/` folder path) and reuse this information to configure TypeScript for example.

One example that comes to mind is analog's angular-vite-plugin, meaning even if nx supported it, that plugin wouldn't be able to know where is the generated tsconfig is. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

I expect to be able to use `buildLibsFromSource: false` in my vitest browser mode tests and reduce the amount of time it takes to run those tests in large scale projects.

In one of my benchmarks I managed to reduce tests from over 1 minute to 9 seconds (!) with this option enabled. 

In order to share the generated tsconfig path I've added another environment variable called `process.env.NX_GENERATED_TSCONFIG_PATH`

Please let me know if this should be added to the documentation somewhere and if so where, and I'll add it. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

