### PR TITLE
fix(core): suppress git stderr output in parseGitOutput

### DIFF
--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -320,6 +320,7 @@ function parseGitOutput(command: string): string[] {
   return execSync(command, {
     maxBuffer: TEN_MEGABYTES,
     cwd: workspaceRoot,
+    stdio: 'pipe',
     windowsHide: false,
   })
     .toString('utf-8')


### PR DESCRIPTION
## Current Behavior

Since Nx 21.6.1, running `nx graph` or other commands that calculate affected projects prints git errors to stderr when the default branch is not fetched:

```
fatal: ambiguous argument 'main': unknown revision or path not in the working tree.
```

This causes CI pipelines with strict stderr checking to fail, even though the nx commands succeed.

## Expected Behavior

Git error messages should not be printed to stderr. The errors are already caught and handled gracefully - they just shouldn't be visible to the user.

## Related Issue(s)

Fixes #33330

## Solution

Added `stdio: 'pipe'` to the `execSync` call in `parseGitOutput()`. This suppresses stderr output while still allowing the command to throw on failure (which is already caught by the try-catch in `graph.ts`).

This matches the pattern used in `getMergeBase()` which already uses `stdio: 'pipe'`.