### PR TITLE
feat(core): support providing schema in sync generators

### DIFF
--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -758,9 +758,7 @@ export function convertSmartDefaultsIntoNamedParams(
   delete opts['__overrides_unparsed__'];
 }
 
-function getGeneratorDefaults(
-  projectName: string | null,
-  projectsConfigurations: ProjectsConfigurations,
+export function getNxJsonGeneratorDefaults(
   nxJsonConfiguration: NxJsonConfiguration,
   collectionName: string,
   generatorName: string
@@ -780,6 +778,16 @@ function getGeneratorDefaults(
       };
     }
   }
+  return defaults;
+}
+
+function getProjectConfigurationGeneratorDefaults(
+  projectName: string | null,
+  projectsConfigurations: ProjectsConfigurations,
+  collectionName: string,
+  generatorName: string
+) {
+  let defaults = {};
   if (
     projectName &&
     projectsConfigurations?.projects[projectName]?.generators
@@ -796,6 +804,28 @@ function getGeneratorDefaults(
     }
   }
   return defaults;
+}
+
+export function getGeneratorDefaults(
+  projectName: string | null,
+  projectsConfigurations: ProjectsConfigurations,
+  nxJsonConfiguration: NxJsonConfiguration,
+  collectionName: string,
+  generatorName: string
+) {
+  return {
+    ...getNxJsonGeneratorDefaults(
+      nxJsonConfiguration,
+      collectionName,
+      generatorName
+    ),
+    ...getProjectConfigurationGeneratorDefaults(
+      projectName,
+      projectsConfigurations,
+      collectionName,
+      generatorName
+    ),
+  };
 }
 
 type Prompt = ConstructorParameters<typeof import('enquirer').Prompt>[0] & {


### PR DESCRIPTION
 ## Summary

  Align sync generator invocation with regular generators by providing schema-based options from `nx.json` and project configuration.

## Current Behavior

  Currently, sync generators are invoked with only a `Tree` parameter and do not receive any configuration options from the generator's schema, `nx.json`, or project configuration:

  ```typescript
  // Before
  export type SyncGenerator = (tree: Tree) => SyncGeneratorResult;
```

  This means sync generators cannot:
  - Access generator-specific options defined in their schema
  - Use options configured in nx.json via generators configuration
  - Use project-level generator defaults
  - Apply schema defaults and validations

## Expected Behavior

  Sync generators should receive combined options from their schema, just like regular generators do, but without command-line arguments (since they're not invoked directly by users).

  ```typescript
  // After
  export type SyncGenerator<T = unknown> = (
    tree: Tree,
    schema: T
  ) => SyncGeneratorResult | Promise<SyncGeneratorResult>;
```

## Related Discussion

Related to https://github.com/nrwl/nx/discussions/32663