### PR TITLE
fix(core): add accept header to http remote cache get

### DIFF
--- a/packages/nx/src/native/cache/http_remote_cache.rs
+++ b/packages/nx/src/native/cache/http_remote_cache.rs
@@ -67,7 +67,12 @@ impl HttpRemoteCache {
         let _guard = span.enter();
 
         let url: String = format!("{}/v1/cache/{}", self.url, hash);
-        let response = self.client.get(&url).send().await;
+        let response = self
+            .client
+            .get(&url)
+            .header("Accept", "application/octet-stream")
+            .send()
+            .await;
         if let Ok(resp) = response {
             trace!("HTTP response status: {}", resp.status());
             let status = resp.status();


### PR DESCRIPTION
With the Accept header in place during the retrieval of cache, the client always expects an octet-stream from the server.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
When the `Accept` header is missing, you might not get the correct data depending on the underlying implementation of a self hosted cache solution. We use AWS API Gateway which has a hard requirement for `Accept` to determine how it should convert the data.


Fixes #33092