### PR TITLE
docs(misc): fix ToC overflow and height stretching issues

### DIFF
--- a/astro-docs/src/components/layout/PageFrame.astro
+++ b/astro-docs/src/components/layout/PageFrame.astro
@@ -43,7 +43,7 @@ const { hasSidebar } = Astro.locals.starlightRoute;
     )
   }
   <div class="main-frame"><slot /></div>
-  <Footer disableThemeSwitcher={true} useDomainPrefix={true} className="mt-32 dark:bg-slate-900" />
+  <Footer disableThemeSwitcher={true} useDomainPrefix={true} className="dark:bg-slate-900" />
   <WebinarNotifier client:load />
 </div>
 

--- a/astro-docs/src/components/layout/TableOfContents.astro
+++ b/astro-docs/src/components/layout/TableOfContents.astro
@@ -175,16 +175,10 @@ const githubStarsCount = Astro.locals.githubStarsCount ?? 0;
     
     /* Container with proper scrolling */
     .toc-container {
-      /* Calculate height based on viewport minus nav and footer with padding */
-      max-height: calc(100vh - var(--sl-nav-height) - 25rem);
-      /* 
-      * prevent ToC from going to 0 height.
-      * if this overlaps the footer it's not a huge issue for such small viewport
-      * */
-      min-height: 300px; 
+      /* Allow ToC to be its natural height - parent sticky container handles viewport constraints */
+      max-height: calc(100vh - var(--sl-nav-height) - 4rem);
       overflow-y: auto;
       overflow-x: hidden;
-      padding-bottom: 1rem;
     }
     
     /* Only enable smooth scrolling if user doesn't prefer reduced motion */

--- a/astro-docs/src/components/layout/TwoColumnContent.astro
+++ b/astro-docs/src/components/layout/TwoColumnContent.astro
@@ -24,21 +24,27 @@ const { data} = Astro.locals.starlightRoute.entry;
     }
 
     @media (min-width: 72rem) {
+      .lg\:sl-flex {
+        align-items: stretch;
+      }
+
       .right-sidebar-container {
         order: 2;
         position: relative;
         width: calc(
           var(--sl-sidebar-width) + (100% - var(--sl-content-width) - var(--sl-sidebar-width)) / 2
         );
+        display: flex;
+        flex-direction: column;
       }
 
       .right-sidebar {
-        position: fixed;
-        top: 0;
+        position: sticky;
+        top: var(--sl-nav-height);
         border-inline-start: 1px solid var(--sl-color-hairline);
-        padding-top: var(--sl-nav-height);
+        padding-top: 1rem;
         width: 100%;
-        height: auto; // MODIFIED: full height conflicts with footer
+        max-height: calc(100vh - var(--sl-nav-height));
         overflow-y: auto;
         scrollbar-width: none;
       }


### PR DESCRIPTION
This PR fixes the ToC so it does not overflow to the footer. It adjusts the height calculation such that it takes up the entire height of the main frame.

The extra top margin is removed from the footer to remove the extra gap between main frame and footer.

BEFORE: 

<img width="1387" height="915" alt="image" src="https://github.com/user-attachments/assets/e7f4d31c-a206-48ab-81e6-9fddfee11b18" />


AFTER:

<img width="1385" height="916" alt="image" src="https://github.com/user-attachments/assets/cf6e2662-3c3d-4d37-9769-235b901cc188" />

<img width="1382" height="918" alt="image" src="https://github.com/user-attachments/assets/9e142edf-259b-482a-b676-9333857ed776" />



Fixes DOC-224