### PR TITLE
fix(nest): set moduleResolution to 'node' in generated apps

### DIFF
--- a/packages/nest/src/generators/application/lib/update-tsconfig.ts
+++ b/packages/nest/src/generators/application/lib/update-tsconfig.ts
@@ -11,6 +11,17 @@ export function updateTsConfig(tree: Tree, options: NormalizedOptions): void {
       json.compilerOptions.experimentalDecorators = true;
       json.compilerOptions.emitDecoratorMetadata = true;
       json.compilerOptions.target = 'es2021';
+      // Fix for Angular workspaces: Force node resolution to avoid TS5095 error
+      // when root tsconfig uses "moduleResolution": "bundler" and module is "commonjs"
+      // Don't override if using TS solution setup (nodenext/node16) or other valid settings
+      if (
+        (!json.compilerOptions.moduleResolution ||
+          json.compilerOptions.moduleResolution === 'bundler') &&
+        json.compilerOptions.module !== 'nodenext' &&
+        json.compilerOptions.module !== 'node16'
+      ) {
+        json.compilerOptions.moduleResolution = 'node';
+      }
       if (options.strict) {
         json.compilerOptions = {
           ...json.compilerOptions,


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Generated NestJS applications in an Angular workspace inherit `moduleResolution: "bundler"` from the root `tsconfig`. This conflicts with `module: "commonjs"` in the app config, causing TypeScript error `TS5095` during build/serve.

## Expected Behavior
Generated NestJS applications explicitly set `moduleResolution: "node"` in their `tsconfig.app.json`. This overrides the root configuration, allowing the application to build and serve successfully without `TS5095` errors.

## Related Issue(s)

Fixes #33589
