### PR TITLE
fix(gradle): do not add gradle plugin to plugins block if using version catalogs

### DIFF
--- a/packages/gradle/src/generators/init/gradle-project-graph-plugin-utils.spec.ts
+++ b/packages/gradle/src/generators/init/gradle-project-graph-plugin-utils.spec.ts
@@ -398,7 +398,7 @@ otherPlugin = { id = "com.other.plugin", version = "1.0.0" }`,
         await tempFs.createFiles({
           'proj/settings.gradle.kts': '',
           'proj/build.gradle.kts': `plugins {
-    alias(libs.plugins.nxProjectGraph)
+    alias(libs.plugins.nx.project.graph)
     id("java")
 }`,
           'proj/libs.versions.toml': `[plugins]
@@ -410,7 +410,7 @@ nx-project-graph = { id = "${gradleProjectGraphPluginName}", version = "1.0.0" }
         const content = tree.read('proj/build.gradle.kts', 'utf-8');
         // Should only have one occurrence of the plugin
         const aliasMatches = content.match(
-          /alias\(libs\.plugins\.nxProjectGraph\)/g
+          /alias\(libs\.plugins\.nx\.project\.graph\)/g
         );
         expect(aliasMatches).toHaveLength(1);
         // Should not add direct version syntax

--- a/packages/gradle/src/utils/version-catalog-ast-utils.spec.ts
+++ b/packages/gradle/src/utils/version-catalog-ast-utils.spec.ts
@@ -5,6 +5,7 @@ import {
   updatePluginVersionInCatalogAst,
   extractPluginVersionFromCatalogAst,
   updateNxPluginVersionInCatalogsAst,
+  getPluginAliasFromCatalogAst,
 } from './version-catalog-ast-utils';
 import { gradleProjectGraphPluginName } from './versions';
 
@@ -101,6 +102,76 @@ nx-graph = { id = '${gradleProjectGraphPluginName}', version = '1.5.0' }
         gradleProjectGraphPluginName
       );
       expect(version).toBe('1.5.0');
+    });
+  });
+
+  describe('getPluginAliasFromCatalogAst', () => {
+    it('should return alias from plugin with direct version', () => {
+      const content = `
+[plugins]
+nxProjectGraph = { id = "${gradleProjectGraphPluginName}", version = "1.2.3" }
+`;
+
+      const alias = getPluginAliasFromCatalogAst(
+        content,
+        gradleProjectGraphPluginName
+      );
+      expect(alias).toBe('nxProjectGraph');
+    });
+
+    it('should return alias from plugin with simple format', () => {
+      const content = `
+[plugins]
+nx-graph = "${gradleProjectGraphPluginName}:3.4.5"
+`;
+
+      const alias = getPluginAliasFromCatalogAst(
+        content,
+        gradleProjectGraphPluginName
+      );
+      expect(alias).toBe('nx-graph');
+    });
+
+    it('should return alias from plugin with version.ref', () => {
+      const content = `
+[versions]
+nx-version = "2.3.4"
+
+[plugins]
+my-nx-plugin = { id = "${gradleProjectGraphPluginName}", version.ref = "nx-version" }
+`;
+
+      const alias = getPluginAliasFromCatalogAst(
+        content,
+        gradleProjectGraphPluginName
+      );
+      expect(alias).toBe('my-nx-plugin');
+    });
+
+    it('should return null if plugin not found', () => {
+      const content = `
+[plugins]
+other-plugin = "com.other:1.0.0"
+`;
+
+      const alias = getPluginAliasFromCatalogAst(
+        content,
+        gradleProjectGraphPluginName
+      );
+      expect(alias).toBeNull();
+    });
+
+    it('should return null if no plugins table exists', () => {
+      const content = `
+[versions]
+some-version = "1.0.0"
+`;
+
+      const alias = getPluginAliasFromCatalogAst(
+        content,
+        gradleProjectGraphPluginName
+      );
+      expect(alias).toBeNull();
     });
   });
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
We would add the gradle project graph plugin to your build.gradle files if we did not already detect it. However, this did mechanism did not recognize aliases for the project graph plugin that came from version catalogs.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When adding the project graph plugin to build.gradle.kts, we check if a version catalogue exists, and if it does we add the alias for the project graph plugin.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
