### PR TITLE
fix(core): store reason when marking daemon as disabled

### DIFF
--- a/packages/nx/src/daemon/tmp-dir.ts
+++ b/packages/nx/src/daemon/tmp-dir.ts
@@ -33,8 +33,8 @@ export function writeDaemonLogs(error?: string) {
   return file;
 }
 
-export function markDaemonAsDisabled() {
-  writeFileSync(join(DAEMON_DIR_FOR_CURRENT_WORKSPACE, 'disabled'), 'true');
+export function markDaemonAsDisabled(reason: string) {
+  writeFileSync(join(DAEMON_DIR_FOR_CURRENT_WORKSPACE, 'disabled'), reason);
 }
 
 export function isDaemonDisabled() {

--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -386,7 +386,7 @@ export async function createProjectGraphAndSourceMapsAsync(
             'Nx Daemon is going to be disabled until you run "nx reset".',
           ],
         });
-        markDaemonAsDisabled();
+        markDaemonAsDisabled(e.message);
         return buildProjectGraphAndSourceMapsWithoutDaemon();
       }
 
@@ -400,7 +400,7 @@ export async function createProjectGraphAndSourceMapsAsync(
             'Nx Daemon is going to be disabled until you run "nx reset".',
           ],
         });
-        markDaemonAsDisabled();
+        markDaemonAsDisabled(e.message);
         return buildProjectGraphAndSourceMapsWithoutDaemon();
       }
 


### PR DESCRIPTION
## Current Behavior

When the daemon is disabled due to an error, the reason isn't captured, making it harder to debug why the daemon was disabled.

## Expected Behavior

The error message/reason is now stored when marking the daemon as disabled, allowing better visibility into what caused the daemon to be disabled.

## Related Issue(s)