### PR TITLE
feat(maven): bump version from 0.0.8 to 0.0.9

### DIFF
--- a/.claude/skills/run-nx-generator/SKILL.md
+++ b/.claude/skills/run-nx-generator/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: run-nx-generator
+description: Run Nx generators with prioritization for workspace-plugin generators. Use this when generating code, scaffolding new features, or automating repetitive tasks in the monorepo.
+allowed-tools: Bash, Read, Glob, Grep, mcp__nx-mcp__nx_generators, mcp__nx-mcp__nx_generator_schema
+---
+
+# Run Nx Generator
+
+This skill helps you execute Nx generators efficiently, with special focus on workspace-plugin generators from your internal tooling.
+
+## Generator Priority List
+
+Use the `mcp__nx-mcp__nx_generator_schema` tool to get more information about how to use the generator
+
+Choose which generators to run in this priority order:
+
+### 🔥 Workspace-Plugin Generators (High Priority)
+
+These are your custom internal tools in `tools/workspace-plugin/`
+
+### 📦 Core Nx Generators (Standard)
+
+Only use these if workspace-plugin generators don't fit:
+
+- `nx generate @nx/devkit:...` - DevKit utilities
+- `nx generate @nx/node:...` - Node.js libraries
+- `nx generate @nx/react:...` - React components and apps
+- Framework-specific generators
+
+## How to Run Generators
+
+1. **List available generators**:
+
+2. **Get generator schema** (to see available options):
+   Use the `mcp__nx-mcp__nx_generator_schema` tool to get more information about how to use the generator
+
+3. **Run the generator**:
+
+   ```bash
+   nx generate [generator-path] [options]
+   ```
+
+4. **Verify the changes**:
+   - Review generated files
+   - Run tests: `nx affected -t test`
+   - Format code: `npx prettier --write [files]`
+
+## Best Practices
+
+- ✅ Always check workspace-plugin first - it has your custom solutions
+- ✅ Use `--dry-run` flag to preview changes before applying
+- ✅ Format generated code immediately with Prettier
+- ✅ Test affected projects after generation
+- ✅ Commit generator changes separately from manual edits
+
+## Examples
+
+### Bumping Maven Version
+
+When updating the Maven plugin version, use the workspace-plugin generator:
+
+```bash
+nx generate @nx/workspace-plugin:bump-maven-version \
+  --newVersion 0.0.10 \
+  --nxVersion 22.1.0-beta.7
+```
+
+This automates all the version bumping instead of manual file edits.
+
+### Creating a New Plugin
+
+For creating a new create-nodes plugin:
+
+```bash
+nx generate @nx/workspace-plugin:create-nodes-plugin \
+  --name my-custom-plugin
+```
+
+## When to Use This Skill
+
+Use this skill when you need to:
+
+- Generate new code or projects
+- Scaffold new features or libraries
+- Automate repetitive setup tasks
+- Update internal tools and configurations
+- Create migrations or version updates

--- a/packages/maven/maven-plugin/pom.xml
+++ b/packages/maven/maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.nx</groupId>
     <artifactId>nx-parent</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/migrations.json
+++ b/packages/maven/migrations.json
@@ -6,6 +6,12 @@
       "version": "22.1.0-beta.4",
       "description": "Update Maven plugin version from 0.0.7 to 0.0.8 in pom.xml files",
       "factory": "./dist/migrations/0-0-8/update-pom-xml-version"
+    },
+    "update-0.0.9": {
+      "cli": "nx",
+      "version": "22.1.0-beta.6",
+      "description": "Update Maven plugin version from 0.0.8 to 0.0.9 in pom.xml files",
+      "factory": "./dist/migrations/0-0-9/update-pom-xml-version"
     }
   }
 }

