### PR TITLE
fix(core): do not print flaky tasks guidance when nx cloud is already enabled

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle-old.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle-old.ts
@@ -1,9 +1,11 @@
+import { readNxJson } from '../../config/nx-json';
 import { Task } from '../../config/task-graph';
 import {
   getHistoryForHashes,
   TaskRun,
   writeTaskRunsToHistory,
 } from '../../utils/legacy-task-history';
+import { isNxCloudUsed } from '../../utils/nx-cloud-utils';
 import { output } from '../../utils/output';
 import { serializeTarget } from '../../utils/serialize-target';
 import { isTuiEnabled } from '../is-tui-enabled';
@@ -72,8 +74,12 @@ export class LegacyTaskHistoryLifeCycle implements LifeCycle {
         bodyLines: [
           ,
           ...this.flakyTasks.map((t) => `  ${t}`),
-          '',
-          `Flaky tasks can disrupt your CI pipeline. Automatically retry them with Nx Cloud. Learn more at https://nx.dev/ci/features/flaky-tasks`,
+          ...(isNxCloudUsed(readNxJson())
+            ? []
+            : [
+                '',
+                `Flaky tasks can disrupt your CI pipeline. Automatically retry them with Nx Cloud. Learn more at https://nx.dev/ci/features/flaky-tasks`,
+              ]),
         ],
       });
     }

--- a/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle.ts
@@ -1,5 +1,7 @@
+import { readNxJson } from '../../config/nx-json';
 import { Task } from '../../config/task-graph';
 import { IS_WASM, type TaskRun as NativeTaskRun } from '../../native';
+import { isNxCloudUsed } from '../../utils/nx-cloud-utils';
 import { output } from '../../utils/output';
 import { serializeTarget } from '../../utils/serialize-target';
 import { getTaskHistory, TaskHistory } from '../../utils/task-history';
@@ -94,8 +96,12 @@ export class TaskHistoryLifeCycle implements LifeCycle {
               taskRun.target.configuration
             )}`;
           }),
-          '',
-          `Flaky tasks can disrupt your CI pipeline. Automatically retry them with Nx Cloud. Learn more at https://nx.dev/ci/features/flaky-tasks`,
+          ...(isNxCloudUsed(readNxJson())
+            ? []
+            : [
+                '',
+                `Flaky tasks can disrupt your CI pipeline. Automatically retry them with Nx Cloud. Learn more at https://nx.dev/ci/features/flaky-tasks`,
+              ]),
         ],
       });
     }


### PR DESCRIPTION
## Current Behavior

When there are flaky tasks in a local run for a workspace that has Nx Cloud enabled, a help message is displayed, advising users to use Nx Cloud and pointing them to documentation on how to do so. Given that the workspace is already using Nx Cloud, the message is redundant.

## Expected Behavior

When there are flaky tasks in a local run for a workspace that has Nx Cloud enabled, no help message should be shown advising users to use Nx Cloud and pointing them to documentation on how to do so. If the workspace doesn't have Nx Cloud set up, the message should still be shown.