### PR TITLE
feat(docker): auto-select version scheme when only one is available

### DIFF
--- a/packages/docker/src/release/version-utils.spec.ts
+++ b/packages/docker/src/release/version-utils.spec.ts
@@ -1,8 +1,13 @@
 import { handleDockerVersion } from './version-utils';
+import { prompt } from 'enquirer';
 
 /** Minimal mock objects to satisfy types without importing full release graph machinery */
 const mockProjectNode: any = { name: 'my-app', data: { root: 'apps/my-app' } };
 const versionActionsVersion = '1.2.3';
+
+jest.mock('enquirer', () => ({
+  prompt: jest.fn(),
+}));
 
 describe('handleDockerVersion {versionActionsVersion} integration', () => {
   beforeEach(() => {
@@ -50,6 +55,64 @@ describe('handleDockerVersion {versionActionsVersion} integration', () => {
     );
 
     expect(newVersion).toBe('explicit-version');
+  });
+
+  it('automatically picks the only available version scheme', async () => {
+    const finalConfigForProject: any = {
+      dockerOptions: {
+        repositoryName: 'repo',
+        registryUrl: undefined,
+        versionSchemes: { prod: '{projectName}-{versionActionsVersion}' },
+      },
+    };
+
+    const { newVersion } = await handleDockerVersion(
+      process.cwd(),
+      mockProjectNode,
+      finalConfigForProject,
+      undefined,
+      undefined,
+      versionActionsVersion
+    );
+
+    expect(newVersion).toBe('my-app-1.2.3');
+  });
+
+  it('prompts for version scheme when multiple are available', async () => {
+    const finalConfigForProject: any = {
+      dockerOptions: {
+        repositoryName: 'repo',
+        registryUrl: undefined,
+        versionSchemes: {
+          prod: '{projectName}-{versionActionsVersion}',
+          dev: '{projectName}-0.0.0',
+        },
+      },
+    };
+
+    // Mock prompt to return 'dev' scheme
+    jest.mocked(prompt).mockResolvedValueOnce({ versionScheme: 'dev' });
+
+    const { newVersion } = await handleDockerVersion(
+      process.cwd(),
+      mockProjectNode,
+      finalConfigForProject,
+      undefined,
+      undefined,
+      versionActionsVersion
+    );
+
+    expect(prompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'versionScheme',
+        type: 'select',
+        choices: expect.arrayContaining([
+          expect.objectContaining({ name: 'prod' }),
+          expect.objectContaining({ name: 'dev' }),
+        ]),
+      })
+    );
+    expect(newVersion).toBe('my-app-0.0.0');
   });
 
   it('falls back to env NX_DOCKER_IMAGE_REF tag if provided (extracting version)', async () => {

--- a/packages/docker/src/release/version-utils.ts
+++ b/packages/docker/src/release/version-utils.ts
@@ -42,6 +42,8 @@ export async function handleDockerVersion(
       const versionScheme =
         dockerVersionScheme && dockerVersionScheme in availableVersionSchemes
           ? dockerVersionScheme
+          : Object.keys(availableVersionSchemes).length === 1
+          ? Object.keys(availableVersionSchemes)[0]
           : await promptForNewVersion(
               availableVersionSchemes,
               projectGraphNode.name


### PR DESCRIPTION
## Problem

When using `{versionActionsVersion}` to manage Docker image versioning, we typically only need a single version scheme:

```json
"docker": {
  "versionSchemes": {
    "default": "{versionActionsVersion}"
  }
}
```

Any version modifications (pre-id, etc.) are handled upstream before the release.

Currently, even with a single scheme defined, the system prompts the user to select it — unless `--dockerVersionScheme` or `--dockerVersion` is explicitly passed. This adds unnecessary friction to the release process.

## Solution

Auto-select the version scheme when only one is available, skipping the prompt entirely.

### Before

```
nx release --projects=my-app
> ? What type of docker release would you like to make for project "my-app"? (Use arrow keys)
> ❯ default
```

### After

```
nx release --projects=my-app
> Using version scheme "default" for project "my-app"
```

No prompt. No extra CLI arguments needed.

## Changes

- Skip version scheme prompt when only one scheme is configured
- Moved single-scheme detection into `promptForNewVersion` for cleaner separation
- Added tests for both single and multiple scheme scenarios