### PR TITLE
fix(nx-js): caching key for external project references

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -1070,7 +1070,7 @@ function isExternalProjectReference(
   workspaceRoot: string,
   projectRoot: string
 ): boolean {
-  const relativePath = posixRelative(workspaceRoot, refTsConfigPath);
+  const relativePath = posixRelative(projectRoot, refTsConfigPath);
   if (cache.isExternalProjectReference[relativePath] !== undefined) {
     return cache.isExternalProjectReference[relativePath];
   }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Generated caching inputs for projects can be incomplete due to faulty caching behavior.

## Expected Behavior
Generated caching inputs for projects can are complete by narrowing the scope of the caching to projects rather than the whole workspace.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #33076
