### PR TITLE
fix(core): pipe plugin stdout to avoid inconsistent terminal state

### DIFF
--- a/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
@@ -447,7 +447,7 @@ async function startPluginWorker(name: string) {
       name,
     ],
     {
-      stdio: 'pipe',
+      stdio: ['ignore', 'pipe', 'pipe'],
       env,
       detached: true,
       shell: false,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
After running commands which spawn plugin workers on the main process (`nx show project`, or any command with the daemon disabled) some users (and notably @FrozenPandaz) experienced terminal issues that resulted in ↑ / ↓ printing escape codes instead of scrolling command history.

## Expected Behavior
This pull request updates how plugin worker processes handle their input/output streams to improve terminal behavior and debugging capabilities. The main change is switching the worker's stdio from `inherit` to `pipe`, and then manually piping the worker's stdout and stderr to the main process. This avoids terminal state issues and enables better debugging.

**Plugin worker process I/O handling:**

* Changed the worker process `stdio` option from `'inherit'` to `'pipe'` in `startPluginWorker`, preventing terminal state issues (such as broken arrow key functionality) after Nx execution.
* Added logic to pipe the worker's `stdout` and `stderr` to the main process, making it easier to debug and allowing plugins to communicate metrics. Increased the max listener count on `process.stdout` and `process.stderr` to avoid warnings from multiple listeners.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30470
