### PR TITLE
fix(core): also look in .nx installation when reading nx.json extends

### DIFF
--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -11,6 +11,7 @@ import type {
   TargetConfiguration,
   TargetDependencyConfig,
 } from './workspace-json-project-json';
+import { getNxRequirePaths } from '../utils/installation-directory';
 
 export type ImplicitDependencyEntry<T = '*' | string[]> = {
   [key: string]: T | ImplicitJsonSubsetDependency<T>;
@@ -892,12 +893,8 @@ export function readNxJson(root: string = workspaceRoot): NxJsonConfiguration {
   if (existsSync(nxJson)) {
     const nxJsonConfiguration = readJsonFile<NxJsonConfiguration>(nxJson);
     if (nxJsonConfiguration.extends) {
-      const paths = [dirname(nxJson)];
-      if (nxJsonConfiguration.installation) {
-        paths.push(join(root, '.nx', 'installation'));
-      }
       const extendedNxJsonPath = require.resolve(nxJsonConfiguration.extends, {
-        paths,
+        paths: getNxRequirePaths(root),
       });
       const baseNxJson = readJsonFile<NxJsonConfiguration>(extendedNxJsonPath);
       return {

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -892,8 +892,12 @@ export function readNxJson(root: string = workspaceRoot): NxJsonConfiguration {
   if (existsSync(nxJson)) {
     const nxJsonConfiguration = readJsonFile<NxJsonConfiguration>(nxJson);
     if (nxJsonConfiguration.extends) {
+      const paths = [dirname(nxJson)];
+      if (nxJsonConfiguration.installation) {
+        paths.push(join(root, '.nx', 'installation'));
+      }
       const extendedNxJsonPath = require.resolve(nxJsonConfiguration.extends, {
-        paths: [dirname(nxJson)],
+        paths,
       });
       const baseNxJson = readJsonFile<NxJsonConfiguration>(extendedNxJsonPath);
       return {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
in a `.nx` installation, `require.resolve` won't find the `extends` preset nx.json file because there are no root `node_modules`

## Expected Behavior
in a `.nx` installation, the nested `.nx/installation/node_modules` are also used to try and resolve the preset.
