### PR TITLE
feat(vitest): split entrypoint into plugin, generators, executors

### DIFF
--- a/packages/angular/src/generators/utils/add-vitest.ts
+++ b/packages/angular/src/generators/utils/add-vitest.ts
@@ -18,10 +18,8 @@ export async function addVitest(
   tree: Tree,
   options: AddVitestOptions
 ): Promise<void> {
-  const { configurationGenerator } = ensurePackage<typeof import('@nx/vitest')>(
-    '@nx/vitest',
-    nxVersion
-  );
+  ensurePackage('@nx/vitest', nxVersion);
+  const { configurationGenerator } = await import('@nx/vitest/generators');
 
   await configurationGenerator(tree, {
     project: options.name,

--- a/packages/nuxt/src/generators/application/lib/add-vitest.ts
+++ b/packages/nuxt/src/generators/application/lib/add-vitest.ts
@@ -16,10 +16,8 @@ export async function addVitest(tree: Tree, options: NormalizedSchema) {
     '@nx/vite',
     nxVersion
   );
-  const { configurationGenerator } = ensurePackage<typeof import('@nx/vitest')>(
-    '@nx/vitest',
-    nxVersion
-  );
+  ensurePackage('@nx/vitest', nxVersion);
+  const { configurationGenerator } = await import('@nx/vitest/generators');
 
   const vitestTask = await configurationGenerator(
     tree,

--- a/packages/react/src/generators/application/lib/bundlers/add-vite.ts
+++ b/packages/react/src/generators/application/lib/bundlers/add-vite.ts
@@ -72,10 +72,8 @@ export async function setupVitestConfiguration(
     '@nx/vite',
     nxVersion
   );
-  const { configurationGenerator } = ensurePackage<typeof import('@nx/vitest')>(
-    '@nx/vitest',
-    nxVersion
-  );
+  ensurePackage('@nx/vitest', nxVersion);
+  const { configurationGenerator } = await import('@nx/vitest/generators');
 
   const vitestTask = await configurationGenerator(tree, {
     uiFramework: 'react',

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -204,9 +204,8 @@ export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
       '@nx/vite',
       nxVersion
     );
-    const { configurationGenerator } = ensurePackage<
-      typeof import('@nx/vitest')
-    >('@nx/vitest', nxVersion);
+    ensurePackage('@nx/vitest', nxVersion);
+    const { configurationGenerator } = await import('@nx/vitest/generators');
     const vitestTask = await configurationGenerator(host, {
       uiFramework: 'react',
       project: options.name,

--- a/packages/remix/src/generators/application/application.impl.ts
+++ b/packages/remix/src/generators/application/application.impl.ts
@@ -192,9 +192,8 @@ export async function remixApplicationGeneratorInternal(
       const { createOrEditViteConfig } = ensurePackage<
         typeof import('@nx/vite')
       >('@nx/vite', nxVersion);
-      const { configurationGenerator } = ensurePackage<
-        typeof import('@nx/vitest')
-      >('@nx/vitest', nxVersion);
+      ensurePackage('@nx/vitest', nxVersion);
+      const { configurationGenerator } = await import('@nx/vitest/generators');
       const vitestTask = await configurationGenerator(tree, {
         uiFramework: 'react',
         project: options.projectName,

--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -14,9 +14,10 @@ export async function* vitestExecutor(
     `The '@nx/vite:test' executor is deprecated. Please use '@nx/vitest:test' instead. This executor will be removed in Nx 23.`
   );
 
-  const { vitestExecutor: actualVitestExecutor } = ensurePackage<
-    typeof import('@nx/vitest')
-  >('@nx/vitest', nxVersion);
+  ensurePackage('@nx/vitest', nxVersion);
+  const { vitestExecutor: actualVitestExecutor } = await import(
+    '@nx/vitest/executors'
+  );
 
   yield* actualVitestExecutor(options, context);
 }

--- a/packages/vite/src/generators/vitest/vitest-generator.ts
+++ b/packages/vite/src/generators/vitest/vitest-generator.ts
@@ -15,10 +15,8 @@ export async function vitestGenerator(
     `The '@nx/vite:vitest' generator is deprecated. Please use '@nx/vitest:configuration' instead. This generator will be removed in Nx 23.`
   );
 
-  const { configurationGenerator } = ensurePackage<typeof import('@nx/vitest')>(
-    '@nx/vitest',
-    nxVersion
-  );
+  ensurePackage('@nx/vitest', nxVersion);
+  const { configurationGenerator } = await import('@nx/vitest/generators');
 
   return await configurationGenerator(tree, schema, hasPlugin);
 }

--- a/packages/vitest/executors.ts
+++ b/packages/vitest/executors.ts
@@ -1,0 +1,2 @@
+export { VitestExecutorOptions } from './src/executors/test/schema';
+export { vitestExecutor } from './src/executors/test/vitest.impl';

--- a/packages/vitest/index.ts
+++ b/packages/vitest/index.ts
@@ -1,4 +1,1 @@
 export { createNodesV2, VitestPluginOptions } from './src/plugins/plugin';
-export { VitestExecutorOptions } from './src/executors/test/schema';
-export { vitestExecutor } from './src/executors/test/vitest.impl';
-export { configurationGenerator } from './src/generators/configuration/configuration';

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -35,7 +35,7 @@
     },
     "./executors": {
       "types": "./executors.d.ts",
-      "default": "./executor.js"
+      "default": "./executors.js"
     },
     "./package.json": "./package.json",
     "./generators.json": "./generators.json",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -33,6 +33,10 @@
       "types": "./generators.d.ts",
       "default": "./generators.js"
     },
+    "./executors": {
+      "types": "./executors.d.ts",
+      "default": "./executor.js"
+    },
     "./package.json": "./package.json",
     "./generators.json": "./generators.json",
     "./executors.json": "./executors.json",

--- a/packages/vitest/project.json
+++ b/packages/vitest/project.json
@@ -6,7 +6,7 @@
   "targets": {
     "build": {
       "command": "node ./scripts/copy-readme.js vitest",
-      "outputs": ["{workspaceRoot}/build/packages/vitest/README.md"]
+      "outputs": ["{workspaceRoot}/dist/packages/vitest/README.md"]
     },
     "legacy-post-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",

--- a/packages/vue/src/generators/application/lib/add-vite.ts
+++ b/packages/vue/src/generators/application/lib/add-vite.ts
@@ -52,10 +52,9 @@ export async function addVite(
 
 export async function addVitest(tree: Tree, options: NormalizedSchema) {
   const tasks: GeneratorCallback[] = [];
-  const { configurationGenerator } = ensurePackage<typeof import('@nx/vitest')>(
-    '@nx/vitest',
-    nxVersion
-  );
+  ensurePackage('@nx/vitest', nxVersion);
+  const { configurationGenerator } = await import('@nx/vitest/generators');
+
   const vitestTask = await configurationGenerator(tree, {
     uiFramework: 'none',
     project: options.projectName,

--- a/packages/vue/src/generators/library/lib/add-vite.ts
+++ b/packages/vue/src/generators/library/lib/add-vite.ts
@@ -52,9 +52,8 @@ export async function addVite(
       '@nx/vite',
       nxVersion
     );
-    const { configurationGenerator } = ensurePackage<
-      typeof import('@nx/vitest')
-    >('@nx/vitest', nxVersion);
+    ensurePackage('@nx/vitest', nxVersion);
+    const { configurationGenerator } = await import('@nx/vitest/generators');
     const vitestTask = await configurationGenerator(tree, {
       uiFramework: 'vue',
       project: options.projectName,

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -390,9 +390,8 @@ export async function applicationGeneratorInternal(host: Tree, schema: Schema) {
       '@nx/vite',
       nxVersion
     );
-    const { configurationGenerator } = ensurePackage<
-      typeof import('@nx/vitest')
-    >('@nx/vitest', nxVersion);
+    ensurePackage('@nx/vitest', nxVersion);
+    const { configurationGenerator } = await import('@nx/vitest/generators');
     const vitestTask = await configurationGenerator(host, {
       uiFramework: 'none',
       project: options.projectName,


### PR DESCRIPTION
Split entry point of `@nx/vitest` into `index.ts` for the Inference Plugin, `generators.ts` for Generators, `executors.ts` for the Executors.
Ensure the `README.md` is copied to the correct output directory

