### PR TITLE
docs(nx-dev): add Framer rewrite support for nx-dev

### DIFF
--- a/nx-dev/nx-dev/lib/framer-proxy.ts
+++ b/nx-dev/nx-dev/lib/framer-proxy.ts
@@ -1,0 +1,58 @@
+import type { GetServerSidePropsContext } from 'next';
+
+// Parse once at module load time
+const framerUrl = process.env.NEXT_PUBLIC_FRAMER_URL;
+const framerPaths = (process.env.NEXT_PUBLIC_FRAMER_REWRITES || '')
+  .split(',')
+  .map((p) => p.trim())
+  .filter((p) => p.length > 0)
+  .map((p) => (p.startsWith('/') ? p : `/${p}`));
+
+/**
+ * Try to proxy the current page to Framer if configured.
+ *
+ * Add this to any page's getServerSideProps:
+ * ```ts
+ * export const getServerSideProps: GetServerSideProps = async (ctx) => {
+ *   if (await tryFramerProxy(ctx)) return { props: {} };
+ *   return { props: { ... } };
+ * };
+ * ```
+ *
+ * @returns true if proxied to Framer (response already sent), false otherwise
+ */
+export async function tryFramerProxy(
+  ctx: GetServerSidePropsContext
+): Promise<boolean> {
+  const pathname = ctx.resolvedUrl.split('?')[0];
+
+  if (!framerUrl || !framerPaths.includes(pathname)) {
+    return false;
+  }
+
+  try {
+    const response = await fetch(`${framerUrl}${pathname}`, {
+      headers: {
+        'User-Agent': ctx.req.headers['user-agent'] || '',
+        Accept: 'text/html',
+      },
+    });
+
+    if (response.ok) {
+      const html = await response.text();
+      // Revalidate every hour so env var changes take effect
+      ctx.res.setHeader(
+        'Cache-Control',
+        'public, max-age=3600, must-revalidate'
+      );
+      ctx.res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      ctx.res.write(html);
+      ctx.res.end();
+      return true;
+    }
+  } catch (error) {
+    console.error('Error fetching Framer page:', error);
+  }
+
+  return false;
+}

