### PR TITLE
fix(core): preserve command output in TUI summary for non-cached tasks

### DIFF
--- a/packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs
+++ b/packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs
@@ -219,8 +219,7 @@ impl PseudoTerminal {
                 .process(command_info.as_bytes());
         } else if !quiet {
             // outside the tui, just print to stdout so the user can see it
-            if let Err(e) = std::io::stdout()
-                .write_all(command_info.as_bytes()) {
+            if let Err(e) = std::io::stdout().write_all(command_info.as_bytes()) {
                 debug!("Failed to write command info to stdout: {}", e);
             }
         }

--- a/packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs
+++ b/packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs
@@ -219,9 +219,10 @@ impl PseudoTerminal {
                 .process(command_info.as_bytes());
         } else if !quiet {
             // outside the tui, just print to stdout so the user can see it
-            std::io::stdout()
-                .write_all(command_info.as_bytes())
-                .expect("Failed to write command info to stdout");
+            if let Err(e) = std::io::stdout()
+                .write_all(command_info.as_bytes()) {
+                debug!("Failed to write command info to stdout: {}", e);
+            }
         }
 
         trace!("Running {}", command_clone);

--- a/packages/nx/src/native/tui/escape_sequences.rs
+++ b/packages/nx/src/native/tui/escape_sequences.rs
@@ -1,0 +1,92 @@
+use crossterm::Command;
+
+/// Wrapper around ANSI escape sequence bytes.
+///
+/// Use `.into()` on any crossterm `Command` to convert it to an `EscapeSequence`.
+pub struct EscapeSequence(Vec<u8>);
+
+impl EscapeSequence {
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl<C: Command> From<C> for EscapeSequence {
+    fn from(cmd: C) -> Self {
+        let mut buffer = String::new();
+        // Writing to a String cannot fail
+        cmd.write_ansi(&mut buffer)
+            .expect("write to String cannot fail");
+        EscapeSequence(buffer.into_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::cursor::{Hide, MoveTo, Show};
+    use crossterm::style::{Color, Print, ResetColor, SetForegroundColor};
+    use crossterm::terminal::{Clear, ClearType};
+
+    #[test]
+    fn test_cursor_hide() {
+        let seq: EscapeSequence = Hide.into();
+        // CSI ?25l - hide cursor
+        assert_eq!(seq.as_bytes(), b"\x1b[?25l");
+    }
+
+    #[test]
+    fn test_cursor_show() {
+        let seq: EscapeSequence = Show.into();
+        // CSI ?25h - show cursor
+        assert_eq!(seq.as_bytes(), b"\x1b[?25h");
+    }
+
+    #[test]
+    fn test_cursor_move_to() {
+        let seq: EscapeSequence = MoveTo(10, 20).into();
+        // CSI row;colH (1-indexed, so row=21, col=11)
+        assert_eq!(seq.as_bytes(), b"\x1b[21;11H");
+    }
+
+    #[test]
+    fn test_print() {
+        let seq: EscapeSequence = Print("hello").into();
+        // Print just outputs the text directly
+        assert_eq!(seq.as_bytes(), b"hello");
+    }
+
+    #[test]
+    fn test_clear_all() {
+        let seq: EscapeSequence = Clear(ClearType::All).into();
+        // CSI 2J - clear entire screen
+        assert_eq!(seq.as_bytes(), b"\x1b[2J");
+    }
+
+    #[test]
+    fn test_reset_color() {
+        let seq: EscapeSequence = ResetColor.into();
+        // CSI 0m - reset all attributes
+        assert_eq!(seq.as_bytes(), b"\x1b[0m");
+    }
+
+    #[test]
+    fn test_set_foreground_color() {
+        let seq: EscapeSequence = SetForegroundColor(Color::Red).into();
+        // Should start with CSI and end with 'm'
+        let bytes = seq.as_bytes();
+        assert!(bytes.starts_with(b"\x1b["));
+        assert!(bytes.ends_with(b"m"));
+    }
+
+    #[test]
+    fn test_into_bytes_consumes() {
+        let seq: EscapeSequence = Hide.into();
+        let bytes = seq.into_bytes();
+        assert_eq!(bytes, b"\x1b[?25l");
+    }
+}

--- a/packages/nx/src/native/tui/mod.rs
+++ b/packages/nx/src/native/tui/mod.rs
@@ -2,6 +2,7 @@ pub mod action;
 pub mod app;
 pub mod components;
 pub mod config;
+pub mod escape_sequences;
 pub mod graph_utils;
 pub mod lifecycle;
 pub mod pty;

--- a/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
@@ -71,8 +71,12 @@ export function getTuiTerminalSummaryLifeCycle({
   lifeCycle.printTaskTerminalOutput = (task, taskStatus, output) => {
     tasksToTaskStatus[task.id] = taskStatus;
     // Store the complete output for display in the summary
-    // This is called with the full output for cached and executed tasks
-    if (output) {
+    // This is called with the full output for cached tasks. For non-cached tasks,
+    // the output doesn't include the portion of the output that prints the command that was being ran.
+    if (
+      output &&
+      !(['failure', 'success'] as Array<TaskStatus>).includes(taskStatus)
+    ) {
       tasksToTerminalOutputs[task.id] = output;
     }
   };

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -95,7 +95,7 @@ async function getTerminalOutputLifeCycle(
   const isRunOne = initiatingProject != null;
 
   if (tasks.length === 1) {
-    process.env.NX_TUI = 'false';
+    process.env.NX_TUI ??= 'false';
   }
 
   if (isTuiEnabled()) {


### PR DESCRIPTION
## Current Behavior

The `printTaskTerminalOutput` callback in the TUI summary life cycle overwrites terminal output for all tasks when output is provided. This causes the command line information (the actual command that was run) to be lost for non-cached tasks because non-cached tasks stream their output via `appendTaskOutput`, which includes the command information.

## Expected Behavior

For non-cached tasks (those with 'failure' or 'success' status), the output should be preserved from the streaming via `appendTaskOutput` which includes the complete command line that was executed. Only cached tasks should have their output overwritten by `printTaskTerminalOutput` since they don't go through the streaming path.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)