### PR TITLE
fix(core): display bottom corner indicator of tui in progress section correctly

### DIFF
--- a/packages/nx/src/native/tui/components/snapshots/nx__native__tui__components__tasks_list__tests__more_in_progress_tasks_than_parallel_limit.snap
+++ b/packages/nx/src/native/tui/components/snapshots/nx__native__tui__components__tasks_list__tests__more_in_progress_tasks_than_parallel_limit.snap
@@ -1,0 +1,19 @@
+---
+source: packages/nx/src/native/tui/components/tasks_list.rs
+expression: terminal.backend()
+---
+"                                                                                "
+" NX    Running Test Tasks...                                    Cache   Duration"
+" │                                                                              "
+" │⠋    task1                                                      ...       <1ms"
+" │⠋    task2                                                      ...       <1ms"
+" │⠋    task3                                                      ...       <1ms"
+">│⠋    task4                                                      ...       <1ms"
+" └                                                                              "
+"                                                                                "
+"                                                                                "
+"                                                                                "
+"                                                                                "
+"                                                                                "
+"                                                                                "
+"                                                                quit: q  help: ?"


### PR DESCRIPTION
## Current Behavior

The bottom corner indicator of the in-progress section in the TUI is not displayed when there are more tasks in progress than the maximum parallel capacity (this can occur when there are continuous tasks).

## Expected Behavior

The bottom corner indicator of the in-progress section in the TUI should always be displayed at the end of the running tasks.