### PR TITLE
docs(nx-dev): remove NEXT_PUBLIC_ASTRO_URL environment variable checks

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -8,8 +8,10 @@ launch-templates:
       GIT_COMMITTER_EMAIL: test@test.com
       GIT_COMMITTER_NAME: Test
       SELECTED_PM: 'pnpm'
-
       NX_NATIVE_LOGGING: 'nx::native::db'
+      # These are need for build and link validation for next.js and astro apps
+      NEXT_PUBLIC_ASTRO_URL: 'https://master--nx-docs.netlify.app'
+      NX_DEV_URL: 'https://canary.nx.dev'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
@@ -91,6 +93,9 @@ launch-templates:
       GIT_COMMITTER_NAME: Test
       SELECTED_PM: 'pnpm'
       NX_NATIVE_LOGGING: 'nx::native::db'
+      # These are need for build and link validation for next.js and astro apps
+      NEXT_PUBLIC_ASTRO_URL: 'https://master--nx-docs.netlify.app'
+      NX_DEV_URL: 'https://canary.nx.dev'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'

--- a/astro-docs/src/components/layout/Header.astro
+++ b/astro-docs/src/components/layout/Header.astro
@@ -13,6 +13,9 @@ import nxLogoLight from '../../assets/nx/Nx-light.svg';
 const shouldRenderSearch =
 	config.pagefind || config.components.Search !== '@astrojs/starlight/components/Search.astro';
 
+// Get the base URL from environment
+const nxDevUrl = import.meta.env.SITE || 'https://nx.dev';
+
 // Version options
 const versions = [
   { version: 'v21', href: '/docs/getting-started/intro', current: true },
@@ -59,7 +62,7 @@ const currentVersion = versions.find(v => v.current);
 		</div>
 	</div>
 	<nav class="hidden lg:flex items-center gap-1 ml-8 flex-shrink-0">
-		<a href="https://nx.dev/blog" class="px-3 py-2 text-sm font-medium text-slate-600 hover:text-blue-500 rounded-md transition-colors whitespace-nowrap no-underline dark:text-slate-200 dark:hover:text-sky-500">
+		<a href={`${nxDevUrl}/blog`} class="px-3 py-2 text-sm font-medium text-slate-600 hover:text-blue-500 rounded-md transition-colors whitespace-nowrap no-underline dark:text-slate-200 dark:hover:text-sky-500">
 			Blog
 		</a>
 		
@@ -76,19 +79,19 @@ const currentVersion = versions.find(v => v.current);
 					<!-- Learn Section -->
 					<div class="space-y-1">
 						<h5 class="text-xs font-semibold uppercase tracking-wider text-slate-500 px-2 pb-2 dark:text-slate-400">Learn</h5>
-						<a href="https://nx.dev/podcast" class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
+						<a href={`${nxDevUrl}/podcast`} class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
 							<svg class="w-5 h-5 text-slate-400 dark:text-slate-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M12 18.75a6 6 0 0 0 6-6v-1.5m-6 7.5a6 6 0 0 1-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 0 1-3-3V4.5a3 3 0 1 1 6 0v8.25a3 3 0 0 1-3 3Z" />
 							</svg>
 							<span class="text-sm font-medium text-slate-900 dark:text-slate-200">Podcasts</span>
 						</a>
-						<a href="https://nx.dev/webinar" class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
+						<a href={`${nxDevUrl}/webinar`} class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
 							<svg class="w-5 h-5 text-slate-400 dark:text-slate-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0V12a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 12V5.25" />
 							</svg>
 							<span class="text-sm font-medium text-slate-900 dark:text-slate-200">Webinars</span>
 						</a>
-						<a href="https://nx.dev/courses" class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
+						<a href={`${nxDevUrl}/courses`} class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
 							<svg class="w-5 h-5 text-slate-400 dark:text-slate-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
 								<path stroke-linecap="round" stroke-linejoin="round" d="M15.91 11.672a.375.375 0 0 1 0 .656l-5.603 3.113a.375.375 0 0 1-.557-.328V8.887c0-.286.307-.466.557-.327l5.603 3.112Z" />
@@ -101,7 +104,7 @@ const currentVersion = versions.find(v => v.current);
 							</svg>
 							<span class="text-sm font-medium text-slate-900 dark:text-slate-200">Newsletter</span>
 						</a>
-						<a href="https://nx.dev/community" class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
+						<a href={`${nxDevUrl}/community`} class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
 							<svg class="w-5 h-5 text-slate-400 dark:text-slate-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
 							</svg>
@@ -129,19 +132,19 @@ const currentVersion = versions.find(v => v.current);
 						<!-- Company Section -->
 						<div class="space-y-1">
 							<h5 class="text-xs font-semibold uppercase tracking-wider text-slate-500 px-2 pb-2 dark:text-slate-400">Company</h5>
-							<a href="https://nx.dev/company" class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
+							<a href={`${nxDevUrl}/company`} class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
 								<svg class="w-5 h-5 text-slate-400 dark:text-slate-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
 									<path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 0 0 3.741-.479 3 3 0 0 0-4.682-2.72m.94 3.198.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0 1 12 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 0 1 6 18.719m12 0a5.971 5.971 0 0 0-.941-3.197m0 0A5.995 5.995 0 0 0 12 12.75a5.995 5.995 0 0 0-5.058 2.772m0 0a3 3 0 0 0-4.681 2.72 8.986 8.986 0 0 0 3.74.477m.94-3.197a5.971 5.971 0 0 0-.94 3.197M15 6.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Zm6 3a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Zm-13.5 0a2.25 2.25 0 1 1-4.5 0 2.25 2.25 0 0 1 4.5 0Z" />
 								</svg>
 								<span class="text-sm font-medium text-slate-900 dark:text-slate-200">About Us</span>
 							</a>
-							<a href="https://nx.dev/customers" class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
+							<a href={`${nxDevUrl}/customers`} class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
 								<svg class="w-5 h-5 text-slate-400 dark:text-slate-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
 									<path stroke-linecap="round" stroke-linejoin="round" d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 3.75h.008v.008h-.008v-.008Zm0 3h.008v.008h-.008v-.008Zm0 3h.008v.008h-.008v-.008Z" />
 								</svg>
 								<span class="text-sm font-medium text-slate-900 dark:text-slate-200">Customers</span>
 							</a>
-							<a href="https://nx.dev/partners" class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
+							<a href={`${nxDevUrl}/partners`} class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60">
 								<svg class="w-5 h-5 text-slate-400 dark:text-slate-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
 									<path stroke-linecap="round" stroke-linejoin="round" d="M16.712 4.33a9.027 9.027 0 0 1 1.652 1.306c.51.51.944 1.064 1.306 1.652M16.712 4.33l-3.448 4.138m3.448-4.138a9.014 9.014 0 0 0-9.424 0M19.67 7.288l-4.138 3.448m4.138-3.448a9.014 9.014 0 0 1 0 9.424m-1.306 1.652a9.027 9.027 0 0 1-1.652 1.306m0 0-3.448-4.138m3.448 4.138a9.014 9.014 0 0 1-9.424 0m5.976-4.138a3.765 3.765 0 0 1-2.528 0m0 0a3.736 3.736 0 0 1-1.388-.88 3.737 3.737 0 0 1-.88-1.388m2.268 2.268L7.288 19.67m0 0a9.024 9.024 0 0 1-1.652-1.306 9.027 9.027 0 0 1-1.306-1.652m0 0 4.138-3.448M4.33 16.712a9.014 9.014 0 0 1 0-9.424m4.138-3.448A9.027 9.027 0 0 1 7.162 5.146a9.024 9.024 0 0 1 1.306 1.652M4.33 7.288 8.468 10.736m0 0a3.736 3.736 0 0 1 .88-1.388 3.737 3.737 0 0 1 1.388-.88m-2.268 2.268L4.33 7.288m6.406 1.18L7.288 4.33m0 0a9.024 9.024 0 0 0-1.652 1.306A9.025 9.025 0 0 0 4.33 7.288" />
 								</svg>
@@ -154,14 +157,14 @@ const currentVersion = versions.find(v => v.current);
 		</div>
 		
 		<div class="h-6 w-px bg-slate-200 mx-1 dark:bg-slate-700"></div>
-		<a href="https://nx.dev/ai" class="px-3 py-2 text-sm font-medium text-slate-600 hover:text-blue-500 rounded-md transition-colors whitespace-nowrap no-underline dark:text-slate-200 dark:hover:text-sky-500">
+		<a href={`${nxDevUrl}/ai`} class="px-3 py-2 text-sm font-medium text-slate-600 hover:text-blue-500 rounded-md transition-colors whitespace-nowrap no-underline dark:text-slate-200 dark:hover:text-sky-500">
 			AI
 		</a>
-		<a href="https://nx.dev/nx-cloud" class="px-3 py-2 text-sm font-medium text-slate-600 hover:text-blue-500 rounded-md transition-colors whitespace-nowrap no-underline dark:text-slate-200 dark:hover:text-sky-500">
+		<a href={`${nxDevUrl}/nx-cloud`} class="px-3 py-2 text-sm font-medium text-slate-600 hover:text-blue-500 rounded-md transition-colors whitespace-nowrap no-underline dark:text-slate-200 dark:hover:text-sky-500">
 			Nx Cloud
 		</a>
 		<div class="h-6 w-px bg-slate-200 mx-1 dark:bg-slate-700"></div>
-		<a href="https://nx.dev/enterprise" class="px-3 py-2 text-sm font-semibold text-slate-600 hover:text-blue-500 rounded-md transition-colors whitespace-nowrap no-underline dark:text-slate-200 dark:hover:text-sky-500">
+		<a href={`${nxDevUrl}/enterprise`} class="px-3 py-2 text-sm font-semibold text-slate-600 hover:text-blue-500 rounded-md transition-colors whitespace-nowrap no-underline dark:text-slate-200 dark:hover:text-sky-500">
 			Nx Enterprise
 		</a>
 	</nav>
@@ -171,8 +174,8 @@ const currentVersion = versions.find(v => v.current);
 	<div class="hidden md:flex items-center gap-4 print:hidden">
 		<!-- CTA Buttons - Hide on screens smaller than xl (1280px) -->
 		<div class="hidden xl:flex items-center gap-2">
-			<a 
-				href="https://nx.dev/contact"
+			<a
+				href={`${nxDevUrl}/contact`}
 				class="inline-flex items-center justify-center px-2.5 py-1.5 text-sm font-medium rounded-md transition no-underline border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 shadow-sm"
 				title="Contact Us"
 			>

--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -74,6 +74,8 @@ export function DocViewer({
     });
   }
 
