### PR TITLE
docs(misc): fix bad line higlighting in docs

### DIFF
--- a/astro-docs/src/content/docs/getting-started/Tutorials/angular-monorepo-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/angular-monorepo-tutorial.mdoc
@@ -533,7 +533,7 @@ In this section, we'll explore how Nx Cloud can help your pull request get to gr
 
 The `npx nx fix-ci` command that is already included in your GitHub Actions workflow (`github/workflows/ci.yml`) is responsible for enabling self-healing CI and will automatically suggest fixes to your failing tasks.
 
-```yaml {32,33}
+```yaml {% meta="{32,33}" %}
 # .github/workflows/ci.yml
 name: CI
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/gradle-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/gradle-tutorial.mdoc
@@ -2471,7 +2471,7 @@ You can copy the example GitHub Action workflow file and place it in the `.githu
 
 The `npx nx-cloud fix-ci` command that is already included in your GitHub Actions workflow (`github/workflows/ci.yml`) is responsible for enabling self-healing CI and will automatically suggest fixes to your failing tasks.
 
-```yaml {34,35}
+```yaml {% meta="{34,35}" %}
 # .github/workflows/ci.yml
 name: CI
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/react-monorepo-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/react-monorepo-tutorial.mdoc
@@ -491,7 +491,7 @@ In this section, we'll explore how Nx Cloud can help your pull request get to gr
 
 The `npx nx-cloud fix-ci` command that is already included in your GitHub Actions workflow (`github/workflows/ci.yml`) is responsible for enabling self-healing CI and will automatically suggest fixes to your failing tasks.
 
-```yaml {32,33}
+```yaml {% meta="{32,33}" %}
 # .github/workflows/ci.yml
 name: CI
 

--- a/astro-docs/src/content/docs/technologies/react/next/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/next/introduction.mdoc
@@ -173,7 +173,7 @@ nx serve my-new-app --prod
 
 You can import a library called `my-new-lib` in your application as follows.
 
-```typescript {1,5-7}
+```typescript {% meta="{1,5-7}" %}
 // apps/my-next-app/pages/index.tsx
 import { MyNewLib } from '@<your nx workspace name>/my-new-lib';
 
@@ -250,7 +250,7 @@ After running a build, the output will be in the `.next` folder inside your app'
 
 You can customize the output folder path by updating the Next.js config. For example, you can set a custom `distDir` in `next.config.js`:
 
-```javascript {2}"
+```javascript {% meta="{2}" %}
 // apps/my-next-app/next.config.js
 const nextConfig = {
   distDir: 'dist',
@@ -271,7 +271,7 @@ This approach is for projects not using the `@nx/next/plugin` in `nx.json`. If y
 
 You can customize the output folder by setting `outputPath` in the project's `project.json` file
 
-```json {9}"
+```json {% meta="{9}" %}
 // apps/my-next-app/project.json
 {
   "root": "apps/my-next-app",
@@ -299,7 +299,7 @@ The library in `dist` is publishable to npm or a private registry.
 
 Next.js applications can be statically exported by changing the output inside your Next.js configuration file.
 
-```js {5}
+```js {% meta="{5}" %}
 // apps/my-next-app/next.config.js
 const nextConfig = {
   nx: {


### PR DESCRIPTION
This PR fixes some pages that don't use the proper markdoc syntax for line lighting in code blocks. The `{% meta %}` tag is needed and it is missing in some places.

Closes DOC-2790
