### PR TITLE
fix(core): kill child process tree in different running tasks

### DIFF
--- a/packages/nx/src/executors/run-commands/running-tasks.ts
+++ b/packages/nx/src/executors/run-commands/running-tasks.ts
@@ -515,20 +515,20 @@ class RunningNodeProcess implements RunningTask {
     });
     // Terminate any task processes on exit
     process.on('exit', () => {
-      this.childProcess.kill();
+      this.kill();
     });
     process.on('SIGINT', () => {
-      this.childProcess.kill('SIGTERM');
+      this.kill('SIGTERM');
       // we exit here because we don't need to write anything to cache.
       process.exit(signalToCode('SIGINT'));
     });
     process.on('SIGTERM', () => {
-      this.childProcess.kill('SIGTERM');
+      this.kill('SIGTERM');
       // no exit here because we expect child processes to terminate which
       // will store results to the cache and will terminate this process
     });
     process.on('SIGHUP', () => {
-      this.childProcess.kill('SIGTERM');
+      this.kill('SIGTERM');
       // no exit here because we expect child processes to terminate which
       // will store results to the cache and will terminate this process
     });

--- a/packages/nx/src/tasks-runner/running-tasks/node-child-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/node-child-process.ts
@@ -1,9 +1,10 @@
-import { ChildProcess, Serializable } from 'child_process';
-import { signalToCode } from '../../utils/exit-codes';
-import { RunningTask } from './running-task';
-import { Transform } from 'stream';
 import * as chalk from 'chalk';
+import type { ChildProcess, Serializable } from 'child_process';
 import { readFileSync } from 'fs';
+import { Transform } from 'stream';
+import * as treeKill from 'tree-kill';
+import { signalToCode } from '../../utils/exit-codes';
+import type { RunningTask } from './running-task';
 
 export class NodeChildProcessWithNonDirectOutput implements RunningTask {
   private terminalOutput: string = '';
@@ -100,8 +101,10 @@ export class NodeChildProcessWithNonDirectOutput implements RunningTask {
     }
   }
   public kill(signal?: NodeJS.Signals) {
-    if (this.childProcess.connected) {
-      this.childProcess.kill(signal);
+    if (this.childProcess?.pid) {
+      treeKill(this.childProcess.pid, signal, () => {
+        // Ignore errors - process may have already exited
+      });
     }
   }
 }
@@ -223,8 +226,10 @@ export class NodeChildProcessWithDirectOutput implements RunningTask {
   }
 
   kill(signal?: NodeJS.Signals): void {
-    if (this.childProcess.connected) {
-      this.childProcess.kill(signal);
+    if (this.childProcess?.pid) {
+      treeKill(this.childProcess.pid, signal, () => {
+        // Ignore errors - process may have already exited
+      });
     }
   }
 }


### PR DESCRIPTION
## Current Behavior

When Nx commands finish or receive termination signals (SIGINT, SIGTERM, SIGHUP), child processes spawned by continuous tasks (such as `nx serve`) can remain orphaned in certain scenarios. This happens because only the direct child process is killed using `childProcess.kill()`, leaving grandchild processes running.

## Expected Behavior

When Nx terminates, all processes in the spawned process tree should be properly terminated and no orphaned processes should remain.

## Changes

- Updated signal handlers in `RunningNodeProcess` to use `this.kill()` instead of `this.childProcess.kill()`, leveraging the existing `tree-kill` implementation
- Added `tree-kill` to `NodeChildProcessWithNonDirectOutput` and `NodeChildProcessWithDirectOutput` kill methods to ensure entire process trees are terminated
