### PR TITLE
feat(gradle): use gitignore to determine dependant task output files

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ shadow = "8.1.1"
 ktfmt = "0.52.0"
 nx-project-graph = "0.1.7"
 gradle-plugin-publish = "1.2.1"
+jgit = "6.8.0.202311291450-r"
 
 [libraries]
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
@@ -23,6 +24,7 @@ junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "jun
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 gradle-tooling-api = { module = "org.gradle:gradle-tooling-api", version.ref = "gradle-tooling-api" }
+jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/packages/gradle/project-graph/build.gradle.kts
+++ b/packages/gradle/project-graph/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
   implementation(libs.gson)
   implementation(libs.javaparser.core)
   implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.jgit)
   // Use compileOnly to avoid runtime conflicts with Kotlin Gradle plugin
   compileOnly(libs.kotlin.compiler.embeddable) {
     exclude(group = "org.jetbrains.kotlin", module = "kotlin-gradle-plugin")

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
@@ -18,7 +18,8 @@ fun addTestCiTargets(
     targetGroups: TargetGroups,
     projectRoot: String,
     workspaceRoot: String,
-    ciTestTargetName: String
+    ciTestTargetName: String,
+    gitIgnoreClassifier: GitIgnoreClassifier
 ) {
   ensureTargetGroupExists(targetGroups, testCiTargetGroup)
 
@@ -33,7 +34,8 @@ fun addTestCiTargets(
       projectRoot,
       workspaceRoot,
       ciTestTargetName,
-      ciDependsOn)
+      ciDependsOn,
+      gitIgnoreClassifier)
 
   ensureParentCiTarget(
       targets,
@@ -43,7 +45,8 @@ fun addTestCiTargets(
       testTask,
       projectRoot,
       workspaceRoot,
-      ciDependsOn)
+      ciDependsOn,
+      gitIgnoreClassifier)
 }
 
 private fun processTestFiles(
@@ -55,7 +58,8 @@ private fun processTestFiles(
     projectRoot: String,
     workspaceRoot: String,
     ciTestTargetName: String,
-    ciDependsOn: MutableList<Map<String, String>>
+    ciDependsOn: MutableList<Map<String, String>>,
+    gitIgnoreClassifier: GitIgnoreClassifier
 ) {
   testFiles
       .filter { isTestFile(it, workspaceRoot) }
@@ -66,7 +70,7 @@ private fun processTestFiles(
           val targetName = "$ciTestTargetName--$className"
           targets[targetName] =
               buildTestCiTarget(
-                  projectBuildPath, testClassPackagePath, testTask, projectRoot, workspaceRoot)
+                  projectBuildPath, testClassPackagePath, testTask, projectRoot, workspaceRoot, gitIgnoreClassifier)
           targetGroups[testCiTargetGroup]?.add(targetName)
 
           ciDependsOn.add(
@@ -96,8 +100,9 @@ private fun buildTestCiTarget(
     testTask: Task,
     projectRoot: String,
     workspaceRoot: String,
+    gitIgnoreClassifier: GitIgnoreClassifier
 ): MutableMap<String, Any?> {
-  val taskInputs = getInputsForTask(null, testTask, projectRoot, workspaceRoot)
+  val taskInputs = getInputsForTask(null, testTask, projectRoot, workspaceRoot, null, gitIgnoreClassifier)
 
   val target =
       mutableMapOf<String, Any?>(
@@ -129,10 +134,11 @@ private fun ensureParentCiTarget(
     testTask: Task,
     projectRoot: String,
     workspaceRoot: String,
-    ciDependsOn: List<Map<String, String>>
+    ciDependsOn: List<Map<String, String>>,
+    gitIgnoreClassifier: GitIgnoreClassifier
 ) {
   if (ciDependsOn.isNotEmpty()) {
-    val taskInputs = getInputsForTask(null, testTask, projectRoot, workspaceRoot)
+    val taskInputs = getInputsForTask(null, testTask, projectRoot, workspaceRoot, null, gitIgnoreClassifier)
 
     targets[ciTestTargetName] =
         mutableMapOf<String, Any?>(

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
@@ -70,7 +70,12 @@ private fun processTestFiles(
           val targetName = "$ciTestTargetName--$className"
           targets[targetName] =
               buildTestCiTarget(
-                  projectBuildPath, testClassPackagePath, testTask, projectRoot, workspaceRoot, gitIgnoreClassifier)
+                  projectBuildPath,
+                  testClassPackagePath,
+                  testTask,
+                  projectRoot,
+                  workspaceRoot,
+                  gitIgnoreClassifier)
           targetGroups[testCiTargetGroup]?.add(targetName)
 
           ciDependsOn.add(
@@ -102,7 +107,8 @@ private fun buildTestCiTarget(
     workspaceRoot: String,
     gitIgnoreClassifier: GitIgnoreClassifier
 ): MutableMap<String, Any?> {
-  val taskInputs = getInputsForTask(null, testTask, projectRoot, workspaceRoot, null, gitIgnoreClassifier)
+  val taskInputs =
+      getInputsForTask(null, testTask, projectRoot, workspaceRoot, null, gitIgnoreClassifier)
 
   val target =
       mutableMapOf<String, Any?>(
@@ -138,7 +144,8 @@ private fun ensureParentCiTarget(
     gitIgnoreClassifier: GitIgnoreClassifier
 ) {
   if (ciDependsOn.isNotEmpty()) {
-    val taskInputs = getInputsForTask(null, testTask, projectRoot, workspaceRoot, null, gitIgnoreClassifier)
+    val taskInputs =
+        getInputsForTask(null, testTask, projectRoot, workspaceRoot, null, gitIgnoreClassifier)
 
     targets[ciTestTargetName] =
         mutableMapOf<String, Any?>(

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/GitIgnoreClassifier.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/GitIgnoreClassifier.kt
@@ -1,99 +1,100 @@
 package dev.nx.gradle.utils
 
-import org.eclipse.jgit.ignore.FastIgnoreRule
 import java.io.File
+import org.eclipse.jgit.ignore.FastIgnoreRule
 
 /**
- * Determines if files match gitignore patterns
- * Provides heuristic for parameter classification: ignored files are likely outputs, tracked files are likely inputs
+ * Determines if files match gitignore patterns Provides heuristic for parameter classification:
+ * ignored files are likely outputs, tracked files are likely inputs
  */
-class GitIgnoreClassifier(
-    private val workspaceRoot: File
-) {
-    private val ignoreRules: MutableList<FastIgnoreRule> = mutableListOf()
+class GitIgnoreClassifier(private val workspaceRoot: File) {
+  private val ignoreRules: MutableList<FastIgnoreRule> = mutableListOf()
 
-    init {
-        loadIgnoreRules()
-    }
+  init {
+    loadIgnoreRules()
+  }
 
-    private fun loadIgnoreRules() {
-        try {
-            val gitIgnoreFile = File(workspaceRoot, ".gitignore")
-            if (gitIgnoreFile.exists()) {
-                gitIgnoreFile.readLines().forEach { line ->
-                    val trimmed = line.trim()
-                    if (trimmed.isNotEmpty() && !trimmed.startsWith("#")) {
-                        try {
-                            val rule = FastIgnoreRule(trimmed)
-                            ignoreRules.add(rule)
-                        } catch (e: Exception) {
-                            // Skip invalid rules silently
-                        }
-                    }
-                }
+  private fun loadIgnoreRules() {
+    try {
+      val gitIgnoreFile = File(workspaceRoot, ".gitignore")
+      if (gitIgnoreFile.exists()) {
+        gitIgnoreFile.readLines().forEach { line ->
+          val trimmed = line.trim()
+          if (trimmed.isNotEmpty() && !trimmed.startsWith("#")) {
+            try {
+              val rule = FastIgnoreRule(trimmed)
+              ignoreRules.add(rule)
+            } catch (e: Exception) {
+              // Skip invalid rules silently
             }
+          }
+        }
+      }
+    } catch (e: Exception) {
+      // If we can't load gitignore rules, continue without them
+    }
+  }
+
+  private fun isPartOfWorkspace(path: File): Boolean {
+    // Use canonicalPath to resolve symlinks and normalize paths
+    val workspaceRootPath =
+        try {
+          workspaceRoot.canonicalPath
         } catch (e: Exception) {
-            // If we can't load gitignore rules, continue without them
+          workspaceRoot.absolutePath
         }
+
+    val filePath =
+        try {
+          path.canonicalPath
+        } catch (e: Exception) {
+          path.absolutePath
+        }
+
+    // Ensure the file path starts with the workspace root and is followed by a separator
+    // or is exactly the workspace root (which we exclude)
+    if (filePath == workspaceRootPath) {
+      return false
     }
 
-    private fun isPartOfWorkspace(path: File): Boolean {
-      // Use canonicalPath to resolve symlinks and normalize paths
-      val workspaceRootPath = try {
-        workspaceRoot.canonicalPath
-      } catch (e: Exception) {
-        workspaceRoot.absolutePath
-      }
+    return filePath.startsWith(workspaceRootPath + File.separator)
+  }
 
-      val filePath = try {
-        path.canonicalPath
-      } catch (e: Exception) {
-        path.absolutePath
-      }
-
-      // Ensure the file path starts with the workspace root and is followed by a separator
-      // or is exactly the workspace root (which we exclude)
-      if (filePath == workspaceRootPath) {
-        return false
-      }
-
-      return filePath.startsWith(workspaceRootPath + File.separator)
+  /**
+   * Determines if a file path should be ignored according to gitignore rules Works for both
+   * existing and non-existent paths by using pattern matching
+   */
+  fun isIgnored(path: File): Boolean {
+    if (ignoreRules.isEmpty()) {
+      return false
     }
 
-    /**
-     * Determines if a file path should be ignored according to gitignore rules
-     * Works for both existing and non-existent paths by using pattern matching
-     */
-    fun isIgnored(path: File): Boolean {
-        if (ignoreRules.isEmpty()) {
-            return false
-        }
+    if (!isPartOfWorkspace(path)) {
+      return false
+    }
 
-        if (!isPartOfWorkspace(path)) {
-          return false
-        }
-
-        val relativePath = try {
+    val relativePath =
+        try {
           path.relativeTo(workspaceRoot).path
         } catch (e: IllegalArgumentException) {
           return false
         }
 
-        return try {
-            // Check path against all ignore rules
-            var isIgnored = false
+    return try {
+      // Check path against all ignore rules
+      var isIgnored = false
 
-            for (rule in ignoreRules) {
-                val isDirectory = path.isDirectory || relativePath.endsWith("/")
-                if (rule.isMatch(relativePath, isDirectory)) {
-                    // FastIgnoreRule.getResult() returns true if should be ignored
-                    isIgnored = rule.result
-                }
-            }
-
-            isIgnored
-        } catch (e: Exception) {
-            false
+      for (rule in ignoreRules) {
+        val isDirectory = path.isDirectory || relativePath.endsWith("/")
+        if (rule.isMatch(relativePath, isDirectory)) {
+          // FastIgnoreRule.getResult() returns true if should be ignored
+          isIgnored = rule.result
         }
+      }
+
+      isIgnored
+    } catch (e: Exception) {
+      false
     }
+  }
 }

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/GitIgnoreClassifier.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/GitIgnoreClassifier.kt
@@ -1,0 +1,73 @@
+package dev.nx.gradle.utils
+
+import org.eclipse.jgit.ignore.FastIgnoreRule
+import java.io.File
+
+/**
+ * Determines if files match gitignore patterns
+ * Provides heuristic for parameter classification: ignored files are likely outputs, tracked files are likely inputs
+ */
+class GitIgnoreClassifier(
+    private val workspaceRoot: File
+) {
+    private val ignoreRules: MutableList<FastIgnoreRule> = mutableListOf()
+
+    init {
+        loadIgnoreRules()
+    }
+
+    private fun loadIgnoreRules() {
+        try {
+            val gitIgnoreFile = File(workspaceRoot, ".gitignore")
+            if (gitIgnoreFile.exists()) {
+                gitIgnoreFile.readLines().forEach { line ->
+                    val trimmed = line.trim()
+                    if (trimmed.isNotEmpty() && !trimmed.startsWith("#")) {
+                        try {
+                            val rule = FastIgnoreRule(trimmed)
+                            ignoreRules.add(rule)
+                        } catch (e: Exception) {
+                            // Skip invalid rules silently
+                        }
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            // If we can't load gitignore rules, continue without them
+        }
+    }
+
+    /**
+     * Determines if a file path should be ignored according to gitignore rules
+     * Works for both existing and non-existent paths by using pattern matching
+     */
+    fun isIgnored(path: File): Boolean {
+        if (ignoreRules.isEmpty()) {
+            return false
+        }
+
+        val relativePath = try {
+            path.relativeTo(workspaceRoot).path
+        } catch (e: IllegalArgumentException) {
+            // Path is outside workspace
+            return false
+        }
+
+        return try {
+            // Check path against all ignore rules
+            var isIgnored = false
+
+            for (rule in ignoreRules) {
+                val isDirectory = path.isDirectory || relativePath.endsWith("/")
+                if (rule.isMatch(relativePath, isDirectory)) {
+                    // FastIgnoreRule.getResult() returns true if should be ignored
+                    isIgnored = rule.result
+                }
+            }
+
+            isIgnored
+        } catch (e: Exception) {
+            false
+        }
+    }
+}

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
@@ -84,6 +84,9 @@ fun processTargetsForProject(
 
   logger.info("Using workspace root: $workspaceRoot")
 
+  // Create GitIgnoreClassifier once for the entire project
+  val gitIgnoreClassifier = GitIgnoreClassifier(File(workspaceRoot))
+
   val projectBuildPath = project.buildTreePath.trimEnd(':')
 
   logger.info("${Date()} ${project}: Process targets")
@@ -123,7 +126,8 @@ fun processTargetsForProject(
               workspaceRoot,
               externalNodes,
               dependencies,
-              targetNameOverrides)
+              targetNameOverrides,
+              gitIgnoreClassifier)
 
       targets[targetName] = target
 
@@ -160,7 +164,8 @@ fun processTargetsForProject(
               targetGroups,
               projectRoot,
               workspaceRoot,
-              ciTestTargetName)
+              ciTestTargetName,
+              gitIgnoreClassifier)
         }
       }
 

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -112,12 +112,11 @@ fun getInputsForTask(
     val inputs = mutableListOf<Any>()
     val externalDependencies = mutableListOf<String>()
 
-    // Get or create cached classifier for this workspace
     val classifier = gitignoreClassifierCache.getOrPut(workspaceRoot) {
       GitIgnoreClassifier(File(workspaceRoot))
     }
 
-    // Step 1: Collect outputs from dependent tasks (always treated as dependentTasksOutputFiles)
+    // Collect outputs from dependent tasks
     val tasksToProcess = dependsOnTasks ?: getDependsOnTask(task)
     tasksToProcess.forEach { dependentTask ->
       dependentTask.outputs.files.files.forEach { outputFile ->
@@ -128,7 +127,7 @@ fun getInputsForTask(
       }
     }
 
-    // Step 2: Process task's input files
+    // Process each tasks's input files from the tooling API
     task.inputs.files.forEach { inputFile ->
       val relativePath = replaceRootInPath(inputFile.path, projectRoot, workspaceRoot)
 

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -88,7 +88,9 @@ fun getGradlewCommand(): String {
 
 /**
  * Cache the gitignore classifier per workspace root to avoid recreating it for every task
- * TODO(lourw): refactor this out. The structure of this plugin should be refactored to use dependency injection rather than maintaining a cached instance
+ *
+ * TODO(lourw): refactor this out. The structure of this plugin should be refactored to use
+ *   dependency injection rather than maintaining a cached instance
  */
 private val gitignoreClassifierCache = mutableMapOf<String, GitIgnoreClassifier>()
 
@@ -112,9 +114,10 @@ fun getInputsForTask(
     val inputs = mutableListOf<Any>()
     val externalDependencies = mutableListOf<String>()
 
-    val classifier = gitignoreClassifierCache.getOrPut(workspaceRoot) {
-      GitIgnoreClassifier(File(workspaceRoot))
-    }
+    val classifier =
+        gitignoreClassifierCache.getOrPut(workspaceRoot) {
+          GitIgnoreClassifier(File(workspaceRoot))
+        }
 
     // Collect outputs from dependent tasks
     val tasksToProcess = dependsOnTasks ?: getDependsOnTask(task)
@@ -135,7 +138,8 @@ fun getInputsForTask(
         // File is outside workspace - treat as external dependency
         relativePath == null -> {
           try {
-            val externalDep = getExternalDepFromInputFile(inputFile.path, externalNodes, task.logger)
+            val externalDep =
+                getExternalDepFromInputFile(inputFile.path, externalNodes, task.logger)
             externalDep?.let { externalDependencies.add(it) }
           } catch (e: Exception) {
             task.logger.info("Error resolving external dependency for ${inputFile.path}: $e")
@@ -168,16 +172,12 @@ fun getInputsForTask(
   }
 }
 
-/**
- * Checks if a file is within the workspace.
- */
+/** Checks if a file is within the workspace. */
 private fun isFileInWorkspace(file: File, workspaceRoot: String): Boolean {
   return file.path.startsWith(workspaceRoot + File.separator)
 }
 
-/**
- * Converts a file to a relative path. If it's a directory, returns a glob pattern.
- */
+/** Converts a file to a relative path. If it's a directory, returns a glob pattern. */
 private fun toRelativePathOrGlob(file: File, workspaceRoot: String): String {
   val relativePath = file.path.substring(workspaceRoot.length + 1)
   val isFile = file.name.contains('.') || (file.exists() && file.isFile)

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -52,7 +52,9 @@ fun processTask(
   }
 
   // process inputs
-  val inputs = getInputsForTask(dependsOnTasks, task, projectRoot, workspaceRoot, externalNodes, gitIgnoreClassifier)
+  val inputs =
+      getInputsForTask(
+          dependsOnTasks, task, projectRoot, workspaceRoot, externalNodes, gitIgnoreClassifier)
   if (!inputs.isNullOrEmpty()) {
     logger.info("${task}: processed ${inputs.size} inputs")
     target["inputs"] = inputs

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/AddTestCiTargetsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/AddTestCiTargetsTest.kt
@@ -46,6 +46,7 @@ class AddTestCiTargetsTest {
     val targets = mutableMapOf<String, MutableMap<String, Any?>>()
     val targetGroups = mutableMapOf<String, MutableList<String>>()
     val ciTestTargetName = "ci"
+    val gitIgnoreClassifier = GitIgnoreClassifier(workspaceRoot)
 
     addTestCiTargets(
         testFiles = testFiles,
@@ -55,7 +56,8 @@ class AddTestCiTargetsTest {
         targetGroups = targetGroups,
         projectRoot = projectRoot.absolutePath,
         workspaceRoot = workspaceRoot.absolutePath,
-        ciTestTargetName = ciTestTargetName)
+        ciTestTargetName = ciTestTargetName,
+        gitIgnoreClassifier = gitIgnoreClassifier)
 
     // Assert each test file created a CI target
     assertTrue(targets.containsKey("ci--MyFirstTest"))
@@ -104,6 +106,7 @@ class AddTestCiTargetsTest {
     val targets = mutableMapOf<String, MutableMap<String, Any?>>()
     val targetGroups = mutableMapOf<String, MutableList<String>>()
     val ciTestTargetName = "ci"
+    val gitIgnoreClassifier = GitIgnoreClassifier(workspaceRoot)
 
     // Always tries compiled test analysis first, then falls back to regex
     addTestCiTargets(
@@ -114,7 +117,8 @@ class AddTestCiTargetsTest {
         targetGroups = targetGroups,
         projectRoot = projectRoot.absolutePath,
         workspaceRoot = workspaceRoot.absolutePath,
-        ciTestTargetName = ciTestTargetName)
+        ciTestTargetName = ciTestTargetName,
+        gitIgnoreClassifier = gitIgnoreClassifier)
 
     // Should create targets using regex-based approach since no compiled classes exist
     assertTrue(targets.containsKey("ci--DefaultTest"))
@@ -159,6 +163,7 @@ class AddTestCiTargetsTest {
     val targets = mutableMapOf<String, MutableMap<String, Any?>>()
     val targetGroups = mutableMapOf<String, MutableList<String>>()
     val ciTestTargetName = "ci"
+    val gitIgnoreClassifier = GitIgnoreClassifier(workspaceRoot)
 
     addTestCiTargets(
         testFiles = testFiles,
@@ -168,7 +173,8 @@ class AddTestCiTargetsTest {
         targetGroups = targetGroups,
         projectRoot = projectRoot.absolutePath,
         workspaceRoot = workspaceRoot.absolutePath,
-        ciTestTargetName = ciTestTargetName)
+        ciTestTargetName = ciTestTargetName,
+        gitIgnoreClassifier = gitIgnoreClassifier)
 
     // Abstract class should not create a CI target
     assertTrue(

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/CompileTestCiTargetsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/CompileTestCiTargetsTest.kt
@@ -64,6 +64,7 @@ class CompileTestCiTargetsTest {
     val targets = mutableMapOf<String, MutableMap<String, Any?>>()
     val targetGroups = mutableMapOf<String, MutableList<String>>()
     val ciTestTargetName = "ci"
+    val gitIgnoreClassifier = GitIgnoreClassifier(workspaceRoot)
 
     addTestCiTargets(
         testFiles = testFiles,
@@ -73,7 +74,8 @@ class CompileTestCiTargetsTest {
         targetGroups = targetGroups,
         projectRoot = projectRoot.absolutePath,
         workspaceRoot = workspaceRoot.absolutePath,
-        ciTestTargetName = ciTestTargetName)
+        ciTestTargetName = ciTestTargetName,
+        gitIgnoreClassifier = gitIgnoreClassifier)
 
     // Should generate targets based on JUnit discovery and AST parsing
     assertTrue(targets.containsKey("ci--UserServiceTest"))

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/GitIgnoreClassifierTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/GitIgnoreClassifierTest.kt
@@ -118,6 +118,10 @@ class GitIgnoreClassifierTest {
         """
             .trimIndent())
 
+    // Create the directories so they exist
+    File(tempDir, "build").mkdirs()
+    File(tempDir, "dist").mkdirs()
+
     val classifier = GitIgnoreClassifier(tempDir)
 
     // Test root-level directories

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/GitIgnoreClassifierTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/GitIgnoreClassifierTest.kt
@@ -21,11 +21,11 @@ class GitIgnoreClassifierTest {
     val gitignore = File(tempDir, ".gitignore")
     gitignore.writeText(
         """
-            # Comments should be ignored
-            node_modules
-            *.log
-            dist
-            build
+        # Comments should be ignored
+        node_modules
+        *.log
+        dist
+        build
         """
             .trimIndent())
 
@@ -54,9 +54,9 @@ class GitIgnoreClassifierTest {
     val gitignore = File(tempDir, ".gitignore")
     gitignore.writeText(
         """
-            build
-            .gradle
-            out
+        build
+        .gradle
+        out
         """
             .trimIndent())
 
@@ -83,10 +83,10 @@ class GitIgnoreClassifierTest {
     val gitignore = File(tempDir, ".gitignore")
     gitignore.writeText(
         """
-            *.class
-            *.jar
-            *.log
-            **/*.tmp
+        *.class
+        *.jar
+        *.log
+        **/*.tmp
         """
             .trimIndent())
 
@@ -113,8 +113,8 @@ class GitIgnoreClassifierTest {
     val gitignore = File(tempDir, ".gitignore")
     gitignore.writeText(
         """
-            /build/
-            /dist/
+        /build/
+        /dist/
         """
             .trimIndent())
 
@@ -136,8 +136,8 @@ class GitIgnoreClassifierTest {
     val gitignore = File(tempDir, ".gitignore")
     gitignore.writeText(
         """
-            *.log
-            !important.log
+        *.log
+        !important.log
         """
             .trimIndent())
 
@@ -168,22 +168,22 @@ class GitIgnoreClassifierTest {
     val gitignore = File(tempDir, ".gitignore")
     gitignore.writeText(
         """
-            # Build outputs
-            build
-            .gradle
-            dist
-            out
-            target
+        # Build outputs
+        build
+        .gradle
+        dist
+        out
+        target
 
-            # IDE
-            .idea
-            .vscode
+        # IDE
+        .idea
+        .vscode
 
-            # Logs
-            *.log
+        # Logs
+        *.log
 
-            # OS
-            .DS_Store
+        # OS
+        .DS_Store
         """
             .trimIndent())
 
@@ -256,10 +256,10 @@ class GitIgnoreClassifierTest {
     val gitignore = File(tempDir, ".gitignore")
     gitignore.writeText(
         """
-            # This is a comment
-            # Another comment
+        # This is a comment
+        # Another comment
 
-            # Yet another comment
+        # Yet another comment
         """
             .trimIndent())
 

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/GitIgnoreClassifierTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/GitIgnoreClassifierTest.kt
@@ -1,0 +1,268 @@
+package dev.nx.gradle.utils
+
+import java.io.File
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class GitIgnoreClassifierTest {
+
+  @Test
+  fun `test isIgnored with no gitignore file`(@TempDir tempDir: File) {
+    val classifier = GitIgnoreClassifier(tempDir)
+
+    val file = File(tempDir, "src/main.kt")
+    assertFalse(classifier.isIgnored(file))
+  }
+
+  @Test
+  fun `test isIgnored with simple patterns`(@TempDir tempDir: File) {
+    // Create .gitignore file
+    val gitignore = File(tempDir, ".gitignore")
+    gitignore.writeText(
+        """
+            # Comments should be ignored
+            node_modules
+            *.log
+            dist
+            build
+        """
+            .trimIndent())
+
+    val classifier = GitIgnoreClassifier(tempDir)
+
+    // Test exact directory matches
+    assertTrue(classifier.isIgnored(File(tempDir, "node_modules")))
+    assertTrue(classifier.isIgnored(File(tempDir, "node_modules/package.json")))
+    assertTrue(classifier.isIgnored(File(tempDir, "dist")))
+    assertTrue(classifier.isIgnored(File(tempDir, "dist/app.js")))
+    assertTrue(classifier.isIgnored(File(tempDir, "build")))
+    assertTrue(classifier.isIgnored(File(tempDir, "build/classes/Main.class")))
+
+    // Test wildcard patterns
+    assertTrue(classifier.isIgnored(File(tempDir, "app.log")))
+    assertTrue(classifier.isIgnored(File(tempDir, "logs/error.log")))
+
+    // Test files that should NOT be ignored
+    assertFalse(classifier.isIgnored(File(tempDir, "src/main.kt")))
+    assertFalse(classifier.isIgnored(File(tempDir, "README.md")))
+    assertFalse(classifier.isIgnored(File(tempDir, "package.json")))
+  }
+
+  @Test
+  fun `test isIgnored with nested paths`(@TempDir tempDir: File) {
+    val gitignore = File(tempDir, ".gitignore")
+    gitignore.writeText(
+        """
+            build
+            .gradle
+            out
+        """
+            .trimIndent())
+
+    val classifier = GitIgnoreClassifier(tempDir)
+
+    // Test nested build directories
+    assertTrue(classifier.isIgnored(File(tempDir, "build")))
+    assertTrue(classifier.isIgnored(File(tempDir, "build/libs")))
+    assertTrue(classifier.isIgnored(File(tempDir, "build/libs/app.jar")))
+    assertTrue(classifier.isIgnored(File(tempDir, "project/build")))
+    assertTrue(classifier.isIgnored(File(tempDir, "project/build/classes/Main.class")))
+
+    // Test .gradle directories
+    assertTrue(classifier.isIgnored(File(tempDir, ".gradle")))
+    assertTrue(classifier.isIgnored(File(tempDir, ".gradle/caches")))
+
+    // Test out directories
+    assertTrue(classifier.isIgnored(File(tempDir, "out")))
+    assertTrue(classifier.isIgnored(File(tempDir, "out/production")))
+  }
+
+  @Test
+  fun `test isIgnored with wildcard patterns`(@TempDir tempDir: File) {
+    val gitignore = File(tempDir, ".gitignore")
+    gitignore.writeText(
+        """
+            *.class
+            *.jar
+            *.log
+            **/*.tmp
+        """
+            .trimIndent())
+
+    val classifier = GitIgnoreClassifier(tempDir)
+
+    // Test file extension wildcards
+    assertTrue(classifier.isIgnored(File(tempDir, "Main.class")))
+    assertTrue(classifier.isIgnored(File(tempDir, "build/classes/Main.class")))
+    assertTrue(classifier.isIgnored(File(tempDir, "app.jar")))
+    assertTrue(classifier.isIgnored(File(tempDir, "libs/dependency.jar")))
+    assertTrue(classifier.isIgnored(File(tempDir, "debug.log")))
+
+    // Test nested tmp files
+    assertTrue(classifier.isIgnored(File(tempDir, "temp.tmp")))
+    assertTrue(classifier.isIgnored(File(tempDir, "cache/temp.tmp")))
+
+    // Files that should NOT match
+    assertFalse(classifier.isIgnored(File(tempDir, "Main.kt")))
+    assertFalse(classifier.isIgnored(File(tempDir, "app.json")))
+  }
+
+  @Test
+  fun `test isIgnored with directory slash patterns`(@TempDir tempDir: File) {
+    val gitignore = File(tempDir, ".gitignore")
+    gitignore.writeText(
+        """
+            /build/
+            /dist/
+        """
+            .trimIndent())
+
+    val classifier = GitIgnoreClassifier(tempDir)
+
+    // Test root-level directories
+    assertTrue(classifier.isIgnored(File(tempDir, "build")))
+    assertTrue(classifier.isIgnored(File(tempDir, "build/output.jar")))
+    assertTrue(classifier.isIgnored(File(tempDir, "dist")))
+    assertTrue(classifier.isIgnored(File(tempDir, "dist/app.js")))
+  }
+
+  @Test
+  fun `test isIgnored with negation patterns`(@TempDir tempDir: File) {
+    val gitignore = File(tempDir, ".gitignore")
+    gitignore.writeText(
+        """
+            *.log
+            !important.log
+        """
+            .trimIndent())
+
+    val classifier = GitIgnoreClassifier(tempDir)
+
+    // Test that .log files are ignored
+    assertTrue(classifier.isIgnored(File(tempDir, "debug.log")))
+    assertTrue(classifier.isIgnored(File(tempDir, "error.log")))
+
+    // Test negation pattern (important.log should NOT be ignored)
+    assertFalse(classifier.isIgnored(File(tempDir, "important.log")))
+  }
+
+  @Test
+  fun `test isIgnored with files outside workspace`(@TempDir tempDir: File) {
+    val gitignore = File(tempDir, ".gitignore")
+    gitignore.writeText("build")
+
+    val classifier = GitIgnoreClassifier(tempDir)
+
+    // File outside workspace should return false
+    val externalFile = File("/tmp/external/build/app.jar")
+    assertFalse(classifier.isIgnored(externalFile))
+  }
+
+  @Test
+  fun `test isIgnored with common build artifacts`(@TempDir tempDir: File) {
+    val gitignore = File(tempDir, ".gitignore")
+    gitignore.writeText(
+        """
+            # Build outputs
+            build
+            .gradle
+            dist
+            out
+            target
+
+            # IDE
+            .idea
+            .vscode
+
+            # Logs
+            *.log
+
+            # OS
+            .DS_Store
+        """
+            .trimIndent())
+
+    val classifier = GitIgnoreClassifier(tempDir)
+
+    // Build outputs
+    assertTrue(classifier.isIgnored(File(tempDir, "build/libs/app.jar")))
+    assertTrue(classifier.isIgnored(File(tempDir, ".gradle/caches")))
+    assertTrue(classifier.isIgnored(File(tempDir, "dist/bundle.js")))
+    assertTrue(classifier.isIgnored(File(tempDir, "out/production")))
+    assertTrue(classifier.isIgnored(File(tempDir, "target/classes")))
+
+    // IDE files
+    assertTrue(classifier.isIgnored(File(tempDir, ".idea/workspace.xml")))
+    assertTrue(classifier.isIgnored(File(tempDir, ".vscode/settings.json")))
+
+    // Logs
+    assertTrue(classifier.isIgnored(File(tempDir, "app.log")))
+    assertTrue(classifier.isIgnored(File(tempDir, "logs/error.log")))
+
+    // OS files
+    assertTrue(classifier.isIgnored(File(tempDir, ".DS_Store")))
+
+    // Source files should NOT be ignored
+    assertFalse(classifier.isIgnored(File(tempDir, "src/main/kotlin/Main.kt")))
+    assertFalse(classifier.isIgnored(File(tempDir, "build.gradle.kts")))
+    assertFalse(classifier.isIgnored(File(tempDir, "settings.gradle.kts")))
+  }
+
+  @Test
+  fun `test isIgnored caching behavior`(@TempDir tempDir: File) {
+    val gitignore = File(tempDir, ".gitignore")
+    gitignore.writeText("build\n*.log")
+
+    // Create classifier - should load gitignore
+    val classifier = GitIgnoreClassifier(tempDir)
+
+    // Test initial checks
+    assertTrue(classifier.isIgnored(File(tempDir, "build/app.jar")))
+    assertTrue(classifier.isIgnored(File(tempDir, "debug.log")))
+
+    // Modify gitignore file (classifier should still use cached rules)
+    gitignore.writeText("other")
+
+    // Should still use original rules
+    assertTrue(classifier.isIgnored(File(tempDir, "build/app.jar")))
+    assertTrue(classifier.isIgnored(File(tempDir, "debug.log")))
+
+    // Create new classifier to pick up changes
+    val newClassifier = GitIgnoreClassifier(tempDir)
+    assertFalse(newClassifier.isIgnored(File(tempDir, "build/app.jar")))
+    assertFalse(newClassifier.isIgnored(File(tempDir, "debug.log")))
+    assertTrue(newClassifier.isIgnored(File(tempDir, "other")))
+  }
+
+  @Test
+  fun `test isIgnored with empty gitignore`(@TempDir tempDir: File) {
+    val gitignore = File(tempDir, ".gitignore")
+    gitignore.writeText("")
+
+    val classifier = GitIgnoreClassifier(tempDir)
+
+    // Nothing should be ignored
+    assertFalse(classifier.isIgnored(File(tempDir, "anything.txt")))
+    assertFalse(classifier.isIgnored(File(tempDir, "build/app.jar")))
+  }
+
+  @Test
+  fun `test isIgnored with only comments`(@TempDir tempDir: File) {
+    val gitignore = File(tempDir, ".gitignore")
+    gitignore.writeText(
+        """
+            # This is a comment
+            # Another comment
+
+            # Yet another comment
+        """
+            .trimIndent())
+
+    val classifier = GitIgnoreClassifier(tempDir)
+
+    // Nothing should be ignored
+    assertFalse(classifier.isIgnored(File(tempDir, "anything.txt")))
+    assertFalse(classifier.isIgnored(File(tempDir, "build/app.jar")))
+  }
+}

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -145,7 +145,9 @@ class ProcessTaskUtilsTest {
       mainTask.inputs.files(inputFile1, inputFile2)
 
       val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
-      val result = getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+      val result =
+          getInputsForTask(
+              null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
 
       assertNotNull(result)
 
@@ -173,7 +175,9 @@ class ProcessTaskUtilsTest {
       mainTask.dependsOn(dependentTask)
 
       val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
-      val result = getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+      val result =
+          getInputsForTask(
+              null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
 
       assertNotNull(result)
 
@@ -210,11 +214,17 @@ class ProcessTaskUtilsTest {
       // Test with pre-computed dependsOnTasks
       val resultWithPreComputed =
           getInputsForTask(
-              preComputedDependsOn, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+              preComputedDependsOn,
+              mainTask,
+              projectRoot,
+              workspaceRoot,
+              mutableMapOf(),
+              gitIgnoreClassifier)
 
       // Test without pre-computed (should compute internally)
       val resultWithoutPreComputed =
-          getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+          getInputsForTask(
+              null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
 
       // Both results should be identical
       assertNotNull(resultWithPreComputed)
@@ -310,7 +320,13 @@ class ProcessTaskUtilsTest {
       val dependsOnTasks = getDependsOnTask(mainTask)
       val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
       val result =
-          getInputsForTask(dependsOnTasks, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+          getInputsForTask(
+              dependsOnTasks,
+              mainTask,
+              projectRoot,
+              workspaceRoot,
+              mutableMapOf(),
+              gitIgnoreClassifier)
 
       assertNotNull(result)
 
@@ -381,7 +397,9 @@ class ProcessTaskUtilsTest {
       mainTask.inputs.files(sourceFile, buildFile, logFile, configFile)
 
       val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
-      val result = getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+      val result =
+          getInputsForTask(
+              null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
 
       assertNotNull(result)
 
@@ -430,7 +448,9 @@ class ProcessTaskUtilsTest {
       mainTask.inputs.files(javaSource, compiledClass, jarTarget)
 
       val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
-      val result = getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+      val result =
+          getInputsForTask(
+              null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
 
       assertNotNull(result)
 

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -3,7 +3,6 @@ package dev.nx.gradle.utils
 import dev.nx.gradle.data.Dependency
 import dev.nx.gradle.data.ExternalNode
 import org.gradle.api.Project
-import org.gradle.internal.serialize.codecs.core.NodeOwner
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -122,7 +121,8 @@ class ProcessTaskUtilsTest {
       projectRoot = project.projectDir.path
 
       val gitIgnore = java.io.File(workspaceRoot, ".gitignore")
-      // Any inputs of tasks that are found in ignored files are considered dependent task output files
+      // Any inputs of tasks that are found in ignored files are considered dependent task output
+      // files
       gitIgnore.writeText("dist")
     }
 
@@ -148,7 +148,7 @@ class ProcessTaskUtilsTest {
 
       // Should contain dependentTasksOutputFiles for the output
       assertTrue(
-        result!!.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "dist/output.jar" })
+          result!!.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "dist/output.jar" })
 
       // Should contain the non-conflicting input file
       assertTrue(result.any { it == "{projectRoot}/src/main.kt" })
@@ -175,13 +175,13 @@ class ProcessTaskUtilsTest {
 
       // File should get exact path
       assertTrue(
-        result!!.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "dist/app.jar" })
+          result!!.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "dist/app.jar" })
 
       // Directory should get glob pattern
       assertTrue(
-        result.any {
-          it is Map<*, *> && (it["dependentTasksOutputFiles"] as String).endsWith("/**/*")
-        })
+          result.any {
+            it is Map<*, *> && (it["dependentTasksOutputFiles"] as String).endsWith("/**/*")
+          })
     }
 
     @Test
@@ -204,11 +204,12 @@ class ProcessTaskUtilsTest {
 
       // Test with pre-computed dependsOnTasks
       val resultWithPreComputed =
-        getInputsForTask(preComputedDependsOn, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+          getInputsForTask(
+              preComputedDependsOn, mainTask, projectRoot, workspaceRoot, mutableMapOf())
 
       // Test without pre-computed (should compute internally)
       val resultWithoutPreComputed =
-        getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+          getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf())
 
       // Both results should be identical
       assertNotNull(resultWithPreComputed)
@@ -217,13 +218,13 @@ class ProcessTaskUtilsTest {
 
       // Should contain dependentTasksOutputFiles for the dependent task output
       assertTrue(
-        resultWithPreComputed.any {
-          it is Map<*, *> && it["dependentTasksOutputFiles"] == "dist/output.jar"
-        })
+          resultWithPreComputed.any {
+            it is Map<*, *> && it["dependentTasksOutputFiles"] == "dist/output.jar"
+          })
       assertTrue(
-        resultWithoutPreComputed.any {
-          it is Map<*, *> && it["dependentTasksOutputFiles"] == "dist/output.jar"
-        })
+          resultWithoutPreComputed.any {
+            it is Map<*, *> && it["dependentTasksOutputFiles"] == "dist/output.jar"
+          })
 
       // Should contain the input file
       assertTrue(resultWithPreComputed.any { it == "{projectRoot}/src/main.kt" })
@@ -284,9 +285,9 @@ class ProcessTaskUtilsTest {
 
       val dependentTask3 = project.tasks.register("dependentTask3").get()
       val multipleOutputs =
-        listOf(
-          java.io.File("$workspaceRoot/reports/test.xml"),
-          java.io.File("$workspaceRoot/reports/coverage"))
+          listOf(
+              java.io.File("$workspaceRoot/reports/test.xml"),
+              java.io.File("$workspaceRoot/reports/coverage"))
       dependentTask3.outputs.files(multipleOutputs)
 
       // Create main task that depends on all three
@@ -295,37 +296,38 @@ class ProcessTaskUtilsTest {
 
       // Add some input files
       val inputFiles =
-        listOf(
-          java.io.File("$workspaceRoot/src/main.kt"),
-          java.io.File("$workspaceRoot/config/app.properties"))
+          listOf(
+              java.io.File("$workspaceRoot/src/main.kt"),
+              java.io.File("$workspaceRoot/config/app.properties"))
       mainTask.inputs.files(inputFiles)
 
       // Get dependsOnTasks once and reuse
       val dependsOnTasks = getDependsOnTask(mainTask)
       val result =
-        getInputsForTask(dependsOnTasks, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+          getInputsForTask(dependsOnTasks, mainTask, projectRoot, workspaceRoot, mutableMapOf())
 
       assertNotNull(result)
 
       // Should contain dependentTasksOutputFiles for file output (exact path)
       assertTrue(
-        result!!.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "dist/app.jar" })
+          result!!.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "dist/app.jar" })
 
       // Should contain dependentTasksOutputFiles for directory output (with /**/* pattern)
       assertTrue(
-        result.any {
-          it is Map<*, *> && (it["dependentTasksOutputFiles"] as String) == "build/classes/**/*"
-        })
+          result.any {
+            it is Map<*, *> && (it["dependentTasksOutputFiles"] as String) == "build/classes/**/*"
+          })
 
       // Should contain dependentTasksOutputFiles for test report file
       assertTrue(
-        result.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "reports/test.xml" })
+          result.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "reports/test.xml" })
 
       // Should contain dependentTasksOutputFiles for coverage directory (with /**/* pattern)
       assertTrue(
-        result.any {
-          it is Map<*, *> && (it["dependentTasksOutputFiles"] as String) == "reports/coverage/**/*"
-        })
+          result.any {
+            it is Map<*, *> &&
+                (it["dependentTasksOutputFiles"] as String) == "reports/coverage/**/*"
+          })
 
       // Should contain regular input files
       assertTrue(result.any { it == "{projectRoot}/src/main.kt" })
@@ -334,7 +336,7 @@ class ProcessTaskUtilsTest {
       // Verify we have the expected number of dependentTasksOutputFiles entries (4 outputs from 3
       // tasks)
       val dependentTasksOutputFilesCount =
-        result.count { it is Map<*, *> && it.containsKey("dependentTasksOutputFiles") }
+          result.count { it is Map<*, *> && it.containsKey("dependentTasksOutputFiles") }
       assertEquals(4, dependentTasksOutputFilesCount)
 
       // Verify we have the expected number of regular input files (2)
@@ -351,24 +353,24 @@ class ProcessTaskUtilsTest {
       // Create .gitignore file
       val gitignore = java.io.File(project.rootDir, ".gitignore")
       gitignore.writeText(
-        """
-            build
-            .gradle
-            *.log
-            dist
-        """
-          .trimIndent())
+          """
+          build
+          .gradle
+          *.log
+          dist
+          """
+              .trimIndent())
 
       val mainTask = project.tasks.register("mainTask").get()
 
       // Add inputs with mixed types
       val sourceFile = java.io.File("$workspaceRoot/src/main.kt") // Not ignored - should be input
-      val buildFile =
-        java.io.File("$workspaceRoot/build/classes/Main.class") // Ignored - should be
+      val buildFile = java.io.File("$workspaceRoot/build/classes/Main.class") // Ignored - should be
       // dependentTasksOutputFiles
-      val logFile = java.io.File("$workspaceRoot/app.log") // Ignored - should be dependentTasksOutputFiles
+      val logFile =
+          java.io.File("$workspaceRoot/app.log") // Ignored - should be dependentTasksOutputFiles
       val configFile =
-        java.io.File("$workspaceRoot/config/app.properties") // Not ignored - should be input
+          java.io.File("$workspaceRoot/config/app.properties") // Not ignored - should be input
 
       mainTask.inputs.files(sourceFile, buildFile, logFile, configFile)
 
@@ -384,13 +386,15 @@ class ProcessTaskUtilsTest {
 
       // Build file should be dependentTasksOutputFiles (matches gitignore)
       assertTrue(
-        result.any {
-          it is Map<*, *> && (it["dependentTasksOutputFiles"] as String).contains("build")
-        })
+          result.any {
+            it is Map<*, *> && (it["dependentTasksOutputFiles"] as String).contains("build")
+          })
 
       // Log file should be dependentTasksOutputFiles (matches gitignore)
       assertTrue(
-        result.any { it is Map<*, *> && (it["dependentTasksOutputFiles"] as String).contains("log") })
+          result.any {
+            it is Map<*, *> && (it["dependentTasksOutputFiles"] as String).contains("log")
+          })
     }
 
     @Test
@@ -402,18 +406,18 @@ class ProcessTaskUtilsTest {
       // Create .gitignore with common patterns
       val gitignore = java.io.File(project.rootDir, ".gitignore")
       gitignore.writeText(
-        """
-            target
-            dist
-        """
-          .trimIndent())
+          """
+          target
+          dist
+          """
+              .trimIndent())
 
       val mainTask = project.tasks.register("mainTask").get()
 
       // Add inputs
       val javaSource = java.io.File("$workspaceRoot/src/Main.java") // Not ignored
       val compiledClass =
-        java.io.File("$workspaceRoot/dist/production/Main.class") // Ignored (*.class pattern)
+          java.io.File("$workspaceRoot/dist/production/Main.class") // Ignored (*.class pattern)
       val jarTarget = java.io.File("$workspaceRoot/dist/app.jar") // Ignored (target)
 
       mainTask.inputs.files(javaSource, compiledClass, jarTarget)
@@ -425,14 +429,14 @@ class ProcessTaskUtilsTest {
       assertTrue(result!!.any { it == "{projectRoot}/src/Main.java" })
 
       assertTrue(
-        result.any {
-          it is Map<*, *> && (it["dependentTasksOutputFiles"] as String).contains("Main.class")
-        })
+          result.any {
+            it is Map<*, *> && (it["dependentTasksOutputFiles"] as String).contains("Main.class")
+          })
 
       assertTrue(
-        result.any {
-          it is Map<*, *> && (it["dependentTasksOutputFiles"] as String).contains("dist")
-        })
+          result.any {
+            it is Map<*, *> && (it["dependentTasksOutputFiles"] as String).contains("dist")
+          })
     }
   }
 
@@ -488,6 +492,4 @@ class ProcessTaskUtilsTest {
           it is Map<*, *> && (it["dependentTasksOutputFiles"] as String) == "build/classes/**/*"
         })
   }
-
-
 }

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -92,6 +92,7 @@ class ProcessTaskUtilsTest {
     task.group = "build"
     task.description = "Compiles Java source files"
 
+    val gitIgnoreClassifier = GitIgnoreClassifier(project.rootDir)
     val result =
         processTask(
             task,
@@ -100,7 +101,8 @@ class ProcessTaskUtilsTest {
             workspaceRoot = project.rootDir.path,
             externalNodes = mutableMapOf(),
             dependencies = mutableSetOf(),
-            targetNameOverrides = emptyMap())
+            targetNameOverrides = emptyMap(),
+            gitIgnoreClassifier = gitIgnoreClassifier)
 
     assertEquals(true, result["cache"])
     assertEquals(result["executor"], "@nx/gradle:gradle")
@@ -142,7 +144,8 @@ class ProcessTaskUtilsTest {
       val inputFile2 = java.io.File("$workspaceRoot/src/main.kt") // Should be included
       mainTask.inputs.files(inputFile1, inputFile2)
 
-      val result = getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+      val result = getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
 
       assertNotNull(result)
 
@@ -169,7 +172,8 @@ class ProcessTaskUtilsTest {
       val mainTask = project.tasks.register("mainTask").get()
       mainTask.dependsOn(dependentTask)
 
-      val result = getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+      val result = getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
 
       assertNotNull(result)
 
@@ -202,14 +206,15 @@ class ProcessTaskUtilsTest {
       // Pre-compute dependsOnTasks using getDependsOnTask
       val preComputedDependsOn = getDependsOnTask(mainTask)
 
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
       // Test with pre-computed dependsOnTasks
       val resultWithPreComputed =
           getInputsForTask(
-              preComputedDependsOn, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+              preComputedDependsOn, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
 
       // Test without pre-computed (should compute internally)
       val resultWithoutPreComputed =
-          getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+          getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
 
       // Both results should be identical
       assertNotNull(resultWithPreComputed)
@@ -303,8 +308,9 @@ class ProcessTaskUtilsTest {
 
       // Get dependsOnTasks once and reuse
       val dependsOnTasks = getDependsOnTask(mainTask)
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
       val result =
-          getInputsForTask(dependsOnTasks, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+          getInputsForTask(dependsOnTasks, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
 
       assertNotNull(result)
 
@@ -374,7 +380,8 @@ class ProcessTaskUtilsTest {
 
       mainTask.inputs.files(sourceFile, buildFile, logFile, configFile)
 
-      val result = getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+      val result = getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
 
       assertNotNull(result)
 
@@ -422,7 +429,8 @@ class ProcessTaskUtilsTest {
 
       mainTask.inputs.files(javaSource, compiledClass, jarTarget)
 
-      val result = getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf())
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+      val result = getInputsForTask(null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
 
       assertNotNull(result)
 
@@ -459,6 +467,7 @@ class ProcessTaskUtilsTest {
     val inputFile = java.io.File("${project.rootDir.path}/src/test.kt")
     mainTask.inputs.files(inputFile)
 
+    val gitIgnoreClassifier = GitIgnoreClassifier(project.rootDir)
     val result =
         processTask(
             mainTask,
@@ -467,7 +476,8 @@ class ProcessTaskUtilsTest {
             workspaceRoot = project.rootDir.path,
             externalNodes = mutableMapOf(),
             dependencies = mutableSetOf(),
-            targetNameOverrides = emptyMap())
+            targetNameOverrides = emptyMap(),
+            gitIgnoreClassifier = gitIgnoreClassifier)
 
     assertNotNull(result)
 

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/GitIgnoreClassifier.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/GitIgnoreClassifier.kt
@@ -9,78 +9,94 @@ import java.io.File
  * Provides heuristic for parameter classification: ignored files are likely outputs, tracked files are likely inputs
  */
 class GitIgnoreClassifier(
-    private val workspaceRoot: File
+  private val workspaceRoot: File
 ) {
     private val log = LoggerFactory.getLogger(GitIgnoreClassifier::class.java)
 
     private val ignoreRules: MutableList<FastIgnoreRule> = mutableListOf()
 
-    init {
-        loadIgnoreRules()
-    }
+  init {
+    loadIgnoreRules()
+  }
 
-    private fun loadIgnoreRules() {
-
-        try {
-            val gitIgnoreFile = File(workspaceRoot, ".gitignore")
-            if (gitIgnoreFile.exists()) {
-                gitIgnoreFile.readLines().forEach { line ->
-                    val trimmed = line.trim()
-                    if (trimmed.isNotEmpty() && !trimmed.startsWith("#")) {
-                        try {
-                            val rule = FastIgnoreRule(trimmed)
-                            ignoreRules.add(rule)
-                            log.debug("Loaded gitignore rule: $trimmed")
-                        } catch (e: Exception) {
-                            log.debug("Failed to parse gitignore rule '$trimmed': ${e.message}")
-                        }
-                    }
-                }
-                log.debug("Loaded ${ignoreRules.size} gitignore rules")
-            } else {
-                log.debug("No .gitignore file found at: ${gitIgnoreFile.path}")
+  private fun loadIgnoreRules() {
+    try {
+      val gitIgnoreFile = File(workspaceRoot, ".gitignore")
+      if (gitIgnoreFile.exists()) {
+        gitIgnoreFile.readLines().forEach { line ->
+          val trimmed = line.trim()
+          if (trimmed.isNotEmpty() && !trimmed.startsWith("#")) {
+            try {
+              val rule = FastIgnoreRule(trimmed)
+              ignoreRules.add(rule)
+            } catch (e: Exception) {
+              // Skip invalid rules silently
             }
-        } catch (e: Exception) {
-            log.debug("Error loading gitignore rules: ${e.message}")
+          }
         }
+      }
+    } catch (e: Exception) {
+      // If we can't load gitignore rules, continue without them
+    }
+  }
+
+  private fun isPartOfWorkspace(path: File): Boolean {
+    // Use canonicalPath to resolve symlinks and normalize paths
+    val workspaceRootPath = try {
+      workspaceRoot.canonicalPath
+    } catch (e: Exception) {
+      workspaceRoot.absolutePath
     }
 
-    /**
-     * Determines if a file path should be ignored according to gitignore rules
-     * Works for both existing and non-existent paths by using pattern matching
-     */
-    fun isIgnored(path: File): Boolean {
-        if (ignoreRules.isEmpty()) {
-            return false
-        }
-
-        val relativePath = try {
-            path.relativeTo(workspaceRoot).path
-        } catch (e: IllegalArgumentException) {
-            // Path is outside workspace
-            return false
-        }
-
-        return try {
-            // Check path against all ignore rules
-            var isIgnored = false
-
-            for (rule in ignoreRules) {
-                val isDirectory = path.isDirectory || relativePath.endsWith("/")
-                if (rule.isMatch(relativePath, isDirectory)) {
-                    // FastIgnoreRule.getResult() returns true if should be ignored
-                    isIgnored = rule.result
-                    log.debug("Path '$relativePath' matched rule, ignored: $isIgnored")
-                }
-            }
-
-            log.debug("Path '$relativePath' final ignored status: $isIgnored")
-            isIgnored
-
-        } catch (e: Exception) {
-            log.debug("Error checking ignore status for path '$path': ${e.message}")
-            false
-        }
+    val filePath = try {
+      path.canonicalPath
+    } catch (e: Exception) {
+      path.absolutePath
     }
 
+    // Ensure the file path starts with the workspace root and is followed by a separator
+    // or is exactly the workspace root (which we exclude)
+    if (filePath == workspaceRootPath) {
+      return false
+    }
+
+    return filePath.startsWith(workspaceRootPath + File.separator)
+  }
+
+  /**
+   * Determines if a file path should be ignored according to gitignore rules
+   * Works for both existing and non-existent paths by using pattern matching
+   */
+  fun isIgnored(path: File): Boolean {
+    if (ignoreRules.isEmpty()) {
+      return false
+    }
+
+    if (!isPartOfWorkspace(path)) {
+      return false
+    }
+
+    val relativePath = try {
+      path.relativeTo(workspaceRoot).path
+    } catch (e: IllegalArgumentException) {
+      return false
+    }
+
+    return try {
+      // Check path against all ignore rules
+      var isIgnored = false
+
+      for (rule in ignoreRules) {
+        val isDirectory = path.isDirectory || relativePath.endsWith("/")
+        if (rule.isMatch(relativePath, isDirectory)) {
+          // FastIgnoreRule.getResult() returns true if should be ignored
+          isIgnored = rule.result
+        }
+      }
+
+      isIgnored
+    } catch (e: Exception) {
+      false
+    }
+  }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently we detect if inputs are found in the build directory to determine if they are considered dependent task output files. We can use a simpler heuristic instead. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

If an input is gitignored (and therefore not hashed by Nx), then we consider it a dependant task output file. This gitignore classifier will be a mirror of the class used within the Maven plugin. There will be another PR to move this classifier into a shared kotlin project that can be used between both projects.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