--- a/packages/maven/package.json
+++ b/packages/maven/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nx/maven",
-  "version": "0.0.8",
+  "version": "0.0.1",
   "private": false,
   "description": "Nx plugin for Maven integration",
   "repository": {

--- a/packages/maven/src/migrations/0-0-9/update-pom-xml-version.ts
+++ b/packages/maven/src/migrations/0-0-9/update-pom-xml-version.ts
@@ -1,0 +1,43 @@
+import { Tree } from '@nx/devkit';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import { updateNxMavenPluginVersion } from '../../utils/pom-xml-updater';
+
+/**
+ * Migration for @nx/maven v0.0.9
+ * Updates the Maven plugin version from 0.0.8 to 0.0.9 in user pom.xml files and maven-plugin pom.xml
+ */
+export default async function update(tree: Tree) {
+  // Update user pom.xml files
+  updateNxMavenPluginVersion(tree, '0.0.9');
+
+  // Update maven-plugin pom.xml parent version
+  const pomPath = 'packages/maven/maven-plugin/pom.xml';
+  if (tree.exists(pomPath)) {
+    const content = tree.read(pomPath, 'utf-8');
+    if (content) {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(content);
+      const projectElement = doc.documentElement;
+
+      if (projectElement.tagName === 'project') {
+        const versionElements = projectElement.getElementsByTagName('version');
+
+        // Find version element within parent element
+        for (let i = 0; i < versionElements.length; i++) {
+          const versionElement = versionElements.item(i);
+          if (
+            versionElement &&
+            versionElement.parentNode?.nodeName === 'parent'
+          ) {
+            versionElement.textContent = '0.0.9';
+            break;
+          }
+        }
+
+        const serializer = new XMLSerializer();
+        const updatedContent = serializer.serializeToString(doc);
+        tree.write(pomPath, updatedContent);
+      }
+    }
+  }
+}

--- a/packages/maven/src/migrations/0-0-9/update-pom-xml-version.ts
+++ b/packages/maven/src/migrations/0-0-9/update-pom-xml-version.ts
@@ -1,43 +1,10 @@
 import { Tree } from '@nx/devkit';
-import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import { updateNxMavenPluginVersion } from '../../utils/pom-xml-updater';
 
 /**
  * Migration for @nx/maven v0.0.9
- * Updates the Maven plugin version from 0.0.8 to 0.0.9 in user pom.xml files and maven-plugin pom.xml
+ * Updates the Maven plugin version from 0.0.8 to 0.0.9 in user pom.xml files
  */
 export default async function update(tree: Tree) {
-  // Update user pom.xml files
   updateNxMavenPluginVersion(tree, '0.0.9');
-
-  // Update maven-plugin pom.xml parent version
-  const pomPath = 'packages/maven/maven-plugin/pom.xml';
-  if (tree.exists(pomPath)) {
-    const content = tree.read(pomPath, 'utf-8');
-    if (content) {
-      const parser = new DOMParser();
-      const doc = parser.parseFromString(content);
-      const projectElement = doc.documentElement;
-
-      if (projectElement.tagName === 'project') {
-        const versionElements = projectElement.getElementsByTagName('version');
-
-        // Find version element within parent element
-        for (let i = 0; i < versionElements.length; i++) {
-          const versionElement = versionElements.item(i);
-          if (
-            versionElement &&
-            versionElement.parentNode?.nodeName === 'parent'
-          ) {
-            versionElement.textContent = '0.0.9';
-            break;
-          }
-        }
-
-        const serializer = new XMLSerializer();
-        const updatedContent = serializer.serializeToString(doc);
-        tree.write(pomPath, updatedContent);
-      }
-    }
-  }
 }

--- a/packages/maven/src/utils/versions.ts
+++ b/packages/maven/src/utils/versions.ts
@@ -1,2 +1,2 @@
 export const nxVersion = require('../../package.json').version;
-export const mavenPluginVersion = '0.0.8';
+export const mavenPluginVersion = '0.0.9';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4414,6 +4414,9 @@ importers:
       '@nx/plugin':
         specifier: workspace:*
         version: link:../../packages/plugin
+      '@xmldom/xmldom':
+        specifier: ^0.8.10
+        version: 0.8.11
       nx:
         specifier: workspace:*
         version: link:../../packages/nx

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>dev.nx</groupId>
   <artifactId>nx-parent</artifactId>
-  <version>0.0.8</version>
+  <version>0.0.9</version>
   <packaging>pom</packaging>
 
   <name>Nx Parent</name>

--- a/tools/workspace-plugin/generators.json
+++ b/tools/workspace-plugin/generators.json
@@ -9,6 +9,11 @@
       "factory": "./src/generators/create-nodes-plugin/generator",
       "schema": "./src/generators/create-nodes-plugin/schema.json",
       "description": "Workspace Generator to create a create-nodes-plugin"
+    },
+    "bump-maven-version": {
+      "factory": "./src/generators/bump-maven-version/generator",
+      "schema": "./src/generators/bump-maven-version/schema.json",
+      "description": "Bump Maven plugin version and create migration"
     }
   }
 }

--- a/tools/workspace-plugin/package.json
+++ b/tools/workspace-plugin/package.json
@@ -9,6 +9,7 @@
     "@nx/eslint": "workspace:*",
     "@nx/plugin": "workspace:*",
     "@nx/js": "workspace:*",