+  // The pages using `DocViewer` should no longer be reachable.
+  // We'll be removing the Next.js app later, but for now just make sure noindex is set so if we somehow missed a redirect, at least nothing should be indexing the page.
   return (
     <>
       <NextSeo
@@ -82,8 +84,8 @@ export function DocViewer({
           vm.description ??
           'Get to green PRs in half the time. Nx optimizes your builds, scales your CI, and fixes failed PRs. Built for developers and AI agents.'
         }
-        noindex={!!process.env.NEXT_PUBLIC_ASTRO_URL}
-        nofollow={!!process.env.NEXT_PUBLIC_ASTRO_URL}
+        noindex={true}
+        nofollow={true}
         openGraph={{
           url: 'https://nx.dev' + currentPath,
           title: vm.title,

--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -2,6 +2,19 @@
 const { withNx } = require('@nx/next/plugins/with-nx');
 const redirectRules = require('./redirect-rules');
 
+if (!process.env.NEXT_PUBLIC_ASTRO_URL) {
+  // If we're building for production throw error as each env must set this value.
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(
+      `The NEXT_PUBLIC_ASTRO_URL environment variable is not set. Please set it to the URL of the Astro site.`
+    );
+  }
+  // For dev, default to the canary docs.
+  else {
+    process.env.NEXT_PUBLIC_ASTRO_URL = 'https://master--nx-docs.netlify.app';
+  }
+}
+
 module.exports = withNx({
   // Disable the type checking for now, we need to resolve the issues first.
   typescript: {

--- a/nx-dev/nx-dev/pages/ai-chat/index.tsx
+++ b/nx-dev/nx-dev/pages/ai-chat/index.tsx
@@ -51,15 +51,9 @@ export default function AiDocs(): JSX.Element {
           'h-[calc(100dvh)]'
         )}
       >
-        {process.env.NEXT_PUBLIC_ASTRO_URL ? (
-          <div className="mb-12">
-            <Header />
-          </div>
-        ) : (
-          <div className="w-full flex-shrink-0">
-            <DocumentationHeader isNavOpen={navIsOpen} toggleNav={toggleNav} />
-          </div>
-        )}
+        <div className="mb-12">
+          <Header />
+        </div>
         <main
           id="main"
           role="main"

--- a/nx-dev/nx-dev/pages/changelog.tsx
+++ b/nx-dev/nx-dev/pages/changelog.tsx
@@ -232,15 +232,9 @@ export default function Changelog(props: ChangeLogProps): JSX.Element {
           type: 'website',
         }}
       />
-      {process.env.NEXT_PUBLIC_ASTRO_URL ? (
-        <div className="mb-12">
-          <Header />
-        </div>
-      ) : (
-        <div className="w-full flex-shrink-0">
-          <DocumentationHeader isNavOpen={navIsOpen} toggleNav={toggleNav} />
-        </div>
-      )}
+      <div className="mb-12">
+        <Header />
+      </div>
 
       <main id="main" role="main">
         <div className="mx-auto flex max-w-7xl flex-col px-4 py-8 sm:px-6 lg:px-8">
@@ -262,11 +256,7 @@ export default function Changelog(props: ChangeLogProps): JSX.Element {
               All the Nx goodies in one page, sorted by release. See our{' '}
               <Link
                 className="underline"
-                href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/reference/releases'
-                    : '/reference/releases'
-                }
+                href={'/docs/reference/releases'}
                 prefetch={false}
               >
                 release page

--- a/nx-dev/nx-dev/pages/plugin-registry.tsx
+++ b/nx-dev/nx-dev/pages/plugin-registry.tsx
@@ -84,8 +84,8 @@ export default function Browse(props: BrowseProps): JSX.Element {
       <NextSeo
         title="Nx Plugin Registry"
         description="Nx Plugins enhance the developer experience in you workspace to make your life simpler. Browse the list of available Nx Plugins."
-        noindex={!!process.env.NEXT_PUBLIC_ASTRO_URL}
-        nofollow={!!process.env.NEXT_PUBLIC_ASTRO_URL}
+        noindex={true}
+        nofollow={true}
         openGraph={{
           url: 'https://nx.dev' + router.asPath,
           title: 'Nx Plugin Registry',
@@ -135,9 +135,7 @@ export default function Browse(props: BrowseProps): JSX.Element {
                     <a
                       className="underline"
                       href={
-                        process.env.NEXT_PUBLIC_ASTRO_URL
-                          ? '/docs/extending-nx/recipes/publish-plugin#list-your-nx-plugin'
-                          : '/extending-nx/recipes/publish-plugin#list-your-nx-plugin'
+                        '/docs/extending-nx/recipes/publish-plugin#list-your-nx-plugin'
                       }
                     >
                       add your plugin to the registry

--- a/nx-dev/nx-dev/redirect-rules.js
+++ b/nx-dev/nx-dev/redirect-rules.js
@@ -895,12 +895,7 @@ const missingAndCatchAllRedirects = {
   '/packages/:path*': '/nx-api/:path*',
 };
 
-if (process.env['NEXT_PUBLIC_ASTRO_URL']) {
-  missingAndCatchAllRedirects['/docs'] = '/docs/getting-started/intro';
-} else {
-  // For new docs, we rewrite all docs URLs to astro site, so we can skip this redirect
-  missingAndCatchAllRedirects['/docs'] = '/getting-started/intro';
-}
+missingAndCatchAllRedirects['/docs'] = '/docs/getting-started/intro';
 
 const marketing = {
   '/conf': 'https://monorepo.world',
@@ -1552,8 +1547,5 @@ module.exports = {
   ciTutorialRedirects,
   dockerReleaseRedirect,
   contentDedupeRedirects,
-  // Only enable these redirects if the new docs are enabled
-  docsToAstroRedirects: process.env['NEXT_PUBLIC_ASTRO_URL']
-    ? docsToAstroRedirects
-    : {},
+  docsToAstroRedirects: docsToAstroRedirects,
 };

--- a/nx-dev/ui-ai-landing-page/src/lib/call-to-action.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/call-to-action.tsx
@@ -62,11 +62,7 @@ export function CallToAction(): ReactElement {
         </h2>
         <div className="mt-10 flex items-center justify-center gap-x-6">
           <Link
-            href={
-              process.env.NEXT_PUBLIC_ASTRO_URL
-                ? '/docs/features/enhance-ai#setting-up-nx-mcp'
-                : '/features/enhance-AI#setting-up-nx-mcp'
-            }
+            href={'/docs/features/enhance-ai#setting-up-nx-mcp'}
             title="Get started with Nx AI integration"
             prefetch={false}
             className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"

--- a/nx-dev/ui-ai-landing-page/src/lib/hero.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/hero.tsx
@@ -493,11 +493,7 @@ export function Hero(): JSX.Element {
               className="mt-8 flex justify-start"
             >
               <ButtonLink
-                href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/features/enhance-ai#setting-up-nx-mcp'
-                    : '/features/enhance-AI#setting-up-nx-mcp'
-                }
+                href={'/docs/features/enhance-ai#setting-up-nx-mcp'}
                 variant="primary"
                 size="default"
                 title="Enhance your AI assistant"

--- a/nx-dev/ui-ai-landing-page/src/lib/new/ai-hero.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/new/ai-hero.tsx
@@ -25,11 +25,7 @@ export function AiHero(): ReactElement {
           </SectionHeading>
           <div className="mt-6">
             <ButtonLink
-              href={
-                process.env.NEXT_PUBLIC_ASTRO_URL
-                  ? '/docs/getting-started/ai-setup'
-                  : '/getting-started/ai-integration'
-              }
+              href={'/docs/getting-started/ai-setup'}
               title="Nx AI Integration"
               variant="primary"
               size="small"

--- a/nx-dev/ui-ai-landing-page/src/lib/new/while-running-ci.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/new/while-running-ci.tsx
@@ -18,11 +18,7 @@ const features: FeatureCardProps[] = [
         </p>
         <div className="mt-4">
           <Link
-            href={
-              process.env.NEXT_PUBLIC_ASTRO_URL
-                ? '/docs/features/ci-features/flaky-tasks'
-                : '/ci/features/flaky-tasks'
-            }
+            href={'/docs/features/ci-features/flaky-tasks'}
             title="How to identify and rerun flaky tasks"
             className="text-sm/6 font-semibold"
           >
@@ -76,11 +72,7 @@ const features: FeatureCardProps[] = [
         </p>
         <div className="mt-4">
           <Link
-            href={
-              process.env.NEXT_PUBLIC_ASTRO_URL
-                ? '/docs/features/ci-features/dynamic-agents'
-                : '/ci/features/dynamic-agents'
-            }
+            href={'/docs/features/ci-features/dynamic-agents'}
             title="How to setup dynamic agents"
             className="text-sm/6 font-semibold"
           >

--- a/nx-dev/ui-blog/src/lib/blog-container.tsx
+++ b/nx-dev/ui-blog/src/lib/blog-container.tsx
@@ -74,42 +74,17 @@ export function BlogContainer({ blogPosts, tags }: BlogContainerProps) {
   return (
     <main id="main" role="main" className="w-full py-8">
       <div className="mx-auto mb-8 w-full max-w-[1088px] px-8">
-        {process.env.NEXT_PUBLIC_ASTRO_URL ? (
-          <>
-            <header className="mb-8 mt-20">
-              <h1
-                id="blog-title"
-                className="text-xl font-semibold tracking-tight text-slate-900 md:text-2xl dark:text-slate-100"
-              >
-                {selectedFilterHeading}
-              </h1>
-            </header>
-            <div className="mb-12 flex items-center justify-between">
-              <div className="flex items-center">
-                <Filters
-                  blogs={blogPosts}
-                  filters={filters}
-                  initialSelectedFilter={initialSelectedFilter}
-                  setFilteredList={setFilteredList}
-                  setSelectedFilterHeading={setSelectedFilterHeading}
-                />
-              </div>
-              <div className="flex w-48 items-center justify-end md:justify-start">
-                <AlgoliaSearch blogOnly={true} />
-              </div>
-            </div>
-          </>
-        ) : (
-          <div className="mb-12 mt-20 flex items-center justify-between">
-            <header>
-              <h1
-                id="blog-title"
-                className="text-xl font-semibold tracking-tight text-slate-900 md:text-2xl dark:text-slate-100"
-              >
-                {selectedFilterHeading}
-              </h1>
-            </header>
-            <div className="flex items-center justify-end md:justify-start">
+        <>
+          <header className="mb-8 mt-20">
+            <h1
+              id="blog-title"
+              className="text-xl font-semibold tracking-tight text-slate-900 md:text-2xl dark:text-slate-100"
+            >
+              {selectedFilterHeading}
+            </h1>
+          </header>
+          <div className="mb-12 flex items-center justify-between">
+            <div className="flex items-center">
               <Filters
                 blogs={blogPosts}
                 filters={filters}
@@ -118,8 +93,11 @@ export function BlogContainer({ blogPosts, tags }: BlogContainerProps) {
                 setSelectedFilterHeading={setSelectedFilterHeading}
               />
             </div>
+            <div className="flex w-48 items-center justify-end md:justify-start">
+              <AlgoliaSearch blogOnly={true} />
+            </div>
           </div>
-        )}
+        </>
         <FeaturedBlogs blogs={firstFiveBlogs} />
         {!!remainingBlogs.length && (
           <>

--- a/nx-dev/ui-cloud/src/lib/pricing.tsx
+++ b/nx-dev/ui-cloud/src/lib/pricing.tsx
@@ -116,11 +116,7 @@ export function Pricing(): ReactElement {
                     <span>
                       Remote caching with{' '}
                       <Link
-                        href={
-                          process.env.NEXT_PUBLIC_ASTRO_URL
-                            ? '/docs/features/ci-features/remote-cache'
-                            : '/ci/features/remote-cache'
-                        }
+                        href={'/docs/features/ci-features/remote-cache'}
                         target="_blank"
                         title="Learn how Nx Replay easily reduces CI execution time"
                         onClick={() =>
@@ -145,9 +141,7 @@ export function Pricing(): ReactElement {
                       Distributed task execution with{' '}
                       <Link
                         href={
-                          process.env.NEXT_PUBLIC_ASTRO_URL
-                            ? '/docs/features/ci-features/distribute-task-execution'
-                            : '/ci/features/distribute-task-execution'
+                          '/docs/features/ci-features/distribute-task-execution'
                         }
                         target="_blank"
                         title="Learn how Nx Agents easily scale your CI pipelines"
@@ -417,11 +411,7 @@ export function Pricing(): ReactElement {
             <p className="text-sm font-medium opacity-80">
               See{' '}
               <Link
-                href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/reference/nx-cloud/credits-pricing'
-                    : '/ci/reference/credits-pricing'
-                }
+                href={'/docs/reference/nx-cloud/credits-pricing'}
                 className="font-semibold underline"
               >
                 Credit Pricing

--- a/nx-dev/ui-common/src/lib/footer.tsx
+++ b/nx-dev/ui-common/src/lib/footer.tsx
@@ -5,6 +5,8 @@ import Link from 'next/link';
 import { DiscordIcon } from './discord-icon';
 import { VersionPicker } from './version-picker';
 
+// Use NX_DEV_URL if set, otherwise default to empty string for relative URLs
+const nxDevUrl = process.env.NX_DEV_URL || '';
 const navigation = {
   nx: [
     { name: 'Status', href: 'https://status.nx.app' },
@@ -18,25 +20,25 @@ const navigation = {
     },
     {
       name: 'Pricing',
-      href: 'https://nx.dev/nx-cloud#plans',
+      href: `${nxDevUrl}/nx-cloud#plans`,
     },
     { name: 'Terms', href: 'https://cloud.nx.app/terms' },
   ],
   solutions: [
-    { name: 'Nx', href: 'https://nx.dev' },
+    { name: 'Nx', href: nxDevUrl || 'https://nx.dev' },
     {
       name: 'Nx Cloud',
-      href: 'https://nx.dev/nx-cloud',
+      href: `${nxDevUrl}/nx-cloud`,
     },
     {
       name: 'Nx Enterprise',
-      href: 'https://nx.dev/enterprise',
+      href: `${nxDevUrl}/enterprise`,
     },
   ],
   resources: [
     {
       name: 'Blog',
-      href: 'https://nx.dev/blog',
+      href: `${nxDevUrl}/blog`,
     },
     {
       name: 'Youtube',
@@ -44,29 +46,29 @@ const navigation = {
     },
     {
       name: 'Community',
-      href: 'https://nx.dev/community',
+      href: `${nxDevUrl}/community`,
     },
     {
       name: 'Customers',
-      href: 'https://nx.dev/customers',
+      href: `${nxDevUrl}/customers`,
     },
   ],
   company: [
     {
       name: 'About us',
-      href: 'https://nx.dev/company',
+      href: `${nxDevUrl}/company`,
     },
     {
       name: 'Careers',
-      href: 'https://nx.dev/careers',
+      href: `${nxDevUrl}/careers`,
     },
     {
       name: 'Brands & Guidelines',
-      href: 'https://nx.dev/brands',
+      href: `${nxDevUrl}/brands`,
     },
     {
       name: 'Contact us',
-      href: 'https://nx.dev/contact',
+      href: `${nxDevUrl}/contact`,
     },
   ],
   social: [
@@ -190,7 +192,7 @@ export function Footer({
 } = {}): JSX.Element {
   const prefixHref = (href: string) => {
     if (useDomainPrefix && href.startsWith('/')) {
-      return `https://nx.dev${href}`;
+      return `${nxDevUrl}${href}`;
     }
     return href;
   };

--- a/nx-dev/ui-common/src/lib/footer.tsx
+++ b/nx-dev/ui-common/src/lib/footer.tsx
@@ -14,15 +14,11 @@ const navigation = {
     { name: 'App', href: 'https://cloud.nx.app' },
     {
       name: 'Docs',
-      href: process.env.NEXT_PUBLIC_ASTRO_URL
-        ? '/docs/features/ci-features'
-        : '/ci/features',
+      href: '/docs/features/ci-features',
     },
     {
       name: 'Pricing',
-      href: process.env.NEXT_PUBLIC_ASTRO_URL
-        ? 'https://nx.dev/nx-cloud#plans'
-        : '/nx-cloud#plans',
+      href: 'https://nx.dev/nx-cloud#plans',
     },
     { name: 'Terms', href: 'https://cloud.nx.app/terms' },
   ],
@@ -30,21 +26,17 @@ const navigation = {
     { name: 'Nx', href: 'https://nx.dev' },
     {
       name: 'Nx Cloud',
-      href: process.env.NEXT_PUBLIC_ASTRO_URL
-        ? 'https://nx.dev/nx-cloud'
-        : '/nx-cloud',
+      href: 'https://nx.dev/nx-cloud',
     },
     {
       name: 'Nx Enterprise',
-      href: process.env.NEXT_PUBLIC_ASTRO_URL
-        ? 'https://nx.dev/enterprise'
-        : '/enterprise',
+      href: 'https://nx.dev/enterprise',
     },
   ],
   resources: [
     {
       name: 'Blog',
-      href: process.env.NEXT_PUBLIC_ASTRO_URL ? 'https://nx.dev/blog' : '/blog',
+      href: 'https://nx.dev/blog',
     },
     {
       name: 'Youtube',
@@ -52,41 +44,29 @@ const navigation = {
     },
     {
       name: 'Community',
-      href: process.env.NEXT_PUBLIC_ASTRO_URL
-        ? 'https://nx.dev/community'
-        : '/community',
+      href: 'https://nx.dev/community',
     },
     {
       name: 'Customers',
-      href: process.env.NEXT_PUBLIC_ASTRO_URL
-        ? 'https://nx.dev/customers'
-        : '/customers',
+      href: 'https://nx.dev/customers',
     },
   ],
   company: [
     {
       name: 'About us',
-      href: process.env.NEXT_PUBLIC_ASTRO_URL
-        ? 'https://nx.dev/company'
-        : '/company',
+      href: 'https://nx.dev/company',
     },
     {
       name: 'Careers',
-      href: process.env.NEXT_PUBLIC_ASTRO_URL
-        ? 'https://nx.dev/careers'
-        : '/careers',
+      href: 'https://nx.dev/careers',
     },
     {
       name: 'Brands & Guidelines',
-      href: process.env.NEXT_PUBLIC_ASTRO_URL
-        ? 'https://nx.dev/brands'
-        : '/brands',
+      href: 'https://nx.dev/brands',
     },
     {
       name: 'Contact us',
-      href: process.env.NEXT_PUBLIC_ASTRO_URL
-        ? 'https://nx.dev/contact'
-        : '/contact',
+      href: 'https://nx.dev/contact',
     },
   ],
   social: [

--- a/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
@@ -92,17 +92,13 @@ export function DocumentationHeader({
   };
 
   // Use the new docs URL when Astro docs are enabled
-  const docsUrl = process.env.NEXT_PUBLIC_ASTRO_URL
-    ? '/docs/getting-started/intro'
-    : '/getting-started/intro';
+  const docsUrl = '/docs/getting-started/intro';
 
   const sections = [
     { name: 'Nx', href: docsUrl, current: isNx },
     {
       name: 'CI',
-      href: process.env.NEXT_PUBLIC_ASTRO_URL
-        ? '/docs/features/ci-features'
-        : '/ci/features',
+      href: '/docs/features/ci-features',
       current: isCI,
     },
     {
@@ -112,9 +108,7 @@ export function DocumentationHeader({
     },
     {
       name: 'Plugins',
-      href: process.env.NEXT_PUBLIC_ASTRO_URL
-        ? '/docs/plugin-registry'
-        : '/plugin-registry',
+      href: '/docs/plugin-registry',
       current: isPlugins,
     },
     {
@@ -245,11 +239,6 @@ export function DocumentationHeader({
           </button>
 
           {/*SEARCH*/}
-          {process.env.NEXT_PUBLIC_ASTRO_URL ? null : (
-            <div className="mx-4 w-auto flex-grow">
-              <AlgoliaSearch />
-            </div>
-          )}
         </div>
         {/*LOGO*/}
         <div className="flex items-center gap-4">
@@ -283,11 +272,6 @@ export function DocumentationHeader({
           <VersionPicker />
         </div>
         {/*SEARCH*/}
-        {process.env.NEXT_PUBLIC_ASTRO_URL ? null : (
-          <div className="hidden w-full max-w-[14rem] lg:inline">
-            <AlgoliaSearch />
-          </div>
-        )}
         {/*NAVIGATION*/}
         <div className="hidden flex-shrink-0 lg:flex">
           <nav

--- a/nx-dev/ui-common/src/lib/headers/header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/header.tsx
@@ -50,9 +50,7 @@ export function Header({
   let [isOpen, setIsOpen] = useState(false);
 
   // Use the new docs URL when Astro docs are enabled
-  const docsUrl = process.env.NEXT_PUBLIC_ASTRO_URL
-    ? '/docs/getting-started/intro'
-    : '/getting-started/intro';
+  const docsUrl = '/docs/getting-started/intro';
   let [isScrolled, setIsScrolled] = useState(false);
 
   const router = useRouter();
@@ -291,14 +289,6 @@ export function Header({
             >
               Nx Enterprise
             </Link>
-            {process.env.NEXT_PUBLIC_ASTRO_URL ? null : (
-              <>
-                <div className="hidden h-6 w-px bg-slate-200 md:block dark:bg-slate-700" />
-                <div className="px-3 opacity-50 hover:opacity-100">
-                  <AlgoliaSearch tiny={true} />
-                </div>
-              </>
-            )}
           </nav>
         </div>
         {/*SECONDARY NAVIGATION*/}

--- a/nx-dev/ui-common/src/lib/headers/menu-items.ts
+++ b/nx-dev/ui-common/src/lib/headers/menu-items.ts
@@ -156,9 +156,7 @@ export const learnItems: MenuItem[] = [
   {
     name: 'Step by step tutorials',
     description: null,
-    href: process.env.NEXT_PUBLIC_ASTRO_URL
-      ? '/docs/getting-started/tutorials'
-      : '/getting-started/tutorials',
+    href: '/docs/getting-started/tutorials',
     icon: AcademicCapIcon,
     isNew: false,
     isHighlight: false,

--- a/nx-dev/ui-common/src/lib/sidebar.tsx
+++ b/nx-dev/ui-common/src/lib/sidebar.tsx
@@ -312,16 +312,12 @@ export function SidebarMobile({
     documentation: [
       {
         name: 'Nx',
-        href: process.env.NEXT_PUBLIC_ASTRO_URL
-          ? '/docs/getting-started/intro'
-          : '/getting-started/intro',
+        href: '/docs/getting-started/intro',
         current: isNx,
       },
       {
         name: 'CI',
-        href: process.env.NEXT_PUBLIC_ASTRO_URL
-          ? '/docs/features/ci-features'
-          : '/ci/features',
+        href: '/docs/features/ci-features',
         current: isCI,
       },
       {
@@ -379,11 +375,6 @@ export function SidebarMobile({
                 </button>
 
                 {/*SEARCH*/}
-                {process.env.NEXT_PUBLIC_ASTRO_URL ? null : (
-                  <div className="mx-4 w-auto">
-                    <AlgoliaSearch />
-                  </div>
-                )}
                 {/*LOGO*/}
                 <div className="ml-auto flex items-center">
                   <Link

--- a/nx-dev/ui-community/src/lib/connect-with-us.tsx
+++ b/nx-dev/ui-community/src/lib/connect-with-us.tsx
@@ -20,11 +20,7 @@ export function ConnectWithUs(): JSX.Element {
           <p className="py-4">
             Looking for community plugins? Find them listed in the{' '}
             <Link
-              href={
-                process.env.NEXT_PUBLIC_ASTRO_URL
-                  ? '/docs/plugin-registry'
-                  : '/plugin-registry'
-              }
+              href={'/docs/plugin-registry'}
               className="font-semibold underline"
               prefetch={false}
             >

--- a/nx-dev/ui-contact/src/lib/contact-links.tsx
+++ b/nx-dev/ui-contact/src/lib/contact-links.tsx
@@ -55,11 +55,7 @@ export function ContactLinks(): JSX.Element {
             Get an overview of Nx's features, integrations, and how to use them.
           </p>
           <Link
-            href={
-              process.env.NEXT_PUBLIC_ASTRO_URL
-                ? '/docs/getting-started/intro'
-                : '/getting-started/intro'
-            }
+            href={'/docs/getting-started/intro'}
             title="Nx documentation"
             className="mt-2 flex items-center gap-2 text-sm text-slate-500 transition hover:text-slate-800 dark:hover:text-slate-400"
             prefetch={false}

--- a/nx-dev/ui-enterprise/src/lib/scale-your-organization.tsx
+++ b/nx-dev/ui-enterprise/src/lib/scale-your-organization.tsx
@@ -157,9 +157,7 @@ export function ScaleYourOrganization(): ReactElement {
                       <li>
                         <Link
                           href={
-                            process.env.NEXT_PUBLIC_ASTRO_URL
-                              ? '/docs/reference/powerpack/conformance/overview'
-                              : '/ci/recipes/enterprise/conformance'
+                            '/docs/reference/powerpack/conformance/overview'
                           }
                           prefetch={false}
                           title="Learn More About Conformance"

--- a/nx-dev/ui-enterprise/src/lib/solutions/engineering/all-speed-no-stress.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/engineering/all-speed-no-stress.tsx
@@ -23,11 +23,7 @@ const features = [
         </p>
         <div className="mt-4">
           <Link
-            href={
-              process.env.NEXT_PUBLIC_ASTRO_URL
-                ? '/docs/features/ci-features/remote-cache'
-                : '/ci/features/remote-cache'
-            }
+            href={'/docs/features/ci-features/remote-cache'}
             title="Learn more about Nx Replay"
             className="text-sm/6 font-semibold"
           >

--- a/nx-dev/ui-enterprise/src/lib/solutions/engineering/developer-experience-that-works-for-you.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/engineering/developer-experience-that-works-for-you.tsx
@@ -58,11 +58,7 @@ const features = [
         </p>
         <div className="mt-4">
           <Link
-            href={
-              process.env.NEXT_PUBLIC_ASTRO_URL
-                ? '/docs/features/enhance-ai'
-                : '/features/enhance-AI'
-            }
+            href={'/docs/features/enhance-ai'}
             title="Learn about Enhancing your LLM"
             className="text-sm/6 font-semibold"
           >

--- a/nx-dev/ui-enterprise/src/lib/solutions/leadership/build-a-modern-engineering-organization.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/leadership/build-a-modern-engineering-organization.tsx
@@ -19,11 +19,7 @@ const features = [
         </p>
         <div className="mt-4">
           <Link
-            href={
-              process.env.NEXT_PUBLIC_ASTRO_URL
-                ? '/docs/features/enhance-ai'
-                : '/features/enhance-AI'
-            }
+            href={'/docs/features/enhance-ai'}
             title="Learn about our Enhancing your LLM"
             className="text-sm/6 font-semibold"
           >

--- a/nx-dev/ui-enterprise/src/lib/solutions/management/keep-teams-aligned.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/management/keep-teams-aligned.tsx
@@ -59,11 +59,7 @@ const features = [
         </p>
         <div className="mt-4">
           <Link
-            href={
-              process.env.NEXT_PUBLIC_ASTRO_URL
-                ? '/docs/features/enhance-ai'
-                : '/features/enhance-AI'
-            }
+            href={'/docs/features/enhance-ai'}
             title="Learn about Enhancing your LLM"
             className="text-sm/6 font-semibold"
           >

--- a/nx-dev/ui-gradle/src/lib/features.tsx
+++ b/nx-dev/ui-gradle/src/lib/features.tsx
@@ -18,11 +18,7 @@ export function Features(): ReactElement {
         <FeatureCard
           title="Task Caching"
           description="Cache task results locally and remotely, avoiding redundant builds and speeding up your development workflow."
-          href={
-            process.env.NEXT_PUBLIC_ASTRO_URL
-              ? '/docs/features/cache-task-results'
-              : '/features/cache-task-results'
-          }
+          href={'/docs/features/cache-task-results'}
           icon={
             <svg
               className="h-6 w-6"

--- a/nx-dev/ui-home/src/lib/features/features-while-coding.tsx
+++ b/nx-dev/ui-home/src/lib/features/features-while-coding.tsx
@@ -29,9 +29,7 @@ export function FeaturesWhileCoding(): ReactElement {
               project structure,{' '}
               <TextLink
                 href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/features/run-tasks?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
-                    : '/features/run-tasks?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                  '/docs/features/run-tasks?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
                 }
                 className="decoration-2"
               >
@@ -40,9 +38,7 @@ export function FeaturesWhileCoding(): ReactElement {
               with intelligent{' '}
               <TextLink
                 href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/features/cache-task-results?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
-                    : '/features/cache-task-results?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                  '/docs/features/cache-task-results?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
                 }
                 className="decoration-2"
               >
@@ -51,9 +47,7 @@ export function FeaturesWhileCoding(): ReactElement {
               and a clean{' '}
               <TextLink
                 href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/guides/tasks--caching/terminal-ui?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
-                    : '/recipes/running-tasks/terminal-ui?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                  '/docs/guides/tasks--caching/terminal-ui?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
                 }
                 className="decoration-2"
               >
@@ -64,9 +58,7 @@ export function FeaturesWhileCoding(): ReactElement {
             <p>
               <TextLink
                 href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/concepts/nx-plugins?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
-                    : '/concepts/nx-plugins?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                  '/docs/concepts/nx-plugins?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
                 }
                 className="decoration-2"
               >
@@ -80,9 +72,7 @@ export function FeaturesWhileCoding(): ReactElement {
               Your{' '}
               <TextLink
                 href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/features/enhance-ai?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
-                    : '/features/enhance-AI?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                  '/docs/features/enhance-ai?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
                 }
                 className="decoration-2"
               >
@@ -96,9 +86,7 @@ export function FeaturesWhileCoding(): ReactElement {
             <div className="mt-10 flex gap-x-6">
               <Link
                 href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/getting-started/intro?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
-                    : '/getting-started/intro?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                  '/docs/getting-started/intro?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
                 }
                 title="Find out about Nx"
                 prefetch={false}

--- a/nx-dev/ui-home/src/lib/features/features-while-running-ci.tsx
+++ b/nx-dev/ui-home/src/lib/features/features-while-running-ci.tsx
@@ -29,9 +29,7 @@ export function FeaturesWhileRunningCI(): ReactElement {
               process.{' '}
               <TextLink
                 href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/features/ci-features/remote-cache?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
-                    : '/ci/features/remote-cache?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                  '/docs/features/ci-features/remote-cache?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
                 }
                 className="decoration-2"
               >
@@ -40,9 +38,7 @@ export function FeaturesWhileRunningCI(): ReactElement {
               and{' '}
               <TextLink
                 href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/features/ci-features/distribute-task-execution?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
-                    : '/ci/features/distribute-task-execution?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                  '/docs/features/ci-features/distribute-task-execution?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
                 }
                 className="decoration-2"
               >
@@ -51,9 +47,7 @@ export function FeaturesWhileRunningCI(): ReactElement {
               speed up CI, while{' '}
               <TextLink
                 href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/features/ci-features/self-healing-ci?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
-                    : '/ci/features/self-healing-ci?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+                  '/docs/features/ci-features/self-healing-ci?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
                 }
                 className="decoration-2"
               >

--- a/nx-dev/ui-home/src/lib/features/features-while-scaling-your-organization.tsx
+++ b/nx-dev/ui-home/src/lib/features/features-while-scaling-your-organization.tsx
@@ -26,11 +26,7 @@ export function FeaturesWhileScalingYourOrganization(): ReactElement {
             <p>
               Nx defines{' '}
               <TextLink
-                href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/features/enforce-module-boundaries'
-                    : '/features/enforce-module-boundaries'
-                }
+                href={'/docs/features/enforce-module-boundaries'}
                 className="decoration-2"
               >
                 clear project boundaries
@@ -38,22 +34,14 @@ export function FeaturesWhileScalingYourOrganization(): ReactElement {
               and leverages monorepo concepts—shared tooling, atomic changes,
               and coordinated releases—so code stays easy to maintain.{' '}
               <TextLink
-                href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/enterprise/powerpack/owners'
-                    : '/nx-enterprise/powerpack/owners'
-                }
+                href={'/docs/enterprise/powerpack/owners'}
                 className="decoration-2"
               >
                 Ownership
               </TextLink>{' '}
               is defined at the project level, while{' '}
               <TextLink
-                href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/enterprise/powerpack/conformance'
-                    : '/nx-enterprise/powerpack/conformance'
-                }
+                href={'/docs/enterprise/powerpack/conformance'}
                 className="decoration-2"
               >
                 conformance rules
@@ -62,34 +50,19 @@ export function FeaturesWhileScalingYourOrganization(): ReactElement {
               <strong>entire codebase</strong>.
             </p>
             <p>
-              <TextLink
-                href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/plugin-registry'
-                    : '/plugin-registry'
-                }
-                className="decoration-2"
-              >
+              <TextLink href={'/docs/plugin-registry'} className="decoration-2">
                 Nx plugins
               </TextLink>{' '}
               and{' '}
               <TextLink
-                href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/features/generate-code'
-                    : '/features/generate-code'
-                }
+                href={'/docs/features/generate-code'}
                 className="decoration-2"
               >
                 code generation
               </TextLink>{' '}
               standardize best practices and eliminate duplication, while{' '}
               <TextLink
-                href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/features/automate-updating-dependencies'
-                    : '/features/automate-updating-dependencies'
-                }
+                href={'/docs/features/automate-updating-dependencies'}
                 className="decoration-2"
               >
                 automated updates

--- a/nx-dev/ui-home/src/lib/features/features.tsx
+++ b/nx-dev/ui-home/src/lib/features/features.tsx
@@ -17,9 +17,7 @@ export function Features(): ReactElement {
           Whether you're a startup shipping fast or managing enterprise{' '}
           <TextLink
             href={
-              process.env.NEXT_PUBLIC_ASTRO_URL
-                ? '/docs/concepts/decisions/why-monorepos?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
-                : '/concepts/decisions/why-monorepos?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
+              '/docs/concepts/decisions/why-monorepos?utm_medium=website&utm_campaign=homepage_links&utm_content=features'
             }
           >
             monorepos

--- a/nx-dev/ui-home/src/lib/hero/hero.tsx
+++ b/nx-dev/ui-home/src/lib/hero/hero.tsx
@@ -50,9 +50,7 @@ export function Hero(): ReactElement {
               Get started
             </ButtonLink>
             <ButtonLink
-              href={`${
-                process.env['NEXT_PUBLIC_ASTRO_URL'] ? '/docs' : ''
-              }/getting-started/intro?utm_medium=website&utm_campaign=homepage_links&utm_content=cta_hero_get_started`}
+              href="/docs/getting-started/intro?utm_medium=website&utm_campaign=homepage_links&utm_content=cta_hero_get_started"
               title="Get started"
               variant="secondary"
               size="default"

--- a/nx-dev/ui-powerpack/src/lib/get-started.tsx
+++ b/nx-dev/ui-powerpack/src/lib/get-started.tsx
@@ -139,22 +139,14 @@ export function GetStarted(): ReactElement {
                 <p className="mt-2">
                   Install Powerpack plugins such as{' '}
                   <TextLink
-                    href={
-                      process.env.NEXT_PUBLIC_ASTRO_URL
-                        ? '/docs/enterprise/powerpack/conformance'
-                        : '/nx-enterprise/powerpack/conformance'
-                    }
+                    href={'/docs/enterprise/powerpack/conformance'}
                     title="Workspace conformance"
                   >
                     workspace conformance
                   </TextLink>
                   , and{' '}
                   <TextLink
-                    href={
-                      process.env.NEXT_PUBLIC_ASTRO_URL
-                        ? '/docs/enterprise/powerpack/owners'
-                        : '/nx-enterprise/powerpack/owners'
-                    }
+                    href={'/docs/enterprise/powerpack/owners'}
                     title="Codeowners for monorepos"
                   >
                     Codeowners for monorepos

--- a/nx-dev/ui-powerpack/src/lib/powerpack-features.tsx
+++ b/nx-dev/ui-powerpack/src/lib/powerpack-features.tsx
@@ -78,7 +78,7 @@ export function PowerpackFeatures(): ReactElement {
                 storage, offering a flexible, self-managed solution for faster
                 builds. Nx Powerpack self-hosted cache storage is{' '}
                 <TextLink
-                  href={process.env.NEXT_PUBLIC_ASTRO_URL ? "/docs/enterprise/powerpack/free-licenses-and-trials" : "/nx-enterprise/powerpack/free-licenses-and-trials"}
+                  href={"/docs/enterprise/powerpack/free-licenses-and-trials"}
                   title="Get a Powerpack license"
                 >
                   free for small teams
@@ -87,7 +87,7 @@ export function PowerpackFeatures(): ReactElement {
               </p>
               <div className="mt-16">
                 <ButtonLink
-                  href={process.env.NEXT_PUBLIC_ASTRO_URL ? "/docs/enterprise/powerpack/custom-caching" : "/nx-enterprise/powerpack/custom-caching"}
+                  href={"/docs/enterprise/powerpack/custom-caching"}
                   title="Learn more about self-hosted cache storage"
                   variant="secondary"
                   size="default"
@@ -128,11 +128,7 @@ export function PowerpackFeatures(): ReactElement {
             </div>
             <div className="flex">
               <ButtonLink
-                href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/enterprise/powerpack/owners'
-                    : '/nx-enterprise/powerpack/owners'
-                }
+                href={'/docs/enterprise/powerpack/owners'}
                 title="Learn more about codeowners"
                 variant="secondary"
                 size="default"
@@ -172,11 +168,7 @@ export function PowerpackFeatures(): ReactElement {
             </div>
             <div className="flex">
               <ButtonLink
-                href={
-                  process.env.NEXT_PUBLIC_ASTRO_URL
-                    ? '/docs/enterprise/powerpack/conformance'
-                    : '/nx-enterprise/powerpack/conformance'
-                }
+                href={'/docs/enterprise/powerpack/conformance'}
                 title="Learn how to set up conformance rules"
                 variant="secondary"
                 size="default"

--- a/nx-dev/ui-pricing/src/lib/plans-display.tsx
+++ b/nx-dev/ui-pricing/src/lib/plans-display.tsx
@@ -110,11 +110,7 @@ export function PlansDisplay(): ReactElement {
                     <span>
                       Remote caching with{' '}
                       <Link
-                        href={
-                          process.env.NEXT_PUBLIC_ASTRO_URL
-                            ? '/docs/features/ci-features/remote-cache'
-                            : '/ci/features/remote-cache'
-                        }
+                        href={'/docs/features/ci-features/remote-cache'}
                         target="_blank"
                         title="Learn how Nx Replay easily reduces CI execution time"
                         onClick={() =>
@@ -139,9 +135,7 @@ export function PlansDisplay(): ReactElement {
                       Distributed task execution with{' '}
                       <Link
                         href={
-                          process.env.NEXT_PUBLIC_ASTRO_URL
-                            ? '/docs/features/ci-features/distribute-task-execution'
-                            : '/ci/features/distribute-task-execution'
+                          '/docs/features/ci-features/distribute-task-execution'
                         }
                         target="_blank"
                         title="Learn how Nx Agents easily scale your CI pipelines"

--- a/nx-dev/ui-react/src/lib/feature-sections.tsx
+++ b/nx-dev/ui-react/src/lib/feature-sections.tsx
@@ -20,11 +20,7 @@ export function FeatureSections(): ReactElement {
             imageSrc="/images/enterprise/nx-affected.avif"
             alt="Nx Affected: Run tasks only on affected projects"
             tag="Affected"
-            href={
-              process.env.NEXT_PUBLIC_ASTRO_URL
-                ? '/docs/ci/features/affected'
-                : '/ci/features/affected'
-            }
+            href={'/docs/ci/features/affected'}
           />
 
           {/* Remote Caching Section */}
@@ -34,11 +30,7 @@ export function FeatureSections(): ReactElement {
             imageSrc="/images/enterprise/nx-replay.avif"
             alt="Nx Replay: Remote caching"
             tag="Nx Replay"
-            href={
-              process.env.NEXT_PUBLIC_ASTRO_URL
-                ? '/docs/features/cache-task-results'
-                : '/features/cache-task-results'
-            }
+            href={'/docs/features/cache-task-results'}
           />
 
           {/* Distribution Section */}
@@ -48,11 +40,7 @@ export function FeatureSections(): ReactElement {
             imageSrc="/images/enterprise/nx-agents.avif"
             alt="Nx Agents: Task distribution"
             tag="Nx Agents"
-            href={
-              process.env.NEXT_PUBLIC_ASTRO_URL
-                ? '/docs/ci/features/distribute-task-execution'
-                : '/ci/features/distribute-task-execution'
-            }
+            href={'/docs/ci/features/distribute-task-execution'}
           />
 
           {/* Atomizer Section */}
@@ -62,11 +50,7 @@ export function FeatureSections(): ReactElement {
             imageSrc="/images/enterprise/nx-atomizer.avif"
             alt="Nx Atomizer: Split large test tasks"
             tag="Atomizer"
-            href={
-              process.env.NEXT_PUBLIC_ASTRO_URL
-                ? '/docs/ci/features/split-e2e-tasks'
-                : '/ci/features/split-e2e-tasks'
-            }
+            href={'/docs/ci/features/split-e2e-tasks'}
           />
 
           {/* Flaky Test Retries Section */}

--- a/nx-dev/ui-react/src/lib/features.tsx
+++ b/nx-dev/ui-react/src/lib/features.tsx
@@ -18,11 +18,7 @@ export function Features(): ReactElement {
         <FeatureCard
           title="Task Caching"
           description="Cache task results locally and remotely, avoiding redundant builds and speeding up your development workflow."
-          href={
-            process.env.NEXT_PUBLIC_ASTRO_URL
-              ? '/docs/features/cache-task-results'
-              : '/features/cache-task-results'
-          }
+          href={'/docs/features/cache-task-results'}
           icon={
             <svg
               className="h-6 w-6"
@@ -50,11 +46,7 @@ export function Features(): ReactElement {
         <FeatureCard
           title="Distributed Task Execution"
           description="Run your project tasks across multiple machines, dramatically reducing build times for large repositories."
-          href={
-            process.env.NEXT_PUBLIC_ASTRO_URL
-              ? '/docs/features/ci-features/distribute-task-execution'
-              : '/ci/features/distribute-task-execution'
-          }
+          href={'/docs/features/ci-features/distribute-task-execution'}
           icon={
             <svg
               className="h-6 w-6"
@@ -94,11 +86,7 @@ export function Features(): ReactElement {
         <FeatureCard
           title="Affected Targets"
           description="Run tasks only on projects affected by your changes, saving time and computing resources."
-          href={
-            process.env.NEXT_PUBLIC_ASTRO_URL
-              ? '/docs/ci/features/affected'
-              : '/ci/features/affected'
-          }
+          href={'/docs/ci/features/affected'}
           icon={
             <svg
               className="h-6 w-6"
@@ -126,11 +114,7 @@ export function Features(): ReactElement {
         <FeatureCard
           title="Project Graph"
           description="Nx automatically infers your project graph from project's configuration, providing visualization and dependency analysis."
-          href={
-            process.env.NEXT_PUBLIC_ASTRO_URL
-              ? '/docs/features/explore-graph'
-              : '/features/explore-graph'
-          }
+          href={'/docs/features/explore-graph'}
           icon={
             <svg
               className="h-6 w-6"
@@ -176,11 +160,7 @@ export function Features(): ReactElement {
         <FeatureCard
           title="Split E2E Tests"
           description="Automatically split your E2E tests for faster parallel execution in CI environments with Atomizer."
-          href={
-            process.env.NEXT_PUBLIC_ASTRO_URL
-              ? '/docs/ci/features/split-e2e-tasks'
-              : '/ci/features/split-e2e-tasks'
-          }
+          href={'/docs/ci/features/split-e2e-tasks'}
           icon={
             <svg
               className="h-6 w-6"
@@ -222,11 +202,7 @@ export function Features(): ReactElement {
         <FeatureCard
           title="Zero Configuration"
           description="Add Nx to your existing monorepo in minutes."
-          href={
-            process.env.NEXT_PUBLIC_ASTRO_URL
-              ? '/docs/recipes/adopting-nx/adding-to-monorepo'
-              : '/recipes/adopting-nx/adding-to-monorepo'
-          }
+          href={'/docs/recipes/adopting-nx/adding-to-monorepo'}
           icon={
             <svg
               className="h-6 w-6"

--- a/nx-dev/ui-react/src/lib/hero.tsx
+++ b/nx-dev/ui-react/src/lib/hero.tsx
@@ -39,11 +39,7 @@ export function Hero(): ReactElement {
 
         <div className="mt-10 flex flex-col items-center justify-center gap-6 sm:flex-row">
           <ButtonLink
-            href={
-              process.env.NEXT_PUBLIC_ASTRO_URL
-                ? '/docs/getting-started/tutorials/react-monorepo-tutorial'
-                : '/getting-started/tutorials/react-monorepo-tutorial'
-            }
+            href={'/docs/getting-started/tutorials/react-monorepo-tutorial'}
             variant="primary"
             size="default"
             title="Get Started"

--- a/nx-dev/ui-remote-cache/src/lib/faq.tsx
+++ b/nx-dev/ui-remote-cache/src/lib/faq.tsx
@@ -68,9 +68,7 @@ export function Faq(): ReactElement {
           authentication requirements.{' '}
           <Link
             href={
-              process.env.NEXT_PUBLIC_ASTRO_URL
-                ? '/docs/guides/tasks--caching/self-hosted-caching#build-your-own-caching-server'
-                : '/recipes/running-tasks/self-hosted-caching#build-your-own-caching-server'
+              '/docs/guides/tasks--caching/self-hosted-caching#build-your-own-caching-server'
             }
             title="Learn more"
             prefetch={false}

--- a/nx-dev/ui-remote-cache/src/lib/remote-cache-solutions.tsx
+++ b/nx-dev/ui-remote-cache/src/lib/remote-cache-solutions.tsx
@@ -168,11 +168,7 @@ export function RemoteCacheSolutions(): ReactElement {
                 </p>
                 <div className="my-8">
                   <ButtonLink
-                    href={
-                      process.env.NEXT_PUBLIC_ASTRO_URL
-                        ? '/docs/guides/tasks--caching/self-hosted-caching'
-                        : '/recipes/running-tasks/self-hosted-caching'
-                    }
+                    href={'/docs/guides/tasks--caching/self-hosted-caching'}
                     aria-describedby="official-plugins"
                     title="Free official remote cache plugins"
                     size="default"
@@ -261,9 +257,7 @@ export function RemoteCacheSolutions(): ReactElement {
                 <div className="mt-8">
                   <ButtonLink
                     href={
-                      process.env.NEXT_PUBLIC_ASTRO_URL
-                        ? '/docs/guides/tasks--caching/self-hosted-caching#build-your-own-caching-server'
-                        : '/recipes/running-tasks/self-hosted-caching#build-your-own-caching-server'
+                      '/docs/guides/tasks--caching/self-hosted-caching#build-your-own-caching-server'
                     }
                     aria-describedby="open-api"
                     title="Remote cache api specs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1579,7 +1579,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.4.1
-        version: 29.7.0(@types/node@24.2.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.9.2))
+        version: 29.7.0(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.16.10)(typescript@5.9.2))
 
   graph/migrate:
     dependencies:
@@ -1592,7 +1592,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.4.1
-        version: 29.7.0(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.16.10)(typescript@5.9.2))
+        version: 29.7.0(@types/node@24.2.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.9.2))
 
   graph/project-details:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1579,7 +1579,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.4.1
-        version: 29.7.0(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.16.10)(typescript@5.9.2))
+        version: 29.7.0(@types/node@24.2.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.9.2))
 
   graph/migrate:
     dependencies:
@@ -1592,7 +1592,7 @@ importers:
     devDependencies:
       jest:
         specifier: ^29.4.1
-        version: 29.7.0(@types/node@24.2.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.9.2))
+        version: 29.7.0(@types/node@20.16.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@20.16.10)(typescript@5.9.2))
 
   graph/project-details:
     dependencies:


### PR DESCRIPTION
The codebase contains conditional logic based on `NEXT_PUBLIC_ASTRO_URL` environment variable to support both old Next.js docs and new Astro docs paths.

Since the migration to Astro is complete, the checks aren't needed.

Also add support for different `NX_DEV_URL` avalues for the Astro docs so canary docs don't point to prod website, for example. (`footer.tsx` and `Header.astro`).

Note: The changes are largely just removing the var check. Some files of interest are:
- astro-docs/src/components/layout/Header.astro
- nx-dev/ui-common/src/lib/footer.tsx
- nx-dev/nx-dev/next.config.js
- nx-dev/nx-dev/redirect-rules.js

Also note that plugin registry and doc viewer should no longer be used. Once we don't need the Next.js app anymore, we can just delete the project rather than removing it right now. For now, just set `noindex`.

Closes DOC-161, DOC-230
