### PR TITLE
feat(vitest): make initial generation for JS projects more lightweight

### DIFF
--- a/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
@@ -66,7 +66,8 @@ The `@nx/vitest` plugin is configured in the `plugins` array in `nx.json`.
     {
       "plugin": "@nx/vitest",
       "options": {
-        "testTargetName": "test"
+        "testTargetName": "test",
+        "testMode": "watch"
       }
     }
   ]
@@ -74,6 +75,9 @@ The `@nx/vitest` plugin is configured in the `plugins` array in `nx.json`.
 ```
 
 - The `testTargetName` option controls the name of the inferred Vitest tasks. The default name is `test`.
+- The `testMode` option controls whether Vitest runs in watch mode or single-run mode. Valid values are:
+  - `watch` (default): Uses `vitest` command, which runs in watch mode locally but auto-detects CI environments and runs once
+  - `run`: Uses `vitest run` command, which always runs tests once and exits
 
 #### Configuring @nx/vitest for both E2E and Unit Tests
 
@@ -87,7 +91,8 @@ While Vitest is most often used for unit tests, there are cases where it can be 
       "plugin": "@nx/vitest",
       "exclude": ["e2e/**/*"],
       "options": {
-        "testTargetName": "test"
+        "testTargetName": "test",
+        "testMode": "watch"
       }
     },
     {
@@ -95,7 +100,8 @@ While Vitest is most often used for unit tests, there are cases where it can be 
       "include": ["e2e/**/*"],
       "options": {
         "testTargetName": "e2e-local",
-        "ciTargetName": "e2e-ci"
+        "ciTargetName": "e2e-ci",
+        "testMode": "run"
       }
     }
   ]

--- a/packages/vitest/src/plugins/plugin.ts
+++ b/packages/vitest/src/plugins/plugin.ts
@@ -33,6 +33,12 @@ export interface VitestPluginOptions {
    * The name that should be used to group atomized tasks on CI
    */
   ciGroupName?: string;
+  /**
+   * Default mode for running tests.
+   * - 'watch': Tests run in watch mode locally, auto-run in CI (default)
+   * - 'run': Tests run once and exit
+   */
+  testMode?: 'watch' | 'run';
 }
 
 type VitestTargets = Pick<
@@ -204,7 +210,8 @@ async function buildVitestTargets(
     targets[options.testTargetName] = await testTarget(
       namedInputs,
       testOutputs,
-      projectRoot
+      projectRoot,
+      options.testMode
     );
 
     if (options.ciTargetName) {
@@ -303,10 +310,12 @@ async function testTarget(
     [inputName: string]: any[];
   },
   outputs: string[],
-  projectRoot: string
+  projectRoot: string,
+  testMode: 'watch' | 'run' = 'watch'
 ) {
+  const command = testMode === 'run' ? 'vitest run' : 'vitest';
   return {
-    command: `vitest`,
+    command,
     options: { cwd: joinPathFragments(projectRoot) },
     cache: true,
     inputs: [
@@ -386,6 +395,7 @@ function normalizeOutputPath(
 function normalizeOptions(options: VitestPluginOptions): VitestPluginOptions {
   options ??= {};
   options.testTargetName ??= 'test';
+  options.testMode ??= 'watch';
   return options;
 }
 

--- a/packages/vitest/src/utils/generator-utils.ts
+++ b/packages/vitest/src/utils/generator-utils.ts
@@ -268,7 +268,22 @@ ${
     return;
   }
 
-  const viteConfigContent = `/// <reference types='vitest' />
+  // When using vitest.config, use vitest/config import and skip vite-specific options
+  const viteConfigContent = vitestFileName
+    ? `import { defineConfig } from 'vitest/config';
+${imports.join(';\n')}${imports.length ? ';' : ''}
+
+export default defineConfig(() => ({
+  root: __dirname,
+  ${printOptions(
+    cacheDir,
+    plugins.length ? `  plugins: [${plugins.join(', ')}],` : '',
+    defineOption,
+    testOption
+  )}
+}));
+`.replace(/\s+(?=(\n|$))/gm, '\n')
+    : `/// <reference types='vitest' />
 import { defineConfig } from 'vite';
 ${imports.join(';\n')}${imports.length ? ';' : ''}
 

--- a/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/vue/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -103,7 +103,36 @@ export default defineConfig({
 "
 `;
 
-exports[`application generator should set up project correctly for rsbuild 1`] = `null`;
+exports[`application generator should set up project correctly for rsbuild 1`] = `
+"/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+export default defineConfig(() => ({
+  root: import.meta.dirname,
+  cacheDir: '../node_modules/.vite/test',
+  plugins: [vue(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+  // Uncomment this if you are using workers.
+  // worker: {
+  //  plugins: [ nxViteTsPaths() ],
+  // },
+  test: {
+    name: 'test',
+    watch: false,
+    globals: true,
+    environment: 'jsdom',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../coverage/test',
+      provider: 'v8' as const,
+    },
+  },
+}));
+"
+`;
 
 exports[`application generator should set up project correctly for rsbuild 3`] = `
 [
@@ -133,7 +162,7 @@ exports[`application generator should set up project correctly for rsbuild 3`] =
   "test/tsconfig.app.json",
   "test/tsconfig.json",
   "test/tsconfig.spec.json",
-  "test/vite.config.mts",
+  "test/vitest.config.mts",
   "tsconfig.base.json",
   "vitest.workspace.ts",
 ]

--- a/packages/vue/src/generators/application/application.ts
+++ b/packages/vue/src/generators/application/application.ts
@@ -143,10 +143,6 @@ export async function applicationGeneratorInternal(
   if (options.bundler === 'rsbuild') {
     tasks.push(...(await addRsbuild(tree, options)));
     tasks.push(...(await addVitest(tree, options)));
-    tree.rename(
-      joinPathFragments(options.appProjectRoot, 'vite.config.ts'),
-      joinPathFragments(options.appProjectRoot, 'vitest.config.ts')
-    );
   } else {
     tasks.push(await addVite(tree, options));
   }

--- a/packages/vue/src/generators/application/lib/add-vite.ts
+++ b/packages/vue/src/generators/application/lib/add-vite.ts
@@ -65,6 +65,7 @@ export async function addVitest(tree: Tree, options: NormalizedSchema) {
     testEnvironment: 'jsdom',
     addPlugin: options.addPlugin,
     runtimeTsconfigFileName: 'tsconfig.app.json',
+    skipViteConfig: true,
   });
   tasks.push(vitestTask);
 
@@ -79,6 +80,8 @@ export async function addVitest(tree: Tree, options: NormalizedSchema) {
       plugins: ['vue()'],
       useEsmExtension: true,
     },
+    true,
+    undefined,
     true
   );
 


### PR DESCRIPTION
## Expected Behavior
Generate only `vitest.config.mts` file when not bundling with Vite
Use `vite.config` file if it exists already
Add `testMode` option to the `@nx/vitest` Inference Plugin to allow easier switching between `vitest` and `vitest run`.

## Related Issue(s)

Fixes NXC-3334
