### PR TITLE
fix(core): avoid changing existing project name if a project.json file is added to a project

### DIFF
--- a/packages/angular/src/generators/ng-add/migrators/projects/e2e.migrator.spec.ts
+++ b/packages/angular/src/generators/ng-add/migrators/projects/e2e.migrator.spec.ts
@@ -43,7 +43,9 @@ describe('e2e migrator', () => {
     config: ProjectConfiguration
   ): MigrationProjectConfiguration {
     config.projectType = 'application';
-    writeJson(tree, `apps/${name}/project.json`, config);
+    config.name ??= name;
+
+    writeJson(tree, `${config.root}/project.json`, config);
     tree.write(`${config.root}/README.md`, '');
     tree.write(`${config.sourceRoot}/main.ts`, '');
 
@@ -62,9 +64,6 @@ describe('e2e migrator', () => {
     logger?: Logger
   ): void {
     migrator = new E2eMigrator(tree, {}, project, lintTargetName, logger);
-    // the app migrator does this before invoking e2e migrator, it's an implementation
-    // detail for now until the e2e migrator is split into builder migrators
-    project.config.root = 'apps/app1';
   }
 
   beforeEach(() => {

--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -279,6 +279,20 @@ function readAndCombineAllProjectConfigurations(tree: Tree): {
     if (basename(projectFile) === 'project.json') {
       const json = readJson(tree, projectFile);
       const config = buildProjectFromProjectJson(json, projectFile);
+      if (!config.name) {
+        try {
+          const packageJson = readJson<PackageJson>(
+            tree,
+            joinPathFragments(config.root, 'package.json')
+          );
+          if (packageJson.name) {
+            config.name = packageJson.name;
+          }
+        } catch {
+          // Maybe no package json, is ok.
+        }
+        config.name ??= toProjectName(projectFile);
+      }
       mergeProjectConfigurationIntoRootMap(
         rootMap,
         config,
@@ -286,7 +300,8 @@ function readAndCombineAllProjectConfigurations(tree: Tree): {
         undefined,
         true
       );
-    } else if (basename(projectFile) === 'package.json') {
+    }
+    if (basename(projectFile) === 'package.json') {
       const packageJson = readJson<PackageJson>(tree, projectFile);
 
       // We don't want to have all of the extra inferred stuff in here, as

--- a/packages/nx/src/plugins/package-json/create-nodes.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.ts
@@ -202,7 +202,7 @@ export function buildProjectConfigurationFromPackageJson(
     }
   }
 
-  if (!packageJson.name && projectRoot === '.') {
+  if (!packageJson.name && projectRoot === '.' && !packageJson.nx?.name) {
     throw new Error(
       'Nx requires the root package.json to specify a name if it is being used as an Nx project.'
     );

--- a/packages/nx/src/plugins/project-json/build-nodes/project-json.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/project-json.ts
@@ -1,13 +1,11 @@
 import { dirname, join } from 'node:path';
 
 import { ProjectConfiguration } from '../../../config/workspace-json-project-json';
-import { toProjectName } from '../../../config/to-project-name';
 import { readJsonFile } from '../../../utils/fileutils';
 import {
   createNodesFromFiles,
   NxPluginV2,
 } from '../../../project-graph/plugins';
-import { PackageJson } from '../../../utils/package-json';
 
 export const ProjectJsonProjectsPlugin: NxPluginV2 = {
   name: 'nx/core/project-json',
@@ -42,21 +40,10 @@ export function buildProjectFromProjectJson(
   json: Partial<ProjectConfiguration>,
   path: string
 ): ProjectConfiguration {
-  const packageJsonPath = join(dirname(path), 'package.json');
   const { name, root, ...rest } = json;
   return {
-    name:
-      name ?? readNameFromPackageJson(packageJsonPath) ?? toProjectName(path),
+    name,
     root: root ?? dirname(path),
     ...rest,
   };
-}
-
-export function readNameFromPackageJson(path: string): string {
-  try {
-    const json = readJsonFile<PackageJson>(path);
-    return json.nx?.name ?? json.name;
-  } catch {
-    return undefined;
-  }
 }


### PR DESCRIPTION
## Current Behavior
When adding a `project.json` file to configure certain aspects of an existing Nx project, that project's name will be changed. We had to fix this for package-json based projects a while back, and as we expand polyglot its coming up again.

## Expected Behavior
The "default name" behavior stamped into the project.json plugin doesn't trample existing names. To do this, it had to be moved out of the project.json plugin and into the validate + normalize flow

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
