### PR TITLE
fix(core): make daemon socket path unique per process to prevent race condition

### DIFF
--- a/packages/nx/bin/init-local.ts
+++ b/packages/nx/bin/init-local.ts
@@ -3,7 +3,9 @@ import { performance } from 'perf_hooks';
 import { commandsObject } from '../src/command-line/nx-commands';
 import { WorkspaceTypeAndRoot } from '../src/utils/find-workspace-root';
 import { stripIndents } from '../src/utils/strip-indents';
-import { ensureNxConsoleInstalled } from '../src/utils/nx-console-prompt';
+import { daemonClient } from '../src/daemon/client/client';
+import { prompt } from 'enquirer';
+import { output } from '../src/utils/output';
 
 /**
  * Nx is being run inside a workspace.
@@ -33,7 +35,7 @@ export async function initLocal(workspace: WorkspaceTypeAndRoot) {
 
     // Ensure NxConsole is installed if the user has it configured.
     try {
-      await ensureNxConsoleInstalled();
+      await ensureNxConsoleInstalledViaDaemon();
     } catch {}
 
     const command = process.argv[2];
@@ -119,6 +121,51 @@ function shouldDelegateToAngularCLI() {
     'update',
   ];
   return commands.indexOf(command) > -1;
+}
+
+async function ensureNxConsoleInstalledViaDaemon(): Promise<void> {
+  // Only proceed if daemon is available
+  if (!daemonClient.enabled()) {
+    return;
+  }
+
+  // Get status from daemon
+  const status = await daemonClient.getNxConsoleStatus();
+
+  // If we should prompt the user
+  if (status.shouldPrompt && process.stdout.isTTY) {
+    output.log({
+      title: "Install Nx's official editor extension to:",
+      bodyLines: [
+        '- Enable your AI assistant to do more by understanding your workspace',
+        '- Add IntelliSense for Nx configuration files',
+        '- Explore your workspace visually',
+      ],
+    });
+
+    try {
+      const { shouldInstallNxConsole } = await prompt<{
+        shouldInstallNxConsole: boolean;
+      }>({
+        type: 'confirm',
+        name: 'shouldInstallNxConsole',
+        message: 'Install Nx Console? (you can uninstall anytime)',
+        initial: true,
+      });
+
+      // Set preference and install if user said yes
+      const result = await daemonClient.setNxConsolePreferenceAndInstall(
+        shouldInstallNxConsole
+      );
+
+      if (result.installed) {
+        output.log({ title: 'Successfully installed Nx Console!' });
+      }
+    } catch (error) {
+      // User cancelled or error occurred, save preference as false
+      await daemonClient.setNxConsolePreferenceAndInstall(false);
+    }
+  }
 }
 
 function handleAngularCLIFallbacks(workspace: WorkspaceTypeAndRoot) {

--- a/packages/nx/src/daemon/cache.ts
+++ b/packages/nx/src/daemon/cache.ts
@@ -2,9 +2,12 @@ import { existsSync, unlinkSync } from 'node:fs';
 import { join } from 'path';
 import { DAEMON_DIR_FOR_CURRENT_WORKSPACE } from './tmp-dir';
 import { readJsonFile, writeJsonFileAsync } from '../utils/fileutils';
+import { nxVersion } from '../utils/versions';
 
 export interface DaemonProcessJson {
   processId: number;
+  socketPath: string;
+  nxVersion: string;
 }
 
 export const serverProcessJsonPath = join(
@@ -13,10 +16,16 @@ export const serverProcessJsonPath = join(
 );
 
 export function readDaemonProcessJsonCache(): DaemonProcessJson | null {
-  if (!existsSync(serverProcessJsonPath)) {
+  try {
+    const daemonJson = readJsonFile(serverProcessJsonPath);
+    // If the daemon version doesn't match the client version, treat it as stale
+    if (daemonJson.nxVersion !== nxVersion) {
+      return null;
+    }
+    return daemonJson;
+  } catch {
     return null;
   }
-  return readJsonFile(serverProcessJsonPath);
 }
 
 export function deleteDaemonJsonProcessCache(): void {
@@ -33,31 +42,6 @@ export async function writeDaemonJsonProcessCache(
   await writeJsonFileAsync(serverProcessJsonPath, daemonJson, {
     appendNewLine: true,
   });
-}
-
-export async function waitForDaemonToExitAndCleanupProcessJson(): Promise<void> {
-  const daemonProcessJson = readDaemonProcessJsonCache();
-  if (daemonProcessJson && daemonProcessJson.processId) {
-    await new Promise<void>((resolve, reject) => {
-      let count = 0;
-      const interval = setInterval(() => {
-        try {
-          // sending a signal 0 to a process checks if the process is running instead of actually killing it
-          process.kill(daemonProcessJson.processId, 0);
-        } catch (e) {
-          clearInterval(interval);
-          resolve();
-        }
-        if ((count += 1) > 200) {
-          clearInterval(interval);
-          reject(
-            `Daemon process ${daemonProcessJson.processId} didn't exit after 2 seconds.`
-          );
-        }
-      }, 10);
-    });
-    deleteDaemonJsonProcessCache();
-  }
 }
 
 // Must be sync for the help output use case

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -97,6 +97,14 @@ import {
   PRE_TASKS_EXECUTION,
 } from '../message-types/run-tasks-execution-hooks';
 import { REGISTER_PROJECT_GRAPH_LISTENER } from '../message-types/register-project-graph-listener';
+import {
+  GET_NX_CONSOLE_STATUS,
+  type HandleGetNxConsoleStatusMessage,
+  type HandleSetNxConsolePreferenceAndInstallMessage,
+  type NxConsoleStatusResponse,
+  SET_NX_CONSOLE_PREFERENCE_AND_INSTALL,
+  type SetNxConsolePreferenceAndInstallResponse,
+} from '../message-types/nx-console';
 import { deserialize } from 'node:v8';
 import { isJsonMessage } from '../../utils/consume-messages-from-socket';
 import { isV8SerializerEnabled } from '../is-v8-serializer-enabled';
@@ -563,6 +571,23 @@ export class DaemonClient {
     const message: HandlePostTasksExecutionMessage = {
       type: POST_TASKS_EXECUTION,
       context,
+    };
+    return this.sendToDaemonViaQueue(message);
+  }
+
+  getNxConsoleStatus(): Promise<NxConsoleStatusResponse> {
+    const message: HandleGetNxConsoleStatusMessage = {
+      type: GET_NX_CONSOLE_STATUS,
+    };
+    return this.sendToDaemonViaQueue(message);
+  }
+
+  setNxConsolePreferenceAndInstall(
+    preference: boolean
+  ): Promise<SetNxConsolePreferenceAndInstallResponse> {
+    const message: HandleSetNxConsolePreferenceAndInstallMessage = {
+      type: SET_NX_CONSOLE_PREFERENCE_AND_INSTALL,
+      preference,
     };
     return this.sendToDaemonViaQueue(message);
   }

--- a/packages/nx/src/daemon/is-nx-version-mismatch.ts
+++ b/packages/nx/src/daemon/is-nx-version-mismatch.ts
@@ -1,0 +1,21 @@
+import { readJsonFile } from '../utils/fileutils';
+import type { PackageJson } from '../utils/package-json';
+import { nxVersion } from '../utils/versions';
+import { workspaceRoot } from '../utils/workspace-root';
+
+export function getInstalledNxVersion(): string | null {
+  try {
+    const nxPackageJsonPath = require.resolve('nx/package.json', {
+      paths: [workspaceRoot],
+    });
+    const { version } = readJsonFile<PackageJson>(nxPackageJsonPath);
+    return version;
+  } catch {
+    // node modules are absent
+    return null;
+  }
+}
+
+export function isNxVersionMismatch(): boolean {
+  return getInstalledNxVersion() !== nxVersion;
+}

--- a/packages/nx/src/daemon/is-nx-version-mismatch.ts
+++ b/packages/nx/src/daemon/is-nx-version-mismatch.ts
@@ -2,11 +2,12 @@ import { readJsonFile } from '../utils/fileutils';
 import type { PackageJson } from '../utils/package-json';
 import { nxVersion } from '../utils/versions';
 import { workspaceRoot } from '../utils/workspace-root';
+import { getNxRequirePaths } from '../utils/installation-directory';
 
 export function getInstalledNxVersion(): string | null {
   try {
     const nxPackageJsonPath = require.resolve('nx/package.json', {
-      paths: [workspaceRoot],
+      paths: getNxRequirePaths(workspaceRoot),
     });
     const { version } = readJsonFile<PackageJson>(nxPackageJsonPath);
     return version;

--- a/packages/nx/src/daemon/message-types/nx-console.ts
+++ b/packages/nx/src/daemon/message-types/nx-console.ts
@@ -1,0 +1,42 @@
+export const GET_NX_CONSOLE_STATUS = 'GET_NX_CONSOLE_STATUS' as const;
+export const SET_NX_CONSOLE_PREFERENCE_AND_INSTALL =
+  'SET_NX_CONSOLE_PREFERENCE_AND_INSTALL' as const;
+
+export type HandleGetNxConsoleStatusMessage = {
+  type: typeof GET_NX_CONSOLE_STATUS;
+};
+
+export type NxConsoleStatusResponse = {
+  shouldPrompt: boolean;
+};
+
+export type HandleSetNxConsolePreferenceAndInstallMessage = {
+  type: typeof SET_NX_CONSOLE_PREFERENCE_AND_INSTALL;
+  preference: boolean;
+};
+
+export type SetNxConsolePreferenceAndInstallResponse = {
+  installed: boolean;
+};
+
+export function isHandleGetNxConsoleStatusMessage(
+  message: unknown
+): message is HandleGetNxConsoleStatusMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message['type'] === GET_NX_CONSOLE_STATUS
+  );
+}
+
+export function isHandleSetNxConsolePreferenceAndInstallMessage(
+  message: unknown
+): message is HandleSetNxConsolePreferenceAndInstallMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message['type'] === SET_NX_CONSOLE_PREFERENCE_AND_INSTALL
+  );
+}

--- a/packages/nx/src/daemon/server/handle-nx-console.ts
+++ b/packages/nx/src/daemon/server/handle-nx-console.ts
@@ -1,0 +1,69 @@
+import type {
+  NxConsoleStatusResponse,
+  SetNxConsolePreferenceAndInstallResponse,
+} from '../message-types/nx-console';
+import type { HandlerResult } from './server';
+import {
+  getNxConsoleStatus,
+  handleNxConsolePreferenceAndInstall,
+} from './nx-console-operations';
+
+// Module-level state for caching
+let cachedShouldPrompt: boolean | null = null;
+let isComputing = false;
+
+export async function handleGetNxConsoleStatus(): Promise<HandlerResult> {
+  // Return cached result if available
+  if (cachedShouldPrompt !== null) {
+    const response: NxConsoleStatusResponse = {
+      shouldPrompt: cachedShouldPrompt,
+    };
+    return {
+      response,
+      description: 'handleGetNxConsoleStatus',
+    };
+  }
+
+  // Kick off background computation if not already running
+  if (!isComputing) {
+    isComputing = true;
+    getNxConsoleStatus()
+      .then((result) => {
+        cachedShouldPrompt = result;
+        isComputing = false;
+      })
+      .catch(() => {
+        cachedShouldPrompt = null;
+        isComputing = false;
+      });
+  }
+
+  // Return false for shouldPrompt if cache not ready (main process will noop)
+  const response: NxConsoleStatusResponse = {
+    shouldPrompt: false,
+  };
+
+  return {
+    response,
+    description: 'handleGetNxConsoleStatus',
+  };
+}
+
+export async function handleSetNxConsolePreferenceAndInstall(
+  preference: boolean
+): Promise<HandlerResult> {
+  // Immediately update cache - we know the answer now!
+  // User answered the prompt, so we won't prompt again
+  cachedShouldPrompt = false;
+
+  const result = await handleNxConsolePreferenceAndInstall({ preference });
+
+  const response: SetNxConsolePreferenceAndInstallResponse = {
+    installed: result.installed,
+  };
+
+  return {
+    response,
+    description: 'handleSetNxConsolePreferenceAndInstall',
+  };
+}

--- a/packages/nx/src/daemon/server/nx-console-operations.ts
+++ b/packages/nx/src/daemon/server/nx-console-operations.ts
@@ -1,0 +1,181 @@
+import { installPackageToTmpAsync } from '../../devkit-internals';
+import { homedir } from 'os';
+import {
+  canInstallNxConsole,
+  installNxConsole,
+  NxConsolePreferences,
+} from '../../native';
+import { serverLogger } from './logger';
+
+// Module-level state - persists across invocations within daemon lifecycle
+let latestNxTmpPath: string | null = null;
+let cleanupFn: (() => void) | null = null;
+
+const log = (...messageParts: unknown[]) => {
+  serverLogger.log('[NX-CONSOLE]:', ...messageParts);
+};
+
+/**
+ * Gets the Nx Console status (whether we should prompt the user to install).
+ * Uses latest Nx version if available, falls back to local implementation.
+ *
+ * @returns boolean indicating whether we should prompt the user
+ */
+export async function getNxConsoleStatus({
+  inner,
+}: {
+  inner?: boolean;
+} = {}): Promise<boolean> {
+  // Use local implementation if explicitly requested
+  if (process.env.NX_USE_LOCAL === 'true' || inner === true) {
+    log('Using local implementation (NX_USE_LOCAL=true or inner call)');
+    return await getNxConsoleStatusImpl();
+  }
+
+  try {
+    // If we don't have a tmp path yet, pull latest Nx
+    if (latestNxTmpPath === null) {
+      log('Pulling latest Nx (latest) to check console status...');
+      const packageInstallResults = await installPackageToTmpAsync(
+        'nx',
+        'latest'
+      );
+      latestNxTmpPath = packageInstallResults.tempDir;
+      cleanupFn = packageInstallResults.cleanup;
+      log('Successfully pulled latest Nx to', latestNxTmpPath);
+    } else {
+      log('Reusing cached Nx installation from', latestNxTmpPath);
+    }
+
+    // Try to use the cached tmp path
+    const modulePath = require.resolve(
+      'nx/src/daemon/server/nx-console-operations.js',
+      { paths: [latestNxTmpPath] }
+    );
+
+    const module = await import(modulePath);
+    const result = await module.getNxConsoleStatus({ inner: true });
+    log('Console status check completed, shouldPrompt:', result);
+    return result;
+  } catch (error) {
+    // If tmp path failed (e.g., directory was deleted), fall back to local immediately
+    log(
+      'Failed to use latest Nx, falling back to local implementation. Error:',
+      error.message
+    );
+    return await getNxConsoleStatusImpl();
+  }
+}
+
+/**
+ * Handles user preference submission and installs Nx Console if requested.
+ * Uses latest Nx version if available, falls back to local implementation.
+ *
+ * @param preference - whether the user wants to install Nx Console
+ * @returns object indicating whether installation succeeded
+ */
+export async function handleNxConsolePreferenceAndInstall({
+  preference,
+  inner,
+}: {
+  preference: boolean;
+  inner?: boolean;
+}): Promise<{ installed: boolean }> {
+  log('Handling user preference:', preference);
+
+  // Use local implementation if explicitly requested
+  if (process.env.NX_USE_LOCAL === 'true' || inner === true) {
+    log('Using local implementation (NX_USE_LOCAL=true or inner call)');
+    return await handleNxConsolePreferenceAndInstallImpl(preference);
+  }
+
+  try {
+    // If we don't have a tmp path yet, pull latest Nx
+    if (latestNxTmpPath === null) {
+      log('Pulling latest Nx (latest) to handle preference and install...');
+      const packageInstallResults = await installPackageToTmpAsync(
+        'nx',
+        'latest'
+      );
+      latestNxTmpPath = packageInstallResults.tempDir;
+      cleanupFn = packageInstallResults.cleanup;
+      log('Successfully pulled latest Nx to', latestNxTmpPath);
+    } else {
+      log('Reusing cached Nx installation from', latestNxTmpPath);
+    }
+
+    // Try to use the cached tmp path
+    const modulePath = require.resolve(
+      'nx/src/daemon/server/nx-console-operations.js',
+      { paths: [latestNxTmpPath] }
+    );
+
+    const module = await import(modulePath);
+    const result = await module.handleNxConsolePreferenceAndInstall({
+      preference,
+      inner: true,
+    });
+    log(
+      'Preference saved and installation',
+      result.installed ? 'succeeded' : 'skipped/failed'
+    );
+    return result;
+  } catch (error) {
+    // If tmp path failed (e.g., directory was deleted), fall back to local immediately
+    log(
+      'Failed to use latest Nx, falling back to local implementation. Error:',
+      error.message
+    );
+    return await handleNxConsolePreferenceAndInstallImpl(preference);
+  }
+}
+
+/**
+ * Clean up the latest Nx installation on daemon shutdown.
+ */
+export function cleanupLatestNxInstallation(): void {
+  if (cleanupFn) {
+    log('Cleaning up latest Nx installation from', latestNxTmpPath);
+    cleanupFn();
+  }
+  latestNxTmpPath = null;
+  cleanupFn = null;
+}
+
+export async function getNxConsoleStatusImpl(): Promise<boolean> {
+  // If no cached preference, read from disk
+  const preferences = new NxConsolePreferences(homedir());
+  const preference = preferences.getAutoInstallPreference();
+
+  const canInstallConsole = canInstallNxConsole();
+
+  // If user previously opted in but extension is not installed,
+  // they must have manually uninstalled it - respect that choice
+  if (preference === true && canInstallConsole) {
+    const preferences = new NxConsolePreferences(homedir());
+    preferences.setAutoInstallPreference(false);
+    return false; // Don't prompt
+  }
+
+  // Noop if can't install
+  if (!canInstallConsole) {
+    return false;
+  }
+
+  // Prompt if we can install and user hasn't answered yet
+  return typeof preference !== 'boolean';
+}
+
+export async function handleNxConsolePreferenceAndInstallImpl(
+  preference: boolean
+): Promise<{ installed: boolean }> {
+  const preferences = new NxConsolePreferences(homedir());
+  preferences.setAutoInstallPreference(preference);
+
+  let installed = false;
+  if (preference) {
+    installed = installNxConsole();
+  }
+
+  return { installed };
+}

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -8,12 +8,11 @@ import {
   consumeMessagesFromSocket,
   isJsonMessage,
 } from '../../utils/consume-messages-from-socket';
