### PR TITLE
feat(release): allow changelog.renderer to be set to an implementation directly

### DIFF
--- a/packages/nx/src/command-line/release/config/config.ts
+++ b/packages/nx/src/command-line/release/config/config.ts
@@ -1406,7 +1406,10 @@ function validateChangelogConfig(
     rootChangelogConfig.workspaceChangelog &&
     typeof rootChangelogConfig.workspaceChangelog !== 'boolean'
   ) {
-    if (rootChangelogConfig.workspaceChangelog.renderer?.length) {
+    if (
+      typeof rootChangelogConfig.workspaceChangelog.renderer === 'string' &&
+      rootChangelogConfig.workspaceChangelog.renderer.length > 0
+    ) {
       uniqueRendererPaths.add(rootChangelogConfig.workspaceChangelog.renderer);
     }
     const createReleaseError = validateCreateReleaseConfig(
@@ -1420,7 +1423,10 @@ function validateChangelogConfig(
     rootChangelogConfig.projectChangelogs &&
     typeof rootChangelogConfig.projectChangelogs !== 'boolean'
   ) {
-    if (rootChangelogConfig.projectChangelogs.renderer?.length) {
+    if (
+      typeof rootChangelogConfig.projectChangelogs.renderer === 'string' &&
+      rootChangelogConfig.projectChangelogs.renderer.length > 0
+    ) {
       uniqueRendererPaths.add(rootChangelogConfig.projectChangelogs.renderer);
     }
     const createReleaseError = validateCreateReleaseConfig(
@@ -1433,7 +1439,10 @@ function validateChangelogConfig(
 
   for (const group of Object.values(releaseGroups)) {
     if (group.changelog && typeof group.changelog !== 'boolean') {
-      if (group.changelog.renderer?.length) {
+      if (
+        typeof group.changelog.renderer === 'string' &&
+        group.changelog.renderer.length > 0
+      ) {
         uniqueRendererPaths.add(group.changelog.renderer);
       }
       const createReleaseError = validateCreateReleaseConfig(group.changelog);

--- a/packages/nx/src/command-line/release/utils/resolve-changelog-renderer.ts
+++ b/packages/nx/src/command-line/release/utils/resolve-changelog-renderer.ts
@@ -5,11 +5,19 @@ import { interpolate } from '../../../tasks-runner/utils';
 import { workspaceRoot } from '../../../utils/workspace-root';
 
 export function resolveChangelogRenderer(
-  changelogRendererPath: string
+  changelogRendererPathOrImplementation: string | typeof ChangelogRenderer
 ): typeof ChangelogRenderer {
-  const interpolatedChangelogRendererPath = interpolate(changelogRendererPath, {
-    workspaceRoot,
-  });
+  // An implementation was provided directly via the programmatic API
+  if (typeof changelogRendererPathOrImplementation === 'function') {
+    return changelogRendererPathOrImplementation;
+  }
+
+  const interpolatedChangelogRendererPath = interpolate(
+    changelogRendererPathOrImplementation,
+    {
+      workspaceRoot,
+    }
+  );
 
   // Try and load the provided (or default) changelog renderer
   let ChangelogRendererClass: typeof ChangelogRenderer;

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import type ChangelogRenderer from '../../release/changelog-renderer';
 import type { ChangelogRenderOptions } from '../../release/changelog-renderer';
 import type { validReleaseVersionPrefixes } from '../command-line/release/utils/release-graph';
 import { readJsonFile } from '../utils/fileutils';
@@ -262,12 +263,17 @@ export interface NxReleaseChangelogConfiguration {
    */
   file?: string | false;
   /**
-   * A path to a valid changelog renderer function used to transform commit messages and other metadata into
-   * the final changelog (usually in markdown format). Its output can be modified using the optional `renderOptions`.
+   * If using nx.json, this can be a path to a valid changelog renderer function used to transform commit messages and
+   * other metadata into the final changelog (usually in markdown format). Its output can be modified using the optional
+   * `renderOptions`.
    *
-   * By default, the renderer is set to "nx/release/changelog-renderer" which nx provides out of the box.
+   * If configuring using a custom `ReleaseClient` via the programmatic API, you can either provide a path or directly
+   * provide the implementation class itself.
+   *
+   * By default, the renderer is set to the DefaultChangelogRenderer implementation from "nx/release/changelog-renderer",
+   * which nx provides out of the box.
    */
-  renderer?: string;
+  renderer?: string | typeof ChangelogRenderer;
   renderOptions?: ChangelogRenderOptions;
 }
 

--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -201,7 +201,8 @@ export const webpack = async (
   );
   const finalConfig = configure(baseWebpackConfig, {
     options: builderOptions,
-    context: { root: workspaceRoot } as ExecutorContext, // The context is not used here.
+    // TODO(JamesHenry): replace as any type assertion with as ExecutorContext once the nx repo is updated to use https://github.com/nrwl/nx/pull/33095
+    context: { root: workspaceRoot } as any, // The context is not used here.
   });
 
   return {

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -30,7 +30,8 @@ export default async function* moduleFederationDevServer(
         },
         context
       )
-    : devServerExecutor(options, context);
+    : // TODO(JamesHenry): remove type assertion once the nx repo is updated to use https://github.com/nrwl/nx/pull/33095
+      devServerExecutor(options, context as any);
 
   const p = context.projectsConfigurations.projects[context.projectName];
 

--- a/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -17,7 +17,8 @@ export default async function* moduleFederationSsrDevServer(
   context: ExecutorContext
 ) {
   const options = normalizeOptions(ssrDevServerOptions);
-  let iter: any = ssrDevServerExecutor(options, context);
+  // TODO(JamesHenry): remove type assertion once the nx repo is updated to use https://github.com/nrwl/nx/pull/33095
+  let iter: any = ssrDevServerExecutor(options, context as any);
   const projectConfig =
     context.projectsConfigurations.projects[context.projectName];
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

A custom changelog renderer can be provided exclusively via a path.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

A custom changelog renderer can be provided as either a path or, if using a custom `ReleaseClient` via the programmatic API, as the implementation class directly.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
