### PR TITLE
chore(expo): run export before e2e to mitigate timeout

### DIFF
--- a/e2e/expo/src/expo-legacy.test.ts
+++ b/e2e/expo/src/expo-legacy.test.ts
@@ -45,6 +45,9 @@ describe('@nx/expo (legacy)', () => {
     runCLI(
       `generate @nx/expo:library libs/${libName} --buildable --publishable --importPath=${proj}/${libName} --unitTestRunner=jest --linter=eslint`
     );
+
+    // Build first to speed up static-serve
+    runCLI(`export ${appName}`);
   });
   afterAll(() => {
     process.env.NX_ADD_PLUGINS = originalEnv;
@@ -283,6 +286,10 @@ describe('@nx/expo (legacy)', () => {
     runCLI(
       `generate @nx/expo:application ${appName2} --e2eTestRunner=playwright --no-interactive --unitTestRunner=jest --linter=eslint`
     );
+
+    // Build first to speed up static-serve
+    runCLI(`export ${appName2}`);
+
     if (runE2ETests()) {
       const results = runCLI(`e2e ${appName2}-e2e`, { verbose: true });
       expect(results).toContain('Successfully ran target e2e');


### PR DESCRIPTION
CI and nightlies can flake out during expo test if cypress or playwright times out waiting for webserver. This makes is to the `export` that powers `static-serve` is run before running e2e.

This is not usually a problem in new workspaces with inference, but this legacy test uses executors so continuous task dependency isn't set up.