### PR TITLE
fix(dotnet): fixup various issues + missing functionality

### DIFF
--- a/packages/dotnet/analyzer/Analyzer.cs
+++ b/packages/dotnet/analyzer/Analyzer.cs
@@ -237,7 +237,7 @@ public static class Analyzer
         List<PackageReference> packageRefs)
     {
         return properties.GetValueOrDefault("IsTestProject") == "true" ||
-               packageRefs.Any(p => p.Include == "Microsoft.NET.Test.Sdk");
+               packageRefs.Any(p => p.Include == "Microsoft.NET.Test.Sdk" || p.Include.StartsWith("Microsoft.Testing"));
     }
 
     private static bool IsExecutableProject(Dictionary<string, string> properties)

--- a/packages/dotnet/analyzer/Models/PluginOptions.cs
+++ b/packages/dotnet/analyzer/Models/PluginOptions.cs
@@ -34,4 +34,14 @@ public class PluginOptions
     /// The name of the pack target. Defaults to "pack".
     /// </summary>
     public string PackTargetName { get; set; } = "pack";
+
+    /// <summary>
+    /// The name of the watch target. Defaults to "watch".
+    /// </summary>
+    public string WatchTargetName { get; set; } = "watch";
+
+    /// <summary>
+    /// The name of the run target. Defaults to "run".
+    /// </summary>
+    public string RunTargetName { get; set; } = "run";
 }

--- a/packages/dotnet/analyzer/Models/Target.cs
+++ b/packages/dotnet/analyzer/Models/Target.cs
@@ -31,6 +31,11 @@ public record Target
     public bool? Cache { get; init; }
 
     /// <summary>
+    /// Whether this target runs continuously.
+    /// </summary>
+    public bool? Continuous { get; init; }
+
+    /// <summary>
     /// Input patterns for cache invalidation.
     /// </summary>
     public object[]? Inputs { get; init; }

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Run.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Run.cs
@@ -1,0 +1,45 @@
+using MsbuildAnalyzer.Models;
+
+namespace MsbuildAnalyzer.Utilities;
+
+/// <summary>
+/// Run target creation methods for TargetBuilder.
+/// </summary>
+public static partial class TargetBuilder
+{
+    private static void AddRunTarget(
+        Dictionary<string, Target> targets,
+        string fileName,
+        PluginOptions options)
+    {
+        string[] defaultFlags = ["--no-build"];
+
+        targets[options.RunTargetName] = new Target
+        {
+            Command = "dotnet run",
+            Options = new TargetOptions
+            {
+                Cwd = "{projectRoot}",
+                Args = defaultFlags
+            },
+            Configurations = new Dictionary<string, TargetConfiguration>
+            {
+                ["debug"] = new TargetConfiguration
+                {
+                    Args = [.. defaultFlags, "--configuration", "Debug"]
+                },
+                ["release"] = new TargetConfiguration
+                {
+                    Args = [.. defaultFlags, "--configuration", "Release"]
+                }
+            },
+            DependsOn = [options.BuildTargetName],
+            Cache = false,
+            Metadata = new TargetMetadata
+            {
+                Description = "Run the .NET application",
+                Technologies = ProjectUtilities.GetTechnologies(fileName)
+            }
+        };
+    }
+}

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Watch.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Watch.cs
@@ -21,6 +21,7 @@ public static partial class TargetBuilder
             },
             DependsOn = [options.RestoreTargetName],
             Cache = false,
+            Continuous = true,
             Metadata = new TargetMetadata
             {
                 Description = "Watch for changes and rebuild/rerun the .NET project",

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Watch.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Watch.cs
@@ -1,0 +1,31 @@
+using MsbuildAnalyzer.Models;
+
+namespace MsbuildAnalyzer.Utilities;
+
+/// <summary>
+/// Watch target creation methods for TargetBuilder.
+/// </summary>
+public static partial class TargetBuilder
+{
+    private static void AddWatchTarget(
+        Dictionary<string, Target> targets,
+        string fileName,
+        PluginOptions options)
+    {
+        targets[options.WatchTargetName] = new Target
+        {
+            Command = "dotnet watch",
+            Options = new TargetOptions
+            {
+                Cwd = "{projectRoot}"
+            },
+            DependsOn = [options.RestoreTargetName],
+            Cache = false,
+            Metadata = new TargetMetadata
+            {
+                Description = "Watch for changes and rebuild/rerun the .NET project",
+                Technologies = ProjectUtilities.GetTechnologies(fileName)
+            }
+        };
+    }
+}

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.cs
@@ -36,10 +36,12 @@ public static partial class TargetBuilder
 
         AddRestoreTarget(targets, fileName, options);
         AddCleanTarget(targets, fileName, isTest, options);
+        AddWatchTarget(targets, fileName, options);
 
         if (isExe)
         {
             AddPublishTarget(targets, projectName, fileName, isTest, properties, workspaceRoot, options, productionInput);
+            AddRunTarget(targets, fileName, options);
         }
 
         if (!isExe && !isTest)

--- a/packages/dotnet/src/analyzer/analyzer-client.ts
+++ b/packages/dotnet/src/analyzer/analyzer-client.ts
@@ -67,7 +67,11 @@ function writeAnalyzerCache(
   }
 }
 
