### PR TITLE
fix(core): exit with error when generator prompts fail

### DIFF
--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -923,7 +923,7 @@ async function promptForValues(
     .then((values) => ({ ...opts, ...values }))
     .catch((e) => {
       console.error(e);
-      process.exit(0);
+      process.exit(1);
     });
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

If there are issues with values passed to generators via prompt, we still see a green output and exit code 0.

A colleague found out about this by pressing `Ctrl+C` when being prompted for parameters for a generator, and this led to the CLI simply continuing execution and showing no issue.

## Expected Behavior

CLI fails.

