### PR TITLE
feat(core): add OSC 9;4 progress indicator support to TUI

### DIFF
--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -311,7 +311,10 @@ impl AppLifeCycle {
 }
 
 #[napi]
-pub fn restore_terminal() -> Result<()> {
+pub fn restore_terminal() -> napi::Result<()> {
+    // Clear terminal progress indicator
+    App::clear_terminal_progress();
+
     // Restore the terminal to a clean state
     if let Ok(mut t) = Tui::new() {
         if let Err(r) = t.exit() {


### PR DESCRIPTION
## Current Behavior

The Nx TUI doesn't provide any visual feedback about task progress outside of the terminal window itself. Users need to keep the terminal visible to see task completion status.

## Expected Behavior

With this PR, the TUI now displays real-time task completion progress in the terminal window chrome (tabs, title bars, dock icons) using the OSC 9;4 escape sequence. This provides at-a-glance progress feedback even when the terminal is minimized or in the background.

## Related Issue(s)

N/A - This is a new feature enhancement

## Implementation Details

### What is OSC 9;4?
OSC 9;4 is a terminal escape sequence for displaying progress indicators, originally from ConEmu and now supported by multiple modern terminals.

### Key Changes
- Added `update_ghostty_progress()` method to calculate and display task completion percentage
- Added `clear_ghostty_progress()` method to hide progress when done
- Integrated progress updates into task lifecycle (start, status update, exit)
- Uses ST terminator (`\x1b\\`) for maximum terminal compatibility
- Writes to stderr to avoid conflicts with TUI rendering on stdout

### Supported Terminals
- **Ghostty** - Full support
- **Windows Terminal** (v1.6+) - Full support
- **VTE-based terminals** (GNOME Terminal, Ptyxis) - Full support
- **Other terminals** - Gracefully ignore sequences (no errors)

### Terminal Compatibility Note
The implementation uses the ST (String Terminator) escape sequence rather than BEL, as this is preferred by Ghostty and required by VTE-based terminals, while remaining compatible with Windows Terminal.

## Testing

Tested with:
- Building the native module successfully
- Rust formatting and linting passes
- Running nx commands with the TUI active

The progress indicator updates in real-time as tasks complete and clears automatically when the TUI exits.