### PR TITLE
fix(core): improve node creation for pnpm parser

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/utils/package-json.ts
+++ b/packages/nx/src/plugins/js/lock-file/utils/package-json.ts
@@ -61,3 +61,13 @@ export function normalizePackageJson(
     resolutions,
   };
 }
+
+export function invertObject(
+  record: Record<string, string>
+): Record<string, string> {
+  const result = {};
+  Object.keys(record).forEach((key) => {
+    result[record[key]] = key;
+  });
+  return result;
+}


### PR DESCRIPTION
| | Before | After |
| ---- | ----- | ---- |
| Total createNodes | 812 | 104 |
| Total matchPropValue | 672 | 2 |

## Current Behavior
The `createNode` function is slow for pnpm due to suboptimal `matchPropValue` function.

## Expected Behavior
The `createNode` function should be fast and not slowdown the graph creation.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
