### PR TITLE
fix(repo): revert to older nightly Rust for WASM builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -541,7 +541,7 @@ jobs:
         run: |
           wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-23/wasi-sdk-23.0-x86_64-linux.tar.gz
           tar -xvf wasi-sdk-23.0-x86_64-linux.tar.gz
-          rustup toolchain install nightly-2025-12-10
+          rustup toolchain install nightly-2025-05-09
           pnpm build:wasm
       - name: Publish
         env:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "preinstall": "node ./scripts/preinstall.js",
     "test": "nx run-many -t test",
     "e2e": "nx run-many -t e2e --projects ./e2e/*",
-    "build:wasm": "RUSTUP_TOOLCHAIN=nightly-2025-12-10 rustup target add wasm32-wasip1-threads && RUSTUP_TOOLCHAIN=nightly-2025-12-10 WASI_SDK_PATH=\"$(pwd)/wasi-sdk-23.0-x86_64-linux\" CMAKE_BUILD_PARALLEL_LEVEL=2 LIBSQLITE3_FLAGS=\"-DLONGDOUBLE_TYPE=double\" pnpm exec nx run-many -t build-native-wasm",
+    "build:wasm": "RUSTUP_TOOLCHAIN=nightly-2025-05-09 rustup target add wasm32-wasip1-threads && RUSTUP_TOOLCHAIN=nightly-2025-05-09 WASI_SDK_PATH=\"$(pwd)/wasi-sdk-23.0-x86_64-linux\" CMAKE_BUILD_PARALLEL_LEVEL=2 LIBSQLITE3_FLAGS=\"-DLONGDOUBLE_TYPE=double\" pnpm exec nx run-many -t build-native-wasm",
     "lint-pnpm-lock": "eslint pnpm-lock.yaml",
     "migrate-to-pnpm-version": "node ./scripts/migrate-to-pnpm-version.js",
     "analyze-docs": "node tools/scripts/analyze-docs.mjs",


### PR DESCRIPTION
## Current Behavior

The nightly-2025-12-10 Rust version removed `mtim()` from the WASI `MetadataExt` trait, causing the WASM build to fail with:

```
error[E0599]: no method named `mtim` found for reference `&std::fs::Metadata` in the current scope
```

## Expected Behavior

WASM builds should compile successfully.

## Solution

Revert to `nightly-2025-05-09` which still has the `mtim()` API available in the WASI `MetadataExt` trait.