### PR TITLE
fix(webpack): prevent errors when importing @nx/webpack before typescript is installed

### DIFF
--- a/packages/webpack/index.ts
+++ b/packages/webpack/index.ts
@@ -6,7 +6,7 @@ import { useLegacyNxPlugin } from './src/plugins/use-legacy-nx-plugin/use-legacy
 // Lazy-loaded to avoid requiring typescript before it's installed.
 // Other generators may import this index before typescript is available.
 // This generator imports @phenomnomnominal/tsquery which requires typescript.
-// Note: This seems to only affet yarn v1.
+// Note: This seems to only affect yarn v1.
 export function convertConfigToWebpackPluginGenerator(
   ...args: Parameters<
     typeof import('./src/generators/convert-config-to-webpack-plugin/convert-config-to-webpack-plugin').convertConfigToWebpackPluginGenerator

--- a/packages/webpack/index.ts
+++ b/packages/webpack/index.ts
@@ -1,14 +1,23 @@
 import { configurationGenerator } from './src/generators/configuration/configuration';
 import { NxAppWebpackPlugin } from './src/plugins/nx-webpack-plugin/nx-app-webpack-plugin';
 import { NxTsconfigPathsWebpackPlugin as _NxTsconfigPathsWebpackPlugin } from './src/plugins/nx-typescript-webpack-plugin/nx-tsconfig-paths-webpack-plugin';
-import { convertConfigToWebpackPluginGenerator } from './src/generators/convert-config-to-webpack-plugin/convert-config-to-webpack-plugin';
 import { useLegacyNxPlugin } from './src/plugins/use-legacy-nx-plugin/use-legacy-nx-plugin';
 
-export {
-  configurationGenerator,
-  convertConfigToWebpackPluginGenerator,
-  useLegacyNxPlugin,
-};
+// Lazy-loaded to avoid requiring typescript before it's installed.
+// Other generators may import this index before typescript is available.
+// This generator imports @phenomnomnominal/tsquery which requires typescript.
+// Note: This seems to only affet yarn v1.
+export function convertConfigToWebpackPluginGenerator(
+  ...args: Parameters<
+    typeof import('./src/generators/convert-config-to-webpack-plugin/convert-config-to-webpack-plugin').convertConfigToWebpackPluginGenerator
+  >
+) {
+  return require('./src/generators/convert-config-to-webpack-plugin/convert-config-to-webpack-plugin').convertConfigToWebpackPluginGenerator(
+    ...args
+  );
+}
+
+export { configurationGenerator, useLegacyNxPlugin };
 
 // Exported for backwards compatibility in case a plugin is using the old name.
 /** @deprecated Use `configurationGenerator` instead. */


### PR DESCRIPTION
This PR wraps one of the exports of `@nx/webpack` within a dynamic function that ultimately requires `tsquery`. This causes an issue in yarn v1 where `typescript` cannot be resolved thus causing an error when `@nx/webpack` is imported.

The errors happens on every new workspace that starts from empty:

```
npx create-nx-workspace --preset=ts --pm=yarn
nx add @nx/web
nx g @nx/web:app apps/demo --bundler=webpack
```

Results in:

```

 NX   Cannot find module 'typescript'

Require stack:
- /private/var/folders/p4/6tvkdn_11xlc_2j999ybhbkr0000gn/T/tmp-59809-4kedkj5a1XsO/node_modules/@phenomnomnominal/tsquery/dist/src/ast.js
- /private/var/folders/p4/6tvkdn_11xlc_2j999ybhbkr0000gn/T/tmp-59809-4kedkj5a1XsO/node_modules/@phenomnomnominal/tsquery/dist/src/index.js
- /private/var/folders/p4/6tvkdn_11xlc_2j999ybhbkr0000gn/T/tmp-59809-4kedkj5a1XsO/node_modules/@nx/webpack/src/generators/convert-config-to-webpack-plugin/lib/extract-webpack-options.js
- /private/var/folders/p4/6tvkdn_11xlc_2j999ybhbkr0000gn/T/tmp-59809-4kedkj5a1XsO/node_modules/@nx/webpack/src/generators/convert-config-to-webpack-plugin/convert-config-to-webpack-plugin.js
- /private/var/folders/p4/6tvkdn_11xlc_2j999ybhbkr0000gn/T/tmp-59809-4kedkj5a1XsO/node_modules/@nx/webpack/index.js
- /private/tmp/web4/node_modules/@nx/devkit/src/utils/package-json.js
- /private/tmp/web4/node_modules/@nx/devkit/src/generators/to-js.js
- /private/tmp/web4/node_modules/@nx/devkit/public-api.js
- /private/tmp/web4/node_modules/@nx/devkit/index.js
- /private/tmp/web4/node_modules/@nx/web/src/generators/application/application.js
- /private/tmp/web4/node_modules/nx/src/config/schema-utils.js
- /private/tmp/web4/node_modules/nx/src/command-line/run/executor-utils.js
- /private/tmp/web4/node_modules/nx/src/project-graph/utils/project-configuration-utils.js
- /private/tmp/web4/node_modules/nx/src/utils/package-json.js
- /private/tmp/web4/node_modules/nx/bin/nx.js
Pass --verbose to see the stacktrace.

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Note: Other generators like React/Vue are fine since they have dependency on tsquery, which installs typescript.