### PR TITLE
fix(core): fix swapped arguments when resolving catalog references from the filesystem

### DIFF
--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -227,7 +227,7 @@ function getDependencyVersionFromPackageJsonFromFileSystem(
   // Resolve catalog reference if needed
   const manager = getCatalogManager(root);
   if (version && manager?.isCatalogReference(version)) {
-    version = manager.resolveCatalogReference(packageName, version, root);
+    version = manager.resolveCatalogReference(root, packageName, version);
   }
 
   return version;

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -604,9 +604,9 @@ function mapRootSnapshot(
         const manager = getCatalogManager(workspaceRoot);
         if (manager?.isCatalogReference(version)) {
           version = manager.resolveCatalogReference(
+            workspaceRoot,
             packageName,
-            version,
-            workspaceRoot
+            version
           );
           if (!version) {
             throw new Error(

--- a/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
+++ b/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
@@ -75,10 +75,10 @@ function normalizeDependencies(
       let resolvedVersionRange = versionRange;
       const manager = getCatalogManager(workspaceRootPath);
       if (manager?.isCatalogReference(versionRange)) {
-        const resolvedVersionRange = manager.resolveCatalogReference(
+        resolvedVersionRange = manager.resolveCatalogReference(
+          workspaceRootPath,
           packageName,
-          versionRange,
-          workspaceRootPath
+          versionRange
         );
         if (!resolvedVersionRange) {
           throw new Error(

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -591,7 +591,7 @@ function getDependencyVersionFromPackageJsonFromFileSystem(
   // Resolve catalog reference if needed
   const manager = getCatalogManager(root);
   if (version && manager?.isCatalogReference(version)) {
-    version = manager.resolveCatalogReference(packageName, version, root);
+    version = manager.resolveCatalogReference(root, packageName, version);
   }
 
   return version;

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -462,9 +462,9 @@ export async function resolvePackageVersionUsingRegistry(
     const manager = getCatalogManager(workspaceRoot);
     if (manager?.isCatalogReference(version)) {
       resolvedVersion = manager.resolveCatalogReference(
+        workspaceRoot,
         packageName,
-        version,
-        workspaceRoot
+        version
       );
       if (!resolvedVersion) {
         throw new Error(
@@ -525,9 +525,9 @@ export async function resolvePackageVersionUsingInstallation(
     const manager = getCatalogManager(workspaceRoot);
     if (manager.isCatalogReference(version)) {
       resolvedVersion = manager.resolveCatalogReference(
+        workspaceRoot,
         packageName,
-        version,
-        workspaceRoot
+        version
       );
       if (!resolvedVersion) {
         throw new Error(


### PR DESCRIPTION
Fixes the order of the arguments in invocations to `resolveCatalogReference` when resolving catalog references from the filesystem (not using a `Tree`).