### PR TITLE
fix(bundling): replace rollup-plugin-copy with nx copy assets plugin

### DIFF
--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -42,7 +42,6 @@
     "picomatch": "catalog:",
     "postcss": "^8.4.38",
     "rollup": "^4.14.0",
-    "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-typescript2": "^0.36.0",
     "tslib": "catalog:typescript"

--- a/packages/rollup/src/plugins/nx-copy-assets.plugin.spec.ts
+++ b/packages/rollup/src/plugins/nx-copy-assets.plugin.spec.ts
@@ -1,0 +1,58 @@
+import { extractGlobLiteralPrefix } from './nx-copy-assets.plugin';
+
+describe('extractGlobLiteralPrefix', () => {
+  it('should extract literal directory prefix from path without globs', () => {
+    expect(extractGlobLiteralPrefix('libs/mylib/README.md')).toEqual({
+      prefix: 'libs/mylib',
+      glob: 'README.md',
+    });
+  });
+
+  it('should return "." prefix for filename-only patterns', () => {
+    expect(extractGlobLiteralPrefix('README.md')).toEqual({
+      prefix: '.',
+      glob: 'README.md',
+    });
+  });
+
+  it('should return "." prefix when glob starts with wildcard', () => {
+    expect(extractGlobLiteralPrefix('**/*.md')).toEqual({
+      prefix: '.',
+      glob: '**/*.md',
+    });
+
+    expect(extractGlobLiteralPrefix('*.md')).toEqual({
+      prefix: '.',
+      glob: '*.md',
+    });
+  });
+
+  it('should split at glob boundary', () => {
+    expect(extractGlobLiteralPrefix('docs/*.md')).toEqual({
+      prefix: 'docs',
+      glob: '*.md',
+    });
+
+    expect(extractGlobLiteralPrefix('libs/mylib/src/assets/**/*.png')).toEqual({
+      prefix: 'libs/mylib/src/assets',
+      glob: '**/*.png',
+    });
+  });
+
+  it('should handle other glob characters', () => {
+    expect(extractGlobLiteralPrefix('libs/[abc]/file.ts')).toEqual({
+      prefix: 'libs',
+      glob: '[abc]/file.ts',
+    });
+
+    expect(extractGlobLiteralPrefix('libs/{a,b}/file.ts')).toEqual({
+      prefix: 'libs',
+      glob: '{a,b}/file.ts',
+    });
+
+    expect(extractGlobLiteralPrefix('libs/file?.ts')).toEqual({
+      prefix: 'libs',
+      glob: 'file?.ts',
+    });
+  });
+});

