### PR TITLE
fix(graph): prevent content from overflowing in the PDV component

### DIFF
--- a/graph/ui-project-details/src/lib/target-configuration-details-header/target-configuration-details-header.tsx
+++ b/graph/ui-project-details/src/lib/target-configuration-details-header/target-configuration-details-header.tsx
@@ -72,15 +72,17 @@ export const TargetConfigurationDetailsHeader = ({
       onClick={collapsable ? toggleCollapse : undefined}
     >
       <div className="flex items-center justify-between gap-4">
-        <div className="flex min-w-0 flex-1 items-center justify-between">
-          <div className="flex min-w-0 flex-1 items-center gap-2">
+        <div className="flex w-full min-w-0 flex-1 items-center justify-between overflow-hidden">
+          <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
             {collapsable &&
               (isCollasped ? (
                 <ChevronDownIcon className="h-3 w-3" />
               ) : (
                 <ChevronUpIcon className="h-3 w-3" />
               ))}
-            <h3 className="font-medium dark:text-slate-300">{targetName}</h3>
+            <h3 className="min-w-0 truncate font-medium dark:text-slate-300">
+              {targetName}
+            </h3>
             <TargetTechnologies
               technologies={targetConfiguration.metadata?.technologies}
               showTooltip={!isCollasped}


### PR DESCRIPTION
This PR fixes and issue where content was overflowing in PDV when the command is too long.

<img width="809" height="518" alt="image" src="https://github.com/user-attachments/assets/113285fe-8d93-4ad2-bbac-b2992a065a4e" />


Fixes DOC-243
