### PR TITLE
feat(core): expose registerProjectGraphRecomputationListener from daemon client

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -99,6 +99,7 @@ import {
   POST_TASKS_EXECUTION,
   PRE_TASKS_EXECUTION,
 } from '../message-types/run-tasks-execution-hooks';
+import { REGISTER_PROJECT_GRAPH_LISTENER } from '../message-types/register-project-graph-listener';
 
 const DAEMON_ENV_SETTINGS = {
   NX_PROJECT_GLOB_CACHE: 'false',
@@ -345,7 +346,7 @@ export class DaemonClient {
         (err) => callback(err, null)
       );
       return messenger.sendMessage({
-        type: 'REGISTER_PROJECT_GRAPH_LISTENER',
+        type: REGISTER_PROJECT_GRAPH_LISTENER,
       });
     });
 

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -319,7 +319,10 @@ export class DaemonClient {
   async registerProjectGraphRecomputationListener(
     callback: (
       error: Error | null | 'closed',
-      projectGraph: ProjectGraph | null
+      data: {
+        projectGraph: ProjectGraph;
+        sourceMaps: ConfigurationSourceMaps;
+      } | null
     ) => void
   ): Promise<UnregisterCallback> {
     let messenger: DaemonSocketMessenger | undefined;

--- a/packages/nx/src/daemon/message-types/register-project-graph-listener.ts
+++ b/packages/nx/src/daemon/message-types/register-project-graph-listener.ts
@@ -1,0 +1,6 @@
+export const REGISTER_PROJECT_GRAPH_LISTENER =
+  'REGISTER_PROJECT_GRAPH_LISTENER';
+
+export type RegisterProjectGraphListenerMessage = {
+  type: typeof REGISTER_PROJECT_GRAPH_LISTENER;
+};

--- a/packages/nx/src/daemon/message-types/register-project-graph-listener.ts
+++ b/packages/nx/src/daemon/message-types/register-project-graph-listener.ts
@@ -4,3 +4,14 @@ export const REGISTER_PROJECT_GRAPH_LISTENER =
 export type RegisterProjectGraphListenerMessage = {
   type: typeof REGISTER_PROJECT_GRAPH_LISTENER;
 };
+
+export function isRegisterProjectGraphListenerMessage(
+  message: unknown
+): message is RegisterProjectGraphListenerMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message['type'] === REGISTER_PROJECT_GRAPH_LISTENER
+  );
+}

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -30,7 +30,10 @@ import { notifyFileWatcherSockets } from './file-watching/file-watcher-sockets';
 import { notifyProjectGraphListenerSockets } from './project-graph-listener-sockets';
 import { serverLogger } from './logger';
 import { NxWorkspaceFilesExternals } from '../../native';
-import { ConfigurationResult } from '../../project-graph/utils/project-configuration-utils';
+import {
+  ConfigurationResult,
+  ConfigurationSourceMaps,
+} from '../../project-graph/utils/project-configuration-utils';
 import type { LoadedNxPlugin } from '../../project-graph/plugins/loaded-nx-plugin';
 import {
   DaemonProjectGraphError,
@@ -47,6 +50,7 @@ interface SerializedProjectGraph {
   allWorkspaceFiles: FileData[] | null;
   serializedProjectGraph: string | null;
   serializedSourceMaps: string | null;
+  sourceMaps: ConfigurationSourceMaps | null;
   rustReferences: NxWorkspaceFilesExternals | null;
 }
 
@@ -64,7 +68,7 @@ export let currentProjectGraph: ProjectGraph | undefined;
 const collectedUpdatedFiles = new Set<string>();
 const collectedDeletedFiles = new Set<string>();
 const projectGraphRecomputationListeners = new Set<
-  (projectGraph: ProjectGraph) => void
+  (projectGraph: ProjectGraph, sourceMaps: ConfigurationSourceMaps) => void
 >();
 let storedWorkspaceConfigHash: string | undefined;
 let waitPeriod = 100;
@@ -107,7 +111,10 @@ export async function getCachedSerializedProjectGraphPromise(): Promise<Serializ
     const result = await cachedSerializedProjectGraphPromise;
 
     if (wasScheduled) {
-      notifyProjectGraphRecomputationListeners(result.projectGraph);
+      notifyProjectGraphRecomputationListeners(
+        result.projectGraph,
+        result.sourceMaps
+      );
     }
 
     return result;
@@ -116,6 +123,7 @@ export async function getCachedSerializedProjectGraphPromise(): Promise<Serializ
       error: e,
       serializedProjectGraph: null,
       serializedSourceMaps: null,
+      sourceMaps: null,
       projectGraph: null,
       projectFileMapCache: null,
       fileMap: null,
@@ -157,19 +165,23 @@ export function addUpdatedAndDeletedFiles(
 
       cachedSerializedProjectGraphPromise =
         processFilesAndCreateAndSerializeProjectGraph(await getPlugins());
-      const { projectGraph } = await cachedSerializedProjectGraphPromise;
+      const { projectGraph, sourceMaps } =
+        await cachedSerializedProjectGraphPromise;
 
       if (createdFiles.length > 0) {
         notifyFileWatcherSockets(createdFiles, null, null);
       }
 
-      notifyProjectGraphRecomputationListeners(projectGraph);
+      notifyProjectGraphRecomputationListeners(projectGraph, sourceMaps);
     }, waitPeriod);
   }
 }
 
 export function registerProjectGraphRecomputationListener(
-  listener: (projectGraph: ProjectGraph) => void
+  listener: (
+    projectGraph: ProjectGraph,
+    sourceMaps: ConfigurationSourceMaps
+  ) => void
 ) {
   projectGraphRecomputationListeners.add(listener);
 }
