### PR TITLE
fix(release): ensure --preid flag considers stable tags for version determination

### DIFF
--- a/packages/nx/src/command-line/release/utils/git.spec.ts
+++ b/packages/nx/src/command-line/release/utils/git.spec.ts
@@ -27,6 +27,10 @@ my-lib-4@1.2.4-alpha.1
 my-lib-4@1.2.3
 alpha-lib@1.2.4
 alpha-lib@1.2.4-beta.1
+my-lib-5@1.1.1
+my-lib-5@1.1.0-alpha.3
+my-lib-5@1.1.0-alpha.2
+my-lib-5@1.1.0
 lib-only-pre-release@1.2.4-beta.1
 lib-only-pre-release@1.2.4-beta.1+build.1
 my-group@1.5.0
@@ -385,8 +389,9 @@ See merge request nx-release-test/nx-release-test!2`,
         {
           pattern: '{projectName}@{version}',
           projectName: 'alpha-lib',
-          expectedTag: 'alpha-lib@1.2.4-beta.1',
-          expectedVersion: '1.2.4-beta.1',
+          // Alpha lib has a stable 1.2.4 release, so this should be returned regardless of preid
+          expectedTag: 'alpha-lib@1.2.4',
+          expectedVersion: '1.2.4',
           preid: 'beta',
         },
         {
@@ -419,6 +424,13 @@ See merge request nx-release-test/nx-release-test!2`,
           projectName: 'lib-only-pre-release',
           expectedTag: undefined,
           expectedVersion: undefined,
+          preid: 'alpha',
+        },
+        {
+          pattern: '{projectName}@{version}',
+          projectName: 'my-lib-5',
+          expectedTag: 'my-lib-5@1.1.1',
+          expectedVersion: '1.1.1',
           preid: 'alpha',
         },
       ];


### PR DESCRIPTION
When using `nx release version --preid=alpha`, the version determination
now correctly considers both prerelease tags AND stable release tags to
determine the "latest" version. Previously, it would only look at
prerelease tags matching the preid, ignoring stable releases that should
have become the new baseline.

For example, with tags: 1.1.0, 1.1.0-alpha.0, 1.1.0-alpha.1, 1.1.1
- Before: Would return 1.1.0-alpha.1 → bump to 1.1.0-alpha.2
- After: Returns 1.1.1 (stable >= preid base) → bump to 1.1.2-alpha.0

Fixes #33343
