### PR TITLE
feat(nx-dev): add v22 to version picker

### DIFF
--- a/astro-docs/src/components/layout/Header.astro
+++ b/astro-docs/src/components/layout/Header.astro
@@ -19,7 +19,8 @@ const nxDevUrl = import.meta.env.SITE || 'https://nx.dev';
 
 // Version options
 const versions = [
-  { version: 'v21', href: '/docs/getting-started/intro', current: true },
+  { version: 'v22', href: '/docs/getting-started/intro', current: true },
+  { version: 'v21', href: 'https://21.nx.dev/docs' },
   { version: 'v20', href: 'https://20.nx.dev/docs' },
   { version: 'v19', href: 'https://19.nx.dev/docs' },
 ];


### PR DESCRIPTION
In preparation for v22, add the new version to the docs header.