### PR TITLE
fix(core): use nx-mcp for older nx versions instead of nx mcp

### DIFF
--- a/packages/nx/src/ai/constants.ts
+++ b/packages/nx/src/ai/constants.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
+import { major } from 'semver';
 import { readJsonFile } from '../utils/fileutils';
 import { getAgentRules } from './set-up-ai-agents/get-agent-rules';
 
@@ -49,8 +49,18 @@ export const getAgentRulesWrapped = (writeNxCloudRules: boolean) => {
 };
 
 export const nxMcpTomlHeader = `[mcp_servers."nx-mcp"]`;
-export const nxMcpTomlConfig = `${nxMcpTomlHeader}
+
+/**
+ * Get the MCP TOML configuration based on the Nx version.
+ * For Nx 22+, uses 'nx mcp'
+ * For Nx < 22, uses 'nx-mcp'
+ */
+export function getNxMcpTomlConfig(nxVersion: string): string {
+  const majorVersion = major(nxVersion);
+  const args = majorVersion >= 22 ? '["nx", "mcp"]' : '["nx-mcp"]';
+  return `${nxMcpTomlHeader}
 type = "stdio"
 command = "npx"
-args = ["nx", "mcp"]
+args = ${args}
 `;
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Older versions don't support the `nx mcp` command yet - but they CAN use the `nx-mcp` package via npx 

## Expected Behavior
We generatee the proper command into their MCP config by matching on their version

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
