### PR TITLE
fix(vite): support vitest v4

### DIFF
--- a/packages/vite/src/generators/configuration/configuration.ts
+++ b/packages/vite/src/generators/configuration/configuration.ts
@@ -164,18 +164,23 @@ export async function viteConfigurationGeneratorInternal(
   }
 
   if (schema.includeVitest) {
-    const vitestTask = await vitestGenerator(tree, {
-      project: schema.project,
-      uiFramework: schema.uiFramework,
-      inSourceTests: schema.inSourceTests,
-      coverageProvider: 'v8',
-      skipViteConfig: true,
-      testTarget: 'test',
-      skipFormat: true,
-      addPlugin: schema.addPlugin,
-      compiler: schema.compiler,
-      projectType,
-    });
+    const vitestTask = await vitestGenerator(
+      tree,
+      {
+        project: schema.project,
+        uiFramework: schema.uiFramework,
+        inSourceTests: schema.inSourceTests,
+        coverageProvider: 'v8',
+        skipViteConfig: true,
+        testTarget: 'test',
+        skipFormat: true,
+        addPlugin: schema.addPlugin,
+        compiler: schema.compiler,
+        projectType,
+      },
+      false,
+      true
+    );
     tasks.push(vitestTask);
   }
 

--- a/packages/vite/src/generators/init/__snapshots__/init.spec.ts.snap
+++ b/packages/vite/src/generators/init/__snapshots__/init.spec.ts.snap
@@ -8,11 +8,11 @@ exports[`@nx/vite:init dependencies for package.json should add required package
   "devDependencies": {
     "@nx/vite": "0.0.1",
     "@nx/web": "0.0.1",
-    "@vitest/ui": "^3.0.0",
+    "@vitest/ui": "^4.0.0",
     "existing": "1.0.0",
     "jiti": "2.4.2",
     "vite": "^7.0.0",
-    "vitest": "^3.0.0",
+    "vitest": "^4.0.0",
   },
   "name": "@proj/source",
 }

--- a/packages/vite/src/generators/vitest/vitest-generator.ts
+++ b/packages/vite/src/generators/vitest/vitest-generator.ts
@@ -9,11 +9,14 @@ import { VitestGeneratorSchema } from './schema';
 export async function vitestGenerator(
   tree: Tree,
   schema: VitestGeneratorSchema,
-  hasPlugin = false
+  hasPlugin = false,
+  suppressDeprecationWarning = false
 ) {
-  logger.warn(
-    `The '@nx/vite:vitest' generator is deprecated. Please use '@nx/vitest:configuration' instead. This generator will be removed in Nx 23.`
-  );
+  if (!suppressDeprecationWarning) {
+    logger.warn(
+      `The '@nx/vite:vitest' generator is deprecated. Please use '@nx/vitest:configuration' instead. This generator will be removed in Nx 23.`
+    );
+  }
 
   ensurePackage('@nx/vitest', nxVersion);
   const { configurationGenerator } = await import('@nx/vitest/generators');

--- a/packages/vite/src/utils/version-utils.ts
+++ b/packages/vite/src/utils/version-utils.ts
@@ -7,9 +7,12 @@ import { clean, coerce, major } from 'semver';
 import {
   vitestCoverageIstanbulVersion,
   vitestCoverageV8Version,
-  vitestV1CoverageIstanbulVersion,
-  vitestV1CoverageV8Version,
-  vitestV1Version,
+  vitestV3CoverageIstanbulVersion,
+  vitestV3CoverageV8Version,
+  vitestV3Version,
+  vitestV2CoverageIstanbulVersion,
+  vitestV2CoverageV8Version,
+  vitestV2Version,
   vitestVersion,
 } from './versions';
 
@@ -22,13 +25,20 @@ type VitestDependenciesVersions = {
 export async function getVitestDependenciesVersionsToInstall(
   tree: Tree
 ): Promise<VitestDependenciesVersions> {
-  if (await isVitestV1(tree)) {
+  if (await isVitestV3(tree)) {
     return {
-      vitest: vitestV1Version,
-      vitestCoverageV8: vitestV1CoverageV8Version,
-      vitestCoverageIstanbul: vitestV1CoverageIstanbulVersion,
+      vitest: vitestV3Version,
+      vitestCoverageV8: vitestV3CoverageV8Version,
+      vitestCoverageIstanbul: vitestV3CoverageIstanbulVersion,
+    };
+  } else if (await isVitestV2(tree)) {
+    return {
+      vitest: vitestV2Version,
+      vitestCoverageV8: vitestV2CoverageV8Version,
+      vitestCoverageIstanbul: vitestV2CoverageIstanbulVersion,
     };
   } else {
+    // Default to latest (v4)
     return {
       vitest: vitestVersion,
       vitestCoverageV8: vitestCoverageV8Version,
@@ -37,12 +47,20 @@ export async function getVitestDependenciesVersionsToInstall(
   }
 }
 
-export async function isVitestV1(tree: Tree) {
+export async function isVitestV3(tree: Tree) {
   let installedVitestVersion = await getInstalledVitestVersionFromGraph();
   if (!installedVitestVersion) {
     installedVitestVersion = getInstalledVitestVersion(tree);
   }
-  return major(installedVitestVersion) === 1;
+  return major(installedVitestVersion) === 3;
+}
+
+export async function isVitestV2(tree: Tree) {
+  let installedVitestVersion = await getInstalledVitestVersionFromGraph();
+  if (!installedVitestVersion) {
+    installedVitestVersion = getInstalledVitestVersion(tree);
+  }
+  return major(installedVitestVersion) === 2;
 }
 
 export function getInstalledVitestVersion(tree: Tree): string {

--- a/packages/vite/src/utils/versions.ts
+++ b/packages/vite/src/utils/versions.ts
@@ -3,7 +3,11 @@ export const nxVersion = require('../../package.json').version;
 export const viteVersion = '^7.0.0';
 export const viteV6Version = '^6.0.0';
 export const viteV5Version = '^5.0.0';
-export const vitestVersion = '^3.0.0';
+// TODO(v23): Remove vitest from here since once we drop vitest support in favor of @nx/vitest.
+export const vitestV4Version = '^4.0.0';
+export const vitestV3Version = '^3.0.0';
+export const vitestV2Version = '^2.1.8';
+export const vitestVersion = vitestV4Version;
 export const vitestV1Version = '^1.3.1';
 export const vitePluginReactVersion = '^4.2.0';
 export const vitePluginReactSwcVersion = '^3.5.0';
@@ -17,7 +21,13 @@ export const jitiVersion = '2.4.2';
 export const analogVitestAngular = '~1.19.1';
 
 // Coverage providers
-export const vitestCoverageV8Version = '^3.0.5';
+export const vitestV4CoverageV8Version = '^4.0.0';
+export const vitestV3CoverageV8Version = '^3.0.5';
+export const vitestV2CoverageV8Version = '^2.1.8';
+export const vitestCoverageV8Version = vitestV4CoverageV8Version;
+export const vitestV4CoverageIstanbulVersion = '^4.0.0';
+export const vitestV3CoverageIstanbulVersion = '^3.0.5';
+export const vitestV2CoverageIstanbulVersion = '^2.1.8';
+export const vitestCoverageIstanbulVersion = vitestV4CoverageIstanbulVersion;
 export const vitestV1CoverageV8Version = '^1.0.4';
-export const vitestCoverageIstanbulVersion = '^3.0.5';
 export const vitestV1CoverageIstanbulVersion = '^1.0.4';


### PR DESCRIPTION
This PR ports the vitest v4 logic back to `@nx/vite` even though users should be using `@nx/vitest`, we still support it until v23. Otherwise running `@nx/vite:configuration --includeVitest` will always fail.

Generator working: https://www.loom.com/share/246c401e114348818b998e0abed8754e
Suppressing warning: https://www.loom.com/share/f769507de6684d4e9cb720cdc277e56a