### PR TITLE
chore(repo): reduce computation in the macos job when there are no e2e tests to run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,36 @@ jobs:
         run: git fetch origin master:master
         if: ${{ github.event_name == 'pull_request' }}
 
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
+        name: Install pnpm
+        with:
+          version: 10.11.1
+          run_install: false
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Set SHAs
+        uses: nrwl/nx-set-shas@1859e66a83ac9be0dceecbd9a023702e27ac47f4 # v4.3.3
+        with:
+          main-branch-name: 'master'
+
+      - name: Check for React Native changes
+        id: check-changes
+        run: |
+          HAS_CHANGED=$(node ./scripts/check-react-native-changes.js $NX_BASE $NX_HEAD);
+          if $HAS_CHANGED; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "React Native projects are affected, will run macOS tests"
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No React Native projects affected, skipping macOS tests"
+          fi
+
       - name: Restore Homebrew packages
+        if: steps.check-changes.outputs.has_changes == 'true'
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: |
@@ -157,11 +186,12 @@ jobs:
           key: nrwl-nx-homebrew-packages
 
       - name: Configure Detox Environment, Install applesimutils
+        if: steps.check-changes.outputs.has_changes == 'true'
         run: |
           # Ensure Xcode command line tools are installed and configured
           xcode-select --print-path || sudo xcode-select --reset
           sudo xcode-select -s /Applications/Xcode.app
-          
+
           # Install or update applesimutils with error handling
           if ! brew list applesimutils &>/dev/null; then
             echo "Installing applesimutils..."
@@ -175,44 +205,45 @@ jobs:
             echo "Updating applesimutils..."
             HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade applesimutils || true
           fi
-          
+
           # Verify applesimutils installation
           applesimutils --version || (echo "applesimutils installation failed" && exit 1)
-          
+
           # Configure environment for M-series Mac
           echo "DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer" >> $GITHUB_ENV
           echo "PLATFORM_NAME=iOS Simulator" >> $GITHUB_ENV
-          
+
           # Set additional environment variables for better debugging
           echo "DETOX_DISABLE_TELEMETRY=1" >> $GITHUB_ENV
           echo "DETOX_LOG_LEVEL=trace" >> $GITHUB_ENV
-          
+
           # Verify Xcode installation
           xcodebuild -version
-          
+
           # List available simulators
           xcrun simctl list devices available
         timeout-minutes: 10
         continue-on-error: false
-  
+
       - name: Reset iOS Simulators
+        if: steps.check-changes.outputs.has_changes == 'true'
         id: reset-simulators
         run: |
           echo "Resetting iOS Simulators..."
-          
+
           # Kill simulator processes
           sudo killall -9 com.apple.CoreSimulator.CoreSimulatorService 2>/dev/null || true
           killall "Simulator" 2>/dev/null || true
           killall "iOS Simulator" 2>/dev/null || true
-          
+
           # Wait for processes to terminate
           sleep 3
-          
+
           # Shutdown and erase all simulators (ignore failures)
           xcrun simctl shutdown all 2>/dev/null || true
           sleep 5
           xcrun simctl erase all 2>/dev/null || true
-          
+
           # If erase failed, try the nuclear option
           if xcrun simctl list devices | grep -q "Booted" 2>/dev/null; then
             echo "Standard reset failed, using nuclear option..."
@@ -220,25 +251,25 @@ jobs:
             launchctl remove com.apple.CoreSimulator.CoreSimulatorService 2>/dev/null || true
             sleep 3
           fi