@@ -307,6 +319,7 @@ async function processFilesAndCreateAndSerializeProjectGraph(
           allWorkspaceFiles: null,
           serializedProjectGraph: null,
           serializedSourceMaps: null,
+          sourceMaps: null,
         };
       }
     }
@@ -330,6 +343,7 @@ async function processFilesAndCreateAndSerializeProjectGraph(
         allWorkspaceFiles: null,
         serializedProjectGraph: null,
         serializedSourceMaps: null,
+        sourceMaps: null,
       };
     } else {
       return g;
@@ -344,6 +358,7 @@ async function processFilesAndCreateAndSerializeProjectGraph(
       allWorkspaceFiles: null,
       serializedProjectGraph: null,
       serializedSourceMaps: null,
+      sourceMaps: null,
     };
   }
 }
@@ -412,6 +427,7 @@ async function createAndSerializeProjectGraph({
       allWorkspaceFiles,
       serializedProjectGraph,
       serializedSourceMaps,
+      sourceMaps,
       rustReferences,
     };
   } catch (e) {
@@ -426,6 +442,7 @@ async function createAndSerializeProjectGraph({
       allWorkspaceFiles: null,
       serializedProjectGraph: null,
       serializedSourceMaps: null,
+      sourceMaps: null,
       rustReferences: null,
     };
   }
@@ -452,9 +469,12 @@ async function resetInternalStateIfNxDepsMissing() {
   }
 }
 
