### PR TITLE
fix(maven): remove incorrect threadSafe to parallelism mapping

### DIFF
--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/NxTarget.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/NxTarget.kt
@@ -9,7 +9,6 @@ data class NxTarget(
   val options: ObjectNode?,
   val cache: Boolean,
   val continuous: Boolean,
-  val parallelism: Boolean,
   var dependsOn: ArrayNode? = null,
   var outputs: ArrayNode? = null,
   var inputs: ArrayNode? = null
@@ -22,7 +21,6 @@ data class NxTarget(
     }
     node.put("cache", cache)
     node.put("continuous", continuous)
-    node.put("parallelism", parallelism)
 
     dependsOn?.let { node.set<ObjectNode>("dependsOn", it) }
     outputs?.let { node.set<ObjectNode>("outputs", it) }

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/utils/MojoAnalyzer.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/utils/MojoAnalyzer.kt
@@ -14,7 +14,6 @@ data class MojoAnalysis(
   val outputs: Set<String>,
   val isCacheable: Boolean,
   val isContinuous: Boolean,
-  val isThreadSafe: Boolean,
 )
 
 class MojoAnalyzer(
@@ -29,7 +28,7 @@ class MojoAnalyzer(
   }
 
   /**
-   * Aggregates cacheability, thread-safety, and input/output metadata for a mojo.
+   * Aggregates cacheability and input/output metadata for a mojo.
    */
   fun analyzeMojo(
     pluginDescriptor: PluginDescriptor,
@@ -44,15 +43,13 @@ class MojoAnalyzer(
         return null
       }
 
-    val isThreadSafe = mojoDescriptor.isThreadSafe
-
     val isCacheable = isPluginCacheable(pluginDescriptor, mojoDescriptor)
 
     val isContinuous = isPluginContinuous(pluginDescriptor, mojoDescriptor)
 
     if (!isCacheable) {
       log.info("${pluginDescriptor.artifactId}:$goal is not cacheable")
-      return MojoAnalysis(emptySet(), emptySet(), emptySet(), false, isContinuous, isThreadSafe)
+      return MojoAnalysis(emptySet(), emptySet(), emptySet(), false, isContinuous)
     }
 
     val (inputs, dependentTaskOutputInputs) = getInputs(pluginDescriptor, mojoDescriptor, project)
@@ -64,7 +61,6 @@ class MojoAnalyzer(
       outputs,
       true,
       isContinuous,
-      isThreadSafe
     )
   }
 


### PR DESCRIPTION
## Current Behavior

The Maven plugin incorrectly maps Maven's `isThreadSafe` mojo property to Nx's `parallelism` target property. Maven's `isThreadSafe` indicates whether a mojo can safely run in parallel with other mojos of the same type within the same Maven build (multi-threaded Maven builds).

## Expected Behavior

Nx's `parallelism` controls whether the target can run in parallel alongside anything else - a fundamentally different concept. All Maven targets now default to `parallelism: true`, letting Nx handle parallelism based on its own task graph analysis rather than using Maven's unrelated thread-safety concept.

## Related Issue(s)

N/A - Internal cleanup based on code review feedback.