### PR TITLE
feat(core): disable interactivity by default for run-one task outputs in tui

### DIFF
--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -216,17 +216,6 @@ impl App {
         }
 
         self.dispatch_action(Action::UpdateTaskStatus(task_id.clone(), status));
-        if status == TaskStatus::InProgress && self.should_set_interactive_by_default(&task_id) {
-            // Find which pane this task is assigned to
-            for (pane_idx, pane_task) in self.pane_tasks.iter().enumerate() {
-                if let Some(pane_task_id) = pane_task {
-                    if pane_task_id == &task_id {
-                        self.terminal_pane_data[pane_idx].set_interactive(true);
-                        break;
-                    }
-                }
-            }
-        }
 
         // Update terminal progress indicator only when task reaches a completed state
         if self.is_status_complete(status) {
@@ -251,14 +240,6 @@ impl App {
             status,
             TaskStatus::NotStarted | TaskStatus::InProgress | TaskStatus::Shared
         )
-    }
-
-    fn should_set_interactive_by_default(&self, task_id: &str) -> bool {
-        matches!(self.run_mode, RunMode::RunOne)
-            && self
-                .pty_instances
-                .get(task_id)
-                .is_some_and(|pty| pty.can_be_interactive())
     }
 
     pub fn print_task_terminal_output(&mut self, task_id: String, output: String) {


### PR DESCRIPTION
Make run-one task terminal outputs in the TUI non-interactive by default. Most tasks don't need interactivity, and it causes TUI to ignore all its key bindings because it forwards them to the underlying program. If interactivity is needed, users can press `i` to enable it.