### PR TITLE
fix(core): devkit util - detect esm config with top level await

### DIFF
--- a/packages/devkit/src/utils/config-utils.ts
+++ b/packages/devkit/src/utils/config-utils.ts
@@ -185,7 +185,7 @@ async function load(path: string): Promise<any> {
     // Modules are CJS unless it is named `.mjs` or `package.json` sets type to "module".
     return await loadCommonJS(path);
   } catch (e: any) {
-    if (e.code === 'ERR_REQUIRE_ESM') {
+    if (['ERR_REQUIRE_ESM', 'ERR_REQUIRE_ASYNC_MODULE'].includes(e.code)) {
       // If `require` fails to load ESM, try dynamic `import()`. ESM requires file url protocol for handling absolute paths.
       return loadESM(path);
     }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
```sh
 NX   Report complete - copy this into the issue template

Node           : 22.21.1
OS             : linux-x64
Native Target  : x86_64-linux
pnpm           : 10.20.0

nx                 : 22.1.2
@nx/js             : 22.1.2
@nx/eslint         : 22.1.2
@nx/workspace      : 22.1.2
@nx/devkit         : 22.1.2
@nx/eslint-plugin  : 22.1.2
@nx/playwright     : 22.1.2
typescript         : 5.9.3
---------------------------------------
Registered Plugins:
@nx/eslint/plugin
@nx/playwright/plugin
@nx/js/typescript
@hdi/web-starter-tools-nx-angular-plugin
---------------------------------------
Community plugins:
@hdi/web-starter-tools-nx-angular-plugin : 0.0.0
angular-eslint                           : 20.6.0
---------------------------------------
Local workspace plugins:
@hdi/web-starter-tools-nx-angular-plugin
---------------------------------------
Cache Usage: 0.00 B / 116.28 GB
---------------------------------------
⚠️ Unable to construct project graph.
Failed to process project graph.
     - e2e/frontend/playwright.config.ts: Error [ERR_REQUIRE_ASYNC_MODULE]: require() cannot be used on an ESM graph with top-level await. Use import() instead. To see where the top-level await comes from, use --experimental-print-required-tla.
    From /azp/_work/1/s/node_modules/.pnpm/@nx+devkit@22.1.2_nx@22.1.2/node_modules/@nx/devkit/src/utils/config-utils.js 
    Requiring /azp/_work/1/s/e2e/frontend/playwright.config.ts 
      at ModuleJobSync.runSync (node:internal/modules/esm/module_job:450:13)
      at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:435:47)
      at loadESMFromCJS (node:internal/modules/cjs/loader:1537:24)
      at Module._compile (node:internal/modules/cjs/loader:1688:5)
      at Object..js (node:internal/modules/cjs/loader:1839:10)
      at Module.load (node:internal/modules/cjs/loader:1441:32)
      at Function._load (node:internal/modules/cjs/loader:1263:12)
      at TracingChannel.traceSync (node:diagnostics_channel:328:14)
      at wrapModuleLoad (node:internal/modules/cjs/loader:237:24)
      at Module.require (node:internal/modules/cjs/loader:1463:12)
```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Allow esm with top level awaits.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
