### PR TITLE
fix(docker): fix releasing non docker projects

### DIFF
--- a/packages/nx/src/command-line/release/version/release-group-processor.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.ts
@@ -261,11 +261,14 @@ export class ReleaseGroupProcessor {
   ) {
     const dockerProjects = new Map<string, FinalConfigForProject>();
     for (const project of this.versionData.keys()) {
-      const finalConfigForProject =
-        this.releaseGraph.finalConfigsByProject.get(project);
-      if (Object.keys(finalConfigForProject.dockerOptions).length === 0) {
+      const hasDockerTechnology = Object.values(
+        this.projectGraph.nodes[project]?.data?.targets ?? []
+      ).some(({ metadata }) => metadata?.technologies?.includes('docker'));
+      if (!hasDockerTechnology) {
         continue;
       }
+      const finalConfigForProject =
+        this.releaseGraph.finalConfigsByProject.get(project);
       dockerProjects.set(project, finalConfigForProject);
     }
     // If no docker projects to process, exit early to avoid unnecessary loading of docker handling


### PR DESCRIPTION
# Fix: Docker release process incorrectly includes non-Docker projects

## Current

The release process determines whether a project is Docker-related by checking if the final release config contains Docker options:

```ts
const finalConfigForProject =
  this.releaseGraph.finalConfigsByProject.get(project);

if (Object.keys(finalConfigForProject.dockerOptions).length === 0) {
  continue;
}
```

In a mixed environment (Docker + non-Docker), having a global `docker` section unintentionally injects default `dockerOptions` into **every** project.
This causes all projects to be treated as Docker projects and included in the Docker release flow.

Example:

```ts
"release": {
  "groups": {
    "backstage-base": {
      "projects": ["backstage-base", "backstage-base-scotty"],
      "projectsRelationship": "fixed",
      "releaseTagPattern": "backstage-base@{version}",
      "groupPreVersionCommand": "npx nx run-many -t build -p backstage-base,backstage-base-scotty"
    },
    "base": {
      "projects": ["base", "base-scotty"],
      "projectsRelationship": "fixed",
      "releaseTagPattern": "base@{version}",
      "groupPreVersionCommand": "npx nx run-many -t build -p base,base-scotty"
    }
  },
  "releaseTag": {
    "pattern": "{releaseGroupName}@{version}"
  },
  "docker": {
    "skipVersionActions": false,
    "registryUrl": "custom.docker.pkg.org.io",
    "versionSchemes": {
      "production": "{versionActionsVersion}"
    }
  }
}
```

Because the `docker` section is defined globally, every project ends up with a `dockerOptions` object and is mistakenly included in the Docker release pipeline.

## Expected

Only projects with explicit Docker configuration should be processed and tagged as Docker releases.