### PR TITLE
chore(maven): only run nx-maven-plugin:install for maven e2e tests

### DIFF
--- a/e2e/maven/project.json
+++ b/e2e/maven/project.json
@@ -5,5 +5,20 @@
   "projectType": "application",
   "implicitDependencies": ["maven", "nx-maven-plugin"],
   "// targets": "to see all targets run: nx show project e2e-maven --web",
-  "targets": {}
+  "targets": {
+    "e2e-local": {
+      "dependsOn": [
+        "@nx/nx-source:populate-local-registry-storage",
+        "@nx/nx-source:local-registry",
+        "nx-maven-plugin:install"
+      ]
+    },
+    "e2e-ci--**/**": {
+      "dependsOn": [
+        "@nx/nx-source:populate-local-registry-storage",
+        "@nx/nx-source:local-registry",
+        "nx-maven-plugin:install"
+      ]
+    }
+  }
 }

--- a/nx.json
+++ b/nx.json
@@ -140,8 +140,7 @@
       "inputs": ["e2eInputs", "^production"],
       "dependsOn": [
         "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry",
-        "nx-maven-plugin:install"
+        "@nx/nx-source:local-registry"
       ]
     },
     "e2e-ci": {
@@ -162,8 +161,7 @@
       "inputs": ["e2eInputs", "^production"],
       "dependsOn": [
         "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry",
-        "nx-maven-plugin:install"
+        "@nx/nx-source:local-registry"
       ],
       "options": {
         "args": ["--forceExit"]
@@ -173,8 +171,7 @@
       "inputs": ["e2eInputs", "^production"],
       "dependsOn": [
         "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry",
-        "nx-maven-plugin:install"
+        "@nx/nx-source:local-registry"
       ]
     },
     "e2e-base": {


### PR DESCRIPTION
## Current Behavior

Maven is installed as a global dependency for all e2e targets (`e2e-local`, `e2e-ci--**/**`, and `e2e-macos-ci--**/*`), even when only the Maven e2e tests need it.

## Expected Behavior

Maven should only be installed as a dependency for the Maven e2e tests that actually use it, avoiding unnecessary installations for other e2e test projects.

## Changes Made

- Removed `nx-maven-plugin:install` from the global e2e target defaults in `nx.json`
- Added `nx-maven-plugin:install` as a specific dependency to the Maven e2e project targets in `e2e/maven/project.json`

This optimization ensures Maven is only installed when needed, reducing unnecessary build overhead for other e2e tests.