### PR TITLE
fix(nextjs): update entrypoints for buildable library with vite to include server entry #31457

### DIFF
--- a/packages/next/src/generators/library/lib/update-vite-config.spec.ts
+++ b/packages/next/src/generators/library/lib/update-vite-config.spec.ts
@@ -1,0 +1,237 @@
+import { Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { updateViteConfigForServerEntry } from './update-vite-config';
+
+describe('updateViteConfigForServerEntry', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should transform entry and fileName properties', () => {
+    const initialConfig = `
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: 'src/index.ts',
+      fileName: 'index',
+    },
+  },
+});
+`;
+
+    tree.write('vite.config.ts', initialConfig);
+    const result = updateViteConfigForServerEntry(tree, 'vite.config.ts');
+
+    expect(result).toBe(true);
+
+    const updatedConfig = tree.read('vite.config.ts', 'utf-8');
+    expect(updatedConfig).toContain("index: 'src/index.ts'");
+    expect(updatedConfig).toContain("server: 'src/server.ts'");
+    expect(updatedConfig).toContain('fileName: (format, entryName) =>');
+    expect(updatedConfig).toContain('`${entryName}.js`');
+  });
+
+  it('should handle double quotes in entry', () => {
+    const initialConfig = `
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: "src/index.ts",
+      fileName: "index",
+    },
+  },
+});
+`;
+
+    tree.write('vite.config.ts', initialConfig);
+    const result = updateViteConfigForServerEntry(tree, 'vite.config.ts');
+
+    expect(result).toBe(true);
+
+    const updatedConfig = tree.read('vite.config.ts', 'utf-8');
+    expect(updatedConfig).toContain("index: 'src/index.ts'");
+    expect(updatedConfig).toContain("server: 'src/server.ts'");
+  });
+
+  it('should not transform if entry is already an object', () => {
+    const initialConfig = `
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: {
+        index: 'src/index.ts',
+        server: 'src/server.ts',
+      },
+      fileName: 'index',
+    },
+  },
+});
+`;
+
+    tree.write('vite.config.ts', initialConfig);
+    const originalConfig = tree.read('vite.config.ts', 'utf-8');
+    const result = updateViteConfigForServerEntry(tree, 'vite.config.ts');
+
+    // Should still update fileName
+    expect(result).toBe(true);
+
+    const updatedConfig = tree.read('vite.config.ts', 'utf-8');
+    // Entry should remain unchanged
+    expect(updatedConfig).toContain("index: 'src/index.ts'");
+    expect(updatedConfig).toContain("server: 'src/server.ts'");
+    // fileName should be updated
+    expect(updatedConfig).toContain('fileName: (format, entryName) =>');
+  });
+
+  it('should not transform if fileName is already a function', () => {
+    const initialConfig = `
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: 'src/index.ts',
+      fileName: (format, entryName) => \`\${entryName}.js\`,
+    },
+  },
+});
+`;
+
+    tree.write('vite.config.ts', initialConfig);
+    const result = updateViteConfigForServerEntry(tree, 'vite.config.ts');
+
+    // Should still update entry
+    expect(result).toBe(true);
+
+    const updatedConfig = tree.read('vite.config.ts', 'utf-8');
+    // Entry should be updated
+    expect(updatedConfig).toContain("index: 'src/index.ts'");
+    expect(updatedConfig).toContain("server: 'src/server.ts'");
+    // fileName should remain a function
+    expect(updatedConfig).toContain('fileName: (format, entryName) =>');
+  });
+
+  it('should not transform if both are already transformed', () => {
+    const initialConfig = `
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: {
+        index: 'src/index.ts',
+        server: 'src/server.ts',
+      },
+      fileName: (format, entryName) => \`\${entryName}.js\`,
+    },
+  },
+});
+`;
+
+    tree.write('vite.config.ts', initialConfig);
+    const result = updateViteConfigForServerEntry(tree, 'vite.config.ts');
+
+    expect(result).toBe(false);
+
+    const originalConfig = initialConfig;
+    const updatedConfig = tree.read('vite.config.ts', 'utf-8');
+    // Should remain unchanged
+    expect(updatedConfig).toBe(originalConfig);
+  });
+
+  it('should return false if file does not exist', () => {
+    const result = updateViteConfigForServerEntry(
+      tree,
+      'non-existent-vite.config.ts'
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('should not transform if entry points to different file', () => {
+    const initialConfig = `
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: 'src/main.ts',
+      fileName: 'index',
+    },
+  },
+});
+`;
+
+    tree.write('vite.config.ts', initialConfig);
+    const result = updateViteConfigForServerEntry(tree, 'vite.config.ts');
+
+    // Should still update fileName
+    expect(result).toBe(true);
+
+    const updatedConfig = tree.read('vite.config.ts', 'utf-8');
+    // Entry should remain unchanged
+    expect(updatedConfig).toContain("entry: 'src/main.ts'");
+    // fileName should be updated
+    expect(updatedConfig).toContain('fileName: (format, entryName) =>');
+  });
+
+  it('should not transform if fileName has custom value', () => {
+    const initialConfig = `
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: 'src/index.ts',
+      fileName: 'custom-name',
+    },
+  },
+});
+`;
+
+    tree.write('vite.config.ts', initialConfig);
+    const result = updateViteConfigForServerEntry(tree, 'vite.config.ts');
+
+    // Should still update entry
+    expect(result).toBe(true);
+
+    const updatedConfig = tree.read('vite.config.ts', 'utf-8');
+    // Entry should be updated
+    expect(updatedConfig).toContain("index: 'src/index.ts'");
+    expect(updatedConfig).toContain("server: 'src/server.ts'");
+    // fileName should remain unchanged
+    expect(updatedConfig).toContain("fileName: 'custom-name'");
+  });
+
+  it('should handle config with no entry or fileName properties', () => {
+    const initialConfig = `
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    lib: {
+      name: 'MyLib',
+    },
+  },
+});
+`;
+
+    tree.write('vite.config.ts', initialConfig);
+    const originalConfig = tree.read('vite.config.ts', 'utf-8');
+    const result = updateViteConfigForServerEntry(tree, 'vite.config.ts');
+
+    expect(result).toBe(false);
+
+    const updatedConfig = tree.read('vite.config.ts', 'utf-8');
+    // Should remain unchanged
+    expect(updatedConfig).toBe(originalConfig);
+  });
+});

--- a/packages/next/src/generators/library/lib/update-vite-config.ts
+++ b/packages/next/src/generators/library/lib/update-vite-config.ts
@@ -1,0 +1,46 @@
+import { Tree } from '@nx/devkit';
+
+/**
+ * Updates a Vite config to support multiple entry points for Next.js libraries.
+ * Transforms:
+ * 1. entry: 'src/index.ts' -> entry: { index: 'src/index.ts', server: 'src/server.ts' }
+ * 2. fileName: 'index' -> fileName: (format, entryName) => `${entryName}.js`
+ *
+ * Note: We know the shape of the vite config that is being generated, therefore string manipulation is fine
+ *
+ * @param tree - The file system tree
+ * @param viteConfigPath - Path to the vite.config.ts file
+ * @returns true if the config was updated, false otherwise
+ */
+export function updateViteConfigForServerEntry(
+  tree: Tree,
+  viteConfigPath: string
+): boolean {
+  if (!tree.exists(viteConfigPath)) {
+    return false;
+  }
+
+  const viteConfigContent = tree.read(viteConfigPath, 'utf-8');
+
+  // Replace single entry string with multiple entry object
+  const updatedViteConfig = viteConfigContent
+    .replace(
+      /entry:\s*['"]src\/index\.ts['"]/,
+      `entry: {
+        index: 'src/index.ts',
+        server: 'src/server.ts',
+      }`
+    )
+    .replace(
+      /fileName:\s*['"]index['"]/,
+      `fileName: (format, entryName) => \`\${entryName}.js\``
+    );
+
+  // Only write if changes were made
+  if (updatedViteConfig !== viteConfigContent) {
+    tree.write(viteConfigPath, updatedViteConfig);
+    return true;
+  }
+
+  return false;
+}

--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -89,6 +89,34 @@ describe('next library', () => {
 
     expect(appTree.exists('my-buildable-lib/vite.config.ts')).toBeTruthy();
   });
+
+  it('should configure server entry point for buildable library with Vite', async () => {
+    const appTree = createTreeWithEmptyWorkspace();
+    await libraryGenerator(appTree, {
+      directory: 'my-buildable-lib',
+      linter: 'eslint',
+      skipFormat: false,
+      skipTsConfig: false,
+      unitTestRunner: 'jest',
+      style: 'css',
+      component: true,
+      bundler: 'vite',
+    });
+
+    // Check vite.config.ts has multiple entry points
+    const viteConfig = appTree.read('my-buildable-lib/vite.config.ts', 'utf-8');
+    expect(viteConfig).toContain("index: 'src/index.ts'");
+    expect(viteConfig).toContain("server: 'src/server.ts'");
+    expect(viteConfig).toContain('fileName: (format, entryName) =>');
+
+    // Check package.json has server export
+    const packageJson = readJson(appTree, 'my-buildable-lib/package.json');
+    expect(packageJson.exports['./server']).toBeDefined();
+    expect(packageJson.exports['./server'].types).toBe('./dist/server.d.ts');
+    expect(packageJson.exports['./server'].import).toBe('./dist/server.js');
+    expect(packageJson.exports['./server'].default).toBe('./dist/server.js');
+  });
+
   it('should generate a server-only entry point', async () => {
     const appTree = createTreeWithEmptyWorkspace();
 


### PR DESCRIPTION
## Current Behavior
When creating a buildable library for Next w/ Vite, we do not configure an additional entry point for server components.

## Expected Behavior
Ensure additional server entry point is configured.

## Related Issue(s)

Fixes #31457
