### PR TITLE
fix(core): prevent file watcher events from being silently lost

### DIFF
--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -513,7 +513,34 @@ const handleWorkspaceChanges: FileWatcherCallback = async (
             }
           }
         } catch (e) {
-          // this can happen when the update file was deleted right after
+          // If stat fails, check if the file still exists
+          const fullPath = join(workspaceRoot, event.path);
+          try {
+            const { existsSync } = require('fs');
+            if (!existsSync(fullPath)) {
+              // File was deleted between event detection and processing
+              serverLogger.watcherLog(
+                `File ${event.path} was deleted after ${event.type} event was detected`
+              );
+              deletedFiles.push(event.path);
+            } else {
+              // File exists but we couldn't stat it (possibly due to timing/locking)
+              // Process it anyway to avoid missing updates
+              serverLogger.watcherLog(
+                `Warning: Could not stat ${event.path} (error: ${e.message}), processing as ${event.type} anyway`
+              );
+              if (event.type === 'update') {
+                updatedFilesToHash.push(event.path);
+              } else {
+                createdFilesToHash.push(event.path);
+              }
+            }
+          } catch (existsError) {
+            // If we can't even check existence, log and skip
+            serverLogger.watcherLog(
+              `Error processing file event for ${event.path}: ${existsError.message}`
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
When processing file change events, statSync() failures were silently caught and events were lost. This caused project.json creation to be occasionally missed, leading to inconsistent project graph state and unreliable remote caching.

The fix:
- Check file existence when stat fails
- Treat non-existent files as delete events
- Process files that exist but can't be stat'd to avoid missing updates
- Add comprehensive logging for debugging

Fixes NXC-2866
