### PR TITLE
fix(core): include require paths when resolving specified plugins

### DIFF
--- a/packages/nx/src/project-graph/plugins/resolve-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/resolve-plugin.ts
@@ -28,7 +28,7 @@ export async function resolveNxPlugin(
   paths: string[]
 ) {
   try {
-    require.resolve(moduleName);
+    require.resolve(moduleName, { paths });
   } catch {
     // If a plugin cannot be resolved, we will need projects to resolve it
     projectsWithoutInferencePromise ??=


### PR DESCRIPTION
## Current Behavior
Loading local plugins that are relative paths from workspace root, that point to a JS file, still require preliminary data from default plugins despite being resolvable. This is because we aren't passing `paths` to `require.resolve`, so it is trying to resolve relative to the nx package instead of the workspace.

## Expected Behavior
The straight JS path resolves

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
