### PR TITLE
fix(js): update vitest generator import in library generator

### DIFF
--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -7,11 +7,9 @@ import {
   GeneratorCallback,
   installPackagesTask,
   joinPathFragments,
-  logger,
   names,
   offsetFromRoot,
   ProjectConfiguration,
-  readJson,
   readNxJson,
   readProjectConfiguration,
   runTasksInSerial,
@@ -175,7 +173,9 @@ export async function libraryGeneratorInternal(
     options.bundler !== 'vite' // Test would have been set up already
   ) {
     const { createOrEditViteConfig } = ensurePackage('@nx/vite', nxVersion);
-    const { configurationGenerator } = ensurePackage('@nx/vitest', nxVersion);
+    ensurePackage('@nx/vitest', nxVersion);
+    // nx-ignore-next-line
+    const { configurationGenerator } = require('@nx/vitest/generators');
     const vitestTask = await configurationGenerator(tree, {
       project: options.name,
       uiFramework: 'none',


### PR DESCRIPTION
## Current Behavior
The library generator has an unused import and incorrect import pattern for the vitest generator.

## Expected Behavior
Clean imports with the correct way to access the configurationGenerator from @nx/vitest.

## Changes
- Removed unused imports (logger, readJson)
- Updated vitest generator import to use direct require instead of ensurePackage pattern for accessing the generator

Fixes #