### PR TITLE
fix(vite): ensure tsconfig file is resolved from workspaceRoot #31987

### DIFF
--- a/packages/vite/src/utils/options-utils.ts
+++ b/packages/vite/src/utils/options-utils.ts
@@ -4,6 +4,7 @@ import {
   logger,
   parseTargetString,
   readTargetOptions,
+  workspaceRoot,
 } from '@nx/devkit';
 import { existsSync } from 'fs';
 import { ViteDevServerExecutorOptions } from '../executors/dev-server/schema';
@@ -53,11 +54,15 @@ export function normalizeViteConfigFilePath(
 export function getProjectTsConfigPath(
   projectRoot: string
 ): string | undefined {
-  return existsSync(joinPathFragments(projectRoot, 'tsconfig.app.json'))
+  return existsSync(
+    joinPathFragments(workspaceRoot, projectRoot, 'tsconfig.app.json')
+  )
     ? joinPathFragments(projectRoot, 'tsconfig.app.json')
-    : existsSync(joinPathFragments(projectRoot, 'tsconfig.lib.json'))
+    : existsSync(
+        joinPathFragments(workspaceRoot, projectRoot, 'tsconfig.lib.json')
+      )
     ? joinPathFragments(projectRoot, 'tsconfig.lib.json')
-    : existsSync(joinPathFragments(projectRoot, 'tsconfig.json'))
+    : existsSync(joinPathFragments(workspaceRoot, projectRoot, 'tsconfig.json'))
     ? joinPathFragments(projectRoot, 'tsconfig.json')
     : undefined;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When resolving the tsconfig file, project root is always used, regardless of cwd.
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Prepend workspaceRoot to force absolute path resolution 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #31987 
