### PR TITLE
fix(repo): install nightly Rust for WASM build in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -541,6 +541,7 @@ jobs:
         run: |
           wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-23/wasi-sdk-23.0-x86_64-linux.tar.gz
           tar -xvf wasi-sdk-23.0-x86_64-linux.tar.gz
+          rustup toolchain install nightly-2025-12-10
           pnpm build:wasm
       - name: Publish
         env:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "preinstall": "node ./scripts/preinstall.js",
     "test": "nx run-many -t test",
     "e2e": "nx run-many -t e2e --projects ./e2e/*",
-    "build:wasm": "rustup override set nightly-2025-05-09 && rustup target add wasm32-wasip1-threads && WASI_SDK_PATH=\"$(pwd)/wasi-sdk-23.0-x86_64-linux\" CMAKE_BUILD_PARALLEL_LEVEL=2 LIBSQLITE3_FLAGS=\"-DLONGDOUBLE_TYPE=double\" pnpm exec nx run-many -t build-native-wasm && rustup override unset",
+    "build:wasm": "rustup override set nightly-2025-12-10 && rustup target add wasm32-wasip1-threads && WASI_SDK_PATH=\"$(pwd)/wasi-sdk-23.0-x86_64-linux\" CMAKE_BUILD_PARALLEL_LEVEL=2 LIBSQLITE3_FLAGS=\"-DLONGDOUBLE_TYPE=double\" pnpm exec nx run-many -t build-native-wasm && rustup override unset",
     "lint-pnpm-lock": "eslint pnpm-lock.yaml",
     "migrate-to-pnpm-version": "node ./scripts/migrate-to-pnpm-version.js",
     "analyze-docs": "node tools/scripts/analyze-docs.mjs",


### PR DESCRIPTION
## Current Behavior

After the mise migration (#33772), the `publish.yml` workflow fails during the "Build Wasm" step with:

```
error[E0554]: `#![feature]` may not be used on the stable release channel
 --> packages/nx/src/lib.rs:2:33
  |
2 | #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
```

The WASM build requires nightly Rust because it uses the unstable `wasi_ext` feature. The `build:wasm` script attempts to switch to nightly via `rustup override set`, but after the mise migration, the nightly toolchain is no longer pre-installed, causing the build to fail with the stable compiler.

## Expected Behavior

The WASM build should successfully compile using nightly Rust with the `wasi_ext` feature.

## Related Issue(s)

Fixes the publish workflow regression introduced in #33772