### PR TITLE
fix(vite): nxViteTsPaths supports local path aliases

### DIFF
--- a/e2e/vite/src/vite.test.ts
+++ b/e2e/vite/src/vite.test.ts
@@ -247,6 +247,42 @@ describe('@nx/vite/plugin', () => {
 
       expect(() => runCLI(`test ${lib1}`)).not.toThrow();
     });
+
+    it('should support local path aliases in project tsconfig.app.json', () => {
+      const myLocalApp = uniq('myapp');
+      runCLI(
+        `generate @nx/react:app ${myLocalApp} --directory=apps/${myLocalApp} --bundler=vite --unitTestRunner=vitest`
+      );
+
+      // Add a local path alias in the project's tsconfig.app.json
+      updateJson(`apps/${myLocalApp}/tsconfig.app.json`, (json) => {
+        json.compilerOptions = json.compilerOptions || {};
+        json.compilerOptions.baseUrl = '.';
+        json.compilerOptions.paths = {
+          '~/*': ['src/*'],
+        };
+        return json;
+      });
+
+      // Update the app to use the local path alias
+      updateFile(
+        `apps/${myLocalApp}/src/app/app.tsx`,
+        `import NxWelcome from '~/app/nx-welcome';
+
+        export function App() {
+          return (
+            <div>
+              <NxWelcome title="${myLocalApp}" />
+            </div>
+          );
+        }
+
+        export default App;`
+      );
+
+      // Ensure build works with local path aliases
+      expect(() => runCLI(`build ${myLocalApp}`)).not.toThrow();
+    });
   });
 
   describe('react with vitest only', () => {

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -998,7 +998,7 @@ module.exports = withNx(
           plugins: [react(), dts({ entryRoot: 'src', tsconfigPath: path.join(__dirname, 'tsconfig.lib.json') })],
           // Uncomment this if you are using workers.
           // worker: {
-          //  plugins: [ nxViteTsPaths() ],
+          //  plugins: [],
           // },
           // Configuration for building your library.
           // See: https://vitejs.dev/guide/build.html#library-mode

--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -72,6 +72,7 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
   options.mainFields ??= [['exports', '.', 'import'], 'module', 'main'];
   options.buildLibsFromSource ??= true;
   let projectRoot = '';
+  let projectRootFromWorkspaceRoot: string;
 
   return {
     name: 'nx-vite-ts-paths',
@@ -80,7 +81,7 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
     enforce: 'pre',
     async configResolved(config: any) {
       projectRoot = config.root;
-      const projectRootFromWorkspaceRoot = relative(workspaceRoot, projectRoot);
+      projectRootFromWorkspaceRoot = relative(workspaceRoot, projectRoot);
       foundTsConfigPath = getTsConfig(
         process.env.NX_TSCONFIG_PATH ??
           join(
@@ -216,10 +217,14 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
   } as Plugin;
 
   function getTsConfig(preferredTsConfigPath: string): string {
-    const projectTsConfigPath = getProjectTsConfigPath(projectRoot);
+    const projectTsConfigPath = getProjectTsConfigPath(
+      projectRootFromWorkspaceRoot
+    );
     return [
       resolve(preferredTsConfigPath),
-      projectTsConfigPath ? resolve(projectTsConfigPath) : null,
+      projectTsConfigPath
+        ? resolve(join(workspaceRoot, projectTsConfigPath))
+        : null,
       resolve(join(workspaceRoot, 'tsconfig.base.json')),
       resolve(join(workspaceRoot, 'tsconfig.json')),
       resolve(join(workspaceRoot, 'jsconfig.json')),

--- a/packages/vite/src/utils/generator-utils.spec.ts
+++ b/packages/vite/src/utils/generator-utils.spec.ts
@@ -296,7 +296,7 @@ describe('generator utils', () => {
           plugins: [dts({ entryRoot: 'src', tsconfigPath: path.join(__dirname, 'tsconfig.lib.json') })],
           // Uncomment this if you are using workers.
           // worker: {
-          //  plugins: [ nxViteTsPaths() ],
+          //  plugins: [],
           // },
           // Configuration for building your library.
           // See: https://vitejs.dev/guide/build.html#library-mode

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -519,7 +519,12 @@ ${
     host: 'localhost',
   },`;
 
-  const workerOption = `  // Uncomment this if you are using workers.
+  const workerOption = isTsSolutionSetup
+    ? `  // Uncomment this if you are using workers.
+  // worker: {
+  //  plugins: [],
+  // },`
+    : `  // Uncomment this if you are using workers.
   // worker: {
   //  plugins: [ nxViteTsPaths() ],
   // },`;

--- a/packages/vue/src/generators/application/application.spec.ts
+++ b/packages/vue/src/generators/application/application.spec.ts
@@ -203,7 +203,7 @@ describe('application generator', () => {
           plugins: [vue()],
           // Uncomment this if you are using workers.
           // worker: {
-          //  plugins: [ nxViteTsPaths() ],
+          //  plugins: [],
           // },
           build: {
             outDir: './dist',

--- a/packages/vue/src/generators/library/library.spec.ts
+++ b/packages/vue/src/generators/library/library.spec.ts
@@ -549,7 +549,7 @@ module.exports = [
           plugins: [vue()],
           // Uncomment this if you are using workers.
           // worker: {
-          //  plugins: [ nxViteTsPaths() ],
+          //  plugins: [],
           // },
           test: {
             name: '@proj/my-lib',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Local `tsconfig.app.json` is never picked up due to wrong resolved path.

## Expected Behavior
Local `tsconfig.app.json` is picked up and the path aliases are added to Vite.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #33231 
