### PR TITLE
chore(maven): bump Maven plugin version to 0.0.10

### DIFF
--- a/packages/maven/maven-plugin/pom.xml
+++ b/packages/maven/maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.nx</groupId>
     <artifactId>nx-parent</artifactId>
-    <version>0.0.9</version>
+    <version>0.0.10</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/migrations.json
+++ b/packages/maven/migrations.json
@@ -12,6 +12,12 @@
       "version": "22.1.0-beta.6",
       "description": "Update Maven plugin version from 0.0.8 to 0.0.9 in pom.xml files",
       "factory": "./dist/migrations/0-0-9/update-pom-xml-version"
+    },
+    "update-0-0-10": {
+      "cli": "nx",
+      "version": "22.1.0-rc.3",
+      "description": "Update Maven plugin version from 0.0.9 to 0.0.10 in pom.xml files",
+      "factory": "./dist/migrations/0-0-10/update-pom-xml-version"
     }
   }
 }

--- a/packages/maven/src/migrations/0-0-10/update-pom-xml-version.ts
+++ b/packages/maven/src/migrations/0-0-10/update-pom-xml-version.ts
@@ -1,0 +1,11 @@
+import { Tree } from '@nx/devkit';
+import { updateNxMavenPluginVersion } from '../../utils/pom-xml-updater';
+
+/**
+ * Migration for @nx/maven v0.0.10
+ * Updates the Maven plugin version to 0.0.10 in pom.xml files
+ */
+export default async function update(tree: Tree) {
+  // Update user pom.xml files
+  updateNxMavenPluginVersion(tree, '0.0.10');
+}

--- a/packages/maven/src/utils/versions.ts
+++ b/packages/maven/src/utils/versions.ts
@@ -1,2 +1,2 @@
 export const nxVersion = require('../../package.json').version;
-export const mavenPluginVersion = '0.0.9';
+export const mavenPluginVersion = '0.0.10';

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0          http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>dev.nx</groupId>
   <artifactId>nx-parent</artifactId>
-  <version>0.0.9</version>
+  <version>0.0.10</version>
   <packaging>pom</packaging>
 
   <name>Nx Parent</name>


### PR DESCRIPTION
## Current Behavior

The Maven plugin is currently at version 0.0.9.

## Expected Behavior

This PR bumps the Maven plugin to version 0.0.10 and creates the necessary migration for users to automatically update their pom.xml files.

## Related Issue(s)

N/A - Routine version bump