### PR TITLE
fix(core): turn v8 serializer off by default but fallback to it if json serialization fails

### DIFF
--- a/packages/nx/src/daemon/is-v8-serializer-enabled.ts
+++ b/packages/nx/src/daemon/is-v8-serializer-enabled.ts
@@ -3,5 +3,5 @@
  * V8 serializer is enabled by default unless explicitly disabled.
  */
 export function isV8SerializerEnabled(): boolean {
-  return process.env.NX_USE_V8_SERIALIZER !== 'false';
+  return process.env.NX_USE_V8_SERIALIZER === 'true';
 }


### PR DESCRIPTION
## Current Behavior
We have tried to enable v8 serialization again... but it still seems problematic. We don't want to revert again... so we evaluated some options:

1. Disable by default
2. Disable for the single client method we think may be problematic
3. Fall back to JSON if v8 fails
4. Disable by default and still fall back if JSON fails

## Expected Behavior
We decided to update Nx such that the default behavior will be a combination of #4, and #2. So by default we use JSON, if that serialization fails we'll try v8... but there's an exception so the method we know to be an issue will never try v8.

If you opt in to v8 by default, the combo changes to #3 + #2. So, by default we'd use v8... if it fails try json... never try v8 for processInBackground

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
