### PR TITLE
feat(release): allow conventional commit style aliases in version plan release types

### DIFF
--- a/packages/nx/src/command-line/release/config/version-plans.spec.ts
+++ b/packages/nx/src/command-line/release/config/version-plans.spec.ts
@@ -241,7 +241,7 @@ describe('version-plans', () => {
                 false
               )
             ).rejects.toThrowErrorMatchingInlineSnapshot(
-              `Found a version bump in 'plan1.md' with an invalid release type. Please specify one of major, premajor, minor, preminor, patch, prepatch, prerelease.`
+              `Found a version bump in 'plan1.md' with an invalid release type. Please specify one of: "major" (aliases: "feat!" or "fix!"), "minor" (alias: "feat"), "patch" (alias: "fix"), "premajor", "preminor", "prepatch", "prerelease".`
             );
           });
 
@@ -404,7 +404,7 @@ describe('version-plans', () => {
                 false
               )
             ).rejects.toThrowErrorMatchingInlineSnapshot(
-              `Found a version bump for project 'pkg1' in 'plan1.md' with an invalid release type. Please specify one of major, premajor, minor, preminor, patch, prepatch, prerelease.`
+              `Found a version bump for project 'pkg1' in 'plan1.md' with an invalid release type. Please specify one of: "major" (aliases: "feat!" or "fix!"), "minor" (alias: "feat"), "patch" (alias: "fix"), "premajor", "preminor", "prepatch", "prerelease".`
             );
           });
 
@@ -537,7 +537,7 @@ describe('version-plans', () => {
                 false
               )
             ).rejects.toThrowErrorMatchingInlineSnapshot(
-              `Found a version bump for group 'group1' in 'plan1.md' with an invalid release type. Please specify one of major, premajor, minor, preminor, patch, prepatch, prerelease.`
+              `Found a version bump for group 'group1' in 'plan1.md' with an invalid release type. Please specify one of: "major" (aliases: "feat!" or "fix!"), "minor" (alias: "feat"), "patch" (alias: "fix"), "premajor", "preminor", "prepatch", "prerelease".`
             );
           });
 
@@ -716,7 +716,7 @@ describe('version-plans', () => {
                 false
               )
             ).rejects.toThrowErrorMatchingInlineSnapshot(
-              `Found a version bump for project 'pkg1' in 'plan1.md' with an invalid release type. Please specify one of major, premajor, minor, preminor, patch, prepatch, prerelease.`
+              `Found a version bump for project 'pkg1' in 'plan1.md' with an invalid release type. Please specify one of: "major" (aliases: "feat!" or "fix!"), "minor" (alias: "feat"), "patch" (alias: "fix"), "premajor", "preminor", "prepatch", "prerelease".`
             );
           });
 

--- a/packages/nx/src/command-line/release/config/version-plans.ts
+++ b/packages/nx/src/command-line/release/config/version-plans.ts
@@ -52,6 +52,18 @@ export interface ProjectsVersionPlan extends VersionPlan {
 
 const versionPlansDirectory = join('.nx', 'version-plans');
 
+const allowedAttributeValues = [
+  // Stable releases (with conventional-commit style aliases)
+  '"major" (aliases: "feat!" or "fix!")',
+  '"minor" (alias: "feat")',
+  '"patch" (alias: "fix")',
+  // Prereleases
+  '"premajor"',
+  '"preminor"',
+  '"prepatch"',
+  '"prerelease"',
+];
+
 export async function readRawVersionPlans(): Promise<RawVersionPlan[]> {
   const versionPlansPath = getVersionPlansAbsolutePath();
   if (!existsSync(versionPlansPath)) {
@@ -67,6 +79,28 @@ export async function readRawVersionPlans(): Promise<RawVersionPlan[]> {
     const versionPlanStats = await stat(filePath);
 
     const parsedContent = fm(versionPlanContent);
+
+    /**
+     * For convenience allow:
+     * - feat to be used as an alias of minor
+     * - fix to be used as an alias of patch
+     * - Either feat! or fix! to be used as an alias of major
+     */
+    for (const [key, value] of Object.entries(parsedContent.attributes)) {
+      switch (value) {
+        case 'feat':
+          parsedContent.attributes[key] = 'minor';
+          break;
+        case 'fix':
+          parsedContent.attributes[key] = 'patch';
+          break;
+        case 'feat!':
+        case 'fix!':
+          parsedContent.attributes[key] = 'major';
+          break;
+      }
+    }
+
     versionPlans.push({
       absolutePath: filePath,
       relativePath: join(versionPlansDirectory, versionPlanFile),
@@ -132,7 +166,7 @@ export async function setResolvedVersionPlansOnGroups(
             throw new Error(
               `Found a version bump in '${
                 rawVersionPlan.fileName
-              }' with an invalid release type. Please specify one of ${RELEASE_TYPES.join(
+              }' with an invalid release type. Please specify one of: ${allowedAttributeValues.join(
                 ', '
               )}.`
             );
@@ -140,7 +174,7 @@ export async function setResolvedVersionPlansOnGroups(
             throw new Error(
               `Found a version bump for group '${key}' in '${
                 rawVersionPlan.fileName
-              }' with an invalid release type. Please specify one of ${RELEASE_TYPES.join(
+              }' with an invalid release type. Please specify one of: ${allowedAttributeValues.join(
                 ', '
               )}.`
             );
@@ -216,7 +250,7 @@ export async function setResolvedVersionPlansOnGroups(
           throw new Error(
             `Found a version bump for project '${key}' in '${
               rawVersionPlan.fileName
-            }' with an invalid release type. Please specify one of ${RELEASE_TYPES.join(
+            }' with an invalid release type. Please specify one of: ${allowedAttributeValues.join(
               ', '
             )}.`
           );


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Strictly only semver keywords can be used for version plan release types.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Conventional commit style keywords can be used in addition to semver keywords for version plan release types.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
