### PR TITLE
feat(nextjs): add support for next 16

### DIFF
--- a/e2e/next/src/__snapshots__/next-e2e-and-snapshots.test.ts.snap
+++ b/e2e/next/src/__snapshots__/next-e2e-and-snapshots.test.ts.snap
@@ -1,8 +1,9 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Next.js Applications - E2E and Snapshots next-env.d.ts should remain the same after a build 1`] = `
 "/// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import './.next/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
@@ -12,6 +13,27 @@ exports[`Next.js Applications - E2E and Snapshots next-env.d.ts should remain th
 exports[`Next.js Applications - E2E and Snapshots next-env.d.ts should remain the same after a build 2`] = `
 "/// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import './.next/types/routes.d.ts';
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+"
+`;
+
+exports[`Next.js Applications - E2E and Snapshots next-env.d.ts should remain the same after a build 3`] = `
+"/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+"
+`;
+
+exports[`Next.js Applications - E2E and Snapshots next-env.d.ts should remain the same after a build 4`] = `
+"/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/e2e/next/src/next-appdir.test.ts
+++ b/e2e/next/src/next-appdir.test.ts
@@ -31,6 +31,8 @@ describe('Next.js App Router', () => {
     );
     runCLI(`generate @nx/js:lib ${jsLib} --no-interactive`);
 
+    // Turbopack interprets the TS source incorrectly assuming ESM despite package.json type stating module
+    // TODO(Colum): remove this when JS Lib generator switches to ESM
     updateJson(`${jsLib}/package.json`, (json) => {
       delete json.type;
       return json;

--- a/e2e/next/src/next-appdir.test.ts
+++ b/e2e/next/src/next-appdir.test.ts
@@ -7,6 +7,7 @@ import {
   runE2ETests,
   uniq,
   updateFile,
+  updateJson,
 } from '@nx/e2e-utils';
 
 describe('Next.js App Router', () => {
@@ -29,6 +30,11 @@ describe('Next.js App Router', () => {
       `generate @nx/next:app ${appName} --e2eTestRunner=playwright --appDir=true`
     );
     runCLI(`generate @nx/js:lib ${jsLib} --no-interactive`);
+
+    updateJson(`${jsLib}/package.json`, (json) => {
+      delete json.type;
+      return json;
+    });
 
     checkFilesExist(`${appName}/src/app/page.tsx`);
     checkFilesExist(`${appName}-e2e/src/example.spec.ts`);
@@ -69,7 +75,7 @@ describe('Next.js App Router', () => {
         `e2e ${appName}-e2e --configuration=production`
       );
       expect(e2eResults).toContain('Successfully ran target e2e for project');
-      expect(await killPorts()).toBeTruthy();
+      await killPorts();
     }
   }, 300_000);
 });

--- a/e2e/next/src/next-e2e-and-snapshots.test.ts
+++ b/e2e/next/src/next-e2e-and-snapshots.test.ts
@@ -63,20 +63,17 @@ describe('Next.js Applications - E2E and Snapshots', () => {
 
     const appDirNextEnv = `${appName}/next-env.d.ts`;
     const appDirNextEnvContent = readFile(appDirNextEnv);
-
+    expect(appDirNextEnvContent).toMatchSnapshot();
     const pagesDirNextEnv = `${pagesAppName}/next-env.d.ts`;
     const pagesDirNextEnvContent = readFile(pagesDirNextEnv);
+    expect(pagesDirNextEnvContent).toMatchSnapshot();
 
     runCLI(`build ${appName}`);
     runCLI(`build ${pagesAppName}`);
 
     const postBuildAppContent = readFile(appDirNextEnv);
     const postBuildPagesContent = readFile(pagesDirNextEnv);
-
-    expect(postBuildAppContent).toEqual(appDirNextEnvContent);
     expect(postBuildAppContent).toMatchSnapshot();
-
-    expect(postBuildPagesContent).toEqual(pagesDirNextEnvContent);
     expect(postBuildPagesContent).toMatchSnapshot();
   });
 });

--- a/e2e/next/src/next-styles.test.ts
+++ b/e2e/next/src/next-styles.test.ts
@@ -39,6 +39,7 @@ describe('Next.js Styles', () => {
       checkUnitTest: false,
       checkLint: false,
       checkE2E: false,
+      useWebpack: true,
     });
 
     const scApp = uniq('app');

--- a/e2e/next/src/next-webpack.test.ts
+++ b/e2e/next/src/next-webpack.test.ts
@@ -87,7 +87,7 @@ describe('Next.js Webpack', () => {
     // by the time it reaches the build executor.
     // this simulates existing behaviour of running a next.js build executor via Nx
     delete process.env.NODE_ENV;
-    const result = runCLI(`build ${appName}`);
+    const result = runCLI(`build ${appName} --webpack`);
 
     checkFilesExist(`dist/${appName}/next.config.js`);
     expect(result).toContain('NODE_ENV is production');
@@ -103,7 +103,7 @@ describe('Next.js Webpack', () => {
       `
     );
     rmDist();
-    runCLI(`build ${appName}`);
+    runCLI(`build ${appName} --webpack`);
     checkFilesExist(`dist/${appName}/next.config.js`);
 
     // Make sure withNx works with run-commands.
@@ -118,7 +118,7 @@ describe('Next.js Webpack', () => {
       return json;
     });
     expect(() => {
-      runCLI(`build ${appName}`);
+      runCLI(`build ${appName} --webpack`);
     }).not.toThrow();
     checkFilesExist(`dist/${appName}/.next/build-manifest.json`);
   }, 300_000);

--- a/e2e/next/src/utils.ts
+++ b/e2e/next/src/utils.ts
@@ -15,6 +15,7 @@ export async function checkApp(
     checkLint: boolean;
     checkE2E: boolean;
     appsDir?: string;
+    useWebpack?: boolean;
   }
 ) {
   if (opts.checkLint) {
@@ -29,7 +30,9 @@ export async function checkApp(
     );
   }
 
-  const buildResult = runCLI(`build ${appName}`);
+  const buildResult = runCLI(
+    `build ${appName}${opts.useWebpack ? ' --webpack' : ''}`
+  );
   expect(buildResult).toContain(`Successfully ran target build`);
   // Executor will point to dist, whereas inferred build target will output to `<proj-root>/.next`
   try {

--- a/packages/next/docs/server-next-executor-examples.md
+++ b/packages/next/docs/server-next-executor-examples.md
@@ -62,19 +62,24 @@ This is the default configuration for Next.js standalone projects. Our `@nx/next
 ```
 
 {% /tab %}
-{% tab label="Enable turbo" %}
+{% tab label="Choosing your bundler" %}
 
-Turbopack (beta) is a cutting-edge bundler designed for JavaScript and TypeScript. To read more about support features see [Next.js Turbopack Documentation](https://turbo.build/pack/docs/features)
+Turbopack is a cutting-edge bundler designed for JavaScript and TypeScript. To read more about supported features see [Next.js Turbopack Documentation](https://turbo.build/pack/docs/features)
 
-In the context of Nx, you can utilize Turbopack within both the `pages` and `app` directories of Next.js to enhance local development speed. To activate Turbopack, simply:
+**Important: Next.js 16 changed the default bundler**
 
-Append the `--turbo` flag while executing the Nx development server.
+- **Next.js 15 and below**: webpack is the default bundler. Use `--turbo` to enable Turbopack.
+- **Next.js 16 and above**: Turbopack is the default bundler. Use `--webpack` to use webpack instead.
+
+### Using Turbopack in Next.js 15 and below
+
+Append the `--turbo` flag while executing the Nx development server:
 
 ```shell
 nx run acme:serve --turbo
 ```
 
-Updating the build options to include `turbo`.
+Or update the serve options to include `turbo`:
 
 ```json
     "serve": {
@@ -89,14 +94,37 @@ Updating the build options to include `turbo`.
           "buildTarget": "acme:build:development",
           "dev": true,
           "turbo": true
-        },
-        //
+        }
+      }
     }
-  }
 ```
 
-```bash
-nx run acme:serve
+### Using webpack in Next.js 16 and above
+
+If you need to use webpack instead of the default Turbopack in Next.js 16+:
+
+```shell
+nx run acme:serve --webpack
+```
+
+Or update the serve options to include `webpack`:
+
+```json
+    "serve": {
+      "executor": "@nx/next:server",
+      "defaultConfiguration": "development",
+      "options": {
+        "buildTarget": "acme:build",
+        "dev": true
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "acme:build:development",
+          "dev": true,
+          "webpack": true
+        }
+      }
+    }
 ```
 
 {% /tab %}

--- a/packages/next/docs/server-next-executor-examples.md
+++ b/packages/next/docs/server-next-executor-examples.md
@@ -68,8 +68,8 @@ Turbopack is a cutting-edge bundler designed for JavaScript and TypeScript. To r
 
 **Important: Next.js 16 changed the default bundler**
 
-- **Next.js 15 and below**: webpack is the default bundler. Use `--turbo` to enable Turbopack.
-- **Next.js 16 and above**: Turbopack is the default bundler. Use `--webpack` to use webpack instead.
+- **Next.js 15 and below**: Webpack is the default bundler. Use `--turbo` to enable Turbopack.
+- **Next.js 16 and above**: Turbopack is the default bundler. Use `--webpack` to use Webpack instead.
 
 ### Using Turbopack in Next.js 15 and below
 
@@ -99,9 +99,9 @@ Or update the serve options to include `turbo`:
     }
 ```
 
-### Using webpack in Next.js 16 and above
+### Using Webpack in Next.js 16 and above
 
-If you need to use webpack instead of the default Turbopack in Next.js 16+:
+If you need to use Webpack instead of the default Turbopack in Next.js 16+:
 
 ```shell
 nx run acme:serve --webpack

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -32,7 +32,7 @@
     "migrations": "./migrations.json"
   },
   "peerDependencies": {
-    "next": ">=14.0.0"
+    "next": ">=14.0.0 <17.0.0"
   },
   "dependencies": {
     "@nx/devkit": "workspace:*",

--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -12,6 +12,7 @@ import {
   type Target,
 } from '@nx/devkit';
 import type { AssetGlobPattern } from '@nx/webpack';
+import { satisfies } from 'semver';
 
 export interface WithNxOptions extends NextConfig {
   nx?: {
@@ -243,12 +244,21 @@ export function getNextConfig(
   }
   const userWebpack = nextConfig.webpack || ((x) => x);
   const { nx, ...validNextConfig } = nextConfig;
-  return {
-    eslint: {
+
+  const baseConfig: NextConfig = {
+    ...validNextConfig,
+  };
+
+  const nextJsVersion = require('next/package.json')?.version ?? '16.0.1';
+  if (satisfies(nextJsVersion, '<16.0.0', { includePrerelease: true })) {
+    baseConfig.eslint = {
       ignoreDuringBuilds: true,
       ...(validNextConfig.eslint ?? {}),
-    },
-    ...validNextConfig,
+    };
+  }
+
+  return {
+    ...baseConfig,
     webpack: (config, options) => {
       /**
        * To support ESM library export, we need to ensure the extensionAlias contains both `.js` and `.ts` extensions.

--- a/packages/next/src/executors/build/schema.json
+++ b/packages/next/src/executors/build/schema.json
@@ -82,6 +82,14 @@
       "type": "string",
       "description": "Change the build mode.",
       "enum": ["compile", "generate"]
+    },
+    "turbo": {
+      "type": "boolean",
+      "description": "Use Turbopack for building (Next.js 15 and below). In Next.js 16+, Turbopack is enabled by default."
+    },
+    "webpack": {
+      "type": "boolean",
+      "description": "Use webpack bundler instead of Turbopack (Next.js 16+ only). This flag is only applicable in Next.js 16 and above where Turbopack is the default."
     }
   },
   "required": ["outputPath"],

--- a/packages/next/src/executors/server/schema.json
+++ b/packages/next/src/executors/server/schema.json
@@ -52,7 +52,11 @@
     },
     "turbo": {
       "type": "boolean",
-      "description": "Activate the incremental bundler for Next.js, which is implemented in Rust. Please note, this feature is exclusively available in development mode."
+      "description": "Activate Turbopack for Next.js (Next.js 15 and below). In Next.js 16+, Turbopack is enabled by default for development mode."
+    },
+    "webpack": {
+      "type": "boolean",
+      "description": "Use webpack bundler instead of Turbopack (Next.js 16+ only). This flag is only applicable in Next.js 16 and above where Turbopack is the default for development mode."
     },
     "experimentalHttps": {
       "type": "boolean",

--- a/packages/next/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/next/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`app --style styled-jsx should use <style jsx> in index page 1`] = `
 "'use client';

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -663,7 +663,7 @@ describe('app', () => {
         });
       });
 
-      it('should install eslint-config-next@14 when an existing Next.js 15 project is detected', async () => {
+      it('should install eslint-config-next@15 when an existing Next.js 15 project is detected', async () => {
         tree.write(
           '/package.json',
           JSON.stringify({

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -657,6 +657,33 @@ describe('app', () => {
         const packageJson = readJson(tree, '/package.json');
         expect(packageJson).toMatchObject({
           devDependencies: {
+            'eslint-config-next': '^16.0.1',
+            '@next/eslint-plugin-next': '^16.0.1',
+          },
+        });
+      });
+
+      it('should install eslint-config-next@14 when an existing Next.js 15 project is detected', async () => {
+        tree.write(
+          '/package.json',
+          JSON.stringify({
+            name: '@proj/source',
+            dependencies: {
+              next: '~15.2.4',
+            },
+            devDependencies: {},
+          })
+        );
+
+        const name = uniq();
+        await applicationGenerator(tree, {
+          directory: name,
+          style: 'css',
+        });
+
+        const packageJson = readJson(tree, '/package.json');
+        expect(packageJson).toMatchObject({
+          devDependencies: {
             'eslint-config-next': '^15.2.4',
             '@next/eslint-plugin-next': '^15.2.4',
           },

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -590,19 +590,12 @@ describe('app', () => {
 
         expect(tree.read(`${name}/eslint.config.mjs`, 'utf-8'))
           .toMatchInlineSnapshot(`
-          "import { FlatCompat } from '@eslint/eslintrc';
-          import { dirname } from 'path';
-          import { fileURLToPath } from 'url';
-          import js from '@eslint/js';
+          "import nextEslintPluginNext from '@next/eslint-plugin-next';
           import nx from '@nx/eslint-plugin';
           import baseConfig from '../eslint.config.mjs';
-          const compat = new FlatCompat({
-            baseDirectory: dirname(fileURLToPath(import.meta.url)),
-            recommendedConfig: js.configs.recommended,
-          });
 
           export default [
-            ...compat.extends('next', 'next/core-web-vitals'),
+            { plugins: { '@next/next': nextEslintPluginNext } },
             ...baseConfig,
             ...nx.configs['flat/react-typescript'],
             {
@@ -624,18 +617,12 @@ describe('app', () => {
 
         expect(tree.read(`${name}/eslint.config.cjs`, 'utf-8'))
           .toMatchInlineSnapshot(`
-          "const { FlatCompat } = require('@eslint/eslintrc');
-          const js = require('@eslint/js');
+          "const nextEslintPluginNext = require('@next/eslint-plugin-next');
           const nx = require('@nx/eslint-plugin');
           const baseConfig = require('../eslint.config.cjs');
 
-          const compat = new FlatCompat({
-            baseDirectory: __dirname,
-            recommendedConfig: js.configs.recommended,
-          });
-
           module.exports = [
-            ...compat.extends('next', 'next/core-web-vitals'),
+            { plugins: { '@next/next': nextEslintPluginNext } },
 
             ...baseConfig,
             ...nx.configs['flat/react-typescript'],
@@ -802,6 +789,57 @@ describe('app', () => {
           ]
         `
         );
+      });
+
+      it('should setup eslint config for standalone projects', async () => {
+        const name = uniq();
+        const prevEslintUseFlatConfigEnvVarValue =
+          process.env['ESLINT_USE_FLAT_CONFIG'];
+        process.env['ESLINT_USE_FLAT_CONFIG'] = 'true';
+        await applicationGenerator(tree, {
+          name,
+          directory: '.',
+          style: 'css',
+          linter: 'eslint',
+          appDir: true,
+          rootProject: true,
+        });
+
+        const eslintContents = tree.read('eslint.config.mjs', 'utf-8');
+
+        expect(eslintContents).toMatchInlineSnapshot(`
+          "import nextEslintPluginNext from '@next/eslint-plugin-next';
+          import nx from '@nx/eslint-plugin';
+
+          export default [
+            { plugins: { '@next/next': nextEslintPluginNext } },
+            ...nx.configs['flat/base'],
+            ...nx.configs['flat/typescript'],
+            ...nx.configs['flat/javascript'],
+            {
+              ignores: ['**/dist', '.next/**/*'],
+            },
+            {
+              files: [
+                '**/*.ts',
+                '**/*.tsx',
+                '**/*.cts',
+                '**/*.mts',
+                '**/*.js',
+                '**/*.jsx',
+                '**/*.cjs',
+                '**/*.mjs',
+              ],
+              rules: {
+                '@next/next/no-html-link-for-pages': ['error', './pages'],
+              },
+            },
+            ...nx.configs['flat/react-typescript'],
+          ];
+          "
+        `);
+        process.env['ESLINT_USE_FLAT_CONFIG'] =
+          prevEslintUseFlatConfigEnvVarValue;
       });
 
       it('should scope tsconfig to the src/ project directory', async () => {
@@ -1074,33 +1112,36 @@ describe('app', () => {
           }
         `);
       expect(readJson(tree, 'myapp-e2e/tsconfig.json')).toMatchInlineSnapshot(`
-          {
-            "compilerOptions": {
-              "allowJs": true,
-              "outDir": "out-tsc/cypress",
-              "sourceMap": false,
-              "types": [
-                "cypress",
-                "node",
-              ],
-            },
-            "exclude": [
-              "out-tsc",
-              "test-output",
+        {
+          "compilerOptions": {
+            "allowJs": true,
+            "outDir": "out-tsc/cypress",
+            "sourceMap": false,
+            "types": [
+              "cypress",
+              "node",
             ],
-            "extends": "../tsconfig.base.json",
-            "include": [
-              "**/*.ts",
-              "**/*.js",
-              "cypress.config.ts",
-              "**/*.cy.ts",
-              "**/*.cy.tsx",
-              "**/*.cy.js",
-              "**/*.cy.jsx",
-              "**/*.d.ts",
-            ],
-          }
-        `);
+          },
+          "exclude": [
+            "out-tsc",
+            "test-output",
+            "eslint.config.js",
+            "eslint.config.cjs",
+            "eslint.config.mjs",
+          ],
+          "extends": "../tsconfig.base.json",
+          "include": [
+            "**/*.ts",
+            "**/*.js",
+            "cypress.config.ts",
+            "**/*.cy.ts",
+            "**/*.cy.tsx",
+            "**/*.cy.js",
+            "**/*.cy.jsx",
+            "**/*.d.ts",
+          ],
+        }
+      `);
     });
 
     it('should respect the provided name', async () => {

--- a/packages/next/src/generators/application/files/common/next-env.d.ts__tmpl__
+++ b/packages/next/src/generators/application/files/common/next-env.d.ts__tmpl__
@@ -1,5 +1,6 @@
 /// <reference types="next" />
-/// <reference types="next/image-types/global" />
+/// <reference types="next/image-types/global" /><% if(isNext16) { %>
+import './.next/types/routes.d.ts';<% } %>
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/<%- appDirType %>/api-reference/config/typescript for more information.

--- a/packages/next/src/generators/application/lib/add-e2e.ts
+++ b/packages/next/src/generators/application/lib/add-e2e.ts
@@ -11,6 +11,7 @@ import { getE2EWebServerInfo } from '@nx/devkit/src/generators/e2e-web-server-in
 import { webStaticServeGenerator } from '@nx/web';
 import type { PackageJson } from 'nx/src/utils/package-json';
 import { nxVersion } from '../../../utils/versions';
+import { isNext16 } from '../../../utils/version-utils';
 import { NormalizedSchema } from './normalize-options';
 
 export async function addE2e(
@@ -31,6 +32,7 @@ export async function addE2e(
     options.addPlugin
   );
 
+  const forceWebpack = options.style === 'less' && (await isNext16(host));
   if (options.e2eTestRunner === 'cypress') {
     const { configurationGenerator } = ensurePackage<
       typeof import('@nx/cypress')
@@ -84,7 +86,9 @@ export async function addE2e(
       baseUrl: e2eWebServerInfo.e2eWebServerAddress,
       jsx: true,
       webServerCommands: {
-        default: e2eWebServerInfo.e2eWebServerCommand,
+        default: `${e2eWebServerInfo.e2eWebServerCommand}${
+          forceWebpack ? ' --webpack' : ''
+        }`,
       },
       ciWebServerCommand: e2eWebServerInfo.e2eCiWebServerCommand,
       ciBaseUrl: e2eWebServerInfo.e2eCiBaseUrl,
@@ -135,7 +139,9 @@ export async function addE2e(
       linter: options.linter,
       setParserOptionsProject: options.setParserOptionsProject,
       webServerAddress: e2eWebServerInfo.e2eCiBaseUrl,
-      webServerCommand: e2eWebServerInfo.e2eCiWebServerCommand,
+      webServerCommand: `${e2eWebServerInfo.e2eWebServerCommand}${
+        forceWebpack ? ' --webpack' : ''
+      }`,
       addPlugin: options.addPlugin,
     });
 

--- a/packages/next/src/generators/application/lib/add-linting.spec.ts
+++ b/packages/next/src/generators/application/lib/add-linting.spec.ts
@@ -103,18 +103,12 @@ describe('updateEslint', () => {
 
     expect(tree.read(`${schema.appProjectRoot}/eslint.config.cjs`, 'utf-8'))
       .toMatchInlineSnapshot(`
-      "const { FlatCompat } = require("@eslint/eslintrc");
-      const js = require("@eslint/js");
+      "const nextEslintPluginNext = require("@next/eslint-plugin-next");
       const nx = require("@nx/eslint-plugin");
       const baseConfig = require("../eslint.config.cjs");
 
-      const compat = new FlatCompat({
-        baseDirectory: __dirname,
-        recommendedConfig: js.configs.recommended,
-      });
-
       module.exports = [
-          ...compat.extends("next", "next/core-web-vitals"),
+          { plugins: { "@next/next": nextEslintPluginNext } },
 
           ...baseConfig,
           ...nx.configs["flat/react-typescript"],

--- a/packages/next/src/generators/application/lib/create-application-files.ts
+++ b/packages/next/src/generators/application/lib/create-application-files.ts
@@ -17,8 +17,12 @@ import {
   createStyleRules,
 } from './create-application-files.helpers';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { isNext16 } from '../../../utils/version-utils';
 
-export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
+export async function createApplicationFiles(
+  host: Tree,
+  options: NormalizedSchema
+) {
   const offsetFromRoot = _offsetFromRoot(options.appProjectRoot);
   const layoutTypeSrcPath = joinPathFragments(
     offsetFromRoot,
@@ -59,6 +63,7 @@ export function createApplicationFiles(host: Tree, options: NormalizedSchema) {
     pageStyleContent: `.page {}`,
     stylesExt: options.style === 'less' ? options.style : 'css',
     isUsingTsSolutionSetup: isUsingTsSolutionSetup(host),
+    isNext16: await isNext16(host),
   };
 
   const generatedAppFilePath = options.src

--- a/packages/next/src/generators/init/init.spec.ts
+++ b/packages/next/src/generators/init/init.spec.ts
@@ -1,7 +1,17 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { readJson, Tree, ProjectGraph } from '@nx/devkit';
+import {
+  readJson,
+  Tree,
+  ProjectGraph,
+  addDependenciesToPackageJson,
+} from '@nx/devkit';
 
 import { nextInitGenerator } from './init';
+import {
+  next14Version,
+  next15Version,
+  next16Version,
+} from '../../utils/versions';
 
 let projectGraph: ProjectGraph;
 jest.mock('@nx/devkit', () => ({
@@ -17,6 +27,7 @@ describe('init', () => {
     projectGraph = {
       nodes: {},
       dependencies: {},
+      externalNodes: {},
     };
     tree = createTreeWithEmptyWorkspace();
   });
@@ -27,5 +38,53 @@ describe('init', () => {
     expect(packageJson.dependencies['@nx/react']).toBeUndefined();
     expect(packageJson.devDependencies['@nx/next']).toBeDefined();
     expect(packageJson.dependencies['next']).toBeDefined();
+  });
+
+  it('should install Next.js 16 by default for new workspaces', async () => {
+    await nextInitGenerator(tree, {});
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.dependencies['next']).toBe(next16Version);
+  });
+
+  it('should keep Next.js 15 when already installed', async () => {
+    projectGraph.externalNodes = {
+      'npm:next': {
+        type: 'npm',
+        name: 'npm:next',
+        data: {
+          packageName: 'next',
+          version: '15.2.4',
+        },
+      },
+    };
+
+    await nextInitGenerator(tree, {});
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.dependencies['next']).toBe(next15Version);
+  });
+
+  it('should keep Next.js 14 when already installed', async () => {
+    projectGraph.externalNodes = {
+      'npm:next': {
+        type: 'npm',
+        name: 'npm:next',
+        data: {
+          packageName: 'next',
+          version: '14.2.26',
+        },
+      },
+    };
+
+    await nextInitGenerator(tree, {});
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.dependencies['next']).toBe(next14Version);
+  });
+
+  it('should respect keepExistingVersions option', async () => {
+    addDependenciesToPackageJson(tree, { next: '15.0.0' }, {});
+
+    await nextInitGenerator(tree, { keepExistingVersions: true });
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.dependencies['next']).toBe('15.0.0');
   });
 });

--- a/packages/next/src/utils/runtime-version-utils.spec.ts
+++ b/packages/next/src/utils/runtime-version-utils.spec.ts
@@ -1,0 +1,20 @@
+import { getInstalledNextVersionRuntime } from './runtime-version-utils';
+
+describe('getInstalledNextVersionRuntime', () => {
+  // Integration test - tests the function in the actual environment
+  // Since Next.js is installed in this monorepo, we test that it returns a valid version
+  it('should return a number when called in an environment with Next.js', () => {
+    const result = getInstalledNextVersionRuntime();
+
+    // In this Nx monorepo, Next.js should be installed
+    // We don't assert the exact version as it may change, but it should be a valid number
+    expect(typeof result).toBe('number');
+    expect(result).toBeGreaterThanOrEqual(14); // Should be at least version 14
+  });
+
+  it('should return null or a number (never undefined)', () => {
+    const result = getInstalledNextVersionRuntime();
+
+    expect(result === null || typeof result === 'number').toBe(true);
+  });
+});

--- a/packages/next/src/utils/runtime-version-utils.ts
+++ b/packages/next/src/utils/runtime-version-utils.ts
@@ -1,0 +1,26 @@
+import { clean, coerce, major } from 'semver';
+import { readJsonFile } from '@nx/devkit';
+
+/**
+ * Get the installed Next.js major version at runtime without requiring a Tree object.
+ * This is useful for executors that need to detect the Next.js version during execution.
+ *
+ * @returns The major version number of the installed Next.js package, or null if not found
+ */
+export function getInstalledNextVersionRuntime(): number | null {
+  try {
+    const nextPackageJsonPath = require.resolve('next/package.json', {
+      paths: [process.cwd()],
+    });
+    const nextPackageJson = readJsonFile(nextPackageJsonPath);
+    const cleanedVersion =
+      clean(nextPackageJson.version) ??
+      coerce(nextPackageJson.version)?.version;
+    if (!cleanedVersion) {
+      return null;
+    }
+    return major(cleanedVersion);
+  } catch {
+    return null;
+  }
+}

--- a/packages/next/src/utils/types.ts
+++ b/packages/next/src/utils/types.ts
@@ -41,7 +41,9 @@ export interface NextBuildBuilderOptions {
   profile?: boolean;
   skipOverrides?: boolean;
   skipPackageManager?: boolean;
+  turbo?: boolean;
   watch?: boolean;
+  webpack?: boolean;
 }
 
 export interface NextServeBuilderOptions {
@@ -55,6 +57,7 @@ export interface NextServeBuilderOptions {
   buildLibsFromSource?: boolean;
   keepAliveTimeout?: number;
   turbo?: boolean;
+  webpack?: boolean;
   experimentalHttps?: boolean;
   experimentalHttpsKey?: string;
   experimentalHttpsCert?: string;

--- a/packages/next/src/utils/version-utils.spec.ts
+++ b/packages/next/src/utils/version-utils.spec.ts
@@ -1,0 +1,206 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { Tree, ProjectGraph, addDependenciesToPackageJson } from '@nx/devkit';
+import {
+  isNext14,
+  isNext15,
+  getNextDependenciesVersionsToInstall,
+} from './version-utils';
+import { next14Version, next15Version, next16Version } from './versions';
+
+let projectGraph: ProjectGraph;
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual<any>('@nx/devkit'),
+  createProjectGraphAsync: jest.fn().mockImplementation(async () => {
+    return projectGraph;
+  }),
+}));
+
+describe('version-utils', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    projectGraph = {
+      nodes: {},
+      dependencies: {},
+      externalNodes: {},
+    };
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('isNext15', () => {
+    it('should return true when Next.js 15 is installed from project graph', async () => {
+      projectGraph.externalNodes = {
+        'npm:next': {
+          type: 'npm',
+          name: 'npm:next',
+          data: {
+            packageName: 'next',
+            version: '15.2.4',
+          },
+        },
+      };
+
+      const result = await isNext15(tree);
+      expect(result).toBe(true);
+    });
+
+    it('should return true when Next.js 15 is installed from package.json', async () => {
+      addDependenciesToPackageJson(tree, { next: '15.2.4' }, {});
+
+      const result = await isNext15(tree);
+      expect(result).toBe(true);
+    });
+
+    it('should return false when Next.js 14 is installed', async () => {
+      projectGraph.externalNodes = {
+        'npm:next': {
+          type: 'npm',
+          name: 'npm:next',
+          data: {
+            packageName: 'next',
+            version: '14.2.26',
+          },
+        },
+      };
+
+      const result = await isNext15(tree);
+      expect(result).toBe(false);
+    });
+
+    it('should return false when Next.js 16 is installed', async () => {
+      projectGraph.externalNodes = {
+        'npm:next': {
+          type: 'npm',
+          name: 'npm:next',
+          data: {
+            packageName: 'next',
+            version: '16.0.1',
+          },
+        },
+      };
+
+      const result = await isNext15(tree);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isNext14', () => {
+    it('should return true when Next.js 14 is installed from project graph', async () => {
+      projectGraph.externalNodes = {
+        'npm:next': {
+          type: 'npm',
+          name: 'npm:next',
+          data: {
+            packageName: 'next',
+            version: '14.2.26',
+          },
+        },
+      };
+
+      const result = await isNext14(tree);
+      expect(result).toBe(true);
+    });
+
+    it('should return true when Next.js 14 is installed from package.json', async () => {
+      addDependenciesToPackageJson(tree, { next: '14.2.26' }, {});
+
+      const result = await isNext14(tree);
+      expect(result).toBe(true);
+    });
+
+    it('should return false when Next.js 15 is installed', async () => {
+      projectGraph.externalNodes = {
+        'npm:next': {
+          type: 'npm',
+          name: 'npm:next',
+          data: {
+            packageName: 'next',
+            version: '15.2.4',
+          },
+        },
+      };
+
+      const result = await isNext14(tree);
+      expect(result).toBe(false);
+    });
+
+    it('should return false when Next.js 16 is installed', async () => {
+      projectGraph.externalNodes = {
+        'npm:next': {
+          type: 'npm',
+          name: 'npm:next',
+          data: {
+            packageName: 'next',
+            version: '16.0.1',
+          },
+        },
+      };
+
+      const result = await isNext14(tree);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getNextDependenciesVersionsToInstall', () => {
+    it('should return Next.js 15 versions when Next.js 15 is installed', async () => {
+      projectGraph.externalNodes = {
+        'npm:next': {
+          type: 'npm',
+          name: 'npm:next',
+          data: {
+            packageName: 'next',
+            version: '15.2.4',
+          },
+        },
+      };
+
+      const result = await getNextDependenciesVersionsToInstall(tree);
+      expect(result).toEqual({
+        next: next15Version,
+      });
+    });
+
+    it('should return Next.js 14 versions when Next.js 14 is installed', async () => {
+      projectGraph.externalNodes = {
+        'npm:next': {
+          type: 'npm',
+          name: 'npm:next',
+          data: {
+            packageName: 'next',
+            version: '14.2.26',
+          },
+        },
+      };
+
+      const result = await getNextDependenciesVersionsToInstall(tree);
+      expect(result).toEqual({
+        next: next14Version,
+      });
+    });
+
+    it('should return Next.js 16 versions (default) when no Next.js is installed', async () => {
+      const result = await getNextDependenciesVersionsToInstall(tree);
+      expect(result).toEqual({
+        next: next16Version,
+      });
+    });
+
+    it('should return Next.js 16 versions when Next.js 16 is installed', async () => {
+      projectGraph.externalNodes = {
+        'npm:next': {
+          type: 'npm',
+          name: 'npm:next',
+          data: {
+            packageName: 'next',
+            version: '16.0.1',
+          },
+        },
+      };
+
+      const result = await getNextDependenciesVersionsToInstall(tree);
+      expect(result).toEqual({
+        next: next16Version,
+      });
+    });
+  });
+});

--- a/packages/next/src/utils/version-utils.ts
+++ b/packages/next/src/utils/version-utils.ts
@@ -6,9 +6,11 @@ import {
 import { clean, coerce, major } from 'semver';
 import {
   nextVersion,
+  next15Version,
   next14Version,
-  eslintConfigNext14Version,
   eslintConfigNextVersion,
+  eslintConfigNext15Version,
+  eslintConfigNext14Version,
 } from './versions';
 
 type NextDependenciesVersions = {
@@ -25,6 +27,10 @@ export async function getNextDependenciesVersionsToInstall(
     return {
       next: next14Version,
     };
+  } else if (await isNext15(tree)) {
+    return {
+      next: next15Version,
+    };
   } else {
     return {
       next: nextVersion,
@@ -35,11 +41,21 @@ export async function getNextDependenciesVersionsToInstall(
 export async function getEslintConfigNextDependenciesVersionsToInstall(
   tree: Tree
 ): Promise<EslintConfigNextVersion> {
-  if (await isNext14(tree)) {
+  if (await isNext15(tree)) {
+    return eslintConfigNext15Version;
+  } else if (await isNext14(tree)) {
     return eslintConfigNext14Version;
   } else {
     return eslintConfigNextVersion;
   }
+}
+
+export async function isNext15(tree: Tree) {
+  let installedNextVersion = await getInstalledNextVersionFromGraph();
+  if (!installedNextVersion) {
+    installedNextVersion = getInstalledNextVersion(tree);
+  }
+  return major(installedNextVersion) === 15;
 }
 
 export async function isNext14(tree: Tree) {

--- a/packages/next/src/utils/version-utils.ts
+++ b/packages/next/src/utils/version-utils.ts
@@ -50,6 +50,14 @@ export async function getEslintConfigNextDependenciesVersionsToInstall(
   }
 }
 
+export async function isNext16(tree: Tree) {
+  let installedNextVersion = await getInstalledNextVersionFromGraph();
+  if (!installedNextVersion) {
+    installedNextVersion = getInstalledNextVersion(tree);
+  }
+  return major(installedNextVersion) === 16;
+}
+
 export async function isNext15(tree: Tree) {
   let installedNextVersion = await getInstalledNextVersionFromGraph();
   if (!installedNextVersion) {

--- a/packages/next/src/utils/versions.ts
+++ b/packages/next/src/utils/versions.ts
@@ -1,9 +1,13 @@
 export const nxVersion = require('../../package.json').version;
 
-export const nextVersion = '~15.2.4';
+export const next16Version = '~16.0.1';
+export const next15Version = '~15.2.4';
 export const next14Version = '~14.2.26';
-export const eslintConfigNextVersion = '^15.2.4';
+export const nextVersion = next16Version;
+export const eslintConfigNext16Version = '^16.0.1';
+export const eslintConfigNext15Version = '^15.2.4';
 export const eslintConfigNext14Version = '~14.2.26';
+export const eslintConfigNextVersion = eslintConfigNext16Version;
 export const sassVersion = '1.62.1';
 export const lessLoader = '11.1.0';
 export const emotionServerVersion = '11.11.0';

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
@@ -383,6 +383,7 @@ function registerPendingPromise(
 }
 
 global.nxPluginWorkerCount ??= 0;
+
 async function startPluginWorker() {
   // this should only really be true when running unit tests within
   // the Nx repo. We still need to start the worker in this case,
@@ -404,7 +405,7 @@ async function startPluginWorker() {
   };
 
   const ipcPath = getPluginOsSocketPath(
-    [process.pid, global.nxPluginWorkerCount++].join('-')
+    [process.pid, global.nxPluginWorkerCount++, performance.now()].join('-')
   );
 
   const worker = spawn(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3494,7 +3494,7 @@ importers:
         specifier: ^5.0.4
         version: 5.3.2
       next:
-        specifier: '>=14.0.0'
+        specifier: '>=14.0.0 <17.0.0'
         version: 14.2.28(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.90.0)
       semver:
         specifier: 'catalog:'


### PR DESCRIPTION
## Current Behavior
We currently support Next 14 and 15.

## Expected Behavior
Add support for Next 16, bringing support to 14, 15, 16.
Existing workspaces will continue to use the version they are on.
New workspaces will use Next 16.

Refer to Next 16 Migration Guide for migrating from Next 15 to 16

## Related Issue(s)

Fixes #33207
