### PR TITLE
docs(misc): fix an issue where devkit types are not pointed to the latest d.ts files but what's installed in root node_modules

### DIFF
--- a/astro-docs/src/plugins/utils/devkit-generation.ts
+++ b/astro-docs/src/plugins/utils/devkit-generation.ts
@@ -19,10 +19,6 @@ export async function loadDevkitPackage(
   const { defaultTypedocOptions, outDir, buildDir } = setupTypeDoc(logger);
   const entries: CollectionEntry<'nx-reference-packages'>[] = [];
 
-  // TODO: Caleb there seems to be a resolution error where this entrypoint will resolved types
-  // from the node_modules/nx package and not the local workspace changes
-  // see: DOC-188
-
   logger.info('Generating devkit docs to dir...');
   // generate main @nx/devkit docs
   const devkitEntryPoint = join(

--- a/astro-docs/src/plugins/utils/typedoc/typedoc.ts
+++ b/astro-docs/src/plugins/utils/typedoc/typedoc.ts
@@ -78,6 +78,16 @@ export function setupTypeDoc(logger: LoaderContext['logger']) {
     join(projectRoot, 'node_modules', '@types'),
   ];
 
+  // This ensures that nx and @nx/<plugin> modules resolve to `dist` rather than what's installed in node_modules.
+  // TODO(jack,caleb): If we move outDir from `dist/packages/nx` to `packages/nx/dist` like standard TS solution setup,
+  //                   then this isn't needed anymore since we should have devDependencies that resolve to local
+  //                   `node_modules` not the root one.
+  tsconfigObj.compilerOptions.baseUrl = workspaceRoot;
+  tsconfigObj.compilerOptions.paths = {
+    'nx/*': ['dist/packages/nx/*', 'packages/nx/src/*'],
+    '@nx/*': ['dist/packages/*', 'packages/*/src/*'],
+  };
+
   tsconfigObj.exclude = [
     ...(tsconfigObj.exclude || []),
     '**/*.spec.ts',


### PR DESCRIPTION
Use tsconfig path aliases to point devkit to the `dist/packages/nx` folder rather than `node_modules/nx` (which is installed  from NPM).

Closes DOC-188