### PR TITLE
fix(misc): handle null exit codes from crashed child processes

### DIFF
--- a/packages/create-nx-workspace/src/utils/child-process-utils.ts
+++ b/packages/create-nx-workspace/src/utils/child-process-utils.ts
@@ -22,7 +22,8 @@ export function spawnAndWait(command: string, args: string[], cwd: string) {
       windowsHide: false,
     });
 
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code !== 0) {
         rej({ code: code });
       } else {
@@ -57,4 +58,17 @@ export function execAndWait(
       }
     );
   });
+}
+
+function signalToCode(signal: NodeJS.Signals | null): number {
+  switch (signal) {
+    case 'SIGHUP':
+      return 128 + 1;
+    case 'SIGINT':
+      return 128 + 2;
+    case 'SIGTERM':
+      return 128 + 15;
+    default:
+      return 128;
+  }
 }

--- a/packages/detox/src/executors/build/build.impl.ts
+++ b/packages/detox/src/executors/build/build.impl.ts
@@ -1,4 +1,5 @@
 import { ExecutorContext } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { resolve as pathResolve } from 'path';
 import { ChildProcess, fork } from 'child_process';
 
@@ -50,7 +51,8 @@ export function runCliBuild(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(code);
       } else {

--- a/packages/detox/src/executors/test/test.impl.ts
+++ b/packages/detox/src/executors/test/test.impl.ts
@@ -3,6 +3,7 @@ import {
   parseTargetString,
   readTargetOptions,
 } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { names } from '@nx/devkit';
 import { resolve as pathResolve } from 'path';
 import { ChildProcess, fork } from 'child_process';
@@ -71,7 +72,8 @@ function runCliTest(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(code);
       } else {

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -1,0 +1,1 @@
+export { signalToCode } from 'nx/src/devkit-internals';

--- a/packages/docker/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/docker/src/executors/release-publish/release-publish.impl.ts
@@ -4,6 +4,7 @@ import {
   logger,
   workspaceRoot,
 } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { exec } from 'child_process';
 import type { DockerReleasePublishSchema } from './schema';
 import { existsSync, readFileSync } from 'fs';
@@ -132,7 +133,8 @@ async function dockerPush(imageReference: string, quiet: boolean) {
       childProcess.on('error', (error) => {
         rej(error);
       });
-      childProcess.on('exit', (code) => {
+      childProcess.on('exit', (code, signal) => {
+        if (code === null) code = signalToCode(signal);
         if (code === 0) {
           res(result.trim());
         } else {

--- a/packages/expo/src/executors/build-list/build-list.impl.ts
+++ b/packages/expo/src/executors/build-list/build-list.impl.ts
@@ -1,4 +1,5 @@
 import { ExecutorContext, logger, names } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { resolve as pathResolve } from 'path';
 import { ChildProcess, fork } from 'child_process';
 
@@ -66,7 +67,8 @@ export function runCliBuildList(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(output);
       } else {

--- a/packages/expo/src/executors/build/build.impl.ts
+++ b/packages/expo/src/executors/build/build.impl.ts
@@ -7,6 +7,7 @@ import {
   readJsonFile,
   writeJsonFile,
 } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { getLockFileName } from '@nx/js';
 import { ChildProcess, fork } from 'child_process';
 import { copyFileSync, existsSync, rmSync, writeFileSync } from 'node:fs';
@@ -74,7 +75,8 @@ function runCliBuild(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(code);
       } else {

--- a/packages/expo/src/executors/export/export.impl.ts
+++ b/packages/expo/src/executors/export/export.impl.ts
@@ -4,6 +4,7 @@ import {
   names,
   offsetFromRoot,
 } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { ChildProcess, fork } from 'child_process';
 import { resolve as pathResolve } from 'path';
 
@@ -53,7 +54,8 @@ function exportAsync(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(code);
       } else {

--- a/packages/expo/src/executors/prebuild/prebuild.impl.ts
+++ b/packages/expo/src/executors/prebuild/prebuild.impl.ts
@@ -1,4 +1,5 @@
 import { ExecutorContext, names, workspaceRoot } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { ChildProcess, fork } from 'child_process';
 import { join } from 'path';
 
@@ -60,7 +61,8 @@ export function prebuildAsync(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(code);
       } else {

--- a/packages/expo/src/executors/run/run.impl.ts
+++ b/packages/expo/src/executors/run/run.impl.ts
@@ -1,4 +1,5 @@
 import { ExecutorContext, names } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { ChildProcess, fork } from 'child_process';
 import { existsSync } from 'node:fs';
 import { platform } from 'os';
@@ -75,7 +76,8 @@ function runCliRun(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(code);
       } else {

--- a/packages/expo/src/executors/serve/serve.impl.ts
+++ b/packages/expo/src/executors/serve/serve.impl.ts
@@ -1,4 +1,5 @@
 import { ExecutorContext, logger, names } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { ChildProcess, fork } from 'child_process';
 import { resolve as pathResolve } from 'path';
 import { isPackagerRunning } from './lib/is-packager-running';
@@ -98,7 +99,8 @@ function serveAsync(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(childProcess);
       } else {

--- a/packages/expo/src/executors/start/start.impl.ts
+++ b/packages/expo/src/executors/start/start.impl.ts
@@ -1,5 +1,6 @@
 import * as pc from 'picocolors';
 import { ExecutorContext, logger, names } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { ChildProcess, fork } from 'child_process';
 import { resolve as pathResolve } from 'path';
 
@@ -61,7 +62,8 @@ function startAsync(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(code);
       } else {

--- a/packages/expo/src/executors/submit/submit.impl.ts
+++ b/packages/expo/src/executors/submit/submit.impl.ts
@@ -1,4 +1,5 @@
 import { ExecutorContext, names } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { resolve as pathResolve } from 'path';
 import { ChildProcess, fork } from 'child_process';
 
@@ -52,7 +53,8 @@ function runCliSubmit(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(code);
       } else {

--- a/packages/expo/src/executors/update/update.impl.ts
+++ b/packages/expo/src/executors/update/update.impl.ts
@@ -1,4 +1,5 @@
 import { ExecutorContext, names } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { resolve as pathResolve } from 'path';
 import { ChildProcess, fork } from 'child_process';
 
@@ -52,7 +53,8 @@ function runCliUpdate(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(code);
       } else {

--- a/packages/gradle/src/utils/exec-gradle.ts
+++ b/packages/gradle/src/utils/exec-gradle.ts
@@ -1,4 +1,5 @@
 import { AggregateCreateNodesError, workspaceRoot } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { ExecFileOptions, execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -50,7 +51,8 @@ export function execGradleAsync(
       stdout += data;
     });
 
-    cp.on('exit', (code) => {
+    cp.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         res(stdout);
       } else {

--- a/packages/js/src/executors/verdaccio/verdaccio.impl.ts
+++ b/packages/js/src/executors/verdaccio/verdaccio.impl.ts
@@ -1,4 +1,5 @@
 import { ExecutorContext, logger } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { ChildProcess, execSync, fork } from 'child_process';
 import * as detectPort from 'detect-port';
 import { existsSync, rmSync } from 'node:fs';
@@ -105,7 +106,8 @@ function startVerdaccio(
     childProcess.on('disconnect', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(code);
       } else {

--- a/packages/js/src/plugins/jest/start-local-registry.ts
+++ b/packages/js/src/plugins/jest/start-local-registry.ts
@@ -1,3 +1,4 @@
+import { signalToCode } from '@nx/devkit/internal';
 import { execSync, fork } from 'child_process';
 
 /**
@@ -92,7 +93,8 @@ export function startLocalRegistry({
       console.log('local registry error', err);
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       console.log('local registry exit', code);
       if (code !== 0) {
         reject(code);

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -19,7 +19,7 @@ import { checkPublicDirectory } from './lib/check-project';
 import { NextBuildBuilderOptions } from '../../utils/types';
 import { ChildProcess, fork } from 'child_process';
 import { createCliOptions } from '../../utils/create-cli-options';
-import { signalToCode } from 'nx/src/utils/exit-codes';
+import { signalToCode } from '@nx/devkit/internal';
 
 let childProcess: ChildProcess;
 
@@ -176,6 +176,7 @@ function runCliBuild(
     });
 
     childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve({ code, signal });
       } else {

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -44,3 +44,4 @@ export { isCI } from './utils/is-ci';
 export { isUsingPrettierInTree } from './utils/is-using-prettier';
 export { readYamlFile } from './utils/fileutils';
 export { globalSpinner } from './utils/spinner';
+export { signalToCode } from './utils/exit-codes';

--- a/packages/nx/src/tasks-runner/fork.ts
+++ b/packages/nx/src/tasks-runner/fork.ts
@@ -45,8 +45,9 @@ process.on('message', (message: Serializable) => {
   pseudoIPC.sendMessageToParent(message);
 });
 
-childProcess.on('exit', (code) => {
+childProcess.on('exit', (code, signal) => {
   cleanup();
+  if (code === null) code = signalToCode(signal);
   process.exit(code);
 });
 

--- a/packages/nx/src/utils/exit-codes.ts
+++ b/packages/nx/src/utils/exit-codes.ts
@@ -2,7 +2,7 @@
  * Translates NodeJS signals to numeric exit code
  * @param signal
  */
-export function signalToCode(signal: NodeJS.Signals): number {
+export function signalToCode(signal: NodeJS.Signals | null): number {
   switch (signal) {
     case 'SIGHUP':
       return 128 + 1;

--- a/packages/react-native/src/executors/build-android/build-android.impl.ts
+++ b/packages/react-native/src/executors/build-android/build-android.impl.ts
@@ -1,4 +1,5 @@
 import { ExecutorContext } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { join, resolve as pathResolve } from 'path';
 import { ChildProcess, fork } from 'child_process';
 import { ReactNativeBuildAndroidOptions } from './schema';
@@ -52,7 +53,8 @@ function runCliBuild(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         res(childProcess);
       } else {

--- a/packages/react-native/src/executors/build-ios/build-ios.impl.ts
+++ b/packages/react-native/src/executors/build-ios/build-ios.impl.ts
@@ -1,4 +1,5 @@
 import { ExecutorContext } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { resolve as pathResolve } from 'path';
 import { ChildProcess, fork } from 'child_process';
 import { platform } from 'os';
@@ -58,7 +59,8 @@ function runCliBuildIOS(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(childProcess);
       } else {

--- a/packages/react-native/src/executors/bundle/bundle.impl.ts
+++ b/packages/react-native/src/executors/bundle/bundle.impl.ts
@@ -1,4 +1,5 @@
 import { names, ExecutorContext } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { dirname, join, resolve as pathResolve } from 'path';
 import { ChildProcess, fork } from 'child_process';
 
@@ -56,7 +57,8 @@ function runCliBuild(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(childProcess);
       } else {

--- a/packages/react-native/src/executors/run-android/run-android.impl.ts
+++ b/packages/react-native/src/executors/run-android/run-android.impl.ts
@@ -1,4 +1,5 @@
 import { ExecutorContext } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { join, resolve as pathResolve } from 'path';
 import { ChildProcess, fork } from 'child_process';
 
@@ -73,7 +74,8 @@ function runCliRunAndroid(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(childProcess);
       } else {

--- a/packages/react-native/src/executors/run-ios/run-ios.impl.ts
+++ b/packages/react-native/src/executors/run-ios/run-ios.impl.ts
@@ -1,4 +1,5 @@
 import { ExecutorContext, GeneratorCallback, workspaceRoot } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { resolve as pathResolve } from 'path';
 import { ChildProcess, fork } from 'child_process';
 import { platform } from 'os';
@@ -73,7 +74,8 @@ function runCliRunIOS(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(childProcess);
       } else {

--- a/packages/react-native/src/executors/start/start.impl.ts
+++ b/packages/react-native/src/executors/start/start.impl.ts
@@ -1,4 +1,5 @@
 import { ExecutorContext, logger } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { ChildProcess, fork } from 'child_process';
 import { resolve as pathResolve } from 'path';
 import { isPackagerRunning } from './lib/is-packager-running';
@@ -74,7 +75,8 @@ function startAsync(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(childProcess);
       } else {

--- a/packages/react-native/src/executors/upgrade/upgrade.impl.ts
+++ b/packages/react-native/src/executors/upgrade/upgrade.impl.ts
@@ -1,4 +1,5 @@
 import { ExecutorContext } from '@nx/devkit';
+import { signalToCode } from '@nx/devkit/internal';
 import { resolve as pathResolve } from 'path';
 import { ChildProcess, fork } from 'child_process';
 
@@ -53,7 +54,8 @@ export function runCliUpgrade(
     childProcess.on('error', (err) => {
       reject(err);
     });
-    childProcess.on('exit', (code) => {
+    childProcess.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code === 0) {
         resolve(childProcess);
       } else {

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -1,3 +1,4 @@
+import { signalToCode } from '@nx/devkit/internal';
 import { execFileSync, fork } from 'child_process';
 import * as pc from 'picocolors';
 import {
@@ -267,7 +268,8 @@ export default async function* fileServerExecutor(
   };
 
   return new Promise<{ success: boolean }>((res) => {
-    serve.on('exit', (code) => {
+    serve.on('exit', (code, signal) => {
+      if (code === null) code = signalToCode(signal);
       if (code == 0) {
         res({ success: true });
       } else {


### PR DESCRIPTION
## Current Behavior

In some scenarios, when some processes terminate unexpectedly (e.g. crashed due to OOM), the task runner will incorrectly determine their exit code to be 0. This results in Nx storing the task results as a success, which can cause cache hits with false positive successes.

## Expected Behavior

When processes terminate unexpectedly (e.g. crashed due to OOM), the task runner should correctly determine their exit code from the signal, and it should never be 0. The stored task result should not be marked as successful.

## Related Issue(s)

Fixes #29204 
