### PR TITLE
fix(core): default input should indeed be default

### DIFF
--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -214,7 +214,7 @@ export type ExpandedDepsOutput = {
 export type ExpandedInput = ExpandedSelfInput | ExpandedDepsOutput;
 const DEFAULT_INPUTS: ReadonlyArray<InputDefinition> = [
   {
-    fileset: '{projectRoot}/**/*',
+    input: 'default',
   },
   {
     dependencies: true,


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

If no inputs or named inputs are defined, this area of code was hit:

```
const DEFAULT_INPUTS: ReadonlyArray<InputDefinition> = [
  {
    fileset: '{projectRoot}/**/*',
  },
  {
    dependencies: true,
    input: 'default',
  },
];

export function getNamedInputs(
  nxJson: NxJsonConfiguration,
  project: ProjectGraphProjectNode
) {
  return {
    default: [{ fileset: '{projectRoot}/**/*' }],
    ...nxJson.namedInputs,
    ...project.data.namedInputs,
  };
}
```

This resulted in weird behavior when the user would define `default` in named inputs, but it would seemingly only be applied to the project's deps and not the project itself

## Expected Behavior
The `default` input is the default for both

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #https://github.com/nrwl/nx/issues/32924
