### PR TITLE
docs(misc): update blog post links to new enterprise paths

### DIFF
--- a/docs/blog/2024-09-25-evolving-nx.md
+++ b/docs/blog/2024-09-25-evolving-nx.md
@@ -24,7 +24,7 @@ When we have new ideas to make Nx better, we've always had two options: it could
 
 ## Introducing Nx Powerpack
 
-**[Nx Powerpack](/powerpack)** — our newest product designed to elevate the Nx CLI experience for enterprise environments. Powerpack offers advanced features like ~~self-hosted remote cache storage,~~ code ownership for monorepos, and workspace conformance, seamlessly integrating into sealed systems with strict security requirements. It's also designed for ease of implementation, helping enterprises bypass lengthy procurement processes and quickly access the tools they need.
+**[Nx Powerpack](/enterprise)** — our newest product designed to elevate the Nx CLI experience for enterprise environments. Powerpack offers advanced features like ~~self-hosted remote cache storage,~~ code ownership for monorepos, and workspace conformance, seamlessly integrating into sealed systems with strict security requirements. It's also designed for ease of implementation, helping enterprises bypass lengthy procurement processes and quickly access the tools they need.
 
 > If you want to get into the technical details, we wrote a separate blog post diving deeper into the technical details: [Introducing Nx Powerpack](/blog/introducing-nx-powerpack).
 
@@ -51,17 +51,17 @@ Open Source projects can:
 
 ## How to Get Nx Powerpack
 
-Powerpack can be easily purchased as a one-off license and is automatically included for all existing enterprise customers. If you're looking to purchase a license, you can [do so on this page](/powerpack).
+Powerpack can be easily purchased as a one-off license and is automatically included for all existing enterprise customers. If you're looking to purchase a license, you can [do so on this page](/enterprise).
 
 Are you a startup? If these features make sense for your team but the cost is a concern, reach out to our support team, and we'll work with you to find a solution that fits.
 
 ## Got Questions?
 
-If you're curious to learn more about these changes for Nx and how to get started, [check out our docs](/docs/enterprise/powerpack).
+If you're curious to learn more about these changes for Nx and how to get started, [check out our docs](/docs/enterprise).
 
 ## Learn more
 
