### PR TITLE
fix(core): repair repo root on setupAiAgents in nx init

### DIFF
--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -174,7 +174,7 @@ export async function initHandler(options: InitArgs): Promise<void> {
   if (selectedAgents && selectedAgents.length > 0) {
     const tree = new FsTree(repoRoot, false);
     const aiAgentsCallback = await setupAiAgentsGenerator(tree, {
-      directory: repoRoot,
+      directory: '.',
       writeNxCloudRules: options.nxCloud !== false,
       packageVersion: 'latest',
       agents: [...selectedAgents],


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
`nx init` will generate `CLAUDE.md` in a wrong path

## Expected Behavior
it should be at the repo root
