### PR TITLE
docs(misc): add reference for Nx Console settings

### DIFF
--- a/astro-docs/src/content/docs/guides/Nx Console/console-troubleshooting.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Console/console-troubleshooting.mdoc
@@ -36,6 +36,7 @@ If you're experiencing issues with Nx Console, enabling debug logging can help d
 2. Reproduce the issue
 3. Access logs via `Help` → `Show Log in Explorer` (Windows) / `Show Log in Finder` (macOS) / `Show Log in Files` (Linux)
 4. Look for `idea.log` file and paste relevant sections when reporting issues
+
 ## Configuration Settings
 
 For a complete reference of all available configuration settings, see the [Nx Console Settings Reference](/docs/reference/nx-console-settings).

--- a/astro-docs/src/content/docs/guides/Nx Console/console-troubleshooting.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Console/console-troubleshooting.mdoc
@@ -36,6 +36,9 @@ If you're experiencing issues with Nx Console, enabling debug logging can help d
 2. Reproduce the issue
 3. Access logs via `Help` → `Show Log in Explorer` (Windows) / `Show Log in Finder` (macOS) / `Show Log in Files` (Linux)
 4. Look for `idea.log` file and paste relevant sections when reporting issues
+## Configuration Settings
+
+For a complete reference of all available configuration settings, see the [Nx Console Settings Reference](/docs/reference/nx-console-settings).
 
 ## VSCode + nvm Issues
 

--- a/astro-docs/src/content/docs/reference/nx-console-settings.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-console-settings.mdoc
@@ -238,7 +238,7 @@ Use the format `@package:generator` or `@package:*` for wildcards. When this lis
 
 Navigate to **Settings/Preferences > Tools > Nx Console** and add patterns in the "Generator Allowlist" field, one per line:
 
-```
+```text
 @nx/react:*
 @nx/next:application
 @nrwl/workspace:library
@@ -275,7 +275,7 @@ Useful for removing generators that aren't relevant to your workflow.
 
 Navigate to **Settings/Preferences > Tools > Nx Console** and add patterns in the "Generator Blocklist" field, one per line:
 
-```
+```text
 @nx/angular:*
 *:stories
 ```
@@ -565,7 +565,7 @@ Navigate to **Settings > Tools > Nx Console** and configure:
 
 **Generator Allowlist:**
 
-```
+```text
 @nx/react:*
 @nx/next:*
 @nx/workspace:library
@@ -573,7 +573,7 @@ Navigate to **Settings > Tools > Nx Console** and configure:
 
 **Generator Blocklist:**
 
-```
+```text
 *:stories
 *:cypress-component-configuration
 ```

--- a/astro-docs/src/content/docs/reference/nx-console-settings.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-console-settings.mdoc
@@ -9,6 +9,27 @@ filter: 'type:References'
 
 This page provides a complete reference of all configuration settings available for Nx Console. Each setting shows how to configure it in both VSCode and JetBrains IDEs (IntelliJ IDEA, WebStorm, etc.).
 
