### PR TITLE
fix(maven): set migration version to 22.1.0-beta.4

### DIFF
--- a/packages/maven/migrations.json
+++ b/packages/maven/migrations.json
@@ -3,7 +3,7 @@
   "generators": {
     "update-0.0.8": {
       "cli": "nx",
-      "version": "0.0.8-beta.0",
+      "version": "22.1.0-beta.4",
       "description": "Update Maven plugin version from 0.0.7 to 0.0.8 in pom.xml files",
       "factory": "./dist/migrations/0-0-8/update-pom-xml-version"
     }


### PR DESCRIPTION
## Current Behavior

The Maven migration version was incorrectly set to `0.0.8-beta.0` in the migrations.json file.

## Expected Behavior

The migration version should be set to `22.1.0-beta.4` to align with the Nx release version.

## Related Issue(s)

Fixes the migration version discrepancy in the Maven plugin.