### PR TITLE
fix(testing): remove --no-experimental-strip-types flag from @nx/jest/plugin + migrate to jest.config.cts if needed

### DIFF
--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -29,6 +29,11 @@
       },
       "description": "Replace removed matcher aliases in Jest v30 with their corresponding matcher",
       "implementation": "./src/migrations/update-21-3-0/replace-removed-matcher-aliases"
+    },
+    "convert-jest-config-to-cjs": {
+      "version": "22.2.0-beta.2",
+      "description": "Convert jest.config.ts files from ESM to CJS syntax (export default -> module.exports, import -> require) for projects using CommonJS resolution to ensure correct loading under Node.js type-stripping.",
+      "implementation": "./src/migrations/update-22-2-0/convert-jest-config-to-cjs"
     }
   },
   "packageJsonUpdates": {

--- a/packages/jest/src/migrations/update-22-2-0/convert-jest-config-to-cjs.spec.ts
+++ b/packages/jest/src/migrations/update-22-2-0/convert-jest-config-to-cjs.spec.ts
@@ -1,0 +1,495 @@
+import { Tree, writeJson, readJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './convert-jest-config-to-cjs';
+
+describe('convert-jest-config-to-cjs', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    // Register @nx/jest/plugin in nx.json - required for migration to run
+    const nxJson = readJson(tree, 'nx.json');
+    nxJson.plugins = ['@nx/jest/plugin'];
+    writeJson(tree, 'nx.json', nxJson);
+  });
+
+  describe('export default conversion', () => {
+    it('should convert export default to module.exports', async () => {
+      tree.write(
+        'apps/app1/jest.config.ts',
+        `export default {
+  displayName: 'app1',
+  preset: '../../jest.preset.js',
+};`
+      );
+      writeJson(tree, 'apps/app1/package.json', { type: 'commonjs' });
+
+      await migration(tree);
+
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain('module.exports =');
+      expect(content).not.toContain('export default');
+    });
+
+    it('should preserve object content when converting export default', async () => {
+      tree.write(
+        'apps/app1/jest.config.ts',
+        `export default {
+  displayName: 'app1',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+};`
+      );
+      writeJson(tree, 'apps/app1/package.json', { name: 'app1' }); // no type, defaults to CJS
+
+      await migration(tree);
+
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain("displayName: 'app1'");
+      expect(content).toContain("preset: '../../jest.preset.js'");
+      expect(content).toContain("testEnvironment: 'node'");
+    });
+  });
+
+  describe('import conversion', () => {
+    it('should convert named imports to require', async () => {
+      tree.write(
+        'apps/app1/jest.config.ts',
+        `import { readFileSync } from 'fs';
+
+export default {
+  displayName: 'app1',
+};`
+      );
+      writeJson(tree, 'apps/app1/package.json', { type: 'commonjs' });
+
+      await migration(tree);
+
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain("const { readFileSync } = require('fs')");
+      expect(content).not.toContain('import { readFileSync }');
+    });
+
+    it('should convert default imports to require', async () => {
+      tree.write(
+        'apps/app1/jest.config.ts',
+        `import path from 'path';
+
+export default {
+  displayName: 'app1',
+};`
+      );
+      writeJson(tree, 'apps/app1/package.json', { type: 'commonjs' });
+
+      await migration(tree);
+
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain("const path = require('path')");
+      expect(content).not.toContain("import path from 'path'");
+    });
+
+    it('should convert namespace imports to require', async () => {
+      tree.write(
+        'apps/app1/jest.config.ts',
+        `import * as fs from 'fs';
+
+export default {
+  displayName: 'app1',
+};`
+      );
+      writeJson(tree, 'apps/app1/package.json', { type: 'commonjs' });
+
+      await migration(tree);
+
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain("const fs = require('fs')");
+      expect(content).not.toContain("import * as fs from 'fs'");
+    });
+
+    it('should convert side-effect imports to require', async () => {
+      tree.write(
+        'apps/app1/jest.config.ts',
+        `import 'reflect-metadata';
+
+export default {
+  displayName: 'app1',
+};`
+      );
+      writeJson(tree, 'apps/app1/package.json', { type: 'commonjs' });
+
+      await migration(tree);
+
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain("require('reflect-metadata')");
+      expect(content).not.toContain("import 'reflect-metadata'");
+    });
+
+    it('should handle renamed imports', async () => {
+      tree.write(
+        'apps/app1/jest.config.ts',
+        `import { readFileSync as readFile } from 'fs';
+
+export default {
+  displayName: 'app1',
+};`
+      );
+      writeJson(tree, 'apps/app1/package.json', { type: 'commonjs' });
+
+      await migration(tree);
+
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain(
+        "const { readFileSync: readFile } = require('fs')"
+      );
+    });
+  });
+
+  describe('ESM module type', () => {
+    it('should NOT convert jest.config.ts when project package.json has type: module', async () => {
+      const originalContent = `import { readFileSync } from 'fs';
+
+export default {
+  displayName: 'app1',
+};`;
+      tree.write('apps/app1/jest.config.ts', originalContent);
+      writeJson(tree, 'apps/app1/package.json', { type: 'module' });
+
+      await migration(tree);
+
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain('export default');
+      expect(content).toContain('import { readFileSync }');
+    });
+
+    it('should NOT convert when root package.json has type: module and no project package.json', async () => {
+      const originalContent = `export default {
+  displayName: 'app1',
+};`;
+      tree.write('apps/app1/jest.config.ts', originalContent);
+      writeJson(tree, 'package.json', { type: 'module' });
+
+      await migration(tree);
+
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain('export default');
+    });
+
+    it('should use project package.json type over root package.json type', async () => {
+      tree.write(
+        'apps/app1/jest.config.ts',
+        `export default {
+  displayName: 'app1',
+};`
+      );
+      writeJson(tree, 'package.json', { type: 'commonjs' });
+      writeJson(tree, 'apps/app1/package.json', { type: 'module' });
+
+      await migration(tree);
+
+      // Should NOT convert because project-level type: module takes precedence
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain('export default');
+    });
+  });
+
+  describe('ESM-only features detection', () => {
+    it('should NOT convert files with import.meta and warn user', async () => {
+      const originalContent = `export default {
+  rootDir: import.meta.dirname,
+};`;
+      tree.write('apps/app1/jest.config.ts', originalContent);
+      writeJson(tree, 'apps/app1/package.json', { type: 'commonjs' });
+
+      await migration(tree);
+
+      // File should remain unchanged
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain('export default');
+      expect(content).toContain('import.meta');
+    });
+
+    it('should NOT convert files with top-level await and warn user', async () => {
+      const originalContent = `const config = await import('./base-config.js');
+
+export default {
+  ...config.default,
+  displayName: 'app1',
+};`;
+      tree.write('apps/app1/jest.config.ts', originalContent);
+      writeJson(tree, 'apps/app1/package.json', { type: 'commonjs' });
+
+      await migration(tree);
+
+      // File should remain unchanged
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain('export default');
+      expect(content).toContain('await import');
+    });
+
+    it('should convert files with await inside functions (not top-level)', async () => {
+      tree.write(
+        'apps/app1/jest.config.ts',
+        `export default async () => {
+  const config = await import('./base-config.js');
+  return {
+    ...config.default,
+    displayName: 'app1',
+  };
+};`
+      );
+      writeJson(tree, 'apps/app1/package.json', { type: 'commonjs' });
+
+      await migration(tree);
+
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain('module.exports =');
+      expect(content).not.toContain('export default');
+    });
+  });
+
+  describe('multiple files', () => {
+    it('should handle multiple jest.config.ts files correctly', async () => {
+      tree.write(
+        'apps/app1/jest.config.ts',
+        `export default {
+  displayName: 'app1',
+};`
+      );
+      tree.write(
+        'apps/app2/jest.config.ts',
+        `export default {
+  displayName: 'app2',
+};`
+      );
+      tree.write(
+        'libs/lib1/jest.config.ts',
+        `import { readFileSync } from 'fs';
+
+export default {
+  displayName: 'lib1',
+};`
+      );
+      writeJson(tree, 'apps/app1/package.json', { type: 'commonjs' });
+      writeJson(tree, 'apps/app2/package.json', { type: 'module' });
+      writeJson(tree, 'libs/lib1/package.json', { name: 'lib1' }); // no type, defaults to CJS
+
+      await migration(tree);
+
+      // app1: should be converted
+      const app1Content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(app1Content).toContain('module.exports =');
+
+      // app2: should NOT be converted (type: module)
+      const app2Content = tree.read('apps/app2/jest.config.ts', 'utf-8');
+      expect(app2Content).toContain('export default');
+
+      // lib1: should be converted
+      const lib1Content = tree.read('libs/lib1/jest.config.ts', 'utf-8');
+      expect(lib1Content).toContain('module.exports =');
+      expect(lib1Content).toContain("const { readFileSync } = require('fs')");
+    });
+  });
+
+  describe('other jest config extensions', () => {
+    it('should not affect other jest config extensions', async () => {
+      tree.write('apps/app1/jest.config.js', 'module.exports = {};');
+      tree.write('apps/app1/jest.config.cjs', 'module.exports = {};');
+      tree.write('apps/app1/jest.config.mjs', 'export default {};');
+      tree.write('apps/app1/jest.config.cts', 'module.exports = {};');
+      tree.write('apps/app1/jest.config.mts', 'export default {};');
+      writeJson(tree, 'apps/app1/package.json', { type: 'commonjs' });
+
+      await migration(tree);
+
+      // All should still exist as-is
+      expect(tree.read('apps/app1/jest.config.js', 'utf-8')).toBe(
+        'module.exports = {};'
+      );
+      expect(tree.read('apps/app1/jest.config.cjs', 'utf-8')).toBe(
+        'module.exports = {};'
+      );
+      expect(tree.read('apps/app1/jest.config.mjs', 'utf-8')).toBe(
+        'export default {};'
+      );
+      expect(tree.read('apps/app1/jest.config.cts', 'utf-8')).toBe(
+        'module.exports = {};'
+      );
+      expect(tree.read('apps/app1/jest.config.mts', 'utf-8')).toBe(
+        'export default {};'
+      );
+    });
+  });
+
+  describe('complex config patterns', () => {
+    it('should handle SWC config pattern with import and export', async () => {
+      tree.write(
+        'apps/app1/jest.config.ts',
+        `import { readFileSync } from 'fs';
+
+const swcJestConfig = JSON.parse(
+  readFileSync(\`\${__dirname}/.spec.swcrc\`, 'utf-8')
+);
+
+swcJestConfig.swcrc = false;
+
+export default {
+  displayName: 'app1',
+  preset: '../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
+  },
+};`
+      );
+      writeJson(tree, 'apps/app1/package.json', { type: 'commonjs' });
+
+      await migration(tree);
+
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain("const { readFileSync } = require('fs')");
+      expect(content).toContain('module.exports =');
+      expect(content).toContain('swcJestConfig.swcrc = false');
+      expect(content).not.toContain('import { readFileSync }');
+      expect(content).not.toContain('export default');
+    });
+  });
+
+  describe('plugin registration guard', () => {
+    it('should NOT run migration when @nx/jest/plugin is not registered', async () => {
+      // Remove the plugin from nx.json
+      const nxJson = readJson(tree, 'nx.json');
+      nxJson.plugins = [];
+      writeJson(tree, 'nx.json', nxJson);
+
+      const originalContent = `export default {
+  displayName: 'app1',
+};`;
+      tree.write('apps/app1/jest.config.ts', originalContent);
+      writeJson(tree, 'apps/app1/package.json', { type: 'commonjs' });
+
+      await migration(tree);
+
+      // File should remain unchanged
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain('export default');
+    });
+
+    it('should run migration when @nx/jest/plugin is registered as object', async () => {
+      // Register plugin as object format
+      const nxJson = readJson(tree, 'nx.json');
+      nxJson.plugins = [{ plugin: '@nx/jest/plugin', options: {} }];
+      writeJson(tree, 'nx.json', nxJson);
+
+      tree.write(
+        'apps/app1/jest.config.ts',
+        `export default {
+  displayName: 'app1',
+};`
+      );
+      writeJson(tree, 'apps/app1/package.json', { type: 'commonjs' });
+
+      await migration(tree);
+
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain('module.exports =');
+    });
+
+    it('should NOT run migration when nx.json does not exist', async () => {
+      tree.delete('nx.json');
+
+      const originalContent = `export default {
+  displayName: 'app1',
+};`;
+      tree.write('apps/app1/jest.config.ts', originalContent);
+      writeJson(tree, 'apps/app1/package.json', { type: 'commonjs' });
+
+      await migration(tree);
+
+      // File should remain unchanged
+      const content = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(content).toContain('export default');
+    });
+
+    it('should NOT convert files excluded from plugin via exclude pattern', async () => {
+      // Register plugin with exclude pattern
+      const nxJson = readJson(tree, 'nx.json');
+      nxJson.plugins = [
+        {
+          plugin: '@nx/jest/plugin',
+          exclude: ['apps/excluded/**/*'],
+        },
+      ];
+      writeJson(tree, 'nx.json', nxJson);
+
+      const originalContent = `export default {
+  displayName: 'excluded-app',
+};`;
+      tree.write('apps/excluded/jest.config.ts', originalContent);
+      writeJson(tree, 'apps/excluded/package.json', { type: 'commonjs' });
+
+      // Also create a non-excluded file to ensure it still gets converted
+      tree.write(
+        'apps/included/jest.config.ts',
+        `export default {
+  displayName: 'included-app',
+};`
+      );
+      writeJson(tree, 'apps/included/package.json', { type: 'commonjs' });
+
+      await migration(tree);
+
+      // Excluded file should remain unchanged
+      const excludedContent = tree.read(
+        'apps/excluded/jest.config.ts',
+        'utf-8'
+      );
+      expect(excludedContent).toContain('export default');
+
+      // Included file should be converted
+      const includedContent = tree.read(
+        'apps/included/jest.config.ts',
+        'utf-8'
+      );
+      expect(includedContent).toContain('module.exports =');
+    });
+
+    it('should only convert files matching include pattern', async () => {
+      // Register plugin with include pattern
+      const nxJson = readJson(tree, 'nx.json');
+      nxJson.plugins = [
+        {
+          plugin: '@nx/jest/plugin',
+          include: ['libs/**/*'],
+        },
+      ];
+      writeJson(tree, 'nx.json', nxJson);
+
+      // Create file outside include pattern
+      tree.write(
+        'apps/app1/jest.config.ts',
+        `export default {
+  displayName: 'app1',
+};`
+      );
+      writeJson(tree, 'apps/app1/package.json', { type: 'commonjs' });
+
+      // Create file inside include pattern
+      tree.write(
+        'libs/lib1/jest.config.ts',
+        `export default {
+  displayName: 'lib1',
+};`
+      );
+      writeJson(tree, 'libs/lib1/package.json', { type: 'commonjs' });
+
+      await migration(tree);
+
+      // File outside include pattern should remain unchanged
+      const appContent = tree.read('apps/app1/jest.config.ts', 'utf-8');
+      expect(appContent).toContain('export default');
+
+      // File inside include pattern should be converted
+      const libContent = tree.read('libs/lib1/jest.config.ts', 'utf-8');
+      expect(libContent).toContain('module.exports =');
+    });
+  });
+});

