### PR TITLE
fix(maven): forward parameters through target dependencies

### DIFF
--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/TestClassDiscovery.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/TestClassDiscovery.kt
@@ -93,8 +93,8 @@ class TestClassDiscovery() {
         // Extract package name (simple approach)
         val packageName = extractPackageName(content)
 
-        // Extract public class name (simple approach)
-        val className = extractPublicClassName(content) ?: return null
+        // Extract class name (simple approach)
+        val className = extractClassName(content) ?: return null
 
         // Double check: does this class actually have test methods?
         if (!hasTestMethodsInClass(content, className)) {
@@ -129,14 +129,15 @@ class TestClassDiscovery() {
     }
 
     /**
-     * Extract public class name from Java file content using simple string matching
+     * Extract class name from Java file content using simple string matching
+     * Matches any class declaration, not just public ones (test classes can be package-private)
      */
-    private fun extractPublicClassName(content: String): String? {
+    private fun extractClassName(content: String): String? {
         val lines = content.lines()
         for (line in lines) {
             val trimmed = line.trim()
-            if (trimmed.contains("public class ")) {
-                // Simple extraction: find "public class ClassName"
+            if (trimmed.contains("class ")) {
+                // Simple extraction: find "class ClassName" (handles public, package-private, etc.)
                 val parts = trimmed.split(" ", "\t").filter { it.isNotEmpty() }
                 val classIndex = parts.indexOf("class")
                 if (classIndex >= 0 && classIndex + 1 < parts.size) {


### PR DESCRIPTION
## Current Behavior

Maven target dependencies are defined as simple strings that reference other targets. Currently, parameters are not forwarded through these dependencies when Maven goals are executed.

## Expected Behavior

Target dependencies in Maven should forward parameters (args) to their dependency targets, enabling better parameter propagation through the build pipeline.

## Changes Made

Modified `NxTargetFactory.kt` to transform simple string dependency references into structured dependency objects with explicit parameter forwarding:

- Install dependencies now forward parameters
- Phase dependencies now forward parameters  
- Test dependencies now forward parameters
- CI target dependencies now forward parameters

This ensures that when a Maven goal executes, any parameters passed to it are properly forwarded to all transitive target dependencies.

## Related Issue(s)

This change enables parameter passing through Maven target dependencies via the new dependency object format with `"params": "forward"`.