### PR TITLE
chore(repo): bump to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
       - name: Install Rust
@@ -152,7 +152,7 @@ jobs:
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 24
           package-manager-cache: false
 
       - name: Set SHAs

--- a/.github/workflows/generate-embeddings.yml
+++ b/.github/workflows/generate-embeddings.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['20.19.0']
+        node-version: ['24']
 
     steps:
       - name: Checkout
@@ -19,7 +19,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: '20.19.0'
+          node-version: '24'
           package-manager-cache: false
 
       - name: Install pnpm

--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Use Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: '20.19.0'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Cache node_modules

--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 24
           package-manager-cache: false
 
       - name: Validate PR title

--- a/e2e/release/src/preserve-local-dependency-protocols.test.ts
+++ b/e2e/release/src/preserve-local-dependency-protocols.test.ts
@@ -67,6 +67,8 @@ describe('nx release preserve local dependency protocols', () => {
     previousPackageManager = process.env.SELECTED_PM;
     // This is the verdaccio instance that the e2e tests themselves are working from
     e2eRegistryUrl = execSync('npm config get registry').toString().trim();
+    // Ignore NPM warnings as to not affect snapshots
+    execSync('npm config set loglevel error');
   });
 
   afterEach(() => cleanupProject());

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 dotnet = "9"
 java = "24"
-node = "20"
+node = "24"
 rust = "1.90.0"
 bun = "1.3"

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -1291,12 +1291,10 @@ describe('TargetProjectLocator', () => {
 describe('isBuiltinModuleImport()', () => {
   const withExclusions = builtinModules
     .concat(
-      builtinModules
-        .filter((a) => true)
-        .map((s) =>
-          // Node 24 includes node:sea, node:sqlite, etc. that already prefixes with `node:`.
-          s.startsWith('node:') ? s : 'node:' + s
-        )
+      builtinModules.map((s) =>
+        // Node 24 includes node:sea, node:sqlite, etc. that already prefixes with `node:`.
+        s.startsWith('node:') ? s : 'node:' + s
+      )
     )
     .concat(['node:test', 'node:sqlite']);
 

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -1290,8 +1290,15 @@ describe('TargetProjectLocator', () => {
 
 describe('isBuiltinModuleImport()', () => {
   const withExclusions = builtinModules
-    .concat(builtinModules.filter((a) => true).map((s) => 'node:' + s))
-    .concat(['node:test', 'node:sqlite', 'node:test']);
+    .concat(
+      builtinModules
+        .filter((a) => true)
+        .map((s) =>
+          // Node 24 includes node:sea, node:sqlite, etc. that already prefixes with `node:`.
+          s.startsWith('node:') ? s : 'node:' + s
+        )
+    )
+    .concat(['node:test', 'node:sqlite']);
 
   it.each(withExclusions)(
     `should return true for %s builtin module`,


### PR DESCRIPTION
Update CI to Node 24. Note that the e2e-release changes are pulled from the original PR.

Note: There are changes to NPM 11 (Node 24) to make it run slower than NPM 10 (Node 20/22) for publish. (https://github.com/nrwl/nx/pull/31934)

e.g. https://github.com/npm/cli/releases/tag/v11.0.0-pre.1 (`Upon publishing, in order to apply a default "latest" dist tag, the command now retrieves all prior versions of the package.` which incurs more network cost)