### PR TITLE
fix(nx-dev): error out when failing to parse plugin manifests

### DIFF
--- a/astro-docs/src/plugins/utils/plugin-schema-parser.ts
+++ b/astro-docs/src/plugins/utils/plugin-schema-parser.ts
@@ -95,10 +95,8 @@ export function parseExecutors(
 
     const schemaPath = join(pluginPath, config.schema);
 
-    if (existsSync(schemaPath)) {
-      const schema = JSON.parse(readFileSync(schemaPath, 'utf-8'));
-      executors.set(name, { config, schema, schemaPath });
-    }
+    const schema = JSON.parse(readFileSync(schemaPath, 'utf-8'));
+    executors.set(name, { config, schema, schemaPath });
   }
 
   return executors;


### PR DESCRIPTION
if there is an error parsing a schema file for generators/executors then
we should fully error out to prevent caching a "bad" build even if the
site techincally works with missing plugin info.
