### PR TITLE
fix(testing): remove declare global wrapper from cypress commands.ts template

### DIFF
--- a/e2e/cypress/src/cypress.test.ts
+++ b/e2e/cypress/src/cypress.test.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import {
   checkFilesExist,
   cleanupProject,
@@ -6,7 +7,9 @@ import {
   newProject,
   readJson,
   runCLI,
+  runCommand,
   runE2ETests,
+  tmpProjPath,
   uniq,
   updateFile,
 } from '@nx/e2e-utils';
@@ -28,6 +31,13 @@ describe('Cypress E2E Test runner', () => {
       runCLI(
         `generate @nx/react:app apps/${myapp} --e2eTestRunner=cypress --linter=eslint`
       );
+
+      // Ensure project typechecks (See: https://github.com/nrwl/nx/issues/32930)
+      expect(() =>
+        runCommand(`npx tsc --noEmit`, {
+          cwd: join(tmpProjPath(), 'apps', `${myapp}-e2e`),
+        })
+      ).not.toThrow();
 
       // Making sure the package.json file contains the Cypress dependency
       const packageJson = readJson('package.json');

--- a/packages/cypress/src/generators/base-setup/files/common/__directory__/support/commands.ts__ext__
+++ b/packages/cypress/src/generators/base-setup/files/common/__directory__/support/commands.ts__ext__
@@ -9,14 +9,12 @@
 // commands please read more here:
 // https://on.cypress.io/custom-commands
 // ***********************************************
-
-declare global {<% if (linter === 'eslint') { %>
-  // eslint-disable-next-line @typescript-eslint/no-namespace<% } %>
-  namespace Cypress {<% if (linter === 'eslint') { %>
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars<% } %>
-    interface Chainable<Subject> {
-      login(email: string, password: string): void;
-    }
+<% if (linter === 'eslint') { %>
+// eslint-disable-next-line @typescript-eslint/no-namespace<% } %>
+declare namespace Cypress {<% if (linter === 'eslint') { %>
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars<% } %>
+  interface Chainable<Subject> {
+    login(email: string, password: string): void;
   }
 }
 

--- a/packages/cypress/src/generators/base-setup/files/config-ts/__directory__/support/commands.ts__ext__
+++ b/packages/cypress/src/generators/base-setup/files/config-ts/__directory__/support/commands.ts__ext__
@@ -9,14 +9,12 @@
 // commands please read more here:
 // https://on.cypress.io/custom-commands
 // ***********************************************
-
-declare global {<% if (linter === 'eslint') { %>
-  // eslint-disable-next-line @typescript-eslint/no-namespace<% } %>
-  namespace Cypress {<% if (linter === 'eslint') { %>
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars<% } %>
-    interface Chainable<Subject> {
-      login(email: string, password: string): void;
-    }
+<% if (linter === 'eslint') { %>
+// eslint-disable-next-line @typescript-eslint/no-namespace<% } %>
+declare namespace Cypress {<% if (linter === 'eslint') { %>
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars<% } %>
+  interface Chainable<Subject> {
+    login(email: string, password: string): void;
   }
 }
 


### PR DESCRIPTION

When adding Cypress to a library, the generated commands.ts causes TS2669 error because declare global requires the file to be a module. Changed to use declare namespace Cypress directly.

Fixes #32930
