### PR TITLE
docs(misc): add PNPM catalog support documentation

### DIFF
--- a/astro-docs/src/content/docs/concepts/Decisions/dependency-management.mdoc
+++ b/astro-docs/src/content/docs/concepts/Decisions/dependency-management.mdoc
@@ -45,6 +45,10 @@ For building and deployment, you'll need to ensure each project only includes it
 
 The main challenge with this approach is coordinating dependency updates across independent teams. When multiple teams work on different, or even the same, applications within the same repo, they need to align on dependency upgrades. While this requires more coordination, it often results in less total work - upgrading a dependency once across all projects is typically more efficient than managing multiple separate upgrades over time.
 
+{% aside type="tip" title="PNPM Catalog Support" %}
+When using PNPM, use [PNPM catalogs](https://pnpm.io/catalogs) to maintain single version policy. Define versions in `pnpm-workspace.yaml` and reference them as `"<package>": "catalog:"` in project `package.json` files (Nx 22+).
+{% /aside %}
+
 **Pros:**
 
 - Ensures consistent dependency versions, preventing runtime conflicts


### PR DESCRIPTION

<img width="784" height="196" alt="image" src="https://github.com/user-attachments/assets/45702b02-a97f-4d75-a67b-76eacdfb56ff" />

## Current Behavior
The dependency management documentation does not mention PNPM catalogs as an option for maintaining single version policy.

## Expected Behavior
Documentation includes information about PNPM catalogs, explaining how they can be used to maintain a single version policy when using PNPM as the package manager. This helps if user searches for PNPM catalogs.

## Related Issue(s)
Fixes DOC-302
