### PR TITLE
fix(core): avoid leaking memory due by creating an unref'd interval for each daemon connection

### DIFF
--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -694,21 +694,21 @@ export async function startServer(): Promise<Server> {
     killSocketOrPath();
   }
 
+  setInterval(() => {
+    if (getDaemonProcessIdSync() !== process.pid) {
+      return handleServerProcessTermination({
+        server,
+        reason: 'this process is no longer the current daemon (native)',
+        sockets: openSockets,
+      });
+    }
+  }, 20).unref();
+
   return new Promise(async (resolve, reject) => {
     try {
       server.listen(getFullOsSocketPath(), async () => {
         try {
           serverLogger.log(`Started listening on: ${getFullOsSocketPath()}`);
-
-          setInterval(() => {
-            if (getDaemonProcessIdSync() !== process.pid) {
-              return handleServerProcessTermination({
-                server,
-                reason: 'this process is no longer the current daemon (native)',
-                sockets: openSockets,
-              });
-            }
-          }, 20).unref();
 
           // this triggers the storage of the lock file hash
           daemonIsOutdated();


### PR DESCRIPTION
## Current Behavior
Every time a daemon connection is opened, we create a new interval and unref it. This results in the daemon checking its process termination at an ever increasing rate, which presents as increased memory usage and practically means the daemon is just doing a lot more work than it needs to in this area.

## Expected Behavior
The interval is registered only on initial server startup.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #29836
