### PR TITLE
fix(core): capture stderr in nx add command for better error messages

### DIFF
--- a/packages/nx/src/command-line/add/add.ts
+++ b/packages/nx/src/command-line/add/add.ts
@@ -65,7 +65,10 @@ async function installPackage(
           if (error) {
             spinner.fail();
             output.addNewline();
-            logger.error(stdout + (stdout && stderr ? '\n' : '') + stderr);
+            const errorOutput = [stdout.trim(), stderr.trim()]
+              .filter(Boolean)
+              .join('\n');
+            logger.error(errorOutput);
             output.error({
               title: `Failed to install ${pkgName}. Please check the error above for more details.`,
             });

--- a/packages/nx/src/command-line/add/add.ts
+++ b/packages/nx/src/command-line/add/add.ts
@@ -61,11 +61,11 @@ async function installPackage(
         {
           windowsHide: false,
         },
-        (error, stdout) => {
+        (error, stdout, stderr) => {
           if (error) {
             spinner.fail();
             output.addNewline();
-            logger.error(stdout);
+            logger.error(stdout + (stdout && stderr ? '\n' : '') + stderr);
             output.error({
               title: `Failed to install ${pkgName}. Please check the error above for more details.`,
             });


### PR DESCRIPTION
## Current Behavior

When `nx add @nx/s3-cache` fails due to incompatible peer dependencies or other installation errors, users see only a generic error message without the actual error details from the package manager.

## Expected Behavior

The command should display complete error messages from the package manager (both stdout and stderr), including peer dependency conflicts and other important diagnostic information.

## Changes

Fixed the exec callback in the `installPackage` function to:
1. Capture the `stderr` parameter (was previously ignored)
2. Log both stdout and stderr with a newline separator for clarity
3. Ensure users see all error information from package managers

## Why It Matters

Package managers write installation errors and peer dependency warnings to stderr. By ignoring stderr, users had no visibility into what actually failed, making it difficult to diagnose and fix issues.

Fixes issue with `nx add` not showing proper error messages.