### PR TITLE
fix(nx-dev): handle null github data

### DIFF
--- a/astro-docs/src/plugins/community-plugins.loader.ts
+++ b/astro-docs/src/plugins/community-plugins.loader.ts
@@ -4,12 +4,38 @@ import communityPlugins from '../content/approved-community-plugins.json';
 import type { CollectionEntry } from 'astro:content';
 import {
   getGithubStars,
-  getNpmData,
-  getNpmDownloads,
   shouldFetchStats,
+  isPluginStatsFetchingEnabled,
+  getCachedOrDefaultStats,
+  fetchFreshStats,
+  type PluginStats,
 } from './utils/plugin-stats';
 
 type DocEntry = CollectionEntry<'community-plugins'>;
+
+/**
+ * Create a community plugin entry with the given stats
+ */
+function createCommunityPluginEntry(
+  plugin: { name: string; url: string; description: string },
+  stats: PluginStats
+): DocEntry {
+  return {
+    id: plugin.name,
+    collection: 'community-plugins',
+    data: {
+      title: plugin.name,
+      slug: plugin.name,
+      description: plugin.description,
+      url: plugin.url,
+      githubStars: stats.githubStars,
+      npmDownloads: stats.npmDownloads,
+      lastPublishedDate: stats.lastPublishedDate,
+      nxVersion: stats.nxVersion ?? '',
+      lastFetched: stats.lastFetched,
+    },
+  };
+}
 
 async function loadCommunityPluginsData(
   logger: LoaderContext['logger'],
@@ -19,54 +45,48 @@ async function loadCommunityPluginsData(
 
   const failedProcessed = new Set<string>();
 
-  // NOTE: GH gql api allows us to get all plugin meta in one call
-  const ghPluginList = communityPlugins
-    .filter((p) => p.url.startsWith('https://github.com'))
-    .map((p) => {
-      const url = new URL(p.url);
-      const [_, owner, repo] = url.pathname.split('/');
-      return {
-        owner,
-        repo,
-      };
-    });
+  // Fetch GitHub stars for all plugins in one API call (only if fetching is enabled)
+  let ghStarsList = new Map<
+    string,
+    { nameWithOwner: string; stargazers: { totalCount: number } }
+  >();
 
-  const ghStarsList = await getGithubStars(ghPluginList);
+  if (isPluginStatsFetchingEnabled()) {
+    const ghPluginList = communityPlugins
+      .filter((p) => p.url.startsWith('https://github.com'))
+      .map((p) => {
+        const url = new URL(p.url);
+        const [_, owner, repo] = url.pathname.split('/');
+        return {
+          owner,
+          repo,
+        };
+      });
 
+    ghStarsList = await getGithubStars(ghPluginList);
+  }
+
+  // Process each plugin
   for (const plugin of communityPlugins) {
-    const existingEntry = store.get<DocEntry['data']>(plugin.name);
-    // re-hydrate if the plugins last publish date is > 1 week old, just to be safe
-    // we could use digests but those still require fetching the data to compare against.Date
-
-    if (!shouldFetchStats(existingEntry)) {
-      logger.debug(
-        `Skipping ${plugin.name} as it's data is already recently fetched`
-      );
-      continue;
-    }
-
     try {
-      const npmMeta = await getNpmData(plugin);
-      const npmDownloads = await getNpmDownloads(plugin);
-      const [_, owner, repo] = new URL(plugin.url).pathname.split('/');
+      const existingEntry = store.get<DocEntry['data']>(plugin.name);
 
-      const entry: DocEntry = {
-        id: plugin.name,
-        collection: 'community-plugins',
-        data: {
-          title: plugin.name,
-          slug: plugin.name,
-          description: plugin.description,
-          url: plugin.url,
-          lastPublishedDate: npmMeta.lastPublishedDate,
-          npmDownloads: npmDownloads,
-          githubStars:
-            ghStarsList.get(`${owner}/${repo}`)?.stargazers?.totalCount ?? 0,
-          nxVersion: npmMeta.nxVersion,
-          lastFetched: new Date(),
-        },
-      };
+      // Determine which stats to use: fresh, cached, or defaults
+      let stats: PluginStats;
+      if (shouldFetchStats(existingEntry)) {
+        // Fetch fresh stats from external sources
+        const [_, owner, repo] = new URL(plugin.url).pathname.split('/');
+        const repoKey = `${owner}/${repo}`;
+        stats = await fetchFreshStats(plugin, repoKey, ghStarsList, true);
+        logger.debug(`Fetched fresh stats for ${plugin.name}`);
+      } else {
+        // Reuse cached stats if available, otherwise use defaults
+        stats = getCachedOrDefaultStats(existingEntry, true);
+        logger.debug(`Using cached/default stats for ${plugin.name}`);
+      }
 
+      // Create and store the plugin entry
+      const entry = createCommunityPluginEntry(plugin, stats);
       store.set(entry);
     } catch (err: any) {
       logger.error(`❌ Unable to process plugin ${plugin.name}`);
@@ -77,8 +97,14 @@ async function loadCommunityPluginsData(
 
   const successCount = communityPlugins.length - failedProcessed.size;
   logger.info(
-    `Successfully loaded ${successCount} community plugins into store`
+    `Successfully loaded ${successCount}/${communityPlugins.length} community plugins into store`
   );
+
+  if (!isPluginStatsFetchingEnabled()) {
+    logger.info(
+      '(Stats fetching disabled - using cached data or defaults. Set NX_DOCS_PLUGIN_STATS=true to fetch fresh stats.)'
+    );
+  }
 }
 
 export function CommunityPluginsLoader(): Loader {

--- a/astro-docs/src/plugins/plugin.loader.ts
+++ b/astro-docs/src/plugins/plugin.loader.ts
@@ -16,10 +16,11 @@ import type { CollectionEntry, RenderedContent } from 'astro:content';
 import { watchAndCall } from './utils/watch';
 import {
   getGithubStars,
-  getNpmData,
-  getNpmDownloads,
   PLUGIN_IGNORE_LIST,
   shouldFetchStats,
+  getCachedOrDefaultStats,
+  fetchFreshStats,
+  type PluginStats,
 } from './utils/plugin-stats';
 import {
   getTechnologyCategory,
@@ -69,6 +70,39 @@ function getPluginDescription(pluginPath: string, pluginName: string): string {
   }
 
   return `The Nx Plugin for ${pluginName}`;
+}
+
+/**
+ * Create a plugin overview entry with the given stats
+ * Features and totalDocs start empty and are populated during processing
+ */
+function createPluginOverview(
+  pluginName: string,
+  packageName: string,
+  pluginDescription: string,
+  technologyCategory: string,
+  stats: PluginStats
+): DocEntry {
+  const slug = getPluginSlug(pluginName, 'introduction');
+
+  return {
+    id: `${pluginName}-overview`,
+    collection: 'plugin-docs',
+    data: {
+      description: pluginDescription,
+      packageName,
+      pluginName,
+      technologyCategory,
+      features: [],
+      totalDocs: 0,
+      docType: 'overview',
+      ...stats,
+      title: pluginName,
+      slug,
+      filter: 'type:References',
+      weight: 2.1,
+    },
+  };
 }
 
 export async function generateAllPluginDocs(
@@ -121,41 +155,30 @@ export async function generateAllPluginDocs(
     // Get technology category for this plugin
     const technologyCategory = getTechnologyCategory(pluginName);
 
-    let pluginOverview = {} as DocEntry;
-
+    // Determine which stats to use: fresh, cached, or defaults
+    let stats: PluginStats;
     if (shouldFetchStats(existingOverviewEntry)) {
+      // Fetch fresh stats from external sources
       const npmPackage = {
         name: packageName,
         url: `https://github.com/nrwl/nx/tree/master/packages/${pluginName}`,
         description: pluginDescription,
       };
-      const npmDownloads = await getNpmDownloads(npmPackage);
-      const npmMeta = await getNpmData(npmPackage);
-      const slug = getPluginSlug(pluginName, 'introduction');
-      pluginOverview = {
-        id: `${pluginName}-overview`,
-        collection: 'plugin-docs',
-        data: {
-          description: pluginDescription,
-          packageName,
-          pluginName,
-          technologyCategory,
-          features: [],
-          totalDocs: 0,
-          docType: 'overview',
-          githubStars: ghStarMap.get('nrwl/nx')?.stargazers?.totalCount || 0,
-          npmDownloads: npmDownloads,
-          lastPublishedDate: npmMeta.lastPublishedDate,
-          lastFetched: new Date(),
-          title: pluginName,
-          slug,
-          filter: 'type:References',
-          weight: 2.1,
-        },
-      };
+      stats = await fetchFreshStats(npmPackage, 'nrwl/nx', ghStarMap, false);
     } else {
-      pluginOverview = existingOverviewEntry as DocEntry;
+      // Reuse cached stats if available, otherwise use defaults
+      stats = getCachedOrDefaultStats(existingOverviewEntry, false);
     }
+
+    // Create plugin overview with the determined stats
+    // Features and totalDocs will be populated as we process generators/executors/migrations
+    const pluginOverview = createPluginOverview(
+      pluginName,
+      packageName,
+      pluginDescription,
+      technologyCategory,
+      stats
+    );
 
     try {
       // Process generators

--- a/astro-docs/src/plugins/utils/plugin-stats.ts
+++ b/astro-docs/src/plugins/utils/plugin-stats.ts
@@ -33,7 +33,7 @@ export function stringifyDate(date: Date) {
  * */
 export async function getNpmData(
   plugin: PluginRegistry,
-  skipNxVersion = false
+  skipNxVersion = false,
 ) {
   try {
     const response = await fetch(`https://registry.npmjs.org/${plugin.name}`);
@@ -45,7 +45,7 @@ export async function getNpmData(
 
     if (!data.repository) {
       console.warn(
-        `- No repository defined in package.json for ${plugin.name}`
+        `- No repository defined in package.json for ${plugin.name}`,
       );
       return { lastPublishedDate, nxVersion, githubRepo: '' };
     }
@@ -82,8 +82,8 @@ export async function getNpmDownloads(plugin: PluginRegistry): Promise<number> {
   try {
     const response = await fetch(
       `https://api.npmjs.org/downloads/point/${stringifyIntervalForUrl(
-        lastMonth
-      )}/${plugin.name}`
+        lastMonth,
+      )}/${plugin.name}`,
     );
     const data = (await response.json()) as NpmDownloadRequest;
     return data.downloads;
@@ -135,7 +135,7 @@ async function findNxRange(devkitVersion: string) {
  * i.e. https://api.github.com/graphql
  * */
 export async function getGithubStars(
-  repos: { owner: string; repo: string }[]
+  repos: { owner: string; repo: string }[],
 ): Promise<Map<string, GitHubRepoStarResult>> {
   if (process.env.GITHUB_TOKEN === undefined) {
     // TODO(caleb): should we error in CI if the token isn't set?
@@ -157,10 +157,10 @@ export async function getGithubStars(
         ({ owner, repo }) =>
           `${owner.replace(/[\-#]/g, '')}${repo.replace(
             /[\-#]/g,
-            ''
+            '',
           )}: repository(owner: "${owner}", name: "${repo}") {
       ...repoProperties
-    }`
+    }`,
       )
       .join('\n')}
   }`;
@@ -178,10 +178,25 @@ export async function getGithubStars(
     });
 
     const result = (await response.json()) as {
-      data: {
+      data?: {
         [escapedName: string]: GitHubRepoStarResult;
       };
+      errors?: Array<{ message: string }>;
     };
+
+    // Check if the response contains errors or missing data
+    if (!result.data) {
+      if (result.errors) {
+        console.warn(
+          'GitHub API returned errors:',
+          result.errors.map((e) => e.message).join(', '),
+        );
+      } else {
+        console.warn('GitHub API returned no data');
+        console.warn('Response', JSON.stringify(result, null, 2));
+      }
+      return new Map<string, GitHubRepoStarResult>();
+    }
 
     const reposWithStars = new Map<string, GitHubRepoStarResult>();
 
@@ -242,9 +257,26 @@ type CacheableEntry = {
 };
 
 const ONE_WEEK_MS = 1000 * 60 * 60 * 24 * 7;
+
+/**
+ * Checks if plugin stats fetching is enabled.
+ * Stats are only fetched when:
+ * - Running in CI (CI=true), OR
+ * - Explicitly enabled via NX_DOCS_PLUGIN_STATS=true
+ */
+export function isPluginStatsFetchingEnabled(): boolean {
+  return (
+    process.env.CI === 'true' || process.env.NX_DOCS_PLUGIN_STATS === 'true'
+  );
+}
+
 export function shouldFetchStats(
-  existingEntry: CacheableEntry | undefined
+  existingEntry: CacheableEntry | undefined,
 ): boolean {
+  if (!isPluginStatsFetchingEnabled()) {
+    return false;
+  }
+
   if (process.env.CI === 'true') {
     return true;
   }
@@ -265,3 +297,104 @@ export const PLUGIN_IGNORE_LIST = [
   'make-angular-cli-faster',
   'tao',
 ];
+
+/**
+ * Common plugin stats structure shared across all plugin loaders
+ */
+export interface PluginStats {
+  githubStars: number;
+  npmDownloads: number;
+  lastPublishedDate: Date | undefined;
+  nxVersion?: string;
+  lastFetched: Date | undefined;
+}
+
+/**
+ * Type for any store entry that has cacheable stats
+ */
+export interface StatsEntry {
+  data?: {
+    githubStars?: number;
+    npmDownloads?: number;
+    lastPublishedDate?: Date;
+    nxVersion?: string;
+    lastFetched?: Date;
+  };
+}
+
+/**
+ * Extract cached stats from an existing store entry, or return defaults if not available.
+ * This is a generic helper used by all plugin loaders.
+ *
+ * @param existingEntry The existing entry from the store (if any)
+ * @param includeNxVersion Whether to include nxVersion in the result (for community plugins)
+ * @returns Stats object with cached values or safe defaults
+ */
+export function getCachedOrDefaultStats(
+  existingEntry: StatsEntry | undefined,
+  includeNxVersion = false,
+): PluginStats {
+  if (existingEntry?.data) {
+    const stats: PluginStats = {
+      githubStars: existingEntry.data.githubStars ?? 0,
+      npmDownloads: existingEntry.data.npmDownloads ?? 0,
+      lastPublishedDate: existingEntry.data.lastPublishedDate,
+      lastFetched: existingEntry.data.lastFetched,
+    };
+
+    if (includeNxVersion) {
+      stats.nxVersion = existingEntry.data.nxVersion ?? '';
+    }
+
+    return stats;
+  }
+
+  // Return defaults when no cached data is available
+  const defaults: PluginStats = {
+    githubStars: 0,
+    npmDownloads: 0,
+    lastPublishedDate: undefined,
+    lastFetched: undefined,
+  };
+
+  if (includeNxVersion) {
+    defaults.nxVersion = '';
+  }
+
+  return defaults;
+}
+
+/**
+ * Fetch fresh plugin stats from NPM and GitHub.
+ * This is a generic helper that can be used by all plugin loaders.
+ *
+ * @param plugin The plugin to fetch stats for
+ * @param repoKey The key to look up GitHub stars (e.g., 'nrwl/nx' or 'owner/repo')
+ * @param ghStarMap Map of GitHub stars by repo key
+ * @param includeNxVersion Whether to fetch and include nxVersion
+ * @returns Fresh stats from external sources
+ */
+export async function fetchFreshStats(
+  plugin: PluginRegistry,
+  repoKey: string,
+  ghStarMap: Map<string, GitHubRepoStarResult>,
+  includeNxVersion = false,
+): Promise<PluginStats> {
+  const [npmDownloads, npmMeta] = await Promise.all([
+    getNpmDownloads(plugin),
+    getNpmData(plugin, !includeNxVersion),
+  ]);
+
+  const stats: PluginStats = {
+    githubStars: ghStarMap.get(repoKey)?.stargazers?.totalCount ?? 0,
+    npmDownloads,
+    lastPublishedDate: npmMeta.lastPublishedDate,
+    lastFetched: new Date(),
+  };
+
+  if (includeNxVersion && npmMeta.nxVersion) {
+    stats.nxVersion = npmMeta.nxVersion;
+  }
+
+  return stats;
+}


### PR DESCRIPTION
technically the fix to plugin stats now showing up was expired GH token.
But refactored the plugin stats fetching to skip locally unless NX_DOCS_PLUGIN_STATS env var is set to help speed up local serves/builds since 99% of the time we're not concerned with the plugin-registry page.
along with trying to centralized the logic between 1st/3rd party plugins since it was a little confusing from my initial impl. 