### PR TITLE
feat(vite): add migration to add @nx/vitest

### DIFF
--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -32,6 +32,11 @@
       },
       "description": "Create AI Instructions to help migrate users workspaces past breaking changes for Vitest 4.",
       "implementation": "./src/migrations/update-22-2-0/create-ai-instructions-for-vitest-4"
+    },
+    "migrate-vitest-to-vitest-package": {
+      "version": "22.2.0-beta.2",
+      "description": "Migrate Vitest usage from @nx/vite to @nx/vitest package.",
+      "implementation": "./src/migrations/update-22-2-0/migrate-vitest-to-vitest-package"
     }
   },
   "packageJsonUpdates": {

--- a/packages/vite/src/migrations/update-22-2-0/migrate-vitest-to-vitest-package.spec.ts
+++ b/packages/vite/src/migrations/update-22-2-0/migrate-vitest-to-vitest-package.spec.ts
@@ -1,0 +1,415 @@
+import {
+  addProjectConfiguration,
+  readJson,
+  readNxJson,
+  readProjectConfiguration,
+  type Tree,
+  updateNxJson,
+  writeJson,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migrateVitestToVitestPackage from './migrate-vitest-to-vitest-package';
+
+describe('migrate-vitest-to-vitest-package', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('package installation', () => {
+    it('should install @nx/vitest if not present', async () => {
+      await migrateVitestToVitestPackage(tree);
+
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@nx/vitest']).toBeDefined();
+    });
+
+    it('should not duplicate @nx/vitest if already present', async () => {
+      const packageJson = readJson(tree, 'package.json');
+      packageJson.devDependencies = packageJson.devDependencies || {};
+      packageJson.devDependencies['@nx/vitest'] = '22.0.0';
+      writeJson(tree, 'package.json', packageJson);
+
+      await migrateVitestToVitestPackage(tree);
+
+      const updatedPackageJson = readJson(tree, 'package.json');
+      expect(updatedPackageJson.devDependencies['@nx/vitest']).toBe('22.0.0');
+    });
+  });
+
+  describe('executor migration', () => {
+    it('should convert @nx/vite:test executor to @nx/vitest:test', async () => {
+      addProjectConfiguration(tree, 'my-lib', {
+        root: 'libs/my-lib',
+        targets: {
+          test: {
+            executor: '@nx/vite:test',
+            options: {
+              configFile: 'libs/my-lib/vite.config.ts',
+            },
+          },
+        },
+      });
+
+      await migrateVitestToVitestPackage(tree);
+
+      const projectConfig = readProjectConfiguration(tree, 'my-lib');
+      expect(projectConfig.targets.test.executor).toBe('@nx/vitest:test');
+      expect(projectConfig.targets.test.options.configFile).toBe(
+        'libs/my-lib/vite.config.ts'
+      );
+    });
+
+    it('should preserve executor options after migration', async () => {
+      addProjectConfiguration(tree, 'my-lib', {
+        root: 'libs/my-lib',
+        targets: {
+          test: {
+            executor: '@nx/vite:test',
+            options: {
+              configFile: 'libs/my-lib/vite.config.ts',
+              reportsDirectory: 'coverage/libs/my-lib',
+              mode: 'test',
+            },
+          },
+        },
+      });
+
+      await migrateVitestToVitestPackage(tree);
+
+      const projectConfig = readProjectConfiguration(tree, 'my-lib');
+      expect(projectConfig.targets.test.options).toEqual({
+        configFile: 'libs/my-lib/vite.config.ts',
+        reportsDirectory: 'coverage/libs/my-lib',
+        mode: 'test',
+      });
+    });
+
+    it('should convert multiple projects with @nx/vite:test', async () => {
+      addProjectConfiguration(tree, 'lib-a', {
+        root: 'libs/lib-a',
+        targets: {
+          test: {
+            executor: '@nx/vite:test',
+          },
+        },
+      });
+
+      addProjectConfiguration(tree, 'lib-b', {
+        root: 'libs/lib-b',
+        targets: {
+          test: {
+            executor: '@nx/vite:test',
+          },
+        },
+      });
+
+      await migrateVitestToVitestPackage(tree);
+
+      expect(
+        readProjectConfiguration(tree, 'lib-a').targets.test.executor
+      ).toBe('@nx/vitest:test');
+      expect(
+        readProjectConfiguration(tree, 'lib-b').targets.test.executor
+      ).toBe('@nx/vitest:test');
+    });
+
+    it('should not modify other executors', async () => {
+      addProjectConfiguration(tree, 'my-lib', {
+        root: 'libs/my-lib',
+        targets: {
+          build: {
+            executor: '@nx/vite:build',
+          },
+          test: {
+            executor: '@nx/vite:test',
+          },
+        },
+      });
+
+      await migrateVitestToVitestPackage(tree);
+
+      const projectConfig = readProjectConfiguration(tree, 'my-lib');
+      expect(projectConfig.targets.build.executor).toBe('@nx/vite:build');
+      expect(projectConfig.targets.test.executor).toBe('@nx/vitest:test');
+    });
+  });
+
+  describe('plugin configuration migration', () => {
+    it('should split @nx/vite/plugin with testTargetName into separate entries', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.plugins = [
+        {
+          plugin: '@nx/vite/plugin',
+          options: {
+            buildTargetName: 'build',
+            testTargetName: 'test',
+          },
+        },
+      ];
+      updateNxJson(tree, nxJson);
+
+      await migrateVitestToVitestPackage(tree);
+
+      const updatedNxJson = readNxJson(tree);
+      expect(updatedNxJson.plugins).toHaveLength(2);
+
+      const vitePlugin = updatedNxJson.plugins.find(
+        (p) => typeof p !== 'string' && p.plugin === '@nx/vite/plugin'
+      );
+      const vitestPlugin = updatedNxJson.plugins.find(
+        (p) => typeof p !== 'string' && p.plugin === '@nx/vitest'
+      );
+
+      expect(vitePlugin).toBeDefined();
+      expect((vitePlugin as any).options).toEqual({
+        buildTargetName: 'build',
+      });
+
+      expect(vitestPlugin).toBeDefined();
+      expect((vitestPlugin as any).options).toEqual({
+        testTargetName: 'test',
+      });
+    });
+
+    it('should migrate ciTargetName and ciGroupName to vitest plugin', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.plugins = [
+        {
+          plugin: '@nx/vite/plugin',
+          options: {
+            buildTargetName: 'build',
+            testTargetName: 'test',
+            ciTargetName: 'test-ci',
+            ciGroupName: 'vitest',
+          },
+        },
+      ];
+      updateNxJson(tree, nxJson);
+
+      await migrateVitestToVitestPackage(tree);
+
+      const updatedNxJson = readNxJson(tree);
+      const vitestPlugin = updatedNxJson.plugins.find(
+        (p) => typeof p !== 'string' && p.plugin === '@nx/vitest'
+      );
+
+      expect((vitestPlugin as any).options).toEqual({
+        testTargetName: 'test',
+        ciTargetName: 'test-ci',
+        ciGroupName: 'vitest',
+      });
+    });
+
+    it('should preserve include/exclude in vitest plugin', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.plugins = [
+        {
+          plugin: '@nx/vite/plugin',
+          include: ['packages/**'],
+          exclude: ['packages/excluded/**'],
+          options: {
+            testTargetName: 'test',
+          },
+        },
+      ];
+      updateNxJson(tree, nxJson);
+
+      await migrateVitestToVitestPackage(tree);
+
+      const updatedNxJson = readNxJson(tree);
+      const vitestPlugin = updatedNxJson.plugins.find(
+        (p) => typeof p !== 'string' && p.plugin === '@nx/vitest'
+      ) as any;
+
+      expect(vitestPlugin.include).toEqual(['packages/**']);
+      expect(vitestPlugin.exclude).toEqual(['packages/excluded/**']);
+    });
+
+    it('should not add vitest plugin if already present', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.plugins = [
+        {
+          plugin: '@nx/vite/plugin',
+          options: {
+            testTargetName: 'test',
+          },
+        },
+        {
+          plugin: '@nx/vitest',
+          options: {
+            testTargetName: 'vitest:test',
+          },
+        },
+      ];
+      updateNxJson(tree, nxJson);
+
+      await migrateVitestToVitestPackage(tree);
+
+      const updatedNxJson = readNxJson(tree);
+      const vitestPlugins = updatedNxJson.plugins.filter(
+        (p) => typeof p !== 'string' && p.plugin === '@nx/vitest'
+      );
+
+      expect(vitestPlugins).toHaveLength(1);
+      expect((vitestPlugins[0] as any).options.testTargetName).toBe(
+        'vitest:test'
+      );
+    });
+
+    it('should handle string plugin format (no splitting needed)', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.plugins = ['@nx/vite/plugin'];
+      updateNxJson(tree, nxJson);
+
+      await migrateVitestToVitestPackage(tree);
+
+      const updatedNxJson = readNxJson(tree);
+      expect(updatedNxJson.plugins).toEqual(['@nx/vite/plugin']);
+    });
+
+    it('should not modify @nx/vite/plugin without test options', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.plugins = [
+        {
+          plugin: '@nx/vite/plugin',
+          options: {
+            buildTargetName: 'build',
+            devTargetName: 'dev',
+          },
+        },
+      ];
+      updateNxJson(tree, nxJson);
+
+      await migrateVitestToVitestPackage(tree);
+
+      const updatedNxJson = readNxJson(tree);
+      expect(updatedNxJson.plugins).toHaveLength(1);
+      expect((updatedNxJson.plugins[0] as any).options).toEqual({
+        buildTargetName: 'build',
+        devTargetName: 'dev',
+      });
+    });
+
+    it('should remove options object from vite plugin if empty after migration', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.plugins = [
+        {
+          plugin: '@nx/vite/plugin',
+          options: {
+            testTargetName: 'test',
+          },
+        },
+      ];
+      updateNxJson(tree, nxJson);
+
+      await migrateVitestToVitestPackage(tree);
+
+      const updatedNxJson = readNxJson(tree);
+      const vitePlugin = updatedNxJson.plugins.find(
+        (p) => typeof p !== 'string' && p.plugin === '@nx/vite/plugin'
+      ) as any;
+
+      expect(vitePlugin.options).toBeUndefined();
+    });
+  });
+
+  describe('targetDefaults migration', () => {
+    it('should migrate @nx/vite:test targetDefaults to @nx/vitest:test', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        '@nx/vite:test': {
+          cache: true,
+          inputs: ['default', '^production'],
+        },
+      };
+      updateNxJson(tree, nxJson);
+
+      await migrateVitestToVitestPackage(tree);
+
+      const updatedNxJson = readNxJson(tree);
+      expect(updatedNxJson.targetDefaults['@nx/vite:test']).toBeUndefined();
+      expect(updatedNxJson.targetDefaults['@nx/vitest:test']).toEqual({
+        cache: true,
+        inputs: ['default', '^production'],
+      });
+    });
+
+    it('should merge with existing @nx/vitest:test targetDefaults', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        '@nx/vite:test': {
+          cache: true,
+        },
+        '@nx/vitest:test': {
+          inputs: ['default'],
+        },
+      };
+      updateNxJson(tree, nxJson);
+
+      await migrateVitestToVitestPackage(tree);
+
+      const updatedNxJson = readNxJson(tree);
+      expect(updatedNxJson.targetDefaults['@nx/vite:test']).toBeUndefined();
+      expect(updatedNxJson.targetDefaults['@nx/vitest:test']).toEqual({
+        cache: true,
+        inputs: ['default'],
+      });
+    });
+
+    it('should not modify targetDefaults if @nx/vite:test is not present', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        build: {
+          cache: true,
+        },
+      };
+      updateNxJson(tree, nxJson);
+
+      await migrateVitestToVitestPackage(tree);
+
+      const updatedNxJson = readNxJson(tree);
+      expect(updatedNxJson.targetDefaults).toEqual({
+        build: {
+          cache: true,
+        },
+      });
+    });
+  });
+
+  describe('no-op scenarios', () => {
+    it('should handle empty workspace', async () => {
+      // Should not throw during migration logic
+      await migrateVitestToVitestPackage(tree);
+
+      // Verify migration ran without issues
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@nx/vitest']).toBeDefined();
+    });
+
+    it('should handle workspace without plugins', async () => {
+      const nxJson = readNxJson(tree);
+      delete nxJson.plugins;
+      updateNxJson(tree, nxJson);
+
+      await migrateVitestToVitestPackage(tree);
+
+      // Should not add plugins if none existed
+      const updatedNxJson = readNxJson(tree);
+      expect(updatedNxJson.plugins).toBeUndefined();
+    });
+
+    it('should handle workspace without targetDefaults', async () => {
+      const nxJson = readNxJson(tree);
+      delete nxJson.targetDefaults;
+      updateNxJson(tree, nxJson);
+
+      await migrateVitestToVitestPackage(tree);
+
+      // Should not fail, just skip targetDefaults migration
+      const updatedNxJson = readNxJson(tree);
+      expect(updatedNxJson.targetDefaults).toBeUndefined();
+    });
+  });
+});

