### PR TITLE
chore(repo): disable docker from macos nightlies since it does not work without vm-in-vm

### DIFF
--- a/.github/workflows/nightly/process-matrix.ts
+++ b/.github/workflows/nightly/process-matrix.ts
@@ -78,7 +78,10 @@ const matrixData: MatrixData = {
       node_versions: ['20.19.0', '22.12.0', '24.0.0'],
       excluded: ['e2e-detox', 'e2e-react-native', 'e2e-expo']
     },
-    { os: 'macos-latest', os_name: 'MacOS', os_timeout: 90, package_managers: ['npm'], node_versions: ['24.0.0'] }
+    // Docker is not supported on ARM-based macOS runners (no nested virtualization)
+    // See: https://github.com/docker/setup-docker-action and https://github.com/douglascamata/setup-docker-macos-action
+    // We may want to look into adding intel only for this docker case, at least until vm-in-vm works on latest macos
+    { os: 'macos-latest', os_name: 'MacOS', os_timeout: 90, package_managers: ['npm'], node_versions: ['24.0.0'], excluded: ['e2e-docker'] }
     // TODO (Jack): Fix Windows support as gradle fails when running nx build https://staging.nx.app/runs/LgD4vxGn8w?utm_source=pull-request&utm_medium=comment
     // { os: 'windows-latest', os_name: 'WinOS', os_timeout: 180, package_managers: ['npm'], node_versions: ['24.0.0'], excluded: ['e2e-detox', 'e2e-react-native', 'e2e-expo'] }
   ]


### PR DESCRIPTION
Disable but add a comment that we could enable it on macos intel if we need to. For now it's covered by linux.