-export interface DotNetPluginOptions {
+/**
+ * Options passed to the MSBuild analyzer.
+ * These are the target names that the analyzer will use to generate targets.
+ */
+export interface DotNetAnalyzerOptions {
   buildTargetName?: string;
   testTargetName?: string;
   cleanTargetName?: string;
@@ -127,7 +131,7 @@ async function calculateProjectFilesHash(
  */
 function runAnalyzer(
   projectFiles: string[],
-  options?: DotNetPluginOptions
+  options?: DotNetAnalyzerOptions
 ): AnalysisSuccessResult {
   if (projectFiles.length === 0) {
     return { nodesByFile: {}, referencesByRoot: {} };
@@ -225,7 +229,7 @@ function runAnalyzer(
  */
 export async function analyzeProjects(
   projectFiles: string[],
-  options?: DotNetPluginOptions
+  options?: DotNetAnalyzerOptions
 ): Promise<AnalysisResult> {
   const filesHash = await calculateProjectFilesHash(projectFiles);
 

--- a/packages/dotnet/src/generators/init/init.spec.ts
+++ b/packages/dotnet/src/generators/init/init.spec.ts
@@ -18,19 +18,9 @@ describe('@nx/dotnet:init', () => {
         skipPackageJson: false,
       });
       const nxJson = readNxJson(tree);
-      expect(nxJson.plugins).toMatchInlineSnapshot(`
+      expect(nxJson?.plugins).toMatchInlineSnapshot(`
         [
-          {
-            "options": {
-              "buildTargetName": "build",
-              "cleanTargetName": "clean",
-              "packTargetName": "pack",
-              "publishTargetName": "publish",
-              "restoreTargetName": "restore",
-              "testTargetName": "test",
-            },
-            "plugin": "@nx/dotnet",
-          },
+          "@nx/dotnet",
         ]
       `);
     });
@@ -44,20 +34,10 @@ describe('@nx/dotnet:init', () => {
         skipPackageJson: false,
       });
       const nxJson = readNxJson(tree);
-      expect(nxJson.plugins).toMatchInlineSnapshot(`
+      expect(nxJson?.plugins).toMatchInlineSnapshot(`
         [
           "foo",
-          {
-            "options": {
-              "buildTargetName": "build",
-              "cleanTargetName": "clean",
-              "packTargetName": "pack",
-              "publishTargetName": "publish",
-              "restoreTargetName": "restore",
-              "testTargetName": "test",
-            },
-            "plugin": "@nx/dotnet",
-          },
+          "@nx/dotnet",
         ]
       `);
     });
@@ -71,7 +51,7 @@ describe('@nx/dotnet:init', () => {
         skipPackageJson: false,
       });
       const nxJson = readNxJson(tree);
-      expect(nxJson.plugins).toMatchInlineSnapshot(`
+      expect(nxJson?.plugins).toMatchInlineSnapshot(`
         [
           "@nx/dotnet",
         ]
@@ -86,7 +66,7 @@ describe('@nx/dotnet:init', () => {
         skipPackageJson: false,
       });
       const nxJson = readNxJson(tree);
-      expect(nxJson.namedInputs).toMatchInlineSnapshot(`
+      expect(nxJson?.namedInputs).toMatchInlineSnapshot(`
         {
           "default": [
             "{projectRoot}/**/*",
@@ -113,7 +93,7 @@ describe('@nx/dotnet:init', () => {
         skipPackageJson: false,
       });
       const nxJson = readNxJson(tree);
-      expect(nxJson.namedInputs).toMatchInlineSnapshot(`
+      expect(nxJson?.namedInputs).toMatchInlineSnapshot(`
         {
           "default": [
             "foo",

--- a/packages/dotnet/src/generators/init/init.ts
+++ b/packages/dotnet/src/generators/init/init.ts
@@ -102,17 +102,7 @@ function addPlugin(tree: Tree) {
 
   if (!hasDotNetPlugin(tree)) {
     nxJson.plugins ??= [];
-    nxJson.plugins.push({
-      plugin: '@nx/dotnet',
-      options: {
-        buildTargetName: 'build',
-        testTargetName: 'test',
-        cleanTargetName: 'clean',
-        restoreTargetName: 'restore',
-        publishTargetName: 'publish',
-        packTargetName: 'pack',
-      },
-    });
+    nxJson.plugins.push('@nx/dotnet');
     updateNxJson(tree, nxJson);
   }
 }

--- a/packages/dotnet/src/plugins/create-nodes.spec.ts
+++ b/packages/dotnet/src/plugins/create-nodes.spec.ts
@@ -26,7 +26,7 @@ function mergeUserTargetConfigurations(
   } = require('nx/src/project-graph/utils/project-configuration-utils');
 
   const targetMappings: Array<{
-    targetOption: TargetConfigurationWithName | undefined;
+    targetOption: TargetConfigurationWithName | false | undefined;
     defaultTargetName: string;
   }> = [
     { targetOption: options.build, defaultTargetName: 'build' },
@@ -532,8 +532,10 @@ describe('@nx/dotnet - createNodes', () => {
         test: {},
       };
 
-      const buildTargetName = options.build?.targetName ?? 'build';
-      const testTargetName = options.test?.targetName ?? 'test';
+      const buildTargetName =
+        (options.build && options.build.targetName) || 'build';
+      const testTargetName =
+        (options.test && options.test.targetName) || 'test';
 
       expect(buildTargetName).toBe('build');
       expect(testTargetName).toBe('test');
@@ -545,8 +547,10 @@ describe('@nx/dotnet - createNodes', () => {
         test: { targetName: 'unit-test' },
       };
 
-      const buildTargetName = options.build?.targetName ?? 'build';
-      const testTargetName = options.test?.targetName ?? 'test';
+      const buildTargetName =
+        (options.build && options.build.targetName) || 'build';
+      const testTargetName =
+        (options.test && options.test.targetName) || 'test';
 
       expect(buildTargetName).toBe('compile');
       expect(testTargetName).toBe('unit-test');
@@ -559,9 +563,12 @@ describe('@nx/dotnet - createNodes', () => {
         clean: { targetName: 'cleanup' },
       };
 
-      const buildTargetName = options.build?.targetName ?? 'build';
-      const testTargetName = options.test?.targetName ?? 'test';
-      const cleanTargetName = options.clean?.targetName ?? 'clean';
+      const buildTargetName =
+        (options.build && options.build.targetName) || 'build';
+      const testTargetName =
+        (options.test && options.test.targetName) || 'test';
+      const cleanTargetName =
+        (options.clean && options.clean.targetName) || 'clean';
 
       expect(buildTargetName).toBe('compile');
       expect(testTargetName).toBe('test');

--- a/packages/dotnet/src/plugins/create-nodes.spec.ts
+++ b/packages/dotnet/src/plugins/create-nodes.spec.ts
@@ -1,0 +1,571 @@
+import { ProjectConfiguration, TargetConfiguration } from '@nx/devkit';
+import {
+  DotNetPluginOptions,
+  TargetConfigurationWithName,
+} from './create-nodes';
+
+// Import the internal function for testing
+// We'll need to export it or test it indirectly through createNodesV2
+// For now, let's create a mock version to test the logic
+
+/**
+ * Merge user-specified target configurations with the generated targets from the analyzer
+ * This is a copy of the function from create-nodes.ts for testing purposes
+ */
+function mergeUserTargetConfigurations(
+  node: ProjectConfiguration,
+  options: DotNetPluginOptions
+): ProjectConfiguration {
+  if (!node.targets || !options) {
+    return node;
+  }
+
+  // Import mergeTargetConfigurations from nx
+  const {
+    mergeTargetConfigurations,
+  } = require('nx/src/project-graph/utils/project-configuration-utils');
+
+  const targetMappings: Array<{
+    targetOption: TargetConfigurationWithName | undefined;
+    defaultTargetName: string;
+  }> = [
+    { targetOption: options.build, defaultTargetName: 'build' },
+    { targetOption: options.test, defaultTargetName: 'test' },
+    { targetOption: options.clean, defaultTargetName: 'clean' },
+    { targetOption: options.restore, defaultTargetName: 'restore' },
+    { targetOption: options.publish, defaultTargetName: 'publish' },
+    { targetOption: options.pack, defaultTargetName: 'pack' },
+  ];
+
+  const mergedTargets = { ...node.targets };
+
+  for (const { targetOption, defaultTargetName } of targetMappings) {
+    if (!targetOption) {
+      continue;
+    }
+
+    const { targetName, ...userSpecifiedConfig } = targetOption;
+    const actualTargetName = targetName ?? defaultTargetName;
+
+    // Find the generated target - it might be under the default name or the user-specified name
+    const generatedTarget =
+      mergedTargets[actualTargetName] ?? mergedTargets[defaultTargetName];
+
+    if (!generatedTarget) {
+      continue;
+    }
+
+    const hasUserConfig = Object.keys(userSpecifiedConfig).length > 0;
+    const isRenamed = actualTargetName !== defaultTargetName;
+
+    // Merge user config with generated target if user config is provided
+    if (hasUserConfig) {
+      mergedTargets[actualTargetName] = mergeTargetConfigurations(
+        userSpecifiedConfig as TargetConfiguration,
+        generatedTarget
+      );
+    } else if (isRenamed) {
+      // If only renaming (no config to merge), just copy the target to the new name
+      mergedTargets[actualTargetName] = { ...generatedTarget };
+    }
+
+    // If target was renamed, remove the old target name
+    if (isRenamed && mergedTargets[defaultTargetName]) {
+      delete mergedTargets[defaultTargetName];
+    }
+  }
+
+  return {
+    ...node,
+    targets: mergedTargets,
+  };
+}
+
+describe('@nx/dotnet - createNodes', () => {
+  describe('mergeUserTargetConfigurations', () => {
+    it('should return node unchanged when no options provided', () => {
+      const node: ProjectConfiguration = {
+        root: 'apps/my-app',
+        name: 'my-app',
+        targets: {
+          build: {
+            executor: 'nx:run-commands',
+            options: {
+              command: 'dotnet build',
+            },
+          },
+        },
+      };
+
+      const result = mergeUserTargetConfigurations(node, {});
+      expect(result).toEqual(node);
+    });
+
+    it('should return node unchanged when no targets exist', () => {
+      const node: ProjectConfiguration = {
+        root: 'apps/my-app',
+        name: 'my-app',
+      };
+
+      const result = mergeUserTargetConfigurations(node, {
+        build: { targetName: 'compile' },
+      });
+      expect(result).toEqual(node);
+    });
+
+    it('should merge user options into generated target', () => {
+      const node: ProjectConfiguration = {
+        root: 'apps/my-app',
+        name: 'my-app',
+        targets: {
+          build: {
+            executor: 'nx:run-commands',
+            options: {
+              command: 'dotnet build',
+              cwd: 'apps/my-app',
+            },
+          },
+        },
+      };
+
+      const options: DotNetPluginOptions = {
+        build: {
+          options: {
+            additionalOption: 'value',
+          },
+        },
+      };
+
+      const result = mergeUserTargetConfigurations(node, options);
+
+      expect(result.targets?.build).toEqual({
+        executor: 'nx:run-commands',
+        options: {
+          command: 'dotnet build',
+          cwd: 'apps/my-app',
+          additionalOption: 'value',
+        },
+      });
+    });
+
+    it('should merge user configurations into generated target', () => {
+      const node: ProjectConfiguration = {
+        root: 'apps/my-app',
+        name: 'my-app',
+        targets: {
+          build: {
+            executor: 'nx:run-commands',
+            options: {
+              command: 'dotnet build',
+            },
+            configurations: {
+              debug: {
+                configuration: 'Debug',
+              },
+              release: {
+                configuration: 'Release',
+              },
+            },
+          },
+        },
+      };
+
+      const options: DotNetPluginOptions = {
+        build: {
+          configurations: {
+            production: {
+              optimization: true,
+            },
+          },
+        },
+      };
+
+      const result = mergeUserTargetConfigurations(node, options);
+
+      expect(result.targets?.build?.configurations).toEqual({
+        debug: {
+          configuration: 'Debug',
+        },
+        release: {
+          configuration: 'Release',
+        },
+        production: {
+          optimization: true,
+        },
+      });
+    });
+
+    it('should rename target when targetName is specified', () => {
+      const node: ProjectConfiguration = {
+        root: 'apps/my-app',
+        name: 'my-app',
+        targets: {
+          build: {
+            executor: 'nx:run-commands',
+            options: {
+              command: 'dotnet build',
+            },
+          },
+        },
+      };
+
+      const options: DotNetPluginOptions = {
+        build: {
+          targetName: 'compile',
+          options: {
+            additionalOption: 'value',
+          },
+        },
+      };
+
+      const result = mergeUserTargetConfigurations(node, options);
+
+      expect(result.targets?.compile).toBeDefined();
+      expect(result.targets?.build).toBeUndefined();
+      expect(result.targets?.compile?.options).toEqual({
+        command: 'dotnet build',
+        additionalOption: 'value',
+      });
+    });
+
+    it('should handle multiple target configurations', () => {
+      const node: ProjectConfiguration = {
+        root: 'apps/my-app',
+        name: 'my-app',
+        targets: {
+          build: {
+            executor: 'nx:run-commands',
+            options: {
+              command: 'dotnet build',
+            },
+          },
+          test: {
+            executor: 'nx:run-commands',
+            options: {
+              command: 'dotnet test',
+            },
+          },
+        },
+      };
+
+      const options: DotNetPluginOptions = {
+        build: {
+          targetName: 'compile',
+        },
+        test: {
+          targetName: 'unit-test',
+          options: {
+            logger: 'console',
+          },
+        },
+      };
+
+      const result = mergeUserTargetConfigurations(node, options);
+
+      expect(result.targets?.compile).toBeDefined();
+      expect(result.targets?.build).toBeUndefined();
+      expect(result.targets?.['unit-test']).toBeDefined();
+      expect(result.targets?.test).toBeUndefined();
+      expect(result.targets?.['unit-test']?.options).toEqual({
+        command: 'dotnet test',
+        logger: 'console',
+      });
+    });
+
+    it('should add dependsOn to target', () => {
+      const node: ProjectConfiguration = {
+        root: 'apps/my-app',
+        name: 'my-app',
+        targets: {
+          test: {
+            executor: 'nx:run-commands',
+            options: {
+              command: 'dotnet test',
+            },
+          },
+        },
+      };
+
+      const options: DotNetPluginOptions = {
+        test: {
+          dependsOn: ['build'],
+        },
+      };
+
+      const result = mergeUserTargetConfigurations(node, options);
+
+      expect(result.targets?.test?.dependsOn).toEqual(['build']);
+    });
+
+    it('should handle cache configuration', () => {
+      const node: ProjectConfiguration = {
+        root: 'apps/my-app',
+        name: 'my-app',
+        targets: {
+          build: {
+            executor: 'nx:run-commands',
+            options: {
+              command: 'dotnet build',
+            },
+          },
+        },
+      };
+
+      const options: DotNetPluginOptions = {
+        build: {
+          cache: true,
+          inputs: ['{projectRoot}/**/*.cs', '^production'],
+          outputs: ['{projectRoot}/bin'],
+        },
+      };
+
+      const result = mergeUserTargetConfigurations(node, options);
+
+      expect(result.targets?.build?.cache).toBe(true);
+      expect(result.targets?.build?.inputs).toEqual([
+        '{projectRoot}/**/*.cs',
+        '^production',
+      ]);
+      expect(result.targets?.build?.outputs).toEqual(['{projectRoot}/bin']);
+    });
+
+    it('should rename target even when no other config is provided', () => {
+      const node: ProjectConfiguration = {
+        root: 'apps/my-app',
+        name: 'my-app',
+        targets: {
+          build: {
+            executor: 'nx:run-commands',
+            options: {
+              command: 'dotnet build',
+            },
+          },
+        },
+      };
+
+      const options: DotNetPluginOptions = {
+        build: {
+          targetName: 'compile',
+          // No other config, but should still rename
+        },
+      };
+
+      const result = mergeUserTargetConfigurations(node, options);
+
+      // Target should be renamed even with no other config
+      expect(result.targets?.compile).toBeDefined();
+      expect(result.targets?.build).toBeUndefined();
+      expect(result.targets?.compile).toEqual({
+        executor: 'nx:run-commands',
+        options: {
+          command: 'dotnet build',
+        },
+      });
+    });
+
+    it('should handle all target types', () => {
+      const node: ProjectConfiguration = {
+        root: 'apps/my-app',
+        name: 'my-app',
+        targets: {
+          build: {
+            executor: 'nx:run-commands',
+            options: { command: 'dotnet build' },
+          },
+          test: {
+            executor: 'nx:run-commands',
+            options: { command: 'dotnet test' },
+          },
+          clean: {
+            executor: 'nx:run-commands',
+            options: { command: 'dotnet clean' },
+          },
+          restore: {
+            executor: 'nx:run-commands',
+            options: { command: 'dotnet restore' },
+          },
+          publish: {
+            executor: 'nx:run-commands',
+            options: { command: 'dotnet publish' },
+          },
+          pack: {
+            executor: 'nx:run-commands',
+            options: { command: 'dotnet pack' },
+          },
+        },
+      };
+
+      const options: DotNetPluginOptions = {
+        build: { options: { b: 1 } },
+        test: { options: { t: 2 } },
+        clean: { options: { c: 3 } },
+        restore: { options: { r: 4 } },
+        publish: { options: { p: 5 } },
+        pack: { options: { pk: 6 } },
+      };
+
+      const result = mergeUserTargetConfigurations(node, options);
+
+      expect(result.targets?.build?.options).toEqual({
+        command: 'dotnet build',
+        b: 1,
+      });
+      expect(result.targets?.test?.options).toEqual({
+        command: 'dotnet test',
+        t: 2,
+      });
+      expect(result.targets?.clean?.options).toEqual({
+        command: 'dotnet clean',
+        c: 3,
+      });
+      expect(result.targets?.restore?.options).toEqual({
+        command: 'dotnet restore',
+        r: 4,
+      });
+      expect(result.targets?.publish?.options).toEqual({
+        command: 'dotnet publish',
+        p: 5,
+      });
+      expect(result.targets?.pack?.options).toEqual({
+        command: 'dotnet pack',
+        pk: 6,
+      });
+    });
+
+    it('should override existing options when user provides same option', () => {
+      const node: ProjectConfiguration = {
+        root: 'apps/my-app',
+        name: 'my-app',
+        targets: {
+          build: {
+            executor: 'nx:run-commands',
+            options: {
+              command: 'dotnet build',
+              cwd: 'apps/my-app',
+            },
+          },
+        },
+      };
+
+      const options: DotNetPluginOptions = {
+        build: {
+          options: {
+            cwd: 'different/path',
+          },
+        },
+      };
+
+      const result = mergeUserTargetConfigurations(node, options);
+
+      expect(result.targets?.build?.options?.cwd).toBe('different/path');
+    });
+
+    it('should handle complex nested configurations', () => {
+      const node: ProjectConfiguration = {
+        root: 'libs/my-lib',
+        name: 'my-lib',
+        targets: {
+          build: {
+            executor: 'nx:run-commands',
+            options: {
+              command: 'dotnet build',
+            },
+            configurations: {
+              debug: {
+                configuration: 'Debug',
+              },
+            },
+          },
+        },
+      };
+
+      const options: DotNetPluginOptions = {
+        build: {
+          targetName: 'compile',
+          options: {
+            verbose: true,
+          },
+          configurations: {
+            release: {
+              configuration: 'Release',
+              optimization: true,
+            },
+          },
+          cache: true,
+          inputs: ['default', '^production'],
+          outputs: ['{projectRoot}/bin/{configuration}'],
+          dependsOn: ['^build'],
+        },
+      };
+
+      const result = mergeUserTargetConfigurations(node, options);
+
+      expect(result.targets?.compile).toBeDefined();
+      expect(result.targets?.build).toBeUndefined();
+      expect(result.targets?.compile).toMatchObject({
+        executor: 'nx:run-commands',
+        options: {
+          command: 'dotnet build',
+          verbose: true,
+        },
+        configurations: {
+          debug: {
+            configuration: 'Debug',
+          },
+          release: {
+            configuration: 'Release',
+            optimization: true,
+          },
+        },
+        cache: true,
+        inputs: ['default', '^production'],
+        outputs: ['{projectRoot}/bin/{configuration}'],
+        dependsOn: ['^build'],
+      });
+    });
+  });
+
+  describe('target name extraction', () => {
+    it('should extract default target names when not specified', () => {
+      const options: DotNetPluginOptions = {
+        build: {},
+        test: {},
+      };
+
+      const buildTargetName = options.build?.targetName ?? 'build';
+      const testTargetName = options.test?.targetName ?? 'test';
+
+      expect(buildTargetName).toBe('build');
+      expect(testTargetName).toBe('test');
+    });
+
+    it('should extract custom target names when specified', () => {
+      const options: DotNetPluginOptions = {
+        build: { targetName: 'compile' },
+        test: { targetName: 'unit-test' },
+      };
+
+      const buildTargetName = options.build?.targetName ?? 'build';
+      const testTargetName = options.test?.targetName ?? 'test';
+
+      expect(buildTargetName).toBe('compile');
+      expect(testTargetName).toBe('unit-test');
+    });
+
+    it('should handle mixed default and custom names', () => {
+      const options: DotNetPluginOptions = {
+        build: { targetName: 'compile' },
+        test: {},
+        clean: { targetName: 'cleanup' },
+      };
+
+      const buildTargetName = options.build?.targetName ?? 'build';
+      const testTargetName = options.test?.targetName ?? 'test';
+      const cleanTargetName = options.clean?.targetName ?? 'clean';
+
+      expect(buildTargetName).toBe('compile');
+      expect(testTargetName).toBe('test');
+      expect(cleanTargetName).toBe('cleanup');
+    });
+  });
+});

--- a/packages/dotnet/src/plugins/create-nodes.spec.ts
+++ b/packages/dotnet/src/plugins/create-nodes.spec.ts
@@ -35,16 +35,20 @@ function mergeUserTargetConfigurations(
     { targetOption: options.restore, defaultTargetName: 'restore' },
     { targetOption: options.publish, defaultTargetName: 'publish' },
     { targetOption: options.pack, defaultTargetName: 'pack' },
+    { targetOption: options.watch, defaultTargetName: 'watch' },
+    { targetOption: options.run, defaultTargetName: 'run' },
   ];
 
   const mergedTargets = { ...node.targets };
 
   for (const { targetOption, defaultTargetName } of targetMappings) {
-    if (!targetOption) {
+    // Disabled target from user configuration
+    if (targetOption === false) {
       continue;
     }
 
-    const { targetName, ...userSpecifiedConfig } = targetOption;
+    // Use empty object as default when option is not provided
+    const { targetName, ...userSpecifiedConfig } = targetOption ?? {};
     const actualTargetName = targetName ?? defaultTargetName;
 
     // Find the generated target - it might be under the default name or the user-specified name

--- a/packages/dotnet/src/plugins/create-nodes.spec.ts
+++ b/packages/dotnet/src/plugins/create-nodes.spec.ts
@@ -44,6 +44,7 @@ function mergeUserTargetConfigurations(
   for (const { targetOption, defaultTargetName } of targetMappings) {
     // Disabled target from user configuration
     if (targetOption === false) {
+      delete mergedTargets[defaultTargetName];
       continue;
     }
 
@@ -526,6 +527,44 @@ describe('@nx/dotnet - createNodes', () => {
         outputs: ['{projectRoot}/bin/{configuration}'],
         dependsOn: ['^build'],
       });
+    });
+
+    it('should remove disabled targets from configuration', () => {
+      const node: ProjectConfiguration = {
+        root: 'apps/my-app',
+        name: 'my-app',
+        targets: {
+          build: {
+            executor: 'nx:run-commands',
+            options: {
+              command: 'dotnet build',
+            },
+          },
+          test: {
+            executor: 'nx:run-commands',
+            options: {
+              command: 'dotnet test',
+            },
+          },
+          clean: {
+            executor: 'nx:run-commands',
+            options: {
+              command: 'dotnet clean',
+            },
+          },
+        },
+      };
+
+      const options: DotNetPluginOptions = {
+        test: false,
+        clean: false,
+      };
+
+      const result = mergeUserTargetConfigurations(node, options);
+
+      expect(result.targets?.build).toBeDefined();
+      expect(result.targets?.test).toBeUndefined();
+      expect(result.targets?.clean).toBeUndefined();
     });
   });
 

--- a/packages/dotnet/src/plugins/create-nodes.ts
+++ b/packages/dotnet/src/plugins/create-nodes.ts
@@ -54,32 +54,42 @@ export interface DotNetPluginOptions {
    * Configuration for the build target.
    * Use `targetName` to rename the target, and provide additional options/configurations to merge with the generated target.
    */
-  build?: TargetConfigurationWithName;
+  build?: TargetConfigurationWithName | false;
   /**
    * Configuration for the test target.
    * Use `targetName` to rename the target, and provide additional options/configurations to merge with the generated target.
    */
-  test?: TargetConfigurationWithName;
+  test?: TargetConfigurationWithName | false;
   /**
    * Configuration for the clean target.
    * Use `targetName` to rename the target, and provide additional options/configurations to merge with the generated target.
    */
-  clean?: TargetConfigurationWithName;
+  clean?: TargetConfigurationWithName | false;
   /**
    * Configuration for the restore target.
    * Use `targetName` to rename the target, and provide additional options/configurations to merge with the generated target.
    */
-  restore?: TargetConfigurationWithName;
+  restore?: TargetConfigurationWithName | false;
   /**
    * Configuration for the publish target.
    * Use `targetName` to rename the target, and provide additional options/configurations to merge with the generated target.
    */
-  publish?: TargetConfigurationWithName;
+  publish?: TargetConfigurationWithName | false;
   /**
    * Configuration for the pack target.
    * Use `targetName` to rename the target, and provide additional options/configurations to merge with the generated target.
    */
-  pack?: TargetConfigurationWithName;
+  pack?: TargetConfigurationWithName | false;
+  /**
+   * Configuration for the watch target.
+   * Use `targetName` to rename the target, and provide additional options/configurations to merge with the generated target.
+   */
+  watch?: TargetConfigurationWithName | false;
+  /**
+   * Configuration for the run target.
+   * Use `targetName` to rename the target, and provide additional options/configurations to merge with the generated target.
+   */
+  run?: TargetConfigurationWithName | false;
 }
 
 const dotnetProjectGlob = '**/*.{csproj,fsproj,vbproj}';
@@ -96,7 +106,7 @@ function mergeUserTargetConfigurations(
   }
 
   const targetMappings: Array<{
-    targetOption: TargetConfigurationWithName | undefined;
+    targetOption: TargetConfigurationWithName | false | undefined;
     defaultTargetName: string;
   }> = [
     { targetOption: options.build, defaultTargetName: 'build' },
@@ -105,12 +115,15 @@ function mergeUserTargetConfigurations(
     { targetOption: options.restore, defaultTargetName: 'restore' },
     { targetOption: options.publish, defaultTargetName: 'publish' },
     { targetOption: options.pack, defaultTargetName: 'pack' },
+    { targetOption: options.watch, defaultTargetName: 'watch' },
+    { targetOption: options.run, defaultTargetName: 'run' },
   ];
 
   const mergedTargets = { ...node.targets };
 
   for (const { targetOption, defaultTargetName } of targetMappings) {
-    if (!targetOption) {
+    // Disabled target from user configuration
+    if (targetOption === false) {
       continue;
     }
 
@@ -158,12 +171,16 @@ export const createNodesV2: CreateNodesV2<DotNetPluginOptions> = [
     try {
       // Extract target names from new format and create options for analyzer
       const analyzerOptions = {
-        buildTargetName: options?.build?.targetName ?? 'build',
-        testTargetName: options?.test?.targetName ?? 'test',
-        cleanTargetName: options?.clean?.targetName ?? 'clean',
-        restoreTargetName: options?.restore?.targetName ?? 'restore',
-        publishTargetName: options?.publish?.targetName ?? 'publish',
-        packTargetName: options?.pack?.targetName ?? 'pack',
+        buildTargetName: (options.build && options.build.targetName) || 'build',
+        testTargetName: (options.test && options.test.targetName) || 'test',
+        cleanTargetName: (options.clean && options.clean.targetName) || 'clean',
+        restoreTargetName:
+          (options.restore && options.restore.targetName) || 'restore',
+        publishTargetName:
+          (options.publish && options.publish.targetName) || 'publish',
+        packTargetName: (options.pack && options.pack.targetName) || 'pack',
+        watchTargetName: (options.watch && options.watch.targetName) || 'watch',
+        runTargetName: (options.run && options.run.targetName) || 'run',
       };
 
       const result = await analyzeProjects(

--- a/packages/dotnet/src/plugins/create-nodes.ts
+++ b/packages/dotnet/src/plugins/create-nodes.ts
@@ -169,18 +169,34 @@ export const createNodesV2: CreateNodesV2<DotNetPluginOptions> = [
   async (configFilePaths, options, context) => {
     // Analyze all projects - the C# analyzer builds the complete Nx structure
     try {
+      // Normalize options to handle undefined (when plugin is registered as string)
+      const normalizedOptions = options ?? {};
+
       // Extract target names from new format and create options for analyzer
       const analyzerOptions = {
-        buildTargetName: (options.build && options.build.targetName) || 'build',
-        testTargetName: (options.test && options.test.targetName) || 'test',
-        cleanTargetName: (options.clean && options.clean.targetName) || 'clean',
+        buildTargetName:
+          (normalizedOptions.build && normalizedOptions.build.targetName) ||
+          'build',
+        testTargetName:
+          (normalizedOptions.test && normalizedOptions.test.targetName) ||
+          'test',
+        cleanTargetName:
+          (normalizedOptions.clean && normalizedOptions.clean.targetName) ||
+          'clean',
         restoreTargetName:
-          (options.restore && options.restore.targetName) || 'restore',
+          (normalizedOptions.restore && normalizedOptions.restore.targetName) ||
+          'restore',
         publishTargetName:
-          (options.publish && options.publish.targetName) || 'publish',
-        packTargetName: (options.pack && options.pack.targetName) || 'pack',
-        watchTargetName: (options.watch && options.watch.targetName) || 'watch',
-        runTargetName: (options.run && options.run.targetName) || 'run',
+          (normalizedOptions.publish && normalizedOptions.publish.targetName) ||
+          'publish',
+        packTargetName:
+          (normalizedOptions.pack && normalizedOptions.pack.targetName) ||
+          'pack',
+        watchTargetName:
+          (normalizedOptions.watch && normalizedOptions.watch.targetName) ||
+          'watch',
+        runTargetName:
+          (normalizedOptions.run && normalizedOptions.run.targetName) || 'run',
       };
 
       const result = await analyzeProjects(
@@ -202,7 +218,10 @@ export const createNodesV2: CreateNodesV2<DotNetPluginOptions> = [
         }
 
         // Merge user-specified target configurations with generated targets
-        const mergedNode = mergeUserTargetConfigurations(node, options);
+        const mergedNode = mergeUserTargetConfigurations(
+          node,
+          normalizedOptions
+        );
 
         return [
           configFile,

--- a/packages/dotnet/src/plugins/create-nodes.ts
+++ b/packages/dotnet/src/plugins/create-nodes.ts
@@ -124,6 +124,7 @@ function mergeUserTargetConfigurations(
   for (const { targetOption, defaultTargetName } of targetMappings) {
     // Disabled target from user configuration
     if (targetOption === false) {
+      delete mergedTargets[defaultTargetName];
       continue;
     }
 

--- a/packages/dotnet/src/plugins/create-nodes.ts
+++ b/packages/dotnet/src/plugins/create-nodes.ts
@@ -127,7 +127,8 @@ function mergeUserTargetConfigurations(
       continue;
     }
 
-    const { targetName, ...userSpecifiedConfig } = targetOption;
+    // Use empty object as default when option is not provided
+    const { targetName, ...userSpecifiedConfig } = targetOption ?? {};
     const actualTargetName = targetName ?? defaultTargetName;
 
     // Find the generated target - it might be under the default name or the user-specified name


### PR DESCRIPTION
…as testing projects<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
- Microsoft.Testing.Platform projects are not detected as having a test target
- `serve` does not have an equivalent

## Expected Behavior
- Test projects are properly detected
- `serve` has been split into 2 targets:
  -  `watch`
  - `run`
  
The split of `serve` mirrors the`dotnet` cli in the same way that we mirrored `vite` when adding `preview` and `dev` targets when we moved with project crystal. `watch` can be used for a variety of cases, but provides hot reload + run a 'la `dev` / `serve`. `run` is more of a fire and forget target that starts up the app. Both targets would only really be used in local dev.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
…as testing projects