### PR TITLE
fix(angular-rspack): use CJS when serving applications for HMR #33106

### DIFF
--- a/examples/angular-rspack/csr-css/src/app/scss-inline-test.ts
+++ b/examples/angular-rspack/csr-css/src/app/scss-inline-test.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
   selector: 'app-scss-inline-test',
   template: `
     <div class="content">
-      <h1>SCSS Inline Test</h1>
+      <h1>SCSS Inline Test {{ appName }}</h1>
       <p>This is a test of SCSS Inline</p>
     </div>
   `,
@@ -33,4 +33,7 @@ import { Component } from '@angular/core';
     `,
   ],
 })
-export class ScssInlineTestComponent {}
+export class ScssInlineTestComponent {
+  // Use this to test HMR updates for TS properties
+  appName = 'hello';
+}

--- a/packages/angular-rspack/src/lib/config/config-utils/browser-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/browser-config.ts
@@ -52,12 +52,21 @@ export async function getBrowserConfig(
       cssFilename: `[name]${hashFormat.file}.css`,
       filename: `[name]${hashFormat.chunk}.js`,
       chunkFilename: `[name]${hashFormat.chunk}.js`,
-      scriptType: 'module',
-      module: true,
+      ...(isDevServer
+        ? {}
+        : {
+            scriptType: 'module',
+            module: true,
+            chunkFormat: 'module',
+            chunkLoading: 'import',
+            workerChunkLoading: 'import',
+          }),
     },
-    experiments: {
-      outputModule: true,
-    },
+    experiments: isDevServer
+      ? {}
+      : {
+          outputModule: true,
+        },
     resolve: {
       ...defaultConfig.resolve,
       mainFields: ['es2020', 'es2015', 'browser', 'module', 'main'],


### PR DESCRIPTION
## Current Behavior
Angular Rspack outputs ESM for build and serve. However, with serve, it causes issue for HMR.

## Expected Behavior
Use CJS for serve to allow HMR to work correctly

## Related Issue(s)

Fixes #33106
