### PR TITLE
docs(nx-dev): update Java landing page to include Maven support

### DIFF
--- a/nx-dev/ui-gradle/src/lib/call-to-action.tsx
+++ b/nx-dev/ui-gradle/src/lib/call-to-action.tsx
@@ -58,65 +58,21 @@ export function CallToAction(): ReactElement {
 
       {/* Content */}
       <div className="mx-auto max-w-2xl text-center">
-        <div className="mb-8 flex justify-center">
-          <GradleIcon className="h-16 w-16 text-slate-900 dark:text-white" />
-        </div>
-
         <h2 className="text-3xl font-medium tracking-tight text-slate-950 sm:text-5xl dark:text-white">
-          Get Started With Gradle
+          Learn More
         </h2>
         <p className="mt-8">
-          Check out the documentation for the <code>@nx/gradle</code> plugin to
-          learn more
+          Check out the documentation for <code>@nx/gradle</code> or{' '}
+          <code>@nx/maven</code> to learn more
         </p>
         <div className="mt-10 flex items-center justify-center gap-x-6">
           <Link
-            href="/nx-api/gradle/documents/overview"
-            title="Get started with the tutorial"
+            href="/docs/technologies/java/gradle/introduction"
+            title="Get started with Gradle"
             prefetch={false}
             className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
           >
-            Read the Docs{' '}
-            <span
-              aria-hidden="true"
-              className="inline-block transition group-hover:translate-x-1"
-            >
-              →
-            </span>
-          </Link>
-
-          {/* <Link
-            href="/packages/gradle/gradle-plugin"
-            title="Read the documentation"
-            prefetch={false}
-            className="group text-sm font-semibold leading-6 text-slate-950 dark:text-white"
-          >
-            Read documentation{' '}
-            <span
-              aria-hidden="true"
-              className="inline-block transition group-hover:translate-x-1"
-            >
-              →
-            </span>
-          </Link> */}
-        </div>
-
-        <h3 className="mt-16 text-3xl font-medium tracking-tight text-slate-950 dark:text-white">
-          Looking for Maven?
-        </h3>
-        <p className="mt-8">
-          {' '}
-          Maven support is coming soon. Follow our blog and social media to be
-          notified when it is released.{' '}
-        </p>
-        <div className="mt-10 flex items-center justify-center gap-x-6">
-          <Link
-            href="/blog"
-            title="Read the blog"
-            prefetch={false}
-            className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
-          >
-            Read the blog{' '}
+            @nx/gradle Docs{' '}
             <span
               aria-hidden="true"
               className="inline-block transition group-hover:translate-x-1"
@@ -126,12 +82,12 @@ export function CallToAction(): ReactElement {
           </Link>
 
           <Link
-            href="/community"
-            title="Follow us on social media"
+            href="/docs/technologies/java/maven/introduction"
+            title="Get started with Maven"
             prefetch={false}
             className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
           >
-            Follow us on social media{' '}
+            @nx/maven Docs{' '}
             <span
               aria-hidden="true"
               className="inline-block transition group-hover:translate-x-1"

--- a/nx-dev/ui-gradle/src/lib/features.tsx
+++ b/nx-dev/ui-gradle/src/lib/features.tsx
@@ -11,7 +11,7 @@ export function Features(): ReactElement {
 
       <p className="mt-4 text-lg text-slate-500 dark:text-slate-400">
         The Nx Plugin for Java integrates seamlessly with your existing Gradle
-        builds, adding powerful capabilities to your workflow.
+        and Maven builds, adding powerful capabilities to your workflow.
       </p>
 
       <div className="mt-12 grid grid-cols-1 gap-6 sm:gap-8 md:grid-cols-2 lg:grid-cols-3">

--- a/nx-dev/ui-gradle/src/lib/hero.tsx
+++ b/nx-dev/ui-gradle/src/lib/hero.tsx
@@ -68,9 +68,7 @@ export function GettingStarted(): ReactElement {
           <h2 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl dark:text-white">
             Add Nx To An Existing Project
           </h2>
-          <p className="mt-8">
-            Currently Nx only supports Gradle. Support for Maven will come soon
-          </p>
+          <p className="mt-8">Nx supports both Gradle and Maven</p>
         </div>
 
         <div className="mt-12 grid grid-cols-1 gap-6 sm:gap-8 md:grid-cols-2 ">
@@ -82,7 +80,7 @@ export function GettingStarted(): ReactElement {
           <GetStartedCard
             title="Add Nx To Your Project"
             command="nx init"
-            description="Select <code>@nx/gradle</code> when prompted."
+            description="Select <code>@nx/gradle</code> or <code>@nx/maven</code> when prompted."
           />
 
           <GetStartedCard


### PR DESCRIPTION
## Current Behavior

The Java landing page at nx.dev/java only mentions Gradle support and indicates that Maven support is coming soon.

## Expected Behavior

The Java landing page should reflect that Maven is now available alongside Gradle.

https://nx-dev-git-mvn-follow-nrwl.vercel.app/java

## Related Issue(s)

Updates the documentation to reflect the Maven plugin introduced in #32947

---

**Changes:**
- Updated hero section to state "Nx supports both Gradle and Maven"
- Modified getting started instructions to mention both `@nx/gradle` and `@nx/maven`
- Updated features description to include Maven builds
- Combined Gradle and Maven documentation links into a single "Learn More" section with buttons for both
- Updated call-to-action links to point to `/docs/technologies/java/{gradle,maven}/introduction`