### PR TITLE
feat(gradle): allow specifying project and task configuration from gradle build files

### DIFF
--- a/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
@@ -421,13 +421,13 @@ tasks.named('integrationTest') {
 
 **Available DSL methods for task-level configuration:**
 
-- `dependsOn` - ListProperty for adding Nx task dependencies (see important note below)
+- `dependsOn` - ListProperty for adding Nx task dependencies
 - `set(key, value)` - Set string, number, or boolean values
 - `array(key, ...values)` - Set array values
 - `set(key) { ... }` - Create nested objects
 - `merge(map)` - Merge a map of properties
 
-{% aside type="warning" title="Important: dependsOn Merge Behavior" %}
+{% aside type="note" title="Important: dependsOn Merge Behavior" %}
 The `dependsOn` property behaves differently from other configuration options:
 
 - **Using `dependsOn.addAll(...)`** (recommended): **Merges** with Gradle-detected dependencies. This adds to the existing dependencies that Gradle automatically discovers.

--- a/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
@@ -341,19 +341,19 @@ nx {
 
 ```groovy
 // build.gradle
-import static dev.nx.gradle.NxProjectExtensionKt.nx
+import static dev.nx.gradle.Groovy.nx
 
-nx {
+nx(project) {
   // Set project name
-  set 'name', 'my-custom-project-name'
+  it.set 'name', 'my-custom-project-name'
 
   // Add tags for organization
-  array 'tags', 'api', 'backend', 'tier:1'
+  it.array 'tags', 'api', 'backend', 'tier:1'
 
   // Add nested metadata
-  set 'metadata', {
-    set 'owner', 'team-payments'
-    set 'criticality', 'high'
+  it.set 'metadata', {
+    it.set 'owner', 'team-payments'
+    it.set 'criticality', 'high'
   }
 }
 ```
@@ -405,22 +405,22 @@ tasks {
 
 ```groovy
 // build.gradle
-import static dev.nx.gradle.NxTaskExtensionKt.nx
+import static dev.nx.gradle.Groovy.nx
 
 tasks.named('integrationTest') {
-  nx {
+  nx(it) {
     // Add Nx-specific dependencies (merges with Gradle dependencies)
-    mergedDependsOn('^build', 'app:lint')
+    it.mergedDependsOn('^build', 'app:lint')
 
     // Configure caching
-    set 'cache', true
+    it.set 'cache', true
 
     // Add target tags
-    array 'tags', 'integration', 'slow'
+    it.array 'tags', 'integration', 'slow'
 
     // Add any custom configuration
-    set 'options', {
-      set 'timeout', 300
+    it.set 'options', {
+      it.set 'timeout', 300
     }
   }
 }

--- a/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
@@ -319,6 +319,8 @@ Use the `nx {}` block at the project level to configure Nx in any way you would 
 
 ```kotlin
 // build.gradle.kts
+import dev.nx.gradle.nx
+
 nx {
   // Set project name
   set("name", "my-custom-project-name")
@@ -339,6 +341,8 @@ nx {
 
 ```groovy
 // build.gradle
+import static dev.nx.gradle.NxProjectExtensionKt.nx
+
 nx {
   // Set project name
   set 'name', 'my-custom-project-name'
@@ -373,11 +377,13 @@ Use the `nx {}` block on individual Gradle tasks to configure target-specific be
 
 ```kotlin
 // build.gradle.kts
+import dev.nx.gradle.nx
+
 tasks {
   build {
     nx {
       // Add Nx-specific dependencies (merges with Gradle dependencies)
-      dependsOn.addAll("^build", "app:lint")
+      mergedDependsOn("^build", "app:lint")
 
       // Configure caching
       set("cache", true)
@@ -399,10 +405,12 @@ tasks {
 
 ```groovy
 // build.gradle
+import static dev.nx.gradle.NxTaskExtensionKt.nx
+
 tasks.named('integrationTest') {
   nx {
     // Add Nx-specific dependencies (merges with Gradle dependencies)
-    dependsOn.addAll('^build', 'app:lint')
+    mergedDependsOn('^build', 'app:lint')
 
     // Configure caching
     set 'cache', true
@@ -423,24 +431,24 @@ tasks.named('integrationTest') {
 
 **Available DSL methods for task-level configuration:**
 
-- `dependsOn` - ListProperty for adding Nx task dependencies
+- `mergedDependsOn` - ListProperty for adding Nx task dependencies
 - `set(key, value)` - Set string, number, or boolean values
 - `array(key, ...values)` - Set array values
 - `set(key) { ... }` - Create nested objects
 - `merge(map)` - Merge a map of properties
 
-{% aside type="note" title="Important: dependsOn Merge Behavior" %}
-The `dependsOn` property behaves differently from other configuration options:
+{% aside type="note" title="Important: mergedDependsOn  Behavior" %}
+The `mergedDependsOn` property behaves differently from other configuration options:
 
-**Using `dependsOn.addAll(...)`** merges your dependencies with Gradle-detected dependencies. This adds to the existing dependencies that Gradle automatically discovers.
+**Using `mergedDependsOn.addAll(...)`** merges your dependencies with Gradle-detected dependencies. This adds to the existing dependencies that Gradle automatically discovers.
 
 ```kotlin
 nx {
-  dependsOn.addAll("^build", "app:lint")  // Adds to Gradle dependencies
+  mergedDependsOn.addAll("^build", "app:lint")  // Merges with Gradle dependencies
 }
 ```
 
 Specifying dependencies in any other way (for example in `project.json` or by using `array("dependsOn", ...)`) will replace all target dependencies instead.
-The `dependsOn` property supports all of [Nx's task dependency patterns](/docs/guides/tasks--caching/defining-task-pipeline).
+The `mergedDependsOn` property supports all of [Nx's task dependency patterns](/docs/guides/tasks--caching/defining-task-pipeline).
 
 {% /aside %}

--- a/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
@@ -382,9 +382,6 @@ import dev.nx.gradle.nx
 tasks {
   build {
     nx {
-      // Add Nx-specific dependencies (merges with Gradle dependencies)
-      mergedDependsOn("^build", "app:lint")
-
       // Configure caching
       set("cache", true)
 
@@ -409,9 +406,6 @@ import static dev.nx.gradle.Groovy.nx
 
 tasks.named('integrationTest') {
   nx(it) {
-    // Add Nx-specific dependencies (merges with Gradle dependencies)
-    it.mergedDependsOn('^build', 'app:lint')
-
     // Configure caching
     it.set 'cache', true
 
@@ -431,24 +425,7 @@ tasks.named('integrationTest') {
 
 **Available DSL methods for task-level configuration:**
 
-- `mergedDependsOn` - ListProperty for adding Nx task dependencies
 - `set(key, value)` - Set string, number, or boolean values
 - `array(key, ...values)` - Set array values
 - `set(key) { ... }` - Create nested objects
 - `merge(map)` - Merge a map of properties
-
-{% aside type="note" title="Important: mergedDependsOn  Behavior" %}
-The `mergedDependsOn` property behaves differently from other configuration options:
-
-**Using `mergedDependsOn.addAll(...)`** merges your dependencies with Gradle-detected dependencies. This adds to the existing dependencies that Gradle automatically discovers.
-
-```kotlin
-nx {
-  mergedDependsOn.addAll("^build", "app:lint")  // Merges with Gradle dependencies
-}
-```
-
-Specifying dependencies in any other way (for example in `project.json` or by using `array("dependsOn", ...)`) will replace all target dependencies instead.
-The `mergedDependsOn` property supports all of [Nx's task dependency patterns](/docs/guides/tasks--caching/defining-task-pipeline).
-
-{% /aside %}

--- a/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
@@ -306,13 +306,13 @@ In a `project.json`, you can specify the target configuration like so:
 {% /tabitem %}
 {% /tabs %}
 
-## Configuring Projects and Tasks with the Gradle DSL
+### Configuring Projects and Tasks with the Gradle DSL
 
 The `dev.nx.gradle.project-graph` plugin provides a type-safe `nx {}` DSL for configuring Nx-specific metadata on your Gradle projects and tasks. This allows you to customize project metadata, configure task dependencies, and control caching behavior directly in your Gradle build files.
 
-### Project-Level Configuration
+#### Project-Level Configuration
 
-Use the `nx {}` block at the project level to configure Nx project metadata such as name, tags, and custom properties:
+Use the `nx {}` block at the project level to configure Nx in any way you would in `project.json`:
 
 {% tabs syncKey="java-lang" %}
 {% tabitem label="build.gradle.kts" %}
@@ -364,29 +364,31 @@ nx {
 - `set(key) { ... }` - Create nested objects
 - `merge(map)` - Merge a map of properties
 
-### Task-Level Configuration
+#### Task-Level Configuration
 
-Use the `nx {}` block on individual Gradle tasks to configure Nx target-specific behavior:
+Use the `nx {}` block on individual Gradle tasks to configure target-specific behavior:
 
 {% tabs syncKey="java-lang" %}
 {% tabitem label="build.gradle.kts" %}
 
 ```kotlin
 // build.gradle.kts
-tasks.named("integrationTest") {
-  nx {
-    // Add Nx-specific dependencies (merges with Gradle dependencies)
-    dependsOn.addAll("^build", "app:lint")
+tasks {
+  build {
+    nx {
+      // Add Nx-specific dependencies (merges with Gradle dependencies)
+      dependsOn.addAll("^build", "app:lint")
 
-    // Configure caching
-    set("cache", true)
+      // Configure caching
+      set("cache", true)
 
-    // Add target tags
-    array("tags", "integration", "slow")
+      // Add target tags
+      array("tags", "integration", "slow")
 
-    // Add custom metadata
-    set("options") {
-      set("timeout", 300)
+      // Add any custom configuration
+      set("options") {
+        set("timeout", 300)
+      }
     }
   }
 }
@@ -408,7 +410,7 @@ tasks.named('integrationTest') {
     // Add target tags
     array 'tags', 'integration', 'slow'
 
-    // Add custom metadata
+    // Add any custom configuration
     set 'options', {
       set 'timeout', 300
     }
@@ -430,125 +432,15 @@ tasks.named('integrationTest') {
 {% aside type="note" title="Important: dependsOn Merge Behavior" %}
 The `dependsOn` property behaves differently from other configuration options:
 
-- **Using `dependsOn.addAll(...)`** (recommended): **Merges** with Gradle-detected dependencies. This adds to the existing dependencies that Gradle automatically discovers.
+**Using `dependsOn.addAll(...)`** merges your dependencies with Gradle-detected dependencies. This adds to the existing dependencies that Gradle automatically discovers.
 
-  ```kotlin
-  nx {
-    dependsOn.addAll("^build", "app:lint")  // Adds to Gradle dependencies
-  }
-  ```
+```kotlin
+nx {
+  dependsOn.addAll("^build", "app:lint")  // Adds to Gradle dependencies
+}
+```
 
-- **Using `set("dependsOn", ...)`**: **Replaces** all dependencies, including those detected by Gradle. Use with caution as this will override automatic dependency detection.
+Specifying dependencies in any other way (for example in `project.json` or by using `array("dependsOn", ...)`) will replace all target dependencies instead.
+The `dependsOn` property supports all of [Nx's task dependency patterns](/docs/guides/tasks--caching/defining-task-pipeline).
 
-  ```kotlin
-  nx {
-    set("dependsOn", listOf("^build"))  // Replaces all Gradle dependencies
-  }
-  ```
-
-In most cases, use `dependsOn.addAll(...)` to ensure your Gradle task dependencies are preserved.
 {% /aside %}
-
-### Nx Dependency Patterns
-
-The `dependsOn` property supports Nx's task dependency patterns:
-
-- `"^build"` - Depends on the 'build' target of all upstream projects
-- `"project:target"` - Depends on a specific target of a specific project
-- `"target"` - Depends on a target of the same project
-
-### Examples
-
-#### Configure Multiple Tasks
-
-{% tabs syncKey="java-lang" %}
-{% tabitem label="build.gradle.kts" %}
-
-```kotlin
-// build.gradle.kts
-// Configure test tasks
-tasks.withType<Test>().configureEach {
-  nx {
-    dependsOn.add("^build")
-    set("cache", true)
-  }
-}
-
-// Configure a specific task
-tasks.named("bootRun") {
-  nx {
-    dependsOn.addAll("^build", "app:processResources")
-  }
-}
-```
-
-{% /tabitem %}
-{% tabitem label="build.gradle" %}
-
-```groovy
-// build.gradle
-// Configure test tasks
-tasks.withType(Test).configureEach {
-  nx {
-    dependsOn.add('^build')
-    set 'cache', true
-  }
-}
-
-// Configure a specific task
-tasks.named('bootRun') {
-  nx {
-    dependsOn.addAll('^build', 'app:processResources')
-  }
-}
-```
-
-{% /tabitem %}
-{% /tabs %}
-
-#### Project and Task Configuration Together
-
-{% tabs syncKey="java-lang" %}
-{% tabitem label="build.gradle.kts" %}
-
-```kotlin
-// build.gradle.kts
-// Project-level metadata
-nx {
-  set("name", "payment-service")
-  array("tags", "service:payments", "tier:2")
-  set("description", "Payment processing service")
-}
-
-// Task-level configuration
-tasks.named("test") {
-  nx {
-    dependsOn.add("^build")
-    array("tags", "unit-test")
-  }
-}
-```
-
-{% /tabitem %}
-{% tabitem label="build.gradle" %}
-
-```groovy
-// build.gradle
-// Project-level metadata
-nx {
-  set 'name', 'payment-service'
-  array 'tags', 'service:payments', 'tier:2'
-  set 'description', 'Payment processing service'
-}
-
-// Task-level configuration
-tasks.named('test') {
-  nx {
-    dependsOn.add('^build')
-    array 'tags', 'unit-test'
-  }
-}
-```
-
-{% /tabitem %}
-{% /tabs %}

--- a/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
@@ -305,3 +305,250 @@ In a `project.json`, you can specify the target configuration like so:
 
 {% /tabitem %}
 {% /tabs %}
+
+## Configuring Projects and Tasks with the Gradle DSL
+
+The `dev.nx.gradle.project-graph` plugin provides a type-safe `nx {}` DSL for configuring Nx-specific metadata on your Gradle projects and tasks. This allows you to customize project metadata, configure task dependencies, and control caching behavior directly in your Gradle build files.
+
+### Project-Level Configuration
+
+Use the `nx {}` block at the project level to configure Nx project metadata such as name, tags, and custom properties:
+
+{% tabs syncKey="java-lang" %}
+{% tabitem label="build.gradle.kts" %}
+
+```kotlin
+// build.gradle.kts
+nx {
+  // Set project name
+  set("name", "my-custom-project-name")
+
+  // Add tags for organization
+  array("tags", "api", "backend", "tier:1")
+
+  // Add nested metadata
+  set("metadata") {
+    set("owner", "team-payments")
+    set("criticality", "high")
+  }
+}
+```
+
+{% /tabitem %}
+{% tabitem label="build.gradle" %}
+
+```groovy
+// build.gradle
+nx {
+  // Set project name
+  set 'name', 'my-custom-project-name'
+
+  // Add tags for organization
+  array 'tags', 'api', 'backend', 'tier:1'
+
+  // Add nested metadata
+  set 'metadata', {
+    set 'owner', 'team-payments'
+    set 'criticality', 'high'
+  }
+}
+```
+
+{% /tabitem %}
+{% /tabs %}
+
+**Available DSL methods for project-level configuration:**
+
+- `set(key, value)` - Set string, number, or boolean values
+- `array(key, ...values)` - Set array values
+- `set(key) { ... }` - Create nested objects
+- `merge(map)` - Merge a map of properties
+
+### Task-Level Configuration
+
+Use the `nx {}` block on individual Gradle tasks to configure Nx target-specific behavior:
+
+{% tabs syncKey="java-lang" %}
+{% tabitem label="build.gradle.kts" %}
+
+```kotlin
+// build.gradle.kts
+tasks.named("integrationTest") {
+  nx {
+    // Add Nx-specific dependencies (merges with Gradle dependencies)
+    dependsOn.addAll("^build", "app:lint")
+
+    // Configure caching
+    set("cache", true)
+
+    // Add target tags
+    array("tags", "integration", "slow")
+
+    // Add custom metadata
+    set("options") {
+      set("timeout", 300)
+    }
+  }
+}
+```
+
+{% /tabitem %}
+{% tabitem label="build.gradle" %}
+
+```groovy
+// build.gradle
+tasks.named('integrationTest') {
+  nx {
+    // Add Nx-specific dependencies (merges with Gradle dependencies)
+    dependsOn.addAll('^build', 'app:lint')
+
+    // Configure caching
+    set 'cache', true
+
+    // Add target tags
+    array 'tags', 'integration', 'slow'
+
+    // Add custom metadata
+    set 'options', {
+      set 'timeout', 300
+    }
+  }
+}
+```
+
+{% /tabitem %}
+{% /tabs %}
+
+**Available DSL methods for task-level configuration:**
+
+- `dependsOn` - ListProperty for adding Nx task dependencies (see important note below)
+- `set(key, value)` - Set string, number, or boolean values
+- `array(key, ...values)` - Set array values
+- `set(key) { ... }` - Create nested objects
+- `merge(map)` - Merge a map of properties
+
+{% aside type="warning" title="Important: dependsOn Merge Behavior" %}
+The `dependsOn` property behaves differently from other configuration options:
+
+- **Using `dependsOn.addAll(...)`** (recommended): **Merges** with Gradle-detected dependencies. This adds to the existing dependencies that Gradle automatically discovers.
+
+  ```kotlin
+  nx {
+    dependsOn.addAll("^build", "app:lint")  // Adds to Gradle dependencies
+  }
+  ```
+
+- **Using `set("dependsOn", ...)`**: **Replaces** all dependencies, including those detected by Gradle. Use with caution as this will override automatic dependency detection.
+
+  ```kotlin
+  nx {
+    set("dependsOn", listOf("^build"))  // Replaces all Gradle dependencies
+  }
+  ```
+
+In most cases, use `dependsOn.addAll(...)` to ensure your Gradle task dependencies are preserved.
+{% /aside %}
+
+### Nx Dependency Patterns
+
+The `dependsOn` property supports Nx's task dependency patterns:
+
+- `"^build"` - Depends on the 'build' target of all upstream projects
+- `"project:target"` - Depends on a specific target of a specific project
+- `"target"` - Depends on a target of the same project
+
+### Examples
+
+#### Configure Multiple Tasks
+
+{% tabs syncKey="java-lang" %}
+{% tabitem label="build.gradle.kts" %}
+
+```kotlin
+// build.gradle.kts
+// Configure test tasks
+tasks.withType<Test>().configureEach {
+  nx {
+    dependsOn.add("^build")
+    set("cache", true)
+  }
+}
+
+// Configure a specific task
+tasks.named("bootRun") {
+  nx {
+    dependsOn.addAll("^build", "app:processResources")
+  }
+}
+```
+
+{% /tabitem %}
+{% tabitem label="build.gradle" %}
+
+```groovy
+// build.gradle
+// Configure test tasks
+tasks.withType(Test).configureEach {
+  nx {
+    dependsOn.add('^build')
+    set 'cache', true
+  }
+}
+
+// Configure a specific task
+tasks.named('bootRun') {
+  nx {
+    dependsOn.addAll('^build', 'app:processResources')
+  }
+}
+```
+
+{% /tabitem %}
+{% /tabs %}
+
+#### Project and Task Configuration Together
+
+{% tabs syncKey="java-lang" %}
+{% tabitem label="build.gradle.kts" %}
+
+```kotlin
+// build.gradle.kts
+// Project-level metadata
+nx {
+  set("name", "payment-service")
+  array("tags", "service:payments", "tier:2")
+  set("description", "Payment processing service")
+}
+
+// Task-level configuration
+tasks.named("test") {
+  nx {
+    dependsOn.add("^build")
+    array("tags", "unit-test")
+  }
+}
+```
+
+{% /tabitem %}
+{% tabitem label="build.gradle" %}
+
+```groovy
+// build.gradle
+// Project-level metadata
+nx {
+  set 'name', 'payment-service'
+  array 'tags', 'service:payments', 'tier:2'
+  set 'description', 'Payment processing service'
+}
+
+// Task-level configuration
+tasks.named('test') {
+  nx {
+    dependsOn.add('^build')
+    array 'tags', 'unit-test'
+  }
+}
+```
+
+{% /tabitem %}
+{% /tabs %}

--- a/e2e/gradle/src/gradle-dsl.test.ts
+++ b/e2e/gradle/src/gradle-dsl.test.ts
@@ -106,10 +106,8 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.metadata).toEqual({
-            owner: 'team-a',
-            criticality: 'high',
-          });
+          expect(config.metadata.owner).toBe('team-a');
+          expect(config.metadata.criticality).toBe('high');
         });
 
         it('should handle complex nested structures', () => {
@@ -128,11 +126,13 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           expect(config.name).toBe('my-custom-app');
           expect(config.tags).toEqual(['api', 'service']);
-          expect(config.metadata).toEqual({
-            owner: 'platform-team',
-            environments: ['dev', 'staging', 'prod'],
-            tier: 1,
-          });
+          expect(config.metadata.owner).toBe('platform-team');
+          expect(config.metadata.environments).toEqual([
+            'dev',
+            'staging',
+            'prod',
+          ]);
+          expect(config.metadata.tier).toBe(1);
         });
 
         it('should handle deeply nested objects', () => {
@@ -149,13 +149,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.config).toEqual({
-            level1: {
-              level2: {
-                value: 'deep',
-              },
-            },
-          });
+          expect(config.config.level1.level2.value).toBe('deep');
         });
 
         it('should handle arrays with mixed content in objects', () => {
@@ -172,10 +166,12 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.services).toEqual({
-            apis: ['user', 'payment', 'notification'],
-            enabled: true,
-          });
+          expect(config.services.apis).toEqual([
+            'user',
+            'payment',
+            'notification',
+          ]);
+          expect(config.services.enabled).toBe(true);
         });
       });
 
@@ -183,8 +179,8 @@ describe('Gradle DSL - nx {} configuration', () => {
         it('should handle dependsOn property', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\ntasks.named("build") {\n  nx {\n    dependsOn.addAll("^build", "app:test")\n  }\n}`
-              : `\ntasks.named('build') {\n  nx {\n    dependsOn.addAll('^build', 'app:test')\n  }\n}`;
+              ? `\ntasks.named("build") {\n  nx {\n    dependsOn.add("^build")\n    dependsOn.add("app:test")\n  }\n}`
+              : `\ntasks.named('build') {\n  nx {\n    dependsOn.add('^build')\n    dependsOn.add('app:test')\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -246,10 +242,10 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.targets.build.metadata).toEqual({
-            description: 'Build the application',
-            runInBand: true,
-          });
+          expect(config.targets.build.metadata.description).toBe(
+            'Build the application'
+          );
+          expect(config.targets.build.metadata.runInBand).toBe(true);
         });
 
         it('should handle multiple properties on target', () => {
@@ -269,7 +265,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           expect(config.targets.test.dependsOn).toContain('^build');
           expect(config.targets.test.cache).toBe(false);
           expect(config.targets.test.tags).toEqual(['integration', 'slow']);
-          expect(config.targets.test.metadata).toEqual({ timeout: 3600 });
+          expect(config.targets.test.metadata.timeout).toBe(3600);
         });
 
         it('should configure multiple tasks', () => {
@@ -320,8 +316,8 @@ describe('Gradle DSL - nx {} configuration', () => {
         it('should handle complex project with multiple configured tasks', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\nnx {\n  set("name", "complex-app")\n  array("tags", "monorepo", "service")\n  set("metadata") {\n    set("owner", "platform")\n    set("tier", 1)\n  }\n}\n\ntasks.named("build") {\n  nx {\n    dependsOn.addAll("^build", "app:test")\n    set("cache", true)\n  }\n}\n\ntasks.named("test") {\n  nx {\n    set("cache", false)\n    array("tags", "unit", "fast")\n    set("metadata") {\n      set("parallel", true)\n    }\n  }\n}`
-              : `\nnx {\n  set 'name', 'complex-app'\n  array 'tags', 'monorepo', 'service'\n  set 'metadata', {\n    set 'owner', 'platform'\n    set 'tier', 1\n  }\n}\n\ntasks.named('build') {\n  nx {\n    dependsOn.addAll('^build', 'app:test')\n    set 'cache', true\n  }\n}\n\ntasks.named('test') {\n  nx {\n    set 'cache', false\n    array 'tags', 'unit', 'fast'\n    set 'metadata', {\n      set 'parallel', true\n    }\n  }\n}`;
+              ? `\nnx {\n  set("name", "complex-app")\n  array("tags", "monorepo", "service")\n  set("metadata") {\n    set("owner", "platform")\n    set("tier", 1)\n  }\n}\n\ntasks.named("build") {\n  nx {\n    dependsOn.add("^build")\n    dependsOn.add("app:test")\n    set("cache", true)\n  }\n}\n\ntasks.named("test") {\n  nx {\n    set("cache", false)\n    array("tags", "unit", "fast")\n    set("metadata") {\n      set("parallel", true)\n    }\n  }\n}`
+              : `\nnx {\n  set 'name', 'complex-app'\n  array 'tags', 'monorepo', 'service'\n  set 'metadata', {\n    set 'owner', 'platform'\n    set 'tier', 1\n  }\n}\n\ntasks.named('build') {\n  nx {\n    dependsOn.add('^build')\n    dependsOn.add('app:test')\n    set 'cache', true\n  }\n}\n\ntasks.named('test') {\n  nx {\n    set 'cache', false\n    array 'tags', 'unit', 'fast'\n    set 'metadata', {\n      set 'parallel', true\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -334,7 +330,8 @@ describe('Gradle DSL - nx {} configuration', () => {
           // Project-level
           expect(config.name).toBe('complex-app');
           expect(config.tags).toEqual(['monorepo', 'service']);
-          expect(config.metadata).toEqual({ owner: 'platform', tier: 1 });
+          expect(config.metadata.owner).toBe('platform');
+          expect(config.metadata.tier).toBe(1);
 
           // Build target
           expect(config.targets.build.dependsOn).toContain('^build');
@@ -344,7 +341,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           // Test target
           expect(config.targets.test.cache).toBe(false);
           expect(config.targets.test.tags).toEqual(['unit', 'fast']);
-          expect(config.targets.test.metadata).toEqual({ parallel: true });
+          expect(config.targets.test.metadata.parallel).toBe(true);
         });
 
         it('should configure multiple projects independently', () => {

--- a/e2e/gradle/src/gradle-dsl.test.ts
+++ b/e2e/gradle/src/gradle-dsl.test.ts
@@ -27,8 +27,8 @@ describe('Gradle DSL - nx {} configuration', () => {
         it('should handle string values', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\nnx {\n  set("name", "custom-app-name")\n}`
-              : `\nnx {\n  set 'name', 'custom-app-name'\n}`;
+              ? `\nnx {\n  set("type", "custom-app-name")\n}`
+              : `\nnx {\n  set 'type', 'custom-app-name'\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -38,7 +38,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.name).toBe('custom-app-name');
+          expect(config.type).toBe('custom-app-name');
         });
 
         it('should handle number values', () => {
@@ -113,8 +113,8 @@ describe('Gradle DSL - nx {} configuration', () => {
         it('should handle complex nested structures', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\nnx {\n  set("name", "my-custom-app")\n  array("tags", "api", "service")\n  set("generators") {\n    set("owner", "platform-team")\n    array("environments", "dev", "staging", "prod")\n    set("tier", 1)\n  }\n}`
-              : `\nnx {\n  set 'name', 'my-custom-app'\n  array 'tags', 'api', 'service'\n  set 'generators', {\n    set 'owner', 'platform-team'\n    array 'environments', 'dev', 'staging', 'prod'\n    set 'tier', 1\n  }\n}`;
+              ? `\nnx {\n  set("type", "my-custom-app")\n  array("tags", "api", "service")\n  set("generators") {\n    set("owner", "platform-team")\n    array("environments", "dev", "staging", "prod")\n    set("tier", 1)\n  }\n}`
+              : `\nnx {\n  set 'type', 'my-custom-app'\n  array 'tags', 'api', 'service'\n  set 'generators', {\n    set 'owner', 'platform-team'\n    array 'environments', 'dev', 'staging', 'prod'\n    set 'tier', 1\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -124,7 +124,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.name).toBe('my-custom-app');
+          expect(config.type).toBe('my-custom-app');
           expect(config.tags).toEqual(['api', 'service']);
           expect(config.generators.owner).toBe('platform-team');
           expect(config.generators.environments).toEqual([
@@ -293,8 +293,8 @@ describe('Gradle DSL - nx {} configuration', () => {
         it('should handle both project and task-level config', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\nnx {\n  set("name", "integrated-app")\n  array("tags", "api", "backend")\n}\n\ntasks.register<DefaultTask>("package") {\n  nx {\n    set("cache", false)\n    set("configurations") {\n      set("profile", "production")\n    }\n  }\n}`
-              : `\nnx {\n  set 'name', 'integrated-app'\n  array 'tags', 'api', 'backend'\n}\n\ntasks.register('package') {\n  nx {\n    set 'cache', false\n    set 'configurations', {\n      set 'profile', 'production'\n    }\n  }\n}`;
+              ? `\nnx {\n  set("type", "integrated-app")\n  array("tags", "api", "backend")\n}\n\ntasks.register<DefaultTask>("package") {\n  nx {\n    set("cache", false)\n    set("configurations") {\n      set("profile", "production")\n    }\n  }\n}`
+              : `\nnx {\n  set 'type', 'integrated-app'\n  array 'tags', 'api', 'backend'\n}\n\ntasks.register('package') {\n  nx {\n    set 'cache', false\n    set 'configurations', {\n      set 'profile', 'production'\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -305,7 +305,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const config = JSON.parse(runCLI('show project app --json'));
 
           // Project-level config
-          expect(config.name).toBe('integrated-app');
+          expect(config.type).toBe('integrated-app');
           expect(config.tags).toEqual(['api', 'backend']);
 
           // Task-level config
@@ -318,8 +318,8 @@ describe('Gradle DSL - nx {} configuration', () => {
         it('should handle complex project with multiple configured tasks', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\nnx {\n  set("name", "complex-app")\n  array("tags", "monorepo", "service")\n  set("generators") {\n    set("owner", "platform")\n    set("tier", 1)\n  }\n}\n\ntasks.register<DefaultTask>("compile") {\n  nx {\n    dependsOn.add("^build")\n    dependsOn.add("app:test")\n    set("cache", true)\n  }\n}\n\ntasks.register<DefaultTask>("validate") {\n  nx {\n    set("cache", false)\n    array("inputs", "src/**/*", "test/**/*")\n    set("configurations") {\n      set("parallel", true)\n    }\n  }\n}`
-              : `\nnx {\n  set 'name', 'complex-app'\n  array 'tags', 'monorepo', 'service'\n  set 'generators', {\n    set 'owner', 'platform'\n    set 'tier', 1\n  }\n}\n\ntasks.register('compile') {\n  nx {\n    dependsOn.add('^build')\n    dependsOn.add('app:test')\n    set 'cache', true\n  }\n}\n\ntasks.register('validate') {\n  nx {\n    set 'cache', false\n    array 'inputs', 'src/**/*', 'test/**/*'\n    set 'configurations', {\n      set 'parallel', true\n    }\n  }\n}`;
+              ? `\nnx {\n  set("type", "complex-app")\n  array("tags", "monorepo", "service")\n  set("generators") {\n    set("owner", "platform")\n    set("tier", 1)\n  }\n}\n\ntasks.register<DefaultTask>("compile") {\n  nx {\n    dependsOn.add("^build")\n    dependsOn.add("app:test")\n    set("cache", true)\n  }\n}\n\ntasks.register<DefaultTask>("validate") {\n  nx {\n    set("cache", false)\n    array("inputs", "src/**/*", "test/**/*")\n    set("configurations") {\n      set("parallel", true)\n    }\n  }\n}`
+              : `\nnx {\n  set 'type', 'complex-app'\n  array 'tags', 'monorepo', 'service'\n  set 'generators', {\n    set 'owner', 'platform'\n    set 'tier', 1\n  }\n}\n\ntasks.register('compile') {\n  nx {\n    dependsOn.add('^build')\n    dependsOn.add('app:test')\n    set 'cache', true\n  }\n}\n\ntasks.register('validate') {\n  nx {\n    set 'cache', false\n    array 'inputs', 'src/**/*', 'test/**/*'\n    set 'configurations', {\n      set 'parallel', true\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -330,7 +330,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const config = JSON.parse(runCLI('show project app --json'));
 
           // Project-level
-          expect(config.name).toBe('complex-app');
+          expect(config.type).toBe('complex-app');
           expect(config.tags).toEqual(['monorepo', 'service']);
           expect(config.generators.owner).toBe('platform');
           expect(config.generators.tier).toBe(1);
@@ -351,8 +351,8 @@ describe('Gradle DSL - nx {} configuration', () => {
           // Configure app project
           const appDslContent =
             type === 'kotlin'
-              ? `\nnx {\n  set("name", "app-project")\n  array("tags", "app")\n}`
-              : `\nnx {\n  set 'name', 'app-project'\n  array 'tags', 'app'\n}`;
+              ? `\nnx {\n  set("type", "app-project")\n  array("tags", "app")\n}`
+              : `\nnx {\n  set 'type', 'app-project'\n  array 'tags', 'app'\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -362,8 +362,8 @@ describe('Gradle DSL - nx {} configuration', () => {
           // Configure list project
           const listDslContent =
             type === 'kotlin'
-              ? `\nnx {\n  set("name", "list-project")\n  array("tags", "lib")\n}`
-              : `\nnx {\n  set 'name', 'list-project'\n  array 'tags', 'lib'\n}`;
+              ? `\nnx {\n  set("type", "list-project")\n  array("tags", "lib")\n}`
+              : `\nnx {\n  set 'type', 'list-project'\n  array 'tags', 'lib'\n}`;
 
           updateFile(
             `list/build.gradle${buildFileExt}`,
@@ -375,10 +375,10 @@ describe('Gradle DSL - nx {} configuration', () => {
           const appConfig = JSON.parse(runCLI('show project app --json'));
           const listConfig = JSON.parse(runCLI('show project list --json'));
 
-          expect(appConfig.name).toBe('app-project');
+          expect(appConfig.type).toBe('app-project');
           expect(appConfig.tags).toEqual(['app']);
 
-          expect(listConfig.name).toBe('list-project');
+          expect(listConfig.type).toBe('list-project');
           expect(listConfig.tags).toEqual(['lib']);
         });
       });

--- a/e2e/gradle/src/gradle-dsl.test.ts
+++ b/e2e/gradle/src/gradle-dsl.test.ts
@@ -205,7 +205,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `tasks.register<DefaultTask>("customTask") {\n  nx {\n    mergedDependsOn("^build", "app:test")\n  }\n}`
-              : `tasks.register('customTask') {\n  nx(it) {\n    mergedDependsOn('^build', 'app:test')\n  }\n}`;
+              : `tasks.register('customTask') {\n  nx(it) {\n    it.mergedDependsOn('^build', 'app:test')\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -225,7 +225,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `tasks.register<DefaultTask>("customTask2") {\n  nx {\n    mergedDependsOn.add("^build")\n    mergedDependsOn.add("app:test")\n  }\n}`
-              : `tasks.register('customTask2') {\n  nx(it) {\n    mergedDependsOn.add('^build')\n    mergedDependsOn.add('app:test')\n  }\n}`;
+              : `tasks.register('customTask2') {\n  nx(it) {\n    it.mergedDependsOn.add('^build')\n    it.mergedDependsOn.add('app:test')\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -301,7 +301,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\ntasks.register<DefaultTask>("e2e") {\n  nx {\n    mergedDependsOn.add("^build")\n    set("cache", false)\n    array("outputs", "coverage/**/*", "reports/**/*")\n    set("configurations") {\n      set("debug") {\n        set("timeout", 3600)\n      }\n    }\n  }\n}`
-              : `\ntasks.register('e2e') {\n  nx(it) {\n    mergedDependsOn.add('^build')\n    it.set 'cache', false\n    it.array 'outputs', 'coverage/**/*', 'reports/**/*'\n    it.set 'configurations', {\n      it.set 'debug', {\n        it.set 'timeout', 3600\n      }\n    }\n  }\n}`;
+              : `\ntasks.register('e2e') {\n  nx(it) {\n    it.mergedDependsOn.add('^build')\n    it.set 'cache', false\n    it.array 'outputs', 'coverage/**/*', 'reports/**/*'\n    it.set 'configurations', {\n      it.set 'debug', {\n        it.set 'timeout', 3600\n      }\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -367,7 +367,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\nnx {\n  set("type", "complex-app")\n  array("tags", "monorepo", "service")\n  set("generators") {\n    set("owner", "platform")\n    set("tier", 1)\n  }\n}\n\ntasks.register<DefaultTask>("compile") {\n  nx {\n    mergedDependsOn.add("^build")\n    mergedDependsOn.add("app:test")\n    set("cache", true)\n  }\n}\n\ntasks.register<DefaultTask>("validate") {\n  nx {\n    set("cache", false)\n    array("inputs", "src/**/*", "test/**/*")\n    set("configurations") {\n      set("debug") {\n        set("parallel", true)\n      }\n    }\n  }\n}`
-              : `\nnx(project) {\n  it.set 'type', 'complex-app'\n  it.array 'tags', 'monorepo', 'service'\n  it.set 'generators', {\n    it.set 'owner', 'platform'\n    it.set 'tier', 1\n  }\n}\n\ntasks.register('compile') {\n  nx(it) {\n    mergedDependsOn.add('^build')\n    mergedDependsOn.add('app:test')\n    it.set 'cache', true\n  }\n}\n\ntasks.register('validate') {\n  nx(it) {\n    it.set 'cache', false\n    it.array 'inputs', 'src/**/*', 'test/**/*'\n    it.set 'configurations', {\n      it.set 'debug', {\n        it.set 'parallel', true\n      }\n    }\n  }\n}`;
+              : `\nnx(project) {\n  it.set 'type', 'complex-app'\n  it.array 'tags', 'monorepo', 'service'\n  it.set 'generators', {\n    it.set 'owner', 'platform'\n    it.set 'tier', 1\n  }\n}\n\ntasks.register('compile') {\n  nx(it) {\n    it.mergedDependsOn.add('^build')\n    it.mergedDependsOn.add('app:test')\n    it.set 'cache', true\n  }\n}\n\ntasks.register('validate') {\n  nx(it) {\n    it.set 'cache', false\n    it.array 'inputs', 'src/**/*', 'test/**/*'\n    it.set 'configurations', {\n      it.set 'debug', {\n        it.set 'parallel', true\n      }\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,

--- a/e2e/gradle/src/gradle-dsl.test.ts
+++ b/e2e/gradle/src/gradle-dsl.test.ts
@@ -179,8 +179,8 @@ describe('Gradle DSL - nx {} configuration', () => {
         it('should handle dependsOn property', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\ntasks.named("build") {\n  nx {\n    dependsOn.add("^build")\n    dependsOn.add("app:test")\n  }\n}`
-              : `\ntasks.named('build') {\n  nx {\n    dependsOn.add('^build')\n    dependsOn.add('app:test')\n  }\n}`;
+              ? `\ntasks.register<DefaultTask>("customTask") {\n  nx {\n    dependsOn.add("^build")\n    dependsOn.add("app:test")\n  }\n}`
+              : `\ntasks.register('customTask') {\n  nx {\n    dependsOn.add('^build')\n    dependsOn.add('app:test')\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -190,15 +190,15 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.targets.build.dependsOn).toContain('^build');
-          expect(config.targets.build.dependsOn).toContain('app:test');
+          expect(config.targets.customTask.dependsOn).toContain('^build');
+          expect(config.targets.customTask.dependsOn).toContain('app:test');
         });
 
         it('should handle scalar values on targets', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\ntasks.named("build") {\n  nx {\n    set("cache", false)\n  }\n}`
-              : `\ntasks.named('build') {\n  nx {\n    set 'cache', false\n  }\n}`;
+              ? `\ntasks.register<DefaultTask>("myBuild") {\n  nx {\n    set("cache", false)\n  }\n}`
+              : `\ntasks.register('myBuild') {\n  nx {\n    set 'cache', false\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -208,14 +208,14 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.targets.build.cache).toBe(false);
+          expect(config.targets.myBuild.cache).toBe(false);
         });
 
         it('should handle arrays on targets', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\ntasks.named("test") {\n  nx {\n    array("inputs", "src/**/*", "config/**/*")\n  }\n}`
-              : `\ntasks.named('test') {\n  nx {\n    array 'inputs', 'src/**/*', 'config/**/*'\n  }\n}`;
+              ? `\ntasks.register<DefaultTask>("myTest") {\n  nx {\n    array("inputs", "src/**/*", "config/**/*")\n  }\n}`
+              : `\ntasks.register('myTest') {\n  nx {\n    array 'inputs', 'src/**/*', 'config/**/*'\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -225,15 +225,15 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.targets.test.inputs).toContain('src/**/*');
-          expect(config.targets.test.inputs).toContain('config/**/*');
+          expect(config.targets.myTest.inputs).toContain('src/**/*');
+          expect(config.targets.myTest.inputs).toContain('config/**/*');
         });
 
         it('should handle nested objects in target config', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\ntasks.named("build") {\n  nx {\n    set("configurations") {\n      set("production", true)\n      set("environment", "prod")\n    }\n  }\n}`
-              : `\ntasks.named('build') {\n  nx {\n    set 'configurations', {\n      set 'production', true\n      set 'environment', 'prod'\n    }\n  }\n}`;
+              ? `\ntasks.register<DefaultTask>("deploy") {\n  nx {\n    set("configurations") {\n      set("production", true)\n      set("environment", "prod")\n    }\n  }\n}`
+              : `\ntasks.register('deploy') {\n  nx {\n    set 'configurations', {\n      set 'production', true\n      set 'environment', 'prod'\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -243,15 +243,15 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.targets.build.configurations.production).toBe(true);
-          expect(config.targets.build.configurations.environment).toBe('prod');
+          expect(config.targets.deploy.configurations.production).toBe(true);
+          expect(config.targets.deploy.configurations.environment).toBe('prod');
         });
 
         it('should handle multiple properties on target', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\ntasks.named("test") {\n  nx {\n    dependsOn.add("^build")\n    set("cache", false)\n    array("outputs", "coverage/**/*", "reports/**/*")\n    set("configurations") {\n      set("timeout", 3600)\n    }\n  }\n}`
-              : `\ntasks.named('test') {\n  nx {\n    dependsOn.add('^build')\n    set 'cache', false\n    array 'outputs', 'coverage/**/*', 'reports/**/*'\n    set 'configurations', {\n      set 'timeout', 3600\n    }\n  }\n}`;
+              ? `\ntasks.register<DefaultTask>("e2e") {\n  nx {\n    dependsOn.add("^build")\n    set("cache", false)\n    array("outputs", "coverage/**/*", "reports/**/*")\n    set("configurations") {\n      set("timeout", 3600)\n    }\n  }\n}`
+              : `\ntasks.register('e2e') {\n  nx {\n    dependsOn.add('^build')\n    set 'cache', false\n    array 'outputs', 'coverage/**/*', 'reports/**/*'\n    set 'configurations', {\n      set 'timeout', 3600\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -261,18 +261,18 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.targets.test.dependsOn).toContain('^build');
-          expect(config.targets.test.cache).toBe(false);
-          expect(config.targets.test.outputs).toContain('coverage/**/*');
-          expect(config.targets.test.outputs).toContain('reports/**/*');
-          expect(config.targets.test.configurations.timeout).toBe(3600);
+          expect(config.targets.e2e.dependsOn).toContain('^build');
+          expect(config.targets.e2e.cache).toBe(false);
+          expect(config.targets.e2e.outputs).toContain('coverage/**/*');
+          expect(config.targets.e2e.outputs).toContain('reports/**/*');
+          expect(config.targets.e2e.configurations.timeout).toBe(3600);
         });
 
         it('should configure multiple tasks', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\ntasks.named("build") {\n  nx {\n    set("cache", true)\n  }\n}\n\ntasks.named("test") {\n  nx {\n    set("cache", false)\n    array("inputs", "src/**/*", "test/**/*")\n  }\n}`
-              : `\ntasks.named('build') {\n  nx {\n    set 'cache', true\n  }\n}\n\ntasks.named('test') {\n  nx {\n    set 'cache', false\n    array 'inputs', 'src/**/*', 'test/**/*'\n  }\n}`;
+              ? `\ntasks.register<DefaultTask>("customBuild") {\n  nx {\n    set("cache", true)\n  }\n}\n\ntasks.register<DefaultTask>("verify") {\n  nx {\n    set("cache", false)\n    array("inputs", "src/**/*", "test/**/*")\n  }\n}`
+              : `\ntasks.register('customBuild') {\n  nx {\n    set 'cache', true\n  }\n}\n\ntasks.register('verify') {\n  nx {\n    set 'cache', false\n    array 'inputs', 'src/**/*', 'test/**/*'\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -282,10 +282,10 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.targets.build.cache).toBe(true);
-          expect(config.targets.test.cache).toBe(false);
-          expect(config.targets.test.inputs).toContain('src/**/*');
-          expect(config.targets.test.inputs).toContain('test/**/*');
+          expect(config.targets.customBuild.cache).toBe(true);
+          expect(config.targets.verify.cache).toBe(false);
+          expect(config.targets.verify.inputs).toContain('src/**/*');
+          expect(config.targets.verify.inputs).toContain('test/**/*');
         });
       });
 
@@ -293,8 +293,8 @@ describe('Gradle DSL - nx {} configuration', () => {
         it('should handle both project and task-level config', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\nnx {\n  set("name", "integrated-app")\n  array("tags", "api", "backend")\n}\n\ntasks.named("build") {\n  nx {\n    set("cache", false)\n    set("configurations") {\n      set("profile", "production")\n    }\n  }\n}`
-              : `\nnx {\n  set 'name', 'integrated-app'\n  array 'tags', 'api', 'backend'\n}\n\ntasks.named('build') {\n  nx {\n    set 'cache', false\n    set 'configurations', {\n      set 'profile', 'production'\n    }\n  }\n}`;
+              ? `\nnx {\n  set("name", "integrated-app")\n  array("tags", "api", "backend")\n}\n\ntasks.register<DefaultTask>("package") {\n  nx {\n    set("cache", false)\n    set("configurations") {\n      set("profile", "production")\n    }\n  }\n}`
+              : `\nnx {\n  set 'name', 'integrated-app'\n  array 'tags', 'api', 'backend'\n}\n\ntasks.register('package') {\n  nx {\n    set 'cache', false\n    set 'configurations', {\n      set 'profile', 'production'\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -309,8 +309,8 @@ describe('Gradle DSL - nx {} configuration', () => {
           expect(config.tags).toEqual(['api', 'backend']);
 
           // Task-level config
-          expect(config.targets.build.cache).toBe(false);
-          expect(config.targets.build.configurations.profile).toBe(
+          expect(config.targets.package.cache).toBe(false);
+          expect(config.targets.package.configurations.profile).toBe(
             'production'
           );
         });
@@ -318,8 +318,8 @@ describe('Gradle DSL - nx {} configuration', () => {
         it('should handle complex project with multiple configured tasks', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\nnx {\n  set("name", "complex-app")\n  array("tags", "monorepo", "service")\n  set("generators") {\n    set("owner", "platform")\n    set("tier", 1)\n  }\n}\n\ntasks.named("build") {\n  nx {\n    dependsOn.add("^build")\n    dependsOn.add("app:test")\n    set("cache", true)\n  }\n}\n\ntasks.named("test") {\n  nx {\n    set("cache", false)\n    array("inputs", "src/**/*", "test/**/*")\n    set("configurations") {\n      set("parallel", true)\n    }\n  }\n}`
-              : `\nnx {\n  set 'name', 'complex-app'\n  array 'tags', 'monorepo', 'service'\n  set 'generators', {\n    set 'owner', 'platform'\n    set 'tier', 1\n  }\n}\n\ntasks.named('build') {\n  nx {\n    dependsOn.add('^build')\n    dependsOn.add('app:test')\n    set 'cache', true\n  }\n}\n\ntasks.named('test') {\n  nx {\n    set 'cache', false\n    array 'inputs', 'src/**/*', 'test/**/*'\n    set 'configurations', {\n      set 'parallel', true\n    }\n  }\n}`;
+              ? `\nnx {\n  set("name", "complex-app")\n  array("tags", "monorepo", "service")\n  set("generators") {\n    set("owner", "platform")\n    set("tier", 1)\n  }\n}\n\ntasks.register<DefaultTask>("compile") {\n  nx {\n    dependsOn.add("^build")\n    dependsOn.add("app:test")\n    set("cache", true)\n  }\n}\n\ntasks.register<DefaultTask>("validate") {\n  nx {\n    set("cache", false)\n    array("inputs", "src/**/*", "test/**/*")\n    set("configurations") {\n      set("parallel", true)\n    }\n  }\n}`
+              : `\nnx {\n  set 'name', 'complex-app'\n  array 'tags', 'monorepo', 'service'\n  set 'generators', {\n    set 'owner', 'platform'\n    set 'tier', 1\n  }\n}\n\ntasks.register('compile') {\n  nx {\n    dependsOn.add('^build')\n    dependsOn.add('app:test')\n    set 'cache', true\n  }\n}\n\ntasks.register('validate') {\n  nx {\n    set 'cache', false\n    array 'inputs', 'src/**/*', 'test/**/*'\n    set 'configurations', {\n      set 'parallel', true\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -335,16 +335,16 @@ describe('Gradle DSL - nx {} configuration', () => {
           expect(config.generators.owner).toBe('platform');
           expect(config.generators.tier).toBe(1);
 
-          // Build target
-          expect(config.targets.build.dependsOn).toContain('^build');
-          expect(config.targets.build.dependsOn).toContain('app:test');
-          expect(config.targets.build.cache).toBe(true);
+          // Compile target
+          expect(config.targets.compile.dependsOn).toContain('^build');
+          expect(config.targets.compile.dependsOn).toContain('app:test');
+          expect(config.targets.compile.cache).toBe(true);
 
-          // Test target
-          expect(config.targets.test.cache).toBe(false);
-          expect(config.targets.test.inputs).toContain('src/**/*');
-          expect(config.targets.test.inputs).toContain('test/**/*');
-          expect(config.targets.test.configurations.parallel).toBe(true);
+          // Validate target
+          expect(config.targets.validate.cache).toBe(false);
+          expect(config.targets.validate.inputs).toContain('src/**/*');
+          expect(config.targets.validate.inputs).toContain('test/**/*');
+          expect(config.targets.validate.configurations.parallel).toBe(true);
         });
 
         it('should configure multiple projects independently', () => {

--- a/e2e/gradle/src/gradle-dsl.test.ts
+++ b/e2e/gradle/src/gradle-dsl.test.ts
@@ -1,6 +1,7 @@
 import {
   cleanupProject,
   newProject,
+  readFile,
   runCLI,
   uniq,
   updateFile,
@@ -13,12 +14,21 @@ describe('Gradle DSL - nx {} configuration', () => {
     ({ type }: { type: 'kotlin' | 'groovy' }) => {
       let gradleProjectName: string;
       const buildFileExt = type === 'kotlin' ? '.kts' : '';
+      let cleanFileContent = '';
 
       beforeAll(() => {
         gradleProjectName = uniq('gradle-dsl-test');
         newProject({ packages: [] });
         createGradleProject(gradleProjectName, type);
         runCLI(`add @nx/gradle`);
+      });
+
+      beforeEach(() => {
+        cleanFileContent = readFile(`app/build.gradle${buildFileExt}`);
+      });
+
+      afterEach(() => {
+        updateFile(`app/build.gradle${buildFileExt}`, cleanFileContent);
       });
 
       afterAll(() => cleanupProject());
@@ -32,7 +42,7 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
-            (content) => content + dslContent
+            (content) => cleanFileContent + dslContent
           );
 
           runCLI('reset');
@@ -49,7 +59,7 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
-            (content) => content + dslContent
+            (content) => cleanFileContent + dslContent
           );
 
           runCLI('reset');
@@ -66,7 +76,7 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
-            (content) => content + dslContent
+            (content) => cleanFileContent + dslContent
           );
 
           runCLI('reset');
@@ -83,7 +93,7 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
-            (content) => content + dslContent
+            (content) => cleanFileContent + dslContent
           );
 
           runCLI('reset');
@@ -118,7 +128,7 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
-            (content) => content + dslContent
+            (content) => cleanFileContent + dslContent
           );
 
           runCLI('reset');
@@ -143,7 +153,7 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
-            (content) => content + dslContent
+            (content) => cleanFileContent + dslContent
           );
 
           runCLI('reset');
@@ -160,7 +170,7 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
-            (content) => content + dslContent
+            (content) => cleanFileContent + dslContent
           );
 
           runCLI('reset');
@@ -177,6 +187,11 @@ describe('Gradle DSL - nx {} configuration', () => {
 
       describe('Task-level DSL', () => {
         it('should handle dependsOn property', () => {
+          console.log(
+            'task-level buildfile content',
+            readFile(`app/build.gradle${buildFileExt}`)
+          );
+
           const dslContent =
             type === 'kotlin'
               ? `\ntasks.register<DefaultTask>("customTask") {\n  nx {\n    dependsOn.add("^build")\n    dependsOn.add("app:test")\n  }\n}`
@@ -184,7 +199,7 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
-            (content) => content + dslContent
+            (content) => cleanFileContent + dslContent
           );
 
           runCLI('reset');
@@ -204,7 +219,7 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
-            (content) => content + dslContent
+            (content) => cleanFileContent + dslContent
           );
 
           runCLI('reset');
@@ -223,7 +238,7 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
-            (content) => content + dslContent
+            (content) => cleanFileContent + dslContent
           );
 
           runCLI('reset');
@@ -243,7 +258,7 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
-            (content) => content + dslContent
+            (content) => cleanFileContent + dslContent
           );
 
           runCLI('reset');
@@ -282,7 +297,7 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
-            (content) => content + dslContent
+            (content) => cleanFileContent + dslContent
           );
 
           runCLI('reset');
@@ -304,7 +319,7 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
-            (content) => content + dslContent
+            (content) => cleanFileContent + dslContent
           );
 
           runCLI('reset');
@@ -329,7 +344,7 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
-            (content) => content + dslContent
+            (content) => cleanFileContent + dslContent
           );
 
           runCLI('reset');
@@ -362,7 +377,7 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
-            (content) => content + appDslContent
+            (content) => cleanFileContent + appDslContent
           );
 
           // Configure list project

--- a/e2e/gradle/src/gradle-dsl.test.ts
+++ b/e2e/gradle/src/gradle-dsl.test.ts
@@ -95,8 +95,8 @@ describe('Gradle DSL - nx {} configuration', () => {
         it('should handle nested objects', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\nnx {\n  set("metadata") {\n    set("owner", "team-a")\n    set("criticality", "high")\n  }\n}`
-              : `\nnx {\n  set 'metadata', {\n    set 'owner', 'team-a'\n    set 'criticality', 'high'\n  }\n}`;
+              ? `\nnx {\n  set("generators") {\n    set("@nx/react:component", "components")\n    set("@nx/node:service", "services")\n  }\n}`
+              : `\nnx {\n  set 'generators', {\n    set '@nx/react:component', 'components'\n    set '@nx/node:service', 'services'\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -106,15 +106,15 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.metadata.owner).toBe('team-a');
-          expect(config.metadata.criticality).toBe('high');
+          expect(config.generators['@nx/react:component']).toBe('components');
+          expect(config.generators['@nx/node:service']).toBe('services');
         });
 
         it('should handle complex nested structures', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\nnx {\n  set("name", "my-custom-app")\n  array("tags", "api", "service")\n  set("metadata") {\n    set("owner", "platform-team")\n    array("environments", "dev", "staging", "prod")\n    set("tier", 1)\n  }\n}`
-              : `\nnx {\n  set 'name', 'my-custom-app'\n  array 'tags', 'api', 'service'\n  set 'metadata', {\n    set 'owner', 'platform-team'\n    array 'environments', 'dev', 'staging', 'prod'\n    set 'tier', 1\n  }\n}`;
+              ? `\nnx {\n  set("name", "my-custom-app")\n  array("tags", "api", "service")\n  set("generators") {\n    set("owner", "platform-team")\n    array("environments", "dev", "staging", "prod")\n    set("tier", 1)\n  }\n}`
+              : `\nnx {\n  set 'name', 'my-custom-app'\n  array 'tags', 'api', 'service'\n  set 'generators', {\n    set 'owner', 'platform-team'\n    array 'environments', 'dev', 'staging', 'prod'\n    set 'tier', 1\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -126,13 +126,13 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           expect(config.name).toBe('my-custom-app');
           expect(config.tags).toEqual(['api', 'service']);
-          expect(config.metadata.owner).toBe('platform-team');
-          expect(config.metadata.environments).toEqual([
+          expect(config.generators.owner).toBe('platform-team');
+          expect(config.generators.environments).toEqual([
             'dev',
             'staging',
             'prod',
           ]);
-          expect(config.metadata.tier).toBe(1);
+          expect(config.generators.tier).toBe(1);
         });
 
         it('should handle deeply nested objects', () => {
@@ -155,8 +155,8 @@ describe('Gradle DSL - nx {} configuration', () => {
         it('should handle arrays with mixed content in objects', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\nnx {\n  set("services") {\n    array("apis", "user", "payment", "notification")\n    set("enabled", true)\n  }\n}`
-              : `\nnx {\n  set 'services', {\n    array 'apis', 'user', 'payment', 'notification'\n    set 'enabled', true\n  }\n}`;
+              ? `\nnx {\n  set("generators") {\n    array("frameworks", "react", "angular", "vue")\n    set("enabled", true)\n  }\n}`
+              : `\nnx {\n  set 'generators', {\n    array 'frameworks', 'react', 'angular', 'vue'\n    set 'enabled', true\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -166,12 +166,12 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.services.apis).toEqual([
-            'user',
-            'payment',
-            'notification',
+          expect(config.generators.frameworks).toEqual([
+            'react',
+            'angular',
+            'vue',
           ]);
-          expect(config.services.enabled).toBe(true);
+          expect(config.generators.enabled).toBe(true);
         });
       });
 
@@ -214,8 +214,8 @@ describe('Gradle DSL - nx {} configuration', () => {
         it('should handle arrays on targets', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\ntasks.named("test") {\n  nx {\n    array("tags", "unit", "fast")\n  }\n}`
-              : `\ntasks.named('test') {\n  nx {\n    array 'tags', 'unit', 'fast'\n  }\n}`;
+              ? `\ntasks.named("test") {\n  nx {\n    array("inputs", "src/**/*", "config/**/*")\n  }\n}`
+              : `\ntasks.named('test') {\n  nx {\n    array 'inputs', 'src/**/*', 'config/**/*'\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -225,14 +225,15 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.targets.test.tags).toEqual(['unit', 'fast']);
+          expect(config.targets.test.inputs).toContain('src/**/*');
+          expect(config.targets.test.inputs).toContain('config/**/*');
         });
 
         it('should handle nested objects in target config', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\ntasks.named("build") {\n  nx {\n    set("metadata") {\n      set("description", "Build the application")\n      set("runInBand", true)\n    }\n  }\n}`
-              : `\ntasks.named('build') {\n  nx {\n    set 'metadata', {\n      set 'description', 'Build the application'\n      set 'runInBand', true\n    }\n  }\n}`;
+              ? `\ntasks.named("build") {\n  nx {\n    set("configurations") {\n      set("production", true)\n      set("environment", "prod")\n    }\n  }\n}`
+              : `\ntasks.named('build') {\n  nx {\n    set 'configurations', {\n      set 'production', true\n      set 'environment', 'prod'\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -242,17 +243,15 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.targets.build.metadata.description).toBe(
-            'Build the application'
-          );
-          expect(config.targets.build.metadata.runInBand).toBe(true);
+          expect(config.targets.build.configurations.production).toBe(true);
+          expect(config.targets.build.configurations.environment).toBe('prod');
         });
 
         it('should handle multiple properties on target', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\ntasks.named("test") {\n  nx {\n    dependsOn.add("^build")\n    set("cache", false)\n    array("tags", "integration", "slow")\n    set("metadata") {\n      set("timeout", 3600)\n    }\n  }\n}`
-              : `\ntasks.named('test') {\n  nx {\n    dependsOn.add('^build')\n    set 'cache', false\n    array 'tags', 'integration', 'slow'\n    set 'metadata', {\n      set 'timeout', 3600\n    }\n  }\n}`;
+              ? `\ntasks.named("test") {\n  nx {\n    dependsOn.add("^build")\n    set("cache", false)\n    array("outputs", "coverage/**/*", "reports/**/*")\n    set("configurations") {\n      set("timeout", 3600)\n    }\n  }\n}`
+              : `\ntasks.named('test') {\n  nx {\n    dependsOn.add('^build')\n    set 'cache', false\n    array 'outputs', 'coverage/**/*', 'reports/**/*'\n    set 'configurations', {\n      set 'timeout', 3600\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -264,15 +263,16 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           expect(config.targets.test.dependsOn).toContain('^build');
           expect(config.targets.test.cache).toBe(false);
-          expect(config.targets.test.tags).toEqual(['integration', 'slow']);
-          expect(config.targets.test.metadata.timeout).toBe(3600);
+          expect(config.targets.test.outputs).toContain('coverage/**/*');
+          expect(config.targets.test.outputs).toContain('reports/**/*');
+          expect(config.targets.test.configurations.timeout).toBe(3600);
         });
 
         it('should configure multiple tasks', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\ntasks.named("build") {\n  nx {\n    set("cache", true)\n    array("tags", "build")\n  }\n}\n\ntasks.named("test") {\n  nx {\n    set("cache", false)\n    array("tags", "test")\n  }\n}`
-              : `\ntasks.named('build') {\n  nx {\n    set 'cache', true\n    array 'tags', 'build'\n  }\n}\n\ntasks.named('test') {\n  nx {\n    set 'cache', false\n    array 'tags', 'test'\n  }\n}`;
+              ? `\ntasks.named("build") {\n  nx {\n    set("cache", true)\n  }\n}\n\ntasks.named("test") {\n  nx {\n    set("cache", false)\n    array("inputs", "src/**/*", "test/**/*")\n  }\n}`
+              : `\ntasks.named('build') {\n  nx {\n    set 'cache', true\n  }\n}\n\ntasks.named('test') {\n  nx {\n    set 'cache', false\n    array 'inputs', 'src/**/*', 'test/**/*'\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -283,9 +283,9 @@ describe('Gradle DSL - nx {} configuration', () => {
           const config = JSON.parse(runCLI('show project app --json'));
 
           expect(config.targets.build.cache).toBe(true);
-          expect(config.targets.build.tags).toEqual(['build']);
           expect(config.targets.test.cache).toBe(false);
-          expect(config.targets.test.tags).toEqual(['test']);
+          expect(config.targets.test.inputs).toContain('src/**/*');
+          expect(config.targets.test.inputs).toContain('test/**/*');
         });
       });
 
@@ -293,8 +293,8 @@ describe('Gradle DSL - nx {} configuration', () => {
         it('should handle both project and task-level config', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\nnx {\n  set("name", "integrated-app")\n  array("tags", "api", "backend")\n}\n\ntasks.named("build") {\n  nx {\n    set("cache", false)\n    array("tags", "critical")\n  }\n}`
-              : `\nnx {\n  set 'name', 'integrated-app'\n  array 'tags', 'api', 'backend'\n}\n\ntasks.named('build') {\n  nx {\n    set 'cache', false\n    array 'tags', 'critical'\n  }\n}`;
+              ? `\nnx {\n  set("name", "integrated-app")\n  array("tags", "api", "backend")\n}\n\ntasks.named("build") {\n  nx {\n    set("cache", false)\n    set("configurations") {\n      set("profile", "production")\n    }\n  }\n}`
+              : `\nnx {\n  set 'name', 'integrated-app'\n  array 'tags', 'api', 'backend'\n}\n\ntasks.named('build') {\n  nx {\n    set 'cache', false\n    set 'configurations', {\n      set 'profile', 'production'\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -310,14 +310,16 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           // Task-level config
           expect(config.targets.build.cache).toBe(false);
-          expect(config.targets.build.tags).toEqual(['critical']);
+          expect(config.targets.build.configurations.profile).toBe(
+            'production'
+          );
         });
 
         it('should handle complex project with multiple configured tasks', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\nnx {\n  set("name", "complex-app")\n  array("tags", "monorepo", "service")\n  set("metadata") {\n    set("owner", "platform")\n    set("tier", 1)\n  }\n}\n\ntasks.named("build") {\n  nx {\n    dependsOn.add("^build")\n    dependsOn.add("app:test")\n    set("cache", true)\n  }\n}\n\ntasks.named("test") {\n  nx {\n    set("cache", false)\n    array("tags", "unit", "fast")\n    set("metadata") {\n      set("parallel", true)\n    }\n  }\n}`
-              : `\nnx {\n  set 'name', 'complex-app'\n  array 'tags', 'monorepo', 'service'\n  set 'metadata', {\n    set 'owner', 'platform'\n    set 'tier', 1\n  }\n}\n\ntasks.named('build') {\n  nx {\n    dependsOn.add('^build')\n    dependsOn.add('app:test')\n    set 'cache', true\n  }\n}\n\ntasks.named('test') {\n  nx {\n    set 'cache', false\n    array 'tags', 'unit', 'fast'\n    set 'metadata', {\n      set 'parallel', true\n    }\n  }\n}`;
+              ? `\nnx {\n  set("name", "complex-app")\n  array("tags", "monorepo", "service")\n  set("generators") {\n    set("owner", "platform")\n    set("tier", 1)\n  }\n}\n\ntasks.named("build") {\n  nx {\n    dependsOn.add("^build")\n    dependsOn.add("app:test")\n    set("cache", true)\n  }\n}\n\ntasks.named("test") {\n  nx {\n    set("cache", false)\n    array("inputs", "src/**/*", "test/**/*")\n    set("configurations") {\n      set("parallel", true)\n    }\n  }\n}`
+              : `\nnx {\n  set 'name', 'complex-app'\n  array 'tags', 'monorepo', 'service'\n  set 'generators', {\n    set 'owner', 'platform'\n    set 'tier', 1\n  }\n}\n\ntasks.named('build') {\n  nx {\n    dependsOn.add('^build')\n    dependsOn.add('app:test')\n    set 'cache', true\n  }\n}\n\ntasks.named('test') {\n  nx {\n    set 'cache', false\n    array 'inputs', 'src/**/*', 'test/**/*'\n    set 'configurations', {\n      set 'parallel', true\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -330,8 +332,8 @@ describe('Gradle DSL - nx {} configuration', () => {
           // Project-level
           expect(config.name).toBe('complex-app');
           expect(config.tags).toEqual(['monorepo', 'service']);
-          expect(config.metadata.owner).toBe('platform');
-          expect(config.metadata.tier).toBe(1);
+          expect(config.generators.owner).toBe('platform');
+          expect(config.generators.tier).toBe(1);
 
           // Build target
           expect(config.targets.build.dependsOn).toContain('^build');
@@ -340,8 +342,9 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           // Test target
           expect(config.targets.test.cache).toBe(false);
-          expect(config.targets.test.tags).toEqual(['unit', 'fast']);
-          expect(config.targets.test.metadata.parallel).toBe(true);
+          expect(config.targets.test.inputs).toContain('src/**/*');
+          expect(config.targets.test.inputs).toContain('test/**/*');
+          expect(config.targets.test.configurations.parallel).toBe(true);
         });
 
         it('should configure multiple projects independently', () => {

--- a/e2e/gradle/src/gradle-dsl.test.ts
+++ b/e2e/gradle/src/gradle-dsl.test.ts
@@ -75,23 +75,6 @@ describe('Gradle DSL - nx {} configuration', () => {
           expect(config.isPublic).toBe(true);
         });
 
-        it('should handle null values', () => {
-          const dslContent =
-            type === 'kotlin'
-              ? `\nnx {\n  setNull("optionalField")\n}`
-              : `\nnx {\n  setNull 'optionalField'\n}`;
-
-          updateFile(
-            `app/build.gradle${buildFileExt}`,
-            (content) => content + dslContent
-          );
-
-          runCLI('reset');
-          const config = JSON.parse(runCLI('show project app --json'));
-
-          expect(config.optionalField).toBeUndefined();
-        });
-
         it('should handle arrays', () => {
           const dslContent =
             type === 'kotlin'

--- a/e2e/gradle/src/gradle-dsl.test.ts
+++ b/e2e/gradle/src/gradle-dsl.test.ts
@@ -197,11 +197,6 @@ describe('Gradle DSL - nx {} configuration', () => {
 
       describe('Task-level DSL', () => {
         it('should handle mergedDependsOn with method syntax', () => {
-          console.log(
-            'task-level buildfile content',
-            readFile(`app/build.gradle${buildFileExt}`)
-          );
-
           const dslContent =
             type === 'kotlin'
               ? `tasks.register<DefaultTask>("customTask") {\n  nx {\n    mergedDependsOn("^build", "app:test")\n  }\n}`
@@ -214,8 +209,6 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
-
-          console.log('target dependsOn', config);
 
           expect(config.targets.customTask.dependsOn).toContain('^build');
           expect(config.targets.customTask.dependsOn).toContain('app:test');
@@ -253,8 +246,6 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          console.log('target scalar', config);
-
           expect(config.targets.myBuild.cache).toBe(false);
         });
 
@@ -271,8 +262,6 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
-
-          console.log('target arrays', config);
 
           expect(config.targets.myTest.inputs).toContain('src/**/*');
           expect(config.targets.myTest.inputs).toContain('config/**/*');

--- a/e2e/gradle/src/gradle-dsl.test.ts
+++ b/e2e/gradle/src/gradle-dsl.test.ts
@@ -26,7 +26,7 @@ describe('Gradle DSL - nx {} configuration', () => {
         const importStatement =
           type === 'kotlin'
             ? `import dev.nx.gradle.nx\n\n`
-            : `import static dev.nx.gradle.NxProjectExtensionKt.nx\nimport static dev.nx.gradle.NxTaskExtensionKt.nx\n\n`;
+            : `import static dev.nx.gradle.Groovy.nx\n\n`;
         updateFile(
           `app/build.gradle${buildFileExt}`,
           (content) => importStatement + content
@@ -48,7 +48,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\nnx {\n  set("type", "custom-app-name")\n}`
-              : `\nnx {\n  set 'type', 'custom-app-name'\n}`;
+              : `\nnx(project) {\n  it.set 'type', 'custom-app-name'\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -65,7 +65,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\nnx {\n  set("priority", 10)\n}`
-              : `\nnx {\n  set 'priority', 10\n}`;
+              : `\nnx(project) {\n  it.set 'priority', 10\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -82,7 +82,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\nnx {\n  set("isPublic", true)\n}`
-              : `\nnx {\n  set 'isPublic', true\n}`;
+              : `\nnx(project) {\n  it.set 'isPublic', true\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -99,7 +99,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\nnx {\n  array("tags", "api", "backend", "tier:1")\n}`
-              : `\nnx {\n  array 'tags', 'api', 'backend', 'tier:1'\n}`;
+              : `\nnx(project) {\n  it.array 'tags', 'api', 'backend', 'tier:1'\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -116,7 +116,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\nnx {\n  set("generators") {\n    set("@nx/react:component", "components")\n    set("@nx/node:service", "services")\n  }\n}`
-              : `\nnx {\n  set 'generators', {\n    set '@nx/react:component', 'components'\n    set '@nx/node:service', 'services'\n  }\n}`;
+              : `\nnx(project) {\n  it.set 'generators', {\n    it.set '@nx/react:component', 'components'\n    it.set '@nx/node:service', 'services'\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -134,7 +134,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\nnx {\n  set("type", "my-custom-app")\n  array("tags", "api", "service")\n  set("generators") {\n    set("owner", "platform-team")\n    array("environments", "dev", "staging", "prod")\n    set("tier", 1)\n  }\n}`
-              : `\nnx {\n  set 'type', 'my-custom-app'\n  array 'tags', 'api', 'service'\n  set 'generators', {\n    set 'owner', 'platform-team'\n    array 'environments', 'dev', 'staging', 'prod'\n    set 'tier', 1\n  }\n}`;
+              : `\nnx(project) {\n  it.set 'type', 'my-custom-app'\n  it.array 'tags', 'api', 'service'\n  it.set 'generators', {\n    it.set 'owner', 'platform-team'\n    it.array 'environments', 'dev', 'staging', 'prod'\n    it.set 'tier', 1\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -159,7 +159,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\nnx {\n  set("config") {\n    set("level1") {\n      set("level2") {\n        set("value", "deep")\n      }\n    }\n  }\n}`
-              : `\nnx {\n  set 'config', {\n    set 'level1', {\n      set 'level2', {\n        set 'value', 'deep'\n      }\n    }\n  }\n}`;
+              : `\nnx(project) {\n  it.set 'config', {\n    it.set 'level1', {\n      it.set 'level2', {\n        set 'value', 'deep'\n      }\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -176,7 +176,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\nnx {\n  set("generators") {\n    array("frameworks", "react", "angular", "vue")\n    set("enabled", true)\n  }\n}`
-              : `\nnx {\n  set 'generators', {\n    array 'frameworks', 'react', 'angular', 'vue'\n    set 'enabled', true\n  }\n}`;
+              : `\nnx(project) {\n  it.set 'generators', {\n    it.array 'frameworks', 'react', 'angular', 'vue'\n    it.set 'enabled', true\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -205,7 +205,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `tasks.register<DefaultTask>("customTask") {\n  nx {\n    mergedDependsOn("^build", "app:test")\n  }\n}`
-              : `tasks.register('customTask') {\n  nx {\n    mergedDependsOn('^build', 'app:test')\n  }\n}`;
+              : `tasks.register('customTask') {\n  nx(it) {\n    mergedDependsOn('^build', 'app:test')\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -225,7 +225,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `tasks.register<DefaultTask>("customTask2") {\n  nx {\n    mergedDependsOn.add("^build")\n    mergedDependsOn.add("app:test")\n  }\n}`
-              : `tasks.register('customTask2') {\n  nx {\n    mergedDependsOn.add('^build')\n    mergedDependsOn.add('app:test')\n  }\n}`;
+              : `tasks.register('customTask2') {\n  nx(it) {\n    mergedDependsOn.add('^build')\n    mergedDependsOn.add('app:test')\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -243,7 +243,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\ntasks.register<DefaultTask>("myBuild") {\n  nx {\n    set("cache", false)\n  }\n}`
-              : `\ntasks.register('myBuild') {\n  nx {\n    set 'cache', false\n  }\n}`;
+              : `\ntasks.register('myBuild') {\n  nx(it) {\n    it.set 'cache', false\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -262,7 +262,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\ntasks.register<DefaultTask>("myTest") {\n  nx {\n    array("inputs", "src/**/*", "config/**/*")\n  }\n}`
-              : `\ntasks.register('myTest') {\n  nx {\n    array 'inputs', 'src/**/*', 'config/**/*'\n  }\n}`;
+              : `\ntasks.register('myTest') {\n  nx(it) {\n    it.array 'inputs', 'src/**/*', 'config/**/*'\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -282,7 +282,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\ntasks.register<DefaultTask>("deploy") {\n  nx {\n    set("configurations") {\n      set("production", true)\n      set("environment", "prod")\n    }\n  }\n}`
-              : `\ntasks.register('deploy') {\n  nx {\n    set 'configurations', {\n      set 'production', true\n      set 'environment', 'prod'\n    }\n  }\n}`;
+              : `\ntasks.register('deploy') {\n  nx(it) {\n    it.set 'configurations', {\n      it.set 'production', true\n      it.set 'environment', 'prod'\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -300,7 +300,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\ntasks.register<DefaultTask>("e2e") {\n  nx {\n    mergedDependsOn.add("^build")\n    set("cache", false)\n    array("outputs", "coverage/**/*", "reports/**/*")\n    set("configurations") {\n      set("timeout", 3600)\n    }\n  }\n}`
-              : `\ntasks.register('e2e') {\n  nx {\n    mergedDependsOn.add('^build')\n    set 'cache', false\n    array 'outputs', 'coverage/**/*', 'reports/**/*'\n    set 'configurations', {\n      set 'timeout', 3600\n    }\n  }\n}`;
+              : `\ntasks.register('e2e') {\n  nx(it) {\n    mergedDependsOn.add('^build')\n    it.set 'cache', false\n    it.array 'outputs', 'coverage/**/*', 'reports/**/*'\n    it.set 'configurations', {\n      it.set 'timeout', 3600\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -321,7 +321,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\ntasks.register<DefaultTask>("customBuild") {\n  nx {\n    set("cache", true)\n  }\n}\n\ntasks.register<DefaultTask>("verify") {\n  nx {\n    set("cache", false)\n    array("inputs", "src/**/*", "test/**/*")\n  }\n}`
-              : `\ntasks.register('customBuild') {\n  nx {\n    set 'cache', true\n  }\n}\n\ntasks.register('verify') {\n  nx {\n    set 'cache', false\n    array 'inputs', 'src/**/*', 'test/**/*'\n  }\n}`;
+              : `\ntasks.register('customBuild') {\n  nx(it) {\n    it.set 'cache', true\n  }\n}\n\ntasks.register('verify') {\n  nx(it) {\n    it.set 'cache', false\n    it.array 'inputs', 'src/**/*', 'test/**/*'\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -343,7 +343,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\nnx {\n  set("type", "integrated-app")\n  array("tags", "api", "backend")\n}\n\ntasks.register<DefaultTask>("package") {\n  nx {\n    set("cache", false)\n    set("configurations") {\n      set("profile", "production")\n    }\n  }\n}`
-              : `\nnx {\n  set 'type', 'integrated-app'\n  array 'tags', 'api', 'backend'\n}\n\ntasks.register('package') {\n  nx {\n    set 'cache', false\n    set 'configurations', {\n      set 'profile', 'production'\n    }\n  }\n}`;
+              : `\nnx(project) {\n  it.set 'type', 'integrated-app'\n  it.array 'tags', 'api', 'backend'\n}\n\ntasks.register('package') {\n  nx(it) {\n    it.set 'cache', false\n    it.set 'configurations', {\n      it.set 'profile', 'production'\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -368,7 +368,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const dslContent =
             type === 'kotlin'
               ? `\nnx {\n  set("type", "complex-app")\n  array("tags", "monorepo", "service")\n  set("generators") {\n    set("owner", "platform")\n    set("tier", 1)\n  }\n}\n\ntasks.register<DefaultTask>("compile") {\n  nx {\n    mergedDependsOn.add("^build")\n    mergedDependsOn.add("app:test")\n    set("cache", true)\n  }\n}\n\ntasks.register<DefaultTask>("validate") {\n  nx {\n    set("cache", false)\n    array("inputs", "src/**/*", "test/**/*")\n    set("configurations") {\n      set("parallel", true)\n    }\n  }\n}`
-              : `\nnx {\n  set 'type', 'complex-app'\n  array 'tags', 'monorepo', 'service'\n  set 'generators', {\n    set 'owner', 'platform'\n    set 'tier', 1\n  }\n}\n\ntasks.register('compile') {\n  nx {\n    mergedDependsOn.add('^build')\n    mergedDependsOn.add('app:test')\n    set 'cache', true\n  }\n}\n\ntasks.register('validate') {\n  nx {\n    set 'cache', false\n    array 'inputs', 'src/**/*', 'test/**/*'\n    set 'configurations', {\n      set 'parallel', true\n    }\n  }\n}`;
+              : `\nnx(project) {\n  it.set 'type', 'complex-app'\n  it.array 'tags', 'monorepo', 'service'\n  it.set 'generators', {\n    it.set 'owner', 'platform'\n    it.set 'tier', 1\n  }\n}\n\ntasks.register('compile') {\n  nx(it) {\n    mergedDependsOn.add('^build')\n    mergedDependsOn.add('app:test')\n    it.set 'cache', true\n  }\n}\n\ntasks.register('validate') {\n  nx(it) {\n    it.set 'cache', false\n    it.array 'inputs', 'src/**/*', 'test/**/*'\n    it.set 'configurations', {\n      it.set 'parallel', true\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -401,7 +401,7 @@ describe('Gradle DSL - nx {} configuration', () => {
           const appDslContent =
             type === 'kotlin'
               ? `\nnx {\n  set("type", "app-project")\n  array("tags", "app")\n}`
-              : `\nnx {\n  set 'type', 'app-project'\n  array 'tags', 'app'\n}`;
+              : `\nnx(project) {\n  it.set 'type', 'app-project'\n  it.array 'tags', 'app'\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -411,13 +411,13 @@ describe('Gradle DSL - nx {} configuration', () => {
           const importStatement =
             type === 'kotlin'
               ? `import dev.nx.gradle.nx\n\n`
-              : `import static dev.nx.gradle.NxProjectExtensionKt.nx\nimport static dev.nx.gradle.NxTaskExtensionKt.nx\n\n`;
+              : `import static dev.nx.gradle.Groovy.nx\n\n`;
 
           // Configure list project
           const listDslContent =
             type === 'kotlin'
               ? `\nnx {\n  set("type", "list-project")\n  array("tags", "lib")\n}`
-              : `\nnx {\n  set 'type', 'list-project'\n  array 'tags', 'lib'\n}`;
+              : `\nnx(project) {\n  it.set 'type', 'list-project'\n  it.array 'tags', 'lib'\n}`;
 
           updateFile(
             `list/build.gradle${buildFileExt}`,

--- a/e2e/gradle/src/gradle-dsl.test.ts
+++ b/e2e/gradle/src/gradle-dsl.test.ts
@@ -190,6 +190,8 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
+          console.log('target dependsOn', config);
+
           expect(config.targets.customTask.dependsOn).toContain('^build');
           expect(config.targets.customTask.dependsOn).toContain('app:test');
         });
@@ -208,6 +210,8 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
+          console.log('target scalar', config);
+
           expect(config.targets.myBuild.cache).toBe(false);
         });
 
@@ -224,6 +228,8 @@ describe('Gradle DSL - nx {} configuration', () => {
 
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
+
+          console.log('target arrays', config);
 
           expect(config.targets.myTest.inputs).toContain('src/**/*');
           expect(config.targets.myTest.inputs).toContain('config/**/*');

--- a/e2e/gradle/src/gradle-dsl.test.ts
+++ b/e2e/gradle/src/gradle-dsl.test.ts
@@ -1,0 +1,404 @@
+import {
+  cleanupProject,
+  newProject,
+  runCLI,
+  uniq,
+  updateFile,
+} from '@nx/e2e-utils';
+import { createGradleProject } from './utils/create-gradle-project';
+
+describe('Gradle DSL - nx {} configuration', () => {
+  describe.each([{ type: 'kotlin' }, { type: 'groovy' }])(
+    '$type',
+    ({ type }: { type: 'kotlin' | 'groovy' }) => {
+      let gradleProjectName: string;
+      const buildFileExt = type === 'kotlin' ? '.kts' : '';
+
+      beforeAll(() => {
+        gradleProjectName = uniq('gradle-dsl-test');
+        newProject({ packages: [] });
+        createGradleProject(gradleProjectName, type);
+        runCLI(`add @nx/gradle`);
+      });
+
+      afterAll(() => cleanupProject());
+
+      describe('Project-level DSL', () => {
+        it('should handle string values', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\nnx {\n  set("name", "custom-app-name")\n}`
+              : `\nnx {\n  set 'name', 'custom-app-name'\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          expect(config.name).toBe('custom-app-name');
+        });
+
+        it('should handle number values', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\nnx {\n  set("priority", 10)\n}`
+              : `\nnx {\n  set 'priority', 10\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          expect(config.priority).toBe(10);
+        });
+
+        it('should handle boolean values', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\nnx {\n  set("isPublic", true)\n}`
+              : `\nnx {\n  set 'isPublic', true\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          expect(config.isPublic).toBe(true);
+        });
+
+        it('should handle null values', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\nnx {\n  setNull("optionalField")\n}`
+              : `\nnx {\n  setNull 'optionalField'\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          expect(config.optionalField).toBeUndefined();
+        });
+
+        it('should handle arrays', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\nnx {\n  array("tags", "api", "backend", "tier:1")\n}`
+              : `\nnx {\n  array 'tags', 'api', 'backend', 'tier:1'\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          expect(config.tags).toEqual(['api', 'backend', 'tier:1']);
+        });
+
+        it('should handle nested objects', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\nnx {\n  set("metadata") {\n    set("owner", "team-a")\n    set("criticality", "high")\n  }\n}`
+              : `\nnx {\n  set 'metadata', {\n    set 'owner', 'team-a'\n    set 'criticality', 'high'\n  }\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          expect(config.metadata).toEqual({
+            owner: 'team-a',
+            criticality: 'high',
+          });
+        });
+
+        it('should handle complex nested structures', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\nnx {\n  set("name", "my-custom-app")\n  array("tags", "api", "service")\n  set("metadata") {\n    set("owner", "platform-team")\n    array("environments", "dev", "staging", "prod")\n    set("tier", 1)\n  }\n}`
+              : `\nnx {\n  set 'name', 'my-custom-app'\n  array 'tags', 'api', 'service'\n  set 'metadata', {\n    set 'owner', 'platform-team'\n    array 'environments', 'dev', 'staging', 'prod'\n    set 'tier', 1\n  }\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          expect(config.name).toBe('my-custom-app');
+          expect(config.tags).toEqual(['api', 'service']);
+          expect(config.metadata).toEqual({
+            owner: 'platform-team',
+            environments: ['dev', 'staging', 'prod'],
+            tier: 1,
+          });
+        });
+
+        it('should handle deeply nested objects', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\nnx {\n  set("config") {\n    set("level1") {\n      set("level2") {\n        set("value", "deep")\n      }\n    }\n  }\n}`
+              : `\nnx {\n  set 'config', {\n    set 'level1', {\n      set 'level2', {\n        set 'value', 'deep'\n      }\n    }\n  }\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          expect(config.config).toEqual({
+            level1: {
+              level2: {
+                value: 'deep',
+              },
+            },
+          });
+        });
+
+        it('should handle arrays with mixed content in objects', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\nnx {\n  set("services") {\n    array("apis", "user", "payment", "notification")\n    set("enabled", true)\n  }\n}`
+              : `\nnx {\n  set 'services', {\n    array 'apis', 'user', 'payment', 'notification'\n    set 'enabled', true\n  }\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          expect(config.services).toEqual({
+            apis: ['user', 'payment', 'notification'],
+            enabled: true,
+          });
+        });
+      });
+
+      describe('Task-level DSL', () => {
+        it('should handle dependsOn property', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\ntasks.named("build") {\n  nx {\n    dependsOn.addAll("^build", "app:test")\n  }\n}`
+              : `\ntasks.named('build') {\n  nx {\n    dependsOn.addAll('^build', 'app:test')\n  }\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          expect(config.targets.build.dependsOn).toContain('^build');
+          expect(config.targets.build.dependsOn).toContain('app:test');
+        });
+
+        it('should handle scalar values on targets', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\ntasks.named("build") {\n  nx {\n    set("cache", false)\n  }\n}`
+              : `\ntasks.named('build') {\n  nx {\n    set 'cache', false\n  }\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          expect(config.targets.build.cache).toBe(false);
+        });
+
+        it('should handle arrays on targets', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\ntasks.named("test") {\n  nx {\n    array("tags", "unit", "fast")\n  }\n}`
+              : `\ntasks.named('test') {\n  nx {\n    array 'tags', 'unit', 'fast'\n  }\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          expect(config.targets.test.tags).toEqual(['unit', 'fast']);
+        });
+
+        it('should handle nested objects in target config', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\ntasks.named("build") {\n  nx {\n    set("metadata") {\n      set("description", "Build the application")\n      set("runInBand", true)\n    }\n  }\n}`
+              : `\ntasks.named('build') {\n  nx {\n    set 'metadata', {\n      set 'description', 'Build the application'\n      set 'runInBand', true\n    }\n  }\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          expect(config.targets.build.metadata).toEqual({
+            description: 'Build the application',
+            runInBand: true,
+          });
+        });
+
+        it('should handle multiple properties on target', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\ntasks.named("test") {\n  nx {\n    dependsOn.add("^build")\n    set("cache", false)\n    array("tags", "integration", "slow")\n    set("metadata") {\n      set("timeout", 3600)\n    }\n  }\n}`
+              : `\ntasks.named('test') {\n  nx {\n    dependsOn.add('^build')\n    set 'cache', false\n    array 'tags', 'integration', 'slow'\n    set 'metadata', {\n      set 'timeout', 3600\n    }\n  }\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          expect(config.targets.test.dependsOn).toContain('^build');
+          expect(config.targets.test.cache).toBe(false);
+          expect(config.targets.test.tags).toEqual(['integration', 'slow']);
+          expect(config.targets.test.metadata).toEqual({ timeout: 3600 });
+        });
+
+        it('should configure multiple tasks', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\ntasks.named("build") {\n  nx {\n    set("cache", true)\n    array("tags", "build")\n  }\n}\n\ntasks.named("test") {\n  nx {\n    set("cache", false)\n    array("tags", "test")\n  }\n}`
+              : `\ntasks.named('build') {\n  nx {\n    set 'cache', true\n    array 'tags', 'build'\n  }\n}\n\ntasks.named('test') {\n  nx {\n    set 'cache', false\n    array 'tags', 'test'\n  }\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          expect(config.targets.build.cache).toBe(true);
+          expect(config.targets.build.tags).toEqual(['build']);
+          expect(config.targets.test.cache).toBe(false);
+          expect(config.targets.test.tags).toEqual(['test']);
+        });
+      });
+
+      describe('Integration - Project and Task DSL combined', () => {
+        it('should handle both project and task-level config', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\nnx {\n  set("name", "integrated-app")\n  array("tags", "api", "backend")\n}\n\ntasks.named("build") {\n  nx {\n    set("cache", false)\n    array("tags", "critical")\n  }\n}`
+              : `\nnx {\n  set 'name', 'integrated-app'\n  array 'tags', 'api', 'backend'\n}\n\ntasks.named('build') {\n  nx {\n    set 'cache', false\n    array 'tags', 'critical'\n  }\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          // Project-level config
+          expect(config.name).toBe('integrated-app');
+          expect(config.tags).toEqual(['api', 'backend']);
+
+          // Task-level config
+          expect(config.targets.build.cache).toBe(false);
+          expect(config.targets.build.tags).toEqual(['critical']);
+        });
+
+        it('should handle complex project with multiple configured tasks', () => {
+          const dslContent =
+            type === 'kotlin'
+              ? `\nnx {\n  set("name", "complex-app")\n  array("tags", "monorepo", "service")\n  set("metadata") {\n    set("owner", "platform")\n    set("tier", 1)\n  }\n}\n\ntasks.named("build") {\n  nx {\n    dependsOn.addAll("^build", "app:test")\n    set("cache", true)\n  }\n}\n\ntasks.named("test") {\n  nx {\n    set("cache", false)\n    array("tags", "unit", "fast")\n    set("metadata") {\n      set("parallel", true)\n    }\n  }\n}`
+              : `\nnx {\n  set 'name', 'complex-app'\n  array 'tags', 'monorepo', 'service'\n  set 'metadata', {\n    set 'owner', 'platform'\n    set 'tier', 1\n  }\n}\n\ntasks.named('build') {\n  nx {\n    dependsOn.addAll('^build', 'app:test')\n    set 'cache', true\n  }\n}\n\ntasks.named('test') {\n  nx {\n    set 'cache', false\n    array 'tags', 'unit', 'fast'\n    set 'metadata', {\n      set 'parallel', true\n    }\n  }\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + dslContent
+          );
+
+          runCLI('reset');
+          const config = JSON.parse(runCLI('show project app --json'));
+
+          // Project-level
+          expect(config.name).toBe('complex-app');
+          expect(config.tags).toEqual(['monorepo', 'service']);
+          expect(config.metadata).toEqual({ owner: 'platform', tier: 1 });
+
+          // Build target
+          expect(config.targets.build.dependsOn).toContain('^build');
+          expect(config.targets.build.dependsOn).toContain('app:test');
+          expect(config.targets.build.cache).toBe(true);
+
+          // Test target
+          expect(config.targets.test.cache).toBe(false);
+          expect(config.targets.test.tags).toEqual(['unit', 'fast']);
+          expect(config.targets.test.metadata).toEqual({ parallel: true });
+        });
+
+        it('should configure multiple projects independently', () => {
+          // Configure app project
+          const appDslContent =
+            type === 'kotlin'
+              ? `\nnx {\n  set("name", "app-project")\n  array("tags", "app")\n}`
+              : `\nnx {\n  set 'name', 'app-project'\n  array 'tags', 'app'\n}`;
+
+          updateFile(
+            `app/build.gradle${buildFileExt}`,
+            (content) => content + appDslContent
+          );
+
+          // Configure list project
+          const listDslContent =
+            type === 'kotlin'
+              ? `\nnx {\n  set("name", "list-project")\n  array("tags", "lib")\n}`
+              : `\nnx {\n  set 'name', 'list-project'\n  array 'tags', 'lib'\n}`;
+
+          updateFile(
+            `list/build.gradle${buildFileExt}`,
+            (content) => content + listDslContent
+          );
+
+          runCLI('reset');
+
+          const appConfig = JSON.parse(runCLI('show project app --json'));
+          const listConfig = JSON.parse(runCLI('show project list --json'));
+
+          expect(appConfig.name).toBe('app-project');
+          expect(appConfig.tags).toEqual(['app']);
+
+          expect(listConfig.name).toBe('list-project');
+          expect(listConfig.tags).toEqual(['lib']);
+        });
+      });
+    }
+  );
+});

--- a/e2e/gradle/src/gradle-dsl.test.ts
+++ b/e2e/gradle/src/gradle-dsl.test.ts
@@ -196,42 +196,6 @@ describe('Gradle DSL - nx {} configuration', () => {
       });
 
       describe('Task-level DSL', () => {
-        it('should handle mergedDependsOn with method syntax', () => {
-          const dslContent =
-            type === 'kotlin'
-              ? `tasks.register<DefaultTask>("customTask") {\n  nx {\n    mergedDependsOn("^build", "app:test")\n  }\n}`
-              : `tasks.register('customTask') {\n  nx(it) {\n    it.mergedDependsOn('^build', 'app:test')\n  }\n}`;
-
-          updateFile(
-            `app/build.gradle${buildFileExt}`,
-            (content) => cleanFileContent + dslContent
-          );
-
-          runCLI('reset');
-          const config = JSON.parse(runCLI('show project app --json'));
-
-          expect(config.targets.customTask.dependsOn).toContain('^build');
-          expect(config.targets.customTask.dependsOn).toContain('app:test');
-        });
-
-        it('should handle mergedDependsOn with property syntax', () => {
-          const dslContent =
-            type === 'kotlin'
-              ? `tasks.register<DefaultTask>("customTask2") {\n  nx {\n    mergedDependsOn.add("^build")\n    mergedDependsOn.add("app:test")\n  }\n}`
-              : `tasks.register('customTask2') {\n  nx(it) {\n    it.mergedDependsOn.add('^build')\n    it.mergedDependsOn.add('app:test')\n  }\n}`;
-
-          updateFile(
-            `app/build.gradle${buildFileExt}`,
-            (content) => cleanFileContent + dslContent
-          );
-
-          runCLI('reset');
-          const config = JSON.parse(runCLI('show project app --json'));
-
-          expect(config.targets.customTask2.dependsOn).toContain('^build');
-          expect(config.targets.customTask2.dependsOn).toContain('app:test');
-        });
-
         it('should handle scalar values on targets', () => {
           const dslContent =
             type === 'kotlin'
@@ -289,8 +253,8 @@ describe('Gradle DSL - nx {} configuration', () => {
         it('should handle multiple properties on target', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\ntasks.register<DefaultTask>("e2e") {\n  nx {\n    mergedDependsOn.add("^build")\n    set("cache", false)\n    array("outputs", "coverage/**/*", "reports/**/*")\n    set("configurations") {\n      set("debug") {\n        set("timeout", 3600)\n      }\n    }\n  }\n}`
-              : `\ntasks.register('e2e') {\n  nx(it) {\n    it.mergedDependsOn.add('^build')\n    it.set 'cache', false\n    it.array 'outputs', 'coverage/**/*', 'reports/**/*'\n    it.set 'configurations', {\n      it.set 'debug', {\n        it.set 'timeout', 3600\n      }\n    }\n  }\n}`;
+              ? `\ntasks.register<DefaultTask>("e2e") {\n  nx {\n    set("cache", false)\n    array("outputs", "coverage/**/*", "reports/**/*")\n    set("configurations") {\n      set("debug") {\n        set("timeout", 3600)\n      }\n    }\n  }\n}`
+              : `\ntasks.register('e2e') {\n  nx(it) {\n    it.set 'cache', false\n    it.array 'outputs', 'coverage/**/*', 'reports/**/*'\n    it.set 'configurations', {\n      it.set 'debug', {\n        it.set 'timeout', 3600\n      }\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -300,7 +264,6 @@ describe('Gradle DSL - nx {} configuration', () => {
           runCLI('reset');
           const config = JSON.parse(runCLI('show project app --json'));
 
-          expect(config.targets.e2e.dependsOn).toContain('^build');
           expect(config.targets.e2e.cache).toBe(false);
           expect(config.targets.e2e.outputs).toContain('coverage/**/*');
           expect(config.targets.e2e.outputs).toContain('reports/**/*');
@@ -355,8 +318,8 @@ describe('Gradle DSL - nx {} configuration', () => {
         it('should handle complex project with multiple configured tasks', () => {
           const dslContent =
             type === 'kotlin'
-              ? `\nnx {\n  set("type", "complex-app")\n  array("tags", "monorepo", "service")\n  set("generators") {\n    set("owner", "platform")\n    set("tier", 1)\n  }\n}\n\ntasks.register<DefaultTask>("compile") {\n  nx {\n    mergedDependsOn.add("^build")\n    mergedDependsOn.add("app:test")\n    set("cache", true)\n  }\n}\n\ntasks.register<DefaultTask>("validate") {\n  nx {\n    set("cache", false)\n    array("inputs", "src/**/*", "test/**/*")\n    set("configurations") {\n      set("debug") {\n        set("parallel", true)\n      }\n    }\n  }\n}`
-              : `\nnx(project) {\n  it.set 'type', 'complex-app'\n  it.array 'tags', 'monorepo', 'service'\n  it.set 'generators', {\n    it.set 'owner', 'platform'\n    it.set 'tier', 1\n  }\n}\n\ntasks.register('compile') {\n  nx(it) {\n    it.mergedDependsOn.add('^build')\n    it.mergedDependsOn.add('app:test')\n    it.set 'cache', true\n  }\n}\n\ntasks.register('validate') {\n  nx(it) {\n    it.set 'cache', false\n    it.array 'inputs', 'src/**/*', 'test/**/*'\n    it.set 'configurations', {\n      it.set 'debug', {\n        it.set 'parallel', true\n      }\n    }\n  }\n}`;
+              ? `\nnx {\n  set("type", "complex-app")\n  array("tags", "monorepo", "service")\n  set("generators") {\n    set("owner", "platform")\n    set("tier", 1)\n  }\n}\n\ntasks.register<DefaultTask>("compile") {\n  nx {\n    set("cache", true)\n  }\n}\n\ntasks.register<DefaultTask>("validate") {\n  nx {\n    set("cache", false)\n    array("inputs", "src/**/*", "test/**/*")\n    set("configurations") {\n      set("debug") {\n        set("parallel", true)\n      }\n    }\n  }\n}`
+              : `\nnx(project) {\n  it.set 'type', 'complex-app'\n  it.array 'tags', 'monorepo', 'service'\n  it.set 'generators', {\n    it.set 'owner', 'platform'\n    it.set 'tier', 1\n  }\n}\n\ntasks.register('compile') {\n  nx(it) {\n    it.set 'cache', true\n  }\n}\n\ntasks.register('validate') {\n  nx(it) {\n    it.set 'cache', false\n    it.array 'inputs', 'src/**/*', 'test/**/*'\n    it.set 'configurations', {\n      it.set 'debug', {\n        it.set 'parallel', true\n      }\n    }\n  }\n}`;
 
           updateFile(
             `app/build.gradle${buildFileExt}`,
@@ -373,8 +336,6 @@ describe('Gradle DSL - nx {} configuration', () => {
           expect(config.generators.tier).toBe(1);
 
           // Compile target
-          expect(config.targets.compile.dependsOn).toContain('^build');
-          expect(config.targets.compile.dependsOn).toContain('app:test');
           expect(config.targets.compile.cache).toBe(true);
 
           // Validate target

--- a/packages/gradle/project-graph/README.md
+++ b/packages/gradle/project-graph/README.md
@@ -77,6 +77,8 @@ Configure project metadata such as name, tags, and custom properties:
 **Kotlin (build.gradle.kts):**
 
 ```kotlin
+import dev.nx.gradle.nx
+
 nx {
   set("name", "my-custom-name")
   array("tags", "api", "backend")
@@ -86,6 +88,8 @@ nx {
 **Groovy (build.gradle):**
 
 ```groovy
+import static dev.nx.gradle.NxProjectExtensionKt.nx
+
 nx {
   set 'name', 'my-custom-name'
   array 'tags', 'api', 'backend'
@@ -99,9 +103,11 @@ Configure Nx target-specific behavior on individual tasks:
 **Kotlin (build.gradle.kts):**
 
 ```kotlin
+import dev.nx.gradle.nx
+
 tasks.named("integrationTest") {
   nx {
-    dependsOn.addAll("^build", "app:lint")  // Merges with Gradle dependencies
+    mergedDependsOn("^build", "app:lint")
     set("cache", true)
   }
 }
@@ -110,9 +116,11 @@ tasks.named("integrationTest") {
 **Groovy (build.gradle):**
 
 ```groovy
+import static dev.nx.gradle.NxTaskExtensionKt.nx
+
 tasks.named('integrationTest') {
   nx {
-    dependsOn.addAll('^build', 'app:lint')  // Merges with Gradle dependencies
+    mergedDependsOn('^build', 'app:lint')
     set 'cache', true
   }
 }

--- a/packages/gradle/project-graph/README.md
+++ b/packages/gradle/project-graph/README.md
@@ -88,11 +88,11 @@ nx {
 **Groovy (build.gradle):**
 
 ```groovy
-import static dev.nx.gradle.NxProjectExtensionKt.nx
+import static dev.nx.gradle.Groovy.nx
 
-nx {
-  set 'name', 'my-custom-name'
-  array 'tags', 'api', 'backend'
+nx(project) {
+  it.set 'name', 'my-custom-name'
+  it.array 'tags', 'api', 'backend'
 }
 ```
 
@@ -116,12 +116,12 @@ tasks.named("integrationTest") {
 **Groovy (build.gradle):**
 
 ```groovy
-import static dev.nx.gradle.NxTaskExtensionKt.nx
+import static dev.nx.gradle.Groovy.nx
 
 tasks.named('integrationTest') {
-  nx {
-    mergedDependsOn('^build', 'app:lint')
-    set 'cache', true
+  nx(it) {
+    it.mergedDependsOn('^build', 'app:lint')
+    it.set 'cache', true
   }
 }
 ```

--- a/packages/gradle/project-graph/README.md
+++ b/packages/gradle/project-graph/README.md
@@ -107,7 +107,6 @@ import dev.nx.gradle.nx
 
 tasks.named("integrationTest") {
   nx {
-    mergedDependsOn("^build", "app:lint")
     set("cache", true)
   }
 }
@@ -120,7 +119,6 @@ import static dev.nx.gradle.Groovy.nx
 
 tasks.named('integrationTest') {
   nx(it) {
-    it.mergedDependsOn('^build', 'app:lint')
     it.set 'cache', true
   }
 }

--- a/packages/gradle/project-graph/README.md
+++ b/packages/gradle/project-graph/README.md
@@ -65,3 +65,57 @@ It generates a json file to be consumed by nx:
   "externalNodes": {}
 }
 ```
+
+## Configuration
+
+The plugin provides a type-safe `nx {}` DSL for configuring Nx-specific metadata on your Gradle projects and tasks.
+
+### Project-Level Configuration
+
+Configure project metadata such as name, tags, and custom properties:
+
+**Kotlin (build.gradle.kts):**
+
+```kotlin
+nx {
+  set("name", "my-custom-name")
+  array("tags", "api", "backend")
+}
+```
+
+**Groovy (build.gradle):**
+
+```groovy
+nx {
+  set 'name', 'my-custom-name'
+  array 'tags', 'api', 'backend'
+}
+```
+
+### Task-Level Configuration
+
+Configure Nx target-specific behavior on individual tasks:
+
+**Kotlin (build.gradle.kts):**
+
+```kotlin
+tasks.named("integrationTest") {
+  nx {
+    dependsOn.addAll("^build", "app:lint")  // Merges with Gradle dependencies
+    set("cache", true)
+  }
+}
+```
+
+**Groovy (build.gradle):**
+
+```groovy
+tasks.named('integrationTest') {
+  nx {
+    dependsOn.addAll('^build', 'app:lint')  // Merges with Gradle dependencies
+    set 'cache', true
+  }
+}
+```
+
+For complete documentation on the Gradle DSL including all available options and examples, see the [Gradle plugin configuration guide](https://nx.dev/packages/gradle/documents/overview#configuring-projects-and-tasks-with-the-gradle-dsl).

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/Nx.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/Nx.kt
@@ -25,7 +25,6 @@ import org.gradle.api.Task
  * // Task-level configuration
  * tasks.named('test') {
  *     nx(it) {
- *         it.mergedDependsOn('^build')
  *         it.set('cache', false)
  *     }
  * }

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/Nx.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/Nx.kt
@@ -1,0 +1,55 @@
+@file:JvmName("Groovy")
+
+package dev.nx.gradle
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+
+/**
+ * Groovy-friendly facade for nx configuration.
+ *
+ * Provides overloaded static methods that Groovy can distinguish based on parameter types. This
+ * allows Groovy users to import a single method name and use it for both project and task
+ * configuration.
+ *
+ * Example usage in Groovy:
+ * ```groovy
+ * import static dev.nx.gradle.Groovy.nx
+ *
+ * // Project-level configuration
+ * nx(project) {
+ *     it.set('type', 'application')
+ *     it.array('tags', 'api', 'backend')
+ * }
+ *
+ * // Task-level configuration
+ * tasks.named('test') {
+ *     nx(it) {
+ *         it.mergedDependsOn('^build')
+ *         it.set('cache', false)
+ *     }
+ * }
+ * ```
+ */
+
+/**
+ * Configure Nx project-level settings.
+ *
+ * @param project The Gradle project to configure
+ * @param configure The configuration block
+ */
+@JvmName("nx")
+fun nx(project: Project, configure: NxProjectExtension.() -> Unit) {
+  project.nx(configure)
+}
+
+/**
+ * Configure Nx task-level settings.
+ *
+ * @param task The Gradle task to configure
+ * @param configure The configuration block
+ */
+@JvmName("nx")
+fun nx(task: Task, configure: NxTaskExtension.() -> Unit) {
+  task.nx(configure)
+}

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectExtension.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectExtension.kt
@@ -82,8 +82,6 @@ open class NxProjectExtension @Inject constructor(objects: ObjectFactory) {
 fun Project.nx(configure: NxProjectExtension.() -> Unit) {
   val extension =
       extensions.findByType(NxProjectExtension::class.java)
-          ?: throw IllegalStateException(
-              "NxProjectExtension not found on project '${this.name}'. " +
-                  "Make sure the dev.nx.gradle.project-graph plugin is applied.")
+          ?: extensions.create("nx", NxProjectExtension::class.java, objects)
   configure(extension)
 }

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectExtension.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectExtension.kt
@@ -49,8 +49,6 @@ open class NxProjectExtension @Inject constructor(objects: ObjectFactory) {
 
   fun set(key: String, value: Boolean) = json.put(key, value)
 
-  fun setNull(key: String) = json.put(key, null as Any?)
-
   fun set(key: String, block: NxObjectBuilder.() -> Unit) {
     val obj = NxObjectBuilder().apply(block).content
     json.put(key, obj)

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectGraphReportPlugin.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectGraphReportPlugin.kt
@@ -10,6 +10,13 @@ class NxProjectGraphReportPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     project.logger.info("${Date()} Applying NxProjectGraphReportPlugin to ${project.name}")
 
+    // Register the nx extension on all tasks to allow users to specify Nx dependencies
+    project.tasks.configureEach { task ->
+      if (task.extensions.findByName("nx") == null) {
+        task.extensions.create("nx", NxTaskExtension::class.java, project.objects)
+      }
+    }
+
     val nxProjectReportTask: TaskProvider<NxProjectReportTask> =
         project.tasks.register("nxProjectReport", NxProjectReportTask::class.java) { task ->
           val hashProperty =
@@ -67,6 +74,13 @@ class NxProjectGraphReportPlugin : Plugin<Project> {
 
     // Ensure all subprojects are processed only once using lazy evaluation
     project.subprojects.distinct().forEach { subProject ->
+      // Register the nx extension on all tasks in subprojects
+      subProject.tasks.configureEach {
+        if (it.extensions.findByName("nx") == null) {
+          it.extensions.create("nx", NxTaskExtension::class.java, subProject.objects)
+        }
+      }
+
       // Add a dependency on each subproject's nxProjectReport task
       nxProjectReportTask.configure {
         it.dependsOn(subProject.tasks.matching { it.name == "nxProjectReport" })

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectGraphReportPlugin.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectGraphReportPlugin.kt
@@ -10,18 +10,6 @@ class NxProjectGraphReportPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     project.logger.info("${Date()} Applying NxProjectGraphReportPlugin to ${project.name}")
 
-    // Register the nx extension at project level
-    if (project.extensions.findByName("nx") == null) {
-      project.extensions.create("nx", NxProjectExtension::class.java, project.objects)
-    }
-
-    // Register the nx extension on all tasks to allow users to specify Nx configuration
-    project.tasks.configureEach { task ->
-      if (task.extensions.findByName("nx") == null) {
-        task.extensions.create("nx", NxTaskExtension::class.java, project.objects)
-      }
-    }
-
     val nxProjectReportTask: TaskProvider<NxProjectReportTask> =
         project.tasks.register("nxProjectReport", NxProjectReportTask::class.java) { task ->
           val hashProperty =
@@ -79,18 +67,6 @@ class NxProjectGraphReportPlugin : Plugin<Project> {
 
     // Ensure all subprojects are processed only once using lazy evaluation
     project.subprojects.distinct().forEach { subProject ->
-      // Register the nx extension at subproject level
-      if (subProject.extensions.findByName("nx") == null) {
-        subProject.extensions.create("nx", NxProjectExtension::class.java, subProject.objects)
-      }
-
-      // Register the nx extension on all tasks in subprojects
-      subProject.tasks.configureEach {
-        if (it.extensions.findByName("nx") == null) {
-          it.extensions.create("nx", NxTaskExtension::class.java, subProject.objects)
-        }
-      }
-
       // Add a dependency on each subproject's nxProjectReport task
       nxProjectReportTask.configure {
         it.dependsOn(subProject.tasks.matching { it.name == "nxProjectReport" })

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectGraphReportPlugin.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectGraphReportPlugin.kt
@@ -10,7 +10,12 @@ class NxProjectGraphReportPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     project.logger.info("${Date()} Applying NxProjectGraphReportPlugin to ${project.name}")
 
-    // Register the nx extension on all tasks to allow users to specify Nx dependencies
+    // Register the nx extension at project level
+    if (project.extensions.findByName("nx") == null) {
+      project.extensions.create("nx", NxProjectExtension::class.java, project.objects)
+    }
+
+    // Register the nx extension on all tasks to allow users to specify Nx configuration
     project.tasks.configureEach { task ->
       if (task.extensions.findByName("nx") == null) {
         task.extensions.create("nx", NxTaskExtension::class.java, project.objects)
@@ -74,6 +79,11 @@ class NxProjectGraphReportPlugin : Plugin<Project> {
 
     // Ensure all subprojects are processed only once using lazy evaluation
     project.subprojects.distinct().forEach { subProject ->
+      // Register the nx extension at subproject level
+      if (subProject.extensions.findByName("nx") == null) {
+        subProject.extensions.create("nx", NxProjectExtension::class.java, subProject.objects)
+      }
+
       // Register the nx extension on all tasks in subprojects
       subProject.tasks.configureEach {
         if (it.extensions.findByName("nx") == null) {

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxTaskExtension.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxTaskExtension.kt
@@ -100,15 +100,6 @@ open class NxTaskExtension @Inject constructor(objects: ObjectFactory) {
 
 /**
  * Type-safe accessor for the nx extension in Kotlin DSL.
- *
- * Example:
- * ```
- * tasks.named("test") {
- *   nx {
- *     dependsOn.add("^build")
- *   }
- * }
- * ```
  */
 fun Task.nx(configure: NxTaskExtension.() -> Unit) {
   val extension =

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxTaskExtension.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxTaskExtension.kt
@@ -98,9 +98,7 @@ open class NxTaskExtension @Inject constructor(objects: ObjectFactory) {
   fun merge(map: Map<String, Any?>) = json.putAll(asJsonMap(map))
 }
 
-/**
- * Type-safe accessor for the nx extension in Kotlin DSL.
- */
+/** Type-safe accessor for the nx extension in Kotlin DSL. */
 fun Task.nx(configure: NxTaskExtension.() -> Unit) {
   val extension =
       extensions.findByType(NxTaskExtension::class.java)

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxTaskExtension.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxTaskExtension.kt
@@ -8,21 +8,17 @@ import javax.inject.Inject
 import org.gradle.api.Action
 import org.gradle.api.Task
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 
 /**
  * Extension for Gradle tasks to declare Nx-specific task configuration.
  *
- * This extension allows Gradle tasks to specify additional Nx metadata including:
- * - Task dependencies (via mergedDependsOn property)
- * - Any Nx target properties (via JSON DSL)
+ * This extension allows Gradle tasks to specify Nx target properties via JSON DSL.
  *
  * Example usage in Kotlin DSL:
  * ```
  * tasks.named("integrationTest") {
  *   nx {
- *     mergedDependsOn("^build", "app:lint")
  *     set("cache", false)
  *     array("tags", "integration", "slow")
  *     set("metadata") {
@@ -37,7 +33,6 @@ import org.gradle.api.provider.MapProperty
  * ```
  * tasks.named('integrationTest') {
  *   nx {
- *     mergedDependsOn('^build', 'app:lint')
  *     set 'cache', false
  *     array 'tags', 'integration', 'slow'
  *   }
@@ -45,47 +40,8 @@ import org.gradle.api.provider.MapProperty
  * ```
  */
 open class NxTaskExtension @Inject constructor(objects: ObjectFactory) {
-  /**
-   * List of Nx task dependencies for this Gradle task.
-   *
-   * **IMPORTANT: This property merges with Gradle-detected dependencies.** Using this property will
-   * ADD to dependencies that Gradle already detected, whereas using `set("dependsOn", ...)` in the
-   * JSON DSL will REPLACE all dependencies.
-   *
-   * Supports Nx dependency patterns such as:
-   * - "^build" - depends on the 'build' target of all upstream projects
-   * - "project:target" - depends on a specific target of a specific project
-   * - "target" - depends on a target of the same project
-   *
-   * Example - MERGES with Gradle dependencies (recommended):
-   * ```kotlin
-   * tasks.named("integrationTest") {
-   *   nx {
-   *     mergedDependsOn("^build", "app:lint")
-   *   }
-   * }
-   * ```
-   */
-  val mergedDependsOn: ListProperty<String> = objects.listProperty(String::class.java)
-
   /** JSON root for task-level Nx config */
   val json: MapProperty<String, Any?> = objects.mapProperty(String::class.java, Any::class.java)
-
-  // DSL methods for mergedDependsOn
-
-  /**
-   * Add Nx task dependencies using method syntax (no import needed).
-   *
-   * @param values Nx dependency patterns (e.g., "^build", "app:lint")
-   */
-  fun mergedDependsOn(vararg values: String) = mergedDependsOn.addAll(*values)
-
-  /**
-   * Add Nx task dependencies from an iterable.
-   *
-   * @param values Collection of Nx dependency patterns
-   */
-  fun mergedDependsOn(values: Iterable<String>) = mergedDependsOn.addAll(values)
 
   // DSL methods for building JSON config
 

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxTaskExtension.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxTaskExtension.kt
@@ -48,10 +48,23 @@ open class NxTaskExtension @Inject constructor(objects: ObjectFactory) {
   /**
    * List of Nx task dependencies for this Gradle task.
    *
+   * **IMPORTANT: This property merges with Gradle-detected dependencies.** Using this ListProperty
+   * will ADD to dependencies that Gradle already detected, whereas using `set("dependsOn", ...)` in
+   * the JSON DSL will REPLACE all dependencies.
+   *
    * Supports Nx dependency patterns such as:
    * - "^build" - depends on the 'build' target of all upstream projects
    * - "project:target" - depends on a specific target of a specific project
    * - "target" - depends on a target of the same project
+   *
+   * Example - MERGES with Gradle dependencies (recommended):
+   * ```kotlin
+   * tasks.named("integrationTest") {
+   *   nx {
+   *     dependsOn.addAll("^build", "app:lint")  // Adds to Gradle dependencies
+   *   }
+   * }
+   * ```
    */
   val dependsOn: ListProperty<String> = objects.listProperty(String::class.java)
 

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxTaskExtension.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxTaskExtension.kt
@@ -1,0 +1,61 @@
+package dev.nx.gradle
+
+import javax.inject.Inject
+import org.gradle.api.Task
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+
+/**
+ * Extension for Gradle tasks to declare Nx-specific task dependencies.
+ *
+ * This extension allows Gradle tasks to specify additional dependencies on Nx tasks that are not
+ * discoverable through Gradle's standard dependency mechanism.
+ *
+ * Example usage in Kotlin DSL:
+ * ```
+ * tasks.named("integrationTest") {
+ *   nx {
+ *     dependsOn.addAll("^build", "app:lint")
+ *   }
+ * }
+ * ```
+ *
+ * Example usage in Groovy DSL:
+ * ```
+ * tasks.named('integrationTest') {
+ *   nx.dependsOn.addAll('^build', 'app:lint')
+ * }
+ * ```
+ */
+open class NxTaskExtension @Inject constructor(objects: ObjectFactory) {
+  /**
+   * List of Nx task dependencies for this Gradle task.
+   *
+   * Supports Nx dependency patterns such as:
+   * - "^build" - depends on the 'build' target of all upstream projects
+   * - "project:target" - depends on a specific target of a specific project
+   * - "target" - depends on a target of the same project
+   */
+  val dependsOn: ListProperty<String> = objects.listProperty(String::class.java)
+}
+
+/**
+ * Type-safe accessor for the nx extension in Kotlin DSL.
+ *
+ * Example:
+ * ```
+ * tasks.named("test") {
+ *   nx {
+ *     dependsOn.add("^build")
+ *   }
+ * }
+ * ```
+ */
+fun Task.nx(configure: NxTaskExtension.() -> Unit) {
+  val extension =
+      extensions.findByType(NxTaskExtension::class.java)
+          ?: throw IllegalStateException(
+              "NxTaskExtension not found on task '${this.name}'. " +
+                  "Make sure the dev.nx.gradle.project-graph plugin is applied.")
+  configure(extension)
+}

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxTaskExtension.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxTaskExtension.kt
@@ -79,8 +79,6 @@ open class NxTaskExtension @Inject constructor(objects: ObjectFactory) {
 
   fun set(key: String, value: Boolean) = json.put(key, value)
 
-  fun setNull(key: String) = json.put(key, null as Any?)
-
   fun set(key: String, block: NxObjectBuilder.() -> Unit) {
     val obj = NxObjectBuilder().apply(block).content
     json.put(key, obj)

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/data/ProjectNode.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/data/ProjectNode.kt
@@ -6,5 +6,6 @@ import org.gradle.api.tasks.Input
 data class ProjectNode(
     @Input val targets: NxTargets,
     @Input val metadata: NodeMetadata,
-    @Input val name: String
+    @Input val name: String,
+    @Input val nxConfig: Map<String, Any?>? = null
 ) : Serializable

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/dsl/NxDsl.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/dsl/NxDsl.kt
@@ -1,0 +1,105 @@
+package dev.nx.gradle.dsl
+
+import org.gradle.api.Action
+
+@DslMarker annotation class NxDslMarker
+
+// --- JSON adapters (restrict to JSON-friendly types) ---
+
+internal fun asJson(value: Any?): Any? =
+    when (value) {
+      null -> null
+      is String,
+      is Number,
+      is Boolean -> value
+      is Map<*, *> -> value.entries.associate { it.key.toString() to asJson(it.value) }
+      is Iterable<*> -> value.map { asJson(it) }
+      is Array<*> -> value.map { asJson(it) }
+      is Enum<*> -> value.name
+      else ->
+          throw IllegalArgumentException(
+              "Unsupported JSON value type: ${value::class.qualifiedName}")
+    }
+
+internal fun asJsonMap(map: Map<String, *>): Map<String, Any?> =
+    map.mapValues { (_, v) -> asJson(v) }
+
+// --- Builders ---
+
+@NxDslMarker
+class NxObjectBuilder internal constructor() {
+  internal val content = linkedMapOf<String, Any?>()
+
+  // Scalars
+  fun set(key: String, value: String) {
+    content[key] = value
+  }
+
+  fun set(key: String, value: Number) {
+    content[key] = value
+  }
+
+  fun set(key: String, value: Boolean) {
+    content[key] = value
+  }
+
+  fun setNull(key: String) {
+    content[key] = null
+  }
+
+  // Nested object
+  fun set(key: String, block: NxObjectBuilder.() -> Unit) {
+    val child = NxObjectBuilder().apply(block)
+    content[key] = child.content
+  }
+
+  fun set(key: String, action: Action<NxObjectBuilder>) = set(key) { action.execute(this) }
+
+  // Arrays
+  fun array(key: String, vararg values: Any?) {
+    content[key] = values.map { asJson(it) }
+  }
+
+  fun array(key: String, values: Iterable<*>) {
+    content[key] = values.map { asJson(it) }
+  }
+
+  fun array(key: String, block: NxArrayBuilder.() -> Unit) {
+    val arr = NxArrayBuilder().apply(block)
+    content[key] = arr.content
+  }
+
+  // Bulk
+  fun merge(map: Map<String, Any?>) {
+    content.putAll(asJsonMap(map))
+  }
+}
+
+@NxDslMarker
+class NxArrayBuilder internal constructor() {
+  internal val content = arrayListOf<Any?>()
+
+  fun add(value: String) {
+    content += value
+  }
+
+  fun add(value: Number) {
+    content += value
+  }
+
+  fun add(value: Boolean) {
+    content += value
+  }
+
+  fun addNull() {
+    content += null
+  }
+
+  fun addAll(values: Iterable<*>) {
+    content.addAll(values.map { asJson(it) })
+  }
+
+  fun obj(block: NxObjectBuilder.() -> Unit) {
+    content += NxObjectBuilder().apply(block).content
+  }
+}

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/dsl/NxDsl.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/dsl/NxDsl.kt
@@ -1,7 +1,5 @@
 package dev.nx.gradle.dsl
 
-import org.gradle.api.Action
-
 @DslMarker annotation class NxDslMarker
 
 // --- JSON adapters (restrict to JSON-friendly types) ---

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/dsl/NxDsl.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/dsl/NxDsl.kt
@@ -53,8 +53,6 @@ class NxObjectBuilder internal constructor() {
     content[key] = child.content
   }
 
-  fun set(key: String, action: Action<NxObjectBuilder>) = set(key) { action.execute(this) }
-
   // Arrays
   fun array(key: String, vararg values: Any?) {
     content[key] = values.map { asJson(it) }

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -53,27 +53,45 @@ fun processTask(
   val nxDependsOn = nxExtension?.dependsOn?.getOrNull()
 
   val combinedDependsOn =
-      when {
-        gradleDependsOn != null && nxDependsOn != null && nxDependsOn.isNotEmpty() -> {
-          // Both Gradle and Nx dependencies exist, merge them
-          logger.info(
-              "${task}: merging ${gradleDependsOn.size} Gradle dependencies with ${nxDependsOn.size} Nx dependencies")
-          gradleDependsOn + nxDependsOn
-        }
-        nxDependsOn != null && nxDependsOn.isNotEmpty() -> {
-          // Only Nx dependencies exist
-          logger.info("${task}: using ${nxDependsOn.size} Nx dependencies")
-          nxDependsOn
-        }
-        else -> {
-          // Only Gradle dependencies or no dependencies
-          gradleDependsOn
-        }
+    when {
+      gradleDependsOn != null && nxDependsOn != null && nxDependsOn.isNotEmpty() -> {
+        // Both Gradle and Nx dependencies exist, merge them
+        logger.info(
+          "${task}: merging ${gradleDependsOn.size} Gradle dependencies with ${nxDependsOn.size} Nx dependencies"
+        )
+        gradleDependsOn + nxDependsOn
       }
+
+      nxDependsOn != null && nxDependsOn.isNotEmpty() -> {
+        // Only Nx dependencies exist
+        logger.info("${task}: using ${nxDependsOn.size} Nx dependencies")
+        nxDependsOn
+      }
+
+      else -> {
+        // Only Gradle dependencies or no dependencies
+        gradleDependsOn
+      }
+    }
 
   if (!combinedDependsOn.isNullOrEmpty()) {
     logger.info("${task}: processed ${combinedDependsOn.size} total dependsOn")
     target["dependsOn"] = combinedDependsOn
+  }
+
+  // Merge nx.json config into target (this allows users to set any Nx target properties)
+  nxExtension?.json?.getOrNull()?.let { nxJson ->
+    if (nxJson.isNotEmpty()) {
+      logger.info("${task}: merging ${nxJson.size} Nx JSON properties")
+      // Merge json properties, but don't override already-set values like dependsOn
+      nxJson.forEach { (key, value) ->
+        if (!target.containsKey(key)) {
+          target[key] = value
+        } else {
+          logger.debug("${task}: skipping nx.json key '$key' as it's already set")
+        }
+      }
+    }
   }
 
   // process inputs
@@ -88,19 +106,21 @@ fun processTask(
   target["executor"] = "@nx/gradle:gradle"
 
   val metadata =
-      getMetadata(
-          task.description ?: "Run ${projectBuildPath}.${task.name}", projectBuildPath, task.name)
+    getMetadata(
+      task.description ?: "Run ${projectBuildPath}.${task.name}", projectBuildPath, task.name
+    )
   target["metadata"] = metadata
 
   target["options"] =
-      if (continuous) {
-        mapOf(
-            "taskName" to "${projectBuildPath}:${task.name}",
-            "continuous" to true,
-            "excludeDependsOn" to shouldExcludeDependsOn(task))
-      } else {
-        mapOf("taskName" to "${projectBuildPath}:${task.name}")
-      }
+    if (continuous) {
+      mapOf(
+        "taskName" to "${projectBuildPath}:${task.name}",
+        "continuous" to true,
+        "excludeDependsOn" to shouldExcludeDependsOn(task)
+      )
+    } else {
+      mapOf("taskName" to "${projectBuildPath}:${task.name}")
+    }
 
   return target
 }
@@ -238,27 +258,29 @@ fun getDependsOnTask(task: Task): Set<Task> {
   return try {
     // First try to get dependencies from task.dependsOn property
     val dependsOnFromProperty: Set<Task> =
-        try {
-          task.dependsOn.filterIsInstance<Task>().toSet()
-        } catch (e: Exception) {
-          task.logger.info(
-              "Cannot access task.dependsOn for ${task.path}, possibly due to configuration cache: ${e.message}")
-          emptySet()
-        }
+      try {
+        task.dependsOn.filterIsInstance<Task>().toSet()
+      } catch (e: Exception) {
+        task.logger.info(
+          "Cannot access task.dependsOn for ${task.path}, possibly due to configuration cache: ${e.message}"
+        )
+        emptySet()
+      }
 
     // Then try to get dependencies from taskDependencies (more comprehensive but riskier with
     // config cache)
     val dependsOnFromTaskDependencies: Set<Task> =
-        try {
-          task.taskDependencies.getDependencies(task)
-        } catch (e: UnsupportedOperationException) {
-          task.logger.info(
-              "Cannot access taskDependencies for ${task.path} due to configuration cache restrictions")
-          emptySet()
-        } catch (e: Exception) {
-          task.logger.info("Error calling getDependencies for ${task.path}: ${e.message}")
-          emptySet()
-        }
+      try {
+        task.taskDependencies.getDependencies(task)
+      } catch (e: UnsupportedOperationException) {
+        task.logger.info(
+          "Cannot access taskDependencies for ${task.path} due to configuration cache restrictions"
+        )
+        emptySet()
+      } catch (e: Exception) {
+        task.logger.info("Error calling getDependencies for ${task.path}: ${e.message}")
+        emptySet()
+      }
 
     val combinedDependsOn = dependsOnFromTaskDependencies.union(dependsOnFromProperty)
 
@@ -284,10 +306,10 @@ fun getDependsOnTask(task: Task): Set<Task> {
 internal val taskDependencyCache = ThreadLocal.withInitial { mutableMapOf<String, List<String>?>() }
 
 fun getDependsOnForTask(
-    dependsOnTasks: Set<Task>?,
-    task: Task,
-    dependencies: MutableSet<Dependency>? = null,
-    targetNameOverrides: Map<String, String> = emptyMap()
+  dependsOnTasks: Set<Task>?,
+  task: Task,
+  dependencies: MutableSet<Dependency>? = null,
+  targetNameOverrides: Map<String, String> = emptyMap()
 ): List<String>? {
 
   // Check cache to prevent infinite recursion, but only if dependsOnTasks is null
@@ -305,23 +327,26 @@ fun getDependsOnForTask(
       val taskProject = task.project
 
       if (task.name != "buildDependents" &&
-          depProject != taskProject &&
-          dependencies != null &&
-          taskProject.buildFile.exists()) {
+        depProject != taskProject &&
+        dependencies != null &&
+        taskProject.buildFile.exists()
+      ) {
         dependencies.add(
-            Dependency(
-                taskProject.projectDir.path,
-                depProject.projectDir.path,
-                taskProject.buildFile.path))
+          Dependency(
+            taskProject.projectDir.path,
+            depProject.projectDir.path,
+            taskProject.buildFile.path
+          )
+        )
       }
 
       if (depProject.buildFile.path != null && depProject.buildFile.exists()) {
         val taskName =
-            if (depTask.name == "test" && targetNameOverrides.containsKey("testTargetName")) {
-              targetNameOverrides["testTargetName"]!!
-            } else {
-              depTask.name
-            }
+          if (depTask.name == "test" && targetNameOverrides.containsKey("testTargetName")) {
+            targetNameOverrides["testTargetName"]!!
+          } else {
+            depTask.name
+          }
         "${depProject.name}:${taskName}"
       } else {
         null
@@ -336,11 +361,11 @@ fun getDependsOnForTask(
       // Compute dependencies
       val combinedDependsOn = getDependsOnTask(task)
       val result =
-          if (combinedDependsOn.isNotEmpty()) {
-            mapTasksToNames(combinedDependsOn)
-          } else {
-            null
-          }
+        if (combinedDependsOn.isNotEmpty()) {
+          mapTasksToNames(combinedDependsOn)
+        } else {
+          null
+        }
       // Cache the actual result before returning
       cache[taskKey] = result
       return result
@@ -358,11 +383,11 @@ fun getDependsOnForTask(
     // When using pre-computed dependencies, don't use cache
     return try {
       val result =
-          if (dependsOnTasks.isNotEmpty()) {
-            mapTasksToNames(dependsOnTasks)
-          } else {
-            null
-          }
+        if (dependsOnTasks.isNotEmpty()) {
+          mapTasksToNames(dependsOnTasks)
+        } else {
+          null
+        }
       result
     } catch (e: Exception) {
       task.logger.info("Unexpected error getting dependencies for ${task.path}: ${e.message}")
@@ -381,18 +406,19 @@ fun getDependsOnForTask(
  * @param nonAtomizedTarget non-atomized target name
  */
 fun getMetadata(
-    description: String?,
-    projectBuildPath: String,
-    helpTaskName: String,
-    nonAtomizedTarget: String? = null
+  description: String?,
+  projectBuildPath: String,
+  helpTaskName: String,
+  nonAtomizedTarget: String? = null
 ): Map<String, Any?> {
   val gradlewCommand = getGradlewCommand()
   return mapOf(
-      "description" to description,
-      "technologies" to arrayOf("gradle"),
-      "help" to
-          mapOf("command" to "$gradlewCommand help --task ${projectBuildPath}:${helpTaskName}"),
-      "nonAtomizedTarget" to nonAtomizedTarget)
+    "description" to description,
+    "technologies" to arrayOf("gradle"),
+    "help" to
+      mapOf("command" to "$gradlewCommand help --task ${projectBuildPath}:${helpTaskName}"),
+    "nonAtomizedTarget" to nonAtomizedTarget
+  )
 }
 
 /**
@@ -410,9 +436,9 @@ fun getMetadata(
  *   fails.
  */
 fun getExternalDepFromInputFile(
-    inputFile: String,
-    externalNodes: MutableMap<String, ExternalNode>?,
-    logger: org.gradle.api.logging.Logger
+  inputFile: String,
+  externalNodes: MutableMap<String, ExternalNode>?,
+  logger: org.gradle.api.logging.Logger
 ): String? {
   try {
     val segments = inputFile.split("/")
@@ -459,7 +485,8 @@ fun replaceRootInPath(path: String, projectRoot: String, workspaceRoot: String):
     path.startsWith(projectRoot + File.separator) -> path.replaceFirst(projectRoot, "{projectRoot}")
     path == projectRoot -> "{projectRoot}"
     path.startsWith(workspaceRoot + File.separator) ->
-        path.replaceFirst(workspaceRoot, "{workspaceRoot}")
+      path.replaceFirst(workspaceRoot, "{workspaceRoot}")
+
     path == workspaceRoot -> "{workspaceRoot}"
     else -> null
   }

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -48,9 +48,11 @@ fun processTask(
   // process dependsOn
   val gradleDependsOn = getDependsOnForTask(dependsOnTasks, task, dependencies, targetNameOverrides)
 
-  // Check for nx extension and merge nx.dependsOn with Gradle dependencies
+  // Check for nx extension and merge nx.mergedDependsOn with Gradle dependencies
   val nxExtension = task.extensions.findByType(NxTaskExtension::class.java)
-  val nxDependsOn = nxExtension?.dependsOn?.getOrNull()
+  val nxDependsOn = nxExtension?.mergedDependsOn?.getOrNull()
+
+  logger.info("processing nxDependsOn ${nxDependsOn}")
 
   val combinedDependsOn =
       when {

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -46,39 +46,15 @@ fun processTask(
   }
 
   // process dependsOn
-  val gradleDependsOn = getDependsOnForTask(dependsOnTasks, task, dependencies, targetNameOverrides)
+  val dependsOn = getDependsOnForTask(dependsOnTasks, task, dependencies, targetNameOverrides)
 
-  // Check for nx extension and merge nx.mergedDependsOn with Gradle dependencies
-  val nxExtension = task.extensions.findByType(NxTaskExtension::class.java)
-  val nxDependsOn = nxExtension?.mergedDependsOn?.getOrNull()
-
-  logger.info("processing nxDependsOn ${nxDependsOn}")
-
-  val combinedDependsOn =
-      when {
-        gradleDependsOn != null && nxDependsOn != null && nxDependsOn.isNotEmpty() -> {
-          // Both Gradle and Nx dependencies exist, merge them
-          logger.info(
-              "${task}: merging ${gradleDependsOn.size} Gradle dependencies with ${nxDependsOn.size} Nx dependencies")
-          gradleDependsOn + nxDependsOn
-        }
-
-        nxDependsOn != null && nxDependsOn.isNotEmpty() -> {
-          // Only Nx dependencies exist
-          logger.info("${task}: using ${nxDependsOn.size} Nx dependencies")
-          nxDependsOn
-        }
-
-        else -> {
-          // Only Gradle dependencies or no dependencies
-          gradleDependsOn
-        }
-      }
-
-  if (!combinedDependsOn.isNullOrEmpty()) {
-    logger.info("${task}: processed ${combinedDependsOn.size} total dependsOn")
-    target["dependsOn"] = combinedDependsOn
+  if (!dependsOn.isNullOrEmpty()) {
+    logger.info("${task}: processed ${dependsOn.size} total dependsOn")
+    target["dependsOn"] = dependsOn
   }
+
+  // Check for nx extension to get additional config
+  val nxExtension = task.extensions.findByType(NxTaskExtension::class.java)
 
   // Merge nx.json config into target (this allows users to set any Nx target properties)
   nxExtension?.json?.getOrNull()?.let { nxJson -> target["nxConfig"] = nxJson }

--- a/packages/gradle/src/plugin/nodes.ts
+++ b/packages/gradle/src/plugin/nodes.ts
@@ -133,7 +133,7 @@ export const createNodesV2: CreateNodesV2<GradlePluginOptions> = [
       options
     );
     const report = getCurrentProjectGraphReport();
-    const { nodes, externalNodes, buildFiles = [] } = report;
+    const { nodes, externalNodes = {}, buildFiles = [] } = report;
 
     // Combine buildFilesFromSplitConfigFiles and buildFiles, making each value distinct
     const allBuildFiles = Array.from(

--- a/packages/gradle/src/plugin/nodes.ts
+++ b/packages/gradle/src/plugin/nodes.ts
@@ -2,7 +2,6 @@ import {
   CreateNodesV2,
   CreateNodesContextV2,
   ProjectConfiguration,
-  createNodesFromFiles,
   readJsonFile,
   writeJsonFile,
   workspaceRoot,
@@ -32,6 +31,83 @@ type GradleTargets = Record<string, Partial<ProjectConfiguration>>;
 
 function readProjectsCache(cachePath: string): GradleTargets {
   return existsSync(cachePath) ? readJsonFile(cachePath) : {};
+}
+
+/**
+ * Strips nxConfig from project and all targets, returning only Gradle-detected configuration.
+ */
+function stripNxConfig(
+  project: Partial<ProjectConfiguration>
+): Partial<ProjectConfiguration> {
+  const { nxConfig, targets, ...rest } = project as Partial<ProjectConfiguration> & {
+    nxConfig?: Record<string, any>;
+  };
+
+  const cleanedTargets: Record<string, any> = {};
+  if (targets) {
+    for (const [targetName, target] of Object.entries(targets)) {
+      const { nxConfig: targetNxConfig, ...targetRest } = target as any;
+      cleanedTargets[targetName] = targetRest;
+    }
+  }
+
+  return {
+    ...rest,
+    targets: cleanedTargets,
+  };
+}
+
+/**
+ * Extracts only nxConfig properties from project and targets.
+ * Returns undefined if no nxConfig exists.
+ */
+function extractNxConfigOnly(
+  project: Partial<ProjectConfiguration>
+): Partial<ProjectConfiguration> | undefined {
+  const projectWithNxConfig = project as Partial<ProjectConfiguration> & {
+    nxConfig?: Record<string, any>;
+  };
+
+  const projectLevelNxConfig = projectWithNxConfig.nxConfig;
+  const targetsWithNxConfig: Record<string, any> = {};
+  let hasAnyNxConfig = false;
+
+  // Extract target-level nxConfig
+  if (project.targets) {
+    for (const [targetName, target] of Object.entries(project.targets)) {
+      const targetNxConfig = (target as any).nxConfig;
+      if (targetNxConfig && Object.keys(targetNxConfig).length > 0) {
+        targetsWithNxConfig[targetName] = targetNxConfig;
+        hasAnyNxConfig = true;
+      }
+    }
+  }
+
+  // Check if we have project-level nxConfig
+  if (projectLevelNxConfig && Object.keys(projectLevelNxConfig).length > 0) {
+    hasAnyNxConfig = true;
+  }
+
+  if (!hasAnyNxConfig) {
+    return undefined;
+  }
+
+  // Build result with only nxConfig properties
+  let result: Partial<ProjectConfiguration> = {};
+
+  // Merge project-level nxConfig into root
+  if (projectLevelNxConfig) {
+  result = {
+  ...projectLevelNxConfig
+  }
+  }
+
+  // Add target-level nxConfig if any exist
+  if (Object.keys(targetsWithNxConfig).length > 0) {
+    result.targets = targetsWithNxConfig;
+  }
+
+  return result;
 }
 
 export function writeTargetsToCache(cachePath: string, results: GradleTargets) {
@@ -64,12 +140,64 @@ export const createNodesV2: CreateNodesV2<GradlePluginOptions> = [
     );
 
     try {
-      return createNodesFromFiles(
-        makeCreateNodesForGradleConfigFile(nodes, projectsCache, externalNodes),
-        allBuildFiles,
-        options,
-        context
-      );
+      const results = [];
+      const normalizedOptions = normalizeOptions(options);
+
+      for (const gradleFilePath of allBuildFiles) {
+        // Skip on Vercel and Netlify
+        if (process.env.VERCEL || process.env.NETLIFY) {
+          continue;
+        }
+
+        const projectRoot = dirname(gradleFilePath);
+        const hash = await calculateHashForCreateNodes(
+          projectRoot,
+          normalizedOptions ?? {},
+          context
+        );
+
+        // Get project from cache or nodes
+        projectsCache[hash] ??=
+          nodes[projectRoot] ?? nodes[join(workspaceRoot, projectRoot)];
+        const project = projectsCache[hash];
+
+        if (!project) {
+          continue;
+        }
+
+        const normalizedProjectRoot = normalizePath(projectRoot);
+
+        // Result 1: Gradle-detected configuration (without nxConfig)
+        const gradleConfig = stripNxConfig(project);
+        gradleConfig.root = normalizedProjectRoot;
+
+        results.push([
+          gradleFilePath,
+          {
+            projects: {
+              [normalizedProjectRoot]: gradleConfig,
+            },
+            externalNodes: externalNodes,
+          },
+        ]);
+
+        // Result 2: nxConfig-only configuration (if exists)
+        const nxConfigOnly = extractNxConfigOnly(project);
+        if (nxConfigOnly) {
+          nxConfigOnly.root = normalizedProjectRoot;
+
+          results.push([
+            gradleFilePath,
+            {
+              projects: {
+                [normalizedProjectRoot]: nxConfigOnly,
+              },
+            },
+          ]);
+        }
+      }
+
+      return results;
     } finally {
       writeTargetsToCache(cachePath, projectsCache);
     }

--- a/packages/gradle/src/plugin/nodes.ts
+++ b/packages/gradle/src/plugin/nodes.ts
@@ -39,9 +39,10 @@ function readProjectsCache(cachePath: string): GradleTargets {
 function stripNxConfig(
   project: Partial<ProjectConfiguration>
 ): Partial<ProjectConfiguration> {
-  const { nxConfig, targets, ...rest } = project as Partial<ProjectConfiguration> & {
-    nxConfig?: Record<string, any>;
-  };
+  const { nxConfig, targets, ...rest } =
+    project as Partial<ProjectConfiguration> & {
+      nxConfig?: Record<string, any>;
+    };
 
   const cleanedTargets: Record<string, any> = {};
   if (targets) {
@@ -97,9 +98,9 @@ function extractNxConfigOnly(
 
   // Merge project-level nxConfig into root
   if (projectLevelNxConfig) {
-  result = {
-  ...projectLevelNxConfig
-  }
+    result = {
+      ...projectLevelNxConfig,
+    };
   }
 
   // Add target-level nxConfig if any exist


### PR DESCRIPTION
## Current Behavior 
Gradle projects in Nx workspaces can only configure metadata through Gradle's built-in mechanisms. There's no way to specify Nx-specific project metadata (like tags) or customize task target configurations other than overriding with `project.json`

 ## Expected Behavior

  Developers can now configure Nx-specific metadata for both projects and tasks using a type-safe Kotlin/Groovy DSL:

 ### Project-level metadata (in build.gradle.kts):
  ```
nx {
    set("name", "my-service")
    array("tags", "scope:backend", "type:api")
    set("description", "Payment processing service")
  }
```

 ### Task-level metadata (in build.gradle.kts):
```
  tasks.named("integrationTest") {
    nx {
      set("cache", false)
      array("tags", "integration", "slow")
    }
  }
```
