### PR TITLE
feat(maven): add option to prefix all maven targets

### DIFF
--- a/e2e/maven/src/maven.test.ts
+++ b/e2e/maven/src/maven.test.ts
@@ -87,13 +87,20 @@ describe('Maven', () => {
   it('should support targetNamePrefix option', () => {
     // Update nx.json to add targetNamePrefix
     updateJson('nx.json', (nxJson) => {
-      const mavenPlugin = nxJson.plugins.find(
-        (p) => typeof p === 'object' && p.plugin === '@nx/maven'
+      // Find the Maven plugin - it could be a string or an object
+      const pluginIndex = nxJson.plugins.findIndex(
+        (p: string | { plugin: string }) =>
+          p === '@nx/maven' ||
+          (typeof p === 'object' && p.plugin === '@nx/maven')
       );
-      if (mavenPlugin && typeof mavenPlugin === 'object') {
-        mavenPlugin.options = {
-          ...mavenPlugin.options,
-          targetNamePrefix: 'mvn-',
+
+      if (pluginIndex !== -1) {
+        // Convert string plugin to object with options
+        nxJson.plugins[pluginIndex] = {
+          plugin: '@nx/maven',
+          options: {
+            targetNamePrefix: 'mvn-',
+          },
         };
       }
       return nxJson;

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt
@@ -46,6 +46,9 @@ class NxProjectAnalyzerMojo : AbstractMojo() {
   @Parameter(property = "workspaceRoot", defaultValue = "\${session.executionRootDirectory}")
   private lateinit var workspaceRoot: File
 
+  @Parameter(property = "targetNamePrefix", defaultValue = "")
+  private var targetNamePrefix: String = ""
+
   private val objectMapper = ObjectMapper()
 
   @Throws(MojoExecutionException::class)
@@ -102,7 +105,8 @@ class NxProjectAnalyzerMojo : AbstractMojo() {
       session,
       mojoAnalyzer,
       pathFormatter,
-      gitIgnoreClassifier
+      gitIgnoreClassifier,
+      targetNamePrefix
     )
 
     // Resolve Maven command once for all projects

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt
@@ -46,8 +46,8 @@ class NxProjectAnalyzerMojo : AbstractMojo() {
   @Parameter(property = "workspaceRoot", defaultValue = "\${session.executionRootDirectory}")
   private lateinit var workspaceRoot: File
 
-  @Parameter(property = "targetNamePrefix", defaultValue = "")
-  private var targetNamePrefix: String = ""
+  @Parameter(property = "targetNamePrefix")
+  private var targetNamePrefix: String? = null
 
   private val objectMapper = ObjectMapper()
 
@@ -106,7 +106,7 @@ class NxProjectAnalyzerMojo : AbstractMojo() {
       mojoAnalyzer,
       pathFormatter,
       gitIgnoreClassifier,
-      targetNamePrefix
+      targetNamePrefix ?: ""
     )
 
     // Resolve Maven command once for all projects

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/NxTargetFactory.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/NxTargetFactory.kt
@@ -98,7 +98,7 @@ class NxTargetFactory(
         project,
         mavenCommand,
         nxTargets,
-        ciPhaseTargets["test-ci"]!!,
+        ciPhaseTargets["${applyPrefix("test-ci")}"]!!,
         phaseGoals["test"]!!
       )
 

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/NxTargetFactory.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/NxTargetFactory.kt
@@ -44,6 +44,7 @@ class NxTargetFactory(
   private val mojoAnalyzer: MojoAnalyzer,
   private val pathFormatter: PathFormatter,
   private val gitIgnoreClassifier: GitIgnoreClassifier,
+  private val targetNamePrefix: String
 ) {
   private val log: Logger = LoggerFactory.getLogger(NxTargetFactory::class.java)
 
@@ -290,7 +291,7 @@ class NxTargetFactory(
 
     if (hasInstall) {
       val dependsOnNode = objectMapper.createObjectNode()
-      dependsOnNode.put("target", "install")
+      dependsOnNode.put("target", applyPrefix("install"))
       dependsOnNode.put("dependencies", true)
       dependsOnNode.put("params", "forward")
       target.dependsOn?.add(dependsOnNode)
@@ -300,17 +301,17 @@ class NxTargetFactory(
     val previousPhase = phases.getOrNull(index - 1)
     if (previousPhase != null) {
       val dependsOnNode = objectMapper.createObjectNode()
-      dependsOnNode.put("target", previousPhase)
+      dependsOnNode.put("target", applyPrefix(previousPhase))
       dependsOnNode.put("params", "forward")
       target.dependsOn?.add(dependsOnNode)
     }
 
-    phaseTargets[phase] = target
+    phaseTargets[applyPrefix(phase)] = target
 
     if (hasGoals) {
-      log.info("Created phase target '$phase' with ${goalsForPhase?.size ?: 0} goals")
+      log.info("Created phase target '${applyPrefix(phase)}' with ${goalsForPhase?.size ?: 0} goals")
     } else {
-      log.info("Created noop phase target '$phase' (no goals)")
+      log.info("Created noop phase target '${applyPrefix(phase)}' (no goals)")
     }
   }
 
@@ -327,7 +328,7 @@ class NxTargetFactory(
   ) {
     val goalsForPhase = phaseGoals[phase]
     val hasGoals = goalsForPhase?.isNotEmpty() == true
-    val ciPhaseName = "$phase-ci"
+    val ciPhaseName = "${applyPrefix(phase)}-ci"
 
     // Test and later phases get a CI counterpart - but only if they have goals
     if (!shouldCreateCiPhase(hasGoals, phase)) {
@@ -351,14 +352,14 @@ class NxTargetFactory(
     if (previousCiPhase != null) {
       log.info("CI phase '$phase' depends on previous CI phase: '$previousCiPhase'")
       val dependsOnNode = objectMapper.createObjectNode()
-      dependsOnNode.put("target", "$previousCiPhase-ci")
+      dependsOnNode.put("target", "${applyPrefix(previousCiPhase)}-ci")
       dependsOnNode.put("params", "forward")
       ciTarget.dependsOn?.add(dependsOnNode)
     }
 
     if (hasInstall) {
       val dependsOnNode = objectMapper.createObjectNode()
-      dependsOnNode.put("target", "install-ci")
+      dependsOnNode.put("target", "${applyPrefix("install")}-ci")
       dependsOnNode.put("dependencies", true)
       dependsOnNode.put("params", "forward")
       ciTarget.dependsOn?.add(dependsOnNode)
@@ -437,7 +438,7 @@ class NxTargetFactory(
         execution.goals.forEach { goal ->
           boundGoals.add(goal)
 
-          val goalTargetName = "$goalPrefix:$goal@${execution.id}"
+          val goalTargetName = applyPrefix("$goalPrefix:$goal@${execution.id}")
           val goalTarget = createSimpleGoalTarget(
             mavenCommand,
             project,
@@ -456,7 +457,7 @@ class NxTargetFactory(
       pluginDescriptor.mojos?.forEach { mojoDescriptor ->
         val goal = mojoDescriptor.goal
         if (!boundGoals.contains(goal)) {
-          val goalTargetName = "$goalPrefix:$goal"
+          val goalTargetName = applyPrefix("$goalPrefix:$goal")
           val goalTarget = createSimpleGoalTarget(
             mavenCommand,
             project,
@@ -577,7 +578,7 @@ class NxTargetFactory(
       ?: return emptyMap()
 
     testClasses.forEach { testClass ->
-      val targetName = "${goalDescriptor.goalSpecifier}--${testClass.packagePath}.${testClass.className}"
+      val targetName = applyPrefix("${goalDescriptor.goalSpecifier}--${testClass.packagePath}.${testClass.className}")
 
       log.info("Generating target for test class: $targetName'")
 
@@ -593,7 +594,7 @@ class NxTargetFactory(
         analysis.isCacheable,
         analysis.isContinuous,
         analysis.isThreadSafe,
-        nxTargets["test-ci"].get("dependsOn").deepCopy() as ArrayNode,
+        nxTargets["${applyPrefix("test")}-ci"].get("dependsOn").deepCopy() as ArrayNode,
         objectMapper.createArrayNode(),
         objectMapper.createArrayNode()
       )
@@ -674,6 +675,17 @@ class NxTargetFactory(
       "pre-integration-test" -> "before:integration-test"
       "post-integration-test" -> "after:integration-test"
       else -> phase
+    }
+  }
+
+  /**
+   * Applies the targetNamePrefix to a target name if the prefix is non-empty.
+   */
+  private fun applyPrefix(targetName: String): String {
+    return if (targetNamePrefix.isNotEmpty()) {
+      "$targetNamePrefix$targetName"
+    } else {
+      targetName
     }
   }
 }

--- a/packages/maven/src/plugins/maven-analyzer.ts
+++ b/packages/maven/src/plugins/maven-analyzer.ts
@@ -71,10 +71,13 @@ export async function runMavenAnalysis(
     '-am',
     `-DoutputFile=${outputFile}`,
     `-DworkspaceRoot=${workspaceRoot}`,
-    `-DtargetNamePrefix=${options.targetNamePrefix || ''}`,
     '--batch-mode',
     '--no-transfer-progress',
   ];
+
+  if (options.targetNamePrefix) {
+    mavenArgs.push(`-DtargetNamePrefix=${options.targetNamePrefix}`);
+  }
 
   if (!isVerbose) {
     mavenArgs.push('-q');

--- a/packages/maven/src/plugins/maven-analyzer.ts
+++ b/packages/maven/src/plugins/maven-analyzer.ts
@@ -71,6 +71,7 @@ export async function runMavenAnalysis(
     '-am',
     `-DoutputFile=${outputFile}`,
     `-DworkspaceRoot=${workspaceRoot}`,
+    `-DtargetNamePrefix=${options.targetNamePrefix || ''}`,
     '--batch-mode',
     '--no-transfer-progress',
   ];

--- a/packages/maven/src/plugins/types.ts
+++ b/packages/maven/src/plugins/types.ts
@@ -3,6 +3,7 @@ import type { RawProjectGraphDependency } from 'nx/src/project-graph/project-gra
 
 export interface MavenPluginOptions {
   verbose?: boolean;
+  targetNamePrefix?: string;
 }
 
 export const DEFAULT_OPTIONS: MavenPluginOptions = {};


### PR DESCRIPTION

## Current Behavior
there is no way to generally influence how maven goals/phases are represented as targets in nx. This could be useful though for organizing targets in nx, for example through nx.json `targetDefaults`

## Expected Behavior
There's a `targetNamePrefix` plugin option that can be passed.
