### PR TITLE
fix(vite): prevent race-condition when importing @vitejs/plugin-vue

### DIFF
--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -203,6 +203,18 @@ async function buildViteTargets(
   } catch {
     // do nothing
   }
+  // Workaround for race condition with ESM-only Vite plugins (e.g. @vitejs/plugin-vue@6+)
+  // If vite.config.ts is compiled as CJS, then when both require('@vitejs/plugin-vue') and import('@vitejs/plugin-vue')
+  // are pending in the same process, Node will throw an error:
+  // Error [ERR_INTERNAL_ASSERTION]: Cannot require() ES Module @vitejs/plugin-vue/dist/index.js because it is not yet fully loaded. 
+  // This may be caused by a race condition if the module is simultaneously dynamically import()-ed via Promise.all().
+  try {
+    const importVuePlugin = () =>
+      new Function('return import("@vitejs/plugin-vue")')();
+    await importVuePlugin();
+  } catch {
+    // Plugin not installed or not needed, ignore
+  }
   const { resolveConfig } = await loadViteDynamicImport();
   const viteBuildConfig = await resolveConfig(
     {

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -206,7 +206,7 @@ async function buildViteTargets(
   // Workaround for race condition with ESM-only Vite plugins (e.g. @vitejs/plugin-vue@6+)
   // If vite.config.ts is compiled as CJS, then when both require('@vitejs/plugin-vue') and import('@vitejs/plugin-vue')
   // are pending in the same process, Node will throw an error:
-  // Error [ERR_INTERNAL_ASSERTION]: Cannot require() ES Module @vitejs/plugin-vue/dist/index.js because it is not yet fully loaded. 
+  // Error [ERR_INTERNAL_ASSERTION]: Cannot require() ES Module @vitejs/plugin-vue/dist/index.js because it is not yet fully loaded.
   // This may be caused by a race condition if the module is simultaneously dynamically import()-ed via Promise.all().
   try {
     const importVuePlugin = () =>


### PR DESCRIPTION
This PR primes the cache for `@vitejs/plugin-vue`, similar to how we already do for `esbuild`. When `vite.config.ts` is compiled into CJS, then doing `require('@vitejs/plugin-vue')` may error with a race condition if an `import` of the same module is in progress.

Fixes #NXC-3289
