### PR TITLE
fix(angular): prevent outputting inline source maps when building an …

### DIFF
--- a/packages/angular/src/executors/utilities/typescript.ts
+++ b/packages/angular/src/executors/utilities/typescript.ts
@@ -17,9 +17,9 @@ async function readDefaultTsConfig(fileName: string) {
     target: ts.ScriptTarget.ES2022,
 
     // sourcemaps
-    sourceMap: false,
+    sourceMap: true,
     inlineSources: true,
-    inlineSourceMap: true,
+    inlineSourceMap: false,
 
     outDir: '',
     declaration: true,


### PR DESCRIPTION
…Angular package

Fixes an issue causing extract-i18n to crash in a project that consumes the packaged Angular library.

Fixes #33081

