### PR TITLE
fix(react): update template comment to be valid css

### DIFF
--- a/packages/react/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/react/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`app --bundler=rsbuild should generate valid rsbuild config files for @e
 import NxWelcome from "./nx-welcome";
 
 const StyledApp = styled.div\`
-    // Your style here
+    /* Your style here */
 \`;
 
 export function App() {
@@ -72,7 +72,7 @@ exports[`app --bundler=rsbuild should generate valid rsbuild config files for st
 import NxWelcome from "./nx-welcome";
 
 const StyledApp = styled.div\`
-    // Your style here
+    /* Your style here */
 \`;
 
 export function App() {
@@ -592,7 +592,7 @@ exports[`app should generate valid .babelrc JSON config for CSS-in-JS solutions 
 import NxWelcome from "./nx-welcome";
 
 const StyledApp = styled.div\`
-    // Your style here
+    /* Your style here */
 \`;
 
 export function App() {
@@ -631,7 +631,7 @@ exports[`app should generate valid .babelrc JSON config for CSS-in-JS solutions 
 import NxWelcome from "./nx-welcome";
 
 const StyledApp = styled.div\`
-    // Your style here
+    /* Your style here */
 \`;
 
 export function App() {

--- a/packages/react/src/generators/application/files/style-styled-module/src/app/__fileName__.tsx__tmpl__
+++ b/packages/react/src/generators/application/files/style-styled-module/src/app/__fileName__.tsx__tmpl__
@@ -7,7 +7,7 @@ import NxWelcome from "./nx-welcome";
 <%_ } _%>
 
 const StyledApp = styled.div`
-    // Your style here
+    /* Your style here */
 `;
 
 <%_ if (classComponent) { _%>


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
The `//` comment in the styled template [is not valid css](https://stackoverflow.com/questions/12298890/is-it-bad-practice-to-prefix-single-lines-of-css-with-as-a-personal-comment-s/20192639#20192639) and is causing [stylelint](https://stylelint.io/) to throw errors upon creating new apps

## Expected Behavior
It should be valid css

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

https://github.com/nrwl/nx/issues/33579