### PR TITLE
feat(nest): ensure dependencies are added to project's package.json #32548

### DIFF
--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -260,7 +260,17 @@ describe('application generator', () => {
       `);
       expect(readJson(tree, 'myapp/package.json')).toMatchInlineSnapshot(`
         {
-          "dependencies": {},
+          "dependencies": {
+            "@nestjs/common": "^11.0.0",
+            "@nestjs/core": "^11.0.0",
+            "@nestjs/platform-express": "^11.0.0",
+            "reflect-metadata": "^0.1.13",
+            "rxjs": "^7.8.0",
+            "tslib": "^2.3.0",
+          },
+          "devDependencies": {
+            "@nestjs/testing": "^11.0.0",
+          },
           "name": "@proj/myapp",
           "nx": {
             "targets": {
@@ -442,6 +452,7 @@ describe('application generator', () => {
           "private",
           "nx",
           "dependencies",
+          "devDependencies",
         ]
       `);
     });

--- a/packages/nest/src/generators/application/application.ts
+++ b/packages/nest/src/generators/application/application.ts
@@ -44,7 +44,13 @@ export async function applicationGeneratorInternal(
   updateTsConfig(tree, options);
 
   if (!options.skipPackageJson) {
+    // Install dependencies to root package.json
     tasks.push(ensureDependencies(tree));
+
+    // Install dependencies to project's package.json (for PM Workspaces)
+    if (tree.exists(`${options.appProjectRoot}/package.json`)) {
+      tasks.push(ensureDependencies(tree, options.appProjectRoot));
+    }
   }
 
   if (!options.skipFormat) {

--- a/packages/nest/src/utils/ensure-dependencies.ts
+++ b/packages/nest/src/utils/ensure-dependencies.ts
@@ -1,5 +1,5 @@
 import type { GeneratorCallback, Tree } from '@nx/devkit';
-import { addDependenciesToPackageJson } from '@nx/devkit';
+import { addDependenciesToPackageJson, joinPathFragments } from '@nx/devkit';
 import {
   nestJsVersion,
   reflectMetadataVersion,
@@ -7,7 +7,14 @@ import {
   tsLibVersion,
 } from './versions';
 
-export function ensureDependencies(tree: Tree): GeneratorCallback {
+export function ensureDependencies(
+  tree: Tree,
+  projectRoot?: string
+): GeneratorCallback {
+  const packageJsonPath = projectRoot
+    ? joinPathFragments(projectRoot, 'package.json')
+    : 'package.json';
+
   return addDependenciesToPackageJson(
     tree,
     {
@@ -20,6 +27,7 @@ export function ensureDependencies(tree: Tree): GeneratorCallback {
     },
     {
       '@nestjs/testing': nestJsVersion,
-    }
+    },
+    packageJsonPath
   );
 }


### PR DESCRIPTION
## Current Behavior
NestJS dependencies are not added to the project's package.json leading to issues when pruning lockfile for dockerfiles.

## Expected Behavior
Ensure NestJS dependencies are added to the project's package.json.

## Related Issue(s)

Fixes #32548
