### PR TITLE
fix(react): dynamic module federation should not initialize remoteUrlDefinitions to empty object

### DIFF
--- a/packages/react/mf/dynamic-federation.ts
+++ b/packages/react/mf/dynamic-federation.ts
@@ -17,7 +17,7 @@ declare const document: {
 
 declare const __webpack_init_sharing__: (scope: 'default') => Promise<void>;
 declare const __webpack_share_scopes__: { default: unknown };
-let remoteUrlDefinitions: Record<string, string> = {};
+let remoteUrlDefinitions: Record<string, string>;
 let resolveRemoteUrl: ResolveRemoteUrlFunction;
 const remoteModuleMap = new Map<string, unknown>();
 const remoteContainerMap = new Map<string, unknown>();
@@ -83,6 +83,7 @@ export function setRemoteDefinitions(definitions: Record<string, string>) {
  * ```
  */
 export function setRemoteDefinition(remoteName: string, remoteUrl: string) {
+  remoteUrlDefinitions ??= {};
   remoteUrlDefinitions[remoteName] = remoteUrl;
 }
 


### PR DESCRIPTION
## Current Behavior

  The `remoteUrlDefinitions` variable in `packages/react/mf/dynamic-federation.ts` is
  initialized as an empty object (`{}`), which causes:
  1. The `resolveRemoteUrl` callback is never called because `remoteUrlDefinitions` is
  always truthy
  2. When `loadRemoteModule` is called before `setRemoteDefinitions`, users get a cryptic
   error "Cannot read properties of undefined (reading 'endsWith')" instead of the
  helpful error message

  ## Expected Behavior

  - `resolveRemoteUrl` should be called when provided and `remoteUrlDefinitions` hasn't
  been set
  - The helpful error message should be shown when `loadRemoteModule` is called before
  setup

  ## Changes Made

  Applied the same fix from PR #27927 (for Angular) to the React implementation:
  - Changed `remoteUrlDefinitions` initialization to be `undefined` by default
  - Added nullish coalescing operator (`??=`) in `setRemoteDefinition` to initialize only
   when needed

  ## Related Issue(s)

  Fixes #33055

  This follows the same pattern as PR #27927 which fixed #27793 and #27842 for Angular.
