### PR TITLE
feat(misc): record stat for initial invocation of create-nx-workspace

### DIFF
--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -79,14 +79,7 @@ async function nxCloudPrompt(key: MessageKey): Promise<NxCloud> {
 export async function determineAiAgents(
   parsedArgs: yargs.Arguments<{ aiAgents?: Agent[]; interactive?: boolean }>
 ): Promise<Agent[]> {
-  if (parsedArgs.interactive === false) {
-    return parsedArgs.aiAgents ?? [];
-  }
-
-  if (parsedArgs.aiAgents) {
-    return parsedArgs.aiAgents;
-  }
-  return await aiAgentsPrompt();
+  return parsedArgs.aiAgents ?? [];
 }
 
 async function aiAgentsPrompt(): Promise<Agent[]> {


### PR DESCRIPTION
## Current Behavior
Currently, telemetry stats are only recorded when `create-nx-workspace` completes successfully. This doesn't capture how many times the command is invoked vs completed.

## Expected Behavior
Record a stat when `create-nx-workspace` is first invoked (before any prompts), enabling analysis of drop-off between initial invocation and workspace completion.

## Changes Made

### Telemetry
- Added `recordStat()` call in `normalizeArgsMiddleware()` immediately after welcome message and before any user prompts
- Records with command name `create-nx-workspace` and metadata `['start']` to distinguish from completion stat
- Allows correlation of invocation and completion events for drop-off analysis

### AI Agents Prompt
- This is being temporarily disabled because we noticed a dip in create-nx-workspace completions that lines up when this was released. Disabling it temporarily to see if the dip is recovered by disabling the prompt.

### React Framework Selection
- Added early returns in `determineReactFramework()` for cases where framework is already provided or interactive mode is disabled
- Improves performance by avoiding unnecessary prompt interactions

### Code Quality
- Reorganized imports in alphabetical order for better maintainability
- Removed unused import (`printSocialInformation`)

## Related Issue(s)
WIP - Draft for discussion