### PR TITLE
docs(nx-cloud): use GitHub's default ref in manual DTE workflow

### DIFF
--- a/astro-docs/src/content/docs/guides/Nx Cloud/manual-dte.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/manual-dte.mdoc
@@ -43,8 +43,6 @@ jobs:
         name: Checkout [Pull Request]
         if: ${{ github.event_name == 'pull_request' }}
         with:
-          # By default, PRs will be checked-out based on the Merge Commit, but we want the actual branch HEAD.
-          ref: ${{ github.event.pull_request.head.sha }}
           # We need to fetch all branches and commits so that Nx affected has a base to compare against.
           fetch-depth: 0
           filter: tree:0


### PR DESCRIPTION
## Current Behavior

The manual DTE workflow explicitly sets the `ref` parameter to `${{ github.event.pull_request.head.sha }}` to checkout the actual branch HEAD instead of the merge commit.

## Expected Behavior

Use GitHub's default ref behavior instead of explicitly overriding it, as the default behavior now handles this correctly.