### PR TITLE
chore(maven): bump version to 0.0.6

### DIFF
--- a/packages/maven/maven-plugin/pom.xml
+++ b/packages/maven/maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.nx</groupId>
     <artifactId>nx-parent</artifactId>
-    <version>0.0.6-SNAPSHOT</version>
+    <version>0.0.6</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/src/utils/versions.ts
+++ b/packages/maven/src/utils/versions.ts
@@ -1,2 +1,2 @@
 export const nxVersion = require('../../package.json').version;
-export const mavenPluginVersion = '0.0.6-SNAPSHOT';
+export const mavenPluginVersion = '0.0.6';

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>dev.nx</groupId>
   <artifactId>nx-parent</artifactId>
-  <version>0.0.6-SNAPSHOT</version>
+  <version>0.0.6</version>
   <packaging>pom</packaging>
 
   <name>Nx Parent</name>


### PR DESCRIPTION
## Summary

Update Maven plugin version from 0.0.6-SNAPSHOT to 0.0.6 for release.

## Changes

- Root pom.xml (nx-parent)
- packages/maven/maven-plugin/pom.xml
- packages/maven/src/utils/versions.ts

## Test plan

- Maven plugin builds correctly with the new version
- No breaking changes to Maven integration