### PR TITLE
feat(core): add template support to create-nx-workspace

### DIFF
--- a/packages/create-nx-plugin/bin/create-nx-plugin.ts
+++ b/packages/create-nx-plugin/bin/create-nx-plugin.ts
@@ -160,6 +160,7 @@ async function main(parsedArgs: yargs.Arguments<CreateNxPluginArguments>) {
       messages.codeOfSelectedPromptMessage('setupCI'),
       messages.codeOfSelectedPromptMessage('setupNxCloud'),
     ],
+    directory: workspaceInfo.directory,
   });
 
   if (parsedArgs.nxCloud && workspaceInfo.nxCloudInfo) {

--- a/packages/create-nx-workspace/.eslintrc.json
+++ b/packages/create-nx-workspace/.eslintrc.json
@@ -33,7 +33,7 @@
           "error",
           {
             "buildTargets": ["build-base"],
-            "ignoredDependencies": []
+            "ignoredDependencies": ["nx"]
           }
         ]
       }

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -18,7 +18,9 @@ import {
   determineDefaultBase,
   determineIfGitHubWillBeUsed,
   determineNxCloud,
+  determineNxCloudSimple,
   determinePackageManager,
+  determineTemplate,
 } from '../src/internal-utils/prompts';
 import {
   withAllPrompts,
@@ -35,6 +37,7 @@ import { isCI } from '../src/utils/ci/is-ci';
 
 interface BaseArguments extends CreateWorkspaceOptions {
   preset: Preset;
+  template?: string;
   linter?: 'none' | 'eslint';
   formatter?: 'none' | 'prettier';
   workspaces?: boolean;
@@ -224,6 +227,10 @@ export const commandsObject: yargs.Argv<Arguments> = yargs
             describe: chalk.dim`List of AI agents to configure.`,
             type: 'array',
             choices: [...supportedAgents],
+          })
+          .option('template', {
+            describe: chalk.dim`GitHub template (e.g., nrwl/react-template)`,
+            type: 'string',
           }),
         withNxCloud,
         withUseGitHub,
@@ -328,44 +335,90 @@ async function normalizeArgsMiddleware(
   argv.workspaces ??= true;
   argv.useProjectJson ??= !argv.workspaces;
 
+  // Check for template + preset conflict
+  if (argv.template && argv.preset) {
+    output.error({
+      title: 'Invalid arguments',
+      bodyLines: [
+        'Cannot use both --template and --preset options together.',
+        'Please choose one:',
+        '  --template: Use a GitHub template repository',
+        '  --preset: Use an Nx preset for workspace generation',
+      ],
+    });
+    process.exit(1);
+  }
+
+  // Validate and expand template if provided
+  if (argv.template) {
+    argv.template = validateAndExpandTemplate(argv.template);
+  }
+
   try {
     argv.name = await determineFolder(argv);
-    if (!argv.preset || isKnownPreset(argv.preset)) {
-      argv.stack = await determineStack(argv);
-      const presetOptions = await determinePresetOptions(argv);
-      Object.assign(argv, presetOptions);
-    } else {
-      try {
-        getPackageNameFromThirdPartyPreset(argv.preset);
-      } catch (e) {
-        if (e instanceof Error) {
-          output.error({
-            title: `Could not find preset "${argv.preset}"`,
-            bodyLines: mapErrorToBodyLines(e),
-          });
-        } else {
-          console.error(e);
-        }
-        process.exit(1);
-      }
-    }
 
-    const packageManager = await determinePackageManager(argv);
-    const aiAgents = await determineAiAgents(argv);
-    const defaultBase = await determineDefaultBase(argv);
-    const nxCloud =
-      argv.skipGit === true ? 'skip' : await determineNxCloud(argv);
-    const useGitHub =
-      nxCloud === 'skip'
-        ? undefined
-        : nxCloud === 'github' || (await determineIfGitHubWillBeUsed(argv));
-    Object.assign(argv, {
-      nxCloud,
-      useGitHub,
-      packageManager,
-      defaultBase,
-      aiAgents,
-    });
+    const template = await determineTemplate(argv);
+
+    if (template !== 'skip') {
+      // Template flow - skip preset prompts
+      argv.template = template;
+      // Still ask: package manager, git branch, AI agents
+      const packageManager = await determinePackageManager(argv);
+      const aiAgents = await determineAiAgents(argv);
+      const defaultBase = await determineDefaultBase(argv);
+      // Use simplified Cloud prompt for templates (yes/no only, no CI selection)
+      const nxCloud =
+        argv.skipGit === true ? 'skip' : await determineNxCloudSimple(argv);
+      const useGitHub =
+        nxCloud === 'skip'
+          ? undefined
+          : await determineIfGitHubWillBeUsed(argv);
+      Object.assign(argv, {
+        nxCloud,
+        useGitHub,
+        packageManager,
+        defaultBase,
+        aiAgents,
+      });
+    } else {
+      // Preset flow - existing behavior
+      if (!argv.preset || isKnownPreset(argv.preset)) {
+        argv.stack = await determineStack(argv);
+        const presetOptions = await determinePresetOptions(argv);
+        Object.assign(argv, presetOptions);
+      } else {
+        try {
+          getPackageNameFromThirdPartyPreset(argv.preset);
+        } catch (e) {
+          if (e instanceof Error) {
+            output.error({
+              title: `Could not find preset "${argv.preset}"`,
+              bodyLines: mapErrorToBodyLines(e),
+            });
+          } else {
+            console.error(e);
+          }
+          process.exit(1);
+        }
+      }
+
+      const packageManager = await determinePackageManager(argv);
+      const aiAgents = await determineAiAgents(argv);
+      const defaultBase = await determineDefaultBase(argv);
+      const nxCloud =
+        argv.skipGit === true ? 'skip' : await determineNxCloud(argv);
+      const useGitHub =
+        nxCloud === 'skip'
+          ? undefined
+          : nxCloud === 'github' || (await determineIfGitHubWillBeUsed(argv));
+      Object.assign(argv, {
+        nxCloud,
+        useGitHub,
+        packageManager,
+        defaultBase,
+        aiAgents,
+      });
+    }
   } catch (e) {
     console.error(e);
     process.exit(1);
@@ -395,6 +448,45 @@ export function validateWorkspaceName(name: string): void {
     });
     process.exit(1);
   }
