### PR TITLE
chore(repo): use recommended pnpm cache location

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -17,7 +17,7 @@ common-init-steps: &common-init-steps
     uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/cache/main.yaml'
     inputs:
       key: 'pnpm-lock.yaml'
-      paths: .pnpm-store
+      paths: ~/.local/share/pnpm/store
       base-branch: 'master'
 
   # reads mise.toml and installs toolchains needed for repo

--- a/astro-docs/src/content/docs/reference/Nx Cloud/launch-templates.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/launch-templates.mdoc
@@ -208,7 +208,7 @@ launch-templates:
           paths: |
             ~/.npm
             # or ~/.cache/yarn
-            # or .pnpm-store
+            # or ~/.local/share/pnpm/store
           base-branch: 'main'
 ```
 
@@ -322,7 +322,7 @@ common-js-init-steps: &common-js-init-steps
       paths: |
         ~/.npm
         # or ~/.cache/yarn
-        # or .pnpm-store
+        # or ~/.local/share/pnpm/store
       base-branch: 'main'
   - name: Restore Browser Binary Cache
     uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/cache/main.yaml'


### PR DESCRIPTION
This also fixes pnpm caching on the nx repo.