### PR TITLE
fix(angular): process only the in progress entry points in ng-packagr-lite's write bundles transform function

### DIFF
--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
@@ -31,13 +31,10 @@ async function shouldWriteFile(
 export const writeBundlesTransform = (_options: NgPackagrOptions) => {
   const { major: ngPackagrMajorVersion } = getNgPackagrVersionInfo();
 
-  const { BuildGraph } = importNgPackagrPath<
-    typeof import('ng-packagr/src/lib/graph/build-graph')
-  >('ng-packagr/src/lib/graph/build-graph', ngPackagrMajorVersion);
   const { transformFromPromise } = importNgPackagrPath<
     typeof import('ng-packagr/src/lib/graph/transform')
   >('ng-packagr/src/lib/graph/transform', ngPackagrMajorVersion);
-  const { isEntryPoint, isPackage } = importNgPackagrPath<
+  const { isEntryPointInProgress, isPackage } = importNgPackagrPath<
     typeof import('ng-packagr/src/lib/ng-package/nodes')
   >('ng-packagr/src/lib/ng-package/nodes', ngPackagrMajorVersion);
   const { NgPackage } = importNgPackagrPath<
@@ -45,39 +42,47 @@ export const writeBundlesTransform = (_options: NgPackagrOptions) => {
   >('ng-packagr/src/lib/ng-package/package', ngPackagrMajorVersion);
 
   return transformFromPromise(async (graph) => {
-    const updatedGraph = new BuildGraph();
+    const entryPointNode = graph.find(isEntryPointInProgress());
+    if (!entryPointNode) {
+      return;
+    }
 
-    for (const entry of graph.entries()) {
-      if (isEntryPoint(entry)) {
-        const entryPoint = toCustomNgEntryPoint(entry.data.entryPoint);
-        entry.data.entryPoint = entryPoint;
-        entry.data.destinationFiles = entryPoint.destinationFiles;
+    const entryPoint = toCustomNgEntryPoint(entryPointNode.data.entryPoint);
+    entryPointNode.data.entryPoint = entryPoint;
+    entryPointNode.data.destinationFiles = entryPoint.destinationFiles;
 
-        for (const [path, outputCache] of entry.cache.outputCache.entries()) {
-          const normalizedPath = normalizeEsm2022Path(path, entryPoint);
+    for (const [
+      path,
+      outputCache,
+    ] of entryPointNode.cache.outputCache.entries()) {
+      const normalizedPath = normalizeEsm2022Path(path, entryPoint);
 
-          // Only write if content has changed
-          if (await shouldWriteFile(normalizedPath, outputCache.content)) {
-            await mkdir(dirname(normalizedPath), { recursive: true });
-            await writeFile(normalizedPath, outputCache.content);
-          }
-        }
-        if (!entry.cache.outputCache.size && entryPoint.isSecondaryEntryPoint) {
-          await mkdir(entryPoint.destinationPath, { recursive: true });
-        }
-      } else if (isPackage(entry)) {
-        entry.data = new NgPackage(
-          entry.data.src,
-          toCustomNgEntryPoint(entry.data.primary),
-          entry.data.secondaries.map((secondary) =>
+      // Only write if content has changed
+      if (await shouldWriteFile(normalizedPath, outputCache.content)) {
+        await mkdir(dirname(normalizedPath), { recursive: true });
+        await writeFile(normalizedPath, outputCache.content);
+      }
+    }
+    if (
+      !entryPointNode.cache.outputCache.size &&
+      entryPoint.isSecondaryEntryPoint
+    ) {
+      await mkdir(entryPoint.destinationPath, { recursive: true });
+    }
+
+    // Update package node only when processing the primary entry point
+    if (!entryPoint.isSecondaryEntryPoint) {
+      const packageNode = graph.find(isPackage);
+      if (packageNode) {
+        packageNode.data = new NgPackage(
+          packageNode.data.src,
+          toCustomNgEntryPoint(packageNode.data.primary),
+          packageNode.data.secondaries.map((secondary) =>
             toCustomNgEntryPoint(secondary)
           )
         );
       }
-      updatedGraph.put(entry);
     }
-
-    return updatedGraph;
   });
 };
 


### PR DESCRIPTION
## Current Behavior

When building Angular libraries with `ng-packagr` >20.3.0, the build fails with:

```bash
TypeError: Cannot read properties of undefined (reading 'outputCache')
```
This occurs because `ng-packagr` v20.3.1 introduced a memory optimization ([ng-packagr#3172](https://github.com/ng-packagr/ng-packagr/pull/3172)) that calls `dispose()` on entry points after they're processed, setting `entry.cache = undefined`.

Nx's custom `writeBundlesTransform` was iterating over **all** entries in the graph, including already-disposed entry points, causing the crash when accessing their cache.

## Expected Behavior

Angular library builds should succeed with `ng-packagr` >20.3.0, including libraries with secondary entry points. Workspaces using lower versions of `ng-packagr` should remain unaffected.

## Solution

Align with `ng-packagr`'s own pattern by using `graph.find(isEntryPointInProgress())` to process only the currently in-progress entry point, rather than iterating over all graph entries.

**Key changes:**

- Use `isEntryPointInProgress()` instead of iterating all entries with `isEntryPoint()`
- Remove unused `BuildGraph` import (no longer creating a new graph)
- Update package node only when processing the primary entry point (more efficient)
- Return nothing from the transform (original graph passes through, same as ng-packagr)

This approach:

- Matches `ng-packagr`'s `writeBundlesTransform` implementation pattern
- Only accesses cache of the in-progress entry point (guaranteed not to be disposed)
- Works with all supported `ng-packagr` versions (v19+) since `isEntryPointInProgress()` has been available since v19

## Related Issue(s)

Fixes #33560