-function notifyProjectGraphRecomputationListeners(projectGraph: ProjectGraph) {
+function notifyProjectGraphRecomputationListeners(
+  projectGraph: ProjectGraph,
+  sourceMaps: ConfigurationSourceMaps
+) {
   for (const listener of projectGraphRecomputationListeners) {
-    listener(projectGraph);
+    listener(projectGraph, sourceMaps);
   }
-  notifyProjectGraphListenerSockets(projectGraph);
+  notifyProjectGraphListenerSockets(projectGraph, sourceMaps);
 }

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -27,6 +27,7 @@ import {
 } from '../../utils/workspace-context';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { notifyFileWatcherSockets } from './file-watching/file-watcher-sockets';
+import { notifyProjectGraphListenerSockets } from './project-graph-listener-sockets';
 import { serverLogger } from './logger';
 import { NxWorkspaceFilesExternals } from '../../native';
 import { ConfigurationResult } from '../../project-graph/utils/project-configuration-utils';
@@ -455,4 +456,5 @@ function notifyProjectGraphRecomputationListeners(projectGraph: ProjectGraph) {
   for (const listener of projectGraphRecomputationListeners) {
     listener(projectGraph);
   }
+  notifyProjectGraphListenerSockets(projectGraph);
 }

--- a/packages/nx/src/daemon/server/project-graph-listener-sockets.ts
+++ b/packages/nx/src/daemon/server/project-graph-listener-sockets.ts
@@ -1,5 +1,6 @@
 import { Socket } from 'net';
 import { ProjectGraph } from '../../config/project-graph';
+import { ConfigurationSourceMaps } from '../../project-graph/utils/project-configuration-utils';
 import { handleResult } from './server';
 
 export let registeredProjectGraphListenerSockets: Socket[] = [];
@@ -14,7 +15,8 @@ export function hasRegisteredProjectGraphListenerSockets() {
 }
 
 export async function notifyProjectGraphListenerSockets(
-  projectGraph: ProjectGraph
+  projectGraph: ProjectGraph,
+  sourceMaps: ConfigurationSourceMaps
 ) {
   if (!hasRegisteredProjectGraphListenerSockets()) {
     return;
@@ -25,7 +27,7 @@ export async function notifyProjectGraphListenerSockets(
       handleResult(socket, 'PROJECT_GRAPH_UPDATED', () =>
         Promise.resolve({
           description: 'Project graph updated',
-          response: JSON.stringify(projectGraph),
+          response: JSON.stringify({ projectGraph, sourceMaps }),
         })
       )
     )

--- a/packages/nx/src/daemon/server/project-graph-listener-sockets.ts
+++ b/packages/nx/src/daemon/server/project-graph-listener-sockets.ts
@@ -1,0 +1,33 @@
+import { Socket } from 'net';
+import { ProjectGraph } from '../../config/project-graph';
+import { handleResult } from './server';
+
+export let registeredProjectGraphListenerSockets: Socket[] = [];
+
+export function removeRegisteredProjectGraphListenerSocket(socket: Socket) {
+  registeredProjectGraphListenerSockets =
+    registeredProjectGraphListenerSockets.filter((s) => s !== socket);
+}
+
+export function hasRegisteredProjectGraphListenerSockets() {
+  return registeredProjectGraphListenerSockets.length > 0;
+}
+
+export async function notifyProjectGraphListenerSockets(
+  projectGraph: ProjectGraph
+) {
+  if (!hasRegisteredProjectGraphListenerSockets()) {
+    return;
+  }
+
+  await Promise.all(
+    registeredProjectGraphListenerSockets.map((socket) =>
+      handleResult(socket, 'PROJECT_GRAPH_UPDATED', () =>
+        Promise.resolve({
+          description: 'Project graph updated',
+          response: JSON.stringify(projectGraph),
+        })
+      )
+    )
+  );
+}

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -134,7 +134,10 @@ import {
   handleRunPostTasksExecution,
   handleRunPreTasksExecution,
 } from './handle-tasks-execution-hooks';
-import { REGISTER_PROJECT_GRAPH_LISTENER } from '../message-types/register-project-graph-listener';
+import {
+  isRegisterProjectGraphListenerMessage,
+  REGISTER_PROJECT_GRAPH_LISTENER,
+} from '../message-types/register-project-graph-listener';
 
 let performanceObserver: PerformanceObserver | undefined;
 let workspaceWatcherError: Error | undefined;
@@ -251,7 +254,7 @@ async function handleMessage(socket, data: string) {
     );
   } else if (payload.type === 'REGISTER_FILE_WATCHER') {
     registeredFileWatcherSockets.push({ socket, config: payload.config });
-  } else if (payload.type === REGISTER_PROJECT_GRAPH_LISTENER) {
+  } else if (isRegisterProjectGraphListenerMessage(payload)) {
     registeredProjectGraphListenerSockets.push(socket);
   } else if (isHandleGlobMessage(payload)) {
     await handleResult(socket, GLOB, () =>

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -21,6 +21,11 @@ import {
   registeredFileWatcherSockets,
   removeRegisteredFileWatcherSocket,
 } from './file-watching/file-watcher-sockets';
+import {
+  hasRegisteredProjectGraphListenerSockets,
+  registeredProjectGraphListenerSockets,
+  removeRegisteredProjectGraphListenerSocket,
+} from './project-graph-listener-sockets';
 import { handleHashTasks } from './handle-hash-tasks';
 import {
   handleOutputsHashesMatch,
@@ -129,6 +134,7 @@ import {
   handleRunPostTasksExecution,
   handleRunPreTasksExecution,
 } from './handle-tasks-execution-hooks';
+import { REGISTER_PROJECT_GRAPH_LISTENER } from '../message-types/register-project-graph-listener';
 
 let performanceObserver: PerformanceObserver | undefined;
 let workspaceWatcherError: Error | undefined;
@@ -180,6 +186,7 @@ const server = createServer(async (socket) => {
     );
 
     removeRegisteredFileWatcherSocket(socket);
+    removeRegisteredProjectGraphListenerSocket(socket);
   });
 });
 registerProcessTerminationListeners();
@@ -244,6 +251,8 @@ async function handleMessage(socket, data: string) {
     );
   } else if (payload.type === 'REGISTER_FILE_WATCHER') {
     registeredFileWatcherSockets.push({ socket, config: payload.config });
+  } else if (payload.type === REGISTER_PROJECT_GRAPH_LISTENER) {
+    registeredProjectGraphListenerSockets.push(socket);
   } else if (isHandleGlobMessage(payload)) {
     await handleResult(socket, GLOB, () =>
       handleGlob(payload.globs, payload.exclude)
@@ -352,9 +361,12 @@ export async function handleResult(
 }
 
 function handleInactivityTimeout() {
-  if (hasRegisteredFileWatcherSockets()) {
+  if (
+    hasRegisteredFileWatcherSockets() ||
+    hasRegisteredProjectGraphListenerSockets()
+  ) {
     serverLogger.log(
-      `There are open file watchers. Resetting inactivity timer.`
+      `There are open file watchers or project graph listeners. Resetting inactivity timer.`
     );
     resetInactivityTimeout(handleInactivityTimeout);
   } else {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
there's already a nice event that exposes project graph recomputations but it's not accessible from the client

## Expected Behavior
the daemon client now has a `registerProjectGraphRecomputationListener` function
