### PR TITLE
fix(nx-dev): add copy-docs back as a dep of serve

### DIFF
--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -74,6 +74,7 @@
     },
     "serve": {
       "executor": "@nx/next:server",
+      "dependsOn": ["copy-docs"],
       "options": {
         "buildTarget": "nx-dev:build-base",
         "dev": true


### PR DESCRIPTION
It was removed when the scripts were cleaned up during next.js->astro migration. Adding this back since blog posts need to be synced first before serving.