### PR TITLE
docs(nx-dev): add click event to header navigation links

### DIFF
--- a/astro-docs/src/components/layout/Header.astro
+++ b/astro-docs/src/components/layout/Header.astro
@@ -448,18 +448,21 @@ const currentVersion = versions.find((v) => v.current);
 
     <div class="h-6 w-px bg-slate-200 mx-1 dark:bg-slate-700"></div>
     <a
+      id="header-ai-link"
       href={`${nxDevUrl}/ai`}
       class="px-3 py-2 text-sm font-medium text-slate-600 hover:text-blue-500 rounded-md transition-colors whitespace-nowrap no-underline dark:text-slate-200 dark:hover:text-sky-500"
     >
       AI
     </a>
     <a
+      id="header-nx-cloud-link"
       href={`${nxDevUrl}/nx-cloud`}
       class="px-3 py-2 text-sm font-medium text-slate-600 hover:text-blue-500 rounded-md transition-colors whitespace-nowrap no-underline dark:text-slate-200 dark:hover:text-sky-500"
     >
       Nx Cloud
     </a>
     <a
+      id="header-pricing-link"
       href={`${nxDevUrl}/nx-cloud#plans`}
       class="px-3 py-2 text-sm font-medium text-slate-600 hover:text-blue-500 rounded-md transition-colors whitespace-nowrap no-underline dark:text-slate-200 dark:hover:text-sky-500"
     >
@@ -467,6 +470,7 @@ const currentVersion = versions.find((v) => v.current);
     </a>
     <div class="h-6 w-px bg-slate-200 mx-1 dark:bg-slate-700"></div>
     <a
+      id="header-enterprise-link"
       href={`${nxDevUrl}/enterprise`}
       class="px-3 py-2 text-sm font-semibold text-slate-600 hover:text-blue-500 rounded-md transition-colors whitespace-nowrap no-underline dark:text-slate-200 dark:hover:text-sky-500"
     >
@@ -516,12 +520,48 @@ const currentVersion = versions.find((v) => v.current);
 
   function setupAnalyticsTracking() {
     const docsHomeLink = document.getElementById('header-docs-home-link');
+    const aiLink = document.getElementById('header-ai-link');
+    const nxCloudLink = document.getElementById('header-nx-cloud-link');
+    const pricingLink = document.getElementById('header-pricing-link');
+    const enterpriseLink = document.getElementById('header-enterprise-link');
     const contactBtn = document.getElementById('header-contact-btn');
     const tryNxCloudBtn = document.getElementById('header-try-nx-cloud-btn');
 
     docsHomeLink?.addEventListener('click', () => {
       sendCustomEvent(
         'documentation-click',
+        'header-navigation',
+        'documentation-header'
+      );
+    });
+
+    aiLink?.addEventListener('click', () => {
+      sendCustomEvent(
+        'ai-click',
+        'header-navigation',
+        'documentation-header'
+      );
+    });
+
+    nxCloudLink?.addEventListener('click', () => {
+      sendCustomEvent(
+        'nx-cloud-click',
+        'header-navigation',
+        'documentation-header'
+      );
+    });
+
+    pricingLink?.addEventListener('click', () => {
+      sendCustomEvent(
+        'pricing-click',
+        'header-navigation',
+        'documentation-header'
+      );
+    });
+
+    enterpriseLink?.addEventListener('click', () => {
+      sendCustomEvent(
+        'enterprise-click',
         'header-navigation',
         'documentation-header'
       );

--- a/nx-dev/ui-common/src/lib/headers/header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/header.tsx
@@ -268,6 +268,9 @@ export function Header({
               title="AI"
               className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
               prefetch={false}
+              onClick={() =>
+                sendCustomEvent('ai-click', 'header-cta', 'page-header')
+              }
             >
               AI
             </Link>
@@ -276,6 +279,9 @@ export function Header({
               title="Nx Cloud"
               className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
               prefetch={false}
+              onClick={() =>
+                sendCustomEvent('nx-cloud-click', 'header-cta', 'page-header')
+              }
             >
               Nx Cloud
             </Link>
@@ -284,6 +290,9 @@ export function Header({
               title="Nx Cloud Pricing"
               className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
               prefetch={false}
+              onClick={() =>
+                sendCustomEvent('pricing-click', 'header-cta', 'page-header')
+              }
             >
               Pricing
             </Link>
@@ -294,6 +303,9 @@ export function Header({
               title="Nx for Enterprises"
               className="hidden gap-2 px-3 py-2 font-semibold leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
               prefetch={false}
+              onClick={() =>
+                sendCustomEvent('enterprise-click', 'header-cta', 'page-header')
+              }
             >
               Nx Enterprise
             </Link>
@@ -607,6 +619,13 @@ export function Header({
                             title="AI"
                             className="flex w-full gap-2 py-4 font-medium leading-tight hover:text-blue-500 dark:text-slate-200 dark:hover:text-sky-500"
                             prefetch={false}
+                            onClick={() =>
+                              sendCustomEvent(
+                                'ai-click',
+                                'mobile-header-cta',
+                                'page-header'
+                              )
+                            }
                           >
                             AI
                           </Link>
@@ -615,6 +634,13 @@ export function Header({
                             title="Nx Cloud"
                             className="flex w-full gap-2 py-4 font-medium leading-tight hover:text-blue-500 dark:text-slate-200 dark:hover:text-sky-500"
                             prefetch={false}
+                            onClick={() =>
+                              sendCustomEvent(
+                                'nx-cloud-click',
+                                'mobile-header-cta',
+                                'page-header'
+                              )
+                            }
                           >
                             Nx Cloud
                           </Link>
@@ -623,6 +649,13 @@ export function Header({
                             title="Nx Cloud Pricing"
                             className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
                             prefetch={false}
+                            onClick={() =>
+                              sendCustomEvent(
+                                'pricing-click',
+                                'mobile-header-cta',
+                                'page-header'
+                              )
+                            }
                           >
                             Pricing
                           </Link>


### PR DESCRIPTION
Added `sendCustomEvent` calls to track clicks on primary header and mobile header navigation links.
