### PR TITLE
docs(misc): update nx release documentation for v22 changes

### DIFF
--- a/astro-docs/src/content/docs/guides/Nx Release/configure-changelog-format.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/configure-changelog-format.mdoc
@@ -93,3 +93,40 @@ Which will generate a changelog that looks similar to the following:
 
 - **rule-tester:** check for missing placeholder data in the message
 ```
+
+## Custom Changelog Renderer {% badge  text="Nx 22+" /%}
+
+For complete control over changelog formatting, you can provide a custom changelog renderer implementation. The renderer can be specified as a path to a module that exports a class extending the base `ChangelogRenderer`.
+
+```jsonc
+{
+  "release": {
+    "changelog": {
+      "projectChangelogs": {
+        "renderer": "./tools/custom-changelog-renderer.ts"
+      }
+    }
+  }
+}
+```
+
+Your custom renderer must extend the `ChangelogRenderer` class and implement the required methods:
+
+```typescript
+// tools/custom-changelog-renderer.ts
+import { ChangelogRenderer, ChangelogRenderOptions } from '@nx/js/release';
+
+export default class CustomChangelogRenderer extends ChangelogRenderer {
+  async renderMarkdown(
+    changes: any[],
+    options: ChangelogRenderOptions
+  ): Promise<string> {
+    // Your custom changelog generation logic
+    return '# My Custom Changelog\n\n...';
+  }
+}
+```
+
+{% aside type="note" title="Programmatic API" %}
+When using the programmatic `ReleaseClient` API (Nx 22+), you can also pass the renderer implementation class directly instead of a file path, allowing for dynamic renderer selection without file system access.
+{% /aside %}

--- a/astro-docs/src/content/docs/guides/Nx Release/file-based-versioning-version-plans.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/file-based-versioning-version-plans.mdoc
@@ -129,7 +129,7 @@ Attempting to keep track of this manually as a part of pull request reviews can 
 nx release plan:check
 ```
 
-Running this command will analyze the changed files (supporting the same options you may be familiar with from `nx affected`, such as `--base`, `--head`, `--files`, `--uncommitted`, etc) and then determine which projects have been "touched" as a result. Note that it is specifically touched projects, and not affected in this case, because only directly changed projects are relevant for versioning. The side-effects of versioning independently released dependents are handled by the release process itself (controllable via the `version.generatorOptions.updateDependents` option).
+Running this command will analyze the changed files (supporting the same options you may be familiar with from `nx affected`, such as `--base`, `--head`, `--files`, `--uncommitted`, etc) and then determine which projects have been "touched" as a result. Note that it is specifically touched projects, and not affected in this case, because only directly changed projects are relevant for versioning. The side-effects of versioning independently released dependents are handled by the release process itself (controllable via the `version.updateDependents` option).
 
 ### Running release plan:check in CI
 

--- a/astro-docs/src/content/docs/guides/Nx Release/publish-rust-crates.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/publish-rust-crates.mdoc
@@ -11,7 +11,7 @@ This recipe guides you through versioning Rust libraries, generating changelogs,
 {% aside type="caution" title="Currently requires legacy versioning" %}
 In Nx v21, the implementation details of versioning were rewritten to enhance flexibility and allow for better cross-ecosystem support. An automated migration was provided in Nx v21 to update your configuration to the new format when running `nx migrate`.
 
-During the lifecycle of Nx v21, you can still opt into the old versioning by setting `release.version.useLegacyVersioning` to `true`, which will keep the original configuration structure and behavior. In Nx v22, the legacy versioning implementation will be removed entirely, so this should only be done temporarily to ease the transition.
+During the lifecycle of Nx v21, you can still opt into the old versioning by setting `release.version.useLegacyVersioning` to `true`, which will keep the original configuration structure and behavior. In Nx v22, the legacy versioning implementation has been removed entirely, so this should only be done temporarily to ease the transition.
 
 Importantly, this recipe currently requires the use of legacy versioning, because the `@monodon/rust` plugin does not yet provide the necessary `VersionActions` implementation to support the new versioning behavior. This will be added in a minor release of Nx v21 and this recipe will be updated accordingly.
 {% /aside %}

