### PR TITLE
chore(nx-dev): remove link checker from build so it is only checked during CI not deploy

### DIFF
--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -4,7 +4,10 @@ const redirectRules = require('./redirect-rules');
 
 if (!process.env.NEXT_PUBLIC_ASTRO_URL && !global.NX_GRAPH_CREATION) {
   // If we're building for production throw error as each env must set this value.
-  if (process.env.NODE_ENV === 'production') {
+  if (
+    process.env.NODE_ENV === 'production' &&
+    (process.env.VERCEL || process.env.NETLIFY)
+  ) {
     throw new Error(
       `The NEXT_PUBLIC_ASTRO_URL environment variable is not set. Please set it to the URL of the Astro site.`
     );

--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -6,26 +6,39 @@
   "targets": {
     "build": {
       "dependsOn": [
-        "astro-docs:build",
         {
           "target": "build-base"
         }
       ],
       "executor": "nx:run-commands",
       "options": {
-        "commands": [
-          "nx run nx-dev:sitemap",
-          "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/documentation/internal-link-checker.ts"
-        ],
+        "commands": ["nx run nx-dev:sitemap"],
         "parallel": false
       },
       "inputs": [
         "production",
         "^production",
-        "{workspaceRoot}/scripts/tsconfig.scripts.json",
-        "{workspaceRoot}/scripts/documentation/internal-link-checker.ts"
+        { "env": "NEXT_PUBLIC_ASTRO_URL" }
       ],
       "outputs": ["{workspaceRoot}/dist/nx-dev/nx-dev"]
+    },
+    "check-links": {
+      "cache": true,
+      "dependsOn": ["nx-dev:build", "astro-docs:build"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "ts-node -P ./scripts/tsconfig.scripts.json ./scripts/documentation/internal-link-checker.ts"
+      },
+      "inputs": [
+        "{workspaceRoot}/docs/**/*",
+        "{workspaceRoot}/dist/nx-dev/nx-dev/public/sitemap.xml",
+        "{workspaceRoot}/astro-docs/dist/sitemap-index.xml",
+        "{workspaceRoot}/scripts/tsconfig.scripts.json",
+        "{workspaceRoot}/scripts/documentation/internal-link-checker.ts"
+      ]
+    },
+    "test": {
+      "dependsOn": ["check-links"]
     },
     "sitemap": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
This PR removes the need to check links during deploy and instead enforces it in CI. This removes the need to build astro-docs when building next.js app.

Reduces Vercel build from 10-11 mins to 6.5 mins.

<img width="1231" height="94" alt="image" src="https://github.com/user-attachments/assets/ad5d4459-f917-4609-8c00-151f61dc29d6" />
