### PR TITLE
feat(core): update formatting of agent rules documentation

### DIFF
--- a/packages/nx/src/ai/constants.ts
+++ b/packages/nx/src/ai/constants.ts
@@ -47,9 +47,12 @@ export const rulesRegex = new RegExp(
   'm'
 );
 
-export const getAgentRulesWrapped = (writeNxCloudRules: boolean) => {
-  const agentRulesString = getAgentRules(writeNxCloudRules);
-  return `${nxRulesMarkerCommentStart}\n${nxRulesMarkerCommentDescription}\n${agentRulesString}\n${nxRulesMarkerCommentEnd}`;
+export const getAgentRulesWrapped = (
+  writeNxCloudRules: boolean,
+  useH1: boolean = true
+) => {
+  const agentRulesString = getAgentRules(writeNxCloudRules, useH1);
+  return `${nxRulesMarkerCommentStart}\n${nxRulesMarkerCommentDescription}\n\n${agentRulesString}\n\n${nxRulesMarkerCommentEnd}`;
 };
 
 export const nxMcpTomlHeader = `[mcp_servers."nx-mcp"]`;

--- a/packages/nx/src/ai/constants.ts
+++ b/packages/nx/src/ai/constants.ts
@@ -2,7 +2,12 @@ import { homedir } from 'os';
 import { join } from 'path';
 import { major } from 'semver';
 import { readJsonFile } from '../utils/fileutils';
-import { getAgentRules } from './set-up-ai-agents/get-agent-rules';
+import {
+  getAgentRules,
+  AgentRulesOptions,
+} from './set-up-ai-agents/get-agent-rules';
+
+export type { AgentRulesOptions };
 
 export function agentsMdPath(root: string): string {
   return join(root, 'AGENTS.md');
@@ -47,11 +52,14 @@ export const rulesRegex = new RegExp(
   'm'
 );
 
-export const getAgentRulesWrapped = (
-  writeNxCloudRules: boolean,
-  useH1: boolean = true
-) => {
-  const agentRulesString = getAgentRules(writeNxCloudRules, useH1);
+export interface AgentRulesWrappedOptions {
+  writeNxCloudRules: boolean;
+  useH1?: boolean;
+}
+
+export const getAgentRulesWrapped = (options: AgentRulesWrappedOptions) => {
+  const { writeNxCloudRules, useH1 = true } = options;
+  const agentRulesString = getAgentRules({ nxCloud: writeNxCloudRules, useH1 });
   return `${nxRulesMarkerCommentStart}\n${nxRulesMarkerCommentDescription}\n\n${agentRulesString}\n\n${nxRulesMarkerCommentEnd}`;
 };
 

--- a/packages/nx/src/ai/set-up-ai-agents/get-agent-rules.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/get-agent-rules.ts
@@ -1,6 +1,6 @@
 export function getAgentRules(nxCloud: boolean) {
   return `
-# General Guidelines for working with Nx
+## General Guidelines for working with Nx
 
 - For navigating/exploring the workspace, invoke the \`nx-workspace\` skill first - it has patterns for querying projects, targets, and dependencies
 - When running tasks (for example build, lint, test, e2e, etc.), always prefer running the task through \`nx\` (i.e. \`nx run\`, \`nx run-many\`, \`nx affected\`) instead of using the underlying tooling directly

--- a/packages/nx/src/ai/set-up-ai-agents/get-agent-rules.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/get-agent-rules.ts
@@ -1,6 +1,6 @@
-export function getAgentRules(nxCloud: boolean) {
-  return `
-## General Guidelines for working with Nx
+export function getAgentRules(nxCloud: boolean, useH1: boolean = true) {
+  const header = useH1 ? '#' : '##';
+  return `${header} General Guidelines for working with Nx
 
 - For navigating/exploring the workspace, invoke the \`nx-workspace\` skill first - it has patterns for querying projects, targets, and dependencies
 - When running tasks (for example build, lint, test, e2e, etc.), always prefer running the task through \`nx\` (i.e. \`nx run\`, \`nx run-many\`, \`nx affected\`) instead of using the underlying tooling directly

--- a/packages/nx/src/ai/set-up-ai-agents/get-agent-rules.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/get-agent-rules.ts
@@ -1,4 +1,10 @@
-export function getAgentRules(nxCloud: boolean, useH1: boolean = true) {
+export interface AgentRulesOptions {
+  nxCloud: boolean;
+  useH1?: boolean;
+}
+
+export function getAgentRules(options: AgentRulesOptions) {
+  const { nxCloud, useH1 = true } = options;
   const header = useH1 ? '#' : '##';
   return `${header} General Guidelines for working with Nx
 

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
@@ -75,7 +75,10 @@ describe('setup-ai-agents generator', () => {
       await setupAiAgentsGenerator(tree, options);
 
       const content = tree.read('AGENTS.md')?.toString();
-      expect(content).toEqual(existing + '\n\n' + getAgentRulesWrapped(true));
+      // When appending to existing content, use h2 header
+      expect(content).toEqual(
+        existing + '\n\n' + getAgentRulesWrapped(true, false)
+      );
     });
 
     it('should NOT modify AGENTS.md when up-to-date nx rules exist', async () => {
@@ -85,7 +88,7 @@ describe('setup-ai-agents generator', () => {
         agents: ['codex'],
       };
 
-      const existing = getAgentRulesWrapped(true);
+      const existing = getAgentRulesWrapped(true, true);
 
       tree.write('AGENTS.md', existing);
 
@@ -102,7 +105,7 @@ describe('setup-ai-agents generator', () => {
         agents: ['codex'],
       };
 
-      const expected = getAgentRulesWrapped(true);
+      const expected = getAgentRulesWrapped(true, true);
       const existing = expected.replace(
         'nx_workspace',
         'nx_workspace_outdated'
@@ -122,7 +125,7 @@ describe('setup-ai-agents generator', () => {
         agents: ['codex'],
       };
 
-      const expected = getAgentRulesWrapped(true);
+      const expected = getAgentRulesWrapped(true, true);
       const existing = expected.replace('#', '\n#');
       tree.write('AGENTS.md', existing);
 

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
@@ -75,9 +75,34 @@ describe('setup-ai-agents generator', () => {
       await setupAiAgentsGenerator(tree, options);
 
       const content = tree.read('AGENTS.md')?.toString();
-      // When appending to existing content, use h2 header
+      // When appending to existing content with an h1 header, use h2 header
       expect(content).toEqual(
-        existing + '\n\n' + getAgentRulesWrapped(true, false)
+        existing +
+          '\n\n' +
+          getAgentRulesWrapped({ writeNxCloudRules: true, useH1: false })
+      );
+    });
+
+    it('should use h1 when appending to AGENTS.md without existing h1 header', async () => {
+      const options: SetupAiAgentsGeneratorSchema = {
+        directory: '.',
+        writeNxCloudRules: true,
+        agents: ['codex'],
+      };
+
+      // Content without an h1 header (just plain text)
+      const existing = 'Some existing content without a header';
+
+      tree.write('AGENTS.md', existing);
+
+      await setupAiAgentsGenerator(tree, options);
+
+      const content = tree.read('AGENTS.md')?.toString();
+      // When appending to existing content without an h1, use h1 header
+      expect(content).toEqual(
+        existing +
+          '\n\n' +
+          getAgentRulesWrapped({ writeNxCloudRules: true, useH1: true })
       );
     });
 
@@ -88,7 +113,10 @@ describe('setup-ai-agents generator', () => {
         agents: ['codex'],
       };
 
-      const existing = getAgentRulesWrapped(true, true);
+      const existing = getAgentRulesWrapped({
+        writeNxCloudRules: true,
+        useH1: true,
+      });
 
       tree.write('AGENTS.md', existing);
 
@@ -105,7 +133,10 @@ describe('setup-ai-agents generator', () => {
         agents: ['codex'],
       };
 
-      const expected = getAgentRulesWrapped(true, true);
+      const expected = getAgentRulesWrapped({
+        writeNxCloudRules: true,
+        useH1: true,
+      });
       const existing = expected.replace(
         'nx_workspace',
         'nx_workspace_outdated'
@@ -125,7 +156,10 @@ describe('setup-ai-agents generator', () => {
         agents: ['codex'],
       };
 
-      const expected = getAgentRulesWrapped(true, true);
+      const expected = getAgentRulesWrapped({
+        writeNxCloudRules: true,
+        useH1: true,
+      });
       const existing = expected.replace('#', '\n#');
       tree.write('AGENTS.md', existing);
 

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -399,10 +399,13 @@ function writeAgentRules(tree: Tree, path: string, writeNxCloudRules: boolean) {
   const existingNxConfiguration = existing.match(regex);
 
   if (existingNxConfiguration) {
-    // Use h1 for comparison since we're replacing existing content
+    // Check the rest of the file (outside nx block) for an h1 header
+    // to ensure only one h1 exists in the document
+    const contentWithoutNxBlock = existing.replace(regex, '');
+    const hasExternalH1 = /^# /m.test(contentWithoutNxBlock);
     const expectedRules = getAgentRulesWrapped({
       writeNxCloudRules,
-      useH1: true,
+      useH1: !hasExternalH1,
     });
     const contentOnly = (str: string) =>
       str

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -385,7 +385,10 @@ export async function setupAiAgentsGeneratorImpl(
 function writeAgentRules(tree: Tree, path: string, writeNxCloudRules: boolean) {
   if (!tree.exists(path)) {
     // File doesn't exist - create with h1 header (standalone content)
-    const expectedRules = getAgentRulesWrapped(writeNxCloudRules, true);
+    const expectedRules = getAgentRulesWrapped({
+      writeNxCloudRules,
+      useH1: true,
+    });
     tree.write(path, expectedRules);
     return;
   }
@@ -397,7 +400,10 @@ function writeAgentRules(tree: Tree, path: string, writeNxCloudRules: boolean) {
 
   if (existingNxConfiguration) {
     // Use h1 for comparison since we're replacing existing content
-    const expectedRules = getAgentRulesWrapped(writeNxCloudRules, true);
+    const expectedRules = getAgentRulesWrapped({
+      writeNxCloudRules,
+      useH1: true,
+    });
     const contentOnly = (str: string) =>
       str
         .replace(nxRulesMarkerCommentStart, '')
@@ -415,8 +421,13 @@ function writeAgentRules(tree: Tree, path: string, writeNxCloudRules: boolean) {
     const updatedContent = existing.replace(regex, expectedRules);
     tree.write(path, updatedContent);
   } else {
-    // Appending to existing content - use h2 header and single blank line separator
-    const expectedRules = getAgentRulesWrapped(writeNxCloudRules, false);
+    // Appending to existing content - use h2 only if the file already has an h1 header
+    // This prevents unnecessary changes when users add content without their own h1
+    const hasExistingH1 = /^# /m.test(existing);
+    const expectedRules = getAgentRulesWrapped({
+      writeNxCloudRules,
+      useH1: !hasExistingH1,
+    });
     tree.write(path, existing + '\n\n' + expectedRules);
   }
 }

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -383,9 +383,9 @@ export async function setupAiAgentsGeneratorImpl(
 }
 
 function writeAgentRules(tree: Tree, path: string, writeNxCloudRules: boolean) {
-  const expectedRules = getAgentRulesWrapped(writeNxCloudRules);
-
   if (!tree.exists(path)) {
+    // File doesn't exist - create with h1 header (standalone content)
+    const expectedRules = getAgentRulesWrapped(writeNxCloudRules, true);
     tree.write(path, expectedRules);
     return;
   }
@@ -396,6 +396,8 @@ function writeAgentRules(tree: Tree, path: string, writeNxCloudRules: boolean) {
   const existingNxConfiguration = existing.match(regex);
 
   if (existingNxConfiguration) {
+    // Use h1 for comparison since we're replacing existing content
+    const expectedRules = getAgentRulesWrapped(writeNxCloudRules, true);
     const contentOnly = (str: string) =>
       str
         .replace(nxRulesMarkerCommentStart, '')
@@ -413,6 +415,8 @@ function writeAgentRules(tree: Tree, path: string, writeNxCloudRules: boolean) {
     const updatedContent = existing.replace(regex, expectedRules);
     tree.write(path, updatedContent);
   } else {
+    // Appending to existing content - use h2 header and single blank line separator
+    const expectedRules = getAgentRulesWrapped(writeNxCloudRules, false);
     tree.write(path, existing + '\n\n' + expectedRules);
   }
 }


### PR DESCRIPTION
Markdown documents should only have one h1 header, it is pretty unlikely that an existing agents config does not already have one, switching to h2 instead should make most linters happy.

In theory you could make this a little smarter by checking beforehand..

I am also considering adding a line akin to 

```
Never use `nx graph` command - This spawns a web server that you don't have access to. 
Use the `nx_visualize_graph` tool or other nx tools instead.
```

since mine keeps doing that. thoughts?

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The header is inserted as an h1

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The header is inserted as an h2

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
