### PR TITLE
fix(gradle): bump gradle migration version

### DIFF
--- a/packages/gradle/migrations.json
+++ b/packages/gradle/migrations.json
@@ -61,7 +61,7 @@
       "factory": "./src/migrations/21-6-1/change-plugin-version-0-1-8"
     },
     "change-plugin-version-0-1-9": {
-      "version": "22.1.0-beta.1",
+      "version": "22.1.0-rc.3",
       "cli": "nx",
       "description": "Change dev.nx.gradle.project-graph to version 0.1.9 in build file",
       "factory": "./src/migrations/22-1-0/change-plugin-version-0-1-9"


### PR DESCRIPTION
Ensure that we bump up Nx plugin for Gradle version to 0.1.9 when going from 22.1.0-rc.3
