### PR TITLE
fix(core): improve database initialization error handling

### DIFF
--- a/packages/nx/src/native/db/initialize.rs
+++ b/packages/nx/src/native/db/initialize.rs
@@ -4,9 +4,124 @@ use crate::native::tasks::running_tasks_service::SCHEMA as RUNNING_TASKS_SCHEMA;
 use crate::native::tasks::task_history::SCHEMA as TASK_HISTORY_SCHEMA;
 use rusqlite::vtab::array;
 use rusqlite::{Connection, OpenFlags};
-use std::fs::{File, remove_file};
+use std::fs::{File, remove_file, write};
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use tracing::{debug, trace};
+
+// Error reporting constants - static strings to avoid allocations in error paths
+const REPORTING_INSTRUCTIONS_PERSISTENT: &str = "If the issue persists, please help us improve Nx by capturing logs and reporting this issue:\n\
+      1. Run: NX_NATIVE_FILE_LOGGING=nx::native::db=trace nx <your-command>\n\
+      2. Create an issue at https://github.com/nrwl/nx/issues/new/choose and include the .nx/workspace-data/nx.log file";
+
+const REPORTING_INSTRUCTIONS_IMMEDIATE: &str = "Please help us improve Nx by capturing logs and reporting this issue:\n\
+      1. Run: NX_NATIVE_FILE_LOGGING=nx::native::db=trace nx <your-command>\n\
+      2. Create an issue at https://github.com/nrwl/nx/issues/new/choose and include the .nx/workspace-data/nx.log file";
+
+/// Returns reporting instructions for error messages.
+///
+/// # Parameters
+/// * `is_known_error` - When `true`, returns instructions with "If the issue persists" prefix
+///   for errors with user-actionable guidance. When `false`, returns immediate reporting
+///   instructions for unexpected errors.
+fn reporting_instructions(is_known_error: bool) -> &'static str {
+    if is_known_error {
+        REPORTING_INSTRUCTIONS_PERSISTENT
+    } else {
+        REPORTING_INSTRUCTIONS_IMMEDIATE
+    }
+}
+
+/// Returns appropriate reset instruction based on whether error has user-actionable guidance.
+///
+/// # Parameters
+/// * `is_known_error` - When `true`, returns "Then try" for errors with guidance already provided.
+///   When `false`, returns more explicit instruction for unexpected errors.
+fn reset_instruction(is_known_error: bool) -> &'static str {
+    if is_known_error {
+        "Then try: nx reset"
+    } else {
+        "To try to fix this, run: nx reset"
+    }
+}
+
+/// Creates a user-friendly error message for filesystem IO errors with specific guidance based on error type
+fn create_io_error(operation: &str, path: &Path, error: std::io::Error) -> anyhow::Error {
+    let specific_guidance = match error.kind() {
+        ErrorKind::PermissionDenied => {
+            format!(
+                "Try:\n\
+                - Verify you have read and write permissions for: {}\n\
+                - Check that you own the file/directory or your user has access\n\
+                - Ensure the filesystem is not mounted read-only\n\
+                - If using Docker, ensure volume has correct permissions\n\
+                - If running in a restricted environment, you may need administrator privileges",
+                path.display()
+            )
+        }
+        ErrorKind::StorageFull => "Try:\n\
+            - Free up disk space on the drive containing the workspace\n\
+            - Move the workspace to a drive with more available space\n\
+            - Check for large files that can be removed"
+            .to_string(),
+        ErrorKind::AlreadyExists => {
+            "This may indicate a previous Nx process did not clean up properly.\n\
+            \n\
+            Try:\n\
+            - Ensure no other Nx processes are running\n\
+            - Run nx reset to clean up stale files"
+                .to_string()
+        }
+        _ => {
+            return anyhow::anyhow!(
+                "An unexpected error occurred while initializing the workspace data:\n\
+                \n\
+                {}\n\
+                \n\
+                {}\n\
+                \n\
+                {}",
+                error,
+                reporting_instructions(false),
+                reset_instruction(false)
+            );
+        }
+    };
+
+    anyhow::anyhow!(
+        "Unable to initialize workspace data while attempting to {}:\n\
+        \n\
+        {}\n\
+        \n\
+        {}\n\
+        \n\
+        {}\n\
+        \n\
+        {}",
+        operation,
+        error,
+        specific_guidance,
+        reporting_instructions(true),
+        reset_instruction(true)
+    )
+}
+
+/// Creates a user-friendly error message for database errors
+fn create_db_error(operation: &str, error: anyhow::Error) -> anyhow::Error {
+    anyhow::anyhow!(
+        "An unexpected error occurred while attempting to {}:\n\
+        \n\
+        {}\n\
+        \n\
+        {}\n\
+        \n\
+        {}",
+        operation,
+        error,
+        reporting_instructions(false),
+        reset_instruction(false)
+    )
+}
 
 pub(super) struct LockFile {
     file: File,
@@ -23,13 +138,14 @@ pub(super) fn unlock_file(lock_file: &LockFile) {
 
 pub(super) fn create_lock_file(db_path: &Path) -> anyhow::Result<LockFile> {
     let lock_file_path = db_path.with_extension("lock");
+    trace!("Creating lock file at {:?}", lock_file_path);
     let lock_file = File::create(&lock_file_path)
-        .map_err(|e| anyhow::anyhow!("Unable to create db lock file: {:?}", e))?;
+        .map_err(|e| create_io_error("create lock file", &lock_file_path, e))?;
 
     trace!("Getting lock on db lock file");
     fs4::fs_std::FileExt::lock_exclusive(&lock_file)
         .inspect(|_| trace!("Got lock on db lock file"))
-        .map_err(|e| anyhow::anyhow!("Unable to lock the db lock file: {:?}", e))?;
+        .map_err(|e| create_io_error("acquire exclusive lock", &lock_file_path, e))?;
     Ok(LockFile {
         file: lock_file,
         path: lock_file_path,
@@ -37,56 +153,96 @@ pub(super) fn create_lock_file(db_path: &Path) -> anyhow::Result<LockFile> {
 }
 
 pub(super) fn initialize_db(nx_version: String, db_path: &Path) -> anyhow::Result<NxDbConnection> {
-    match open_database_connection(db_path) {
-        Ok(mut c) => {
-            trace!(
-                "Checking if current existing database is compatible with Nx {}",
-                nx_version
-            );
-            let db_version = c.query_row(
-                "SELECT value FROM metadata WHERE key='NX_VERSION'",
-                [],
-                |row| {
-                    let r: String = row.get(0)?;
-                    Ok(r)
-                },
-            );
-            let c = match db_version {
-                Ok(Some(version)) if version == nx_version => {
-                    trace!("Database is compatible with Nx {}", nx_version);
-                    c
-                }
-                // If there is no metadata, it means that this database is new
-                Err(s) if s.to_string().contains("metadata") => {
-                    configure_database(&c)?;
-                    create_metadata_table(&mut c, &nx_version)?;
-                    create_all_tables(&mut c)?;
-                    c
-                }
-                reason => {
-                    trace!("Incompatible database because: {:?}", reason);
-                    trace!("Disconnecting from existing incompatible database");
-                    c.close()?;
-                    trace!("Removing existing incompatible database");
-                    remove_file(db_path)?;
+    // Track if DB existed before we opened it for safety check on new DB creation
+    let db_existed_before_open = db_path.exists();
+    let mut database_recreated = false;
 
-                    trace!("Initializing a new database");
-                    initialize_db(nx_version, db_path)?
-                }
-            };
+    loop {
+        match open_database_connection(db_path) {
+            Ok(mut c) => {
+                trace!(
+                    "Checking if current existing database is compatible with Nx {}",
+                    nx_version
+                );
+                let db_version = c.query_row(
+                    "SELECT value FROM metadata WHERE key='NX_VERSION'",
+                    [],
+                    |row| {
+                        let r: String = row.get(0)?;
+                        Ok(r)
+                    },
+                );
+                let c = match db_version {
+                    Ok(Some(version)) if version == nx_version => {
+                        trace!("Database is compatible with Nx {}", nx_version);
+                        c
+                    }
+                    // No metadata table found - database needs initialization
+                    // (either newly created or missing metadata from previous incomplete setup)
+                    Err(s) if s.to_string().contains("metadata") => {
+                        // Check if DB file existed before we opened it. If it did, it may be open
+                        // by another process (e.g., daemon) and it's not safe to configure it.
+                        if db_existed_before_open {
+                            c.close()?;
+                            return Err(anyhow::anyhow!(
+                                "Database file exists but has no metadata table.\n\
+                                This may indicate database corruption or incomplete initialization from a previous crash.\n\
+                                \n\
+                                To fix this issue:\n\
+                                1. Run: nx reset\n\
+                                2. Try your command again\n\
+                                \n\
+                                {}\n\
+                                \n\
+                                {}",
+                                reporting_instructions(true),
+                                reset_instruction(true)
+                            ));
+                        }
 
-            Ok(c)
-        }
-        Err(reason) => {
-            trace!(
-                "Unable to connect to existing database because: {:?}",
-                reason
-            );
-            trace!("Removing existing incompatible database");
-            remove_file(db_path)?;
+                        // Safe: DB didn't exist before, we just created it, no other process has it open
+                        match configure_database(&c, db_path, database_recreated) {
+                            Ok(_) => {
+                                create_metadata_table(&mut c, &nx_version)?;
+                                create_all_tables(&mut c)?;
+                                c
+                            }
+                            Err(config_error) if !database_recreated => {
+                                trace!("Failed to configure new database: {:?}", config_error);
+                                c.close()?;
+                                trace!("Removing new database files and retrying with fallback");
+                                remove_all_database_files(db_path)?;
+                                database_recreated = true;
+                                continue;
+                            }
+                            Err(config_error) => return Err(config_error),
+                        }
+                    }
+                    reason => {
+                        trace!("Incompatible database because: {:?}", reason);
+                        trace!("Disconnecting from existing incompatible database");
+                        c.close()?;
+                        trace!("Removing existing incompatible database");
+                        remove_file(db_path)?;
 
-            trace!("Initializing a new database");
-            initialize_db(nx_version, db_path)
+                        trace!("Initializing a new database");
+                        return initialize_db(nx_version, db_path);
+                    }
+                };
+
+                return Ok(c);
+            }
+            Err(reason) => {
+                trace!(
+                    "Unable to connect to existing database because: {:?}",
+                    reason
+                );
+                trace!("Removing existing incompatible database");
+                remove_file(db_path)?;
+
+                trace!("Initializing a new database");
+                return initialize_db(nx_version, db_path);
+            }
         }
     }
 }
@@ -131,6 +287,7 @@ fn create_all_tables(c: &mut NxDbConnection) -> anyhow::Result<()> {
 }
 
 fn open_database_connection(db_path: &Path) -> anyhow::Result<NxDbConnection> {
+    trace!("Opening database connection to {:?}", db_path);
     let conn = Connection::open_with_flags(
         db_path,
         OpenFlags::SQLITE_OPEN_READ_WRITE
@@ -138,26 +295,243 @@ fn open_database_connection(db_path: &Path) -> anyhow::Result<NxDbConnection> {
             | OpenFlags::SQLITE_OPEN_URI
             | OpenFlags::SQLITE_OPEN_FULL_MUTEX,
     )
-    .map_err(|e| anyhow::anyhow!("Error creating connection {:?}", e))?;
+    .map_err(|e| create_db_error("open database", e.into()))?;
 
     // Load array module for rarray() functionality - needed per connection
+    trace!("Loading SQLite array module");
     array::load_module(&conn)
-        .map_err(|e| anyhow::anyhow!("Unable to load array module: {:?}", e))?;
+        .map_err(|e| create_db_error("load SQLite array extension", e.into()))?;
 
     Ok(NxDbConnection::new(conn))
 }
 
-fn configure_database(connection: &NxDbConnection) -> anyhow::Result<()> {
-    connection
-        .pragma_update(None, "journal_mode", "WAL")
-        .map_err(|e| anyhow::anyhow!("Unable to set journal_mode: {:?}", e))?;
+fn configure_database(
+    connection: &NxDbConnection,
+    db_path: &Path,
+    allow_wal_fallback: bool,
+) -> anyhow::Result<()> {
+    // Try to set journal mode with automatic fallback
+    let journal_mode = set_journal_mode(connection, db_path, allow_wal_fallback)?;
+    trace!("Database configured with {} journal mode", journal_mode);
+
+    // Set other pragmas
+    trace!("Configuring database pragmas");
     connection
         .pragma_update(None, "synchronous", "NORMAL")
-        .map_err(|e| anyhow::anyhow!("Unable to set synchronous: {:?}", e))?;
+        .map_err(|e| create_db_error("configure database synchronous mode", e.into()))?;
+
     connection
         .busy_handler(Some(|tries| tries <= 12))
-        .map_err(|e| anyhow::anyhow!("Unable to set busy handler: {:?}", e))?;
+        .map_err(|e| create_db_error("configure database busy handler", e.into()))?;
+
     Ok(())
+}
+
+fn set_journal_mode(
+    connection: &NxDbConnection,
+    db_path: &Path,
+    allow_wal_fallback: bool,
+) -> anyhow::Result<&'static str> {
+    // Proactively skip WAL on known-incompatible environments
+    if is_known_incompatible_environment() {
+        debug!("Detected environment with known WAL incompatibilities");
+        debug!("Using DELETE journal mode");
+        connection
+            .pragma_update(None, "journal_mode", "DELETE")
+            .map_err(|e| {
+                diagnose_filesystem_issue(
+                    db_path,
+                    e.into(),
+                    "DELETE (required for this environment)",
+                )
+            })?;
+        trace!("Successfully enabled DELETE journal mode");
+        return Ok("DELETE");
+    }
+
+    // Try WAL mode (best performance)
+    match connection.pragma_update(None, "journal_mode", "WAL") {
+        Ok(_) => {
+            trace!("Successfully enabled WAL journal mode");
+            return Ok("WAL");
+        }
+        Err(wal_error) => {
+            trace!("WAL mode failed: {:?}", wal_error);
+
+            // If fallback is not allowed yet, WAL failure might be due to stale auxiliary files
+            // Return error to trigger cleanup and retry
+            if !allow_wal_fallback {
+                trace!("WAL failed before cleanup");
+                trace!("Will clean up database files and retry");
+                return Err(anyhow::anyhow!(
+                    "WAL mode failed - cleanup needed: {}",
+                    wal_error
+                ));
+            }
+
+            // After cleanup, WAL still not supported - fall back to DELETE mode
+            debug!("WAL not supported on this system after cleanup");
+        }
+    }
+
+    // Fallback to DELETE mode (universal compatibility)
+    connection
+        .pragma_update(None, "journal_mode", "DELETE")
+        .map_err(|e| {
+            diagnose_filesystem_issue(db_path, e.into(), "DELETE (fallback after WAL failed)")
+        })?;
+
+    trace!("Successfully enabled DELETE journal mode");
+    Ok("DELETE")
+}
+
+fn is_known_incompatible_environment() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        if is_wsl1() {
+            debug!("WSL1 detected - will use DELETE journal mode");
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(target_os = "linux")]
+fn is_wsl1() -> bool {
+    use std::sync::OnceLock;
+    static IS_WSL1: OnceLock<bool> = OnceLock::new();
+
+    *IS_WSL1.get_or_init(|| {
+        // WSL1 has "Microsoft" in /proc/version but not "WSL2"
+        std::fs::read_to_string("/proc/version")
+            .map(|contents| contents.contains("Microsoft") && !contents.contains("WSL2"))
+            .unwrap_or(false)
+    })
+}
+
+/// Creates an auxiliary database file path by appending a suffix to the database path.
+/// Uses OsString operations to avoid UTF-8 conversion and handle all valid paths correctly.
+fn auxiliary_path(db_path: &Path, suffix: &str) -> PathBuf {
+    let mut path = db_path.as_os_str().to_os_string();
+    path.push(suffix);
+    PathBuf::from(path)
+}
+
+fn remove_all_database_files(db_path: &Path) -> anyhow::Result<()> {
+    // Build list of all database-related files to remove
+    let files_to_remove = [
+        (db_path.to_path_buf(), "database file"),
+        (auxiliary_path(db_path, "-wal"), "WAL file"),
+        (auxiliary_path(db_path, "-shm"), "shared memory file"),
+    ];
+
+    // Remove all files with consistent error handling
+    for (path, description) in files_to_remove {
+        if path.exists() {
+            match remove_file(&path) {
+                Ok(_) => trace!("Removed {}: {:?}", description, path),
+                Err(e) => trace!("Warning: failed to remove {}: {}", description, e),
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Diagnose specific filesystem issues when setting journal mode fails
+fn diagnose_filesystem_issue(
+    db_path: &Path,
+    original_error: anyhow::Error,
+    context: &str,
+) -> anyhow::Error {
+    // Try to get the parent directory from the database path
+    if let Some(parent_dir) = db_path.parent() {
+        // Check if directory is writable by attempting to create a test file
+        let test_file = parent_dir.join(".nx-write-test");
+        match write(&test_file, b"test") {
+            Ok(_) => {
+                // Successfully wrote, clean up test file
+                remove_file(&test_file).ok();
+
+                // Directory is writable, so the issue is something else
+                return anyhow::anyhow!(
+                    "Unable to configure workspace database:\n\
+                    \n\
+                    Failed to set {} journal mode.\n\
+                    \n\
+                    {}\n\
+                    \n\
+                    The directory at {} exists and is writable, but SQLite cannot set the journal mode.\n\
+                    This typically indicates:\n\
+                    - The filesystem doesn't support SQLite's locking requirements (e.g., NFS, network drive)\n\
+                    - The filesystem lacks support for required features\n\
+                    - There are conflicting locks from another process\n\
+                    \n\
+                    Try:\n\
+                    - Move your workspace to a local filesystem\n\
+                    - Check for other processes accessing the cache directory\n\
+                    \n\
+                    {}\n\
+                    \n\
+                    {}",
+                    context,
+                    original_error,
+                    parent_dir.display(),
+                    reporting_instructions(true),
+                    reset_instruction(true)
+                );
+            }
+            Err(write_error) => {
+                // Directory exists but is not writable
+                return anyhow::anyhow!(
+                    "Unable to configure workspace database:\n\
+                    \n\
+                    Failed to set {} journal mode.\n\
+                    \n\
+                    {}\n\
+                    \n\
+                    The directory at {} exists but has restricted permissions.\n\
+                    SQLite successfully created the database file but cannot configure it due to filesystem restrictions.\n\
+                    \n\
+                    Try:\n\
+                    - Verify you have read and write permissions for the cache directory\n\
+                    - Check that you own the directory or your user has access\n\
+                    - Ensure the filesystem is not mounted read-only\n\
+                    - If using Docker, ensure volume has correct permissions\n\
+                    - If running in a restricted environment, you may need administrator privileges\n\
+                    \n\
+                    {}\n\
+                    \n\
+                    {}\n\
+                    \n\
+                    Write error: {}",
+                    context,
+                    original_error,
+                    parent_dir.display(),
+                    reporting_instructions(true),
+                    reset_instruction(true),
+                    write_error
+                );
+            }
+        }
+    }
+
+    // Fallback if we can't get the parent directory path
+    anyhow::anyhow!(
+        "Unable to configure workspace database:\n\
+        \n\
+        Failed to set {} journal mode.\n\
+        \n\
+        {}\n\
+        \n\
+        {}\n\
+        \n\
+        {}",
+        context,
+        original_error,
+        reporting_instructions(false),
+        reset_instruction(false)
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Current Behavior

When database initialization fails due to filesystem issues, permission problems, or environment incompatibilities (like WAL mode not being supported), Nx shows generic error messages that don't provide actionable guidance to users. For example:
- "Unable to create db lock file: PermissionDenied"
- "Unable to set journal_mode: <sqlite error>"

This makes it difficult for users to diagnose and resolve issues, especially in restricted environments like Docker containers, network filesystems, or WSL1.

## Expected Behavior

With this PR, database initialization errors now provide:

1. **Context-specific error messages** - Different guidance based on the error type:
   - Permission denied: Instructions about file ownership, Docker volume permissions, and read-only filesystems
   - Storage full: Suggestions to free disk space
   - Already exists: Guidance about stale files from crashed processes

2. **Automatic WAL mode fallback** - When WAL journal mode is not supported by the filesystem, Nx now automatically falls back to DELETE journal mode instead of failing. This improves compatibility with:
   - Network filesystems (NFS, CIFS)
   - Some Docker volume configurations
   - Other environments with limited locking support

3. **WSL1 detection** - Proactively detects WSL1 environments (which have known WAL incompatibilities) and uses DELETE mode from the start, avoiding failed attempts and retries.

4. **Better cleanup on retry** - When database initialization fails and needs to retry, all auxiliary files (WAL and SHM files) are also cleaned up, not just the main database file.

5. **Actionable reporting instructions** - All error messages now include:
   - How to capture detailed logs (`NX_NATIVE_FILE_LOGGING=nx::native::db=trace`)
   - Link to create an issue
   - Suggestion to run `nx reset`