+}
+
+function validateAndExpandTemplate(template: string): string {
+  // Strip .git suffix if present
+  const cleanTemplate = template.endsWith('.git')
+    ? template.slice(0, -4)
+    : template;
+
+  // If it's already a full URL, reject it
+  if (
+    cleanTemplate.startsWith('http://') ||
+    cleanTemplate.startsWith('https://')
+  ) {
+    output.error({
+      title: 'Invalid template format',
+      bodyLines: [
+        `Template should be in the format: nrwl/repo-name`,
+        `Example: nrwl/react-template`,
+        `Do not provide the full GitHub URL.`,
+      ],
+    });
+    process.exit(1);
+  }
+
+  // Pattern: nrwl/repo-name
+  const pattern = /^nrwl\/[a-zA-Z0-9-]+$/;
+
+  if (!pattern.test(cleanTemplate)) {
+    output.error({
+      title: 'Invalid template',
+      bodyLines: [
+        `Template must be in format: nrwl/repo-name (e.g., nrwl/react-template)`,
+        `Only templates from the nrwl organization are supported.`,
+      ],
+    });
+    process.exit(1);
+  }
+
+  return `https://github.com/${cleanTemplate}`;
 }
 
 async function determineFolder(

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -341,7 +341,7 @@ async function normalizeArgsMiddleware(
     const template = await determineTemplate(argv);
 
     // Old (start) vs new (start-v2) flows
-    const startPrefix = template === 'custom' ? 'start-v2' : 'start';
+    const startPrefix = getFlowVariant() === '1' ? 'start-v2' : 'start';
     await recordStat({
       nxVersion,
       command: 'create-nx-workspace',

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -290,7 +290,7 @@ async function main(parsedArgs: yargs.Arguments<Arguments>) {
     meta: [
       messages.codeOfSelectedPromptMessage('setupCI'),
       messages.codeOfSelectedPromptMessage('setupNxCloud'),
-      messages.codeOfSelectedPromptMessage('setupNxCloudSimple'),
+      messages.codeOfSelectedPromptMessage('setupNxCloudV2'),
       parsedArgs.nxCloud,
       rawArgs.nxCloud,
       workspaceInfo.pushedToVcs,
@@ -374,7 +374,7 @@ async function normalizeArgsMiddleware(
       const nxCloudPromptCode =
         nxCloud === 'skip'
           ? undefined
-          : messages.metaCodeOfSelectedPromptMessage('setupNxCloudSimple');
+          : messages.metaCodeOfSelectedPromptMessage('setupNxCloudV2');
       const useGitHub =
         nxCloud === 'skip'
           ? undefined

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -30,7 +30,11 @@ import {
   withPackageManager,
   withUseGitHub,
 } from '../src/internal-utils/yargs-options';
-import { messages, recordStat } from '../src/utils/nx/ab-testing';
+import {
+  getFlowVariant,
+  messages,
+  recordStat,
+} from '../src/utils/nx/ab-testing';
 import { mapErrorToBodyLines } from '../src/utils/error-utils';
 import { existsSync } from 'fs';
 import { isCI } from '../src/utils/ci/is-ci';
@@ -291,6 +295,7 @@ async function main(parsedArgs: yargs.Arguments<Arguments>) {
       parsedArgs.nxCloud,
       rawArgs.nxCloud,
       workspaceInfo.pushedToVcs,
+      `flow-variant-${getFlowVariant()}`,
     ],
     directory: workspaceInfo.directory,
   });

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -352,10 +352,15 @@ async function normalizeArgsMiddleware(
         nxCloud === 'skip'
           ? undefined
           : messages.codeOfSelectedPromptMessage('setupNxCloudV2');
+      const completionMessageKey =
+        nxCloud === 'skip'
+          ? undefined
+          : messages.completionMessageOfSelectedPrompt('setupNxCloudV2');
       Object.assign(argv, {
         nxCloud,
         useGitHub: nxCloud !== 'skip',
         nxCloudPromptCode,
+        completionMessageKey,
         packageManager,
         defaultBase,
         aiAgents,

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -340,8 +340,8 @@ async function normalizeArgsMiddleware(
 
     const template = await determineTemplate(argv);
 
-    // Record start stat with flow variant prefix
-    const startPrefix = template !== 'custom' ? 'start-v2' : 'start';
+    // Old (start) vs new (start-v2) flows
+    const startPrefix = template === 'custom' ? 'start-v2' : 'start';
     await recordStat({
       nxVersion,
       command: 'create-nx-workspace',

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -18,7 +18,7 @@ import {
   determineDefaultBase,
   determineIfGitHubWillBeUsed,
   determineNxCloud,
-  determineNxCloudSimple,
+  determineNxCloudV2,
   determinePackageManager,
   determineTemplate,
 } from '../src/internal-utils/prompts';
@@ -369,7 +369,7 @@ async function normalizeArgsMiddleware(
       const defaultBase = await determineDefaultBase(argv);
       // Use simplified Cloud prompt for templates (yes/no only, no CI selection)
       const nxCloud =
-        argv.skipGit === true ? 'skip' : await determineNxCloudSimple(argv);
+        argv.skipGit === true ? 'skip' : await determineNxCloudV2(argv);
       // Capture prompt variant code for tracking
       const nxCloudPromptCode =
         nxCloud === 'skip'

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -290,6 +290,7 @@ async function main(parsedArgs: yargs.Arguments<Arguments>) {
     meta: [
       messages.codeOfSelectedPromptMessage('setupCI'),
       messages.codeOfSelectedPromptMessage('setupNxCloud'),
+      messages.codeOfSelectedPromptMessage('setupNxCloudSimple'),
       parsedArgs.nxCloud,
       rawArgs.nxCloud,
       workspaceInfo.pushedToVcs,
@@ -369,12 +370,18 @@ async function normalizeArgsMiddleware(
       // Use simplified Cloud prompt for templates (yes/no only, no CI selection)
       const nxCloud =
         argv.skipGit === true ? 'skip' : await determineNxCloudSimple(argv);
+      // Capture prompt variant code for tracking
+      const nxCloudPromptCode =
+        nxCloud === 'skip'
+          ? undefined
+          : messages.metaCodeOfSelectedPromptMessage('setupNxCloudSimple');
       const useGitHub =
         nxCloud === 'skip'
           ? undefined
           : await determineIfGitHubWillBeUsed(argv);
       Object.assign(argv, {
         nxCloud,
+        nxCloudPromptCode,
         useGitHub,
         packageManager,
         defaultBase,

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -238,8 +238,10 @@ export const commandsObject: yargs.Argv<Arguments> = yargs
       await main(argv).catch((error) => {
         const { version } = require('../package.json');
         output.error({
-          title: `Something went wrong! v${version}`,
+          title: `Failed to create workspace!`,
+          bodyLines: mapErrorToBodyLines(error),
         });
+        process.exit(1);
         throw error;
       });
     },

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -349,6 +349,7 @@ async function normalizeArgsMiddleware(
           : messages.metaCodeOfSelectedPromptMessage('setupNxCloudV2');
       Object.assign(argv, {
         nxCloud,
+        useGitHub: nxCloud !== 'skip',
         nxCloudPromptCode,
         packageManager,
         defaultBase,

--- a/packages/create-nx-workspace/src/create-workspace-options.ts
+++ b/packages/create-nx-workspace/src/create-workspace-options.ts
@@ -6,6 +6,7 @@ export interface CreateWorkspaceOptions {
   packageManager: PackageManager; // Package manager to use
   nxCloud: NxCloud; // Enable Nx Cloud
   useGitHub?: boolean; // Will you be using GitHub as your git hosting provider?
+  template?: string; // GitHub template repository URL (e.g., https://github.com/nrwl/react-template)
   /**
    * @description Enable interactive mode with presets
    * @default true

--- a/packages/create-nx-workspace/src/create-workspace-options.ts
+++ b/packages/create-nx-workspace/src/create-workspace-options.ts
@@ -8,7 +8,6 @@ export interface CreateWorkspaceOptions {
   nxCloud: NxCloud; // Enable Nx Cloud
   useGitHub?: boolean; // Will you be using GitHub as your git hosting provider?
   template?: string; // GitHub template repository URL (e.g., https://github.com/nrwl/react-template)
-  nxCloudPromptCode?: string; // Prompt code for tracking in template flow (e.g., 'cloud-v2-remote-cache')
   completionMessageKey?: CompletionMessageKey; // Key for the completion message to show at the end
   /**
    * @description Enable interactive mode with presets

--- a/packages/create-nx-workspace/src/create-workspace-options.ts
+++ b/packages/create-nx-workspace/src/create-workspace-options.ts
@@ -1,4 +1,5 @@
 import { NxCloud } from './utils/nx/nx-cloud';
+import type { CompletionMessageKey } from './utils/nx/messages';
 import { PackageManager } from './utils/package-manager';
 
 export interface CreateWorkspaceOptions {
@@ -7,7 +8,8 @@ export interface CreateWorkspaceOptions {
   nxCloud: NxCloud; // Enable Nx Cloud
   useGitHub?: boolean; // Will you be using GitHub as your git hosting provider?
   template?: string; // GitHub template repository URL (e.g., https://github.com/nrwl/react-template)
-  nxCloudPromptCode?: string; // Prompt variant meta code for tracking (e.g., 'green-prs', 'remote-cache', 'fast-ci')
+  nxCloudPromptCode?: string; // Prompt variant meta code for tracking (e.g., 'cloud-v2-green-prs', 'cloud-v2-remote-cache')
+  completionMessageKey?: CompletionMessageKey; // Key for the completion message to show at the end
   /**
    * @description Enable interactive mode with presets
    * @default true

--- a/packages/create-nx-workspace/src/create-workspace-options.ts
+++ b/packages/create-nx-workspace/src/create-workspace-options.ts
@@ -7,6 +7,7 @@ export interface CreateWorkspaceOptions {
   nxCloud: NxCloud; // Enable Nx Cloud
   useGitHub?: boolean; // Will you be using GitHub as your git hosting provider?
   template?: string; // GitHub template repository URL (e.g., https://github.com/nrwl/react-template)
+  nxCloudPromptCode?: string; // Prompt variant meta code for tracking (e.g., 'green-prs', 'remote-cache', 'fast-ci')
   /**
    * @description Enable interactive mode with presets
    * @default true

--- a/packages/create-nx-workspace/src/create-workspace-options.ts
+++ b/packages/create-nx-workspace/src/create-workspace-options.ts
@@ -8,7 +8,7 @@ export interface CreateWorkspaceOptions {
   nxCloud: NxCloud; // Enable Nx Cloud
   useGitHub?: boolean; // Will you be using GitHub as your git hosting provider?
   template?: string; // GitHub template repository URL (e.g., https://github.com/nrwl/react-template)
-  nxCloudPromptCode?: string; // Prompt variant meta code for tracking (e.g., 'cloud-v2-green-prs', 'cloud-v2-remote-cache')
+  nxCloudPromptCode?: string; // Prompt code for tracking in template flow (e.g., 'cloud-v2-remote-cache')
   completionMessageKey?: CompletionMessageKey; // Key for the completion message to show at the end
   /**
    * @description Enable interactive mode with presets

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -49,11 +49,10 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
   let directory: string;
 
   if (options.template) {
-    // Template flow - clone and setup
-    const templateUrl = options.template;
+    const templateUrl = `https://github.com/${options.template}`;
     directory = name;
 
-    await cloneTemplate(templateUrl, directory, name);
+    await cloneTemplate(templateUrl, directory);
     await cleanupLockfiles(directory, packageManager);
 
     // Install dependencies

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -59,12 +59,26 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
     const workingDir = process.cwd().replace(/\\/g, '/');
     directory = join(workingDir, name);
 
-    await cloneTemplate(templateUrl, name);
-    await cleanupLockfiles(directory, packageManager);
+    const ora = require('ora');
+    const workspaceSetupSpinner = ora(
+      `Creating workspace from template`
+    ).start();
 
-    // Install dependencies
-    const pmc = getPackageManagerCommand(packageManager);
-    await execAndWait(pmc.install, directory);
+    try {
+      await cloneTemplate(templateUrl, name);
+      await cleanupLockfiles(directory, packageManager);
+
+      // Install dependencies
+      const pmc = getPackageManagerCommand(packageManager);
+      await execAndWait(pmc.install, directory);
+
+      workspaceSetupSpinner.succeed(
+        `Successfully created the workspace: ${directory}`
+      );
+    } catch (e) {
+      workspaceSetupSpinner.fail();
+      throw e;
+    }
 
     // Connect to Nx Cloud for template flow
     if (nxCloud !== 'skip') {

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -14,6 +14,7 @@ import {
   connectToNxCloudForTemplate,
   createNxCloudOnboardingUrl,
   getNxCloudInfo,
+  getSkippedNxCloudInfo,
   readNxCloudToken,
 } from './utils/nx/nx-cloud';
 import { output } from './utils/output';
@@ -170,11 +171,13 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
 
   if (connectUrl) {
     nxCloudInfo = await getNxCloudInfo(
-      nxCloud,
       connectUrl,
       pushedToVcs,
-      rawArgs?.nxCloud
+      options.completionMessageKey
     );
+  } else if (isTemplate && nxCloud === 'skip') {
+    // Show nx connect message when user skips cloud in template flow
+    nxCloudInfo = getSkippedNxCloudInfo();
   }
 
   return {

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -131,7 +131,6 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
       token,
       directory,
       useGitHub,
-      isTemplate,
       options.nxCloudPromptCode
     );
   }
@@ -174,8 +173,7 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
       nxCloud,
       connectUrl,
       pushedToVcs,
-      rawArgs?.nxCloud,
-      isTemplate
+      rawArgs?.nxCloud
     );
   }
 

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -161,8 +161,7 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
       connectUrl,
       pushedToVcs,
       rawArgs?.nxCloud,
-      isTemplate,
-      options.nxCloudPromptCode
+      isTemplate
     );
   }
 

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -17,6 +17,7 @@ import {
   getSkippedNxCloudInfo,
   readNxCloudToken,
 } from './utils/nx/nx-cloud';
+import { getFlowVariant } from './utils/nx/ab-testing';
 import { output } from './utils/output';
 import { getPackageNameFromThirdPartyPreset } from './utils/preset/get-third-party-preset';
 import { Preset } from './utils/preset/preset';
@@ -132,6 +133,7 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
       token,
       directory,
       useGitHub,
+      getFlowVariant(),
       options.nxCloudPromptCode
     );
   }

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -102,7 +102,8 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
       token,
       directory,
       useGitHub,
-      isTemplate
+      isTemplate,
+      options.nxCloudPromptCode
     );
   }
 
@@ -139,7 +140,8 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
       connectUrl,
       pushedToVcs,
       rawArgs?.nxCloud,
-      isTemplate
+      isTemplate,
+      options.nxCloudPromptCode
     );
   }
 

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -17,16 +17,11 @@ import {
   getSkippedNxCloudInfo,
   readNxCloudToken,
 } from './utils/nx/nx-cloud';
-import { getFlowVariant } from './utils/nx/ab-testing';
 import { output } from './utils/output';
 import { getPackageNameFromThirdPartyPreset } from './utils/preset/get-third-party-preset';
 import { Preset } from './utils/preset/preset';
-import {
-  cleanupLockfiles,
-  cloneTemplate,
-} from './utils/template/clone-template';
+import { cloneTemplate } from './utils/template/clone-template';
 import { execAndWait } from './utils/child-process-utils';
-import { getPackageManagerCommand } from './utils/package-manager';
 
 export async function createWorkspace<T extends CreateWorkspaceOptions>(
   preset: string,
@@ -68,11 +63,9 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
 
     try {
       await cloneTemplate(templateUrl, name);
-      await cleanupLockfiles(directory, packageManager);
 
-      // Install dependencies
-      const pmc = getPackageManagerCommand(packageManager);
-      await execAndWait(pmc.install, directory);
+      // Install dependencies (template flow always uses npm)
+      await execAndWait('npm install --silent --ignore-scripts', directory);
 
       workspaceSetupSpinner.succeed(
         `Successfully created the workspace: ${directory}`
@@ -132,9 +125,7 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
       nxCloud,
       token,
       directory,
-      useGitHub,
-      getFlowVariant(),
-      options.nxCloudPromptCode
+      useGitHub
     );
   }
 

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -33,10 +33,10 @@ export async function determineNxCloud(
 
 export async function determineNxCloudV2(
   parsedArgs: yargs.Arguments<{ nxCloud?: string; interactive?: boolean }>
-): Promise<'yes' | 'skip'> {
+): Promise<'github' | 'skip'> {
   // Provided via flag
   if (parsedArgs.nxCloud) {
-    return parsedArgs.nxCloud === 'skip' ? 'skip' : 'yes';
+    return parsedArgs.nxCloud === 'skip' ? 'skip' : 'github';
   }
 
   // Non-interactive mode
@@ -62,7 +62,7 @@ export async function determineNxCloudV2(
     promptConfig.hint = () => hint;
   }
 
-  const result = await enquirer.prompt<{ nxCloud: 'yes' | 'skip' }>([
+  const result = await enquirer.prompt<{ nxCloud: 'github' | 'skip' }>([
     promptConfig,
   ]);
   return result.nxCloud;
@@ -115,10 +115,12 @@ async function nxCloudPrompt(key: MessageKey): Promise<NxCloud> {
 
 export async function determineTemplate(
   parsedArgs: yargs.Arguments<{
+    template?: string;
     preset?: string;
     interactive?: boolean;
   }>
 ): Promise<string | 'skip'> {
+  if (parsedArgs.template) return parsedArgs.template;
   if (parsedArgs.preset) return 'skip';
   if (!parsedArgs.interactive || isCI()) return 'skip';
   const { template } = await enquirer.prompt<{ template: string }>([

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -31,7 +31,7 @@ export async function determineNxCloud(
   }
 }
 
-export async function determineNxCloudSimple(
+export async function determineNxCloudV2(
   parsedArgs: yargs.Arguments<{ nxCloud?: string; interactive?: boolean }>
 ): Promise<'yes' | 'skip'> {
   // Provided via flag

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -2,7 +2,11 @@ import * as yargs from 'yargs';
 import * as enquirer from 'enquirer';
 import * as chalk from 'chalk';
 
-import { MessageKey, messages } from '../utils/nx/ab-testing';
+import {
+  MessageKey,
+  messages,
+  shouldUseTemplateFlow,
+} from '../utils/nx/ab-testing';
 import { output } from '../utils/output';
 import { deduceDefaultBase } from '../utils/git/default-base';
 import {
@@ -123,6 +127,8 @@ export async function determineTemplate(
   if (parsedArgs.template) return parsedArgs.template;
   if (parsedArgs.preset) return 'skip';
   if (!parsedArgs.interactive || isCI()) return 'skip';
+  // A/B test: shouldUseTemplateFlow() determines if user sees template or preset flow
+  if (!shouldUseTemplateFlow()) return 'skip';
   const { template } = await enquirer.prompt<{ template: string }>([
     {
       name: 'template',

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -46,7 +46,7 @@ export async function determineNxCloudSimple(
 
   // Show simplified prompt
   const { message, choices, initial, footer, hint } =
-    messages.getPrompt('setupNxCloudSimple');
+    messages.getPrompt('setupNxCloudV2');
 
   const promptConfig = {
     name: 'nxCloud',
@@ -135,24 +135,26 @@ export async function determineTemplate(
   const { template } = await enquirer.prompt<{ template: string }>([
     {
       name: 'template',
-      message: 'Which stack do you want to use?',
+      message: 'Which starter do you want to use?',
       type: 'autocomplete',
       choices: [
         {
           name: 'https://github.com/nrwl/empty-template',
-          message: 'Empty                  (minimal Nx workspace)',
+          message: 'Empty             (minimal monorepo without projects)',
         },
         {
           name: 'https://github.com/nrwl/typescript-template',
-          message: 'TypeScript             (Node.js with TypeScript)',
+          message: 'TypeScript        (monorepo with TypeScript packages)',
         },
         {
           name: 'https://github.com/nrwl/react-template',
-          message: 'React                  (React app with Vite)',
+          message:
+            'React             (fullstack monorepo with React and Express)',
         },
         {
           name: 'https://github.com/nrwl/angular-template',
-          message: 'Angular                (Angular app)',
+          message:
+            'Angular           (fullstack monorepo with Angular and Express)',
         },
       ],
       initial: 0,

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -123,12 +123,12 @@ export async function determineTemplate(
     preset?: string;
     interactive?: boolean;
   }>
-): Promise<string | 'skip'> {
+): Promise<string | 'custom'> {
   if (parsedArgs.template) return parsedArgs.template;
-  if (parsedArgs.preset) return 'skip';
-  if (!parsedArgs.interactive || isCI()) return 'skip';
+  if (parsedArgs.preset) return 'custom';
+  if (!parsedArgs.interactive || isCI()) return 'custom';
   // A/B test: shouldUseTemplateFlow() determines if user sees template or preset flow
-  if (!shouldUseTemplateFlow()) return 'skip';
+  if (!shouldUseTemplateFlow()) return 'custom';
   const { template } = await enquirer.prompt<{ template: string }>([
     {
       name: 'template',
@@ -156,7 +156,7 @@ export async function determineTemplate(
             'Angular           (fullstack monorepo with Angular and Express)',
         },
         {
-          name: 'skip',
+          name: 'custom',
           message:
             'Custom            (more options for frameworks, test runners, etc.)',
         },

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -115,23 +115,12 @@ async function nxCloudPrompt(key: MessageKey): Promise<NxCloud> {
 
 export async function determineTemplate(
   parsedArgs: yargs.Arguments<{
-    template?: string;
     preset?: string;
     interactive?: boolean;
   }>
 ): Promise<string | 'skip'> {
-  // Already provided via flag
-  if (parsedArgs.template) return parsedArgs.template;
-
-  // Using preset flow instead
   if (parsedArgs.preset) return 'skip';
-
-  // Non-interactive mode - default to preset flow
-  if (!parsedArgs.interactive || isCI()) {
-    return 'skip';
-  }
-
-  // Show template selection prompt
+  if (!parsedArgs.interactive || isCI()) return 'skip';
   const { template } = await enquirer.prompt<{ template: string }>([
     {
       name: 'template',
@@ -139,20 +128,20 @@ export async function determineTemplate(
       type: 'autocomplete',
       choices: [
         {
-          name: 'https://github.com/nrwl/empty-template',
+          name: 'nrwl/empty-template',
           message: 'Empty             (minimal monorepo without projects)',
         },
         {
-          name: 'https://github.com/nrwl/typescript-template',
+          name: 'nrwl/typescript-template',
           message: 'TypeScript        (monorepo with TypeScript packages)',
         },
         {
-          name: 'https://github.com/nrwl/react-template',
+          name: 'nrwl/react-template',
           message:
             'React             (fullstack monorepo with React and Express)',
         },
         {
-          name: 'https://github.com/nrwl/angular-template',
+          name: 'nrwl/angular-template',
           message:
             'Angular           (fullstack monorepo with Angular and Express)',
         },

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -131,11 +131,13 @@ export async function determineTemplate(
       choices: [
         {
           name: 'nrwl/empty-template',
-          message: 'Empty             (minimal monorepo without projects)',
+          message:
+            'TypeScript        (minimal TypeScript monorepo without projects)',
         },
         {
           name: 'nrwl/typescript-template',
-          message: 'TypeScript        (monorepo with TypeScript packages)',
+          message:
+            'NPM Packages      (monorepo with TypeScript packages ready to publish)',
         },
         {
           name: 'nrwl/react-template',
@@ -146,6 +148,11 @@ export async function determineTemplate(
           name: 'nrwl/angular-template',
           message:
             'Angular           (fullstack monorepo with Angular and Express)',
+        },
+        {
+          name: 'skip',
+          message:
+            'Custom            (more options for frameworks, test runners, etc.)',
         },
       ],
       initial: 0,

--- a/packages/create-nx-workspace/src/utils/child-process-utils.ts
+++ b/packages/create-nx-workspace/src/utils/child-process-utils.ts
@@ -8,7 +8,13 @@ import { CreateNxWorkspaceError } from './error-utils';
  */
 export function spawnAndWait(command: string, args: string[], cwd: string) {
   return new Promise((res, rej) => {
-    const childProcess = spawn(command, args, {
+    // Combine command and args into a single string to avoid DEP0190 warning
+    // (passing args with shell: true is deprecated)
+    const fullCommand = [command, ...args]
+      .map((arg) => (arg.includes(' ') ? `"${arg}"` : arg))
+      .join(' ');
+
+    const childProcess = spawn(fullCommand, {
       cwd,
       stdio: 'inherit',
       env: {

--- a/packages/create-nx-workspace/src/utils/git/git.ts
+++ b/packages/create-nx-workspace/src/utils/git/git.ts
@@ -178,7 +178,7 @@ export async function pushToGitHub(
     const { push } = await enquirer.prompt<{ push: 'Yes' | 'No' }>([
       {
         name: 'push',
-        message: 'Would you like to push this workspace to Github?',
+        message: 'Would you like to push this workspace to GitHub?',
         type: 'autocomplete',
         choices: [{ name: 'Yes' }, { name: 'No' }],
         initial: 0,

--- a/packages/create-nx-workspace/src/utils/git/git.ts
+++ b/packages/create-nx-workspace/src/utils/git/git.ts
@@ -249,7 +249,7 @@ export async function pushToGitHub(
     const errorMessage = e instanceof Error ? e.message : String(e);
 
     // Error code 127 means gh wasn't installed
-    const title = 'Push your repo to complete setup.';
+    const title = 'Could not push. Push repo to complete setup.';
 
     const createRepoUrl = `https://github.com/new?name=${encodeURIComponent(
       options.name
@@ -258,11 +258,11 @@ export async function pushToGitHub(
       title,
       bodyLines: isVerbose
         ? [
-            `Please create a repo at ${createRepoUrl} and push this workspace.`,
+            `Go to ${createRepoUrl} and push this workspace.`,
             'Error details:',
             errorMessage,
           ]
-        : [`Please create a repo at ${createRepoUrl} and push this workspace.`],
+        : [`Go to ${createRepoUrl} and push this workspace.`],
     });
     return VcsPushStatus.FailedToPushToVcs;
   }

--- a/packages/create-nx-workspace/src/utils/git/git.ts
+++ b/packages/create-nx-workspace/src/utils/git/git.ts
@@ -39,14 +39,22 @@ async function getGitHubUsername(directory: string): Promise<string> {
   return username;
 }
 
+// Module-level promise for background repo fetching
+let existingReposPromise: Promise<Set<string>> | undefined;
+
+function populateExistingRepos(directory: string): void {
+  existingReposPromise ??= getUserRepositories(directory);
+}
+
 async function getUserRepositories(directory: string): Promise<Set<string>> {
   try {
     const allRepos = new Set<string>();
 
     // Get user's personal repos and organizations concurrently
+    // Limit to 100 repos for faster response (covers most use cases)
     const [userRepos, orgsResult] = await Promise.all([
       execAndWait(
-        'gh repo list --limit 1000 --json nameWithOwner --jq ".[].nameWithOwner"',
+        'gh repo list --limit 100 --json nameWithOwner --jq ".[].nameWithOwner"',
         directory
       ),
       execAndWait('gh api user/orgs --jq ".[].login"', directory),
@@ -69,7 +77,7 @@ async function getUserRepositories(directory: string): Promise<Set<string>> {
     const orgRepoPromises = orgs.map(async (org) => {
       try {
         const orgRepos = await execAndWait(
-          `gh repo list ${org} --limit 1000 --json nameWithOwner --jq ".[].nameWithOwner"`,
+          `gh repo list ${org} --limit 100 --json nameWithOwner --jq ".[].nameWithOwner"`,
           directory
         );
         return orgRepos.stdout
@@ -177,6 +185,10 @@ export async function pushToGitHub(
     // We check gh authentication early to provide a better error message.
     const username = await getGitHubUsername(directory);
 
+    // Start fetching existing repositories in the background immediately
+    // This runs while user is answering prompts, so validation is usually instant
+    populateExistingRepos(directory);
+
     // First prompt: Ask if they want to push to GitHub
     const { push } = await enquirer.prompt<{ push: 'Yes' | 'No' }>([
       {
@@ -192,11 +204,11 @@ export async function pushToGitHub(
       return VcsPushStatus.OptedOutOfPushingToVcs;
     }
 
-    // Preload existing repositories for validation
-    const existingRepos = await getUserRepositories(directory);
-
     // Create default repository name using the username we already have
     const defaultRepo = `${username}/${options.name}`;
+    const createRepoUrl = `https://github.com/new?name=${encodeURIComponent(
+      options.name
+    )}`;
 
     // Second prompt: Ask where to create the repository with validation
     const { repoName } = await enquirer.prompt<{ repoName: string }>([
@@ -210,8 +222,10 @@ export async function pushToGitHub(
             return 'Repository name must be in format: username/repo-name';
           }
 
-          if (existingRepos.has(value)) {
-            return `Repository '${value}' already exists. Please choose a different name.`;
+          // Wait for background fetch to complete before validating
+          const existingRepos = await existingReposPromise;
+          if (existingRepos?.has(value)) {
+            return `Repository '${value}' already exists. Choose a different name or create manually: ${createRepoUrl}`;
           }
 
           return true;
@@ -221,6 +235,10 @@ export async function pushToGitHub(
 
     // Create GitHub repository using gh CLI from the workspace directory
     // This will automatically add remote origin and push the current branch
+    output.log({
+      title:
+        'Creating GitHub repository and pushing (this may take a moment)...',
+    });
     await spawnAndWait(
       'gh',
       [

--- a/packages/create-nx-workspace/src/utils/git/git.ts
+++ b/packages/create-nx-workspace/src/utils/git/git.ts
@@ -249,10 +249,7 @@ export async function pushToGitHub(
     const errorMessage = e instanceof Error ? e.message : String(e);
 
     // Error code 127 means gh wasn't installed
-    const title =
-      e instanceof GitHubPushSkippedError || (e as any)?.code === 127
-        ? 'Push your workspace to GitHub.'
-        : 'Failed to push workspace to GitHub.';
+    const title = 'Push your repo to complete setup.';
 
     const createRepoUrl = `https://github.com/new?name=${encodeURIComponent(
       options.name

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -55,6 +55,50 @@ const messageOptions: Record<string, MessageData[]> = {
       fallback: undefined,
     },
   ],
+  /**
+   * Simplified Cloud prompt for template flow (no CI provider selection)
+   */
+  setupNxCloudSimple: [
+    {
+      code: 'simple-cloud-v1',
+      message: 'Get to green PRs faster with Nx Cloud?',
+      initial: 0,
+      choices: [
+        { value: 'yes', name: 'Yes, set up Nx Cloud' },
+        { value: 'skip', name: 'Skip' },
+      ],
+      footer:
+        '\nAutomated validation, self-healing tests, and 70% faster CI: https://nx.dev/docs/guides/nx-cloud/optimize-your-ttg',
+      hint: `\n(free for open source)`,
+      fallback: undefined,
+    },
+    {
+      code: 'simple-cloud-v2',
+      message: 'Would you like to enable remote caching with Nx Cloud?',
+      initial: 0,
+      choices: [
+        { value: 'yes', name: 'Yes, enable caching' },
+        { value: 'skip', name: 'No, configure it later' },
+      ],
+      footer:
+        '\nRemote caching makes your builds faster: https://nx.dev/ci/features/remote-cache',
+      hint: `\n(can be enabled any time)`,
+      fallback: undefined,
+    },
+    {
+      code: 'simple-cloud-v3',
+      message: 'Speed up CI and reduce compute costs with Nx Cloud?',
+      initial: 0,
+      choices: [
+        { value: 'yes', name: 'Yes' },
+        { value: 'skip', name: 'Skip' },
+      ],
+      footer:
+        '\n70% faster CI, 60% less compute, automated test healing: https://nx.dev/ci/features/remote-cache',
+      hint: `\n(can be enabled later)`,
+      fallback: undefined,
+    },
+  ],
 };
 
 export type MessageKey = keyof typeof messageOptions;

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -56,11 +56,11 @@ const messageOptions: Record<string, MessageData[]> = {
     },
   ],
   /**
-   * Simplified Cloud prompt for template flow (no CI provider selection)
+   * Simplified Cloud prompt for template flow
    */
-  setupNxCloudSimple: [
+  setupNxCloudV2: [
     {
-      code: 'simple-cloud-v1',
+      code: 'cloud-v2-green-prs',
       metaCode: 'green-prs',
       message: 'Get to green PRs faster with Nx Cloud?',
       initial: 0,
@@ -74,7 +74,7 @@ const messageOptions: Record<string, MessageData[]> = {
       fallback: undefined,
     },
     {
-      code: 'simple-cloud-v2',
+      code: 'cloud-v2-remote-cache',
       metaCode: 'remote-cache',
       message: 'Would you like to enable remote caching with Nx Cloud?',
       initial: 0,
@@ -88,7 +88,7 @@ const messageOptions: Record<string, MessageData[]> = {
       fallback: undefined,
     },
     {
-      code: 'simple-cloud-v3',
+      code: 'cloud-v2-fast-ci',
       metaCode: 'fast-ci',
       message: 'Speed up CI and reduce compute costs with Nx Cloud?',
       initial: 0,

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -51,7 +51,7 @@ const messageOptions: Record<string, MessageData[]> = {
       ],
       footer:
         '\nRead more about remote caching at https://nx.dev/ci/features/remote-cache',
-      hint: `\n(can be disabled any time)`,
+      hint: `\n(can be disabled any time).`,
       fallback: undefined,
     },
   ],

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -61,6 +61,7 @@ const messageOptions: Record<string, MessageData[]> = {
   setupNxCloudSimple: [
     {
       code: 'simple-cloud-v1',
+      metaCode: 'green-prs',
       message: 'Get to green PRs faster with Nx Cloud?',
       initial: 0,
       choices: [
@@ -74,6 +75,7 @@ const messageOptions: Record<string, MessageData[]> = {
     },
     {
       code: 'simple-cloud-v2',
+      metaCode: 'remote-cache',
       message: 'Would you like to enable remote caching with Nx Cloud?',
       initial: 0,
       choices: [
@@ -87,6 +89,7 @@ const messageOptions: Record<string, MessageData[]> = {
     },
     {
       code: 'simple-cloud-v3',
+      metaCode: 'fast-ci',
       message: 'Speed up CI and reduce compute costs with Nx Cloud?',
       initial: 0,
       choices: [
@@ -104,6 +107,7 @@ const messageOptions: Record<string, MessageData[]> = {
 export type MessageKey = keyof typeof messageOptions;
 interface MessageData {
   code: string;
+  metaCode?: string; // Optional short code for URL meta tracking
   message: string;
   initial: number;
   choices: Array<{ value: string; name: string }>;
@@ -134,6 +138,16 @@ export class PromptMessages {
       return '';
     } else {
       return messageOptions[key][selected].code;
+    }
+  }
+
+  metaCodeOfSelectedPromptMessage(key: MessageKey): string {
+    const selected = this.selectedMessages[key];
+    if (selected === undefined) {
+      return '';
+    } else {
+      const message = messageOptions[key][selected];
+      return message.metaCode || message.code;
     }
   }
 }

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -143,7 +143,7 @@ const messageOptions: Record<string, MessageData[]> = {
    */
   setupNxCloudV2: [
     {
-      code: 'cloud-v2-remote-cache',
+      code: 'cloud-v2-remote-cache-visit',
       message: 'Enable remote caching with Nx Cloud?',
       initial: 0,
       choices: [
@@ -156,7 +156,7 @@ const messageOptions: Record<string, MessageData[]> = {
       completionMessage: 'cache-setup',
     },
     {
-      code: 'cloud-v2-fast-ci',
+      code: 'cloud-v2-fast-ci-visit',
       message: 'Speed up CI and reduce compute costs with Nx Cloud?',
       initial: 0,
       choices: [
@@ -169,7 +169,7 @@ const messageOptions: Record<string, MessageData[]> = {
       completionMessage: 'ci-setup',
     },
     {
-      code: 'cloud-v2-green-prs',
+      code: 'cloud-v2-green-prs-visit',
       message: 'Get to green PRs faster with Nx Cloud?',
       initial: 0,
       choices: [
@@ -182,7 +182,7 @@ const messageOptions: Record<string, MessageData[]> = {
       completionMessage: 'ci-setup',
     },
     {
-      code: 'cloud-v2-full-platform',
+      code: 'cloud-v2-full-platform-visit',
       message: 'Try the full Nx platform?',
       initial: 0,
       choices: [

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process';
 import { isCI } from '../ci/is-ci';
 import { getPackageManagerCommand } from '../package-manager';
+import type { CompletionMessageKey } from './messages';
 
 export const NxCloudChoices = [
   'github',
@@ -32,6 +33,7 @@ const messageOptions: Record<string, MessageData[]> = {
       footer:
         '\nSelf-healing CI, remote caching, and task distribution are provided by Nx Cloud: https://nx.dev/nx-cloud',
       fallback: { value: 'skip', key: 'setupNxCloud' },
+      completionMessage: 'ci-setup',
     },
   ],
   /**
@@ -53,6 +55,7 @@ const messageOptions: Record<string, MessageData[]> = {
         '\nRead more about remote caching at https://nx.dev/ci/features/remote-cache',
       hint: `\n(can be disabled any time).`,
       fallback: undefined,
+      completionMessage: 'cache-setup',
     },
   ],
   /**
@@ -70,6 +73,7 @@ const messageOptions: Record<string, MessageData[]> = {
       footer:
         '\nRemote caching makes your builds faster for development and in CI: https://nx.dev/ci/features/remote-cache',
       fallback: undefined,
+      completionMessage: 'cache-setup',
     },
     {
       code: 'cloud-v2-fast-ci',
@@ -82,6 +86,7 @@ const messageOptions: Record<string, MessageData[]> = {
       footer:
         '\n70% faster CI, 60% less compute, Automatically fix broken PRs: https://nx.dev/nx-cloud',
       fallback: undefined,
+      completionMessage: 'ci-setup',
     },
     {
       code: 'cloud-v2-green-prs',
@@ -94,6 +99,7 @@ const messageOptions: Record<string, MessageData[]> = {
       footer:
         '\nAutomatically fix broken PRs, 70% faster CI: https://nx.dev/nx-cloud',
       fallback: undefined,
+      completionMessage: 'ci-setup',
     },
     {
       code: 'cloud-v2-full-platform',
@@ -106,6 +112,7 @@ const messageOptions: Record<string, MessageData[]> = {
       footer:
         '\nAutomatically fix broken PRs, 70% faster CI: https://nx.dev/nx-cloud',
       fallback: undefined,
+      completionMessage: 'platform-setup',
     },
   ],
 };
@@ -119,6 +126,7 @@ interface MessageData {
   footer: string;
   hint?: string;
   fallback?: { value: string; key: MessageKey };
+  completionMessage: CompletionMessageKey;
 }
 
 export class PromptMessages {
@@ -143,6 +151,15 @@ export class PromptMessages {
       return '';
     } else {
       return messageOptions[key][selected].code;
+    }
+  }
+
+  completionMessageOfSelectedPrompt(key: MessageKey): CompletionMessageKey {
+    const selected = this.selectedMessages[key];
+    if (selected === undefined) {
+      return 'ci-setup';
+    } else {
+      return messageOptions[key][selected].completionMessage;
     }
   }
 }

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -8,7 +8,7 @@ import type { CompletionMessageKey } from './messages';
 
 // TODO(jack): Remove flow variant logic after A/B testing is complete
 const FLOW_VARIANT_CACHE_FILE = join(tmpdir(), 'nx-cnw-flow-variant');
-const FLOW_VARIANT_EXPIRY_MS = 24 * 60 * 60 * 1000; // 24 hours
+const FLOW_VARIANT_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000; // 1 week
 
 // In-memory cache to ensure consistency within a single run
 let flowVariantCache: string | null = null;

--- a/packages/create-nx-workspace/src/utils/nx/messages.spec.ts
+++ b/packages/create-nx-workspace/src/utils/nx/messages.spec.ts
@@ -15,7 +15,6 @@ describe('Nx Cloud Messages', () => {
             "Go to Nx Cloud and finish the setup: https://nx.app/setup/123",
           ],
           "title": "Your CI setup is almost complete.",
-          "type": "success",
         }
       `);
     });
@@ -32,7 +31,6 @@ describe('Nx Cloud Messages', () => {
             "Return to Nx Cloud and finish the setup.",
           ],
           "title": "Your CI setup is almost complete.",
-          "type": "success",
         }
       `);
     });
@@ -49,7 +47,6 @@ describe('Nx Cloud Messages', () => {
             "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
           ],
           "title": "Your CI setup is almost complete.",
-          "type": "success",
         }
       `);
     });
@@ -66,7 +63,6 @@ describe('Nx Cloud Messages', () => {
             "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
           ],
           "title": "Your CI setup is almost complete.",
-          "type": "success",
         }
       `);
     });
@@ -83,7 +79,6 @@ describe('Nx Cloud Messages', () => {
             "Push your repo, then return to Nx Cloud and finish the setup.",
           ],
           "title": "Your CI setup is almost complete.",
-          "type": "success",
         }
       `);
     });
@@ -100,7 +95,6 @@ describe('Nx Cloud Messages', () => {
             "Push your repo, then return to Nx Cloud and finish the setup.",
           ],
           "title": "Your CI setup is almost complete.",
-          "type": "success",
         }
       `);
     });
@@ -119,7 +113,6 @@ describe('Nx Cloud Messages', () => {
             "Go to Nx Cloud and finish the setup: https://nx.app/setup/456",
           ],
           "title": "Your remote cache setup is almost complete.",
-          "type": "success",
         }
       `);
     });
@@ -136,7 +129,6 @@ describe('Nx Cloud Messages', () => {
             "Return to Nx Cloud and finish the setup.",
           ],
           "title": "Your remote cache setup is almost complete.",
-          "type": "success",
         }
       `);
     });
@@ -153,7 +145,6 @@ describe('Nx Cloud Messages', () => {
             "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/456",
           ],
           "title": "Your remote cache setup is almost complete.",
-          "type": "success",
         }
       `);
     });
@@ -170,7 +161,6 @@ describe('Nx Cloud Messages', () => {
             "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/456",
           ],
           "title": "Your remote cache setup is almost complete.",
-          "type": "success",
         }
       `);
     });
@@ -187,7 +177,6 @@ describe('Nx Cloud Messages', () => {
             "Push your repo, then return to Nx Cloud and finish the setup.",
           ],
           "title": "Your remote cache setup is almost complete.",
-          "type": "success",
         }
       `);
     });
@@ -204,7 +193,6 @@ describe('Nx Cloud Messages', () => {
             "Push your repo, then return to Nx Cloud and finish the setup.",
           ],
           "title": "Your remote cache setup is almost complete.",
-          "type": "success",
         }
       `);
     });
@@ -258,7 +246,6 @@ describe('Nx Cloud Messages', () => {
         expect(message.title).toBe(
           'Your remote cache setup is almost complete.'
         );
-        expect(message.type).toBe('success');
       });
     });
   });
@@ -271,7 +258,6 @@ describe('Nx Cloud Messages', () => {
         VcsPushStatus.PushedToVcs
       );
       expect(message.title).toBe('Your platform setup is almost complete.');
-      expect(message.type).toBe('success');
     });
   });
 
@@ -298,7 +284,6 @@ describe('Nx Cloud Messages', () => {
             "Learn more at https://nx.dev/nx-cloud",
           ],
           "title": "Next steps",
-          "type": "success",
         }
       `);
     });

--- a/packages/create-nx-workspace/src/utils/nx/messages.spec.ts
+++ b/packages/create-nx-workspace/src/utils/nx/messages.spec.ts
@@ -1,17 +1,11 @@
-import { getMessageFactory } from './messages';
+import { getCompletionMessage, getSkippedCloudMessage } from './messages';
 import { VcsPushStatus } from '../git/git';
 
 describe('Nx Cloud Messages', () => {
   describe('CI Setup Messages', () => {
-    let messageFactory: ReturnType<typeof getMessageFactory>;
-    beforeEach(() => {
-      messageFactory = getMessageFactory(
-        'create-nx-workspace-success-ci-setup'
-      );
-    });
-
     it('should show the setup link user pushed but is not coming from Nx Cloud', () => {
-      const message = messageFactory.createMessage(
+      const message = getCompletionMessage(
+        'ci-setup',
         'https://nx.app/setup/123',
         VcsPushStatus.PushedToVcs
       );
@@ -27,7 +21,8 @@ describe('Nx Cloud Messages', () => {
     });
 
     it('should instruct the user to return to Nx Cloud when they have pushed the repo without instructing them to push', () => {
-      const message = messageFactory.createMessage(
+      const message = getCompletionMessage(
+        'ci-setup',
         null,
         VcsPushStatus.PushedToVcs
       );
@@ -43,7 +38,8 @@ describe('Nx Cloud Messages', () => {
     });
 
     it('should instruct user to push repo first when they opted out of pushing', () => {
-      const message = messageFactory.createMessage(
+      const message = getCompletionMessage(
+        'ci-setup',
         'https://nx.app/setup/123',
         VcsPushStatus.OptedOutOfPushingToVcs
       );
@@ -59,7 +55,8 @@ describe('Nx Cloud Messages', () => {
     });
 
     it('should instruct user to go to Nx Cloud after pushing when they have failed to push and URL is available', () => {
-      const message = messageFactory.createMessage(
+      const message = getCompletionMessage(
+        'ci-setup',
         'https://nx.app/setup/123',
         VcsPushStatus.FailedToPushToVcs
       );
@@ -75,7 +72,8 @@ describe('Nx Cloud Messages', () => {
     });
 
     it('should show "return to Nx Cloud" when failed to push and no URL', () => {
-      const message = messageFactory.createMessage(
+      const message = getCompletionMessage(
+        'ci-setup',
         null,
         VcsPushStatus.FailedToPushToVcs
       );
@@ -91,7 +89,8 @@ describe('Nx Cloud Messages', () => {
     });
 
     it('should show "return to Nx Cloud" when opted out and no URL', () => {
-      const message = messageFactory.createMessage(
+      const message = getCompletionMessage(
+        'ci-setup',
         null,
         VcsPushStatus.OptedOutOfPushingToVcs
       );
@@ -108,15 +107,9 @@ describe('Nx Cloud Messages', () => {
   });
 
   describe('Cache Setup Messages', () => {
-    let messageFactory: ReturnType<typeof getMessageFactory>;
-    beforeEach(() => {
-      messageFactory = getMessageFactory(
-        'create-nx-workspace-success-cache-setup'
-      );
-    });
-
     it('should show the setup link when user pushed but is not coming from Nx Cloud', () => {
-      const message = messageFactory.createMessage(
+      const message = getCompletionMessage(
+        'cache-setup',
         'https://nx.app/setup/456',
         VcsPushStatus.PushedToVcs
       );
@@ -125,14 +118,15 @@ describe('Nx Cloud Messages', () => {
           "bodyLines": [
             "Go to Nx Cloud and finish the setup: https://nx.app/setup/456",
           ],
-          "title": "Your remote cache is almost complete.",
+          "title": "Your remote cache setup is almost complete.",
           "type": "success",
         }
       `);
     });
 
     it('should instruct the user to return to Nx Cloud when they have pushed the repo without instructing them to push', () => {
-      const message = messageFactory.createMessage(
+      const message = getCompletionMessage(
+        'cache-setup',
         null,
         VcsPushStatus.PushedToVcs
       );
@@ -141,14 +135,15 @@ describe('Nx Cloud Messages', () => {
           "bodyLines": [
             "Return to Nx Cloud and finish the setup.",
           ],
-          "title": "Your remote cache is almost complete.",
+          "title": "Your remote cache setup is almost complete.",
           "type": "success",
         }
       `);
     });
 
     it('should instruct user to push repo first when they opted out of pushing', () => {
-      const message = messageFactory.createMessage(
+      const message = getCompletionMessage(
+        'cache-setup',
         'https://nx.app/setup/456',
         VcsPushStatus.OptedOutOfPushingToVcs
       );
@@ -157,14 +152,15 @@ describe('Nx Cloud Messages', () => {
           "bodyLines": [
             "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/456",
           ],
-          "title": "Your remote cache is almost complete.",
+          "title": "Your remote cache setup is almost complete.",
           "type": "success",
         }
       `);
     });
 
     it('should instruct user to go to Nx Cloud after pushing when they have failed to push and URL is available', () => {
-      const message = messageFactory.createMessage(
+      const message = getCompletionMessage(
+        'cache-setup',
         'https://nx.app/setup/456',
         VcsPushStatus.FailedToPushToVcs
       );
@@ -173,14 +169,15 @@ describe('Nx Cloud Messages', () => {
           "bodyLines": [
             "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/456",
           ],
-          "title": "Your remote cache is almost complete.",
+          "title": "Your remote cache setup is almost complete.",
           "type": "success",
         }
       `);
     });
 
     it('should instruct user to return to Nx Cloud after pushing when they have failed to push and no URL is available', () => {
-      const message = messageFactory.createMessage(
+      const message = getCompletionMessage(
+        'cache-setup',
         null,
         VcsPushStatus.FailedToPushToVcs
       );
@@ -189,14 +186,15 @@ describe('Nx Cloud Messages', () => {
           "bodyLines": [
             "Push your repo, then return to Nx Cloud and finish the setup.",
           ],
-          "title": "Your remote cache is almost complete.",
+          "title": "Your remote cache setup is almost complete.",
           "type": "success",
         }
       `);
     });
 
     it('should show "return to Nx Cloud" when opted out and no URL', () => {
-      const message = messageFactory.createMessage(
+      const message = getCompletionMessage(
+        'cache-setup',
         null,
         VcsPushStatus.OptedOutOfPushingToVcs
       );
@@ -205,26 +203,30 @@ describe('Nx Cloud Messages', () => {
           "bodyLines": [
             "Push your repo, then return to Nx Cloud and finish the setup.",
           ],
-          "title": "Your remote cache is almost complete.",
+          "title": "Your remote cache setup is almost complete.",
           "type": "success",
         }
       `);
     });
 
-    it('should always include exactly two body lines for cache setup messages', () => {
-      const messageWithUrl = messageFactory.createMessage(
+    it('should always include exactly one body line for cache setup messages', () => {
+      const messageWithUrl = getCompletionMessage(
+        'cache-setup',
         'https://nx.app/setup/456',
         VcsPushStatus.PushedToVcs
       );
-      const messageWithoutUrl = messageFactory.createMessage(
+      const messageWithoutUrl = getCompletionMessage(
+        'cache-setup',
         null,
         VcsPushStatus.PushedToVcs
       );
-      const messageNotPushedWithUrl = messageFactory.createMessage(
+      const messageNotPushedWithUrl = getCompletionMessage(
+        'cache-setup',
         'https://nx.app/setup/456',
         VcsPushStatus.FailedToPushToVcs
       );
-      const messageNotPushedWithoutUrl = messageFactory.createMessage(
+      const messageNotPushedWithoutUrl = getCompletionMessage(
+        'cache-setup',
         null,
         VcsPushStatus.FailedToPushToVcs
       );
@@ -252,10 +254,53 @@ describe('Nx Cloud Messages', () => {
       ];
 
       scenarios.forEach(({ url, pushed }) => {
-        const message = messageFactory.createMessage(url, pushed);
-        expect(message.title).toBe('Your remote cache is almost complete.');
+        const message = getCompletionMessage('cache-setup', url, pushed);
+        expect(message.title).toBe(
+          'Your remote cache setup is almost complete.'
+        );
         expect(message.type).toBe('success');
       });
+    });
+  });
+
+  describe('Platform Setup Messages', () => {
+    it('should show platform setup title', () => {
+      const message = getCompletionMessage(
+        'platform-setup',
+        'https://nx.app/setup/789',
+        VcsPushStatus.PushedToVcs
+      );
+      expect(message.title).toBe('Your platform setup is almost complete.');
+      expect(message.type).toBe('success');
+    });
+  });
+
+  describe('Default Messages', () => {
+    it('should default to ci-setup when no key is provided', () => {
+      const message = getCompletionMessage(
+        undefined,
+        'https://nx.app/setup/123',
+        VcsPushStatus.PushedToVcs
+      );
+      expect(message.title).toBe('Your CI setup is almost complete.');
+    });
+  });
+
+  describe('Skipped Cloud Messages', () => {
+    it('should return next steps message with nx connect instruction', () => {
+      const message = getSkippedCloudMessage();
+      expect(message).toMatchInlineSnapshot(`
+        {
+          "bodyLines": [
+            "Run "nx connect" to enable remote caching and speed up your CI.",
+            "",
+            "70% faster CI, 60% less compute, automatically fix broken PRs.",
+            "Learn more at https://nx.dev/nx-cloud",
+          ],
+          "title": "Next steps",
+          "type": "success",
+        }
+      `);
     });
   });
 });

--- a/packages/create-nx-workspace/src/utils/nx/messages.ts
+++ b/packages/create-nx-workspace/src/utils/nx/messages.ts
@@ -38,24 +38,21 @@ export function getCompletionMessage(
   completionMessageKey: CompletionMessageKey | undefined,
   url: string | null,
   pushedToVcs: VcsPushStatus
-): { title: string; type: 'success'; bodyLines: string[] } {
+): { title: string; bodyLines: string[] } {
   const key = completionMessageKey ?? 'ci-setup';
 
   return {
     title: completionMessages[key].title,
-    type: 'success',
     bodyLines: [getSetupMessage(url, pushedToVcs)],
   };
 }
 
 export function getSkippedCloudMessage(): {
   title: string;
-  type: 'success';
   bodyLines: string[];
 } {
   return {
     title: 'Next steps',
-    type: 'success',
     bodyLines: [
       'Run "nx connect" to enable remote caching and speed up your CI.',
       '',

--- a/packages/create-nx-workspace/src/utils/nx/messages.ts
+++ b/packages/create-nx-workspace/src/utils/nx/messages.ts
@@ -41,48 +41,6 @@ const outputMessages = {
       },
     },
   ],
-  'create-nx-workspace-template-cloud': [
-    {
-      code: 'template-cloud-connect-v1',
-      createMessage: (url: string | null, pushedToVcs: VcsPushStatus) => ({
-        title: 'Connect to Nx Cloud to complete setup',
-        type: 'success',
-        bodyLines: [
-          url || 'Run: nx connect',
-          '',
-          'Nx Cloud provides:',
-          '  • Remote caching across your team',
-          '  • Distributed task execution',
-          '  • Real-time build insights',
-        ],
-      }),
-    },
-    {
-      code: 'template-cloud-connect-v2',
-      createMessage: (url: string | null, pushedToVcs: VcsPushStatus) => ({
-        title: 'One more step: activate remote caching',
-        type: 'success',
-        bodyLines: [
-          'Visit the link below to connect your workspace:',
-          url || '',
-          '',
-          'This enables 10x faster builds by sharing cache across your team.',
-        ],
-      }),
-    },
-    {
-      code: 'template-cloud-connect-v3',
-      createMessage: (url: string | null, pushedToVcs: VcsPushStatus) => ({
-        title: 'Almost done! Finish Nx Cloud setup',
-        type: 'success',
-        bodyLines: [
-          url || 'Run: nx connect',
-          '',
-          'Takes 30 seconds. Makes your builds 10x faster.',
-        ],
-      }),
-    },
-  ],
 } as const;
 type OutputMessageKey = keyof typeof outputMessages;
 

--- a/packages/create-nx-workspace/src/utils/nx/messages.ts
+++ b/packages/create-nx-workspace/src/utils/nx/messages.ts
@@ -41,6 +41,48 @@ const outputMessages = {
       },
     },
   ],
+  'create-nx-workspace-template-cloud': [
+    {
+      code: 'template-cloud-connect-v1',
+      createMessage: (url: string | null, pushedToVcs: VcsPushStatus) => ({
+        title: 'Connect to Nx Cloud to complete setup',
+        type: 'success',
+        bodyLines: [
+          url || 'Run: nx connect',
+          '',
+          'Nx Cloud provides:',
+          '  • Remote caching across your team',
+          '  • Distributed task execution',
+          '  • Real-time build insights',
+        ],
+      }),
+    },
+    {
+      code: 'template-cloud-connect-v2',
+      createMessage: (url: string | null, pushedToVcs: VcsPushStatus) => ({
+        title: 'One more step: activate remote caching',
+        type: 'success',
+        bodyLines: [
+          'Visit the link below to connect your workspace:',
+          url || '',
+          '',
+          'This enables 10x faster builds by sharing cache across your team.',
+        ],
+      }),
+    },
+    {
+      code: 'template-cloud-connect-v3',
+      createMessage: (url: string | null, pushedToVcs: VcsPushStatus) => ({
+        title: 'Almost done! Finish Nx Cloud setup',
+        type: 'success',
+        bodyLines: [
+          url || 'Run: nx connect',
+          '',
+          'Takes 30 seconds. Makes your builds 10x faster.',
+        ],
+      }),
+    },
+  ],
 } as const;
 type OutputMessageKey = keyof typeof outputMessages;
 

--- a/packages/create-nx-workspace/src/utils/nx/messages.ts
+++ b/packages/create-nx-workspace/src/utils/nx/messages.ts
@@ -16,53 +16,51 @@ function getSetupMessage(
   return `Push your repo, then ${action} to Nx Cloud and finish the setup${urlSuffix}`;
 }
 
-const outputMessages = {
-  'create-nx-workspace-success-ci-setup': [
-    {
-      code: 'ci-setup-visit',
-      createMessage: (url: string | null, pushedToVcs: VcsPushStatus) => {
-        return {
-          title: `Your CI setup is almost complete.`,
-          type: 'success',
-          bodyLines: [getSetupMessage(url, pushedToVcs)],
-        };
-      },
-    },
-  ],
-  'create-nx-workspace-success-cache-setup': [
-    {
-      code: 'remote-cache-visit',
-      createMessage: (url: string | null, pushedToVcs: VcsPushStatus) => {
-        return {
-          title: `Your remote cache is almost complete.`,
-          type: 'success',
-          bodyLines: [getSetupMessage(url, pushedToVcs)],
-        };
-      },
-    },
-  ],
+/**
+ * Completion messages shown after workspace creation.
+ * Keys are referenced by ab-testing.ts prompts via completionMessage field.
+ */
+const completionMessages = {
+  'ci-setup': {
+    title: 'Your CI setup is almost complete.',
+  },
+  'cache-setup': {
+    title: 'Your remote cache setup is almost complete.',
+  },
+  'platform-setup': {
+    title: 'Your platform setup is almost complete.',
+  },
 } as const;
-type OutputMessageKey = keyof typeof outputMessages;
 
-class ABTestingMessages {
-  private selectedMessages: Record<string, number> = {};
+export type CompletionMessageKey = keyof typeof completionMessages;
 
-  getMessageFactory(key: OutputMessageKey) {
-    if (this.selectedMessages[key] === undefined) {
-      if (process.env.NX_GENERATE_DOCS_PROCESS === 'true') {
-        this.selectedMessages[key] = 0;
-      } else {
-        this.selectedMessages[key] = Math.floor(
-          Math.random() * outputMessages[key].length
-        );
-      }
-    }
-    return outputMessages[key][this.selectedMessages[key]!];
-  }
+export function getCompletionMessage(
+  completionMessageKey: CompletionMessageKey | undefined,
+  url: string | null,
+  pushedToVcs: VcsPushStatus
+): { title: string; type: 'success'; bodyLines: string[] } {
+  const key = completionMessageKey ?? 'ci-setup';
+
+  return {
+    title: completionMessages[key].title,
+    type: 'success',
+    bodyLines: [getSetupMessage(url, pushedToVcs)],
+  };
 }
 
-const messages = new ABTestingMessages();
-
-export function getMessageFactory(key: OutputMessageKey) {
-  return messages.getMessageFactory(key);
+export function getSkippedCloudMessage(): {
+  title: string;
+  type: 'success';
+  bodyLines: string[];
+} {
+  return {
+    title: 'Next steps',
+    type: 'success',
+    bodyLines: [
+      'Run "nx connect" to enable remote caching and speed up your CI.',
+      '',
+      '70% faster CI, 60% less compute, automatically fix broken PRs.',
+      'Learn more at https://nx.dev/nx-cloud',
+    ],
+  };
 }

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -119,8 +119,7 @@ export async function getNxCloudInfo(
   connectCloudUrl: string,
   pushedToVcs: VcsPushStatus,
   rawNxCloud?: NxCloud,
-  isTemplate?: boolean,
-  promptCode?: string
+  isTemplate?: boolean
 ) {
   const source = getCloudMessageSource(!!isTemplate, nxCloud);
   const { createMessage } = getMessageFactory(source);

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -47,7 +47,8 @@ export async function createNxCloudOnboardingUrl(
   token: string,
   directory: string,
   useGitHub?: boolean,
-  isTemplate?: boolean
+  isTemplate?: boolean,
+  promptCode?: string
 ) {
   // nx-ignore-next-line
   const { createNxCloudOnboardingURL } = require(require.resolve(
@@ -59,11 +60,18 @@ export async function createNxCloudOnboardingUrl(
   )) as any;
 
   const source = getCloudMessageSource(!!isTemplate, nxCloud);
-  const { code } = getMessageFactory(source);
+  const { code: successMessageCode } = getMessageFactory(source);
+
+  // Combine prompt code with success message code
+  // Format: "prompt-code:success-code" or just "success-code" if no prompt
+  const meta = promptCode
+    ? `${promptCode}:${successMessageCode}`
+    : successMessageCode;
+
   return await createNxCloudOnboardingURL(
     source,
     token,
-    code,
+    meta,
     false,
     useGitHub ??
       (nxCloud === 'yes' || nxCloud === 'github' || nxCloud === 'circleci')
@@ -75,7 +83,8 @@ export async function getNxCloudInfo(
   connectCloudUrl: string,
   pushedToVcs: VcsPushStatus,
   rawNxCloud?: NxCloud,
-  isTemplate?: boolean
+  isTemplate?: boolean,
+  promptCode?: string
 ) {
   const source = getCloudMessageSource(!!isTemplate, nxCloud);
   const { createMessage } = getMessageFactory(source);

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -26,6 +26,42 @@ function getCloudMessageSource(
     : 'create-nx-workspace-success-ci-setup';
 }
 
+export async function connectToNxCloudForTemplate(
+  directory: string,
+  installationSource: string,
+  useGitHub?: boolean
+): Promise<string | null> {
+  // nx-ignore-next-line
+  const { connectToNxCloud } = require(require.resolve(
+    'nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud',
+    {
+      paths: [directory],
+    }
+    // nx-ignore-next-line
+  )) as typeof import('nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud');
+
+  // nx-ignore-next-line
+  const { FsTree, flushChanges } = require(require.resolve(
+    'nx/src/generators/tree',
+    {
+      paths: [directory],
+      // nx-ignore-next-line
+    }
+  )) as typeof import('nx/src/generators/tree');
+
+  const tree = new FsTree(directory, false);
+  const result = await connectToNxCloud(tree, {
+    installationSource,
+    directory: '',
+    github: useGitHub,
+  });
+
+  // Flush the tree changes to disk
+  flushChanges(directory, tree.listChanges());
+
+  return result;
+}
+
 export function readNxCloudToken(directory: string) {
   const nxCloudSpinner = ora(`Checking Nx Cloud setup`).start();
   // nx-ignore-next-line

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -73,6 +73,7 @@ export async function createNxCloudOnboardingUrl(
   token: string,
   directory: string,
   useGitHub?: boolean,
+  flowVariant?: string,
   promptCode?: string
 ): Promise<string> {
   // nx-ignore-next-line
@@ -90,14 +91,27 @@ export async function createNxCloudOnboardingUrl(
       ? 'create-nx-workspace-success-cache-setup'
       : 'create-nx-workspace-success-ci-setup';
 
-  return await createNxCloudOnboardingURL(
+  // Meta: "start" or "start-v2" prefix, with prompt code
+  // For template flow: use specific prompt code (e.g., 'cloud-v2-remote-cache')
+  // For preset flow or Custom: use visit codes based on nxCloud value
+  const prefix = flowVariant === '1' ? 'start-v2' : 'start';
+  const code =
+    promptCode ?? (nxCloud === 'yes' ? 'remote-cache-visit' : 'ci-setup-visit');
+  const meta = `${prefix}-${code}`;
+
+  const x = await createNxCloudOnboardingURL(
     source,
     token,
-    promptCode ?? '',
+    meta,
     false,
     useGitHub ??
       (nxCloud === 'yes' || nxCloud === 'github' || nxCloud === 'circleci')
   );
+  require('fs').appendFileSync(
+    '/tmp/nx-cloud-onboarding-url.txt',
+    `${x} - ${meta}\n`
+  );
+  return x;
 }
 
 export async function getNxCloudInfo(

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -12,6 +12,20 @@ export type NxCloud =
   | 'circleci'
   | 'skip';
 
+function getCloudMessageSource(
+  isTemplate: boolean,
+  nxCloud: NxCloud
+):
+  | 'create-nx-workspace-template-cloud'
+  | 'create-nx-workspace-success-cache-setup'
+  | 'create-nx-workspace-success-ci-setup' {
+  return isTemplate
+    ? 'create-nx-workspace-template-cloud'
+    : nxCloud === 'yes'
+    ? 'create-nx-workspace-success-cache-setup'
+    : 'create-nx-workspace-success-ci-setup';
+}
+
 export function readNxCloudToken(directory: string) {
   const nxCloudSpinner = ora(`Checking Nx Cloud setup`).start();
   // nx-ignore-next-line
@@ -32,7 +46,8 @@ export async function createNxCloudOnboardingUrl(
   nxCloud: NxCloud,
   token: string,
   directory: string,
-  useGitHub?: boolean
+  useGitHub?: boolean,
+  isTemplate?: boolean
 ) {
   // nx-ignore-next-line
   const { createNxCloudOnboardingURL } = require(require.resolve(
@@ -43,10 +58,7 @@ export async function createNxCloudOnboardingUrl(
     // nx-ignore-next-line
   )) as any;
 
-  const source =
-    nxCloud === 'yes'
-      ? 'create-nx-workspace-success-cache-setup'
-      : 'create-nx-workspace-success-ci-setup';
+  const source = getCloudMessageSource(!!isTemplate, nxCloud);
   const { code } = getMessageFactory(source);
   return await createNxCloudOnboardingURL(
     source,
@@ -62,12 +74,10 @@ export async function getNxCloudInfo(
   nxCloud: NxCloud,
   connectCloudUrl: string,
   pushedToVcs: VcsPushStatus,
-  rawNxCloud?: NxCloud
+  rawNxCloud?: NxCloud,
+  isTemplate?: boolean
 ) {
-  const source =
-    nxCloud === 'yes'
-      ? 'create-nx-workspace-success-cache-setup'
-      : 'create-nx-workspace-success-ci-setup';
+  const source = getCloudMessageSource(!!isTemplate, nxCloud);
   const { createMessage } = getMessageFactory(source);
   const out = new CLIOutput(false);
   const message = createMessage(

--- a/packages/create-nx-workspace/src/utils/template/clone-template.ts
+++ b/packages/create-nx-workspace/src/utils/template/clone-template.ts
@@ -9,6 +9,12 @@ export async function cloneTemplate(
   templateUrl: string,
   targetDirectory: string
 ): Promise<void> {
+  if (existsSync(targetDirectory)) {
+    throw new Error(
+      `The directory '${targetDirectory}' already exists and is not empty. Choose a different name or remove the existing directory.`
+    );
+  }
+
   try {
     await execAndWait(
       `git clone --depth 1 "${templateUrl}" "${targetDirectory}"`,
@@ -23,7 +29,7 @@ export async function cloneTemplate(
   } catch (e) {
     if (e instanceof Error) {
       output.error({
-        title: 'Failed to clone template',
+        title: 'Failed to create starter workspace',
         bodyLines: mapErrorToBodyLines(e),
       });
     } else {

--- a/packages/create-nx-workspace/src/utils/template/clone-template.ts
+++ b/packages/create-nx-workspace/src/utils/template/clone-template.ts
@@ -1,61 +1,24 @@
 import { execAndWait } from '../child-process-utils';
 import { existsSync } from 'fs';
-import { rm, readFile, writeFile } from 'fs/promises';
+import { rm } from 'fs/promises';
 import { join } from 'path';
 import { output } from '../output';
 import { mapErrorToBodyLines } from '../error-utils';
 
 export async function cloneTemplate(
   templateUrl: string,
-  targetDirectory: string,
-  workspaceName: string
+  targetDirectory: string
 ): Promise<void> {
   try {
-    // 1. Clone with shallow history
     await execAndWait(
       `git clone --depth 1 "${templateUrl}" "${targetDirectory}"`,
       process.cwd()
     );
 
-    // 2. Remove git history (start fresh)
+    // Ensure clean history
     const gitDir = join(targetDirectory, '.git');
     if (existsSync(gitDir)) {
       await rm(gitDir, { recursive: true, force: true });
-    }
-
-    // 3. Update workspace name in package.json
-    const pkgPath = join(targetDirectory, 'package.json');
-    if (existsSync(pkgPath)) {
-      const pkg = JSON.parse(await readFile(pkgPath, 'utf-8'));
-      pkg.name = workspaceName;
-      await writeFile(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
-    } else {
-      output.error({
-        title: 'Invalid template',
-        bodyLines: [
-          'Template is missing package.json file.',
-          'Please ensure the template is a valid Nx workspace.',
-        ],
-      });
-      process.exit(1);
-    }
-
-    // 4. Remove any Cloud config from template's nx.json
-    const nxJsonPath = join(targetDirectory, 'nx.json');
-    if (existsSync(nxJsonPath)) {
-      const nxJson = JSON.parse(await readFile(nxJsonPath, 'utf-8'));
-      delete nxJson.nxCloudId;
-      delete nxJson.nxCloudAccessToken;
-      await writeFile(nxJsonPath, JSON.stringify(nxJson, null, 2) + '\n');
-    } else {
-      output.error({
-        title: 'Invalid template',
-        bodyLines: [
-          'Template is missing nx.json file.',
-          'Please ensure the template is a valid Nx workspace.',
-        ],
-      });
-      process.exit(1);
     }
   } catch (e) {
     if (e instanceof Error) {

--- a/packages/create-nx-workspace/src/utils/template/clone-template.ts
+++ b/packages/create-nx-workspace/src/utils/template/clone-template.ts
@@ -1,0 +1,92 @@
+import { execAndWait } from '../child-process-utils';
+import { existsSync } from 'fs';
+import { rm, readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { output } from '../output';
+import { mapErrorToBodyLines } from '../error-utils';
+
+export async function cloneTemplate(
+  templateUrl: string,
+  targetDirectory: string,
+  workspaceName: string
+): Promise<void> {
+  try {
+    // 1. Clone with shallow history
+    await execAndWait(
+      `git clone --depth 1 "${templateUrl}" "${targetDirectory}"`,
+      process.cwd()
+    );
+
+    // 2. Remove git history (start fresh)
+    const gitDir = join(targetDirectory, '.git');
+    if (existsSync(gitDir)) {
+      await rm(gitDir, { recursive: true, force: true });
+    }
+
+    // 3. Update workspace name in package.json
+    const pkgPath = join(targetDirectory, 'package.json');
+    if (existsSync(pkgPath)) {
+      const pkg = JSON.parse(await readFile(pkgPath, 'utf-8'));
+      pkg.name = workspaceName;
+      await writeFile(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+    } else {
+      output.error({
+        title: 'Invalid template',
+        bodyLines: [
+          'Template is missing package.json file.',
+          'Please ensure the template is a valid Nx workspace.',
+        ],
+      });
+      process.exit(1);
+    }
+
+    // 4. Remove any Cloud config from template's nx.json
+    const nxJsonPath = join(targetDirectory, 'nx.json');
+    if (existsSync(nxJsonPath)) {
+      const nxJson = JSON.parse(await readFile(nxJsonPath, 'utf-8'));
+      delete nxJson.nxCloudId;
+      delete nxJson.nxCloudAccessToken;
+      await writeFile(nxJsonPath, JSON.stringify(nxJson, null, 2) + '\n');
+    } else {
+      output.error({
+        title: 'Invalid template',
+        bodyLines: [
+          'Template is missing nx.json file.',
+          'Please ensure the template is a valid Nx workspace.',
+        ],
+      });
+      process.exit(1);
+    }
+  } catch (e) {
+    if (e instanceof Error) {
+      output.error({
+        title: 'Failed to clone template',
+        bodyLines: mapErrorToBodyLines(e),
+      });
+    } else {
+      console.error(e);
+    }
+    process.exit(1);
+  }
+}
+
+export async function cleanupLockfiles(
+  targetDirectory: string,
+  packageManager: string
+): Promise<void> {
+  const lockfiles = {
+    npm: 'package-lock.json',
+    yarn: 'yarn.lock',
+    pnpm: 'pnpm-lock.yaml',
+    bun: 'bun.lockb',
+  };
+
+  for (const [pm, lockfile] of Object.entries(lockfiles)) {
+    if (pm !== packageManager) {
+      const lockPath = join(targetDirectory, lockfile);
+      if (existsSync(lockPath)) {
+        await rm(lockPath, { force: true });
+      }
+    }
+  }
+}

--- a/packages/create-nx-workspace/src/utils/template/clone-template.ts
+++ b/packages/create-nx-workspace/src/utils/template/clone-template.ts
@@ -38,24 +38,3 @@ export async function cloneTemplate(
     process.exit(1);
   }
 }
-
-export async function cleanupLockfiles(
-  targetDirectory: string,
-  packageManager: string
-): Promise<void> {
-  const lockfiles = {
-    npm: 'package-lock.json',
-    yarn: 'yarn.lock',
-    pnpm: 'pnpm-lock.yaml',
-    bun: 'bun.lockb',
-  };
-
-  for (const [pm, lockfile] of Object.entries(lockfiles)) {
-    if (pm !== packageManager) {
-      const lockPath = join(targetDirectory, lockfile);
-      if (existsSync(lockPath)) {
-        await rm(lockPath, { force: true });
-      }
-    }
-  }
-}


### PR DESCRIPTION
This PR simplifies the CNW process so we only prompt for a starter (TS, NPM Packages, React, Angular) and we clone a full example to showcase Nx monorepo for the given starter. This speeds up CNW drastically and allows users to get the workspace in 5-10 seconds vs 1-3 minutes.

Users can choose `Custom` to fall back to the previous prompts, which will ask framework, unit test runner, e2e runner, etc.