--- a/astro-docs/src/content/docs/guides/Nx Release/publish-rust-crates.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/publish-rust-crates.mdoc
@@ -211,9 +211,12 @@ By default, Nx Release will stage all changes it makes with git. This includes u
 
 The commit message created by Nx Release defaults to 'chore(release): publish {version}', where `{version}` will be dynamically interpolated with the relevant value based on your actual release, but can be customized with the `release.git.commitMessage` property in nx.json.
 
-The structure of the git tag defaults to `v{version}`. For example, if the version is `1.2.3`, the tag will be `v1.2.3`. This can be customized by setting the `release.releaseTag.pattern` property in nx.json.
+The structure of the git tag defaults to `v{version}`. For example, if the version is `1.2.3`, the tag will be `v1.2.3`. This can be customized by setting the `release.releaseTag.pattern` property (Nx 22+) or `release.releaseTagPattern` property (Nx < 22) in nx.json.
 
 For this same example, if you want the commit message to be 'chore(release): 1.2.3' and the tag to be `release/1.2.3`, you would configure nx.json like this:
+
+{% tabs syncKey="nx-release-configuration" %}
+{% tabitem label="Nx 22+" %}
 
 ```json
 // nx.json
@@ -228,6 +231,24 @@ For this same example, if you want the commit message to be 'chore(release): 1.2
   }
 }
 ```
+
+{% /tabitem %}
+{% tabitem label="Nx < 22" %}
+
+```json
+// nx.json
+{
+  "release": {
+    "releaseTagPattern": "release/{version}",
+    "git": {
+      "commitMessage": "chore(release): {version}"
+    }
+  }
+}
+```
+
+{% /tabitem %}
+{% /tabs %}
 
 When using release groups in which the member projects are versioned together, you can also leverage `{releaseGroupName}` and it will be interpolated appropriately in the commit/tag that gets created for that release group.
 

--- a/astro-docs/src/content/docs/guides/Nx Release/release-docker-images.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/release-docker-images.mdoc
@@ -147,7 +147,7 @@ Docker images have to be pushed to a repository, and this must be set on each ap
 
 For example, from the previous `apps/api` Node.js application, you can set the `nx.release.docker.repositoryName` in `package.json`.
 
