### PR TITLE
fix(core): invalidate sync generator cache on file changes and use up-to-date project graph

### DIFF
--- a/packages/nx/src/daemon/server/file-watching/file-change-events.ts
+++ b/packages/nx/src/daemon/server/file-watching/file-change-events.ts
@@ -1,0 +1,25 @@
+import { serverLogger } from '../logger';
+
+export interface FileChangeEvent {
+  createdFiles: string[];
+  updatedFiles: string[];
+  deletedFiles: string[];
+}
+
+const fileChangeListeners = new Set<(event: FileChangeEvent) => void>();
+
+export function registerFileChangeListener(
+  listener: (event: FileChangeEvent) => void
+): void {
+  fileChangeListeners.add(listener);
+}
+
+export function notifyFileChangeListeners(event: FileChangeEvent): void {
+  for (const listener of fileChangeListeners) {
+    try {
+      listener(event);
+    } catch (error) {
+      serverLogger.log('Error notifying file change listener:', error);
+    }
+  }
+}

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -27,6 +27,7 @@ import {
 } from '../../utils/workspace-context';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { notifyFileWatcherSockets } from './file-watching/file-watcher-sockets';
+import { notifyFileChangeListeners } from './file-watching/file-change-events';
 import { notifyProjectGraphListenerSockets } from './project-graph-listener-sockets';
 import { serverLogger } from './logger';
 import { NxWorkspaceFilesExternals } from '../../native';
@@ -169,6 +170,15 @@ export function addUpdatedAndDeletedFiles(
   for (let f of deletedFiles) {
     collectedUpdatedFiles.delete(f);
     collectedDeletedFiles.add(f);
+  }
+
+  // Notify file change listeners immediately when files change
+  if (
+    createdFiles.length > 0 ||
+    updatedFiles.length > 0 ||
+    deletedFiles.length > 0
+  ) {
+    notifyFileChangeListeners({ createdFiles, updatedFiles, deletedFiles });
   }
 
   if (updatedFiles.length > 0 || deletedFiles.length > 0) {

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -110,7 +110,11 @@ import {
   isHandleGetSyncGeneratorChangesMessage,
 } from '../message-types/get-sync-generator-changes';
 import { handleGetSyncGeneratorChanges } from './handle-get-sync-generator-changes';
-import { collectAndScheduleSyncGenerators } from './sync-generators';
+import {
+  clearSyncGeneratorsCache,
+  collectAndScheduleSyncGenerators,
+} from './sync-generators';
+import { registerFileChangeListener } from './file-watching/file-change-events';
 import {
   GET_REGISTERED_SYNC_GENERATORS,
   isHandleGetRegisteredSyncGeneratorsMessage,
@@ -720,6 +724,8 @@ export async function startServer(): Promise<Server> {
           registerProjectGraphRecomputationListener(
             collectAndScheduleSyncGenerators
           );
+          // register file change listener to invalidate sync generator cache
+          registerFileChangeListener(clearSyncGeneratorsCache);
           // trigger an initial project graph recomputation
           addUpdatedAndDeletedFiles([], [], []);
 


### PR DESCRIPTION
## Current Behavior

Sync generators are processed in the background by the daemon server. Their results are cached and reprocessed when the project graph is recomputed. There are currently two issues:

- The cache is only invalidated after the project graph finishes recomputing, which means that there's an interval between files changed (triggering the project graph recomputation) and the recomputation finishes, where the cache is not invalidated, and it's stale. During that interval, any request to get the sync generator changes will use the stale cache.
- Sync generators are scheduled to be processed after the project graph is recomputed, so a quick succession of recomputations can be coalesced. The problem is that the scheduled closure uses the project graph from the initial scheduling, rather than the latest available project graph at the time it runs. This results in the usage of stale data to process the sync generators.

## Expected Behavior

Getting sync generators changes should always return up-to-date information.