### PR TITLE
chore(repo): remove hack that enables legacy peer deps so we can catch errors

### DIFF
--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -122,12 +122,10 @@ export function newProject({
         createNxWorkspaceEnd.name
       );
 
-      // Temporary hack to prevent installing with `--frozen-lockfile`
+      // Workaround: pnpm defaults to frozen-lockfile in CI, but e2e tests
+      // dynamically add packages after workspace creation
       if (isCI && packageManager === 'pnpm') {
-        updateFile(
-          '.npmrc',
-          'prefer-frozen-lockfile=false\nstrict-peer-dependencies=false\nauto-install-peers=true'
-        );
+        updateFile('.npmrc', 'prefer-frozen-lockfile=false');
       }
 
       let packagesToInstall: Array<NxPackage> = [];
@@ -224,14 +222,6 @@ ${
     logError(`Failed to set up project for e2e tests.`, e.message);
     throw e;
   }
-}
-
-// pnpm v7 sadly doesn't automatically install peer dependencies
-export function addPnpmRc() {
-  updateFile(
-    '.npmrc',
-    'strict-peer-dependencies=false\nauto-install-peers=true'
-  );
 }
 
 export function runCreateWorkspace(


### PR DESCRIPTION
We missed a peer dep error in the Nuxt 4 PR since CI allowed install to go through, but in a real repo it would have failed.

We _may_ need to still have the `prefer-frozen-lockfile=false` option, but let's let CI run with this first.