### PR TITLE
docs(testing): update atomizer documentation for Vite and Vitest plugins

### DIFF
--- a/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
@@ -61,7 +61,7 @@ nx add @nx/jest
 {% tabitem label="Vitest" %}
 
 ```shell
-nx add @nx/vite
+nx add @nx/vitest
 ```
 
 {% /tabitem %}
@@ -89,12 +89,12 @@ If you upgraded Nx from an older version, ensure that [inferred tasks](/docs/con
 
 ## Update an Existing Project to use Automated Task Splitting
 
-If you are already using the `@nx/cypress`, `@nx/playwright`, `@nx/jest`, `@nx/vite` or `@nx/gradle` plugin, you need to manually add the appropriate configuration to the `plugins` array of `nx.json`. Follow the instructions for the plugin you are using:
+If you are already using the `@nx/cypress`, `@nx/playwright`, `@nx/jest`, `@nx/vitest`, or `@nx/gradle` plugin, you need to manually add the appropriate configuration to the `plugins` array of `nx.json`. Follow the instructions for the plugin you are using:
 
 - [Configure Cypress Task Splitting](/docs/technologies/test-tools/cypress/introduction#nxcypress-configuration)
 - [Configure Playwright Task Splitting](/docs/technologies/test-tools/playwright/introduction#nxplaywright-configuration)
 - [Configure Jest Task Splitting](/docs/technologies/test-tools/jest/introduction#splitting-e2e-tests)
-- [Configure Vitest Task Splitting](/docs/technologies/build-tools/vite/introduction#splitting-e2e-tests)
+- [Configure Vitest Task Splitting](/docs/technologies/test-tools/vitest/introduction#splitting-e2e-tests)
 - [Configure Gradle Testing Task Splitting](/docs/technologies/java/gradle/introduction#test-distribution)
 
 ## Verify Automated Task Splitting Works

--- a/astro-docs/src/content/docs/technologies/build-tools/vite/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/vite/introduction.mdoc
@@ -66,6 +66,8 @@ To view inferred tasks for a project, open the [project details view](/docs/conc
 
 The `@nx/vite/plugin` is configured in the `plugins` array in `nx.json`.
 
+<!-- TODO(v23): remove testTargetName -->
+
 ```json
 // nx.json
 {
@@ -76,7 +78,7 @@ The `@nx/vite/plugin` is configured in the `plugins` array in `nx.json`.
         "buildTargetName": "build",
         "previewTargetName": "preview",
         "testTargetName": "test",
-        "serveTargetName": "serve",
+        "devTargetName": "dev",
         "serveStaticTargetName": "serve-static"
       }
     }
@@ -84,7 +86,9 @@ The `@nx/vite/plugin` is configured in the `plugins` array in `nx.json`.
 }
 ```
 
-The `buildTargetName`, `previewTargetName`, `testTargetName`, `serveTargetName` and `serveStaticTargetName` options control the names of the inferred Vite tasks. The default names are `build`, `preview`, `test`, `serve` and `serve-static`.
+**Note:** In Nx 22, testTargetName has moved to `@nx/vitest` and will be removed from `@nx/vite/plugin` in Nx 23.
+
+The `buildTargetName`, `previewTargetName`, `devTargetName` and `serveStaticTargetName` options control the names of the inferred Vite tasks. The default names are `build`, `preview`, `dev` and `serve-static`.
 
 ## Using @nx/vite
 
@@ -121,47 +125,3 @@ You can read more about this generator on the [`@nx/vite:configuration`](/docs/t
 You can use the `@nx/vite:vitest` generator to generate Vitest configuration for your project. This generator will generate a `vitest.config.ts` file in the root of your project, and it will also install all the necessary dependencies.
 
 You can read more about this generator on the [`@nx/vite:vitest`](/docs/technologies/build-tools/vite/generators#vitest) generator page.
-
-### Splitting E2E Tests
-
-If Vitest is used to run E2E tests, you can enable [splitting the tasks](/docs/features/ci-features/split-e2e-tasks) by file to get
-improved caching, distribution, and retrying flaky tests. Enable this Atomizer feature by providing a `ciTargetName`. This will create a
-target with that name which can be used in CI to run the tests for each file in a distributed fashion.
-
-```json
-// nx.json
-{
-  "plugins": [
-    {
-      "plugin": "@nx/vite/plugin",
-      "include": ["e2e/**/*"],
-      "options": {
-        "testTargetName": "e2e-local",
-        "ciTargetName": "e2e-ci"
-      }
-    }
-  ]
-}
-```
-
-### Customizing atomized unit/e2e tasks group name
-
-By default, the atomized tasks group name is derived from the `ciTargetName`. For example, atomized tasks for the `e2e-ci` target will be grouped under the name "E2E (CI)" when displayed in Nx Cloud or `nx show project <project>` UI.
-You can customize that name by explicitly providing the optional `ciGroupName` plugin option as such:
-
-```json
-// nx.json
-{
-  "plugins": [
-    {
-      "plugin": "@nx/vite/plugin",
-      "include": ["e2e/**/*"],
-      "options": {
-        "testTargetName": "e2e-local",
-        "ciTargetName": "e2e-ci",
-        "ciGroupName": "My E2E tests (CI)"
-      }
-    }
-  ]
-}
-```

--- a/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
@@ -66,14 +66,86 @@ The `@nx/vitest` plugin is configured in the `plugins` array in `nx.json`.
     {
       "plugin": "@nx/vitest",
       "options": {
-        "targetName": "test"
+        "testTargetName": "test"
       }
     }
   ]
 }
 ```
 
-- The `targetName` option controls the name of the inferred Vitest tasks. The default name is `test`.
+- The `testTargetName` option controls the name of the inferred Vitest tasks. The default name is `test`.
+
+#### Configuring @nx/vitest for both E2E and Unit Tests
+
+While Vitest is most often used for unit tests, there are cases where it can be used for e2e tests as well as unit tests within the same workspace. In this case, you can configure the `@nx/vitest` plugin twice for the different cases.
+
+```json
+// nx.json
+{
+  "plugins": [
+    {
+      "plugin": "@nx/vitest",
+      "exclude": ["e2e/**/*"],
+      "options": {
+        "testTargetName": "test"
+      }
+    },
+    {
+      "plugin": "@nx/vitest",
+      "include": ["e2e/**/*"],
+      "options": {
+        "testTargetName": "e2e-local",
+        "ciTargetName": "e2e-ci"
+      }
+    }
+  ]
+}
+```
+
+### Splitting E2E Tests
+
+{% aside type="note" title="Migrating from @nx/vite" %}
+In Nx 21 and earlier, Vitest task splitting was configured through `@nx/vite/plugin`. Starting with Nx 22, this functionality has moved to `@nx/vitest`. The `@nx/vite` plugin will have its Vitest features removed in Nx 23.
+{% /aside %}
+
+If Vitest is used to run E2E tests, you can enable [splitting the tasks](/docs/features/ci-features/split-e2e-tasks) by file to get improved caching, distribution, and retrying flaky tests. Enable this Atomizer feature by providing a `ciTargetName`. This will create a target with that name which can be used in CI to run the tests for each file in a distributed fashion.
+
+```json
+// nx.json
+{
+  "plugins": [
+    {
+      "plugin": "@nx/vitest",
+      "include": ["e2e/**/*"],
+      "options": {
+        "testTargetName": "e2e-local",
+        "ciTargetName": "e2e-ci"
+      }
+    }
+  ]
+}
+```
+
+### Customizing Atomized Tasks Group Name
+
+By default, the atomized tasks group name is derived from the `ciTargetName`. For example, atomized tasks for the `e2e-ci` target will be grouped under the name "E2E (CI)" when displayed in Nx Cloud or `nx show project <project>` UI. You can customize that name by explicitly providing the optional `ciGroupName` plugin option:
+
+```json
+// nx.json
+{
+  "plugins": [
+    {
+      "plugin": "@nx/vitest",
+      "include": ["e2e/**/*"],
+      "options": {
+        "testTargetName": "e2e-local",
+        "ciTargetName": "e2e-ci",
+        "ciGroupName": "My E2E tests (CI)"
+      }
+    }
+  ]
+}
+```
 
 ## Using Vitest
 


### PR DESCRIPTION
## Current Behavior

The atomizer/task splitting documentation for Vite and Vitest was incomplete:
- The @nx/vite/plugin introduction page was missing the dual configuration example for both E2E and unit tests
- The @nx/vitest introduction page was missing all atomizer-related sections (splitting E2E tests, ciTargetName, ciGroupName)
- The split-e2e-tasks feature page only referenced @nx/vite for Vitest, not the dedicated @nx/vitest plugin
- The @nx/vitest docs had incorrect option name (targetName instead of testTargetName)

## Expected Behavior

- @nx/vitest introduction page now have complete atomizer documentation
- The split-e2e-tasks page now references both @nx/vitest and @nx/vite options for Vitest users
- Configuration examples use the correct option names matching the actual plugin interfaces
- Users can easily find how to configure task splitting for Vitest whether they use @nx/vite or @nx/vitest
---

Affected pages:
- https://deploy-preview-33620--nx-docs.netlify.app/docs/features/ci-features/split-e2e-tasks#update-an-existing-project-to-use-automated-task-splitting
- https://deploy-preview-33620--nx-docs.netlify.app/docs/technologies/build-tools/vite/introduction
- https://deploy-preview-33620--nx-docs.netlify.app/docs/technologies/test-tools/vitest/introduction

Closes DOC-346