--- a/nx-dev/nx-dev/pages/advent-of-code/index.tsx
+++ b/nx-dev/nx-dev/pages/advent-of-code/index.tsx
@@ -14,6 +14,13 @@ import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export default function AdventOfCode(): JSX.Element {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/ai-chat/index.tsx
+++ b/nx-dev/nx-dev/pages/ai-chat/index.tsx
@@ -2,6 +2,13 @@ import { FeedContainer } from '@nx/nx-dev-feature-ai';
 import { Header } from '@nx/nx-dev-ui-common';
 import { NextSeo } from 'next-seo';
 import { cx } from '@nx/nx-dev-ui-primitives';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export default function AiDocs(): JSX.Element {
   return (

--- a/nx-dev/nx-dev/pages/ai.tsx
+++ b/nx-dev/nx-dev/pages/ai.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from 'next';
 import { DefaultLayout } from '@nx/nx-dev-ui-common';
 import {
   AiHero,
@@ -7,8 +6,15 @@ import {
   WhileRunningCi,
   WhileScalingYourOrganization,
 } from '@nx/nx-dev-ui-ai-landing-page';
+import type { GetServerSideProps } from 'next';
 import type { ReactElement } from 'react';
 import { NextSeo } from 'next-seo';
+import { tryFramerProxy } from '../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function Ai(): ReactElement {
   return (

--- a/nx-dev/nx-dev/pages/community.tsx
+++ b/nx-dev/nx-dev/pages/community.tsx
@@ -11,6 +11,13 @@ import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
 import { champions } from '../lib/champions';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function ChampionsList(): JSX.Element {
   return (

--- a/nx-dev/nx-dev/pages/company.tsx
+++ b/nx-dev/nx-dev/pages/company.tsx
@@ -3,6 +3,13 @@ import { NextSeo } from 'next-seo';
 import { CoFounders, Hero, TheTeam, Layout } from '@nx/nx-dev-ui-company';
 import { CustomerLogos } from '@nx/nx-dev-ui-enterprise';
 import { SectionHeading } from '@nx/nx-dev-ui-common';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function Company(): JSX.Element {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/conf.tsx
+++ b/nx-dev/nx-dev/pages/conf.tsx
@@ -8,6 +8,13 @@ import {
 import { NextSeo } from 'next-seo';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export default function ConfPage(): JSX.Element {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/contact/engineering.tsx
+++ b/nx-dev/nx-dev/pages/contact/engineering.tsx
@@ -2,6 +2,13 @@ import { useRouter } from 'next/router';
 import { NextSeo } from 'next-seo';
 import { Footer, Header } from '@nx/nx-dev-ui-common';
 import { TalkToOurEngineeringTeam } from '@nx/nx-dev-ui-contact';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function EngineeringTeam(): JSX.Element {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/contact/index.tsx
+++ b/nx-dev/nx-dev/pages/contact/index.tsx
@@ -2,6 +2,13 @@ import { useRouter } from 'next/router';
 import { NextSeo } from 'next-seo';
 import { Footer, Header } from '@nx/nx-dev-ui-common';
 import { ContactLinks, HowCanWeHelp } from '@nx/nx-dev-ui-contact';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function Contact(): JSX.Element {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/contact/labs.tsx
+++ b/nx-dev/nx-dev/pages/contact/labs.tsx
@@ -3,6 +3,13 @@ import { NextSeo } from 'next-seo';
 import { Footer, Header } from '@nx/nx-dev-ui-common';
 import { NxLabsContact } from '@nx/nx-dev-ui-contact';
 import { type ReactElement } from 'react';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function ContactNxLabs(): ReactElement {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/contact/sales.tsx
+++ b/nx-dev/nx-dev/pages/contact/sales.tsx
@@ -3,6 +3,13 @@ import { NextSeo } from 'next-seo';
 import { Footer, Header } from '@nx/nx-dev-ui-common';
 import { TalkToOurTeam } from '@nx/nx-dev-ui-contact';
 import { type ReactElement } from 'react';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function ContactSales(): ReactElement {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/customers.tsx
+++ b/nx-dev/nx-dev/pages/customers.tsx
@@ -11,6 +11,13 @@ import {
   OssProjects,
 } from '@nx/nx-dev-ui-customers';
 import { sendCustomEvent } from '@nx/nx-dev-feature-analytics';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function Customers(): JSX.Element {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/enterprise/index.tsx
+++ b/nx-dev/nx-dev/pages/enterprise/index.tsx
@@ -17,6 +17,13 @@ import {
 import { ReactElement } from 'react';
 import { ButtonLinkProps } from '@nx/nx-dev-ui-common';
 import { sendCustomEvent } from '@nx/nx-dev-feature-analytics';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function Enterprise(): ReactElement {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/enterprise/security.tsx
+++ b/nx-dev/nx-dev/pages/enterprise/security.tsx
@@ -12,6 +12,13 @@ import {
   WhyCiSecurityMatters,
 } from '@nx/nx-dev-ui-enterprise';
 import { type ReactElement, useEffect, useState } from 'react';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function EnterpriseSecurity(): ReactElement {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/enterprise/trial.tsx
+++ b/nx-dev/nx-dev/pages/enterprise/trial.tsx
@@ -3,6 +3,13 @@ import { NextSeo } from 'next-seo';
 import { Footer, Header } from '@nx/nx-dev-ui-common';
 import { TrialNxEnterprise } from '@nx/nx-dev-ui-enterprise';
 import { type ReactElement } from 'react';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function EnterpriseTrial(): ReactElement {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/index.tsx
+++ b/nx-dev/nx-dev/pages/index.tsx
@@ -1,4 +1,5 @@
 import { CallToAction, DefaultLayout } from '@nx/nx-dev-ui-common';
+import type { GetServerSideProps } from 'next';
 import { NextSeo } from 'next-seo';
 import {
   Hero,
@@ -9,6 +10,12 @@ import {
   Solution,
   Features,
 } from '@nx/nx-dev-ui-home';
+import { tryFramerProxy } from '../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export default function Index(): JSX.Element {
   return (

--- a/nx-dev/nx-dev/pages/launch-nx.tsx
+++ b/nx-dev/nx-dev/pages/launch-nx.tsx
@@ -10,6 +10,13 @@ import {
 import { NextSeo } from 'next-seo';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export default function ConfPage(): JSX.Element {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/nx-cloud/index.tsx
+++ b/nx-dev/nx-dev/pages/nx-cloud/index.tsx
@@ -15,6 +15,13 @@ import {
   TimeToGreen,
 } from '@nx/nx-dev-ui-cloud';
 import { ButtonLinkProps } from '@nx/nx-dev-ui-common';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function NxCloud(): ReactElement {
   return (

--- a/nx-dev/nx-dev/pages/partners.tsx
+++ b/nx-dev/nx-dev/pages/partners.tsx
@@ -2,6 +2,13 @@ import { DefaultLayout } from '@nx/nx-dev-ui-common';
 import { Hero, PartnersList } from '@nx/nx-dev-ui-partners';
 import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function Partners(): JSX.Element {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/resources-library/index.tsx
+++ b/nx-dev/nx-dev/pages/resources-library/index.tsx
@@ -1,10 +1,14 @@
 import { DefaultLayout } from '@nx/nx-dev-ui-common';
+import type { GetServerSideProps } from 'next';
 import type { ReactElement } from 'react';
 import { NextSeo } from 'next-seo';
 import { ResourceContainer } from '@nx/nx-dev-ui-resources';
 import { Resource } from '@nx/nx-dev-ui-resources';
+import { tryFramerProxy } from '../../lib/framer-proxy';
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: { resources: [] } };
+
   const fs = require('fs');
   const path = require('path');
 
@@ -17,7 +21,7 @@ export async function getStaticProps() {
       resources,
     },
   };
-}
+};
 
 interface ResourcesPageProps {
   resources: Resource[];

--- a/nx-dev/nx-dev/pages/solutions/engineering.tsx
+++ b/nx-dev/nx-dev/pages/solutions/engineering.tsx
@@ -14,6 +14,13 @@ import {
 } from '@nx/nx-dev-ui-enterprise';
 import { type ReactElement } from 'react';
 import { sendCustomEvent } from '@nx/nx-dev-feature-analytics';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function EnterpriseSolutionsEngineering(): ReactElement {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/solutions/leadership.tsx
+++ b/nx-dev/nx-dev/pages/solutions/leadership.tsx
@@ -15,6 +15,13 @@ import {
 } from '@nx/nx-dev-ui-enterprise';
 import { type ReactElement } from 'react';
 import { sendCustomEvent } from '@nx/nx-dev-feature-analytics';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function EnterpriseSolutionsLeadership(): ReactElement {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/solutions/management.tsx
+++ b/nx-dev/nx-dev/pages/solutions/management.tsx
@@ -15,6 +15,13 @@ import {
 } from '@nx/nx-dev-ui-enterprise';
 import { type ReactElement } from 'react';
 import { sendCustomEvent } from '@nx/nx-dev-feature-analytics';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function EnterpriseSolutionsManagement(): ReactElement {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/solutions/platform.tsx
+++ b/nx-dev/nx-dev/pages/solutions/platform.tsx
@@ -15,6 +15,13 @@ import {
 } from '@nx/nx-dev-ui-enterprise';
 import { type ReactElement } from 'react';
 import { sendCustomEvent } from '@nx/nx-dev-feature-analytics';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function EnterpriseSolutionsPlatform(): ReactElement {
   const router = useRouter();

--- a/nx-dev/nx-dev/pages/whitepaper-fast-ci.tsx
+++ b/nx-dev/nx-dev/pages/whitepaper-fast-ci.tsx
@@ -17,6 +17,13 @@ import {
 import { type ReactElement } from 'react';
 import { ArrowDownTrayIcon } from '@heroicons/react/24/outline';
 import { sendCustomEvent } from '@nx/nx-dev-feature-analytics';
+import type { GetServerSideProps } from 'next';
+import { tryFramerProxy } from '../lib/framer-proxy';
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  if (await tryFramerProxy(ctx)) return { props: {} };
+  return { props: {} };
+};
 
 export function WhitePaperFastCI(): ReactElement {
   const router = useRouter();

--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -18,7 +18,9 @@
       "inputs": [
         "production",
         "^production",
-        { "env": "NEXT_PUBLIC_ASTRO_URL" }
+        { "env": "NEXT_PUBLIC_ASTRO_URL" },
+        { "env": "NEXT_PUBLIC_FRAMER_URL" },
+        { "env": "NEXT_PUBLIC_FRAMER_REWRITES" }
       ],
       "outputs": ["{workspaceRoot}/dist/nx-dev/nx-dev"]
     },


### PR DESCRIPTION
## Current Behavior
The nx-dev Next.js app can only serve pages from its own codebase or proxy to Astro docs.

## Expected Behavior
Support proxying specific pages to a Framer site via environment variables:
- `NEXT_PUBLIC_FRAMER_URL`: Base URL of the Framer site
- `NEXT_PUBLIC_FRAMER_REWRITES`: Comma-separated paths for new pages

For existing pages like `/ai`, the proxy is handled in `getServerSideProps`.

## Related Issue(s)
Closes DOC-349
