### PR TITLE
fix(js): skip TS project references migration for non-TS-solution workspaces

### DIFF
--- a/packages/js/src/migrations/update-22-1-0/remove-redundant-ts-project-references.ts
+++ b/packages/js/src/migrations/update-22-1-0/remove-redundant-ts-project-references.ts
@@ -1,6 +1,12 @@
 import type { Tree } from '@nx/devkit';
+import { isUsingTsSolutionSetup } from '../../utils/typescript/ts-solution-setup';
 import { syncGenerator } from '../../generators/typescript-sync/typescript-sync';
 
 export default async function (tree: Tree) {
+  // Skip if not using TypeScript solution setup
+  if (!isUsingTsSolutionSetup(tree)) {
+    return;
+  }
+
   await syncGenerator(tree);
 }


### PR DESCRIPTION
## Current Behavior

The `remove-redundant-ts-project-references` migration fails with an error when run on workspaces that don't have a root `tsconfig.json` file, such as nx-examples.

## Expected Behavior

The migration should skip workspaces that are not using TypeScript solution setup instead of throwing an error.

## Related Issue(s)

Fixes the issue encountered when running the migration on nrwl/nx-examples repo.

## Changes

- Added check to skip migration if workspace is not using TS solution setup
- Updated test setup to properly configure TS solution for existing tests
- Added new test cases to verify skip behavior

The migration now uses `isUsingTsSolutionSetup()` to detect if:
- `tsconfig.base.json` exists
- `tsconfig.json` exists and extends the base
- Package manager workspaces are configured
- Proper TS solution structure is in place

Workspaces missing any of these requirements will have the migration skip silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)