### PR TITLE
fix(react): exclude tailwind from CSS modules syntax in component generator

### DIFF
--- a/packages/react/src/generators/component/__snapshots__/component.spec.ts.snap
+++ b/packages/react/src/generators/component/__snapshots__/component.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`component --style @emotion/styled should use @emotion/styled as the styled API library 1`] = `
 "import styled from '@emotion/styled';
@@ -70,7 +70,7 @@ export default Hello;
 exports[`component --style tailwind should not generate any style in component 1`] = `
 "export function Hello() {
   return (
-    <div className={styles['container']}>
+    <div>
       <h1>Welcome to Hello!</h1>
     </div>
   );

--- a/packages/react/src/generators/component/component.spec.ts
+++ b/packages/react/src/generators/component/component.spec.ts
@@ -332,6 +332,8 @@ describe('component', () => {
       expect(appTree.exists('my-lib/src/lib/hello/hello.tsx')).toBeTruthy();
 
       const content = appTree.read('my-lib/src/lib/hello/hello.tsx').toString();
+      expect(content).not.toContain("styles['container']");
+      expect(content).not.toContain('import styles');
       expect(content).toMatchSnapshot();
     });
   });

--- a/packages/react/src/generators/component/files/__fileName__.__ext__
+++ b/packages/react/src/generators/component/files/__fileName__.__ext__
@@ -13,7 +13,7 @@ import { Route, Link } from 'react-router-dom';
 import styled from '<%= styledModule %>';
   <%_ } else {
     var wrapper = 'div';
-    var extras = globalCss || styledModule === 'styled-jsx' ? '' : " className={styles['container']}";
+    var extras = globalCss || styledModule === 'styled-jsx' || styledModule === 'tailwind' ? '' : " className={styles['container']}";
   _%>
 <%- style !== 'styled-jsx' && style!== 'tailwind' ? globalCss ? `import './${fileName}.${style}';` : `import styles from './${fileName}.module.${style}';`: '' %>
   <%_ }


### PR DESCRIPTION


## Current Behavior
When generating a React component with --style=tailwind, the component template incorrectly includes `className={styles['container']}` and attempts to import CSS modules.

## Expected Behavior
Components generated with --style=tailwind should not include CSS modules imports or `styles['container']` references, since Tailwind doesn't use CSS modules.

## Related Issue(s)
Closes NXC-3511
