### PR TITLE
fix(core): handle various directories when importing prettier

### DIFF
--- a/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.ts
+++ b/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import type * as Prettier from 'prettier';
 import { isUsingPrettier } from '../../utils/is-using-prettier';
 import type { Tree } from '../tree';
+import { getNxRequirePaths } from '../../utils/installation-directory';
 
 /**
  * Formats all the created or updated files using Prettier
@@ -39,7 +40,10 @@ export async function formatFilesWithPrettierIfAvailable(
 
   let prettier: typeof Prettier;
   try {
-    prettier = await import('prettier');
+    const prettierPath = require.resolve('prettier', {
+      paths: [...getNxRequirePaths(root), __dirname],
+    });
+    prettier = require(prettierPath);
     /**
      * Even after we discovered prettier in node_modules, we need to be sure that the user is intentionally using prettier
      * before proceeding to format with it.


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
when trying to format with prettier while outside of the workspace (for example in a `tmp` nx installation like is created during `configure-ai-agents`), resolving prettier could fail even though it's present in the actual workspace.

## Expected Behavior
resolving prettier works if it's available in either the proper workspace or the tmp one by specifying `paths` in `require.resolve`
