### PR TITLE
fix(vitest): do not fail when cleanedAngularVersion is of incorrect type

### DIFF
--- a/packages/vitest/src/generators/configuration/configuration.ts
+++ b/packages/vitest/src/generators/configuration/configuration.ts
@@ -419,6 +419,11 @@ function isAngularV20(tree: Tree) {
   const cleanedAngularVersion =
     clean(angularVersion) ?? coerce(angularVersion).version;
 
+  if (typeof cleanedAngularVersion !== 'string') {
+    // assume the latest version will be installed,
+    return true;
+  }
+
   return major(cleanedAngularVersion) >= 20;
 }
 


### PR DESCRIPTION
## Current Behavior
There may be a scenario when `cleanedAngularVersion` is of type `object` rather than `string` which proceeds to error when passed to `semver.major()`.

## Expected Behavior
If `cleanedAngularVersion` is not `string`, assume the latest version will be installed. Similar to how no found angular version is handled.

## Related Issue(s)

Fixes #33347
