### PR TITLE
chore(repo): add Node 24 to e2e nightly matrix

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -28,19 +28,20 @@ jobs:
           # - windows-latest Windows fails to build gradle wrapper which always runs when we build nx.
           ## https://staging.nx.app/runs/LgD4vxGn8w?utm_source=pull-request&utm_medium=comment
         node_version:
+          # TODO(v23): remove node 20 - EOL April 2026
           - 20
           - 22
-          # - 23
+          - 24
         exclude:
-          # run just node v20 on macos and windows
+          # run just node v24 on macos and windows
+          - os: macos-latest
+            node_version: 20
           - os: macos-latest
             node_version: 22
-          # - os: macos-latest
-          #   node_version: 23
-          # - os: windows-latest TODO (emily): Windows fails to build gradle wrapper which always runs when we build nx. Re-enable when we fix this.
-          # node_version: 22
-          # - os: windows-latest TODO (emily): Windows fails to build gradle wrapper which always runs when we build nx. Re-enable when we fix this.
-          #   node_version: 23
+          # - os: windows-latest TODO(Jack): Windows fails to build gradle wrapper which always runs when we build nx. Re-enable when we fix this.
+          #   node_version: 20
+          # - os: windows-latest TODO (Jack): Windows fails to build gradle wrapper which always runs when we build nx. Re-enable when we fix this.
+          #   node_version: 22
 
     name: Cache install (${{ matrix.os }}, node v${{ matrix.node_version }})
     steps:

--- a/.github/workflows/nightly/process-matrix.ts
+++ b/.github/workflows/nightly/process-matrix.ts
@@ -67,6 +67,7 @@ const matrixData: MatrixData = {
     { name: 'e2e-storybook', codeowners: 'S04SVQ8H0G5' },
     { name: 'e2e-nuxt', codeowners: 'S04SJ6PL98X' }
   ],
+  // TODO(v23): remove node 20 - EOL April 2026
   nodeTLS: 20,
   setup: [
     {
@@ -74,12 +75,12 @@ const matrixData: MatrixData = {
       os_name: 'Linux',
       os_timeout: 60,
       package_managers: ['npm', 'pnpm', 'yarn'],
-      node_versions: ['20.19.0', '22.12.0'],
+      node_versions: ['20.19.0', '22.12.0', '24.0.0'],
       excluded: ['e2e-detox', 'e2e-react-native', 'e2e-expo']
     },
-    { os: 'macos-latest', os_name: 'MacOS', os_timeout: 90, package_managers: ['npm'], node_versions: ['20.19.0'] }
-    // TODO (emily): Fix Windows support as gradle fails when running nx build https://staging.nx.app/runs/LgD4vxGn8w?utm_source=pull-request&utm_medium=comment
-    // { os: 'windows-latest', os_name: 'WinOS', os_timeout: 180, package_managers: ['npm'], node_versions: ['20.19.0'], excluded: ['e2e-detox', 'e2e-react-native', 'e2e-expo'] }
+    { os: 'macos-latest', os_name: 'MacOS', os_timeout: 90, package_managers: ['npm'], node_versions: ['24.0.0'] }
+    // TODO (Jack): Fix Windows support as gradle fails when running nx build https://staging.nx.app/runs/LgD4vxGn8w?utm_source=pull-request&utm_medium=comment
+    // { os: 'windows-latest', os_name: 'WinOS', os_timeout: 180, package_managers: ['npm'], node_versions: ['24.0.0'], excluded: ['e2e-detox', 'e2e-react-native', 'e2e-expo'] }
   ]
 };
 


### PR DESCRIPTION
- E2E nightly tests only run on Node 20 and 22.
- E2E nightly tests now also run on Node 24, 22, and 20 for linux. For Windows and Mac run only 24.

Did a test run from this branch, and Node 24 passes where other versions pass, and fails where other versions fail. It shouldn't make any golden tests fail just due to Node 24, but it's possible that things will flake more since the matrix has expanded. We just have to make them more robust.

<img width="920" height="1089" alt="image" src="https://github.com/user-attachments/assets/90ee4d04-68d5-4d0d-9729-60cacfbc99db" />


Close NXC-3491