### PR TITLE
chore(core): improvements to native build and error handling

### DIFF
--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -69,7 +69,11 @@
         {
           "dependentTasksOutputFiles": "**/*.node",
           "transitive": true
-        }
+        },
+        "{workspaceRoot}/scripts/copy-local-native.js",
+        "{workspaceRoot}/scripts/copy-graph-client.js",
+        "{workspaceRoot}/scripts/chmod.js",
+        "{workspaceRoot}/scripts/copy-readme.js"
       ],
       "executor": "nx:run-commands",
       "outputs": [

--- a/scripts/copy-local-native.js
+++ b/scripts/copy-local-native.js
@@ -5,7 +5,12 @@ const glob = require('tinyglobby');
 
 const p = process.argv[2];
 
-const nativeFiles = glob.globSync(`packages/${p}/**/*.{node,wasm,js,mjs,cjs}`);
+const nativeFiles = glob.globSync(`packages/${p}/**/*.{node,wasm,js,mjs,cjs}`, {
+  ignore: [
+    '**/node_modules/**',
+    'src/command-line/migrate/run-migration-process.js',
+  ],
+});
 
 console.log({ nativeFiles });
 


### PR DESCRIPTION
## Current Behavior

`node_modules` are being copied during copy-local-native

## Expected Behavior

`node_modules` are not being copied during `copy-local-native`