### PR TITLE
feat(core): add packageManager field when setting up new workspaces

### DIFF
--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -444,7 +444,10 @@ export function runCreatePlugin(
     const create = execSync(`${command}${isVerbose() ? ' --verbose' : ''}`, {
       cwd: e2eCwd,
       stdio: 'pipe',
-      env: process.env,
+      env: {
+        ...process.env,
+        COREPACK_ENABLE_PROJECT_FIELD: '0',
+      },
       encoding: 'utf-8',
     });
 
@@ -484,7 +487,10 @@ export function packageInstall(
     const install = execSync(command, {
       cwd,
       stdio: isVerbose() ? 'inherit' : 'pipe',
-      env: process.env,
+      env: {
+        ...process.env,
+        COREPACK_ENABLE_PROJECT_FIELD: '0',
+      },
       encoding: 'utf-8',
     });
 
@@ -538,7 +544,10 @@ export function runNgNew(
   execSync(command, {
     cwd: e2eCwd,
     stdio: isVerbose() ? 'inherit' : 'pipe',
-    env: process.env,
+    env: {
+      ...process.env,
+      COREPACK_ENABLE_PROJECT_FIELD: '0',
+    },
     encoding: 'utf-8',
   });
 
@@ -561,7 +570,10 @@ export function runNgNew(
   execSync(pmc.install, {
     cwd: join(e2eCwd, projName),
     stdio: isVerbose() ? 'inherit' : 'pipe',
-    env: process.env,
+    env: {
+      ...process.env,
+      COREPACK_ENABLE_PROJECT_FIELD: '0',
+    },
     encoding: 'utf-8',
   });
 

--- a/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
+++ b/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`new --preset should generate necessary npm dependencies for empty preset 1`] = `
 {
@@ -10,6 +10,7 @@ exports[`new --preset should generate necessary npm dependencies for empty prese
   },
   "license": "MIT",
   "name": "@my-workspace/source",
+  "packageManager": "npm@<version>",
   "private": true,
   "scripts": {},
   "version": "0.0.0",

--- a/packages/workspace/src/generators/new/files-integrated-repo/package.json__tmpl__
+++ b/packages/workspace/src/generators/new/files-integrated-repo/package.json__tmpl__
@@ -2,6 +2,7 @@
   "name": "@<%= formattedNames.fileName %>/source",
   "version": "0.0.0",
   "license": "MIT",
+  "packageManager": "<%= packageManager %>@<%= packageManagerVersion %>",
   "scripts": {
   },
   "private": true,

--- a/packages/workspace/src/generators/new/files-package-based-repo/package.json__tmpl__
+++ b/packages/workspace/src/generators/new/files-package-based-repo/package.json__tmpl__
@@ -2,6 +2,7 @@
   "name": "@<%= formattedNames.fileName %>/source",
   "version": "0.0.0",
   "license": "MIT",
+  "packageManager": "<%= packageManager %>@<%= packageManagerVersion %>",
   "scripts": {
   },
   "private": true,

--- a/packages/workspace/src/generators/new/files-root-app/package.json__tmpl__
+++ b/packages/workspace/src/generators/new/files-root-app/package.json__tmpl__
@@ -2,6 +2,7 @@
   "name": "@<%= formattedNames.fileName %>/source",
   "version": "0.0.0",
   "license": "MIT",
+  "packageManager": "<%= packageManager %>@<%= packageManagerVersion %>",
   "scripts": {
   },
   "private": true,

--- a/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
@@ -12,6 +12,7 @@ import * as nxSchema from 'nx/schemas/nx-schema.json';
 import { join } from 'path';
 import { Preset } from '../utils/presets';
 import { generateWorkspaceFiles } from './generate-workspace-files';
+import { packageManagerSnapshotSerializer } from './test-utils/package-manager-snapshot-serializer';
 
 jest.mock(
   'nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud',
@@ -30,6 +31,8 @@ jest.mock('nx/src/nx-cloud/utilities/url-shorten', () => ({
     return `https://test.nx.app/connect?source=${source}&token=${token}`;
   },
 }));
+
+expect.addSnapshotSerializer(packageManagerSnapshotSerializer);
 
 describe('@nx/workspace:generateWorkspaceFiles', () => {
   let tree: Tree;
@@ -234,6 +237,7 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
         },
         "license": "MIT",
         "name": "@proj/source",
+        "packageManager": "npm@<version>",
         "private": true,
         "scripts": {},
         "version": "0.0.0",
@@ -263,6 +267,7 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
         },
         "license": "MIT",
         "name": "@proj/source",
+        "packageManager": "pnpm@<version>",
         "private": true,
         "scripts": {},
         "version": "0.0.0",
@@ -314,6 +319,7 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
         },
         "license": "MIT",
         "name": "@proj/source",
+        "packageManager": "npm@<version>",
         "private": true,
         "scripts": {},
         "version": "0.0.0",

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -1,4 +1,5 @@
 import {
+  detectPackageManager,
   generateFiles,
   getPackageManagerVersion,
   names,
@@ -167,7 +168,7 @@ export async function generateWorkspaceFiles(
     tree.root
   );
   options = normalizeOptions(options);
-  createFiles(tree, options);
+  createFiles(tree, options, packageManagerVersion);
   const nxJson = createNxJson(tree, options);
 
   const token =
@@ -266,7 +267,11 @@ function createNxJson(
   return nxJson;
 }
 
-function createFiles(tree: Tree, options: NormalizedSchema) {
+function createFiles(
+  tree: Tree,
+  options: NormalizedSchema,
+  packageManagerVersion: string
+) {
   const formattedNames = names(options.name);
   const filesDirName =
     options.preset === Preset.AngularStandalone ||
@@ -291,7 +296,8 @@ function createFiles(tree: Tree, options: NormalizedSchema) {
     nxCli: false,
     ...(options as object),
     nxVersion,
-    packageManager: options.packageManager,
+    packageManager: options.packageManager ?? detectPackageManager(),
+    packageManagerVersion,
   });
 }
 

--- a/packages/workspace/src/generators/new/new.spec.ts
+++ b/packages/workspace/src/generators/new/new.spec.ts
@@ -10,6 +10,9 @@ import { Preset } from '../utils/presets';
 import { newGenerator, NormalizedSchema } from './new';
 import * as getNpmPackageVersion from './../utils/get-npm-package-version';
 import * as generatePreset from './generate-preset';
+import { packageManagerSnapshotSerializer } from './test-utils/package-manager-snapshot-serializer';
+
+expect.addSnapshotSerializer(packageManagerSnapshotSerializer);
 
 const DEFAULT_PACKAGE_VERSION = '1.0.0';
 
@@ -90,6 +93,7 @@ describe('new', () => {
         directory: 'my-workspace',
         appName: 'app',
         preset: Preset.Apps,
+        packageManager: 'npm',
       });
 
       expect(readJson(tree, 'my-workspace/package.json')).toMatchSnapshot();

--- a/packages/workspace/src/generators/new/test-utils/package-manager-snapshot-serializer.ts
+++ b/packages/workspace/src/generators/new/test-utils/package-manager-snapshot-serializer.ts
@@ -1,0 +1,27 @@
+/**
+ * Jest snapshot serializer that normalizes packageManager versions.
+ * Replaces version numbers like "npm@11.6.1" with "npm@<version>" to prevent
+ * snapshot failures when local/CI package manager versions differ.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const packageManagerSnapshotSerializer: any = {
+  serialize(val, config, indentation, depth, refs, printer) {
+    const normalized = {
+      ...val,
+      packageManager: val.packageManager.replace(
+        /^(npm|pnpm|yarn|bun)@[\d.]+$/,
+        '$1@<version>'
+      ),
+    };
+    return printer(normalized, config, indentation, depth, refs);
+  },
+  test(val) {
+    return (
+      val != null &&
+      typeof val === 'object' &&
+      'packageManager' in val &&
+      typeof val.packageManager === 'string' &&
+      /^(npm|pnpm|yarn|bun)@[\d.]+$/.test(val.packageManager)
+    );
+  },
+};


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently we don't add the `packageManager` property when generating a new workspace. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

We should have it as more and more tooling relies on it to make decisions. (e.g. on CI etc..)

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
