### PR TITLE
fix(core): set max listeners for process in task orchestrator

### DIFF
--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -133,6 +133,7 @@ export class TaskOrchestrator {
 
     process.stdout.setMaxListeners(threadCount + defaultMaxListeners);
     process.stderr.setMaxListeners(threadCount + defaultMaxListeners);
+    process.setMaxListeners(threadCount + defaultMaxListeners);
 
     // initial seeding of the queue
     for (let i = 0; i < threadCount; ++i) {


### PR DESCRIPTION
When 8+ dependent tasks exist, each adds an `exit` listener to track completion. This listener attaches to `process`. So we apply the same fix that worked for `stdout` and `stderr`, and was merged through [PR 16693](https://github.com/nrwl/nx/pull/16993)

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
For `nx` targets with 8+ dependent targets, we encounter `maxListenersExceededWarning`:
```
(node: 22553) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGINT listeners added to [process]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit.
(node: 22553) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGTERM listeners added to [process]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit.
(node: 22553) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGHUP listeners added to [process]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit.
```
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
No `MaxListenersExceededWarning` should be thrown on account of the nx run.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #32439
