### PR TITLE
feat(core): make console daemon check backgroundable and pulling from latest

### DIFF
--- a/packages/nx/bin/init-local.ts
+++ b/packages/nx/bin/init-local.ts
@@ -3,7 +3,9 @@ import { performance } from 'perf_hooks';
 import { commandsObject } from '../src/command-line/nx-commands';
 import { WorkspaceTypeAndRoot } from '../src/utils/find-workspace-root';
 import { stripIndents } from '../src/utils/strip-indents';
-import { ensureNxConsoleInstalled } from '../src/utils/nx-console-prompt';
+import { daemonClient } from '../src/daemon/client/client';
+import { prompt } from 'enquirer';
+import { output } from '../src/utils/output';
 
 /**
  * Nx is being run inside a workspace.
@@ -33,7 +35,7 @@ export async function initLocal(workspace: WorkspaceTypeAndRoot) {
 
     // Ensure NxConsole is installed if the user has it configured.
     try {
-      await ensureNxConsoleInstalled();
+      await ensureNxConsoleInstalledViaDaemon();
     } catch {}
 
     const command = process.argv[2];
@@ -119,6 +121,51 @@ function shouldDelegateToAngularCLI() {
     'update',
   ];
   return commands.indexOf(command) > -1;
+}
+
+async function ensureNxConsoleInstalledViaDaemon(): Promise<void> {
+  // Only proceed if daemon is available
+  if (!daemonClient.enabled()) {
+    return;
+  }
+
+  // Get status from daemon
+  const status = await daemonClient.getNxConsoleStatus();
+
+  // If we should prompt the user
+  if (status.shouldPrompt && process.stdout.isTTY) {
+    output.log({
+      title: "Install Nx's official editor extension to:",
+      bodyLines: [
+        '- Enable your AI assistant to do more by understanding your workspace',
+        '- Add IntelliSense for Nx configuration files',
+        '- Explore your workspace visually',
+      ],
+    });
+
+    try {
+      const { shouldInstallNxConsole } = await prompt<{
+        shouldInstallNxConsole: boolean;
+      }>({
+        type: 'confirm',
+        name: 'shouldInstallNxConsole',
+        message: 'Install Nx Console? (you can uninstall anytime)',
+        initial: true,
+      });
+
+      // Set preference and install if user said yes
+      const result = await daemonClient.setNxConsolePreferenceAndInstall(
+        shouldInstallNxConsole
+      );
+
+      if (result.installed) {
+        output.log({ title: 'Successfully installed Nx Console!' });
+      }
+    } catch (error) {
+      // User cancelled or error occurred, save preference as false
+      await daemonClient.setNxConsolePreferenceAndInstall(false);
+    }
+  }
 }
 
 function handleAngularCLIFallbacks(workspace: WorkspaceTypeAndRoot) {

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -100,6 +100,14 @@ import {
   PRE_TASKS_EXECUTION,
 } from '../message-types/run-tasks-execution-hooks';
 import { REGISTER_PROJECT_GRAPH_LISTENER } from '../message-types/register-project-graph-listener';
+import {
+  GET_NX_CONSOLE_STATUS,
+  type HandleGetNxConsoleStatusMessage,
+  type HandleSetNxConsolePreferenceAndInstallMessage,
+  type NxConsoleStatusResponse,
+  SET_NX_CONSOLE_PREFERENCE_AND_INSTALL,
+  type SetNxConsolePreferenceAndInstallResponse,
+} from '../message-types/nx-console';
 import { deserialize } from 'node:v8';
 import { isJsonMessage } from '../../utils/consume-messages-from-socket';
 import { isV8SerializerEnabled } from '../is-v8-serializer-enabled';
@@ -546,6 +554,23 @@ export class DaemonClient {
     const message: HandlePostTasksExecutionMessage = {
       type: POST_TASKS_EXECUTION,
       context,
+    };
+    return this.sendToDaemonViaQueue(message);
+  }
+
+  getNxConsoleStatus(): Promise<NxConsoleStatusResponse> {
+    const message: HandleGetNxConsoleStatusMessage = {
+      type: GET_NX_CONSOLE_STATUS,
+    };
+    return this.sendToDaemonViaQueue(message);
+  }
+
+  setNxConsolePreferenceAndInstall(
+    preference: boolean
+  ): Promise<SetNxConsolePreferenceAndInstallResponse> {
+    const message: HandleSetNxConsolePreferenceAndInstallMessage = {
+      type: SET_NX_CONSOLE_PREFERENCE_AND_INSTALL,
+      preference,
     };
     return this.sendToDaemonViaQueue(message);
   }

--- a/packages/nx/src/daemon/message-types/nx-console.ts
+++ b/packages/nx/src/daemon/message-types/nx-console.ts
@@ -8,8 +8,6 @@ export type HandleGetNxConsoleStatusMessage = {
 
 export type NxConsoleStatusResponse = {
   shouldPrompt: boolean;
-  canInstall: boolean;
-  currentPreference: boolean | null;
 };
 
 export type HandleSetNxConsolePreferenceAndInstallMessage = {

--- a/packages/nx/src/daemon/message-types/nx-console.ts
+++ b/packages/nx/src/daemon/message-types/nx-console.ts
@@ -1,0 +1,44 @@
+export const GET_NX_CONSOLE_STATUS = 'GET_NX_CONSOLE_STATUS' as const;
+export const SET_NX_CONSOLE_PREFERENCE_AND_INSTALL =
+  'SET_NX_CONSOLE_PREFERENCE_AND_INSTALL' as const;
+
+export type HandleGetNxConsoleStatusMessage = {
+  type: typeof GET_NX_CONSOLE_STATUS;
+};
+
+export type NxConsoleStatusResponse = {
+  shouldPrompt: boolean;
+  canInstall: boolean;
+  currentPreference: boolean | null;
+};
+
+export type HandleSetNxConsolePreferenceAndInstallMessage = {
+  type: typeof SET_NX_CONSOLE_PREFERENCE_AND_INSTALL;
+  preference: boolean;
+};
+
+export type SetNxConsolePreferenceAndInstallResponse = {
+  installed: boolean;
+};
+
+export function isHandleGetNxConsoleStatusMessage(
+  message: unknown
+): message is HandleGetNxConsoleStatusMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message['type'] === GET_NX_CONSOLE_STATUS
+  );
+}
+
+export function isHandleSetNxConsolePreferenceAndInstallMessage(
+  message: unknown
+): message is HandleSetNxConsolePreferenceAndInstallMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message['type'] === SET_NX_CONSOLE_PREFERENCE_AND_INSTALL
+  );
+}

--- a/packages/nx/src/daemon/server/handle-nx-console.ts
+++ b/packages/nx/src/daemon/server/handle-nx-console.ts
@@ -1,46 +1,46 @@
-import { homedir } from 'os';
-import {
-  canInstallNxConsole,
-  installNxConsole,
-  NxConsolePreferences,
-} from '../../native';
 import type {
   NxConsoleStatusResponse,
   SetNxConsolePreferenceAndInstallResponse,
 } from '../message-types/nx-console';
 import type { HandlerResult } from './server';
+import {
+  getNxConsoleStatus,
+  handleNxConsolePreferenceAndInstall,
+} from './nx-console-operations';
+
+// Module-level state for caching
+let cachedShouldPrompt: boolean | null = null;
+let isComputing = false;
 
 export async function handleGetNxConsoleStatus(): Promise<HandlerResult> {
-  const preferences = new NxConsolePreferences(homedir());
-  const setting = preferences.getAutoInstallPreference();
-  const canInstallConsole = canInstallNxConsole();
-
-  // If user previously opted in but extension is not installed,
-  // they must have manually uninstalled it - respect that choice
-  if (setting === true && canInstallConsole) {
-    // User had auto-install enabled but extension is missing
-    // This means they manually uninstalled it
-    preferences.setAutoInstallPreference(false);
-
+  // Return cached result if available
+  if (cachedShouldPrompt !== null) {
     const response: NxConsoleStatusResponse = {
-      shouldPrompt: false,
-      canInstall: canInstallConsole,
-      currentPreference: false, // Updated preference
+      shouldPrompt: cachedShouldPrompt,
     };
-
     return {
       response,
       description: 'handleGetNxConsoleStatus',
     };
   }
 
-  // Determine if we should prompt
-  const shouldPrompt = canInstallConsole && typeof setting !== 'boolean';
+  // Kick off background computation if not already running
+  if (!isComputing) {
+    isComputing = true;
+    getNxConsoleStatus()
+      .then((result) => {
+        cachedShouldPrompt = result;
+        isComputing = false;
+      })
+      .catch(() => {
+        cachedShouldPrompt = null;
+        isComputing = false;
+      });
+  }
 
+  // Return false for shouldPrompt if cache not ready (main process will noop)
   const response: NxConsoleStatusResponse = {
-    shouldPrompt,
-    canInstall: canInstallConsole,
-    currentPreference: typeof setting === 'boolean' ? setting : null,
+    shouldPrompt: false,
   };
 
   return {
@@ -52,16 +52,14 @@ export async function handleGetNxConsoleStatus(): Promise<HandlerResult> {
 export async function handleSetNxConsolePreferenceAndInstall(
   preference: boolean
 ): Promise<HandlerResult> {
-  const preferences = new NxConsolePreferences(homedir());
-  preferences.setAutoInstallPreference(preference);
+  // Immediately update cache - we know the answer now!
+  // User answered the prompt, so we won't prompt again
+  cachedShouldPrompt = false;
 
-  let installed = false;
-  if (preference) {
-    installed = installNxConsole();
-  }
+  const result = await handleNxConsolePreferenceAndInstall({ preference });
 
   const response: SetNxConsolePreferenceAndInstallResponse = {
-    installed,
+    installed: result.installed,
   };
 
   return {

--- a/packages/nx/src/daemon/server/handle-nx-console.ts
+++ b/packages/nx/src/daemon/server/handle-nx-console.ts
@@ -1,0 +1,71 @@
+import { homedir } from 'os';
+import {
+  canInstallNxConsole,
+  installNxConsole,
+  NxConsolePreferences,
+} from '../../native';
+import type {
+  NxConsoleStatusResponse,
+  SetNxConsolePreferenceAndInstallResponse,
+} from '../message-types/nx-console';
+import type { HandlerResult } from './server';
+
+export async function handleGetNxConsoleStatus(): Promise<HandlerResult> {
+  const preferences = new NxConsolePreferences(homedir());
+  const setting = preferences.getAutoInstallPreference();
+  const canInstallConsole = canInstallNxConsole();
+
+  // If user previously opted in but extension is not installed,
+  // they must have manually uninstalled it - respect that choice
+  if (setting === true && canInstallConsole) {
+    // User had auto-install enabled but extension is missing
+    // This means they manually uninstalled it
+    preferences.setAutoInstallPreference(false);
+
+    const response: NxConsoleStatusResponse = {
+      shouldPrompt: false,
+      canInstall: canInstallConsole,
+      currentPreference: false, // Updated preference
+    };
+
+    return {
+      response,
+      description: 'handleGetNxConsoleStatus',
+    };
+  }
+
+  // Determine if we should prompt
+  const shouldPrompt = canInstallConsole && typeof setting !== 'boolean';
+
+  const response: NxConsoleStatusResponse = {
+    shouldPrompt,
+    canInstall: canInstallConsole,
+    currentPreference: typeof setting === 'boolean' ? setting : null,
+  };
+
+  return {
+    response,
+    description: 'handleGetNxConsoleStatus',
+  };
+}
+
+export async function handleSetNxConsolePreferenceAndInstall(
+  preference: boolean
+): Promise<HandlerResult> {
+  const preferences = new NxConsolePreferences(homedir());
+  preferences.setAutoInstallPreference(preference);
+
+  let installed = false;
+  if (preference) {
+    installed = installNxConsole();
+  }
+
+  const response: SetNxConsolePreferenceAndInstallResponse = {
+    installed,
+  };
+
+  return {
+    response,
+    description: 'handleSetNxConsolePreferenceAndInstall',
+  };
+}

--- a/packages/nx/src/daemon/server/nx-console-operations.ts
+++ b/packages/nx/src/daemon/server/nx-console-operations.ts
@@ -1,0 +1,181 @@
+import { installPackageToTmpAsync } from '../../devkit-internals';
+import { homedir } from 'os';
+import {
+  canInstallNxConsole,
+  installNxConsole,
+  NxConsolePreferences,
+} from '../../native';
+import { serverLogger } from './logger';
+
+// Module-level state - persists across invocations within daemon lifecycle
+let latestNxTmpPath: string | null = null;
+let cleanupFn: (() => void) | null = null;
+
+const log = (...messageParts: unknown[]) => {
+  serverLogger.log('[NX-CONSOLE]:', ...messageParts);
+};
+
+/**
+ * Gets the Nx Console status (whether we should prompt the user to install).
+ * Uses latest Nx version if available, falls back to local implementation.
+ *
+ * @returns boolean indicating whether we should prompt the user
+ */
+export async function getNxConsoleStatus({
+  inner,
+}: {
+  inner?: boolean;
+} = {}): Promise<boolean> {
+  // Use local implementation if explicitly requested
+  if (process.env.NX_USE_LOCAL === 'true' || inner === true) {
+    log('Using local implementation (NX_USE_LOCAL=true or inner call)');
+    return await getNxConsoleStatusImpl();
+  }
+
+  try {
+    // If we don't have a tmp path yet, pull latest Nx
+    if (latestNxTmpPath === null) {
+      log('Pulling latest Nx (latest) to check console status...');
+      const packageInstallResults = await installPackageToTmpAsync(
+        'nx',
+        'latest'
+      );
+      latestNxTmpPath = packageInstallResults.tempDir;
+      cleanupFn = packageInstallResults.cleanup;
+      log('Successfully pulled latest Nx to', latestNxTmpPath);
+    } else {
+      log('Reusing cached Nx installation from', latestNxTmpPath);
+    }
+
+    // Try to use the cached tmp path
+    const modulePath = require.resolve(
+      'nx/src/daemon/server/nx-console-operations.js',
+      { paths: [latestNxTmpPath] }
+    );
+
+    const module = await import(modulePath);
+    const result = await module.getNxConsoleStatus({ inner: true });
+    log('Console status check completed, shouldPrompt:', result);
+    return result;
+  } catch (error) {
+    // If tmp path failed (e.g., directory was deleted), fall back to local immediately
+    log(
+      'Failed to use latest Nx, falling back to local implementation. Error:',
+      error.message
+    );
+    return await getNxConsoleStatusImpl();
+  }
+}
+
+/**
+ * Handles user preference submission and installs Nx Console if requested.
+ * Uses latest Nx version if available, falls back to local implementation.
+ *
+ * @param preference - whether the user wants to install Nx Console
+ * @returns object indicating whether installation succeeded
+ */
+export async function handleNxConsolePreferenceAndInstall({
+  preference,
+  inner,
+}: {
+  preference: boolean;
+  inner?: boolean;
+}): Promise<{ installed: boolean }> {
+  log('Handling user preference:', preference);
+
+  // Use local implementation if explicitly requested
+  if (process.env.NX_USE_LOCAL === 'true' || inner === true) {
+    log('Using local implementation (NX_USE_LOCAL=true or inner call)');
+    return await handleNxConsolePreferenceAndInstallImpl(preference);
+  }
+
+  try {
+    // If we don't have a tmp path yet, pull latest Nx
+    if (latestNxTmpPath === null) {
+      log('Pulling latest Nx (latest) to handle preference and install...');
+      const packageInstallResults = await installPackageToTmpAsync(
+        'nx',
+        'latest'
+      );
+      latestNxTmpPath = packageInstallResults.tempDir;
+      cleanupFn = packageInstallResults.cleanup;
+      log('Successfully pulled latest Nx to', latestNxTmpPath);
+    } else {
+      log('Reusing cached Nx installation from', latestNxTmpPath);
+    }
+
+    // Try to use the cached tmp path
+    const modulePath = require.resolve(
+      'nx/src/daemon/server/nx-console-operations.js',
+      { paths: [latestNxTmpPath] }
+    );
+
+    const module = await import(modulePath);
+    const result = await module.handleNxConsolePreferenceAndInstall({
+      preference,
+      inner: true,
+    });
+    log(
+      'Preference saved and installation',
+      result.installed ? 'succeeded' : 'skipped/failed'
+    );
+    return result;
+  } catch (error) {
+    // If tmp path failed (e.g., directory was deleted), fall back to local immediately
+    log(
+      'Failed to use latest Nx, falling back to local implementation. Error:',
+      error.message
+    );
+    return await handleNxConsolePreferenceAndInstallImpl(preference);
+  }
+}
+
+/**
+ * Clean up the latest Nx installation on daemon shutdown.
+ */
+export function cleanupLatestNxInstallation(): void {
+  if (cleanupFn) {
+    log('Cleaning up latest Nx installation from', latestNxTmpPath);
+    cleanupFn();
+  }
+  latestNxTmpPath = null;
+  cleanupFn = null;
+}
+
+export async function getNxConsoleStatusImpl(): Promise<boolean> {
+  // If no cached preference, read from disk
+  const preferences = new NxConsolePreferences(homedir());
+  const preference = preferences.getAutoInstallPreference();
+
+  const canInstallConsole = canInstallNxConsole();
+
+  // If user previously opted in but extension is not installed,
+  // they must have manually uninstalled it - respect that choice
+  if (preference === true && canInstallConsole) {
+    const preferences = new NxConsolePreferences(homedir());
+    preferences.setAutoInstallPreference(false);
+    return false; // Don't prompt
+  }
+
+  // Noop if can't install
+  if (!canInstallConsole) {
+    return false;
+  }
+
+  // Prompt if we can install and user hasn't answered yet
+  return typeof preference !== 'boolean';
+}
+
+export async function handleNxConsolePreferenceAndInstallImpl(
+  preference: boolean
+): Promise<{ installed: boolean }> {
+  const preferences = new NxConsolePreferences(homedir());
+  preferences.setAutoInstallPreference(preference);
+
+  let installed = false;
+  if (preference) {
+    installed = installNxConsole();
+  }
+
+  return { installed };
+}

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -727,6 +727,11 @@ export async function startServer(): Promise<Server> {
           // trigger an initial project graph recomputation
           addUpdatedAndDeletedFiles([], [], []);
 
+          // Kick off Nx Console check in background to prime the cache
+          handleGetNxConsoleStatus().catch(() => {
+            // Ignore errors, this is a background operation
+          });
+
           return resolve(server);
         } catch (err) {
           await handleWorkspaceChanges(err, []);

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -141,6 +141,16 @@ import {
   isRegisterProjectGraphListenerMessage,
   REGISTER_PROJECT_GRAPH_LISTENER,
 } from '../message-types/register-project-graph-listener';
+import {
+  GET_NX_CONSOLE_STATUS,
+  isHandleGetNxConsoleStatusMessage,
+  isHandleSetNxConsolePreferenceAndInstallMessage,
+  SET_NX_CONSOLE_PREFERENCE_AND_INSTALL,
+} from '../message-types/nx-console';
+import {
+  handleGetNxConsoleStatus,
+  handleSetNxConsolePreferenceAndInstall,
+} from './handle-nx-console';
 import { deserialize, serialize } from 'v8';
 
 let performanceObserver: PerformanceObserver | undefined;
@@ -412,6 +422,20 @@ async function handleMessage(socket: Socket, data: string) {
       socket,
       POST_TASKS_EXECUTION,
       () => handleRunPostTasksExecution(payload.context),
+      mode
+    );
+  } else if (isHandleGetNxConsoleStatusMessage(payload)) {
+    await handleResult(
+      socket,
+      GET_NX_CONSOLE_STATUS,
+      () => handleGetNxConsoleStatus(),
+      mode
+    );
+  } else if (isHandleSetNxConsolePreferenceAndInstallMessage(payload)) {
+    await handleResult(
+      socket,
+      SET_NX_CONSOLE_PREFERENCE_AND_INSTALL,
+      () => handleSetNxConsolePreferenceAndInstall(payload.preference),
       mode
     );
   } else {

--- a/packages/nx/src/daemon/server/shutdown-utils.ts
+++ b/packages/nx/src/daemon/server/shutdown-utils.ts
@@ -11,6 +11,7 @@ import {
 import { removeDbConnections } from '../../utils/db-connection';
 import { cleanupPlugins } from '../../project-graph/plugins/get-plugins';
 import { MESSAGE_END_SEQ } from '../../utils/consume-messages-from-socket';
+import { cleanupLatestNxInstallation } from './nx-console-operations';
 
 export const SERVER_INACTIVITY_TIMEOUT_MS = 10800000 as const; // 10800000 ms = 3 hours
 
@@ -74,6 +75,9 @@ export async function handleServerProcessTermination({
     cleanupPlugins();
 
     removeDbConnections();
+
+    // Clean up Nx Console latest installation
+    cleanupLatestNxInstallation();
 
     serverLogger.log(`Server stopped because: "${reason}"`);
   } finally {

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -24,6 +24,7 @@ export { stripIndent } from './utils/logger';
 export {
   readModulePackageJson,
   installPackageToTmp,
+  installPackageToTmpAsync,
 } from './utils/package-json';
 export { splitByColons } from './utils/split-target';
 export { hashObject } from './hasher/file-hasher';


### PR DESCRIPTION

## Current Behavior
The Nx Console install check for the prompt happens in the main process, adding some overhead to each invocation of nx.

## Expected Behavior
We want this check to happen on the daemon so that it's running in the background. If it's still running when nx is invoked, we can just skip the prompt since it's non-critical.
Running it in the background also allows us to pull the latest version of the logic from npm when executing - that way we can keep the logic older versions up-to-date  even when ppl don't migrate to latest.
