### PR TITLE
feat(core): export TypeScript schema definitions via wildcard patterns

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -31,8 +31,12 @@
     "./src/generators/move/move-impl": "./src/generators/move/move-impl.js",
     "./src/builders/*/schema.json": "./src/builders/*/schema.json",
     "./src/builders/*.impl": "./src/builders/*.impl.js",
+    "./src/builders/*/schema": "./src/builders/*/schema.d.ts",
     "./src/executors/*/schema.json": "./src/executors/*/schema.json",
-    "./src/executors/*.impl": "./src/executors/*.impl.js"
+    "./src/executors/*.impl": "./src/executors/*.impl.js",
+    "./src/executors/*/schema": "./src/executors/*/schema.d.ts",
+    "./src/generators/*/schema.json": "./src/generators/*/schema.json",
+    "./src/generators/*/schema": "./src/generators/*/schema.d.ts"
   },
   "author": "Victor Savkin",
   "license": "MIT",

--- a/packages/docker/package.json
+++ b/packages/docker/package.json
@@ -36,6 +36,10 @@
       "types": "./generators.d.ts",
       "default": "./generators.js"
     },
+    "./executors/*/schema.json": "./src/executors/*/schema.json",
+    "./executors/*/schema": "./src/executors/*/schema.d.ts",
+    "./generators/*/schema.json": "./src/generators/*/schema.json",
+    "./generators/*/schema": "./src/generators/*/schema.d.ts",
     "./package.json": "./package.json",
     "./generators.json": "./generators.json",
     "./executors.json": "./executors.json",

--- a/packages/dotnet/package.json
+++ b/packages/dotnet/package.json
@@ -33,6 +33,8 @@
       "default": "./dist/plugin.js",
       "types": "./dist/plugin.d.ts"
     },
+    "./generators/*/schema.json": "./dist/generators/*/schema.json",
+    "./generators/*/schema": "./dist/generators/*/schema.d.ts",
     "./generators.json": "./generators.json",
     "./migrations.json": "./migrations.json",
     "./package.json": "./package.json"

--- a/packages/gradle/package.json
+++ b/packages/gradle/package.json
@@ -27,6 +27,10 @@
   "exports": {
     ".": "./index.js",
     "./plugin-v1": "./plugin-v1.js",
+    "./executors/*/schema.json": "./src/executors/*/schema.json",
+    "./executors/*/schema": "./src/executors/*/schema.d.ts",
+    "./generators/*/schema.json": "./src/generators/*/schema.json",
+    "./generators/*/schema": "./src/generators/*/schema.d.ts",
     "./package.json": "./package.json",
     "./migrations.json": "./migrations.json",
     "./generators.json": "./generators.json"

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -30,6 +30,8 @@
       "default": "./index.js",
       "types": "./index.d.ts"
     },
+    "./generators/*/schema.json": "./src/generators/*/schema.json",
+    "./generators/*/schema": "./src/generators/*/schema.d.ts",
     "./package.json": "./package.json",
     "./generators.json": "./generators.json",
     "./executors.json": "./executors.json",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -59,8 +59,10 @@
     "./migrations.json": "./migrations.json",
     "./generators.json": "./generators.json",
     "./generators/*/schema.json": "./src/generators/*/schema.json",
+    "./generators/*/schema": "./src/generators/*/schema.d.ts",
     "./executors.json": "./executors.json",
     "./executors/*/schema.json": "./src/executors/*/schema.json",
+    "./executors/*/schema": "./src/executors/*/schema.d.ts",
     "./plugin": "./plugin.js",
     "./preset": "./src/utils/preset.js"
   },

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -51,6 +51,10 @@
       "default": "./index.js",
       "types": "./index.d.ts"
     },
+    "./executors/*/schema.json": "./src/executors/*/schema.json",
+    "./executors/*/schema": "./src/executors/*/schema.d.ts",
+    "./generators/*/schema.json": "./src/generators/*/schema.json",
+    "./generators/*/schema": "./src/generators/*/schema.d.ts",
     "./package.json": "./package.json",
     "./generators.json": "./generators.json",
     "./executors.json": "./executors.json",

--- a/packages/rsbuild/package.json
+++ b/packages/rsbuild/package.json
@@ -48,6 +48,10 @@
       "types": "./index.d.ts",
       "default": "./index.js"
     },
+    "./executors/*/schema.json": "./src/executors/*/schema.json",
+    "./executors/*/schema": "./src/executors/*/schema.d.ts",
+    "./generators/*/schema.json": "./src/generators/*/schema.json",
+    "./generators/*/schema": "./src/generators/*/schema.d.ts",
     "./package.json": {
       "default": "./package.json"
     },

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -61,7 +61,10 @@
     "./executors": "./executors.js",
     "./src/executors/*/schema.json": "./src/executors/*/schema.json",
     "./src/executors/*.impl": "./src/executors/*.impl.js",
+    "./src/executors/*/schema": "./src/executors/*/schema.d.ts",
     "./src/executors/*/compat": "./src/executors/*/compat.js",
+    "./src/generators/*/schema.json": "./src/generators/*/schema.json",
+    "./src/generators/*/schema": "./src/generators/*/schema.d.ts",
     "./plugins/nx-copy-assets.plugin": "./plugins/nx-copy-assets.plugin.js",
     "./plugins/nx-tsconfig-paths.plugin": "./plugins/nx-tsconfig-paths.plugin.js",
     "./plugins/rollup-replace-files.plugin": "./plugins/rollup-replace-files.plugin.js"

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -29,6 +29,10 @@
       "types": "./index.d.ts",
       "default": "./index.js"
     },
+    "./executors/*/schema.json": "./src/executors/*/schema.json",
+    "./executors/*/schema": "./src/executors/*/schema.d.ts",
+    "./generators/*/schema.json": "./src/generators/*/schema.json",
+    "./generators/*/schema": "./src/generators/*/schema.d.ts",
     "./generators": {
       "types": "./generators.d.ts",
       "default": "./generators.js"


### PR DESCRIPTION
Users cannot import TypeScript schema definitions or schema.json files from Nx packages due to strict package exports introduced in Nx 21.0.0.

Users can now import both TypeScript definitions and JSON schemas from generator/executor/builder paths using wildcard export patterns. Both first-level (`*`) and second-level (`*/*`) patterns are supported to handle different import depths.

Note: For old plugins that had `src/...` deep imports we keep those in `exports`, but for newer plugins that always used `exports` we skip `src/` in the export path. So `@nx/nuxt/generators` instead of `@nx/nuxt/src/generators`.

Fixes #33336