### PR TITLE
fix(docker): enhance docker project filtering and configuration handling

### DIFF
--- a/packages/nx/src/command-line/release/version/test-utils.spec.ts
+++ b/packages/nx/src/command-line/release/version/test-utils.spec.ts
@@ -15,6 +15,11 @@ describe('parseGraphDefinition', () => {
     );
     expect(testGraph).toMatchInlineSnapshot(`
       {
+        "groupConfigs": {
+          "__default__": {
+            "projectsRelationship": "fixed",
+          },
+        },
         "projects": {
           "projectD": {
             "alternateNameInManifest": undefined,
@@ -81,6 +86,11 @@ describe('parseGraphDefinition', () => {
     );
     expect(testGraph).toMatchInlineSnapshot(`
       {
+        "groupConfigs": {
+          "__default__": {
+            "projectsRelationship": "independent",
+          },
+        },
         "projects": {
           "projectA": {
             "alternateNameInManifest": undefined,
@@ -123,6 +133,11 @@ describe('parseGraphDefinition', () => {
     );
     expect(testGraph).toMatchInlineSnapshot(`
       {
+        "groupConfigs": {
+          "__default__": {
+            "projectsRelationship": "independent",
+          },
+        },
         "projects": {
           "projectA": {
             "alternateNameInManifest": undefined,


### PR DESCRIPTION
## Current Behavior

When a release group has docker configuration, all projects in that group inherit the docker options, regardless of whether they are actually docker projects. This causes issues when you have mixed release groups containing both npm packages and docker-based applications.

For example, if you have a release group with:
- Docker applications (with `@nx/docker:release-publish` executor)
- Regular npm packages

Currently, the npm packages would incorrectly receive docker configuration and potentially be processed during docker operations, even though they don't have docker capabilities.

Additionally, a regression was observed where projects without any version changes were still being processed for docker publishing, causing tag failures. #33276

## Expected Behavior

With this PR, docker options are only applied to projects that meet one of these conditions:
1. The project has explicit project-level docker configuration, OR
2. The project has the `nx-release-publish` target with the `@nx/docker:release-publish` executor

This ensures that:
- Only actual docker projects get docker configuration
- Docker processing skips projects without docker targets
- Docker processing skips projects with no version changes (preventing tag failures)
- Mixed release groups (npm + docker) work correctly

The fix includes proper filtering in both the release graph construction and the docker processing pipeline, with test coverage for the described scenarios.

## Related Issue(s)

Fixes #33276