### PR TITLE
fix(core): include create-nx-workspace in migration package group

### DIFF
--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -136,6 +136,7 @@
       "@nx/web",
       "@nx/webpack",
       "@nx/docker",
+      "create-nx-workspace",
       {
         "package": "nx-cloud",
         "version": "latest"


### PR DESCRIPTION
## Current Behavior

When running `nx migrate latest`, the `create-nx-workspace` package is not updated along with other Nx packages, even though it's a core part of the Nx ecosystem that users may have as a dependency (especially when extending the install package pattern).

## Expected Behavior

The `create-nx-workspace` package should be updated to the same version as `nx` and other `@nx/*` packages when running migrations.

## Related Issue(s)

Fixes #33585