### PR TITLE
fix(angular-rspack): ensure root node_modules included when resolving packages

### DIFF
--- a/examples/angular-rspack/csr-css/src/styles.css
+++ b/examples/angular-rspack/csr-css/src/styles.css
@@ -1,3 +1,5 @@
+@import 'jasmine-core/lib/jasmine-core/jasmine.css';
+
 div {
   color: red;
 }

--- a/packages/angular-rspack/src/lib/config/config-utils/common-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/common-config.ts
@@ -4,6 +4,7 @@ import {
   JS_ALL_EXT_REGEX,
   TS_ALL_EXT_REGEX,
 } from '@nx/angular-rspack-compiler';
+import { workspaceRoot } from '@nx/devkit';
 import {
   HashFormat,
   I18nOptions,
@@ -74,7 +75,8 @@ export async function getCommonConfig(
     resolve: {
       extensions: ['.ts', '.tsx', '.mjs', '.js'],
       symlinks: !normalizedOptions.preserveSymlinks,
-      modules: ['node_modules'],
+      // Make sure we add the root node_modules directory to the node resolver
+      modules: ['node_modules', join(workspaceRoot, 'node_modules')],
       conditionNames: ['es2020', 'es2015', '...'],
       tsConfig: {
         configFile: normalizedOptions.tsConfig,


### PR DESCRIPTION
## Current Behavior
When configuring `resolve` config for the `rspack` config with Angular Rspack, we only consider `node_modules` local to the application.

## Expected Behavior
Ensure workspace root node_modules are also considered and added to the `resolve` config.

## Related Issue(s)

Closes NXC-3267
Fixes #33026
