### PR TITLE
feat(angular): add migration to set bundler module resolution

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -401,6 +401,15 @@
       },
       "description": "Updates webpack-based SSR configuration to use preserve module format and bundler module resolution.",
       "factory": "./src/migrations/update-22-2-0/update-ssr-webpack-config"
+    },
+    "update-module-resolution-22-2-0": {
+      "cli": "nx",
+      "version": "22.2.0-beta.0",
+      "requires": {
+        "@angular/core": ">=21.0.0-rc.3"
+      },
+      "description": "Update 'module' to 'preserve' and 'moduleResolution' to 'bundler' in TypeScript configurations for Angular projects.",
+      "factory": "./src/migrations/update-22-2-0/update-module-resolution"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/migrations/update-22-2-0/update-module-resolution.md
+++ b/packages/angular/src/migrations/update-22-2-0/update-module-resolution.md
@@ -1,0 +1,81 @@
+#### Update `module` to `preserve` and `moduleResolution` to `bundler` in TypeScript configurations
+
+Updates the TypeScript `module` and `moduleResolution` compiler options to `'preserve'` and `'bundler'` respectively for Angular projects. These settings are required for Angular's build system to work correctly with modern module resolution algorithms used by bundlers like Webpack, Vite, and esbuild.
+
+#### Examples
+
+The migration updates TypeScript configuration files in Angular projects to set both compiler options:
+
+##### Before
+
+```jsonc {4-5}
+// apps/my-app/tsconfig.app.json
+{
+  "compilerOptions": {
+    "module": "es2020",
+    "moduleResolution": "node"
+  }
+}
+```
+
+##### After
+
+```jsonc {4-5}
+// apps/my-app/tsconfig.app.json
+{
+  "compilerOptions": {
+    "module": "preserve",
+    "moduleResolution": "bundler"
+  }
+}
+```
+
+If both values are already set correctly and inherited from an extended tsconfig file, the migration will not modify the configuration:
+
+##### Before
+
+```jsonc {5-6}
+// apps/my-app/tsconfig.json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "preserve",
+    "moduleResolution": "bundler"
+  }
+}
+```
+
+```jsonc {4-6}
+// apps/my-app/tsconfig.app.json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": []
+  }
+}
+```
+
+##### After
+
+```jsonc {5-6}
+// apps/my-app/tsconfig.json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "preserve",
+    "moduleResolution": "bundler"
+  }
+}
+```
+
+```jsonc {4-6}
+// apps/my-app/tsconfig.app.json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": []
+  }
+}
+```
+
+The migration only processes TypeScript configuration files that are referenced by Angular project build targets, ensuring that only Angular-specific configurations are updated.

--- a/packages/angular/src/migrations/update-22-2-0/update-module-resolution.spec.ts
+++ b/packages/angular/src/migrations/update-22-2-0/update-module-resolution.spec.ts
@@ -1,0 +1,235 @@
+import {
+  addProjectConfiguration,
+  readJson,
+  writeJson,
+  type ProjectConfiguration,
+  type ProjectGraph,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './update-module-resolution';
+
+let projectGraph: ProjectGraph;
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual('@nx/devkit'),
+  createProjectGraphAsync: jest
+    .fn()
+    .mockImplementation(() => Promise.resolve(projectGraph)),
+}));
+
+describe('update-module-resolution migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should set both module and moduleResolution when neither is set', async () => {
+    addProject('app1', {
+      root: 'apps/app1',
+      sourceRoot: 'apps/app1/src',
+      targets: {
+        build: {
+          executor: '@angular-devkit/build-angular:browser',
+          options: {
+            tsConfig: 'apps/app1/tsconfig.app.json',
+          },
+        },
+      },
+    });
+    writeJson(tree, 'apps/app1/tsconfig.app.json', {
+      extends: '../tsconfig.json',
+      compilerOptions: {},
+    });
+
+    await migration(tree);
+
+    const appConfig = readJson(tree, 'apps/app1/tsconfig.app.json');
+    expect(appConfig.compilerOptions.module).toBe('preserve');
+    expect(appConfig.compilerOptions.moduleResolution).toBe('bundler');
+  });
+
+  it('should set both module and moduleResolution when only module is set to es2020', async () => {
+    addProject('app1', {
+      root: 'apps/app1',
+      sourceRoot: 'apps/app1/src',
+      targets: {
+        build: {
+          executor: '@angular-devkit/build-angular:browser',
+          options: {
+            tsConfig: 'apps/app1/tsconfig.app.json',
+          },
+        },
+      },
+    });
+    writeJson(tree, 'apps/app1/tsconfig.app.json', {
+      extends: '../tsconfig.json',
+      compilerOptions: {
+        module: 'es2020',
+      },
+    });
+
+    await migration(tree);
+
+    const appConfig = readJson(tree, 'apps/app1/tsconfig.app.json');
+    expect(appConfig.compilerOptions.module).toBe('preserve');
+    expect(appConfig.compilerOptions.moduleResolution).toBe('bundler');
+  });
+
+  it('should set both module and moduleResolution when only moduleResolution is set to node', async () => {
+    addProject('app1', {
+      root: 'apps/app1',
+      sourceRoot: 'apps/app1/src',
+      targets: {
+        build: {
+          executor: '@angular-devkit/build-angular:browser',
+          options: {
+            tsConfig: 'apps/app1/tsconfig.app.json',
+          },
+        },
+      },
+    });
+    writeJson(tree, 'apps/app1/tsconfig.app.json', {
+      extends: '../tsconfig.json',
+      compilerOptions: {
+        moduleResolution: 'node',
+      },
+    });
+
+    await migration(tree);
+
+    const appConfig = readJson(tree, 'apps/app1/tsconfig.app.json');
+    expect(appConfig.compilerOptions.module).toBe('preserve');
+    expect(appConfig.compilerOptions.moduleResolution).toBe('bundler');
+  });
+
+  it('should not update when both module and moduleResolution are already correct', async () => {
+    addProject('app1', {
+      root: 'apps/app1',
+      sourceRoot: 'apps/app1/src',
+      targets: {
+        build: {
+          executor: '@angular-devkit/build-angular:browser',
+          options: {
+            tsConfig: 'apps/app1/tsconfig.app.json',
+          },
+        },
+      },
+    });
+    writeJson(tree, 'apps/app1/tsconfig.app.json', {
+      compilerOptions: {
+        module: 'preserve',
+        moduleResolution: 'bundler',
+      },
+    });
+
+    await migration(tree);
+
+    const config = readJson(tree, 'apps/app1/tsconfig.app.json');
+    expect(config.compilerOptions.module).toBe('preserve');
+    expect(config.compilerOptions.moduleResolution).toBe('bundler');
+  });
+
+  it('should handle tsconfig with extends correctly', async () => {
+    addProject('app1', {
+      root: 'apps/app1',
+      sourceRoot: 'apps/app1/src',
+      targets: {
+        build: {
+          executor: '@angular-devkit/build-angular:browser',
+          options: {
+            tsConfig: 'apps/app1/tsconfig.app.json',
+          },
+        },
+      },
+    });
+    // Base tsconfig with preserve and bundler at the workspace root
+    writeJson(tree, 'tsconfig.json', {
+      compilerOptions: {
+        module: 'preserve',
+        moduleResolution: 'bundler',
+      },
+    });
+    // App tsconfig in apps folder
+    writeJson(tree, 'apps/tsconfig.json', {
+      extends: '../tsconfig.json',
+      compilerOptions: {},
+    });
+    // App-specific tsconfig extends the apps tsconfig (inherits the values)
+    writeJson(tree, 'apps/app1/tsconfig.app.json', {
+      extends: '../tsconfig.json',
+      compilerOptions: {},
+    });
+
+    await migration(tree);
+
+    // Should not add duplicate settings since they're inherited
+    const config = readJson(tree, 'apps/app1/tsconfig.app.json');
+    // The migration should skip this file since readCompilerOptionsFromTsConfig
+    // resolves the inherited values and sees they're already correct
+    expect(config.compilerOptions.module).toBeUndefined();
+    expect(config.compilerOptions.moduleResolution).toBeUndefined();
+  });
+
+  it('should update multiple Angular project tsconfig files', async () => {
+    addProject('app1', {
+      root: 'apps/app1',
+      sourceRoot: 'apps/app1/src',
+      targets: {
+        build: {
+          executor: '@angular-devkit/build-angular:browser',
+          options: {
+            tsConfig: 'apps/app1/tsconfig.app.json',
+          },
+        },
+        test: {
+          executor: '@angular-devkit/build-angular:karma',
+          options: {
+            tsConfig: 'apps/app1/tsconfig.spec.json',
+          },
+        },
+      },
+    });
+    writeJson(tree, 'apps/app1/tsconfig.app.json', {
+      compilerOptions: {
+        module: 'es2020',
+        moduleResolution: 'node',
+      },
+    });
+    writeJson(tree, 'apps/app1/tsconfig.spec.json', {
+      compilerOptions: {
+        module: 'es2020',
+        moduleResolution: 'node',
+      },
+    });
+
+    await migration(tree);
+
+    const appConfig = readJson(tree, 'apps/app1/tsconfig.app.json');
+    const specConfig = readJson(tree, 'apps/app1/tsconfig.spec.json');
+    expect(appConfig.compilerOptions.module).toBe('preserve');
+    expect(appConfig.compilerOptions.moduleResolution).toBe('bundler');
+    expect(specConfig.compilerOptions.module).toBe('preserve');
+    expect(specConfig.compilerOptions.moduleResolution).toBe('bundler');
+  });
+
+  function addProject(
+    projectName: string,
+    config: ProjectConfiguration,
+    dependencies: string[] = ['npm:@angular/core']
+  ): void {
+    projectGraph = {
+      dependencies: {
+        [projectName]: dependencies.map((d) => ({
+          source: projectName,
+          target: d,
+          type: 'static',
+        })),
+      },
+      nodes: {
+        [projectName]: { data: config, name: projectName, type: 'app' },
+      },
+    };
+    addProjectConfiguration(tree, projectName, config);
+  }
+});

