### PR TITLE
fix(core): prevent args from being split by spaces when executing through nx wrapper

### DIFF
--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -135,6 +135,12 @@
       "version": "22.0.0-beta.2",
       "description": "Consolidates releaseTag* options into nested releaseTag object structure",
       "implementation": "./src/migrations/update-22-0-0/consolidate-release-tag-config"
+    },
+    "22-1-0-update-nx-wrapper": {
+      "cli": "nx",
+      "version": "22.1.0-beta.5",
+      "description": "Updates the nx wrapper.",
+      "implementation": "./src/migrations/update-22-1-0/update-nx-wrapper"
     }
   }
 }

--- a/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
@@ -104,6 +104,16 @@ export function getNxWrapperContents() {
   );
 }
 
+// Gets the contents for the nx bash script
+export function getShellScriptContents() {
+  return SHELL_SCRIPT_CONTENTS;
+}
+
+// Gets the contents for the nx.bat batch script
+export function getBatchScriptContents() {
+  return BATCH_SCRIPT_CONTENTS;
+}
+
 // Remove any empty comments or comments that start with `//#: ` or eslint-disable comments.
 // This removes the sourceMapUrl since it is invalid, as well as any internal comments.
 export function sanitizeWrapperScript(input: string) {

--- a/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
@@ -48,7 +48,7 @@ const SHELL_SCRIPT_CONTENTS = [
   // Gets the path to the root of the project
   `path_to_root=$(dirname $BASH_SOURCE)`,
   // Executes the nx wrapper script
-  `node ${path.posix.join('$path_to_root', nxWrapperPath(path.posix))} $@`,
+  `node ${path.posix.join('$path_to_root', nxWrapperPath(path.posix))} "$@"`,
 ].join('\n');
 
 export function generateDotNxSetup(version?: string) {

--- a/packages/nx/src/migrations/update-22-1-0/update-nx-wrapper.ts
+++ b/packages/nx/src/migrations/update-22-1-0/update-nx-wrapper.ts
@@ -1,0 +1,6 @@
+import type { Tree } from '../../generators/tree';
+import { updateNxw } from '../../utils/update-nxw';
+
+export default async function (tree: Tree) {
+  updateNxw(tree);
+}

--- a/packages/nx/src/utils/update-nxw.ts
+++ b/packages/nx/src/utils/update-nxw.ts
@@ -1,13 +1,28 @@
 import {
   getNxWrapperContents,
   nxWrapperPath,
+  getShellScriptContents,
+  getBatchScriptContents,
 } from '../command-line/init/implementation/dot-nx/add-nx-scripts';
 import type { Tree } from '../generators/tree';
 import { normalizePath } from '../utils/path';
+import { constants as FsConstants } from 'fs';
 
 export function updateNxw(tree: Tree) {
   const wrapperPath = normalizePath(nxWrapperPath());
   if (tree.exists(wrapperPath)) {
     tree.write(wrapperPath, getNxWrapperContents());
+  }
+
+  const bashScriptPath = 'nx';
+  if (tree.exists(bashScriptPath) && tree.isFile(bashScriptPath)) {
+    tree.write(bashScriptPath, getShellScriptContents(), {
+      mode: FsConstants.S_IXUSR | FsConstants.S_IRUSR | FsConstants.S_IWUSR,
+    });
+  }
+
+  const batchScriptPath = 'nx.bat';
+  if (tree.exists(batchScriptPath) && tree.isFile(batchScriptPath)) {
+    tree.write(batchScriptPath, getBatchScriptContents());
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Because `./nx` is passing args with `$@`, args are being split by spaces. Reference for this behaviour: https://www.gnu.org/software/bash/manual/html_node/Special-Parameters.html#Special-Parameters-1

This results in this set of process args when running `./nx start-ci-run --distribute-on="3 linux-medium-jvm"`

```
[
  "<user path>/.nvm/versions/node/v22.19.0/bin/node",
  "<user path>/Projects/OTW/mm-test/.nx/nxw.js",
  "start-ci-run",
  "--distribute-on=3",
  "linux-medium-jvm",
]
```

## Expected Behavior
the arg with whitespace should not be split before being passed to nx:
```
[
  "<user path>/.nvm/versions/node/v22.19.0/bin/node",
  "<user path>/.nx/nxw.js",
  "start-ci-run",
  "--distribute-on=3 linux-medium-jvm",
]
```
