### PR TITLE
fix(react): update @emotion/styled to latest version #31252

### DIFF
--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -119,6 +119,23 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "22.2.0-emotion": {
+      "version": "22.2.0-beta.3",
+      "packages": {
+        "@emotion/react": {
+          "version": "11.14.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@emotion/styled": {
+          "version": "11.14.1",
+          "alwaysAddToPackageJson": false
+        },
+        "@emotion/babel-plugin": {
+          "version": "11.13.5",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -25,9 +25,9 @@ export const babelCoreVersion = '^7.14.5';
 export const styledComponentsVersion = '5.3.6';
 export const typesStyledComponentsVersion = '5.1.26';
 
-export const emotionStyledVersion = '11.11.0';
-export const emotionReactVersion = '11.11.1';
-export const emotionBabelPlugin = '11.11.0';
+export const emotionStyledVersion = '11.14.1';
+export const emotionReactVersion = '11.14.0';
+export const emotionBabelPlugin = '11.13.5';
 
 // WARNING: This needs to be in sync with Next.js' dependency or else there might be issues.
 export const styledJsxVersion = '5.1.2';


### PR DESCRIPTION
## Current Behavior
We currently install an outdated version of `@emotion/styled` that causes Typecheck issues.

## Expected Behavior
Use latest version of Emotion

## Related Issue(s)

Fixes #31252
