### PR TITLE
fix(vite): ensure atomizer does not consider projects outside the project root

### DIFF
--- a/packages/vite/src/plugins/plugin-vitest.spec.ts
+++ b/packages/vite/src/plugins/plugin-vitest.spec.ts
@@ -1,3 +1,4 @@
+import * as devkit from '@nx/devkit';
 import { CreateNodesContextV2 } from '@nx/devkit';
 import { createNodesV2 } from './plugin';
 


### PR DESCRIPTION
## Current Behavior
Vitest's `createVitest` can be over-eager and include other projects in the workspace when finding relevant test specifications.
This leads atomizer to look at relative paths outside the project root.

## Expected Behavior
Ensure that the plugin does not look at projects outside the project root.
