### PR TITLE
fix(maven): resolve maven dependencies from project roots

### DIFF
--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -1,1 +1,4 @@
-export { signalToCode } from 'nx/src/devkit-internals';
+export {
+  signalToCode,
+  createProjectRootMappingsFromProjectConfigurations,
+} from 'nx/src/devkit-internals';

--- a/packages/dotnet/src/plugins/create-dependencies.ts
+++ b/packages/dotnet/src/plugins/create-dependencies.ts
@@ -37,13 +37,13 @@ export const createDependencies: CreateDependencies<
   for (const [sourceRoot, referencedRoots] of Object.entries(
     referencesByRoot
   )) {
-    const sourceName = rootMap[sourceRoot];
+    const sourceName = rootMap.get(sourceRoot);
     if (!sourceName) {
       continue;
     }
 
     for (const targetRoot of referencedRoots.refs) {
-      const targetName = rootMap[targetRoot];
+      const targetName = rootMap.get(targetRoot);
       if (targetName) {
         dependencies.push({
           source: sourceName,

--- a/packages/dotnet/src/plugins/create-dependencies.ts
+++ b/packages/dotnet/src/plugins/create-dependencies.ts
@@ -1,7 +1,6 @@
 import {
   CreateDependencies,
   DependencyType,
-  ProjectConfiguration,
   RawProjectGraphDependency,
 } from '@nx/devkit';
 
@@ -10,24 +9,15 @@ import {
   readCachedAnalysisResult,
   isAnalysisErrorResult,
 } from '../analyzer/analyzer-client';
-
-function createProjectRootMappings(
-  projects: Record<string, ProjectConfiguration>
-): Record<string, string> {
-  const rootMap: Record<string, string> = {};
-  for (const [, project] of Object.entries(projects)) {
-    if (project.root && project.name) {
-      rootMap[project.root] = project.name;
-    }
-  }
-  return rootMap;
-}
+import { createProjectRootMappingsFromProjectConfigurations } from '@nx/devkit/internal';
 
 export const createDependencies: CreateDependencies<
   DotNetPluginOptions
 > = async (_, ctx) => {
   const dependencies: RawProjectGraphDependency[] = [];
-  const rootMap = createProjectRootMappings(ctx.projects);
+  const rootMap = createProjectRootMappingsFromProjectConfigurations(
+    ctx.projects
+  );
 
   // Read the cached analysis result populated by createNodes
   // createNodes always runs before createDependencies, so the cache should be populated

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
 import dev.nx.maven.targets.NxTargetFactory
+import dev.nx.maven.utils.PathFormatter
 import org.apache.maven.project.MavenProject
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -18,7 +19,8 @@ class NxProjectAnalyzer(
   private val workspaceRoot: File,
   private val nxTargetFactory: NxTargetFactory,
   private val coordinatesMap: Map<String, String>,
-  private val mavenCommand: String
+  private val mavenCommand: String,
+  private val pathFormatter: PathFormatter,
 ) {
   private val objectMapper = ObjectMapper()
   private val log: Logger = LoggerFactory.getLogger(NxProjectAnalyzer::class.java)
@@ -35,7 +37,7 @@ class NxProjectAnalyzer(
     val pathCalculationStart = System.currentTimeMillis()
     val canonicalWorkspaceRoot = workspaceRoot.canonicalFile
     val canonicalBasedir = project.basedir.canonicalFile
-    val root = canonicalBasedir.relativeTo(canonicalWorkspaceRoot).path
+    val root = pathFormatter.normalizeRelativePath(canonicalBasedir.relativeTo(canonicalWorkspaceRoot).path)
     val projectName = "${project.groupId}:${project.artifactId}"
     val projectType = determineProjectType(project.packaging)
     val pathCalculationTime = System.currentTimeMillis() - pathCalculationStart
@@ -107,7 +109,7 @@ class NxProjectAnalyzer(
       dependency.put("type", nxDependency.type.name.lowercase())
       dependency.put("source", nxDependency.source)
       dependency.put("target", nxDependency.target)
-      dependency.put("sourceFile", nxDependency.sourceFile.canonicalFile.relativeTo(canonicalWorkspaceRoot).path)
+      dependency.put("sourceFile", pathFormatter.normalizeRelativePath(nxDependency.sourceFile.canonicalFile.relativeTo(canonicalWorkspaceRoot).path))
       dependency
     }
 

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt
@@ -89,14 +89,16 @@ class NxProjectAnalyzer(
     }.toMutableList()
 
     if (project.parent != null) {
-      dependencies.add(
-        NxDependency(
-          NxDependencyType.Static,
-          coordinatesMap.getValue(projectName),
-          coordinatesMap.getValue("${project.parent.groupId}:${project.parent.artifactId}"),
-          project.file
+      coordinatesMap.get("${project.parent.groupId}:${project.parent.artifactId}")?.let { parentPath ->
+        dependencies.add(
+          NxDependency(
+            NxDependencyType.Static,
+            coordinatesMap.getValue(projectName),
+            parentPath,
+            project.file
+          )
         )
-      )
+      }
     }
 
     val dependenciesJson = dependencies.map { nxDependency ->

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt
@@ -17,105 +17,109 @@ class NxProjectAnalyzer(
   private val project: MavenProject,
   private val workspaceRoot: File,
   private val nxTargetFactory: NxTargetFactory,
+  private val coordinatesMap: Map<String, String>,
   private val mavenCommand: String
 ) {
-    private val objectMapper = ObjectMapper()
-    private val log: Logger = LoggerFactory.getLogger(NxProjectAnalyzer::class.java)
+  private val objectMapper = ObjectMapper()
+  private val log: Logger = LoggerFactory.getLogger(NxProjectAnalyzer::class.java)
 
-    /**
-     * Analyzes the project and returns Nx project config
-     */
-    fun analyze(): ProjectAnalysis {
-        val startTime = System.currentTimeMillis()
-        log.info("Starting analysis for project: ${project.artifactId}")
+  /**
+   * Analyzes the project and returns Nx project config
+   */
+  fun analyze(): ProjectAnalysis {
+    val startTime = System.currentTimeMillis()
+    log.info("Starting analysis for project: ${project.artifactId}")
 
-        // Calculate relative path from workspace root
-        // Canonicalize both paths to resolve symlinks (e.g., /tmp -> /private/tmp on macOS)
-        val pathCalculationStart = System.currentTimeMillis()
-        val canonicalWorkspaceRoot = workspaceRoot.canonicalFile
-        val canonicalBasedir = project.basedir.canonicalFile
-        val root = canonicalBasedir.relativeTo(canonicalWorkspaceRoot).path
-        val projectName = "${project.groupId}:${project.artifactId}"
-        val projectType = determineProjectType(project.packaging)
-        val pathCalculationTime = System.currentTimeMillis() - pathCalculationStart
-        log.info("Path calculation took ${pathCalculationTime}ms for project: ${project.artifactId} ($root)")
+    // Calculate relative path from workspace root
+    // Canonicalize both paths to resolve symlinks (e.g., /tmp -> /private/tmp on macOS)
+    val pathCalculationStart = System.currentTimeMillis()
+    val canonicalWorkspaceRoot = workspaceRoot.canonicalFile
+    val canonicalBasedir = project.basedir.canonicalFile
+    val root = canonicalBasedir.relativeTo(canonicalWorkspaceRoot).path
+    val projectName = "${project.groupId}:${project.artifactId}"
+    val projectType = determineProjectType(project.packaging)
+    val pathCalculationTime = System.currentTimeMillis() - pathCalculationStart
+    log.info("Path calculation took ${pathCalculationTime}ms for project: ${project.artifactId} ($root)")
 
-        // Create Nx project configuration
-        val configCreationStart = System.currentTimeMillis()
-        val nxProject = objectMapper.createObjectNode()
-        nxProject.put("name", projectName)
-        nxProject.put("root", root)
-        nxProject.put("projectType", projectType)
-        nxProject.put("sourceRoot", "${root}/src/main/java")
-        val configCreationTime = System.currentTimeMillis() - configCreationStart
-        log.info("Basic config creation took ${configCreationTime}ms for project: ${project.artifactId}")
+    // Create Nx project configuration
+    val configCreationStart = System.currentTimeMillis()
+    val nxProject = objectMapper.createObjectNode()
+    nxProject.put("name", projectName)
+    nxProject.put("root", root)
+    nxProject.put("projectType", projectType)
+    nxProject.put("sourceRoot", "${root}/src/main/java")
+    val configCreationTime = System.currentTimeMillis() - configCreationStart
+    log.info("Basic config creation took ${configCreationTime}ms for project: ${project.artifactId}")
 
-        val targetAnalysisStart = System.currentTimeMillis()
-        val (nxTargets, targetGroups) = nxTargetFactory.createNxTargets(mavenCommand, project)
-        val targetAnalysisTime = System.currentTimeMillis() - targetAnalysisStart
-        log.info("Target analysis took ${targetAnalysisTime}ms for project: ${project.artifactId}")
+    val targetAnalysisStart = System.currentTimeMillis()
+    val (nxTargets, targetGroups) = nxTargetFactory.createNxTargets(mavenCommand, project)
+    val targetAnalysisTime = System.currentTimeMillis() - targetAnalysisStart
+    log.info("Target analysis took ${targetAnalysisTime}ms for project: ${project.artifactId}")
 
-        nxProject.set<ObjectNode>("targets", nxTargets)
+    nxProject.set<ObjectNode>("targets", nxTargets)
 
-        // Project metadata including target groups
-        val metadataStart = System.currentTimeMillis()
-        val projectMetadata = objectMapper.createObjectNode()
-        projectMetadata.put("targetGroups", targetGroups)
-        nxProject.put("metadata", projectMetadata)
+    // Project metadata including target groups
+    val metadataStart = System.currentTimeMillis()
+    val projectMetadata = objectMapper.createObjectNode()
+    projectMetadata.put("targetGroups", targetGroups)
+    nxProject.put("metadata", projectMetadata)
 
-        // Tags
-        val tags = objectMapper.createArrayNode()
-        tags.add("maven:${project.groupId}")
-        tags.add("maven:${project.packaging}")
-        nxProject.put("tags", tags)
-        val metadataTime = System.currentTimeMillis() - metadataStart
-        log.info("Metadata and tags creation took ${metadataTime}ms for project: ${project.artifactId}")
+    // Tags
+    val tags = objectMapper.createArrayNode()
+    tags.add("maven:${project.groupId}")
+    tags.add("maven:${project.packaging}")
+    nxProject.put("tags", tags)
+    val metadataTime = System.currentTimeMillis() - metadataStart
+    log.info("Metadata and tags creation took ${metadataTime}ms for project: ${project.artifactId}")
 
-        val totalTime = System.currentTimeMillis() - startTime
-        log.info("Analyzed project: ${project.artifactId} at $root in ${totalTime}ms")
+    val totalTime = System.currentTimeMillis() - startTime
+    log.info("Analyzed project: ${project.artifactId} at $root in ${totalTime}ms")
 
 
-        val dependencies = project.dependencies.map { dependency ->
-            NxDependency(
-                NxDependencyType.Static,
-                projectName,
-                "${dependency.groupId}:${dependency.artifactId}",
-                project.file
-            )
-        }.toMutableList()
+    log.info("Collecting dependencies for project: ${project.artifactId}")
+    val dependencies = project.dependencies.mapNotNull { dependency ->
+      coordinatesMap.get("${dependency.groupId}:${dependency.artifactId}")
+    }.map { target ->
+      NxDependency(
+        NxDependencyType.Static,
+        coordinatesMap.getValue(projectName),
+        target,
+        project.file
+      )
+    }.toMutableList()
 
-        if (project.parent != null) {
-            dependencies.add(
-                NxDependency(
-                    NxDependencyType.Static,
-                    projectName,
-                    "${project.parent.groupId}:${project.parent.artifactId}",
-                    project.file
-                )
-            )
-        }
-
-        val dependenciesJson = dependencies.map { nxDependency ->
-            val dependency = objectMapper.createObjectNode()
-
-            dependency.put("type", nxDependency.type.name.lowercase())
-            dependency.put("source", nxDependency.source)
-            dependency.put("target", nxDependency.target)
-            dependency.put("sourceFile", nxDependency.sourceFile.canonicalFile.relativeTo(canonicalWorkspaceRoot).path)
-            dependency
-        }
-
-        return ProjectAnalysis(project.file, root, nxProject, dependenciesJson)
+    if (project.parent != null) {
+      dependencies.add(
+        NxDependency(
+          NxDependencyType.Static,
+          coordinatesMap.getValue(projectName),
+          coordinatesMap.getValue("${project.parent.groupId}:${project.parent.artifactId}"),
+          project.file
+        )
+      )
     }
 
-    private fun determineProjectType(packaging: String): String {
-        return when (packaging.lowercase()) {
-            "pom" -> "library"
-            "jar", "war", "ear" -> "application"
-            "maven-plugin" -> "library"
-            else -> "library"
-        }
+    val dependenciesJson = dependencies.map { nxDependency ->
+      val dependency = objectMapper.createObjectNode()
+
+      dependency.put("type", nxDependency.type.name.lowercase())
+      dependency.put("source", nxDependency.source)
+      dependency.put("target", nxDependency.target)
+      dependency.put("sourceFile", nxDependency.sourceFile.canonicalFile.relativeTo(canonicalWorkspaceRoot).path)
+      dependency
     }
+
+    return ProjectAnalysis(project.file, root, nxProject, dependenciesJson)
+  }
+
+  private fun determineProjectType(packaging: String): String {
+    return when (packaging.lowercase()) {
+      "pom" -> "library"
+      "jar", "war", "ear" -> "application"
+      "maven-plugin" -> "library"
+      else -> "library"
+    }
+  }
 }
 
 data class ProjectAnalysis(val pomFile: File, val root: String, val project: JsonNode, val dependencies: List<JsonNode>)
@@ -123,5 +127,5 @@ data class ProjectAnalysis(val pomFile: File, val root: String, val project: Jso
 data class NxDependency(val type: NxDependencyType, val source: String, val target: String, val sourceFile: File)
 
 enum class NxDependencyType {
-    Implicit, Static, Dynamic
+  Implicit, Static, Dynamic
 }

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt
@@ -13,7 +13,10 @@ import org.apache.maven.execution.MavenSession
 import org.apache.maven.lifecycle.DefaultLifecycles
 import org.apache.maven.plugin.AbstractMojo
 import org.apache.maven.plugin.MojoExecutionException
-import org.apache.maven.plugins.annotations.*
+import org.apache.maven.plugins.annotations.Component
+import org.apache.maven.plugins.annotations.Mojo
+import org.apache.maven.plugins.annotations.Parameter
+import org.apache.maven.plugins.annotations.ResolutionScope
 import org.apache.maven.project.MavenProject
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -23,207 +26,216 @@ import java.io.File
  * Maven plugin to analyze project structure and generate JSON for Nx integration
  */
 @Mojo(
-    name = "analyze",
-    aggregator = true,
-    requiresDependencyResolution = ResolutionScope.NONE
+  name = "analyze",
+  aggregator = true,
+  requiresDependencyResolution = ResolutionScope.NONE
 )
 class NxProjectAnalyzerMojo : AbstractMojo() {
 
-    private val log: Logger = LoggerFactory.getLogger(NxProjectAnalyzerMojo::class.java)
+  private val log: Logger = LoggerFactory.getLogger(NxProjectAnalyzerMojo::class.java)
 
-    @Parameter(defaultValue = "\${session}", readonly = true, required = true)
-    private lateinit var session: MavenSession
+  @Parameter(defaultValue = "\${session}", readonly = true, required = true)
+  private lateinit var session: MavenSession
 
-    @Component
-    private lateinit var pluginManager: org.apache.maven.plugin.MavenPluginManager
+  @Component
+  private lateinit var pluginManager: org.apache.maven.plugin.MavenPluginManager
 
-    @Component
-    private lateinit var lifecycles: DefaultLifecycles
+  @Component
+  private lateinit var lifecycles: DefaultLifecycles
 
-    @Parameter(property = "outputFile", defaultValue = "nx-maven-projects.json")
-    private lateinit var outputFile: String
+  @Parameter(property = "outputFile", defaultValue = "nx-maven-projects.json")
+  private lateinit var outputFile: String
 
-    @Parameter(property = "workspaceRoot", defaultValue = "\${session.executionRootDirectory}")
-    private lateinit var workspaceRoot: File
+  @Parameter(property = "workspaceRoot", defaultValue = "\${session.executionRootDirectory}")
+  private lateinit var workspaceRoot: File
 
-    private val objectMapper = ObjectMapper()
+  private val objectMapper = ObjectMapper()
 
-    @Throws(MojoExecutionException::class)
-    override fun execute() {
-        log.info("Analyzing Maven projects using optimized two-tier approach...")
-        log.info("Parameters: outputFile='$outputFile', workspaceRoot='$workspaceRoot'")
+  @Throws(MojoExecutionException::class)
+  override fun execute() {
+    log.info("Analyzing Maven projects using optimized two-tier approach...")
+    log.info("Parameters: outputFile='$outputFile', workspaceRoot='$workspaceRoot'")
 
-        // Canonicalize workspace root in place to resolve symlinks (e.g., /tmp -> /private/tmp on macOS)
-        workspaceRoot = workspaceRoot.canonicalFile
-        log.info("Canonical workspace root: $workspaceRoot")
+    // Canonicalize workspace root in place to resolve symlinks (e.g., /tmp -> /private/tmp on macOS)
+    workspaceRoot = workspaceRoot.canonicalFile
+    log.info("Canonical workspace root: $workspaceRoot")
 
-        try {
-            val allProjects = session.allProjects
-            log.info("Found ${allProjects.size} Maven projects")
+    try {
+      val allProjects = session.allProjects
+      log.info("Found ${allProjects.size} Maven projects")
 
-            // Step 1: Execute per-project analysis for all projects (in-memory)
-            log.info("Step 1: Running optimized per-project analysis...")
-            val inMemoryAnalyses = executePerProjectAnalysisInMemory(allProjects)
+      // Step 1: Execute per-project analysis for all projects (in-memory)
+      log.info("Step 1: Running optimized per-project analysis...")
+      val inMemoryAnalyses = executePerProjectAnalysisInMemory(allProjects)
 
-            // Step 2: Write project analyses to output file
-            log.info("Step 2: Writing project analyses to output file...")
-            writeProjectAnalysesToFile(inMemoryAnalyses)
+      // Step 2: Write project analyses to output file
+      log.info("Step 2: Writing project analyses to output file...")
+      writeProjectAnalysesToFile(inMemoryAnalyses)
 
-            log.info("Optimized two-tier analysis completed successfully")
+      log.info("Optimized two-tier analysis completed successfully")
 
-        } catch (e: Exception) {
-            throw MojoExecutionException("Failed to execute optimized two-tier Maven analysis", e)
-        }
+    } catch (e: Exception) {
+      throw MojoExecutionException("Failed to execute optimized two-tier Maven analysis", e)
     }
+  }
 
-    private fun executePerProjectAnalysisInMemory(
-        allProjects: List<MavenProject>
-    ): List<ProjectAnalysis> {
+  private fun executePerProjectAnalysisInMemory(
+    allProjects: List<MavenProject>
+  ): List<ProjectAnalysis> {
 
-        val gitIgnoreClassifier = GitIgnoreClassifier(workspaceRoot)
-        val startTime = System.currentTimeMillis()
-        log.info("Creating shared component instances for optimized analysis...")
+    val gitIgnoreClassifier = GitIgnoreClassifier(workspaceRoot)
+    val startTime = System.currentTimeMillis()
+    log.info("Creating shared component instances for optimized analysis...")
 
-        // Create deeply shared components for maximum caching efficiency
-        val sharedExpressionResolver = MavenExpressionResolver(session)
+    // Create deeply shared components for maximum caching efficiency
+    val sharedExpressionResolver = MavenExpressionResolver(session)
 
-        // Create shared component instances ONCE for all projects (major optimization)
+    // Create shared component instances ONCE for all projects (major optimization)
 
-        val pathFormatter = PathFormatter()
-        val mojoAnalyzer = MojoAnalyzer(sharedExpressionResolver, pathFormatter, gitIgnoreClassifier)
+    val pathFormatter = PathFormatter()
+    val mojoAnalyzer = MojoAnalyzer(sharedExpressionResolver, pathFormatter, gitIgnoreClassifier)
 
-        val sharedTestClassDiscovery = TestClassDiscovery()
+    val sharedTestClassDiscovery = TestClassDiscovery()
 
-        val sharedLifecycleAnalyzer = NxTargetFactory(
-            lifecycles,
-            objectMapper,
-            sharedTestClassDiscovery,
-            pluginManager,
-            session,
-            mojoAnalyzer,
-            pathFormatter,
-            gitIgnoreClassifier
+    val sharedTargetFactory = NxTargetFactory(
+      lifecycles,
+      objectMapper,
+      sharedTestClassDiscovery,
+      pluginManager,
+      session,
+      mojoAnalyzer,
+      pathFormatter,
+      gitIgnoreClassifier
+    )
+
+    // Resolve Maven command once for all projects
+    val mavenCommandStart = System.currentTimeMillis()
+    val mavenCommand = MavenCommandResolver.getMavenCommand(workspaceRoot)
+    val mavenCommandTime = System.currentTimeMillis() - mavenCommandStart
+    log.info("Maven command resolved to '$mavenCommand' in ${mavenCommandTime}ms")
+
+    val setupTime = System.currentTimeMillis() - startTime
+    log.info("Shared components created in ${setupTime}ms, analyzing ${allProjects.size} projects...")
+
+    val projectStartTime = System.currentTimeMillis()
+
+    // Generate coordinates map from all projects
+    val coordinatesMap = generateCoordinatesMap(allProjects);
+
+    // Process projects in parallel with separate analyzer instances
+    val results = allProjects.parallelStream().map { mavenProject ->
+      try {
+        log.info("Analyzing project: ${mavenProject.artifactId}")
+
+        // Create separate analyzer instance for each project (thread-safe)
+        val singleAnalyzer = NxProjectAnalyzer(
+          mavenProject,
+          workspaceRoot,
+          sharedTargetFactory,
+          coordinatesMap,
+          mavenCommand
         )
 
-        // Resolve Maven command once for all projects
-        val mavenCommandStart = System.currentTimeMillis()
-        val mavenCommand = MavenCommandResolver.getMavenCommand(workspaceRoot)
-        val mavenCommandTime = System.currentTimeMillis() - mavenCommandStart
-        log.info("Maven command resolved to '$mavenCommand' in ${mavenCommandTime}ms")
+        // Get Nx config for project
+        val nxConfig = singleAnalyzer.analyze()
 
-        val setupTime = System.currentTimeMillis() - startTime
-        log.info("Shared components created in ${setupTime}ms, analyzing ${allProjects.size} projects...")
+        Result.success(nxConfig)
 
-        val projectStartTime = System.currentTimeMillis()
+      } catch (e: Exception) {
+        Result.failure(e)
+      }
+    }.collect(java.util.stream.Collectors.toList())
 
-        // Process projects in parallel with separate analyzer instances
-        val results = allProjects.parallelStream().map { mavenProject ->
-            try {
-                log.info("Analyzing project: ${mavenProject.artifactId}")
+    val errors = results.filter { it.isFailure }
 
-                // Create separate analyzer instance for each project (thread-safe)
-                val singleAnalyzer = NxProjectAnalyzer(
-                    mavenProject,
-                    workspaceRoot,
-                    sharedLifecycleAnalyzer,
-                    mavenCommand
-                )
+    if (errors.isNotEmpty()) {
+      errors.forEach { error ->
+        log.error("Failed to analyze project", error.exceptionOrNull())
+      }
 
-                // Get Nx config for project
-                val nxConfig = singleAnalyzer.analyze()
-
-                Result.success(nxConfig)
-
-            } catch (e: Exception) {
-                Result.failure(e)
-            }
-        }.collect(java.util.stream.Collectors.toList())
-
-        val errors = results.filter { it.isFailure }
-
-        if (errors.isNotEmpty()) {
-            errors.forEach { error ->
-                log.error("Failed to analyze project", error.exceptionOrNull())
-            }
-
-            throw MojoExecutionException("Failed to analyze ${errors.size} of ${allProjects.size} projects. See errors above.")
-        }
-
-        val inMemoryAnalyses = results.map { it.getOrThrow() }
-
-        val totalTime = System.currentTimeMillis() - startTime
-        val analysisTime = System.currentTimeMillis() - projectStartTime
-        log.info("Completed in-memory analysis of ${allProjects.size} projects in ${totalTime}ms (setup: ${setupTime}ms, analysis: ${analysisTime}ms)")
-
-        return inMemoryAnalyses
+      throw MojoExecutionException("Failed to analyze ${errors.size} of ${allProjects.size} projects. See errors above.")
     }
 
-    private fun writeProjectAnalysesToFile(inMemoryAnalyses: List<ProjectAnalysis>) {
-        val outputPath = if (File(outputFile).isAbsolute) {
-            File(outputFile)
-        } else {
-            File(workspaceRoot, outputFile)
-        }
+    val inMemoryAnalyses = results.map { it.getOrThrow() }
 
-        // Ensure parent directory exists
-        outputPath.parentFile?.mkdirs()
+    val totalTime = System.currentTimeMillis() - startTime
+    val analysisTime = System.currentTimeMillis() - projectStartTime
+    log.info("Completed in-memory analysis of ${allProjects.size} projects in ${totalTime}ms (setup: ${setupTime}ms, analysis: ${analysisTime}ms)")
 
-        // Create JSON structure with both project analyses and createNodesResults
-        val rootNode = objectMapper.createObjectNode()
-        val projectsNode = objectMapper.createObjectNode()
+    return inMemoryAnalyses
+  }
 
-        // Skip project analyses section - all data is in createNodesResults
-        rootNode.set<JsonNode>("projects", projectsNode)
-
-        // Generate createNodesResults for Nx plugin consumption
-        val createNodesResults = generateCreateNodesResults(inMemoryAnalyses)
-        rootNode.set<JsonNode>("createNodesResults", createNodesResults)
-
-
-        val createDependenciesResults = generateCreateDependenciesResults(inMemoryAnalyses)
-        rootNode.set<JsonNode>("createDependenciesResults", createDependenciesResults)
-
-        // Add metadata
-        rootNode.put("totalProjects", inMemoryAnalyses.size)
-        rootNode.put("workspaceRoot", workspaceRoot.absolutePath)
-        rootNode.put("analysisMethod", "optimized-parallel")
-        rootNode.put("analyzedProjects", inMemoryAnalyses.size)
-
-        objectMapper.writerWithDefaultPrettyPrinter().writeValue(outputPath, rootNode)
-        log.info("Generated project analyses with ${inMemoryAnalyses.size} projects: ${outputPath.absolutePath}")
+  private fun writeProjectAnalysesToFile(inMemoryAnalyses: List<ProjectAnalysis>) {
+    val outputPath = if (File(outputFile).isAbsolute) {
+      File(outputFile)
+    } else {
+      File(workspaceRoot, outputFile)
     }
 
-    private fun generateCreateDependenciesResults(projectAnalyses: List<ProjectAnalysis>): ArrayNode {
-        val result = objectMapper.createArrayNode()
-        projectAnalyses.forEach { analysis ->
-            analysis.dependencies.forEach { dependency -> result.add(dependency) }
-        }
-        return result
+    // Ensure parent directory exists
+    outputPath.parentFile?.mkdirs()
+
+    // Create JSON structure with both project analyses and createNodesResults
+    val rootNode = objectMapper.createObjectNode()
+    val projectsNode = objectMapper.createObjectNode()
+
+    // Skip project analyses section - all data is in createNodesResults
+    rootNode.set<JsonNode>("projects", projectsNode)
+
+    // Generate createNodesResults for Nx plugin consumption
+    val createNodesResults = generateCreateNodesResults(inMemoryAnalyses)
+    rootNode.set<JsonNode>("createNodesResults", createNodesResults)
+
+
+    val createDependenciesResults = generateCreateDependenciesResults(inMemoryAnalyses)
+    rootNode.set<JsonNode>("createDependenciesResults", createDependenciesResults)
+
+    // Add metadata
+    rootNode.put("totalProjects", inMemoryAnalyses.size)
+    rootNode.put("workspaceRoot", workspaceRoot.absolutePath)
+    rootNode.put("analysisMethod", "optimized-parallel")
+    rootNode.put("analyzedProjects", inMemoryAnalyses.size)
+
+    objectMapper.writerWithDefaultPrettyPrinter().writeValue(outputPath, rootNode)
+    log.info("Generated project analyses with ${inMemoryAnalyses.size} projects: ${outputPath.absolutePath}")
+  }
+
+  private fun generateCreateDependenciesResults(projectAnalyses: List<ProjectAnalysis>): ArrayNode {
+    val result = objectMapper.createArrayNode()
+    projectAnalyses.forEach { analysis ->
+      analysis.dependencies.forEach { dependency -> result.add(dependency) }
+    }
+    return result
+  }
+
+  private fun generateCreateNodesResults(inMemoryAnalyses: List<ProjectAnalysis>): ArrayNode {
+    val createNodesResults = objectMapper.createArrayNode()
+
+    inMemoryAnalyses.forEach { analysis ->
+      val resultTuple = objectMapper.createArrayNode()
+      resultTuple.add(analysis.pomFile.canonicalFile.relativeTo(workspaceRoot).path) // Root path (workspace root)
+
+      // Group projects by root directory (for now, assume all projects are at workspace root)
+      val projects = objectMapper.createObjectNode()
+
+      val root = analysis.root
+      val project = analysis.project
+
+      val projectsWrapper = objectMapper.createObjectNode()
+      projects.set<JsonNode>(root, project)
+      projectsWrapper.set<JsonNode>("projects", projects)
+      resultTuple.add(projectsWrapper)
+
+      createNodesResults.add(resultTuple)
     }
 
-    private fun generateCreateNodesResults(inMemoryAnalyses: List<ProjectAnalysis>): ArrayNode {
-        val createNodesResults = objectMapper.createArrayNode()
+    return createNodesResults
+  }
 
-        inMemoryAnalyses.forEach { analysis ->
-            val resultTuple = objectMapper.createArrayNode()
-            resultTuple.add(analysis.pomFile.canonicalFile.relativeTo(workspaceRoot).path) // Root path (workspace root)
-
-            // Group projects by root directory (for now, assume all projects are at workspace root)
-            val projects = objectMapper.createObjectNode()
-
-            val root = analysis.root
-            val project = analysis.project
-
-            val projectsWrapper = objectMapper.createObjectNode()
-            projects.set<JsonNode>(root, project)
-            projectsWrapper.set<JsonNode>("projects", projects)
-            resultTuple.add(projectsWrapper)
-
-            createNodesResults.add(resultTuple)
-        }
-
-        return createNodesResults
+  private fun generateCoordinatesMap(
+    projects: List<MavenProject>
+  ): Map<String, String> =
+    projects.associate { project ->
+      "${project.groupId}:${project.artifactId}" to project.basedir.canonicalFile.relativeTo(workspaceRoot).path
     }
-
-
 }

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/utils/PathFormatter.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/utils/PathFormatter.kt
@@ -25,6 +25,8 @@ class PathFormatter {
 
     return "{projectRoot}/$relativePath"
   }
+
+  fun normalizeRelativePath(path: String): String = path.takeIf { it.isNotEmpty() } ?: "."
 }
 
 data class DependentTaskOutputs(val path: String, val transitive: Boolean = true)

--- a/packages/maven/src/plugins/dependencies.ts
+++ b/packages/maven/src/plugins/dependencies.ts
@@ -1,6 +1,7 @@
 import { CreateDependencies, logger, hashArray } from '@nx/devkit';
 import { readMavenCache, getCachePath } from './maven-data-cache';
 import { calculateHashesForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
+import { createProjectRootMappingsFromProjectConfigurations } from '@nx/devkit/internal';
 import { DEFAULT_OPTIONS, MavenPluginOptions } from './types';
 import { globWithWorkspaceContext } from 'nx/src/utils/workspace-context';
 import { dirname } from 'path';
@@ -54,6 +55,19 @@ export const createDependencies: CreateDependencies = async (
     'dependencies'
   );
 
-  // Extract dependencies from the mavenData
-  return mavenData.createDependenciesResults;
+  // Create a mapping from project root to project name
+  const rootToProjectMap = createProjectRootMappingsFromProjectConfigurations(
+    context.projects
+  );
+
+  // Extract and transform dependencies from the mavenData
+  const transformedDependencies = mavenData.createDependenciesResults.map(
+    (dep) => ({
+      ...dep,
+      source: rootToProjectMap.get(dep.source),
+      target: rootToProjectMap.get(dep.target),
+    })
+  );
+
+  return transformedDependencies;
 };

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -33,6 +33,7 @@ export {
 } from './utils/workspace-context';
 export {
   createProjectRootMappingsFromProjectConfigurations,
+  createProjectRootMappings,
   findProjectForPath,
 } from './project-graph/utils/find-project-for-path';
 export { retrieveProjectConfigurations } from './project-graph/utils/retrieve-workspace-files';


### PR DESCRIPTION
## Current Behavior

Maven dependencies were not being resolved correctly from project roots, which affected the dependency analysis in monorepos with Maven projects.

## Expected Behavior

Maven dependencies should be properly resolved from each project's root, allowing Nx to correctly understand the project graph for Maven-based projects.

## Changes Made

- Updated Maven plugin Kotlin code to properly resolve dependencies from project roots
- Fixed devkit internal utilities to properly handle Maven dependency resolution
- Updated TypeScript dependencies plugin to align with the new resolution logic

## Files Changed

- `packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt`
- `packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt`
- `packages/maven/src/plugins/dependencies.ts`
- `packages/dotnet/src/plugins/create-dependencies.ts`
- `packages/devkit/internal.ts`
- `packages/nx/src/devkit-internals.ts`

Fixes #XXXXX