### PR TITLE
feat(storybook): add watch-deps and build-deps targets

### DIFF
--- a/packages/storybook/src/generators/init/init.ts
+++ b/packages/storybook/src/generators/init/init.ts
@@ -127,6 +127,16 @@ export async function initGeneratorInternal(tree: Tree, schema: Schema) {
           'static:storybook',
           'storybook:static',
         ],
+        buildDepsTargetName: [
+          'build-deps',
+          'storybook:build-deps',
+          'storybook-build-deps',
+        ],
+        watchDepsTargetName: [
+          'watch-deps',
+          'storybook:watch-deps',
+          'storybook-watch-deps',
+        ],
       },
       schema.updatePackageScripts
     );

--- a/packages/storybook/src/plugins/plugin.spec.ts
+++ b/packages/storybook/src/plugins/plugin.spec.ts
@@ -38,7 +38,6 @@ describe('@nx/storybook/plugin', () => {
   afterEach(() => {
     jest.resetModules();
     tempFs.cleanup();
-    tempFs = null;
   });
 
   it('should create nodes', async () => {
@@ -59,6 +58,8 @@ describe('@nx/storybook/plugin', () => {
         staticStorybookTargetName: 'static-storybook',
         serveStorybookTargetName: 'serve-storybook',
         testStorybookTargetName: 'test-storybook',
+        buildDepsTargetName: 'build-deps',
+        watchDepsTargetName: 'watch-deps',
       },
       context
     );
@@ -72,6 +73,11 @@ describe('@nx/storybook/plugin', () => {
               "my-app": {
                 "root": "my-app",
                 "targets": {
+                  "build-deps": {
+                    "dependsOn": [
+                      "^build",
+                    ],
+                  },
                   "build-storybook": {
                     "cache": true,
                     "command": "storybook build",
@@ -112,6 +118,13 @@ describe('@nx/storybook/plugin', () => {
                       "staticFilePath": "my-app/storybook-static",
                     },
                   },
+                  "watch-deps": {
+                    "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+                    "continuous": true,
+                    "dependsOn": [
+                      "build-deps",
+                    ],
+                  },
                 },
               },
             },
@@ -139,6 +152,8 @@ describe('@nx/storybook/plugin', () => {
         staticStorybookTargetName: 'static-storybook',
         serveStorybookTargetName: 'serve-storybook',
         testStorybookTargetName: 'test-storybook',
+        buildDepsTargetName: 'build-deps',
+        watchDepsTargetName: 'watch-deps',
       },
       context
     );
@@ -152,6 +167,11 @@ describe('@nx/storybook/plugin', () => {
               "my-ng-app": {
                 "root": "my-ng-app",
                 "targets": {
+                  "build-deps": {
+                    "dependsOn": [
+                      "^build",
+                    ],
+                  },
                   "build-storybook": {
                     "cache": true,
                     "executor": "@storybook/angular:build-storybook",
@@ -198,6 +218,13 @@ describe('@nx/storybook/plugin', () => {
                       "staticFilePath": "my-ng-app/storybook-static",
                     },
                   },
+                  "watch-deps": {
+                    "command": "npx nx watch --projects my-ng-app --includeDependentProjects -- npx nx build-deps my-ng-app",
+                    "continuous": true,
+                    "dependsOn": [
+                      "build-deps",
+                    ],
+                  },
                 },
               },
             },
@@ -229,6 +256,8 @@ describe('@nx/storybook/plugin', () => {
         staticStorybookTargetName: 'static-storybook',
         serveStorybookTargetName: 'serve-storybook',
         testStorybookTargetName: 'test-storybook',
+        buildDepsTargetName: 'build-deps',
+        watchDepsTargetName: 'watch-deps',
       },
       context
     );
@@ -242,6 +271,11 @@ describe('@nx/storybook/plugin', () => {
               "my-react-lib": {
                 "root": "my-react-lib",
                 "targets": {
+                  "build-deps": {
+                    "dependsOn": [
+                      "^build",
+                    ],
+                  },
                   "build-storybook": {
                     "cache": true,
                     "command": "storybook build",
@@ -281,6 +315,13 @@ describe('@nx/storybook/plugin', () => {
                       "buildTarget": "build-storybook",
                       "staticFilePath": "my-react-lib/storybook-static",
                     },
+                  },
+                  "watch-deps": {
+                    "command": "npx nx watch --projects my-react-lib --includeDependentProjects -- npx nx build-deps my-react-lib",
+                    "continuous": true,
+                    "dependsOn": [
+                      "build-deps",
+                    ],
                   },
                 },
               },

--- a/packages/storybook/src/plugins/plugin.ts
+++ b/packages/storybook/src/plugins/plugin.ts
@@ -4,6 +4,7 @@ import {
   createNodesFromFiles,
   CreateNodesV2,
   detectPackageManager,
+  getPackageManagerCommand,
   joinPathFragments,
   parseJson,
   readJsonFile,
@@ -20,12 +21,17 @@ import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
 import type { StorybookConfig } from 'storybook/internal/types';
 import { hashObject } from 'nx/src/hasher/file-hasher';
 import { tsquery } from '@phenomnomnominal/tsquery';
+import { addBuildAndWatchDepsTargets } from '@nx/js/src/plugins/typescript/util';
+
+const pmc = getPackageManagerCommand();
 
 export interface StorybookPluginOptions {
   buildStorybookTargetName?: string;
   serveStorybookTargetName?: string;
   staticStorybookTargetName?: string;
   testStorybookTargetName?: string;
+  buildDepsTargetName?: string;
+  watchDepsTargetName?: string;
 }
 
 function readTargetsCache(
@@ -187,6 +193,14 @@ async function buildStorybookTargets(
   targets[options.staticStorybookTargetName] = serveStaticTarget(
     options,
     projectRoot
+  );
+
+  addBuildAndWatchDepsTargets(
+    context.workspaceRoot,
+    projectRoot,
+    targets,
+    options,
+    pmc
   );
 
   return targets;
@@ -400,6 +414,8 @@ function normalizeOptions(
       options.testStorybookTargetName ?? 'test-storybook',
     staticStorybookTargetName:
       options.staticStorybookTargetName ?? 'static-storybook',
+    buildDepsTargetName: options.buildDepsTargetName ?? 'build-deps',
+    watchDepsTargetName: options.watchDepsTargetName ?? 'watch-deps',
   };
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Right now if you have a project that doesn't use another plugin like Vite or something that adds the `watch-deps` etc targets, you cannot run watching and automatic rebuilding of child libraries when serving storybook. This came out of a Discord question and seems legit.

More: https://x.com/juristr/status/1979117054759219384

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

This PR makes sure `watch-deps` and `build-deps` are added also for Storybook targets.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
