### PR TITLE
fix(module-federation): optimize performance with caching and algorithm improvements

### DIFF
--- a/packages/module-federation/src/plugins/utils/start-remote-proxies.ts
+++ b/packages/module-federation/src/plugins/utils/start-remote-proxies.ts
@@ -1,6 +1,8 @@
 import { StaticRemoteConfig } from '../../utils';
-import { existsSync, readFileSync } from 'fs';
-import { Express } from 'express';
+import {
+  createRemoteProxyServers,
+  RemoteProxyConfig,
+} from '../../utils/proxy-server';
 
 export function startRemoteProxies(
   staticRemotesConfig: Record<string, StaticRemoteConfig>,
@@ -11,52 +13,14 @@ export function startRemoteProxies(
   },
   isServer?: boolean
 ) {
-  const { createProxyMiddleware } = require('http-proxy-middleware');
-  const express = require('express');
-  let sslCert: Buffer | undefined;
-  let sslKey: Buffer | undefined;
-  if (sslOptions && sslOptions.pathToCert && sslOptions.pathToKey) {
-    if (existsSync(sslOptions.pathToCert) && existsSync(sslOptions.pathToKey)) {
-      sslCert = readFileSync(sslOptions.pathToCert);
-      sslKey = readFileSync(sslOptions.pathToKey);
-    } else {
-      console.warn(
-        `Encountered SSL options in project.json, however, the certificate files do not exist in the filesystem. Using http.`
-      );
-      console.warn(
-        `Attempted to find '${sslOptions.pathToCert}' and '${sslOptions.pathToKey}'.`
-      );
-    }
+  // Build remote proxy config map
+  const remotes: Record<string, RemoteProxyConfig> = {};
+  for (const app of Object.keys(staticRemotesConfig)) {
+    remotes[app] = {
+      target: mappedLocationsOfRemotes[app],
+      port: staticRemotesConfig[app].port,
+    };
   }
-  const http = require('http');
-  const https = require('https');
 
-  const remotes = Object.keys(staticRemotesConfig);
-  console.log(`NX Starting static remotes proxies...`);
-  for (const app of remotes) {
-    const appConfig = staticRemotesConfig[app];
-    const expressProxy: Express = express();
-    expressProxy.use(
-      createProxyMiddleware({
-        target: mappedLocationsOfRemotes[app],
-        changeOrigin: true,
-        secure: sslCert ? false : undefined,
-        pathRewrite: isServer
-          ? (path) => {
-              if (path.includes('/server')) {
-                return path;
-              } else {
-                return `browser/${path}`;
-              }
-            }
-          : undefined,
-      })
-    );
-    const proxyServer = (sslCert ? https : http)
-      .createServer({ cert: sslCert, key: sslKey }, expressProxy)
-      .listen(appConfig.port);
-    process.on('SIGTERM', () => proxyServer.close());
-    process.on('exit', () => proxyServer.close());
-  }
-  console.info(`NX Static remotes proxies started successfully`);
+  createRemoteProxyServers(remotes, { sslOptions, isServer });
 }

--- a/packages/module-federation/src/utils/package-json.ts
+++ b/packages/module-federation/src/utils/package-json.ts
@@ -2,7 +2,14 @@ import { joinPathFragments, readJsonFile, workspaceRoot } from '@nx/devkit';
 import { existsSync } from 'fs';
 import type { PackageJson } from 'nx/src/utils/package-json';
 
+// Cache for root package.json to avoid repeated file reads
+let cachedRootPackageJson: PackageJson | undefined;
+
 export function readRootPackageJson(): PackageJson {
+  if (cachedRootPackageJson) {
+    return cachedRootPackageJson;
+  }
+
   const pkgJsonPath = joinPathFragments(workspaceRoot, 'package.json');
   if (!existsSync(pkgJsonPath)) {
     throw new Error(
@@ -10,5 +17,14 @@ export function readRootPackageJson(): PackageJson {
     );
   }
 
-  return readJsonFile(pkgJsonPath);
+  cachedRootPackageJson = readJsonFile(pkgJsonPath);
+  return cachedRootPackageJson;
+}
+
+/**
+ * Clears the cached root package.json.
+ * Primarily used for testing purposes.
+ */
+export function clearRootPackageJsonCache(): void {
+  cachedRootPackageJson = undefined;
 }

--- a/packages/module-federation/src/utils/proxy-server.ts
+++ b/packages/module-federation/src/utils/proxy-server.ts
@@ -1,0 +1,94 @@
+import type { Express } from 'express';
+import { logger } from '@nx/devkit';
+import { existsSync, readFileSync } from 'fs';
+
+export interface ProxyServerOptions {
+  /** SSL certificate and key paths */
+  sslOptions?: {
+    pathToCert: string;
+    pathToKey: string;
+  };
+  /** Whether to apply SSR path rewriting */
+  isServer?: boolean;
+  /** Custom log prefix (default: 'NX') */
+  logPrefix?: string;
+}
+
+export interface RemoteProxyConfig {
+  /** Target URL for the proxy */
+  target: string;
+  /** Port to listen on */
+  port: number;
+}
+
+/**
+ * Creates and starts proxy servers for static remotes.
+ * This is a shared utility used by both regular and SSR remote proxies.
+ *
+ * @param remotes - Map of remote names to their proxy configurations
+ * @param options - Proxy server options
+ */
+export function createRemoteProxyServers(
+  remotes: Record<string, RemoteProxyConfig>,
+  options: ProxyServerOptions = {}
+): void {
+  const { sslOptions, isServer = false, logPrefix = 'NX' } = options;
+
+  const { createProxyMiddleware } = require('http-proxy-middleware');
+  const express = require('express');
+  const http = require('http');
+  const https = require('https');
+
+  // Load SSL certificates if provided
+  let sslCert: Buffer | undefined;
+  let sslKey: Buffer | undefined;
+  if (sslOptions?.pathToCert && sslOptions?.pathToKey) {
+    if (existsSync(sslOptions.pathToCert) && existsSync(sslOptions.pathToKey)) {
+      sslCert = readFileSync(sslOptions.pathToCert);
+      sslKey = readFileSync(sslOptions.pathToKey);
+    } else {
+      logger.warn(
+        `Encountered SSL options in project.json, however, the certificate files do not exist in the filesystem. Using http.`
+      );
+      logger.warn(
+        `Attempted to find '${sslOptions.pathToCert}' and '${sslOptions.pathToKey}'.`
+      );
+    }
+  }
+
+  logger.info(`${logPrefix} Starting static remotes proxies...`);
+
+  for (const [app, config] of Object.entries(remotes)) {
+    const expressProxy: Express = express();
+
+    expressProxy.use(
+      createProxyMiddleware({
+        target: config.target,
+        changeOrigin: true,
+        secure: sslCert ? false : undefined,
+        pathRewrite: isServer
+          ? (path: string) => {
+              if (path.includes('/server')) {
+                return path;
+              } else {
+                return `browser/${path}`;
+              }
+            }
+          : undefined,
+      })
+    );
+
+    const proxyServer = (sslCert ? https : http)
+      .createServer({ cert: sslCert, key: sslKey }, expressProxy)
+      .listen(config.port);
+
+    process.on('SIGTERM', () => proxyServer.close());
+    process.on('exit', () => proxyServer.close());
+  }
+
+  logger.info(
+    `${logPrefix}${
+      isServer ? ' SSR' : ''
+    } Static remotes proxies started successfully`
+  );
+}

--- a/packages/module-federation/src/utils/remote-url.ts
+++ b/packages/module-federation/src/utils/remote-url.ts
@@ -1,0 +1,85 @@
+import { readCachedProjectConfiguration } from 'nx/src/project-graph/project-graph';
+
+// Cache for parsed static remotes environment variable to avoid repeated JSON.parse calls
+let cachedStaticRemotesFromEnv: Record<string, string> | undefined;
+let cachedStaticRemotesEnvValue: string | undefined;
+
+/**
+ * Gets static remotes configuration from the NX_MF_DEV_SERVER_STATIC_REMOTES environment variable.
+ * Results are cached to avoid repeated JSON.parse calls.
+ */
+export function getStaticRemotesFromEnv(): Record<string, string> | undefined {
+  const currentEnvValue = process.env.NX_MF_DEV_SERVER_STATIC_REMOTES;
+  // Only re-parse if the environment variable value has changed
+  if (currentEnvValue !== cachedStaticRemotesEnvValue) {
+    cachedStaticRemotesEnvValue = currentEnvValue;
+    cachedStaticRemotesFromEnv = currentEnvValue
+      ? JSON.parse(currentEnvValue)
+      : undefined;
+  }
+  return cachedStaticRemotesFromEnv;
+}
+
+export interface RemoteUrlOptions {
+  /** Whether this is for a server-side rendering remote */
+  isServer?: boolean;
+  /** The bundler being used ('webpack', 'rspack', or 'angular-rspack') */
+  bundler?: 'webpack' | 'rspack' | 'angular-webpack' | 'angular-rspack';
+}
+
+/**
+ * Creates a function that determines the remote URL for a given remote name.
+ * This is a shared utility used by webpack, rspack, and angular module federation configs.
+ *
+ * @param options - Configuration options for URL determination
+ * @returns A function that takes a remote name and returns its URL
+ */
+export function createRemoteUrlResolver(
+  options: RemoteUrlOptions = {}
+): (remote: string) => string {
+  const { isServer = false, bundler = 'rspack' } = options;
+  const target = 'serve';
+
+  // Determine the remote entry file based on bundler and server mode
+  let remoteEntry: string;
+  if (isServer) {
+    remoteEntry = 'server/remoteEntry.js';
+  } else if (bundler === 'angular-webpack') {
+    remoteEntry = 'remoteEntry.mjs';
+  } else {
+    remoteEntry = 'remoteEntry.js';
+  }
+
+  return function (remote: string): string {
+    const mappedStaticRemotesFromEnv = getStaticRemotesFromEnv();
+    if (mappedStaticRemotesFromEnv && mappedStaticRemotesFromEnv[remote]) {
+      return `${mappedStaticRemotesFromEnv[remote]}/${remoteEntry}`;
+    }
+
+    let remoteConfiguration = null;
+    try {
+      remoteConfiguration = readCachedProjectConfiguration(remote);
+    } catch (e) {
+      throw new Error(
+        `Cannot find remote "${remote}". Check that the remote name is correct in your module federation config file.\n`
+      );
+    }
+
+    const serveTarget = remoteConfiguration?.targets?.[target];
+
+    if (!serveTarget) {
+      throw new Error(
+        `Cannot automatically determine URL of remote (${remote}). Looked for property "host" in the project's "serve" target.\n` +
+          `You can also use the tuple syntax in your config to configure your remotes. e.g. \`remotes: [['remote1', 'http://localhost:4201']]\``
+      );
+    }
+
+    const host =
+      serveTarget.options?.host ??
+      `http${serveTarget.options.ssl ? 's' : ''}://localhost`;
+    const port = serveTarget.options?.port ?? 4201;
+    return `${
+      host.endsWith('/') ? host.slice(0, -1) : host
+    }:${port}/${remoteEntry}`;
+  };
+}

--- a/packages/module-federation/src/utils/share.spec.ts
+++ b/packages/module-federation/src/utils/share.spec.ts
@@ -13,9 +13,14 @@ import {
   sharePackages,
   shareWorkspaceLibraries,
 } from './share';
+import { clearRootPackageJsonCache } from './package-json';
 
 describe('MF Share Utils', () => {
-  afterEach(() => jest.clearAllMocks());
+  afterEach(() => {
+    jest.clearAllMocks();
+    // Clear cached root package.json to ensure fresh reads in each test
+    clearRootPackageJsonCache();
+  });
 
   describe('ShareWorkspaceLibraries', () => {
     it('should error when the tsconfig file does not exist', () => {

--- a/packages/module-federation/src/utils/start-remote-proxies.ts
+++ b/packages/module-federation/src/utils/start-remote-proxies.ts
@@ -1,48 +1,19 @@
-import type { Express } from 'express';
-import { logger } from '@nx/devkit';
 import { StaticRemotesConfig } from './parse-static-remotes-config';
-import { existsSync, readFileSync } from 'fs';
+import { createRemoteProxyServers, RemoteProxyConfig } from './proxy-server';
 
 export function startRemoteProxies(
   staticRemotesConfig: StaticRemotesConfig,
   mappedLocationsOfRemotes: Record<string, string>,
   sslOptions?: { pathToCert: string; pathToKey: string }
 ) {
-  const { createProxyMiddleware } = require('http-proxy-middleware');
-  const express = require('express');
-  let sslCert: Buffer;
-  let sslKey: Buffer;
-  if (sslOptions && sslOptions.pathToCert && sslOptions.pathToKey) {
-    if (existsSync(sslOptions.pathToCert) && existsSync(sslOptions.pathToKey)) {
-      sslCert = readFileSync(sslOptions.pathToCert);
-      sslKey = readFileSync(sslOptions.pathToKey);
-    } else {
-      logger.warn(
-        `Encountered SSL options in project.json, however, the certificate files do not exist in the filesystem. Using http.`
-      );
-      logger.warn(
-        `Attempted to find '${sslOptions.pathToCert}' and '${sslOptions.pathToKey}'.`
-      );
-    }
-  }
-  const http = require('http');
-  const https = require('https');
-
-  logger.info(`NX Starting static remotes proxies...`);
+  // Build remote proxy config map
+  const remotes: Record<string, RemoteProxyConfig> = {};
   for (const app of staticRemotesConfig.remotes) {
-    const expressProxy: Express = express();
-    expressProxy.use(
-      createProxyMiddleware({
-        target: mappedLocationsOfRemotes[app],
-        changeOrigin: true,
-        secure: sslCert ? false : undefined,
-      })
-    );
-    const proxyServer = (sslCert ? https : http)
-      .createServer({ cert: sslCert, key: sslKey }, expressProxy)
-      .listen(staticRemotesConfig.config[app].port);
-    process.on('SIGTERM', () => proxyServer.close());
-    process.on('exit', () => proxyServer.close());
+    remotes[app] = {
+      target: mappedLocationsOfRemotes[app],
+      port: staticRemotesConfig.config[app].port,
+    };
   }
-  logger.info(`NX Static remotes proxies started successfully`);
+
+  createRemoteProxyServers(remotes, { sslOptions });
 }

--- a/packages/module-federation/src/utils/start-ssr-remote-proxies.ts
+++ b/packages/module-federation/src/utils/start-ssr-remote-proxies.ts
@@ -1,65 +1,21 @@
-import type { Express } from 'express';
-import { logger } from '@nx/devkit';
 import type { StaticRemotesConfig } from './parse-static-remotes-config';
-import { existsSync, readFileSync } from 'fs';
+import { createRemoteProxyServers, RemoteProxyConfig } from './proxy-server';
 
 export function startSsrRemoteProxies(
   staticRemotesConfig: StaticRemotesConfig,
   mappedLocationsOfRemotes: Record<string, string>,
   sslOptions?: { pathToCert: string; pathToKey: string }
 ) {
-  const { createProxyMiddleware } = require('http-proxy-middleware');
-  const express = require('express');
-
-  let sslCert: Buffer;
-  let sslKey: Buffer;
-  if (sslOptions && sslOptions.pathToCert && sslOptions.pathToKey) {
-    if (existsSync(sslOptions.pathToCert) && existsSync(sslOptions.pathToKey)) {
-      sslCert = readFileSync(sslOptions.pathToCert);
-      sslKey = readFileSync(sslOptions.pathToKey);
-    } else {
-      logger.warn(
-        `Encountered SSL options in project.json, however, the certificate files do not exist in the filesystem. Using http.`
-      );
-      logger.warn(
-        `Attempted to find '${sslOptions.pathToCert}' and '${sslOptions.pathToKey}'.`
-      );
-    }
-  }
-
-  const http = require('http');
-  const https = require('https');
-
-  logger.info(`NX Starting static remotes proxies...`);
+  // Build remote proxy config map
+  const remotes: Record<string, RemoteProxyConfig> = {};
   for (const app of staticRemotesConfig.remotes) {
-    const expressProxy: Express = express();
-    /**
-     * SSR remotes have two output paths: one for the browser and one for the server.
-     * We need to handle paths for both of them.
-     * The browser output path is used to serve the client-side code.
-     * The server output path is used to serve the server-side code.
-     */
-
-    expressProxy.use(
-      createProxyMiddleware({
-        target: `${mappedLocationsOfRemotes[app]}`,
-        secure: sslCert ? false : undefined,
-        changeOrigin: true,
-        pathRewrite: (path) => {
-          if (path.includes('/server')) {
-            return path;
-          } else {
-            return `browser/${path}`;
-          }
-        },
-      })
-    );
-
-    const proxyServer = (sslCert ? https : http)
-      .createServer({ cert: sslCert, key: sslKey }, expressProxy)
-      .listen(staticRemotesConfig.config[app].port);
-    process.on('SIGTERM', () => proxyServer.close());
-    process.on('exit', () => proxyServer.close());
+    remotes[app] = {
+      target: mappedLocationsOfRemotes[app],
+      port: staticRemotesConfig.config[app].port,
+    };
   }
-  logger.info(`Nx SSR Static remotes proxies started successfully`);
+
+  // SSR remotes have two output paths: one for the browser and one for the server.
+  // The isServer flag enables path rewriting to handle both paths.
+  createRemoteProxyServers(remotes, { sslOptions, isServer: true });
 }

--- a/packages/module-federation/src/with-module-federation/webpack/utils.ts
+++ b/packages/module-federation/src/with-module-federation/webpack/utils.ts
@@ -18,15 +18,28 @@ import { readCachedProjectConfiguration } from 'nx/src/project-graph/project-gra
 import { applyDefaultEagerPackages as applyReactEagerPackages } from '../react/utils';
 import { isReactProject } from '../../utils/framework-detection';
 
+// Cache for parsed static remotes environment variable to avoid repeated JSON.parse calls
+let cachedStaticRemotesFromEnv: Record<string, string> | undefined;
+let cachedStaticRemotesEnvValue: string | undefined;
+
+function getStaticRemotesFromEnv(): Record<string, string> | undefined {
+  const currentEnvValue = process.env.NX_MF_DEV_SERVER_STATIC_REMOTES;
+  // Only re-parse if the environment variable value has changed
+  if (currentEnvValue !== cachedStaticRemotesEnvValue) {
+    cachedStaticRemotesEnvValue = currentEnvValue;
+    cachedStaticRemotesFromEnv = currentEnvValue
+      ? JSON.parse(currentEnvValue)
+      : undefined;
+  }
+  return cachedStaticRemotesFromEnv;
+}
+
 export function getFunctionDeterminateRemoteUrl(isServer: boolean = false) {
   const target = 'serve';
   const remoteEntry = isServer ? 'server/remoteEntry.js' : 'remoteEntry.js';
 
   return function (remote: string) {
-    const mappedStaticRemotesFromEnv = process.env
-      .NX_MF_DEV_SERVER_STATIC_REMOTES
-      ? JSON.parse(process.env.NX_MF_DEV_SERVER_STATIC_REMOTES)
-      : undefined;
+    const mappedStaticRemotesFromEnv = getStaticRemotesFromEnv();
     if (mappedStaticRemotesFromEnv && mappedStaticRemotesFromEnv[remote]) {
       return `${mappedStaticRemotesFromEnv[remote]}/${remoteEntry}`;
     }

--- a/packages/module-federation/src/with-module-federation/webpack/utils.ts
+++ b/packages/module-federation/src/with-module-federation/webpack/utils.ts
@@ -8,67 +8,18 @@ import {
   sharePackages,
   shareWorkspaceLibraries,
 } from '../../utils';
+import { createRemoteUrlResolver } from '../../utils/remote-url';
 
 import {
   createProjectGraphAsync,
   ProjectGraph,
   readCachedProjectGraph,
 } from '@nx/devkit';
-import { readCachedProjectConfiguration } from 'nx/src/project-graph/project-graph';
 import { applyDefaultEagerPackages as applyReactEagerPackages } from '../react/utils';
 import { isReactProject } from '../../utils/framework-detection';
 
-// Cache for parsed static remotes environment variable to avoid repeated JSON.parse calls
-let cachedStaticRemotesFromEnv: Record<string, string> | undefined;
-let cachedStaticRemotesEnvValue: string | undefined;
-
-function getStaticRemotesFromEnv(): Record<string, string> | undefined {
-  const currentEnvValue = process.env.NX_MF_DEV_SERVER_STATIC_REMOTES;
-  // Only re-parse if the environment variable value has changed
-  if (currentEnvValue !== cachedStaticRemotesEnvValue) {
-    cachedStaticRemotesEnvValue = currentEnvValue;
-    cachedStaticRemotesFromEnv = currentEnvValue
-      ? JSON.parse(currentEnvValue)
-      : undefined;
-  }
-  return cachedStaticRemotesFromEnv;
-}
-
 export function getFunctionDeterminateRemoteUrl(isServer: boolean = false) {
-  const target = 'serve';
-  const remoteEntry = isServer ? 'server/remoteEntry.js' : 'remoteEntry.js';
-
-  return function (remote: string) {
-    const mappedStaticRemotesFromEnv = getStaticRemotesFromEnv();
-    if (mappedStaticRemotesFromEnv && mappedStaticRemotesFromEnv[remote]) {
-      return `${mappedStaticRemotesFromEnv[remote]}/${remoteEntry}`;
-    }
-
-    let remoteConfiguration = null;
-    try {
-      remoteConfiguration = readCachedProjectConfiguration(remote);
-    } catch (e) {
-      throw new Error(
-        `Cannot find remote: "${remote}". Check that the remote name is correct in your module federation config file.\n`
-      );
-    }
-    const serveTarget = remoteConfiguration?.targets?.[target];
-
-    if (!serveTarget) {
-      throw new Error(
-        `Cannot automatically determine URL of remote (${remote}). Looked for property "host" in the project's "${serveTarget}" target.\n
-      You can also use the tuple syntax in your webpack config to configure your remotes. e.g. \`remotes: [['remote1', 'http://localhost:4201']]\``
-      );
-    }
-
-    const host =
-      serveTarget.options?.host ??
-      `http${serveTarget.options.ssl ? 's' : ''}://localhost`;
-    const port = serveTarget.options?.port ?? 4201;
-    return `${
-      host.endsWith('/') ? host.slice(0, -1) : host
-    }:${port}/${remoteEntry}`;
-  };
+  return createRemoteUrlResolver({ isServer, bundler: 'webpack' });
 }
 
 export async function getModuleFederationConfig(


### PR DESCRIPTION
## Current Behavior

The module federation utilities have several performance inefficiencies and code duplication:

### Performance Issues

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                    BEFORE: Performance Bottlenecks                           │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                              │
│  Build Start                                                                 │
│      │                                                                       │
│      ▼                                                                       │
│  ┌──────────────────────────────────────┐                                   │
│  │ For each remote (10+ times):         │                                   │
│  │   • JSON.parse(env variable)  ──────►│ Repeated parsing!                 │
│  │   • readRootPackageJson()     ──────►│ Repeated file I/O!                │
│  └──────────────────────────────────────┘                                   │
│      │                                                                       │
│      ▼                                                                       │
│  ┌──────────────────────────────────────┐                                   │
│  │ For each library in dependency tree: │                                   │
│  │   • readTsPathMappings()      ──────►│ Called in loop!                   │
│  │   • Array.find() for lookup   ──────►│ O(n) per lookup!                  │
│  └──────────────────────────────────────┘                                   │
│      │                                                                       │
│      ▼                                                                       │
│  ┌──────────────────────────────────────┐                                   │
│  │ For EVERY import during build:       │                                   │
│  │   • dirname(library.path)     ──────►│ Hot path!                         │
│  │   • normalize(...)            ──────►│ Computed every time!              │
│  └──────────────────────────────────────┘                                   │
│                                                                              │
└─────────────────────────────────────────────────────────────────────────────┘
```

### Code Duplication

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                    BEFORE: Duplicated Code (~400 lines)                      │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                              │
│  webpack/utils.ts ─────┐                                                     │
│                        │                                                     │
│  rspack/utils.ts  ─────┼─► getFunctionDeterminateRemoteUrl() (~38 lines x 3) │
│                        │   • Same logic, different remoteEntry extension     │
│  angular/utils.ts ─────┘                                                     │
│                                                                              │
│  ────────────────────────────────────────────────────────────────────────   │
│                                                                              │
│  plugins/utils/start-remote-proxies.ts ─┐                                    │
│                                         │                                    │
│  utils/start-remote-proxies.ts ─────────┼─► Proxy server setup (~50 lines x 3)│
│                                         │   • SSL handling                   │
│  utils/start-ssr-remote-proxies.ts ─────┘   • Express + middleware           │
│                                             • Process signal handlers        │
│                                                                              │
│  ────────────────────────────────────────────────────────────────────────   │
│                                                                              │
│  parseStaticRemotesConfig() ────┐                                            │
│                                 ├─► 94% identical code (~35 lines x 2)       │
│  parseStaticSsrRemotesConfig() ─┘   • Only diff: dirname(outputPath) for SSR │
│                                                                              │
└─────────────────────────────────────────────────────────────────────────────┘
```

## Expected Behavior

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                    AFTER: Optimized Architecture                             │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                              │
│  Build Start                                                                 │
│      │                                                                       │
│      ▼                                                                       │
│  ┌──────────────────────────────────────┐                                   │
│  │ Cached Operations (computed once):   │                                   │
│  │   • getStaticRemotesFromEnv() ──────►│ Cached with invalidation          │
│  │   • readRootPackageJson()     ──────►│ Cached                            │
│  │   • readTsPathMappings()      ──────►│ Hoisted outside loops             │
│  │   • getDependentPackages()    ──────►│ WeakMap memoization               │
│  └──────────────────────────────────────┘                                   │
│      │                                                                       │
│      ▼                                                                       │
│  ┌──────────────────────────────────────┐                                   │
│  │ Pre-computed Values:                 │                                   │
│  │   • workspaceLibsByImportKey  ──────►│ Map for O(1) lookup               │
│  │   • keyDepths Map             ──────►│ Pre-computed for sorting          │
│  │   • pathMappings[].libFolder  ──────►│ Pre-computed dirname/normalize    │
│  └──────────────────────────────────────┘                                   │
│      │                                                                       │
│      ▼                                                                       │
│  ┌──────────────────────────────────────┐                                   │
│  │ Hot Path (every import):             │                                   │
│  │   • Use pre-computed libFolder ─────►│ No computation needed!            │
│  └──────────────────────────────────────┘                                   │
│                                                                              │
└─────────────────────────────────────────────────────────────────────────────┘
```

### Shared Utilities

```
┌─────────────────────────────────────────────────────────────────────────────┐
│                    AFTER: Consolidated Code                                  │
├─────────────────────────────────────────────────────────────────────────────┤
│                                                                              │
│  NEW: utils/remote-url.ts                                                    │
│  ┌─────────────────────────────────────────────────┐                        │
│  │ createRemoteUrlResolver({ isServer, bundler })  │                        │
│  │   • Cached getStaticRemotesFromEnv()            │                        │
│  │   • Bundler-specific remoteEntry extension      │                        │
│  └─────────────────────────────────────────────────┘                        │
│           │                                                                  │
│           ├─► webpack/utils.ts  (3 lines)                                    │
│           ├─► rspack/utils.ts   (3 lines)                                    │
│           └─► angular/utils.ts  (4 lines)                                    │
│                                                                              │
│  ────────────────────────────────────────────────────────────────────────   │
│                                                                              │
│  NEW: utils/proxy-server.ts                                                  │
│  ┌─────────────────────────────────────────────────┐                        │
│  │ createRemoteProxyServers(remotes, options)      │                        │
│  │   • SSL certificate handling                    │                        │
│  │   • Express server + proxy middleware           │                        │
│  │   • Process signal handlers                     │                        │
│  └─────────────────────────────────────────────────┘                        │
│           │                                                                  │
│           ├─► plugins/utils/start-remote-proxies.ts  (10 lines)              │
│           ├─► utils/start-remote-proxies.ts          (10 lines)              │
│           └─► utils/start-ssr-remote-proxies.ts      (10 lines)              │
│                                                                              │
└─────────────────────────────────────────────────────────────────────────────┘
```

## Changes Made

### Performance Optimizations

| # | Optimization | File(s) | Impact |
|---|-------------|---------|--------|
| 1 | Cache env variable parsing | webpack, rspack, angular utils | Eliminates 10+ JSON.parse per build |
| 2 | Pre-compute sort depths | share.ts | O(n) vs O(n log n) string splits |
| 3 | Map for O(1) lookups | share.ts | O(1) vs O(n) per lookup |
| 4 | Memoize secondary entry points | secondary-entry-points.ts | Avoids repeated dir scans |
| 5 | Cache readRootPackageJson | package-json.ts | Single file read per build |
| 6 | Hoist tsConfigPathMappings | dependencies.ts | Avoids repeated calls in loop |
| 7 | Memoize getDependentPackages | dependencies.ts | WeakMap with auto-invalidation |
| 8 | Pre-compute libFolder | share.ts | No hot-path computation |

### Code Deduplication

| # | Consolidation | Lines Removed | New Shared Module |
|---|--------------|---------------|-------------------|
| 9 | Remote URL resolver | ~80 lines | utils/remote-url.ts |
| 10 | Proxy server setup | ~120 lines | utils/proxy-server.ts |
| 11 | Parse remotes config | ~35 lines | Shared core function |

### Bug Fix

| # | Fix | File | Issue |
|---|-----|------|-------|
| 12 | require.resolve error handling | share.ts | Was checking for null, but it throws |

## Test Results

```
Test Suites: 10 passed, 10 total
Tests:       1 skipped, 56 passed, 57 total
```

## Summary

```diff
 13 files changed
+ 346 insertions
- 357 deletions
──────────────────
  -11 lines net (with MORE functionality!)
```

**New shared utilities:**
- `packages/module-federation/src/utils/proxy-server.ts`
- `packages/module-federation/src/utils/remote-url.ts`

## Related Issue(s)

Performance improvements for module federation - no specific issue

## Merge Dependencies

**Must be merged AFTER:** #33733
**Must be merged BEFORE:** #33735

---