### PR TITLE
fix(core): sanitize project names for valid git tag names in nx release

### DIFF
--- a/packages/nx/src/command-line/release/utils/release-graph.ts
+++ b/packages/nx/src/command-line/release/utils/release-graph.ts
@@ -21,7 +21,7 @@ import {
   type AfterAllProjectsVersioned,
   type VersionActions,
 } from '../version/version-actions';
-import { getLatestGitTagForPattern } from './git';
+import { getLatestGitTagForPattern, sanitizeProjectNameForGitTag } from './git';
 import { shouldSkipVersionActions, type VersionDataEntry } from './shared';
 
 /**
@@ -627,7 +627,7 @@ export class ReleaseGraph {
           latestMatchingGitTag = await getLatestGitTagForPattern(
             releaseTagPattern,
             {
-              projectName: projectGraphNode.name,
+              projectName: sanitizeProjectNameForGitTag(projectGraphNode.name),
               releaseGroupName: releaseGroupNode.group.name,
             },
             {

--- a/packages/nx/src/command-line/release/utils/shared.spec.ts
+++ b/packages/nx/src/command-line/release/utils/shared.spec.ts
@@ -457,6 +457,89 @@ describe('shared', () => {
       ]);
     });
 
+    it('should sanitize Gradle-style project names with colons in independent groups', () => {
+      const projects = [':common:iam-client'];
+      const releaseGroup: ReleaseGroupWithName = {
+        name: 'gradle-group',
+        projects,
+        projectsRelationship: 'independent',
+        releaseTag: {
+          pattern: 'release/{projectName}/{version}',
+          checkAllBranchesWhen: undefined,
+          requireSemver: true,
+          preferDockerVersion: undefined,
+          strictPreid: false,
+        },
+        changelog: undefined,
+        version: undefined,
+        versionPlans: false,
+        resolvedVersionPlans: false,
+      };
+
+      const releaseGroupToFilteredProjects = new Map<
+        ReleaseGroupWithName,
+        Set<string>
+      >().set(releaseGroup, new Set(projects));
+
+      const versionData = {
+        ':common:iam-client': {
+          currentVersion: '1.0.0',
+          dependentProjects: [],
+          newVersion: '1.0.1',
+        },
+      };
+
+      const tags = createGitTagValues(
+        [releaseGroup],
+        releaseGroupToFilteredProjects,
+        versionData
+      );
+
+      // Colons should be replaced with slashes
+      expect(tags).toEqual(['release/common/iam-client/1.0.1']);
+    });
+
+    it('should sanitize nested Gradle-style project names', () => {
+      const projects = [':apps:backend:api-service'];
+      const releaseGroup: ReleaseGroupWithName = {
+        name: 'gradle-group',
+        projects,
+        projectsRelationship: 'independent',
+        releaseTag: {
+          pattern: '{projectName}@{version}',
+          checkAllBranchesWhen: undefined,
+          requireSemver: true,
+          preferDockerVersion: undefined,
+          strictPreid: false,
+        },
+        changelog: undefined,
+        version: undefined,
+        versionPlans: false,
+        resolvedVersionPlans: false,
+      };
+
+      const releaseGroupToFilteredProjects = new Map<
+        ReleaseGroupWithName,
+        Set<string>
+      >().set(releaseGroup, new Set(projects));
+
+      const versionData = {
+        ':apps:backend:api-service': {
+          currentVersion: '2.0.0',
+          dependentProjects: [],
+          newVersion: '2.1.0',
+        },
+      };
+
+      const tags = createGitTagValues(
+        [releaseGroup],
+        releaseGroupToFilteredProjects,
+        versionData
+      );
+
+      expect(tags).toEqual(['apps/backend/api-service@2.1.0']);
+    });
+
     function setUpReleaseGroup() {
       const projects = ['a', 'b'];
       const releaseGroup: ReleaseGroupWithName = {

--- a/packages/nx/src/command-line/release/utils/shared.ts
+++ b/packages/nx/src/command-line/release/utils/shared.ts
@@ -12,7 +12,12 @@ import { interpolate } from '../../../tasks-runner/utils';
 import type { NxArgs } from '../../../utils/command-line-utils';
 import { output } from '../../../utils/output';
 import type { ReleaseGroupWithName } from '../config/filter-release-groups';
-import { GitCommit, gitAdd, gitCommit } from './git';
+import {
+  GitCommit,
+  gitAdd,
+  gitCommit,
+  sanitizeProjectNameForGitTag,
+} from './git';
 import { NxReleaseConfig } from '../config/config';
 
 export const noDiffInChangelogMessage = chalk.yellow(
@@ -73,7 +78,9 @@ export class ReleaseVersion {
     this.rawVersion = version;
     this.gitTag = interpolate(releaseTagPattern, {
       version,
-      projectName,
+      projectName: projectName
+        ? sanitizeProjectNameForGitTag(projectName)
+        : projectName,
     });
     this.isPrerelease = isPrerelease(version);
   }
@@ -288,7 +295,7 @@ export function createGitTagValues(
               tags.push(
                 interpolate(releaseGroup.releaseTag.pattern, {
                   version: projectVersionData.dockerVersion,
-                  projectName: project,
+                  projectName: sanitizeProjectNameForGitTag(project),
                 })
               );
             }
@@ -296,7 +303,7 @@ export function createGitTagValues(
               tags.push(
                 interpolate(releaseGroup.releaseTag.pattern, {
                   version: projectVersionData.newVersion,
-                  projectName: project,
+                  projectName: sanitizeProjectNameForGitTag(project),
                 })
               );
             }
@@ -307,7 +314,7 @@ export function createGitTagValues(
                 version: preferDockerVersion
                   ? projectVersionData.dockerVersion
                   : projectVersionData.newVersion,
-                projectName: project,
+                projectName: sanitizeProjectNameForGitTag(project),
               })
             );
           }


### PR DESCRIPTION
Gradle multi-module projects have project names with colons (e.g., `:common:iam-client`)
which are invalid in git tag names. This adds a `sanitizeProjectNameForGitTag()` function
that replaces colons with slashes and other invalid git ref characters with hyphens.

The sanitization is applied when:
- Creating git tags in `createGitTagValues()`
- Creating the `ReleaseVersion` class gitTag property
- Matching existing tags in `getLatestGitTagForPattern()`

Fixes #33262
