### PR TITLE
fix(release): ensure emoji is not repeated in breaking changes summary

### DIFF
--- a/e2e/release/src/conventional-commits-config.test.ts
+++ b/e2e/release/src/conventional-commits-config.test.ts
@@ -399,7 +399,7 @@ describe('nx release conventional commits config', () => {
 
       ### ⚠️  Breaking Changes
 
-      - ⚠️  **{project-name}:** this is a breaking change
+      - **{project-name}:** this is a breaking change
     `);
 
     const pkg2Changelog = readFile(`${pkg2}/CHANGELOG.md`);

--- a/e2e/release/src/conventional-commits-config.workspaces.test.ts
+++ b/e2e/release/src/conventional-commits-config.workspaces.test.ts
@@ -406,7 +406,7 @@ describe('nx release conventional commits config', () => {
 
       ### ⚠️  Breaking Changes
 
-      - ⚠️  **{project-name}:** this is a breaking change
+      - **{project-name}:** this is a breaking change
     `);
 
     const pkg2Changelog = readFile(`${pkg2}/CHANGELOG.md`);

--- a/packages/nx/release/changelog-renderer/index.spec.ts
+++ b/packages/nx/release/changelog-renderer/index.spec.ts
@@ -708,20 +708,20 @@ describe('ChangelogRenderer', () => {
         }).render();
 
         expect(markdown).toMatchInlineSnapshot(`
-                  "## v1.1.0
+          "## v1.1.0
 
-                  ### 🚀 Features
+          ### 🚀 Features
 
-                  - ⚠️  **WebSocketSubject:** no longer extends \`Subject\`.
+          - ⚠️  **WebSocketSubject:** no longer extends \`Subject\`.
 
-                  ### ⚠️  Breaking Changes
+          ### ⚠️  Breaking Changes
 
-                  - ⚠️  **WebSocketSubject:** no longer extends \`Subject\`.
+          - **WebSocketSubject:** no longer extends \`Subject\`.
 
-                  ### ❤️ Thank You
+          ### ❤️ Thank You
 
-                  - James Henry"
-              `);
+          - James Henry"
+        `);
       });
 
       it('should extract the explanation of a breaking change and render it preferentially with references', async () => {

--- a/packages/nx/release/changelog-renderer/index.ts
+++ b/packages/nx/release/changelog-renderer/index.ts
@@ -408,42 +408,44 @@ export default class DefaultChangelogRenderer {
     return changeLine;
   }
 
-  protected formatBreakingChange(change: ChangelogChange): string {
-    const explanation = this.extractBreakingChangeExplanation(change.body);
-
-    if (!explanation) {
-      // No explanation found, use the regular formatChange which includes references
-      return this.formatChange(change);
-    }
-
-    // Build the breaking change line with scope, explanation, and references
+  protected formatBreakingChangeBase(change: ChangelogChange): string {
     let breakingLine = '- ';
 
     if (change.scope) {
       breakingLine += `**${change.scope.trim()}:** `;
     }
-    // Ensure first line of the breaking change contains the commit title
+
     if (change.description) {
-      breakingLine += `${change.description.trim()} `;
+      breakingLine += `${change.description.trim()}`;
     }
 
-    // Add PR/commit references
     if (
       this.remoteReleaseClient.getRemoteRepoData() &&
       this.changelogRenderOptions.commitReferences &&
       change.githubReferences
     ) {
-      breakingLine += `${this.remoteReleaseClient.formatReferences(
+      breakingLine += ` ${this.remoteReleaseClient.formatReferences(
         change.githubReferences
       )}`;
     }
 
+    return breakingLine;
+  }
+
+  protected formatBreakingChange(change: ChangelogChange): string {
+    const explanation = this.extractBreakingChangeExplanation(change.body);
+    const baseLine = this.formatBreakingChangeBase(change);
+
+    if (!explanation) {
+      return baseLine;
+    }
+
     const indentation = '  ';
-    breakingLine += `\n${indentation}`;
+    let breakingLine = baseLine + `\n${indentation}`;
 
     // Handle multi-line explanations
     let explanationText = explanation;
-    let extraLines = [];
+    let extraLines: string[] = [];
     if (explanation.includes('\n')) {
       [explanationText, ...extraLines] = explanation.split('\n');
     }


### PR DESCRIPTION
## Current Behavior
The ⚠️ emoji at the beginning of bc commits is duplicated in the bc section of the changelog.
This is unneeded.

## Expected Behavior
Ensure the ⚠️ is not repeated in the bc section of the changelog