--- a/packages/jest/src/migrations/update-22-2-0/convert-jest-config-to-cjs.ts
+++ b/packages/jest/src/migrations/update-22-2-0/convert-jest-config-to-cjs.ts
@@ -49,9 +49,7 @@ export default async function convertJestConfigToCjs(tree: Tree) {
       '@nx/jest/plugin',
       configPath
     );
-    if (!pluginRegistration) {
-      continue;
-    }
+    if (!pluginRegistration) continue;
 
     const projectRoot = dirname(configPath);
     const packageJsonPath = joinPathFragments(projectRoot, 'package.json');
@@ -130,6 +128,7 @@ export default async function convertJestConfigToCjs(tree: Tree) {
 }
 
 function checkForTopLevelAwait(content: string, tsquery: any): boolean {
+  const ts = require('typescript');
   // Check for await expressions that are not inside a function
   const ast = tsquery.ast(content);
   const awaitExpressions = tsquery.query(ast, 'AwaitExpression');
@@ -139,12 +138,7 @@ function checkForTopLevelAwait(content: string, tsquery: any): boolean {
     let isInsideFunction = false;
 
     while (parent) {
-      if (
-        parent.kind === require('typescript').SyntaxKind.FunctionDeclaration ||
-        parent.kind === require('typescript').SyntaxKind.FunctionExpression ||
-        parent.kind === require('typescript').SyntaxKind.ArrowFunction ||
-        parent.kind === require('typescript').SyntaxKind.MethodDeclaration
-      ) {
+      if (ts.isFunctionLike(parent)) {
         isInsideFunction = true;
         break;
       }

--- a/packages/jest/src/migrations/update-22-2-0/convert-jest-config-to-cjs.ts
+++ b/packages/jest/src/migrations/update-22-2-0/convert-jest-config-to-cjs.ts
@@ -1,0 +1,272 @@
+import {
+  formatFiles,
+  globAsync,
+  joinPathFragments,
+  logger,
+  NxJsonConfiguration,
+  readJson,
+  Tree,
+} from '@nx/devkit';
+import { findPluginForConfigFile } from '@nx/devkit/src/utils/find-plugin-for-config-file';
+import { dirname } from 'path';
+
+/**
+ * Migration to convert jest.config.ts files from ESM to CJS syntax for projects
+ * using CommonJS resolution. This is needed because Node.js type-stripping
+ * in newer versions (22+, 24+) can cause issues with ESM syntax in .ts files
+ * when the project is configured for CommonJS.
+ *
+ * This migration only runs if @nx/jest/plugin is registered in nx.json.
+ *
+ * Conversions:
+ * - `export default { ... }` -> `module.exports = { ... }`
+ * - `import { x } from 'y'` -> `const { x } = require('y')`
+ * - `import x from 'y'` -> `const x = require('y').default ?? require('y')`
+ *
+ * ESM-only features that cannot be converted (will warn user):
+ * - `import.meta`
+ * - top-level `await`
+ *
+ * Projects with `type: module` in package.json will be warned as they are
+ * incompatible with @nx/jest/plugin which forces CommonJS resolution.
+ */
+export default async function convertJestConfigToCjs(tree: Tree) {
+  // If @nx/jest/plugin not used, then there will not be any problems with graph construction, which
+  // is what we're trying to address.
+  if (!isJestPluginRegistered(tree)) return;
+
+  const { tsquery } = require('@phenomnomnominal/tsquery');
+
+  const jestConfigPaths = await globAsync(tree, ['**/jest.config.ts']);
+  const projectsWithEsmOnlyFeatures: string[] = [];
+  const projectsWithTypeModule: string[] = [];
+  const modifiedFiles: string[] = [];
+
+  for (const configPath of jestConfigPaths) {
+    // Skip config files that are excluded from the plugin via include/exclude patterns
+    const pluginRegistration = await findPluginForConfigFile(
+      tree,
+      '@nx/jest/plugin',
+      configPath
+    );
+    if (!pluginRegistration) {
+      continue;
+    }
+
+    const projectRoot = dirname(configPath);
+    const packageJsonPath = joinPathFragments(projectRoot, 'package.json');
+    const rootPackageJsonPath = 'package.json';
+
+    // Check project-level package.json first, then root
+    let projectPackageJson: { type?: string } | null = null;
+    let rootPackageJson: { type?: string } | null = null;
+
+    if (tree.exists(packageJsonPath)) {
+      projectPackageJson = readJson(tree, packageJsonPath);
+    }
+
+    if (tree.exists(rootPackageJsonPath)) {
+      rootPackageJson = readJson(tree, rootPackageJsonPath);
+    }
+
+    const effectiveType =
+      projectPackageJson?.type ?? rootPackageJson?.type ?? 'commonjs'; // CJS is default if missing
+
+    // If type is "module", warn user - this is incompatible with @nx/jest/plugin
+    // Should not be possible, but it's possible that there's a way to get this working that we're unaware of
+    if (effectiveType === 'module') {
+      projectsWithTypeModule.push(configPath);
+      continue;
+    }
+
+    let content = tree.read(configPath, 'utf-8');
+
+    // Check for ESM-only features that can't be converted
+    const hasImportMeta =
+      tsquery.query(content, 'MetaProperty').length > 0 ||
+      content.includes('import.meta');
+    const hasTopLevelAwait = checkForTopLevelAwait(content, tsquery);
+
+    if (hasImportMeta || hasTopLevelAwait) {
+      projectsWithEsmOnlyFeatures.push(configPath);
+      continue;
+    }
+
+    content = convertImportsToRequire(content, tsquery);
+
+    content = convertExportDefaultToModuleExports(content, tsquery);
+
+    tree.write(configPath, content);
+    modifiedFiles.push(configPath);
+  }
+
+  if (modifiedFiles.length > 0) {
+    await formatFiles(tree);
+  }
+
+  const hasWarnings =
+    projectsWithEsmOnlyFeatures.length > 0 || projectsWithTypeModule.length > 0;
+
+  if (hasWarnings) {
+    return () => {
+      if (projectsWithTypeModule.length > 0) {
+        logger.warn(
+          `The following projects have "type": "module" in their package.json which is incompatible ` +
+            `with @nx/jest/plugin. Consider removing "type": "module" ` +
+            `or using a different Jest configuration approach:\n` +
+            projectsWithTypeModule.map((p) => `  - ${p}`).join('\n')
+        );
+      }
+
+      if (projectsWithEsmOnlyFeatures.length > 0) {
+        logger.warn(
+          `The following jest.config.ts files use ESM-only features (import.meta or top-level await) ` +
+            `and could not be automatically converted to CommonJS. Please update them manually:\n` +
+            projectsWithEsmOnlyFeatures.map((p) => `  - ${p}`).join('\n')
+        );
+      }
+    };
+  }
+}
+
+function checkForTopLevelAwait(content: string, tsquery: any): boolean {
+  // Check for await expressions that are not inside a function
+  const ast = tsquery.ast(content);
+  const awaitExpressions = tsquery.query(ast, 'AwaitExpression');
+
+  for (const awaitExpr of awaitExpressions) {
+    let parent = awaitExpr.parent;
+    let isInsideFunction = false;
+
+    while (parent) {
+      if (
+        parent.kind === require('typescript').SyntaxKind.FunctionDeclaration ||
+        parent.kind === require('typescript').SyntaxKind.FunctionExpression ||
+        parent.kind === require('typescript').SyntaxKind.ArrowFunction ||
+        parent.kind === require('typescript').SyntaxKind.MethodDeclaration
+      ) {
+        isInsideFunction = true;
+        break;
+      }
+      parent = parent.parent;
+    }
+
+    if (!isInsideFunction) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function convertImportsToRequire(content: string, tsquery: any): string {
+  const ts = require('typescript');
+  const ast = tsquery.ast(content);
+  const importDeclarations = tsquery.query(ast, 'ImportDeclaration');
+
+  if (importDeclarations.length === 0) {
+    return content;
+  }
+
+  // Sort imports by position (descending) to replace from end to start
+  // This preserves positions of earlier nodes
+  const sortedImports = [...importDeclarations].sort(
+    (a, b) => b.getStart() - a.getStart()
+  );
+
+  for (const importDecl of sortedImports) {
+    const moduleSpecifier = importDecl.moduleSpecifier
+      .getText()
+      .replace(/['"]/g, '');
+    const importClause = importDecl.importClause;
+
+    if (!importClause) {
+      // Side-effect import: import 'module'
+      const requireStatement = `require('${moduleSpecifier}')`;
+      content = replaceNode(content, importDecl, requireStatement);
+      continue;
+    }
+
+    const parts: string[] = [];
+
+    // Default import: import x from 'module'
+    if (importClause.name) {
+      const defaultName = importClause.name.getText();
+      parts.push(
+        `const ${defaultName} = require('${moduleSpecifier}').default ?? require('${moduleSpecifier}')`
+      );
+    }
+
+    // Named imports: import { a, b } from 'module'
+    if (importClause.namedBindings) {
+      if (ts.isNamedImports(importClause.namedBindings)) {
+        const namedImports = importClause.namedBindings.elements
+          .map((element) => {
+            const name = element.name.getText();
+            const propertyName = element.propertyName?.getText();
+            if (propertyName) {
+              return `${propertyName}: ${name}`;
+            }
+            return name;
+          })
+          .join(', ');
+        parts.push(`const { ${namedImports} } = require('${moduleSpecifier}')`);
+      } else if (ts.isNamespaceImport(importClause.namedBindings)) {
+        // Namespace import: import * as x from 'module'
+        const namespaceName = importClause.namedBindings.name.getText();
+        parts.push(`const ${namespaceName} = require('${moduleSpecifier}')`);
+      }
+    }
+
+    const requireStatement = parts.join(';\n');
+    content = replaceNode(content, importDecl, requireStatement);
+  }
+
+  return content;
+}
+
+function convertExportDefaultToModuleExports(
+  content: string,
+  tsquery: any
+): string {
+  // Handle: export default { ... }
+  const exportAssignments = tsquery.query(content, 'ExportAssignment');
+
+  if (exportAssignments.length > 0) {
+    for (const exportAssignment of exportAssignments) {
+      const expression = exportAssignment.expression;
+      if (expression) {
+        const exportedValue = expression.getText();
+        const replacement = `module.exports = ${exportedValue}`;
+        content = replaceNode(content, exportAssignment, replacement);
+      }
+    }
+  }
+
+  return content;
+}
+
+function replaceNode(content: string, node: any, replacement: string): string {
+  const start = node.getStart();
+  const end = node.getEnd();
+  // Remove trailing semicolon if present to avoid double semicolons
+  let endPos = end;
+  if (content[end] === ';') {
+    endPos = end + 1;
+  }
+  return content.slice(0, start) + replacement + ';' + content.slice(endPos);
+}
+
+function isJestPluginRegistered(tree: Tree): boolean {
+  if (!tree.exists('nx.json')) {
+    return false;
+  }
+
+  const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+  const plugins = nxJson.plugins ?? [];
+
+  return plugins.some((plugin) => {
+    const pluginName = typeof plugin === 'string' ? plugin : plugin.plugin;
+    return pluginName === '@nx/jest/plugin' || pluginName === '@nx/jest';
+  });
+}

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -34,7 +34,6 @@ import { combineGlobPatterns } from 'nx/src/utils/globs';
 import { getNxRequirePaths } from 'nx/src/utils/installation-directory';
 import { deriveGroupNameFromTarget } from 'nx/src/utils/plugins';
 import { globWithWorkspaceContext } from 'nx/src/utils/workspace-context';
-import { major } from 'semver';
 import { getInstalledJestMajorVersion } from '../utils/versions';
 
 const pmc = getPackageManagerCommand();
@@ -240,23 +239,9 @@ async function buildJestTargets(
     customConditions: null,
   });
 
-  // Jest 30 + Node.js 24 can't parse TS configs with imports.
-  // This flag does not exist in Node 20/22.
-  // https://github.com/jestjs/jest/issues/15682
-  const nodeVersion = major(process.version);
-
   const env: Record<string, string> = {
     TS_NODE_COMPILER_OPTIONS: tsNodeCompilerOptions,
   };
-
-  if (nodeVersion >= 24) {
-    const currentOptions = process.env.NODE_OPTIONS || '';
-    if (!currentOptions.includes('--no-experimental-strip-types')) {
-      env.NODE_OPTIONS = (
-        currentOptions + ' --no-experimental-strip-types'
-      ).trim();
-    }
-  }
 
   const target: TargetConfiguration = (targets[options.targetName] = {
     command: 'jest',


### PR DESCRIPTION


## Current Behavior
On Node.js v24+, the `@nx/jest/plugin` sets `--no-experimental-strip-types` in NODE_OPTIONS which causes an error: "node: --no-experimental-strip-types is not allowed in NODE_OPTIONS".

Additionally, `jest.config.ts` files using ESM syntax (`export default`, `import`) fail to load correctly under Node.js type-stripping when the project is configured for CommonJS.

## Expected Behavior
- Remove the NODE_OPTIONS manipulation that adds `--no-experimental-strip-types`
- Add a migration (22.2.0-beta.2) that converts `jest.config.ts` files from ESM to CJS syntax for projects using `@nx/jest/plugin`
- The migration only runs when `@nx/jest/plugin` is registered in `nx.json`
- Projects with `type: module` are warned as they're incompatible with the plugin
- Files using ESM-only features (import.meta, top-level await) are skipped with a warning for manual conversion

## Demo

https://www.loom.com/share/8a157a0b01d144ae8d6ae48b9b0cd0e4


## Related Issue(s)
Closes NXC-3541
