### PR TITLE
chore(repo): add dotnet commit scope

### DIFF
--- a/scripts/commitizen.js
+++ b/scripts/commitizen.js
@@ -35,6 +35,7 @@ const scopes = [
   { value: 'gradle',            name: 'gradle:                anything Gradle specific'},
   { value: 'module-federation', name: 'module-federation:     anything Module Federation specific'},
   { value: 'docker',            name: 'docker:                anything Docker specific'},
+  { value: 'dotnet',            name: 'dotnet:                anything .NET specific'},
 ];
 
 // precomputed scope


### PR DESCRIPTION
## Current Behavior
The PR to add the .NET plugin is failing because it uses the scope `dotnet`, and that has to be present in master since the pr-title-checks workflow validates against scopes in master.

## Expected Behavior
The scope is in master

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
