### PR TITLE
fix(core): validate native file cache size before applying it

### DIFF
--- a/packages/nx/src/native/index.js
+++ b/packages/nx/src/native/index.js
@@ -134,7 +134,7 @@ Module._load = function (request, parent, isMain) {
 
     // All retries failed - warn and load from original location
     console.warn(
-      `Warning: Failed to copy native module to cache after ${maxRetries} attempts. ` +
+      `Warning: Failed to copy native module to cache after ${MAX_COPY_RETRIES} attempts. ` +
         `Loading from original location instead. ` +
         `This may cause file locking issues on Windows.`
     );


### PR DESCRIPTION
## Current Behavior
We dont validate the size of the native file cache after copying it, which sometimes fails and corrupts the data. This failure results in a different size, so we can detect it. In certain situations, the corruption causes node to hang instead of throw.

## Expected Behavior
We detect the corruption

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #30653
Fixes #31300