-import { readJsonFile } from '../../utils/fileutils';
-import { PackageJson } from '../../utils/package-json';
 import { nxVersion } from '../../utils/versions';
 import { setupWorkspaceContext } from '../../utils/workspace-context';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { getDaemonProcessIdSync, writeDaemonJsonProcessCache } from '../cache';
+import { isNxVersionMismatch } from '../is-nx-version-mismatch';
 import {
   getFullOsSocketPath,
   isWindows,
@@ -509,28 +508,12 @@ function registerProcessTerminationListeners() {
 let existingLockHash: string | undefined;
 
 function daemonIsOutdated(): string | null {
-  if (nxVersionChanged()) {
+  if (isNxVersionMismatch()) {
     return 'NX_VERSION_CHANGED';
   } else if (lockFileHashChanged()) {
     return 'LOCK_FILES_CHANGED';
   }
   return null;
-}
-
-function nxVersionChanged(): boolean {
-  return nxVersion !== getInstalledNxVersion();
-}
-
-const nxPackageJsonPath = require.resolve('nx/package.json');
-
-function getInstalledNxVersion() {
-  try {
-    const { version } = readJsonFile<PackageJson>(nxPackageJsonPath);
-    return version;
-  } catch (e) {
-    // node modules are absent, so we can return null, which would shut down the daemon
-    return null;
-  }
 }
 
 function lockFileHashChanged(): boolean {
@@ -660,9 +643,13 @@ const handleOutputsChanges: FileWatcherCallback = async (err, changeEvents) => {
 export async function startServer(): Promise<Server> {
   setupWorkspaceContext(workspaceRoot);
 
+  const socketPath = getFullOsSocketPath();
+
   // Persist metadata about the background process so that it can be cleaned up later if needed
   await writeDaemonJsonProcessCache({
     processId: process.pid,
+    socketPath,
+    nxVersion,
   });
 
   // See notes in socket-command-line-utils.ts on OS differences regarding clean up of existings connections.
@@ -682,9 +669,9 @@ export async function startServer(): Promise<Server> {
 
   return new Promise(async (resolve, reject) => {
     try {
-      server.listen(getFullOsSocketPath(), async () => {
+      server.listen(socketPath, async () => {
         try {
-          serverLogger.log(`Started listening on: ${getFullOsSocketPath()}`);
+          serverLogger.log(`Started listening on: ${socketPath}`);
 
           // this triggers the storage of the lock file hash
           daemonIsOutdated();

--- a/packages/nx/src/daemon/server/shutdown-utils.ts
+++ b/packages/nx/src/daemon/server/shutdown-utils.ts
@@ -11,6 +11,7 @@ import {
 import { removeDbConnections } from '../../utils/db-connection';
 import { cleanupPlugins } from '../../project-graph/plugins/get-plugins';
 import { MESSAGE_END_SEQ } from '../../utils/consume-messages-from-socket';
+import { cleanupLatestNxInstallation } from './nx-console-operations';
 
 export const SERVER_INACTIVITY_TIMEOUT_MS = 10800000 as const; // 10800000 ms = 3 hours
 
@@ -74,6 +75,9 @@ export async function handleServerProcessTermination({
     cleanupPlugins();
 
     removeDbConnections();
+
+    // Clean up Nx Console latest installation
+    cleanupLatestNxInstallation();
 
     serverLogger.log(`Server stopped because: "${reason}"`);
   } finally {

--- a/packages/nx/src/daemon/tmp-dir.ts
+++ b/packages/nx/src/daemon/tmp-dir.ts
@@ -49,6 +49,7 @@ export function isDaemonDisabled() {
 function socketDirName() {
   const hasher = createHash('sha256');
   hasher.update(workspaceRoot.toLowerCase());
+  hasher.update(String(process.pid));
   const unique = hasher.digest('hex').substring(0, 20);
   return join(tmpdir, unique);
 }

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -24,6 +24,7 @@ export { stripIndent } from './utils/logger';
 export {
   readModulePackageJson,
   installPackageToTmp,
+  installPackageToTmpAsync,
 } from './utils/package-json';
 export { splitByColons } from './utils/split-target';
 export { hashObject } from './hasher/file-hasher';


### PR DESCRIPTION
## Current Behavior

  1. **Socket Race Condition**: All daemon servers listen on the same socket path, causing a race condition where shutting down daemons remove sockets that newly started
  daemons are listening on.

  2. **Daemon Console Check Blocks**: The daemon availability check runs synchronously and blocks the main thread.

  3. **Version Mismatch Issues**: Packages using a different nx version than what's installed in the workspace could still use the daemon, leading to potential issues.

  ## Expected Behavior

  1. Each daemon server creates a unique socket path based on its process ID, preventing race conditions.

  2. The daemon console check runs in the background without blocking.

  3. The daemon is disabled when there's a version mismatch between the running nx and the workspace's installed version.

  ## Changes

  ### 1. Unique Daemon Socket Paths
  - Include `process.pid` in the socket directory hash to make each daemon's path unique
  - Store the socket path in `server-process.json` so clients know where to connect
  - Clients read the socket path from the file instead of calculating it

  ### 2. Backgroundable Daemon Check
  - Reapplied #33491 which makes the Nx Console install check run on the daemon in the background
  - This was previously reverted due to the socket race condition (now fixed by change 1.)
  - Running in background also allows pulling the latest check logic from npm

  ### 3. Version Mismatch Check
  - Added `isNxVersionMismatch()` check in `DaemonClient.enabled()`
  - Created shared utility `is-nx-version-mismatch.ts` for version comparison
  - Refactored server.ts to use the shared utility
  - Uses `require.resolve('nx/package.json', { paths: [workspaceRoot] })` to properly resolve the workspace's installed nx version

  ## Related Issue(s)

  Fixes daemon socket path race condition and improves daemon reliability.