### PR TITLE
feat(release): add option to opt-out commit scope filter

### DIFF
--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -1253,6 +1253,10 @@
     "NxReleaseConventionalCommitsConfiguration": {
       "type": "object",
       "properties": {
+        "useCommitScope": {
+          "type": "boolean",
+          "description": "Whether or not to rely on commit scope to resolve version specifier.\nIf set to 'true', then only commits with scope matching projectName and commits without scope affects version determined, rest are assumed as patch change.\nIf set to 'false', then all commits that affected project used to determine semver change.\nIf not set, this will default to 'true'"
+        },
         "types": {
           "type": "object",
           "description": "A map of commit types to their configuration. If a type is set to 'true', then it will be enabled with the default 'semverBump' of 'patch' and will appear in the changelog. If a type is set to 'false', then it will not trigger a version bump and will be hidden from the changelog.",

--- a/packages/nx/src/command-line/release/changelog/commit-utils.spec.ts
+++ b/packages/nx/src/command-line/release/changelog/commit-utils.spec.ts
@@ -69,6 +69,7 @@ describe('commit-utils', () => {
 
   describe('filterHiddenChanges', () => {
     const conventionalCommitsConfig: NxReleaseConfig['conventionalCommits'] = {
+      useCommitScope: true,
       types: {
         fix: {
           semverBump: 'patch',
@@ -369,6 +370,7 @@ describe('commit-utils', () => {
 
       const conventionalCommitsConfig: NxReleaseConfig['conventionalCommits'] =
         {
+          useCommitScope: true,
           types: {
             fix: {
               semverBump: 'patch',

--- a/packages/nx/src/command-line/release/config/config.spec.ts
+++ b/packages/nx/src/command-line/release/config/config.spec.ts
@@ -278,6 +278,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -491,6 +492,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -707,6 +709,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -954,6 +957,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -1185,6 +1189,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -1425,6 +1430,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -1663,6 +1669,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -1886,6 +1893,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -2104,6 +2112,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -2325,6 +2334,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -2549,6 +2559,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -2807,6 +2818,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -3032,6 +3044,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -3283,6 +3296,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -3546,6 +3560,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -3812,6 +3827,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -4085,6 +4101,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -4377,6 +4394,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -4596,6 +4614,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -4818,6 +4837,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -5036,6 +5056,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -5259,6 +5280,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -5472,6 +5494,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -5712,6 +5735,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -5959,6 +5983,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": {
               "preVersionCommand": "npx nx run-many docker:build -p lib-a",
@@ -6192,6 +6217,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": {
               "preVersionCommand": "npx nx run-many -t docker:build",
@@ -6428,6 +6454,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -6649,6 +6676,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -6893,6 +6921,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -7109,6 +7138,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -7334,6 +7364,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -7554,6 +7585,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -7794,6 +7826,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -8035,6 +8068,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -8265,6 +8299,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -8489,6 +8524,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -8716,6 +8752,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -8943,6 +8980,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -9171,6 +9209,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -9462,6 +9501,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -9706,6 +9746,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -10131,6 +10172,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -10348,6 +10390,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -10601,6 +10644,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -10830,6 +10874,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -11062,6 +11107,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -11295,6 +11341,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -11531,6 +11578,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -11779,6 +11827,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -12105,6 +12154,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -12366,6 +12416,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -12607,6 +12658,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -13082,6 +13134,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -13515,6 +13568,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -13747,6 +13801,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -13966,6 +14021,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -14183,6 +14239,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -14402,6 +14459,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -14631,6 +14689,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -14854,6 +14913,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -15076,6 +15136,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -15304,6 +15365,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -15548,6 +15610,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -15796,6 +15859,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {
@@ -16042,6 +16106,7 @@ describe('createNxReleaseConfig()', () => {
                   "semverBump": "none",
                 },
               },
+              "useCommitScope": true,
             },
             "docker": undefined,
             "git": {

--- a/packages/nx/src/command-line/release/config/conventional-commits.ts
+++ b/packages/nx/src/command-line/release/config/conventional-commits.ts
@@ -2,6 +2,7 @@ import { NxReleaseConfig } from './config';
 
 export const DEFAULT_CONVENTIONAL_COMMITS_CONFIG: NxReleaseConfig['conventionalCommits'] =
   {
+    useCommitScope: true,
     types: {
       feat: {
         semverBump: 'minor',

--- a/packages/nx/src/command-line/release/utils/semver.spec.ts
+++ b/packages/nx/src/command-line/release/utils/semver.spec.ts
@@ -79,6 +79,7 @@ describe('semver', () => {
   // tests for determineSemverChange()
   describe('determineSemverChange()', () => {
     const config: NxReleaseConfig['conventionalCommits'] = {
+      useCommitScope: true,
       types: {
         feat: {
           semverBump: 'minor',
@@ -160,6 +161,30 @@ describe('semver', () => {
           config
         ).get('default')
       ).toEqual(SemverSpecifier.PATCH);
+    });
+
+    it('should return a minor bump level if useCommitScope is false and none of the commits are project scoped', () => {
+      expect(
+        determineSemverChange(
+          new Map([
+            [
+              'default',
+              [
+                { commit: fixCommit, isProjectScopedCommit: false },
+                {
+                  commit: featNonBreakingCommit,
+                  isProjectScopedCommit: false,
+                },
+                { commit: choreCommit, isProjectScopedCommit: false },
+              ],
+            ],
+          ]),
+          {
+            ...config,
+            useCommitScope: false,
+          }
+        ).get('default')
+      ).toEqual(SemverSpecifier.MINOR);
     });
 
     it('should return major if any commits are breaking', () => {

--- a/packages/nx/src/command-line/release/utils/semver.ts
+++ b/packages/nx/src/command-line/release/utils/semver.ts
@@ -41,7 +41,7 @@ export function determineSemverChange(
     let highestChange: SemverSpecifier | null = null;
 
     for (const { commit, isProjectScopedCommit } of relevantCommit) {
-      if (!isProjectScopedCommit) {
+      if (config.useCommitScope && !isProjectScopedCommit) {
         // commit is relevant to the project, but not directly, report patch change to match side-effectful bump behavior in update dependents in release-group-processor
         highestChange = Math.max(SemverSpecifier.PATCH, highestChange ?? 0);
         continue;

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -320,6 +320,13 @@ export interface NxReleaseGitConfiguration {
 }
 
 export interface NxReleaseConventionalCommitsConfiguration {
+  /**
+   * Whether or not to rely on commit scope to resolve version specifier.
+   * If set to 'true', then only commits with scope matching projectName and commits without scope affects version determined, rest are assumed as patch change.
+   * If set to 'false', then all commits that affected project used to determine semver change.
+   * If not set, this will default to 'true'
+   */
+  useCommitScope?: boolean;
   types?: Record<
     string,
     /**


### PR DESCRIPTION
## Current Behavior

PR #32915 changed how conventional commits determine version, making them rely on commit scope:
commits with types configured to bump minor / major version bumps only patch if commit scope exists and it does not include project name

## Expected Behavior

In our project we do not use projectName as commit scope, so we would like to bring back old behavior, this can be achieved by adding option to opt-out such behavior