-```json {% meta="{6-8}" %}
+```json {% meta="{6-10}" %}
 // apps/api/package.json
 {
   "name": "@acme/api",
@@ -165,7 +165,7 @@ For example, from the previous `apps/api` Node.js application, you can set the `
 
 Or if you don't have a `package.json` (e.g. for non-JS projects), set it in `project.json`:
 
-```json {% meta="{6-8}" %}
+```json {% meta="{6-10}" %}
 // apps/api/project.json
 {
   "name": "api",

--- a/astro-docs/src/content/docs/guides/Nx Release/release-docker-images.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/release-docker-images.mdoc
@@ -70,6 +70,9 @@ Configure Docker applications in a separate release group called `apps` so it do
 
 To learn more about release groups, see the [Release Groups](/docs/guides/nx-release/release-groups) guide.
 
+{% tabs syncKey="nx-release-configuration" %}
+{% tabitem label="Nx 22+" %}
+
 ```jsonc
 // nx.json
 {
@@ -98,6 +101,39 @@ To learn more about release groups, see the [Release Groups](/docs/guides/nx-rel
   }
 }
 ```
+
+{% /tabitem %}
+{% tabitem label="Nx < 22" %}
+
+```jsonc
+// nx.json
+{
+  "release": {
+    "releaseTagPattern": "release/{projectName}/{version}",
+    "groups": {
+      "apps": {
+        "projects": ["api"],
+        "projectsRelationship": "independent",
+        "docker": {
+          // This should be true to skip versioning with other tools like NPM or Rust crates.
+          "skipVersionActions": true,
+          // You can also use a custom registry like `ghcr.io` for GitHub Container Registry.
+          // `docker.io` is the default so you could leave this out for Docker Hub.
+          "registryUrl": "docker.io",
+          // The pre-version command is run before versioning, useful for verifying the Docker image.
+          "groupPreVersionCommand": "echo BEFORE VERSIONING"
+        },
+        "changelog": {
+          "projectChangelogs": true
+        }
+      }
+    }
+  }
+}
+```
+
+{% /tabitem %}
+{% /tabs %}
 
 The `release.groups.apps.docker.skipVersionActions` option should be set to `true` to skip versioning for other tooling such as NPM or Rust crates.
 

--- a/astro-docs/src/content/docs/guides/Nx Release/release-npm-packages.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/release-npm-packages.mdoc
@@ -255,9 +255,12 @@ By default, Nx Release will stage all changes it makes with git. This includes u
 
 The commit message created by Nx Release defaults to 'chore(release): publish {version}', where `{version}` will be dynamically interpolated with the relevant value based on your actual release, but can be customized with the `release.git.commitMessage` property in nx.json.
 
-The structure of the git tag defaults to `v{version}`. For example, if the version is `1.2.3`, the tag will be `v1.2.3`. This can be customized by setting the `release.releaseTag.pattern` property in nx.json.
+The structure of the git tag defaults to `v{version}`. For example, if the version is `1.2.3`, the tag will be `v1.2.3`. This can be customized by setting the `release.releaseTag.pattern` property (Nx 22+) or `release.releaseTagPattern` property (Nx < 22) in nx.json.
 
 For this same example, if you want the commit message to be 'chore(release): 1.2.3' and the tag to be `release/1.2.3`, you would configure nx.json like this:
+
+{% tabs syncKey="nx-release-configuration" %}
+{% tabitem label="Nx 22+" %}
 
 ```json
 // nx.json
@@ -272,6 +275,24 @@ For this same example, if you want the commit message to be 'chore(release): 1.2
   }
 }
 ```
+
+{% /tabitem %}
+{% tabitem label="Nx < 22" %}
+
+```json
+// nx.json
+{
+  "release": {
+    "releaseTagPattern": "release/{version}",
+    "git": {
+      "commitMessage": "chore(release): {version}"
+    }
+  }
+}
+```
+
+{% /tabitem %}
+{% /tabs %}
 
 When using release groups in which the member projects are versioned together, you can also leverage `{releaseGroupName}` and it will be interpolated appropriately in the commit/tag that gets created for that release group.
 

--- a/astro-docs/src/content/docs/guides/Nx Release/release-projects-independently.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/release-projects-independently.mdoc
@@ -33,9 +33,12 @@ When configured for independent releases, Nx Release will prompt for a version b
 
 Since each project can have a different version, Nx Release will create a git tag for each project that is being released. By default, the tag for each project will follow the pattern `{projectName}@{version}`. For example, if the `pkg-1` project is being released with version `1.1.0`, its git tag will be `pkg-1@1.1.0`.
 
-This can still be changed with the `release.releaseTag.pattern` property in `nx.json`, but be sure to include `{projectName}` in the pattern so that each generated tag is unique.
+This can still be changed with the `release.releaseTag.pattern` property (Nx 22+) or `release.releaseTagPattern` (Nx < 22) in `nx.json`, but be sure to include `{projectName}` in the pattern so that each generated tag is unique.
 
 For example, to generate the tags `release/pkg-1/1.1.0` and `release/pkg-2/1.2.1` for the `pkg-1` and `pkg-2` projects respectively, you would use the following configuration in nx.json:
+
+{% tabs syncKey="nx-release-configuration" %}
+{% tabitem label="Nx 22+" %}
 
 ```json
 // nx.json
