### PR TITLE
fix(node): set generatePackageJson:false for TS Solution workspaces

### DIFF
--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -967,7 +967,7 @@ describe('app', () => {
               assets: ["./src/assets"],
               optimization: false,
               outputHashing: 'none',
-              generatePackageJson: true,
+              generatePackageJson: false,
               sourceMaps: true,
             })
           ],

--- a/packages/node/src/generators/application/files/common/webpack.config.js__tmpl__
+++ b/packages/node/src/generators/application/files/common/webpack.config.js__tmpl__
@@ -19,7 +19,7 @@ module.exports = {
       assets: <%- JSON.stringify(webpackPluginOptions.assets) %>,
       optimization: false,
       outputHashing: 'none',
-      generatePackageJson: true,
+      generatePackageJson: <%= webpackPluginOptions.generatePackageJson %>,
       sourceMaps: true,
     })
   ],

--- a/packages/node/src/generators/application/lib/create-files.ts
+++ b/packages/node/src/generators/application/lib/create-files.ts
@@ -39,6 +39,7 @@ export function addAppFiles(tree: Tree, options: NormalizedSchema) {
               main: './src/main' + (options.js ? '.js' : '.ts'),
               tsConfig: './tsconfig.app.json',
               assets: ['./src/assets'],
+              generatePackageJson: !options.isUsingTsSolutionConfig,
             }
           : null,
     }


### PR DESCRIPTION
## Current Behavior
In TS Solution setups, we generate webpack config with `generatePackageJson: true`. This is confusing and unneeded.
It should be set to false in TS Solution repos.

## Expected Behavior
Set `generatePackageJson: false` in webpack config for TS Solution Setups


Closes NXC-3521
