### PR TITLE
chore(repo): add root Maven and Gradle files to Java reviewers in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -110,10 +110,13 @@ rust-toolchain.toml @nrwl/nx-native-reviewers
 # Gradle
 /packages/gradle/** @FrozenPandaz @MaxKless @lourw
 /e2e/gradle/** @FrozenPandaz @MaxKless @lourw
+/build.gradle.kts @FrozenPandaz @MaxKless @lourw
+/settings.gradle.kts @FrozenPandaz @MaxKless @lourw
 
 # Maven
 /packages/maven/** @FrozenPandaz @MaxKless @lourw
 /e2e/maven/** @FrozenPandaz @MaxKless @lourw
+/pom.xml @FrozenPandaz @MaxKless @lourw
 
 # Nx-Plugin
 /packages/plugin/** @nrwl/nx-devkit-reviewers


### PR DESCRIPTION
## Current Behavior

Root Maven and Gradle build files (pom.xml, build.gradle.kts, settings.gradle.kts) are not explicitly assigned to the Java reviewers in CODEOWNERS.

## Expected Behavior

With this PR, the Java reviewers (@FrozenPandaz @MaxKless @lourw) will be automatically added as reviewers when changes are made to:
- `/pom.xml` - Root Maven build file
- `/build.gradle.kts` - Root Gradle build file  
- `/settings.gradle.kts` - Gradle settings file

This ensures the Java team has visibility into changes affecting the root Java build configuration.

## Related Issue(s)

N/A - Maintenance improvement to CODEOWNERS