### PR TITLE
feat(js): improve SWC compilation error logging

### DIFF
--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -89,9 +89,12 @@ export async function compileSwc(
     });
     logger.log(swcCmdLog.replace(/\n/, ''));
   } catch (error) {
-    logger.error('SWC compilation failed');
-    if (error.stderr) {
+    logger.error(`SWC compilation failed: ${error?.message ?? error}`);
+    if (error?.stderr) {
       logger.error(error.stderr.toString());
+    }
+    if (error?.stdout) {
+      logger.error(error.stdout.toString());
     }
     return { success: false };
   }


### PR DESCRIPTION
Currently, when SWC compilation fails, Nx logs only a generic message:

  "SWC compilation failed"

There is no `error.message`, no `stderr` and no `stdout` printed.  
In many cases the actual cause of failure is completely hidden, which makes debugging very difficult, especially in CI.

This PR improves the logging by printing:

- error.message (or the error itself)
- stderr if available
- stdout if available

This makes SWC failures visible and debuggable again.



## Current Behavior
Only a generic "SWC compilation failed" message is logged. No error message or stdout are shown.

## Expected Behavior
Include error.message, stderr, and stdout (when available) so developers can understand and debug failures.
