### PR TITLE
fix(core): stream without prefixes showing tui

### DIFF
--- a/packages/nx/src/tasks-runner/is-tui-enabled.spec.ts
+++ b/packages/nx/src/tasks-runner/is-tui-enabled.spec.ts
@@ -80,7 +80,7 @@ describe('shouldUseTui', () => {
       }
     ));
 
-  it.each(['dynamic-legacy', 'static', 'stream'])(
+  it.each(['dynamic-legacy', 'static', 'stream', 'stream-without-prefixes'])(
     'should be disabled if output-style=%s',
     (outputStyle) =>
       withEnvironmentVariables(

--- a/packages/nx/src/tasks-runner/is-tui-enabled.ts
+++ b/packages/nx/src/tasks-runner/is-tui-enabled.ts
@@ -45,7 +45,11 @@ export function shouldUseTui(
     return false;
   }
 
-  if (['static', 'stream', 'dynamic-legacy'].includes(nxArgs.outputStyle)) {
+  if (
+    ['static', 'stream', 'stream-without-prefixes', 'dynamic-legacy'].includes(
+      nxArgs.outputStyle
+    )
+  ) {
     // If the user has specified a non-TUI output style, we disable the TUI
     return false;
   }

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -916,6 +916,7 @@ export function setEnvVarsBasedOnArgs(
   }
   if (nxArgs.outputStyle == 'stream-without-prefixes') {
     process.env.NX_STREAM_OUTPUT = 'true';
+    process.env.NX_PREFIX_OUTPUT = 'false';
   }
   if (loadDotEnvFiles) {
     process.env.NX_LOAD_DOT_ENV_FILES = 'true';
@@ -1104,7 +1105,12 @@ function shouldUseDynamicLifeCycle(
   }
   if (!process.stdout.isTTY) return false;
   if (isCI()) return false;
-  if (outputStyle === 'static' || outputStyle === 'stream') return false;
+  if (
+    outputStyle === 'static' ||
+    outputStyle === 'stream' ||
+    outputStyle === 'stream-without-prefixes'
+  )
+    return false;
 
   return !tasks.find((t) => shouldStreamOutput(t, null));
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
When using `--output-style=stream-without-prefixes` nx incorrectly shows the TUI instead of streaming

## Expected Behavior
When using `--output-style=stream-without-prefixes`, nx should stream with no prefixes just like it does with `--output-style=stream`

## Related Issue(s)


Fixes #32535