### PR TITLE
feat(release): support {versionActionsVersion} in docker version scheme

### DIFF
--- a/astro-docs/src/content/docs/guides/Nx Release/release-docker-images.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/release-docker-images.mdoc
@@ -4,7 +4,7 @@ description: Learn how to use Nx Release to version and publish Docker images fr
 filter: 'type:Guides'
 ---
 
-This guide walks you through setting up Nx Release to version and publish Docker images from your monorepo using calendar-based versioning.
+This guide walks you through setting up Nx Release to version and publish Docker images from your monorepo.
 
 {% youtube title="What is Nx?" src="https://www.youtube.com/embed/TOPxKJXUaqw" /%}
 
@@ -79,6 +79,7 @@ Configure Docker applications in a separate release group called `apps` so it do
         "projectsRelationship": "independent",
         "docker": {
           // This should be true to skip versioning with other tools like NPM or Rust crates.
+          // Only set this if you are not using {versionActionsVersion} in your docker version scheme
           "skipVersionActions": true,
           // You can also use a custom registry like `ghcr.io` for GitHub Container Registry.
           // `docker.io` is the default so you could leave this out for Docker Hub.
@@ -246,5 +247,13 @@ You can customize Docker version schemes in your `nx.json` to match your deploym
 The above configuration swaps `hotfix` scheme for `staging` and adds a `ci` scheme that uses an environment variable. You can customize this list to fit your needs, and you can also change the patterns for each scheme.
 
 Version patterns can include environment variables using the `{env.VAR_NAME}` syntax, allowing you to inject CI/CD pipeline information like build numbers or deployment environments directly into your Docker tags.
+
+You can also include the semantic version generated during version actions using `{versionActionsVersion}`. For example:
+
+```json
+"production": "{projectName}-{versionActionsVersion}"
+```
+
+If you use `{versionActionsVersion}`, do not enable `docker.skipVersionActions` (or include the project in `skipVersionActions`) because the placeholder cannot be resolved when version actions are skipped.
 
 See the [`docker.versionScheme` documentation](/docs/reference/nx-json#version-scheme-syntax) for more details on how to customize the tag pattern.

--- a/astro-docs/src/content/docs/reference/nx-json.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-json.mdoc
@@ -608,6 +608,7 @@ The `docker` property configures Docker image versioning and publishing when usi
       },
 
       // Skip Docker versioning for these projects to prevent versioning with other tools like NPM
+      // Only set this if you are not using {versionActionsVersion} in your docker version scheme
       "skipVersionActions": ["api"],
 
       // Default Docker repository name (can be overridden per project)
@@ -638,12 +639,14 @@ Docker version schemes support calendar-based patterns using the following place
   - `ss` - 2-digit seconds (00-59)
 - `{shortCommitSha}` - First 7 characters of the current commit SHA
 - `{commitSha}` - Full commit SHA
+- `{versionActionsVersion}` - The version generated during the version actions such as "1.2.3"
 
 Example patterns:
 
 - `{currentDate|YYMM.DD}.{shortCommitSha}` - Results in: 2501.30.a1b2c3d
 - `{projectName}-{currentDate|YYYY.MM.DD}` - Results in: api-2025.01.30
 - `{currentDate|YY.MM.DD.HHmm}-{commitSha}` - Results in: 25.01.30.1430-abcdef1234567890
+- `{projectName}-{versionActionsVersion}` - Results in: api-1.2.3
 
 #### Group-Level Docker Configuration
 
@@ -658,6 +661,7 @@ You can configure [Docker release](/docs/guides/nx-release/release-docker-images
         "projects": ["api"],
         "projectsRelationship": "independent",
         "docker": {
+          // Only set this to true if you are not using {versionActionsVersion} in your docker version scheme
           "skipVersionActions": true
           // Run a script before tagging Docker version
           "groupPreVersionCommand": "echo Preparing backend release",

--- a/packages/docker/src/release/version-pattern-utils.spec.ts
+++ b/packages/docker/src/release/version-pattern-utils.spec.ts
@@ -151,6 +151,24 @@ describe('version-pattern-utils', () => {
       expect(result).toBe('app-{prod}-{version}');
     });
 
+    it('should substitute versionActionsVersion token when provided', () => {
+      const result = interpolateVersionPattern(
+        '{projectName}-{versionActionsVersion}',
+        {
+          projectName: 'app',
+          versionActionsVersion: '1.2.3',
+        }
+      );
+      expect(result).toBe('app-1.2.3');
+    });
+
+    it('should return versionActionsVersion when pattern is just versionActionsVersion token', () => {
+      const result = interpolateVersionPattern('{versionActionsVersion}', {
+        versionActionsVersion: '4.5.6',
+      });
+      expect(result).toBe('4.5.6');
+    });
+
     it('should handle special characters in projectName', () => {
       const result = interpolateVersionPattern('{projectName}', {
         projectName: '@org/package-name',

--- a/packages/docker/src/release/version-pattern-utils.ts
+++ b/packages/docker/src/release/version-pattern-utils.ts
@@ -8,12 +8,14 @@ import { getLatestCommitSha } from 'nx/src/utils/git-utils';
  * {commitSha} - The full commit sha for the current commit
  * {shortCommitSha} - The seven character commit sha for the current commit
  * {env.VAR_NAME} - The value of the environment variable VAR_NAME
+ * {versionActionsVersion} - The version generated during the version actions such as "1.2.3"
  */
 export interface PatternTokens {
   projectName: string;
   currentDate: Date;
   commitSha: string;
   shortCommitSha: string;
+  versionActionsVersion: string;
 }
 
 const tokenRegex = /\{(env\.([^}]+)|([^|{}]+)(?:\|([^{}]+))?)\}/g;
@@ -46,6 +48,7 @@ export function interpolateVersionPattern(
     currentDate: data.currentDate ?? new Date(),
     commitSha: data.commitSha ?? commitSha,
     shortCommitSha: data.shortCommitSha ?? commitSha.slice(0, 7),
+    versionActionsVersion: data.versionActionsVersion ?? '',
   };
 
   return versionPattern.replace(

--- a/packages/docker/src/release/version-utils.spec.ts
+++ b/packages/docker/src/release/version-utils.spec.ts
@@ -1,0 +1,76 @@
+import { handleDockerVersion } from './version-utils';
+
+/** Minimal mock objects to satisfy types without importing full release graph machinery */
+const mockProjectNode: any = { name: 'my-app', data: { root: 'apps/my-app' } };
+const versionActionsVersion = '1.2.3';
+
+describe('handleDockerVersion {versionActionsVersion} integration', () => {
+  beforeEach(() => {
+    process.env.NX_DRY_RUN = 'true';
+    delete process.env.NX_DOCKER_IMAGE_REF;
+  });
+
+  it('interpolates {versionActionsVersion} within selected version scheme', async () => {
+    const finalConfigForProject: any = {
+      dockerOptions: {
+        repositoryName: 'repo',
+        registryUrl: undefined,
+        versionSchemes: { prod: '{projectName}-{versionActionsVersion}' },
+      },
+    };
+
+    const { newVersion } = await handleDockerVersion(
+      process.cwd(),
+      mockProjectNode,
+      finalConfigForProject,
+      'prod',
+      undefined,
+      versionActionsVersion
+    );
+
+    expect(newVersion).toBe('my-app-1.2.3');
+  });
+
+  it('uses explicit dockerVersion when provided (bypassing scheme interpolation)', async () => {
+    const finalConfigForProject: any = {
+      dockerOptions: {
+        repositoryName: 'repo',
+        registryUrl: undefined,
+        versionSchemes: { prod: '{projectName}-{versionActionsVersion}' },
+      },
+    };
+
+    const { newVersion } = await handleDockerVersion(
+      process.cwd(),
+      mockProjectNode,
+      finalConfigForProject,
+      undefined,
+      'explicit-version',
+      versionActionsVersion
+    );
+
+    expect(newVersion).toBe('explicit-version');
+  });
+
+  it('falls back to env NX_DOCKER_IMAGE_REF tag if provided (extracting version)', async () => {
+    process.env.NX_DOCKER_IMAGE_REF = 'registry.example.com/repo:9.9.9';
+    const finalConfigForProject: any = {
+      dockerOptions: {
+        repositoryName: 'repo',
+        registryUrl: 'registry.example.com',
+        versionSchemes: { prod: '{projectName}-{versionActionsVersion}' },
+      },
+    };
+
+    const { newVersion } = await handleDockerVersion(
+      process.cwd(),
+      mockProjectNode,
+      finalConfigForProject,
+      'prod',
+      undefined,
+      versionActionsVersion
+    );
+
+    expect(newVersion).toBe('9.9.9');
+  });
+});

--- a/packages/docker/src/release/version-utils.ts
+++ b/packages/docker/src/release/version-utils.ts
@@ -23,7 +23,8 @@ export async function handleDockerVersion(
   projectGraphNode: ProjectGraphProjectNode,
   finalConfigForProject: FinalConfigForProject,
   dockerVersionScheme?: string,
-  dockerVersion?: string
+  dockerVersion?: string,
+  versionActionsVersion?: string
 ) {
   // If the full docker image reference is provided, use it directly
   const nxDockerImageRefEnvOverride =
@@ -48,7 +49,8 @@ export async function handleDockerVersion(
       newVersion = calculateNewVersion(
         projectGraphNode.name,
         versionScheme,
-        availableVersionSchemes
+        availableVersionSchemes,
+        versionActionsVersion
       );
     }
   }
@@ -91,7 +93,8 @@ async function promptForNewVersion(
 function calculateNewVersion(
   projectName: string,
   versionScheme: string,
-  versionSchemes: Record<string, string>
+  versionSchemes: Record<string, string>,
+  versionActionsVersion?: string
 ): string {
   if (!(versionScheme in versionSchemes)) {
     throw new Error(
@@ -102,6 +105,7 @@ function calculateNewVersion(
   }
   return interpolateVersionPattern(versionSchemes[versionScheme], {
     projectName,
+    versionActionsVersion,
   });
 }
 

--- a/packages/nx/src/command-line/release/version/release-group-processor.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.ts
@@ -277,7 +277,8 @@ export class ReleaseGroupProcessor {
       projectGraphNode: ProjectGraphProjectNode,
       finalConfigForProject: FinalConfigForProject,
       dockerVersionScheme?: string,
-      dockerVersion?: string
+      dockerVersion?: string,
+      versionActionsVersion?: string
     ) => Promise<{ newVersion: string; logs: string[] }>;
     try {
       const {
@@ -294,19 +295,21 @@ export class ReleaseGroupProcessor {
     }
     for (const [project, finalConfigForProject] of dockerProjects.entries()) {
       const projectNode = this.projectGraph.nodes[project];
+      const projectVersionData = this.versionData.get(project);
       const { newVersion, logs } = await handleDockerVersion(
         workspaceRoot,
         projectNode,
         finalConfigForProject,
         dockerVersionScheme,
-        dockerVersion
+        dockerVersion,
+        projectVersionData.newVersion
       );
 
       logs.forEach((log) =>
         this.getProjectLoggerForProject(project).buffer(log)
       );
       const newVersionData = {
-        ...this.versionData.get(project),
+        ...projectVersionData,
         dockerVersion: newVersion,
       };
       this.versionData.set(project, newVersionData);

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -78,6 +78,8 @@ export interface NxReleaseDockerConfiguration {
    *     "skipVersionActions": ["api"]
    *   }
    * ```
+   * Note: if you are using {versionActionsVersion} in your docker version scheme you should not skip version actions for that project
+   * as the docker versioning will not be able to resolve the {versionActionsVersion} placeholder.
    */
   skipVersionActions?: string[] | boolean;
   /**


### PR DESCRIPTION
This commit adds support for using `{versionActionsVersion}` in the Docker version scheme. When interpolated, it will be automatically replaced with the version your project is being bumped to. This ensures that your `package.json`, `tags`, `changelog`, `releases`, and **Docker image versions** remain consistent and aligned.

## Current Behavior
Currently, `@nx/docker` integrates with `nx release`, but Docker image tagging does not support semantic versions generated automatically based on conventional commits, for example. When running `nx release`, the `@nx/docker` plugin can build and push images using custom calendar and commit-based schemas, but there is no option to tag images with the semantic version resolved by Nx’s release mechanism (e.g. 1.2.3, v1.2.3, etc.).

## Expected Behavior
Merging this PR will allow engineers to align Docker image tags with the semantic version of the released project — a common best practice for production CI/CD workflows.

**For example:**
```json
{
  "release": {
    "groups": {
      "apps": {
        "projects": ["apps/*"],
        "projectsRelationship": "independent",
        "docker": {
          "registryUrl": "ghcr.io",
          "versionSchemes": {
            "semVer": "{versionActionsVersion}"
          }
        }
      }
    }
  }
}
```

**Running:**

```bash
nx release
```

**Would then build, tag, and push Docker images like:**
```
ghcr.io/my-org/app:1.2.3
```

## Related Issue(s)

Fixes #33131

## Additional info

<details>  
  <summary>Output of a local dry-run pointing to the code with the new feature</summary>    
  
  ```
pnpm nx release --dry-run --first-release --verbose --dockerVersionScheme=semVer
(node:71192) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)

 NX   Running release version for project: @loci/config

@loci/config ⚠️  Unable to resolve the current version from git tags using pattern "{projectName}@{version}". Falling back to the version 0.0.1 in manifest: packages/config/package.json
@loci/config 📄 Resolved the specifier as "minor" using git history and the conventional commits standard
@loci/config ❓ Applied semver relative bump "minor", derived from conventional commits data, to get new version 0.1.0
@loci/config ✍️  New version 0.1.0 written to manifest: packages/config/package.json

 NX   Running release version for project: api

api ⚠️  Unable to resolve the current version from git tags using pattern "{projectName}@{version}". Falling back to the version 0.0.1 in manifest: apps/api/package.json
api ❓ Applied semver relative bump "patch", because a dependency was bumped, to get new version 0.0.2
api ✍️  New version 0.0.2 written to manifest: apps/api/package.json
api 📄 Resolved the specifier as "minor" using git history and the conventional commits standard
api ❓ Applied semver relative bump "minor", derived from conventional commits data, to get new version 0.1.0
api ✍️  New version 0.1.0 written to manifest: apps/api/package.json

 NX   Running release version for project: www

www ⚠️  Unable to resolve the current version from git tags using pattern "{projectName}@{version}". Falling back to the version 0.0.1 in manifest: apps/www/package.json
www ❓ Applied semver relative bump "patch", because a dependency was bumped, to get new version 0.0.2
www ✍️  New version 0.0.2 written to manifest: apps/www/package.json
www 📄 Resolved the specifier as "minor" using git history and the conventional commits standard
www ❓ Applied semver relative bump "minor", derived from conventional commits data, to get new version 0.1.0
www ✍️  New version 0.1.0 written to manifest: apps/www/package.json

UPDATE packages/config/package.json [dry-run]

    "name": "@loci/config",
-   "version": "0.0.1",
+   "version": "0.1.0",
    "description": "Shared configuration for Loci monorepo",

UPDATE apps/api/package.json [dry-run]

    "name": "api",
-   "version": "0.0.1",
+   "version": "0.1.0",
    "description": "The Loci API",

UPDATE apps/www/package.json [dry-run]

    "name": "www",
-   "version": "0.0.1",
+   "version": "0.1.0",
    "private": true,


 NX   Updating pnpm lock file

Would update pnpm-lock.yaml with the following command, but --dry-run was set:
pnpm install --lockfile-only

 NX   Warning

Docker support is experimental. Breaking changes may occur and not adhere to semver versioning.


 NX   Running release version for project: api

api Image tagged with ghcr.io/loci/api:0.1.0.

 NX   Running release version for project: www

www Image tagged with ghcr.io/loci/www:0.1.0.

 NX   Staging changed files with git

Would stage files in git with the following command, but --dry-run was set:
git add packages/config/package.json apps/api/package.json apps/www/package.json
Determined workspace --from ref from the first commit in the workspace: 5bac5fc2f0fd63947a9056741e85fb737d4614e3
Determined --from ref for api from the first commit in which it exists: 6b437b1

 NX   Previewing an entry in apps/api/CHANGELOG.md for api@0.1.0


CREATE apps/api/CHANGELOG.md [dry-run]
+ ## 0.1.0 (2025-10-21)
+
+ ### 🚀 Features
+
+ - continuous release and deployment ([6b437b1](https://github.com/emiliosheinz/loci/commit/6b437b1))
+ - monorepo scaffolding with simple apps, packages, and github actions ([b81b6f0](https://github.com/emiliosheinz/loci/commit/b81b6f0))
+
+ ### 🩹 Fixes
+
+ - **biome:** set biome config files as non root ([5361c11](https://github.com/emiliosheinz/loci/commit/5361c11))
+ - **api:** exclude test related files from ts build ([9b4f7b4](https://github.com/emiliosheinz/loci/commit/9b4f7b4))
+
+ ### 🧱 Updated Dependencies
+
+ - Updated @loci/config to 0.1.0
+
+ ### ❤️ Thank You
+
+ - Emilio Heinzmann

Determined --from ref for www from the first commit in which it exists: 6b437b1

 NX   Previewing an entry in apps/www/CHANGELOG.md for www@0.1.0


CREATE apps/www/CHANGELOG.md [dry-run]
+ ## 0.1.0 (2025-10-21)
+
+ ### 🚀 Features
+
+ - continuous release and deployment ([6b437b1](https://github.com/emiliosheinz/loci/commit/6b437b1))
+ - **www:** add geist as default font family ([a3b96f0](https://github.com/emiliosheinz/loci/commit/a3b96f0))
+ - **www:** home page ([9d1e22e](https://github.com/emiliosheinz/loci/commit/9d1e22e))
+ - **www:** setup marketing website scaffolding ([adaa493](https://github.com/emiliosheinz/loci/commit/adaa493))
+
+ ### 🩹 Fixes
+
+ - **www:** target contributing link on redirects ([d885417](https://github.com/emiliosheinz/loci/commit/d885417))
+ - **www:** update snapshot and ignore e2e tests in jest config ([353e14b](https://github.com/emiliosheinz/loci/commit/353e14b))
+ - **biome:** set biome config files as non root ([5361c11](https://github.com/emiliosheinz/loci/commit/5361c11))
+
+ ### 🧱 Updated Dependencies
+
+ - Updated @loci/config to 0.1.0
+
+ ### ❤️ Thank You
+
+ - Emilio Heinzmann

Determined --from ref for @loci/config from the first commit in which it exists: 6b437b1

 NX   Previewing an entry in packages/config/CHANGELOG.md for @loci/config@0.1.0


CREATE packages/config/CHANGELOG.md [dry-run]
+ ## 0.1.0 (2025-10-21)
+
+ ### 🚀 Features
+
+ - continuous release and deployment ([6b437b1](https://github.com/emiliosheinz/loci/commit/6b437b1))
+ - monorepo scaffolding with simple apps, packages, and github actions ([b81b6f0](https://github.com/emiliosheinz/loci/commit/b81b6f0))
+
+ ### ❤️ Thank You
+
+ - Emilio Heinzmann


 NX   Staging changed files with git

Would stage files in git with the following command, but --dry-run was set:
git add apps/api/CHANGELOG.md apps/www/CHANGELOG.md packages/config/CHANGELOG.md

 NX   Committing changes with git

Would commit all previously staged files in git with the following command, but --dry-run was set:
git commit --message chore(release): publish --message - project: api 0.1.0 --message - project: www 0.1.0 --message - project: @loci/config 0.1.0

 NX   Tagging commit with git

Would tag the current commit in git with the following command, but --dry-run was set:
git tag --annotate api@0.1.0 --message api@0.1.0
Would tag the current commit in git with the following command, but --dry-run was set:
git tag --annotate www@0.1.0 --message www@0.1.0
Would tag the current commit in git with the following command, but --dry-run was set:
git tag --annotate @loci/config@0.1.0 --message @loci/config@0.1.0

 NX   Pushing to git remote "origin"

Would push the current branch to the remote with the following command, but --dry-run was set:
git push --follow-tags --no-verify --atomic

 NX   Creating GitHub Release

CREATE https://github.com/emiliosheinz/loci/releases/tag/@loci/config@0.1.0 [dry-run]

+ ## 0.1.0 (2025-10-21)
+
+ ### 🚀 Features
+
+ - continuous release and deployment ([6b437b1](https://github.com/emiliosheinz/loci/commit/6b437b1))
+ - monorepo scaffolding with simple apps, packages, and github actions ([b81b6f0](https://github.com/emiliosheinz/loci/commit/b81b6f0))
+
+ ### ❤️ Thank You
+
+ - Emilio Heinzmann


 NX   Creating GitHub Release

CREATE https://github.com/emiliosheinz/loci/releases/tag/api@0.1.0 [dry-run]

+ ## 0.1.0 (2025-10-21)
+
+ ### 🚀 Features
+
+ - continuous release and deployment ([6b437b1](https://github.com/emiliosheinz/loci/commit/6b437b1))
+ - monorepo scaffolding with simple apps, packages, and github actions ([b81b6f0](https://github.com/emiliosheinz/loci/commit/b81b6f0))
+
+ ### 🩹 Fixes
+
+ - **biome:** set biome config files as non root ([5361c11](https://github.com/emiliosheinz/loci/commit/5361c11))
+ - **api:** exclude test related files from ts build ([9b4f7b4](https://github.com/emiliosheinz/loci/commit/9b4f7b4))
+
+ ### 🧱 Updated Dependencies
+
+ - Updated @loci/config to 0.1.0
+
+ ### ❤️ Thank You
+
+ - Emilio Heinzmann


 NX   Creating GitHub Release

CREATE https://github.com/emiliosheinz/loci/releases/tag/www@0.1.0 [dry-run]

+ ## 0.1.0 (2025-10-21)
+
+ ### 🚀 Features
+
+ - continuous release and deployment ([6b437b1](https://github.com/emiliosheinz/loci/commit/6b437b1))
+ - **www:** add geist as default font family ([a3b96f0](https://github.com/emiliosheinz/loci/commit/a3b96f0))
+ - **www:** home page ([9d1e22e](https://github.com/emiliosheinz/loci/commit/9d1e22e))
+ - **www:** setup marketing website scaffolding ([adaa493](https://github.com/emiliosheinz/loci/commit/adaa493))
+
+ ### 🩹 Fixes
+
+ - **www:** target contributing link on redirects ([d885417](https://github.com/emiliosheinz/loci/commit/d885417))
+ - **www:** update snapshot and ignore e2e tests in jest config ([353e14b](https://github.com/emiliosheinz/loci/commit/353e14b))
+ - **biome:** set biome config files as non root ([5361c11](https://github.com/emiliosheinz/loci/commit/5361c11))
+
+ ### 🧱 Updated Dependencies
+
+ - Updated @loci/config to 0.1.0
+
+ ### ❤️ Thank You
+
+ - Emilio Heinzmann


 NX   Skipped publishing packages.


NOTE: The "dryRun" flag means no changes were made.
  ```
</details>

<details>  
  <summary>Config I used during the run above</summary>    
  
  ```json
{
  "$schema": "./node_modules/nx/schemas/nx-schema.json",
  "workspaceLayout": {
    "appsDir": "apps",
    "libsDir": "packages"
  },
  "plugins": [
    {
      "plugin": "@nx/docker",
      "options": {
        "buildTarget": "docker:build",
        "runTarget": "docker:run"
      }
    }
  ],
  "release": {
    "projectChangelogs": true,
    "version": {
      "conventionalCommits": true
    },
    "releaseTagPattern": "{projectName}@{version}",
    "changelog": {
      "projectChangelogs": {
        "createRelease": "github",
        "renderOptions": {
          "authors": true,
          "applyUsernameToAuthors": true,
          "commitReferences": true,
          "versionTitleDate": true
        }
      }
    },
    "groups": {
      "apps": {
        "projects": ["apps/*"],
        "projectsRelationship": "independent",
        "docker": {
          "registryUrl": "ghcr.io",
          "skipVersionActions": true,
          "versionSchemes": {
            "semVer": "{versionActionsVersion}"
          }
        }
      },
      "packages": {
        "projects": ["packages/*"],
        "projectsRelationship": "independent"
      }
    }
  },
  "targetDefaults": {
    "docker:build": {
      "options": {
        "cwd": "."
      }
    },
    "build": {
      "dependsOn": ["^build"],
      "cache": true
    },
    "start:dev": {
      "dependsOn": ["^build"]
    },
    "lint": {
      "dependsOn": ["^build"],
      "cache": true
    },
    "format": {
      "dependsOn": ["^build"],
      "cache": true
    },
    "check": {
      "dependsOn": ["^build"],
      "cache": true
    },
    "lint:fix": {
      "dependsOn": ["^build"]
    },
    "format:fix": {
      "dependsOn": ["^build"]
    },
    "check:fix": {
      "dependsOn": ["^build"]
    },
    "test": {
      "dependsOn": ["^build"],
      "cache": true
    },
    "test:watch": {
      "dependsOn": ["^build"]
    },
    "test:cov": {
      "dependsOn": ["^build"]
    },
    "test:e2e": {
      "dependsOn": ["^build"]
    }
  },
  "cacheDirectory": ".nx/cache",
  "defaultBase": "origin/main"
}
  ``` 
</details>

> NOTE: I really wan't this feature to be available on Nx, so if this isn't the best approach to achieve what I wan't, please, let me know, I will happily refactor things to get them aligned with the project standards :) 