### PR TITLE
fix(angular-rspack): resolve postcss plugins relative to config file

### DIFF
--- a/packages/angular-rspack/src/lib/config/config-utils/style-config-utils.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/style-config-utils.ts
@@ -63,8 +63,16 @@ export async function getStylesConfig(
     searchDirectories
   );
   if (postcssConfiguration) {
-    for (const [pluginName, pluginOptions] of postcssConfiguration.plugins) {
-      const { default: plugin } = await import(pluginName);
+    const postCssPluginRequire = createRequire(
+      dirname(postcssConfiguration.configPath) + '/'
+    );
+
+    for (const [pluginName, pluginOptions] of postcssConfiguration.config
+      .plugins) {
+      const pluginModule = postCssPluginRequire(pluginName);
+      const plugin = pluginModule.__esModule
+        ? pluginModule['default']
+        : pluginModule;
       if (typeof plugin !== 'function' || plugin.postcss !== true) {
         throw new Error(
           `Attempted to load invalid Postcss plugin: "${pluginName}"`

--- a/packages/angular-rspack/src/lib/utils/postcss-configuration.ts
+++ b/packages/angular-rspack/src/lib/utils/postcss-configuration.ts
@@ -83,7 +83,13 @@ async function readPostcssConfiguration(
 
 export async function loadPostcssConfiguration(
   searchDirectories: SearchDirectory[]
-): Promise<PostcssConfiguration | undefined> {
+): Promise<
+  | {
+      configPath: string;
+      config: PostcssConfiguration;
+    }
+  | undefined
+> {
   const configPath = findFile(searchDirectories, postcssConfigurationFiles);
   if (!configPath) {
     return undefined;
@@ -113,7 +119,7 @@ export async function loadPostcssConfiguration(
       }
     }
 
-    return config;
+    return { configPath, config };
   }
 
   // Normalize plugin object map form
@@ -134,5 +140,5 @@ export async function loadPostcssConfiguration(
     config.plugins.push([name, options]);
   }
 
-  return config;
+  return { configPath, config };
 }


### PR DESCRIPTION
Resolve PostCSS plugins relative to the config file. It was previously resolving them relative to the location of `@nx/angular-rspack`