### PR TITLE
fix(core): remove requirement to be in a package manager workspace

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -334,7 +334,7 @@ export class TargetProjectLocator {
 
     const maybeDepMetadata = maybeDep?.data.metadata.js;
 
-    if (!maybeDepMetadata?.isInPackageManagerWorkspaces) {
+    if (!maybeDepMetadata) {
       return null;
     }
 


### PR DESCRIPTION


## Current Behavior
<!-- This is the behavior we have today -->

Workspaces that did not use package manager workspaces lost some dependencies with the other fix.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Workspaces that do not use package manager workspaces will still get the correct dependencies.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
