### PR TITLE
fix(repo): restore mise tools in e2e-matrix workflow

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -53,10 +53,8 @@ jobs:
 
       - name: Setup dev tools with mise
         uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
-        with:
-          mise_toml: |
-            [tools]
-            node = "${{ matrix.node_version }}"
+        env:
+          NODE_VERSION: ${{ matrix.node_version }}
 
       - name: Enable corepack and install pnpm
         run: |
@@ -156,10 +154,8 @@ jobs:
 
       - name: Setup dev tools with mise
         uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
-        with:
-          mise_toml: |
-            [tools]
-            node = "${{ matrix.node_version }}"
+        env:
+          NODE_VERSION: ${{ matrix.node_version }}
 
       - name: Enable corepack and install pnpm
         run: |

--- a/mise.toml
+++ b/mise.toml
@@ -2,5 +2,5 @@
 bun = "1.3"
 dotnet = "9"
 java = "24"
-node = "24"
+node = "{{ env['NODE_VERSION'] | default(value='24') }}"
 rust = "1.90.0"


### PR DESCRIPTION
## Current Behavior

The inline `mise_toml` config in `e2e-matrix.yml` was overwriting the entire `mise.toml` file, causing rust, dotnet, bun, and java to NOT be installed by mise. This resulted in slow package installs as these tools were downloaded during `pnpm install` instead.

## Expected Behavior

All tools from `mise.toml` (rust, dotnet, bun, java) should be installed by mise, with only the node version varying based on the matrix.

## Solution

Use mise's template syntax to make node version configurable via `NODE_VERSION` env var while preserving all other tools from `mise.toml`:

```toml
node = "{{ env['NODE_VERSION'] | default(value='24') }}"
```

Then in the workflow, set the env var instead of overriding the entire config:

```yaml
- name: Setup dev tools with mise
  uses: jdx/mise-action@v3
  env:
    NODE_VERSION: ${{ matrix.node_version }}
```

## Related Issue(s)

Fixes slow install times in nightly e2e-matrix workflow after #33772.