### PR TITLE
chore(repo): add .NET format check + codeowners and unify native target handling

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -133,6 +133,10 @@ rust-toolchain.toml @nrwl/nx-native-reviewers
 /e2e/workspace-create/** @nrwl/nx-core-reviewers
 /e2e/release/** @nrwl/nx-core-reviewers
 
+# .NET
+/packages/dotnet/** @FrozenPandaz @AgentEnder
+/e2e/dotnet/** @FrozenPandaz @AgentEnder
+
 # Misc
 /e2e/lerna-smoke-tests/** @vsavkin @JamesHenry
 /e2e/utils/** @meeroslav @nrwl/nx-testing-tools-reviewers @vsavkin

--- a/packages/dotnet/project.json
+++ b/packages/dotnet/project.json
@@ -22,7 +22,7 @@
       "cache": true
     },
     "build-analyzer": {
-      "command": "node ./scripts/build-msbuild-analyzer.js",
+      "command": "node ./scripts/run-native-target.js _build-analyzer dotnet",
       "cache": true,
       "outputs": ["{workspaceRoot}/dist/msbuild-analyzer"],
       "inputs": ["{projectRoot}/analyzer/**", { "env": "SKIP_ANALYZER_BUILD" }]
@@ -38,6 +38,20 @@
           "node scripts/chmod.js dist/msbuild-analyzer/MsbuildAnalyzer"
         ],
         "parallel": false
+      }
+    },
+    "format-native": {
+      "command": "node ./scripts/run-native-target.js _format-native dotnet"
+    },
+    "_format-native": {
+      "command": "dotnet format {projectRoot}/analyzer/MsbuildAnalyzer.csproj",
+      "options": {
+        "args": ["--verify-no-changes"]
+      },
+      "configurations": {
+        "fix": {
+          "args": []
+        }
       }
     },
     "legacy-post-build": {

--- a/packages/maven/maven-plugin/project.json
+++ b/packages/maven/maven-plugin/project.json
@@ -8,7 +8,7 @@
       "command": "for i in {1..5}; do ./mvnw install && break || sleep 10; done"
     },
     "_install": {
-      "command": "node scripts/build-maven-analyzer.js"
+      "command": "node scripts/run-native-target.js install nx-maven-plugin"
     }
   }
 }

--- a/scripts/build-maven-analyzer.js
+++ b/scripts/build-maven-analyzer.js
@@ -1,7 +1,0 @@
-// @ts-check
-
-const { execSync } = require('node:child_process');
-
-if (process.env.SKIP_ANALYZER_BUILD !== 'true') {
-  execSync('nx install nx-maven-plugin', { stdio: 'inherit' });
-}

--- a/scripts/build-msbuild-analyzer.js
+++ b/scripts/build-msbuild-analyzer.js
@@ -1,7 +1,0 @@
-// @ts-check
-
-const { execSync } = require('node:child_process');
-
-if (process.env.SKIP_ANALYZER_BUILD !== 'true') {
-  execSync('nx _build-analyzer dotnet', { stdio: 'inherit' });
-}

--- a/scripts/run-native-target.js
+++ b/scripts/run-native-target.js
@@ -1,0 +1,11 @@
+// @ts-check
+
+const { execSync } = require('node:child_process');
+
+if (
+  process.env.SKIP_ANALYZER_BUILD !== 'true' &&
+  process.env.SKIP_NATIVE_TARGET !== 'true'
+) {
+  const [target, project] = process.argv.slice(2);
+  execSync(`nx run ${project}:${target}`, { stdio: 'inherit' });
+}


### PR DESCRIPTION
## Current Behavior
Maven and .NET use a bespoke script to handle skipping an optional native target in case a system is not setup on a dev's machine.

.NET isn't in codeowners

## Expected Behavior
This pull request introduces improvements to the build and formatting workflows for the `.NET` and Maven plugins, streamlining the execution of native targets and updating code ownership assignments. The changes focus on refactoring build scripts to use a unified runner, adding new formatting capabilities for .NET projects, and updating the CODEOWNERS file for clearer team responsibilities.

**Build and Format Workflow Improvements**

* Refactored the `.NET` analyzer build command in `packages/dotnet/project.json` to use the new `run-native-target.js` script, replacing the previous direct script invocation. [[1]](diffhunk://#diff-036c1a7f2e7d98f5a3207441f2ff1cb25b5b5a03343672ce473f4ff0189a5946L25-R25) [[2]](diffhunk://#diff-42d990ddcbf8d3585553503097ee8b8d1fff8cb6e25e0cd545a87e11d64c03a8L1-L7)
* Added new `format-native` and `_format-native` targets to `packages/dotnet/project.json`, enabling verification and fixing of code formatting for the .NET analyzer using `dotnet format`.

**Unified Native Target Runner**

* Introduced the `scripts/run-native-target.js` script to standardize running native build and install targets, controlled by environment variables for skipping builds.

**Maven Plugin Build Refactor**

* Updated the Maven plugin's install workflow in `packages/maven/maven-plugin/project.json` to use the new native target runner, and removed the obsolete `scripts/build-maven-analyzer.js` script. [[1]](diffhunk://#diff-2763fe8a7c2989643f53370a14a08c06616e85c29340fd5bcfa1a67d0deaee7aL11-R11) [[2]](diffhunk://#diff-972edab06956ad35145cbc20b8e250e7067fbb288b1f99c92661c24f64d3e69dL1-L7)

**Ownership Updates**

* Updated the `CODEOWNERS` file to assign `.NET`-related directories to `@FrozenPandaz` and `@AgentEnder`, clarifying team responsibilities.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
