### PR TITLE
fix(angular): ensure ngpackagr tsconfig options set correctly based on version 

### DIFF
--- a/packages/angular/src/executors/utilities/typescript.ts
+++ b/packages/angular/src/executors/utilities/typescript.ts
@@ -10,16 +10,20 @@
 import { resolve } from 'path';
 import * as ts from 'typescript';
 import { loadEsmModule } from './module-loader';
+import { getNgPackagrVersionInfo } from './ng-packagr/ng-packagr-version';
 
 async function readDefaultTsConfig(fileName: string) {
+  const ngPackagrVersion = getNgPackagrVersionInfo();
+
   // these options are mandatory
   const extraOptions: ts.CompilerOptions = {
     target: ts.ScriptTarget.ES2022,
 
+    composite: false,
     // sourcemaps
-    sourceMap: false,
+    sourceMap: ngPackagrVersion.major < 20 ? false : true,
     inlineSources: true,
-    inlineSourceMap: true,
+    inlineSourceMap: ngPackagrVersion.major < 20 ? true : false,
 
     outDir: '',
     declaration: true,


### PR DESCRIPTION
## Current Behavior
TsConfig options are being set based on older versions of ng-packagr. These values changed in Angular 20.

## Expected Behavior
Ensure TsConfig options are set based on the version of `ng-packagr` installed.

## Related Issue(s)

Fixes #33081


Kudos to @daiscog for the initial work on this 🚀
