### PR TITLE
fix(core): prevent undefined importer crash in pnpm lockfile parsing

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -1685,4 +1685,84 @@ describe('pnpm LockFile utility', () => {
       expect(result).toEqual(expectedPrunedLockFile);
     });
   });
+
+  describe('missing workspace importer', () => {
+    beforeEach(() => {
+      const fileSys = {
+        'node_modules/.modules.yaml': `hoistedDependencies: {}`,
+        'node_modules/lodash/package.json': '{"version": "4.17.21"}',
+      };
+      vol.fromJSON(fileSys, '/root');
+    });
+
+    it('should throw clear error when workspace package importer is missing', () => {
+      // v9.0 lockfile
+      // Only has root importer (.)
+      // Root importer references a workspace package with link:
+      // But the workspace package's importer is MISSING
+      const lockFile = `lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+      my-workspace-lib:
+        specifier: workspace:*
+        version: link:packages/my-workspace-lib
+
+packages:
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+snapshots:
+
+  lodash@4.17.21: {}`;
+
+      const packageJson = {
+        name: 'test-app',
+        version: '1.0.0',
+        dependencies: {
+          lodash: '^4.17.21',
+          'my-workspace-lib': 'workspace:*',
+        },
+      };
+
+      const graph: ProjectGraph = {
+        nodes: {
+          'my-workspace-lib': {
+            name: 'my-workspace-lib',
+            type: 'lib',
+            data: {
+              root: 'packages/my-workspace-lib',
+              metadata: {
+                js: {
+                  packageName: 'my-workspace-lib',
+                },
+              },
+            },
+          },
+        },
+        dependencies: {},
+        externalNodes: {
+          'npm:lodash': {
+            type: 'npm',
+            name: 'npm:lodash',
+            data: {
+              version: '4.17.21',
+              packageName: 'lodash',
+              hash: 'sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==',
+            },
+          },
+        },
+      };
+
+      expect(() =>
+        stringifyPnpmLockfile(graph, lockFile, packageJson, '/virtual')
+      ).not.toThrow();
+    });
+  });
 });

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -428,8 +428,10 @@ export function stringifyPnpmLockfile(
   const workspaceDependencyImporters: Record<string, ProjectSnapshot> = {};
   for (const [packageName, importerPath] of Object.entries(requiredImporters)) {
     const baseImporter = importers[importerPath];
-    workspaceDependencyImporters[`workspace_modules/${packageName}`] =
-      baseImporter;
+    if (baseImporter) {
+      workspaceDependencyImporters[`workspace_modules/${packageName}`] =
+        baseImporter;
+    }
   }
 
   const output: Lockfile = {


### PR DESCRIPTION
When stringifying a pnpm v9 lockfile with workspace packages, Nx crashes with: "Cannot destructure property 'specifiers' of 'projectSnapshot' as it is undefined."

This occurs when:
- The lockfile has a root importer with `link:` references to workspace packages
- But the lockfile is missing the workspace package importer entries
- The code tries to access `importers[importerPath]` which returns undefined
- This undefined value gets added to the output lockfile
- During serialization, it crashes when trying to destructure undefined

Workspace packages with missing importers are now silently skipped during lockfile serialization. This prevents the crash and allows Nx to continue operating with out-of-sync lockfiles.

The fix adds a null check before adding workspace dependency importers to the output lockfile.

Closes NXC-3244