### PR TITLE
docs(nx-dev): fix redirect for gradle and java overview/intro pages

### DIFF
--- a/nx-dev/nx-dev/redirect-rules-docs-to-astro.js
+++ b/nx-dev/nx-dev/redirect-rules-docs-to-astro.js
@@ -1036,8 +1036,7 @@ const docsToAstroRedirects = {
     '/docs/technologies/node/guides/wait-for-tasks',
   '/technologies/node/express/api': '/docs/technologies/node/express',
   '/technologies/node/nest/api': '/docs/technologies/node/nest',
-  '/technologies/java/introduction':
-    '/docs/technologies/angular/angular-rspack/introduction',
+  '/technologies/java/introduction': '/docs/technologies/java/introduction',
   '/technologies/module-federation/recipes/create-a-host':
     '/docs/technologies/module-federation/guides/create-a-host',
   '/technologies/module-federation/recipes/create-a-remote':

--- a/nx-dev/nx-dev/redirect-rules.js
+++ b/nx-dev/nx-dev/redirect-rules.js
@@ -1339,8 +1339,8 @@ const nxApiRedirects = {
   '/nx-api/detox/documents/overview':
     '/technologies/test-tools/detox/introduction',
   '/nx-api/js/documents/overview': '/technologies/typescript/introduction',
-  '/nx-api/gradle/documents': '/technologies/java/introduction',
-  '/nx-api/gradle/documents/overview': '/technologies/java/introduction',
+  '/nx-api/gradle/documents': '/docs/technologies/java/gradle/introduction',
+  '/nx-api/gradle/documents/overview': '/docs/technologies/java/gradle/introduction',
   '/nx-api/eslint/documents/overview': '/technologies/eslint/introduction',
   '/nx-api/eslint-plugin/documents/overview':
     '/technologies/eslint/eslint-plugin/api',

--- a/nx-dev/nx-dev/redirect-rules.js
+++ b/nx-dev/nx-dev/redirect-rules.js
@@ -1340,7 +1340,8 @@ const nxApiRedirects = {
     '/technologies/test-tools/detox/introduction',
   '/nx-api/js/documents/overview': '/technologies/typescript/introduction',
   '/nx-api/gradle/documents': '/docs/technologies/java/gradle/introduction',
-  '/nx-api/gradle/documents/overview': '/docs/technologies/java/gradle/introduction',
+  '/nx-api/gradle/documents/overview':
+    '/docs/technologies/java/gradle/introduction',
   '/nx-api/eslint/documents/overview': '/technologies/eslint/introduction',
   '/nx-api/eslint-plugin/documents/overview':
     '/technologies/eslint/eslint-plugin/api',


### PR DESCRIPTION
This PR fixes a bad redirect where Java intro page went to Angular Rspack. Also update original Gradle API redirect to go to the Gradle page rather than the generic Java one.

Closes DOC-298
