### PR TITLE
docs(nx-plugin): add callout for local plugin name

### DIFF
--- a/astro-docs/src/content/docs/extending-nx/create-sync-generator.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/create-sync-generator.mdoc
@@ -68,7 +68,7 @@ Sync generators can optionally return an `outOfSyncMessage` to display to users 
 ```ts
 // tools/my-plugin/src/generators/my-sync-generator/my-sync-generator.ts
 import { Tree } from '@nx/devkit';
-import { SyncGeneratorResult } from 'nx/src/utils/sync-generators';
+import type { SyncGeneratorResult } from 'nx/src/utils/sync-generators';
 
 export async function mySyncGenerator(
   tree: Tree
@@ -96,20 +96,14 @@ Global sync generators are registered in the `nx.json` file like this:
 // nx.json
 {
   "sync": {
-    "globalGenerators": ["my-plugin:my-sync-generator"]
+    "globalGenerators": ["@myprg/my-plugin:my-sync-generator"]
   }
 }
 ```
 
 {% aside type="caution" title="Verify the name of your plugin" %}
-You might have to adjust the name of your plugin based on your specific workspace scope. Verify the name in `tools/my-plugin/package.json`. If the name there is `@myorg/my-plugin` you have to register it as:
-
-```
-{
-  "syncGenerators": ["@myorg/my-plugin:my-sync-generator"]
-}
-```
-
+You might have to adjust the name of your plugin based on your specific workspace scope. Verify the name in `tools/my-plugin/package.json`.
+If your package.json has a different name, adjust the `nx.json` configuration accordingly.
 {% /aside %}
 
 Now `my-sync-generator` will be executed any time the `nx sync` command is run.
@@ -121,7 +115,7 @@ Task sync generators are run before a particular task and are used to ensure tha
 ```ts
 // tools/my-plugin/src/generators/my-sync-generator/my-sync-generator.ts
 import { Tree, createProjectGraphAsync, joinPathFragments } from '@nx/devkit';
-import { SyncGeneratorResult } from 'nx/src/utils/sync-generators';
+import type { SyncGeneratorResult } from 'nx/src/utils/sync-generators';
 
 export async function mySyncGenerator(
   tree: Tree

--- a/astro-docs/src/content/docs/extending-nx/local-executors.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/local-executors.mdoc
@@ -118,6 +118,12 @@ Our last step is to add this executor to a given project's `targets` object in y
 }
 ```
 
+{% aside type="caution" title="Use the package.json name" %}
+When referencing your plugin, you must use the name defined in `tools/my-plugin/package.json`.
+In this example, we're using `@myorg/my-plugin` as the plugin name.
+If your package.json has a different name, adjust the command accordingly.
+{% /aside %}
+
 Finally, you run the executor via the CLI as follows:
 
 ```shell {% frame="none" %}

--- a/astro-docs/src/content/docs/extending-nx/local-generators.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/local-generators.mdoc
@@ -105,6 +105,12 @@ To run a generator, invoke the `nx generate` command with the name of the genera
 nx generate @myorg/my-plugin:my-generator mylib
 ```
 
+{% aside type="caution" title="Use the package.json name" %}
+When referencing your plugin, you must use the name defined in `tools/my-plugin/package.json`.
+In this example, we're using `@myorg/my-plugin` as the plugin name.
+If your package.json has a different name, adjust the command accordingly.
+{% /aside %}
+
 {% aside type="caution" title="TsConfig" %}
 
 Nx uses the paths from `tsconfig.base.json` when running plugins locally, but uses the recommended tsconfig for node 16 for other compiler options. See https://github.com/tsconfig/bases/blob/main/bases/node16.json

--- a/astro-docs/src/content/docs/extending-nx/organization-specific-plugin.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/organization-specific-plugin.mdoc
@@ -74,6 +74,12 @@ To try out the generator in dry-run mode, use the following command:
 npx nx g @myorg/recommended:library test-library --dry-run
 ```
 
+{% aside type="caution" title="Use the package.json name" %}
+When referencing your plugin, you must use the name defined in `tools/recommended/package.json`. 
+In this example, we're using `@myorg/recommended` as the plugin name. 
+If your package.json has a different name, adjust the command accordingly.
+{% /aside %}
+
 Remove the `--dry-run` flag to actually create a new project.
 
 ### Add Generator Options

--- a/astro-docs/src/content/docs/extending-nx/organization-specific-plugin.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/organization-specific-plugin.mdoc
@@ -75,8 +75,8 @@ npx nx g @myorg/recommended:library test-library --dry-run
 ```
 
 {% aside type="caution" title="Use the package.json name" %}
-When referencing your plugin, you must use the name defined in `tools/recommended/package.json`. 
-In this example, we're using `@myorg/recommended` as the plugin name. 
+When referencing your plugin, you must use the name defined in `tools/recommended/package.json`.
+In this example, we're using `@myorg/recommended` as the plugin name.
 If your package.json has a different name, adjust the command accordingly.
 {% /aside %}
 


### PR DESCRIPTION
Clarify which name should be used when calling a local plugin

Fixes DOC-232
