### PR TITLE
fix(core): filter out automated release commits in getCommitsRelevant…

### DIFF
--- a/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
+++ b/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
@@ -11,7 +11,7 @@ export async function resolveSemverSpecifierFromConventionalCommits(
   from: string,
   projectGraph: ProjectGraph,
   projectNames: string[],
-  conventionalCommitsConfig: NxReleaseConfig['conventionalCommits']
+  releaseConfig: NxReleaseConfig
 ): // Map of projectName to semver bump type
 Promise<Map<string, SemverSpecifier | null>> {
   const commits = await getGitDiff(from);
@@ -19,9 +19,13 @@ Promise<Map<string, SemverSpecifier | null>> {
   const relevantCommits = await getCommitsRelevantToProjects(
     projectGraph,
     parsedCommits,
-    projectNames
+    projectNames,
+    releaseConfig
   );
-  return determineSemverChange(relevantCommits, conventionalCommitsConfig);
+  return determineSemverChange(
+    relevantCommits,
+    releaseConfig.conventionalCommits
+  );
 }
 
 export async function resolveSemverSpecifierFromPrompt(

--- a/packages/nx/src/command-line/release/version/derive-specifier-from-conventional-commits.ts
+++ b/packages/nx/src/command-line/release/version/derive-specifier-from-conventional-commits.ts
@@ -55,7 +55,7 @@ export async function deriveSpecifierFromConventionalCommits(
       previousVersionRef,
       projectGraph,
       affectedProjects,
-      nxReleaseConfig.conventionalCommits
+      nxReleaseConfig
     );
 
   const getHighestSemverChange = (


### PR DESCRIPTION
…ToProjects

## Current Behavior

While testing the new release flow, I noticed that some projects we're being version bumped excessively and unexpectedly by automated `chore(release): ...` commits that affected projects for various reasons.

For example, as reported in https://github.com/nrwl/nx/issues/33374, if a `chore(release): ...` commit touches a `package.json`/`CHANGELOG.md` that has since been deleted, that release commit will be returned in `getCommitsRelevantToProjects` and evaluated as a patch bump in `determineSemverChange`.

Another example I'm seeing is that if the commit updates the `package.json`/`CHANGELOG.md` for a package that also happens to be installed as a dependency in the workspace root `package.json` then all projects in the repo are affected and patch bumped. (I'm not sure if this is an anti-pattern, but to provide more context, we have an eslint config package that we version & publish, but also have installed in the repo itself using pnpm workspace protocol).

## Expected Behavior

I could be missing something, but I can't think of a valid scenario where an automated release commit containing only `package.json#version` bumps and/or `CHANGELOG.md` updates should trigger a new release for any projects.

## Related Issue(s)

I did not file an issue for this and couldn't find an existing one that matched.

Fixes #