+## VSCode Configuration
+
+VSCode uses JSON files for configuration. Settings can be configured at different scopes:
+
+**User Settings** (global across all workspaces):
+
+- Apply to all VSCode projects
+- Location: `~/.config/Code/User/settings.json` (Linux/macOS) or `%APPDATA%\Code\User\settings.json` (Windows)
+- Access via: `Cmd+,` (macOS) or `Ctrl+,` (Windows/Linux), then click the "Open Settings (JSON)" icon
+
+**Workspace Settings** (specific to one workspace):
+
+- Apply only to the current workspace
+- Location: `.vscode/settings.json` in your workspace root
+- Recommended for team-shared configurations (commit to version control)
+- Override user settings
+
+Learn more about VSCode settings in the [official VSCode documentation](https://code.visualstudio.com/docs/getstarted/settings).
+
+## JetBrains IDE Configuration
+
 {% callout type="note" title="JetBrains IDE Configuration" %}
 JetBrains IDEs configure Nx Console through the Settings/Preferences UI panel (**Settings > Tools > Nx Console**) rather than JSON configuration files. Only a subset of VSCode settings are available.
 {% /callout %}
@@ -78,8 +99,26 @@ Defines how the Projects view displays entries in the sidebar.
 {% /tabitem %}
 {% tabitem label="JetBrains" %}
 
-{% callout type="warning" title="Not Available" %}
-This setting is not available in JetBrains IDEs. The project view style is determined by the IDE's native project structure view.
+**Location:** Settings > Tools > Nx Console > Tool Window Style
+
+**Type:** Dropdown
+
+**Options:** List | Tree | Automatic
+
+**Default:** Automatic
+
+**Configuration:**
+
+Navigate to **Settings/Preferences > Tools > Nx Console** and select the desired style from the "Tool Window Style" dropdown.
+
+**Options explained:**
+
+- **List**: Shows projects as a flat ordered list
+- **Tree**: Displays projects in a folder/tree structure
+- **Automatic**: Adaptively switches between list and tree based on workspace structure
+
+{% callout type="note" title="Screenshots Needed" %}
+TODO: Add screenshot showing the Tool Window Style dropdown in JetBrains settings panel
 {% /callout %}
 
 {% /tabitem %}
@@ -493,19 +532,7 @@ This setting is not available in JetBrains IDEs. MCP port configuration is not c
 {% /tabitem %}
 {% /tabs %}
 
-## Configuration File Locations
-
-### VSCode
-
-Settings can be configured in multiple locations:
-
-1. **User Settings** (global): `~/.config/Code/User/settings.json` (Linux/macOS) or `%APPDATA%\Code\User\settings.json` (Windows)
-2. **Workspace Settings**: `.vscode/settings.json` in your workspace root
-3. **UI Settings Editor**: Open with `Cmd+,` (macOS) or `Ctrl+,` (Windows/Linux)
-
-Workspace settings override user settings.
-
-### JetBrains IDEs
+## JetBrains Settings Storage
 
 Settings are configured through the IDE's Settings/Preferences panel:
 
@@ -620,7 +647,7 @@ To reduce notifications and automatic behaviors:
 | Setting                      | VSCode | JetBrains |
 | ---------------------------- | ------ | --------- |
 | Common Nx Commands           | ✅     | ❌        |
-| Project Viewing Style        | ✅     | ❌        |
+| Project Viewing Style        | ✅     | ✅        |
 | Nx Workspace Path            | ✅     | ✅        |
 | Enable CodeLens              | ✅     | ❌        |
 | Enable Library Imports       | ✅     | ❌        |

--- a/astro-docs/src/content/docs/reference/nx-console-settings.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-console-settings.mdoc
@@ -10,6 +10,7 @@ filter: 'type:References'
 This page provides a complete reference of all configuration settings available for Nx Console. Each setting shows how to configure it in both VSCode and JetBrains IDEs (IntelliJ IDEA, WebStorm, etc.).
 
 ## Editor Settings
+
 {% tabs syncKey="ide" %}
 {% tabitem label="VSCode" %}
 
@@ -39,6 +40,7 @@ JetBrains IDEs configure Nx Console through the Settings/Preferences UI panel (*
 
 {% /tabitem %}
 {% /tabs  %}
+
 ## Common Nx Commands
 
 Configure which Nx commands appear in the sidebar view.

--- a/astro-docs/src/content/docs/reference/nx-console-settings.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-console-settings.mdoc
@@ -9,7 +9,9 @@ filter: 'type:References'
 
 This page provides a complete reference of all configuration settings available for Nx Console. Each setting shows how to configure it in both VSCode and JetBrains IDEs (IntelliJ IDEA, WebStorm, etc.).
 
-## VSCode Configuration
+## Editor Settings
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
 
 VSCode uses JSON files for configuration. Settings can be configured at different scopes:
 
@@ -28,13 +30,16 @@ VSCode uses JSON files for configuration. Settings can be configured at differen
 
 Learn more about VSCode settings in the [official VSCode documentation](https://code.visualstudio.com/docs/getstarted/settings).
 
-## JetBrains IDE Configuration
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
 
-{% callout type="note" title="JetBrains IDE Configuration" %}
+{% aside type="note" title="JetBrains IDE Configuration" %}
 JetBrains IDEs configure Nx Console through the Settings/Preferences UI panel (**Settings > Tools > Nx Console**) rather than JSON configuration files. Only a subset of VSCode settings are available.
-{% /callout %}
+{% /aside %}
 
-### Common Nx Commands
+{% /tabitem %}
+{% /tabs  %}
+## Common Nx Commands
 
 Configure which Nx commands appear in the sidebar view.
 
@@ -43,11 +48,11 @@ Configure which Nx commands appear in the sidebar view.
 
 **Setting:** `nxConsole.commonNxCommands`
 
-**Type:** `array` of `string`
+
 
 **Default:** `["run", "run-many", "affected", "affected --graph", "list"]`
 
-**Configuration:**
+
 
 ```json
 {
@@ -60,14 +65,14 @@ This setting supports both arbitrary commands and UI-based commands that open de
 {% /tabitem %}
 {% tabitem label="JetBrains" %}
 
-{% callout type="warning" title="Not Available" %}
+{% aside type="caution" title="Not Available" %}
 This setting is not available in JetBrains IDEs. Command customization is not currently supported.
-{% /callout %}
+{% /aside %}
 
 {% /tabitem %}
 {% /tabs %}
 
-### Project Viewing Style
+## Project Viewing Style
 
 Defines how the Projects view displays entries in the sidebar.
 
@@ -76,13 +81,13 @@ Defines how the Projects view displays entries in the sidebar.
 
 **Setting:** `nxConsole.projectViewingStyle`
 
-**Type:** `string` (enum)
+
 
 **Options:** `"list"` | `"tree"` | `"automatic"`
 
 **Default:** `"automatic"`
 
-**Configuration:**
+
 
 ```json
 {
@@ -101,13 +106,13 @@ Defines how the Projects view displays entries in the sidebar.
 
 **Location:** Settings > Tools > Nx Console > Tool Window Style
 
-**Type:** Dropdown
+
 
 **Options:** List | Tree | Automatic
 
 **Default:** Automatic
 
-**Configuration:**
+
 
 Navigate to **Settings/Preferences > Tools > Nx Console** and select the desired style from the "Tool Window Style" dropdown.
 
@@ -117,14 +122,11 @@ Navigate to **Settings/Preferences > Tools > Nx Console** and select the desired
 - **Tree**: Displays projects in a folder/tree structure
 - **Automatic**: Adaptively switches between list and tree based on workspace structure
 
-{% callout type="note" title="Screenshots Needed" %}
-TODO: Add screenshot showing the Tool Window Style dropdown in JetBrains settings panel
-{% /callout %}
 
 {% /tabitem %}
 {% /tabs %}
 
-### Nx Workspace Path
+## Nx Workspace Path
 
 Specifies the relative path to the Nx workspace root directory.
 
@@ -133,11 +135,11 @@ Specifies the relative path to the Nx workspace root directory.
 
 **Setting:** `nxConsole.nxWorkspacePath`
 
-**Type:** `string`
+
 
 **Default:** `undefined`
 
-**Configuration:**
+
 
 ```json
 {
@@ -152,24 +154,21 @@ Useful when working in a monorepo where the Nx workspace is nested within a larg
 
 **Location:** Settings > Tools > Nx Console > Nx Workspace Path
 
-**Type:** Text field
+
 
 **Default:** Empty (uses project root)
 
-**Configuration:**
+
 
 Navigate to **Settings/Preferences > Tools > Nx Console** and enter the relative path in the "Nx Workspace Path" field.
 
 For example: `packages/workspace`
 
-{% callout type="note" title="Screenshots Needed" %}
-TODO: Add screenshot showing the Nx Workspace Path field in JetBrains settings panel
-{% /callout %}
 
 {% /tabitem %}
 {% /tabs %}
 
-### Enable CodeLens
+## Enable CodeLens
 
 Controls the visibility of CodeLens features for Nx-specific files.
 
@@ -178,11 +177,11 @@ Controls the visibility of CodeLens features for Nx-specific files.
 
 **Setting:** `nxConsole.enableCodeLens`
 
-**Type:** `boolean`
+
 
 **Default:** `true`
 
-**Configuration:**
+
 
 ```json
 {
@@ -195,14 +194,14 @@ CodeLens provides inline actionable commands directly in your editor for files l
 {% /tabitem %}
 {% tabitem label="JetBrains" %}
 
-{% callout type="warning" title="Not Available" %}
+{% aside type="caution" title="Not Available" %}
 This setting is not available in JetBrains IDEs. CodeLens is a VSCode-specific feature. JetBrains IDEs use their native intention actions and code inspections instead.
-{% /callout %}
+{% /aside %}
 
 {% /tabitem %}
 {% /tabs %}
 
-### Enable Library Imports
+## Enable Library Imports
 
 Configures the TypeScript language server plugin to include configured libraries.
 
@@ -211,11 +210,11 @@ Configures the TypeScript language server plugin to include configured libraries
 
 **Setting:** `nxConsole.enableLibraryImports`
 
-**Type:** `boolean`
+
 
 **Default:** `true`
 
-**Configuration:**
+
 
 ```json
 {
@@ -228,14 +227,14 @@ This enables better IntelliSense and autocompletion for library imports in your 
 {% /tabitem %}
 {% tabitem label="JetBrains" %}
 
-{% callout type="warning" title="Not Available" %}
+{% aside type="caution" title="Not Available" %}
 This setting is not available in JetBrains IDEs. TypeScript library imports are handled through JetBrains' native TypeScript language services.
-{% /callout %}
+{% /aside %}
 
 {% /tabitem %}
 {% /tabs %}
 
-### Generator Allowlist
+## Generator Allowlist
 
 Specifies generator names or wildcard patterns to show in the generator picker.
 
@@ -244,11 +243,11 @@ Specifies generator names or wildcard patterns to show in the generator picker.
 
 **Setting:** `nxConsole.generatorAllowlist`
 
-**Type:** `array` of `string`
+
 
 **Default:** `[]` (all generators shown)
 
-**Configuration:**
+
 
 ```json
 {
@@ -267,11 +266,11 @@ Use the format `@package:generator` or `@package:*` for wildcards. When this lis
 
 **Location:** Settings > Tools > Nx Console > Generator Allowlist
 
-**Type:** List field (one entry per line)
+
 
 **Default:** Empty (all generators shown)
 
-**Configuration:**
+
 
 Navigate to **Settings/Preferences > Tools > Nx Console** and add patterns in the "Generator Allowlist" field, one per line:
 
@@ -281,14 +280,11 @@ Navigate to **Settings/Preferences > Tools > Nx Console** and add patterns in th
 @nrwl/workspace:library
 ```
 
-{% callout type="note" title="Screenshots Needed" %}
-TODO: Add screenshot showing the Generator Allowlist field in JetBrains settings panel
-{% /callout %}
 
 {% /tabitem %}
 {% /tabs %}
 
-### Generator Blocklist
+## Generator Blocklist
 
 Specifies generator names or wildcard patterns to hide from the generator picker.
 
@@ -297,11 +293,11 @@ Specifies generator names or wildcard patterns to hide from the generator picker
 
 **Setting:** `nxConsole.generatorBlocklist`
 
-**Type:** `array` of `string`
+
 
 **Default:** `[]`
 
-**Configuration:**
+
 
 ```json
 {
@@ -316,11 +312,11 @@ Useful for removing generators that aren't relevant to your workflow.
 
 **Location:** Settings > Tools > Nx Console > Generator Blocklist
 
-**Type:** List field (one entry per line)
+
 
 **Default:** Empty
 
-**Configuration:**
+
 
 Navigate to **Settings/Preferences > Tools > Nx Console** and add patterns in the "Generator Blocklist" field, one per line:
 
@@ -329,14 +325,11 @@ Navigate to **Settings/Preferences > Tools > Nx Console** and add patterns in th
 *:stories
 ```
 
-{% callout type="note" title="Screenshots Needed" %}
-TODO: Add screenshot showing the Generator Blocklist field in JetBrains settings panel
-{% /callout %}
 
 {% /tabitem %}
 {% /tabs %}
 
-### Enable Dry Run on Change
+## Enable Dry Run on Change
 
 Enables automatic dry runs when using the Generate command.
 
@@ -345,11 +338,11 @@ Enables automatic dry runs when using the Generate command.
 
 **Setting:** `nxConsole.enableTaskExecutionDryRunOnChange`
 
-**Type:** `boolean`
+
 
 **Default:** `true`
 
-**Configuration:**
+
 
 ```json
 {
@@ -364,22 +357,19 @@ When enabled, changing generator options triggers a dry run to preview the chang
 
 **Location:** Settings > Tools > Nx Console > Enable Dry Run on Change
 
-**Type:** Checkbox
+
 
 **Default:** Checked (enabled)
 
-**Configuration:**
+
 
 Navigate to **Settings/Preferences > Tools > Nx Console** and toggle the "Enable Dry Run on Change" checkbox.
 
-{% callout type="note" title="Screenshots Needed" %}
-TODO: Add screenshot showing the Enable Dry Run on Change checkbox in JetBrains settings panel
-{% /callout %}
 
 {% /tabitem %}
 {% /tabs %}
 
-### Move Generator Patterns
+## Move Generator Patterns
 
 Controls which collections' move generators should be used based on project path patterns.
 
@@ -388,11 +378,11 @@ Controls which collections' move generators should be used based on project path
 
 **Setting:** `nxConsole.moveGeneratorPatterns`
 
-**Type:** `object`
+
 
 **Default:** `{}`
 
-**Configuration:**
+
 
 ```json
 {
@@ -408,14 +398,14 @@ This is useful when you have multiple generator collections and want to specify 
 {% /tabitem %}
 {% tabitem label="JetBrains" %}
 
-{% callout type="warning" title="Not Available" %}
+{% aside type="caution" title="Not Available" %}
 This setting is not available in JetBrains IDEs. Move generator pattern customization is not currently supported.
-{% /callout %}
+{% /aside %}
 
 {% /tabitem %}
 {% /tabs %}
 
-### Nx Cloud Notifications
+## Nx Cloud Notifications
 
 Controls which Nx Cloud notifications are displayed.
 
@@ -424,13 +414,13 @@ Controls which Nx Cloud notifications are displayed.
 
 **Setting:** `nxConsole.nxCloudNotifications`
 
-**Type:** `string` (enum)
+
 
 **Options:** `"all"` | `"errors"` | `"none"`
 
 **Default:** `"all"`
 
-**Configuration:**
+
 
 ```json
 {
@@ -449,24 +439,21 @@ Controls which Nx Cloud notifications are displayed.
 
 **Location:** Settings > Tools > Nx Console > Nx Cloud Notifications
 
-**Type:** Dropdown
+
 
 **Options:** All | Errors Only | None
 
 **Default:** All
 
-**Configuration:**
+
 
 Navigate to **Settings/Preferences > Tools > Nx Console** and select the desired notification level from the "Nx Cloud Notifications" dropdown.
 
-{% callout type="note" title="Screenshots Needed" %}
-TODO: Add screenshot showing the Nx Cloud Notifications dropdown in JetBrains settings panel
-{% /callout %}
 
 {% /tabitem %}
 {% /tabs %}
 
-### Show Node Version on Startup
+## Show Node Version on Startup
 
 Shows a notification with the Node.js version information when the IDE starts.
 
@@ -475,11 +462,11 @@ Shows a notification with the Node.js version information when the IDE starts.
 
 **Setting:** `nxConsole.showNodeVersionOnStartup`
 
-**Type:** `boolean`
+
 
 **Default:** `false`
 
-**Configuration:**
+
 
 ```json
 {
@@ -492,14 +479,14 @@ Useful for debugging version-related issues, especially when using nvm or simila
 {% /tabitem %}
 {% tabitem label="JetBrains" %}
 
-{% callout type="warning" title="Not Available" %}
+{% aside type="caution" title="Not Available" %}
 This setting is not available in JetBrains IDEs. Node version management is handled through the IDE's Node.js interpreter settings (**Settings > Languages & Frameworks > Node.js**).
-{% /callout %}
+{% /aside %}
 
 {% /tabitem %}
 {% /tabs %}
 
-### MCP Port
+## MCP Port
 
 Specifies a fixed port for the Nx MCP (Model Context Protocol) server.
 
@@ -508,11 +495,11 @@ Specifies a fixed port for the Nx MCP (Model Context Protocol) server.
 
 **Setting:** `nxConsole.mcpPort`
 
-**Type:** `number`
+
 
 **Default:** `undefined` (random port)
 
-**Configuration:**
+
 
 ```json
 {
@@ -525,21 +512,13 @@ Set to `0` to explicitly use a random available port. If not specified, a random
 {% /tabitem %}
 {% tabitem label="JetBrains" %}
 
-{% callout type="warning" title="Not Available" %}
+{% aside type="caution" title="Not Available" %}
 This setting is not available in JetBrains IDEs. MCP port configuration is not currently supported.
-{% /callout %}
+{% /aside %}
 
 {% /tabitem %}
 {% /tabs %}
 
-## JetBrains Settings Storage
-
-Settings are configured through the IDE's Settings/Preferences panel:
-
-- **macOS**: `Preferences > Tools > Nx Console` or `Cmd+,`
-- **Windows/Linux**: `Settings > Tools > Nx Console` or `Ctrl+Alt+S`
-
-Settings are stored per project in `.idea/workspace.xml` or globally in the IDE's configuration directory.
 
 ## Common Configuration Scenarios
 
@@ -641,23 +620,6 @@ To reduce notifications and automatic behaviors:
 
 {% /tabitem %}
 {% /tabs %}
-
-## Settings Availability Matrix
-
-| Setting                      | VSCode | JetBrains |
-| ---------------------------- | ------ | --------- |
-| Common Nx Commands           | ✅     | ❌        |
-| Project Viewing Style        | ✅     | ✅        |
-| Nx Workspace Path            | ✅     | ✅        |
-| Enable CodeLens              | ✅     | ❌        |
-| Enable Library Imports       | ✅     | ❌        |
-| Generator Allowlist          | ✅     | ✅        |
-| Generator Blocklist          | ✅     | ✅        |
-| Enable Dry Run on Change     | ✅     | ✅        |
-| Move Generator Patterns      | ✅     | ❌        |
-| Nx Cloud Notifications       | ✅     | ✅        |
-| Show Node Version on Startup | ✅     | ❌        |
-| MCP Port                     | ✅     | ❌        |
 
 ## See Also
 

--- a/astro-docs/src/content/docs/reference/nx-console-settings.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-console-settings.mdoc
@@ -1,0 +1,640 @@
+---
+title: 'Nx Console Settings Reference'
+description: Complete reference of all configuration settings for Nx Console in VSCode and JetBrains IDEs.
+sidebar:
+  label: Nx Console Settings
+weight: 2.1
+filter: 'type:References'
+---
+
+This page provides a complete reference of all configuration settings available for Nx Console. Each setting shows how to configure it in both VSCode and JetBrains IDEs (IntelliJ IDEA, WebStorm, etc.).
+
+{% callout type="note" title="JetBrains IDE Configuration" %}
+JetBrains IDEs configure Nx Console through the Settings/Preferences UI panel (**Settings > Tools > Nx Console**) rather than JSON configuration files. Only a subset of VSCode settings are available.
+{% /callout %}
+
+### Common Nx Commands
+
+Configure which Nx commands appear in the sidebar view.
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+**Setting:** `nxConsole.commonNxCommands`
+
+**Type:** `array` of `string`
+
+**Default:** `["run", "run-many", "affected", "affected --graph", "list"]`
+
+**Configuration:**
+
+```json
+{
+  "nxConsole.commonNxCommands": ["run", "run-many", "affected", "test", "build"]
+}
+```
+
+This setting supports both arbitrary commands and UI-based commands that open dedicated interfaces.
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+{% callout type="warning" title="Not Available" %}
+This setting is not available in JetBrains IDEs. Command customization is not currently supported.
+{% /callout %}
+
+{% /tabitem %}
+{% /tabs %}
+
+### Project Viewing Style
+
+Defines how the Projects view displays entries in the sidebar.
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+**Setting:** `nxConsole.projectViewingStyle`
+
+**Type:** `string` (enum)
+
+**Options:** `"list"` | `"tree"` | `"automatic"`
+
+**Default:** `"automatic"`
+
+**Configuration:**
+
+```json
+{
+  "nxConsole.projectViewingStyle": "tree"
+}
+```
+
+**Options explained:**
+
+- `"list"`: Shows projects as a flat ordered list
+- `"tree"`: Displays projects in a folder/tree structure
+- `"automatic"`: Adaptively switches between list and tree based on workspace structure
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+{% callout type="warning" title="Not Available" %}
+This setting is not available in JetBrains IDEs. The project view style is determined by the IDE's native project structure view.
+{% /callout %}
+
+{% /tabitem %}
+{% /tabs %}
+
+### Nx Workspace Path
+
+Specifies the relative path to the Nx workspace root directory.
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+**Setting:** `nxConsole.nxWorkspacePath`
+
+**Type:** `string`
+
+**Default:** `undefined`
+
+**Configuration:**
+
+```json
+{
+  "nxConsole.nxWorkspacePath": "packages/workspace"
+}
+```
+
+Useful when working in a monorepo where the Nx workspace is nested within a larger repository structure.
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+**Location:** Settings > Tools > Nx Console > Nx Workspace Path
+
+**Type:** Text field
+
+**Default:** Empty (uses project root)
+
+**Configuration:**
+
+Navigate to **Settings/Preferences > Tools > Nx Console** and enter the relative path in the "Nx Workspace Path" field.
+
+For example: `packages/workspace`
+
+{% callout type="note" title="Screenshots Needed" %}
+TODO: Add screenshot showing the Nx Workspace Path field in JetBrains settings panel
+{% /callout %}
+
+{% /tabitem %}
+{% /tabs %}
+
+### Enable CodeLens
+
+Controls the visibility of CodeLens features for Nx-specific files.
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+**Setting:** `nxConsole.enableCodeLens`
+
+**Type:** `boolean`
+
+**Default:** `true`
+
+**Configuration:**
+
+```json
+{
+  "nxConsole.enableCodeLens": false
+}
+```
+
+CodeLens provides inline actionable commands directly in your editor for files like `project.json` and workspace configuration files.
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+{% callout type="warning" title="Not Available" %}
+This setting is not available in JetBrains IDEs. CodeLens is a VSCode-specific feature. JetBrains IDEs use their native intention actions and code inspections instead.
+{% /callout %}
+
+{% /tabitem %}
+{% /tabs %}
+
+### Enable Library Imports
+
+Configures the TypeScript language server plugin to include configured libraries.
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+**Setting:** `nxConsole.enableLibraryImports`
+
+**Type:** `boolean`
+
+**Default:** `true`
+
+**Configuration:**
+
+```json
+{
+  "nxConsole.enableLibraryImports": true
+}
+```
+
+This enables better IntelliSense and autocompletion for library imports in your workspace.
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+{% callout type="warning" title="Not Available" %}
+This setting is not available in JetBrains IDEs. TypeScript library imports are handled through JetBrains' native TypeScript language services.
+{% /callout %}
+
+{% /tabitem %}
+{% /tabs %}
+
+### Generator Allowlist
+
+Specifies generator names or wildcard patterns to show in the generator picker.
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+**Setting:** `nxConsole.generatorAllowlist`
+
+**Type:** `array` of `string`
+
+**Default:** `[]` (all generators shown)
+
+**Configuration:**
+
+```json
+{
+  "nxConsole.generatorAllowlist": [
+    "@nx/react:*",
+    "@nx/next:application",
+    "@nrwl/workspace:library"
+  ]
+}
+```
+
+Use the format `@package:generator` or `@package:*` for wildcards. When this list is populated, only matching generators will be shown.
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+**Location:** Settings > Tools > Nx Console > Generator Allowlist
+
+**Type:** List field (one entry per line)
+
+**Default:** Empty (all generators shown)
+
+**Configuration:**
+
+Navigate to **Settings/Preferences > Tools > Nx Console** and add patterns in the "Generator Allowlist" field, one per line:
+
+```
+@nx/react:*
+@nx/next:application
+@nrwl/workspace:library
+```
+
+{% callout type="note" title="Screenshots Needed" %}
+TODO: Add screenshot showing the Generator Allowlist field in JetBrains settings panel
+{% /callout %}
+
+{% /tabitem %}
+{% /tabs %}
+
+### Generator Blocklist
+
+Specifies generator names or wildcard patterns to hide from the generator picker.
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+**Setting:** `nxConsole.generatorBlocklist`
+
+**Type:** `array` of `string`
+
+**Default:** `[]`
+
+**Configuration:**
+
+```json
+{
+  "nxConsole.generatorBlocklist": ["@nx/angular:*", "*:stories"]
+}
+```
+
+Useful for removing generators that aren't relevant to your workflow.
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+**Location:** Settings > Tools > Nx Console > Generator Blocklist
+
+**Type:** List field (one entry per line)
+
+**Default:** Empty
+
+**Configuration:**
+
+Navigate to **Settings/Preferences > Tools > Nx Console** and add patterns in the "Generator Blocklist" field, one per line:
+
+```
+@nx/angular:*
+*:stories
+```
+
+{% callout type="note" title="Screenshots Needed" %}
+TODO: Add screenshot showing the Generator Blocklist field in JetBrains settings panel
+{% /callout %}
+
+{% /tabitem %}
+{% /tabs %}
+
+### Enable Dry Run on Change
+
+Enables automatic dry runs when using the Generate command.
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+**Setting:** `nxConsole.enableTaskExecutionDryRunOnChange`
+
+**Type:** `boolean`
+
+**Default:** `true`
+
+**Configuration:**
+
+```json
+{
+  "nxConsole.enableTaskExecutionDryRunOnChange": false
+}
+```
+
+When enabled, changing generator options triggers a dry run to preview the changes before applying them.
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+**Location:** Settings > Tools > Nx Console > Enable Dry Run on Change
+
+**Type:** Checkbox
+
+**Default:** Checked (enabled)
+
+**Configuration:**
+
+Navigate to **Settings/Preferences > Tools > Nx Console** and toggle the "Enable Dry Run on Change" checkbox.
+
+{% callout type="note" title="Screenshots Needed" %}
+TODO: Add screenshot showing the Enable Dry Run on Change checkbox in JetBrains settings panel
+{% /callout %}
+
+{% /tabitem %}
+{% /tabs %}
+
+### Move Generator Patterns
+
+Controls which collections' move generators should be used based on project path patterns.
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+**Setting:** `nxConsole.moveGeneratorPatterns`
+
+**Type:** `object`
+
+**Default:** `{}`
+
+**Configuration:**
+
+```json
+{
+  "nxConsole.moveGeneratorPatterns": {
+    "apps/**": "@nx/workspace:move",
+    "libs/**": "@custom/generators:move"
+  }
+}
+```
+
+This is useful when you have multiple generator collections and want to specify which move generator to use for different project types.
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+{% callout type="warning" title="Not Available" %}
+This setting is not available in JetBrains IDEs. Move generator pattern customization is not currently supported.
+{% /callout %}
+
+{% /tabitem %}
+{% /tabs %}
+
+### Nx Cloud Notifications
+
+Controls which Nx Cloud notifications are displayed.
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+**Setting:** `nxConsole.nxCloudNotifications`
+
+**Type:** `string` (enum)
+
+**Options:** `"all"` | `"errors"` | `"none"`
+
+**Default:** `"all"`
+
+**Configuration:**
+
+```json
+{
+  "nxConsole.nxCloudNotifications": "errors"
+}
+```
+
+**Options explained:**
+
+- `"all"`: Show all Nx Cloud notifications
+- `"errors"`: Only show error notifications
+- `"none"`: Disable all Nx Cloud notifications
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+**Location:** Settings > Tools > Nx Console > Nx Cloud Notifications
+
+**Type:** Dropdown
+
+**Options:** All | Errors Only | None
+
+**Default:** All
+
+**Configuration:**
+
+Navigate to **Settings/Preferences > Tools > Nx Console** and select the desired notification level from the "Nx Cloud Notifications" dropdown.
+
+{% callout type="note" title="Screenshots Needed" %}
+TODO: Add screenshot showing the Nx Cloud Notifications dropdown in JetBrains settings panel
+{% /callout %}
+
+{% /tabitem %}
+{% /tabs %}
+
+### Show Node Version on Startup
+
+Shows a notification with the Node.js version information when the IDE starts.
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+**Setting:** `nxConsole.showNodeVersionOnStartup`
+
+**Type:** `boolean`
+
+**Default:** `false`
+
+**Configuration:**
+
+```json
+{
+  "nxConsole.showNodeVersionOnStartup": true
+}
+```
+
+Useful for debugging version-related issues, especially when using nvm or similar Node version managers.
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+{% callout type="warning" title="Not Available" %}
+This setting is not available in JetBrains IDEs. Node version management is handled through the IDE's Node.js interpreter settings (**Settings > Languages & Frameworks > Node.js**).
+{% /callout %}
+
+{% /tabitem %}
+{% /tabs %}
+
+### MCP Port
+
+Specifies a fixed port for the Nx MCP (Model Context Protocol) server.
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+**Setting:** `nxConsole.mcpPort`
+
+**Type:** `number`
+
+**Default:** `undefined` (random port)
+
+**Configuration:**
+
+```json
+{
+  "nxConsole.mcpPort": 3333
+}
+```
+
+Set to `0` to explicitly use a random available port. If not specified, a random port is used by default.
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+{% callout type="warning" title="Not Available" %}
+This setting is not available in JetBrains IDEs. MCP port configuration is not currently supported.
+{% /callout %}
+
+{% /tabitem %}
+{% /tabs %}
+
+## Configuration File Locations
+
+### VSCode
+
+Settings can be configured in multiple locations:
+
+1. **User Settings** (global): `~/.config/Code/User/settings.json` (Linux/macOS) or `%APPDATA%\Code\User\settings.json` (Windows)
+2. **Workspace Settings**: `.vscode/settings.json` in your workspace root
+3. **UI Settings Editor**: Open with `Cmd+,` (macOS) or `Ctrl+,` (Windows/Linux)
+
+Workspace settings override user settings.
+
+### JetBrains IDEs
+
+Settings are configured through the IDE's Settings/Preferences panel:
+
+- **macOS**: `Preferences > Tools > Nx Console` or `Cmd+,`
+- **Windows/Linux**: `Settings > Tools > Nx Console` or `Ctrl+Alt+S`
+
+Settings are stored per project in `.idea/workspace.xml` or globally in the IDE's configuration directory.
+
+## Common Configuration Scenarios
+
+### Team Configuration for Specific Framework
+
+If your team works primarily with React and Next.js:
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+Add to `.vscode/settings.json`:
+
+```json
+{
+  "nxConsole.generatorAllowlist": [
+    "@nx/react:*",
+    "@nx/next:*",
+    "@nx/workspace:library"
+  ],
+  "nxConsole.generatorBlocklist": [
+    "*:stories",
+    "*:cypress-component-configuration"
+  ],
+  "nxConsole.projectViewingStyle": "tree",
+  "nxConsole.enableTaskExecutionDryRunOnChange": true,
+  "nxConsole.nxCloudNotifications": "errors"
+}
+```
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+Navigate to **Settings > Tools > Nx Console** and configure:
+
+**Generator Allowlist:**
+
+```
+@nx/react:*
+@nx/next:*
+@nx/workspace:library
+```
+
+**Generator Blocklist:**
+
+```
+*:stories
+*:cypress-component-configuration
+```
+
+**Nx Cloud Notifications:** Errors Only
+
+**Enable Dry Run on Change:** Checked
+
+{% /tabitem %}
+{% /tabs %}
+
+### Nested Workspace Setup
+
+For monorepos where Nx is nested within a larger repository:
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+```json
+{
+  "nxConsole.nxWorkspacePath": "packages/my-workspace"
+}
+```
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+**Nx Workspace Path:** `packages/my-workspace`
+
+{% /tabitem %}
+{% /tabs %}
+
+### Minimal Noise Configuration
+
+To reduce notifications and automatic behaviors:
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+```json
+{
+  "nxConsole.nxCloudNotifications": "errors",
+  "nxConsole.enableTaskExecutionDryRunOnChange": false,
+  "nxConsole.enableCodeLens": false
+}
+```
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+**Nx Cloud Notifications:** Errors Only
+
+**Enable Dry Run on Change:** Unchecked
+
+{% /tabitem %}
+{% /tabs %}
+
+## Settings Availability Matrix
+
+| Setting                      | VSCode | JetBrains |
+| ---------------------------- | ------ | --------- |
+| Common Nx Commands           | ✅     | ❌        |
+| Project Viewing Style        | ✅     | ❌        |
+| Nx Workspace Path            | ✅     | ✅        |
+| Enable CodeLens              | ✅     | ❌        |
+| Enable Library Imports       | ✅     | ❌        |
+| Generator Allowlist          | ✅     | ✅        |
+| Generator Blocklist          | ✅     | ✅        |
+| Enable Dry Run on Change     | ✅     | ✅        |
+| Move Generator Patterns      | ✅     | ❌        |
+| Nx Cloud Notifications       | ✅     | ✅        |
+| Show Node Version on Startup | ✅     | ❌        |
+| MCP Port                     | ✅     | ❌        |
+
+## See Also
+
+- [Nx Console Overview](/docs/guides/nx-console)
+- [Nx Console Generate Command](/docs/guides/nx-console/console-generate-command)
+- [Nx Console Run Command](/docs/guides/nx-console/console-run-command)
+- [Nx Console Troubleshooting](/docs/guides/nx-console/console-troubleshooting)

--- a/astro-docs/src/content/docs/reference/nx-console-settings.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-console-settings.mdoc
@@ -48,11 +48,7 @@ Configure which Nx commands appear in the sidebar view.
 
 **Setting:** `nxConsole.commonNxCommands`
 
-
-
 **Default:** `["run", "run-many", "affected", "affected --graph", "list"]`
-
-
 
 ```json
 {
@@ -81,13 +77,9 @@ Defines how the Projects view displays entries in the sidebar.
 
 **Setting:** `nxConsole.projectViewingStyle`
 
-
-
 **Options:** `"list"` | `"tree"` | `"automatic"`
 
 **Default:** `"automatic"`
-
-
 
 ```json
 {
@@ -106,13 +98,9 @@ Defines how the Projects view displays entries in the sidebar.
 
 **Location:** Settings > Tools > Nx Console > Tool Window Style
 
-
-
 **Options:** List | Tree | Automatic
 
 **Default:** Automatic
-
-
 
 Navigate to **Settings/Preferences > Tools > Nx Console** and select the desired style from the "Tool Window Style" dropdown.
 
@@ -121,7 +109,6 @@ Navigate to **Settings/Preferences > Tools > Nx Console** and select the desired
 - **List**: Shows projects as a flat ordered list
 - **Tree**: Displays projects in a folder/tree structure
 - **Automatic**: Adaptively switches between list and tree based on workspace structure
-
 
 {% /tabitem %}
 {% /tabs %}
@@ -135,11 +122,7 @@ Specifies the relative path to the Nx workspace root directory.
 
 **Setting:** `nxConsole.nxWorkspacePath`
 
-
-
 **Default:** `undefined`
-
-
 
 ```json
 {
@@ -154,16 +137,11 @@ Useful when working in a monorepo where the Nx workspace is nested within a larg
 
 **Location:** Settings > Tools > Nx Console > Nx Workspace Path
 
-
-
 **Default:** Empty (uses project root)
-
-
 
 Navigate to **Settings/Preferences > Tools > Nx Console** and enter the relative path in the "Nx Workspace Path" field.
 
 For example: `packages/workspace`
-
 
 {% /tabitem %}
 {% /tabs %}
@@ -177,11 +155,7 @@ Controls the visibility of CodeLens features for Nx-specific files.
 
 **Setting:** `nxConsole.enableCodeLens`
 
-
-
 **Default:** `true`
-
-
 
 ```json
 {
@@ -210,11 +184,7 @@ Configures the TypeScript language server plugin to include configured libraries
 
 **Setting:** `nxConsole.enableLibraryImports`
 
-
-
 **Default:** `true`
-
-
 
 ```json
 {
@@ -243,11 +213,7 @@ Specifies generator names or wildcard patterns to show in the generator picker.
 
 **Setting:** `nxConsole.generatorAllowlist`
 
-
-
 **Default:** `[]` (all generators shown)
-
-
 
 ```json
 {
@@ -266,11 +232,7 @@ Use the format `@package:generator` or `@package:*` for wildcards. When this lis
 
 **Location:** Settings > Tools > Nx Console > Generator Allowlist
 
-
-
 **Default:** Empty (all generators shown)
-
-
 
 Navigate to **Settings/Preferences > Tools > Nx Console** and add patterns in the "Generator Allowlist" field, one per line:
 
@@ -279,7 +241,6 @@ Navigate to **Settings/Preferences > Tools > Nx Console** and add patterns in th
 @nx/next:application
 @nrwl/workspace:library
 ```
-
 
 {% /tabitem %}
 {% /tabs %}
@@ -293,11 +254,7 @@ Specifies generator names or wildcard patterns to hide from the generator picker
 
 **Setting:** `nxConsole.generatorBlocklist`
 
-
-
 **Default:** `[]`
-
-
 
 ```json
 {
@@ -312,11 +269,7 @@ Useful for removing generators that aren't relevant to your workflow.
 
 **Location:** Settings > Tools > Nx Console > Generator Blocklist
 
-
-
 **Default:** Empty
-
-
 
 Navigate to **Settings/Preferences > Tools > Nx Console** and add patterns in the "Generator Blocklist" field, one per line:
 
@@ -324,7 +277,6 @@ Navigate to **Settings/Preferences > Tools > Nx Console** and add patterns in th
 @nx/angular:*
 *:stories
 ```
-
 
 {% /tabitem %}
 {% /tabs %}
@@ -338,11 +290,7 @@ Enables automatic dry runs when using the Generate command.
 
 **Setting:** `nxConsole.enableTaskExecutionDryRunOnChange`
 
-
-
 **Default:** `true`
-
-
 
 ```json
 {
@@ -357,14 +305,9 @@ When enabled, changing generator options triggers a dry run to preview the chang
 
 **Location:** Settings > Tools > Nx Console > Enable Dry Run on Change
 
-
-
 **Default:** Checked (enabled)
 
-
-
 Navigate to **Settings/Preferences > Tools > Nx Console** and toggle the "Enable Dry Run on Change" checkbox.
-
 
 {% /tabitem %}
 {% /tabs %}
@@ -378,11 +321,7 @@ Controls which collections' move generators should be used based on project path
 
 **Setting:** `nxConsole.moveGeneratorPatterns`
 
-
-
 **Default:** `{}`
-
-
 
 ```json
 {
@@ -414,13 +353,9 @@ Controls which Nx Cloud notifications are displayed.
 
 **Setting:** `nxConsole.nxCloudNotifications`
 
-
-
 **Options:** `"all"` | `"errors"` | `"none"`
 
 **Default:** `"all"`
-
-
 
 ```json
 {
@@ -439,16 +374,11 @@ Controls which Nx Cloud notifications are displayed.
 
 **Location:** Settings > Tools > Nx Console > Nx Cloud Notifications
 
-
-
 **Options:** All | Errors Only | None
 
 **Default:** All
 
-
-
 Navigate to **Settings/Preferences > Tools > Nx Console** and select the desired notification level from the "Nx Cloud Notifications" dropdown.
-
 
 {% /tabitem %}
 {% /tabs %}
@@ -462,11 +392,7 @@ Shows a notification with the Node.js version information when the IDE starts.
 
 **Setting:** `nxConsole.showNodeVersionOnStartup`
 
-
-
 **Default:** `false`
-
-
 
 ```json
 {
@@ -495,11 +421,7 @@ Specifies a fixed port for the Nx MCP (Model Context Protocol) server.
 
 **Setting:** `nxConsole.mcpPort`
 
-
-
 **Default:** `undefined` (random port)
-
-
 
 ```json
 {
@@ -519,6 +441,92 @@ This setting is not available in JetBrains IDEs. MCP port configuration is not c
 {% /tabitem %}
 {% /tabs %}
 
+## MCP Tools Filter
+
+Filters which MCP tools are enabled using glob patterns with negation support.
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+**Setting:** `nxConsole.mcpToolsFilter`
+
+**Default:** `[]` (all tools enabled)
+
+```json
+{
+  "nxConsole.mcpToolsFilter": ["nx_*", "!nx_cloud_*"]
+}
+```
+
+Use glob patterns to include or exclude specific MCP tools. Prefix with `!` to negate a pattern (exclude matching tools).
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+{% aside type="caution" title="Not Available" %}
+This setting is not available in JetBrains IDEs. MCP tools filtering is not currently supported.
+{% /aside %}
+
+{% /tabitem %}
+{% /tabs %}
+
+## Enable Debug Logging
+
+Activates debug logging in output channels and the Language Server.
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+**Setting:** `nxConsole.enableDebugLogging`
+
+**Default:** `false`
+
+```json
+{
+  "nxConsole.enableDebugLogging": true
+}
+```
+
+Useful for troubleshooting Nx Console issues. When enabled, detailed debug information is written to the output channels.
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+{% aside type="caution" title="Not Available" %}
+This setting is not available in JetBrains IDEs. Debug logging configuration is handled through the IDE's native logging system.
+{% /aside %}
+
+{% /tabitem %}
+{% /tabs %}
+
+## Disable File Watching
+
+Disables automatic workspace refresh after file changes in the Language Server.
+
+{% tabs syncKey="ide" %}
+{% tabitem label="VSCode" %}
+
+**Setting:** `nxConsole.disableFileWatching`
+
+**Default:** `false`
+
+```json
+{
+  "nxConsole.disableFileWatching": true
+}
+```
+
+When enabled, the workspace will not automatically refresh when files change. This can be useful for performance optimization in very large workspaces, but you will need to manually refresh the workspace to see changes.
+
+{% /tabitem %}
+{% tabitem label="JetBrains" %}
+
+{% aside type="caution" title="Not Available" %}
+This setting is not available in JetBrains IDEs. File watching behavior is managed by the IDE's native file system watcher.
+{% /aside %}
+
+{% /tabitem %}
+{% /tabs %}
 
 ## Common Configuration Scenarios
 


### PR DESCRIPTION
## Current Behavior

The Nx Console settings reference lacks explanation of VSCode's user vs workspace settings and incorrectly states that Project Viewing Style is unavailable in JetBrains IDEs.

## Expected Behavior
Nx consoles are documented for vscode/jetbrains editors

https://deploy-preview-33363--nx-docs.netlify.app/docs/reference/nx-console-settings

fixes: DOC-315