### PR TITLE
fix(storybook): remove optional nature of migration

### DIFF
--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -14,11 +14,11 @@
     },
     "update-22-1-0-migrate-storybook-v10": {
       "cli": "nx",
-      "version": "22.1.0-beta.3",
+      "version": "22.1.0-beta.8",
       "requires": {
-        "storybook": ">=10.0.0"
+        "storybook": ">=9.0.0 <10.0.0"
       },
-      "description": "Update workspce to use Storybok v10",
+      "description": "Update workspace to use Storybook v10",
       "implementation": "./src/migrations/update-22-1-0/migrate-to-storybook-10"
     }
   },
@@ -635,9 +635,7 @@
       }
     },
     "22.1.0": {
-      "version": "22.1.0-beta.6",
-      "x-prompt": "Do you want to update Storybook to version 10?",
-      "implementation": "./src/migrations/update-21-2-0/migrate-to-storybook-10",
+      "version": "22.1.0-beta.8",
       "requires": {
         "storybook": ">=9.0.0 <10.0.0"
       },

--- a/packages/storybook/src/migrations/update-22-1-0/migrate-to-storybook-10.ts
+++ b/packages/storybook/src/migrations/update-22-1-0/migrate-to-storybook-10.ts
@@ -29,9 +29,9 @@ export default async function migrateToStorybook10(tree: Tree) {
   }
 
   const contents = readFileSync(pathToAiInstructions);
-  tree.write('MIGRATE_STORYBOOK_10.md', contents);
+  tree.write('ai-migrations/MIGRATE_STORYBOOK_10.md', contents);
   return [
     `Storybook 10 requires Storybook Configs to use ESM.`,
-    `We created 'MIGRATE_STORYBOOK_10.md' with instructions for an AI Agent to convert CJS Storybook Configs to ESM in your workspace.`,
+    `We created 'ai-migrations/MIGRATE_STORYBOOK_10.md' with instructions for an AI Agent to convert CJS Storybook Configs to ESM in your workspace.`,
   ];
 }


### PR DESCRIPTION
## Current Behavior
The Storybook 10 migration was originally intended to be optional.

## Expected Behavior
Make Storybook 10 migration add the migration generator to migrations.json always. Users can remove it from here if they do not want it, or they can use the Migrate UI from Nx Console to choose not to run it.
