### PR TITLE
feat(maven): update Maven plugin version to 0.0.11

### DIFF
--- a/packages/maven/maven-plugin/pom.xml
+++ b/packages/maven/maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.nx</groupId>
     <artifactId>nx-parent</artifactId>
-    <version>0.0.10</version>
+    <version>0.0.11</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/migrations.json
+++ b/packages/maven/migrations.json
@@ -18,6 +18,12 @@
       "version": "22.1.0-rc.3",
       "description": "Update Maven plugin version from 0.0.9 to 0.0.10 in pom.xml files",
       "factory": "./dist/migrations/0-0-10/update-pom-xml-version"
+    },
+    "update-0-0-11": {
+      "cli": "nx",
+      "version": "22.2.0-beta.4",
+      "description": "Update Maven plugin version from 0.0.10 to 0.0.11 in pom.xml files",
+      "factory": "./dist/migrations/0-0-11/update-pom-xml-version"
     }
   }
 }

--- a/packages/maven/src/migrations/0-0-11/update-pom-xml-version.ts
+++ b/packages/maven/src/migrations/0-0-11/update-pom-xml-version.ts
@@ -1,0 +1,11 @@
+import { Tree } from '@nx/devkit';
+import { updateNxMavenPluginVersion } from '../../utils/pom-xml-updater';
+
+/**
+ * Migration for @nx/maven v0.0.11
+ * Updates the Maven plugin version to 0.0.11 in pom.xml files
+ */
+export default async function update(tree: Tree) {
+  // Update user pom.xml files
+  updateNxMavenPluginVersion(tree, '0.0.11');
+}

--- a/packages/maven/src/utils/versions.ts
+++ b/packages/maven/src/utils/versions.ts
@@ -1,2 +1,2 @@
 export const nxVersion = require('../../package.json').version;
-export const mavenPluginVersion = '0.0.10';
+export const mavenPluginVersion = '0.0.11';

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>dev.nx</groupId>
   <artifactId>nx-parent</artifactId>
-  <version>0.0.10</version>
+  <version>0.0.11</version>
   <packaging>pom</packaging>
 
   <name>Nx Parent</name>


### PR DESCRIPTION
## Current Behavior

The Maven plugin version is currently at 0.0.10 across all pom.xml files in the repository.

## Expected Behavior

With this PR, the Maven plugin version will be updated to 0.0.11. This includes:
- Updating the version in the root pom.xml
- Updating the version in packages/maven/maven-plugin/pom.xml
- Updating the mavenPluginVersion constant in packages/maven/src/utils/versions.ts
- Adding a migration script to automatically update user pom.xml files from 0.0.10 to 0.0.11

## Related Issue(s)

N/A - Version bump for the Maven plugin