### PR TITLE
chore(core): skip connect to cloud prompt during migration if `neverConnectToCloud` is set

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -78,7 +78,7 @@ import {
 import { readNxJson } from '../../config/configuration';
 import { runNxSync } from '../../utils/child-process';
 import { daemonClient } from '../../daemon/client/client';
-import { isNxCloudUsed } from '../../utils/nx-cloud-utils';
+import { isNxCloudUsed, isNxCloudDisabled } from '../../utils/nx-cloud-utils';
 import {
   createProjectGraphAsync,
   readProjectsConfigurationFromProjectGraph,
@@ -1551,6 +1551,7 @@ async function generateMigrationsJsonAndUpdatePackageJson(
         ['nx', '@nrwl/workspace'].includes(opts.targetPackage) &&
         (await isMigratingToNewMajor(from, opts.targetVersion)) &&
         !isCI() &&
+        !isNxCloudDisabled(originalNxJson) &&
         !isNxCloudUsed(originalNxJson)
       ) {
         output.success({

--- a/packages/nx/src/utils/nx-cloud-utils.ts
+++ b/packages/nx/src/utils/nx-cloud-utils.ts
@@ -1,7 +1,11 @@
 import { NxJsonConfiguration } from '../config/nx-json';
 
+export function isNxCloudDisabled(nxJson: NxJsonConfiguration): boolean {
+  return process.env.NX_NO_CLOUD === 'true' || nxJson.neverConnectToCloud;
+}
+
 export function isNxCloudUsed(nxJson: NxJsonConfiguration): boolean {
-  if (process.env.NX_NO_CLOUD === 'true' || nxJson.neverConnectToCloud) {
+  if (isNxCloudDisabled(nxJson)) {
     return false;
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

User is always prompted to connect to Nx cloud, unless already connected, in some scenarios (such as jumping major version).

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Under some conditions, like explicitly setting `NX_NO_CLOUD`, the prompt should not appear.

I am aware that setting `CI=true` also prevents that, but it also forces other behaviours that users might not want. When programmatically migrating repos, the best way is to simply execute a command, without having to interact with its options.

