### PR TITLE
fix(release): ensure schema for release.groups is correct

### DIFF
--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -160,95 +160,98 @@
         },
         "groups": {
           "type": "object",
-          "properties": {
-            "projectsRelationship": {
-              "type": "string",
-              "enum": ["fixed", "independent"]
-            },
-            "projects": {
-              "oneOf": [
-                {
-                  "type": "string",
-                  "description": "A project name"
-                },
-                {
-                  "type": "array",
-                  "description": "An array of project names",
-                  "minItems": 1,
-                  "items": {
-                    "type": "string"
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "projectsRelationship": {
+                "type": "string",
+                "enum": ["fixed", "independent"]
+              },
+              "projects": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "description": "A project name"
+                  },
+                  {
+                    "type": "array",
+                    "description": "An array of project names",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
                   }
-                }
-              ]
-            },
-            "version": {
-              "$ref": "#/definitions/NxReleaseGroupVersionConfiguration"
-            },
-            "changelog": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/NxReleaseChangelogConfiguration"
-                },
-                {
-                  "type": "boolean"
-                }
-              ]
-            },
-            "releaseTagPattern": {
-              "type": "string",
-              "description": "Optionally override the git/release tag pattern to use for this group."
-            },
-            "releaseTagPatternCheckAllBranchesWhen": {
-              "oneOf": [
-                {
-                  "type": "boolean"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
+                ]
+              },
+              "version": {
+                "$ref": "#/definitions/NxReleaseGroupVersionConfiguration"
+              },
+              "changelog": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/NxReleaseChangelogConfiguration"
+                  },
+                  {
+                    "type": "boolean"
                   }
-                }
-              ],
-              "description": "By default, we will try and resolve the latest match for the releaseTagPattern from the current branch, falling back to all branches if no match is found on the current branch. Setting this to true will cause us to ALWAYS check all branches for the latest match. Setting it to false will cause us to ONLY check the current branch for the latest match. Setting it to an array of strings will cause us to check all branches WHEN the current branch is one of the strings in the array. Glob patterns are supported."
+                ]
+              },
+              "releaseTagPattern": {
+                "type": "string",
+                "description": "Optionally override the git/release tag pattern to use for this group."
+              },
+              "releaseTagPatternCheckAllBranchesWhen": {
+                "oneOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ],
+                "description": "By default, we will try and resolve the latest match for the releaseTagPattern from the current branch, falling back to all branches if no match is found on the current branch. Setting this to true will cause us to ALWAYS check all branches for the latest match. Setting it to false will cause us to ONLY check the current branch for the latest match. Setting it to an array of strings will cause us to check all branches WHEN the current branch is one of the strings in the array. Glob patterns are supported."
+              },
+              "releaseTagPatternRequireSemver": {
+                "type": "boolean",
+                "description": "Whether to require semver to be used for the release tag pattern. If set to false, the release tag pattern will not be checked for semver compliance."
+              },
+              "releaseTagPatternPreferDockerVersion": {
+                "type": ["boolean", "string"],
+                "enum": [true, false, "both"],
+                "description": "Controls how docker versions are used relative to semver versions when creating git tags and changelog entries. Set to true to use only the docker version, false to use only the semver version, or 'both' to create tags and changelog entries for both docker and semver versions. By default, this is set to true when docker configuration is present, and false otherwise."
+              },
+              "releaseTagPatternStrictPreid": {
+                "$ref": "#/definitions/NxReleaseReleaseTagPatternStrictPreidConfiguration"
+              },
+              "versionPlans": {
+                "oneOf": [
+                  {
+                    "$ref": "#/definitions/NxReleaseVersionPlansConfiguration"
+                  },
+                  {
+                    "type": "boolean",
+                    "description": "Enables using version plans as a specifier source for versioning and to determine changes for changelog generation."
+                  }
+                ]
+              },
+              "docker": {
+                "oneOf": [
+                  {
+                    "type": "boolean",
+                    "enum": [true],
+                    "description": "Enable docker configuration with default settings. Warning: Docker support is experimental. Breaking changes may occur and not adhere to semver versioning. "
+                  },
+                  {
+                    "$ref": "#/definitions/NxReleaseGroupDockerConfiguration"
+                  }
+                ]
+              }
             },
-            "releaseTagPatternRequireSemver": {
-              "type": "boolean",
-              "description": "Whether to require semver to be used for the release tag pattern. If set to false, the release tag pattern will not be checked for semver compliance."
-            },
-            "releaseTagPatternPreferDockerVersion": {
-              "type": ["boolean", "string"],
-              "enum": [true, false, "both"],
-              "description": "Controls how docker versions are used relative to semver versions when creating git tags and changelog entries. Set to true to use only the docker version, false to use only the semver version, or 'both' to create tags and changelog entries for both docker and semver versions. By default, this is set to true when docker configuration is present, and false otherwise."
-            },
-            "releaseTagPatternStrictPreid": {
-              "$ref": "#/definitions/NxReleaseReleaseTagPatternStrictPreidConfiguration"
-            },
-            "versionPlans": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/NxReleaseVersionPlansConfiguration"
-                },
-                {
-                  "type": "boolean",
-                  "description": "Enables using version plans as a specifier source for versioning and to determine changes for changelog generation."
-                }
-              ]
-            },
-            "docker": {
-              "oneOf": [
-                {
-                  "type": "boolean",
-                  "enum": [true],
-                  "description": "Enable docker configuration with default settings. Warning: Docker support is experimental. Breaking changes may occur and not adhere to semver versioning. "
-                },
-                {
-                  "$ref": "#/definitions/NxReleaseGroupDockerConfiguration"
-                }
-              ]
-            }
-          },
-          "required": ["projects"]
+            "required": ["projects"]
+          }
         },
         "changelog": {
           "type": "object",


### PR DESCRIPTION
## Current Behavior
Currently the `nx-schema.json` is enforcing a `groups: properites` type when it should be `groups: Record<string, properties>`

## Expected Behavior
Update `nx-schema.json` to have `release.groups: Record<string, propeties>`
