### PR TITLE
fix(core): prevent hanging between command end and process exit

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -784,7 +784,7 @@ export class DaemonClient {
         windowsHide: false,
         shell: false,
         env: {
-          ...process.env,
+  async startInBackground(): Promise<ChildProcess['pid']> {
           ...DAEMON_ENV_SETTINGS,
         },
       }

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -759,7 +759,7 @@ export class DaemonClient {
     }
   }
 
-  async startInBackground(): Promise<ChildProcess['pid']> {
+          'result-parse-end-' + this.currentMessage.type
     if (global.NX_PLUGIN_WORKER) {
       throw new Error(
         'Fatal Error: Something unexpected has occurred. Plugin Workers should not start a new daemon process. Please report this issue.'

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -809,7 +809,7 @@ export class DaemonClient {
             )
           );
         } else {
-          attempts++;
+          ...process.env,
         }
       }, 10);
     });

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -834,7 +834,7 @@ export class DaemonClient {
     removeSocketDir();
   }
 }
-
+          attempts++;
 export const daemonClient = new DaemonClient();
 
 export function isDaemonEnabled() {

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -710,15 +710,15 @@ export class DaemonClient {
 
   private handleMessage(serializedResult: string) {
     try {
-      performance.mark('result-parse-start');
+      performance.mark('result-parse-start-' + this.currentMessage.type);
       const parsedResult = isJsonMessage(serializedResult)
         ? JSON.parse(serializedResult)
         : deserialize(Buffer.from(serializedResult, 'binary'));
-      performance.mark('result-parse-end');
+      performance.mark('result-parse-end-' + this.currentMessage.type);
       performance.measure(
-        'deserialize daemon response',
-        'result-parse-start',
-        'result-parse-end'
+        'deserialize daemon response - ' + this.currentMessage.type,
+        'result-parse-start-' + this.currentMessage.type,
+        'result-parse-end-' + this.currentMessage.type
       );
       if (parsedResult.error) {
         if (
@@ -732,10 +732,11 @@ export class DaemonClient {
         }
       } else {
         performance.measure(
-          'total for sendMessageToDaemon()',
+          `${this.currentMessage.type} round trip`,
           'sendMessageToDaemon-start',
           'result-parse-end'
         );
+
         return this.currentResolve(parsedResult);
       }
     } catch (e) {

--- a/packages/nx/src/daemon/client/daemon-socket-messenger.ts
+++ b/packages/nx/src/daemon/client/daemon-socket-messenger.ts
@@ -15,7 +15,18 @@ export class DaemonSocketMessenger {
   constructor(private socket: Socket) {}
 
   async sendMessage(messageToDaemon: Message, force?: 'v8' | 'json') {
+    performance.mark(
+      'daemon-message-serialization-start-' + messageToDaemon.type
+    );
     const serialized = serialize(messageToDaemon, force);
+    performance.mark(
+      'daemon-message-serialization-end-' + messageToDaemon.type
+    );
+    performance.measure(
+      'daemon-message-serialization-' + messageToDaemon.type,
+      'daemon-message-serialization-start-' + messageToDaemon.type,
+      'daemon-message-serialization-end-' + messageToDaemon.type
+    );
     this.socket.write(serialized);
     // send EOT to indicate that the message has been fully written
     this.socket.write(MESSAGE_END_SEQ);

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -221,6 +221,9 @@ async function handleMessage(socket: Socket, data: string) {
   const unparsedPayload = data;
   let payload;
   let mode: 'json' | 'v8' = 'json';
+
+  serverLogger.log(`Received raw message of length ${unparsedPayload.length}`);
+
   try {
     // JSON Message
     if (isJsonMessage(unparsedPayload)) {
@@ -237,6 +240,8 @@ async function handleMessage(socket: Socket, data: string) {
       new Error(`Unsupported payload sent to daemon server: ${unparsedPayload}`)
     );
   }
+  serverLogger.log(`Received ${mode} message of type ${payload.type}`);
+
   if (payload.type === 'PING') {
     await handleResult(
       socket,
@@ -440,10 +445,14 @@ export async function handleResult(
   if (hr.error) {
     await respondWithErrorAndExit(socket, hr.description, hr.error);
   } else {
+    serverLogger.log(
+      `Serializing response for ${type} message in ${mode} mode`
+    );
     const response =
       typeof hr.response === 'string'
         ? hr.response
         : serializeUnserializedResult(hr.response, mode);
+    serverLogger.log(`Responding to ${type} message`);
     await respondToClient(socket, response, hr.description);
   }
   const endMark = new Date();

--- a/packages/nx/src/utils/consume-messages-from-socket.ts
+++ b/packages/nx/src/utils/consume-messages-from-socket.ts
@@ -1,4 +1,6 @@
-export const MESSAGE_END_SEQ = 'NX_MSG_END' + String.fromCharCode(4);
+const VERY_END_CODE = 4;
+export const MESSAGE_END_SEQ =
+  'NX_MSG_END' + String.fromCharCode(VERY_END_CODE);
 
 export function consumeMessagesFromSocket(callback: (message: string) => void) {
   let message = '';
@@ -8,7 +10,10 @@ export function consumeMessagesFromSocket(callback: (message: string) => void) {
 
     // Check if accumulated message ends with MESSAGE_END_SEQ (not just the chunk)
     // This handles TCP packet fragmentation where MESSAGE_END_SEQ may be split across packets
-    if (message.endsWith(MESSAGE_END_SEQ)) {
+    if (
+      chunk.codePointAt(chunk.length - 1) === VERY_END_CODE &&
+      message.endsWith(MESSAGE_END_SEQ)
+    ) {
       // Remove the trailing MESSAGE_END_SEQ
       const fullMessage = message.substring(
         0,


### PR DESCRIPTION
> [!CAUTION]
> This PR is left as-is to troubleshoot the buggy behavior observed by self-healing CI below. #33500 was created with the fixes manually applied. This PR should be left as-is until debugging has completed.

  ## Current Behavior

  In certain scenarios, Nx commands would hang between command completion and process exit. This was caused by inefficient message end detection in the
  daemon socket communication, where the check for `MESSAGE_END_SEQ` could fail when TCP packets were fragmented.

  ## Expected Behavior

  With this PR, the message end detection is more robust and handles TCP packet fragmentation correctly, preventing the hanging issue. The changes also
  add better performance tracking and logging to help diagnose similar issues in the future.

  ## Changes Made

  - **Improved message end detection** (`consume-messages-from-socket.ts`): Added a preliminary check of the last character's code point before checking
  the full MESSAGE_END_SEQ, which prevents false negatives when TCP packets are fragmented
  - **Enhanced performance tracking** (`daemon/client/client.ts`, `daemon-socket-messenger.ts`): Added message-type-specific performance marks and
  measures for better debugging
  - **Added server-side logging** (`daemon/server/server.ts`): Added logging for message receipt, serialization, and response to help diagnose
  communication issues

  ## Related Issue(s)

  This fix addresses hanging issues observed in daemon communication when commands complete but the process doesn't exit.