### PR TITLE
feat(docker): add skipDefaultTag option to build target (#33477)

### DIFF
--- a/astro-docs/src/content/docs/reference/nx-json.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-json.mdoc
@@ -703,6 +703,34 @@ The `docker` property configures Docker image versioning and publishing when usi
 
 Read more about it in the [Release Docker Images guide](/docs/guides/nx-release/release-docker-images).
 
+#### Docker Plugin Options
+
+When configuring the `@nx/docker` plugin in `nx.json`, you can customize the behavior of Docker build and run targets. One important option is `skipDefaultTag`:
+
+```jsonc
+// nx.json
+{
+  "plugins": [
+    {
+      "plugin": "@nx/docker/plugin",
+      "options": {
+        "buildTarget": {
+          "name": "docker:build",
+          // Skip the default --tag argument
+          "skipDefaultTag": true,
+          // You must provide your own tags via args
+          "args": ["--tag myorg/myapp:latest", "--tag myorg/myapp:1.0.0"]
+        }
+      }
+    }
+  ]
+}
+```
+
+**Important:** Setting `skipDefaultTag: true` opts out of Nx Release support for that project. When you explicitly manage your own Docker tags via the `args` property, the automatic versioning and publishing features of `nx release` will not work for those Docker projects. Only use `skipDefaultTag: true` if you are not using `nx release` to manage your Docker image versions.
+
+If you want to use `nx release` with Docker projects, leave `skipDefaultTag` as `false` (the default) or omit it entirely.
+
 #### Version Scheme Syntax
 
 Docker version schemes support calendar-based patterns using the following placeholders:


### PR DESCRIPTION
Add a skipDefaultTag option to the DockerTargetOptions interface that allows users to opt out of the automatic default tag that is prepended to build targets.

This is useful for multi-platform builds that need to push during build (e.g., using --platform linux/amd64,linux/arm64 --push), where the default tag causes build failures because it attempts to push a tag that was not configured.

- Add skipDefaultTag?: boolean to DockerTargetOptions interface
- Modify buildTargetOptions to conditionally skip default tag when skipDefaultTag is true
- Inherit skipDefaultTag from parent target in configurations
- Add comprehensive unit tests for skipDefaultTag functionality
- Add e2e test to verify skipDefaultTag works end-to-end
- Maintains backward compatibility (default behavior unchanged when option not specified)

Fixes #33477
