### PR TITLE
fix(core): temporarily disable tui for run-one

### DIFF
--- a/packages/nx/src/tasks-runner/is-tui-enabled.ts
+++ b/packages/nx/src/tasks-runner/is-tui-enabled.ts
@@ -4,8 +4,6 @@ import { NxArgs } from '../utils/command-line-utils';
 import { isCI } from '../utils/is-ci';
 import { logger } from '../utils/logger';
 
-let tuiEnabled = undefined;
-
 /**
  * @returns If tui is enabled
  */

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -94,6 +94,10 @@ async function getTerminalOutputLifeCycle(
 
   const isRunOne = initiatingProject != null;
 
+  if (tasks.length === 1) {
+    process.env.NX_TUI = 'false';
+  }
+
   if (isTuiEnabled()) {
     const interceptedNxCloudLogs: (string | Uint8Array<ArrayBufferLike>)[] = [];
 


### PR DESCRIPTION
## Current Behavior
The tui is enabled even for a single task, and it currently doesn't bring a lot of value for those single-task use cases

## Expected Behavior
The tui is disabled for single task runs.


