### PR TITLE
fix(linter): update generators to use ESLint v9 compatible versions

### DIFF
--- a/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.ts
+++ b/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.ts
@@ -17,7 +17,8 @@ import { getRelativePathToRootTsConfig } from '@nx/js';
 import { addSwcRegisterDependencies } from '@nx/js/src/utils/swc/add-swc-dependencies';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { join } from 'path';
-import { nxVersion, typescriptESLintVersion } from '../../utils/versions';
+import { nxVersion } from '../../utils/versions';
+import { getTypeScriptEslintVersionToInstall } from '../../utils/version-utils';
 import { workspaceLintPluginDir } from '../../utils/workspace-lint-rules';
 
 export const WORKSPACE_RULES_PROJECT_NAME = 'eslint-rules';
@@ -117,12 +118,13 @@ export async function lintWorkspaceRulesProjectGenerator(
   // Add swc dependencies
   tasks.push(addSwcRegisterDependencies(tree));
 
+  const typescriptEslintVersion = getTypeScriptEslintVersionToInstall(tree);
   tasks.push(
     addDependenciesToPackageJson(
       tree,
       {},
       {
-        '@typescript-eslint/utils': typescriptESLintVersion,
+        '@typescript-eslint/utils': typescriptEslintVersion,
       }
     )
   );


### PR DESCRIPTION
This PR updates the `workspace-rule` generator so use ESLint v9 by default. It currently forces the unsupported ESLint v8.

In theory this is only useful if not using workspaces and you need tsconfig paths to be mapped and resolved correctly. For workspaces, you can easily just generate any library to be used to contain custom rules.

Closes NXC-3500