### PR TITLE
fix(maven): add support for unbound goals in plugin targets

### DIFF
--- a/packages/maven/maven-plugin/pom.xml
+++ b/packages/maven/maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.nx</groupId>
     <artifactId>nx-parent</artifactId>
-    <version>0.0.6</version>
+    <version>0.0.7</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/NxTarget.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/NxTarget.kt
@@ -5,27 +5,29 @@ import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 
 data class NxTarget(
-    val executor: String,
-    val options: ObjectNode?,
-    val cache: Boolean,
-    val parallelism: Boolean,
-    var dependsOn: ArrayNode? = null,
-    var outputs: ArrayNode? = null,
-    var inputs: ArrayNode? = null
+  val executor: String,
+  val options: ObjectNode?,
+  val cache: Boolean,
+  val continuous: Boolean,
+  val parallelism: Boolean,
+  var dependsOn: ArrayNode? = null,
+  var outputs: ArrayNode? = null,
+  var inputs: ArrayNode? = null
 ) {
-    fun toJSON(objectMapper: ObjectMapper): ObjectNode {
-        val node = objectMapper.createObjectNode()
-        node.put("executor", executor)
-        if (options != null) {
-            node.set<ObjectNode>("options", options)
-        }
-        node.put("cache", cache)
-        node.put("parallelism", parallelism)
-
-        dependsOn?.let { node.set<ObjectNode>("dependsOn", it) }
-        outputs?.let { node.set<ObjectNode>("outputs", it) }
-        inputs?.let { node.set<ObjectNode>("inputs", it) }
-
-        return node
+  fun toJSON(objectMapper: ObjectMapper): ObjectNode {
+    val node = objectMapper.createObjectNode()
+    node.put("executor", executor)
+    if (options != null) {
+      node.set<ObjectNode>("options", options)
     }
+    node.put("cache", cache)
+    node.put("continuous", continuous)
+    node.put("parallelism", parallelism)
+
+    dependsOn?.let { node.set<ObjectNode>("dependsOn", it) }
+    outputs?.let { node.set<ObjectNode>("outputs", it) }
+    inputs?.let { node.set<ObjectNode>("inputs", it) }
+
+    return node
+  }
 }

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/utils/MojoAnalyzer.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/utils/MojoAnalyzer.kt
@@ -13,6 +13,7 @@ data class MojoAnalysis(
   val dependentTaskOutputInputs: Set<DependentTaskOutputs>,
   val outputs: Set<String>,
   val isCacheable: Boolean,
+  val isContinuous: Boolean,
   val isThreadSafe: Boolean,
 )
 
@@ -47,9 +48,11 @@ class MojoAnalyzer(
 
     val isCacheable = isPluginCacheable(pluginDescriptor, mojoDescriptor)
 
+    val isContinuous = isPluginContinuous(pluginDescriptor, mojoDescriptor)
+
     if (!isCacheable) {
       log.info("${pluginDescriptor.artifactId}:$goal is not cacheable")
-      return MojoAnalysis(emptySet(), emptySet(), emptySet(), false, isThreadSafe)
+      return MojoAnalysis(emptySet(), emptySet(), emptySet(), false, isContinuous, isThreadSafe)
     }
 
     val (inputs, dependentTaskOutputInputs) = getInputs(pluginDescriptor, mojoDescriptor, project)
@@ -60,6 +63,7 @@ class MojoAnalyzer(
       dependentTaskOutputInputs,
       outputs,
       true,
+      isContinuous,
       isThreadSafe
     )
   }
@@ -172,6 +176,10 @@ class MojoAnalyzer(
     }
 
     return outputs
+  }
+
+  private fun isPluginContinuous(pluginDescriptor: PluginDescriptor, mojoDescriptor: MojoDescriptor): Boolean {
+    return cacheConfig.continuous.contains("${pluginDescriptor.artifactId}:${mojoDescriptor.goal}")
   }
 
   private fun isPluginCacheable(pluginDescriptor: PluginDescriptor, mojoDescriptor: MojoDescriptor): Boolean {

--- a/packages/maven/src/utils/versions.ts
+++ b/packages/maven/src/utils/versions.ts
@@ -1,2 +1,2 @@
 export const nxVersion = require('../../package.json').version;
-export const mavenPluginVersion = '0.0.6';
+export const mavenPluginVersion = '0.0.7';

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>dev.nx</groupId>
   <artifactId>nx-parent</artifactId>
-  <version>0.0.6</version>
+  <version>0.0.7</version>
   <packaging>pom</packaging>
 
   <name>Nx Parent</name>


### PR DESCRIPTION
## Current Behavior

Maven plugin targets are only created for goals explicitly bound to executions in the POM. Goals defined in a plugin but not bound to any execution are not available as Nx targets.

## Expected Behavior

All available Maven goals should be accessible as Nx targets, including:
- Goals bound to executions (existing behavior)
- Unbound goals defined in the plugin (new behavior)

## Changes Made

1. **Added unbound goal support**: The `NxTargetFactory` now creates targets for goals defined in a plugin but not bound to any execution. These targets are created with the format `goalPrefix:goalName` without an execution ID.

2. **Added continuous build tracking**: 
   - Added `continuous` property to `NxTarget` data class to track whether a goal supports continuous builds
   - Updated `MojoAnalyzer` to detect continuous goals from the cache configuration
   - All targets now properly propagate continuous mode information

3. **Code improvements**:
   - Improved formatting and indentation for consistency
   - Made `execution` parameter optional in `createSimpleGoalTarget` to support both bound and unbound goals
   - Updated command generation to work with or without execution IDs

## Related Issue(s)

This change enables better Maven goal discovery and execution in Nx monorepos.