### PR TITLE
fix(docker): handle undefined options when creating graph

### DIFF
--- a/packages/docker/src/plugins/plugin.ts
+++ b/packages/docker/src/plugins/plugin.ts
@@ -348,7 +348,7 @@ function normalizePluginOptions(
   };
 
   return {
-    buildTarget: normalizeTarget(options.buildTarget, 'docker:build'),
-    runTarget: normalizeTarget(options.runTarget, 'docker:run'),
+    buildTarget: normalizeTarget(options?.buildTarget, 'docker:build'),
+    runTarget: normalizeTarget(options?.runTarget, 'docker:run'),
   };
 }


### PR DESCRIPTION
## Current Behavior
When `@nx/docker` is registered via string only (`nxJson.plugins: ["@nx/docker"]`, project graph creation fails because we try to access `options.buildTarget`.

## Expected Behavior
Handle undefined `options` gracefully, and still create the default target.

## Related Issue(s)

Fixes NXC-3320