+    "@xmldom/xmldom": "^0.8.10",
     "nx": "workspace:*",
     "tslib": "catalog:typescript"
   },

--- a/tools/workspace-plugin/src/generators/bump-maven-version/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/bump-maven-version/generator.spec.ts
@@ -1,0 +1,155 @@
+import { Tree, readJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import generator from './generator';
+
+describe('bump-maven-version generator', () => {
+  let tree: Tree;
+
+  const mockPomXml = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>dev.nx</groupId>
+  <artifactId>nx-parent</artifactId>
+  <version>0.0.8</version>
+</project>`;
+
+  const mockMavenPluginPomXml = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <parent>
+    <groupId>dev.nx</groupId>
+    <artifactId>nx-parent</artifactId>
+    <version>0.0.8</version>
+  </parent>
+  <groupId>dev.nx.maven</groupId>
+  <artifactId>nx-maven-plugin</artifactId>
+  <version>\${project.parent.version}</version>
+</project>`;
+
+  const mockVersionsTs = `export const nxVersion = require('../../package.json').version;
+export const mavenPluginVersion = '0.0.8';`;
+
+  const mockMigrationsJson = {
+    $schema: '../../node_modules/nx/schemas/generators-schema.json',
+    generators: {
+      'update-0.0.8': {
+        cli: 'nx',
+        version: '22.1.0-beta.4',
+        description:
+          'Update Maven plugin version from 0.0.7 to 0.0.8 in pom.xml files',
+        factory: './dist/migrations/0-0-8/update-pom-xml-version',
+      },
+    },
+  };
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+
+    // Setup mock files
+    tree.write('pom.xml', mockPomXml);
+    tree.write('packages/maven/maven-plugin/pom.xml', mockMavenPluginPomXml);
+    tree.write('packages/maven/src/utils/versions.ts', mockVersionsTs);
+    tree.write(
+      'packages/maven/migrations.json',
+      JSON.stringify(mockMigrationsJson)
+    );
+  });
+
+  it('should update root pom.xml version', async () => {
+    await generator(tree, {
+      newVersion: '0.0.9',
+      nxVersion: '22.1.0-beta.6',
+    });
+
+    const updatedPom = tree.read('pom.xml', 'utf-8');
+    expect(updatedPom).toContain('<version>0.0.9</version>');
+  });
+
+  it('should update maven-plugin pom.xml parent version', async () => {
+    await generator(tree, {
+      newVersion: '0.0.9',
+      nxVersion: '22.1.0-beta.6',
+    });
+
+    const updatedPom = tree.read(
+      'packages/maven/maven-plugin/pom.xml',
+      'utf-8'
+    );
+    expect(updatedPom).toContain('<version>0.0.9</version>');
+  });
+
+  it('should update versions.ts mavenPluginVersion', async () => {
+    await generator(tree, {
+      newVersion: '0.0.9',
+      nxVersion: '22.1.0-beta.6',
+    });
+
+    const updatedVersions = tree.read(
+      'packages/maven/src/utils/versions.ts',
+      'utf-8'
+    );
+    expect(updatedVersions).toContain("mavenPluginVersion = '0.0.9'");
+  });
+
+  it('should add migration entry to migrations.json', async () => {
+    await generator(tree, {
+      newVersion: '0.0.9',
+      nxVersion: '22.1.0-beta.6',
+    });
+
+    const migrationsJson = readJson(tree, 'packages/maven/migrations.json');
+    expect(migrationsJson.generators['update-0-0-9']).toBeDefined();
+    expect(migrationsJson.generators['update-0-0-9'].version).toBe(
+      '22.1.0-beta.6'
+    );
+    expect(migrationsJson.generators['update-0-0-9'].factory).toContain(
+      '0-0-9'
+    );
+  });
+
+  it('should create migration file with correct content', async () => {
+    await generator(tree, {
+      newVersion: '0.0.9',
+      nxVersion: '22.1.0-beta.6',
+    });
+
+    const migrationFile = tree.read(
+      'packages/maven/src/migrations/0-0-9/update-pom-xml-version.ts',
+      'utf-8'
+    );
+    expect(migrationFile).toMatchInlineSnapshot(`
+      "import { Tree } from '@nx/devkit';
+      import { updateNxMavenPluginVersion } from '../../utils/pom-xml-updater';
+
+      /**
+       * Migration for @nx/maven v0.0.9
+       * Updates the Maven plugin version to 0.0.9 in pom.xml files
+       */
+      export default async function update(tree: Tree) {
+        // Update user pom.xml files
+        updateNxMavenPluginVersion(tree, '0.0.9');
+      }
+      "
+    `);
+  });
+
+  it('should handle version format correctly for different versions', async () => {
+    await generator(tree, {
+      newVersion: '0.0.10',
+      nxVersion: '22.1.0-beta.7',
+    });
+
+    const migrationFile = tree.read(
+      'packages/maven/src/migrations/0-0-10/update-pom-xml-version.ts',
+      'utf-8'
+    );
+    expect(migrationFile).toContain("'0.0.10'");
+  });
+
+  it('should reject invalid version format', async () => {
+    expect(async () => {
+      await generator(tree, {
+        newVersion: '0.0',
+        nxVersion: '22.1.0-beta.6',
+      });
+    }).rejects.toThrow();
+  });
+});

