### PR TITLE
fix(angular-rspack): ensure rebuild logs are only printed once

### DIFF
--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -301,13 +301,13 @@ export class AngularRspackPlugin implements RspackPluginInstance {
           }
         }
       });
+    });
 
-      compiler.hooks.afterDone.tap(PLUGIN_NAME, (stats) => {
-        rspackStatsLogger(stats, getStatsOptions(this.#_options.verbose));
-        if (stats.hasErrors()) {
-          process.exit(1);
-        }
-      });
+    compiler.hooks.afterDone.tap(PLUGIN_NAME, (stats) => {
+      rspackStatsLogger(stats, getStatsOptions(this.#_options.verbose));
+      if (stats.hasErrors()) {
+        process.exit(1);
+      }
     });
 
     compiler.hooks.normalModuleFactory.tap(


### PR DESCRIPTION
## Current Behavior
Rebuild logs during serve of Angular Rspack applications are logged an exponential number of times with each change.

## Expected Behavior
Log only once
