### PR TITLE
fix(angular): prevent outputting inline source maps when building an Angular package

### DIFF
--- a/packages/angular/src/executors/utilities/typescript.ts
+++ b/packages/angular/src/executors/utilities/typescript.ts
@@ -17,9 +17,9 @@ async function readDefaultTsConfig(fileName: string) {
     target: ts.ScriptTarget.ES2022,
 
     // sourcemaps
-    sourceMap: false,
+    sourceMap: true,
     inlineSources: true,
-    inlineSourceMap: true,
+    inlineSourceMap: false,
 
     outDir: '',
     declaration: true,

--- a/packages/angular/src/executors/utilities/typescript.ts
+++ b/packages/angular/src/executors/utilities/typescript.ts
@@ -10,16 +10,20 @@
 import { resolve } from 'path';
 import * as ts from 'typescript';
 import { loadEsmModule } from './module-loader';
+import { getNgPackagrVersionInfo } from './ng-packagr/ng-packagr-version';
 
 async function readDefaultTsConfig(fileName: string) {
+  const ngPackagrVersion = getNgPackagrVersionInfo();
+
   // these options are mandatory
   const extraOptions: ts.CompilerOptions = {
     target: ts.ScriptTarget.ES2022,
 
+    composite: false,
     // sourcemaps
-    sourceMap: true,
+    sourceMap: ngPackagrVersion.major < 20 ? false : true,
     inlineSources: true,
-    inlineSourceMap: false,
+    inlineSourceMap: ngPackagrVersion.major < 20 ? true : false,
 
     outDir: '',
     declaration: true,


### PR DESCRIPTION
Fixes #33081

Cherry-picks the commits from #33150 into `21.6.x`.

As per my comments on [my original PR](https://github.com/nrwl/nx/pull/33147#issuecomment-3425569125), our organization is in the process of upgrading all our repos to nx 21 and Angular 20, but this issue is blocking our ability to complete this work.

The comment from @Coly010 indicates that the fix will be included in nx 22, but we have a schedule for major version upgrades and won't be able to adopt nx 22 until six months time (this is non-trivial for us because of our internal tooling/plugins, and the volume of repos affected).

We would therefore be extremely grateful if you would accept this fix as a patch for the current latest version - 21.6.x.
