### PR TITLE
fix(release): changelog renderer should render commit title with breaking changes

### DIFF
--- a/packages/nx/release/changelog-renderer/index.spec.ts
+++ b/packages/nx/release/changelog-renderer/index.spec.ts
@@ -771,7 +771,8 @@ describe('ChangelogRenderer', () => {
 
           ### ⚠️  Breaking Changes
 
-          - **WebSocketSubject:** \`WebSocketSubject\` is no longer \`instanceof Subject\`. Check for \`instanceof WebSocketSubject\` instead. ([54f2f6ed1](https://example.com/example/example/commit/54f2f6ed1))
+          - **WebSocketSubject:** no longer extends \`Subject\`.  ([54f2f6ed1](https://example.com/example/example/commit/54f2f6ed1))
+            \`WebSocketSubject\` is no longer \`instanceof Subject\`. Check for \`instanceof WebSocketSubject\` instead.
 
           ### ❤️ Thank You
 
@@ -819,8 +820,8 @@ describe('ChangelogRenderer', () => {
 
           ### ⚠️  Breaking Changes
 
-          - **misc:** The \`--legacy-peer-deps\` behavior is no longer forced. ([#33014](https://example.com/example/example/pull/33014))
-
+          - **misc:** don't set legacy-peer-deps by default  ([#33014](https://example.com/example/example/pull/33014))
+            The \`--legacy-peer-deps\` behavior is no longer forced.
             If you need it, configure your package manager to enforce it.
 
           ### ❤️ Thank You
@@ -870,8 +871,8 @@ describe('ChangelogRenderer', () => {
 
           ### ⚠️  Breaking Changes
 
-          - **core:** First paragraph of explanation. ([#12345](https://example.com/example/example/pull/12345))
-
+          - **core:** major refactor  ([#12345](https://example.com/example/example/pull/12345))
+            First paragraph of explanation.
             Second paragraph with more details.
             Continued explanation.
 
@@ -1002,7 +1003,8 @@ A	packages/nx/src/migrations/update-22-0-0/consolidate-release-tag-config.ts
 
           ### ⚠️  Breaking Changes
 
-          - **release:** This is a breaking change in the preferred configuration structure. Existing configurations will continue to work through the migration period, but users should update to the new nested format. ([#12345](https://example.com/example/example/pull/12345))
+          - **release:** improve release configuration  ([#12345](https://example.com/example/example/pull/12345))
+            This is a breaking change in the preferred configuration structure. Existing configurations will continue to work through the migration period, but users should update to the new nested format.
 
           ### ❤️ Thank You
 

--- a/packages/nx/release/changelog-renderer/index.ts
+++ b/packages/nx/release/changelog-renderer/index.ts
@@ -422,6 +422,24 @@ export default class DefaultChangelogRenderer {
     if (change.scope) {
       breakingLine += `**${change.scope.trim()}:** `;
     }
+    // Ensure first line of the breaking change contains the commit title
+    if (change.description) {
+      breakingLine += `${change.description.trim()} `;
+    }
+
+    // Add PR/commit references
+    if (
+      this.remoteReleaseClient.getRemoteRepoData() &&
+      this.changelogRenderOptions.commitReferences &&
+      change.githubReferences
+    ) {
+      breakingLine += `${this.remoteReleaseClient.formatReferences(
+        change.githubReferences
+      )}`;
+    }
+
+    const indentation = '  ';
+    breakingLine += `\n${indentation}`;
 
     // Handle multi-line explanations
     let explanationText = explanation;
@@ -432,26 +450,14 @@ export default class DefaultChangelogRenderer {
 
     breakingLine += explanationText;
 
-    // Add PR/commit references
-    if (
-      this.remoteReleaseClient.getRemoteRepoData() &&
-      this.changelogRenderOptions.commitReferences &&
-      change.githubReferences
-    ) {
-      breakingLine += this.remoteReleaseClient.formatReferences(
-        change.githubReferences
-      );
-    }
-
     // Add extra lines with indentation (matching formatChange behavior)
     if (extraLines.length > 0) {
-      const indentation = '  ';
       const extraLinesStr = extraLines
         .filter((l) => l.trim().length > 0)
         .map((l) => `${indentation}${l}`)
         .join('\n');
       if (extraLinesStr) {
-        breakingLine += '\n\n' + extraLinesStr;
+        breakingLine += '\n' + extraLinesStr;
       }
     }
 


### PR DESCRIPTION
## Current Behavior
We do not render the commit title in the BC section of generated changelogs.

## Expected Behavior
We should render the commit title in the BC section of generated changelogs along with the Remote Release Client reference to the commit.

## Related Issue(s)

Closes NXC-3290

