### PR TITLE
fix(core): remove premature socket cleanup on non-Windows systems

### DIFF
--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -14,11 +14,7 @@ import { nxVersion } from '../../utils/versions';
 import { setupWorkspaceContext } from '../../utils/workspace-context';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { getDaemonProcessIdSync, writeDaemonJsonProcessCache } from '../cache';
-import {
-  getFullOsSocketPath,
-  isWindows,
-  killSocketOrPath,
-} from '../socket-utils';
+import { getFullOsSocketPath } from '../socket-utils';
 import {
   hasRegisteredFileWatcherSockets,
   registeredFileWatcherSockets,
@@ -688,11 +684,6 @@ export async function startServer(): Promise<Server> {
   await writeDaemonJsonProcessCache({
     processId: process.pid,
   });
-
-  // See notes in socket-command-line-utils.ts on OS differences regarding clean up of existings connections.
-  if (!isWindows) {
-    killSocketOrPath();
-  }
 
   setInterval(() => {
     if (getDaemonProcessIdSync() !== process.pid) {


### PR DESCRIPTION
The socket cleanup call was being triggered too early during server startup, causing connection issues on non-Windows systems. Remove this cleanup to let the proper shutdown handlers manage socket cleanup instead.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When daemon servers overtake one another... it removes the socket path... there can be a race condition where the file ends up removed indefinitely and causes problems detecting if the daemon is available causing more daemons to be created and causing a lot of thrashing.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When daemon servers overtake one another... it no longer removes the socket path... and daemon servers are only started when expected

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/33472
