### PR TITLE
fix(core): don't presume a task is long running if its marked cacheable

### DIFF
--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -576,7 +576,7 @@ export function isCacheableTask(
     cacheableTargets?: string[] | null;
   }
 ): boolean {
-  if (task.cache !== undefined && !longRunningTask(task)) {
+  if (task.cache !== undefined) {
     return task.cache;
   }
 
@@ -591,6 +591,7 @@ export function isCacheableTask(
 function longRunningTask(task: Task) {
   const t = task.target.target;
   return (
+    task.continuous ||
     (!!task.overrides['watch'] && task.overrides['watch'] !== 'false') ||
     t.endsWith(':watch') ||
     t.endsWith('-watch') ||

--- a/packages/nx/src/utils/assert-workspace-validity.spec.ts
+++ b/packages/nx/src/utils/assert-workspace-validity.spec.ts
@@ -32,7 +32,7 @@ describe('assertWorkspaceValidity', () => {
 
     expect(() => assertWorkspaceValidity(mockProjects, {}))
       .toThrowErrorMatchingInlineSnapshot(`
-      "Configuration Error
+      "[Configuration Error]:
       The following implicitDependencies should be an array of strings:
         lib1.implicitDependencies: "*"
 

--- a/packages/nx/src/utils/assert-workspace-validity.ts
+++ b/packages/nx/src/utils/assert-workspace-validity.ts
@@ -37,36 +37,33 @@ export function assertWorkspaceValidity(
 
   const projectsWithNonArrayImplicitDependencies = new Map<string, unknown>();
 
-  projectNames
-    .filter((projectName) => {
-      const project = projects[projectName];
+  projectNames.reduce((map, projectName) => {
+    const project = projects[projectName];
 
-      // Report if for whatever reason, a project is configured to use implicitDependencies but it is not an array
-      if (
-        !!project.implicitDependencies &&
-        !Array.isArray(project.implicitDependencies)
-      ) {
-        projectsWithNonArrayImplicitDependencies.set(
-          projectName,
-          project.implicitDependencies
-        );
-      }
-      return (
-        !!project.implicitDependencies &&
-        Array.isArray(project.implicitDependencies)
-      );
-    })
-    .reduce((map, projectName) => {
-      const project = projects[projectName];
-      detectAndSetInvalidProjectGlobValues(
-        map,
+    if (
+      !!project.implicitDependencies &&
+      !Array.isArray(project.implicitDependencies)
+    ) {
+      projectsWithNonArrayImplicitDependencies.set(
         projectName,
-        project.implicitDependencies,
-        projects,
-        projectGraphNodes
+        project.implicitDependencies
       );
       return map;
-    }, invalidImplicitDependencies);
+    }
+
+    if (!project.implicitDependencies) {
+      return map;
+    }
+
+    detectAndSetInvalidProjectGlobValues(
+      map,
+      projectName,
+      project.implicitDependencies,
+      projects,
+      projectGraphNodes
+    );
+    return map;
+  }, invalidImplicitDependencies);
 
   if (
     projectsWithNonArrayImplicitDependencies.size === 0 &&


### PR DESCRIPTION
## Current Behavior
`cache: true` is overridden if task name is dev

## Expected Behavior
`cache: true` has priority

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #32610
