### PR TITLE
docs(nx-dev): add missing custom events back

### DIFF
--- a/astro-docs/astro.config.mjs
+++ b/astro-docs/astro.config.mjs
@@ -9,6 +9,7 @@ import { sidebar } from './sidebar.mts';
 
 const BASE = '/docs';
 
+// This is exposed as window.__CONFIG
 const PUBLIC_CONFIG = {
   cookiebotDisabled: process.env.COOKIEBOT_DISABLED === 'true',
   cookiebotId: process.env.COOKIEBOT_ID ?? null,
@@ -49,6 +50,7 @@ export default defineConfig({
         dark: './src/assets/nx/Nx-light.png',
         replacesTitle: true,
       },
+      disable404Route: true,
       head: [
         {
           tag: 'script',

--- a/astro-docs/src/components/layout/Header.astro
+++ b/astro-docs/src/components/layout/Header.astro
@@ -34,6 +34,7 @@ const currentVersion = versions.find((v) => v.current);
       <Image src={nxLogoLight} alt="Nx" class="h-12 w-auto hidden dark:block" />
     </a>
     <a
+      id="header-docs-home-link"
       href="/docs/getting-started/intro"
       class="px-3.5 py-2 text-sm font-medium text-slate-600 hover:text-blue-500 rounded-md transition-colors whitespace-nowrap no-underline dark:text-slate-200 dark:hover:text-sky-500"
     >
@@ -438,8 +439,13 @@ const currentVersion = versions.find((v) => v.current);
   import { sendCustomEvent } from '@nx/nx-dev-feature-analytics';
 
   function setupAnalyticsTracking() {
+    const docsHomeLink = document.getElementById('header-docs-home-link');
     const contactBtn = document.getElementById('header-contact-btn');
     const tryNxCloudBtn = document.getElementById('header-try-nx-cloud-btn');
+
+    docsHomeLink?.addEventListener('click', () => {
+      sendCustomEvent('documentation-click', 'header-navigation', 'documentation-header');
+    });
 
     contactBtn?.addEventListener('click', () => {
       sendCustomEvent('contact-click', 'header-cta', 'documentation-header');

--- a/astro-docs/src/pages/404.astro
+++ b/astro-docs/src/pages/404.astro
@@ -1,0 +1,25 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+---
+
+<StarlightPage
+  frontmatter={{
+    title: 'Page not found',
+    description: 'Page not found. Check the URL or try using the search bar.',
+    hero: {
+      title: '404',
+      tagline: 'Page not found. Check the URL or try using the search bar.',
+    },
+    template: 'splash',
+    editUrl: false,
+  }}
+  headings={[]}
+>
+</StarlightPage>
+
+<script>
+import { sendCustomEvent } from '@nx/nx-dev-feature-analytics';
+document.addEventListener('DOMContentLoaded', () => {
+  sendCustomEvent('custom_page_view', '404', window.location.pathname);
+});
+</script>

--- a/nx-dev/feature-analytics/src/lib/google-analytics.ts
+++ b/nx-dev/feature-analytics/src/lib/google-analytics.ts
@@ -22,8 +22,14 @@ export function sendPageViewEvent(data: {
 
   // Check if user has consented to statistics cookies
   if (
-    process.env.NEXT_PUBLIC_COOKIEBOT_DISABLE !== 'true' &&
+    // Browswer only
     typeof window !== 'undefined' &&
+    // Disabled for Astro
+    !window.__CONFIG?.disableCookiebot &&
+    // Disabled for Next.js
+    typeof process === 'object' &&
+    process.env.NEXT_PUBLIC_COOKIEBOT_DISABLE !== 'true' &&
+    // Cookiebot
     window.Cookiebot &&
     !window.Cookiebot.consent?.statistics
   ) {
@@ -56,8 +62,14 @@ export function sendCustomEvent(
 
   // Check if user has consented to statistics cookies
   if (
-    process.env.NEXT_PUBLIC_COOKIEBOT_DISABLE !== 'true' &&
+    // Browswer only
     typeof window !== 'undefined' &&
+    // Disabled for Astro
+    !window.__CONFIG?.disableCookiebot &&
+    // Disabled for Next.js
+    typeof process === 'object' &&
+    process.env.NEXT_PUBLIC_COOKIEBOT_DISABLE !== 'true' &&
+    // Cookiebot
     window.Cookiebot &&
     !window.Cookiebot.consent?.statistics
   ) {


### PR DESCRIPTION
This PR adds 404 and header custom events back for docs. These were previously in the Next.js docs pages, but were missing when we migrated to Astro.

The `sendCustomEvent` and `sendPageEvent` functions did not account for the way that Astro is configured via `window.__CONFIG` object, so this PR fixes those too.

## Screenshots

I ran these in preview mode with the site built with `COOKIEBOT_DISABlED=true`.

Custom page view on 404:

<img width="2672" height="1527" alt="Screenshot 2025-10-15 at 3 10 05 PM" src="https://github.com/user-attachments/assets/5bbe30fc-56cb-4427-b138-56edcf3bbc71" />

Header docs CTA event:
<img width="2672" height="1527" alt="Screenshot 2025-10-15 at 3 13 02 PM" src="https://github.com/user-attachments/assets/246cb99d-0a30-4d94-a4a3-8f8659062f23" />

Header `Try Cloud` CTA event:
<img width="2672" height="1527" alt="Screenshot 2025-10-15 at 3 10 10 PM" src="https://github.com/user-attachments/assets/addd2645-cf3e-4c83-ae39-9f00a434a21d" />
