### PR TITLE
fix(nest): set moduleResolution to node to prevent TS5095 error

### DIFF
--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -157,6 +157,7 @@ describe('application generator', () => {
     const tsConfig = devkit.readJson(tree, `${appDirectory}/tsconfig.app.json`);
     expect(tsConfig.compilerOptions.emitDecoratorMetadata).toBe(true);
     expect(tsConfig.compilerOptions.target).toBe('es2021');
+    expect(tsConfig.compilerOptions.moduleResolution).toBe('node');
     expect(tsConfig.exclude).toEqual([
       'jest.config.ts',
       'jest.config.cts',

--- a/packages/nest/src/generators/application/lib/update-tsconfig.ts
+++ b/packages/nest/src/generators/application/lib/update-tsconfig.ts
@@ -11,6 +11,11 @@ export function updateTsConfig(tree: Tree, options: NormalizedOptions): void {
       json.compilerOptions.experimentalDecorators = true;
       json.compilerOptions.emitDecoratorMetadata = true;
       json.compilerOptions.target = 'es2021';
+
+      // Only set this when not using TS solution setup, as TS solution setup uses 'nodenext'
+      if (!isUsingTsSolutionSetup(tree)) {
+        json.compilerOptions.moduleResolution = 'node';
+      }
       if (options.strict) {
         json.compilerOptions = {
           ...json.compilerOptions,


### PR DESCRIPTION
When generating NestJS applications in Angular workspaces, the base tsconfig sets moduleResolution to 'bundler' which causes TS5095 errors because 'bundler' requires module to be 'preserve' or 'es2015+'. 

NestJS applications should use Node.js module resolution instead. This fix sets moduleResolution to 'node' for NestJS applications (except when using TS solution setup, which uses 'nodenext').

Fixes #33589
