### PR TITLE
fix(docker): guard commitSha null in plugin interpolation

### DIFF
--- a/packages/docker/src/plugins/plugin.spec.ts
+++ b/packages/docker/src/plugins/plugin.spec.ts
@@ -776,6 +776,20 @@ describe('@nx/docker', () => {
   });
 
   describe('pattern interpolation', () => {
+    it('should not throw when commitSha is null', async () => {
+      mockGetLatestCommitSha.mockReturnValue(null);
+      await tempFs.createFiles({
+        'proj/Dockerfile': 'FROM node:18',
+        'proj/project.json': '{}',
+      });
+      expect(
+        await createNodesFunction(['proj/Dockerfile'], {}, context)
+      ).toBeDefined();
+      const targets = (
+        await createNodesFunction(['proj/Dockerfile'], {}, context)
+      )[0][1].projects['proj'].targets;
+      expect(targets['docker:build']).toBeDefined();
+    });
     it('should interpolate imageRef in args', async () => {
       await tempFs.createFiles({
         'proj/Dockerfile': 'FROM node:18',

--- a/packages/docker/src/plugins/plugin.ts
+++ b/packages/docker/src/plugins/plugin.ts
@@ -134,7 +134,7 @@ function interpolateDockerTargetOptions(
     imageRef,
     currentDate: new Date(),
     commitSha,
-    shortCommitSha: commitSha.slice(0, 7),
+    shortCommitSha: commitSha ? commitSha.slice(0, 7) : null,
   };
 
   return interpolateObject(options, tokens);


### PR DESCRIPTION
## Current Behavior
Docker plugin assumed `commitSha` was always non-null; when `null`, `shortCommitSha.slice` caused a runtime error during target interpolation.

## Expected Behavior
Plugin should succeed even if latest commit SHA cannot be resolved, simply omitting shortCommitSha-based substitutions.

## Changes
- Added null guard: `shortCommitSha` now set to `commitSha ? commitSha.slice(0,7) : null`.
- Added test "should not throw when commitSha is null" verifying node / target creation succeeds.
- No breaking changes; only broadens safe input surface.

## Additional notes
Logic only executes when `commitSha` was previously null (error case); normal paths unchanged. If consumers interpolate `{shortCommitSha}`, they should handle possible null (unchanged if interpolation is already optional).
