### PR TITLE
fix(js): support rootDir in node executor

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -490,6 +490,11 @@ function getFileToRun(
         // This ensures consistency when calculating the relative output path
         if (path.isAbsolute(sourceRoot)) {
           sourceRoot = path.relative(context.root, sourceRoot);
+        } else {
+          // If rootDir is a relative path (e.g., 'src' or './src'),
+          // it should be resolved relative to the project root.
+          // Join with project root to get the full path from workspace root.
+          sourceRoot = path.join(project.data.root, sourceRoot);
         }
       }
 


### PR DESCRIPTION
The node executor now correctly handles TypeScript's rootDir configuration when calculating output file paths.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
A Nx project has a build target using `@nx/js:tsc` with options:
- `rootDir: "{projectRoot}/src"`
- `main: "{projectRoot}/src/main.ts"`

Running `nx build` correctly generates `main.js` in `dist/apps/project_a` respecting `rootDir`.

However, the serve target (@nx/js:node) fails.

## Expected Behavior
The `serve` target runs without errors.

The `@nx/js:node` executor correctly resolves the built JS file’s path, respecting the `rootDir` configuration, instead of incorrectly adding `src` under `dist`.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #33577 where rootDir breaks js:node executor.
