### PR TITLE
fix(storybook): remove STORYBOOK_PROJECT_ROOT when running automigrate to prevent hanging

### DIFF
--- a/packages/storybook/src/generators/migrate-9/calling-storybook-cli.ts
+++ b/packages/storybook/src/generators/migrate-9/calling-storybook-cli.ts
@@ -91,10 +91,7 @@ export function callAutomigrate(
           {
             stdio: 'inherit',
             windowsHide: false,
-            env: {
-              ...process.env,
-              STORYBOOK_PROJECT_ROOT: storybookProjectInfo.configDir,
-            },
+            env: process.env,
           }
         );
 


### PR DESCRIPTION
This PR fixes an issue where migrations can hang due to out invocation of `storybook automigrate`. We are passing both `--config-dir` and `STORYBOOK_PROJECT_ROOT`, the latter causes hanging with Storybook v9.

https://www.loom.com/share/39bbb350595c4a13aef86ec29f4b748f

## Current Behavior
Hangs

## Expected Behavior
Does not hang

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #32492