### PR TITLE
chore(repo): mark dotnet e2e as parallel 1

### DIFF
--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -36,6 +36,7 @@ assignment-rules:
       - e2e-docker
       - e2e-js
       - e2e-nx-init
+      - e2e-dotnet
     targets:
       - e2e-ci**
     run-on:


### PR DESCRIPTION
## Current Behavior
.NET sometimes bails on a failed mutex in e2e

## Expected Behavior
it runs only 1 at a time

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
