### PR TITLE
feat(bundling): support rollup nested export

### DIFF
--- a/packages/js/src/plugins/rollup/type-definitions.ts
+++ b/packages/js/src/plugins/rollup/type-definitions.ts
@@ -1,6 +1,6 @@
 // nx-ignore-next-line
 import type { OutputBundle } from 'rollup'; // only used  for types
-import { relative } from 'path';
+import { relative, dirname } from 'path';
 import { stripIndents } from '@nx/devkit';
 
 //NOTE: This is here so we can share between `@nx/rollup` and `@nx/vite`.
@@ -46,7 +46,7 @@ export function typeDefinitions(options: { projectRoot: string }) {
           '.d.ts'
         );
 
-        const relativeSourceDtsName = JSON.stringify('./' + entrySourceDtsName);
+        const relativeSourceDtsName = JSON.stringify('./' + relative(dirname(file.name), entrySourceDtsName));
         const dtsFileSource = hasDefaultExport
           ? stripIndents`
               export * from ${relativeSourceDtsName};

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -137,6 +137,13 @@
       },
       "x-priority": "important"
     },
+    "additionalEntryPointsRootDir": {
+      "type": "array",
+      "description": "Root dir for the additional entry-points. If provided, the paths in `additionalEntryPoints` are relative to this root dir.",
+      "items": {
+        "type": "string"
+      }
+    },
     "buildLibsFromSource": {
       "type": "boolean",
       "description": "Read buildable libraries from source instead of building them separately.",

--- a/packages/rollup/src/plugins/package-json/generate-package-json.ts
+++ b/packages/rollup/src/plugins/package-json/generate-package-json.ts
@@ -20,8 +20,8 @@ export function generatePackageJson(
 ): Plugin {
   return {
     name: pluginName,
-    writeBundle: () => {
-      updatePackageJson(options, packageJson);
+    writeBundle: (rollupOptions, bundle) => {
+      updatePackageJson(options, packageJson, bundle);
     },
   };
 }

--- a/packages/rollup/src/plugins/with-nx/normalize-options.ts
+++ b/packages/rollup/src/plugins/with-nx/normalize-options.ts
@@ -29,6 +29,7 @@ export function normalizeOptions(
       options.additionalEntryPoints,
       workspaceRoot
     ),
+    additionalEntryPointsRootDir: options.additionalEntryPointsRootDir ? resolve(workspaceRoot, options.additionalEntryPointsRootDir) : undefined,
     allowJs: options.allowJs ?? false,
     assets: options.assets
       ? normalizeAssets(options.assets, workspaceRoot, sourceRoot)

--- a/packages/rollup/src/plugins/with-nx/with-nx-options.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx-options.ts
@@ -4,6 +4,11 @@ export interface RollupWithNxPluginOptions {
    * */
   additionalEntryPoints?: string[];
   /**
+   * Root dir for the additional entry-points.
+   * If provided, the paths in `additionalEntryPoints` are relative to this root dir.
+   * */
+  additionalEntryPointsRootDir?: string;
+  /**
    * Allow JavaScript files to be compiled.
    */
   allowJs?: boolean;

--- a/packages/rollup/src/plugins/with-nx/with-nx.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx.ts
@@ -21,7 +21,7 @@ import { getBabelInputPlugin } from '@rollup/plugin-babel';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import * as autoprefixer from 'autoprefixer';
 import { existsSync } from 'node:fs';
-import { dirname, join, parse } from 'node:path';
+import { dirname, join, parse, relative } from 'node:path';
 import { PackageJson } from 'nx/src/utils/package-json';
 import * as rollup from 'rollup';
 import { analyze } from '../analyze';
@@ -356,7 +356,9 @@ function createInput(
     join(workspaceRoot, options.main)
   );
   options.additionalEntryPoints?.forEach((entry) => {
-    input[parse(entry).name] = normalizePath(join(workspaceRoot, entry));
+    const path = normalizePath(join(workspaceRoot, entry))
+    const inputName = options.additionalEntryPointsRootDir ? relative(options.additionalEntryPointsRootDir, entry) : parse(entry).name
+    input[inputName] = path;
   });
   return input;
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

nested additionalEntryPoints are all moved to the root or the library

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

additionalEntryPoints path should be kept when bundling a library

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->


Fixes https://github.com/nrwl/nx/discussions/33789
