### PR TITLE
fix(core): hash git-ignored files when explicitly listed as inputs

### DIFF
--- a/packages/nx/src/native/tasks/hashers/hash_project_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_project_files.rs
@@ -316,10 +316,7 @@ mod tests {
             file: format!("{}/file1.ts", proj_root),
             hash: hash(&b"content1"[..]),
         };
-        file_map.insert(
-            String::from(proj_name),
-            vec![file_data1.clone()],
-        );
+        file_map.insert(String::from(proj_name), vec![file_data1.clone()]);
 
         // File sets explicitly include the git-ignored .env file
         let file_sets = &[
@@ -332,15 +329,25 @@ mod tests {
         env::set_current_dir(&temp).unwrap();
 
         // Hash without git-ignored files
-        let hash_without_gitignored = hash_project_files(proj_name, proj_root, &[format!("{}/**/*.ts", proj_root)], &file_map).unwrap();
+        let hash_without_gitignored = hash_project_files(
+            proj_name,
+            proj_root,
+            &[format!("{}/**/*.ts", proj_root)],
+            &file_map,
+        )
+        .unwrap();
 
         // Hash with git-ignored files
-        let hash_with_gitignored = hash_project_files(proj_name, proj_root, file_sets, &file_map).unwrap();
+        let hash_with_gitignored =
+            hash_project_files(proj_name, proj_root, file_sets, &file_map).unwrap();
 
         // Restore the original directory
         env::set_current_dir(original_dir).unwrap();
 
         // The two hashes should be different because .env should be included in the second hash
-        assert_ne!(hash_without_gitignored, hash_with_gitignored, "Hash should change when git-ignored .env file is explicitly specified as an input");
+        assert_ne!(
+            hash_without_gitignored, hash_with_gitignored,
+            "Hash should change when git-ignored .env file is explicitly specified as an input"
+        );
     }
 }

--- a/packages/nx/src/native/tasks/hashers/hash_project_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_project_files.rs
@@ -1,9 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::*;
 use tracing::{trace, trace_span};
 
 use crate::native::glob::build_glob_set;
