### PR TITLE
fix(repo): use RUSTUP_TOOLCHAIN env var for WASM builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "preinstall": "node ./scripts/preinstall.js",
     "test": "nx run-many -t test",
     "e2e": "nx run-many -t e2e --projects ./e2e/*",
-    "build:wasm": "rustup override set nightly-2025-12-10 && rustup target add wasm32-wasip1-threads && WASI_SDK_PATH=\"$(pwd)/wasi-sdk-23.0-x86_64-linux\" CMAKE_BUILD_PARALLEL_LEVEL=2 LIBSQLITE3_FLAGS=\"-DLONGDOUBLE_TYPE=double\" pnpm exec nx run-many -t build-native-wasm && rustup override unset",
+    "build:wasm": "RUSTUP_TOOLCHAIN=nightly-2025-12-10 rustup target add wasm32-wasip1-threads && RUSTUP_TOOLCHAIN=nightly-2025-12-10 WASI_SDK_PATH=\"$(pwd)/wasi-sdk-23.0-x86_64-linux\" CMAKE_BUILD_PARALLEL_LEVEL=2 LIBSQLITE3_FLAGS=\"-DLONGDOUBLE_TYPE=double\" pnpm exec nx run-many -t build-native-wasm",
     "lint-pnpm-lock": "eslint pnpm-lock.yaml",
     "migrate-to-pnpm-version": "node ./scripts/migrate-to-pnpm-version.js",
     "analyze-docs": "node tools/scripts/analyze-docs.mjs",


### PR DESCRIPTION
## Current Behavior

The `build:wasm` script uses `rustup override set nightly-2025-12-10` to set the Rust toolchain. However, when mise is configured to manage Rust (e.g., `rust = "1.90.0"` in `mise.toml`), it sets the `RUSTUP_TOOLCHAIN` environment variable which has higher precedence than directory overrides.

This causes the WASM build to fail with:
```
error[E0554]: `#![feature]` may not be used on the stable release channel
```

## Expected Behavior

WASM builds should use nightly Rust regardless of mise configuration.

## Solution

Set `RUSTUP_TOOLCHAIN=nightly-2025-12-10` directly in the script, which overrides any existing env var from mise or other sources.