### PR TITLE
feat(angular): split `vitest` unit test runner choice into `vitest-angular` and `vitest-analog`

### DIFF
--- a/e2e/angular/src/module-federation-host-remote.test.ts
+++ b/e2e/angular/src/module-federation-host-remote.test.ts
@@ -2,14 +2,12 @@ import { names } from '@nx/devkit';
 import {
   checkFilesExist,
   killProcessAndPorts,
-  readJson,
   runCLI,
   runCommandUntil,
   uniq,
   updateFile,
   updateJson,
 } from '@nx/e2e-utils';
-import { join } from 'path';
 import {
   setupModuleFederationTest,
   cleanupModuleFederationTest,
@@ -37,11 +35,11 @@ describe('Angular Module Federation - Host and Remote', () => {
 
     // generate host app
     runCLI(
-      `generate @nx/angular:host ${hostApp} --style=css --no-standalone --no-interactive`
+      `generate @nx/angular:host ${hostApp} --style=css --no-standalone --unitTestRunner=jest --no-interactive`
     );
     // generate remote app
     runCLI(
-      `generate @nx/angular:remote ${remoteApp1} --host=${hostApp} --port=${remotePort} --style=css --no-standalone --no-interactive`
+      `generate @nx/angular:remote ${remoteApp1} --host=${hostApp} --port=${remotePort} --style=css --no-standalone --unitTestRunner=jest --no-interactive`
     );
 
     // check files are generated without the layout directory ("apps/")
@@ -177,10 +175,10 @@ describe('Angular Module Federation - Host and Remote', () => {
 
     // generate apps
     runCLI(
-      `generate @nx/angular:application ${app1} --routing --bundler=webpack --no-interactive`
+      `generate @nx/angular:application ${app1} --routing --bundler=webpack --unitTestRunner=jest --no-interactive`
     );
     runCLI(
-      `generate @nx/angular:application ${app2} --bundler=webpack --no-interactive`
+      `generate @nx/angular:application ${app2} --bundler=webpack --unitTestRunner=jest --no-interactive`
     );
 
     // convert apps

--- a/e2e/angular/src/tailwind.test.ts
+++ b/e2e/angular/src/tailwind.test.ts
@@ -408,7 +408,7 @@ describe('Tailwind support', () => {
     it('should build correctly and only output the tailwind utilities used when using webpack and incremental builds', async () => {
       const appWithTailwind = uniq('app-with-tailwind');
       runCLI(
-        `generate @nx/angular:app ${appWithTailwind} --add-tailwind --bundler=webpack --no-interactive`
+        `generate @nx/angular:app ${appWithTailwind} --add-tailwind --bundler=webpack --unitTestRunner=jest --no-interactive`
       );
       setupTailwindAndProjectDependencies(appWithTailwind);
       updateJson(join(appWithTailwind, 'project.json'), (config) => {

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -419,6 +419,11 @@
       },
       "description": "Updates the 'lib' property in tsconfig files to use 'es2022' or a more modern version.",
       "factory": "./src/migrations/update-22-2-0/update-typescript-lib"
+    },
+    "update-unit-test-runner-option": {
+      "version": "22.2.0-beta.0",
+      "description": "Update 'vitest' unit test runner option to 'vitest-analog' in generator defaults.",
+      "factory": "./src/migrations/update-22-2-0/update-unit-test-runner-option"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -689,7 +689,7 @@ bootstrapApplication(AppComponent, appConfig).catch((err) =>
 "
 `;
 
-exports[`app angular compat support vitest & angular < 21 should add tsconfig.spec.json 1`] = `
+exports[`app angular compat support vitest-analog & angular < 21 should add tsconfig.spec.json 1`] = `
 "{
   "extends": "./tsconfig.json",
   "compilerOptions": {
@@ -724,7 +724,7 @@ exports[`app angular compat support vitest & angular < 21 should add tsconfig.sp
 "
 `;
 
-exports[`app angular compat support vitest & angular < 21 should generate src/test-setup.ts 1`] = `
+exports[`app angular compat support vitest-analog & angular < 21 should generate src/test-setup.ts 1`] = `
 "import '@angular/compiler';
 import '@analogjs/vitest-angular/setup-zone';
 import {
@@ -740,7 +740,7 @@ getTestBed().initTestEnvironment(
 "
 `;
 
-exports[`app angular compat support vitest & angular < 21 should generate vite.config.mts 1`] = `
+exports[`app angular compat support vitest-analog & angular < 21 should generate vite.config.mts 1`] = `
 "/// <reference types='vitest' />
 import { defineConfig } from 'vite';
 import angular from '@analogjs/vite-plugin-angular';

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -750,10 +750,10 @@ describe('app', () => {
       });
     });
 
-    describe('vitest', () => {
+    describe('vitest-angular', () => {
       it('should setup test target with @angular/build:unit-test and configure target defaults', async () => {
         await generateApp(appTree, 'my-app', {
-          unitTestRunner: UnitTestRunner.Vitest,
+          unitTestRunner: UnitTestRunner.VitestAngular,
         });
 
         const project = readProjectConfiguration(appTree, 'my-app');
@@ -772,7 +772,7 @@ describe('app', () => {
 
       it('should install vitest, jsdom and @angular/build packages', async () => {
         await generateApp(appTree, 'my-app', {
-          unitTestRunner: UnitTestRunner.Vitest,
+          unitTestRunner: UnitTestRunner.VitestAngular,
         });
 
         const { devDependencies } = readJson(appTree, 'package.json');
@@ -788,7 +788,7 @@ describe('app', () => {
 
       it('should configure typescript correctly', async () => {
         await generateApp(appTree, 'my-app', {
-          unitTestRunner: UnitTestRunner.Vitest,
+          unitTestRunner: UnitTestRunner.VitestAngular,
         });
 
         const tsconfigSpec = appTree.read('my-app/tsconfig.spec.json', 'utf-8');
@@ -1233,23 +1233,23 @@ describe('app', () => {
       expect(jestPlugin).toBeDefined();
     });
 
-    it('should generate test target with @angular/build:unit-test executor for vitest when --bundler=rspack', async () => {
+    it('should use crystal vitest when --bundler=rspack and vitest-analog with addPlugin', async () => {
       await generateApp(appTree, 'app1', {
         bundler: 'rspack',
-        unitTestRunner: UnitTestRunner.Vitest,
+        unitTestRunner: UnitTestRunner.VitestAnalog,
+        addPlugin: true,
       });
 
       const project = readProjectConfiguration(appTree, 'app1');
-      expect(project.targets.test).toStrictEqual({
-        executor: '@angular/build:unit-test',
-        options: {},
-      });
+      expect(project.targets.test).not.toBeDefined();
 
       const nxJson = readNxJson(appTree);
-      expect(nxJson.targetDefaults['@angular/build:unit-test']).toStrictEqual({
-        cache: true,
-        inputs: ['default', '^default'],
-      });
+      const vitestPlugin = nxJson.plugins.find(
+        (p) =>
+          (typeof p === 'string' && p === '@nx/vitest') ||
+          (typeof p !== 'string' && p.plugin === '@nx/vitest')
+      );
+      expect(vitestPlugin).toBeDefined();
     });
 
     it('should generate target options "browser" and "buildTarget"', async () => {
@@ -1732,7 +1732,7 @@ describe('app', () => {
       `);
     });
 
-    describe('vitest & angular < 21', () => {
+    describe('vitest-analog & angular < 21', () => {
       beforeEach(() => {
         updateJson(appTree, 'package.json', (json) => ({
           ...json,
@@ -1746,7 +1746,7 @@ describe('app', () => {
       it('should generate vite.config.mts', async () => {
         await generateApp(appTree, 'my-app', {
           skipFormat: false,
-          unitTestRunner: UnitTestRunner.Vitest,
+          unitTestRunner: UnitTestRunner.VitestAnalog,
         });
 
         expect(
@@ -1756,7 +1756,7 @@ describe('app', () => {
 
       it('should generate src/test-setup.ts', async () => {
         await generateApp(appTree, 'my-app', {
-          unitTestRunner: UnitTestRunner.Vitest,
+          unitTestRunner: UnitTestRunner.VitestAnalog,
         });
 
         expect(
@@ -1766,7 +1766,7 @@ describe('app', () => {
 
       it('should exclude src/test-setup.ts in tsconfig.app.json', async () => {
         await generateApp(appTree, 'my-app', {
-          unitTestRunner: UnitTestRunner.Vitest,
+          unitTestRunner: UnitTestRunner.VitestAnalog,
         });
 
         const tsConfig = readJson(appTree, 'my-app/tsconfig.app.json');
@@ -1775,7 +1775,7 @@ describe('app', () => {
 
       it('should add tsconfig.spec.json', async () => {
         await generateApp(appTree, 'my-app', {
-          unitTestRunner: UnitTestRunner.Vitest,
+          unitTestRunner: UnitTestRunner.VitestAnalog,
         });
 
         expect(
@@ -1785,7 +1785,7 @@ describe('app', () => {
 
       it('should add a reference to tsconfig.spec.json in tsconfig.json', async () => {
         await generateApp(appTree, 'my-app', {
-          unitTestRunner: UnitTestRunner.Vitest,
+          unitTestRunner: UnitTestRunner.VitestAnalog,
         });
 
         const { references } = readJson(appTree, 'my-app/tsconfig.json');
@@ -1796,7 +1796,7 @@ describe('app', () => {
 
       it('should add @nx/vitest dependency', async () => {
         await generateApp(appTree, 'my-app', {
-          unitTestRunner: UnitTestRunner.Vitest,
+          unitTestRunner: UnitTestRunner.VitestAnalog,
         });
 
         const { devDependencies } = readJson(appTree, 'package.json');
@@ -1805,7 +1805,7 @@ describe('app', () => {
 
       it('should add vitest-angular', async () => {
         await generateApp(appTree, 'my-app', {
-          unitTestRunner: UnitTestRunner.Vitest,
+          unitTestRunner: UnitTestRunner.VitestAnalog,
         });
 
         const { devDependencies } = readJson(appTree, 'package.json');
@@ -1813,26 +1813,27 @@ describe('app', () => {
         expect(devDependencies['@analogjs/vitest-angular']).toBeDefined();
       });
 
-      it('should not override build configuration when using vitest as a test runner', async () => {
+      it('should not override build configuration when using vitest-analog as a test runner', async () => {
         await generateApp(appTree, 'my-app', {
-          unitTestRunner: UnitTestRunner.Vitest,
+          unitTestRunner: UnitTestRunner.VitestAnalog,
         });
         const { targets } = readProjectConfiguration(appTree, 'my-app');
         expect(targets.build.executor).toBe('@angular/build:application');
       });
 
-      it('should not override serve configuration when using vitest as a test runner', async () => {
+      it('should not override serve configuration when using vitest-analog as a test runner', async () => {
         await generateApp(appTree, 'my-app', {
-          unitTestRunner: UnitTestRunner.Vitest,
+          unitTestRunner: UnitTestRunner.VitestAnalog,
         });
         const { targets } = readProjectConfiguration(appTree, 'my-app');
         expect(targets.serve.executor).toBe('@angular/build:dev-server');
       });
 
-      it('should use crystal vitest when --bundler=rspack', async () => {
+      it('should use crystal vitest when --bundler=rspack and addPlugin', async () => {
         await generateApp(appTree, 'app1', {
           bundler: 'rspack',
-          unitTestRunner: UnitTestRunner.Vitest,
+          unitTestRunner: UnitTestRunner.VitestAnalog,
+          addPlugin: true,
         });
 
         const project = readProjectConfiguration(appTree, 'app1');

--- a/packages/angular/src/generators/application/lib/add-unit-test-runner.ts
+++ b/packages/angular/src/generators/application/lib/add-unit-test-runner.ts
@@ -1,7 +1,7 @@
-import { Tree } from '@nx/devkit';
+import type { Tree } from '@nx/devkit';
 import { UnitTestRunner } from '../../../utils/test-runners';
 import { addJest } from '../../utils/add-jest';
-import { addVitest } from '../../utils/add-vitest';
+import { addVitestAnalog, addVitestAngular } from '../../utils/add-vitest';
 import type { NormalizedSchema } from './normalized-schema';
 
 export async function addUnitTestRunner(host: Tree, options: NormalizedSchema) {
@@ -17,8 +17,15 @@ export async function addUnitTestRunner(host: Tree, options: NormalizedSchema) {
         zoneless: options.zoneless,
       });
       break;
-    case UnitTestRunner.Vitest:
-      await addVitest(host, {
+    case UnitTestRunner.VitestAngular:
+      await addVitestAngular(host, {
+        name: options.name,
+        projectRoot: options.appProjectRoot,
+        skipPackageJson: options.skipPackageJson,
+      });
+      break;
+    case UnitTestRunner.VitestAnalog:
+      await addVitestAnalog(host, {
         name: options.name,
         projectRoot: options.appProjectRoot,
         skipFormat: options.skipFormat,

--- a/packages/angular/src/generators/application/lib/normalize-options.ts
+++ b/packages/angular/src/generators/application/lib/normalize-options.ts
@@ -54,7 +54,11 @@ export async function normalizeOptions(
   const zonelessDefaultValue = angularMajorVersion >= 21 ? true : false;
   const unitTestRunner =
     options.unitTestRunner ??
-    (angularMajorVersion >= 21 ? UnitTestRunner.Vitest : UnitTestRunner.Jest);
+    (angularMajorVersion >= 21 && bundler === 'esbuild'
+      ? UnitTestRunner.VitestAngular
+      : angularMajorVersion >= 21
+      ? UnitTestRunner.VitestAnalog
+      : UnitTestRunner.Jest);
 
   // Set defaults and then overwrite with user options
   return {

--- a/packages/angular/src/generators/application/lib/validate-options.ts
+++ b/packages/angular/src/generators/application/lib/validate-options.ts
@@ -1,4 +1,5 @@
 import type { Tree } from '@nx/devkit';
+import { UnitTestRunner } from '../../../utils/test-runners';
 import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { Schema } from '../schema';
 
@@ -10,6 +11,24 @@ export function validateOptions(tree: Tree, options: Schema) {
     if (options.zoneless) {
       throw new Error(
         `The "zoneless" option is only supported for Angular versions >= 21.0.0. You are using Angular ${angularVersion}.`
+      );
+    }
+  }
+
+  if (options.unitTestRunner === UnitTestRunner.VitestAngular) {
+    if (angularMajorVersion < 21) {
+      throw new Error(
+        `The "vitest-angular" unit test runner requires Angular v21 or higher. ` +
+          `Detected Angular v${angularVersion}. Use "vitest-analog" or "jest" instead.`
+      );
+    }
+    // Only fail if bundler is explicitly set to a non-esbuild value.
+    // If bundler is undefined, it will default to 'esbuild' for Angular v21+.
+    if (options.bundler && options.bundler !== 'esbuild') {
+      throw new Error(
+        `The "vitest-angular" unit test runner requires the "esbuild" bundler ` +
+          `which uses the "@angular/build:application" executor. ` +
+          `Use "vitest-analog" or "jest" instead. Or use the "esbuild" bundler.`
       );
     }
   }

--- a/packages/angular/src/generators/application/schema.json
+++ b/packages/angular/src/generators/application/schema.json
@@ -99,8 +99,8 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["vitest", "jest", "none"],
-      "description": "Test runner to use for unit tests. It defaults to `vitest` when using the `esbuild` bundler for Angular versions >= 21.0.0. Otherwise, it defaults to `jest`.",
+      "enum": ["vitest-angular", "vitest-analog", "jest", "none"],
+      "description": "Test runner to use for unit tests. `vitest-angular` uses the `@angular/build:unit-test` executor (requires Angular v21+ and the `esbuild` bundler). `vitest-analog` uses AnalogJS-based setup with `@nx/vitest`. It defaults to `vitest-angular` when using the `esbuild` bundler for Angular versions >= 21.0.0, `vitest-analog` when using other bundlers on Angular >= 21.0.0, otherwise `jest`.",
       "x-prompt": "Which unit test runner would you like to use?"
     },
     "e2eTestRunner": {

--- a/packages/angular/src/generators/federate-module/federate-module.ts
+++ b/packages/angular/src/generators/federate-module/federate-module.ts
@@ -25,8 +25,11 @@ export async function federateModuleGenerator(tree: Tree, schema: Schema) {
   schema.standalone = schema.standalone ?? true;
 
   const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
+  // federate-module uses webpack/rspack bundlers, so vitest-angular is not available
   schema.unitTestRunner ??=
-    angularMajorVersion >= 21 ? UnitTestRunner.Vitest : UnitTestRunner.Jest;
+    angularMajorVersion >= 21
+      ? UnitTestRunner.VitestAnalog
+      : UnitTestRunner.Jest;
 
   const { tasks, projectRoot, remoteName } = await addRemote(tree, schema);
 

--- a/packages/angular/src/generators/federate-module/schema.d.ts
+++ b/packages/angular/src/generators/federate-module/schema.d.ts
@@ -1,4 +1,4 @@
-import { UnitTestRunner, E2eTestRunner } from '../utils/testing';
+import type { E2eTestRunner, UnitTestRunner } from '../../utils/test-runners';
 
 export interface Schema {
   name: string;
@@ -6,7 +6,7 @@ export interface Schema {
   remote: string;
   remoteDirectory?: string;
   host?: string;
-  unitTestRunner?: UnitTestRunner;
+  unitTestRunner?: Exclude<UnitTestRunner, UnitTestRunner.VitestAngular>;
   e2eTestRunner?: E2eTestRunner;
   standalone?: boolean;
   skipFormat?: boolean;

--- a/packages/angular/src/generators/federate-module/schema.json
+++ b/packages/angular/src/generators/federate-module/schema.json
@@ -57,8 +57,8 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["vitest", "jest", "none"],
-      "description": "Test runner to use for unit tests of the Producer (remote) if it needs to be created. It defaults to `vitest` for Angular versions >= 21.0.0. Otherwise, it defaults to `jest`.",
+      "enum": ["vitest-analog", "jest", "none"],
+      "description": "Test runner to use for unit tests of the Producer (remote) if it needs to be created. `vitest-analog` uses AnalogJS-based setup with `@nx/vitest`. It defaults to `vitest-analog` for Angular versions >= 21.0.0, otherwise `jest`.",
       "x-prompt": "Which unit test runner would you like to use?"
     },
     "e2eTestRunner": {

--- a/packages/angular/src/generators/host/schema.d.ts
+++ b/packages/angular/src/generators/host/schema.d.ts
@@ -17,7 +17,7 @@ export interface Schema {
   skipTests?: boolean;
   tags?: string;
   linter?: Linter | LinterType;
-  unitTestRunner?: UnitTestRunner;
+  unitTestRunner?: Exclude<UnitTestRunner, UnitTestRunner.VitestAngular>;
   e2eTestRunner?: E2eTestRunner;
   backendProject?: string;
   strict?: boolean;

--- a/packages/angular/src/generators/host/schema.json
+++ b/packages/angular/src/generators/host/schema.json
@@ -119,10 +119,9 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["vitest", "jest", "none"],
-      "description": "Test runner to use for unit tests. It defaults to `vitest` for Angular versions >= 21.0.0. Otherwise, it defaults to `jest`.",
-      "x-prompt": "Which unit test runner would you like to use?",
-      "default": "jest"
+      "enum": ["vitest-analog", "jest", "none"],
+      "description": "Test runner to use for unit tests. `vitest-analog` uses AnalogJS-based setup with `@nx/vitest`. It defaults to `vitest-analog` for Angular versions >= 21.0.0, otherwise `jest`.",
+      "x-prompt": "Which unit test runner would you like to use?"
     },
     "e2eTestRunner": {
       "type": "string",

--- a/packages/angular/src/generators/library/lib/normalize-options.ts
+++ b/packages/angular/src/generators/library/lib/normalize-options.ts
@@ -56,7 +56,11 @@ export async function normalizeOptions(
   const { major: angularMajorVersion } = getInstalledAngularVersionInfo(host);
   const unitTestRunner =
     options.unitTestRunner ??
-    (angularMajorVersion >= 21 ? UnitTestRunner.Vitest : UnitTestRunner.Jest);
+    (angularMajorVersion >= 21 && (options.buildable || options.publishable)
+      ? UnitTestRunner.VitestAngular
+      : angularMajorVersion >= 21
+      ? UnitTestRunner.VitestAnalog
+      : UnitTestRunner.Jest);
 
   const ngCliSchematicLibRoot = projectName;
   const allNormalizedOptions = {

--- a/packages/angular/src/generators/library/lib/validate-options.ts
+++ b/packages/angular/src/generators/library/lib/validate-options.ts
@@ -1,0 +1,41 @@
+import type { Tree } from '@nx/devkit';
+import { UnitTestRunner } from '../../../utils/test-runners';
+import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
+import type { Schema } from '../schema';
+
+export function validateOptions(tree: Tree, options: Schema): void {
+  if (!options.routing && options.lazy) {
+    throw new Error(`To use "--lazy" option, "--routing" must also be set.`);
+  }
+
+  if (options.publishable === true && !options.importPath) {
+    throw new Error(
+      `For publishable libs you have to provide a proper "--importPath" which needs to be a valid npm package name (e.g. my-awesome-lib or @myorg/my-lib)`
+    );
+  }
+
+  if (options.addTailwind && !options.buildable && !options.publishable) {
+    throw new Error(
+      `To use "--addTailwind" option, you have to set either "--buildable" or "--publishable".`
+    );
+  }
+
+  if (options.unitTestRunner === UnitTestRunner.VitestAngular) {
+    const { major: angularMajorVersion, version: angularVersion } =
+      getInstalledAngularVersionInfo(tree);
+
+    if (angularMajorVersion < 21) {
+      throw new Error(
+        `The "vitest-angular" unit test runner requires Angular v21 or higher. ` +
+          `Detected Angular v${angularVersion}. Use "vitest-analog" or "jest" instead.`
+      );
+    }
+
+    if (!options.buildable && !options.publishable) {
+      throw new Error(
+        `The "vitest-angular" unit test runner requires the library to be buildable or publishable. ` +
+          `Use "vitest-analog" or "jest" instead.`
+      );
+    }
+  }
+}

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -96,9 +96,10 @@ describe('lib', () => {
     expect(dependencies['zone.js']).toBeUndefined();
   });
 
-  it('should add @angular/build when using vitest', async () => {
+  it('should add @angular/build when using vitest-angular', async () => {
     await runLibraryGeneratorWithOpts({
-      unitTestRunner: UnitTestRunner.Vitest,
+      unitTestRunner: UnitTestRunner.VitestAngular,
+      buildable: true,
     });
 
     const { devDependencies } = readJson(tree, 'package.json');

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -83,8 +83,8 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["vitest", "jest", "none"],
-      "description": "Test runner to use for unit tests. It defaults to `vitest` when using Angular versions >= 21.0.0. Otherwise, it defaults to `jest`.",
+      "enum": ["vitest-angular", "vitest-analog", "jest", "none"],
+      "description": "Test runner to use for unit tests. `vitest-angular` uses the `@nx/angular:unit-test` executor (requires Angular v21+ and a buildable/publishable library). `vitest-analog` uses AnalogJS-based setup with `@nx/vitest`. It defaults to `vitest-angular` for buildable/publishable libraries on Angular >= 21.0.0, `vitest-analog` for non-buildable libraries on Angular >= 21.0.0, otherwise `jest`.",
       "x-prompt": "Which unit test runner would you like to use?"
     },
     "importPath": {

--- a/packages/angular/src/generators/remote/schema.d.ts
+++ b/packages/angular/src/generators/remote/schema.d.ts
@@ -16,7 +16,7 @@ export interface Schema {
   skipTests?: boolean;
   tags?: string;
   linter?: Linter | LinterType;
-  unitTestRunner?: UnitTestRunner;
+  unitTestRunner?: Exclude<UnitTestRunner, UnitTestRunner.VitestAngular>;
   e2eTestRunner?: E2eTestRunner;
   backendProject?: string;
   strict?: boolean;

--- a/packages/angular/src/generators/remote/schema.json
+++ b/packages/angular/src/generators/remote/schema.json
@@ -113,10 +113,9 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["vitest", "jest", "none"],
-      "description": "Test runner to use for unit tests. It defaults to `vitest` for Angular versions >= 21.0.0. Otherwise, it defaults to `jest`.",
-      "x-prompt": "Which unit test runner would you like to use?",
-      "default": "jest"
+      "enum": ["vitest-analog", "jest", "none"],
+      "description": "Test runner to use for unit tests. `vitest-analog` uses AnalogJS-based setup with `@nx/vitest`. It defaults to `vitest-analog` for Angular versions >= 21.0.0, otherwise `jest`.",
+      "x-prompt": "Which unit test runner would you like to use?"
     },
     "e2eTestRunner": {
       "type": "string",

--- a/packages/angular/src/migrations/update-22-2-0/update-unit-test-runner-option.md
+++ b/packages/angular/src/migrations/update-22-2-0/update-unit-test-runner-option.md
@@ -1,0 +1,33 @@
+#### Update `vitest` unit test runner option to `vitest-analog` in generator defaults
+
+Updates the `unitTestRunner` generator default from `vitest` to `vitest-analog` in `nx.json`. The `vitest` option has been split into two explicit options: `vitest-angular` (uses `@angular/build:unit-test`) and `vitest-analog` (uses AnalogJS-based setup).
+
+#### Examples
+
+The migration updates generator defaults in `nx.json`:
+
+##### Before
+
+```jsonc {5}
+// nx.json
+{
+  "generators": {
+    "@nx/angular:application": {
+      "unitTestRunner": "vitest"
+    }
+  }
+}
+```
+
+##### After
+
+```jsonc {5}
+// nx.json
+{
+  "generators": {
+    "@nx/angular:application": {
+      "unitTestRunner": "vitest-analog"
+    }
+  }
+}
+```

--- a/packages/angular/src/migrations/update-22-2-0/update-unit-test-runner-option.spec.ts
+++ b/packages/angular/src/migrations/update-22-2-0/update-unit-test-runner-option.spec.ts
@@ -1,0 +1,126 @@
+import { readNxJson, updateNxJson, type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import updateUnitTestRunnerOption from './update-unit-test-runner-option';
+
+describe('update-unit-test-runner-option migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should update vitest to vitest-analog in flat generator key format', async () => {
+    updateNxJson(tree, {
+      generators: {
+        '@nx/angular:application': {
+          unitTestRunner: 'vitest',
+        },
+      },
+    });
+
+    await updateUnitTestRunnerOption(tree);
+
+    const nxJson = readNxJson(tree);
+    expect(nxJson.generators['@nx/angular:application']).toEqual({
+      unitTestRunner: 'vitest-analog',
+    });
+  });
+
+  it('should update vitest to vitest-analog in nested generator format', async () => {
+    updateNxJson(tree, {
+      generators: {
+        '@nx/angular': {
+          application: {
+            unitTestRunner: 'vitest',
+          },
+        },
+      },
+    });
+
+    await updateUnitTestRunnerOption(tree);
+
+    const nxJson = readNxJson(tree);
+    expect(nxJson.generators['@nx/angular']['application']).toEqual({
+      unitTestRunner: 'vitest-analog',
+    });
+  });
+
+  it('should update multiple generators', async () => {
+    updateNxJson(tree, {
+      generators: {
+        '@nx/angular:application': {
+          unitTestRunner: 'vitest',
+        },
+        '@nx/angular:library': {
+          unitTestRunner: 'vitest',
+        },
+        '@nx/angular:host': {
+          unitTestRunner: 'vitest',
+        },
+      },
+    });
+
+    await updateUnitTestRunnerOption(tree);
+
+    const nxJson = readNxJson(tree);
+    expect(nxJson.generators['@nx/angular:application'].unitTestRunner).toBe(
+      'vitest-analog'
+    );
+    expect(nxJson.generators['@nx/angular:library'].unitTestRunner).toBe(
+      'vitest-analog'
+    );
+    expect(nxJson.generators['@nx/angular:host'].unitTestRunner).toBe(
+      'vitest-analog'
+    );
+  });
+
+  it('should not update jest or none values', async () => {
+    updateNxJson(tree, {
+      generators: {
+        '@nx/angular:application': {
+          unitTestRunner: 'jest',
+        },
+        '@nx/angular:library': {
+          unitTestRunner: 'none',
+        },
+      },
+    });
+
+    await updateUnitTestRunnerOption(tree);
+
+    const nxJson = readNxJson(tree);
+    expect(nxJson.generators['@nx/angular:application'].unitTestRunner).toBe(
+      'jest'
+    );
+    expect(nxJson.generators['@nx/angular:library'].unitTestRunner).toBe(
+      'none'
+    );
+  });
+
+  it('should handle missing generators section', async () => {
+    updateNxJson(tree, {});
+
+    await expect(updateUnitTestRunnerOption(tree)).resolves.not.toThrow();
+  });
+
+  it('should preserve other generator options', async () => {
+    updateNxJson(tree, {
+      generators: {
+        '@nx/angular:application': {
+          unitTestRunner: 'vitest',
+          style: 'scss',
+          routing: true,
+        },
+      },
+    });
+
+    await updateUnitTestRunnerOption(tree);
+
+    const nxJson = readNxJson(tree);
+    expect(nxJson.generators['@nx/angular:application']).toEqual({
+      unitTestRunner: 'vitest-analog',
+      style: 'scss',
+      routing: true,
+    });
+  });
+});

--- a/packages/angular/src/migrations/update-22-2-0/update-unit-test-runner-option.ts
+++ b/packages/angular/src/migrations/update-22-2-0/update-unit-test-runner-option.ts
@@ -1,0 +1,54 @@
+import { formatFiles, readNxJson, updateNxJson, type Tree } from '@nx/devkit';
+
+const ANGULAR_GENERATORS = [
+  'application',
+  'library',
+  'host',
+  'remote',
+  'federate-module',
+] as const;
+
+export default async function (tree: Tree) {
+  const nxJson = readNxJson(tree);
+  if (!nxJson?.generators) {
+    return;
+  }
+
+  let updated = false;
+
+  for (const generator of ANGULAR_GENERATORS) {
+    if (updateGeneratorDefault(nxJson.generators, '@nx/angular', generator)) {
+      updated = true;
+    }
+  }
+
+  if (updated) {
+    updateNxJson(tree, nxJson);
+    await formatFiles(tree);
+  }
+}
+
+function updateGeneratorDefault(
+  generators: Record<string, unknown>,
+  collection: string,
+  generator: string
+): boolean {
+  const generatorKey = `${collection}:${generator}`;
+
+  // Check "@nx/angular:application" format
+  const flatConfig = generators[generatorKey] as Record<string, unknown>;
+  if (flatConfig?.unitTestRunner === 'vitest') {
+    flatConfig.unitTestRunner = 'vitest-analog';
+    return true;
+  }
+
+  // Check { "@nx/angular": { "application": {...} } } format
+  const nestedConfig = generators[collection] as Record<string, unknown>;
+  const generatorConfig = nestedConfig?.[generator] as Record<string, unknown>;
+  if (generatorConfig?.unitTestRunner === 'vitest') {
+    generatorConfig.unitTestRunner = 'vitest-analog';
+    return true;
+  }
+
+  return false;
+}

--- a/packages/angular/src/utils/test-runners.ts
+++ b/packages/angular/src/utils/test-runners.ts
@@ -1,7 +1,8 @@
 export enum UnitTestRunner {
   Jest = 'jest',
   None = 'none',
-  Vitest = 'vitest',
+  VitestAngular = 'vitest-angular',
+  VitestAnalog = 'vitest-analog',
 }
 
 export enum E2eTestRunner {


### PR DESCRIPTION
Splits the `vitest` unit test runner choice in generators into `vitest-angular` and `vitest-analog`.

The `@angular/build:unit-test` executor requires a build task with specific executors, so it doesn't work in all setups. This gives users the choice of what setup they want to use. A migration is provided to ensure existing generator defaults with `vitest` are switched to `vitest-analog`, which is the equivalent.