### PR TITLE
fix(vite): vitest executor to return the async iterable #33588

### DIFF
--- a/packages/vite/src/executors/test/vitest.impl.ts
+++ b/packages/vite/src/executors/test/vitest.impl.ts
@@ -19,7 +19,7 @@ export async function* vitestExecutor(
     '@nx/vitest/executors'
   );
 
-  yield* actualVitestExecutor(options, context);
+  return yield* actualVitestExecutor(options, context);
 }
 
 export default vitestExecutor;


### PR DESCRIPTION
## Current Behavior
The `@nx/vite:test` executor is not returning the async iterable. This causes a destructuring issue.

## Expected Behavior
Ensure the `@nx/vite:test` executor returns the async iterable.

## Related Issue(s)

Fixes #33588