-- [Nx Powerpack](/powerpack)
+- [Nx Powerpack](/enterprise)
 - [Blog: Introducing Nx Powerpack](/blog/introducing-nx-powerpack)
 - [Docs: Powerpack features](/docs/getting-started/intro)
 - [X/Twitter](https://twitter.com/nxdevtools) -- [LinkedIn](https://www.linkedin.com/company/nrwl/)

--- a/docs/blog/2024-09-25-introducing-nx-powerpack.md
+++ b/docs/blog/2024-09-25-introducing-nx-powerpack.md
@@ -37,7 +37,7 @@ Let's dive in!
 
 ## Get an Nx Powerpack License
 
-All Powerpack features require a dedicated commercial license. You can get one here: [Nx Powerpack](/powerpack).
+All Powerpack features require a dedicated commercial license. You can get one here: [Nx Powerpack](/enterprise).
 
 Once you have your license, run the following command
 
@@ -124,14 +124,14 @@ A dedicated `nx sync` command automatically synchronizes these definitions to a 
 ...
 ```
 
-Read all about how to [configure Codeowners for your project in our docs](/docs/enterprise/powerpack/owners).
+Read all about how to [configure Codeowners for your project in our docs](/docs/enterprise/owners).
 
 ## Workspace Conformance (Beta)
 
 We're releasing the `@nx/conformance` plugin in an early preview. This new package focuses specifically on the maintainability of your monorepo. It allows you to encode your organization's standards so they can be enforced automatically. In this first version, the workspace conformance package ships with:
 
-- [Enforce Module Boundaries](/docs/reference/powerpack/conformance#enforce-module-boundaries): Similar to the Nx ESLint [Enforce Module Boundaries rule](/docs/features/enforce-module-boundaries), but enforces boundaries on every project dependency, not just those created from TypeScript imports or `package.json` dependencies.
-- [Ensure Owners](/docs/reference/powerpack/conformance#ensure-owners): Requires every project to have an owner defined for the `@nx/owners` plugin.
+- [Enforce Module Boundaries](/docs/reference/conformance#enforce-module-boundaries): Similar to the Nx ESLint [Enforce Module Boundaries rule](/docs/features/enforce-module-boundaries), but enforces boundaries on every project dependency, not just those created from TypeScript imports or `package.json` dependencies.
+- [Ensure Owners](/docs/reference/conformance#ensure-owners): Requires every project to have an owner defined for the `@nx/owners` plugin.
 
 To get started, install the following package:
 
@@ -191,7 +191,7 @@ You can then run `nx conformance` to execute the conformance checks:
 
 In this first preview release, you'll only be able to run workspace conformance rules on a single workspace. In future iterations, you **will be able to connect it to your existing Nx Cloud organization**, allowing you to upload conformance rules and run them across connected workspaces.
 
-Read all the details on how to [get started with workspace conformance rules in our docs](/docs/enterprise/powerpack/conformance).
+Read all the details on how to [get started with workspace conformance rules in our docs](/docs/enterprise/conformance).
 
 ## Learn More
 

--- a/docs/blog/2025-02-06-hetzner-cloud-success-story.md
+++ b/docs/blog/2025-02-06-hetzner-cloud-success-story.md
@@ -48,8 +48,8 @@ Hetzner Cloud needed a solution that would streamline their development process,
 After evaluating Nx and Turborepo, Hetzner Cloud selected Nx for its advanced monorepo management capabilities. They started a [Nx Enterprise](/enterprise) contract and closely collaborated with the Nx Developer Productivity Engineers to assess Hetzner's current software landscape and evaluate the best strategy. Their goal was not necessarily to create a monorepo in the first place, but to modularize their monolithic application. Nx provided the right tools to:
 
 - **Break down the monolith** into modular packages without affecting deployment.
-- **Define clear domain boundaries** using [module boundary rules](/docs/features/enforce-module-boundaries) and [conformance rules](/docs/reference/powerpack/conformance).
-- **Improve ownership management** by having a more modular structure with clear boundaries allowing for easier allocaton of owernship. Something that could further be improved in the future by using [CodeOwners](/docs/enterprise/powerpack/owners).
+- **Define clear domain boundaries** using [module boundary rules](/docs/features/enforce-module-boundaries) and [conformance rules](/docs/reference/conformance).
+- **Improve ownership management** by having a more modular structure with clear boundaries allowing for easier allocaton of owernship. Something that could further be improved in the future by using [CodeOwners](/docs/enterprise/owners).
 
 Beyond modularization, Nx helped consolidate fragmented projects into a single, structured workspace. This reduced the overhead of maintaining multiple repositories and simplified dependency management. Using the [Nx Graph](/docs/features/explore-graph), the team gained visibility into their project relationships, making it easier to coordinate work and optimize collaboration.
 

--- a/docs/blog/2025-02-17-monorepos-are-ai-future-proof.md
+++ b/docs/blog/2025-02-17-monorepos-are-ai-future-proof.md
@@ -63,7 +63,7 @@ This is where Nx comes in.
 
 Monorepos don't come for free. While they improve visibility and collaboration, they introduce scaling challenges. This is where tools like Nx step in, helping you get the benefits of a monorepo while managing the complexity that comes with it.
 
-Over the years, we've built features like [Nx Replay](/docs/features/ci-features/remote-cache) and [Nx Agents](/docs/features/ci-features/distribute-task-execution) to keep CI fast, while [conformance rules](/docs/enterprise/powerpack/conformance), [ownership](/docs/enterprise/powerpack/owners), and [local repository automation](/docs/extending-nx/intro) help manage and scale a monorepo in the long run.
+Over the years, we've built features like [Nx Replay](/docs/features/ci-features/remote-cache) and [Nx Agents](/docs/features/ci-features/distribute-task-execution) to keep CI fast, while [conformance rules](/docs/enterprise/conformance), [ownership](/docs/enterprise/owners), and [local repository automation](/docs/extending-nx/intro) help manage and scale a monorepo in the long run.
 
 To power these features, **Nx collects metadata about your workspace**, understanding relationships between projects, ownership, technology types, available tasks, and more. The [Nx daemon](/docs/concepts/nx-daemon) runs in the background, keeping this metadata up to date and making sure Nx operates efficiently.
 
@@ -71,7 +71,7 @@ To power these features, **Nx collects metadata about your workspace**, understa
 
 ![nx-ai-project-relationships.avif](/blog/images/articles/nx-ai-project-relationships.avif)
 
-**Nx also tracks available targets for each project**. If you're using [Code Owners](/docs/enterprise/powerpack/owners), it **knows who owns what within your monorepo**.
+**Nx also tracks available targets for each project**. If you're using [Code Owners](/docs/enterprise/owners), it **knows who owns what within your monorepo**.
 
 ![nx-ai-project-detail-view.avif](/blog/images/articles/nx-ai-project-detail-view.avif)
 

--- a/docs/blog/2025-07-17-polygraph-conformance.md
+++ b/docs/blog/2025-07-17-polygraph-conformance.md
@@ -28,7 +28,7 @@ This is where **Conformance** comes in.
 
 ## What Is Conformance?
 
-[Conformance](/docs/enterprise/powerpack/conformance) is part of Nx Cloud's Polygraph suite: a collection of features that extend the benefits of Nx workspaces to your entire organization. Conformance allows you to write **technology-agnostic rules** that you can enforce across your organization, no matter what technology you're using.
+[Conformance](/docs/enterprise/conformance) is part of Nx Cloud's Polygraph suite: a collection of features that extend the benefits of Nx workspaces to your entire organization. Conformance allows you to write **technology-agnostic rules** that you can enforce across your organization, no matter what technology you're using.
 
 Think of it as automated governance for your entire codebase. Platform teams can now:
 
@@ -59,11 +59,11 @@ You have two options for storing Conformance rules:
 
 **Add Conformance rules to an existing workspace**
 
-You can check out the [full details in our docs](/docs/enterprise/powerpack/publish-conformance-rules-to-nx-cloud), but here's an overview of adding Conformance rules to an existing workspace.
+You can check out the [full details in our docs](/docs/enterprise/publish-conformance-rules-to-nx-cloud), but here's an overview of adding Conformance rules to an existing workspace.
 
 1. Open your existing Nx workspace.
 2. Add the `@nx/conformance` plugin: `npx nx add @nx/conformance`.
-3. [Set up a new library project](/docs/enterprise/powerpack/publish-conformance-rules-to-nx-cloud) for your conformance rules.
+3. [Set up a new library project](/docs/enterprise/publish-conformance-rules-to-nx-cloud) for your conformance rules.
 4. Run `npx nx login` in your workspace.
 5. Be sure to bundle your rules using the `@nx/conformance:bundle-rules` executor (covered in the above docs).
 6. Publish the rules using the `nx-cloud` CLI: `npx nx-cloud publish-conformance-rules /path/to/rule-outputs`.

--- a/docs/blog/2025-11-14-monorepo-myths.md
+++ b/docs/blog/2025-11-14-monorepo-myths.md
@@ -105,7 +105,7 @@ In a huge repository with hundreds of projects and hundreds of people, it's unde
 
 **The Reality**: Monorepo tools can provide better [code boundaries](/docs/features/enforce-module-boundaries) and source control than traditional multi-repo setups. You can use:
 
-- Path-based ownership and review rules (like [CODEOWNERS files](/docs/enterprise/powerpack/owners))
+- Path-based ownership and review rules (like [CODEOWNERS files](/docs/enterprise/owners))
 - Granular write controls enforced by branch protection or server-side policies
 - Automated checks for code requiring approvals from owners
 - [Cross-boundary change validation](/blog/mastering-the-project-boundaries-in-nx)


### PR DESCRIPTION
## Current Behavior
Blog posts contain broken links pointing to old `/powerpack` and `/docs/enterprise/powerpack/*` paths that no longer exist.

## Expected Behavior
Links should point to the new enterprise documentation paths:
- `/powerpack` → `/enterprise`
- `/docs/enterprise/powerpack/*` → `/docs/enterprise/*`
- `/docs/reference/powerpack/*` → `/docs/reference/*`

## Related Issue(s)
Closes DOC-354