### PR TITLE
fix(release): replace local dependency protocols of unchanged dependencies #30995

### DIFF
--- a/packages/nx/src/command-line/release/version/release-group-processor.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.ts
@@ -22,7 +22,6 @@ import {
   SemverBumpType,
   VersionActions,
 } from './version-actions';
-import { resolveCurrentVersion } from './resolve-current-version';
 
 // Any semver version string such as "1.2.3" or "1.2.3-beta.1"
 type SemverVersion = string;
@@ -788,26 +787,10 @@ export class ReleaseGroupProcessor {
             finalPrefix = cachedFinalConfigForProject.versionPrefix;
           }
 
-          let newVersion: string;
-          if (targetVersionData.newVersion === null) {
-            const hasLocalProtocol =
-              currentDependencyVersion.startsWith('workspace:') ||
-              currentDependencyVersion.startsWith('file:');
-
-            if (
-              hasLocalProtocol &&
-              cachedFinalConfigForProject.preserveLocalDependencyProtocols
-            ) {
-              newVersion = currentDependencyVersion;
-            } else {
-              newVersion = this.releaseGraph.cachedCurrentVersions.get(
-                dep.target
-              );
-            }
-          } else {
-            newVersion =
-              targetVersionData.newVersion || currentDependencyVersion;
-          }
+          const newVersion =
+            targetVersionData.newVersion ??
+            this.releaseGraph.cachedCurrentVersions.get(dep.target) ??
+            currentDependencyVersion;
 
           // Remove any existing prefix from the new version before applying the finalPrefix
           const cleanNewVersion = newVersion.replace(/^[~^=]/, '');


### PR DESCRIPTION
## Current Behavior
When independent versioning with conventional commits, and only one project in a release group needs bumped, but it depends on another project via local dependency protocols such as `file://` or `workspace:` protocol, the local protocol dependency is not replaced.

## Expected Behavior
local protocol is replaced with the current version of the dependency.

## Related Issue(s)

Fixes #30995
