### PR TITLE
docs(core): correctly parse alias args with single dash

### DIFF
--- a/astro-docs/src/plugins/utils/nx-cli-generation.ts
+++ b/astro-docs/src/plugins/utils/nx-cli-generation.ts
@@ -134,16 +134,19 @@ nx ${cmd.command || cmdName}
       );
 
       for (const option of sortedOptions) {
-        const optionNames = option.name.map((n) => `\`--${n}\``).join(', ');
+        // Format option names following the convention:
+        // - Canonical (first) option always gets --
+        // - Single-character aliases get -
+        // - Multi-character aliases get --
+        const [canonical, ...aliases] = option.name;
+        const formattedNames = [canonical, ...aliases].map((name) => {
+          if (name === canonical) {
+            return `\`--${name}\``;
+          }
+          return name.length === 1 ? `\`-${name}\`` : `\`--${name}\``;
+        });
+        const optionNames = formattedNames.join(', ');
         let description = option.description || '';
-
-        if (option.name.length > 1) {
-          const aliases = option.name
-            .slice(1)
-            .map((a) => `\`-${a}\``)
-            .join(', ');
-          description += ` (alias: ${aliases})`;
-        }
 
         if (option.deprecated) {
           description += ` **⚠️ Deprecated**${


### PR DESCRIPTION
@alberturria fixed this issue for the old docs as we migrated to astro, so applied their change to the astro part of the docs as well. Original PR: https://github.com/nrwl/nx/pull/33085
made sure to co-author alberturria as well

Thanks! 
![wm_2025-10-21T16-07-56@2x](https://github.com/user-attachments/assets/8bfb8a8c-d8eb-4892-8642-06c3c882e958)

Fixes #32723