### PR TITLE
fix(core): make sure that gemini contextFileName is string before trying to resolve

### DIFF
--- a/packages/nx/src/ai/utils.ts
+++ b/packages/nx/src/ai/utils.ts
@@ -125,8 +125,7 @@ async function getAgentConfiguration(
 
       const geminiSettings = parseGeminiSettings(workspaceRoot);
       const customContextFilePath: string | undefined =
-        geminiSettings?.contextFileName &&
-        typeof geminiSettings.contextFileName === 'string'
+        typeof geminiSettings?.contextFileName === 'string'
           ? geminiSettings.contextFileName
           : undefined;
 

--- a/packages/nx/src/ai/utils.ts
+++ b/packages/nx/src/ai/utils.ts
@@ -125,7 +125,11 @@ async function getAgentConfiguration(
 
       const geminiSettings = parseGeminiSettings(workspaceRoot);
       const customContextFilePath: string | undefined =
-        geminiSettings?.contextFileName;
+        geminiSettings?.contextFileName &&
+        typeof geminiSettings.contextFileName === 'string'
+          ? geminiSettings.contextFileName
+          : undefined;
+
       const customContextFilePathExists = customContextFilePath
         ? existsSync(resolve(workspaceRoot, customContextFilePath))
         : false;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
the implementation is brittle and will fail if `contextFileName` is not a string

## Expected Behavior
we should just not handle other things that folks are putting in there. but not fail
