### PR TITLE
fix(core): allow prerelease versions of nx to be used with devkit

### DIFF
--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -41,7 +41,7 @@
     "nx": "workspace:*"
   },
   "peerDependencies": {
-    "nx": ">= 21 <= 23"
+    "nx": ">= 21 <= 23 || ^22.0.0-0"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -525,7 +525,7 @@ function hackFixForDevkitPeerDependencies() {
     );
     devkitPackageJson.peerDependencies['nx'] = `>= ${majorVersion - 1} <= ${
       majorVersion + 1
-    }`;
+    } || ^${majorVersion}.0.0-0`;
     writeFileSync(
       './dist/packages/devkit/package.json',
       JSON.stringify(devkitPackageJson, null, 2)


### PR DESCRIPTION
This PR fixes an issue where due to the removal or `--legacy-peer-deps` for NPM, you can no longer install prerelease versions of Nx. This also means `npx create-nx-workspace@next` cannot be used with NPM.

For example, if you have this `package.json`:

```json
{
  "dependencies": {
    "nx": "22.0.0-beta.4",
    "@nx/devkit": "22.0.0-beta.4"
  },
  "license": "MIT"
}
```

And tried `npm install`, it will error out with:

```
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: undefined@undefined
npm error Found: nx@22.0.0-beta.1
npm error node_modules/nx
npm error   nx@"22.0.0-beta.1" from the root project
npm error
npm error Could not resolve dependency:
npm error peer nx@">= 21 <= 23" from @nx/devkit@22.0.0-beta.1
npm error node_modules/@nx/devkit
npm error   @nx/devkit@"22.0.0-beta.1" from the root project
```

By allowing prereleases via `^22.0.0-0` NPM can work again.

Note: pnpm and yarn are fine.