### PR TITLE
fix(graph): align exclude flag with others by using findMatchingProjects

### DIFF
--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -53,6 +53,7 @@ import { getAffectedGraphNodes } from '../affected/affected';
 import { readFileMapCache } from '../../project-graph/nx-deps-cache';
 import { filterUsingGlobPatterns } from '../../hasher/task-hasher';
 import { ConfigurationSourceMaps } from '../../project-graph/utils/project-configuration-utils';
+import { findMatchingProjects } from '../../utils/find-matching-projects';
 
 import { createTaskHasher } from '../../hasher/create-task-hasher';
 import { ProjectGraphError } from '../../project-graph/error-types';
@@ -351,19 +352,29 @@ export async function generateGraph(
     affectedProjects = [];
   }
 
-  if (args.exclude) {
-    const invalidExcludes: string[] = [];
+  let excludePatterns: string[] = [];
+  if (args.exclude && args.exclude.length > 0) {
+    try {
+      // Convert projects array to the format expected by findMatchingProjects
+      const projectsMap = projects.reduce((acc, project) => {
+        acc[project.name] = project;
+        return acc;
+      }, {} as Record<string, ProjectGraphProjectNode>);
 
-    args.exclude.forEach((project) => {
-      if (!projectExists(projects, project)) {
-        invalidExcludes.push(project);
+      // Use findMatchingProjects to expand patterns (supports globs, tags, directories, etc.)
+      excludePatterns = findMatchingProjects(args.exclude, projectsMap);
+
+      // If no projects matched any of the exclude patterns, show a warning
+      if (excludePatterns.length === 0) {
+        output.warn({
+          title: `No projects matched the following exclude patterns:`,
+          bodyLines: args.exclude,
+        });
       }
-    });
-
-    if (invalidExcludes.length > 0) {
+    } catch (e) {
       output.error({
-        title: `The following projects provided to --exclude do not exist:`,
-        bodyLines: invalidExcludes,
+        title: `Invalid exclude pattern:`,
+        bodyLines: [e.message],
       });
       process.exit(1);
     }
@@ -374,11 +385,7 @@ export async function generateGraph(
     'utf-8'
   );
 
-  prunedGraph = filterGraph(
-    prunedGraph,
-    args.focus || null,
-    args.exclude || []
-  );
+  prunedGraph = filterGraph(prunedGraph, args.focus || null, excludePatterns);
 
   if (args.print || args.file === 'stdout') {
     console.log(
@@ -435,7 +442,7 @@ export async function generateGraph(
       );
 
       const environmentJs = buildEnvironmentJs(
-        args.exclude || [],
+        excludePatterns,
         args.watch,
         !!args.file && args.file.endsWith('html') ? 'build' : 'serve',
         projectGraphClientResponse,
@@ -481,7 +488,7 @@ export async function generateGraph(
     process.exit(0);
   } else {
     const environmentJs = buildEnvironmentJs(
-      args.exclude || [],
+      excludePatterns,
       args.watch,
       !!args.file && args.file.endsWith('html') ? 'build' : 'serve'
     );
@@ -498,7 +505,7 @@ export async function generateGraph(
         affectedProjects,
         args.focus,
         args.groupByFolder,
-        args.exclude
+        excludePatterns
       );
       app = result.app;
       url = result.url;
@@ -624,7 +631,11 @@ async function startServer(
   }
 
   const { projectGraphClientResponse, sourceMapResponse } =
-    await createProjectGraphAndSourceMapClientResponse(affected);
+    await createProjectGraphAndSourceMapClientResponse(
+      affected,
+      focus,
+      exclude
+    );
 
   currentProjectGraphClientResponse = projectGraphClientResponse;
   currentProjectGraphClientResponse.focus = focus;
@@ -824,7 +835,11 @@ function createFileWatcher() {
         output.note({ title: 'Recalculating project graph...' });
 
         const { projectGraphClientResponse, sourceMapResponse } =
-          await createProjectGraphAndSourceMapClientResponse();
+          await createProjectGraphAndSourceMapClientResponse(
+            [],
+            currentProjectGraphClientResponse.focus,
+            currentProjectGraphClientResponse.exclude
+          );
 
         if (
           projectGraphClientResponse.hash !==
@@ -861,7 +876,9 @@ function createFileWatcher() {
 }
 
 async function createProjectGraphAndSourceMapClientResponse(
-  affected: string[] = []
+  affected: string[] = [],
+  focus: string = null,
+  exclude: string[] = []
 ): Promise<{
   projectGraphClientResponse: ProjectGraphClientResponse;
   sourceMapResponse: ConfigurationSourceMaps;
@@ -905,6 +922,10 @@ async function createProjectGraphAndSourceMapClientResponse(
   }
 
   let graph = pruneExternalNodes(projectGraph);
+
+  // Apply focus and exclude filters
+  graph = filterGraph(graph, focus, exclude);
+
   const fileMap: ProjectFileMap =
     readFileMapCache()?.fileMap.projectFileMap || {};
   performance.mark('project graph watch calculation:end');

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -355,14 +355,8 @@ export async function generateGraph(
   let excludePatterns: string[] = [];
   if (args.exclude && args.exclude.length > 0) {
     try {
-      // Convert projects array to the format expected by findMatchingProjects
-      const projectsMap = projects.reduce((acc, project) => {
-        acc[project.name] = project;
-        return acc;
-      }, {} as Record<string, ProjectGraphProjectNode>);
-
       // Use findMatchingProjects to expand patterns (supports globs, tags, directories, etc.)
-      excludePatterns = findMatchingProjects(args.exclude, projectsMap);
+      excludePatterns = findMatchingProjects(args.exclude, prunedGraph.nodes);
 
       // If no projects matched any of the exclude patterns, show a warning
       if (excludePatterns.length === 0) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
- you can only exclude project names from `graph` commands
- the exclusion is also only honored in cli versions of the command (for example `--print`) but not in the web client.

## Expected Behavior
- You can use any matching logic that other commands support (like globs, paths, tags)
- exclusions are also honored in the graph client and projects aren't shown 

Example for running `npx nx graph --exclude='!tag:type:ui' `
<img width="1702" height="626" alt="image" src="https://github.com/user-attachments/assets/2a81d748-8efc-4b7e-9c9c-a3d59a6e6b76" />
