### PR TITLE
fix(linter): base eslint config should ignore out-tsc directories

### DIFF
--- a/packages/angular/src/generators/add-linting/add-linting.spec.ts
+++ b/packages/angular/src/generators/add-linting/add-linting.spec.ts
@@ -188,7 +188,8 @@ describe('addLinting generator', () => {
           ...nx.configs["flat/javascript"],
           {
               ignores: [
-                  "**/dist"
+                  "**/dist",
+                  "**/out-tsc"
               ]
           },
           {

--- a/packages/eslint/src/generators/convert-to-flat-config/__snapshots__/generator.spec.ts.snap
+++ b/packages/eslint/src/generators/convert-to-flat-config/__snapshots__/generator.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`convert-to-flat-config generator CJS should add env configuration 1`] = `
 "const { FlatCompat } = require('@eslint/eslintrc');
@@ -13,7 +13,7 @@ const compat = new FlatCompat({
 
 module.exports = [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   { languageOptions: { globals: { ...globals.browser, ...globals.node } } },
@@ -74,7 +74,7 @@ const compat = new FlatCompat({
 
 module.exports = [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   {
@@ -138,7 +138,7 @@ const compat = new FlatCompat({
 
 module.exports = [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   { languageOptions: { globals: { myCustomGlobal: 'readonly' } } },
@@ -198,7 +198,7 @@ const compat = new FlatCompat({
 
 module.exports = [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   {
@@ -261,7 +261,7 @@ const compat = new FlatCompat({
 
 module.exports = [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   { languageOptions: { parser: typescriptEslintParser } },
@@ -324,7 +324,7 @@ const compat = new FlatCompat({
 
 module.exports = [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   {
     plugins: {
@@ -390,7 +390,7 @@ const compat = new FlatCompat({
 
 module.exports = [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   {
@@ -454,7 +454,7 @@ const compat = new FlatCompat({
 
 module.exports = [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   {
@@ -506,7 +506,7 @@ exports[`convert-to-flat-config generator CJS should convert json successfully 2
 
 module.exports = [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   ...baseConfig,
   {
@@ -540,7 +540,7 @@ const compat = new FlatCompat({
 
 module.exports = [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   {
@@ -592,7 +592,7 @@ exports[`convert-to-flat-config generator CJS should convert yaml successfully 2
 
 module.exports = [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   ...baseConfig,
   {
@@ -626,7 +626,7 @@ const compat = new FlatCompat({
 
 module.exports = [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   {
@@ -678,7 +678,7 @@ exports[`convert-to-flat-config generator CJS should convert yml successfully 2`
 
 module.exports = [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   ...baseConfig,
   {
@@ -705,7 +705,7 @@ exports[`convert-to-flat-config generator CJS should handle custom eslintignores
 
 module.exports = [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   ...baseConfig,
   {
@@ -748,7 +748,7 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   { languageOptions: { globals: { ...globals.browser, ...globals.node } } },
@@ -811,7 +811,7 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   {
@@ -877,7 +877,7 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   { languageOptions: { globals: { myCustomGlobal: 'readonly' } } },
@@ -939,7 +939,7 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   {
@@ -1004,7 +1004,7 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   { languageOptions: { parser: typescriptEslintParser } },
@@ -1069,7 +1069,7 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   {
     plugins: {
@@ -1137,7 +1137,7 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   {
@@ -1203,7 +1203,7 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   {
@@ -1255,7 +1255,7 @@ exports[`convert-to-flat-config generator MJS should convert json successfully 2
 
 export default [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   ...baseConfig,
   {
@@ -1291,7 +1291,7 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   {
@@ -1343,7 +1343,7 @@ exports[`convert-to-flat-config generator MJS should convert yaml successfully 2
 
 export default [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   ...baseConfig,
   {
@@ -1379,7 +1379,7 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   { plugins: { '@nx': nxEslintPlugin } },
   {
@@ -1431,7 +1431,7 @@ exports[`convert-to-flat-config generator MJS should convert yml successfully 2`
 
 export default [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   ...baseConfig,
   {
@@ -1458,7 +1458,7 @@ exports[`convert-to-flat-config generator MJS should handle custom eslintignores
 
 export default [
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/out-tsc'],
   },
   ...baseConfig,
   {

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.spec.ts
@@ -90,7 +90,8 @@ describe('convertEslintJsonToFlatConfig', () => {
         export default [
             {
                 ignores: [
-                    "**/dist"
+                    "**/dist",
+                    "**/out-tsc"
                 ]
             },
             { plugins: { "@nx": nxEslintPlugin } },
@@ -239,87 +240,88 @@ describe('convertEslintJsonToFlatConfig', () => {
       );
 
       expect(content).toMatchInlineSnapshot(`
-              "import { FlatCompat } from "@eslint/eslintrc";
-              import { dirname } from "path";
-              import { fileURLToPath } from "url";
-              import js from "@eslint/js";
-              import baseConfig from "../../eslint.config.mjs";
-              import globals from "globals";
+        "import { FlatCompat } from "@eslint/eslintrc";
+        import { dirname } from "path";
+        import { fileURLToPath } from "url";
+        import js from "@eslint/js";
+        import baseConfig from "../../eslint.config.mjs";
+        import globals from "globals";
 
-              const compat = new FlatCompat({
-                baseDirectory: dirname(fileURLToPath(import.meta.url)),
-                recommendedConfig: js.configs.recommended,
-              });
+        const compat = new FlatCompat({
+          baseDirectory: dirname(fileURLToPath(import.meta.url)),
+          recommendedConfig: js.configs.recommended,
+        });
 
 
-              export default [
-                  {
-                      ignores: [
-                          "**/dist"
-                      ]
-                  },
-                  ...baseConfig,
-                  ...compat.extends("plugin:@nx/react-typescript", "next", "next/core-web-vitals"),
-                  { languageOptions: { globals: { ...globals.jest } } },
-                  {
-                      rules: {
-                          "@next/next/no-html-link-for-pages": "off"
-                      }
-                  },
-                  {
-                      files: [
-                          "**/*.ts",
-                          "**/*.tsx",
-                          "**/*.js",
-                          "**/*.jsx"
-                      ],
-                      rules: {
-                          "@next/next/no-html-link-for-pages": [
-                              "error",
-                              "apps/test-next/pages"
-                          ]
-                      }
-                  },
-                  {
-                      files: [
-                          "**/*.ts",
-                          "**/*.tsx"
-                      ],
-                      // Override or add rules here
-                      rules: {}
-                  },
-                  {
-                      files: [
-                          "**/*.js",
-                          "**/*.jsx"
-                      ],
-                      // Override or add rules here
-                      rules: {}
-                  },
-                  {
-                      files: [
-                          "**/*.json"
-                      ],
-                      rules: {
-                          "@nx/dependency-checks": "error"
-                      },
-                      languageOptions: {
-                          parser: await import("jsonc-eslint-parser")
-                      }
-                  },
-                  {
-                      ignores: [
-                          ".next/**/*"
-                      ]
-                  },
-                  {
-                      ignores: [
-                          "something/else"
-                      ]
-                  }
-              ];
-              "
-          `);
+        export default [
+            {
+                ignores: [
+                    "**/dist",
+                    "**/out-tsc"
+                ]
+            },
+            ...baseConfig,
+            ...compat.extends("plugin:@nx/react-typescript", "next", "next/core-web-vitals"),
+            { languageOptions: { globals: { ...globals.jest } } },
+            {
+                rules: {
+                    "@next/next/no-html-link-for-pages": "off"
+                }
+            },
+            {
+                files: [
+                    "**/*.ts",
+                    "**/*.tsx",
+                    "**/*.js",
+                    "**/*.jsx"
+                ],
+                rules: {
+                    "@next/next/no-html-link-for-pages": [
+                        "error",
+                        "apps/test-next/pages"
+                    ]
+                }
+            },
+            {
+                files: [
+                    "**/*.ts",
+                    "**/*.tsx"
+                ],
+                // Override or add rules here
+                rules: {}
+            },
+            {
+                files: [
+                    "**/*.js",
+                    "**/*.jsx"
+                ],
+                // Override or add rules here
+                rules: {}
+            },
+            {
+                files: [
+                    "**/*.json"
+                ],
+                rules: {
+                    "@nx/dependency-checks": "error"
+                },
+                languageOptions: {
+                    parser: await import("jsonc-eslint-parser")
+                }
+            },
+            {
+                ignores: [
+                    ".next/**/*"
+                ]
+            },
+            {
+                ignores: [
+                    "something/else"
+                ]
+            }
+        ];
+        "
+      `);
     });
   });
 
@@ -400,7 +402,8 @@ describe('convertEslintJsonToFlatConfig', () => {
         module.exports = [
             {
                 ignores: [
-                    "**/dist"
+                    "**/dist",
+                    "**/out-tsc"
                 ]
             },
             { plugins: { "@nx": nxEslintPlugin } },
@@ -562,7 +565,8 @@ describe('convertEslintJsonToFlatConfig', () => {
         module.exports = [
             {
                 ignores: [
-                    "**/dist"
+                    "**/dist",
+                    "**/out-tsc"
                 ]
             },
             ...baseConfig,

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
@@ -34,7 +34,7 @@ export function convertEslintJsonToFlatConfig(
   // exclude dist and eslint config from being linted, which matches the default for new workspaces
   exportElements.push(
     generateAst({
-      ignores: ['**/dist'],
+      ignores: ['**/dist', '**/out-tsc'],
     })
   );
 

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
@@ -181,91 +181,91 @@ describe('convert-to-flat-config generator', () => {
       await convertToFlatConfigGenerator(tree, options);
 
       expect(tree.read('eslint.config.cjs', 'utf-8')).toMatchInlineSnapshot(`
-              "const { FlatCompat } = require('@eslint/eslintrc');
-              const js = require('@eslint/js');
-              const nxEslintPlugin = require('@nx/eslint-plugin');
+        "const { FlatCompat } = require('@eslint/eslintrc');
+        const js = require('@eslint/js');
+        const nxEslintPlugin = require('@nx/eslint-plugin');
 
-              const compat = new FlatCompat({
-                baseDirectory: __dirname,
-                recommendedConfig: js.configs.recommended,
-              });
+        const compat = new FlatCompat({
+          baseDirectory: __dirname,
+          recommendedConfig: js.configs.recommended,
+        });
 
-              module.exports = [
+        module.exports = [
+          {
+            ignores: ['**/dist', '**/out-tsc'],
+          },
+          ...compat.extends('plugin:storybook/recommended'),
+          { plugins: { '@nx': nxEslintPlugin } },
+          {
+            files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+            rules: {
+              '@nx/enforce-module-boundaries': [
+                'error',
                 {
-                  ignores: ['**/dist'],
-                },
-                ...compat.extends('plugin:storybook/recommended'),
-                { plugins: { '@nx': nxEslintPlugin } },
-                {
-                  files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
-                  rules: {
-                    '@nx/enforce-module-boundaries': [
-                      'error',
-                      {
-                        enforceBuildableLibDependency: true,
-                        allow: [],
-                        depConstraints: [
-                          {
-                            sourceTag: '*',
-                            onlyDependOnLibsWithTags: ['*'],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                },
-                ...compat
-                  .config({
-                    extends: ['plugin:@nx/typescript'],
-                  })
-                  .map((config) => ({
-                    ...config,
-                    files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-                    rules: {
-                      ...config.rules,
+                  enforceBuildableLibDependency: true,
+                  allow: [],
+                  depConstraints: [
+                    {
+                      sourceTag: '*',
+                      onlyDependOnLibsWithTags: ['*'],
                     },
-                  })),
-                ...compat
-                  .config({
-                    extends: ['plugin:@nx/javascript'],
-                  })
-                  .map((config) => ({
-                    ...config,
-                    files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-                    rules: {
-                      ...config.rules,
-                    },
-                  })),
-              ];
-              "
-          `);
+                  ],
+                },
+              ],
+            },
+          },
+          ...compat
+            .config({
+              extends: ['plugin:@nx/typescript'],
+            })
+            .map((config) => ({
+              ...config,
+              files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
+              rules: {
+                ...config.rules,
+              },
+            })),
+          ...compat
+            .config({
+              extends: ['plugin:@nx/javascript'],
+            })
+            .map((config) => ({
+              ...config,
+              files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
+              rules: {
+                ...config.rules,
+              },
+            })),
+        ];
+        "
+      `);
       expect(tree.read('libs/test-lib/eslint.config.cjs', 'utf-8'))
         .toMatchInlineSnapshot(`
-              "const baseConfig = require('../../eslint.config.cjs');
+        "const baseConfig = require('../../eslint.config.cjs');
 
-              module.exports = [
-                {
-                  ignores: ['**/dist'],
-                },
-                ...baseConfig,
-                {
-                  files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
-                  // Override or add rules here
-                  rules: {},
-                },
-                {
-                  files: ['**/*.ts', '**/*.tsx'],
-                  // Override or add rules here
-                  rules: {},
-                },
-                {
-                  files: ['**/*.js', '**/*.jsx'],
-                  // Override or add rules here
-                  rules: {},
-                },
-              ];
-              "
-          `);
+        module.exports = [
+          {
+            ignores: ['**/dist', '**/out-tsc'],
+          },
+          ...baseConfig,
+          {
+            files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+            // Override or add rules here
+            rules: {},
+          },
+          {
+            files: ['**/*.ts', '**/*.tsx'],
+            // Override or add rules here
+            rules: {},
+          },
+          {
+            files: ['**/*.js', '**/*.jsx'],
+            // Override or add rules here
+            rules: {},
+          },
+        ];
+        "
+      `);
       expect(
         readJson(tree, 'package.json').devDependencies['@eslint/eslintrc']
       ).toEqual(eslintrcVersion);
@@ -451,68 +451,68 @@ describe('convert-to-flat-config generator', () => {
       await convertToFlatConfigGenerator(tree, options);
 
       expect(tree.read('eslint.config.cjs', 'utf-8')).toMatchInlineSnapshot(`
-              "const { FlatCompat } = require('@eslint/eslintrc');
-              const js = require('@eslint/js');
-              const nxEslintPlugin = require('@nx/eslint-plugin');
+        "const { FlatCompat } = require('@eslint/eslintrc');
+        const js = require('@eslint/js');
+        const nxEslintPlugin = require('@nx/eslint-plugin');
 
-              const compat = new FlatCompat({
-                baseDirectory: __dirname,
-                recommendedConfig: js.configs.recommended,
-              });
+        const compat = new FlatCompat({
+          baseDirectory: __dirname,
+          recommendedConfig: js.configs.recommended,
+        });
 
-              module.exports = [
+        module.exports = [
+          {
+            ignores: ['**/dist', '**/out-tsc'],
+          },
+          { plugins: { '@nx': nxEslintPlugin } },
+          {
+            linterOptions: {
+              noInlineConfig: true,
+            },
+          },
+          {
+            files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+            rules: {
+              '@nx/enforce-module-boundaries': [
+                'error',
                 {
-                  ignores: ['**/dist'],
-                },
-                { plugins: { '@nx': nxEslintPlugin } },
-                {
-                  linterOptions: {
-                    noInlineConfig: true,
-                  },
-                },
-                {
-                  files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
-                  rules: {
-                    '@nx/enforce-module-boundaries': [
-                      'error',
-                      {
-                        enforceBuildableLibDependency: true,
-                        allow: [],
-                        depConstraints: [
-                          {
-                            sourceTag: '*',
-                            onlyDependOnLibsWithTags: ['*'],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                },
-                ...compat
-                  .config({
-                    extends: ['plugin:@nx/typescript'],
-                  })
-                  .map((config) => ({
-                    ...config,
-                    files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-                    rules: {
-                      ...config.rules,
+                  enforceBuildableLibDependency: true,
+                  allow: [],
+                  depConstraints: [
+                    {
+                      sourceTag: '*',
+                      onlyDependOnLibsWithTags: ['*'],
                     },
-                  })),
-                ...compat
-                  .config({
-                    extends: ['plugin:@nx/javascript'],
-                  })
-                  .map((config) => ({
-                    ...config,
-                    files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-                    rules: {
-                      ...config.rules,
-                    },
-                  })),
-              ];
-              "
-          `);
+                  ],
+                },
+              ],
+            },
+          },
+          ...compat
+            .config({
+              extends: ['plugin:@nx/typescript'],
+            })
+            .map((config) => ({
+              ...config,
+              files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
+              rules: {
+                ...config.rules,
+              },
+            })),
+          ...compat
+            .config({
+              extends: ['plugin:@nx/javascript'],
+            })
+            .map((config) => ({
+              ...config,
+              files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
+              rules: {
+                ...config.rules,
+              },
+            })),
+        ];
+        "
+      `);
     });
 
     it('should convert project if target is defined via plugin as string', async () => {
@@ -622,39 +622,39 @@ describe('convert-to-flat-config generator', () => {
       expect(tree.exists('eslint.config.cjs')).toBeTruthy();
       expect(tree.read('apps/dx-assets-ui/eslint.config.cjs', 'utf-8'))
         .toMatchInlineSnapshot(`
-              "const baseConfig = require('../../eslint.config.cjs');
+        "const baseConfig = require('../../eslint.config.cjs');
 
-              module.exports = [
-                {
-                  ignores: ['**/dist'],
-                },
-                ...baseConfig,
-                {
-                  files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
-                  // Override or add rules here
-                  rules: {},
-                  languageOptions: {
-                    parserOptions: {
-                      project: ['apps/dx-assets-ui/tsconfig.*?.json'],
-                    },
-                  },
-                },
-                {
-                  files: ['**/*.ts', '**/*.tsx'],
-                  // Override or add rules here
-                  rules: {},
-                },
-                {
-                  files: ['**/*.js', '**/*.jsx'],
-                  // Override or add rules here
-                  rules: {},
-                },
-                {
-                  ignores: ['__fixtures__/**/*'],
-                },
-              ];
-              "
-          `);
+        module.exports = [
+          {
+            ignores: ['**/dist', '**/out-tsc'],
+          },
+          ...baseConfig,
+          {
+            files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+            // Override or add rules here
+            rules: {},
+            languageOptions: {
+              parserOptions: {
+                project: ['apps/dx-assets-ui/tsconfig.*?.json'],
+              },
+            },
+          },
+          {
+            files: ['**/*.ts', '**/*.tsx'],
+            // Override or add rules here
+            rules: {},
+          },
+          {
+            files: ['**/*.js', '**/*.jsx'],
+            // Override or add rules here
+            rules: {},
+          },
+          {
+            ignores: ['__fixtures__/**/*'],
+          },
+        ];
+        "
+      `);
     });
   });
 
@@ -809,7 +809,7 @@ describe('convert-to-flat-config generator', () => {
 
         export default [
           {
-            ignores: ['**/dist'],
+            ignores: ['**/dist', '**/out-tsc'],
           },
           ...compat.extends('plugin:storybook/recommended'),
           { plugins: { '@nx': nxEslintPlugin } },
@@ -862,7 +862,7 @@ describe('convert-to-flat-config generator', () => {
 
         export default [
           {
-            ignores: ['**/dist'],
+            ignores: ['**/dist', '**/out-tsc'],
           },
           ...baseConfig,
           {
@@ -1081,7 +1081,7 @@ describe('convert-to-flat-config generator', () => {
 
         export default [
           {
-            ignores: ['**/dist'],
+            ignores: ['**/dist', '**/out-tsc'],
           },
           { plugins: { '@nx': nxEslintPlugin } },
           {
@@ -1245,7 +1245,7 @@ describe('convert-to-flat-config generator', () => {
 
         export default [
           {
-            ignores: ['**/dist'],
+            ignores: ['**/dist', '**/out-tsc'],
           },
           ...baseConfig,
           {

--- a/packages/eslint/src/generators/init/global-eslint-config.ts
+++ b/packages/eslint/src/generators/init/global-eslint-config.ts
@@ -117,7 +117,7 @@ export const getGlobalFlatEslintConfiguration = (
     content,
     generateFlatOverride(
       {
-        ignores: ['**/dist'],
+        ignores: ['**/dist', '**/out-tsc'],
       },
       format
     )

--- a/packages/eslint/src/generators/lint-project/lint-project.spec.ts
+++ b/packages/eslint/src/generators/lint-project/lint-project.spec.ts
@@ -292,7 +292,8 @@ describe('@nx/eslint:lint-project', () => {
           ...nx.configs["flat/javascript"],
           {
               ignores: [
-                  "**/dist"
+                  "**/dist",
+                  "**/out-tsc"
               ]
           },
           {
@@ -363,7 +364,8 @@ describe('@nx/eslint:lint-project', () => {
           ...nx.configs["flat/javascript"],
           {
               ignores: [
-                  "**/dist"
+                  "**/dist",
+                  "**/out-tsc"
               ]
           },
           {

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -817,7 +817,7 @@ describe('app', () => {
             ...nx.configs['flat/typescript'],
             ...nx.configs['flat/javascript'],
             {
-              ignores: ['**/dist', '.next/**/*'],
+              ignores: ['**/dist', '**/out-tsc', '.next/**/*'],
             },
             {
               files: [


### PR DESCRIPTION
## Current Behavior
The base `eslint` config will ignore `**/dist` but not `**/out-tsc`.
This can cause issues if lint is run after a `typecheck` which has placed `.d.ts` files into an `out-tsc` directory.

## Expected Behavior
Base eslint config should ignore `**/out-tsc`
