### PR TITLE
fix(nx-dev): fix GitHub star button styling in mobile view

### DIFF
--- a/astro-docs/src/components/layout/PageFrame.astro
+++ b/astro-docs/src/components/layout/PageFrame.astro
@@ -1,10 +1,11 @@
 ---
 // Copied from https://github.com/withastro/starlight/blob/f14eb0c/packages/starlight/components/PageFrame.astro with modifications.
 import MobileMenuToggle from '@astrojs/starlight/components/MobileMenuToggle.astro';
-import { Footer } from '@nx/nx-dev-ui-common';
+import { Footer, GitHubStarWidget  } from '@nx/nx-dev-ui-common';
 import { WebinarNotifier } from '@nx/nx-dev-ui-common/src/lib/webinar-notifier';
 
 const { hasSidebar } = Astro.locals.starlightRoute;
+const githubStarsCount = Astro.locals.githubStarsCount ?? 0;
 ---
 
 <div class="page sl-flex">
@@ -19,22 +20,25 @@ const { hasSidebar } = Astro.locals.starlightRoute;
             <!-- CTA Buttons for Mobile Menu - Show when not in header (below xl breakpoint) -->
             <div class="mobile-cta-buttons xl:hidden mt-auto pt-4 pb-4 border-t border-slate-800 dark:border-slate-700">
               <div class="flex flex-col gap-2">
-                <a 
-                  href="https://nx.dev/contact"
-                  class="w-full inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition no-underline border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 shadow-sm"
-                  title="Contact Us"
-                >
-                  Contact
-                </a>
-                <a 
-                  href="https://cloud.nx.app?utm_source=nx-dev&utm_medium=header"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="w-full inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition no-underline bg-blue-500 dark:bg-sky-500 text-white hover:bg-blue-600 dark:hover:bg-sky-600 shadow-sm"
-                  title="Login to Nx Cloud"
-                >
-                  Login
-                </a>
+                <GitHubStarWidget starsCount={githubStarsCount} client:load />
+                <div class="flex flex-col mx-2 gap-2">
+                  <a
+                    href="https://nx.dev/contact"
+                    class="w-full inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition no-underline border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 shadow-sm"
+                    title="Contact Us"
+                  >
+                    Contact
+                  </a>
+                  <a
+                    href="https://cloud.nx.app?utm_source=nx-dev&utm_medium=header"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="w-full inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition no-underline bg-blue-500 dark:bg-sky-500 text-white hover:bg-blue-600 dark:hover:bg-sky-600 shadow-sm"
+                    title="Login to Nx Cloud"
+                  >
+                    Login
+                  </a>
+                </div>
               </div>
             </div>
           </div>

--- a/astro-docs/src/components/layout/Sidebar.astro
+++ b/astro-docs/src/components/layout/Sidebar.astro
@@ -12,9 +12,6 @@ const githubStarsCount = Astro.locals.githubStarsCount ?? 0;
     <SidebarPersister>
         <SidebarSublist sublist={sidebar}/>
     </SidebarPersister>
-    <div class="github-star-widget-sidebar">
-        <GitHubStarWidget starsCount={githubStarsCount} client:load />
-    </div>
     <div class="md:sl-hidden">
         <MobileMenuFooter/>
     </div>
@@ -44,10 +41,5 @@ const githubStarsCount = Astro.locals.githubStarsCount ?? 0;
 
     .sidebar-wrapper :global(details[open] summary .group-label) {
         color: var(--sl-color-gray-2);
-    }
-
-    .github-star-widget-sidebar {
-        margin-top: 1rem;
-        padding: 0 1rem;
     }
 </style>

--- a/nx-dev/ui-common/src/lib/github-star-widget.tsx
+++ b/nx-dev/ui-common/src/lib/github-star-widget.tsx
@@ -47,7 +47,7 @@ export function GitHubStarWidget({
         href="https://github.com/nrwl/nx"
         target="_blank"
         rel="noreferrer noopener"
-        className="flex items-center gap-2 border-transparent font-bold text-white dark:text-slate-950"
+        className="flex items-center gap-2 border-transparent font-bold text-white no-underline dark:text-slate-950"
         onClick={() => handleClick('githubstars_buttonclick')}
       >
         <span className="absolute inset-0" />


### PR DESCRIPTION
This PR fixes the GitHub star widget in the left sidebar such that it only shows in smaller screens (e.g. mobile). For desktop we have it in the ToC.

Also styles it to be consistent with the login and sign up buttons.

Large screen, don't show:

<img width="1483" height="881" alt="image" src="https://github.com/user-attachments/assets/d3c88d87-4905-4c3f-85c4-b7b4c14546d4" />


Smaller screen, show:

<img width="1136" height="811" alt="image" src="https://github.com/user-attachments/assets/22aa652f-c523-493f-a01e-87e55934e1c9" />

Mobile view, show:

<img width="511" height="880" alt="image" src="https://github.com/user-attachments/assets/283ffca2-4e4e-4706-811f-ce27b02e607b" />


Fixes DOC-325