@@ -48,7 +51,22 @@ For example, to generate the tags `release/pkg-1/1.1.0` and `release/pkg-2/1.2.1
 }
 ```
 
-See the [`releaseTag.pattern` documentation](/docs/reference/nx-json#release-tag-pattern) for more details on how to customize the tag pattern.
+{% /tabitem %}
+{% tabitem label="Nx < 22" %}
+
+```json
+// nx.json
+{
+  "release": {
+    "releaseTagPattern": "release/{projectName}/{version}"
+  }
+}
+```
+
+{% /tabitem %}
+{% /tabs %}
+
+See the [`releaseTag.pattern` documentation](/docs/reference/nx-json#release-tag) for more details on how to customize the tag pattern.
 
 ### Different Commit Message Structure
 

--- a/astro-docs/src/content/docs/reference/nx-json.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-json.mdoc
@@ -422,13 +422,13 @@ Release tag configuration now uses a nested `releaseTag` object. Old flat proper
 
 #### Configuration Options
 
-| Property | Type | Default | Description |
-| -------- | ---- | ------- | ----------- |
-| **pattern** | string | `v{version}` for fixed, `{projectName}@{version}` for independent | The git tag pattern to use. Supports interpolation of `{version}`, `{projectName}`, and `{releaseGroupName}` |
-| **requireSemver** | boolean | `false` | Whether to require that all tags match semantic versioning |
-| **strictPreid** | boolean | `false` for independent, `true` for fixed release groups | Whether to ensure prerelease IDs are consistent across packages |
-| **preferDockerVersion** | boolean | `false` | Whether to prefer Docker-compatible version format in git tags |
-| **checkAllBranchesWhen** | string | undefined | Branch to check when resolving current versions from git tags |
+| Property                 | Type    | Default                                                           | Description                                                                                                  |
+| ------------------------ | ------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **pattern**              | string  | `v{version}` for fixed, `{projectName}@{version}` for independent | The git tag pattern to use. Supports interpolation of `{version}`, `{projectName}`, and `{releaseGroupName}` |
+| **requireSemver**        | boolean | `false`                                                           | Whether to require that all tags match semantic versioning                                                   |
+| **strictPreid**          | boolean | `false` for independent, `true` for fixed release groups          | Whether to ensure prerelease IDs are consistent across packages                                              |
+| **preferDockerVersion**  | boolean | `false`                                                           | Whether to prefer Docker-compatible version format in git tags                                               |
+| **checkAllBranchesWhen** | string  | undefined                                                         | Branch to check when resolving current versions from git tags                                                |
 
 #### Tag Pattern Syntax
 
@@ -497,6 +497,10 @@ For Nx 22, this automated migration was re-added to allow updating your configur
 
 Behind the scenes, ecosystem-specific `version` logic is powered by a `VersionActions` implementation. Out of the box Nx wires up the most widely applicable `VersionActions` implementation for you, which is `@nx/js/src/release/version-actions` provided by the `@nx/js` plugin.
 
+{% aside type="note" title="Programmatic API (Nx 22+)" %}
+For advanced use cases, the `ReleaseClient` programmatic API allows you to trigger releases from custom scripts. In Nx 22+, you can optionally ignore the `nx.json` release configuration entirely when using the API, which is useful for ad-hoc scripts that only work with a subset of the repository.
+{% /aside %}
+
 Core version options are therefore directly at the top level of the `version` property (as of Nx v21), while ecosystem-specific options are available through `versionActionsOptions`:
 
 ```jsonc
@@ -518,8 +522,14 @@ Core version options are therefore directly at the top level of the `version` pr
 
 Some important changes in Nx 22:
 
-- `preserveMatchingDependencyRanges` now defaults to `true`
-- `updateDependents` now defaults to "always"
+- `preserveMatchingDependencyRanges` now defaults to `true` (previously `false`)
+  - When `true`, dependency version ranges are preserved if they already satisfy the new version being released
+  - Example: If releasing version `1.2.0` and a dependent has range `^1.0.0`, it remains `^1.0.0` instead of being updated to `1.2.0`
+  - Set to `false` explicitly if you need exact versions in all dependents
+- `updateDependents` now defaults to `"always"` (previously `"auto"`)
+  - `"always"`: Update dependents wherever they exist in the graph, regardless of filter selection
+  - `"auto"`: Update dependents only if they're within the selected projects or release groups
+  - `"never"`: Never update dependents
 - `releaseTag*` properties such as `releaseTagPattern` and `releaseTagPatternStrictPreid` have been coalesced into a single `releaseTag` object. (`releaseTagPattern` -> `releaseTag.pattern`, `releaseTagPatternStrictPreid` -> `releaseTag.strictPreid`)
 - `releaseTag.strictPreid` now defaults to `true`
 - Fixed Release Group Release Tag Pattern now defaults to `{releaseGroupName}-v{version}`
@@ -602,6 +612,26 @@ The `changelog.projectChangelogs` property configures the project changelogs. It
   }
 }
 ```
+
+#### Replace Existing Contents {% badge  text="Nx 22+" /%}
+
+By default, changelog entries are prepended to existing changelog files. To completely replace the entire changelog file contents instead, use the `replaceExistingContents` option:
+
+```jsonc
+// nx.json
+{
+  "release": {
+    "changelog": {
+      "workspaceChangelog": {
+        // Replaces the entire CHANGELOG.md file with the new content
+        "replaceExistingContents": true
+      }
+    }
+  }
+}
+```
+
+This option is available for both `workspaceChangelog` and `projectChangelogs`. It's useful when you want to regenerate the entire changelog from scratch rather than maintaining a cumulative history.
 
 ### Git
 

--- a/astro-docs/src/content/docs/reference/nx-json.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-json.mdoc
@@ -9,6 +9,12 @@ filter: 'type:References'
 
 The `nx.json` file configures the Nx CLI and project defaults. The full [machine readable schema](https://github.com/nrwl/nx/blob/master/packages/nx/schemas/nx-schema.json) is available on GitHub.
 
+{% aside type="note" title="Nx 22 Changes" %}
+Release tag configuration now uses a nested `releaseTag` object (e.g., `releaseTag.pattern` instead of `releaseTagPattern`). Old properties work until Nx 23.
+
+See [Release Tag](#release-tag) for details.
+{% /aside %}
+
 The following is an expanded example showing all options. Your `nx.json` will likely be much shorter.
 
 ```json
@@ -402,40 +408,81 @@ The `projectsRelationship` property tells Nx whether to release projects indepen
 }
 ```
 
-### Release Tag Pattern
+### Release Tag
 
-Optionally override the git/release tag pattern to use. This field is the source of truth for changelog generation and release tagging, as well as for conventional commits parsing.
+The `releaseTag` property controls how git tags are parsed and generated. By default tags conform to semantic version and are validated as such.
 
-It supports interpolating the version as `{version}` and (if releasing independently or forcing project level version control system releases) the project name as `{projectName}` within the string. When using release groups in which the member projects are versioned together, you can also leverage `{releaseGroupName}` and it will be interpolated appropriately in the commit/tag that gets created for that release group.
+{% aside type="note" title="Nx 22 Changes" %}
+Release tag configuration now uses a nested `releaseTag` object. Old flat properties (`releaseTagPattern`, etc.) are deprecated but work until Nx 23.
 
-The default `"releaseTag.pattern"` for fixed/unified releases is: `v{version}`
+**Nx 22+:** `releaseTag.pattern`, `releaseTag.requireSemver`, `releaseTag.strictPreid`
 
-The default `"releaseTag.pattern"` for independent releases at the project level is: `{projectName}@{version}`
+**Nx < 22:** `releaseTagPattern`, `releaseTagPatternRequireSemver`, `releaseTagPatternStrictPreid`
+{% /aside %}
+
+#### Configuration Options
+
+| Property | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| **pattern** | string | `v{version}` for fixed, `{projectName}@{version}` for independent | The git tag pattern to use. Supports interpolation of `{version}`, `{projectName}`, and `{releaseGroupName}` |
+| **requireSemver** | boolean | `false` | Whether to require that all tags match semantic versioning |
+| **strictPreid** | boolean | `false` for independent, `true` for fixed release groups | Whether to ensure prerelease IDs are consistent across packages |
+| **preferDockerVersion** | boolean | `false` | Whether to prefer Docker-compatible version format in git tags |
+| **checkAllBranchesWhen** | string | undefined | Branch to check when resolving current versions from git tags |
+
+#### Tag Pattern Syntax
+
+The tag pattern supports interpolating the following values:
+
+- `{version}` - The version currently being released
+- `{projectName}` - The name of the project being released (for independent releases)
+- `{releaseGroupName}` - The name of the release group being released (when using release groups)
+
+Example patterns and their results:
+
+- `v{version}` → `v1.0.0` (default for fixed releases)
+- `{projectName}@{version}` → `my-lib@1.0.0` (default for independent releases)
+- `{releaseGroupName}/{projectName}/{version}` → `backend/api/1.0.0`
+- `release/{version}` → `release/1.0.0`
+
+#### Example Configuration
+
+{% tabs syncKey="nx-release-configuration" %}
+{% tabitem label="Nx 22+" %}
 
 ```jsonc
 // nx.json
 {
   "release": {
-    // Here we are configuring nx release to use a custom release
-    // tag pattern (we have dropped the v prefix from the default)
     "releaseTag": {
-      "pattern": "{version}"
+      "pattern": "{releaseGroupName}-v{version}",
+      "requireSemver": true,
+      "strictPreid": true,
+      "preferDockerVersion": false,
+      "checkAllBranchesWhen": "main"
     }
   }
 }
 ```
 
-#### Tag Pattern Syntax
+{% /tabitem %}
+{% tabitem label="Nx < 22" %}
 
-The `releaseTag.pattern` supports interpolated values:
+```jsonc
+// nx.json
+{
+  "release": {
+    "releaseTagPattern": "{releaseGroupName}-v{version}",
+    "releaseTagPatternRequireSemver": true,
+    "releaseTagPatternStrictPreid": true,
+    "releaseTagPatternPreferDockerVersion": false,
+    "releaseTagPatternCheckAllBranchesWhen": "main"
+  }
+}
+```
 
-- `{version}` - The version currently being released
-- `{projectName}` - The name of the project being released
-- `{releaseGroupname}` - The name of the release group being released (if applicable)
-- Example patterns:
-
-- `{projectName}@{version}` - Results in: my-lib@1.0.0
-- `{releaseGroupName}/{projectName}/{version}` - Results in: my-group/my-lib/1.0.0
+{% /tabitem %}
+{% /tabs %}
 
 ### Version
 


### PR DESCRIPTION
Changes:
- Update all Nx Release guides to show the config for v22 and prior verisons
- Update `nx.json` reference page to show `releaseTag` property and what they are prior to v22
- Add example showing all releaseTag options in v22 and < v22 (pattern, requireSemver, strictPreid, preferDockerVersion, checkAllBranchesWhen)
- Update asides to use "Nx 22 Changes" instead of "Breaking Changes" (properties deprecated, not breaking until v23)
- Fix `version.generatorOptions.updateDependents` → `version.updateDependents` reference

Closes DOC-261

<img width="781" height="513" alt="image" src="https://github.com/user-attachments/assets/3b8a13c4-e863-40da-87cb-ae5a6264bb9e" />

<img width="866" height="626" alt="image" src="https://github.com/user-attachments/assets/e02fd179-80d7-42ea-993c-5da0ed793eaa" />

<img width="796" height="408" alt="image" src="https://github.com/user-attachments/assets/14bb5c54-089c-4ed3-8774-731cbdaa37a5" />
