### PR TITLE
fix(core): cnw sends correct selectedRepositoryName; prints instructions when user Ctrl+C

### DIFF
--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -109,7 +109,8 @@ export async function createNxCloudOnboardingUrl(
     meta,
     false,
     useGitHub ??
-      (nxCloud === 'yes' || nxCloud === 'github' || nxCloud === 'circleci')
+      (nxCloud === 'yes' || nxCloud === 'github' || nxCloud === 'circleci'),
+    directory
   );
 }
 

--- a/packages/nx/src/nx-cloud/utilities/url-shorten.ts
+++ b/packages/nx/src/nx-cloud/utilities/url-shorten.ts
@@ -10,9 +10,10 @@ export async function createNxCloudOnboardingURL(
   accessToken?: string,
   meta?: string,
   forceManual = false,
-  forceGithub = false
+  forceGithub = false,
+  directory?: string
 ) {
-  const remoteInfo = getVcsRemoteInfo();
+  const remoteInfo = getVcsRemoteInfo(directory);
   const apiUrl = getCloudUrl();
 
   const installationSupportsGitHub = await getInstallationSupportsGitHub(

--- a/packages/nx/src/utils/git-utils.ts
+++ b/packages/nx/src/utils/git-utils.ts
@@ -289,11 +289,12 @@ export function parseVcsRemoteUrl(url: string): VcsRemoteInfo | null {
   return null;
 }
 
-export function getVcsRemoteInfo(): VcsRemoteInfo | null {
+export function getVcsRemoteInfo(directory?: string): VcsRemoteInfo | null {
   try {
     const gitRemote = execSync('git remote -v', {
       stdio: 'pipe',
       windowsHide: false,
+      cwd: directory,
     })
       .toString()
       .trim();


### PR DESCRIPTION
This PR adds `SIGINT` handling when user kills the process via `Ctrl+C` during CNW. This only prints when the workspace setup is complete, and we also print the Cloud onboarding URL if it has been set up.

Also fixes an issue where `selectedRepositoryName` is never sent during CNW.