### PR TITLE
fix(core): format catalog definition files when appropriate in `nx migrate`

### DIFF
--- a/packages/devkit/src/utils/catalog/index.ts
+++ b/packages/devkit/src/utils/catalog/index.ts
@@ -2,7 +2,7 @@ import { readJson, type Tree } from 'nx/src/devkit-exports';
 import { getCatalogManager } from './manager-factory';
 import type { CatalogManager } from './manager';
 
-export { getCatalogManager };
+export { type CatalogManager, getCatalogManager };
 
 /**
  * Detects which packages in a package.json use catalog references

--- a/packages/nx/src/utils/catalog/index.ts
+++ b/packages/nx/src/utils/catalog/index.ts
@@ -3,7 +3,7 @@ import { readJson } from '../../generators/utils/json';
 import type { CatalogManager } from './manager';
 import { getCatalogManager } from './manager-factory';
 
-export { getCatalogManager };
+export { type CatalogManager, getCatalogManager };
 
 /**
  * Detects which packages in a package.json use catalog references

--- a/packages/nx/src/utils/catalog/manager.ts
+++ b/packages/nx/src/utils/catalog/manager.ts
@@ -12,6 +12,8 @@ export interface CatalogManager {
 
   parseCatalogReference(version: string): CatalogReference | null;
 
+  getCatalogDefinitionFilePaths(): string[];
+
   /**
    * Get catalog definitions from the workspace.
    */

--- a/packages/nx/src/utils/catalog/pnpm-manager.ts
+++ b/packages/nx/src/utils/catalog/pnpm-manager.ts
@@ -34,6 +34,10 @@ export class PnpmCatalogManager implements CatalogManager {
     };
   }
 
+  getCatalogDefinitionFilePaths(): string[] {
+    return ['pnpm-workspace.yaml'];
+  }
+
   getCatalogDefinitions(treeOrRoot: Tree | string): PnpmWorkspaceYaml | null {
     if (typeof treeOrRoot === 'string') {
       const pnpmWorkspacePath = join(treeOrRoot, 'pnpm-workspace.yaml');


### PR DESCRIPTION
Formats the `pnpm-workspace.yaml` when catalog definitions are updated after running `nx migrate`. Like the rest of the Catalog feature, it's agnostic to the package manager, allowing for an easier addition of support for future package managers.