### PR TITLE
feat(linter): add util to load eslint rules from a directory

### DIFF
--- a/packages/devkit/src/utils/config-utils.ts
+++ b/packages/devkit/src/utils/config-utils.ts
@@ -118,7 +118,7 @@ export function clearRequireCache(): void {
   }
 }
 
-export async function load(path: string): Promise<any> {
+async function load(path: string): Promise<any> {
   try {
     // Try using `require` first, which works for CJS modules.
     // Modules are CJS unless it is named `.mjs` or `package.json` sets type to "module".
@@ -137,7 +137,7 @@ export async function load(path: string): Promise<any> {
 /**
  * Load the module after ensuring that the require cache is cleared.
  */
-export async function loadCommonJS(path: string): Promise<any> {
+async function loadCommonJS(path: string): Promise<any> {
   // Clear cache if the path is in the cache
   if (require.cache[path]) {
     clearRequireCache();
@@ -145,7 +145,7 @@ export async function loadCommonJS(path: string): Promise<any> {
   return require(path);
 }
 
-export async function loadESM(path: string): Promise<any> {
+async function loadESM(path: string): Promise<any> {
   const pathAsFileUrl = pathToFileURL(path).pathname;
   return await dynamicImport(`${pathAsFileUrl}?t=${Date.now()}`);
 }

--- a/packages/devkit/src/utils/config-utils.ts
+++ b/packages/devkit/src/utils/config-utils.ts
@@ -118,7 +118,7 @@ export function clearRequireCache(): void {
   }
 }
 
-async function load(path: string): Promise<any> {
+export async function load(path: string): Promise<any> {
   try {
     // Try using `require` first, which works for CJS modules.
     // Modules are CJS unless it is named `.mjs` or `package.json` sets type to "module".
@@ -137,7 +137,7 @@ async function load(path: string): Promise<any> {
 /**
  * Load the module after ensuring that the require cache is cleared.
  */
-async function loadCommonJS(path: string): Promise<any> {
+export async function loadCommonJS(path: string): Promise<any> {
   // Clear cache if the path is in the cache
   if (require.cache[path]) {
     clearRequireCache();
@@ -145,7 +145,7 @@ async function loadCommonJS(path: string): Promise<any> {
   return require(path);
 }
 
-async function loadESM(path: string): Promise<any> {
+export async function loadESM(path: string): Promise<any> {
   const pathAsFileUrl = pathToFileURL(path).pathname;
   return await dynamicImport(`${pathAsFileUrl}?t=${Date.now()}`);
 }

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -22,7 +22,7 @@ import dependencyChecks, {
 } from './rules/dependency-checks';
 
 // Resolve any custom rules that might exist in the current workspace
-import { workspaceRules } from './resolve-workspace-rules';
+import { workspaceRules, loadWorkspaceRules } from './resolve-workspace-rules';
 
 const configs = {
   // eslintrc configs
@@ -72,4 +72,4 @@ const rules = {
 };
 
 export default { configs, rules };
-export { configs, rules };
+export { configs, rules, loadWorkspaceRules };

--- a/packages/eslint-plugin/src/resolve-workspace-rules.ts
+++ b/packages/eslint-plugin/src/resolve-workspace-rules.ts
@@ -1,10 +1,172 @@
+import { workspaceRoot } from '@nx/devkit';
+import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
+import { registerTsProject } from '@nx/js/src/internal';
 import type { TSESLint } from '@typescript-eslint/utils';
 import { existsSync } from 'fs';
-import { registerTsProject } from '@nx/js/src/internal';
+import { dirname, isAbsolute, join, normalize, resolve, sep } from 'path';
 import { WORKSPACE_PLUGIN_DIR, WORKSPACE_RULE_PREFIX } from './constants';
-import { join } from 'path';
 
 type ESLintRules = Record<string, TSESLint.RuleModule<string, unknown[]>>;
+
+// ESM import() cannot resolve directories to index files like require() can
+const INDEX_FILE_EXTENSIONS = [
+  '.ts',
+  '.mts',
+  '.cts',
+  '.js',
+  '.mjs',
+  '.cjs',
+] as const;
+
+function resolveDirectoryEntryFile(directory: string): string {
+  for (const ext of INDEX_FILE_EXTENSIONS) {
+    const candidatePath = join(directory, `index${ext}`);
+    if (existsSync(candidatePath)) {
+      return candidatePath;
+    }
+  }
+
+  throw new Error(
+    `No index file found in directory: ${directory}. ` +
+      `Expected one of: ${INDEX_FILE_EXTENSIONS.map(
+        (ext) => `index${ext}`
+      ).join(', ')}`
+  );
+}
+
+function normalizePath(path: string): string {
+  return `${normalize(path).replace(/[\/\\]$/g, '')}${sep}`;
+}
+
+function findTsConfig(
+  directory: string,
+  tsConfigPath?: string
+): string | undefined {
+  let effectiveTsConfigPath = tsConfigPath;
+  const normalizedWorkspaceRoot = normalizePath(workspaceRoot);
+
+  if (effectiveTsConfigPath) {
+    if (!isAbsolute(effectiveTsConfigPath)) {
+      effectiveTsConfigPath = resolve(workspaceRoot, effectiveTsConfigPath);
+    }
+
+    if (!effectiveTsConfigPath.startsWith(normalizedWorkspaceRoot)) {
+      console.warn(
+        `TypeScript config "${effectiveTsConfigPath}" is outside the workspace root "${workspaceRoot}". Falling back to automatic tsconfig detection.`
+      );
+      effectiveTsConfigPath = undefined;
+    }
+  }
+
+  if (!effectiveTsConfigPath) {
+    let currentDir = directory;
+
+    while (currentDir.startsWith(normalizedWorkspaceRoot)) {
+      const candidatePath = join(currentDir, 'tsconfig.json');
+      if (existsSync(candidatePath)) {
+        effectiveTsConfigPath = candidatePath;
+        break;
+      }
+
+      const parentDir = dirname(currentDir);
+      if (normalizePath(parentDir) === normalizedWorkspaceRoot) {
+        break;
+      }
+      currentDir = parentDir;
+    }
+  }
+
+  if (!tsConfigPath && !effectiveTsConfigPath) {
+    console.warn(
+      `No TypeScript config found. Crawled up to workspace root "${workspaceRoot}" ` +
+        `from directory "${directory}" without finding a tsconfig.json file. Provide ` +
+        `a tsconfig.json file path to the loadWorkspaceRules function.`
+    );
+  }
+
+  return effectiveTsConfigPath;
+}
+
+/**
+ * Load ESLint rules from a directory.
+ *
+ * This utility allows loading custom ESLint rules from any directory within the workspace,
+ * not just the default `tools/eslint-rules` location. It's useful for:
+ * - Loading rules from a custom directory structure
+ * - Loading rules from npm workspace packages (e.g., linked packages via npm/yarn/pnpm workspaces)
+ * - Loading rules from multiple directories with different configurations
+ *
+ * The directory must contain an index file (index.ts, index.js, etc.) that exports the rules.
+ *
+ * @param directory - The directory path to load rules from. Can be absolute or relative to workspace root.
+ * @param tsConfigPath - Optional path to tsconfig.json for TypeScript compilation.
+ *                       If not provided, will search for tsconfig.json starting from
+ *                       the directory and traversing up to the workspace root.
+ * @returns An object containing the loaded ESLint rules (without any prefix).
+ *          Returns an empty object if the directory doesn't exist or loading fails.
+ *
+ * @example
+ * ```typescript
+ * // Load rules from a custom directory (relative to workspace root)
+ * const customRules = await loadWorkspaceRules('packages/my-eslint-plugin/rules');
+ *
+ * // Load rules with a specific tsconfig
+ * const customRules = await loadWorkspaceRules(
+ *   'packages/my-eslint-plugin/rules',
+ *   'packages/my-eslint-plugin/tsconfig.json'
+ * );
+ *
+ * // Or use absolute paths
+ * const customRules = loadWorkspaceRules('/absolute/path/to/rules');
+ * ```
+ */
+export async function loadWorkspaceRules(
+  directory: string,
+  tsConfigPath?: string
+): Promise<ESLintRules> {
+  const resolvedDirectory = isAbsolute(directory)
+    ? directory
+    : resolve(workspaceRoot, directory);
+
+  if (!resolvedDirectory.startsWith(normalizePath(workspaceRoot))) {
+    console.warn(
+      `Directory "${resolvedDirectory}" is outside the workspace root "${workspaceRoot}". ESLint rules can only be loaded from within the workspace.`
+    );
+    return {};
+  }
+
+  if (!existsSync(resolvedDirectory)) {
+    console.warn(
+      `Directory "${resolvedDirectory}" does not exist. Skipping loading ESLint rules from this directory.`
+    );
+    return {};
+  }
+
+  let registrationCleanup: (() => void) | null = null;
+
+  try {
+    const effectiveTsConfigPath = findTsConfig(resolvedDirectory, tsConfigPath);
+
+    if (effectiveTsConfigPath) {
+      registrationCleanup = registerTsProject(effectiveTsConfigPath);
+    }
+
+    const entryFile = resolveDirectoryEntryFile(resolvedDirectory);
+
+    // Only rules are supported (not configs, processors, etc.)
+    const module = await loadConfigFile(entryFile);
+    const rules = module.rules || module;
+
+    return rules as ESLintRules;
+  } catch (err) {
+    console.error(err);
+    return {};
+  } finally {
+    if (registrationCleanup) {
+      registrationCleanup();
+    }
+  }
+}
 
 export const workspaceRules = ((): ESLintRules => {
   // If `tools/eslint-rules` folder doesn't exist, there is no point trying to register and load it


### PR DESCRIPTION
This PR adds the ability for users to import ESLint rules from arbitrary location in the workspace rather than storing them in `tools/eslint-rules`. This is useful for monorepo not using npm/yarn/pnpm workspaces and need a mechanism to load from any custom rules location without them being installed/symlinked.

It also handles TS files automatically.

Demo: https://www.loom.com/share/3c32af4555614eeab4f81fce8db0c955

Example:

```js
import baseConfig from "../../eslint.config.mjs";
import { loadWorkspaceRules } from "@nx/eslint-plugin";

const customRules = await loadWorkspaceRules("foo/bar/eslint-rules");

export default [
  ...baseConfig,
  {
    ignores: ["**/out-tsc"],
  },
  {
    files: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
    plugins: {
      custom: { rules: customRules },
    },
    rules: {
      "custom/valid-command-object": "error",
    },
  },
];
```