### PR TITLE
fix(linter): install correct deps in eslint convert to flat config generator

### DIFF
--- a/e2e/esbuild/src/esbuild-setup.ts
+++ b/e2e/esbuild/src/esbuild-setup.ts
@@ -1,7 +1,7 @@
 import { cleanupProject, newProject } from '@nx/e2e-utils';
 
 export function setupEsbuildTest(): string {
-  return newProject();
+  return newProject({ packages: ['@nx/js'] });
 }
 
 export function cleanupEsbuildTest(): void {

--- a/e2e/gradle/src/gradle.test.ts
+++ b/e2e/gradle/src/gradle.test.ts
@@ -17,7 +17,7 @@ describe('Gradle', () => {
     ({ type }: { type: 'kotlin' | 'groovy' }) => {
       let gradleProjectName = uniq('my-gradle-project');
       beforeAll(() => {
-        newProject();
+        newProject({ packages: [] });
         createGradleProject(gradleProjectName, type);
         runCLI(`add @nx/gradle`);
       });

--- a/e2e/js/src/js-executor-node.test.ts
+++ b/e2e/js/src/js-executor-node.test.ts
@@ -12,7 +12,7 @@ describe('js:node executor', () => {
   let scope: string;
 
   beforeAll(() => {
-    scope = newProject();
+    scope = newProject({ packages: ['@nx/js', '@nx/node'] });
   });
 
   afterAll(() => cleanupProject());

--- a/e2e/js/src/js-executor-swc.test.ts
+++ b/e2e/js/src/js-executor-swc.test.ts
@@ -15,7 +15,7 @@ describe('js:swc executor', () => {
   let scope: string;
 
   beforeAll(() => {
-    scope = newProject();
+    scope = newProject({ packages: ['@nx/js'] });
   });
 
   afterAll(() => {

--- a/e2e/js/src/js-executor-tsc.test.ts
+++ b/e2e/js/src/js-executor-tsc.test.ts
@@ -23,7 +23,7 @@ import {
 
 describe('js:tsc executor', () => {
   let scope;
-  beforeAll(() => (scope = newProject()));
+  beforeAll(() => (scope = newProject({ packages: ['@nx/js'] })));
   afterAll(() => cleanupProject());
 
   it('should create libs with js executors (--compiler=tsc)', async () => {

--- a/e2e/js/src/js-packaging.test.ts
+++ b/e2e/js/src/js-packaging.test.ts
@@ -19,7 +19,7 @@ describe('packaging libs', () => {
   let scope: string;
 
   beforeEach(() => {
-    scope = newProject();
+    scope = newProject({ packages: ['@nx/js'] });
   });
 
   afterEach(() => cleanupProject());

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -117,19 +117,28 @@ export function newProject({
         );
       }
 
+      let packagesToInstall: Array<NxPackage> = [];
       if (!packages) {
         console.warn(
           'ATTENTION: All packages are installed into the new workspace. To make this test faster, please pass the subset of packages that this test needs by passing a packages array in the options'
         );
+        packagesToInstall = [...nxPackages];
+      } else if (packages.length > 0) {
+        packagesToInstall = packages;
       }
-      const packageInstallStart = performance.mark('packageInstall:start');
-      packageInstall((packages ?? nxPackages).join(` `), projScope);
-      const packageInstallEnd = performance.mark('packageInstall:end');
-      packageInstallMeasure = performance.measure(
-        'packageInstall',
-        packageInstallStart.name,
-        packageInstallEnd.name
-      );
+
+      if (packagesToInstall.length) {
+        const packageInstallStart = performance.mark('packageInstall:start');
+        packageInstall(packagesToInstall.join(` `), projScope);
+        const packageInstallEnd = performance.mark('packageInstall:end');
+        packageInstallMeasure = performance.measure(
+          'packageInstall',
+          packageInstallStart.name,
+          packageInstallEnd.name
+        );
+      } else {
+        console.info('No packages to install');
+      }
       // stop the daemon
       execSync(`${getPackageManagerCommand({ packageManager }).runNx} reset`, {
         cwd: `${e2eCwd}/proj`,

--- a/e2e/web/src/file-server-legacy.test.ts
+++ b/e2e/web/src/file-server-legacy.test.ts
@@ -10,7 +10,10 @@ import {
 
 describe('file-server', () => {
   beforeAll(() => {
-    newProject({ name: uniq('fileserver') });
+    newProject({
+      name: uniq('fileserver'),
+      packages: ['@nx/web', '@nx/angular', '@nx/react'],
+    });
   });
 
   afterAll(() => cleanupProject());

--- a/e2e/web/src/file-server.test.ts
+++ b/e2e/web/src/file-server.test.ts
@@ -13,7 +13,7 @@ import { join } from 'path';
 
 describe('file-server', () => {
   beforeAll(() => {
-    newProject({ name: uniq('fileserver') });
+    newProject({ name: uniq('fileserver'), packages: ['@nx/web'] });
   });
 
   afterAll(() => cleanupProject());

--- a/e2e/web/src/web-legacy.test.ts
+++ b/e2e/web/src/web-legacy.test.ts
@@ -14,7 +14,7 @@ import {
 import { join } from 'path';
 
 describe('Web Components Applications (legacy)', () => {
-  beforeEach(() => newProject());
+  beforeEach(() => newProject({ packages: ['@nx/web', '@nx/react'] }));
   afterEach(() => cleanupProject());
 
   it('should remove previous output before building', async () => {

--- a/e2e/web/src/web-vite.test.ts
+++ b/e2e/web/src/web-vite.test.ts
@@ -13,7 +13,7 @@ import {
 } from '@nx/e2e-utils';
 
 describe('Web Components Applications with bundler set as vite', () => {
-  beforeEach(() => newProject());
+  beforeEach(() => newProject({ packages: ['@nx/web', '@nx/react'] }));
   afterEach(() => cleanupProject());
 
   it('should be able to generate a web app', async () => {

--- a/e2e/web/src/web-webpack.test.ts
+++ b/e2e/web/src/web-webpack.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@nx/e2e-utils';
 
 describe('Web Components Applications with bundler set as webpack', () => {
-  beforeEach(() => newProject());
+  beforeEach(() => newProject({ packages: ['@nx/web'] }));
   afterEach(() => cleanupProject());
 
   it('should support https for dev-server (legacy)', async () => {

--- a/e2e/web/src/web.test.ts
+++ b/e2e/web/src/web.test.ts
@@ -20,7 +20,7 @@ import { join } from 'path';
 import { copyFileSync } from 'fs';
 
 describe('Web Components Applications', () => {
-  beforeAll(() => newProject());
+  beforeAll(() => newProject({ packages: ['@nx/web'] }));
   afterAll(() => cleanupProject());
 
   it('should be able to generate a web app', async () => {

--- a/e2e/webpack/src/webpack.test.ts
+++ b/e2e/webpack/src/webpack.test.ts
@@ -17,7 +17,9 @@ import {
 import { join } from 'path';
 
 describe('Webpack Plugin', () => {
-  beforeAll(() => newProject());
+  beforeAll(() =>
+    newProject({ packages: ['@nx/webpack', '@nx/js', '@nx/react', '@nx/web'] })
+  );
   afterAll(() => cleanupProject());
 
   it('should be able to setup project to build node programs with webpack and different compilers', async () => {

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
@@ -67,6 +67,8 @@ describe('convert-to-flat-config generator', () => {
             "@eslint/eslintrc": "^2.1.1",
             "@nx/eslint": "0.0.1",
             "@nx/eslint-plugin": "0.0.1",
+            "@typescript-eslint/eslint-plugin": "^8.40.0",
+            "@typescript-eslint/parser": "^8.40.0",
             "eslint": "^9.8.0",
             "eslint-config-prettier": "^10.0.0",
             "typescript-eslint": "^8.40.0"
@@ -680,6 +682,8 @@ describe('convert-to-flat-config generator', () => {
             "@eslint/eslintrc": "^2.1.1",
             "@nx/eslint": "0.0.1",
             "@nx/eslint-plugin": "0.0.1",
+            "@typescript-eslint/eslint-plugin": "^8.40.0",
+            "@typescript-eslint/parser": "^8.40.0",
             "eslint": "^9.8.0",
             "eslint-config-prettier": "^10.0.0",
             "typescript-eslint": "^8.40.0"

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.ts
@@ -2,13 +2,13 @@ import {
   addDependenciesToPackageJson,
   formatFiles,
   GeneratorCallback,
+  getDependencyVersionFromPackageJson,
   getProjects,
   installPackagesTask,
   NxJsonConfiguration,
   ProjectConfiguration,
   readJson,
   readNxJson,
-  removeDependenciesFromPackageJson,
   Tree,
   updateJson,
   updateProjectConfiguration,
@@ -248,7 +248,20 @@ function processConvertedConfig(
     eslint: eslint9__eslintVersion,
     'eslint-config-prettier': eslintConfigPrettierVersion,
     'typescript-eslint': eslint9__typescriptESLintVersion,
+    '@typescript-eslint/eslint-plugin': eslint9__typescriptESLintVersion,
+    '@typescript-eslint/parser': eslint9__typescriptESLintVersion,
   };
+
+  if (getDependencyVersionFromPackageJson(tree, '@typescript-eslint/utils')) {
+    devDependencies['@typescript-eslint/utils'] =
+      eslint9__typescriptESLintVersion;
+  }
+  if (
+    getDependencyVersionFromPackageJson(tree, '@typescript-eslint/type-utils')
+  ) {
+    devDependencies['@typescript-eslint/type-utils'] =
+      eslint9__typescriptESLintVersion;
+  }
 
   // add missing packages
   if (addESLintRC) {
@@ -260,10 +273,4 @@ function processConvertedConfig(
   }
 
   addDependenciesToPackageJson(tree, {}, devDependencies);
-
-  removeDependenciesFromPackageJson(
-    tree,
-    ['@typescript-eslint/eslint-plugin', '@typescript-eslint/parser'],
-    ['@typescript-eslint/eslint-plugin', '@typescript-eslint/parser']
-  );
 }


### PR DESCRIPTION
Installs the correct dependencies after converting to the ESLint Flat configuration. This was highlighted after removing the npm `--legacy-peer-deps` flag from default usage in Nx.

Additionally, it fixes nightly e2e failures:

- `e2e-esbuild`
- `e2e-eslint`
- `e2e-gradle`
- `e2e-js`
- `e2e-web`
- `e2e-webpack`

Nightly run where all pass: https://github.com/nrwl/nx/actions/runs/18592750415