--- a/packages/angular/src/migrations/update-22-2-0/update-module-resolution.ts
+++ b/packages/angular/src/migrations/update-22-2-0/update-module-resolution.ts
@@ -1,0 +1,67 @@
+import { formatFiles, type Tree, updateJson } from '@nx/devkit';
+import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
+import { readCompilerOptionsFromTsConfig } from '../../generators/utils/tsconfig-utils';
+import { allProjectTargets, allTargetOptions } from '../../utils/targets';
+import { getProjectsFilteredByDependencies } from '../utils/projects';
+
+type TsConfig = {
+  compilerOptions?: {
+    module?: string;
+    moduleResolution?: string;
+  };
+};
+
+export default async function (tree: Tree) {
+  const uniqueTsConfigs = new Set<string>();
+
+  const projects = await getProjectsFilteredByDependencies([
+    'npm:@angular/core',
+  ]);
+
+  for (const graphNode of projects) {
+    for (const [, target] of allProjectTargets(graphNode.data)) {
+      for (const [, options] of allTargetOptions<{ tsConfig?: string }>(
+        target
+      )) {
+        if (
+          typeof options?.tsConfig === 'string' &&
+          tree.exists(options.tsConfig)
+        ) {
+          uniqueTsConfigs.add(options.tsConfig);
+        }
+      }
+    }
+  }
+
+  for (const tsConfig of uniqueTsConfigs) {
+    updateModuleAndModuleResolution(tree, tsConfig);
+  }
+
+  await formatFiles(tree);
+}
+
+function updateModuleAndModuleResolution(
+  tree: Tree,
+  tsConfigPath: string
+): void {
+  const ts = ensureTypescript();
+
+  // Read the resolved compiler options from the tsconfig
+  const compilerOptions = readCompilerOptionsFromTsConfig(tree, tsConfigPath);
+
+  // Check if both module and moduleResolution are already set correctly
+  if (
+    compilerOptions.module === ts.ModuleKind.Preserve &&
+    compilerOptions.moduleResolution === ts.ModuleResolutionKind.Bundler
+  ) {
+    return;
+  }
+
+  // Ensure both module and moduleResolution are set to the correct values
+  updateJson<TsConfig>(tree, tsConfigPath, (json) => {
+    json.compilerOptions ??= {};
+    json.compilerOptions.module = 'preserve';
+    json.compilerOptions.moduleResolution = 'bundler';
+    return json;
+  });
+}


### PR DESCRIPTION
Add migration to set `module: preserve` and `moduleResolution: bundler` to Angular projects.