--- a/packages/vite/src/migrations/update-22-2-0/migrate-vitest-to-vitest-package.ts
+++ b/packages/vite/src/migrations/update-22-2-0/migrate-vitest-to-vitest-package.ts
@@ -1,0 +1,193 @@
+import {
+  addDependenciesToPackageJson,
+  formatFiles,
+  type GeneratorCallback,
+  readJson,
+  readNxJson,
+  readProjectConfiguration,
+  type Tree,
+  updateNxJson,
+  updateProjectConfiguration,
+} from '@nx/devkit';
+import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
+import { nxVersion } from '../../utils/versions';
+
+interface ViteTestExecutorOptions {
+  configFile?: string;
+  reportsDirectory?: string;
+  mode?: string;
+  testFiles?: string[];
+  watch?: boolean;
+}
+
+/**
+ * Migrates Vitest usage from @nx/vite to @nx/vitest package.
+ *
+ * This migration:
+ * 1. Installs @nx/vitest package if not present
+ * 2. Converts @nx/vite:test executor usages to @nx/vitest:test
+ * 3. Splits @nx/vite/plugin configurations to add @nx/vitest plugin
+ * 4. Migrates targetDefaults from @nx/vite:test to @nx/vitest:test
+ */
+export default async function migrateVitestToVitestPackage(
+  tree: Tree
+): Promise<GeneratorCallback> {
+  const installTask = installVitestPackageIfNeeded(tree);
+  migrateExecutorUsages(tree);
+  migratePluginConfigurations(tree);
+  migrateTargetDefaults(tree);
+
+  await formatFiles(tree);
+
+  return installTask;
+}
+
+function installVitestPackageIfNeeded(tree: Tree): GeneratorCallback {
+  const packageJson = readJson(tree, 'package.json');
+  const hasVitest =
+    packageJson.dependencies?.['@nx/vitest'] ||
+    packageJson.devDependencies?.['@nx/vitest'];
+
+  if (hasVitest) {
+    return () => {};
+  }
+
+  return addDependenciesToPackageJson(tree, {}, { '@nx/vitest': nxVersion });
+}
+
+function migrateExecutorUsages(tree: Tree): void {
+  const projectsToUpdate = new Set<string>();
+
+  forEachExecutorOptions<ViteTestExecutorOptions>(
+    tree,
+    '@nx/vite:test',
+    (_options, projectName, _targetName, _configuration) => {
+      projectsToUpdate.add(projectName);
+    }
+  );
+
+  for (const projectName of projectsToUpdate) {
+    const projectConfig = readProjectConfiguration(tree, projectName);
+
+    for (const [targetName, target] of Object.entries(
+      projectConfig.targets || {}
+    )) {
+      if (target.executor === '@nx/vite:test') {
+        target.executor = '@nx/vitest:test';
+      }
+    }
+
+    updateProjectConfiguration(tree, projectName, projectConfig);
+  }
+}
+
+function migratePluginConfigurations(tree: Tree): void {
+  const nxJson = readNxJson(tree);
+  if (!nxJson?.plugins) {
+    return;
+  }
+
+  const newPlugins: typeof nxJson.plugins = [];
+  let needsVitestPlugin = false;
+  const vitestPluginOptions: Record<string, unknown> = {};
+  let vitestInclude: string[] | undefined;
+  let vitestExclude: string[] | undefined;
+
+  const hasVitestPlugin = nxJson.plugins.some((p) =>
+    typeof p === 'string' ? p === '@nx/vitest' : p.plugin === '@nx/vitest'
+  );
+
+  for (const plugin of nxJson.plugins) {
+    // Handle string plugin format
+    if (typeof plugin === 'string') {
+      newPlugins.push(plugin);
+      continue;
+    }
+
+    // Handle non-vite plugins
+    if (plugin.plugin !== '@nx/vite/plugin') {
+      newPlugins.push(plugin);
+      continue;
+    }
+
+    const options = (plugin.options as Record<string, unknown>) || {};
+    const { testTargetName, ciTargetName, ciGroupName, ...viteOptions } =
+      options;
+
+    // Check if this plugin has test-related options
+    if (testTargetName || ciTargetName || ciGroupName) {
+      // Only collect test options once (from first entry found)
+      if (!needsVitestPlugin) {
+        needsVitestPlugin = true;
+
+        if (testTargetName) {
+          vitestPluginOptions.testTargetName = testTargetName;
+        }
+        if (ciTargetName) {
+          vitestPluginOptions.ciTargetName = ciTargetName;
+        }
+        if (ciGroupName) {
+          vitestPluginOptions.ciGroupName = ciGroupName;
+        }
+
+        // Track include/exclude for vitest plugin
+        if (plugin.include) {
+          vitestInclude = plugin.include as string[];
+        }
+        if (plugin.exclude) {
+          vitestExclude = plugin.exclude as string[];
+        }
+      }
+
+      // Update the vite plugin to remove test options
+      const updatedVitePlugin = { ...plugin };
+      if (Object.keys(viteOptions).length > 0) {
+        updatedVitePlugin.options = viteOptions;
+      } else {
+        delete updatedVitePlugin.options;
+      }
+      newPlugins.push(updatedVitePlugin);
+    } else {
+      newPlugins.push(plugin);
+    }
+  }
+
+  // Add @nx/vitest plugin if needed and not already present
+  if (needsVitestPlugin && !hasVitestPlugin) {
+    const vitestPlugin: {
+      plugin: string;
+      options?: Record<string, unknown>;
+      include?: string[];
+      exclude?: string[];
+    } = { plugin: '@nx/vitest' };
+
+    if (Object.keys(vitestPluginOptions).length > 0) {
+      vitestPlugin.options = vitestPluginOptions;
+    }
+    if (vitestInclude) {
+      vitestPlugin.include = vitestInclude;
+    }
+    if (vitestExclude) {
+      vitestPlugin.exclude = vitestExclude;
+    }
+
+    newPlugins.push(vitestPlugin);
+  }
+
+  nxJson.plugins = newPlugins;
+  updateNxJson(tree, nxJson);
+}
+
+function migrateTargetDefaults(tree: Tree): void {
+  const nxJson = readNxJson(tree);
+  if (!nxJson?.targetDefaults?.['@nx/vite:test']) {
+    return;
+  }
+
+  const viteTestDefaults = nxJson.targetDefaults['@nx/vite:test'];
+  nxJson.targetDefaults['@nx/vitest:test'] ??= {};
+  Object.assign(nxJson.targetDefaults['@nx/vitest:test'], viteTestDefaults);
+  delete nxJson.targetDefaults['@nx/vite:test'];
+
+  updateNxJson(tree, nxJson);
+}


### PR DESCRIPTION
## Current Behavior
We don't have a migration to migrate users to use the new @nx/vitest package if they're currently using @nx/vite
Given that we have Vitest-related operations marked as deprecated when used via @nx/vite, we should have a migration.

## Expected Behavior
Add a migration that:
1. Installs @nx/vitest
2. Switches @nx/vite:test executor usage to use @nx/vitest:test executor usage
3. Splits `@nx/vite/plugin` in nx.json that sets up vitest test targets to use `@nx/vitest` instead
