### PR TITLE
chore(repo): update CI to use Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
 
       - name: Install Rust
@@ -151,7 +151,7 @@ jobs:
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 22
           package-manager-cache: false
 
       - name: Set SHAs

--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Use Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: '20.19.0'
+          node-version: '22.21.0'
           cache: 'pnpm'
 
       - name: Cache node_modules

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -16,6 +16,11 @@ launch-templates:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
 
+      - name: Install Node
+        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-node/main.yaml'
+        inputs:
+          node_version: '22.21'
+
       - name: Check Node Version
         script: node --version
 
@@ -107,6 +112,11 @@ launch-templates:
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
+
+      - name: Install Node
+        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-node/main.yaml'
+        inputs:
+          node_version: '22.21'
 
       - name: Check Node Version
         script: node --version


### PR DESCRIPTION
## Current Behavior
CI workflows and agents are using Node 20.

## Expected Behavior
CI workflows and agents should use Node 22 to test against this version before potentially moving to Node 24.

## Related Issue(s)
Closes NXC-3227