### PR TITLE
fix(testing): show warning instead of error when no blob outputs found during merge

### DIFF
--- a/packages/playwright/src/executors/merge-reports/merge-reports.impl.ts
+++ b/packages/playwright/src/executors/merge-reports/merge-reports.impl.ts
@@ -62,15 +62,17 @@ export async function mergeReportsExecutor(
   const absoluteBlobReportDir = join(projectRoot, blobReportDir);
 
   if (!existsSync(absoluteBlobReportDir)) {
-    output.error({
-      title: 'The blob reporter output directory does not exist',
+    output.warn({
+      title: 'Merging the blob reports skipped',
       bodyLines: [
         `The blob reporter output directory "${blobReportDir}" does not exist.`,
-        'Please ensure the directory is configured correctly and it exists.',
+        'This can happen if no Playwright tests were run, or due to a misconfiguration.',
+        '',
+        'For more information see:',
+        '- Merge Atomized Outputs: https://nx.dev/docs/technologies/test-tools/playwright/guides/merge-atomized-outputs',
       ],
     });
-
-    return { success: false };
+    return { success: true };
   }
 
   const blobReportFiles = collectBlobReports(absoluteBlobReportDir);


### PR DESCRIPTION

The blob outputs could be missing because CI or user ran `affected -t e2e-ci` and the changeset did not affect e2e tests, thus no reports generated. In this case, intead of erroring we should just log out a warning so users know what happened.
<img width="1252" height="212" alt="image" src="https://github.com/user-attachments/assets/a90f1f93-0d49-4976-8fa6-a40d2a46161a" />
