### PR TITLE
fix(nx-dev): add docker to build-tools tech section

### DIFF
--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -181,6 +181,11 @@ export const sidebar: StarlightUserConfig['sidebar'] = [
             collapsed: true,
             items: getPluginItems('rsbuild', 'build-tools'),
           },
+          {
+            label: 'Docker',
+            collapsed: true,
+            items: getPluginItems('docker', 'build-tools'),
+          },
         ],
       },
       {

--- a/astro-docs/src/plugins/utils/plugin-mappings.ts
+++ b/astro-docs/src/plugins/utils/plugin-mappings.ts
@@ -190,17 +190,17 @@ function hasValidConfig(
   const content = JSON.parse(readFileSync(configPath, 'utf-8'));
 
   if (type === 'executors') {
-    return (
+    const hasExecutors =
       content.executors &&
       typeof content.executors === 'object' &&
-      Object.keys(content.executors).length > 0
-    );
+      Object.keys(content.executors).length > 0;
+
+    return hasExecutors && hasVisibleImpls(content.executors);
   }
 
   // migrations can be generators or packageJsonUpdates
   const hasGenerators =
-    isGeneratorsConfig(content) &&
-    Object.values(content.generators).filter((g) => !g.hidden).length > 0;
+    isGeneratorsConfig(content) && hasVisibleImpls(content.generators);
 
   const hasPackageJsonUpdates =
     content.packageJsonUpdates &&
@@ -377,5 +377,17 @@ function isGeneratorsConfig(
     typeof content === 'object' &&
     'generators' in content &&
     typeof content.generators === 'object'
+  );
+}
+
+/**
+ * validate that a generator/migration/executor config has at least 1 visible implmentation
+ **/
+function hasVisibleImpls(content: Record<string, unknown>): boolean {
+  return (
+    content &&
+    Object.values(content).some(
+      (impl: any) => typeof impl === 'object' && !impl.hidden
+    )
   );
 }


### PR DESCRIPTION
- add docker to sidebar
- sidebar only shows when there are non-hidden executor/generator/migration impls to prevent linking to 404 pages

fixes DOC-299