### PR TITLE
fix(core): prevent Nx Console prompt from blocking non-interactive commands

### DIFF
--- a/packages/nx/src/utils/nx-console-prompt.ts
+++ b/packages/nx/src/utils/nx-console-prompt.ts
@@ -6,6 +6,7 @@ import {
   canInstallNxConsole,
   NxConsolePreferences,
 } from '../native';
+import { isCI } from './is-ci';
 
 export async function ensureNxConsoleInstalled() {
   const preferences = new NxConsolePreferences(homedir());
@@ -27,7 +28,10 @@ export async function ensureNxConsoleInstalled() {
     return;
   }
 
-  if (process.stdout.isTTY && typeof setting !== 'boolean') {
+  // Only prompt if both stdin and stdout are TTY (interactive terminal)
+  // and we're not in a CI environment
+  const isInteractive = process.stdin.isTTY && process.stdout.isTTY && !isCI();
+  if (isInteractive && typeof setting !== 'boolean') {
     setting = await promptForNxConsoleInstallation();
     preferences.setAutoInstallPreference(setting);
   }


### PR DESCRIPTION
## Current Behavior

The Nx Console installation prompt blocks commands when run in non-interactive contexts such as:
- CI environments
- AI agents
- Piped commands

The prompt only checked `process.stdout.isTTY` but not `process.stdin.isTTY`, causing it to wait indefinitely for input that would never arrive.

## Expected Behavior

Commands should complete without prompting when run in non-interactive environments.

## Related Issue(s)

Fixes #33552

## Solution

Updated the check to verify:
1. Both `stdin` and `stdout` are TTY (truly interactive terminal)
2. Not running in a CI environment (using existing `isCI()` utility)

This ensures the prompt only appears when the user can actually provide input.