### PR TITLE
fix(testing): set moduleResolution to node in Cypress tsconfig to prevent TS5095 error

### DIFF
--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -601,6 +601,7 @@ exports[`app --strict should enable strict type checking: e2e tsconfig.json 1`] 
   "compilerOptions": {
     "allowJs": true,
     "module": "commonjs",
+    "moduleResolution": "node10",
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,
@@ -1061,6 +1062,7 @@ exports[`app not nested should generate files: e2e tsconfig.json 1`] = `
   "compilerOptions": {
     "allowJs": true,
     "module": "commonjs",
+    "moduleResolution": "node10",
     "noFallthroughCasesInSwitch": true,
     "noImplicitOverride": true,
     "noImplicitReturns": true,

--- a/packages/cypress/src/generators/base-setup/files/tsconfig/non-ts-solution/__directory__/tsconfig.json__ext__
+++ b/packages/cypress/src/generators/base-setup/files/tsconfig/non-ts-solution/__directory__/tsconfig.json__ext__
@@ -1,7 +1,7 @@
 {
   "extends": "<%= tsConfigPath %>",
   "compilerOptions": {
-    "moduleResolution": "node",
+    "moduleResolution": "node10",
     "allowJs": true,
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
     "module": "commonjs",

--- a/packages/cypress/src/generators/base-setup/files/tsconfig/non-ts-solution/__directory__/tsconfig.json__ext__
+++ b/packages/cypress/src/generators/base-setup/files/tsconfig/non-ts-solution/__directory__/tsconfig.json__ext__
@@ -1,6 +1,7 @@
 {
   "extends": "<%= tsConfigPath %>",
   "compilerOptions": {
+    "moduleResolution": "node",
     "allowJs": true,
     "outDir": "<%= offsetFromRoot %>dist/out-tsc",
     "module": "commonjs",

--- a/packages/cypress/src/generators/component-configuration/component-configuration.spec.ts
+++ b/packages/cypress/src/generators/component-configuration/component-configuration.spec.ts
@@ -177,7 +177,7 @@ describe('Cypress Component Configuration', () => {
       '../**/*.d.ts',
     ]);
     expect(cyTsConfig.compilerOptions.outDir).toEqual('../../dist/out-tsc');
-    expect(cyTsConfig.compilerOptions.moduleResolution).toBe('node');
+    expect(cyTsConfig.compilerOptions.moduleResolution).toBe('node10');
     const libTsConfig = readJson(tree, 'libs/cool-lib/tsconfig.lib.json');
     expect(libTsConfig.exclude).toEqual(
       expect.arrayContaining([

--- a/packages/cypress/src/generators/component-configuration/component-configuration.spec.ts
+++ b/packages/cypress/src/generators/component-configuration/component-configuration.spec.ts
@@ -177,6 +177,7 @@ describe('Cypress Component Configuration', () => {
       '../**/*.d.ts',
     ]);
     expect(cyTsConfig.compilerOptions.outDir).toEqual('../../dist/out-tsc');
+    expect(cyTsConfig.compilerOptions.moduleResolution).toBe('node');
     const libTsConfig = readJson(tree, 'libs/cool-lib/tsconfig.lib.json');
     expect(libTsConfig.exclude).toEqual(
       expect.arrayContaining([

--- a/packages/cypress/src/generators/configuration/configuration.spec.ts
+++ b/packages/cypress/src/generators/configuration/configuration.spec.ts
@@ -64,28 +64,29 @@ describe('Cypress e2e configuration', () => {
     ).toBeUndefined();
 
     expect(readJson(tree, 'apps/my-app/tsconfig.json')).toMatchInlineSnapshot(`
-        {
-          "compilerOptions": {
-            "allowJs": true,
-            "module": "commonjs",
-            "outDir": "../../dist/out-tsc",
-            "sourceMap": false,
-            "types": [
-              "cypress",
-              "node",
-            ],
-          },
-          "extends": "../../tsconfig.base.json",
-          "include": [
-            "**/*.ts",
-            "**/*.js",
-            "cypress.config.ts",
-            "**/*.cy.ts",
-            "**/*.cy.js",
-            "**/*.d.ts",
+      {
+        "compilerOptions": {
+          "allowJs": true,
+          "module": "commonjs",
+          "moduleResolution": "node10",
+          "outDir": "../../dist/out-tsc",
+          "sourceMap": false,
+          "types": [
+            "cypress",
+            "node",
           ],
-        }
-      `);
+        },
+        "extends": "../../tsconfig.base.json",
+        "include": [
+          "**/*.ts",
+          "**/*.js",
+          "cypress.config.ts",
+          "**/*.cy.ts",
+          "**/*.cy.js",
+          "**/*.d.ts",
+        ],
+      }
+    `);
     assertCypressFiles(tree, 'apps/my-app/src');
   });
 
@@ -131,28 +132,29 @@ describe('Cypress e2e configuration', () => {
       }
     `);
     expect(readJson(tree, 'apps/my-app/tsconfig.json')).toMatchInlineSnapshot(`
-        {
-          "compilerOptions": {
-            "allowJs": true,
-            "module": "commonjs",
-            "outDir": "../../dist/out-tsc",
-            "sourceMap": false,
-            "types": [
-              "cypress",
-              "node",
-            ],
-          },
-          "extends": "../../tsconfig.base.json",
-          "include": [
-            "**/*.ts",
-            "**/*.js",
-            "cypress.config.ts",
-            "**/*.cy.ts",
-            "**/*.cy.js",
-            "**/*.d.ts",
+      {
+        "compilerOptions": {
+          "allowJs": true,
+          "module": "commonjs",
+          "moduleResolution": "node10",
+          "outDir": "../../dist/out-tsc",
+          "sourceMap": false,
+          "types": [
+            "cypress",
+            "node",
           ],
-        }
-      `);
+        },
+        "extends": "../../tsconfig.base.json",
+        "include": [
+          "**/*.ts",
+          "**/*.js",
+          "cypress.config.ts",
+          "**/*.cy.ts",
+          "**/*.cy.js",
+          "**/*.d.ts",
+        ],
+      }
+    `);
     assertCypressFiles(tree, 'apps/my-app/src');
   });
 
@@ -282,28 +284,29 @@ describe('Cypress e2e configuration', () => {
     assertCypressFiles(tree, 'apps/my-app/e2e/something');
     expect(readJson(tree, 'apps/my-app/e2e/something/tsconfig.json'))
       .toMatchInlineSnapshot(`
-        {
-          "compilerOptions": {
-            "allowJs": true,
-            "module": "commonjs",
-            "outDir": "../../dist/out-tsc",
-            "sourceMap": false,
-            "types": [
-              "cypress",
-              "node",
-            ],
-          },
-          "extends": "../../tsconfig.json",
-          "include": [
-            "**/*.ts",
-            "**/*.js",
-            "../../cypress.config.ts",
-            "../../**/*.cy.ts",
-            "../../**/*.cy.js",
-            "../../**/*.d.ts",
+      {
+        "compilerOptions": {
+          "allowJs": true,
+          "module": "commonjs",
+          "moduleResolution": "node10",
+          "outDir": "../../dist/out-tsc",
+          "sourceMap": false,
+          "types": [
+            "cypress",
+            "node",
           ],
-        }
-      `);
+        },
+        "extends": "../../tsconfig.json",
+        "include": [
+          "**/*.ts",
+          "**/*.js",
+          "../../cypress.config.ts",
+          "../../**/*.cy.ts",
+          "../../**/*.cy.js",
+          "../../**/*.d.ts",
+        ],
+      }
+    `);
     expect(readJson(tree, 'apps/my-app/tsconfig.json').references).toEqual(
       expect.arrayContaining([{ path: './e2e/something/tsconfig.json' }])
     );


### PR DESCRIPTION
When generating Cypress component testing in Angular workspaces, the base tsconfig sets moduleResolution to 'bundler' which causes TS5095 errors because 'bundler' requires module to be 'preserve' or 'es2015+'.

Cypress runs in Node.js and should use Node.js module resolution instead. This fix sets moduleResolution to 'node' for Cypress tsconfig.json templates.

## Current Behavior

When generating Cypress component testing configuration in Angular workspaces, the generated `cypress/tsconfig.json` inherits `moduleResolution: "bundler"` from the workspace base config. Since Cypress uses `module: "commonjs"` for Node.js runtime, this causes TypeScript compiler error TS5095: "Option 'bundler' can only be used when 'module' is set to 'preserve' or to 'es2015' or later."

## Expected Behavior

The generated `cypress/tsconfig.json` should explicitly set `moduleResolution: "node"` to match the `module: "commonjs"` setting, preventing TS5095 errors. This aligns with how NestJS applications handle the same issue (see #33607).