### PR TITLE
fix(js): remove redundant typescript project references

### DIFF
--- a/packages/js/migrations.json
+++ b/packages/js/migrations.json
@@ -9,6 +9,11 @@
       "version": "22.0.0-beta.0",
       "description": "Remove the deprecated `external` and `externalBuildTargets` options from the `@nx/js:swc` and `@nx/js:tsc` executors.",
       "factory": "./src/migrations/update-22-0-0/remove-external-options-from-js-executors"
+    },
+    "remove-redundant-ts-project-references": {
+      "version": "22.1.0-beta.8",
+      "description": "Removes redundant TypeScript project references from project's tsconfig.json files when runtime tsconfig files (e.g., tsconfig.lib.json, tsconfig.app.json) exist.",
+      "factory": "./src/migrations/update-22-1-0/remove-redundant-ts-project-references"
     }
   },
   "packageJsonUpdates": {

--- a/packages/js/src/generators/typescript-sync/typescript-sync.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.ts
@@ -241,6 +241,7 @@ export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
       collectedDependencies
     );
 
+    let foundRuntimeTsConfig = false;
     for (const runtimeTsConfigFileName of runtimeTsConfigFileNames) {
       const runtimeTsConfigPath = joinPathFragments(
         sourceProjectNode.data.root,
@@ -249,6 +250,8 @@ export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
       if (!tsconfigExists(tree, tsconfigInfoCaches, runtimeTsConfigPath)) {
         continue;
       }
+
+      foundRuntimeTsConfig = true;
 
       // Update project references for the runtime tsconfig
       updateTsConfigReferences(
@@ -265,13 +268,15 @@ export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
       );
     }
 
-    // Update project references for the tsconfig.json file
     updateTsConfigReferences(
       tree,
       tsSysFromTree,
       tsconfigInfoCaches,
       sourceProjectTsconfigPath,
-      dependencies,
+      // If we find a runtime tsconfig file, we make sure the external
+      // dependencies are emptied from the tsconfig.json file instead,
+      // otherwise we update the project references for the tsconfig.json file
+      foundRuntimeTsConfig ? [] : dependencies,
       sourceProjectNode.data.root,
       projectRoots,
       changedFiles

--- a/packages/js/src/migrations/update-22-1-0/remove-redundant-ts-project-references.md
+++ b/packages/js/src/migrations/update-22-1-0/remove-redundant-ts-project-references.md
@@ -1,0 +1,158 @@
+#### Removes Redundant TypeScript Project References from tsconfig.json Files
+
+Removes redundant TypeScript project references from `tsconfig.json` files when runtime tsconfig files (e.g., `tsconfig.lib.json`, `tsconfig.app.json`) exist. Previously, external project references were duplicated in both the project's `tsconfig.json` and runtime tsconfig files. This migration syncs the TypeScript project references to match the project graph, ensuring that external references only appear in runtime tsconfig files when they exist.
+
+#### Examples
+
+When a project has runtime tsconfig files like `tsconfig.lib.json`, the migration will remove external project references from the project's `tsconfig.json` file:
+
+{% tabs %}
+{% tab label="Before" %}
+
+```json {% fileName="libs/my-lib/tsconfig.json" highlightLines=["6-8"] %}
+{
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "../other-lib"
+    }
+  ]
+}
+```
+
+{% /tab %}
+
+{% tab label="After" %}
+
+```json {% fileName="libs/my-lib/tsconfig.json" %}
+{
+  "compilerOptions": {
+    "composite": true
+  }
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
+The external references remain in the runtime tsconfig file where they belong:
+
+{% tabs %}
+{% tab label="Before" %}
+
+```json {% fileName="libs/my-lib/tsconfig.lib.json" highlightLines=["6-8"] %}
+{
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "../other-lib/tsconfig.lib.json"
+    }
+  ]
+}
+```
+
+{% /tab %}
+
+{% tab label="After" %}
+
+```json {% fileName="libs/my-lib/tsconfig.lib.json" highlightLines=["6-8"] %}
+{
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "../other-lib/tsconfig.lib.json"
+    }
+  ]
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
+For projects without runtime tsconfig files, the project's `tsconfig.json` file will continue to contain external project references:
+
+{% tabs %}
+{% tab label="Before" %}
+
+```json {% fileName="libs/legacy-lib/tsconfig.json" highlightLines=["6-8"] %}
+{
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "../other-lib"
+    }
+  ]
+}
+```
+
+{% /tab %}
+
+{% tab label="After" %}
+
+```json {% fileName="libs/legacy-lib/tsconfig.json" highlightLines=["6-8"] %}
+{
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "../other-lib"
+    }
+  ]
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
+Internal project references (references within the same project directory) are preserved in the project's `tsconfig.json`:
+
+{% tabs %}
+{% tab label="Before" %}
+
+```json {% fileName="libs/my-lib/tsconfig.json" highlightLines=["6-11"] %}
+{
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}
+```
+
+{% /tab %}
+
+{% tab label="After" %}
+
+```json {% fileName="libs/my-lib/tsconfig.json" highlightLines=["6-11"] %}
+{
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}
+```
+
+{% /tab %}
+{% /tabs %}

--- a/packages/js/src/migrations/update-22-1-0/remove-redundant-ts-project-references.md
+++ b/packages/js/src/migrations/update-22-1-0/remove-redundant-ts-project-references.md
@@ -6,10 +6,10 @@ Removes redundant TypeScript project references from `tsconfig.json` files when 
 
 When a project has runtime tsconfig files like `tsconfig.lib.json`, the migration will remove external project references from the project's `tsconfig.json` file:
 
-{% tabs %}
-{% tab label="Before" %}
+##### Before
 
-```json {% fileName="libs/my-lib/tsconfig.json" highlightLines=["6-8"] %}
+```jsonc {7-9}
+// libs/my-lib/tsconfig.json
 {
   "compilerOptions": {
     "composite": true
@@ -22,27 +22,24 @@ When a project has runtime tsconfig files like `tsconfig.lib.json`, the migratio
 }
 ```
 
