### PR TITLE
fix(angular): improve message for unsupported typescript project references

### DIFF
--- a/packages/angular/src/generators/application/application.ts
+++ b/packages/angular/src/generators/application/application.ts
@@ -12,12 +12,12 @@ import {
 } from '@nx/devkit';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 import { initGenerator as jsInitGenerator } from '@nx/js';
-import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { convertToRspack } from '../convert-to-rspack/convert-to-rspack';
 import { angularInitGenerator } from '../init/init';
 import { setupSsr } from '../setup-ssr/setup-ssr';
 import { setupTailwindGenerator } from '../setup-tailwind/setup-tailwind';
 import { ensureAngularDependencies } from '../utils/ensure-angular-dependencies';
+import { assertNotUsingTsSolutionSetup } from '../utils/validations';
 import {
   getInstalledAngularDevkitVersion,
   getInstalledAngularVersionInfo,
@@ -41,7 +41,7 @@ export async function applicationGenerator(
   tree: Tree,
   schema: Partial<Schema>
 ): Promise<GeneratorCallback> {
-  assertNotUsingTsSolutionSetup(tree, 'angular', 'application');
+  assertNotUsingTsSolutionSetup(tree, 'application');
   const isRspack = schema.bundler === 'rspack';
   if (isRspack) {
     schema.bundler = 'webpack';

--- a/packages/angular/src/generators/host/host.ts
+++ b/packages/angular/src/generators/host/host.ts
@@ -12,19 +12,19 @@ import {
   ensureRootProjectName,
 } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import { isValidVariable } from '@nx/js';
-import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { E2eTestRunner } from '../../utils/test-runners';
 import applicationGenerator from '../application/application';
+import convertToRspack from '../convert-to-rspack/convert-to-rspack';
 import remoteGenerator from '../remote/remote';
 import { setupMf } from '../setup-mf/setup-mf';
 import { addMfEnvToTargetDefaultInputs } from '../utils/add-mf-env-to-inputs';
+import { assertRspackIsCSR } from '../utils/assert-mf-utils';
+import { assertNotUsingTsSolutionSetup } from '../utils/validations';
 import { updateSsrSetup } from './lib';
 import type { Schema } from './schema';
-import { assertRspackIsCSR } from '../utils/assert-mf-utils';
-import convertToRspack from '../convert-to-rspack/convert-to-rspack';
 
 export async function host(tree: Tree, schema: Schema) {
-  assertNotUsingTsSolutionSetup(tree, 'angular', 'host');
+  assertNotUsingTsSolutionSetup(tree, 'host');
   // TODO: Replace with Rspack when confidence is high enough
   schema.bundler ??= 'webpack';
   const isRspack = schema.bundler === 'rspack';

--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -10,8 +10,8 @@ import {
   type Tree,
 } from '@nx/devkit';
 import { addPlugin } from '@nx/devkit/src/utils/add-plugin';
-import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { createNodesV2 } from '../../plugins/plugin';
+import { assertNotUsingTsSolutionSetup } from '../utils/validations';
 import {
   getInstalledAngularDevkitVersion,
   versions,
@@ -22,7 +22,7 @@ export async function angularInitGenerator(
   tree: Tree,
   options: Schema
 ): Promise<GeneratorCallback> {
-  assertNotUsingTsSolutionSetup(tree, 'angular', 'init');
+  assertNotUsingTsSolutionSetup(tree, 'init');
 
   ignoreAngularCacheDirectory(tree);
   const installTask = installAngularDevkitCoreIfMissing(tree, options);

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -3,14 +3,12 @@ import {
   formatFiles,
   GeneratorCallback,
   installPackagesTask,
-  logger,
   runTasksInSerial,
   Tree,
 } from '@nx/devkit';
 import { logShowProjectCommand } from '@nx/devkit/src/utils/log-show-project-command';
 import { initGenerator as jsInitGenerator } from '@nx/js';
 import { releaseTasks } from '@nx/js/src/generators/library/utils/add-release-config';
-import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import init from '../../generators/init/init';
 import { UnitTestRunner } from '../../utils/test-runners';
 import addLintingGenerator from '../add-linting/add-linting';
@@ -19,6 +17,7 @@ import { addJest } from '../utils/add-jest';
 import { addVitest } from '../utils/add-vitest';
 import { addBuildableLibrariesPostCssDependencies } from '../utils/dependencies';
 import { ensureAngularDependencies } from '../utils/ensure-angular-dependencies';
+import { assertNotUsingTsSolutionSetup } from '../utils/validations';
 import { versions } from '../utils/version-utils';
 import { addModule } from './lib/add-module';
 import { addProject } from './lib/add-project';
@@ -35,7 +34,7 @@ export async function libraryGenerator(
   tree: Tree,
   schema: Schema
 ): Promise<GeneratorCallback> {
-  assertNotUsingTsSolutionSetup(tree, 'angular', 'library');
+  assertNotUsingTsSolutionSetup(tree, 'library');
 
   // Do some validation checks
   if (!schema.routing && schema.lazy) {

--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -12,19 +12,19 @@ import {
   determineProjectNameAndRootOptions,
   ensureRootProjectName,
 } from '@nx/devkit/src/generators/project-name-and-root-utils';
-import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { swcHelpersVersion } from '@nx/js/src/utils/versions';
 import { E2eTestRunner } from '../../utils/test-runners';
 import { applicationGenerator } from '../application/application';
+import convertToRspack from '../convert-to-rspack/convert-to-rspack';
 import { setupMf } from '../setup-mf/setup-mf';
 import { addMfEnvToTargetDefaultInputs } from '../utils/add-mf-env-to-inputs';
+import { assertRspackIsCSR } from '../utils/assert-mf-utils';
+import { assertNotUsingTsSolutionSetup } from '../utils/validations';
 import { findNextAvailablePort, updateSsrSetup } from './lib';
 import type { Schema } from './schema';
-import { assertRspackIsCSR } from '../utils/assert-mf-utils';
-import convertToRspack from '../convert-to-rspack/convert-to-rspack';
 
 export async function remote(tree: Tree, schema: Schema) {
-  assertNotUsingTsSolutionSetup(tree, 'angular', 'remote');
+  assertNotUsingTsSolutionSetup(tree, 'remote');
   // TODO: Replace with Rspack when confidence is high enough
   schema.bundler ??= 'webpack';
   const isRspack = schema.bundler === 'rspack';

--- a/packages/angular/src/generators/utils/validations.ts
+++ b/packages/angular/src/generators/utils/validations.ts
@@ -1,5 +1,5 @@
-import type { Tree } from '@nx/devkit';
-import { getProjects } from '@nx/devkit';
+import { getProjects, output, type Tree } from '@nx/devkit';
+import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 export function validateProject(tree: Tree, projectName: string): void {
   const projects = getProjects(tree);
@@ -22,4 +22,32 @@ export function validateClassName(className: string): void {
   if (!ecmaIdentifierNameRegExp.test(className)) {
     throw new Error(`Class name "${className}" is invalid.`);
   }
+}
+
+export function assertNotUsingTsSolutionSetup(
+  tree: Tree,
+  generatorName: string
+): void {
+  if (
+    process.env.NX_IGNORE_UNSUPPORTED_TS_SETUP === 'true' ||
+    !isUsingTsSolutionSetup(tree)
+  ) {
+    return;
+  }
+
+  const artifactString =
+    generatorName === 'init'
+      ? `"@nx/angular" plugin`
+      : `"@nx/angular:${generatorName}" generator`;
+  output.error({
+    title: `The ${artifactString} doesn't support the existing TypeScript setup`,
+    bodyLines: [
+      `The Angular framework doesn't support a TypeScript setup with project references. See https://github.com/angular/angular/issues/37276 for more details.`,
+      `You can ignore this error, at your own risk, by setting the "NX_IGNORE_UNSUPPORTED_TS_SETUP" environment variable to "true".`,
+    ],
+  });
+
+  throw new Error(
+    `The ${artifactString} doesn't support the existing TypeScript setup. See the error above.`
+  );
 }


### PR DESCRIPTION
## Current Behavior

The `@nx/angular` plugin doesn't support generating any project or artifact when the workspace is using TypeScript project references because the Angular framework doesn't support it. The message logged to the users is very generic and slightly misleading. It's not clear enough and doesn't provide relevant information to allow users to understand the exact limitation.

## Expected Behavior

The generators from the `@nx/angular` plugin should log a clear error message with information pointing to the specific issue in the Angular framework preventing the setup from working for Angular projects.