+use crate::native::hasher::hash_file_path;
 use crate::native::types::FileData;
 
 pub fn hash_project_files(
@@ -16,12 +17,83 @@ pub fn hash_project_files(
     let collected_files =
         collect_project_files(project_name, project_root, file_sets, project_file_map)?;
     trace!("collected_files: {:?}", collected_files.len());
+
+    // Hash files from the project file map
     let mut hasher = xxhash_rust::xxh3::Xxh3::new();
+    let mut hashed_files: HashSet<String> = HashSet::new();
     for file in collected_files {
         hasher.update(file.hash.as_bytes());
         hasher.update(file.file.as_bytes());
+        hashed_files.insert(file.file.clone());
     }
+
+    // Check for git-ignored files that match the input patterns
+    // These files won't be in project_file_map but should still be hashed
+    hash_missing_files(&mut hasher, &mut hashed_files, project_root, file_sets)?;
+
     Ok(hasher.digest().to_string())
+}
+
+/// Hashes files that exist on the filesystem but are not in the file map (e.g., git-ignored files)
+fn hash_missing_files(
+    hasher: &mut xxhash_rust::xxh3::Xxh3,
+    hashed_files: &mut HashSet<String>,
+    project_root: &str,
+    file_sets: &[String],
+) -> Result<()> {
+    use crate::native::walker::nx_walker_sync;
+    use std::path::Path;
+
+    let globs = file_sets
+        .iter()
+        .map(|f| {
+            if project_root == "." {
+                f.replace("{projectRoot}/", "")
+            } else {
+                f.replace("{projectRoot}", project_root)
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let glob_set = build_glob_set(&globs)?;
+
+    // Walk the project directory to find files that match the patterns
+    // but weren't in the file map (because they were git-ignored)
+    let project_path = if project_root == "." {
+        Path::new(".")
+    } else {
+        Path::new(project_root)
+    };
+
+    for relative_file_path in nx_walker_sync(project_path, None) {
+        // Build the full path for matching and hashing
+        let full_path = if project_root == "." {
+            relative_file_path.to_string_lossy().to_string()
+        } else {
+            format!("{}/{}", project_root, relative_file_path.to_string_lossy())
+        };
+
+        // Skip if we've already hashed this file
+        if hashed_files.contains(&full_path) {
+            continue;
+        }
+
+        // Check if the file matches the glob patterns
+        if !glob_set.is_match(&full_path) {
+            continue;
+        }
+
+        // Hash this git-ignored file
+        let absolute_path = project_path.join(&relative_file_path);
+        if let Some(hash) = hash_file_path(&absolute_path) {
+            trace!("Hashing git-ignored file: {}", full_path);
+            hasher.update(hash.as_bytes());
+            hasher.update(full_path.as_bytes());
+            hashed_files.insert(full_path);
+        }
+    }
+
+    Ok(())
 }
 
 /// base function that should be testable (to make sure that we're getting the proper files back)
@@ -219,5 +291,56 @@ mod tests {
                 .concat()
             )
         );
+    }
+
+    #[test]
+    fn should_hash_git_ignored_files_when_explicitly_specified() {
+        use assert_fs::TempDir;
+        use assert_fs::prelude::*;
+        use std::env;
+
+        let temp = TempDir::new().unwrap();
+        let proj_name = "test_project";
+        let proj_root = temp.path().to_str().unwrap();
+
+        // Create a project directory structure
+        temp.child("file1.ts").write_str("content1").unwrap();
+        temp.child(".env").write_str("SECRET=value").unwrap();
+
+        // Create a .gitignore file that ignores .env
+        temp.child(".gitignore").write_str(".env\n").unwrap();
+
+        // Only file1.ts should be in the file map (since .env is git-ignored)
+        let mut file_map = HashMap::new();
+        let file_data1 = FileData {
+            file: format!("{}/file1.ts", proj_root),
+            hash: hash(&b"content1"[..]),
+        };
+        file_map.insert(
+            String::from(proj_name),
+            vec![file_data1.clone()],
+        );
+
+        // File sets explicitly include the git-ignored .env file
+        let file_sets = &[
+            format!("{}/.env", proj_root),
+            format!("{}/**/*.ts", proj_root),
+        ];
+
+        // Change to the temp directory for the test
+        let original_dir = env::current_dir().unwrap();
+        env::set_current_dir(&temp).unwrap();
+
+        // Hash without git-ignored files
+        let hash_without_gitignored = hash_project_files(proj_name, proj_root, &[format!("{}/**/*.ts", proj_root)], &file_map).unwrap();
+
+        // Hash with git-ignored files
+        let hash_with_gitignored = hash_project_files(proj_name, proj_root, file_sets, &file_map).unwrap();
+
+        // Restore the original directory
+        env::set_current_dir(original_dir).unwrap();
+
+        // The two hashes should be different because .env should be included in the second hash
+        assert_ne!(hash_without_gitignored, hash_with_gitignored, "Hash should change when git-ignored .env file is explicitly specified as an input");
     }
 }

--- a/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
@@ -1,9 +1,10 @@
 use rayon::prelude::*;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::native::glob::build_glob_set;
 use crate::native::glob::glob_files::glob_files;
-use crate::native::hasher::hash;
+use crate::native::hasher::{hash, hash_file_path};
 use crate::native::types::FileData;
 use anyhow::*;
 use dashmap::DashMap;
@@ -61,6 +62,8 @@ pub fn hash_workspace_files(
     let glob = build_glob_set(&globs)?;
 
     let mut hasher = xxhash_rust::xxh3::Xxh3::new();
+    let mut hashed_files: HashSet<String> = HashSet::new();
+
     debug_span!("Hashing workspace fileset", cache_key).in_scope(|| {
         for file in all_workspace_files
             .iter()
@@ -69,13 +72,60 @@ pub fn hash_workspace_files(
             debug!("Adding {:?} ({:?}) to hash", file.hash, file.file);
             hasher.update(file.file.clone().as_bytes());
             hasher.update(file.hash.clone().as_bytes());
+            hashed_files.insert(file.file.clone());
         }
+
+        // Check for git-ignored files that match the input patterns
+        hash_missing_workspace_files(&mut hasher, &mut hashed_files, &globs);
+
         let hashed_value = hasher.digest().to_string();
         debug!("Hash Value: {:?}", hashed_value);
 
         cache.insert(cache_key.to_string(), hashed_value.clone());
         Ok(hashed_value)
     })
+}
+
+/// Hashes workspace files that exist on the filesystem but are not in the file map (e.g., git-ignored files)
+fn hash_missing_workspace_files(
+    hasher: &mut xxhash_rust::xxh3::Xxh3,
+    hashed_files: &mut HashSet<String>,
+    globs: &[String],
+) {
+    use crate::native::walker::nx_walker_sync;
+    use std::path::Path;
+
+    let glob_set = match build_glob_set(globs) {
+        core::result::Result::Ok(set) => set,
+        core::result::Result::Err(e) => {
+            warn!("Failed to build glob set: {}", e);
+            return;
+        }
+    };
+
+    // Walk the workspace root to find files that match the patterns
+    // but weren't in the file map (because they were git-ignored)
+    for file_path in nx_walker_sync(Path::new("."), None) {
+        let file_str = file_path.to_string_lossy().to_string();
+
+        // Skip if we've already hashed this file
+        if hashed_files.contains(&file_str) {
+            continue;
+        }
+
+        // Check if the file matches the glob patterns
+        if !glob_set.is_match(&file_str) {
+            continue;
+        }
+
+        // Hash this git-ignored file
+        if let Some(file_hash) = hash_file_path(&file_path) {
+            trace!("Hashing git-ignored workspace file: {}", file_str);
+            hasher.update(file_str.as_bytes());
+            hasher.update(file_hash.as_bytes());
+            hashed_files.insert(file_str);
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Current Behavior

When a file is listed as an input for a task but is git-ignored (e.g., `.env`, `secrets.json`), its contents are not included in the hash computation. This causes incorrect cache hits when these git-ignored input files change.

**Example:**
```json
{
  "targets": {
    "build": {
      "inputs": ["{projectRoot}/.env"],
      "cache": true
    }
  }
}
```

If `.env` is in `.gitignore`, changes to `.env` do NOT invalidate the cache (bug).

## Expected Behavior

Files explicitly listed as inputs should be hashed regardless of git-ignore status. When a git-ignored input file changes, the cache should be invalidated.

## Changes Made

### Core Fix (Rust)
- Modified `hash_project_files()` in `packages/nx/src/native/tasks/hashers/hash_project_files.rs`
  - Added `hash_missing_files()` helper that walks the filesystem without git-ignore
  - Finds files matching input patterns that were filtered out by git-ignore
  - Hashes these files directly from the filesystem

- Modified `hash_workspace_files()` in `packages/nx/src/native/tasks/hashers/hash_workspace_files.rs`
  - Same approach for workspace-level inputs

### Tests
- Added Rust unit test: `should_hash_git_ignored_files_when_explicitly_specified`
- Added e2e test in `cache.test.ts`: `should invalidate cache when git-ignored input file changes`

## Important Note for Reviewers ⚠️

This implementation hashes **all git-ignored files that match the input patterns**, including broad wildcards like `{projectRoot}/**/*`.

**Potential concerns:**
1. **Performance**: Walks the directory twice (once with gitignore, once without)
2. **Broad patterns**: If someone uses `{projectRoot}/**/*` (the default), ALL git-ignored files will now be hashed

**Should we refine this to:**
- Only hash git-ignored files for explicit patterns (no wildcards)?  
- Add caching to avoid double directory walking?
- Optimize walk scope to specific subdirectories?

Would appreciate team feedback on whether the current approach is acceptable or if we should implement the refinements mentioned above.

## Test Plan

- [x] Rust unit test passes
- [x] E2e test added (demonstrates the fix)
- [ ] Run full e2e test suite
- [ ] Performance testing with large monorepos

🤖 Generated with [Claude Code](https://claude.com/claude-code)