### PR TITLE
docs(nx-dev): add global Cmd+K search shortcut for non-docs pages

### DIFF
--- a/astro-docs/public/global-scripts.js
+++ b/astro-docs/public/global-scripts.js
@@ -1,4 +1,40 @@
 (function () {
+  // Open search modal if signaled via sessionStorage (e.g., from Cmd+K on non-docs pages)
+  var SEARCH_STORAGE_KEY = 'nx-open-search';
+  var SEARCH_EXPIRY_MS = 30000; // 30 seconds
+
+  function openSearchFromStorage() {
+    var timestamp = sessionStorage.getItem(SEARCH_STORAGE_KEY);
+    if (!timestamp) return;
+
+    // Clear immediately to prevent re-triggering
+    sessionStorage.removeItem(SEARCH_STORAGE_KEY);
+
+    // Check if expired (older than 30 seconds)
+    var age = Date.now() - parseInt(timestamp, 10);
+    if (age > SEARCH_EXPIRY_MS) return;
+
+    var openSearchBtn = document.querySelector('button[data-open-modal]');
+    if (openSearchBtn) {
+      openSearchBtn.click();
+      // Focus the search input after modal opens
+      setTimeout(function () {
+        var searchInput = document.querySelector('dialog[open] input');
+        if (searchInput) {
+          searchInput.focus();
+        }
+      }, 100);
+    }
+  }
+
+  // Check on load
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', openSearchFromStorage);
+  } else {
+    // Small delay to ensure search component is initialized
+    setTimeout(openSearchFromStorage, 100);
+  }
+
   const config = window.__CONFIG || {};
   if (!config.isProd) return;
 

--- a/nx-dev/nx-dev/app/layout.tsx
+++ b/nx-dev/nx-dev/app/layout.tsx
@@ -4,6 +4,7 @@ import Script from 'next/script';
 import AppRouterAnalytics from './app-router-analytics';
 import GlobalScripts from './global-scripts';
 // import { LiveStreamNotifier } from '@nx/nx-dev-ui-common';
+import { GlobalSearchHandler } from '@nx/nx-dev-ui-common';
 import '../styles/main.css';
 import { FrontendObservability } from '../lib/components/frontend-observability';
 
@@ -119,6 +120,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         />
       </head>
       <body className="h-full bg-white text-slate-700 antialiased selection:bg-blue-500 selection:text-white dark:bg-slate-900 dark:text-slate-400 dark:selection:bg-sky-500">
+        <GlobalSearchHandler />
         {children}
         {/* <LiveStreamNotifier /> */}
         <FrontendObservability />

--- a/nx-dev/nx-dev/pages/_app.tsx
+++ b/nx-dev/nx-dev/pages/_app.tsx
@@ -9,7 +9,7 @@ import '../styles/main.css';
 import Link from 'next/link';
 import { FrontendObservability } from '../lib/components/frontend-observability';
 import GlobalScripts from '../app/global-scripts';
-import { WebinarNotifier } from 'nx-dev/ui-common/src';
+import { WebinarNotifier, GlobalSearchHandler } from '@nx/nx-dev-ui-common';
 
 export default function CustomApp({
   Component,
@@ -99,6 +99,7 @@ export default function CustomApp({
       <Component {...pageProps} />
       {/* <LiveStreamNotifier /> */}
       <WebinarNotifier />
+      <GlobalSearchHandler />
 
       {/* All tracking scripts consolidated in GlobalScripts component */}
       <GlobalScripts

--- a/nx-dev/ui-common/src/index.ts
+++ b/nx-dev/ui-common/src/index.ts
@@ -28,6 +28,7 @@ export * from './lib/webinar-notifier';
 export * from './lib/hubspot-form';
 export * from './lib/video-modal';
 export * from './lib/video-player';
+export * from './lib/global-search-handler';
 
 export { resourceMenuItems } from './lib/headers/menu-items';
 export { eventItems } from './lib/headers/menu-items';

--- a/nx-dev/ui-common/src/lib/global-search-handler.tsx
+++ b/nx-dev/ui-common/src/lib/global-search-handler.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const SEARCH_STORAGE_KEY = 'nx-open-search';
+const SEARCH_EXPIRY_MS = 30000; // 30 seconds
+
+/**
+ * GlobalSearchHandler - Listens for Cmd+K / Ctrl+K keyboard shortcuts
+ * and redirects to the docs page with the search modal open.
+ *
+ * This component should be included in the root layout of non-docs pages
+ * to provide a consistent search experience across the entire site.
+ *
+ * Uses sessionStorage to signal Astro docs to open the search modal.
+ */
+export function GlobalSearchHandler(): null {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Check for Cmd+K (Mac) or Ctrl+K (Windows/Linux)
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        // Store timestamp in sessionStorage for Astro docs to read
+        sessionStorage.setItem(SEARCH_STORAGE_KEY, Date.now().toString());
+
+        // Redirect to docs
+        window.location.assign('/docs/getting-started/intro');
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  // This component doesn't render anything
+  return null;
+}


### PR DESCRIPTION
Pressing Cmd+K (or Ctrl+K) on non-docs pages does nothing. The Pagefind search is only accessible when already on the documentation pages.

Pressing Cmd+K on any non-docs page redirects to the docs and automatically opens the search modal with focus on the input field.


https://www.loom.com/share/72fcee74620640cab28639e9ad33d962


Closes DOC-314