--- a/tools/workspace-plugin/src/generators/bump-maven-version/generator.ts
+++ b/tools/workspace-plugin/src/generators/bump-maven-version/generator.ts
@@ -1,0 +1,204 @@
+import { formatFiles, logger, readJson, Tree, updateJson } from '@nx/devkit';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import * as path from 'path';
+
+interface BumpMavenVersionSchema {
+  newVersion: string;
+  nxVersion: string;
+}
+
+/**
+ * Parses a semantic version string into components
+ * @example "0.0.10" -> { major: "0", minor: "0", patch: "10" }
+ */
+function parseVersion(version: string): {
+  major: string;
+  minor: string;
+  patch: string;
+} {
+  const parts = version.split('.');
+  if (parts.length !== 3) {
+    throw new Error(
+      `Invalid version format: ${version}. Expected X.Y.Z format.`
+    );
+  }
+  return {
+    major: parts[0],
+    minor: parts[1],
+    patch: parts[2],
+  };
+}
+
+/**
+ * Converts version X.Y.Z to directory format X-Y-Z
+ */
+function versionToDirFormat(version: string): string {
+  return version.replace(/\./g, '-');
+}
+
+/**
+ * Updates an XML file's version element
+ */
+function updateXmlVersion(
+  tree: Tree,
+  filePath: string,
+  newVersion: string,
+  isRoot: boolean
+): void {
+  const content = tree.read(filePath, 'utf-8');
+  if (!content) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+
+  try {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(content);
+
+    // Find the version element(s) and update them
+    let updated = false;
+
+    // For root pom.xml, update <version> directly under <project>
+    if (isRoot) {
+      const projectElement = doc.documentElement;
+      if (projectElement.tagName === 'project') {
+        const versionElements = projectElement.getElementsByTagName('version');
+
+        // Update the first version element (direct child of project)
+        for (let i = 0; i < versionElements.length; i++) {
+          const versionElement = versionElements.item(i);
+          if (versionElement && versionElement.parentNode === projectElement) {
+            versionElement.textContent = newVersion;
+            updated = true;
+            break;
+          }
+        }
+      }
+    } else {
+      const parentElement = doc.getElementsByTagName('parent').item(0);
+      if (parentElement) {
+        const versionElements = parentElement.getElementsByTagName('version');
+
+        // Update the first version element within parent
+        for (let i = 0; i < versionElements.length; i++) {
+          const versionElement = versionElements.item(i);
+          if (versionElement) {
+            versionElement.textContent = newVersion;
+            updated = true;
+            break;
+          }
+        }
+      }
+    }
+
+    if (!updated) {
+      throw new Error(`Could not find version element in ${filePath}`);
+    }
+
+    const serializer = new XMLSerializer();
+    const updatedContent = serializer.serializeToString(doc);
+    tree.write(filePath, updatedContent);
+    logger.info(`Updated version in ${filePath} to ${newVersion}`);
+  } catch (error) {
+    throw new Error(`Failed to update XML in ${filePath}: ${error.message}`);
+  }
+}
+
+export default async function runGenerator(
+  tree: Tree,
+  options: BumpMavenVersionSchema
+) {
+  const { newVersion, nxVersion } = options;
+
+  // Validate version format
+  parseVersion(newVersion);
+
+  const dirFormat = versionToDirFormat(newVersion);
+  const migrationsDir = `packages/maven/src/migrations/${dirFormat}`;
+
+  logger.info(
+    `Bumping Maven plugin version to ${newVersion} for Nx ${nxVersion}`
+  );
+
+  try {
+    // 1. Update root pom.xml
+    logger.info('Updating /pom.xml...');
+    updateXmlVersion(tree, 'pom.xml', newVersion, true);
+
+    // 2. Update maven-plugin pom.xml
+    logger.info('Updating packages/maven/maven-plugin/pom.xml...');
+    updateXmlVersion(
+      tree,
+      'packages/maven/maven-plugin/pom.xml',
+      newVersion,
+      false
+    );
+
+    // 3. Update versions.ts
+    logger.info('Updating packages/maven/src/utils/versions.ts...');
+    const versionsFile = tree.read(
+      'packages/maven/src/utils/versions.ts',
+      'utf-8'
+    );
+    if (!versionsFile) {
+      throw new Error('packages/maven/src/utils/versions.ts not found');
+    }
+
+    const updatedVersionsFile = versionsFile.replace(
+      /export const mavenPluginVersion = '[^']*';/,
+      `export const mavenPluginVersion = '${newVersion}';`
+    );
+
+    tree.write('packages/maven/src/utils/versions.ts', updatedVersionsFile);
+
+    // 4. Update migrations.json
+    logger.info('Updating packages/maven/migrations.json...');
+    const migrationsJsonPath = 'packages/maven/migrations.json';
+    const migrationEntry = {
+      [migrationsJsonPath]: (current: any) => {
+        const migrationKey = `update-${dirFormat}`;
+        return {
+          ...current,
+          generators: {
+            ...current.generators,
+            [migrationKey]: {
+              cli: 'nx',
+              version: nxVersion,
+              description: `Update Maven plugin version from 0.0.${
+                parseInt(newVersion.split('.')[2]) - 1
+              } to ${newVersion} in pom.xml files`,
+              factory: `./dist/migrations/${dirFormat}/update-pom-xml-version`,
+            },
+          },
+        };
+      },
+    };
+
+    updateJson(tree, migrationsJsonPath, migrationEntry[migrationsJsonPath]);
+
+    // 5. Create migration file
+    logger.info(`Creating migration file in ${migrationsDir}...`);
+    const migrationContent = `import { Tree } from '@nx/devkit';
+import { updateNxMavenPluginVersion } from '../../utils/pom-xml-updater';
+
+/**
+ * Migration for @nx/maven v${newVersion}
+ * Updates the Maven plugin version to ${newVersion} in pom.xml files
+ */
+export default async function update(tree: Tree) {
+  // Update user pom.xml files
+  updateNxMavenPluginVersion(tree, '${newVersion}');
+}
+`;
+
+    tree.write(`${migrationsDir}/update-pom-xml-version.ts`, migrationContent);
+
+    logger.info('Formatting files...');
+    await formatFiles(tree);
+
+    logger.info(`✅ Successfully bumped Maven plugin version to ${newVersion}`);
+    logger.info(`   Migration created for Nx ${nxVersion}`);
+  } catch (error) {
+    logger.error(`Failed to bump Maven version: ${error.message}`);
+    throw error;
+  }
+}