-          
+
           # Clean up additional directories
           rm -rf ~/Library/Developer/CoreSimulator/Caches/* 2>/dev/null || true
           rm -rf ~/Library/Logs/CoreSimulator/* 2>/dev/null || true
           rm -rf ~/Library/Developer/Xcode/DerivedData/* 2>/dev/null || true
-          
+
           echo "Simulator reset completed"
         timeout-minutes: 5
         continue-on-error: true
 
       - name: Verify Simulator Reset
-        if: ${{ steps.reset-simulators.outcome == 'success' }}
+        if: steps.check-changes.outputs.has_changes == 'true' && steps.reset-simulators.outcome == 'success'
         run: |
           # Verify CoreSimulator service restarted
           pgrep -fl "CoreSimulator" || (echo "CoreSimulator service not running" && exit 1)
-          
+
           # Check simulator list is clean
           xcrun simctl list devices
-          
+
           # Verify simulator runtime paths exist and are writable
           test -d ~/Library/Developer/CoreSimulator/Devices || (echo "Simulator devices directory missing" && exit 1)
           touch ~/Library/Developer/CoreSimulator/Devices/test || (echo "Simulator devices directory not writable" && exit 1)
@@ -246,7 +277,7 @@ jobs:
         timeout-minutes: 5
 
       - name: Diagnose Simulator Reset Failure
-        if: ${{ steps.reset-simulators.outcome == 'failure' }}
+        if: steps.check-changes.outputs.has_changes == 'true' && steps.reset-simulators.outcome == 'failure'
         run: |
           echo "Simulator reset failed. Collecting diagnostic information..."
           xcrun simctl list
@@ -254,6 +285,7 @@ jobs:
           ls -la ~/Library/Logs/CoreSimulator/ || echo "No simulator logs found"
 
       - name: Save Homebrew Cache
+        if: steps.check-changes.outputs.has_changes == 'true'
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
         with:
           path: |
@@ -261,37 +293,19 @@ jobs:
             ~/Library/Caches/Homebrew
           key: nrwl-nx-homebrew-packages
 
-      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
-        name: Install pnpm
-        with:
-          version: 10.11.1
-          run_install: false
-
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
-        with:
-          node-version: 20
-          cache: 'pnpm'
-
       - name: Install Rust
+        if: steps.check-changes.outputs.has_changes == 'true'
         uses: actions-rust-lang/setup-rust-toolchain@ac90e63697ac2784f4ecfe2964e1a285c304003a # v1
         with:
           rustflags: ''
 
       - name: Install project dependencies
+        if: steps.check-changes.outputs.has_changes == 'true'
         run: |
           pnpm install --frozen-lockfile
           pnpm playwright install --with-deps
 
-      - name: Set SHAs
-        uses: nrwl/nx-set-shas@1859e66a83ac9be0dceecbd9a023702e27ac47f4 # v4.3.3
-        with:
-          main-branch-name: 'master'
-
       - name: Run E2E Tests for macOS
+        if: steps.check-changes.outputs.has_changes == 'true'
         run: |
-          HAS_CHANGED=$(node ./scripts/check-react-native-changes.js $NX_BASE $NX_HEAD);
-          if $HAS_CHANGED; then
-            pnpm nx affected -t e2e-macos-local --parallel=1 --base=$NX_BASE --head=$NX_HEAD
-          else
-            echo "Skip E2E tests for macOS as there are no changes in React Native projects."
-          fi
+          pnpm nx affected -t e2e-macos-local --parallel=1 --base=$NX_BASE --head=$NX_HEAD


### PR DESCRIPTION
## Current Behavior

The `main-macos` in the CI verification workflow runs some setup only needed by the e2e tests unconditionally. This means that even when the tests are not run, up to ~9 minutes can be spent setting up things that will not be used.

## Expected Behavior

The `main-macos` in the CI verification workflow should only run the minimal steps needed to verify whether the tests will be run. If the tests are to be run, the job should proceed with the remaining required setup steps; otherwise, it should skip them.

The job will now check whether tests will be run as early as possible and gate the rest of the steps based on the result.

## Example similar runs

Before: 10m 48s (https://github.com/nrwl/nx/actions/runs/18625394891/job/53102778452)
After: 1m 3s (https://github.com/nrwl/nx/actions/runs/18654449747/job/53189013526)