### PR TITLE
feat(release): add resolveVersionPlans option to changelog CLI and API

### DIFF
--- a/packages/nx/src/command-line/release/changelog/commit-utils.spec.ts
+++ b/packages/nx/src/command-line/release/changelog/commit-utils.spec.ts
@@ -1,0 +1,396 @@
+import { GitCommit } from '../utils/git';
+import { FileData, ProjectFileMap } from '../../../config/project-graph';
+import {
+  mapCommitToChange,
+  createChangesFromCommits,
+  filterHiddenChanges,
+  getProjectsAffectedByCommit,
+  commitChangesNonProjectFiles,
+  createFileToProjectMap,
+} from './commit-utils';
+import { NxReleaseConfig } from '../config/config';
+import { ChangelogChange } from './version-plan-utils';
+
+describe('commit-utils', () => {
+  describe('mapCommitToChange', () => {
+    it('should map a GitCommit to a ChangelogChange', () => {
+      const commit: GitCommit = {
+        type: 'fix',
+        scope: 'core',
+        description: 'Fix critical bug',
+        body: 'This fixes a critical bug in the core module',
+        isBreaking: false,
+        references: [{ value: '123', type: 'issue' }],
+        authors: [{ name: 'John Doe', email: 'john@example.com' }],
+        shortHash: 'abc123',
+        revertedHashes: [],
+        message: 'fix(core): Fix critical bug',
+        author: { name: 'John Doe', email: 'john@example.com' },
+        affectedFiles: ['src/core/index.ts'],
+      };
+
+      const result = mapCommitToChange(commit, ['project1', 'project2']);
+
+      expect(result).toEqual({
+        type: 'fix',
+        scope: 'core',
+        description: 'Fix critical bug',
+        body: 'This fixes a critical bug in the core module',
+        isBreaking: false,
+        githubReferences: [{ value: '123', type: 'issue' }],
+        authors: [{ name: 'John Doe', email: 'john@example.com' }],
+        shortHash: 'abc123',
+        revertedHashes: [],
+        affectedProjects: ['project1', 'project2'],
+      });
+    });
+
+    it('should handle commits affecting all projects', () => {
+      const commit: GitCommit = {
+        type: 'chore',
+        scope: '',
+        description: 'Update dependencies',
+        body: '',
+        isBreaking: false,
+        references: [],
+        authors: [{ name: 'Jane Doe', email: 'jane@example.com' }],
+        shortHash: 'def456',
+        revertedHashes: [],
+        message: 'chore: Update dependencies',
+        author: { name: 'Jane Doe', email: 'jane@example.com' },
+        affectedFiles: ['package.json'],
+      };
+
+      const result = mapCommitToChange(commit, '*');
+
+      expect(result.affectedProjects).toBe('*');
+    });
+  });
+
+  describe('filterHiddenChanges', () => {
+    const conventionalCommitsConfig: NxReleaseConfig['conventionalCommits'] = {
+      types: {
+        fix: {
+          semverBump: 'patch',
+          changelog: { title: 'Bug Fixes', hidden: false },
+        },
+        feat: {
+          semverBump: 'minor',
+          changelog: { title: 'Features', hidden: false },
+        },
+        chore: {
+          semverBump: 'none',
+          changelog: { title: 'Chores', hidden: true },
+        },
+        docs: {
+          semverBump: 'none',
+          changelog: { title: 'Documentation', hidden: true },
+        },
+      },
+    };
+
+    it('should filter out hidden change types', () => {
+      const changes: ChangelogChange[] = [
+        {
+          type: 'fix',
+          scope: '',
+          description: 'Fix bug',
+          affectedProjects: '*',
+        },
+        {
+          type: 'feat',
+          scope: '',
+          description: 'Add feature',
+          affectedProjects: '*',
+        },
+        {
+          type: 'chore',
+          scope: '',
+          description: 'Update deps',
+          affectedProjects: '*',
+        },
+        {
+          type: 'docs',
+          scope: '',
+          description: 'Update docs',
+          affectedProjects: '*',
+        },
+      ];
+
+      const result = filterHiddenChanges(changes, conventionalCommitsConfig);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].type).toBe('fix');
+      expect(result[1].type).toBe('feat');
+    });
+
+    it('should filter out changes with unknown types', () => {
+      const changes: ChangelogChange[] = [
+        {
+          type: 'fix',
+          scope: '',
+          description: 'Fix bug',
+          affectedProjects: '*',
+        },
+        {
+          type: 'unknown',
+          scope: '',
+          description: 'Unknown change',
+          affectedProjects: '*',
+        },
+      ];
+
+      const result = filterHiddenChanges(changes, conventionalCommitsConfig);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('fix');
+    });
+  });
+
+  describe('getProjectsAffectedByCommit', () => {
+    it('should return projects affected by commit', () => {
+      const commit: GitCommit = {
+        type: 'fix',
+        scope: '',
+        description: 'Fix bug',
+        body: '',
+        isBreaking: false,
+        references: [],
+        authors: [],
+        shortHash: 'abc123',
+        revertedHashes: [],
+        message: 'fix: Fix bug',
+        author: { name: 'Test', email: 'test@example.com' },
+        affectedFiles: [
+          'packages/project1/src/index.ts',
+          'packages/project1/README.md',
+          'packages/project2/src/main.ts',
+        ],
+      };
+
+      const fileToProjectMap = {
+        'packages/project1/src/index.ts': 'project1',
+        'packages/project1/README.md': 'project1',
+        'packages/project2/src/main.ts': 'project2',
+        'packages/project3/src/index.ts': 'project3',
+      };
+
+      const result = getProjectsAffectedByCommit(commit, fileToProjectMap);
+
+      expect(result).toEqual(['project1', 'project2']);
+    });
+
+    it('should return empty array when no projects are affected', () => {
+      const commit: GitCommit = {
+        type: 'chore',
+        scope: '',
+        description: 'Update root config',
+        body: '',
+        isBreaking: false,
+        references: [],
+        authors: [],
+        shortHash: 'def456',
+        revertedHashes: [],
+        message: 'chore: Update root config',
+        author: { name: 'Test', email: 'test@example.com' },
+        affectedFiles: ['README.md'],
+      };
+
+      const fileToProjectMap = {
+        'packages/project1/src/index.ts': 'project1',
+        'packages/project2/src/main.ts': 'project2',
+      };
+
+      const result = getProjectsAffectedByCommit(commit, fileToProjectMap);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle duplicate projects (multiple files from same project)', () => {
+      const commit: GitCommit = {
+        type: 'refactor',
+        scope: '',
+        description: 'Refactor project1',
+        body: '',
+        isBreaking: false,
+        references: [],
+        authors: [],
+        shortHash: 'ghi789',
+        revertedHashes: [],
+        message: 'refactor: Refactor project1',
+        author: { name: 'Test', email: 'test@example.com' },
+        affectedFiles: [
+          'packages/project1/src/index.ts',
+          'packages/project1/src/utils.ts',
+          'packages/project1/src/types.ts',
+        ],
+      };
+
+      const fileToProjectMap = {
+        'packages/project1/src/index.ts': 'project1',
+        'packages/project1/src/utils.ts': 'project1',
+        'packages/project1/src/types.ts': 'project1',
+      };
+
+      const result = getProjectsAffectedByCommit(commit, fileToProjectMap);
+
+      expect(result).toEqual(['project1']);
+    });
+  });
+
+  describe('commitChangesNonProjectFiles', () => {
+    const nonProjectFiles: FileData[] = [
+      { file: 'nx.json', hash: 'hash1' },
+      { file: 'package.json', hash: 'hash2' },
+      { file: 'README.md', hash: 'hash3' },
+    ];
+
+    it('should return true when commit affects non-project files', () => {
+      const commit: GitCommit = {
+        type: 'chore',
+        scope: '',
+        description: 'Update workspace config',
+        body: '',
+        isBreaking: false,
+        references: [],
+        authors: [],
+        shortHash: 'abc123',
+        revertedHashes: [],
+        message: 'chore: Update workspace config',
+        author: { name: 'Test', email: 'test@example.com' },
+        affectedFiles: ['nx.json', 'packages/project1/src/index.ts'],
+      };
+
+      const result = commitChangesNonProjectFiles(commit, nonProjectFiles);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when commit only affects project files', () => {
+      const commit: GitCommit = {
+        type: 'feat',
+        scope: '',
+        description: 'Add feature to project',
+        body: '',
+        isBreaking: false,
+        references: [],
+        authors: [],
+        shortHash: 'def456',
+        revertedHashes: [],
+        message: 'feat: Add feature to project',
+        author: { name: 'Test', email: 'test@example.com' },
+        affectedFiles: [
+          'packages/project1/src/index.ts',
+          'packages/project2/src/main.ts',
+        ],
+      };
+
+      const result = commitChangesNonProjectFiles(commit, nonProjectFiles);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('createFileToProjectMap', () => {
+    it('should create a map from file paths to project names', () => {
+      const projectFileMap: ProjectFileMap = {
+        project1: [
+          { file: 'packages/project1/src/index.ts', hash: 'hash1' },
+          { file: 'packages/project1/src/utils.ts', hash: 'hash2' },
+        ],
+        project2: [
+          { file: 'packages/project2/src/main.ts', hash: 'hash3' },
+          { file: 'packages/project2/README.md', hash: 'hash4' },
+        ],
+      };
+
+      const result = createFileToProjectMap(projectFileMap);
+
+      expect(result).toEqual({
+        'packages/project1/src/index.ts': 'project1',
+        'packages/project1/src/utils.ts': 'project1',
+        'packages/project2/src/main.ts': 'project2',
+        'packages/project2/README.md': 'project2',
+      });
+    });
+
+    it('should handle empty project file map', () => {
+      const projectFileMap: ProjectFileMap = {};
+
+      const result = createFileToProjectMap(projectFileMap);
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('createChangesFromCommits', () => {
+    it('should create changes from commits with project mapping', () => {
+      const commits: GitCommit[] = [
+        {
+          type: 'fix',
+          scope: 'core',
+          description: 'Fix bug in project1',
+          body: '',
+          isBreaking: false,
+          references: [],
+          authors: [],
+          shortHash: 'abc123',
+          revertedHashes: [],
+          message: 'fix(core): Fix bug in project1',
+          author: { name: 'Test', email: 'test@example.com' },
+          affectedFiles: ['packages/project1/src/index.ts'],
+        },
+        {
+          type: 'feat',
+          scope: '',
+          description: 'Add feature to workspace',
+          body: '',
+          isBreaking: false,
+          references: [],
+          authors: [],
+          shortHash: 'def456',
+          revertedHashes: [],
+          message: 'feat: Add feature to workspace',
+          author: { name: 'Test', email: 'test@example.com' },
+          affectedFiles: ['nx.json'],
+        },
+      ];
+
+      const fileMap = {
+        projectFileMap: {
+          project1: [{ file: 'packages/project1/src/index.ts', hash: 'hash1' }],
+        } as ProjectFileMap,
+        nonProjectFiles: [{ file: 'nx.json', hash: 'hash2' }],
+      };
+
+      const fileToProjectMap = {
+        'packages/project1/src/index.ts': 'project1',
+      };
+
+      const conventionalCommitsConfig: NxReleaseConfig['conventionalCommits'] =
+        {
+          types: {
+            fix: {
+              semverBump: 'patch',
+              changelog: { title: 'Bug Fixes', hidden: false },
+            },
+            feat: {
+              semverBump: 'minor',
+              changelog: { title: 'Features', hidden: false },
+            },
+          },
+        };
+
+      const result = createChangesFromCommits(
+        commits,
+        fileMap,
+        fileToProjectMap,
+        conventionalCommitsConfig
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0].affectedProjects).toEqual(['project1']);
+      expect(result[1].affectedProjects).toBe('*');
+    });
+  });
+});

--- a/packages/nx/src/command-line/release/changelog/commit-utils.ts
+++ b/packages/nx/src/command-line/release/changelog/commit-utils.ts
@@ -1,0 +1,93 @@
+import { GitCommit } from '../utils/git';
+import { FileData, ProjectFileMap } from '../../../config/project-graph';
+import { NxReleaseConfig } from '../config/config';
+import { ChangelogChange } from './version-plan-utils';
+
+export function mapCommitToChange(
+  commit: GitCommit,
+  affectedProjects: string[] | '*'
+): ChangelogChange {
+  return {
+    type: commit.type,
+    scope: commit.scope,
+    description: commit.description,
+    body: commit.body,
+    isBreaking: commit.isBreaking,
+    githubReferences: commit.references,
+    authors: commit.authors,
+    shortHash: commit.shortHash,
+    revertedHashes: commit.revertedHashes,
+    affectedProjects,
+  };
+}
+
+export function createChangesFromCommits(
+  commits: GitCommit[],
+  fileMap: { projectFileMap: ProjectFileMap; nonProjectFiles: FileData[] },
+  fileToProjectMap: Record<string, string>,
+  conventionalCommitsConfig: NxReleaseConfig['conventionalCommits']
+): ChangelogChange[] {
+  return filterHiddenChanges(
+    commits.map((c) => {
+      const affectedProjects = commitChangesNonProjectFiles(
+        c,
+        fileMap.nonProjectFiles
+      )
+        ? '*'
+        : getProjectsAffectedByCommit(c, fileToProjectMap);
+      return mapCommitToChange(c, affectedProjects);
+    }),
+    conventionalCommitsConfig
+  );
+}
+
+export function filterHiddenChanges(
+  changes: ChangelogChange[],
+  conventionalCommitsConfig: NxReleaseConfig['conventionalCommits']
+): ChangelogChange[] {
+  return changes.filter((change) => {
+    const type = change.type;
+
+    const typeConfig = conventionalCommitsConfig.types[type];
+    if (!typeConfig) {
+      // don't include changes with unknown types
+      return false;
+    }
+    return !typeConfig.changelog.hidden;
+  });
+}
+
+export function getProjectsAffectedByCommit(
+  commit: GitCommit,
+  fileToProjectMap: Record<string, string>
+): string[] {
+  const affectedProjects = new Set<string>();
+  for (const affectedFile of commit.affectedFiles) {
+    const affectedProject = fileToProjectMap[affectedFile];
+    if (affectedProject) {
+      affectedProjects.add(affectedProject);
+    }
+  }
+  return Array.from(affectedProjects);
+}
+
+export function commitChangesNonProjectFiles(
+  commit: GitCommit,
+  nonProjectFiles: FileData[]
+): boolean {
+  return nonProjectFiles.some((fileData) =>
+    commit.affectedFiles.includes(fileData.file)
+  );
+}
+
+export function createFileToProjectMap(
+  projectFileMap: ProjectFileMap
+): Record<string, string> {
+  const fileToProjectMap = {};
+  for (const [projectName, projectFiles] of Object.entries(projectFileMap)) {
+    for (const file of projectFiles) {
+      fileToProjectMap[file.file] = projectName;
+    }
+  }
+  return fileToProjectMap;
+}

--- a/packages/nx/src/command-line/release/changelog/version-plan-filtering.spec.ts
+++ b/packages/nx/src/command-line/release/changelog/version-plan-filtering.spec.ts
@@ -1,0 +1,452 @@
+import { exec } from 'child_process';
+import { RawVersionPlan } from '../config/version-plans';
+import * as gitUtils from '../utils/git';
+import type { VersionData } from '../utils/shared';
+import {
+  extractPreidFromVersion,
+  extractProjectsPreidFromVersionData,
+  filterVersionPlansByCommitRange,
+  resolveWorkspaceChangelogFromSHA,
+} from './version-plan-filtering';
+
+jest.mock('node:child_process');
+jest.mock('../utils/git');
+
+describe('version-plan-filtering', () => {
+  const mockExec = exec as unknown as jest.Mock;
+  const mockGetCommitHash = gitUtils.getCommitHash as jest.Mock;
+  const mockGetFirstGitCommit = gitUtils.getFirstGitCommit as jest.Mock;
+  const mockGetLatestGitTagForPattern =
+    gitUtils.getLatestGitTagForPattern as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('filterVersionPlansByCommitRange', () => {
+    const createMockVersionPlan = (
+      fileName: string,
+      absolutePath: string
+    ): RawVersionPlan => ({
+      fileName,
+      absolutePath,
+      relativePath: `.nx/version-plans/${fileName}`,
+      createdOnMs: Date.now(),
+      content: {},
+      message: 'Test message',
+    });
+
+    it('should include version plans added within the commit range', async () => {
+      const versionPlans = [
+        createMockVersionPlan('plan-1.md', '/path/to/plan-1.md'),
+        createMockVersionPlan('plan-2.md', '/path/to/plan-2.md'),
+        createMockVersionPlan('plan-3.md', '/path/to/plan-3.md'),
+      ];
+
+      // Mock git log responses
+      mockExec.mockImplementation((command, options, callback) => {
+        if (command.includes('plan-1.md')) {
+          callback(null, 'abc123', ''); // Has commit in range
+        } else if (command.includes('plan-2.md')) {
+          callback(null, '', ''); // No commit in range
+        } else if (command.includes('plan-3.md')) {
+          callback(null, 'def456', ''); // Has commit in range
+        }
+      });
+
+      const result = await filterVersionPlansByCommitRange(
+        versionPlans,
+        'fromSHA',
+        'toSHA',
+        false
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0].fileName).toBe('plan-1.md');
+      expect(result[1].fileName).toBe('plan-3.md');
+    });
+
+    it('should include all plans when there is a git error', async () => {
+      const versionPlans = [
+        createMockVersionPlan('plan-1.md', '/path/to/plan-1.md'),
+      ];
+
+      mockExec.mockImplementation((command, options, callback) => {
+        callback(new Error('Git error'), '', '');
+      });
+
+      const result = await filterVersionPlansByCommitRange(
+        versionPlans,
+        'fromSHA',
+        'toSHA',
+        false
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].fileName).toBe('plan-1.md');
+    });
+
+    it('should log verbose output when verbose is true', async () => {
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+      const versionPlans = [
+        createMockVersionPlan('plan-1.md', '/path/to/plan-1.md'),
+        createMockVersionPlan('plan-2.md', '/path/to/plan-2.md'),
+      ];
+
+      mockExec.mockImplementation((command, options, callback) => {
+        if (command.includes('plan-1.md')) {
+          callback(null, 'abc123', '');
+        } else {
+          callback(null, '', '');
+        }
+      });
+
+      await filterVersionPlansByCommitRange(
+        versionPlans,
+        'fromSHA',
+        'toSHA',
+        true
+      );
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Version plan 'plan-1.md' was added in commit range"
+        )
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Filtering out version plan')
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Filtered 2 version plans down to 1')
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle empty version plans array', async () => {
+      const result = await filterVersionPlansByCommitRange(
+        [],
+        'fromSHA',
+        'toSHA',
+        false
+      );
+
+      expect(result).toEqual([]);
+      expect(mockExec).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resolveWorkspaceChangelogFromSHA', () => {
+    it('should resolve user-provided from ref to SHA', async () => {
+      mockGetCommitHash.mockResolvedValue('resolved-sha');
+
+      const result = await resolveWorkspaceChangelogFromSHA({
+        args: { from: 'v1.0.0' } as any,
+        nxReleaseConfig: {
+          releaseTag: {
+            pattern: '{version}',
+            checkAllBranchesWhen: false,
+            requireSemver: true,
+            strictPreid: false,
+          },
+        } as any,
+        useAutomaticFromRef: false,
+      });
+
+      expect(mockGetCommitHash).toHaveBeenCalledWith('v1.0.0');
+      expect(result).toBe('resolved-sha');
+    });
+
+    it('should resolve from latest tag when no from ref provided', async () => {
+      mockGetLatestGitTagForPattern.mockResolvedValue({ tag: 'v1.0.0' });
+      mockGetCommitHash.mockResolvedValue('tag-sha');
+
+      const result = await resolveWorkspaceChangelogFromSHA({
+        args: { version: '2.0.0' } as any,
+        nxReleaseConfig: {
+          releaseTag: {
+            pattern: '{version}',
+            checkAllBranchesWhen: false,
+            requireSemver: true,
+            strictPreid: false,
+          },
+        } as any,
+        useAutomaticFromRef: false,
+      });
+
+      expect(mockGetLatestGitTagForPattern).toHaveBeenCalled();
+      expect(mockGetCommitHash).toHaveBeenCalledWith('v1.0.0');
+      expect(result).toBe('tag-sha');
+    });
+
+    it('should use first commit when automatic from ref is enabled and no tag found', async () => {
+      mockGetLatestGitTagForPattern.mockResolvedValue(null);
+      mockGetFirstGitCommit.mockResolvedValue('first-commit-sha');
+
+      const result = await resolveWorkspaceChangelogFromSHA({
+        args: {} as any,
+        nxReleaseConfig: {
+          releaseTag: {
+            pattern: '{version}',
+            checkAllBranchesWhen: false,
+            requireSemver: true,
+            strictPreid: false,
+          },
+        } as any,
+        useAutomaticFromRef: true,
+      });
+
+      expect(mockGetFirstGitCommit).toHaveBeenCalled();
+      expect(result).toBe('first-commit-sha');
+    });
+
+    it('should return null when no from ref can be resolved', async () => {
+      mockGetLatestGitTagForPattern.mockResolvedValue(null);
+
+      const result = await resolveWorkspaceChangelogFromSHA({
+        args: {} as any,
+        nxReleaseConfig: {
+          releaseTag: {
+            pattern: '{version}',
+            checkAllBranchesWhen: false,
+            requireSemver: true,
+            strictPreid: false,
+          },
+        } as any,
+        useAutomaticFromRef: false,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it('should extract preid from prerelease version', async () => {
+      const prereleaseSpyOn = jest
+        .spyOn(require('semver'), 'prerelease')
+        .mockReturnValue(['beta', 1]);
+      mockGetLatestGitTagForPattern.mockResolvedValue({ tag: 'v2.0.0-beta.1' });
+      mockGetCommitHash.mockResolvedValue('prerelease-sha');
+
+      const result = await resolveWorkspaceChangelogFromSHA({
+        args: { version: '2.0.0-beta.2' } as any,
+        nxReleaseConfig: {
+          releaseTag: {
+            pattern: '{version}',
+            checkAllBranchesWhen: false,
+            requireSemver: true,
+            strictPreid: true,
+          },
+        } as any,
+        useAutomaticFromRef: false,
+      });
+
+      expect(mockGetLatestGitTagForPattern).toHaveBeenCalledWith(
+        '{version}',
+        {},
+        expect.objectContaining({
+          preid: 'beta',
+        })
+      );
+      expect(result).toBe('prerelease-sha');
+
+      prereleaseSpyOn.mockRestore();
+    });
+
+    it('should handle version data with project preids', async () => {
+      const prereleaseSpyOn = jest
+        .spyOn(require('semver'), 'prerelease')
+        .mockImplementation((version) =>
+          typeof version === 'string' && version.includes('alpha')
+            ? ['alpha', 1]
+            : null
+        );
+      mockGetLatestGitTagForPattern.mockResolvedValue({
+        tag: 'proj1-v1.0.0-alpha.1',
+      });
+      mockGetCommitHash.mockResolvedValue('project-sha');
+
+      const result = await resolveWorkspaceChangelogFromSHA({
+        args: {
+          versionData: {
+            proj1: { newVersion: '1.0.0-alpha.2' },
+            proj2: { newVersion: '2.0.0' },
+          },
+        } as any,
+        nxReleaseConfig: {
+          releaseTag: {
+            pattern: '{projectName}-v{version}',
+            checkAllBranchesWhen: false,
+            requireSemver: true,
+            strictPreid: true,
+          },
+        } as any,
+        useAutomaticFromRef: false,
+      });
+
+      expect(mockGetLatestGitTagForPattern).toHaveBeenCalledWith(
+        '{projectName}-v{version}',
+        {},
+        expect.objectContaining({
+          preid: 'alpha',
+        })
+      );
+      expect(result).toBe('project-sha');
+
+      prereleaseSpyOn.mockRestore();
+    });
+  });
+
+  describe('extractPreidFromVersion', () => {
+    it('should extract preid from basic prerelease versions', () => {
+      expect(extractPreidFromVersion('1.0.0-beta.1')).toBe('beta');
+      expect(extractPreidFromVersion('2.0.0-alpha.5')).toBe('alpha');
+      expect(extractPreidFromVersion('3.0.0-rc.2')).toBe('rc');
+    });
+
+    it('should return undefined for stable release versions', () => {
+      expect(extractPreidFromVersion('1.0.0')).toBeUndefined();
+      expect(extractPreidFromVersion('2.5.3')).toBeUndefined();
+    });
+
+    it('should return undefined for null undefined or empty input versions', () => {
+      expect(extractPreidFromVersion(null)).toBeUndefined();
+      expect(extractPreidFromVersion(undefined)).toBeUndefined();
+      expect(extractPreidFromVersion('')).toBeUndefined();
+    });
+
+    it('should handle numeric preids by returning undefined value', () => {
+      // Numeric preids like "1.0.0-0" have the preid as a number
+      expect(extractPreidFromVersion('1.0.0-0')).toBeUndefined();
+      expect(extractPreidFromVersion('1.0.0-1')).toBeUndefined();
+    });
+
+    it('should handle complex multi-part prerelease versions', () => {
+      // Only the first part is considered the preid
+      expect(extractPreidFromVersion('1.0.0-beta.1.exp.2')).toBe('beta');
+      expect(extractPreidFromVersion('2.0.0-alpha.0.next.1')).toBe('alpha');
+    });
+
+    it('should handle prerelease versions containing dashes', () => {
+      expect(extractPreidFromVersion('1.0.0-pre-release.1')).toBe(
+        'pre-release'
+      );
+      expect(extractPreidFromVersion('1.0.0-my-custom-tag.5')).toBe(
+        'my-custom-tag'
+      );
+    });
+  });
+
+  describe('extractProjectsPreidFromVersionData', () => {
+    it('should extract preids from multiple project versions', () => {
+      const versionData = {
+        'project-a': {
+          newVersion: '1.0.0-beta.1',
+          currentVersion: '0.9.0',
+          dependentProjects: [],
+        },
+        'project-b': {
+          newVersion: '2.0.0-alpha.3',
+          currentVersion: '1.9.0',
+          dependentProjects: [],
+        },
+        'project-c': {
+          newVersion: '3.0.0',
+          currentVersion: '2.9.0',
+          dependentProjects: [],
+        },
+      };
+
+      const result = extractProjectsPreidFromVersionData(versionData);
+
+      expect(result).toEqual({
+        'project-a': 'beta',
+        'project-b': 'alpha',
+        'project-c': undefined,
+      });
+    });
+
+    it('should return undefined for undefined versionData input', () => {
+      expect(extractProjectsPreidFromVersionData(undefined)).toBeUndefined();
+    });
+
+    it('should handle empty versionData object', () => {
+      expect(extractProjectsPreidFromVersionData({})).toEqual({});
+    });
+
+    it('should handle projects with missing or empty newVersion', () => {
+      const versionData = {
+        'project-a': {
+          currentVersion: '1.0.0',
+          newVersion: '',
+          dependentProjects: [],
+        },
+        'project-b': {
+          newVersion: '2.0.0-beta.1',
+          currentVersion: '1.9.0',
+          dependentProjects: [],
+        },
+      };
+
+      const result = extractProjectsPreidFromVersionData(versionData);
+
+      expect(result).toEqual({
+        'project-b': 'beta',
+      });
+    });
+
+    it('should handle projects with null or undefined newVersion fields', () => {
+      const versionData = {
+        'project-a': {
+          newVersion: null,
+          currentVersion: '1.0.0',
+          dependentProjects: [],
+        },
+        'project-b': {
+          newVersion: undefined,
+          currentVersion: '1.9.0',
+          dependentProjects: [],
+        },
+        'project-c': {
+          newVersion: '3.0.0-rc.1',
+          currentVersion: '2.9.0',
+          dependentProjects: [],
+        },
+      };
+
+      const result = extractProjectsPreidFromVersionData(
+        versionData as unknown as VersionData
+      );
+
+      expect(result).toEqual({
+        'project-c': 'rc',
+      });
+    });
+
+    it('should handle projects with complex multi-part prerelease versions', () => {
+      const versionData = {
+        'project-a': {
+          newVersion: '1.0.0-beta.1.exp.3',
+          currentVersion: '0.9.0',
+          dependentProjects: [],
+        },
+        'project-b': {
+          newVersion: '2.0.0-pre-release.2',
+          currentVersion: '1.9.0',
+          dependentProjects: [],
+        },
+        'project-c': {
+          newVersion: '3.0.0-0',
+          currentVersion: '2.9.0',
+          dependentProjects: [],
+        }, // numeric preid
+      };
+
+      const result = extractProjectsPreidFromVersionData(versionData);
+
+      expect(result).toEqual({
+        'project-a': 'beta',
+        'project-b': 'pre-release',
+        'project-c': undefined, // numeric preids return undefined
+      });
+    });
+  });
+});

--- a/packages/nx/src/command-line/release/changelog/version-plan-filtering.ts
+++ b/packages/nx/src/command-line/release/changelog/version-plan-filtering.ts
@@ -1,0 +1,208 @@
+import { exec } from 'node:child_process';
+import { prerelease } from 'semver';
+import type { ChangelogOptions } from '../command-object';
+import type { NxReleaseConfig } from '../config/config';
+import { RawVersionPlan } from '../config/version-plans';
+import {
+  getCommitHash,
+  getFirstGitCommit,
+  getLatestGitTagForPattern,
+} from '../utils/git';
+import type { VersionData } from '../utils/shared';
+
+/**
+ * Filters version plans to only include those that were committed between the specified SHAs
+ * @param versionPlans The raw version plans to filter
+ * @param fromSHA The starting commit SHA (exclusive)
+ * @param toSHA The ending commit SHA (inclusive)
+ * @param isVerbose Whether to output verbose logging
+ * @returns The filtered version plans
+ */
+export async function filterVersionPlansByCommitRange(
+  versionPlans: RawVersionPlan[],
+  fromSHA: string,
+  toSHA: string,
+  isVerbose: boolean
+): Promise<RawVersionPlan[]> {
+  const filteredPlans: RawVersionPlan[] = [];
+
+  for (const plan of versionPlans) {
+    const isInRange = await isVersionPlanInCommitRange(
+      plan,
+      fromSHA,
+      toSHA,
+      isVerbose
+    );
+    if (isInRange) {
+      filteredPlans.push(plan);
+    } else if (isVerbose) {
+      console.log(
+        `Filtering out version plan '${plan.fileName}' as it was not committed in the range ${fromSHA}..${toSHA}`
+      );
+    }
+  }
+
+  if (isVerbose) {
+    console.log(
+      `Filtered ${versionPlans.length} version plans down to ${filteredPlans.length} based on commit range`
+    );
+  }
+
+  return filteredPlans;
+}
+
+/**
+ * Checks if a version plan file was added in the commit range
+ * @param versionPlan The version plan to check
+ * @param fromSHA The starting commit SHA (exclusive)
+ * @param toSHA The ending commit SHA (inclusive)
+ * @param isVerbose Whether to output verbose logging
+ * @returns True if the version plan was added in the commit range
+ */
+async function isVersionPlanInCommitRange(
+  versionPlan: RawVersionPlan,
+  fromSHA: string,
+  toSHA: string,
+  isVerbose: boolean
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    // Use git log to check if the file was added (A) in the commit range
+    const command = `git log ${fromSHA}..${toSHA} --diff-filter=A --pretty=format:"%H" -- ${versionPlan.absolutePath}`;
+
+    exec(
+      command,
+      {
+        windowsHide: false,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          if (isVerbose) {
+            console.error(
+              `Error checking commit range for ${versionPlan.relativePath}: ${error.message}`
+            );
+          }
+          // If there's an error, we'll include the plan to be safe
+          return resolve(true);
+        }
+        if (stderr && isVerbose) {
+          console.error(
+            `Git command stderr for ${versionPlan.relativePath}: ${stderr}`
+          );
+        }
+
+        // If stdout has content, the file was added in the range
+        const hasCommit = stdout.trim().length > 0;
+        if (isVerbose && hasCommit) {
+          console.log(
+            `Version plan '${versionPlan.fileName}' was added in commit range`
+          );
+        }
+        resolve(hasCommit);
+      }
+    );
+  });
+}
+
+/**
+ * Resolves the "from SHA" for changelog purposes.
+ * This determines the starting point for changelog generation and optional version plan filtering.
+ */
+export async function resolveChangelogFromSHA({
+  fromRef,
+  tagPattern,
+  tagPatternValues,
+  checkAllBranchesWhen,
+  preid,
+  requireSemver,
+  strictPreid,
+  useAutomaticFromRef,
+}: {
+  fromRef?: string;
+  tagPattern: string;
+  tagPatternValues: Record<string, string>;
+  checkAllBranchesWhen: boolean | string[];
+  preid?: string;
+  requireSemver: boolean;
+  strictPreid: boolean;
+  useAutomaticFromRef: boolean;
+}): Promise<string | null> {
+  // If user provided a from ref, resolve it to a SHA
+  if (fromRef) {
+    return await getCommitHash(fromRef);
+  }
+  // Otherwise, try to resolve it from the latest tag
+  const latestTag = await getLatestGitTagForPattern(
+    tagPattern,
+    tagPatternValues,
+    {
+      checkAllBranchesWhen,
+      preid,
+      requireSemver,
+      strictPreid,
+    }
+  );
+  if (latestTag?.tag) {
+    return await getCommitHash(latestTag.tag);
+  }
+  // Finally, if automatic from ref is enabled, use the first commit as a fallback
+  if (useAutomaticFromRef) {
+    return await getFirstGitCommit();
+  }
+
+  return null;
+}
+
+/**
+ * Helper function for workspace-level "from SHA" resolution.
+ * Extracts preids and calls the generic resolver.
+ */
+export async function resolveWorkspaceChangelogFromSHA({
+  args,
+  nxReleaseConfig,
+  useAutomaticFromRef,
+}: {
+  args: ChangelogOptions;
+  nxReleaseConfig: NxReleaseConfig;
+  useAutomaticFromRef: boolean;
+}): Promise<string | null> {
+  const workspacePreid = extractPreidFromVersion(args.version);
+  const projectsPreid = extractProjectsPreidFromVersionData(args.versionData);
+
+  return resolveChangelogFromSHA({
+    fromRef: args.from,
+    tagPattern: nxReleaseConfig.releaseTag.pattern,
+    tagPatternValues: {},
+    checkAllBranchesWhen: nxReleaseConfig.releaseTag.checkAllBranchesWhen,
+    preid: workspacePreid ?? projectsPreid?.[Object.keys(projectsPreid)[0]],
+    requireSemver: nxReleaseConfig.releaseTag.requireSemver,
+    strictPreid: nxReleaseConfig.releaseTag.strictPreid,
+    useAutomaticFromRef,
+  });
+}
+
+export function extractPreidFromVersion(
+  version: string | null | undefined
+): string | undefined {
+  try {
+    const preid = prerelease(version)?.[0];
+    return typeof preid === 'string' ? preid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function extractProjectsPreidFromVersionData(
+  versionData: VersionData | undefined
+): Record<string, string | undefined> | undefined {
+  if (!versionData) {
+    return undefined;
+  }
+
+  const result: Record<string, string | undefined> = {};
+  for (const [project, data] of Object.entries(versionData)) {
+    if (data?.newVersion) {
+      result[project] = extractPreidFromVersion(data.newVersion);
+    }
+  }
+  return result;
+}

--- a/packages/nx/src/command-line/release/changelog/version-plan-utils.spec.ts
+++ b/packages/nx/src/command-line/release/changelog/version-plan-utils.spec.ts
@@ -1,0 +1,272 @@
+import { ReleaseType } from 'semver';
+import {
+  createChangesFromGroupVersionPlans,
+  createChangesFromProjectsVersionPlans,
+  extractVersionPlanMetadata,
+  versionPlanSemverReleaseTypeToChangelogType,
+} from './version-plan-utils';
+import { GroupVersionPlan, ProjectsVersionPlan } from '../config/version-plans';
+import { RawGitCommit } from '../utils/git';
+
+describe('version-plan-utils', () => {
+  describe('versionPlanSemverReleaseTypeToChangelogType', () => {
+    it('should map major and premajor to feat with breaking', () => {
+      expect(versionPlanSemverReleaseTypeToChangelogType('major')).toEqual({
+        type: 'feat',
+        isBreaking: true,
+      });
+      expect(versionPlanSemverReleaseTypeToChangelogType('premajor')).toEqual({
+        type: 'feat',
+        isBreaking: true,
+      });
+    });
+
+    it('should map minor and preminor to feat without breaking', () => {
+      expect(versionPlanSemverReleaseTypeToChangelogType('minor')).toEqual({
+        type: 'feat',
+        isBreaking: false,
+      });
+      expect(versionPlanSemverReleaseTypeToChangelogType('preminor')).toEqual({
+        type: 'feat',
+        isBreaking: false,
+      });
+    });
+
+    it('should map patch, prepatch, and prerelease to fix without breaking', () => {
+      expect(versionPlanSemverReleaseTypeToChangelogType('patch')).toEqual({
+        type: 'fix',
+        isBreaking: false,
+      });
+      expect(versionPlanSemverReleaseTypeToChangelogType('prepatch')).toEqual({
+        type: 'fix',
+        isBreaking: false,
+      });
+      expect(versionPlanSemverReleaseTypeToChangelogType('prerelease')).toEqual(
+        {
+          type: 'fix',
+          isBreaking: false,
+        }
+      );
+    });
+
+    it('should throw an error for invalid bump type', () => {
+      expect(() =>
+        versionPlanSemverReleaseTypeToChangelogType('invalid' as ReleaseType)
+      ).toThrow('Invalid semver bump type: invalid');
+    });
+  });
+
+  describe('extractVersionPlanMetadata', () => {
+    it('should return empty metadata for null commit', () => {
+      expect(extractVersionPlanMetadata(null)).toEqual({
+        githubReferences: [],
+        authors: undefined,
+      });
+    });
+
+    it('should extract metadata from valid commit', () => {
+      const mockCommit: RawGitCommit = {
+        message: 'fix: some fix (#123)',
+        body: 'Co-authored-by: John Doe <john@example.com>',
+        shortHash: 'abc123',
+        author: {
+          name: 'Jane Doe',
+          email: 'jane@example.com',
+        },
+      };
+      const result = extractVersionPlanMetadata(mockCommit);
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "authors": [
+            {
+              "email": "jane@example.com",
+              "name": "Jane Doe",
+            },
+            {
+              "email": "john@example.com",
+              "name": "John Doe",
+            },
+          ],
+          "githubReferences": [
+            {
+              "type": "pull-request",
+              "value": "#123",
+            },
+            {
+              "type": "hash",
+              "value": "abc123",
+            },
+          ],
+        }
+      `);
+    });
+  });
+
+  describe('createChangesFromGroupVersionPlans', () => {
+    it('should create changes for group version plans without triggered projects', () => {
+      const versionPlans: GroupVersionPlan[] = [
+        {
+          groupVersionBump: 'minor',
+          message: 'New feature added',
+          commit: null,
+          triggeredByProjects: undefined,
+          fileName: 'version-plan-1.md',
+          createdOnMs: 123456789,
+          absolutePath: '/path/to/version-plan-1.md',
+          relativePath: '.nx/version-plans/version-plan-1.md',
+        },
+      ];
+
+      const changes = createChangesFromGroupVersionPlans(versionPlans);
+
+      expect(changes).toHaveLength(1);
+      expect(changes[0]).toEqual({
+        type: 'feat',
+        scope: '',
+        description: 'New feature added',
+        body: '',
+        isBreaking: false,
+        githubReferences: [],
+        authors: undefined,
+        affectedProjects: '*',
+      });
+    });
+
+    it('should create changes for group version plans with triggered projects', () => {
+      const versionPlans: GroupVersionPlan[] = [
+        {
+          groupVersionBump: 'major',
+          message: 'Breaking change',
+          commit: null,
+          triggeredByProjects: ['proj1', 'proj2'],
+          fileName: 'version-plan-2.md',
+          createdOnMs: 123456789,
+          absolutePath: '/path/to/version-plan-2.md',
+          relativePath: '.nx/version-plans/version-plan-2.md',
+        },
+      ];
+
+      const changes = createChangesFromGroupVersionPlans(versionPlans);
+
+      expect(changes).toHaveLength(2);
+      expect(changes[0]).toEqual({
+        type: 'feat',
+        scope: 'proj1',
+        description: 'Breaking change',
+        body: '',
+        isBreaking: true,
+        githubReferences: [],
+        authors: undefined,
+        affectedProjects: ['proj1'],
+      });
+      expect(changes[1]).toEqual({
+        type: 'feat',
+        scope: 'proj2',
+        description: 'Breaking change',
+        body: '',
+        isBreaking: true,
+        githubReferences: [],
+        authors: undefined,
+        affectedProjects: ['proj2'],
+      });
+    });
+  });
+
+  describe('createChangesFromProjectsVersionPlans', () => {
+    it('should create changes for project version plans', () => {
+      const versionPlans: ProjectsVersionPlan[] = [
+        {
+          projectVersionBumps: {
+            'my-project': 'patch',
+            'other-project': 'minor',
+          },
+          message: 'Fix bug in my-project',
+          commit: null,
+          fileName: 'version-plan-3.md',
+          createdOnMs: 123456789,
+          absolutePath: '/path/to/version-plan-3.md',
+          relativePath: '.nx/version-plans/version-plan-3.md',
+        },
+      ];
+
+      const changes = createChangesFromProjectsVersionPlans(
+        versionPlans,
+        'my-project'
+      );
+
+      expect(changes).toHaveLength(1);
+      expect(changes[0]).toEqual({
+        type: 'fix',
+        scope: 'my-project',
+        description: 'Fix bug in my-project',
+        body: '',
+        isBreaking: false,
+        affectedProjects: ['my-project', 'other-project'],
+        githubReferences: [],
+        authors: undefined,
+      });
+    });
+
+    it('should filter out version plans that do not affect the specified project', () => {
+      const versionPlans: ProjectsVersionPlan[] = [
+        {
+          projectVersionBumps: {
+            'other-project': 'minor',
+          },
+          message: 'Update other project',
+          commit: null,
+          fileName: 'version-plan-4.md',
+          createdOnMs: 123456789,
+          absolutePath: '/path/to/version-plan-4.md',
+          relativePath: '.nx/version-plans/version-plan-4.md',
+        },
+      ];
+
+      const changes = createChangesFromProjectsVersionPlans(
+        versionPlans,
+        'my-project'
+      );
+
+      expect(changes).toHaveLength(0);
+    });
+
+    it('should handle multiple version plans affecting the same project', () => {
+      const versionPlans: ProjectsVersionPlan[] = [
+        {
+          projectVersionBumps: {
+            'my-project': 'patch',
+          },
+          message: 'Fix bug',
+          commit: null,
+          fileName: 'version-plan-5.md',
+          createdOnMs: 123456789,
+          absolutePath: '/path/to/version-plan-5.md',
+          relativePath: '.nx/version-plans/version-plan-5.md',
+        },
+        {
+          projectVersionBumps: {
+            'my-project': 'minor',
+            'another-project': 'patch',
+          },
+          message: 'Add feature',
+          commit: null,
+          fileName: 'version-plan-6.md',
+          createdOnMs: 123456790,
+          absolutePath: '/path/to/version-plan-6.md',
+          relativePath: '.nx/version-plans/version-plan-6.md',
+        },
+      ];
+
+      const changes = createChangesFromProjectsVersionPlans(
+        versionPlans,
+        'my-project'
+      );
+
+      expect(changes).toHaveLength(2);
+      expect(changes[0].description).toBe('Fix bug');
+      expect(changes[0].type).toBe('fix');
+      expect(changes[1].description).toBe('Add feature');
+      expect(changes[1].type).toBe('feat');
+    });
+  });
+});

--- a/packages/nx/src/command-line/release/changelog/version-plan-utils.ts
+++ b/packages/nx/src/command-line/release/changelog/version-plan-utils.ts
@@ -1,0 +1,129 @@
+import { ReleaseType } from 'semver';
+import { GroupVersionPlan, ProjectsVersionPlan } from '../config/version-plans';
+import { RawGitCommit, parseVersionPlanCommit, Reference } from '../utils/git';
+
+export interface ChangelogChange {
+  type: string;
+  scope: string;
+  description: string;
+  affectedProjects: string[] | '*';
+  body?: string;
+  isBreaking?: boolean;
+  githubReferences?: Reference[];
+  authors?: { name: string; email: string }[];
+  shortHash?: string;
+  revertedHashes?: string[];
+}
+
+export function createChangesFromGroupVersionPlans(
+  versionPlans: GroupVersionPlan[]
+): ChangelogChange[] {
+  return versionPlans
+    .flatMap((vp) => {
+      const releaseType = versionPlanSemverReleaseTypeToChangelogType(
+        vp.groupVersionBump
+      );
+      const { githubReferences, authors } = extractVersionPlanMetadata(
+        vp.commit
+      );
+
+      const changes: ChangelogChange[] = !vp.triggeredByProjects
+        ? [
+            {
+              type: releaseType.type,
+              scope: '',
+              description: vp.message,
+              body: '',
+              isBreaking: releaseType.isBreaking,
+              githubReferences,
+              authors,
+              affectedProjects: '*',
+            },
+          ]
+        : vp.triggeredByProjects.map((project) => {
+            return {
+              type: releaseType.type,
+              scope: project,
+              description: vp.message,
+              body: '',
+              isBreaking: releaseType.isBreaking,
+              githubReferences,
+              authors,
+              affectedProjects: [project],
+            };
+          });
+      return changes;
+    })
+    .filter(Boolean);
+}
+
+export function createChangesFromProjectsVersionPlans(
+  versionPlans: ProjectsVersionPlan[],
+  projectName: string
+): ChangelogChange[] {
+  return versionPlans
+    .map((vp) => {
+      const bumpForProject = vp.projectVersionBumps[projectName];
+      if (!bumpForProject) {
+        return null;
+      }
+      const releaseType =
+        versionPlanSemverReleaseTypeToChangelogType(bumpForProject);
+      const { githubReferences, authors } = extractVersionPlanMetadata(
+        vp.commit
+      );
+
+      return {
+        type: releaseType.type,
+        scope: projectName,
+        description: vp.message,
+        body: '',
+        isBreaking: releaseType.isBreaking,
+        affectedProjects: Object.keys(vp.projectVersionBumps),
+        githubReferences,
+        authors,
+      } as ChangelogChange;
+    })
+    .filter(Boolean);
+}
+
+export function extractVersionPlanMetadata(commit: RawGitCommit | null): {
+  githubReferences: Reference[];
+  authors: { name: string; email: string }[] | undefined;
+} {
+  if (!commit) {
+    return { githubReferences: [], authors: undefined };
+  }
+
+  const parsedCommit = parseVersionPlanCommit(commit);
+  if (!parsedCommit) {
+    return { githubReferences: [], authors: undefined };
+  }
+
+  return {
+    githubReferences: parsedCommit.references,
+    authors: parsedCommit.authors,
+  };
+}
+
+export function versionPlanSemverReleaseTypeToChangelogType(
+  bump: ReleaseType
+): {
+  type: 'fix' | 'feat';
+  isBreaking: boolean;
+} {
+  switch (bump) {
+    case 'premajor':
+    case 'major':
+      return { type: 'feat', isBreaking: true };
+    case 'preminor':
+    case 'minor':
+      return { type: 'feat', isBreaking: false };
+    case 'prerelease':
+    case 'prepatch':
+    case 'patch':
+      return { type: 'fix', isBreaking: false };
+    default:
+      throw new Error(`Invalid semver bump type: ${bump}`);
+  }
+}

--- a/packages/nx/src/command-line/release/command-object.ts
+++ b/packages/nx/src/command-line/release/command-object.ts
@@ -68,6 +68,7 @@ export type ChangelogOptions = NxReleaseArgs &
     from?: string;
     interactive?: string;
     createRelease?: false | 'github' | 'gitlab';
+    resolveVersionPlans?: 'all' | 'using-from-and-to';
     replaceExistingContents?: boolean;
     // This will only be set if using the `nx release` top level command, or orchestrating via the programmatic API
     releaseGraph?: ReleaseGraph;
@@ -324,6 +325,13 @@ const changelogCommand: CommandModule<NxReleaseArgs, ChangelogOptions> = {
             description:
               'Whether to overwrite the existing changelog contents instead of prepending to them.',
             default: false,
+          })
+          .option('resolve-version-plans', {
+            type: 'string',
+            description:
+              'How to resolve version plans for changelog generation, defaults to resolving all version plan files available on disk.',
+            choices: ['all', 'using-from-and-to'],
+            default: 'all',
           })
           .check((argv) => {
             if (!argv.version) {

--- a/packages/nx/src/command-line/release/utils/shared.ts
+++ b/packages/nx/src/command-line/release/utils/shared.ts
@@ -1,11 +1,10 @@
 import * as chalk from 'chalk';
 import { prerelease } from 'semver';
-import { extname } from 'path';
 import { ProjectGraph } from '../../../config/project-graph';
-import { interpolate } from '../../../tasks-runner/utils';
-import { output } from '../../../utils/output';
 import { filterAffected } from '../../../project-graph/affected/affected-project-graph';
 import { WholeFileChange } from '../../../project-graph/file-utils';
+import { interpolate } from '../../../tasks-runner/utils';
+import { output } from '../../../utils/output';
 import type { ReleaseGroupWithName } from '../config/filter-release-groups';
 import { GitCommit, gitAdd, gitCommit } from './git';
 


### PR DESCRIPTION
## Current Behavior

Version plan filtering is not available for changelog generation, all version plans on disk are always included regardless of when they were added.

## Expected Behavior

- `--resolve-version-plans` flag with options `all` (default) or `using-from-and-to` to control which version plans
are included in changelog generation
- When set to `using-from-and-to`, only version plans added within the resolved already resolved commit range (influenceable with the existing `--from` and `--to` arguments) are considered

This allows more precise control over changelog generation, particularly useful when recreating historical releases or working with specific commit ranges and not needing to worry about cleaning up used version plan files immediately.

Additionally, this PR refactors some of the internals of the changelog implementation to make it easier to follow and adds a lot of unit tests for existing subsections of functionality