### PR TITLE
feat(vite): add vitest 4 to peerDep range to prevent conflicts

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "vite": "^5.0.0 || ^6.0.0 || ^7.0.0",
-    "vitest": "^1.3.1 || ^2.0.0 || ^3.0.0"
+    "vitest": "^1.3.1 || ^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4191,7 +4191,7 @@ importers:
         specifier: ^5.0.0 || ^6.0.0 || ^7.0.0
         version: 7.1.3(@types/node@24.2.0)(jiti@2.4.2)(less@4.4.0)(lightningcss@1.30.1)(sass-embedded@1.85.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.0)
       vitest:
-        specifier: ^1.3.1 || ^2.0.0 || ^3.0.0
+        specifier: ^1.3.1 || ^2.0.0 || ^3.0.0 || ^4.0.0
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.2.0)(jiti@2.4.2)(jsdom@26.1.0)(less@4.4.0)(lightningcss@1.30.1)(sass-embedded@1.85.1)(sass@1.90.0)(stylus@0.64.0)(terser@5.43.1)(tsx@4.20.5)(yaml@2.8.0)
     devDependencies:
       nx:


### PR DESCRIPTION
## Current Behavior
`@nx/vite` has a peerDep range of only `1 | 2 | 3` for `vitest`.
This will cause peer dep conflicts for using wishing to use Vitest 4.

## Expected Behavior
Add Vitest 4 to the peerDep range of `@nx/vite` to prevent conflicts.
