### PR TITLE
fix(misc): handle ERR_USE_AFTER_CLOSE gracefully in nx init and create-nx-workspace

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -252,6 +252,19 @@ export const commandsObject: yargs.Argv<Arguments> = yargs
     nxVersion
   ) as yargs.Argv<Arguments>;
 
+// Node 24 has stricter readline behavior, and enquirer is not checking for closed state
+// when invoking operations, thus you get an ERR_USE_AFTER_CLOSE error.
+process.on('uncaughtException', (error: unknown) => {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    error['code'] === 'ERR_USE_AFTER_CLOSE'
+  )
+    return;
+  throw error;
+});
+
 let rawArgs: Arguments;
 async function main(parsedArgs: yargs.Arguments<Arguments>) {
   output.log({

--- a/packages/nx/src/command-line/init/command-object.ts
+++ b/packages/nx/src/command-line/init/command-object.ts
@@ -7,6 +7,19 @@ export const yargsInitCommand: CommandModule = {
     'Adds Nx to any type of workspace. It installs nx, creates an nx.json configuration file and optionally sets up remote caching. For more info, check https://nx.dev/recipes/adopting-nx.',
   builder: (yargs) => withInitOptions(yargs),
   handler: async (args: any) => {
+    // Node 24 has stricter readline behavior, and enquirer is not checking for closed state
+    // when invoking operations, thus you get an ERR_USE_AFTER_CLOSE error.
+    process.on('uncaughtException', (error) => {
+      if (
+        error &&
+        typeof error === 'object' &&
+        'code' in error &&
+        error['code'] === 'ERR_USE_AFTER_CLOSE'
+      )
+        return;
+      throw error;
+    });
+
     try {
       const useV2 = await isInitV2();
       if (useV2) {


### PR DESCRIPTION
https://www.loom.com/share/560ceccdad45462e9fd3e3f185fc9fa5

Node 24 has stricter readline behavior, and enquirer is not checking for closed state when invoking operations, resulting in an ERR_USE_AFTER_CLOSE error when users press Ctrl+C during interactive prompts.

This commit fixes the issue by adding uncaughtException handler to ignore ERR_USE_AFTER_CLOSE errors.

When users press Ctrl+C, the process now exits cleanly without showing an ugly error stack trace.

Fixes NXC-3412