### PR TITLE
fix(core): swc register base url missing when using tsgo

### DIFF
--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -123,7 +123,10 @@ export function getSwcTranspiler(
   const register = require('@swc-node/register/register')
     .register as ISwcRegister;
 
-  const cleanupFn = register(compilerOptions);
+  const cleanupFn = register({
+    ...compilerOptions,
+    baseUrl: compilerOptions.baseUrl ?? './',
+  });
 
   return typeof cleanupFn === 'function' ? cleanupFn : () => {};
 }


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

With the new tsgo `baseUrl` has been completely removed, this breaks compilation of plugins using swc when calling them with nx due to swc needing the baseUrl. I patched my company workspace with this fix and it did resolve it, not sure if its the right fix or what the ramifications are so happy to discuss that more. Since `baseUrl` is removed in tsgo (and recommended against in general), we need to find a way to provide it to swc (potentially through an `.swcrc` alternatively, I tried adding that to my workspace though and it didn't do anything).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
