### PR TITLE
fix(repo): fix dotnet installation on Windows

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,11 @@
 [tools]
 bun = "1.3"
-dotnet = "9"
 java = "24"
 node = "24"
 rust = "1.90.0"
+
+# dotnet via mise only works on Linux/macOS.
+# On Windows, the vfox plugin is buggy: https://github.com/jdx/mise/discussions/4738
+[tools.dotnet]
+version = "9"
+os = ["linux", "macos"]


### PR DESCRIPTION
## Current Behavior

The mise vfox-dotnet plugin fails on Windows with:
```
mise ERROR Failed to install vfox:mise-plugins/vfox-dotnet@9:
     0: error converting Lua table to PreInstall (no version returned from vfox plugin)
```

This prevents the publish workflow from running on Windows.

## Expected Behavior

The publish workflow should run successfully on Windows.

## Related Issue(s)

Related upstream issue: https://github.com/jdx/mise/discussions/4738

## Solution

Made dotnet installation conditional on Linux/macOS only in `mise.toml` using the `os` option. Dotnet was never needed for the Windows native builds - it was only added to mise.toml for Nx Cloud agents (which don't run on Windows).