### PR TITLE
chore(js): update migration version to 22.1.0-rc.1

### DIFF
--- a/packages/js/migrations.json
+++ b/packages/js/migrations.json
@@ -11,7 +11,7 @@
       "factory": "./src/migrations/update-22-0-0/remove-external-options-from-js-executors"
     },
     "remove-redundant-ts-project-references": {
-      "version": "22.1.0-beta.8",
+      "version": "22.1.0-rc.1",
       "description": "Removes redundant TypeScript project references from project's tsconfig.json files when runtime tsconfig files (e.g., tsconfig.lib.json, tsconfig.app.json) exist.",
       "factory": "./src/migrations/update-22-1-0/remove-redundant-ts-project-references"
     }


### PR DESCRIPTION
## Current Behavior

The migration for removing redundant TypeScript project references is set to version `22.1.0-beta.8`.

## Expected Behavior

The migration should be updated to version `22.1.0-rc.1` to align with the release candidate version.

## Related Issue(s)

N/A - Version update as requested.