### PR TITLE
perf(core): optimize project graph builder and operators

### DIFF
--- a/packages/nx/src/project-graph/operators.ts
+++ b/packages/nx/src/project-graph/operators.ts
@@ -85,8 +85,9 @@ export function withDeps(
   subsetNodes: ProjectGraphProjectNode[]
 ): ProjectGraph {
   const res = { nodes: {}, dependencies: {} } as ProjectGraph;
-  const visitedNodes = [];
-  const visitedEdges = [];
+  // Use Set for O(1) lookup instead of Array.indexOf O(n)
+  const visitedNodes = new Set<string>();
+  const visitedEdges = new Set<string>();
   Object.values(subsetNodes).forEach(recurNodes);
   Object.values(subsetNodes).forEach(recurEdges);
   return res;
@@ -94,12 +95,12 @@ export function withDeps(
   // ---------------------------------------------------------------------------
 
   function recurNodes(node) {
-    if (visitedNodes.indexOf(node.name) > -1) return;
+    if (visitedNodes.has(node.name)) return;
     res.nodes[node.name] = node;
     if (!res.dependencies[node.name]) {
       res.dependencies[node.name] = [];
     }
-    visitedNodes.push(node.name);
+    visitedNodes.add(node.name);
 
     original.dependencies[node.name].forEach((n) => {
       if (original.nodes[n.target]) {
@@ -109,8 +110,8 @@ export function withDeps(
   }
 
   function recurEdges(node) {
-    if (visitedEdges.indexOf(node.name) > -1) return;
-    visitedEdges.push(node.name);
+    if (visitedEdges.has(node.name)) return;
+    visitedEdges.add(node.name);
 
     const ds = original.dependencies[node.name];
     ds.forEach((n) => {

--- a/packages/nx/src/project-graph/project-graph-builder.ts
+++ b/packages/nx/src/project-graph/project-graph-builder.ts
@@ -355,19 +355,15 @@ export class ProjectGraphBuilder {
     // remove all source dependencies
     delete this.graph.dependencies[name];
 
-    // remove all target dependencies
-    for (const dependencies of Object.values(this.graph.dependencies)) {
-      for (const [index, { source, target }] of dependencies.entries()) {
-        if (target === name) {
-          const deps = this.graph.dependencies[source];
-          this.graph.dependencies[source] = [
-            ...deps.slice(0, index),
-            ...deps.slice(index + 1),
-          ];
-          if (this.graph.dependencies[source].length === 0) {
-            delete this.graph.dependencies[source];
-          }
-        }
+    // remove all target dependencies - O(n) single pass with filter
+    // Previous implementation was O(n²) due to nested loop and slice operations
+    for (const source of Object.keys(this.graph.dependencies)) {
+      const deps = this.graph.dependencies[source];
+      const filtered = deps.filter((d) => d.target !== name);
+      if (filtered.length === 0) {
+        delete this.graph.dependencies[source];
+      } else if (filtered.length !== deps.length) {
+        this.graph.dependencies[source] = filtered;
       }
     }
   }


### PR DESCRIPTION
## Current Behavior

### `removeDependenciesWithNode` (project-graph-builder.ts:354-372)

When removing a node, the current implementation has **O(n²)** complexity with expensive array operations:

```
For each source's dependencies:    <- O(n) sources
  For each dependency (by index):  <- O(n) deps per source
    If target matches:
      Create new array via slice()  <- O(n) per match!
```

**Problem**: The nested loop plus array slice operations create significant overhead when removing nodes from large graphs.

### `withDeps` (operators.ts:83-132)

The recursive graph traversal uses `Array.indexOf()` for visited tracking:

```
visitedNodes.indexOf(name) > -1  <- O(n) per recursive call!
visitedEdges.indexOf(name) > -1  <- O(n) per recursive call!
```

**Problem**: In recursive traversal, these O(n) lookups compound. For a graph depth of `d` with `n` nodes:
- **Worst case**: O(n × d) lookups, each O(n) = O(n² × d)

## Expected Behavior

### `removeDependenciesWithNode` - O(n²) → O(n)

```
                    BEFORE                          AFTER
                    ═══════                         ═════
             ┌─────────────────────┐        ┌────────────────────┐
             │ For each source (n) │        │ For each source (n)│
             └──────────┬──────────┘        └──────────┬─────────┘
                        │                              │
             ┌──────────▼──────────┐        ┌──────────▼─────────┐
             │For each dep[i] (n)  │        │ Single filter()    │
             │  if target matches: │        │   remove all       │
             │    slice(0,i)  O(n) │        │   matching targets │
             │    slice(i+1)  O(n) │        │       O(n)         │
             └──────────┬──────────┘        └──────────┬─────────┘
                        │                              │
              Total: O(n²) + slice                Total: O(n)
                   overhead                    single pass filter
```

### `withDeps` - O(n² × d) → O(n × d)

```
                    BEFORE                          AFTER
                    ═══════                         ═════
              ┌──────────────────┐          ┌──────────────────┐
              │ visitedNodes = []│          │visitedNodes = Set│
              │ visitedEdges = []│          │visitedEdges = Set│
              └────────┬─────────┘          └────────┬─────────┘
                       │                             │
              ┌────────▼─────────┐          ┌────────▼─────────┐
              │  recurNodes(n)   │          │  recurNodes(n)   │
              │                  │          │                  │
              │ indexOf() = O(n) │          │  has() = O(1)    │
              │ push()           │          │  add()           │
              └────────┬─────────┘          └────────┬─────────┘
                       │                             │
                       ▼                             ▼
              For depth d nodes:            For depth d nodes:
              O(n) × d = O(n×d)             O(1) × d = O(d)
              lookups each O(n)             lookups each O(1)
              
              Total: O(n² × d)              Total: O(n × d)
```

## Performance Impact

| Operation | Before | After | Improvement |
|-----------|--------|-------|-------------|
| `removeDependenciesWithNode` | O(n²) + slice overhead | O(n) | **~n× faster** |
| `withDeps` (visited check) | O(n) per call | O(1) per call | **~n× faster** |

**Example**: For a graph with 500 nodes, depth 10:
- `removeDependenciesWithNode`: 250,000 ops → 500 ops
- `withDeps` lookups: 2,500,000 ops → 5,000 ops

## Changes

1. **project-graph-builder.ts**:
   - Replace nested loop + slice with single-pass filter()
   - Only reassign when filter actually removes items
   - Maintains all existing behavior including empty array deletion

2. **operators.ts**:
   - Convert `visitedNodes` array to `Set<string>`
   - Convert `visitedEdges` array to `Set<string>`
   - Replace `.indexOf() > -1` with `.has()`
   - Replace `.push()` with `.add()`

## Related Issue(s)

Contributes to #32265

## Merge Dependencies

This PR has no dependencies and can be merged independently.

**Must be merged BEFORE:** #33748

---