### PR TITLE
fix(core): restore migrations used by `nx repair`

### DIFF
--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -1,5 +1,42 @@
 {
   "generators": {
+    "16.0.0-remove-nrwl-cli": {
+      "cli": "nx",
+      "version": "16.0.0-beta.0",
+      "description": "Remove @nrwl/cli.",
+      "implementation": "./src/migrations/update-16-0-0/remove-nrwl-cli"
+    },
+    "16.0.0-tokens-for-depends-on": {
+      "cli": "nx",
+      "version": "16.0.0-beta.9",
+      "description": "Replace `dependsOn.projects` and `inputs` definitions with new configuration format.",
+      "implementation": "./src/migrations/update-16-0-0/update-depends-on-to-tokens"
+    },
+    "16.0.0-update-nx-cloud-runner": {
+      "cli": "nx",
+      "version": "16.0.0-beta.0",
+      "description": "Replace @nrwl/nx-cloud with nx-cloud",
+      "implementation": "./src/migrations/update-16-0-0/update-nx-cloud-runner"
+    },
+    "16.2.0-remove-output-path-from-run-commands": {
+      "cli": "nx",
+      "version": "16.2.0-beta.0",
+      "description": "Remove outputPath from run commands",
+      "implementation": "./src/migrations/update-16-2-0/remove-run-commands-output-path"
+    },
+    "16.6.0-prefix-outputs": {
+      "cli": "nx",
+      "version": "16.6.0-beta.6",
+      "description": "Prefix outputs with {workspaceRoot}/{projectRoot} if needed",
+      "implementation": "./src/migrations/update-15-0-0/prefix-outputs"
+    },
+    "16.8.0-escape-dollar-sign-env": {
+      "cli": "nx",
+      "version": "16.8.0-beta.3",
+      "description": "Escape $ in env variables",
+      "implementation": "./src/migrations/update-16-8-0/escape-dollar-sign-env-variables",
+      "x-repair-skip": true
+    },
     "17.0.0-move-cache-directory": {
       "cli": "nx",
       "version": "17.0.0-beta.1",

--- a/packages/nx/src/migrations/update-15-0-0/prefix-outputs.spec.ts
+++ b/packages/nx/src/migrations/update-15-0-0/prefix-outputs.spec.ts
@@ -1,0 +1,192 @@
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import type { Tree } from '../../generators/tree';
+import {
+  addProjectConfiguration,
+  readNxJson,
+  readProjectConfiguration,
+  updateNxJson,
+} from '../../generators/utils/project-configuration';
+import { readJson, writeJson } from '../../generators/utils/json';
+import prefixOutputs from './prefix-outputs';
+import { validateOutputs } from '../../tasks-runner/utils';
+
+describe('15.0.0 migration (prefix-outputs)', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('should prefix project outputs', async () => {
+    addProjectConfiguration(tree, 'proj', {
+      root: 'proj',
+      targets: {
+        build: {
+          executor: 'nx:run-commands',
+          outputs: [
+            'dist',
+            'dist/{projectRoot}',
+            'dist/{projectRoot}/**/*.js',
+            'proj/coverage',
+            './test-results',
+            '{projectRoot}/build',
+            '{options.outputDirectory}',
+          ],
+          options: {},
+        },
+      },
+    });
+
+    await prefixOutputs(tree);
+
+    const updated = readProjectConfiguration(tree, 'proj');
+
+    expect(updated.targets.build.outputs).toEqual([
+      '{workspaceRoot}/dist',
+      '{workspaceRoot}/dist/{projectRoot}',
+      '{workspaceRoot}/dist/{projectRoot}/**/*.js',
+      '{projectRoot}/coverage',
+      '{projectRoot}/test-results',
+      '{projectRoot}/build',
+      '{options.outputDirectory}',
+    ]);
+
+    expect(() => validateOutputs(updated.targets.build.outputs)).not.toThrow();
+  });
+
+  it('should prefix target default outputs', async () => {
+    const nxJson = readNxJson(tree);
+    updateNxJson(tree, {
+      ...nxJson,
+      targetDefaults: {
+        build: {
+          outputs: ['dist', '{projectRoot}/build', '{options.outputPath}'],
+        },
+      },
+    });
+
+    await prefixOutputs(tree);
+
+    const updated = readNxJson(tree);
+
+    expect(updated.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "build": {
+          "outputs": [
+            "{workspaceRoot}/dist",
+            "{projectRoot}/build",
+            "{options.outputPath}",
+          ],
+        },
+      }
+    `);
+  });
+
+  it('should migrate package.json projects', async () => {
+    writeJson(tree, 'proj/package.json', {
+      name: 'proj',
+      scripts: {
+        build: 'echo',
+      },
+      nx: {
+        targets: {
+          build: {
+            outputs: ['dist/proj', 'proj/build'],
+          },
+        },
+      },
+    });
+    tree.delete('workspace.json');
+
+    await prefixOutputs(tree);
+
+    expect(readJson(tree, 'proj/package.json').nx.targets.build).toEqual({
+      outputs: ['{workspaceRoot}/dist/proj', '{projectRoot}/build'],
+    });
+  });
+
+  it('should not error for package.json projects', async () => {
+    writeJson(tree, 'proj/package.json', {
+      name: 'proj',
+      scripts: {
+        build: 'echo',
+      },
+    });
+    tree.delete('workspace.json');
+
+    await prefixOutputs(tree);
+  });
+
+  it('should handle negated outputs', async () => {
+    const nxJson = readNxJson(tree);
+    updateNxJson(tree, {
+      ...nxJson,
+      targetDefaults: {
+        build: {
+          outputs: ['!dist', '{projectRoot}/build', '{options.outputPath}'],
+        },
+      },
+    });
+
+    await prefixOutputs(tree);
+
+    const updated = readNxJson(tree);
+
+    expect(updated.targetDefaults).toMatchInlineSnapshot(`
+      {
+        "build": {
+          "outputs": [
+            "!{workspaceRoot}/dist",
+            "{projectRoot}/build",
+            "{options.outputPath}",
+          ],
+        },
+      }
+    `);
+  });
+});
+
+describe('15.0.0 migration (prefix-outputs) (v1)', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('should prefix project outputs', async () => {
+    addProjectConfiguration(tree, 'proj', {
+      root: 'proj',
+      targets: {
+        build: {
+          executor: 'nx:run-commands',
+          outputs: [
+            'dist',
+            'dist/{projectRoot}',
+            'dist/{projectRoot}/**/*.js',
+            'proj/coverage',
+            './test-results',
+            '{projectRoot}/build',
+            '{options.outputDirectory}',
+          ],
+          options: {},
+        },
+      },
+    });
+
+    await prefixOutputs(tree);
+
+    const updated = readProjectConfiguration(tree, 'proj');
+
+    expect(updated.targets.build.outputs).toEqual([
+      '{workspaceRoot}/dist',
+      '{workspaceRoot}/dist/{projectRoot}',
+      '{workspaceRoot}/dist/{projectRoot}/**/*.js',
+      '{projectRoot}/coverage',
+      '{projectRoot}/test-results',
+      '{projectRoot}/build',
+      '{options.outputDirectory}',
+    ]);
+
+    expect(() => validateOutputs(updated.targets.build.outputs)).not.toThrow();
+  });
+});

--- a/packages/nx/src/migrations/update-15-0-0/prefix-outputs.ts
+++ b/packages/nx/src/migrations/update-15-0-0/prefix-outputs.ts
@@ -1,0 +1,69 @@
+import { Tree } from '../../generators/tree';
+import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
+import {
+  getProjects,
+  updateProjectConfiguration,
+} from '../../generators/utils/project-configuration';
+import { readNxJson, updateNxJson } from '../../generators/utils/nx-json';
+import { joinPathFragments } from '../../utils/path';
+import { join } from 'path';
+import {
+  transformLegacyOutputs,
+  validateOutputs,
+} from '../../tasks-runner/utils';
+import { updateJson } from '../../generators/utils/json';
+import { PackageJson } from '../../utils/package-json';
+
+export default async function (tree: Tree) {
+  // If the workspace doesn't have a nx.json, don't make any changes
+  if (!tree.exists('nx.json')) {
+    return;
+  }
+
+  const nxJson = readNxJson(tree);
+
+  for (const [projectName, project] of getProjects(tree)) {
+    for (const [_, target] of Object.entries(project.targets ?? {})) {
+      if (!target.outputs) {
+        continue;
+      }
+
+      target.outputs = transformLegacyOutputs(project.root, target.outputs);
+    }
+    try {
+      updateProjectConfiguration(tree, projectName, project);
+    } catch {
+      if (tree.exists(join(project.root, 'package.json'))) {
+        updateJson<PackageJson>(
+          tree,
+          join(project.root, 'package.json'),
+          (json) => {
+            for (const target of Object.values(json.nx?.targets ?? {})) {
+              if (target.outputs) {
+                target.outputs = transformLegacyOutputs(
+                  project.root,
+                  target.outputs
+                );
+              }
+            }
+
+            return json;
+          }
+        );
+      }
+    }
+  }
+
+  if (nxJson.targetDefaults) {
+    for (const [_, target] of Object.entries(nxJson.targetDefaults)) {
+      if (!target.outputs) {
+        continue;
+      }
+      target.outputs = transformLegacyOutputs('{projectRoot}', target.outputs);
+    }
+
+    updateNxJson(tree, nxJson);
+  }
+
+  await formatChangedFilesWithPrettierIfAvailable(tree);
+}

--- a/packages/nx/src/migrations/update-16-0-0/remove-nrwl-cli.ts
+++ b/packages/nx/src/migrations/update-16-0-0/remove-nrwl-cli.ts
@@ -1,0 +1,17 @@
+import { Tree } from '../../generators/tree';
+import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
+import { updateJson } from '../../generators/utils/json';
+
+export default async function (tree: Tree) {
+  updateJson(tree, 'package.json', (json) => {
+    for (const deps of [json.dependencies, json.devDependencies]) {
+      if (deps) {
+        delete deps['@nrwl/cli'];
+      }
+    }
+
+    return json;
+  });
+
+  await formatChangedFilesWithPrettierIfAvailable(tree);
+}

--- a/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.spec.ts
+++ b/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.spec.ts
@@ -1,0 +1,131 @@
+import {
+  addProjectConfiguration,
+  readNxJson,
+  readProjectConfiguration,
+} from '../../generators/utils/project-configuration';
+
+import update from './update-depends-on-to-tokens';
+import { updateJson, writeJson } from '../../generators/utils/json';
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import { assertRunsAgainstNxRepo } from '../../internal-testing-utils/run-migration-against-this-workspace';
+
+describe('update-depends-on-to-tokens', () => {
+  it('should update nx.json', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'nx.json', (json) => {
+      json.targetDefaults = {
+        build: {
+          dependsOn: [
+            {
+              projects: 'self',
+            },
+          ],
+          inputs: [{ projects: 'self', input: 'someInput' }],
+        },
+        test: {
+          dependsOn: [
+            {
+              projects: 'dependencies',
+            },
+          ],
+          inputs: [{ projects: 'dependencies', input: 'someInput' }],
+        },
+        other: {
+          dependsOn: ['^deps'],
+        },
+      };
+      return json;
+    });
+    await update(tree);
+    const nxJson = readNxJson(tree);
+    const buildDependencyConfiguration = nxJson.targetDefaults.build
+      .dependsOn[0] as any;
+    const testDependencyConfiguration = nxJson.targetDefaults.test
+      .dependsOn[0] as any;
+    const buildInputConfiguration = nxJson.targetDefaults.build
+      .inputs[0] as any;
+    const testInputConfiguration = nxJson.targetDefaults.test.inputs[0] as any;
+    expect(buildDependencyConfiguration.projects).not.toBeDefined();
+    expect(buildDependencyConfiguration.dependencies).not.toBeDefined();
+    expect(buildInputConfiguration.projects).not.toBeDefined();
+    expect(buildInputConfiguration.dependencies).not.toBeDefined();
+    expect(testInputConfiguration.projects).not.toBeDefined();
+    expect(testInputConfiguration.dependencies).toEqual(true);
+    expect(testDependencyConfiguration.projects).not.toBeDefined();
+    expect(testDependencyConfiguration.dependencies).toEqual(true);
+    expect(nxJson.targetDefaults.other.dependsOn).toEqual(['^deps']);
+  });
+
+  it('should update project configurations', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'proj1', {
+      root: 'proj1',
+      targets: {
+        build: {
+          dependsOn: [
+            {
+              projects: 'self',
+              target: 'build',
+            },
+          ],
+          inputs: [{ projects: 'self', input: 'someInput' }],
+        },
+        test: {
+          dependsOn: [
+            {
+              projects: 'dependencies',
+              target: 'test',
+            },
+          ],
+          inputs: [{ projects: 'dependencies', input: 'someInput' }],
+        },
+        other: {
+          dependsOn: ['^deps'],
+        },
+      },
+    });
+    await update(tree);
+    const project = readProjectConfiguration(tree, 'proj1');
+    const buildDependencyConfiguration = project.targets.build
+      .dependsOn[0] as any;
+    const testDependencyConfiguration = project.targets.test
+      .dependsOn[0] as any;
+    const buildInputConfiguration = project.targets.build.inputs[0] as any;
+    const testInputConfiguration = project.targets.test.inputs[0] as any;
+    expect(buildDependencyConfiguration.projects).not.toBeDefined();
+    expect(buildDependencyConfiguration.dependencies).not.toBeDefined();
+    expect(buildInputConfiguration.projects).not.toBeDefined();
+    expect(buildInputConfiguration.dependencies).not.toBeDefined();
+    expect(testDependencyConfiguration.projects).not.toBeDefined();
+    expect(testDependencyConfiguration.dependencies).toEqual(true);
+    expect(testInputConfiguration.projects).not.toBeDefined();
+    expect(testInputConfiguration.dependencies).toEqual(true);
+    expect(project.targets.other.dependsOn).toEqual(['^deps']);
+    expect(project.targets.other.inputs).not.toBeDefined();
+  });
+
+  it('should not throw on nulls', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'proj1', {
+      root: 'proj1',
+    });
+    addProjectConfiguration(tree, 'proj2', {
+      root: 'proj2',
+      targets: {
+        build: {},
+      },
+    });
+    writeJson(tree, 'nx.json', {});
+    let promise = update(tree);
+    await expect(promise).resolves.toBeUndefined();
+    writeJson(tree, 'nx.json', {
+      targetDefaults: {
+        build: {},
+      },
+    });
+    promise = update(tree);
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  assertRunsAgainstNxRepo(update);
+});

--- a/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.ts
+++ b/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.ts
@@ -1,0 +1,119 @@
+import {
+  getProjects,
+  readNxJson,
+  updateNxJson,
+  updateProjectConfiguration,
+} from '../../generators/utils/project-configuration';
+import { Tree } from '../../generators/tree';
+import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
+
+export default async function (tree: Tree) {
+  updateDependsOnAndInputsInsideNxJson(tree);
+
+  const projectsConfigurations = getProjects(tree);
+  for (const [projectName, projectConfiguration] of projectsConfigurations) {
+    let projectChanged = false;
+    for (const [targetName, targetConfiguration] of Object.entries(
+      projectConfiguration.targets ?? {}
+    )) {
+      for (const dependency of targetConfiguration.dependsOn ?? []) {
+        if (typeof dependency !== 'string') {
+          if (
+            dependency.projects === 'self' ||
+            dependency.projects === '{self}'
+          ) {
+            delete dependency.projects;
+            projectChanged = true;
+          } else if (
+            dependency.projects === 'dependencies' ||
+            dependency.projects === '{dependencies}'
+          ) {
+            delete dependency.projects;
+            dependency.dependencies = true;
+            projectChanged = true;
+          }
+        }
+      }
+      for (let i = 0; i < (targetConfiguration.inputs?.length ?? 0); i++) {
+        const input = targetConfiguration.inputs[i];
+        if (typeof input !== 'string') {
+          if (
+            'projects' in input &&
+            (input.projects === 'self' || input.projects === '{self}')
+          ) {
+            delete input.projects;
+            projectChanged = true;
+          } else if (
+            'projects' in input &&
+            (input.projects === 'dependencies' ||
+              input.projects === '{dependencies}')
+          ) {
+            delete input.projects;
+            targetConfiguration.inputs[i] = {
+              ...input,
+              dependencies: true,
+            };
+            projectChanged = true;
+          }
+        }
+      }
+    }
+    if (projectChanged) {
+      updateProjectConfiguration(tree, projectName, projectConfiguration);
+    }
+  }
+
+  await formatChangedFilesWithPrettierIfAvailable(tree);
+}
+function updateDependsOnAndInputsInsideNxJson(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  let nxJsonChanged = false;
+  for (const [target, defaults] of Object.entries(
+    nxJson?.targetDefaults ?? {}
+  )) {
+    for (const dependency of defaults.dependsOn ?? []) {
+      if (typeof dependency !== 'string') {
+        if (
+          dependency.projects === 'self' ||
+          dependency.projects === '{self}'
+        ) {
+          delete dependency.projects;
+          nxJsonChanged = true;
+        } else if (
+          dependency.projects === 'dependencies' ||
+          dependency.projects === '{dependencies}'
+        ) {
+          delete dependency.projects;
+          dependency.dependencies = true;
+          nxJsonChanged = true;
+        }
+      }
+    }
+    for (let i = 0; i < (defaults.inputs?.length ?? 0); i++) {
+      const input = defaults.inputs[i];
+      if (typeof input !== 'string') {
+        if (
+          'projects' in input &&
+          (input.projects === 'self' || input.projects === '{self}')
+        ) {
+          delete input.projects;
+          nxJsonChanged = true;
+        } else if (
+          'projects' in input &&
+          (input.projects === 'dependencies' ||
+            input.projects === '{dependencies}')
+        ) {
+          delete input.projects;
+          defaults.inputs[i] = {
+            ...input,
+            dependencies: true,
+          };
+          nxJsonChanged = true;
+        }
+      }
+    }
+  }
+  if (nxJsonChanged) {
+    updateNxJson(tree, nxJson);
+  }
+}

--- a/packages/nx/src/migrations/update-16-0-0/update-nx-cloud-runner.ts
+++ b/packages/nx/src/migrations/update-16-0-0/update-nx-cloud-runner.ts
@@ -1,0 +1,34 @@
+import {
+  readNxJson,
+  updateNxJson,
+} from '../../generators/utils/project-configuration';
+import { Tree } from '../../generators/tree';
+import { updateJson } from '../../generators/utils/json';
+import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
+
+export default async function (tree: Tree) {
+  updateJson(tree, 'package.json', (json) => {
+    if (json.dependencies && json.dependencies['@nrwl/nx-cloud']) {
+      json.dependencies['nx-cloud'] = json.dependencies['@nrwl/nx-cloud'];
+      delete json.dependencies['@nrwl/nx-cloud'];
+    }
+
+    if (json.devDependencies && json.devDependencies['@nrwl/nx-cloud']) {
+      json.devDependencies['nx-cloud'] = json.devDependencies['@nrwl/nx-cloud'];
+      delete json.devDependencies['@nrwl/nx-cloud'];
+    }
+
+    return json;
+  });
+
+  const nxJson = readNxJson(tree);
+  if (!nxJson) return;
+  for (let opts of Object.values(nxJson.tasksRunnerOptions ?? {})) {
+    if (opts.runner === '@nrwl/nx-cloud') {
+      opts.runner = 'nx-cloud';
+    }
+  }
+  updateNxJson(tree, nxJson);
+
+  await formatChangedFilesWithPrettierIfAvailable(tree);
+}

--- a/packages/nx/src/migrations/update-16-2-0/remove-run-commands-output-path.spec.ts
+++ b/packages/nx/src/migrations/update-16-2-0/remove-run-commands-output-path.spec.ts
@@ -1,0 +1,102 @@
+import { TargetConfiguration } from '../../config/workspace-json-project-json';
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import { readJson, writeJson } from '../../generators/utils/json';
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+} from '../../generators/utils/project-configuration';
+import { assertRunsAgainstNxRepo } from '../../internal-testing-utils/run-migration-against-this-workspace';
+import removeRunCommandsOutputPath from './remove-run-commands-output-path';
+
+describe('removeRunCommandsOutputPath', () => {
+  it('should migrate target options correctly', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    const startingTargets: Record<string, TargetConfiguration> = {
+      build: {
+        executor: 'nx:run-commands',
+        outputs: ['{options.outputPath}'],
+        options: {
+          outputPath: 'dist/apps/my-app',
+          commands: [],
+        },
+      },
+      other: {
+        executor: 'nx:run-script',
+        options: {
+          script: 'start',
+        },
+      },
+    };
+    addProjectConfiguration(tree, 'my-app', {
+      root: 'apps/my-app',
+      targets: startingTargets,
+    });
+    removeRunCommandsOutputPath(tree);
+    const migratedTargets = readProjectConfiguration(tree, 'my-app').targets;
+    expect(migratedTargets.build).not.toEqual(startingTargets.build);
+    expect(migratedTargets.build).toEqual({
+      executor: 'nx:run-commands',
+      outputs: ['{workspaceRoot}/dist/apps/my-app'],
+      options: {
+        commands: [],
+      },
+    });
+    expect(migratedTargets.other).toEqual(startingTargets.other);
+  });
+
+  it('should handle null options correctly', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    const startingTargets: Record<string, TargetConfiguration> = {
+      build: {
+        executor: 'nx:run-commands',
+        outputs: ['dist/some/path'],
+      },
+    };
+    addProjectConfiguration(tree, 'my-app', {
+      root: 'apps/my-app',
+      targets: startingTargets,
+    });
+    expect(() => removeRunCommandsOutputPath(tree)).not.toThrow();
+    const migratedTargets = readProjectConfiguration(tree, 'my-app').targets;
+    expect(migratedTargets.build).toEqual(startingTargets.build);
+    expect(migratedTargets.other).toEqual(startingTargets.other);
+  });
+
+  it('should migrate target defaults correctly', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    const startingTargetDefaults: Record<string, TargetConfiguration> = {
+      build: {
+        executor: 'nx:run-commands',
+        outputs: ['{options.outputPath}'],
+        options: {
+          outputPath: 'dist/apps/my-app',
+          commands: [],
+        },
+      },
+      other: {
+        executor: 'nx:run-script',
+        options: {
+          script: 'start',
+        },
+      },
+    };
+    writeJson(tree, 'nx.json', {
+      targetDefaults: startingTargetDefaults,
+    });
+    removeRunCommandsOutputPath(tree);
+    const migratedTargetDefaults = readJson(tree, 'nx.json').targetDefaults;
+    expect(migratedTargetDefaults.build).not.toEqual(
+      startingTargetDefaults.build
+    );
+    expect(migratedTargetDefaults.build).toEqual({
+      executor: 'nx:run-commands',
+      outputs: ['{workspaceRoot}/dist/apps/my-app'],
+      options: {
+        commands: [],
+      },
+    });
+    expect(migratedTargetDefaults.other).toEqual(startingTargetDefaults.other);
+  });
+
+  assertRunsAgainstNxRepo(removeRunCommandsOutputPath);
+});

--- a/packages/nx/src/migrations/update-16-2-0/remove-run-commands-output-path.ts
+++ b/packages/nx/src/migrations/update-16-2-0/remove-run-commands-output-path.ts
@@ -1,0 +1,52 @@
+import { joinPathFragments } from '../../utils/path';
+import { NxJsonConfiguration } from '../../config/nx-json';
+import { TargetConfiguration } from '../../config/workspace-json-project-json';
+import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
+import { Tree } from '../../generators/tree';
+import { updateJson } from '../../generators/utils/json';
+import {
+  getProjects,
+  updateProjectConfiguration,
+} from '../../generators/utils/project-configuration';
+
+export default async function removeRunCommandsOutputPath(tree: Tree) {
+  for (const [project, configuration] of getProjects(tree).entries()) {
+    const targets = configuration.targets ?? {};
+    let changed = false;
+    for (const [, target] of Object.entries(targets)) {
+      changed ||= updateTargetBlock(target);
+    }
+    if (changed) {
+      updateProjectConfiguration(tree, project, configuration);
+    }
+  }
+  if (tree.exists('nx.json')) {
+    updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      for (const [, target] of Object.entries(json.targetDefaults ?? {})) {
+        updateTargetBlock(target);
+      }
+      return json;
+    });
+  }
+  await formatChangedFilesWithPrettierIfAvailable(tree);
+}
+
+function updateTargetBlock(target: TargetConfiguration): boolean {
+  let changed = false;
+  if (target.executor === 'nx:run-commands' && target.options?.outputPath) {
+    changed = true;
+    const outputs = new Set(target.outputs ?? []);
+    outputs.delete('{options.outputPath}');
+    const newOutputs = Array.isArray(target.options.outputPath)
+      ? target.options.outputPath.map((p) =>
+          joinPathFragments('{workspaceRoot}', p)
+        )
+      : [joinPathFragments('{workspaceRoot}', target.options.outputPath)];
+    for (const outputPath of newOutputs) {
+      outputs.add(outputPath);
+    }
+    delete target.options.outputPath;
+    target.outputs = Array.from(outputs);
+  }
+  return changed;
+}

--- a/packages/nx/src/migrations/update-16-8-0/escape-dollar-sign-env-variables.spec.ts
+++ b/packages/nx/src/migrations/update-16-8-0/escape-dollar-sign-env-variables.spec.ts
@@ -1,0 +1,132 @@
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import { addProjectConfiguration } from '../../generators/utils/project-configuration';
+import escapeDollarSignEnvVariables from './escape-dollar-sign-env-variables';
+
+describe('escape $ in env variables', () => {
+  let tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should escape $ in env variables in .env file', () => {
+    tree.write(
+      '.env',
+      `dollar=$
+NX_SOME_VAR=$ABC`
+    );
+    escapeDollarSignEnvVariables(tree);
+    expect(tree.read('.env', 'utf-8')).toEqual(`dollar=\\$
+NX_SOME_VAR=\\$ABC`);
+  });
+
+  it('should escape $ env variables in .env file under project', () => {
+    addProjectConfiguration(tree, 'my-app', {
+      root: 'apps/my-app',
+    });
+    addProjectConfiguration(tree, 'my-app2', {
+      root: 'apps/my-app2',
+    });
+    tree.write(
+      'apps/my-app/.env',
+      `dollar=$
+NX_SOME_VAR=$ABC`
+    );
+    tree.write(
+      'apps/my-app2/.env',
+      `dollar=$
+NX_SOME_VAR=$DEF`
+    );
+    escapeDollarSignEnvVariables(tree);
+    expect(tree.read('apps/my-app/.env', 'utf-8')).toEqual(`dollar=\\$
+NX_SOME_VAR=\\$ABC`);
+    expect(tree.read('apps/my-app2/.env', 'utf-8')).toEqual(`dollar=\\$
+NX_SOME_VAR=\\$DEF`);
+  });
+
+  it('should escape $ env variables in .env for target', () => {
+    tree.write('.env', 'dollar=$');
+    tree.write('.env.build', 'dollar=$');
+    addProjectConfiguration(tree, 'my-app', {
+      root: 'apps/my-app',
+      targets: {
+        build: {
+          executor: '@nx/node:build',
+          configurations: {
+            production: {},
+          },
+        },
+      },
+    });
+    tree.write(
+      'apps/my-app/.build.env',
+      `dollar=$
+NX_SOME_VAR=$ABC`
+    );
+    tree.write(
+      'apps/my-app/.env',
+      `dollar=$
+NX_SOME_VAR=$ABC`
+    );
+    escapeDollarSignEnvVariables(tree);
+    expect(tree.read('.env', 'utf-8')).toEqual(`dollar=\\$`);
+    expect(tree.read('apps/my-app/.env', 'utf-8')).toEqual(`dollar=\\$
+NX_SOME_VAR=\\$ABC`);
+    expect(tree.read('apps/my-app/.build.env', 'utf-8')).toEqual(`dollar=\\$
+NX_SOME_VAR=\\$ABC`);
+  });
+
+  it('should escape $ env variables in .env for configuration', () => {
+    tree.write('.env', 'dollar=$');
+    tree.write('.env.production', 'dollar=$');
+    addProjectConfiguration(tree, 'my-app', {
+      root: 'apps/my-app',
+      targets: {
+        build: {
+          executor: '@nx/node:build',
+          configurations: {
+            production: {},
+          },
+        },
+      },
+    });
+    tree.write(
+      'apps/my-app/.production.env',
+      `dollar=$
+NX_SOME_VAR=$ABC`
+    );
+    tree.write(
+      'apps/my-app/.build.production.env',
+      `dollar=$
+NX_SOME_VAR=$ABC`
+    );
+    tree.write(
+      'apps/my-app/.env',
+      `dollar=$
+NX_SOME_VAR=$ABC`
+    );
+    escapeDollarSignEnvVariables(tree);
+    expect(tree.read('.env', 'utf-8')).toEqual(`dollar=\\$`);
+    expect(tree.read('apps/my-app/.env', 'utf-8')).toEqual(`dollar=\\$
+NX_SOME_VAR=\\$ABC`);
+    expect(tree.read('apps/my-app/.build.production.env', 'utf-8'))
+      .toEqual(`dollar=\\$
+NX_SOME_VAR=\\$ABC`);
+    expect(tree.read('apps/my-app/.production.env', 'utf-8'))
+      .toEqual(`dollar=\\$
+NX_SOME_VAR=\\$ABC`);
+  });
+
+  it('should not escape $ env variables if it is already escaped', () => {
+    addProjectConfiguration(tree, 'my-app', {
+      root: 'apps/my-app',
+    });
+    tree.write(
+      'apps/my-app/.env',
+      `dollar=\\$
+NX_SOME_VAR=\\$ABC`
+    );
+    escapeDollarSignEnvVariables(tree);
+    expect(tree.read('apps/my-app/.env', 'utf-8')).toEqual(`dollar=\\$
+NX_SOME_VAR=\\$ABC`);
+  });
+});

--- a/packages/nx/src/migrations/update-16-8-0/escape-dollar-sign-env-variables.ts
+++ b/packages/nx/src/migrations/update-16-8-0/escape-dollar-sign-env-variables.ts
@@ -1,0 +1,92 @@
+import { logger } from '../../utils/logger';
+import { Tree } from '../../generators/tree';
+import { getProjects } from '../../generators/utils/project-configuration';
+
+/**
+ * This function escapes dollar sign in env variables
+ * It will go through:
+ * - '.env', '.local.env', '.env.local'
+ * - .env.[target-name], .[target-name].env
+ * - .env.[target-name].[configuration-name], .[target-name].[configuration-name].env
+ * - .env.[configuration-name], .[configuration-name].env
+ * at each project root and workspace root
+ * @param tree
+ */
+export default function escapeDollarSignEnvVariables(tree: Tree) {
+  const envFiles = ['.env', '.local.env', '.env.local'];
+  for (const [_, configuration] of getProjects(tree).entries()) {
+    envFiles.push(
+      `${configuration.root}/.env`,
+      `${configuration.root}/.local.env`,
+      `${configuration.root}/.env.local`
+    );
+    for (const targetName in configuration.targets) {
+      const task = configuration.targets[targetName];
+      envFiles.push(
+        `.env.${targetName}`,
+        `.${targetName}.env`,
+        `${configuration.root}/.env.${targetName}`,
+        `${configuration.root}/.${targetName}.env`
+      );
+
+      if (task.configurations) {
+        for (const configurationName in task.configurations) {
+          envFiles.push(
+            `.env.${targetName}.${configurationName}`,
+            `.${targetName}.${configurationName}.env`,
+            `.env.${configurationName}`,
+            `.${configurationName}.env`,
+            `${configuration.root}/.env.${targetName}.${configurationName}`,
+            `${configuration.root}/.${targetName}.${configurationName}.env`,
+            `${configuration.root}/.env.${configurationName}`,
+            `${configuration.root}/.${configurationName}.env`
+          );
+        }
+      }
+    }
+  }
+  for (const envFile of new Set(envFiles)) {
+    parseEnvFile(tree, envFile);
+  }
+}
+
+/**
+ * This function parse the env file and escape dollar sign
+ * @param tree
+ * @param envFilePath
+ * @returns
+ */
+function parseEnvFile(tree: Tree, envFilePath: string) {
+  if (!tree.exists(envFilePath)) {
+    return;
+  }
+
+  let envFileContent = tree.read(envFilePath, 'utf-8');
+  if (!envFileContent) {
+    // envFileContent is null if we fail to read the file for any reason
+    // e.g. the file is not utf-8 encoded
+    logger.info(
+      `Unable to update ${envFilePath}. Nx interpolates environment variables in the form of $VAR_NAME. To escape the dollar sign, use \\$VAR_NAME.`
+    );
+    return;
+  }
+
+  envFileContent = envFileContent
+    .split('\n')
+    .map((line) => {
+      line = line.trim();
+
+      if (!line || !line.includes('$')) {
+        return line;
+      }
+
+      const declarations = line.split('=');
+      if (declarations[1].includes('$') && !declarations[1].includes(`\\$`)) {
+        declarations[1] = declarations[1].replace('$', `\\$`);
+        line = declarations.join('=');
+      }
+      return line;
+    })
+    .join('\n');
+  tree.write(envFilePath, envFileContent);
+}


### PR DESCRIPTION
## Current Behavior
Some migrations used by `nx repair` are missing

## Expected Behavior
Migrations used by `nx repair` are only removed when deemed applicable.

This reverts a portion of commit a637f9eef9039d9ad59de568737488f9ba2e2cdb.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
