### PR TITLE
fix(core): correctly identify local workspace dependencies on windows

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -1,5 +1,5 @@
 import { isBuiltin } from 'node:module';
-import { dirname, join, posix, relative, resolve } from 'node:path';
+import { dirname, join, posix, relative } from 'node:path';
 import { clean, satisfies } from 'semver';
 import type {
   ProjectGraphExternalNode,
@@ -357,7 +357,7 @@ export class TargetProjectLocator {
       const targetPath = maybeDep?.data.root;
 
       const normalizedPath = normalizedRange.replace('file:', '');
-      const resolvedPath = join(dirname(packageJsonPath), normalizedPath);
+      const resolvedPath = posix.join(dirname(packageJsonPath), normalizedPath);
 
       if (targetPath === resolvedPath) {
         return maybeDep?.name;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When local dependency resolution was improved in https://github.com/nrwl/nx/pull/32784 there was a regression introduced for Windows because of path matching behaviour.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Windows matches other OSes and benefits from the improved resolution.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
