### PR TITLE
chore(repo): update ocean repo to use pnpm

### DIFF
--- a/tools/update-repos/config/repos.json
+++ b/tools/update-repos/config/repos.json
@@ -8,7 +8,7 @@
     "ocean": {
       "repo": "nrwl/ocean",
       "branch": "main",
-      "packageManager": "npm"
+      "packageManager": "pnpm"
     },
     "nx-examples": {
       "repo": "nrwl/nx-examples",


### PR DESCRIPTION
## Current Behavior

The `tools/update-repos/config/repos.json` configuration has the ocean repository set to use `npm` as its package manager.

## Expected Behavior

The ocean repository should be configured to use `pnpm` as its package manager, reflecting the actual package manager used by the repository.

## Related Issue(s)

N/A - Configuration update to reflect actual repository state.