### PR TITLE
fix(core): split lockfile cache and other performance improvements

### DIFF
--- a/packages/nx/src/project-graph/plugins/resolve-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/resolve-plugin.ts
@@ -18,6 +18,9 @@ import { retrieveProjectConfigurationsWithoutPluginInference } from '../utils/re
 import type { ProjectConfiguration } from '../../config/workspace-json-project-json';
 
 let projectsWithoutInference: Record<string, ProjectConfiguration>;
+let projectsWithoutInferencePromise: Promise<
+  typeof projectsWithoutInference
+> | null = null;
 
 export async function resolveNxPlugin(
   moduleName: string,
@@ -28,8 +31,9 @@ export async function resolveNxPlugin(
     require.resolve(moduleName);
   } catch {
     // If a plugin cannot be resolved, we will need projects to resolve it
-    projectsWithoutInference ??=
-      await retrieveProjectConfigurationsWithoutPluginInference(root);
+    projectsWithoutInferencePromise ??=
+      retrieveProjectConfigurationsWithoutPluginInference(root);
+    projectsWithoutInference ??= await projectsWithoutInferencePromise;
   }
   const { pluginPath, name, shouldRegisterTSTranspiler } = getPluginPathAndName(
     moduleName,

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -696,7 +696,10 @@ function validateAndNormalizeProjectRootMap(
         throw e;
       }
     }
+  }
 
+  for (const root in projectRootMap) {
+    const project = projectRootMap[root];
     normalizeTargets(
       project,
       sourceMaps,


### PR DESCRIPTION
## Summary
This PR includes three performance and correctness improvements:

1. **Split lockfile cache into separate node and dependency caches** - Previously, both createNodes and createDependencies would read/write the entire cache. Now each manages its own cache independently:
   - `parsed-lock-file.nodes.json` for external nodes
   - `parsed-lock-file.dependencies.json` for dependencies

2. **Prevent duplicate plugin resolution calls with promise cache** - Added a promise cache to prevent concurrent duplicate calls to `retrieveProjectConfigurationsWithoutPluginInference` when multiple plugins fail to resolve simultaneously

3. **Normalize targets in separate loop after validation** - Moved target normalization out of the validation loop to ensure proper sequencing

## Test plan
- [ ] Tests pass (currently failing in CI - needs investigation)
- [ ] Build succeeds
- [ ] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)