--- a/tools/workspace-plugin/src/generators/bump-maven-version/schema.json
+++ b/tools/workspace-plugin/src/generators/bump-maven-version/schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "type": "object",
+  "description": "Bump the Maven plugin version and create a migration for users.",
+  "properties": {
+    "newVersion": {
+      "type": "string",
+      "description": "The version to which to bump maven to. New Maven plugin version (e.g., '0.0.10')",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "nxVersion": {
+      "type": "string",
+      "description": "Nx version for the migration (e.g., '22.1.0-beta.7'). To find a good value for this, use 'npm view nx@next' and choose the next prerelease version which will follow that. For example, if the next version of `nx` is 22.1.0-beta.2, then use 22.1.0-beta.3"
+    }
+  },
+  "required": ["newVersion", "nxVersion"],
+  "examples": [
+    {
+      "newVersion": "0.0.10",
+      "nxVersion": "22.1.0-beta.7"
+    }
+  ]
+}


### PR DESCRIPTION
## Current Behavior

Maven plugin is currently at version 0.0.8.

## Expected Behavior

Maven plugin should be bumped to version 0.0.9 with a corresponding migration for users.

## Changes Made

- Updated parent POM version to 0.0.9
- Updated package.json version to 0.0.9  
- Updated mavenPluginVersion constant to 0.0.9
- Added new migration (0-0-9) to update user pom.xml files from 0.0.8 to 0.0.9
- Scheduled migration for Nx v22.1.0-beta.6

## Testing

- ✅ Maven package tests pass
- ✅ Build succeeds
- ✅ Linting passes