### PR TITLE
chore(repo): fix quotes in e2e matrix workflow

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Get pnpm store directory
         id: pnpm-cache
-        run: echo 'path=$(pnpm store path)' >> $GITHUB_OUTPUT
+        run: echo "path=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Cache pnpm store
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
@@ -87,7 +87,7 @@ jobs:
       - name: Homebrew cache directory path
         if: ${{ matrix.os == 'macos-latest' }}
         id: homebrew-cache-dir-path
-        run: echo 'dir=$(brew --cache)' >> $GITHUB_OUTPUT
+        run: echo "dir=$(brew --cache)" >> $GITHUB_OUTPUT
 
       - name: Cache Homebrew
         if: ${{ matrix.os == 'macos-latest' }}
@@ -127,7 +127,7 @@ jobs:
 
       - name: Process matrix data
         id: process-json
-        run: echo 'MATRIX=$(npx tsx .github/workflows/nightly/process-matrix.ts | jq -c .)' >> $GITHUB_OUTPUT
+        run: echo "MATRIX=$(npx tsx .github/workflows/nightly/process-matrix.ts | jq -c .)" >> $GITHUB_OUTPUT
 
   e2e:
     if: ${{ github.repository_owner == 'nrwl' }}
@@ -169,12 +169,12 @@ jobs:
         if: ${{ matrix.os != 'windows-latest' }}
         run: |
           curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y
-          source '$HOME/.cargo/env'
+          source "$HOME/.cargo/env"
           rustup toolchain install 1.70.0
 
       - name: Load Cargo Env
         if: ${{ matrix.os != 'windows-latest' }}
-        run: echo 'PATH=$HOME/.cargo/bin:$PATH' >> $GITHUB_ENV
+        run: echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
 
       - name: Setup .NET 9
         uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0
@@ -200,14 +200,14 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf '/usr/local/share/boost'
-          sudo rm -rf '$AGENT_TOOLSDIRECTORY'
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo apt-get install lsof
           echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
       - name: Homebrew cache directory path
         if: ${{ matrix.os == 'macos-latest' }}
         id: homebrew-cache-dir-path
-        run: echo 'dir=$(brew --cache)' >> $GITHUB_OUTPUT
+        run: echo "dir=$(brew --cache)" >> $GITHUB_OUTPUT
 
       - name: Cache Homebrew
         if: ${{ matrix.os == 'macos-latest' }}
@@ -334,7 +334,7 @@ jobs:
         id: before-e2e
         shell: bash
         run: |
-          echo 'timestamp=$(date +%s)' >> $GITHUB_OUTPUT
+          echo "timestamp=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: Run e2e tests with pnpm (Linux/Windows)
         id: e2e-run-pnpm
@@ -397,8 +397,8 @@ jobs:
 
           matrix=$((
             echo '${{ toJSON(matrix) }}'
-          ) | jq --argjson delta $delta -c '. + { 'status': '''$outcome''', 'duration': $delta }')
-          echo '$matrix' > 'outputs/matrix.json'
+          ) | jq --argjson delta $delta -c '. + { "status": "'"$outcome"'", "duration": $delta }')
+          echo "$matrix" > 'outputs/matrix.json'
 
       - name: Upload matrix config
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -446,7 +446,7 @@ jobs:
         id: combine-json
         run: |
           combined=$(jq -sc . outputs/*/matrix.json)
-          echo 'combined=$combined' >> $GITHUB_OUTPUT
+          echo "combined=$combined" >> $GITHUB_OUTPUT
 
       - name: Process results with TypeScript script
         id: process-json


### PR DESCRIPTION
Fixes wrong single quotes in the E2E matrix workflow file that were preventing variable expansion in bash.