### PR TITLE
feat(gradle): add targetNamePrefix option to mark all gradle targets

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectGraphReportPlugin.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectGraphReportPlugin.kt
@@ -32,10 +32,14 @@ class NxProjectGraphReportPlugin : Plugin<Project> {
               project.properties
                   .filterKeys { it.endsWith("TargetName") }
                   .mapValues { it.value.toString() }
+
+          val targetNamePrefix: String = project.findProperty("targetNamePrefix")?.toString() ?: ""
+
           task.projectName.set(project.name)
           task.projectRef.set(project)
           task.hash.set(hashProperty)
           task.targetNameOverrides.set(targetNameOverrides)
+          task.targetNamePrefix.set(targetNamePrefix)
           task.workspaceRoot.set(workspaceRootProperty)
 
           val conflictingTargetNames =

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectReportTask.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectReportTask.kt
@@ -30,12 +30,15 @@ abstract class NxProjectReportTask @Inject constructor(private val projectLayout
 
   @get:Input abstract val targetNameOverrides: MapProperty<String, String>
 
+  @get:Input abstract val targetNamePrefix: Property<String>
+
   // Don't compute report at configuration time, move it to execution time
   @get:Internal // Prevent Gradle from caching this reference
   abstract val projectRef: Property<Project>
 
   init {
     atomized.convention(true)
+    targetNamePrefix.convention("")
   }
 
   @get:OutputFile
@@ -47,6 +50,7 @@ abstract class NxProjectReportTask @Inject constructor(private val projectLayout
     logger.info("${Date()} Apply task action NxProjectReportTask for ${projectName.get()}")
     logger.info("${Date()} Hash input: ${hash.get()}")
     logger.info("${Date()} Target Name Overrides ${targetNameOverrides.get()}")
+    logger.info("${Date()} Target Name Prefix: ${targetNamePrefix.get()}")
     logger.info("${Date()} Atomized: ${atomized.get()}")
     val project = projectRef.get() // Get project reference at execution time
     val report =
@@ -54,7 +58,8 @@ abstract class NxProjectReportTask @Inject constructor(private val projectLayout
             project,
             targetNameOverrides.get(),
             workspaceRoot.get(),
-            atomized.get()) // Compute report at execution time
+            atomized.get(),
+            targetNamePrefix.get()) // Compute report at execution time
     val reportJson = gson.toJson(report)
 
     if (outputFile.exists() && outputFile.readText() == reportJson) {

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
@@ -12,7 +12,8 @@ fun createNodeForProject(
     project: Project,
     targetNameOverrides: Map<String, String>,
     workspaceRoot: String,
-    atomized: Boolean
+    atomized: Boolean,
+    targetNamePrefix: String = ""
 ): GradleNodeReport {
   val logger = project.logger
   logger.info("${Date()} ${project.name} createNodeForProject: get nodes and dependencies")
@@ -35,7 +36,7 @@ fun createNodeForProject(
   try {
     val gradleTargets: GradleTargets =
         processTargetsForProject(
-            project, dependencies, targetNameOverrides, workspaceRoot, atomized)
+            project, dependencies, targetNameOverrides, workspaceRoot, atomized, targetNamePrefix)
     val projectRoot = project.projectDir.path
 
     // Read project-level nx config if it exists
@@ -84,7 +85,8 @@ fun processTargetsForProject(
     dependencies: MutableSet<Dependency>,
     targetNameOverrides: Map<String, String>,
     workspaceRoot: String,
-    atomized: Boolean
+    atomized: Boolean,
+    targetNamePrefix: String = ""
 ): GradleTargets {
   val targets: NxTargets = mutableMapOf()
   val targetGroups: TargetGroups = mutableMapOf()
@@ -94,6 +96,11 @@ fun processTargetsForProject(
   val logger = project.logger
 
   logger.info("Using workspace root: $workspaceRoot")
+  logger.info("Using target name prefix: '$targetNamePrefix'")
+
+  // Helper function to apply prefix to target names
+  fun applyPrefix(name: String): String =
+      if (targetNamePrefix.isNotEmpty()) "$targetNamePrefix$name" else name
 
   // Create GitIgnoreClassifier once for the entire project
   val gitIgnoreClassifier = GitIgnoreClassifier(File(workspaceRoot))
@@ -102,8 +109,8 @@ fun processTargetsForProject(
 
   logger.info("${Date()} ${project}: Process targets")
 
-  val ciTestTargetBaseName = targetNameOverrides["ciTestTargetName"]
-  val testTargetName = targetNameOverrides.getOrDefault("testTargetName", "test")
+  val ciTestTargetBaseName = targetNameOverrides["ciTestTargetName"]?.let { applyPrefix(it) }
+  val testTargetName = applyPrefix(targetNameOverrides.getOrDefault("testTargetName", "test"))
 
   val testTasks = project.tasks.withType(Test::class.java)
   val hasCiTestTarget = ciTestTargetBaseName != null && testTasks.isNotEmpty() && atomized
@@ -116,13 +123,14 @@ fun processTargetsForProject(
       val now = Date()
       logger.info("$now ${project.name}: Processing task ${task.path}")
 
-      // Apply target name override if applicable
+      // Apply target name override if applicable, then apply prefix
       val targetName =
-          if (task.name == "test" && targetNameOverrides.containsKey("testTargetName")) {
-            targetNameOverrides["testTargetName"]!!
-          } else {
-            task.name
-          }
+          applyPrefix(
+              if (task.name == "test" && targetNameOverrides.containsKey("testTargetName")) {
+                targetNameOverrides["testTargetName"]!!
+              } else {
+                task.name
+              })
 
       // Group task under its group if available, using the overridden name
       task.group
@@ -138,7 +146,8 @@ fun processTargetsForProject(
               externalNodes,
               dependencies,
               targetNameOverrides,
-              gitIgnoreClassifier)
+              gitIgnoreClassifier,
+              targetNamePrefix)
 
       targets[targetName] = target
 
@@ -164,7 +173,7 @@ fun processTargetsForProject(
               if (it.name == "test") {
                 ciTestTargetBaseName
               } else {
-                "$ciTestTargetBaseName-${it.name}"
+                "$ciTestTargetBaseName-${applyPrefix(it.name)}"
               }
 
           addTestCiTargets(
@@ -181,7 +190,8 @@ fun processTargetsForProject(
       }
 
       if (ciTestTargetBaseName != null) {
-        val ciCheckTargetName = targetNameOverrides.getOrDefault("ciCheckTargetName", "check-ci")
+        val ciCheckTargetName =
+            applyPrefix(targetNameOverrides.getOrDefault("ciCheckTargetName", "check-ci"))
         if (task.name == "check") {
           val replacedDependencies =
               (target["dependsOn"] as? List<*>)?.map { dependency ->
@@ -194,8 +204,10 @@ fun processTargetsForProject(
                   hasCiTestTarget && dependsOn.startsWith("${project.name}:") -> {
                     val taskName = dependsOn.removePrefix("${project.name}:")
                     // Check if it's a test task that's not the default test target
-                    if (testTasks.any { it.name == taskName } && taskName != testTargetName) {
-                      "${project.name}:$ciTestTargetBaseName-$taskName"
+                    val prefixedTaskName = applyPrefix(taskName)
+                    if (testTasks.any { it.name == taskName } &&
+                        prefixedTaskName != testTargetName) {
+                      "${project.name}:$ciTestTargetBaseName-$prefixedTaskName"
                     } else {
                       dependency
                     }
@@ -217,11 +229,12 @@ fun processTargetsForProject(
         }
 
         if (task.name == "build") {
-          val ciBuildTargetName = targetNameOverrides.getOrDefault("ciBuildTargetName", "build-ci")
+          val ciBuildTargetName =
+              applyPrefix(targetNameOverrides.getOrDefault("ciBuildTargetName", "build-ci"))
           val replacedDependencies =
               (target["dependsOn"] as? List<*>)?.map { dep ->
                 val dependsOn = dep.toString()
-                if (dependsOn == "${project.name}:check") {
+                if (dependsOn == "${project.name}:${applyPrefix("check")}") {
                   "${project.name}:$ciCheckTargetName"
                 } else {
                   dep

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
@@ -173,7 +173,7 @@ fun processTargetsForProject(
               if (it.name == "test") {
                 ciTestTargetBaseName
               } else {
-                "$ciTestTargetBaseName-${applyPrefix(it.name)}"
+                "$ciTestTargetBaseName-${it.name}"
               }
 
           addTestCiTargets(
@@ -204,10 +204,9 @@ fun processTargetsForProject(
                   hasCiTestTarget && dependsOn.startsWith("${project.name}:") -> {
                     val taskName = dependsOn.removePrefix("${project.name}:")
                     // Check if it's a test task that's not the default test target
-                    val prefixedTaskName = applyPrefix(taskName)
                     if (testTasks.any { it.name == taskName } &&
-                        prefixedTaskName != testTargetName) {
-                      "${project.name}:$ciTestTargetBaseName-$prefixedTaskName"
+                        applyPrefix(taskName) != testTargetName) {
+                      "${project.name}:$ciTestTargetBaseName-$taskName"
                     } else {
                       dependency
                     }

--- a/packages/gradle/src/plugin/utils/gradle-plugin-options.ts
+++ b/packages/gradle/src/plugin/utils/gradle-plugin-options.ts
@@ -2,6 +2,7 @@ export interface GradlePluginOptions {
   testTargetName?: string;
   ciTestTargetName?: string;
   gradleExecutableDirectory?: string;
+  targetNamePrefix?: string;
   [taskTargetName: string]: string | undefined | boolean;
 }
 


### PR DESCRIPTION
## Current Behavior
you can mark some targets generated by gradle by specifying options.

## Expected Behavior
you can apply a prefix to all targets generated by gradle. This is useful for targetDefaults, for example.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Gradle option to prefix all generated Nx target names (including dependencies and CI targets) with tests to avoid double-prefixing.
> 
> - **Gradle project graph**:
>   - Apply optional `targetNamePrefix` to all target names and dependency rewrites in `createNodeForProject`, `processTargetsForProject`, and `getDependsOnForTask`.
>   - Wire prefix through plugin/task: read in `NxProjectGraphReportPlugin`, expose on `NxProjectReportTask`, and pass to processing functions.
>   - Ensure CI targets (`ciTestTargetName`, `check-ci`, `build-ci`) are correctly prefixed and not double-prefixed; update dependency replacement logic accordingly.
>   - Add logging for prefix usage.
> - **Plugin options (TS)**:
>   - Extend `GradlePluginOptions` with `targetNamePrefix` in `packages/gradle/src/plugin/utils/gradle-plugin-options.ts`.
> - **E2E tests**:
>   - Add tests validating prefixed targets exist and run, and that CI test targets are not double-prefixed in `e2e/gradle/src/gradle.test.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a5160b8855a32d6c13c33c97379e7aa143a0737. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->