### PR TITLE
fix(nx-dev): update nextjs internal-link-checker to include astro urls

### DIFF
--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -6,6 +6,7 @@
   "targets": {
     "build": {
       "dependsOn": [
+        "astro-docs:build",
         {
           "target": "build-base"
         }


### PR DESCRIPTION
blog and marketing pages will still link to astro docs, so depend on the
astro sitemap to check all links available to be used.
NOTE: the specific header links (url fragments) are skipped for pages
that come from astro docs (prefixed with /docs) due to not having a
simple way to create these lists without parsing all the build html
files out and that's not the part we really care about

confirmed working https://github.com/nrwl/nx/pull/33042 and https://github.com/nrwl/nx/pull/33036 which are blocked until this change merges

Fixes DOC-264
