### PR TITLE
docs(nx-dev): skip check for NEXT_PUBLIC_ASTRO_URL during graph creation just in case

### DIFF
--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -2,7 +2,7 @@
 const { withNx } = require('@nx/next/plugins/with-nx');
 const redirectRules = require('./redirect-rules');
 
-if (!process.env.NEXT_PUBLIC_ASTRO_URL) {
+if (!process.env.NEXT_PUBLIC_ASTRO_URL && !global.NX_GRAPH_CREATION) {
   // If we're building for production throw error as each env must set this value.
   if (process.env.NODE_ENV === 'production') {
     throw new Error(


### PR DESCRIPTION
This PR skips check for the required env var during graph creation. Although it only happens when `NODE_ENV === 'production'` it is possible that this is set as such, which would cause an error.