### PR TITLE
fix(core): ensure `terminalOutput` is always a string in task results

### DIFF
--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -425,6 +425,7 @@ export class TaskOrchestrator {
         task: this.taskGraph.tasks[rootTaskId],
         code: 1,
         status: 'failure' as TaskStatus,
+        terminalOutput: e.stack ?? e.message ?? '',
       }));
     } finally {
       const runBatchEnd = performance.mark('TaskOrchestrator-run-batch:end');
@@ -712,7 +713,7 @@ export class TaskOrchestrator {
       }
       return new NoopChildProcess({
         code: 1,
-        terminalOutput: undefined,
+        terminalOutput: e.stack ?? e.message ?? '',
       });
     }
   }


### PR DESCRIPTION
## Current Behavior

When some tasks fail during execution, it can result in a cryptic:

```bash
Failed to convert JavaScript value 'Undefined' into rust type 'String'
```

This happens because the reported `terminalOutput` for the errored tasks can be `undefined`, and it hides the actual error that occurred.

## Expected Behavior

Error handling paths should always provide a valid string for `terminalOutput`, using the error stack/message, or an empty string as a fallback.

## Related Issue(s)

Fixes #32675 
