### PR TITLE
cleanup(misc): fix nightly e2e test failures due to npm peer deps conflicts

### DIFF
--- a/e2e/next/src/next-jest-config.test.ts
+++ b/e2e/next/src/next-jest-config.test.ts
@@ -10,7 +10,7 @@ describe('Next.js Jest Configuration', () => {
   let proj: string;
 
   beforeAll(() => {
-    proj = newProject();
+    proj = newProject({ packages: ['@nx/next'] });
   });
 
   afterAll(() => cleanupProject());

--- a/e2e/nx/src/affected-graph.test.ts
+++ b/e2e/nx/src/affected-graph.test.ts
@@ -20,7 +20,7 @@ import { join } from 'path';
 describe('Nx Affected and Graph Tests', () => {
   let proj: string;
 
-  beforeAll(() => (proj = newProject()));
+  beforeAll(() => (proj = newProject({ packages: ['@nx/js', '@nx/web'] })));
   afterAll(() => cleanupProject());
 
   describe('affected:*', () => {
@@ -530,7 +530,7 @@ describe('Nx Affected and Graph Tests', () => {
 describe('show projects --affected', () => {
   let proj: string;
 
-  beforeAll(() => (proj = newProject()));
+  beforeAll(() => (proj = newProject({ packages: ['@nx/js', '@nx/web'] })));
   afterAll(() => cleanupProject());
 
   it('should print information about affected projects', async () => {

--- a/e2e/nx/src/run.test.ts
+++ b/e2e/nx/src/run.test.ts
@@ -631,7 +631,7 @@ describe('Nx Running Tests', () => {
   describe('run-many', () => {
     it('should build specific and all projects', () => {
       // This is required to ensure the numbers used in the assertions make sense for this test
-      const proj = newProject();
+      const proj = newProject({ packages: ['@nx/js', '@nx/node', '@nx/web'] });
       const appA = uniq('appa-rand');
       const libA = uniq('liba-rand');
       const libB = uniq('libb-rand');

--- a/e2e/nx/src/workspace.test.ts
+++ b/e2e/nx/src/workspace.test.ts
@@ -189,7 +189,7 @@ describe('@nx/workspace:convert-to-monorepo', () => {
 
 describe('Workspace Tests', () => {
   beforeAll(() => {
-    proj = newProject();
+    proj = newProject({ packages: ['@nx/workspace', '@nx/js'] });
   });
 
   afterAll(() => cleanupProject());

--- a/e2e/plugin/src/nx-plugin.test.ts
+++ b/e2e/plugin/src/nx-plugin.test.ts
@@ -26,7 +26,7 @@ describe('Nx Plugin', () => {
   let workspaceName: string;
 
   beforeAll(() => {
-    workspaceName = newProject();
+    workspaceName = newProject({ packages: ['@nx/plugin'] });
   });
 
   afterAll(() => cleanupProject());

--- a/e2e/react/src/module-federation/federate-module.rspack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.rspack.test.ts
@@ -14,7 +14,7 @@ describe('Federate Module', () => {
   let proj: string;
 
   beforeAll(() => {
-    proj = newProject();
+    proj = newProject({ packages: ['@nx/react', '@nx/js'] });
   });
 
   afterAll(() => cleanupProject());

--- a/e2e/react/src/module-federation/federate-module.webpack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.webpack.test.ts
@@ -14,7 +14,7 @@ describe('Federate Module', () => {
   let proj: string;
 
   beforeAll(() => {
-    proj = newProject();
+    proj = newProject({ packages: ['@nx/react', '@nx/js'] });
   });
 
   afterAll(() => cleanupProject());

--- a/e2e/react/src/module-federation/independent-deployability.rspack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.rspack.test.ts
@@ -16,7 +16,7 @@ describe('Independent Deployability', () => {
   let proj: string;
 
   beforeAll(() => {
-    proj = newProject();
+    proj = newProject({ packages: ['@nx/react', '@nx/js'] });
   });
 
   afterAll(() => {

--- a/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
@@ -16,7 +16,7 @@ describe('Independent Deployability', () => {
   let proj: string;
   beforeAll(() => {
     process.env.NX_ADD_PLUGINS = 'false';
-    proj = newProject();
+    proj = newProject({ packages: ['@nx/react', '@nx/js'] });
   });
 
   afterAll(() => {

--- a/e2e/rollup/src/rollup.test.ts
+++ b/e2e/rollup/src/rollup.test.ts
@@ -182,7 +182,7 @@ describe('Rollup Plugin', () => {
 
   it('should work correctly with custom, non-Nx rollup config', () => {
     // ARRANGE
-    packageInstall('@rollup/plugin-babel', undefined, '5.3.0', 'prod');
+    packageInstall('@rollup/plugin-babel', undefined, '6.1.0', 'prod');
     packageInstall('@rollup/plugin-commonjs', undefined, '25.0.7', 'prod');
     packageInstall('rollup-plugin-typescript2', undefined, '0.36.0', 'prod');
     runCLI(`generate @nx/js:init --no-interactive`);

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -66,6 +66,7 @@ const nxPackages = [
   `@nx/react-native`,
   `@nx/expo`,
   '@nx/dotnet',
+  `@nx/workspace`,
 ] as const;
 
 type NxPackage = (typeof nxPackages)[number];

--- a/packages/react-native/src/generators/library/library.spec.ts
+++ b/packages/react-native/src/generators/library/library.spec.ts
@@ -499,7 +499,7 @@ describe('lib', () => {
           "main": "./src/index.ts",
           "name": "@proj/my-lib",
           "peerDependencies": {
-            "react": "19.0.0",
+            "react": "^19.0.0",
             "react-native": "~0.79.3",
           },
           "types": "./src/index.ts",
@@ -625,7 +625,7 @@ describe('lib', () => {
             }
           },
           "peerDependencies": {
-            "react": "19.0.0",
+            "react": "^19.0.0",
             "react-native": "~0.79.3"
           }
         }

--- a/packages/react-native/src/utils/versions.ts
+++ b/packages/react-native/src/utils/versions.ts
@@ -14,13 +14,13 @@ export const reactNativeWebVersion = '~0.20.0';
 
 export const metroVersion = '~0.82.4';
 
-export const reactVersion = '19.0.0';
-export const reactDomVersion = '19.0.0';
-export const typesReactVersion = '~19.0.10';
-export const typesReactDomVersion = '~19.0.6';
+export const reactVersion = '^19.0.0';
+export const reactDomVersion = '^19.0.0';
+export const typesReactVersion = '^19.0.10';
+export const typesReactDomVersion = '^19.0.6';
 
 export const testingLibraryReactNativeVersion = '~13.2.0';
-export const reactTestRendererVersion = '~19.0.0';
+export const reactTestRendererVersion = '^19.2.0';
 
 export const reactNativeSvgTransformerVersion = '~1.5.1';
 export const reactNativeSvgVersion = '~15.11.2';


### PR DESCRIPTION
Fix a few failing e2e nightly tests due to npm peer dep conflicts.

Reduced nightly run with the fixed test suites: https://github.com/nrwl/nx/actions/runs/18651446735. Most of them still fail, but with existing failures unrelated to npm peer deps issues. These are not part of the Golden nightly tests yet.