### PR TITLE
fix(testing): use .cts config files for Jest 30+ to fix __dirname issues

### DIFF
--- a/e2e/jest/src/jest.test.ts
+++ b/e2e/jest/src/jest.test.ts
@@ -95,7 +95,7 @@ describe('Jest', () => {
     );
 
     updateFile(
-      `libs/${mylib}/jest.config.ts`,
+      `libs/${mylib}/jest.config.cts`,
       stripIndents`
         export default {
           testEnvironment: 'node',

--- a/e2e/nx-init/src/nx-init-react.test.ts
+++ b/e2e/nx-init/src/nx-init-react.test.ts
@@ -44,7 +44,7 @@ describe('nx init (React)', () => {
       'tools/tsconfig.tools.json',
       'babel.config.json',
       'jest.preset.js',
-      'jest.config.ts'
+      'jest.config.cts'
     );
 
     const packageJson = readJson('package.json');

--- a/e2e/nx/src/__snapshots__/extras.test.ts.snap
+++ b/e2e/nx/src/__snapshots__/extras.test.ts.snap
@@ -8,6 +8,7 @@ exports[`Extra Nx Misc Tests task graph inputs should correctly expand default t
   ],
   "lib-base-123": [
     "libs/lib-base-123/README.md",
+    "libs/lib-base-123/jest.config.cts",
     "libs/lib-base-123/package.json",
     "libs/lib-base-123/project.json",
     "libs/lib-base-123/src/index.ts",

--- a/e2e/nx/src/__snapshots__/extras.test.ts.snap
+++ b/e2e/nx/src/__snapshots__/extras.test.ts.snap
@@ -27,7 +27,7 @@ exports[`Extra Nx Misc Tests task graph inputs should correctly expand dependent
   "lib-base-123": [
     "libs/lib-base-123/README.md",
     "libs/lib-base-123/eslint.config.mjs",
-    "libs/lib-base-123/jest.config.ts",
+    "libs/lib-base-123/jest.config.cts",
     "libs/lib-base-123/package.json",
     "libs/lib-base-123/project.json",
     "libs/lib-base-123/src/index.ts",
@@ -40,7 +40,7 @@ exports[`Extra Nx Misc Tests task graph inputs should correctly expand dependent
   "lib-dependent-123": [
     "libs/lib-dependent-123/README.md",
     "libs/lib-dependent-123/eslint.config.mjs",
-    "libs/lib-dependent-123/jest.config.ts",
+    "libs/lib-dependent-123/jest.config.cts",
     "libs/lib-dependent-123/package.json",
     "libs/lib-dependent-123/project.json",
     "libs/lib-dependent-123/src/index.ts",

--- a/e2e/nx/src/workspace.test.ts
+++ b/e2e/nx/src/workspace.test.ts
@@ -283,7 +283,7 @@ describe('Workspace Tests', () => {
       expect(moveOutput).toContain(`CREATE ${readmePath}`);
       checkFilesExist(readmePath);
 
-      const jestConfigPath = `${newPath}/jest.config.ts`;
+      const jestConfigPath = `${newPath}/jest.config.cts`;
       expect(moveOutput).toContain(`CREATE ${jestConfigPath}`);
       checkFilesExist(jestConfigPath);
       const jestConfig = readFile(jestConfigPath);
@@ -420,7 +420,7 @@ describe('Workspace Tests', () => {
       expect(moveOutput).toContain(`CREATE ${readmePath}`);
       checkFilesExist(readmePath);
 
-      const jestConfigPath = `${newPath}/jest.config.ts`;
+      const jestConfigPath = `${newPath}/jest.config.cts`;
       expect(moveOutput).toContain(`CREATE ${jestConfigPath}`);
       checkFilesExist(jestConfigPath);
       const jestConfig = readFile(jestConfigPath);
@@ -543,7 +543,7 @@ describe('Workspace Tests', () => {
       expect(moveOutput).toContain(`CREATE ${readmePath}`);
       checkFilesExist(readmePath);
 
-      const jestConfigPath = `${newPath}/jest.config.ts`;
+      const jestConfigPath = `${newPath}/jest.config.cts`;
       expect(moveOutput).toContain(`CREATE ${jestConfigPath}`);
       checkFilesExist(jestConfigPath);
       const jestConfig = readFile(jestConfigPath);

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -6,7 +6,7 @@ import {
   runCommand,
 } from './command-utils';
 import { uniq } from './create-project-utils';
-import { readFile, updateFile } from './file-utils';
+import { readFile, fileExists, updateFile } from './file-utils';
 
 type GeneratorsWithDefaultTests =
   | '@nx/js:lib'
@@ -48,9 +48,21 @@ export function expectNoAngularDevkit() {
 
 // TODO(meeroslav): This is test specific, it should not be in the utils
 export function expectNoTsJestInJestConfig(appName: string) {
-  const jestConfig = readFile(
-    joinPathFragments('apps', appName, 'jest.config.ts')
-  );
+  const candidates = [
+    joinPathFragments('apps', appName, 'jest.config.js'),
+    joinPathFragments('apps', appName, 'jest.config.ts'),
+    joinPathFragments('apps', appName, 'jest.config.cts'),
+  ];
+  let jestConfig: string;
+  for (const c of candidates) {
+    if (fileExists(c)) {
+      jestConfig = readFile(c);
+      break;
+    }
+  }
+  if (!jestConfig) {
+    throw new Error(`Could not find jest config for app/lib: ${appName}`);
+  }
   expect(jestConfig).not.toContain('ts-jest');
 }
 

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -1,4 +1,4 @@
-import { joinPathFragments } from '@nx/devkit';
+import { join } from 'node:path';
 import {
   getPackageManagerCommand,
   runCLI,
@@ -6,6 +6,7 @@ import {
   runCommand,
 } from './command-utils';
 import { uniq } from './create-project-utils';
+import { tmpProjPath } from './create-project-utils';
 import { readFile, fileExists, updateFile } from './file-utils';
 
 type GeneratorsWithDefaultTests =
@@ -49,9 +50,9 @@ export function expectNoAngularDevkit() {
 // TODO(meeroslav): This is test specific, it should not be in the utils
 export function expectNoTsJestInJestConfig(appName: string) {
   const candidates = [
-    joinPathFragments('apps', appName, 'jest.config.js'),
-    joinPathFragments('apps', appName, 'jest.config.ts'),
-    joinPathFragments('apps', appName, 'jest.config.cts'),
+    tmpProjPath(join('apps', appName, 'jest.config.js')),
+    tmpProjPath(join('apps', appName, 'jest.config.ts')),
+    tmpProjPath(join('apps', appName, 'jest.config.cts')),
   ];
   let jestConfig: string;
   for (const c of candidates) {

--- a/e2e/workspace-create/src/create-nx-workspace-react.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace-react.test.ts
@@ -103,7 +103,7 @@ describe('create-nx-workspace --preset=react', () => {
 
     expectNoAngularDevkit();
     checkFilesExist('vitest.workspace.ts');
-    checkFilesDoNotExist('jest.config.ts');
+    checkFilesDoNotExist('jest.config.cts');
     const packageJson = readJson('package.json');
     expect(packageJson.devDependencies['@nx/vite']).toBeDefined(); // vite should be default bundler
     expectCodeIsFormatted();

--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`app --minimal should generate a correct setup when --bundler=rspack and ssr 1`] = `
 "
@@ -1124,6 +1124,7 @@ exports[`app not nested should generate files: tsconfig.app.json 1`] = `
     "src/test-setup.ts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
+    "jest.config.cts",
   ],
   "extends": "./tsconfig.json",
   "include": [

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -362,6 +362,7 @@ describe('app', () => {
             'src/test-setup.ts',
             'src/**/*.test.ts',
             'src/**/*.spec.ts',
+            'jest.config.cts',
           ],
         },
         {
@@ -451,6 +452,7 @@ describe('app', () => {
             'src/test-setup.ts',
             'src/**/*.test.ts',
             'src/**/*.spec.ts',
+            'jest.config.cts',
           ],
         },
         {
@@ -1589,7 +1591,8 @@ describe('app', () => {
             "jest.config.ts",
             "src/test-setup.ts",
             "src/**/*.test.ts",
-            "src/**/*.spec.ts"
+            "src/**/*.spec.ts",
+            "jest.config.cts"
           ]
         }
         "
@@ -1606,7 +1609,8 @@ describe('app', () => {
             "jest.config.ts",
             "src/test-setup.ts",
             "src/**/*.test.ts",
-            "src/**/*.spec.ts"
+            "src/**/*.spec.ts",
+            "jest.config.cts"
           ]
         }
         "

--- a/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
@@ -207,6 +207,7 @@ describe('librarySecondaryEntryPoint generator', () => {
       'src/test-setup.ts',
       'jest.config.ts',
       'src/**/*.test.ts',
+      'jest.config.cts',
     ]);
 
     await librarySecondaryEntryPointGenerator(tree, {
@@ -222,6 +223,7 @@ describe('librarySecondaryEntryPoint generator', () => {
       'test-setup.ts',
       'jest.config.ts',
       '**/*.test.ts',
+      'jest.config.cts',
     ]);
   });
 

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -412,6 +412,7 @@ describe('lib', () => {
           'src/test-setup.ts',
           'jest.config.ts',
           'src/**/*.test.ts',
+          'jest.config.cts',
         ]);
       });
 
@@ -861,6 +862,7 @@ describe('lib', () => {
           'src/test-setup.ts',
           'jest.config.ts',
           'src/**/*.test.ts',
+          'jest.config.cts',
         ]);
 
         expect(moduleContents2).toMatchInlineSnapshot(`
@@ -894,6 +896,7 @@ describe('lib', () => {
           'src/test-setup.ts',
           'jest.config.ts',
           'src/**/*.test.ts',
+          'jest.config.cts',
         ]);
 
         expect(moduleContents3).toMatchSnapshot();
@@ -903,6 +906,7 @@ describe('lib', () => {
           'src/test-setup.ts',
           'jest.config.ts',
           'src/**/*.test.ts',
+          'jest.config.cts',
         ]);
       });
 

--- a/packages/angular/src/generators/setup-ssr/__snapshots__/setup-ssr.spec.ts.snap
+++ b/packages/angular/src/generators/setup-ssr/__snapshots__/setup-ssr.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`setupSSR with application builder should create the files correctly for ssr 1`] = `
 {

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
@@ -68,7 +68,8 @@ describe('setupSSR', () => {
             "jest.config.ts",
             "src/test-setup.ts",
             "src/**/*.test.ts",
-            "src/**/*.spec.ts"
+            "src/**/*.spec.ts",
+            "jest.config.cts"
           ]
         }
         "
@@ -175,7 +176,8 @@ describe('setupSSR', () => {
             "jest.config.ts",
             "src/test-setup.ts",
             "src/**/*.test.ts",
-            "src/**/*.spec.ts"
+            "src/**/*.spec.ts",
+            "jest.config.cts"
           ]
         }
         "
@@ -1080,16 +1082,16 @@ describe('setupSSR', () => {
 
         expect(tree.read('app1/src/main.server.ts', 'utf-8'))
           .toMatchInlineSnapshot(`
-        "import { BootstrapContext, bootstrapApplication } from '@angular/platform-browser';
-        import { AppComponent } from './app/app.component';
-        import { config } from './app/app.config.server';
+                  "import { BootstrapContext, bootstrapApplication } from '@angular/platform-browser';
+                  import { AppComponent } from './app/app.component';
+                  import { config } from './app/app.config.server';
 
-        const bootstrap = (context: BootstrapContext) =>
-          bootstrapApplication(AppComponent, config, context);
+                  const bootstrap = (context: BootstrapContext) =>
+                    bootstrapApplication(AppComponent, config, context);
 
-        export default bootstrap;
-        "
-        `);
+                  export default bootstrap;
+                  "
+                `);
       }
     );
 
@@ -1114,15 +1116,15 @@ describe('setupSSR', () => {
 
         expect(tree.read('app1/src/main.server.ts', 'utf-8'))
           .toMatchInlineSnapshot(`
-        "import { bootstrapApplication } from '@angular/platform-browser';
-        import { AppComponent } from './app/app.component';
-        import { config } from './app/app.config.server';
+                  "import { bootstrapApplication } from '@angular/platform-browser';
+                  import { AppComponent } from './app/app.component';
+                  import { config } from './app/app.config.server';
 
-        const bootstrap = () => bootstrapApplication(AppComponent, config);
+                  const bootstrap = () => bootstrapApplication(AppComponent, config);
 
-        export default bootstrap;
-        "
-        `);
+                  export default bootstrap;
+                  "
+                `);
       }
     );
 

--- a/packages/detox/src/generators/application/application.spec.ts
+++ b/packages/detox/src/generators/application/application.spec.ts
@@ -597,11 +597,11 @@ describe('detox application generator', () => {
 
       expect(tree.exists('apps/my-app-e2e/test-setup.ts')).toBeTruthy();
       const detoxrc = readJson(tree, 'apps/my-app-e2e/.detoxrc.json');
-      expect(detoxrc.testRunner.args.config).toEqual('./jest.config.ts');
-      expect(tree.read('apps/my-app-e2e/jest.config.ts', 'utf-8'))
+      expect(detoxrc.testRunner.args.config).toEqual('./jest.config.cts');
+      expect(tree.read('apps/my-app-e2e/jest.config.cts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "/* eslint-disable */
-        import { readFileSync } from 'fs';
+        const { readFileSync } = require('fs');
 
         // Reading the SWC compilation config for the spec files
         const swcJestConfig = JSON.parse(
@@ -611,7 +611,7 @@ describe('detox application generator', () => {
         // Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
         swcJestConfig.swcrc = false;
 
-        export default {
+        module.exports = {
           preset: "../../jest.preset",
           rootDir: ".",
           testMatch: [

--- a/packages/detox/src/generators/application/files/ts-solution/jest.config.cts.template
+++ b/packages/detox/src/generators/application/files/ts-solution/jest.config.cts.template
@@ -1,5 +1,5 @@
 /* eslint-disable */
-<% if (js) { %>const { readFileSync } = require('fs')<% } else { %>import { readFileSync } from 'fs';<% } %>
+const { readFileSync } = require('fs');
 
 // Reading the SWC compilation config for the spec files
 const swcJestConfig = JSON.parse(
@@ -9,7 +9,7 @@ const swcJestConfig = JSON.parse(
 // Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
 swcJestConfig.swcrc = false;
 
-<% if (js) { %>module.exports =<% } else { %>export default<% } %> {
+module.exports = {
   preset: "<%= offsetFromRoot %>jest.preset",
   rootDir: ".",
   testMatch: [

--- a/packages/detox/src/generators/application/lib/create-files.ts
+++ b/packages/detox/src/generators/application/lib/create-files.ts
@@ -25,7 +25,7 @@ export function createFiles(host: Tree, options: NormalizedSchema) {
     offsetFromRoot,
     rootTsConfigPath,
     jestConfigFileName: options.isUsingTsSolutionConfig
-      ? 'jest.config.ts'
+      ? 'jest.config.cts'
       : 'jest.config.json',
   });
   if (options.isUsingTsSolutionConfig) {

--- a/packages/eslint/src/generators/workspace-rules-project/__snapshots__/workspace-rules-project.spec.ts.snap
+++ b/packages/eslint/src/generators/workspace-rules-project/__snapshots__/workspace-rules-project.spec.ts.snap
@@ -78,7 +78,7 @@ exports[`@nx/eslint:workspace-rules-project should generate the required files 4
 `;
 
 exports[`@nx/eslint:workspace-rules-project should generate the required files 5`] = `
-"export default {
+"module.exports = {
   displayName: 'eslint-rules',
   preset: '../../jest.preset.js',
   testEnvironment: 'node',

--- a/packages/eslint/src/generators/workspace-rules-project/__snapshots__/workspace-rules-project.spec.ts.snap
+++ b/packages/eslint/src/generators/workspace-rules-project/__snapshots__/workspace-rules-project.spec.ts.snap
@@ -72,7 +72,7 @@ exports[`@nx/eslint:workspace-rules-project should generate the required files 4
     "outDir": "../../dist/out-tsc",
     "types": ["jest", "node"]
   },
-  "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+  "include": ["jest.config.cts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
 }
 "
 `;

--- a/packages/eslint/src/generators/workspace-rules-project/__snapshots__/workspace-rules-project.spec.ts.snap
+++ b/packages/eslint/src/generators/workspace-rules-project/__snapshots__/workspace-rules-project.spec.ts.snap
@@ -72,7 +72,13 @@ exports[`@nx/eslint:workspace-rules-project should generate the required files 4
     "outDir": "../../dist/out-tsc",
     "types": ["jest", "node"]
   },
-  "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+  "include": [
+    "jest.config.ts",
+    "jest.config.cts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
 }
 "
 `;

--- a/packages/eslint/src/generators/workspace-rules-project/__snapshots__/workspace-rules-project.spec.ts.snap
+++ b/packages/eslint/src/generators/workspace-rules-project/__snapshots__/workspace-rules-project.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`@nx/eslint:workspace-rules-project should generate the required files 1`] = `
 "/**
@@ -72,7 +72,7 @@ exports[`@nx/eslint:workspace-rules-project should generate the required files 4
     "outDir": "../../dist/out-tsc",
     "types": ["jest", "node"]
   },
-  "include": ["jest.config.cts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+  "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
 }
 "
 `;

--- a/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.spec.ts
+++ b/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.spec.ts
@@ -77,7 +77,7 @@ describe('@nx/eslint:workspace-rules-project', () => {
     expect(tree.exists('tools/eslint-rules/jest.config.cts')).toBeTruthy();
     expect(tree.read('tools/eslint-rules/jest.config.cts', 'utf-8'))
       .toMatchInlineSnapshot(`
-      "export default {
+      "module.exports = {
         displayName: 'eslint-rules',
         preset: '../../jest.preset.js',
         testEnvironment: 'node',
@@ -145,7 +145,7 @@ describe('@nx/eslint:workspace-rules-project', () => {
       expect(tree.read('tools/eslint-rules/jest.config.cts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "/* eslint-disable */
-        import { readFileSync } from 'fs';
+        const { readFileSync } = require('fs');
 
         // Reading the SWC compilation config for the spec files
         const swcJestConfig = JSON.parse(
@@ -155,7 +155,7 @@ describe('@nx/eslint:workspace-rules-project', () => {
         // Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
         swcJestConfig.swcrc = false;
 
-        export default {
+        module.exports = {
           displayName: 'eslint-rules',
           preset: '../../jest.preset.js',
           testEnvironment: 'node',

--- a/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.spec.ts
+++ b/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.spec.ts
@@ -51,7 +51,7 @@ describe('@nx/eslint:workspace-rules-project', () => {
       tree.read('tools/eslint-rules/tsconfig.spec.json', 'utf-8')
     ).toMatchSnapshot();
     expect(
-      tree.read('tools/eslint-rules/jest.config.ts', 'utf-8')
+      tree.read('tools/eslint-rules/jest.config.cts', 'utf-8')
     ).toMatchSnapshot();
   });
 
@@ -74,8 +74,8 @@ describe('@nx/eslint:workspace-rules-project', () => {
   it('should create the jest config using ts-jest', async () => {
     await lintWorkspaceRulesProjectGenerator(tree);
 
-    expect(tree.exists('tools/eslint-rules/jest.config.ts')).toBeTruthy();
-    expect(tree.read('tools/eslint-rules/jest.config.ts', 'utf-8'))
+    expect(tree.exists('tools/eslint-rules/jest.config.cts')).toBeTruthy();
+    expect(tree.read('tools/eslint-rules/jest.config.cts', 'utf-8'))
       .toMatchInlineSnapshot(`
       "export default {
         displayName: 'eslint-rules',
@@ -141,8 +141,8 @@ describe('@nx/eslint:workspace-rules-project', () => {
     it('should create the jest config using @swc/jest', async () => {
       await lintWorkspaceRulesProjectGenerator(tree);
 
-      expect(tree.exists('tools/eslint-rules/jest.config.ts')).toBeTruthy();
-      expect(tree.read('tools/eslint-rules/jest.config.ts', 'utf-8'))
+      expect(tree.exists('tools/eslint-rules/jest.config.cts')).toBeTruthy();
+      expect(tree.read('tools/eslint-rules/jest.config.cts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "/* eslint-disable */
         import { readFileSync } from 'fs';

--- a/packages/expo/src/generators/application/application.spec.ts
+++ b/packages/expo/src/generators/application/application.spec.ts
@@ -505,6 +505,7 @@ describe('app', () => {
           ],
           "include": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.test.tsx",

--- a/packages/expo/src/generators/application/application.spec.ts
+++ b/packages/expo/src/generators/application/application.spec.ts
@@ -100,7 +100,7 @@ describe('app', () => {
       unitTestRunner: 'jest',
     });
 
-    expect(appTree.exists('my-app/jest.config.ts')).toBeTruthy();
+    expect(appTree.exists('my-app/jest.config.cts')).toBeTruthy();
     expect(appTree.exists('my-app/src/app/App.spec.tsx')).toBeTruthy();
     expect(appTree.exists('my-app/tsconfig.spec.json')).toBeTruthy();
     expect(readJson(appTree, 'my-app/tsconfig.json').references).toEqual(
@@ -127,7 +127,7 @@ describe('app', () => {
       unitTestRunner: 'none',
     });
 
-    expect(appTree.exists('my-app/jest.config.ts')).toBe(false);
+    expect(appTree.exists('my-app/jest.config.cts')).toBe(false);
     expect(appTree.exists('my-app/src/app/App.spec.tsx')).toBe(false);
     expect(appTree.exists('my-app/tsconfig.spec.json')).toBe(false);
     expect(readJson(appTree, 'my-app/tsconfig.json').references).not.toEqual(
@@ -463,6 +463,7 @@ describe('app', () => {
             "**/*.spec.jsx",
             "src/test-setup.ts",
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.spec.ts",
             "src/**/*.test.ts",
             "jest.resolver.js",

--- a/packages/expo/src/generators/library/library.spec.ts
+++ b/packages/expo/src/generators/library/library.spec.ts
@@ -335,8 +335,8 @@ describe('lib', () => {
       `);
       expect(appTree.read('my-lib/jest.config.cts', 'utf-8'))
         .toMatchInlineSnapshot(`
-        "// <reference types="jest" />
-        // <reference types="node" />
+        "/// <reference types="jest" />
+        /// <reference types="node" />
         module.exports = {
           displayName: 'my-lib',
           resolver: require.resolve('./jest.resolver.js'),

--- a/packages/expo/src/generators/library/library.spec.ts
+++ b/packages/expo/src/generators/library/library.spec.ts
@@ -335,7 +335,9 @@ describe('lib', () => {
       `);
       expect(appTree.read('my-lib/jest.config.cts', 'utf-8'))
         .toMatchInlineSnapshot(`
-        "module.exports = {
+        "// <reference types="jest" />
+        // <reference types="node" />
+        module.exports = {
           displayName: 'my-lib',
           resolver: require.resolve('./jest.resolver.js'),
           preset: 'jest-expo',

--- a/packages/expo/src/generators/library/library.spec.ts
+++ b/packages/expo/src/generators/library/library.spec.ts
@@ -318,6 +318,7 @@ describe('lib', () => {
           "files": ["src/test-setup.ts"],
           "include": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.test.tsx",
@@ -654,6 +655,7 @@ describe('lib', () => {
           ],
           "include": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.test.tsx",

--- a/packages/expo/src/generators/library/library.spec.ts
+++ b/packages/expo/src/generators/library/library.spec.ts
@@ -132,6 +132,7 @@ describe('lib', () => {
             "**/*.spec.jsx",
             "src/test-setup.ts",
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.spec.ts",
             "src/**/*.test.ts",
             "jest.resolver.js",
@@ -255,7 +256,7 @@ describe('lib', () => {
       });
 
       expect(appTree.exists('my-lib/tsconfig.spec.json')).toBeFalsy();
-      expect(appTree.exists('my-lib/jest.config.ts')).toBeFalsy();
+      expect(appTree.exists('my-lib/jest.config.cts')).toBeFalsy();
       const projectConfiguration = readProjectConfiguration(appTree, 'my-lib');
       expect(projectConfiguration).toMatchInlineSnapshot(`
         {
@@ -331,7 +332,7 @@ describe('lib', () => {
         }
         "
       `);
-      expect(appTree.read('my-lib/jest.config.ts', 'utf-8'))
+      expect(appTree.read('my-lib/jest.config.cts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "module.exports = {
           displayName: 'my-lib',
@@ -622,6 +623,7 @@ describe('lib', () => {
             "eslint.config.cjs",
             "eslint.config.mjs",
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.spec.ts",
             "src/**/*.test.ts",
             "jest.resolver.js",

--- a/packages/expo/src/migrations/update-21-4-0/add-jest-resolver.spec.ts
+++ b/packages/expo/src/migrations/update-21-4-0/add-jest-resolver.spec.ts
@@ -72,7 +72,7 @@ describe('add-jest-resolver migration', () => {
         test: {
           executor: '@nx/jest:jest',
           options: {
-            jestConfig: 'apps/my-expo-app/jest.config.ts',
+            jestConfig: 'apps/my-expo-app/jest.config.cts',
           },
         },
       },
@@ -102,7 +102,7 @@ describe('add-jest-resolver migration', () => {
 
     // Create jest config with expo preset
     tree.write(
-      'apps/my-expo-app/jest.config.ts',
+      'apps/my-expo-app/jest.config.cts',
       `module.exports = {
   displayName: 'my-expo-app',
   resolver: '@nx/jest/plugins/resolver',
@@ -143,7 +143,10 @@ describe('add-jest-resolver migration', () => {
     expect(resolverContent).toContain('./runtime.ts');
 
     // Check that the jest config was updated
-    const updatedConfig = tree.read('apps/my-expo-app/jest.config.ts', 'utf-8');
+    const updatedConfig = tree.read(
+      'apps/my-expo-app/jest.config.cts',
+      'utf-8'
+    );
     expect(updatedConfig).toContain(
       "resolver: require.resolve('./jest.resolver.js')"
     );
@@ -159,7 +162,7 @@ describe('add-jest-resolver migration', () => {
         test: {
           executor: '@nx/jest:jest',
           options: {
-            jestConfig: 'apps/my-react-app/jest.config.ts',
+            jestConfig: 'apps/my-react-app/jest.config.cts',
           },
         },
       },
@@ -185,7 +188,7 @@ describe('add-jest-resolver migration', () => {
 
     // Create jest config without expo preset
     tree.write(
-      'apps/my-react-app/jest.config.ts',
+      'apps/my-react-app/jest.config.cts',
       `module.exports = {
         displayName: 'my-react-app',
         resolver: '@nx/jest/plugins/resolver',
@@ -205,7 +208,7 @@ describe('add-jest-resolver migration', () => {
     expect(tree.exists('apps/my-react-app/jest.resolver.js')).toBe(false);
 
     // Check that the jest config was NOT modified
-    const config = tree.read('apps/my-react-app/jest.config.ts', 'utf-8');
+    const config = tree.read('apps/my-react-app/jest.config.cts', 'utf-8');
     expect(config).toContain("resolver: '@nx/jest/plugins/resolver'");
     expect(config).not.toContain('transformIgnorePatterns');
   });
@@ -218,7 +221,7 @@ describe('add-jest-resolver migration', () => {
         test: {
           executor: '@nx/jest:jest',
           options: {
-            jestConfig: 'apps/my-expo-app/jest.config.ts',
+            jestConfig: 'apps/my-expo-app/jest.config.cts',
           },
         },
       },
@@ -248,7 +251,7 @@ describe('add-jest-resolver migration', () => {
 
     // Create jest config with expo preset and existing custom resolver
     tree.write(
-      'apps/my-expo-app/jest.config.ts',
+      'apps/my-expo-app/jest.config.cts',
       `module.exports = {
         displayName: 'my-expo-app',
         resolver: './my-custom-resolver.js',

--- a/packages/expo/src/migrations/update-21-4-0/add-jest-resolver.ts
+++ b/packages/expo/src/migrations/update-21-4-0/add-jest-resolver.ts
@@ -17,6 +17,7 @@ export default async function addJestResolver(tree: Tree) {
       // Check if this is an Expo project by looking for jest.config file with expo preset
       const jestConfigPath = join(config.root, 'jest.config.ts');
       const jestConfigJsPath = join(config.root, 'jest.config.js');
+      const jestConfigCtsPath = join(config.root, 'jest.config.cts');
 
       let jestConfigContent = '';
       let configPath = '';
@@ -24,6 +25,9 @@ export default async function addJestResolver(tree: Tree) {
       if (tree.exists(jestConfigPath)) {
         jestConfigContent = tree.read(jestConfigPath, 'utf-8');
         configPath = jestConfigPath;
+      } else if (tree.exists(jestConfigCtsPath)) {
+        jestConfigContent = tree.read(jestConfigCtsPath, 'utf-8');
+        configPath = jestConfigCtsPath;
       } else if (tree.exists(jestConfigJsPath)) {
         jestConfigContent = tree.read(jestConfigJsPath, 'utf-8');
         configPath = jestConfigJsPath;

--- a/packages/expo/src/utils/add-linting.ts
+++ b/packages/expo/src/utils/add-linting.ts
@@ -66,6 +66,7 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
             '@nx/rollup',
             '@rollup/plugin-url',
             '@svgr/rollup',
+            'jest-expo',
           ];
           for (const dep of ignoredDeps) {
             if (!rule[1].ignoredDependencies.includes(dep)) {

--- a/packages/expo/src/utils/jest/add-jest.ts
+++ b/packages/expo/src/utils/jest/add-jest.ts
@@ -37,8 +37,8 @@ export async function addJest(
   // use preset from https://github.com/expo/expo/blob/main/packages/jest-expo/jest-preset.js
   // Workaround issue where Jest is not picking tyope node nor jest types from tsconfig by using <reference>.
   const configPath = `${appProjectRoot}/jest.config.${js ? 'js' : 'cts'}`;
-  const content = `// <reference types="jest" />
-// <reference types="node" />
+  const content = `/// <reference types="jest" />
+/// <reference types="node" />
 module.exports = {
   displayName: '${projectName}',
   resolver: require.resolve('./jest.resolver.js'),

--- a/packages/expo/src/utils/jest/add-jest.ts
+++ b/packages/expo/src/utils/jest/add-jest.ts
@@ -35,7 +35,7 @@ export async function addJest(
 
   // Overwrite the jest.config.ts file because react native needs to have special transform property
   // use preset from https://github.com/expo/expo/blob/main/packages/jest-expo/jest-preset.js
-  const configPath = `${appProjectRoot}/jest.config.${js ? 'js' : 'ts'}`;
+  const configPath = `${appProjectRoot}/jest.config.${js ? 'js' : 'cts'}`;
   const content = `module.exports = {
   displayName: '${projectName}',
   resolver: require.resolve('./jest.resolver.js'),

--- a/packages/expo/src/utils/jest/add-jest.ts
+++ b/packages/expo/src/utils/jest/add-jest.ts
@@ -35,8 +35,11 @@ export async function addJest(
 
   // Overwrite the jest.config.ts file because react native needs to have special transform property
   // use preset from https://github.com/expo/expo/blob/main/packages/jest-expo/jest-preset.js
+  // Workaround issue where Jest is not picking tyope node nor jest types from tsconfig by using <reference>.
   const configPath = `${appProjectRoot}/jest.config.${js ? 'js' : 'cts'}`;
-  const content = `module.exports = {
+  const content = `// <reference types="jest" />
+// <reference types="node" />
+module.exports = {
   displayName: '${projectName}',
   resolver: require.resolve('./jest.resolver.js'),
   preset: 'jest-expo',

--- a/packages/express/src/generators/application/application.spec.ts
+++ b/packages/express/src/generators/application/application.spec.ts
@@ -100,6 +100,7 @@ describe('app', () => {
         },
         "exclude": [
           "jest.config.ts",
+          "jest.config.cts",
           "src/**/*.spec.ts",
           "src/**/*.test.ts",
         ],
@@ -329,6 +330,7 @@ describe('app', () => {
             "out-tsc",
             "dist",
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.spec.ts",
             "src/**/*.test.ts",
             "eslint.config.js",

--- a/packages/express/src/generators/application/application.spec.ts
+++ b/packages/express/src/generators/application/application.spec.ts
@@ -358,6 +358,7 @@ describe('app', () => {
           "extends": "../tsconfig.base.json",
           "include": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.d.ts",

--- a/packages/express/src/generators/application/application.spec.ts
+++ b/packages/express/src/generators/application/application.spec.ts
@@ -284,7 +284,7 @@ describe('app', () => {
               "test": {
                 "executor": "@nx/jest:jest",
                 "options": {
-                  "jestConfig": "myapp/jest.config.ts",
+                  "jestConfig": "myapp/jest.config.cts",
                   "passWithNoTests": true,
                 },
                 "outputs": [
@@ -496,7 +496,7 @@ describe('app', () => {
             "test": {
               "executor": "@nx/jest:jest",
               "options": {
-                "jestConfig": "myapp/jest.config.ts",
+                "jestConfig": "myapp/jest.config.cts",
                 "passWithNoTests": true,
               },
               "outputs": [

--- a/packages/express/tsconfig.lib.json
+++ b/packages/express/tsconfig.lib.json
@@ -11,7 +11,8 @@
     "**/*.test.ts",
     "**/*_spec.ts",
     "**/*_test.ts",
-    "jest.config.ts"
+    "jest.config.ts",
+    "jest.config.cts"
   ],
   "include": ["**/*.ts", "**/*.json"],
   "references": [

--- a/packages/jest/index.ts
+++ b/packages/jest/index.ts
@@ -14,3 +14,4 @@ export {
 export { jestConfigObjectAst } from './src/utils/config/functions';
 export { jestInitGenerator } from './src/generators/init/init';
 export { getJestProjectsAsync } from './src/utils/config/get-jest-projects';
+export { findJestConfig } from './src/utils/config/config-file';

--- a/packages/jest/src/generators/configuration/configuration.spec.ts
+++ b/packages/jest/src/generators/configuration/configuration.spec.ts
@@ -703,10 +703,8 @@ describe('jestProject', () => {
   describe('Jest 30+', () => {
     const { getInstalledJestMajorVersion } = require('../../utils/versions');
 
-    it('should create jest.config.cts for Jest 30+', async () => {
-      // Mock returns Jest 30 twice because generator calls it in two places
-      getInstalledJestMajorVersion
-        .mockReturnValue(30);
+    it('should create jest.config.cts', async () => {
+      getInstalledJestMajorVersion.mockReturnValue(30);
 
       await configurationGenerator(tree, {
         ...defaultOptions,
@@ -724,9 +722,7 @@ describe('jestProject', () => {
     });
 
     it('should create jest.config.cts when Jest version cannot be determined (null)', async () => {
-      // Mock returns null twice because generator calls it in two places
-      getInstalledJestMajorVersion
-        .mockReturnValue(null);
+      getInstalledJestMajorVersion.mockReturnValue(null);
 
       await configurationGenerator(tree, {
         ...defaultOptions,
@@ -740,10 +736,8 @@ describe('jestProject', () => {
       );
     });
 
-    it('should exclude jest.config.cts from tsconfig for Jest 30+', async () => {
-      // Mock returns Jest 30 twice because generator calls it in two places
-      getInstalledJestMajorVersion
-        .mockReturnValue(30);
+    it('should exclude jest.config.ts and jest.config.cts from tsconfig', async () => {
+      getInstalledJestMajorVersion.mockReturnValue(30);
 
       // Create tsconfig.lib.json first
       writeJson(tree, 'libs/lib1/tsconfig.lib.json', {
@@ -761,14 +755,12 @@ describe('jestProject', () => {
       } as JestProjectSchema);
 
       const tsConfig = readJson(tree, 'libs/lib1/tsconfig.lib.json');
+      expect(tsConfig.exclude).toContain('jest.config.ts');
       expect(tsConfig.exclude).toContain('jest.config.cts');
-      expect(tsConfig.exclude).not.toContain('jest.config.ts');
     });
 
-    it('root jest.config.cts should be project config for Jest 30+', async () => {
-      // Mock returns Jest 30 twice because generator calls it in two places
-      getInstalledJestMajorVersion
-        .mockReturnValue(30);
+    it('root jest.config.cts should be project config', async () => {
+      getInstalledJestMajorVersion.mockReturnValue(30);
 
       writeJson(tree, 'tsconfig.json', {
         files: [],

--- a/packages/jest/src/generators/configuration/configuration.spec.ts
+++ b/packages/jest/src/generators/configuration/configuration.spec.ts
@@ -16,6 +16,13 @@ import { jestConfigObject } from '../../utils/config/functions';
 import configurationGenerator from './configuration';
 import { JestProjectSchema } from './schema.d';
 
+// Mock Jest version detection to return Jest 29 by default
+// This ensures existing tests continue to work with .ts config files
+jest.mock('../../utils/versions', () => ({
+  ...jest.requireActual('../../utils/versions'),
+  getInstalledJestMajorVersion: jest.fn(() => 29),
+}));
+
 describe('jestProject', () => {
   let tree: Tree;
   let defaultOptions: Omit<JestProjectSchema, 'project'> = {
@@ -688,6 +695,109 @@ describe('jestProject', () => {
           "sourceMaps": true,
           "exclude": []
         }
+        "
+      `);
+    });
+  });
+
+  describe('Jest 30+', () => {
+    const { getInstalledJestMajorVersion } = require('../../utils/versions');
+
+    it('should create jest.config.cts for Jest 30+', async () => {
+      // Mock returns Jest 30 twice because generator calls it in two places
+      getInstalledJestMajorVersion
+        .mockReturnValue(30);
+
+      await configurationGenerator(tree, {
+        ...defaultOptions,
+        project: 'lib1',
+      } as JestProjectSchema);
+
+      expect(tree.exists('libs/lib1/jest.config.cts')).toBeTruthy();
+      expect(tree.exists('libs/lib1/jest.config.ts')).toBeFalsy();
+      expect(tree.read('libs/lib1/jest.config.cts', 'utf-8')).toContain(
+        'module.exports ='
+      );
+      expect(tree.read('libs/lib1/jest.config.cts', 'utf-8')).not.toContain(
+        'export default'
+      );
+    });
+
+    it('should create jest.config.cts when Jest version cannot be determined (null)', async () => {
+      // Mock returns null twice because generator calls it in two places
+      getInstalledJestMajorVersion
+        .mockReturnValue(null);
+
+      await configurationGenerator(tree, {
+        ...defaultOptions,
+        project: 'lib1',
+      } as JestProjectSchema);
+
+      expect(tree.exists('libs/lib1/jest.config.cts')).toBeTruthy();
+      expect(tree.exists('libs/lib1/jest.config.ts')).toBeFalsy();
+      expect(tree.read('libs/lib1/jest.config.cts', 'utf-8')).toContain(
+        'module.exports ='
+      );
+    });
+
+    it('should exclude jest.config.cts from tsconfig for Jest 30+', async () => {
+      // Mock returns Jest 30 twice because generator calls it in two places
+      getInstalledJestMajorVersion
+        .mockReturnValue(30);
+
+      // Create tsconfig.lib.json first
+      writeJson(tree, 'libs/lib1/tsconfig.lib.json', {
+        extends: './tsconfig.json',
+        compilerOptions: {
+          outDir: '../../dist/out-tsc',
+        },
+        include: ['src/**/*.ts'],
+        exclude: [],
+      });
+
+      await configurationGenerator(tree, {
+        ...defaultOptions,
+        project: 'lib1',
+      } as JestProjectSchema);
+
+      const tsConfig = readJson(tree, 'libs/lib1/tsconfig.lib.json');
+      expect(tsConfig.exclude).toContain('jest.config.cts');
+      expect(tsConfig.exclude).not.toContain('jest.config.ts');
+    });
+
+    it('root jest.config.cts should be project config for Jest 30+', async () => {
+      // Mock returns Jest 30 twice because generator calls it in two places
+      getInstalledJestMajorVersion
+        .mockReturnValue(30);
+
+      writeJson(tree, 'tsconfig.json', {
+        files: [],
+        include: [],
+        references: [],
+      });
+      addProjectConfiguration(tree, 'my-project', {
+        root: '',
+        sourceRoot: 'src',
+        name: 'my-project',
+        targets: {},
+      });
+      await configurationGenerator(tree, {
+        ...defaultOptions,
+        project: 'my-project',
+      });
+
+      expect(tree.exists('jest.config.cts')).toBeTruthy();
+      expect(tree.exists('jest.config.ts')).toBeFalsy();
+      expect(tree.read('jest.config.cts', 'utf-8')).toMatchInlineSnapshot(`
+        "module.exports = {
+          displayName: 'my-project',
+          preset: './jest.preset.js',
+          coverageDirectory: './coverage/my-project',
+          testMatch: [
+            '<rootDir>/src/**/__tests__/**/*.[jt]s?(x)',
+            '<rootDir>/src/**/*(*.)@(spec|test).[jt]s?(x)',
+          ],
+        };
         "
       `);
     });

--- a/packages/jest/src/generators/configuration/files/common/tsconfig.spec.json__tmpl__
+++ b/packages/jest/src/generators/configuration/files/common/tsconfig.spec.json__tmpl__
@@ -9,6 +9,7 @@
   "files": ["src/test-setup.ts"],<% } %>
   "include": [
     "jest.config.ts",
+    "jest.config.cts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",<% if (supportTsx) { %>
     "src/**/*.test.tsx",

--- a/packages/jest/src/generators/configuration/lib/create-files.ts
+++ b/packages/jest/src/generators/configuration/lib/create-files.ts
@@ -115,10 +115,10 @@ export function createFiles(
 
   const configPath = join(projectConfig.root, 'jest.config.ts');
   if (tree.exists(configPath)) {
-    if (useCommonJsConfig) {
-      tree.rename(configPath, join(projectConfig.root, 'jest.config.cts'));
-    } else if (options.js) {
+    if (options.js) {
       tree.rename(configPath, join(projectConfig.root, 'jest.config.js'));
+    } else if (useCommonJsConfig) {
+      tree.rename(configPath, join(projectConfig.root, 'jest.config.cts'));
     }
   }
 }

--- a/packages/jest/src/generators/configuration/lib/create-files.ts
+++ b/packages/jest/src/generators/configuration/lib/create-files.ts
@@ -7,6 +7,7 @@ import {
 import { addSwcTestConfig } from '@nx/js/src/utils/swc/add-swc-config';
 import { join } from 'path';
 import type { JestPresetExtension } from '../../../utils/config/config-file';
+import { getInstalledJestMajorVersion } from '../../../utils/versions';
 import { NormalizedJestProjectSchema } from '../schema';
 
 export function createFiles(
@@ -15,6 +16,12 @@ export function createFiles(
   presetExt: JestPresetExtension
 ) {
   const projectConfig = readProjectConfiguration(tree, options.project);
+
+  // Detect Jest 30+ to use .cts config files (CommonJS TypeScript)
+  // Treat null (version cannot be determined) as Jest 30+
+  const jestMajorVersion = getInstalledJestMajorVersion(tree);
+  const useCommonJsConfig = jestMajorVersion === null || jestMajorVersion >= 30;
+  const useJsSyntax = useCommonJsConfig || !!options.js;
 
   const commonFilesFolder =
     options.setupFile === 'angular' ? '../files-angular' : '../files/common';
@@ -59,7 +66,7 @@ export function createFiles(
     testEnvironment,
     transformer,
     transformerOptions,
-    js: !!options.js,
+    js: useJsSyntax,
     rootProject: options.rootProject,
     projectRoot,
     offsetFromRoot: rootOffset,
@@ -93,7 +100,7 @@ export function createFiles(
         testEnvironment,
         transformer,
         transformerOptions,
-        js: !!options.js,
+        js: useJsSyntax,
         rootProject: options.rootProject,
         offsetFromRoot: rootOffset,
         presetExt,
@@ -106,10 +113,12 @@ export function createFiles(
     tree.delete(join(projectConfig.root, './src/test-setup.ts'));
   }
 
-  if (options.js) {
-    tree.rename(
-      join(projectConfig.root, 'jest.config.ts'),
-      join(projectConfig.root, 'jest.config.js')
-    );
+  const configPath = join(projectConfig.root, 'jest.config.ts');
+  if (tree.exists(configPath)) {
+    if (useCommonJsConfig) {
+      tree.rename(configPath, join(projectConfig.root, 'jest.config.cts'));
+    } else if (options.js) {
+      tree.rename(configPath, join(projectConfig.root, 'jest.config.js'));
+    }
   }
 }

--- a/packages/jest/src/generators/configuration/lib/update-tsconfig.ts
+++ b/packages/jest/src/generators/configuration/lib/update-tsconfig.ts
@@ -34,6 +34,16 @@ export function updateTsConfig(
         path: './tsconfig.spec.json',
       });
     }
+
+    // If compilerOptions.types is defined, ensure "node" is included to support
+    // module.exports syntax in jest.config.cts. If types is not defined,
+    // TypeScript automatically loads @types/node.
+    if (json.compilerOptions?.types) {
+      if (!json.compilerOptions.types.includes('node')) {
+        json.compilerOptions.types.push('node');
+      }
+    }
+
     return json;
   });
   const projectType = getProjectType(host, root, _projectType);

--- a/packages/jest/src/generators/configuration/lib/update-tsconfig.ts
+++ b/packages/jest/src/generators/configuration/lib/update-tsconfig.ts
@@ -7,7 +7,6 @@ import {
 } from '@nx/devkit';
 import type { NormalizedJestProjectSchema } from '../schema';
 import { getProjectType } from '@nx/js/src/utils/typescript/ts-solution-setup';
-import { getInstalledJestMajorVersion } from '../../../utils/versions';
 
 export function updateTsConfig(
   host: Tree,
@@ -26,17 +25,6 @@ export function updateTsConfig(
     );
   }
 
-  // Detect Jest 30+ to determine the correct config extension
-  const jestMajorVersion = getInstalledJestMajorVersion(host);
-  const useCommonJsConfig = jestMajorVersion === null || jestMajorVersion >= 30;
-  let jestConfigFile: string;
-  if (useCommonJsConfig) {
-    jestConfigFile = 'jest.config.cts';
-  } else if (options.js) {
-    jestConfigFile = 'jest.config.js';
-  } else {
-    jestConfigFile = 'jest.config.ts';
-  }
   updateJson(host, joinPathFragments(root, 'tsconfig.json'), (json) => {
     if (
       json.references &&
@@ -82,7 +70,9 @@ export function updateTsConfig(
     updateJson(host, runtimeTsconfigPath, (json) => {
       const uniqueExclude = new Set([
         ...(json.exclude || []),
-        jestConfigFile,
+        ...(options.js
+          ? ['jest.config.js']
+          : ['jest.config.ts', 'jest.config.cts']),
         'src/**/*.spec.ts',
         'src/**/*.test.ts',
         ...(options.js ? ['src/**/*.spec.js', 'src/**/*.test.js'] : []),

--- a/packages/jest/src/generators/configuration/lib/update-workspace.ts
+++ b/packages/jest/src/generators/configuration/lib/update-workspace.ts
@@ -4,6 +4,7 @@ import {
   type Tree,
   updateProjectConfiguration,
 } from '@nx/devkit';
+import { getInstalledJestMajorVersion } from '../../../utils/versions';
 import type { NormalizedJestProjectSchema } from '../schema';
 
 export function updateWorkspace(
@@ -14,6 +15,11 @@ export function updateWorkspace(
   if (!projectConfig.targets) {
     projectConfig.targets = {};
   }
+
+  // Detect Jest 30+ to use .cts config files (CommonJS TypeScript)
+  const jestMajorVersion = getInstalledJestMajorVersion(tree);
+  const useCommonJsConfig = jestMajorVersion === null || jestMajorVersion >= 30;
+  const jestConfigExt = options.js ? 'js' : useCommonJsConfig ? 'cts' : 'ts';
 
   projectConfig.targets[options.targetName] = {
     executor: '@nx/jest:jest',
@@ -29,7 +35,7 @@ export function updateWorkspace(
     options: {
       jestConfig: joinPathFragments(
         projectConfig.root,
-        `jest.config.${options.js ? 'js' : 'ts'}`
+        `jest.config.${jestConfigExt}`
       ),
     },
   };

--- a/packages/jest/src/utils/config/config-file.ts
+++ b/packages/jest/src/utils/config/config-file.ts
@@ -40,6 +40,14 @@ export function findRootJestConfig(tree: Tree): string | null {
   return ext ? `jest.config.${ext}` : null;
 }
 
+export function findJestConfig(tree: Tree, projectPath: string): string | null {
+  const ext = jestConfigExtensions.find((ext) =>
+    tree.exists(`${projectPath}/jest.config.${ext}`)
+  );
+
+  return ext ? `${projectPath}/jest.config.${ext}` : null;
+}
+
 export function findRootJestPreset(tree: Tree): string | null {
   const ext = jestPresetExtensions.find((ext) =>
     tree.exists(`jest.preset.${ext}`)

--- a/packages/js/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/js/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`lib --unit-test-runner jest should generate test configuration with swc and js 1`] = `
 "/* eslint-disable */

--- a/packages/js/src/generators/library/files/jest-config/jest.config.__ext__
+++ b/packages/js/src/generators/library/files/jest-config/jest.config.__ext__
@@ -1,5 +1,5 @@
 /* eslint-disable */
-<% if(js) {%>const { readFileSync } = require('fs')<% } else { %>import { readFileSync } from 'fs';<% } %>
+<% if(ext === 'js' || ext === 'cts') {%>const { readFileSync } = require('fs')<% } else { %>import { readFileSync } from 'fs';<% } %>
 
 // Reading the SWC compilation config and remove the "exclude"
 // for the test files to be compiled by SWC
@@ -18,7 +18,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-<% if(js) {%>module.exports =<% } else { %>export default<% } %> {
+<% if(ext === 'js' || ext === 'cts') {%>module.exports =<% } else { %>export default<% } %> {
   displayName: '<%= project %>',
   preset: '<%= offsetFromRoot %><%= jestPreset %>',
   transform: {

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1849,7 +1849,7 @@ describe('lib', () => {
             "test": {
               "executor": "@nx/jest:jest",
               "options": {
-                "jestConfig": "my-lib/jest.config.ts",
+                "jestConfig": "my-lib/jest.config.cts",
               },
               "outputs": [
                 "{workspaceRoot}/coverage/{projectRoot}",

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1849,7 +1849,7 @@ describe('lib', () => {
             "test": {
               "executor": "@nx/jest:jest",
               "options": {
-                "jestConfig": "my-lib/jest.config.cts",
+                "jestConfig": "my-lib/jest.config.ts",
               },
               "outputs": [
                 "{workspaceRoot}/coverage/{projectRoot}",
@@ -1900,8 +1900,10 @@ describe('lib', () => {
 
         expect(tree.read('pnpm-workspace.yaml', 'utf-8'))
           .toMatchInlineSnapshot(`
-                  "packages:
-                  - '`);
+          "packages:
+            - '${expected}'
+          "
+        `);
       }
     );
 
@@ -2091,7 +2093,7 @@ describe('lib', () => {
           },
           "sourceMaps": true,
           "exclude": [
-            "jest.config.cts",
+            "jest.config.[ct]s",
             ".*\\\\.spec.tsx?$",
             ".*\\\\.test.tsx?$",
             "./src/jest-setup.ts$",

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1849,7 +1849,7 @@ describe('lib', () => {
             "test": {
               "executor": "@nx/jest:jest",
               "options": {
-                "jestConfig": "my-lib/jest.config.ts",
+                "jestConfig": "my-lib/jest.config.cts",
               },
               "outputs": [
                 "{workspaceRoot}/coverage/{projectRoot}",
@@ -2091,7 +2091,7 @@ describe('lib', () => {
           },
           "sourceMaps": true,
           "exclude": [
-            "jest.config.ts",
+            "jest.config.cts",
             ".*\\\\.spec.tsx?$",
             ".*\\\\.test.tsx?$",
             "./src/jest-setup.ts$",

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -254,7 +254,7 @@ describe('lib', () => {
           name: 'my-lib',
           directory: 'my-dir/my-lib',
         });
-        expect(tree.exists(`my-dir/my-lib/jest.config.ts`)).toBeTruthy();
+        expect(tree.exists(`my-dir/my-lib/jest.config.cts`)).toBeTruthy();
         expect(tree.exists('my-dir/my-lib/src/index.ts')).toBeTruthy();
         expect(tree.exists('my-dir/my-lib/src/lib/my-lib.ts')).toBeTruthy();
         expect(
@@ -862,10 +862,10 @@ describe('lib', () => {
 
         expect(tree.exists('my-lib/tsconfig.spec.json')).toBeTruthy();
         expect(tree.exists('my-lib/src/lib/my-lib.spec.ts')).toBeTruthy();
-        expect(tree.exists('my-lib/jest.config.ts')).toBeTruthy();
-        expect(tree.read('my-lib/jest.config.ts', 'utf-8'))
+        expect(tree.exists('my-lib/jest.config.cts')).toBeTruthy();
+        expect(tree.read('my-lib/jest.config.cts', 'utf-8'))
           .toMatchInlineSnapshot(`
-                  "export default {
+                  "module.exports = {
                     displayName: 'my-lib',
                     preset: '../jest.preset.js',
                     transform: {
@@ -897,41 +897,41 @@ describe('lib', () => {
 
         expect(tree.exists('my-lib/tsconfig.spec.json')).toBeTruthy();
         expect(tree.exists('my-lib/src/lib/my-lib.spec.ts')).toBeTruthy();
-        expect(tree.exists('my-lib/jest.config.ts')).toBeTruthy();
-        expect(tree.read('my-lib/jest.config.ts', 'utf-8'))
+        expect(tree.exists('my-lib/jest.config.cts')).toBeTruthy();
+        expect(tree.read('my-lib/jest.config.cts', 'utf-8'))
           .toMatchInlineSnapshot(`
-        "/* eslint-disable */
-        import { readFileSync } from 'fs';
+                  "/* eslint-disable */
+                  const { readFileSync } = require('fs');
 
-        // Reading the SWC compilation config and remove the "exclude"
-        // for the test files to be compiled by SWC
-        const { exclude: _, ...swcJestConfig } = JSON.parse(
-          readFileSync(\`\${__dirname}/.swcrc\`, 'utf-8')
-        );
+                  // Reading the SWC compilation config and remove the "exclude"
+                  // for the test files to be compiled by SWC
+                  const { exclude: _, ...swcJestConfig } = JSON.parse(
+                    readFileSync(\`\${__dirname}/.swcrc\`, 'utf-8')
+                  );
 
-        // disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
-        // If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
-        if (swcJestConfig.swcrc === undefined) {
-          swcJestConfig.swcrc = false;
-        }
+                  // disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+                  // If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+                  if (swcJestConfig.swcrc === undefined) {
+                    swcJestConfig.swcrc = false;
+                  }
 
-        // Uncomment if using global setup/teardown files being transformed via swc
-        // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
-        // jest needs EsModule Interop to find the default exported setup/teardown functions
-        // swcJestConfig.module.noInterop = false;
+                  // Uncomment if using global setup/teardown files being transformed via swc
+                  // https://nx.dev/nx-api/jest/documents/overview#global-setupteardown-with-nx-libraries
+                  // jest needs EsModule Interop to find the default exported setup/teardown functions
+                  // swcJestConfig.module.noInterop = false;
 
-        export default {
-          displayName: 'my-lib',
-          preset: '../jest.preset.js',
-          transform: {
-            '^.+\\\\.[tj]s$': ['@swc/jest', swcJestConfig],
-          },
-          moduleFileExtensions: ['ts', 'js', 'html'],
-          testEnvironment: 'jsdom',
-          coverageDirectory: '../coverage/my-lib',
-        };
-        "
-      `);
+                  module.exports = {
+                    displayName: 'my-lib',
+                    preset: '../jest.preset.js',
+                    transform: {
+                      '^.+\\\\.[tj]s$': ['@swc/jest', swcJestConfig],
+                    },
+                    moduleFileExtensions: ['ts', 'js', 'html'],
+                    testEnvironment: 'jsdom',
+                    coverageDirectory: '../coverage/my-lib',
+                  };
+                  "
+              `);
         const readme = tree.read('my-lib/README.md', 'utf-8');
         expect(readme).toContain('nx test my-lib');
         // assert the TS solution setup doesn't leak into the old/integrated setup
@@ -1037,7 +1037,7 @@ describe('lib', () => {
           bundler: 'swc',
         });
 
-        const jestConfig = tree.read('my-lib/jest.config.ts').toString();
+        const jestConfig = tree.read('my-lib/jest.config.cts').toString();
         expect(jestConfig).toContain('@swc/jest');
       });
 
@@ -1114,7 +1114,7 @@ describe('lib', () => {
           compiler: 'swc',
         });
 
-        const jestConfig = tree.read('my-lib/jest.config.ts').toString();
+        const jestConfig = tree.read('my-lib/jest.config.cts').toString();
         expect(jestConfig).toContain('@swc/jest');
       });
 
@@ -1900,10 +1900,8 @@ describe('lib', () => {
 
         expect(tree.read('pnpm-workspace.yaml', 'utf-8'))
           .toMatchInlineSnapshot(`
-        "packages:
-          - '${expected}'
-        "
-      `);
+                  "packages:
+                  - '`);
       }
     );
 
@@ -2190,31 +2188,31 @@ describe('lib', () => {
 
         expect(tree.exists('my-lib/tsconfig.spec.json')).toBeTruthy();
         expect(tree.exists('my-lib/src/lib/my-lib.spec.ts')).toBeTruthy();
-        expect(tree.exists('my-lib/jest.config.ts')).toBeTruthy();
-        expect(tree.read('my-lib/jest.config.ts', 'utf-8'))
+        expect(tree.exists('my-lib/jest.config.cts')).toBeTruthy();
+        expect(tree.read('my-lib/jest.config.cts', 'utf-8'))
           .toMatchInlineSnapshot(`
-        "/* eslint-disable */
-        import { readFileSync } from 'fs';
+                  "/* eslint-disable */
+                  const { readFileSync } = require('fs');
 
-        // Reading the SWC compilation config for the spec files
-        const swcJestConfig = JSON.parse(
-          readFileSync(\`\${__dirname}/.spec.swcrc\`, 'utf-8')
-        );
+                  // Reading the SWC compilation config for the spec files
+                  const swcJestConfig = JSON.parse(
+                    readFileSync(\`\${__dirname}/.spec.swcrc\`, 'utf-8')
+                  );
 
-        // Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
-        swcJestConfig.swcrc = false;
+                  // Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
+                  swcJestConfig.swcrc = false;
 
-        export default {
-          displayName: '@proj/my-lib',
-          preset: '../jest.preset.js',
-          transform: {
-            '^.+\\\\.[tj]s$': ['@swc/jest', swcJestConfig],
-          },
-          moduleFileExtensions: ['ts', 'js', 'html'],
-          coverageDirectory: 'test-output/jest/coverage',
-        };
-        "
-      `);
+                  module.exports = {
+                    displayName: '@proj/my-lib',
+                    preset: '../jest.preset.js',
+                    transform: {
+                      '^.+\\\\.[tj]s$': ['@swc/jest', swcJestConfig],
+                    },
+                    moduleFileExtensions: ['ts', 'js', 'html'],
+                    coverageDirectory: 'test-output/jest/coverage',
+                  };
+                  "
+              `);
         expect(tree.read('my-lib/.spec.swcrc', 'utf-8')).toMatchInlineSnapshot(`
           "{
             "jsc": {

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -753,7 +753,7 @@ function replaceJestConfig(
   // the existing config has to be deleted otherwise the new config won't overwrite it
   const existingJestConfig = joinPathFragments(
     filesDir,
-    `jest.config.${options.js ? 'js' : 'ts'}`
+    `jest.config.${options.js ? 'js' : 'cts'}`
   );
   if (tree.exists(existingJestConfig)) {
     tree.delete(existingJestConfig);
@@ -762,7 +762,7 @@ function replaceJestConfig(
 
   // replace with JS:SWC specific jest config
   generateFiles(tree, filesDir, options.projectRoot, {
-    ext: options.js ? 'js' : 'ts',
+    ext: options.js ? 'js' : 'cts',
     jestPreset,
     js: !!options.js,
     project: options.name,

--- a/packages/js/src/utils/swc/add-swc-config.ts
+++ b/packages/js/src/utils/swc/add-swc-config.ts
@@ -2,7 +2,7 @@ import { type Tree } from '@nx/devkit';
 import { join } from 'path';
 
 export const defaultExclude = [
-  'jest.config.ts',
+  'jest.config.[ct]s',
   '.*\\.spec.tsx?$',
   '.*\\.test.tsx?$',
   './src/jest-setup.ts$',

--- a/packages/js/tsconfig.lib.json
+++ b/packages/js/tsconfig.lib.json
@@ -10,7 +10,8 @@
     "**/*.spec.ts",
     "**/*.test.ts",
     "./src/**/test-fixtures/**/*",
-    "jest.config.ts"
+    "jest.config.ts",
+    "jest.config.cts"
   ],
   "include": ["**/*.ts"],
   "references": [

--- a/packages/js/tsconfig.spec.json
+++ b/packages/js/tsconfig.spec.json
@@ -16,7 +16,7 @@
     "**/*.spec.jsx",
     "**/*.test.jsx",
     "**/*.d.ts",
-    "jest.config.ts",
+    "jest.config.cts",
     "*.json"
   ],
   "references": [

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -420,6 +420,7 @@ describe('application generator', () => {
           "extends": "../tsconfig.base.json",
           "include": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.d.ts",

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -579,7 +579,7 @@ describe('application generator', () => {
               ],
               "executor": "@nx/jest:jest",
               "options": {
-                "jestConfig": "myapp-e2e/jest.config.ts",
+                "jestConfig": "myapp-e2e/jest.config.cts",
                 "passWithNoTests": true,
               },
               "outputs": [

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -159,6 +159,7 @@ describe('application generator', () => {
     expect(tsConfig.compilerOptions.target).toBe('es2021');
     expect(tsConfig.exclude).toEqual([
       'jest.config.ts',
+      'jest.config.cts',
       'src/**/*.spec.ts',
       'src/**/*.test.ts',
     ]);
@@ -390,6 +391,7 @@ describe('application generator', () => {
             "out-tsc",
             "dist",
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.spec.ts",
             "src/**/*.test.ts",
             "eslint.config.js",

--- a/packages/nest/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/nest/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`lib --testEnvironment should set target jest testEnvironment to jsdom 1`] = `
-"export default {
+"module.exports = {
   displayName: 'my-lib',
   preset: '../jest.preset.js',
   transform: {
@@ -14,7 +14,7 @@ exports[`lib --testEnvironment should set target jest testEnvironment to jsdom 1
 `;
 
 exports[`lib --testEnvironment should set target jest testEnvironment to node by default 1`] = `
-"export default {
+"module.exports = {
   displayName: 'my-lib',
   preset: '../jest.preset.js',
   testEnvironment: 'node',

--- a/packages/nest/src/generators/library/library.spec.ts
+++ b/packages/nest/src/generators/library/library.spec.ts
@@ -472,6 +472,7 @@ describe('lib', () => {
           "extends": "../tsconfig.base.json",
           "include": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.d.ts",

--- a/packages/nest/src/generators/library/library.spec.ts
+++ b/packages/nest/src/generators/library/library.spec.ts
@@ -385,7 +385,7 @@ describe('lib', () => {
               "test": {
                 "executor": "@nx/jest:jest",
                 "options": {
-                  "jestConfig": "mylib/jest.config.ts",
+                  "jestConfig": "mylib/jest.config.cts",
                 },
                 "outputs": [
                   "{projectRoot}/test-output/jest/coverage",
@@ -522,7 +522,7 @@ describe('lib', () => {
                   "{projectRoot}/test-output/jest/coverage"
                 ],
                 "options": {
-                  "jestConfig": "mylib/jest.config.ts"
+                  "jestConfig": "mylib/jest.config.cts"
                 }
               },
               "build": {
@@ -634,7 +634,7 @@ describe('lib', () => {
             "test": {
               "executor": "@nx/jest:jest",
               "options": {
-                "jestConfig": "mylib/jest.config.ts",
+                "jestConfig": "mylib/jest.config.cts",
               },
               "outputs": [
                 "{projectRoot}/test-output/jest/coverage",

--- a/packages/nest/src/generators/library/library.spec.ts
+++ b/packages/nest/src/generators/library/library.spec.ts
@@ -145,6 +145,7 @@ describe('lib', () => {
       expect(tsconfigJson.extends).toEqual('./tsconfig.json');
       expect(tsconfigJson.exclude).toEqual([
         'jest.config.ts',
+        'jest.config.cts',
         'src/**/*.spec.ts',
         'src/**/*.test.ts',
       ]);
@@ -155,7 +156,7 @@ describe('lib', () => {
         directory: 'my-lib',
       });
 
-      expect(tree.exists(`my-lib/jest.config.ts`)).toBeTruthy();
+      expect(tree.exists(`my-lib/jest.config.cts`)).toBeTruthy();
       expect(tree.exists(`my-lib/src/index.ts`)).toBeTruthy();
       expect(tree.exists(`my-lib/src/lib/my-lib.spec.ts`)).toBeFalsy();
       expect(readJson(tree, `my-lib/.eslintrc.json`)).toMatchSnapshot();
@@ -182,7 +183,7 @@ describe('lib', () => {
         directory: 'my-dir/my-lib',
       });
 
-      expect(tree.exists(`my-dir/my-lib/jest.config.ts`)).toBeTruthy();
+      expect(tree.exists(`my-dir/my-lib/jest.config.cts`)).toBeTruthy();
       expect(tree.exists(`my-dir/my-lib/src/index.ts`)).toBeTruthy();
       expect(tree.exists(`my-dir/my-lib/src/lib/my-lib.spec.ts`)).toBeFalsy();
     });
@@ -234,7 +235,7 @@ describe('lib', () => {
       });
 
       expect(tree.exists(`my-lib/tsconfig.spec.json`)).toBeFalsy();
-      expect(tree.exists(`my-lib/jest.config.ts`)).toBeFalsy();
+      expect(tree.exists(`my-lib/jest.config.cts`)).toBeFalsy();
       expect(tree.exists(`my-lib/lib/my-lib.spec.ts`)).toBeFalsy();
       expect(readJson(tree, `my-lib/tsconfig.json`)).toMatchSnapshot();
     });
@@ -315,7 +316,7 @@ describe('lib', () => {
         directory: 'my-lib',
       });
 
-      expect(tree.read(`my-lib/jest.config.ts`, 'utf-8')).toMatchSnapshot();
+      expect(tree.read(`my-lib/jest.config.cts`, 'utf-8')).toMatchSnapshot();
     });
 
     it('should set target jest testEnvironment to jsdom', async () => {
@@ -324,7 +325,7 @@ describe('lib', () => {
         testEnvironment: 'jsdom',
       });
 
-      expect(tree.read(`my-lib/jest.config.ts`, 'utf-8')).toMatchSnapshot();
+      expect(tree.read(`my-lib/jest.config.cts`, 'utf-8')).toMatchSnapshot();
     });
   });
 
@@ -440,6 +441,7 @@ describe('lib', () => {
           },
           "exclude": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.spec.ts",
             "src/**/*.test.ts",
           ],

--- a/packages/nest/tsconfig.lib.json
+++ b/packages/nest/tsconfig.lib.json
@@ -12,6 +12,7 @@
     "**/*_spec.ts",
     "**/*_test.ts",
     "jest.config.ts",
+    "jest.config.cts",
     "test-setup.ts"
   ],
   "include": ["**/*.ts", "**/*.json"],

--- a/packages/next/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/next/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`app --style styled-jsx should use <style jsx> in index page 1`] = `
 "'use client';

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -1030,6 +1030,7 @@ describe('app', () => {
           "extends": "../tsconfig.base.json",
           "include": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.test.tsx",

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -483,7 +483,7 @@ describe('app', () => {
       style: 'css',
     });
 
-    expect(tree.read(`${name}/jest.config.ts`, 'utf-8')).toContain(
+    expect(tree.read(`${name}/jest.config.cts`, 'utf-8')).toContain(
       `moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],`
     );
     expect(
@@ -499,7 +499,7 @@ describe('app', () => {
       style: 'css',
     });
 
-    expect(tree.read(`${name}/jest.config.ts`, 'utf-8')).toContain(
+    expect(tree.read(`${name}/jest.config.cts`, 'utf-8')).toContain(
       `'^(?!.*\\\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest'`
     );
   });
@@ -546,7 +546,7 @@ describe('app', () => {
         style: 'css',
         unitTestRunner: 'none',
       });
-      expect(tree.exists('jest.config.ts')).toBeFalsy();
+      expect(tree.exists('jest.config.cts')).toBeFalsy();
       expect(tree.exists(`${name}/specs/index.spec.tsx`)).toBeFalsy();
     });
   });
@@ -952,100 +952,101 @@ describe('app', () => {
           ]
         `);
       expect(readJson(tree, 'myapp/tsconfig.json')).toMatchInlineSnapshot(`
-          {
-            "compilerOptions": {
-              "allowJs": true,
-              "allowSyntheticDefaultImports": true,
-              "emitDeclarationOnly": false,
-              "esModuleInterop": true,
-              "forceConsistentCasingInFileNames": true,
-              "incremental": true,
-              "isolatedModules": true,
-              "jsx": "preserve",
-              "lib": [
-                "dom",
-                "dom.iterable",
-                "esnext",
-              ],
-              "module": "esnext",
-              "moduleResolution": "bundler",
-              "noEmit": true,
-              "outDir": "dist",
-              "paths": {
-                "@/*": [
-                  "./src/*",
-                ],
-              },
-              "plugins": [
-                {
-                  "name": "next",
-                },
-              ],
-              "resolveJsonModule": true,
-              "rootDir": "src",
-              "strict": true,
-              "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
-              "types": [
-                "jest",
-                "node",
+        {
+          "compilerOptions": {
+            "allowJs": true,
+            "allowSyntheticDefaultImports": true,
+            "emitDeclarationOnly": false,
+            "esModuleInterop": true,
+            "forceConsistentCasingInFileNames": true,
+            "incremental": true,
+            "isolatedModules": true,
+            "jsx": "preserve",
+            "lib": [
+              "dom",
+              "dom.iterable",
+              "esnext",
+            ],
+            "module": "esnext",
+            "moduleResolution": "bundler",
+            "noEmit": true,
+            "outDir": "dist",
+            "paths": {
+              "@/*": [
+                "./src/*",
               ],
             },
-            "exclude": [
-              "out-tsc",
-              "dist",
-              "node_modules",
-              "jest.config.ts",
-              "src/**/*.spec.ts",
-              "src/**/*.test.ts",
-              ".next",
-              "eslint.config.js",
-              "eslint.config.cjs",
-              "eslint.config.mjs",
-            ],
-            "extends": "../tsconfig.base.json",
-            "include": [
-              "src/**/*.ts",
-              "src/**/*.tsx",
-              "src/**/*.js",
-              "src/**/*.jsx",
-              "../myapp/.next/types/**/*.ts",
-              "../dist/myapp/.next/types/**/*.ts",
-              "next-env.d.ts",
-            ],
-          }
-        `);
-      expect(readJson(tree, 'myapp/tsconfig.spec.json')).toMatchInlineSnapshot(`
-          {
-            "compilerOptions": {
-              "jsx": "preserve",
-              "module": "esnext",
-              "moduleResolution": "bundler",
-              "outDir": "./out-tsc/jest",
-              "types": [
-                "jest",
-                "node",
-              ],
-            },
-            "extends": "../tsconfig.base.json",
-            "include": [
-              "jest.config.ts",
-              "src/**/*.test.ts",
-              "src/**/*.spec.ts",
-              "src/**/*.test.tsx",
-              "src/**/*.spec.tsx",
-              "src/**/*.test.js",
-              "src/**/*.spec.js",
-              "src/**/*.test.jsx",
-              "src/**/*.spec.jsx",
-              "src/**/*.d.ts",
-            ],
-            "references": [
+            "plugins": [
               {
-                "path": "./tsconfig.json",
+                "name": "next",
               },
             ],
-          }
-        `);
+            "resolveJsonModule": true,
+            "rootDir": "src",
+            "strict": true,
+            "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+            "types": [
+              "jest",
+              "node",
+            ],
+          },
+          "exclude": [
+            "out-tsc",
+            "dist",
+            "node_modules",
+            "jest.config.ts",
+            "jest.config.cts",
+            "src/**/*.spec.ts",
+            "src/**/*.test.ts",
+            ".next",
+            "eslint.config.js",
+            "eslint.config.cjs",
+            "eslint.config.mjs",
+          ],
+          "extends": "../tsconfig.base.json",
+          "include": [
+            "src/**/*.ts",
+            "src/**/*.tsx",
+            "src/**/*.js",
+            "src/**/*.jsx",
+            "../myapp/.next/types/**/*.ts",
+            "../dist/myapp/.next/types/**/*.ts",
+            "next-env.d.ts",
+          ],
+        }
+      `);
+      expect(readJson(tree, 'myapp/tsconfig.spec.json')).toMatchInlineSnapshot(`
+        {
+          "compilerOptions": {
+            "jsx": "preserve",
+            "module": "esnext",
+            "moduleResolution": "bundler",
+            "outDir": "./out-tsc/jest",
+            "types": [
+              "jest",
+              "node",
+            ],
+          },
+          "extends": "../tsconfig.base.json",
+          "include": [
+            "jest.config.ts",
+            "src/**/*.test.ts",
+            "src/**/*.spec.ts",
+            "src/**/*.test.tsx",
+            "src/**/*.spec.tsx",
+            "src/**/*.test.js",
+            "src/**/*.spec.js",
+            "src/**/*.test.jsx",
+            "src/**/*.spec.jsx",
+            "src/**/*.d.ts",
+          ],
+          "references": [
+            {
+              "path": "./tsconfig.json",
+            },
+          ],
+        }
+      `);
       expect(readJson(tree, 'myapp-e2e/tsconfig.json')).toMatchInlineSnapshot(`
           {
             "compilerOptions": {
@@ -1182,16 +1183,15 @@ describe('app', () => {
         unitTestRunner: 'jest',
       });
 
-      const jestConfig = tree.read(`${name}/jest.config.ts`, 'utf-8');
+      const jestConfig = tree.read(`${name}/jest.config.cts`, 'utf-8');
       expect(jestConfig).toMatchInlineSnapshot(`
-        "import type { Config } from 'jest';
-        import nextJest from 'next/jest.js';
+        "const nextJest = require('next/jest.js');
 
         const createJestConfig = nextJest({
           dir: './',
         });
 
-        const config: Config = {
+        const config = {
           displayName: 'myapp',
           preset: '../jest.preset.js',
           transform: {
@@ -1202,7 +1202,7 @@ describe('app', () => {
           testEnvironment: 'jsdom',
         };
 
-        export default createJestConfig(config);
+        module.exports = createJestConfig(config);
         "
       `);
     });
@@ -1290,16 +1290,15 @@ describe('app (legacy)', () => {
         unitTestRunner: 'jest',
       });
 
-      const jestConfig = tree.read(`${name}/jest.config.ts`, 'utf-8');
+      const jestConfig = tree.read(`${name}/jest.config.cts`, 'utf-8');
       expect(jestConfig).toMatchInlineSnapshot(`
-        "import type { Config } from 'jest';
-        import nextJest from 'next/jest.js';
+        "const nextJest = require('next/jest.js');
 
         const createJestConfig = nextJest({
           dir: './',
         });
 
-        const config: Config = {
+        const config = {
           displayName: 'myapp',
           preset: '../jest.preset.js',
           transform: {
@@ -1310,7 +1309,7 @@ describe('app (legacy)', () => {
           testEnvironment: 'jsdom',
         };
 
-        export default createJestConfig(config);
+        module.exports = createJestConfig(config);
         "
       `);
     });

--- a/packages/next/src/generators/application/files/common/tsconfig.json__tmpl__
+++ b/packages/next/src/generators/application/files/common/tsconfig.json__tmpl__
@@ -32,5 +32,5 @@
     <% } %>
     "next-env.d.ts"
   ],
-  "exclude": ["node_modules", "jest.config.ts", "<%= rootPath %>**/*.spec.ts", "<%= rootPath %>**/*.test.ts"]
+  "exclude": ["node_modules", "jest.config.ts", "jest.config.cts", "<%= rootPath %>**/*.spec.ts", "<%= rootPath %>**/*.test.ts"]
 }

--- a/packages/next/src/generators/application/lib/add-jest.ts
+++ b/packages/next/src/generators/application/lib/add-jest.ts
@@ -57,13 +57,15 @@ export async function addJest(
     joinPathFragments(options.appProjectRoot, 'tsconfig.spec.json'),
     (json) => {
       json.compilerOptions.jsx = 'react';
-      // have to override exclude otherwise lint will fail with setParserOptionsProject and jest.config.ts
+      // have to override exclude otherwise lint will fail with setParserOptionsProject and jest.config.ts/jest.config.cts
       if (options.setParserOptionsProject) {
         const tsConfig = readJson(
           host,
           joinPathFragments(options.appProjectRoot, 'tsconfig.json')
         );
-        json.exclude = tsConfig.exclude.filter((e) => e !== 'jest.config.ts');
+        json.exclude = tsConfig.exclude.filter(
+          (e) => e !== 'jest.config.ts' && e !== 'jest.config.cts'
+        );
       }
       return json;
     }

--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -255,6 +255,7 @@ describe('next library', () => {
             "out-tsc",
             "dist",
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.spec.ts",
             "src/**/*.test.ts",
             "src/**/*.spec.tsx",

--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -292,6 +292,7 @@ describe('next library', () => {
           "extends": "../tsconfig.base.json",
           "include": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.test.tsx",
@@ -394,7 +395,7 @@ describe('next library', () => {
                   "{projectRoot}/test-output/jest/coverage"
                 ],
                 "options": {
-                  "jestConfig": "mylib/jest.config.ts"
+                  "jestConfig": "mylib/jest.config.cts"
                 }
               }
             },

--- a/packages/next/src/utils/jest-config-util.ts
+++ b/packages/next/src/utils/jest-config-util.ts
@@ -1,9 +1,6 @@
 import { Tree, offsetFromRoot } from '@nx/devkit';
 
-function findProjectJestConfig(
-  host: Tree,
-  projectRoot: string
-): string | null {
+function findProjectJestConfig(host: Tree, projectRoot: string): string | null {
   const extensions = ['js', 'ts', 'cts'];
 
   for (const ext of extensions) {

--- a/packages/next/src/utils/jest-config-util.ts
+++ b/packages/next/src/utils/jest-config-util.ts
@@ -1,5 +1,21 @@
 import { Tree, offsetFromRoot } from '@nx/devkit';
 
+function findProjectJestConfig(
+  host: Tree,
+  projectRoot: string
+): string | null {
+  const extensions = ['js', 'ts', 'cts'];
+
+  for (const ext of extensions) {
+    const configPath = `${projectRoot}/jest.config.${ext}`;
+    if (host.exists(configPath)) {
+      return configPath;
+    }
+  }
+
+  return null;
+}
+
 export function updateJestConfig(
   host: Tree,
   options: {
@@ -13,15 +29,15 @@ export function updateJestConfig(
     return;
   }
 
-  const configPath = `${options.projectRoot}/jest.config.${
-    options.js ? 'js' : 'ts'
-  }`;
+  const configPath = findProjectJestConfig(host, options.projectRoot);
 
-  if (!host.exists(configPath)) return;
+  if (!configPath) return;
 
   const offset = offsetFromRoot(options.projectRoot);
+  const isCommonJS = configPath.endsWith('.js') || configPath.endsWith('.cts');
+
   // Easier to override the whole file rather than replace content since the structure has changed with `next/jest.js` being used.
-  const newContent = options.js
+  const newContent = isCommonJS
     ? `const nextJest = require('next/jest.js');
 
 const createJestConfig = nextJest({

--- a/packages/next/tsconfig.lib.json
+++ b/packages/next/tsconfig.lib.json
@@ -11,7 +11,8 @@
     "**/*.test.ts",
     "**/*_spec.ts",
     "**/*_test.ts",
-    "jest.config.ts"
+    "jest.config.ts",
+    "jest.config.cts"
   ],
   "include": ["**/*.ts", "**/*.json"],
   "references": [

--- a/packages/next/tsconfig.spec.json
+++ b/packages/next/tsconfig.spec.json
@@ -18,7 +18,7 @@
     "**/*.spec.jsx",
     "**/*.test.jsx",
     "**/*.d.ts",
-    "jest.config.ts",
+    "jest.config.cts",
     "*.json"
   ],
   "references": [

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -837,6 +837,7 @@ describe('app', () => {
           "extends": "../tsconfig.base.json",
           "include": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.d.ts",

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -157,7 +157,7 @@ describe('app', () => {
         directory: 'my-node-app',
         addPlugin: true,
       });
-      expect(tree.exists(`my-node-app/jest.config.ts`)).toBeTruthy();
+      expect(tree.exists(`my-node-app/jest.config.cts`)).toBeTruthy();
       expect(tree.exists('my-node-app/src/main.ts')).toBeTruthy();
 
       const tsconfig = readJson(tree, 'my-node-app/tsconfig.json');
@@ -185,6 +185,7 @@ describe('app', () => {
       expect(tsconfigApp.extends).toEqual('./tsconfig.json');
       expect(tsconfigApp.exclude).toEqual([
         'jest.config.ts',
+        'jest.config.cts',
         'src/**/*.spec.ts',
         'src/**/*.test.ts',
       ]);
@@ -391,7 +392,7 @@ describe('app', () => {
 
       // Make sure these exist
       [
-        `my-dir/my-node-app/jest.config.ts`,
+        `my-dir/my-node-app/jest.config.cts`,
         'my-dir/my-node-app/src/main.ts',
       ].forEach((path) => {
         expect(tree.exists(path)).toBeTruthy();
@@ -414,6 +415,7 @@ describe('app', () => {
           lookupFn: (json) => json.exclude,
           expectedValue: [
             'jest.config.ts',
+            'jest.config.cts',
             'src/**/*.spec.ts',
             'src/**/*.test.ts',
           ],
@@ -434,11 +436,11 @@ describe('app', () => {
         unitTestRunner: 'none',
         addPlugin: true,
       });
-      expect(tree.exists('jest.config.ts')).toBeFalsy();
+      expect(tree.exists('jest.config.cts')).toBeFalsy();
       expect(tree.exists('my-node-app/src/test-setup.ts')).toBeFalsy();
       expect(tree.exists('my-node-app/src/test.ts')).toBeFalsy();
       expect(tree.exists('my-node-app/tsconfig.spec.json')).toBeFalsy();
-      expect(tree.exists('my-node-app/jest.config.ts')).toBeFalsy();
+      expect(tree.exists('my-node-app/jest.config.cts')).toBeFalsy();
     });
   });
 
@@ -495,9 +497,9 @@ describe('app', () => {
         addPlugin: true,
       } as Schema);
 
-      expect(tree.read(`my-node-app/jest.config.ts`, 'utf-8'))
+      expect(tree.read(`my-node-app/jest.config.cts`, 'utf-8'))
         .toMatchInlineSnapshot(`
-        "export default {
+        "module.exports = {
           displayName: 'my-node-app',
           preset: '../jest.preset.js',
           testEnvironment: 'node',
@@ -521,9 +523,9 @@ describe('app', () => {
         addPlugin: true,
       } as Schema);
 
-      expect(tree.read(`my-node-app/jest.config.ts`, 'utf-8'))
+      expect(tree.read(`my-node-app/jest.config.cts`, 'utf-8'))
         .toMatchInlineSnapshot(`
-        "export default {
+        "module.exports = {
           displayName: 'my-node-app',
           preset: '../jest.preset.js',
           testEnvironment: 'node',
@@ -628,7 +630,7 @@ describe('app', () => {
         addPlugin: true,
       });
 
-      expect(tree.exists(`api/jest.config.ts`)).toBeTruthy();
+      expect(tree.exists(`api/jest.config.cts`)).toBeTruthy();
 
       if (checkSpecFile) {
         expect(tree.exists(`api/src/app/app.spec.ts`)).toBeTruthy();
@@ -808,6 +810,7 @@ describe('app', () => {
             "out-tsc",
             "dist",
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.spec.ts",
             "src/**/*.test.ts",
             "eslint.config.js",
@@ -879,10 +882,10 @@ describe('app', () => {
         useProjectJson: false,
       } as Schema);
 
-      expect(tree.read('apps/my-app/jest.config.ts', 'utf-8'))
+      expect(tree.read('apps/my-app/jest.config.cts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "/* eslint-disable */
-        import { readFileSync } from 'fs';
+        const { readFileSync } = require('fs');
 
         // Reading the SWC compilation config for the spec files
         const swcJestConfig = JSON.parse(
@@ -892,7 +895,7 @@ describe('app', () => {
         // Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
         swcJestConfig.swcrc = false;
 
-        export default {
+        module.exports = {
           displayName: '@proj/my-app',
           preset: '../../jest.preset.js',
           testEnvironment: 'node',

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -1109,7 +1109,7 @@ describe('app', () => {
               ],
               "executor": "@nx/jest:jest",
               "options": {
-                "jestConfig": "myapp-e2e/jest.config.ts",
+                "jestConfig": "myapp-e2e/jest.config.cts",
                 "passWithNoTests": true,
               },
               "outputs": [

--- a/packages/node/src/generators/e2e-project/e2e-project.spec.ts
+++ b/packages/node/src/generators/e2e-project/e2e-project.spec.ts
@@ -58,9 +58,28 @@ describe('e2eProjectGenerator', () => {
       addPlugin: true,
     });
 
-    expect(tree.read('api-e2e/jest.config.cts', 'utf-8')).toMatchInlineSnapshot(
-      `null`
-    );
+    expect(tree.read('api-e2e/jest.config.cts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "export default {
+        displayName: 'api-e2e',
+        preset: '../jest.preset.js',
+        globalSetup: '<rootDir>/src/support/global-setup.ts',
+        globalTeardown: '<rootDir>/src/support/global-teardown.ts',
+        setupFiles: ['<rootDir>/src/support/test-setup.ts'],
+        testEnvironment: 'node',
+        transform: {
+          '^.+\\\\.[tj]s$': [
+            'ts-jest',
+            {
+              tsconfig: '<rootDir>/tsconfig.spec.json',
+            },
+          ],
+        },
+        moduleFileExtensions: ['ts', 'js', 'html'],
+        coverageDirectory: '../coverage/api-e2e',
+      };
+      "
+    `);
     expect(tree.exists('api-e2e/.spec.swcrc')).toBeFalsy();
   });
 
@@ -107,9 +126,26 @@ describe('e2eProjectGenerator', () => {
       addPlugin: true,
     });
 
-    expect(tree.read('cli-e2e/jest.config.cts', 'utf-8')).toMatchInlineSnapshot(
-      `null`
-    );
+    expect(tree.read('cli-e2e/jest.config.cts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "export default {
+        displayName: 'cli-e2e',
+        preset: '../jest.preset.js',
+        setupFiles: ['<rootDir>/src/test-setup.ts'],
+        testEnvironment: 'node',
+        transform: {
+          '^.+\\\\.[tj]s$': [
+            'ts-jest',
+            {
+              tsconfig: '<rootDir>/tsconfig.spec.json',
+            },
+          ],
+        },
+        moduleFileExtensions: ['ts', 'js', 'html'],
+        coverageDirectory: '../coverage/cli-e2e',
+      };
+      "
+    `);
     expect(tree.exists('cli-e2e/.spec.swcrc')).toBeFalsy();
   });
 
@@ -189,9 +225,34 @@ describe('e2eProjectGenerator', () => {
         addPlugin: true,
       });
 
-      expect(
-        tree.read('api-e2e/jest.config.cts', 'utf-8')
-      ).toMatchInlineSnapshot(`null`);
+      expect(tree.read('api-e2e/jest.config.cts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "/* eslint-disable */
+        import { readFileSync } from 'fs';
+
+        // Reading the SWC compilation config for the spec files
+        const swcJestConfig = JSON.parse(
+          readFileSync(\`\${__dirname}/.spec.swcrc\`, 'utf-8')
+        );
+
+        // Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
+        swcJestConfig.swcrc = false;
+
+        export default {
+          displayName: 'api-e2e',
+          preset: '../jest.preset.js',
+          globalSetup: '<rootDir>/src/support/global-setup.ts',
+          globalTeardown: '<rootDir>/src/support/global-teardown.ts',
+          setupFiles: ['<rootDir>/src/support/test-setup.ts'],
+          testEnvironment: 'node',
+          transform: {
+            '^.+\\\\.[tj]s$': ['@swc/jest', swcJestConfig],
+          },
+          moduleFileExtensions: ['ts', 'js', 'html'],
+          coverageDirectory: 'test-output/jest/coverage',
+        };
+        "
+      `);
       expect(tree.read('api-e2e/.spec.swcrc', 'utf-8')).toMatchInlineSnapshot(`
         "{
           "jsc": {
@@ -234,9 +295,32 @@ describe('e2eProjectGenerator', () => {
         useProjectJson: false,
       });
 
-      expect(
-        tree.read('cli-e2e/jest.config.cts', 'utf-8')
-      ).toMatchInlineSnapshot(`null`);
+      expect(tree.read('cli-e2e/jest.config.cts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "/* eslint-disable */
+        import { readFileSync } from 'fs';
+
+        // Reading the SWC compilation config for the spec files
+        const swcJestConfig = JSON.parse(
+          readFileSync(\`\${__dirname}/.spec.swcrc\`, 'utf-8')
+        );
+
+        // Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
+        swcJestConfig.swcrc = false;
+
+        export default {
+          displayName: 'cli-e2e',
+          preset: '../jest.preset.js',
+          setupFiles: ['<rootDir>/src/test-setup.ts'],
+          testEnvironment: 'node',
+          transform: {
+            '^.+\\\\.[tj]s$': ['@swc/jest', swcJestConfig],
+          },
+          moduleFileExtensions: ['ts', 'js', 'html'],
+          coverageDirectory: 'test-output/jest/coverage',
+        };
+        "
+      `);
       expect(tree.read('cli-e2e/.spec.swcrc', 'utf-8')).toMatchInlineSnapshot(`
         "{
           "jsc": {

--- a/packages/node/src/generators/e2e-project/e2e-project.spec.ts
+++ b/packages/node/src/generators/e2e-project/e2e-project.spec.ts
@@ -58,27 +58,9 @@ describe('e2eProjectGenerator', () => {
       addPlugin: true,
     });
 
-    expect(tree.read('api-e2e/jest.config.ts', 'utf-8')).toMatchInlineSnapshot(`
-      "export default {
-        displayName: 'api-e2e',
-        preset: '../jest.preset.js',
-        globalSetup: '<rootDir>/src/support/global-setup.ts',
-        globalTeardown: '<rootDir>/src/support/global-teardown.ts',
-        setupFiles: ['<rootDir>/src/support/test-setup.ts'],
-        testEnvironment: 'node',
-        transform: {
-          '^.+\\\\.[tj]s$': [
-            'ts-jest',
-            {
-              tsconfig: '<rootDir>/tsconfig.spec.json',
-            },
-          ],
-        },
-        moduleFileExtensions: ['ts', 'js', 'html'],
-        coverageDirectory: '../coverage/api-e2e',
-      };
-      "
-    `);
+    expect(tree.read('api-e2e/jest.config.cts', 'utf-8')).toMatchInlineSnapshot(
+      `null`
+    );
     expect(tree.exists('api-e2e/.spec.swcrc')).toBeFalsy();
   });
 
@@ -125,25 +107,9 @@ describe('e2eProjectGenerator', () => {
       addPlugin: true,
     });
 
-    expect(tree.read('cli-e2e/jest.config.ts', 'utf-8')).toMatchInlineSnapshot(`
-      "export default {
-        displayName: 'cli-e2e',
-        preset: '../jest.preset.js',
-        setupFiles: ['<rootDir>/src/test-setup.ts'],
-        testEnvironment: 'node',
-        transform: {
-          '^.+\\\\.[tj]s$': [
-            'ts-jest',
-            {
-              tsconfig: '<rootDir>/tsconfig.spec.json',
-            },
-          ],
-        },
-        moduleFileExtensions: ['ts', 'js', 'html'],
-        coverageDirectory: '../coverage/cli-e2e',
-      };
-      "
-    `);
+    expect(tree.read('cli-e2e/jest.config.cts', 'utf-8')).toMatchInlineSnapshot(
+      `null`
+    );
     expect(tree.exists('cli-e2e/.spec.swcrc')).toBeFalsy();
   });
 
@@ -223,34 +189,9 @@ describe('e2eProjectGenerator', () => {
         addPlugin: true,
       });
 
-      expect(tree.read('api-e2e/jest.config.ts', 'utf-8'))
-        .toMatchInlineSnapshot(`
-        "/* eslint-disable */
-        import { readFileSync } from 'fs';
-
-        // Reading the SWC compilation config for the spec files
-        const swcJestConfig = JSON.parse(
-          readFileSync(\`\${__dirname}/.spec.swcrc\`, 'utf-8')
-        );
-
-        // Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
-        swcJestConfig.swcrc = false;
-
-        export default {
-          displayName: 'api-e2e',
-          preset: '../jest.preset.js',
-          globalSetup: '<rootDir>/src/support/global-setup.ts',
-          globalTeardown: '<rootDir>/src/support/global-teardown.ts',
-          setupFiles: ['<rootDir>/src/support/test-setup.ts'],
-          testEnvironment: 'node',
-          transform: {
-            '^.+\\\\.[tj]s$': ['@swc/jest', swcJestConfig],
-          },
-          moduleFileExtensions: ['ts', 'js', 'html'],
-          coverageDirectory: 'test-output/jest/coverage',
-        };
-        "
-      `);
+      expect(
+        tree.read('api-e2e/jest.config.cts', 'utf-8')
+      ).toMatchInlineSnapshot(`null`);
       expect(tree.read('api-e2e/.spec.swcrc', 'utf-8')).toMatchInlineSnapshot(`
         "{
           "jsc": {
@@ -293,32 +234,9 @@ describe('e2eProjectGenerator', () => {
         useProjectJson: false,
       });
 
-      expect(tree.read('cli-e2e/jest.config.ts', 'utf-8'))
-        .toMatchInlineSnapshot(`
-        "/* eslint-disable */
-        import { readFileSync } from 'fs';
-
-        // Reading the SWC compilation config for the spec files
-        const swcJestConfig = JSON.parse(
-          readFileSync(\`\${__dirname}/.spec.swcrc\`, 'utf-8')
-        );
-
-        // Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
-        swcJestConfig.swcrc = false;
-
-        export default {
-          displayName: 'cli-e2e',
-          preset: '../jest.preset.js',
-          setupFiles: ['<rootDir>/src/test-setup.ts'],
-          testEnvironment: 'node',
-          transform: {
-            '^.+\\\\.[tj]s$': ['@swc/jest', swcJestConfig],
-          },
-          moduleFileExtensions: ['ts', 'js', 'html'],
-          coverageDirectory: 'test-output/jest/coverage',
-        };
-        "
-      `);
+      expect(
+        tree.read('cli-e2e/jest.config.cts', 'utf-8')
+      ).toMatchInlineSnapshot(`null`);
       expect(tree.read('cli-e2e/.spec.swcrc', 'utf-8')).toMatchInlineSnapshot(`
         "{
           "jsc": {

--- a/packages/node/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/node/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -1,7 +1,7 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`lib not nested should update configuration 1`] = `
-"export default {
+"module.exports = {
   displayName: 'my-lib',
   preset: '../jest.preset.js',
   testEnvironment: 'node',

--- a/packages/node/src/generators/library/files/non-ts-solution/tsconfig.lib.json
+++ b/packages/node/src/generators/library/files/non-ts-solution/tsconfig.lib.json
@@ -6,6 +6,6 @@
     "declaration": true,
     "types": ["node"]
   },
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "exclude": ["jest.config.ts", "jest.config.cts", "src/**/*.spec.ts", "src/**/*.test.ts"],
   "include": ["src/**/*.ts"]
 }

--- a/packages/node/src/generators/library/files/non-ts-solution/tsconfig.lib.json
+++ b/packages/node/src/generators/library/files/non-ts-solution/tsconfig.lib.json
@@ -6,6 +6,11 @@
     "declaration": true,
     "types": ["node"]
   },
-  "exclude": ["jest.config.ts", "jest.config.cts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "exclude": [
+    "jest.config.ts",
+    "jest.config.cts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ],
   "include": ["src/**/*.ts"]
 }

--- a/packages/node/src/generators/library/files/ts-solution/tsconfig.lib.json
+++ b/packages/node/src/generators/library/files/ts-solution/tsconfig.lib.json
@@ -10,6 +10,6 @@
     "emitDeclarationOnly": false,
     "types": ["node"]
   },
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "exclude": ["jest.config.ts", "jest.config.cts", "src/**/*.spec.ts", "src/**/*.test.ts"],
   "include": ["src/**/*.ts"]
 }

--- a/packages/node/src/generators/library/files/ts-solution/tsconfig.lib.json
+++ b/packages/node/src/generators/library/files/ts-solution/tsconfig.lib.json
@@ -10,6 +10,11 @@
     "emitDeclarationOnly": false,
     "types": ["node"]
   },
-  "exclude": ["jest.config.ts", "jest.config.cts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "exclude": [
+    "jest.config.ts",
+    "jest.config.cts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ],
   "include": ["src/**/*.ts"]
 }

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -644,6 +644,7 @@ describe('lib', () => {
           "extends": "../tsconfig.base.json",
           "include": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.d.ts",

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -32,7 +32,7 @@ describe('lib', () => {
       const configuration = readProjectConfiguration(tree, 'my-lib');
       expect(configuration.root).toEqual('my-lib');
       expect(configuration.targets.build).toBeUndefined();
-      expect(tree.read('my-lib/jest.config.ts', 'utf-8')).toMatchSnapshot();
+      expect(tree.read('my-lib/jest.config.cts', 'utf-8')).toMatchSnapshot();
       expect(
         readJson(tree, 'package.json').devDependencies['jest-environment-jsdom']
       ).not.toBeDefined();
@@ -115,6 +115,7 @@ describe('lib', () => {
       const tsconfigJson = readJson(tree, 'my-lib/tsconfig.lib.json');
       expect(tsconfigJson.exclude).toEqual([
         'jest.config.ts',
+        'jest.config.cts',
         'src/**/*.spec.ts',
         'src/**/*.test.ts',
       ]);
@@ -122,7 +123,7 @@ describe('lib', () => {
 
     it('should generate files', async () => {
       await libraryGenerator(tree, baseLibraryConfig);
-      expect(tree.exists(`my-lib/jest.config.ts`)).toBeTruthy();
+      expect(tree.exists(`my-lib/jest.config.cts`)).toBeTruthy();
       expect(tree.exists('my-lib/src/index.ts')).toBeTruthy();
 
       const eslintrc = readJson(tree, 'my-lib/.eslintrc.json');
@@ -200,7 +201,7 @@ describe('lib', () => {
         ...baseLibraryConfig,
         directory: 'my-dir/my-lib',
       });
-      expect(tree.exists(`my-dir/my-lib/jest.config.ts`)).toBeTruthy();
+      expect(tree.exists(`my-dir/my-lib/jest.config.cts`)).toBeTruthy();
       expect(tree.exists('my-dir/my-lib/src/index.ts')).toBeTruthy();
     });
 
@@ -276,7 +277,7 @@ describe('lib', () => {
         directory: 'my-dir/my-lib',
         simpleModuleName: true,
       });
-      expect(tree.exists(`my-dir/my-lib/jest.config.ts`)).toBeTruthy();
+      expect(tree.exists(`my-dir/my-lib/jest.config.cts`)).toBeTruthy();
       expect(tree.exists('my-dir/my-lib/src/index.ts')).toBeTruthy();
       expect(tree.exists('my-dir/my-lib/src/lib/my-lib.ts')).toBeTruthy();
       expect(tree.exists('my-dir/my-lib/src/lib/my-lib.spec.ts')).toBeTruthy();
@@ -318,7 +319,7 @@ describe('lib', () => {
         unitTestRunner: 'none',
       });
       expect(tree.exists('my-lib/tsconfig.spec.json')).toBeFalsy();
-      expect(tree.exists('my-lib/jest.config.ts')).toBeFalsy();
+      expect(tree.exists('my-lib/jest.config.cts')).toBeFalsy();
       expect(tree.exists('my-lib/lib/my-lib.spec.ts')).toBeFalsy();
       expect(
         readProjectConfiguration(tree, 'my-lib').targets.test
@@ -439,9 +440,9 @@ describe('lib', () => {
         babelJest: true,
       } as Schema);
 
-      expect(tree.read(`my-lib/jest.config.ts`, 'utf-8'))
+      expect(tree.read(`my-lib/jest.config.cts`, 'utf-8'))
         .toMatchInlineSnapshot(`
-        "export default {
+        "module.exports = {
           displayName: 'my-lib',
           preset: '../jest.preset.js',
           testEnvironment: 'node',
@@ -618,6 +619,7 @@ describe('lib', () => {
           },
           "exclude": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.spec.ts",
             "src/**/*.test.ts",
           ],

--- a/packages/node/tsconfig.lib.json
+++ b/packages/node/tsconfig.lib.json
@@ -11,7 +11,8 @@
     "**/*.test.ts",
     "**/*_spec.ts",
     "**/*_test.ts",
-    "jest.config.ts"
+    "jest.config.ts",
+    "jest.config.cts"
   ],
   "include": ["**/*.ts", "**/*.json"],
   "references": [

--- a/packages/node/tsconfig.spec.json
+++ b/packages/node/tsconfig.spec.json
@@ -18,7 +18,7 @@
     "**/*.spec.jsx",
     "**/*.test.jsx",
     "**/*.d.ts",
-    "jest.config.ts",
+    "jest.config.cts",
     "*.json"
   ],
   "references": [

--- a/packages/plugin/src/generators/e2e-project/__snapshots__/e2e.spec.ts.snap
+++ b/packages/plugin/src/generators/e2e-project/__snapshots__/e2e.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`NxPlugin e2e-project Generator should setup the eslint builder 1`] = `
 "{

--- a/packages/plugin/src/generators/e2e-project/e2e.spec.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.spec.ts
@@ -133,7 +133,7 @@ describe('NxPlugin e2e-project Generator', () => {
         ],
         "executor": "@nx/jest:jest",
         "options": {
-          "jestConfig": "my-plugin-e2e/jest.config.ts",
+          "jestConfig": "my-plugin-e2e/jest.config.cts",
           "runInBand": true,
         },
         "outputs": [
@@ -195,7 +195,7 @@ describe('NxPlugin e2e-project Generator', () => {
     expect(tree.exists('my-plugin-e2e/jest.config.cts')).toBeTruthy();
     expect(tree.read('my-plugin-e2e/jest.config.cts', 'utf-8'))
       .toMatchInlineSnapshot(`
-      "export default {
+      "module.exports = {
         displayName: 'my-plugin-e2e',
         preset: '../jest.preset.js',
         transform: {
@@ -277,7 +277,7 @@ describe('NxPlugin e2e-project Generator', () => {
       expect(tree.read('packages/my-plugin-e2e/jest.config.cts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "/* eslint-disable */
-        import { readFileSync } from 'fs';
+        const { readFileSync } = require('fs');
 
         // Reading the SWC compilation config for the spec files
         const swcJestConfig = JSON.parse(
@@ -287,7 +287,7 @@ describe('NxPlugin e2e-project Generator', () => {
         // Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
         swcJestConfig.swcrc = false;
 
-        export default {
+        module.exports = {
           displayName: 'my-plugin-e2e',
           preset: '../../jest.preset.js',
           transform: {

--- a/packages/plugin/src/generators/e2e-project/e2e.spec.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.spec.ts
@@ -133,7 +133,7 @@ describe('NxPlugin e2e-project Generator', () => {
         ],
         "executor": "@nx/jest:jest",
         "options": {
-          "jestConfig": "my-plugin-e2e/jest.config.cts",
+          "jestConfig": "my-plugin-e2e/jest.config.ts",
           "runInBand": true,
         },
         "outputs": [

--- a/packages/plugin/src/generators/e2e-project/e2e.spec.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.spec.ts
@@ -133,7 +133,7 @@ describe('NxPlugin e2e-project Generator', () => {
         ],
         "executor": "@nx/jest:jest",
         "options": {
-          "jestConfig": "my-plugin-e2e/jest.config.ts",
+          "jestConfig": "my-plugin-e2e/jest.config.cts",
           "runInBand": true,
         },
         "outputs": [
@@ -187,13 +187,13 @@ describe('NxPlugin e2e-project Generator', () => {
 
     expect(project.targets.e2e).toMatchObject({
       options: expect.objectContaining({
-        jestConfig: 'my-plugin-e2e/jest.config.ts',
+        jestConfig: 'my-plugin-e2e/jest.config.cts',
       }),
     });
 
     expect(tree.exists('my-plugin-e2e/tsconfig.spec.json')).toBeTruthy();
-    expect(tree.exists('my-plugin-e2e/jest.config.ts')).toBeTruthy();
-    expect(tree.read('my-plugin-e2e/jest.config.ts', 'utf-8'))
+    expect(tree.exists('my-plugin-e2e/jest.config.cts')).toBeTruthy();
+    expect(tree.read('my-plugin-e2e/jest.config.cts', 'utf-8'))
       .toMatchInlineSnapshot(`
       "export default {
         displayName: 'my-plugin-e2e',
@@ -264,15 +264,15 @@ describe('NxPlugin e2e-project Generator', () => {
 
       expect(project.targets.e2e).toMatchObject({
         options: expect.objectContaining({
-          jestConfig: 'packages/my-plugin-e2e/jest.config.ts',
+          jestConfig: 'packages/my-plugin-e2e/jest.config.cts',
         }),
       });
 
       expect(
         tree.exists('packages/my-plugin-e2e/tsconfig.spec.json')
       ).toBeTruthy();
-      expect(tree.exists('packages/my-plugin-e2e/jest.config.ts')).toBeTruthy();
-      expect(tree.read('packages/my-plugin-e2e/jest.config.ts', 'utf-8'))
+      expect(tree.exists('packages/my-plugin-e2e/jest.config.cts')).toBeTruthy();
+      expect(tree.read('packages/my-plugin-e2e/jest.config.cts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "/* eslint-disable */
         import { readFileSync } from 'fs';

--- a/packages/plugin/src/generators/e2e-project/e2e.spec.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.spec.ts
@@ -271,7 +271,9 @@ describe('NxPlugin e2e-project Generator', () => {
       expect(
         tree.exists('packages/my-plugin-e2e/tsconfig.spec.json')
       ).toBeTruthy();
-      expect(tree.exists('packages/my-plugin-e2e/jest.config.cts')).toBeTruthy();
+      expect(
+        tree.exists('packages/my-plugin-e2e/jest.config.cts')
+      ).toBeTruthy();
       expect(tree.read('packages/my-plugin-e2e/jest.config.cts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "/* eslint-disable */

--- a/packages/plugin/src/generators/e2e-project/e2e.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.ts
@@ -19,7 +19,11 @@ import {
 } from '@nx/devkit';
 import { determineProjectNameAndRootOptions } from '@nx/devkit/src/generators/project-name-and-root-utils';
 import { LinterType, lintProjectGenerator } from '@nx/eslint';
-import { addPropertyToJestConfig, configurationGenerator } from '@nx/jest';
+import {
+  addPropertyToJestConfig,
+  configurationGenerator,
+  findJestConfig,
+} from '@nx/jest';
 import { getRelativePathToRootTsConfig } from '@nx/js';
 import { setupVerdaccio } from '@nx/js/src/generators/setup-verdaccio/generator';
 import { addLocalRegistryScripts } from '@nx/js/src/utils/add-local-registry-scripts';
@@ -153,15 +157,22 @@ async function addJest(host: Tree, options: NormalizedSchema) {
   const { startLocalRegistryPath, stopLocalRegistryPath } =
     addLocalRegistryScripts(host);
 
+  const jestConfigPath = findJestConfig(host, options.projectRoot);
+  if (!jestConfigPath) {
+    throw new Error(
+      `Could not find Jest config for project ${options.projectName} at ${options.projectRoot}`
+    );
+  }
+
   addPropertyToJestConfig(
     host,
-    join(options.projectRoot, 'jest.config.ts'),
+    jestConfigPath,
     'globalSetup',
     join(offsetFromRoot(options.projectRoot), startLocalRegistryPath)
   );
   addPropertyToJestConfig(
     host,
-    join(options.projectRoot, 'jest.config.ts'),
+    jestConfigPath,
     'globalTeardown',
     join(offsetFromRoot(options.projectRoot), stopLocalRegistryPath)
   );

--- a/packages/plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/plugin/src/generators/plugin/plugin.spec.ts
@@ -491,6 +491,7 @@ describe('NxPlugin Plugin Generator', () => {
             ],
           },
           "exclude": [
+            "jest.config.ts",
             "jest.config.cts",
             "src/**/*.spec.ts",
             "src/**/*.test.ts",
@@ -516,7 +517,7 @@ describe('NxPlugin Plugin Generator', () => {
           },
           "extends": "../tsconfig.base.json",
           "include": [
-            "jest.config.cts",
+            "jest.config.ts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.d.ts",

--- a/packages/plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/plugin/src/generators/plugin/plugin.spec.ts
@@ -195,7 +195,7 @@ describe('NxPlugin Plugin Generator', () => {
         expect(tree.exists('my-plugin/jest.config.cts')).toBeTruthy();
         expect(tree.read('my-plugin/jest.config.cts', 'utf-8'))
           .toMatchInlineSnapshot(`
-          "export default {
+          "module.exports = {
             displayName: 'my-plugin',
             preset: '../jest.preset.js',
             testEnvironment: 'node',
@@ -362,7 +362,7 @@ describe('NxPlugin Plugin Generator', () => {
       expect(tree.read('my-plugin/jest.config.cts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "/* eslint-disable */
-        import { readFileSync } from 'fs';
+        const { readFileSync } = require('fs');
 
         // Reading the SWC compilation config for the spec files
         const swcJestConfig = JSON.parse(
@@ -372,7 +372,7 @@ describe('NxPlugin Plugin Generator', () => {
         // Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
         swcJestConfig.swcrc = false;
 
-        export default {
+        module.exports = {
           displayName: '@proj/my-plugin',
           preset: '../jest.preset.js',
           testEnvironment: 'node',

--- a/packages/plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/plugin/src/generators/plugin/plugin.spec.ts
@@ -518,6 +518,7 @@ describe('NxPlugin Plugin Generator', () => {
           "extends": "../tsconfig.base.json",
           "include": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.d.ts",

--- a/packages/plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/plugin/src/generators/plugin/plugin.spec.ts
@@ -168,7 +168,7 @@ describe('NxPlugin Plugin Generator', () => {
           })
         );
 
-        ['my-plugin/jest.config.ts'].forEach((path) =>
+        ['my-plugin/jest.config.cts'].forEach((path) =>
           expect(tree.exists(path)).toBeFalsy()
         );
 
@@ -183,7 +183,7 @@ describe('NxPlugin Plugin Generator', () => {
     });
 
     describe('jest', () => {
-      it('should generate test files with jest.config.ts', async () => {
+      it('should generate test files with jest.config.cts', async () => {
         await pluginGenerator(
           tree,
           getSchema({
@@ -192,8 +192,8 @@ describe('NxPlugin Plugin Generator', () => {
           })
         );
 
-        expect(tree.exists('my-plugin/jest.config.ts')).toBeTruthy();
-        expect(tree.read('my-plugin/jest.config.ts', 'utf-8'))
+        expect(tree.exists('my-plugin/jest.config.cts')).toBeTruthy();
+        expect(tree.read('my-plugin/jest.config.cts', 'utf-8'))
           .toMatchInlineSnapshot(`
           "export default {
             displayName: 'my-plugin',
@@ -348,7 +348,7 @@ describe('NxPlugin Plugin Generator', () => {
       });
     });
 
-    it('should generate test files with jest.config.ts', async () => {
+    it('should generate test files with jest.config.cts', async () => {
       await pluginGenerator(
         tree,
         getSchema({
@@ -358,8 +358,8 @@ describe('NxPlugin Plugin Generator', () => {
         })
       );
 
-      expect(tree.exists('my-plugin/jest.config.ts')).toBeTruthy();
-      expect(tree.read('my-plugin/jest.config.ts', 'utf-8'))
+      expect(tree.exists('my-plugin/jest.config.cts')).toBeTruthy();
+      expect(tree.read('my-plugin/jest.config.cts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "/* eslint-disable */
         import { readFileSync } from 'fs';
@@ -491,7 +491,7 @@ describe('NxPlugin Plugin Generator', () => {
             ],
           },
           "exclude": [
-            "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.spec.ts",
             "src/**/*.test.ts",
           ],
@@ -516,7 +516,7 @@ describe('NxPlugin Plugin Generator', () => {
           },
           "extends": "../tsconfig.base.json",
           "include": [
-            "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.d.ts",

--- a/packages/react-native/src/generators/application/application.spec.ts
+++ b/packages/react-native/src/generators/application/application.spec.ts
@@ -427,6 +427,7 @@ describe('app', () => {
           ],
           "include": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.test.tsx",

--- a/packages/react-native/src/generators/application/application.spec.ts
+++ b/packages/react-native/src/generators/application/application.spec.ts
@@ -71,8 +71,8 @@ describe('app', () => {
     expect(appTree.exists('my-app/.eslintrc.json')).toBe(true);
     expect(appTree.read('my-app/jest.config.cts', 'utf-8'))
       .toMatchInlineSnapshot(`
-      "// <reference types="jest" />
-      // <reference types="node" />
+      "/// <reference types="jest" />
+      /// <reference types="node" />
       module.exports = {
         displayName: 'my-app',
         preset: 'react-native',

--- a/packages/react-native/src/generators/application/application.spec.ts
+++ b/packages/react-native/src/generators/application/application.spec.ts
@@ -71,7 +71,9 @@ describe('app', () => {
     expect(appTree.exists('my-app/.eslintrc.json')).toBe(true);
     expect(appTree.read('my-app/jest.config.cts', 'utf-8'))
       .toMatchInlineSnapshot(`
-      "module.exports = {
+      "// <reference types="jest" />
+      // <reference types="node" />
+      module.exports = {
         displayName: 'my-app',
         preset: 'react-native',
         resolver: '@nx/jest/plugins/resolver',

--- a/packages/react-native/src/generators/application/application.spec.ts
+++ b/packages/react-native/src/generators/application/application.spec.ts
@@ -69,7 +69,7 @@ describe('app', () => {
     expect(tsconfig.extends).toEqual('../tsconfig.base.json');
 
     expect(appTree.exists('my-app/.eslintrc.json')).toBe(true);
-    expect(appTree.read('my-app/jest.config.ts', 'utf-8'))
+    expect(appTree.read('my-app/jest.config.cts', 'utf-8'))
       .toMatchInlineSnapshot(`
       "module.exports = {
         displayName: 'my-app',
@@ -108,7 +108,7 @@ describe('app', () => {
       bundler: 'vite',
     });
 
-    expect(appTree.exists('my-app/jest.config.ts')).toBeTruthy();
+    expect(appTree.exists('my-app/jest.config.cts')).toBeTruthy();
   });
 
   it('should extend from root tsconfig.json when no tsconfig.base.json', async () => {
@@ -387,6 +387,7 @@ describe('app', () => {
             "src/**/*.spec.jsx",
             "src/test-setup.ts",
             "jest.config.ts",
+            "jest.config.cts",
             "eslint.config.js",
             "eslint.config.cjs",
             "eslint.config.mjs",

--- a/packages/react-native/src/generators/library/library.spec.ts
+++ b/packages/react-native/src/generators/library/library.spec.ts
@@ -209,6 +209,7 @@ describe('lib', () => {
             "src/**/*.spec.jsx",
             "src/test-setup.ts",
             "jest.config.ts",
+            "jest.config.cts",
           ],
           "extends": "./tsconfig.json",
           "include": [
@@ -243,7 +244,7 @@ describe('lib', () => {
       });
 
       expect(appTree.exists('my-lib/tsconfig.spec.json')).toBeFalsy();
-      expect(appTree.exists('my-lib/jest.config.ts')).toBeFalsy();
+      expect(appTree.exists('my-lib/jest.config.cts')).toBeFalsy();
     });
 
     it('should generate test configuration', async () => {
@@ -279,7 +280,7 @@ describe('lib', () => {
         }
         "
       `);
-      expect(appTree.read('my-lib/jest.config.ts', 'utf-8'))
+      expect(appTree.read('my-lib/jest.config.cts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "module.exports = {
           displayName: 'my-lib',
@@ -548,6 +549,7 @@ describe('lib', () => {
             "src/**/*.spec.jsx",
             "src/test-setup.ts",
             "jest.config.ts",
+            "jest.config.cts",
             "eslint.config.js",
             "eslint.config.cjs",
             "eslint.config.mjs",

--- a/packages/react-native/src/generators/library/library.spec.ts
+++ b/packages/react-native/src/generators/library/library.spec.ts
@@ -283,7 +283,9 @@ describe('lib', () => {
       `);
       expect(appTree.read('my-lib/jest.config.cts', 'utf-8'))
         .toMatchInlineSnapshot(`
-        "module.exports = {
+        "// <reference types="jest" />
+        // <reference types="node" />
+        module.exports = {
           displayName: 'my-lib',
           preset: 'react-native',
           resolver: '@nx/jest/plugins/resolver',

--- a/packages/react-native/src/generators/library/library.spec.ts
+++ b/packages/react-native/src/generators/library/library.spec.ts
@@ -283,8 +283,8 @@ describe('lib', () => {
       `);
       expect(appTree.read('my-lib/jest.config.cts', 'utf-8'))
         .toMatchInlineSnapshot(`
-        "// <reference types="jest" />
-        // <reference types="node" />
+        "/// <reference types="jest" />
+        /// <reference types="node" />
         module.exports = {
           displayName: 'my-lib',
           preset: 'react-native',

--- a/packages/react-native/src/generators/library/library.spec.ts
+++ b/packages/react-native/src/generators/library/library.spec.ts
@@ -267,6 +267,7 @@ describe('lib', () => {
           "files": ["src/test-setup.ts"],
           "include": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.test.tsx",
@@ -582,6 +583,7 @@ describe('lib', () => {
           ],
           "include": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.test.tsx",

--- a/packages/react-native/src/utils/add-jest.ts
+++ b/packages/react-native/src/utils/add-jest.ts
@@ -34,7 +34,7 @@ export async function addJest(
   });
 
   // overwrite the jest.config.ts file because react native needs to have special transform property
-  const configPath = `${appProjectRoot}/jest.config.${js ? 'js' : 'ts'}`;
+  const configPath = `${appProjectRoot}/jest.config.${js ? 'js' : 'cts'}`;
   const content = `module.exports = {
   displayName: '${projectName}',
   preset: 'react-native',

--- a/packages/react-native/src/utils/add-jest.ts
+++ b/packages/react-native/src/utils/add-jest.ts
@@ -34,8 +34,11 @@ export async function addJest(
   });
 
   // overwrite the jest.config.ts file because react native needs to have special transform property
+  // Workaround issue where Jest is not picking tyope node nor jest types from tsconfig by using <reference>.
   const configPath = `${appProjectRoot}/jest.config.${js ? 'js' : 'cts'}`;
-  const content = `module.exports = {
+  const content = `// <reference types="jest" />
+// <reference types="node" />
+module.exports = {
   displayName: '${projectName}',
   preset: 'react-native',
   resolver: '@nx/jest/plugins/resolver',

--- a/packages/react-native/src/utils/add-jest.ts
+++ b/packages/react-native/src/utils/add-jest.ts
@@ -36,8 +36,8 @@ export async function addJest(
   // overwrite the jest.config.ts file because react native needs to have special transform property
   // Workaround issue where Jest is not picking tyope node nor jest types from tsconfig by using <reference>.
   const configPath = `${appProjectRoot}/jest.config.${js ? 'js' : 'cts'}`;
-  const content = `// <reference types="jest" />
-// <reference types="node" />
+  const content = `/// <reference types="jest" />
+/// <reference types="node" />
 module.exports = {
   displayName: '${projectName}',
   preset: 'react-native',

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -314,6 +314,7 @@ describe('app', () => {
         'src/**/*.test.js',
         'src/**/*.spec.jsx',
         'src/**/*.test.jsx',
+        'jest.config.ts',
         'jest.config.cts',
       ]);
 
@@ -452,6 +453,7 @@ describe('app', () => {
             'src/**/*.test.js',
             'src/**/*.spec.jsx',
             'src/**/*.test.jsx',
+            'jest.config.ts',
             'jest.config.cts',
           ],
         },

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -1198,6 +1198,7 @@ describe('app', () => {
           "files": ["src/test-setup.ts"],
           "include": [
             "jest.config.ts",
+            "jest.config.cts",
             "src/**/*.test.ts",
             "src/**/*.spec.ts",
             "src/**/*.test.tsx",

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -1147,6 +1147,7 @@ describe('app', () => {
         'vite/client',
         'vitest',
         '@react-router/node',
+        'node',
       ]);
     });
 

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -289,7 +289,7 @@ describe('app', () => {
       expect(appTree.exists('my-app/src/app/app.spec.tsx')).toBeTruthy();
       expect(appTree.exists('my-app/src/app/app.module.css')).toBeTruthy();
 
-      const jestConfig = appTree.read('my-app/jest.config.ts').toString();
+      const jestConfig = appTree.read('my-app/jest.config.cts').toString();
       expect(jestConfig).toContain('@nx/react/plugins/jest');
 
       const tsconfig = readJson(appTree, 'my-app/tsconfig.json');
@@ -314,7 +314,7 @@ describe('app', () => {
         'src/**/*.test.js',
         'src/**/*.spec.jsx',
         'src/**/*.test.jsx',
-        'jest.config.ts',
+        'jest.config.cts',
       ]);
 
       const eslintJson = readJson(appTree, 'my-app/.eslintrc.json');
@@ -452,7 +452,7 @@ describe('app', () => {
             'src/**/*.test.js',
             'src/**/*.spec.jsx',
             'src/**/*.test.jsx',
-            'jest.config.ts',
+            'jest.config.cts',
           ],
         },
         {
@@ -560,7 +560,7 @@ describe('app', () => {
   it('should setup jest with tsx support', async () => {
     await applicationGenerator(appTree, { ...schema, directory: 'my-app' });
 
-    expect(appTree.read('my-app/jest.config.ts').toString()).toContain(
+    expect(appTree.read('my-app/jest.config.cts').toString()).toContain(
       `moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],`
     );
   });
@@ -568,7 +568,7 @@ describe('app', () => {
   it('should setup jest with babel-jest support', async () => {
     await applicationGenerator(appTree, { ...schema, directory: 'my-app' });
 
-    expect(appTree.read('my-app/jest.config.ts').toString()).toContain(
+    expect(appTree.read('my-app/jest.config.cts').toString()).toContain(
       "['babel-jest', { presets: ['@nx/react/babel'] }]"
     );
   });
@@ -576,7 +576,7 @@ describe('app', () => {
   it('should setup jest without serializers', async () => {
     await applicationGenerator(appTree, { ...schema, directory: 'my-app' });
 
-    expect(appTree.read('my-app/jest.config.ts').toString()).not.toContain(
+    expect(appTree.read('my-app/jest.config.cts').toString()).not.toContain(
       `'jest-preset-angular/build/AngularSnapshotSerializer.js',`
     );
   });
@@ -637,10 +637,10 @@ describe('app', () => {
         unitTestRunner: 'none',
       });
 
-      expect(appTree.exists('jest.config.ts')).toBeFalsy();
+      expect(appTree.exists('jest.config.cts')).toBeFalsy();
       expect(appTree.exists('my-app/src/app/app.spec.tsx')).toBeFalsy();
       expect(appTree.exists('my-app/tsconfig.spec.json')).toBeFalsy();
-      expect(appTree.exists('my-app/jest.config.ts')).toBeFalsy();
+      expect(appTree.exists('my-app/jest.config.cts')).toBeFalsy();
     });
   });
 
@@ -1175,7 +1175,7 @@ describe('app', () => {
         unitTestRunner: 'jest',
       });
 
-      const jestConfig = appTree.read('my-app/jest.config.ts').toString();
+      const jestConfig = appTree.read('my-app/jest.config.cts').toString();
       expect(jestConfig).toContain('@nx/react/plugins/jest');
       expect(appTree.read('my-app/tsconfig.spec.json').toString())
         .toMatchInlineSnapshot(`

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -217,6 +217,7 @@ export async function applicationGeneratorInternal(
       (json) => {
         const types = new Set(json.compilerOptions?.types || []);
         types.add('@react-router/node');
+        types.add('node');
         return {
           ...json,
           compilerOptions: {

--- a/packages/react/src/generators/application/files/react-router-ssr/common/tsconfig.json__tmpl__
+++ b/packages/react/src/generators/application/files/react-router-ssr/common/tsconfig.json__tmpl__
@@ -2,7 +2,7 @@
   "extends": "<%= offsetFromRoot %>tsconfig.base.json",
   "compilerOptions": {
       "lib": ["DOM", "DOM.Iterable", "ES2019"],
-      "types": ["@react-router/node", "vite/client"],
+      "types": ["@react-router/node", "vite/client", "node"],
       "isolatedModules": true,
       "esModuleInterop": true,
       "jsx": "react-jsx",

--- a/packages/react/src/generators/application/lib/update-jest-config.ts
+++ b/packages/react/src/generators/application/lib/update-jest-config.ts
@@ -1,5 +1,7 @@
-import { maybeJs } from '../../../utils/maybe-js';
-import { updateJestConfigContent } from '../../../utils/jest-utils';
+import {
+  updateJestConfigContent,
+  findProjectJestConfig,
+} from '../../../utils/jest-utils';
 import { NormalizedSchema } from '../schema';
 import { Tree, updateJson } from '@nx/devkit';
 
@@ -32,10 +34,10 @@ export function updateSpecConfig(host: Tree, options: NormalizedSchema) {
     return;
   }
 
-  const configPath = maybeJs(
-    options,
-    `${options.appProjectRoot}/jest.config.ts`
-  );
+  const configPath = findProjectJestConfig(host, options.appProjectRoot);
+  if (!configPath) {
+    return;
+  }
   const originalContent = host.read(configPath, 'utf-8');
   const content = updateJestConfigContent(originalContent);
   host.write(configPath, content);

--- a/packages/react/src/generators/library/files/common/tsconfig.lib.json__tmpl__
+++ b/packages/react/src/generators/library/files/common/tsconfig.lib.json__tmpl__
@@ -9,6 +9,6 @@
       "@nx/react/typings/image.d.ts"
     ]
   },
-  "exclude": ["jest.config.cts", "src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.spec.tsx", "src/**/*.test.tsx", "src/**/*.spec.js", "src/**/*.test.js", "src/**/*.spec.jsx", "src/**/*.test.jsx"],
+  "exclude": ["jest.config.ts", "jest.config.cts", "src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.spec.tsx", "src/**/*.test.tsx", "src/**/*.spec.js", "src/**/*.test.js", "src/**/*.spec.jsx", "src/**/*.test.jsx"],
   "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react/src/generators/library/files/common/tsconfig.lib.json__tmpl__
+++ b/packages/react/src/generators/library/files/common/tsconfig.lib.json__tmpl__
@@ -9,6 +9,6 @@
       "@nx/react/typings/image.d.ts"
     ]
   },
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.spec.tsx", "src/**/*.test.tsx", "src/**/*.spec.js", "src/**/*.test.js", "src/**/*.spec.jsx", "src/**/*.test.jsx"],
+  "exclude": ["jest.config.cts", "src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.spec.tsx", "src/**/*.test.tsx", "src/**/*.spec.js", "src/**/*.test.js", "src/**/*.spec.jsx", "src/**/*.test.jsx"],
   "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
 }

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -183,6 +183,7 @@ describe('lib', () => {
     await libraryGenerator(tree, defaultSchema);
     const tsconfigJson = readJson(tree, 'my-lib/tsconfig.lib.json');
     expect(tsconfigJson.exclude).toEqual([
+      'jest.config.ts',
       'jest.config.cts',
       'src/**/*.spec.ts',
       'src/**/*.test.ts',

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -183,7 +183,7 @@ describe('lib', () => {
     await libraryGenerator(tree, defaultSchema);
     const tsconfigJson = readJson(tree, 'my-lib/tsconfig.lib.json');
     expect(tsconfigJson.exclude).toEqual([
-      'jest.config.ts',
+      'jest.config.cts',
       'src/**/*.spec.ts',
       'src/**/*.test.ts',
       'src/**/*.spec.tsx',
@@ -198,7 +198,7 @@ describe('lib', () => {
   it('should generate files', async () => {
     await libraryGenerator(tree, { ...defaultSchema, skipFormat: false });
     expect(tree.exists('my-lib/package.json')).toBeFalsy();
-    expect(tree.exists(`my-lib/jest.config.ts`)).toBeTruthy();
+    expect(tree.exists(`my-lib/jest.config.cts`)).toBeTruthy();
     expect(tree.exists('my-lib/src/index.ts')).toBeTruthy();
     expect(tree.exists('my-lib/src/lib/my-lib.tsx')).toBeTruthy();
     expect(tree.exists('my-lib/src/lib/my-lib.module.css')).toBeTruthy();
@@ -242,13 +242,13 @@ describe('lib', () => {
         }
       `);
   });
-  it('should update jest.config.ts for babel', async () => {
+  it('should update jest.config.cts for babel', async () => {
     await libraryGenerator(tree, {
       ...defaultSchema,
       buildable: true,
       compiler: 'babel',
     });
-    expect(tree.read('my-lib/jest.config.ts', 'utf-8')).toContain(
+    expect(tree.read('my-lib/jest.config.cts', 'utf-8')).toContain(
       "['babel-jest', { presets: ['@nx/react/babel'] }]"
     );
   });
@@ -302,7 +302,7 @@ describe('lib', () => {
         name: 'my-dir-my-lib',
       });
 
-      expect(tree.exists(`my-dir/my-lib/jest.config.ts`)).toBeTruthy();
+      expect(tree.exists(`my-dir/my-lib/jest.config.cts`)).toBeTruthy();
       expect(tree.exists('my-dir/my-lib/src/index.ts')).toBeTruthy();
       expect(
         tree.exists('my-dir/my-lib/src/lib/my-dir-my-lib.tsx')
@@ -315,14 +315,14 @@ describe('lib', () => {
       ).toBeTruthy();
     });
 
-    it('should update jest.config.ts for babel', async () => {
+    it('should update jest.config.cts for babel', async () => {
       await libraryGenerator(tree, {
         ...defaultSchema,
         directory: 'my-dir/my-lib',
         buildable: true,
         compiler: 'babel',
       });
-      expect(tree.read('my-dir/my-lib/jest.config.ts', 'utf-8')).toContain(
+      expect(tree.read('my-dir/my-lib/jest.config.cts', 'utf-8')).toContain(
         "['babel-jest', { presets: ['@nx/react/babel'] }]"
       );
     });
@@ -460,7 +460,7 @@ describe('lib', () => {
       });
 
       expect(tree.exists('my-lib/tsconfig.spec.json')).toBeFalsy();
-      expect(tree.exists('my-lib/jest.config.ts')).toBeFalsy();
+      expect(tree.exists('my-lib/jest.config.cts')).toBeFalsy();
     });
   });
 

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -188,7 +188,7 @@ export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
     tasks.push(jestTask);
     const jestConfigPath = joinPathFragments(
       options.projectRoot,
-      options.js ? 'jest.config.js' : 'jest.config.ts'
+      options.js ? 'jest.config.js' : 'jest.config.cts'
     );
     if (options.compiler === 'babel' && host.exists(jestConfigPath)) {
       const updatedContent = updateJestConfigContent(

--- a/packages/react/src/utils/jest-utils.ts
+++ b/packages/react/src/utils/jest-utils.ts
@@ -1,3 +1,5 @@
+import { joinPathFragments, type Tree } from '@nx/devkit';
+
 export function updateJestConfigContent(content: string) {
   return content
     .replace(
@@ -8,4 +10,20 @@ export function updateJestConfigContent(content: string) {
       `'babel-jest'`,
       `['babel-jest', { presets: ['@nx/react/babel'] }]`
     );
+}
+
+export function findProjectJestConfig(
+  tree: Tree,
+  projectRoot: string
+): string | null {
+  const extensions = ['js', 'ts', 'cts'];
+
+  for (const ext of extensions) {
+    const configPath = joinPathFragments(projectRoot, `jest.config.${ext}`);
+    if (tree.exists(configPath)) {
+      return configPath;
+    }
+  }
+
+  return null;
 }

--- a/packages/react/tsconfig.lib.json
+++ b/packages/react/tsconfig.lib.json
@@ -11,6 +11,7 @@
     "**/*.test.ts",
     "**/*_spec.ts",
     "**/*_test.ts",
+    "jest.config.ts",
     "jest.config.cts"
   ],
   "include": ["**/*.ts", "**/*.json"],

--- a/packages/react/tsconfig.lib.json
+++ b/packages/react/tsconfig.lib.json
@@ -11,7 +11,7 @@
     "**/*.test.ts",
     "**/*_spec.ts",
     "**/*_test.ts",
-    "jest.config.ts"
+    "jest.config.cts"
   ],
   "include": ["**/*.ts", "**/*.json"],
   "references": [

--- a/packages/react/tsconfig.spec.json
+++ b/packages/react/tsconfig.spec.json
@@ -18,7 +18,7 @@
     "**/*.spec.jsx",
     "**/*.test.jsx",
     "**/*.d.ts",
-    "jest.config.ts",
+    "jest.config.cts",
     "*.json"
   ],
   "references": [

--- a/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
+++ b/packages/remix/src/generators/application/__snapshots__/application.impl.spec.ts.snap
@@ -226,7 +226,7 @@ export default defineConfig({
 `;
 
 exports[`Remix Application Integrated Repo --unitTestRunner should generate the correct files for testing using jest 1`] = `
-"export default {
+"module.exports = {
   displayName: 'test',
   preset: '../jest.preset.js',
   transform: {
@@ -405,7 +405,7 @@ export default defineConfig({
 `;
 
 exports[`Remix Application Standalone Project Repo --unitTestRunner should generate the correct files for testing using jest 1`] = `
-"export default {
+"module.exports = {
   setupFilesAfterEnv: ['<rootDir>/test-setup.ts'],
   displayName: 'test',
   preset: './jest.preset.cjs',

--- a/packages/remix/src/generators/application/application.impl.spec.ts
+++ b/packages/remix/src/generators/application/application.impl.spec.ts
@@ -150,7 +150,7 @@ describe('Remix Application', () => {
         expectTargetsToBeCorrect(tree, '.');
 
         expect(tree.exists('remix.config.js')).toBeFalsy();
-        expect(tree.read('jest.config.ts', 'utf-8')).toMatchSnapshot();
+        expect(tree.read('jest.config.cts', 'utf-8')).toMatchSnapshot();
         expect(tree.read('test-setup.ts', 'utf-8')).toMatchSnapshot();
         expect(
           tree.read('tests/routes/_index.spec.tsx', 'utf-8')
@@ -368,7 +368,7 @@ describe('Remix Application', () => {
 
         expect(tree.exists(`${appDir}/remix.config.js`)).toBeFalsy();
         expect(
-          tree.read(`${appDir}/jest.config.ts`, 'utf-8')
+          tree.read(`${appDir}/jest.config.cts`, 'utf-8')
         ).toMatchSnapshot();
         expect(tree.read(`${appDir}/test-setup.ts`, 'utf-8')).toMatchSnapshot();
       });
@@ -543,6 +543,8 @@ describe('Remix Application', () => {
           "exclude": [
             "out-tsc",
             "dist",
+            "jest.config.ts",
+            "jest.config.cts",
             "tests/**/*.spec.ts",
             "tests/**/*.test.ts",
             "tests/**/*.spec.tsx",
@@ -551,7 +553,6 @@ describe('Remix Application', () => {
             "tests/**/*.test.js",
             "tests/**/*.spec.jsx",
             "tests/**/*.test.jsx",
-            "jest.config.ts",
             "src/**/*.spec.ts",
             "src/**/*.test.ts",
             "eslint.config.js",
@@ -724,10 +725,11 @@ describe('Remix Application', () => {
 
       expect(tree.exists('myapp/tsconfig.spec.json')).toBeTruthy();
       expect(tree.exists('myapp/tests/routes/_index.spec.tsx')).toBeTruthy();
-      expect(tree.exists('myapp/jest.config.ts')).toBeTruthy();
-      expect(tree.read('myapp/jest.config.ts', 'utf-8')).toMatchInlineSnapshot(`
+      expect(tree.exists('myapp/jest.config.cts')).toBeTruthy();
+      expect(tree.read('myapp/jest.config.cts', 'utf-8'))
+        .toMatchInlineSnapshot(`
         "/* eslint-disable */
-        import { readFileSync } from 'fs';
+        const { readFileSync } = require('fs')
 
         // Reading the SWC compilation config for the spec files
         const swcJestConfig = JSON.parse(
@@ -737,7 +739,7 @@ describe('Remix Application', () => {
         // Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
         swcJestConfig.swcrc = false;
 
-        export default {
+        module.exports = {
           displayName: '@proj/myapp',
           preset: '../jest.preset.js',
           transform: {

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -325,7 +325,7 @@ export default {...nxPreset};
 
       updateJestTestMatch(
         tree,
-        'jest.config.ts',
+        'jest.config.cts',
         '<rootDir>/tests/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'
       );
     }

--- a/packages/remix/src/generators/application/files/common/tsconfig.app.json__tmpl__
+++ b/packages/remix/src/generators/application/files/common/tsconfig.app.json__tmpl__
@@ -11,6 +11,8 @@
     "**/.client/**/*.tsx"
   ],
   "exclude": [
+    "jest.config.ts",
+    "jest.config.cts",
     "tests/**/*.spec.ts",
     "tests/**/*.test.ts",
     "tests/**/*.spec.tsx",

--- a/packages/remix/src/generators/application/files/ts-solution/tsconfig.app.json__tmpl__
+++ b/packages/remix/src/generators/application/files/ts-solution/tsconfig.app.json__tmpl__
@@ -27,6 +27,8 @@
     "**/.client/**/*.tsx"
   ],
   "exclude": [
+    "jest.config.ts",
+    "jest.config.cts",
     "tests/**/*.spec.ts",
     "tests/**/*.test.ts",
     "tests/**/*.spec.tsx",

--- a/packages/remix/src/generators/application/lib/update-unit-test-config.ts
+++ b/packages/remix/src/generators/application/lib/update-unit-test-config.ts
@@ -48,7 +48,7 @@ export function updateUnitTestConfig(
     );
     updateVitestTestSetup(tree, pathToViteConfig, 'test-setup.ts');
   } else if (unitTestRunner === 'jest' && rootProject) {
-    const pathToJestConfig = joinPathFragments(pathToRoot, 'jest.config.ts');
+    const pathToJestConfig = joinPathFragments(pathToRoot, 'jest.config.cts');
     tree.write('jest.preset.cjs', tree.read('jest.preset.js', 'utf-8'));
     updateJestTestSetup(tree, pathToJestConfig, `<rootDir>/test-setup.ts`);
     tree.write(

--- a/packages/remix/src/generators/library/__snapshots__/library.impl.spec.ts.snap
+++ b/packages/remix/src/generators/library/__snapshots__/library.impl.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Remix Library Generator --unitTestRunner should create the correct config files for testing with jest 1`] = `
-"export default {
+"module.exports = {
   setupFilesAfterEnv: ['./src/test-setup.ts'],
   displayName: 'test',
   preset: '../jest.preset.js',

--- a/packages/remix/src/generators/library/lib/add-unit-testing.ts
+++ b/packages/remix/src/generators/library/lib/add-unit-testing.ts
@@ -44,7 +44,7 @@ export function addUnitTestingSetup(tree: Tree, options: RemixLibraryOptions) {
   } else if (options.unitTestRunner === 'jest') {
     const pathToJestConfig = joinPathFragments(
       options.projectRoot,
-      `jest.config.ts`
+      `jest.config.cts`
     );
     updateJestTestSetup(tree, pathToJestConfig, './src/test-setup.ts');
   }

--- a/packages/remix/src/generators/library/library.impl.spec.ts
+++ b/packages/remix/src/generators/library/library.impl.spec.ts
@@ -74,7 +74,7 @@ describe('Remix Library Generator', () => {
       });
 
       // ASSERT
-      expect(tree.exists(`test/jest.config.ts`)).toBeFalsy();
+      expect(tree.exists(`test/jest.config.cts`)).toBeFalsy();
       expect(tree.exists(`test/vite.config.ts`)).toBeFalsy();
     });
 
@@ -91,7 +91,7 @@ describe('Remix Library Generator', () => {
       });
 
       // ASSERT
-      expect(tree.read(`test/jest.config.ts`, 'utf-8')).toMatchSnapshot();
+      expect(tree.read(`test/jest.config.cts`, 'utf-8')).toMatchSnapshot();
       expect(tree.read(`test/src/test-setup.ts`, 'utf-8')).toMatchSnapshot();
     });
 

--- a/packages/remix/tsconfig.lib.json
+++ b/packages/remix/tsconfig.lib.json
@@ -7,7 +7,12 @@
     "resolveJsonModule": true,
     "tsBuildInfoFile": "../../dist/packages/remix/tsconfig.tsbuildinfo"
   },
-  "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
+  "exclude": [
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "jest.config.ts",
+    "jest.config.cts"
+  ],
   "include": ["**/*.ts", "**/*.json"],
   "references": [
     {

--- a/packages/remix/tsconfig.spec.json
+++ b/packages/remix/tsconfig.spec.json
@@ -17,7 +17,7 @@
     "**/*.test.jsx",
     "**/*.spec.jsx",
     "**/*.d.ts",
-    "jest.config.ts",
+    "jest.config.cts",
     "*.json"
   ],
   "references": [

--- a/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -135,7 +135,7 @@ exports[`@nx/vite:configuration js library with --bundler=vite should respect pr
 `;
 
 exports[`@nx/vite:configuration js library with --bundler=vite should respect provided unitTestRunner="jest" 3`] = `
-"export default {
+"module.exports = {
   displayName: 'my-lib',
   preset: '../jest.preset.js',
   transform: {

--- a/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -129,7 +129,12 @@ exports[`@nx/vite:configuration js library with --bundler=vite should respect pr
     "types": ["node", "vite/client"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["jest.config.cts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+  "exclude": [
+    "jest.config.ts",
+    "jest.config.cts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
 }
 "
 `;

--- a/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vite/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -129,7 +129,7 @@ exports[`@nx/vite:configuration js library with --bundler=vite should respect pr
     "types": ["node", "vite/client"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+  "exclude": ["jest.config.cts", "src/**/*.spec.ts", "src/**/*.test.ts"]
 }
 "
 `;

--- a/packages/vite/src/generators/configuration/configuration.spec.ts
+++ b/packages/vite/src/generators/configuration/configuration.spec.ts
@@ -308,7 +308,7 @@ describe('@nx/vite:configuration', () => {
     it.each`
       unitTestRunner | configPath
       ${'none'}      | ${undefined}
-      ${'jest'}      | ${'my-lib/jest.config.ts'}
+      ${'jest'}      | ${'my-lib/jest.config.cts'}
     `(
       'should respect provided unitTestRunner="$unitTestRunner"',
       async ({ unitTestRunner, configPath }) => {

--- a/packages/vite/src/utils/test-utils.ts
+++ b/packages/vite/src/utils/test-utils.ts
@@ -187,7 +187,7 @@ export function mockReactAppGenerator(tree: Tree, userAppName?: string): Tree {
         "../../node_modules/@nx/react/typings/image.d.ts"
       ],
       "exclude": [
-        "jest.config.ts",
+        "jest.config.cts",
         "**/*.spec.ts",
         "**/*.test.ts",
         "**/*.spec.tsx",
@@ -276,7 +276,7 @@ export function mockReactMixedAppGenerator(tree: Tree): Tree {
         "../../node_modules/@nx/react/typings/image.d.ts"
       ],
       "exclude": [
-        "jest.config.ts",
+        "jest.config.cts",
         "**/*.spec.ts",
         "**/*.test.ts",
         "**/*.spec.tsx",
@@ -536,7 +536,7 @@ export function mockReactLibNonBuildableJestTestRunnerGenerator(
         "../../node_modules/@nx/react/typings/image.d.ts"
       ],
       "exclude": [
-        "jest.config.ts",
+        "jest.config.cts",
         "src/**/*.spec.ts",
         "src/**/*.test.ts",
         "src/**/*.spec.tsx",

--- a/packages/web/src/generators/application/application.legacy.spec.ts
+++ b/packages/web/src/generators/application/application.legacy.spec.ts
@@ -121,7 +121,7 @@ describe('web app generator (legacy)', () => {
           "test": {
             "executor": "@nx/jest:jest",
             "options": {
-              "jestConfig": "my-app/jest.config.ts",
+              "jestConfig": "my-app/jest.config.cts",
             },
             "outputs": [
               "{workspaceRoot}/coverage/{projectRoot}",
@@ -230,7 +230,7 @@ describe('web app generator (legacy)', () => {
           "test": {
             "executor": "@nx/jest:jest",
             "options": {
-              "jestConfig": "my-vite-app/jest.config.ts",
+              "jestConfig": "my-vite-app/jest.config.cts",
             },
             "outputs": [
               "{workspaceRoot}/coverage/{projectRoot}",

--- a/packages/web/src/generators/application/application.legacy.spec.ts
+++ b/packages/web/src/generators/application/application.legacy.spec.ts
@@ -121,7 +121,7 @@ describe('web app generator (legacy)', () => {
           "test": {
             "executor": "@nx/jest:jest",
             "options": {
-              "jestConfig": "my-app/jest.config.cts",
+              "jestConfig": "my-app/jest.config.ts",
             },
             "outputs": [
               "{workspaceRoot}/coverage/{projectRoot}",
@@ -230,7 +230,7 @@ describe('web app generator (legacy)', () => {
           "test": {
             "executor": "@nx/jest:jest",
             "options": {
-              "jestConfig": "my-vite-app/jest.config.cts",
+              "jestConfig": "my-vite-app/jest.config.ts",
             },
             "outputs": [
               "{workspaceRoot}/coverage/{projectRoot}",

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -619,7 +619,7 @@ describe('app', () => {
 
       expect(tree.read(`my-app/jest.config.cts`, 'utf-8'))
         .toMatchInlineSnapshot(`
-        "export default {
+        "module.exports = {
           displayName: 'my-app',
           preset: '../jest.preset.js',
           setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
@@ -645,7 +645,7 @@ describe('app', () => {
 
       expect(tree.read(`my-app/jest.config.cts`, 'utf-8'))
         .toMatchInlineSnapshot(`
-        "export default {
+        "module.exports = {
           displayName: 'my-app',
           preset: '../jest.preset.js',
           setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -439,7 +439,7 @@ describe('app', () => {
       addPlugin: true,
     });
 
-    expect(tree.read('my-app/jest.config.ts', 'utf-8')).not.toContain(
+    expect(tree.read('my-app/jest.config.cts', 'utf-8')).not.toContain(
       `'jest-preset-angular/build/AngularSnapshotSerializer.js',`
     );
   });
@@ -522,10 +522,10 @@ describe('app', () => {
         unitTestRunner: 'none',
         addPlugin: true,
       });
-      expect(tree.exists('jest.config.ts')).toBeFalsy();
+      expect(tree.exists('jest.config.cts')).toBeFalsy();
       expect(tree.exists('my-app/src/app/app.element.spec.ts')).toBeFalsy();
       expect(tree.exists('my-app/tsconfig.spec.json')).toBeFalsy();
-      expect(tree.exists('my-app/jest.config.ts')).toBeFalsy();
+      expect(tree.exists('my-app/jest.config.cts')).toBeFalsy();
     });
 
     it('--bundler=none should use jest as the default', async () => {
@@ -534,7 +534,7 @@ describe('app', () => {
         bundler: 'none',
         addPlugin: true,
       });
-      expect(tree.exists('my-cool-app/jest.config.ts')).toBeTruthy();
+      expect(tree.exists('my-cool-app/jest.config.cts')).toBeTruthy();
       expect(
         readJson(tree, 'my-cool-app/tsconfig.spec.json').compilerOptions.types
       ).toMatchInlineSnapshot(`
@@ -557,7 +557,7 @@ describe('app', () => {
         addPlugin: true,
       });
       expect(tree.exists('my-vite-app/vite.config.ts')).toBeTruthy();
-      expect(tree.exists('my-vite-app/jest.config.ts')).toBeTruthy();
+      expect(tree.exists('my-vite-app/jest.config.cts')).toBeTruthy();
     });
 
     it('--bundler=vite --unitTestRunner=none', async () => {
@@ -582,7 +582,7 @@ describe('app', () => {
         addPlugin: true,
       });
       expect(tree.exists('my-webpack-app/vite.config.ts')).toBeTruthy();
-      expect(tree.exists('my-webpack-app/jest.config.ts')).toBeFalsy();
+      expect(tree.exists('my-webpack-app/jest.config.cts')).toBeFalsy();
       expect(
         readJson(tree, 'my-webpack-app/tsconfig.spec.json').compilerOptions
           .types
@@ -617,7 +617,7 @@ describe('app', () => {
         addPlugin: true,
       } as Schema);
 
-      expect(tree.read(`my-app/jest.config.ts`, 'utf-8'))
+      expect(tree.read(`my-app/jest.config.cts`, 'utf-8'))
         .toMatchInlineSnapshot(`
         "export default {
           displayName: 'my-app',
@@ -643,7 +643,7 @@ describe('app', () => {
         addPlugin: true,
       } as Schema);
 
-      expect(tree.read(`my-app/jest.config.ts`, 'utf-8'))
+      expect(tree.read(`my-app/jest.config.cts`, 'utf-8'))
         .toMatchInlineSnapshot(`
         "export default {
           displayName: 'my-app',

--- a/packages/workspace/src/generators/move/lib/extract-base-configs.ts
+++ b/packages/workspace/src/generators/move/lib/extract-base-configs.ts
@@ -4,6 +4,7 @@ import {
   ProjectConfiguration,
   Tree,
 } from '@nx/devkit';
+import { findProjectJestConfig } from '../../utils/jest-config';
 
 export function maybeExtractTsConfigBase(tree: Tree): void {
   let extractTsConfigBase: any;
@@ -41,9 +42,6 @@ export function maybeMigrateEslintConfigIfRootProject(
   migrateConfigToMonorepoStyle?.(
     Array.from(getProjects(tree).values()),
     tree,
-    tree.exists(joinPathFragments(rootProject.root, 'jest.config.ts')) ||
-      tree.exists(joinPathFragments(rootProject.root, 'jest.config.js'))
-      ? 'jest'
-      : 'none'
+    findProjectJestConfig(tree, rootProject.root) ? 'jest' : 'none'
   );
 }

--- a/packages/workspace/src/generators/move/lib/update-jest-config.ts
+++ b/packages/workspace/src/generators/move/lib/update-jest-config.ts
@@ -1,7 +1,9 @@
 import { ProjectConfiguration, Tree } from '@nx/devkit';
-import * as path from 'path';
 import { NormalizedSchema } from '../schema';
-import { findRootJestConfig } from '../../utils/jest-config';
+import {
+  findRootJestConfig,
+  findProjectJestConfig,
+} from '../../utils/jest-config';
 
 /**
  * Updates the project name and coverage folder in the jest.config.js if it exists
@@ -15,12 +17,12 @@ export function updateJestConfig(
   schema: NormalizedSchema,
   project: ProjectConfiguration
 ) {
-  const jestConfigPath = path.join(
-    schema.relativeToRootDestination,
-    'jest.config.ts'
+  const jestConfigPath = findProjectJestConfig(
+    tree,
+    schema.relativeToRootDestination
   );
 
-  if (tree.exists(jestConfigPath)) {
+  if (jestConfigPath) {
     const oldContent = tree.read(jestConfigPath, 'utf-8');
 
     let newContent = oldContent;

--- a/packages/workspace/src/generators/move/lib/update-project-root-files.ts
+++ b/packages/workspace/src/generators/move/lib/update-project-root-files.ts
@@ -3,7 +3,7 @@ import { workspaceRoot } from '@nx/devkit';
 import * as path from 'path';
 import { extname, join } from 'path';
 import { NormalizedSchema } from '../schema';
-const allowedExt = ['.ts', '.js', '.json'];
+const allowedExt = ['.ts', '.js', '.json', '.cts', '.cjs'];
 
 /**
  * Updates the files in the root of the project

--- a/packages/workspace/src/generators/move/move.spec.ts
+++ b/packages/workspace/src/generators/move/move.spec.ts
@@ -42,7 +42,7 @@ describe('move', () => {
       destination: 'shared/my-lib-new',
     });
 
-    const jestConfigPath = 'shared/my-lib-new/jest.config.ts';
+    const jestConfigPath = 'shared/my-lib-new/jest.config.cts';
     const afterJestConfig = tree.read(jestConfigPath, 'utf-8');
     expect(tree.exists(jestConfigPath)).toBeTruthy();
     expect(afterJestConfig).toContain("preset: '../../jest.preset.js'");
@@ -110,7 +110,7 @@ describe('move', () => {
       destination: 'my-lib-new',
     });
 
-    const jestConfigPath = 'my-lib-new/jest.config.ts';
+    const jestConfigPath = 'my-lib-new/jest.config.cts';
     const afterJestConfig = tree.read(jestConfigPath, 'utf-8');
     expect(tree.exists(jestConfigPath)).toBeTruthy();
     expect(afterJestConfig).toContain("preset: '../jest.preset.js'");

--- a/packages/workspace/src/generators/remove/lib/update-jest-config.ts
+++ b/packages/workspace/src/generators/remove/lib/update-jest-config.ts
@@ -12,9 +12,11 @@ import type {
   PropertyAssignment,
   StringLiteral,
 } from 'typescript';
-import { join } from 'path';
 import { ensureTypescript } from '../../../utilities/typescript';
-import { findRootJestConfig } from '../../utils/jest-config';
+import {
+  findRootJestConfig,
+  findProjectJestConfig,
+} from '../../utils/jest-config';
 
 let tsModule: typeof import('typescript');
 
@@ -64,11 +66,12 @@ export function updateJestConfig(
   const projectToRemove = schema.projectName;
 
   const rootConfigPath = findRootJestConfig(tree);
+  const projectJestConfig = findProjectJestConfig(tree, projectConfig.root);
 
   if (
     !rootConfigPath ||
     !tree.exists(rootConfigPath) ||
-    !tree.exists(join(projectConfig.root, 'jest.config.ts')) ||
+    !projectJestConfig ||
     isUsingUtilityFunction(tree) ||
     !isMonorepoConfig(tree)
   ) {

--- a/packages/workspace/src/generators/utils/jest-config.ts
+++ b/packages/workspace/src/generators/utils/jest-config.ts
@@ -1,4 +1,4 @@
-import type { Tree } from '@nx/devkit';
+import { joinPathFragments, type Tree } from '@nx/devkit';
 
 export function findRootJestConfig(tree: Tree): string | null {
   if (tree.exists('jest.config.js')) {
@@ -7,6 +7,26 @@ export function findRootJestConfig(tree: Tree): string | null {
 
   if (tree.exists('jest.config.ts')) {
     return 'jest.config.ts';
+  }
+
+  if (tree.exists('jest.config.cts')) {
+    return 'jest.config.cts';
+  }
+
+  return null;
+}
+
+export function findProjectJestConfig(
+  tree: Tree,
+  projectRoot: string
+): string | null {
+  const extensions = ['js', 'ts', 'cts'];
+
+  for (const ext of extensions) {
+    const configPath = joinPathFragments(projectRoot, `jest.config.${ext}`);
+    if (tree.exists(configPath)) {
+      return configPath;
+    }
   }
 
   return null;


### PR DESCRIPTION
When using Jest 30 with SWC, users are seeing an error where `__dirname` is not defined for ESM modules. This is because the `.ts` extension is type-stripped by Node 22.17/24+ via checking for [`process.features.typescript`](https://github.com/jestjs/jest/blob/fe7f28c9d1941f5c2726831cd9d9e479b401610e/packages/jest-config/src/readConfigFileAndSetRootDir.ts#L46).

This means that instead of using the `commonjs` we set for `ts-node`, normal Node resolution kicks in, and is now treating `jest.config.ts` as ESM.

This PR fixes this issue by using an explicit `.cts` extension, which forces CommonJS that we assume for Jest configs.

Note: For Jest 29 or earlier we need to keep `jest.config.ts` since the `.cts` extension is not supported prior to Jest 30.

There's also a fix for an existing issue where using `module.exports` of anything else from `@types/node` will error out if `tsconfig.json` has a `types` field but does not include `node`. See: https://www.loom.com/share/7ebe3c90a70e4ec7bfa53cbcccaaea7d

Fixes #32236