--- a/packages/rollup/src/plugins/nx-copy-assets.plugin.ts
+++ b/packages/rollup/src/plugins/nx-copy-assets.plugin.ts
@@ -16,6 +16,8 @@ export function nxCopyAssetsPlugin(options: NxCopyAssetsPluginOptions): Plugin {
 
   if (global.NX_GRAPH_CREATION) return { name: 'nx-copy-assets-plugin' };
 
+  const relativeProjectRoot = relative(workspaceRoot, options.projectRoot);
+
   return {
     name: 'nx-copy-assets-plugin',
     async buildStart() {
@@ -23,16 +25,11 @@ export function nxCopyAssetsPlugin(options: NxCopyAssetsPluginOptions): Plugin {
       // CopyAssetsHandler expects paths relative to rootDir.
       const assets = options.assets.map((a) => {
         if (typeof a === 'string') {
-          const relativeProjectRoot = relative(
-            workspaceRoot,
-            options.projectRoot
-          );
-          return joinPathFragments(relativeProjectRoot, a);
+          return isAbsolute(a) ? a : join(relativeProjectRoot, a);
         } else {
-          const relativeInput = relative(workspaceRoot, a.input);
           return {
             ...a,
-            input: relativeInput || '.',
+            input: isAbsolute(a.input) ? a.input : join(workspaceRoot, a.input),
           };
         }
       });

--- a/packages/rollup/src/plugins/nx-copy-assets.plugin.ts
+++ b/packages/rollup/src/plugins/nx-copy-assets.plugin.ts
@@ -1,0 +1,56 @@
+import { join, relative, isAbsolute } from 'node:path';
+import type { Plugin } from 'rollup';
+import { isDaemonEnabled, joinPathFragments, workspaceRoot } from '@nx/devkit';
+import { AssetGlob } from '@nx/js/src/utils/assets/assets';
+import { CopyAssetsHandler } from '@nx/js/src/utils/assets/copy-assets-handler';
+
+export interface NxCopyAssetsPluginOptions {
+  assets: (string | AssetGlob)[];
+  outputPath: string;
+  projectRoot: string;
+}
+
+export function nxCopyAssetsPlugin(options: NxCopyAssetsPluginOptions): Plugin {
+  let handler: CopyAssetsHandler;
+  let dispose: () => void;
+
+  if (global.NX_GRAPH_CREATION) return { name: 'nx-copy-assets-plugin' };
+
+  return {
+    name: 'nx-copy-assets-plugin',
+    async buildStart() {
+      const relativeProjectRoot = relative(workspaceRoot, options.projectRoot);
+      const assets = options.assets.map((a) => {
+        if (typeof a === 'string') {
+          return joinPathFragments(relativeProjectRoot, a);
+        } else {
+          return {
+            ...a,
+            input: joinPathFragments(relativeProjectRoot, a.input),
+          };
+        }
+      });
+
+      const outputDir = isAbsolute(options.outputPath)
+        ? options.outputPath
+        : join(workspaceRoot, options.outputPath);
+
+      handler = new CopyAssetsHandler({
+        rootDir: workspaceRoot,
+        projectDir: options.projectRoot,
+        outputDir,
+        assets,
+      });
+
+      if (this.meta.watchMode && isDaemonEnabled()) {
+        dispose = await handler.watchAndProcessOnAssetChange();
+      }
+    },
+    async writeBundle() {
+      await handler.processAllAssetsOnce();
+    },
+    closeWatcher() {
+      dispose?.();
+    },
+  };
+}

--- a/packages/rollup/src/plugins/nx-copy-assets.plugin.ts
+++ b/packages/rollup/src/plugins/nx-copy-assets.plugin.ts
@@ -19,14 +19,19 @@ export function nxCopyAssetsPlugin(options: NxCopyAssetsPluginOptions): Plugin {
   return {
     name: 'nx-copy-assets-plugin',
     async buildStart() {
-      const relativeProjectRoot = relative(workspaceRoot, options.projectRoot);
+      // Assets from normalizeOptions already have absolute paths in input field.
+      // CopyAssetsHandler expects paths relative to rootDir.
       const assets = options.assets.map((a) => {
         if (typeof a === 'string') {
+          const relativeProjectRoot = relative(
+            workspaceRoot,
+            options.projectRoot
+          );
           return joinPathFragments(relativeProjectRoot, a);
         } else {
           return {
             ...a,
-            input: joinPathFragments(relativeProjectRoot, a.input),
+            input: relative(workspaceRoot, a.input),
           };
         }
       });

--- a/packages/rollup/src/plugins/nx-copy-assets.plugin.ts
+++ b/packages/rollup/src/plugins/nx-copy-assets.plugin.ts
@@ -29,9 +29,10 @@ export function nxCopyAssetsPlugin(options: NxCopyAssetsPluginOptions): Plugin {
           );
           return joinPathFragments(relativeProjectRoot, a);
         } else {
+          const relativeInput = relative(workspaceRoot, a.input);
           return {
             ...a,
-            input: relative(workspaceRoot, a.input),
+            input: relativeInput || '.',
           };
         }
       });

--- a/packages/rollup/src/plugins/with-nx/with-nx.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx.ts
@@ -26,18 +26,18 @@ import { PackageJson } from 'nx/src/utils/package-json';
 import * as rollup from 'rollup';
 import { analyze } from '../analyze';
 import { deleteOutput } from '../delete-output';
+import { nxCopyAssetsPlugin } from '../nx-copy-assets.plugin';
 import { generatePackageJson } from '../package-json/generate-package-json';
 import { swc } from '../swc';
 import { getProjectNode } from './get-project-node';
 import { normalizeOptions } from './normalize-options';
-import { AssetGlobPattern, RollupWithNxPluginOptions } from './with-nx-options';
+import { RollupWithNxPluginOptions } from './with-nx-options';
 
 // These use require because the ES import isn't correct.
 const commonjs = require('@rollup/plugin-commonjs');
 const image = require('@rollup/plugin-image');
 
 const json = require('@rollup/plugin-json');
-const copy = require('rollup-plugin-copy');
 const postcss = require('rollup-plugin-postcss');
 
 const fileExtensions = ['.js', '.jsx', '.ts', '.tsx'];
@@ -241,11 +241,10 @@ export function withNx(
       : finalConfig.output.dir;
 
     finalConfig.plugins = [
-      copy({
-        targets: convertCopyAssetsToRollupOptions(
-          options.outputPath,
-          options.assets
-        ),
+      nxCopyAssetsPlugin({
+        assets: options.assets,
+        outputPath: options.outputPath,
+        projectRoot,
       }),
       image(),
       json(),
@@ -386,23 +385,6 @@ function createTsCompilerOptions(
     compilerOptions['emitDeclarationOnly'] = true;
   }
   return compilerOptions;
-}
-
-interface RollupCopyAssetOption {
-  src: string;
-  dest: string;
-}
-
-function convertCopyAssetsToRollupOptions(
-  outputPath: string,
-  assets: AssetGlobPattern[]
-): RollupCopyAssetOption[] {
-  return assets
-    ? assets.map((a) => ({
-        src: join(a.input, a.glob).replace(/\\/g, '/'),
-        dest: join(workspaceRoot, outputPath, a.output).replace(/\\/g, '/'),
-      }))
-    : undefined;
 }
 
 function readCompatibleFormats(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3988,9 +3988,6 @@ importers:
       rollup:
         specifier: ^4.14.0
         version: 4.44.2
-      rollup-plugin-copy:
-        specifier: ^3.5.0
-        version: 3.5.0
       rollup-plugin-postcss:
         specifier: ^4.0.2
         version: 4.0.2(postcss@8.5.3)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.9.2))


### PR DESCRIPTION
There's a problem when `@nx/rollup` is installed with yarn@1.22, and typechecks.

This is caused by the transitive dependency chain:

```
rollup-plugin-copy@3.5.0 -> globby@10.0.1 -> @types/glob@7.2.0 -> @types/minimatch
```

When users run tsc without explicit `types` configuration, TypeScript auto-discovers `@types/minimatch` from `node_modules` but can't properly resolve it.

Note: This doesn't happen with NPM and PNPM, nor newer yarn versions.

Verified fix with this repro: https://github.com/jaysoo/rollup-251124

Fixes #32398

