### PR TITLE
chore(repo): add debug logging to hanging webpack e2e tests

### DIFF
--- a/e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts
@@ -36,9 +36,12 @@ describe('React Module Federation - Webpack Basic - Playwright', () => {
     checkFilesExist(`apps/${remote2}/module-federation.config.ts`);
     checkFilesExist(`apps/${remote3}/module-federation.config.ts`);
 
+    // TODO(@jaysoo): Remove these logs once we identify why this test hangs in CI.
+    console.log(`[core-webpack-basic-playwright] Running test for ${shell}`);
     await expect(runCLIAsync(`test ${shell}`)).resolves.toMatchObject({
       combinedOutput: expect.stringContaining('Test Suites: 1 passed, 1 total'),
     });
+    console.log(`[core-webpack-basic-playwright] Test complete`);
 
     updateFile(
       `apps/${shell}-e2e/src/example.spec.ts`,
@@ -67,13 +70,28 @@ describe('React Module Federation - Webpack Basic - Playwright', () => {
     );
 
     if (runE2ETests()) {
+      console.log(
+        `[core-webpack-basic-playwright] Starting e2e (swc) for ${shell}-e2e`
+      );
       const e2eResultsSwc = await runCommandUntil(
         `e2e ${shell}-e2e`,
         (output) => output.includes('Successfully ran target e2e for project')
       );
+      console.log(
+        `[core-webpack-basic-playwright] e2e (swc) completed with PID ${e2eResultsSwc.pid}`
+      );
 
+      console.log(
+        `[core-webpack-basic-playwright] Killing e2eResultsSwc (PID: ${
+          e2eResultsSwc.pid
+        }, port: ${readPort(shell)})`
+      );
       await killProcessAndPorts(e2eResultsSwc.pid, readPort(shell));
+      console.log(`[core-webpack-basic-playwright] Killed e2eResultsSwc`);
 
+      console.log(
+        `[core-webpack-basic-playwright] Starting e2e (ts-node) for ${shell}-e2e`
+      );
       const e2eResultsTsNode = await runCommandUntil(
         `e2e ${shell}-e2e`,
         (output) => output.includes('Successfully ran target e2e for project'),
@@ -81,7 +99,19 @@ describe('React Module Federation - Webpack Basic - Playwright', () => {
           env: { NX_PREFER_TS_NODE: 'true' },
         }
       );
+      console.log(
+        `[core-webpack-basic-playwright] e2e (ts-node) completed with PID ${e2eResultsTsNode.pid}`
+      );
+
+      console.log(
+        `[core-webpack-basic-playwright] Killing e2eResultsTsNode (PID: ${
+          e2eResultsTsNode.pid
+        }, port: ${readPort(shell)})`
+      );
       await killProcessAndPorts(e2eResultsTsNode.pid, readPort(shell));
+      console.log(
+        `[core-webpack-basic-playwright] Killed e2eResultsTsNode - test complete`
+      );
     }
   }, 500_000);
 });

--- a/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
+++ b/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
@@ -85,28 +85,56 @@ describe('Dynamic Module Federation', () => {
         `
     );
 
+    // TODO(@jaysoo): Remove these logs once we identify why this test hangs in CI.
     // Build host and remote
+    console.log(`[dynamic-federation.webpack] Building ${shell}`);
     const buildOutput = runCLI(`build ${shell}`);
+    console.log(`[dynamic-federation.webpack] Built ${shell}`);
+
+    console.log(`[dynamic-federation.webpack] Building ${remote}`);
     const remoteOutput = runCLI(`build ${remote}`);
+    console.log(`[dynamic-federation.webpack] Built ${remote}`);
 
     expect(buildOutput).toContain('Successfully ran target build');
     expect(remoteOutput).toContain('Successfully ran target build');
 
     if (runE2ETests()) {
       // Serve Remote since it is dynamic and won't be started with the host
+      console.log(
+        `[dynamic-federation.webpack] Starting serve-static for ${remote} on port ${remotePort}`
+      );
       const remoteProcess = await runCommandUntil(
         `serve-static ${remote} --no-watch --verbose`,
         () => {
           return true;
         }
       );
+      console.log(
+        `[dynamic-federation.webpack] serve-static started with PID ${remoteProcess.pid}`
+      );
+
+      console.log(`[dynamic-federation.webpack] Starting e2e for ${shell}-e2e`);
       const hostE2eResultsSwc = await runCommandUntil(
         `e2e ${shell}-e2e --no-watch --verbose`,
         (output) => output.includes('All specs passed!')
       );
+      console.log(
+        `[dynamic-federation.webpack] e2e completed with PID ${hostE2eResultsSwc.pid}`
+      );
 
+      console.log(
+        `[dynamic-federation.webpack] Killing remoteProcess (PID: ${remoteProcess.pid}, port: ${remotePort})`
+      );
       await killProcessAndPorts(remoteProcess.pid, remotePort);
+      console.log(`[dynamic-federation.webpack] Killed remoteProcess`);
+
+      console.log(
+        `[dynamic-federation.webpack] Killing hostE2eResultsSwc (PID: ${hostE2eResultsSwc.pid}, port: ${shellPort})`
+      );
       await killProcessAndPorts(hostE2eResultsSwc.pid, shellPort);
+      console.log(
+        `[dynamic-federation.webpack] Killed hostE2eResultsSwc - test complete`
+      );
     }
   }, 500_000);
 });


### PR DESCRIPTION
Webpack e2e tests occasionally hang in CI without clear indication of where the test gets stuck.

Debug logs will help identify which step the test hangs at, making it easier to diagnose and fix the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)