### PR TITLE
fix(bundling): set buildLibsFromSource in normalize options for Rollup

### DIFF
--- a/packages/rollup/src/executors/rollup/lib/normalize.ts
+++ b/packages/rollup/src/executors/rollup/lib/normalize.ts
@@ -21,6 +21,7 @@ export function normalizeRollupExecutorOptions(
       .concat(options.rollupConfig)
       .filter(Boolean)
       .map((p) => normalizePluginPath(p, root)),
+    buildLibsFromSource: options.buildLibsFromSource ?? true,
     projectRoot: context.projectGraph.nodes[context.projectName].data.root,
     skipTypeCheck: skipTypeCheck || false,
   };

--- a/packages/rollup/src/plugins/with-nx/normalize-options.ts
+++ b/packages/rollup/src/plugins/with-nx/normalize-options.ts
@@ -42,6 +42,12 @@ export function normalizeOptions(
     javascriptEnabled: options.javascriptEnabled ?? false,
     skipTypeCheck: options.skipTypeCheck ?? false,
     skipTypeField: options.skipTypeField ?? false,
+    /**
+     * TODO(v23): Update default to true
+     * This defaults to false for pure plugin usage to match what is the current behaviour for users
+     * However, this differs from the Rollup executor usage as it defaulted to `true` in the `schema.json`
+     */
+    buildLibsFromSource: options.buildLibsFromSource ?? false,
   };
 }
 


### PR DESCRIPTION
## Current Behavior
`buildLibsFromSource` defaults to true only in the `@nx/rollup:rollup` executor.
In the normalize options helper for the executor, it is not handled at all. Programmatic usage would therefore result in `undefined`.

For pure Inference Plugin usage, `buildLibsFromSource` is also not handled in normalize options.
Therefore, it always defaults to `undefined`.

## Expected Behavior
To reduce breaking changes, force `buildLibsFromSource` to be false for Inference Plugin usage.
Explicitly set it in executor's normalize options helper to true to match the schema default.

## Related Issue(s)

Fixes NXC-3537
