### PR TITLE
fix(rspack): enable build mode for TypeScript checker in TS solution setups

### DIFF
--- a/packages/rspack/src/plugins/utils/apply-base-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.ts
@@ -291,9 +291,11 @@ function applyNxDependentConfig(
 
     // When using TS solution setup, enable build mode to generate declaration files
     // This prevents TS6305 errors when declaration files are expected but missing
-    // from module federation remote imports
+    // from module federation remote imports but disable emitting tsbuildinfo files
+    // so that tsc builds are not affected.
     if (isUsingTsSolution) {
       pluginConfig.typescript.build = true;
+      pluginConfig.typescript.mode = 'readonly';
     }
 
     plugins.push(new TsCheckerRspackPlugin(pluginConfig));


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
When using Nx React Module Federation with Rspack, running `nx run-many -t e2e` before `nx run-many -t typecheck`, it causes typecheck to fail.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`nx run-many -t typecheck` should succeed regardless of whether Rspack (via `nx preview`) was executed before it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/33445
