### PR TITLE
feat(vitest): update @analogjs/vitest-angular to 2.1.2 #33602

### DIFF
--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -136,6 +136,19 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "22.2.0-analog": {
+      "version": "22.2.0-beta.3",
+      "packages": {
+        "@analogjs/vite-plugin-angular": {
+          "version": "~2.1.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@analogjs/vitest-angular": {
+          "version": "~2.1.2",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/vite/src/utils/versions.ts
+++ b/packages/vite/src/utils/versions.ts
@@ -18,7 +18,7 @@ export const happyDomVersion = '~9.20.3';
 export const edgeRuntimeVmVersion = '~3.0.2';
 export const jitiVersion = '2.4.2';
 
-export const analogVitestAngular = '~1.19.1';
+export const analogVitestAngular = '~2.1.2';
 
 // Coverage providers
 export const vitestV4CoverageV8Version = '^4.0.0';

--- a/packages/vitest/migrations.json
+++ b/packages/vitest/migrations.json
@@ -32,6 +32,19 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "22.2.0-analog": {
+      "version": "22.2.0-beta.3",
+      "packages": {
+        "@analogjs/vite-plugin-angular": {
+          "version": "~2.1.2",
+          "alwaysAddToPackageJson": false
+        },
+        "@analogjs/vitest-angular": {
+          "version": "~2.1.2",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/vitest/src/utils/versions.ts
+++ b/packages/vitest/src/utils/versions.ts
@@ -16,7 +16,7 @@ export const happyDomVersion = '~9.20.3';
 export const edgeRuntimeVmVersion = '~3.0.2';
 export const jitiVersion = '2.4.2';
 
-export const analogVitestAngular = '~1.19.1';
+export const analogVitestAngular = '~2.1.2';
 
 // Coverage providers
 export const vitestV4CoverageV8Version = '^4.0.0';


### PR DESCRIPTION
## Current Behavior
Trying to create a new workspace is failing on npm peer dep conflicts when trying to use Vitest with Angular.
The version of `@analogjs/vitest-angular` only supports Vitest <4.

## Expected Behavior
Update to latest version of `@analogjs/vitest-angular` to support Vitest 4

## Related Issue(s)

Fixes #33602
