### PR TITLE
docs(dotnet): improve dotnet docs around option types

### DIFF
--- a/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
@@ -114,6 +114,14 @@ To view inferred tasks for a project, open the [project details view](/docs/feat
 
 The `@nx/dotnet` is configured in the `plugins` array in `nx.json`.
 
+Each target type can be configured with:
+
+- `targetName` - Rename the target if needed (e.g., change "build" to "compile")
+- Additional target configuration properties (options, configurations, dependsOn, cache, inputs, outputs)
+- Set to `false` to disable a target
+
+For example:
+
 ```json
 // nx.json
 {
@@ -121,19 +129,26 @@ The `@nx/dotnet` is configured in the `plugins` array in `nx.json`.
     {
       "plugin": "@nx/dotnet",
       "options": {
-        "buildTargetName": "build",
-        "testTargetName": "test",
-        "cleanTargetName": "clean",
-        "restoreTargetName": "restore",
-        "publishTargetName": "publish",
-        "packTargetName": "pack"
+        "build": {
+          "targetName": "compile",
+          "configurations": {
+            "production": {
+              "optimization": true
+            }
+          }
+        },
+        "test": {
+          "targetName": "unit-test",
+          "dependsOn": ["build"]
+        },
+        "pack": false
       }
     }
   ]
 }
 ```
 
-Once a .NET project file has been identified, the targets are created with the names you specify in the `nx.json` `plugins` array. The default names for the inferred targets are:
+Once a .NET project file has been identified, the targets are created with the configuration you specify in the `nx.json` `plugins` array. The default names for the inferred targets are:
 
 - `build` - Compiles the project
 - `test` - Runs unit tests (for test projects)


### PR DESCRIPTION
This pull request updates the documentation for configuring .NET target types in the `nx.json` file to provide clearer instructions and examples. The changes make it easier to understand how to customize target names and configurations for the `@nx/dotnet` plugin.

Improvements to configuration documentation:

* Added a section describing how each target type can be configured, including renaming targets, customizing options, disabling targets, and specifying additional properties.
* Updated the example configuration to show how to rename targets (e.g., "build" to "compile"), add configurations (e.g., production optimization), set dependencies between targets, and disable targets (e.g., disabling "pack").
* Clarified that targets are created with the configuration specified in the `nx.json` `plugins` array, rather than just with custom names.