### PR TITLE
feat(release)!: set preserveMatchingDependencyRanges to true by default

### DIFF
--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -76,7 +76,6 @@ import {
   isPrerelease,
   noDiffInChangelogMessage,
 } from './utils/shared';
-import * as console from 'node:console';
 
 export interface NxReleaseChangelogResult {
   workspaceChangelog?: {

--- a/packages/nx/src/command-line/release/version/release-group-processor.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.ts
@@ -1337,11 +1337,10 @@ Valid values are: ${validReleaseVersionPrefixes
       releaseGroupVersionConfig?.preserveLocalDependencyProtocols ??
       true;
 
-    // TODO(v22): flip to true by default
     const preserveMatchingDependencyRanges =
       projectVersionConfig?.preserveMatchingDependencyRanges ??
       releaseGroupVersionConfig?.preserveMatchingDependencyRanges ??
-      false;
+      true;
 
     /**
      * fallbackCurrentVersionResolver, defaults to disk when performing a first release, otherwise undefined


### PR DESCRIPTION
Set `preserveMatchingDependencyRanges` to `true` by default. Previous default was `false`.

BREAKING CHANGE: Previously, Nx Release would always update the version of workspace dependecies within manifest files to be the new value that is being released, regardless if the dependent package had defined a valid range.
The new behavior being introduced will keep valid ranges in manifest files. If the range is not valid for the new version being released an error will be thrown asking the user to update the range to be valid.
