### PR TITLE
feat(storybook): generate ai instructions for converting from CJS to ESM after migration

### DIFF
--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -634,8 +634,8 @@
         }
       }
     },
-    "21.2.0": {
-      "version": "21.2.0-beta.3",
+    "22.1.0": {
+      "version": "22.1.0-beta.6",
       "x-prompt": "Do you want to update Storybook to version 10?",
       "implementation": "./src/migrations/update-21-2-0/migrate-to-storybook-10",
       "requires": {

--- a/packages/storybook/src/migrations/update-22-1-0/files/ai-instructions-for-cjs-esm.md
+++ b/packages/storybook/src/migrations/update-22-1-0/files/ai-instructions-for-cjs-esm.md
@@ -1,0 +1,175 @@
+# Instructions for LLM: Transform Storybook Config Files from CommonJS to ESM
+
+## Task Overview
+
+Find all .storybook/main.ts and .storybook/main.js files in the workspace and transform
+any CommonJS (CJS) configurations to ES Modules (ESM).
+
+### Step 1: Find All Storybook Config Files
+
+Use glob patterns to locate all Storybook main configuration files:
+**/.storybook/main.js
+**/.storybook/main.ts
+
+### Step 2: Identify CommonJS vs ESM
+
+For each file found, read its contents and determine if it uses CommonJS syntax by
+checking for:
+
+CommonJS indicators:
+
+- `module.exports =` or `module.exports.`
+- `exports.`
+- `require()` function calls
+
+ESM indicators (already correct):
+
+- export default
+- export const/export function
+- import statements
+
+### Step 3: Transform CJS to ESM
+
+For each file identified as CommonJS, perform the following transformations:
+
+A. Convert `module.exports`
+
+// FROM (CJS):
+
+```
+module.exports = {
+    stories: ['../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+    addons: ['@storybook/addon-essentials']
+};
+```
+
+// TO (ESM):
+
+```
+export default {
+    stories: ['../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+    addons: ['@storybook/addon-essentials']
+};
+```
+
+B. Convert `require()` to import
+
+// FROM (CJS):
+
+```
+const { nxViteTsPaths } = require('@nx/vite/plugins/nx-tsconfig-paths.plugin');
+const { mergeConfig } = require('vite');
+```
+
+// TO (ESM):
+
+```
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { mergeConfig } from 'vite';
+```
+
+C. Handle `path.join()` patterns
+
+// FROM (CJS):
+
+```
+const path = require('path');
+const rootMain = require(path.join(__dirname, '../../.storybook/main'));
+```
+
+// TO (ESM):
+
+```
+import { join } from 'path';
+import rootMain from '../../.storybook/main';
+```
+
+D. Handle Dynamic Requires in Config Functions
+
+// FROM (CJS):
+
+```
+module.exports = {
+    viteFinal: async (config) => {
+        const { mergeConfig } = require('vite');
+        return mergeConfig(config, {});
+    }
+};
+```
+
+// TO (ESM):
+
+```
+import { mergeConfig } from 'vite';
+
+export default {
+    viteFinal: async (config) => {
+        return mergeConfig(config, {});
+    }
+};
+```
+
+### Step 4: Validation Checks
+
+After transformation, verify:
+
+1. All require() calls have been converted to import statements at the top of the file
+2. All module.exports have been converted to export default or named exports
+3. Imports are at the top of the file (before the export)
+4. The file maintains proper TypeScript typing if it's a .ts file
+
+### Step 5: Report Results
+
+Provide a summary of:
+
+- Total files found
+- Files that were already ESM (no changes needed)
+- Files that were transformed from CJS to ESM
+- List the specific files that were modified
+
+### Example Complete Transformation
+
+Before (CJS):
+
+```
+const path = require('path');
+const { mergeConfig } = require('vite');
+
+module.exports = {
+    stories: ['../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+    addons: ['@storybook/addon-essentials'],
+    viteFinal: async (config) => {
+        return mergeConfig(config, {
+            resolve: {
+                alias: {}
+            }
+        });
+    }
+};
+```
+
+After (ESM):
+
+```
+import { join } from 'path';
+import { mergeConfig } from 'vite';
+
+export default {
+    stories: ['../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+    addons: ['@storybook/addon-essentials'],
+    viteFinal: async (config) => {
+        return mergeConfig(config, {
+            resolve: {
+                alias: {}
+            }
+        });
+    }
+};
+```
+
+## Important Notes
+
+- Preserve all comments in the original files
+- Maintain the same indentation and formatting style
+- For TypeScript files (.ts), ensure type imports use import type when appropriate
+- Test that the transformations don't break the Storybook configuration

--- a/packages/storybook/src/migrations/update-22-1-0/migrate-to-storybook-10.ts
+++ b/packages/storybook/src/migrations/update-22-1-0/migrate-to-storybook-10.ts
@@ -32,6 +32,6 @@ export default async function migrateToStorybook10(tree: Tree) {
   tree.write('MIGRATE_STORYBOOK_10.md', contents);
   return [
     `Storybook 10 requires Storybook Configs to use ESM.`,
-    `We have created 'MIGRATE_STORYBOOK_10.md' which is a set of instructions you can feed to an AI Agent to find and transform any Storybook Configs in your workspace that are currently CJS to ESM.`,
+    `We created 'MIGRATE_STORYBOOK_10.md' with instructions for an AI Agent to convert CJS Storybook Configs to ESM in your workspace.`,
   ];
 }

--- a/packages/storybook/src/migrations/update-22-1-0/migrate-to-storybook-10.ts
+++ b/packages/storybook/src/migrations/update-22-1-0/migrate-to-storybook-10.ts
@@ -2,6 +2,8 @@ import { Tree } from '@nx/devkit';
 import { output } from 'nx/src/utils/output';
 import migrate10Generator from '../../generators/migrate-10/migrate-10';
 import { storybookMajorVersion } from '../../utils/utilities';
+import { join } from 'path';
+import { existsSync, readFileSync } from 'fs';
 
 export default async function migrateToStorybook10(tree: Tree) {
   output.log({
@@ -13,7 +15,23 @@ export default async function migrateToStorybook10(tree: Tree) {
       `https://nx.dev/nx-api/storybook/generators/migrate-10`,
     ],
   });
-  return migrate10Generator(tree, {
+  await migrate10Generator(tree, {
     autoAcceptAllPrompts: true,
   });
+
+  const pathToAiInstructions = join(
+    __dirname,
+    'files',
+    'ai-instructions-for-cjs-esm.md'
+  );
+  if (!existsSync(pathToAiInstructions)) {
+    return;
+  }
+
+  const contents = readFileSync(pathToAiInstructions);
+  tree.write('MIGRATE_STORYBOOK_10.md', contents);
+  return [
+    `Storybook 10 requires Storybook Configs to use ESM.`,
+    `We have created 'MIGRATE_STORYBOOK_10.md' which is a set of instructions you can feed to an AI Agent to find and transform any Storybook Configs in your workspace that are currently CJS to ESM.`,
+  ];
 }


### PR DESCRIPTION
## Current Behavior
Storybook 10 Changelog states that CJS is no longer supported.
The migration does not do this automatically.
https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#the-storybookmain-file-and-other-presets-must-be-valid-esm

## Expected Behavior
Generate instructions for an AI Agent to find and convert CJS Storybook Config files to ESM.

## Related Issue(s)

Fixes NXC-3409
Fixes NXC-3336
