### PR TITLE
fix(core): optimize pnpm lockfile parsing with pre-built indexes

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -367,17 +367,13 @@ function getHoistedVersion(
   hoistedDependencies: Record<string, any>,
   packageName: string,
   isV5: boolean,
-  hoistedKeysByPackage?: Map<string, string>
+  hoistedKeysByPackage: Map<string, string>
 ): string {
   let version = getHoistedPackageVersion(packageName);
 
   if (!version) {
-    // Use pre-built index for O(1) lookup if available, otherwise fallback to O(n) search
-    const key = hoistedKeysByPackage
-      ? hoistedKeysByPackage.get(packageName)
-      : Object.keys(hoistedDependencies).find((k) =>
-          k.startsWith(`/${packageName}/`)
-        );
+    // Use pre-built index for O(1) lookup
+    const key = hoistedKeysByPackage.get(packageName);
     if (key) {
       version = parseBaseVersion(getVersion(key.slice(1), packageName), isV5);
     } else {

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -89,9 +89,11 @@ function matchPropValue(
   if (!record) {
     return undefined;
   }
-  const index = Object.values(record).findIndex((version) => version === key);
-  if (index > -1) {
-    return Object.keys(record)[index];
+  // Use Object.entries() for single-pass iteration instead of separate Object.values() + Object.keys()
+  for (const [name, version] of Object.entries(record)) {
+    if (version === key) {
+      return name;
+    }
   }
   // check if non-aliased name is found
   if (
@@ -316,6 +318,25 @@ function getNodes(
   }
 
   const hoistedDeps = loadPnpmHoistedDepsDefinition();
+
+  // Pre-build packageName -> key index for O(1) lookup instead of O(n) find() per package
+  const hoistedKeysByPackage = new Map<string, string>();
+  for (const key of Object.keys(hoistedDeps)) {
+    if (key.startsWith('/')) {
+      // Extract package name from key format: /{packageName}/{version}... or /@scope/name/{version}...
+      const withoutSlash = key.slice(1);
+      const slashIndex = withoutSlash.startsWith('@')
+        ? withoutSlash.indexOf('/', withoutSlash.indexOf('/') + 1)
+        : withoutSlash.indexOf('/');
+      if (slashIndex > 0) {
+        const pkgName = withoutSlash.slice(0, slashIndex);
+        if (!hoistedKeysByPackage.has(pkgName)) {
+          hoistedKeysByPackage.set(pkgName, key);
+        }
+      }
+    }
+  }
+
   const results: Record<string, ProjectGraphExternalNode> = {};
 
   for (const [packageName, versionMap] of nodes.entries()) {
@@ -323,7 +344,12 @@ function getNodes(
     if (versionMap.size === 1) {
       hoistedNode = versionMap.values().next().value;
     } else {
-      const hoistedVersion = getHoistedVersion(hoistedDeps, packageName, isV5);
+      const hoistedVersion = getHoistedVersion(
+        hoistedDeps,
+        packageName,
+        isV5,
+        hoistedKeysByPackage
+      );
       hoistedNode = versionMap.get(hoistedVersion);
     }
     if (hoistedNode) {
@@ -340,14 +366,18 @@ function getNodes(
 function getHoistedVersion(
   hoistedDependencies: Record<string, any>,
   packageName: string,
-  isV5: boolean
+  isV5: boolean,
+  hoistedKeysByPackage?: Map<string, string>
 ): string {
   let version = getHoistedPackageVersion(packageName);
 
   if (!version) {
-    const key = Object.keys(hoistedDependencies).find((k) =>
-      k.startsWith(`/${packageName}/`)
-    );
+    // Use pre-built index for O(1) lookup if available, otherwise fallback to O(n) search
+    const key = hoistedKeysByPackage
+      ? hoistedKeysByPackage.get(packageName)
+      : Object.keys(hoistedDependencies).find((k) =>
+          k.startsWith(`/${packageName}/`)
+        );
     if (key) {
       version = parseBaseVersion(getVersion(key.slice(1), packageName), isV5);
     } else {


### PR DESCRIPTION
## Current Behavior

When parsing pnpm lockfiles to build the project graph:

### matchPropValue function
- Uses separate `Object.values()` + `Object.keys()` iterations
- Two passes over the same data to find a value and get its key

### Hoisted Dependencies Lookup
- For each package, calls `Object.keys(hoistedDeps).find(k => k.startsWith(...))`
- O(n) search performed m times = O(n*m) total

## Expected Behavior

### Single-pass Iteration

```
BEFORE: matchPropValue
┌─────────────────────────────────────────────────────────────┐
│  const index = Object.values(record).findIndex(v === key)   │
│  if (index > -1)                                            │
│    return Object.keys(record)[index]  ← Another iteration!  │
│                                                             │
│  = 2 iterations over the same data                          │
└─────────────────────────────────────────────────────────────┘

AFTER: Object.entries() single pass
┌─────────────────────────────────────────────────────────────┐
│  for (const [name, version] of Object.entries(record)) {    │
│    if (version === key) return name  ← Early exit           │
│  }                                                          │
│                                                             │
│  = 1 iteration with early exit on match                     │
└─────────────────────────────────────────────────────────────┘
```

### Pre-built Index for Hoisted Dependencies

```
BEFORE: O(n*m) Hoisted Lookup
┌─────────────────────────────────────────────────────────────┐
│  for each package (n packages):                             │
│    Object.keys(hoistedDeps).find(k => k.startsWith(...))    │
│    ← O(m) search where m = hoisted deps                     │
│                                                             │
│  Total: O(n * m)                                            │
│                                                             │
│  Example: 500 packages × 200 hoisted deps                   │
│         = 100,000 string comparisons                        │
└─────────────────────────────────────────────────────────────┘

AFTER: Pre-built Index Map O(n+m)
┌─────────────────────────────────────────────────────────────┐
│  Build hoistedKeysByPackage Map once:  O(m)                 │
│    Map<packageName, hoistedKey>                             │
│                                                             │
│  for each package (n packages):                             │
│    hoistedKeysByPackage.get(packageName)  O(1)              │
│                                                             │
│  Total: O(n + m)                                            │
│                                                             │
│  Example: 500 packages + 200 hoisted deps                   │
│         = 700 operations (vs 100,000)                       │
└─────────────────────────────────────────────────────────────┘
```

## Impact

For large pnpm monorepos:

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| matchPropValue iterations | 2 | 1 | 50% fewer iterations |
| Hoisted lookup complexity | O(n×m) | O(n+m) | ~100x for large repos |
| String comparisons | n×m | n+m | Dramatic reduction |

## Related Issue(s)

Contributes to #32669, #32254

## Merge Dependencies

This PR has no dependencies and can be merged independently.

**Must be merged BEFORE:** #33751

---