### PR TITLE
chore(repo): force storybook@9 so types resolve

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -42,7 +42,8 @@
     "@nx/eslint": "workspace:*"
   },
   "devDependencies": {
-    "nx": "workspace:*"
+    "nx": "workspace:*",
+    "storybook": "9.0.6"
   },
   "peerDependencies": {
     "storybook": ">=7.0.0 <11.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4159,9 +4159,6 @@ importers:
       semver:
         specifier: 'catalog:'
         version: 7.7.2
-      storybook:
-        specifier: '>=7.0.0 <11.0.0'
-        version: 9.0.6(@testing-library/dom@10.4.0)(prettier@3.6.2)
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
@@ -4169,6 +4166,9 @@ importers:
       nx:
         specifier: workspace:*
         version: link:../nx
+      storybook:
+        specifier: 9.0.6
+        version: 9.0.6(@testing-library/dom@10.4.0)(prettier@3.6.2)
 
   packages/vite:
     dependencies:


### PR DESCRIPTION
Master has v9 in lockfile, but it's not a guarantee. This forces v9 until we have a better solution to resolve v10 types.