### PR TITLE
fix(nuxt): update preset test for v4 app directory structure

### DIFF
--- a/packages/workspace/src/generators/preset/preset.spec.ts
+++ b/packages/workspace/src/generators/preset/preset.spec.ts
@@ -179,7 +179,8 @@ describe('preset', () => {
       style: 'css',
       linter: 'eslint',
     });
-    expect(tree.exists(`apps/${name}/src/app.vue`)).toBe(true);
+    // Nuxt v4 uses app directory structure by default
+    expect(tree.exists(`apps/${name}/app/app.vue`)).toBe(true);
     expect(readProjectConfiguration(tree, name)).toBeDefined();
   });
 


### PR DESCRIPTION
## Current Behavior

The nuxt preset test was checking for `apps/${name}/src/app.vue`, but since the generator now defaults to Nuxt v4 which uses the app directory structure, this file is no longer created at that path.

## Expected Behavior

Tests should pass on master.

## Solution

Updated the test to check for `apps/${name}/app/app.vue` which is the correct path for Nuxt v4's app directory structure.