### PR TITLE
fix(core): fix record stat on initial CNW call

### DIFF
--- a/packages/create-nx-plugin/bin/create-nx-plugin.ts
+++ b/packages/create-nx-plugin/bin/create-nx-plugin.ts
@@ -154,13 +154,12 @@ async function main(parsedArgs: yargs.Arguments<CreateNxPluginArguments>) {
 
   await recordStat({
     nxVersion,
-    command: 'create-nx-workspace',
+    command: 'create-nx-plugin',
     useCloud: parsedArgs.nxCloud !== 'skip',
     meta: [
       messages.codeOfSelectedPromptMessage('setupCI'),
       messages.codeOfSelectedPromptMessage('setupNxCloud'),
     ],
-    directory: workspaceInfo.directory,
   });
 
   if (parsedArgs.nxCloud && workspaceInfo.nxCloudInfo) {
@@ -179,6 +178,13 @@ async function normalizeArgsMiddleware(
 ): Promise<void> {
   rawArgs = { ...argv };
   try {
+    await recordStat({
+      nxVersion,
+      command: 'create-nx-plugin',
+      meta: ['start'],
+      useCloud: argv.nxCloud !== 'skip',
+    });
+
     const pluginName = await determinePluginName(argv);
     const createPackageName = await determineCreatePackageName(argv);
     const packageManager = await determinePackageManager(argv);

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -261,21 +261,11 @@ export async function recordStat(opts: {
   nxVersion: string;
   useCloud: boolean;
   meta: string[];
-  directory: string;
 }) {
   try {
     if (!shouldRecordStats()) {
       return;
     }
-
-    // nx-ignore-next-line
-    const { getCloudUrl } = require(require.resolve(
-      'nx/src/nx-cloud/utilities/get-cloud-options',
-      {
-        paths: [opts.directory],
-      }
-      // nx-ignore-next-line
-    )) as typeof import('nx/src/nx-cloud/utilities/get-cloud-options');
 
     const axios = require('axios');
     await (axios['default'] ?? axios)


### PR DESCRIPTION
This PR fixes an issue with CNW where the initial `recordStat` call is not working due to a logic error on passing `directory` that isn't initialized yet.