### PR TITLE
 docs(core): update search filter on createnodes compat page

### DIFF
--- a/astro-docs/src/content/docs/extending-nx/createnodes-compatibility.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/createnodes-compatibility.mdoc
@@ -1,7 +1,7 @@
 ---
 title: CreateNodes API Compatibility
 description: Understand which createNodes API version is used by different Nx versions and how to write plugins that support multiple Nx versions.
-filter: 'type:Reference'
+filter: 'type:References'
 ---
 
 This is a reference for knowing how Nx versions and the `createNodes`/`createNodesV2` APIs interact. If you plan on supporting multiple Nx versions with a custom plugin, then it's important to know which APIs to use.


### PR DESCRIPTION
This PR updates one filter from `Reference` to `References` to keep consistency with our other pages.

Before (Both Reference and References show up):

<img width="137" height="206" alt="image" src="https://github.com/user-attachments/assets/729379b6-0315-4b99-af90-fd96b3e96830" />


After (Just References, and every filter is plural):

<img width="736" height="535" alt="image" src="https://github.com/user-attachments/assets/9c2ecbcd-67c4-4923-9d05-e2081b0e9dba" />

Closes DOC-309