### PR TITLE
fix(core): resolve lockfile cache regression with keyMap state

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/lock-file.ts
+++ b/packages/nx/src/plugins/js/lock-file/lock-file.ts
@@ -74,7 +74,10 @@ export function getLockFileNodes(
   contents: string,
   lockFileHash: string,
   context: CreateNodesContextV2
-): Record<string, ProjectGraphExternalNode> {
+): {
+  nodes: Record<string, ProjectGraphExternalNode>;
+  keyMap: Map<string, any>;
+} {
   try {
     if (packageManager === 'yarn') {
       const packageJson = readJsonFile(
@@ -92,7 +95,8 @@ export function getLockFileNodes(
       const lockFilePath = getLockFilePath(packageManager);
       if (lockFilePath.endsWith(BUN_TEXT_LOCK_FILE)) {
         // Use new text-based parser
-        return getBunTextLockfileNodes(contents, lockFileHash);
+        const nodes = getBunTextLockfileNodes(contents, lockFileHash);
+        return { nodes, keyMap: new Map() };
       } else {
         // Fallback to yarn parser for binary format
         const packageJson = readJsonFile(
@@ -120,25 +124,47 @@ export function getLockFileDependencies(
   packageManager: PackageManager,
   contents: string,
   lockFileHash: string,
-  context: CreateDependenciesContext
+  context: CreateDependenciesContext,
+  keyMap: Map<string, any>
 ): RawProjectGraphDependency[] {
   try {
     if (packageManager === 'yarn') {
-      return getYarnLockfileDependencies(contents, lockFileHash, context);
+      return getYarnLockfileDependencies(
+        contents,
+        lockFileHash,
+        context,
+        keyMap
+      );
     }
     if (packageManager === 'pnpm') {
-      return getPnpmLockfileDependencies(contents, lockFileHash, context);
+      return getPnpmLockfileDependencies(
+        contents,
+        lockFileHash,
+        context,
+        keyMap
+      );
     }
     if (packageManager === 'npm') {
-      return getNpmLockfileDependencies(contents, lockFileHash, context);
+      return getNpmLockfileDependencies(
+        contents,
+        lockFileHash,
+        context,
+        keyMap
+      );
     }
     if (packageManager === 'bun') {
       const lockFilePath = getLockFilePath(packageManager);
       if (lockFilePath.endsWith(BUN_TEXT_LOCK_FILE)) {
+        // Bun parser doesn't use keyMap
         return getBunTextLockfileDependencies(contents, lockFileHash, context);
       } else {
         // Fallback to yarn parser for binary format
-        return getYarnLockfileDependencies(contents, lockFileHash, context);
+        return getYarnLockfileDependencies(
+          contents,
+          lockFileHash,
+          context,
+          keyMap
+        );
       }
     }
   } catch (e) {

--- a/packages/nx/src/plugins/js/lock-file/npm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/npm-parser.spec.ts
@@ -33,7 +33,7 @@ describe('NPM lock file utility', () => {
 
     beforeEach(() => {
       const hash = uniq('mock-hash');
-      const externalNodes = getNpmLockfileNodes(
+      const { nodes: externalNodes, keyMap } = getNpmLockfileNodes(
         JSON.stringify(rootLockFile),
         hash
       );
@@ -59,7 +59,8 @@ describe('NPM lock file utility', () => {
       const dependencies = getNpmLockfileDependencies(
         JSON.stringify(rootLockFile),
         hash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(pg);
@@ -90,7 +91,7 @@ describe('NPM lock file utility', () => {
 
       // this is original generated lock file
       const hash = uniq('mock-hash');
-      const externalNodes = getNpmLockfileNodes(
+      const { nodes: externalNodes, keyMap } = getNpmLockfileNodes(
         JSON.stringify(appLockFile),
         hash
       );
@@ -116,7 +117,8 @@ describe('NPM lock file utility', () => {
       const dependencies = getNpmLockfileDependencies(
         JSON.stringify(appLockFile),
         hash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(pg);
@@ -175,7 +177,7 @@ describe('NPM lock file utility', () => {
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getNpmLockfileNodes(
+      const { nodes: externalNodes, keyMap } = getNpmLockfileNodes(
         JSON.stringify(rootLockFile),
         hash
       );
@@ -201,7 +203,8 @@ describe('NPM lock file utility', () => {
       const dependencies = getNpmLockfileDependencies(
         JSON.stringify(rootLockFile),
         hash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(pg);
@@ -271,7 +274,7 @@ describe('NPM lock file utility', () => {
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getNpmLockfileNodes(
+      const { nodes: externalNodes, keyMap } = getNpmLockfileNodes(
         JSON.stringify(rootV2LockFile),
         hash
       );
@@ -297,7 +300,8 @@ describe('NPM lock file utility', () => {
       const dependencies = getNpmLockfileDependencies(
         JSON.stringify(rootV2LockFile),
         hash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(pg);
@@ -407,7 +411,7 @@ describe('NPM lock file utility', () => {
       cleanupTypes(prunedV2LockFile.dependencies, true);
 
       const hash = uniq('mock-hash');
-      const externalNodes = getNpmLockfileNodes(
+      const { nodes: externalNodes, keyMap } = getNpmLockfileNodes(
         JSON.stringify(rootV2LockFile),
         hash
       );
@@ -433,7 +437,8 @@ describe('NPM lock file utility', () => {
       const dependencies = getNpmLockfileDependencies(
         JSON.stringify(rootV2LockFile),
         hash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(pg);
@@ -532,7 +537,7 @@ describe('NPM lock file utility', () => {
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getNpmLockfileNodes(
+      const { nodes: externalNodes, keyMap } = getNpmLockfileNodes(
         JSON.stringify(rootLockFile),
         hash
       );
@@ -558,7 +563,8 @@ describe('NPM lock file utility', () => {
       const dependencies = getNpmLockfileDependencies(
         JSON.stringify(rootLockFile),
         hash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(pg);
@@ -581,7 +587,7 @@ describe('NPM lock file utility', () => {
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getNpmLockfileNodes(
+      const { nodes: externalNodes, keyMap } = getNpmLockfileNodes(
         JSON.stringify(rootLockFile),
         hash
       );
@@ -607,7 +613,8 @@ describe('NPM lock file utility', () => {
       const dependencies = getNpmLockfileDependencies(
         JSON.stringify(rootLockFile),
         hash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(pg);
@@ -637,7 +644,10 @@ describe('NPM lock file utility', () => {
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getNpmLockfileNodes(JSON.stringify(lockFile), hash);
+      const { nodes: externalNodes, keyMap } = getNpmLockfileNodes(
+        JSON.stringify(lockFile),
+        hash
+      );
       const pg = {
         nodes: {},
         dependencies: {},
@@ -660,7 +670,8 @@ describe('NPM lock file utility', () => {
       const dependencies = getNpmLockfileDependencies(
         JSON.stringify(lockFile),
         hash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(pg);
@@ -698,7 +709,7 @@ describe('NPM lock file utility', () => {
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getNpmLockfileNodes(
+      const { nodes: externalNodes, keyMap } = getNpmLockfileNodes(
         JSON.stringify(rootLockFile),
         hash
       );
@@ -724,7 +735,8 @@ describe('NPM lock file utility', () => {
       const dependencies = getNpmLockfileDependencies(
         JSON.stringify(rootLockFile),
         hash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(pg);
@@ -764,7 +776,7 @@ describe('NPM lock file utility', () => {
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getNpmLockfileNodes(
+      const { nodes: externalNodes, keyMap } = getNpmLockfileNodes(
         JSON.stringify(rootLockFile),
         hash
       );
@@ -790,7 +802,8 @@ describe('NPM lock file utility', () => {
       const dependencies = getNpmLockfileDependencies(
         JSON.stringify(rootLockFile),
         hash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(pg);
@@ -841,7 +854,7 @@ describe('NPM lock file utility', () => {
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getNpmLockfileNodes(
+      const { nodes: externalNodes, keyMap } = getNpmLockfileNodes(
         JSON.stringify(rootLockFile),
         hash
       );
@@ -867,7 +880,8 @@ describe('NPM lock file utility', () => {
       const dependencies = getNpmLockfileDependencies(
         JSON.stringify(rootLockFile),
         hash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(pg);
@@ -910,7 +924,7 @@ describe('NPM lock file utility', () => {
         '__fixtures__/workspaces/package-lock.json'
       ));
 
-      const externalNodes = getNpmLockfileNodes(
+      const { nodes: externalNodes } = getNpmLockfileNodes(
         JSON.stringify(lockFile),
         uniq('mock-hash')
       );
@@ -923,7 +937,7 @@ describe('NPM lock file utility', () => {
         __dirname,
         '__fixtures__/workspaces/package-lock.v1.json'
       ));
-      const externalNodes = getNpmLockfileNodes(
+      const { nodes: externalNodes } = getNpmLockfileNodes(
         JSON.stringify(lockFile),
         uniq('mock')
       );
@@ -948,7 +962,7 @@ describe('NPM lock file utility', () => {
         '__fixtures__/mixed-keys/package.json'
       ));
 
-      const externalNodes = getNpmLockfileNodes(
+      const { nodes: externalNodes, keyMap } = getNpmLockfileNodes(
         JSON.stringify(lockFile),
         lockFileHash
       );
@@ -974,7 +988,8 @@ describe('NPM lock file utility', () => {
       const dependencies = getNpmLockfileDependencies(
         JSON.stringify(lockFile),
         lockFileHash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(graph);

--- a/packages/nx/src/plugins/js/lock-file/npm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/npm-parser.ts
@@ -56,9 +56,6 @@ type NpmLockFile = {
   packages?: Record<string, NpmDependencyV3>;
   dependencies?: Record<string, NpmDependencyV1>;
 };
-
-// we use key => node map to avoid duplicate work when parsing keys
-let keyMap = new Map<string, ProjectGraphExternalNode>();
 let currentLockFileHash: string;
 
 let parsedLockFile: NpmLockFile;
@@ -68,7 +65,6 @@ function parsePackageLockFile(lockFileContent: string, lockFileHash: string) {
     return parsedLockFile;
   }
 
-  keyMap.clear();
   const results = JSON.parse(lockFileContent) as NpmLockFile;
   parsedLockFile = results;
   currentLockFileHash = lockFileHash;
@@ -78,20 +74,23 @@ function parsePackageLockFile(lockFileContent: string, lockFileHash: string) {
 export function getNpmLockfileNodes(
   lockFileContent: string,
   lockFileHash: string
-) {
+): {
+  nodes: Record<string, ProjectGraphExternalNode>;
+  keyMap: Map<string, ProjectGraphExternalNode>;
+} {
   const data = parsePackageLockFile(
     lockFileContent,
     lockFileHash
   ) as NpmLockFile;
 
-  // we use key => node map to avoid duplicate work when parsing keys
-  return getNodes(data, keyMap);
+  return getNodes(data);
 }
 
 export function getNpmLockfileDependencies(
   lockFileContent: string,
   lockFileHash: string,
-  ctx: CreateDependenciesContext
+  ctx: CreateDependenciesContext,
+  keyMap: Map<string, ProjectGraphExternalNode>
 ) {
   const data = parsePackageLockFile(
     lockFileContent,
@@ -101,10 +100,11 @@ export function getNpmLockfileDependencies(
   return getDependencies(data, keyMap, ctx);
 }
 
-function getNodes(
-  data: NpmLockFile,
-  keyMap: Map<string, ProjectGraphExternalNode>
-) {
+function getNodes(data: NpmLockFile): {
+  nodes: Record<string, ProjectGraphExternalNode>;
+  keyMap: Map<string, ProjectGraphExternalNode>;
+} {
+  const keyMap = new Map<string, ProjectGraphExternalNode>();
   const nodes: Map<string, Map<string, ProjectGraphExternalNode>> = new Map();
 
   if (data.lockfileVersion > 1) {
@@ -164,7 +164,7 @@ function getNodes(
       results[node.name] = node;
     });
   }
-  return results;
+  return { nodes: results, keyMap };
 }
 
 function addV1Node(

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -4,7 +4,10 @@ import {
   getPnpmLockfileDependencies,
   stringifyPnpmLockfile,
 } from './pnpm-parser';
-import { ProjectGraph } from '../../../config/project-graph';
+import {
+  ProjectGraph,
+  type ProjectGraphExternalNode,
+} from '../../../config/project-graph';
 import { vol } from 'memfs';
 import { pruneProjectGraph } from './project-graph-pruning';
 import {
@@ -128,6 +131,7 @@ describe('pnpm LockFile utility', () => {
     });
 
     let externalNodes: ProjectGraph['externalNodes'];
+    let keyMap: Map<string, Set<ProjectGraphExternalNode>>;
     let dependencies: RawProjectGraphDependency[];
     let graph: ProjectGraph;
 
@@ -142,7 +146,9 @@ describe('pnpm LockFile utility', () => {
         )).default;
         lockFileHash = '__fixtures__/nextjs/pnpm-lock.yaml';
 
-        externalNodes = getPnpmLockfileNodes(lockFile, lockFileHash);
+        const result = getPnpmLockfileNodes(lockFile, lockFileHash);
+        externalNodes = result.nodes;
+        keyMap = result.keyMap;
         graph = {
           nodes: {},
           dependencies: {},
@@ -162,7 +168,12 @@ describe('pnpm LockFile utility', () => {
           nxJsonConfiguration: null,
           workspaceRoot: '/virtual',
         };
-        dependencies = getPnpmLockfileDependencies(lockFile, lockFileHash, ctx);
+        dependencies = getPnpmLockfileDependencies(
+          lockFile,
+          lockFileHash,
+          ctx,
+          keyMap
+        );
 
         const builder = new ProjectGraphBuilder(graph);
         for (const dep of dependencies) {
@@ -214,7 +225,9 @@ describe('pnpm LockFile utility', () => {
           '__fixtures__/nextjs/pnpm-lock-v6.yaml'
         )).default;
         lockFileHash = '__fixtures__/nextjs/pnpm-lock-v6.yaml';
-        externalNodes = getPnpmLockfileNodes(lockFile, lockFileHash);
+        const result = getPnpmLockfileNodes(lockFile, lockFileHash);
+        externalNodes = result.nodes;
+        keyMap = result.keyMap;
         graph = {
           nodes: {},
           dependencies: {},
@@ -234,7 +247,12 @@ describe('pnpm LockFile utility', () => {
           nxJsonConfiguration: null,
           workspaceRoot: '/virtual',
         };
-        dependencies = getPnpmLockfileDependencies(lockFile, lockFileHash, ctx);
+        dependencies = getPnpmLockfileDependencies(
+          lockFile,
+          lockFileHash,
+          ctx,
+          keyMap
+        );
 
         const builder = new ProjectGraphBuilder(graph);
         for (const dep of dependencies) {
@@ -264,7 +282,7 @@ describe('pnpm LockFile utility', () => {
         )).default;
         const appLockFileHash = '__fixtures__/nextjs/app/pnpm-lock-v6.yaml';
 
-        const externalNodes = getPnpmLockfileNodes(
+        const { nodes: externalNodes, keyMap } = getPnpmLockfileNodes(
           appLockFile,
           appLockFileHash
         );
@@ -290,7 +308,8 @@ describe('pnpm LockFile utility', () => {
         const dependencies = getPnpmLockfileDependencies(
           appLockFile,
           appLockFileHash,
-          appCtx
+          appCtx,
+          keyMap
         );
 
         const builder = new ProjectGraphBuilder(appGraph);
@@ -356,7 +375,10 @@ describe('pnpm LockFile utility', () => {
       )).default;
       const lockFileHash = '__fixtures__/auxiliary-packages/pnpm-lock.yaml';
 
-      const externalNodes = getPnpmLockfileNodes(lockFile, lockFileHash);
+      const { nodes: externalNodes, keyMap } = getPnpmLockfileNodes(
+        lockFile,
+        lockFileHash
+      );
       let graph: ProjectGraph = {
         nodes: {},
         dependencies: {},
@@ -379,7 +401,8 @@ describe('pnpm LockFile utility', () => {
       const dependencies = getPnpmLockfileDependencies(
         lockFile,
         lockFileHash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(graph);
@@ -473,7 +496,10 @@ describe('pnpm LockFile utility', () => {
         },
       };
 
-      const externalNodes = getPnpmLockfileNodes(lockFile, lockFileHash);
+      const { nodes: externalNodes, keyMap } = getPnpmLockfileNodes(
+        lockFile,
+        lockFileHash
+      );
       let graph: ProjectGraph = {
         nodes: {},
         dependencies: {},
@@ -496,7 +522,8 @@ describe('pnpm LockFile utility', () => {
       const dependencies = getPnpmLockfileDependencies(
         lockFile,
         lockFileHash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(graph);
@@ -548,7 +575,10 @@ describe('pnpm LockFile utility', () => {
       )).default;
       const lockFileHash = '__fixtures__/duplicate-package/pnpm-lock.yaml';
 
-      const externalNodes = getPnpmLockfileNodes(lockFile, lockFileHash);
+      const { nodes: externalNodes, keyMap } = getPnpmLockfileNodes(
+        lockFile,
+        lockFileHash
+      );
       let graph: ProjectGraph = {
         nodes: {},
         dependencies: {},
@@ -571,7 +601,8 @@ describe('pnpm LockFile utility', () => {
       const dependencies = getPnpmLockfileDependencies(
         lockFile,
         lockFileHash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(graph);
@@ -608,7 +639,10 @@ describe('pnpm LockFile utility', () => {
         '__fixtures__/optional/pnpm-lock.yaml'
       )).default;
       const lockFileHash = '__fixtures__/optional/pnpm-lock.yaml';
-      const externalNodes = getPnpmLockfileNodes(lockFile, lockFileHash);
+      const { nodes: externalNodes, keyMap } = getPnpmLockfileNodes(
+        lockFile,
+        lockFileHash
+      );
       let graph: ProjectGraph = {
         nodes: {},
         dependencies: {},
@@ -631,7 +665,8 @@ describe('pnpm LockFile utility', () => {
       const dependencies = getPnpmLockfileDependencies(
         lockFile,
         lockFileHash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(graph);
@@ -681,7 +716,10 @@ describe('pnpm LockFile utility', () => {
         )).default;
         lockFileHash = '__fixtures__/pruning/pnpm-lock.yaml';
 
-        const externalNodes = getPnpmLockfileNodes(lockFile, lockFileHash);
+        const { nodes: externalNodes, keyMap } = getPnpmLockfileNodes(
+          lockFile,
+          lockFileHash
+        );
         graph = {
           nodes: {},
           dependencies: {},
@@ -704,7 +742,8 @@ describe('pnpm LockFile utility', () => {
         const dependencies = getPnpmLockfileDependencies(
           lockFile,
           lockFileHash,
-          ctx
+          ctx,
+          keyMap
         );
 
         const builder = new ProjectGraphBuilder(graph);
@@ -782,7 +821,10 @@ describe('pnpm LockFile utility', () => {
         )).default;
         lockFileHash = '__fixtures__/pruning/pnpm-lock-v6.yaml';
 
-        const externalNodes = getPnpmLockfileNodes(lockFile, lockFileHash);
+        const { nodes: externalNodes, keyMap } = getPnpmLockfileNodes(
+          lockFile,
+          lockFileHash
+        );
         graph = {
           nodes: {},
           dependencies: {},
@@ -805,7 +847,8 @@ describe('pnpm LockFile utility', () => {
         const dependencies = getPnpmLockfileDependencies(
           lockFile,
           lockFileHash,
-          ctx
+          ctx,
+          keyMap
         );
 
         const builder = new ProjectGraphBuilder(graph);
@@ -883,7 +926,10 @@ describe('pnpm LockFile utility', () => {
         )).default;
         lockFileHash = '__fixtures__/pruning/pnpm-lock-v9.yaml';
 
-        const externalNodes = getPnpmLockfileNodes(lockFile, lockFileHash);
+        const { nodes: externalNodes, keyMap } = getPnpmLockfileNodes(
+          lockFile,
+          lockFileHash
+        );
         graph = {
           nodes: {},
           dependencies: {},
@@ -906,7 +952,8 @@ describe('pnpm LockFile utility', () => {
         const dependencies = getPnpmLockfileDependencies(
           lockFile,
           lockFileHash,
-          ctx
+          ctx,
+          keyMap
         );
 
         const builder = new ProjectGraphBuilder(graph);
@@ -998,7 +1045,10 @@ describe('pnpm LockFile utility', () => {
     });
 
     it('should parse lock file', async () => {
-      const externalNodes = getPnpmLockfileNodes(lockFile, lockFileHash);
+      const { nodes: externalNodes } = getPnpmLockfileNodes(
+        lockFile,
+        lockFileHash
+      );
       expect(Object.keys(externalNodes).length).toEqual(5);
     });
   });
@@ -1044,7 +1094,10 @@ describe('pnpm LockFile utility', () => {
         '__fixtures__/mixed-keys/package.json'
       ));
 
-      const externalNodes = getPnpmLockfileNodes(lockFile, lockFileHash);
+      const { nodes: externalNodes, keyMap } = getPnpmLockfileNodes(
+        lockFile,
+        lockFileHash
+      );
       let graph: ProjectGraph = {
         nodes: {},
         dependencies: {},
@@ -1067,7 +1120,8 @@ describe('pnpm LockFile utility', () => {
       const dependencies = getPnpmLockfileDependencies(
         lockFile,
         lockFileHash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(graph);
@@ -1297,7 +1351,10 @@ describe('pnpm LockFile utility', () => {
         '__fixtures__/mixed-keys/package.json'
       ));
 
-      const externalNodes = getPnpmLockfileNodes(lockFile, lockFileHash);
+      const { nodes: externalNodes, keyMap } = getPnpmLockfileNodes(
+        lockFile,
+        lockFileHash
+      );
       let graph: ProjectGraph = {
         nodes: {},
         dependencies: {},
@@ -1320,7 +1377,8 @@ describe('pnpm LockFile utility', () => {
       const dependencies = getPnpmLockfileDependencies(
         lockFile,
         lockFileHash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(graph);
@@ -1568,7 +1626,10 @@ describe('pnpm LockFile utility', () => {
         '__fixtures__/pnpm-regression/package.json'
       ));
 
-      const externalNodes = getPnpmLockfileNodes(lockFile, lockFileHash);
+      const { nodes: externalNodes, keyMap } = getPnpmLockfileNodes(
+        lockFile,
+        lockFileHash
+      );
       let graph: ProjectGraph = {
         nodes: {},
         dependencies: {},
@@ -1591,7 +1652,8 @@ describe('pnpm LockFile utility', () => {
       const dependencies = getPnpmLockfileDependencies(
         lockFile,
         lockFileHash,
-        ctx
+        ctx,
+        keyMap
       );
 
       const builder = new ProjectGraphBuilder(graph);

--- a/packages/nx/src/plugins/js/lock-file/yarn-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/yarn-parser.spec.ts
@@ -183,7 +183,11 @@ describe('yarn LockFile utility', () => {
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
       const pg = {
         nodes: {},
         dependencies: {},
@@ -203,7 +207,12 @@ describe('yarn LockFile utility', () => {
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
-      const dependencies = getYarnLockfileDependencies(lockFile, hash, ctx);
+      const dependencies = getYarnLockfileDependencies(
+        lockFile,
+        hash,
+        ctx,
+        keyMap
+      );
 
       const builder = new ProjectGraphBuilder(pg);
       for (const dep of dependencies) {
@@ -421,7 +430,7 @@ describe('yarn LockFile utility', () => {
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
         classicLockFile,
         hash,
         packageJson
@@ -507,7 +516,11 @@ describe('yarn LockFile utility', () => {
       )).default;
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
       const pg = {
         nodes: {},
         dependencies: {},
@@ -527,7 +540,12 @@ describe('yarn LockFile utility', () => {
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
-      const dependencies = getYarnLockfileDependencies(lockFile, hash, ctx);
+      const dependencies = getYarnLockfileDependencies(
+        lockFile,
+        hash,
+        ctx,
+        keyMap
+      );
 
       const builder = new ProjectGraphBuilder(pg);
       for (const dep of dependencies) {
@@ -576,7 +594,7 @@ describe('yarn LockFile utility', () => {
       )).default;
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
         lockFile,
         hash,
         normalizedPackageJson
@@ -600,7 +618,12 @@ describe('yarn LockFile utility', () => {
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
-      const dependencies = getYarnLockfileDependencies(lockFile, hash, ctx);
+      const dependencies = getYarnLockfileDependencies(
+        lockFile,
+        hash,
+        ctx,
+        keyMap
+      );
 
       const builder = new ProjectGraphBuilder(pg);
       for (const dep of dependencies) {
@@ -638,7 +661,7 @@ describe('yarn LockFile utility', () => {
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
         berryLockFile,
         hash,
         packageJson
@@ -725,7 +748,11 @@ describe('yarn LockFile utility', () => {
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
       const pg = {
         nodes: {},
         dependencies: {},
@@ -745,7 +772,12 @@ describe('yarn LockFile utility', () => {
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
-      const dependencies = getYarnLockfileDependencies(lockFile, hash, ctx);
+      const dependencies = getYarnLockfileDependencies(
+        lockFile,
+        hash,
+        ctx,
+        keyMap
+      );
 
       const builder = new ProjectGraphBuilder(pg);
       for (const dep of dependencies) {
@@ -808,7 +840,11 @@ __metadata:
         };
 
         const hash = uniq('mock-hash');
-        const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+        const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+          lockFile,
+          hash,
+          packageJson
+        );
         const pg = {
           nodes: {},
           dependencies: {},
@@ -828,7 +864,12 @@ __metadata:
           nxJsonConfiguration: null,
           workspaceRoot: '/virtual',
         };
-        const dependencies = getYarnLockfileDependencies(lockFile, hash, ctx);
+        const dependencies = getYarnLockfileDependencies(
+          lockFile,
+          hash,
+          ctx,
+          keyMap
+        );
 
         const builder = new ProjectGraphBuilder(pg);
         for (const dep of dependencies) {
@@ -903,7 +944,11 @@ __metadata:
         };
 
         const hash = uniq('mock-hash');
-        const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+        const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+          lockFile,
+          hash,
+          packageJson
+        );
 
         expect(externalNodes).toMatchInlineSnapshot(`
                   {
@@ -981,7 +1026,11 @@ __metadata:
         };
 
         const hash = uniq('mock-hash');
-        const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+        const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+          lockFile,
+          hash,
+          packageJson
+        );
         const pg = {
           nodes: {},
           dependencies: {},
@@ -1001,7 +1050,12 @@ __metadata:
           nxJsonConfiguration: null,
           workspaceRoot: '/virtual',
         };
-        const dependencies = getYarnLockfileDependencies(lockFile, hash, ctx);
+        const dependencies = getYarnLockfileDependencies(
+          lockFile,
+          hash,
+          ctx,
+          keyMap
+        );
         const builder = new ProjectGraphBuilder(pg);
         for (const dep of dependencies) {
           builder.addDependency(
@@ -1100,7 +1154,11 @@ postgres@charsleysa/postgres#fix-errors-compiled:
       };
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
 
       expect(externalNodes['npm:@nrwl/nx-cloud']).toMatchInlineSnapshot(`
         {
@@ -1170,7 +1228,11 @@ postgres@charsleysa/postgres#fix-errors-compiled:
       };
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
 
       expect(externalNodes['npm:@nrwl/nx-cloud']).toMatchInlineSnapshot(`
           {
@@ -1226,7 +1288,11 @@ nx-cloud@latest:
       };
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
 
       expect(externalNodes['npm:nx-cloud']).toMatchInlineSnapshot(`
           {
@@ -1254,7 +1320,7 @@ nx-cloud@latest:
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
         berryLockFile,
         hash,
         packageJson
@@ -1370,7 +1436,7 @@ nx-cloud@latest:
         '__fixtures__/duplicate-package/package.json'
       ));
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
         classicLockFile,
         hash,
         packageJson
@@ -1405,7 +1471,11 @@ nx-cloud@latest:
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
       const pg = {
         nodes: {},
         dependencies: {},
@@ -1425,7 +1495,12 @@ nx-cloud@latest:
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
-      const dependencies = getYarnLockfileDependencies(lockFile, hash, ctx);
+      const dependencies = getYarnLockfileDependencies(
+        lockFile,
+        hash,
+        ctx,
+        keyMap
+      );
 
       const builder = new ProjectGraphBuilder(pg);
       for (const dep of dependencies) {
@@ -1620,7 +1695,11 @@ nx-cloud@latest:
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
       const pg = {
         nodes: {},
         dependencies: {},
@@ -1640,7 +1719,12 @@ nx-cloud@latest:
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
-      const dependencies = getYarnLockfileDependencies(lockFile, hash, ctx);
+      const dependencies = getYarnLockfileDependencies(
+        lockFile,
+        hash,
+        ctx,
+        keyMap
+      );
 
       const builder = new ProjectGraphBuilder(pg);
       for (const dep of dependencies) {
@@ -1683,7 +1767,11 @@ nx-cloud@latest:
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
       const pg = {
         nodes: {},
         dependencies: {},
@@ -1703,7 +1791,12 @@ nx-cloud@latest:
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
-      const dependencies = getYarnLockfileDependencies(lockFile, hash, ctx);
+      const dependencies = getYarnLockfileDependencies(
+        lockFile,
+        hash,
+        ctx,
+        keyMap
+      );
 
       const builder = new ProjectGraphBuilder(pg);
       for (const dep of dependencies) {
@@ -1751,7 +1844,11 @@ nx-cloud@latest:
         '__fixtures__/workspaces/package.json'
       ));
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
 
       expect(Object.keys(externalNodes).length).toEqual(5);
     });
@@ -1766,7 +1863,11 @@ nx-cloud@latest:
         '__fixtures__/workspaces/package.json'
       ));
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
 
       expect(Object.keys(externalNodes).length).toEqual(5);
     });
@@ -1832,7 +1933,11 @@ type-fest@^0.20.2:
         },
       };
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
       const pg = {
         nodes: {},
         dependencies: {},
@@ -1852,7 +1957,12 @@ type-fest@^0.20.2:
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
-      const dependencies = getYarnLockfileDependencies(lockFile, hash, ctx);
+      const dependencies = getYarnLockfileDependencies(
+        lockFile,
+        hash,
+        ctx,
+        keyMap
+      );
 
       const builder = new ProjectGraphBuilder(pg);
       for (const dep of dependencies) {
@@ -1951,7 +2061,11 @@ __metadata:
       };
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
       const pg = {
         nodes: {},
         dependencies: {},
@@ -1971,7 +2085,12 @@ __metadata:
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
-      const dependencies = getYarnLockfileDependencies(lockFile, hash, ctx);
+      const dependencies = getYarnLockfileDependencies(
+        lockFile,
+        hash,
+        ctx,
+        keyMap
+      );
 
       const builder = new ProjectGraphBuilder(pg);
       for (const dep of dependencies) {
@@ -2080,7 +2199,11 @@ __metadata:
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
       const pg = {
         nodes: {},
         dependencies: {},
@@ -2100,7 +2223,12 @@ __metadata:
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
-      const dependencies = getYarnLockfileDependencies(lockFile, hash, ctx);
+      const dependencies = getYarnLockfileDependencies(
+        lockFile,
+        hash,
+        ctx,
+        keyMap
+      );
 
       const builder = new ProjectGraphBuilder(pg);
       for (const dep of dependencies) {
@@ -2323,7 +2451,11 @@ __metadata:
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
       const pg = {
         nodes: {},
         dependencies: {},
@@ -2343,7 +2475,12 @@ __metadata:
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
-      const dependencies = getYarnLockfileDependencies(lockFile, hash, ctx);
+      const dependencies = getYarnLockfileDependencies(
+        lockFile,
+        hash,
+        ctx,
+        keyMap
+      );
 
       const builder = new ProjectGraphBuilder(pg);
       for (const dep of dependencies) {
@@ -2618,7 +2755,11 @@ __metadata:
       };
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
 
       expect(externalNodes).toMatchInlineSnapshot(`
         {
@@ -2717,7 +2858,11 @@ __metadata:
       };
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
       const pg = {
         nodes: {},
         dependencies: {},
@@ -2737,7 +2882,12 @@ __metadata:
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
-      const dependencies = getYarnLockfileDependencies(lockFile, hash, ctx);
+      const dependencies = getYarnLockfileDependencies(
+        lockFile,
+        hash,
+        ctx,
+        keyMap
+      );
 
       const builder = new ProjectGraphBuilder(pg);
       for (const dep of dependencies) {
@@ -2843,7 +2993,11 @@ __metadata:
       };
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
       const pg = {
         nodes: {},
         dependencies: {},
@@ -2863,7 +3017,12 @@ __metadata:
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
-      const dependencies = getYarnLockfileDependencies(lockFile, hash, ctx);
+      const dependencies = getYarnLockfileDependencies(
+        lockFile,
+        hash,
+        ctx,
+        keyMap
+      );
 
       const builder = new ProjectGraphBuilder(pg);
       for (const dep of dependencies) {
@@ -2944,7 +3103,11 @@ __metadata:
       ));
 
       const hash = uniq('mock-hash');
-      const externalNodes = getYarnLockfileNodes(lockFile, hash, packageJson);
+      const { nodes: externalNodes, keyMap } = getYarnLockfileNodes(
+        lockFile,
+        hash,
+        packageJson
+      );
       const pg = {
         nodes: {},
         dependencies: {},
@@ -2964,7 +3127,12 @@ __metadata:
         nxJsonConfiguration: null,
         workspaceRoot: '/virtual',
       };
-      const dependencies = getYarnLockfileDependencies(lockFile, hash, ctx);
+      const dependencies = getYarnLockfileDependencies(
+        lockFile,
+        hash,
+        ctx,
+        keyMap
+      );
       const builder = new ProjectGraphBuilder(pg);
       for (const dep of dependencies) {
         builder.addDependency(


### PR DESCRIPTION
After PR #33256 split lockfile parsing into separate node and dependency caches, a regression occurred where dependencies could be regenerated without nodes, leaving a shared module-level variable (`keyMap`) empty and causing incorrect dependency resolution.

Changes:
- Serialize `keyMap` with nodes cache to maintain state between phases
- Remove module-level shared state from pnpm, npm, and yarn parsers
- Move `keyMap` creation inside `getNodes` functions for better encapsulation
- Update `readCachedExternalNodes` to deserialize `keyMap` internally