### PR TITLE
fix(vite): ensure createVitest looks only from projectRoot

### DIFF
--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -698,6 +698,7 @@ async function getTestPathsRelativeToProjectRoot(
   const fullProjectRoot = join(workspaceRoot, projectRoot);
   const { createVitest } = await import('vitest/node');
   const vitest = await createVitest('test', {
+    root: fullProjectRoot,
     dir: fullProjectRoot,
     filesOnly: true,
     watch: false,


### PR DESCRIPTION
## Current Behavior
`createVitest` is looking at the full workspace every time. It should only look at the directory with the config file.

## Expected Behavior
Pass the root as the projectRoot of the config file found.
