### PR TITLE
fix(core): correct gitignore pattern rooting for parent directories

### DIFF
--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -1,5 +1,5 @@
-use ignore::{WalkBuilder, Match};
 use ignore::gitignore::GitignoreBuilder;
+use ignore::{Match, WalkBuilder};
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -486,11 +486,8 @@ nested/child-two/
         // Git repo in nested directory
         temp_dir.child("workspace/.git").touch().unwrap();
 
-        // Workspace gitignore (empty - doesn't ignore dist/)
-        temp_dir
-            .child("workspace/.gitignore")
-            .write_str("")
-            .unwrap();
+        // Create workspace with its own git repo and gitignore
+        temp_dir.child("workspace/.gitignore").write_str("").unwrap();
 
         // Create workspace/dist/ (should NOT be ignored - parent pattern shouldn't apply here)
         temp_dir
@@ -522,9 +519,11 @@ nested/child-two/
 
         // Should include dist/ and build/ files because parent gitignore patterns
         // are now correctly scoped to the parent directory
+        // Note: .gitignore file itself is also included
         assert_eq!(
             files,
             vec![
+                ".gitignore".to_string(),
                 "build/output.js".to_string(),
                 "dist/app.css".to_string(),
                 "dist/bundle.js".to_string(),
@@ -538,10 +537,7 @@ nested/child-two/
         let temp_dir = assert_fs::TempDir::new().unwrap();
 
         // Root .gitignore ignoring "temp/"
-        temp_dir
-            .child(".gitignore")
-            .write_str("temp/\n")
-            .unwrap();
+        temp_dir.child(".gitignore").write_str("temp/\n").unwrap();
 
         // Middle level .gitignore ignoring "logs/"
         temp_dir


### PR DESCRIPTION
## Current Behavior

When a workspace is nested within a git repository, parent `.gitignore` patterns are incorrectly applied relative to the current working directory instead of relative to the directory containing the `.gitignore` file.

This occurs because the code uses `WalkBuilder::add_ignore()`, which has a known limitation in the Rust `ignore` crate where patterns are not properly rooted to their source directory ([ripgrep#1394](https://github.com/BurntSushi/ripgrep/issues/1394)).

**Example of the bug:**
```
/parent/
  .gitignore (contains "dist/")
  workspace/
    .git/
    dist/bundle.js  ← Incorrectly ignored by parent's pattern
    src/index.js
```

The pattern `dist/` from `/parent/.gitignore` incorrectly filters `/parent/workspace/dist/` when it should only apply to `/parent/dist/`.

## Expected Behavior

Parent `.gitignore` patterns should be applied relative to the directory where the `.gitignore` file is located, not relative to the workspace root or current working directory.

With this fix, the pattern `dist/` in `/parent/.gitignore` will only match `/parent/dist/` and will not affect `/parent/workspace/dist/`.

## Related Issue(s)

This addresses a correctness issue in gitignore pattern application for cache invalidation in nested workspace scenarios.

---

## Implementation Details

### Changes Made

**File:** `packages/nx/src/native/walker.rs`

1. **Added imports:**
   - `ignore::Match` - for pattern matching results
   - `ignore::gitignore::GitignoreBuilder` - for building directory-scoped matchers
   - `std::sync::Arc` - for thread-safe sharing of matchers

2. **Replaced `add_ignore()` with `GitignoreBuilder`:**
   - Create a `GitignoreBuilder` for each parent `.gitignore` file
   - Initialize each builder with the parent directory as the base path
   - Store matchers in `Arc<Vec<_>>` for thread-safe sharing across parallel walker threads

3. **Integrated matchers into `filter_entry`:**
   - Check each file path against parent gitignore matchers with proper directory context
   - Use `matched_path_or_any_parents()` to handle directory hierarchies correctly

### Tests Added

1. **`parent_gitignore_patterns_respect_directory_context`**
   - Verifies that patterns like `dist/` in a parent `.gitignore` don't incorrectly filter workspace files
   - Ensures patterns are scoped to their source directory

2. **`nested_parent_gitignores_apply_correctly`**
   - Tests multiple levels of parent `.gitignore` files
   - Verifies each `.gitignore` only affects its own directory tree

### Benefits

- **Correctness:** Parent gitignore patterns now respect directory boundaries
- **Performance:** Patterns are compiled once and shared across threads via `Arc`
- **Consistency:** Matches how the watch system handles gitignores (which uses `IgnoreFilter`)

---

**Note:** This is a draft PR to verify that the Rust code compiles and tests pass in CI. The implementation is complete but needs CI validation since Rust is not installed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>