### PR TITLE
docs(linter): show options for module boundary rule in flat config

### DIFF
--- a/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
+++ b/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
@@ -126,7 +126,22 @@ export default [
       '@nx/enforce-module-boundaries': [
         'error',
         {
-          /* options */
+          allow: [],
+          // update depConstraints based on your tags
+          depConstraints: [
+            {
+              sourceTag: 'scope:shared',
+              onlyDependOnLibsWithTags: ['scope:shared']
+            },
+            {
+              sourceTag: 'scope:admin',
+              onlyDependOnLibsWithTags: ['scope:shared', 'scope:admin']
+            },
+            {
+              sourceTag: 'scope:client',
+              onlyDependOnLibsWithTags: ['scope:shared', 'scope:client']
+            },
+          ],
         },
       ],
     },

--- a/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
+++ b/astro-docs/src/content/docs/features/enforce-module-boundaries.mdoc
@@ -131,15 +131,15 @@ export default [
           depConstraints: [
             {
               sourceTag: 'scope:shared',
-              onlyDependOnLibsWithTags: ['scope:shared']
+              onlyDependOnLibsWithTags: ['scope:shared'],
             },
             {
               sourceTag: 'scope:admin',
-              onlyDependOnLibsWithTags: ['scope:shared', 'scope:admin']
+              onlyDependOnLibsWithTags: ['scope:shared', 'scope:admin'],
             },
             {
               sourceTag: 'scope:client',
-              onlyDependOnLibsWithTags: ['scope:shared', 'scope:client']
+              onlyDependOnLibsWithTags: ['scope:shared', 'scope:client'],
             },
           ],
         },


### PR DESCRIPTION
Show the same options for flat config as we do for legacy config.