-{% /tab %}
+##### After
 
-{% tab label="After" %}
-
-```json {% fileName="libs/my-lib/tsconfig.json" %}
+```jsonc {6}
+// libs/my-lib/tsconfig.json
 {
   "compilerOptions": {
     "composite": true
-  }
+  },
+  "references": []
 }
 ```
-
-{% /tab %}
-{% /tabs %}
 
 The external references remain in the runtime tsconfig file where they belong:
 
-{% tabs %}
-{% tab label="Before" %}
+##### Before
 
-```json {% fileName="libs/my-lib/tsconfig.lib.json" highlightLines=["6-8"] %}
+```jsonc {7-9}
+// libs/my-lib/tsconfig.lib.json
 {
   "compilerOptions": {
     "composite": true
@@ -55,11 +52,10 @@ The external references remain in the runtime tsconfig file where they belong:
 }
 ```
 
-{% /tab %}
+##### After
 
-{% tab label="After" %}
-
-```json {% fileName="libs/my-lib/tsconfig.lib.json" highlightLines=["6-8"] %}
+```jsonc {7-9}
+// libs/my-lib/tsconfig.lib.json
 {
   "compilerOptions": {
     "composite": true
@@ -71,16 +67,13 @@ The external references remain in the runtime tsconfig file where they belong:
   ]
 }
 ```
-
-{% /tab %}
-{% /tabs %}
 
 For projects without runtime tsconfig files, the project's `tsconfig.json` file will continue to contain external project references:
 
-{% tabs %}
-{% tab label="Before" %}
+##### Before
 
-```json {% fileName="libs/legacy-lib/tsconfig.json" highlightLines=["6-8"] %}
+```jsonc {7-9}
+// libs/legacy-lib/tsconfig.json
 {
   "compilerOptions": {
     "composite": true
@@ -93,11 +86,10 @@ For projects without runtime tsconfig files, the project's `tsconfig.json` file 
 }
 ```
 
-{% /tab %}
+##### After
 
-{% tab label="After" %}
-
-```json {% fileName="libs/legacy-lib/tsconfig.json" highlightLines=["6-8"] %}
+```jsonc {7-9}
+// libs/legacy-lib/tsconfig.json
 {
   "compilerOptions": {
     "composite": true
@@ -109,16 +101,13 @@ For projects without runtime tsconfig files, the project's `tsconfig.json` file 
   ]
 }
 ```
-
-{% /tab %}
-{% /tabs %}
 
 Internal project references (references within the same project directory) are preserved in the project's `tsconfig.json`:
 
-{% tabs %}
-{% tab label="Before" %}
+##### Before
 
-```json {% fileName="libs/my-lib/tsconfig.json" highlightLines=["6-11"] %}
+```jsonc {7-12}
+// libs/my-lib/tsconfig.json
 {
   "compilerOptions": {
     "composite": true
@@ -134,11 +123,10 @@ Internal project references (references within the same project directory) are p
 }
 ```
 
