### PR TITLE
fix(core): run post-task lifecycle for run-command parallel exections

### DIFF
--- a/packages/nx/src/executors/run-commands/running-tasks.ts
+++ b/packages/nx/src/executors/run-commands/running-tasks.ts
@@ -520,7 +520,7 @@ class RunningNodeProcess implements RunningTask {
     process.on('SIGINT', () => {
       this.kill('SIGTERM');
       // we exit here because we don't need to write anything to cache.
-      process.exit(signalToCode('SIGINT'));
+      process.exitCode = signalToCode('SIGINT');
     });
     process.on('SIGTERM', () => {
       this.kill('SIGTERM');
@@ -702,7 +702,7 @@ function registerProcessListener(
   process.on('SIGINT', () => {
     runningTask.kill('SIGTERM');
     // we exit here because we don't need to write anything to cache.
-    process.exit(signalToCode('SIGINT'));
+    process.exitCode = signalToCode('SIGINT');
   });
   process.on('SIGTERM', () => {
     runningTask.kill('SIGTERM');

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -441,7 +441,7 @@ export class ForkedProcessTaskRunner {
       this.cleanup('SIGTERM');
       process.off('message', messageHandler);
       // we exit here because we don't need to write anything to cache.
-      process.exit(signalToCode('SIGINT'));
+      process.exitCode = signalToCode('SIGINT');
     });
     process.once('SIGTERM', () => {
       this.cleanup('SIGTERM');

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -761,7 +761,7 @@ export class TaskOrchestrator {
           runningTask.onExit((code) => {
             if (!this.tuiEnabled) {
               if (code > 128) {
-                process.exit(code);
+                process.exitCode = code;
               }
             }
             res();
@@ -836,7 +836,7 @@ export class TaskOrchestrator {
         childProcess.onExit((code) => {
           if (!this.tuiEnabled) {
             if (code > 128) {
-              process.exit(code);
+              process.exitCode = code;
             }
           }
           res();


### PR DESCRIPTION
## Current Behavior
When using a plugin with `postTasksExecution`, this is never called in some complex scenarios with continuous tasks. 

For instance, we have a task `dev` which runs the server, and then depends on `watch-deps` (both continuous). In these scenarios, we never get stats output when the NX run is killed. However, if we remove the watch-deps it seems to work.

This seems to happen because tasks which have a slow cleanup can cause the overall NX task to finish and thus report results before they are actually killed:
```
Time →

SIGINT received
    │
    ├─► ForkedProcessTaskRunner: cleanup() + process.exit() scheduled
    │
    └─► TaskOrchestrator.cleanup() starts
            │
            ├─► cleaningUp = true
            │
            ├─► kill(prerequisite task)  ──────► Process dies quickly
            │                                         │
            │                                         └─► onExit fires
            │                                               │
            │                                               └─► postRunSteps() ✅
            │
            └─► kill(initiating task)  ────────► Process still dying...
                                                      │
        Promise.all resolves                          │ (takes longer)
        run() returns                                 │
        endCommand() writes stats  ◄──────────────────┼── Stats written HERE
                                                      │
                                                      └─► onExit fires (too late)
                                                            │
                                                            └─► postRunSteps() ❌ missed
```

In short the kill command is not awaited and even though we have async handling for onExit, that does nothing since it's a fire and forget .


## Expected Behavior
All invocations of NX which run tasks should ultimately output task data.

NOTE: This changes the output in non-TUI mode to include the second command which was lost before:
```
 NX   Successfully ran target build-deps for project mylib and 56 tasks it depends on

Nx read the output from the cache instead of running the command for 56 out of 57 tasks.

Licensed to Block Inc..
^CWarning: command "pnpm exec nx watch --projects mylib --includeDependentProjects -- pnpm exec nx build-deps mylib" exited with non-zero status code
———————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 NX   Successfully ran target dev for project banking-mfe and 58 tasks it depends on

Nx read the output from the cache instead of running the command for 56 out of 59 tasks.

Licensed to Block Inc..

```

## Related Issue(s)
This is related to https://github.com/nrwl/nx/pull/33562, but potentially upstream of that as well. I've tried to test the changes together and ensure that not only do we get invocations, but we see the continuous tasks as well

Closes #33586
