### PR TITLE
fix(node): sourceMaps option to sourceMap in webpack config

### DIFF
--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -127,7 +127,7 @@ describe('app', () => {
               optimization: false,
               outputHashing: 'none',
               generatePackageJson: true,
-              sourceMaps: true,
+              sourceMap: true,
             }),
           ],
         };
@@ -968,7 +968,7 @@ describe('app', () => {
               optimization: false,
               outputHashing: 'none',
               generatePackageJson: false,
-              sourceMaps: true,
+              sourceMap: true,
             })
           ],
         };

--- a/packages/node/src/generators/application/files/common/webpack.config.js__tmpl__
+++ b/packages/node/src/generators/application/files/common/webpack.config.js__tmpl__
@@ -20,7 +20,7 @@ module.exports = {
       optimization: false,
       outputHashing: 'none',
       generatePackageJson: <%= webpackPluginOptions.generatePackageJson %>,
-      sourceMaps: true,
+      sourceMap: true,
     })
   ],
 };

--- a/packages/rspack/src/generators/convert-webpack/convert-webpack.spec.ts
+++ b/packages/rspack/src/generators/convert-webpack/convert-webpack.spec.ts
@@ -46,7 +46,7 @@ describe('Convert webpack', () => {
               optimization: false,
               outputHashing: 'none',
               generatePackageJson: true,
-              sourceMaps: true,
+              sourceMap: true,
             }),
           ],
         };


### PR DESCRIPTION
## Current Behavior
when I run the below nx workspace command
nx g @nx/express:app kafka-service --directory=apps/kafka-service --e2eTestRunner=none

the apps/kafka-service/webpack.config.json is generated with the below lines

const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
const { join } = require('path');

module.exports = {
  output: {
    path: join(__dirname, 'dist'),
    ...(process.env.NODE_ENV !== 'production' && {
      devtoolModuleFilenameTemplate: '[absolute-resource-path]',
    }),
  },
  plugins: [
    new NxAppWebpackPlugin({
      target: 'node',
      compiler: 'tsc',
      main: './src/main.ts',
      tsConfig: './tsconfig.app.json',
      assets: ["./src/assets"],
      optimization: false,
      outputHashing: 'none',
      generatePackageJson: true,
      sourceMaps: true,
    })
  ],
};

there is no such property in NxAppWebpackPluginOptions called **sourceMaps**, hence source maps are not generated
the correct property is **sourceMap**


## Expected Behavior
module.exports = {
  output: {
    path: join(__dirname, 'dist'),
    ...(process.env.NODE_ENV !== 'production' && {
      devtoolModuleFilenameTemplate: '[absolute-resource-path]',
    }),
  },
  plugins: [
    new NxAppWebpackPlugin({
      target: 'node',
      compiler: 'tsc',
      main: './src/main.ts',
      tsConfig: './tsconfig.app.json',
      assets: ["./src/assets"],
      optimization: false,
      outputHashing: 'none',
      generatePackageJson: true,
      sourceMap: true,
    })
  ],
};

## Related Issue(s)

Fixes #
