### PR TITLE
fix(repo): fix pr releases to not depend on a broken range

### DIFF
--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -518,11 +518,11 @@ function hackFixForDevkitPeerDependencies() {
   );
 
   const beforeVersion = devkitPackageJson.peerDependencies['nx'];
-  if (!beforeVersion.includes('<')) {
+  const majorVersion = major(beforeVersion);
+  if (!beforeVersion.includes('<') && majorVersion !== 0) {
     console.log(
       '@nx/devkit peer dependencies range is broken - needs release fix. Patching it to avoid broken publishes.'
     );
-    const majorVersion = major(beforeVersion);
     devkitPackageJson.peerDependencies['nx'] = `>= ${majorVersion - 1} <= ${
       majorVersion + 1
     }`;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

PR releases are being released with a range of `-1 - 1` which is incorrect

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

PR releases have a peer dependency on just that PR release.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