-{% /tab %}
+##### After
 
-{% tab label="After" %}
-
-```json {% fileName="libs/my-lib/tsconfig.json" highlightLines=["6-11"] %}
+```jsonc {7-12}
+// libs/my-lib/tsconfig.json
 {
   "compilerOptions": {
     "composite": true
@@ -153,6 +141,3 @@ Internal project references (references within the same project directory) are p
   ]
 }
 ```
-
-{% /tab %}
-{% /tabs %}

--- a/packages/js/src/migrations/update-22-1-0/remove-redundant-ts-project-references.spec.ts
+++ b/packages/js/src/migrations/update-22-1-0/remove-redundant-ts-project-references.spec.ts
@@ -1,0 +1,296 @@
+import * as devkit from '@nx/devkit';
+import { readJson, writeJson, type ProjectGraph, type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './remove-redundant-ts-project-references';
+
+let projectGraph: ProjectGraph;
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual('@nx/devkit'),
+  createProjectGraphAsync: jest.fn(() => Promise.resolve(projectGraph)),
+  formatFiles: jest.fn(() => Promise.resolve()),
+}));
+
+describe('remove-redundant-ts-project-references migration', () => {
+  let tree: Tree;
+
+  function addProject(
+    name: string,
+    dependencies: string[] = [],
+    extraRuntimeTsConfigs: string[] = [],
+    root: string = `packages/${name}`
+  ) {
+    projectGraph.nodes[name] = {
+      name,
+      type: 'lib',
+      data: { root },
+    };
+    projectGraph.dependencies[name] = dependencies.map((dep) => ({
+      type: 'static',
+      source: name,
+      target: dep,
+    }));
+    writeJson(tree, `${root}/tsconfig.json`, {
+      compilerOptions: {
+        composite: true,
+      },
+    });
+    for (const runtimeTsConfigFileName of extraRuntimeTsConfigs) {
+      writeJson(tree, `${root}/${runtimeTsConfigFileName}`, {
+        compilerOptions: {
+          composite: true,
+        },
+      });
+    }
+    writeJson(tree, `${root}/package.json`, {
+      name: name,
+      version: '0.0.0',
+      dependencies: dependencies.reduce(
+        (acc, dep) => ({ ...acc, [dep]: '0.0.0' }),
+        {}
+      ),
+    });
+  }
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    projectGraph = {
+      nodes: {},
+      dependencies: {},
+    };
+
+    jest
+      .spyOn(devkit, 'formatFiles')
+      .mockImplementation(() => Promise.resolve());
+
+    writeJson(tree, 'nx.json', {
+      plugins: ['@nx/js/typescript'],
+    });
+
+    writeJson(tree, 'tsconfig.json', {
+      compilerOptions: {
+        composite: true,
+      },
+    });
+  });
+
+  it('should remove redundant references from tsconfig.json when tsconfig.lib.json exists', async () => {
+    // Setup: Two projects where lib2 depends on lib1
+    // lib1 has a tsconfig.lib.json (runtime tsconfig)
+    // Before migration, both tsconfig.json and tsconfig.lib.json have references
+    addProject('lib1', [], ['tsconfig.lib.json']);
+    addProject('lib2', ['lib1'], ['tsconfig.lib.json']);
+
+    // Simulate old behavior: both tsconfig.json and tsconfig.lib.json have references
+    writeJson(tree, 'packages/lib2/tsconfig.json', {
+      compilerOptions: {
+        composite: true,
+      },
+      references: [{ path: '../lib1' }],
+    });
+    writeJson(tree, 'packages/lib2/tsconfig.lib.json', {
+      compilerOptions: {
+        composite: true,
+      },
+      references: [{ path: '../lib1/tsconfig.lib.json' }],
+    });
+
+    await migration(tree);
+
+    // After migration: tsconfig.json should NOT have external references
+    const tsconfig = readJson(tree, 'packages/lib2/tsconfig.json');
+    expect(tsconfig.references).toEqual([]);
+
+    // tsconfig.lib.json should still have the references
+    const tsconfigLib = readJson(tree, 'packages/lib2/tsconfig.lib.json');
+    expect(tsconfigLib.references).toEqual([
+      { path: '../lib1/tsconfig.lib.json' },
+    ]);
+  });
+
+  it('should handle multiple runtime tsconfig files (tsconfig.lib.json and tsconfig.app.json)', async () => {
+    addProject('lib1', [], ['tsconfig.lib.json']);
+    addProject('app1', ['lib1'], ['tsconfig.lib.json', 'tsconfig.app.json']);
+
+    // Simulate old behavior
+    writeJson(tree, 'packages/app1/tsconfig.json', {
+      compilerOptions: {
+        composite: true,
+      },
+      references: [{ path: '../lib1' }],
+    });
+    writeJson(tree, 'packages/app1/tsconfig.lib.json', {
+      compilerOptions: {
+        composite: true,
+      },
+      references: [{ path: '../lib1/tsconfig.lib.json' }],
+    });
+    writeJson(tree, 'packages/app1/tsconfig.app.json', {
+      compilerOptions: {
+        composite: true,
+      },
+      references: [{ path: '../lib1/tsconfig.lib.json' }],
+    });
+
+    await migration(tree);
+
+    // tsconfig.json should NOT have external references
+    const tsconfig = readJson(tree, 'packages/app1/tsconfig.json');
+    expect(tsconfig.references).toEqual([]);
+
+    // Runtime tsconfigs should have references
+    const tsconfigLib = readJson(tree, 'packages/app1/tsconfig.lib.json');
+    expect(tsconfigLib.references).toBeDefined();
+    const tsconfigApp = readJson(tree, 'packages/app1/tsconfig.app.json');
+    expect(tsconfigApp.references).toBeDefined();
+  });
+
+  it('should handle projects with multiple dependencies', async () => {
+    addProject('lib1', [], ['tsconfig.lib.json']);
+    addProject('lib2', [], ['tsconfig.lib.json']);
+    addProject('lib3', ['lib1', 'lib2'], ['tsconfig.lib.json']);
+
+    // Simulate old behavior
+    writeJson(tree, 'packages/lib3/tsconfig.json', {
+      compilerOptions: {
+        composite: true,
+      },
+      references: [{ path: '../lib1' }, { path: '../lib2' }],
+    });
+    writeJson(tree, 'packages/lib3/tsconfig.lib.json', {
+      compilerOptions: {
+        composite: true,
+      },
+      references: [
+        { path: '../lib1/tsconfig.lib.json' },
+        { path: '../lib2/tsconfig.lib.json' },
+      ],
+    });
+
+    await migration(tree);
+
+    // tsconfig.json should NOT have external references
+    const tsconfig = readJson(tree, 'packages/lib3/tsconfig.json');
+    expect(tsconfig.references).toEqual([]);
+
+    // tsconfig.lib.json should have all references
+    const tsconfigLib = readJson(tree, 'packages/lib3/tsconfig.lib.json');
+    expect(tsconfigLib.references).toEqual([
+      { path: '../lib1/tsconfig.lib.json' },
+      { path: '../lib2/tsconfig.lib.json' },
+    ]);
+  });
+
+  it('should keep references in tsconfig.json when no runtime tsconfig exists', async () => {
+    // Projects without runtime tsconfigs should keep references in tsconfig.json
+    addProject('lib1');
+    addProject('lib2', ['lib1']);
+
+    await migration(tree);
+
+    // tsconfig.json should have references (legacy behavior)
+    const tsconfig = readJson(tree, 'packages/lib2/tsconfig.json');
+    expect(tsconfig.references).toEqual([{ path: '../lib1' }]);
+  });
+
+  it('should handle projects with no dependencies', async () => {
+    addProject('standalone-lib');
+
+    await migration(tree);
+
+    const tsconfig = readJson(tree, 'packages/standalone-lib/tsconfig.json');
+    expect(tsconfig.references).toBeUndefined();
+  });
+
+  it('should handle workspace with both types of projects', async () => {
+    // lib1: no runtime tsconfig
+    // lib2: has runtime tsconfig, depends on lib1
+    // lib3: no runtime tsconfig, depends on lib1
+    addProject('lib1');
+    addProject('lib2', ['lib1'], ['tsconfig.lib.json']);
+    addProject('lib3', ['lib1']);
+
+    // Simulate old behavior for lib2
+    writeJson(tree, 'packages/lib2/tsconfig.json', {
+      compilerOptions: {
+        composite: true,
+      },
+      references: [{ path: '../lib1' }],
+    });
+    writeJson(tree, 'packages/lib2/tsconfig.lib.json', {
+      compilerOptions: {
+        composite: true,
+      },
+      references: [{ path: '../lib1/tsconfig.json' }],
+    });
+
+    await migration(tree);
+
+    // lib1: should have no references (no dependencies)
+    const lib1Tsconfig = readJson(tree, 'packages/lib1/tsconfig.json');
+    expect(lib1Tsconfig.references).toBeUndefined();
+
+    // lib2: tsconfig.json should NOT have external references (has runtime tsconfig)
+    const lib2Tsconfig = readJson(tree, 'packages/lib2/tsconfig.json');
+    expect(lib2Tsconfig.references).toEqual([]);
+    const lib2TsconfigLib = readJson(tree, 'packages/lib2/tsconfig.lib.json');
+    expect(lib2TsconfigLib.references).toBeDefined();
+
+    // lib3: tsconfig.json SHOULD have references (no runtime tsconfig)
+    const lib3Tsconfig = readJson(tree, 'packages/lib3/tsconfig.json');
+    expect(lib3Tsconfig.references).toEqual([{ path: '../lib1' }]);
+  });
+
+  it('should not error when projects have no package.json dependencies', async () => {
+    addProject('lib1', [], ['tsconfig.lib.json']);
+    addProject('lib2', [], ['tsconfig.lib.json']);
+
+    // Manually remove dependencies from package.json
+    writeJson(tree, 'packages/lib2/package.json', {
+      name: 'lib2',
+      version: '0.0.0',
+    });
+
+    await expect(migration(tree)).resolves.not.toThrow();
+  });
+
+  it('should not error when tsconfig.json does not have composite: true', async () => {
+    addProject('lib1');
+    addProject('lib2', ['lib1'], ['tsconfig.lib.json']);
+
+    // Remove composite from lib1
+    writeJson(tree, 'packages/lib1/tsconfig.json', {
+      compilerOptions: {},
+    });
+
+    await expect(migration(tree)).resolves.not.toThrow();
+  });
+
+  it('should handle empty workspace', async () => {
+    // Just the root tsconfig
+    await expect(migration(tree)).resolves.not.toThrow();
+  });
+
+  it('should preserve internal project references', async () => {
+    addProject('lib1', [], ['tsconfig.lib.json', 'tsconfig.spec.json']);
+
+    // Add internal references (within same project)
+    writeJson(tree, 'packages/lib1/tsconfig.json', {
+      compilerOptions: {
+        composite: true,
+      },
+      references: [
+        { path: './tsconfig.lib.json' },
+        { path: './tsconfig.spec.json' },
+      ],
+    });
+
+    await migration(tree);
+
+    // Internal references should be preserved
+    const tsconfig = readJson(tree, 'packages/lib1/tsconfig.json');
+    expect(tsconfig.references).toEqual([
+      { path: './tsconfig.lib.json' },
+      { path: './tsconfig.spec.json' },
+    ]);
+  });
+});

--- a/packages/js/src/migrations/update-22-1-0/remove-redundant-ts-project-references.ts
+++ b/packages/js/src/migrations/update-22-1-0/remove-redundant-ts-project-references.ts
@@ -1,0 +1,6 @@
+import type { Tree } from '@nx/devkit';
+import { syncGenerator } from '../../generators/typescript-sync/typescript-sync';
+
+export default async function (tree: Tree) {
+  await syncGenerator(tree);
+}


### PR DESCRIPTION
## Current Behavior

The `@nx/js:typescript-sync` generator adds project dependencies as TypeScript project references to each project's `tsconfig.json` and runtime tsconfig file (e.g., `tsconfig.app.json`, `tsconfig.lib.json`, etc.). This is redundant since projects' `tsconfig.json` files already reference the runtime tsconfig file, which would reference the dependencies.

## Expected Behavior

The `@nx/js:typescript-sync` generator should add project dependencies as TypeScript project references to each project's runtime tsconfig file (e.g., `tsconfig.app.json`, `tsconfig.lib.json`, etc.). If the project only has a `tsconfig.json` file, it should add them to it.

We've observed some performance improvement with this change while running the `typecheck` tasks.