### PR TITLE
feat(js): add option for using tsgo compiler over tsc for build, typecheck

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -390,6 +390,314 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
       `);
     });
 
+    it('should create a typecheck target with custom compiler option (tsgo)', async () => {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+        'libs/my-lib/tsconfig.json': JSON.stringify({ files: [] }),
+        'libs/my-lib/package.json': `{}`,
+      });
+      expect(
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
+          compiler: 'tsgo',
+        })
+      ).toMatchInlineSnapshot(`
+        {
+          "projects": {
+            "libs/my-lib": {
+              "targets": {
+                "typecheck": {
+                  "cache": true,
+                  "command": "tsgo --build --emitDeclarationOnly",
+                  "dependsOn": [
+                    "^typecheck",
+                  ],
+                  "inputs": [
+                    "production",
+                    "^production",
+                  ],
+                  "metadata": {
+                    "description": "Runs type-checking for the project.",
+                    "help": {
+                      "command": "npx tsgo --build --help",
+                      "example": {
+                        "args": [
+                          "--force",
+                        ],
+                      },
+                    },
+                    "technologies": [
+                      "typescript",
+                    ],
+                  },
+                  "options": {
+                    "cwd": "libs/my-lib",
+                  },
+                  "outputs": [],
+                  "syncGenerators": [
+                    "@nx/js:typescript-sync",
+                  ],
+                },
+              },
+            },
+          },
+        }
+      `);
+    });
+
+    it('should create a typecheck target with custom compiler option (tsgo) and verboseOutput', async () => {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+        'libs/my-lib/tsconfig.json': JSON.stringify({ files: [] }),
+        'libs/my-lib/package.json': `{}`,
+      });
+      expect(
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
+          compiler: 'tsgo',
+          verboseOutput: true,
+        })
+      ).toMatchInlineSnapshot(`
+        {
+          "projects": {
+            "libs/my-lib": {
+              "targets": {
+                "typecheck": {
+                  "cache": true,
+                  "command": "tsgo --build --emitDeclarationOnly --verbose",
+                  "dependsOn": [
+                    "^typecheck",
+                  ],
+                  "inputs": [
+                    "production",
+                    "^production",
+                  ],
+                  "metadata": {
+                    "description": "Runs type-checking for the project.",
+                    "help": {
+                      "command": "npx tsgo --build --help",
+                      "example": {
+                        "args": [
+                          "--force",
+                        ],
+                      },
+                    },
+                    "technologies": [
+                      "typescript",
+                    ],
+                  },
+                  "options": {
+                    "cwd": "libs/my-lib",
+                  },
+                  "outputs": [],
+                  "syncGenerators": [
+                    "@nx/js:typescript-sync",
+                  ],
+                },
+              },
+            },
+          },
+        }
+      `);
+    });
+
+    it('should create a typecheck target with custom compiler option (tsgo) and custom targetName', async () => {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+        'libs/my-lib/tsconfig.json': JSON.stringify({ files: [] }),
+        'libs/my-lib/package.json': `{}`,
+      });
+      expect(
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
+          compiler: 'tsgo',
+          typecheck: {
+            targetName: 'type-check',
+          },
+        })
+      ).toMatchInlineSnapshot(`
+        {
+          "projects": {
+            "libs/my-lib": {
+              "targets": {
+                "type-check": {
+                  "cache": true,
+                  "command": "tsgo --build --emitDeclarationOnly",
+                  "dependsOn": [
+                    "^type-check",
+                  ],
+                  "inputs": [
+                    "production",
+                    "^production",
+                  ],
+                  "metadata": {
+                    "description": "Runs type-checking for the project.",
+                    "help": {
+                      "command": "npx tsgo --build --help",
+                      "example": {
+                        "args": [
+                          "--force",
+                        ],
+                      },
+                    },
+                    "technologies": [
+                      "typescript",
+                    ],
+                  },
+                  "options": {
+                    "cwd": "libs/my-lib",
+                  },
+                  "outputs": [],
+                  "syncGenerators": [
+                    "@nx/js:typescript-sync",
+                  ],
+                },
+              },
+            },
+          },
+        }
+      `);
+    });
+
+    it('should create a typecheck target with explicit tsc compiler option', async () => {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+        'libs/my-lib/tsconfig.json': JSON.stringify({ files: [] }),
+        'libs/my-lib/package.json': `{}`,
+      });
+      expect(
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
+          compiler: 'tsc',
+        })
+      ).toMatchInlineSnapshot(`
+        {
+          "projects": {
+            "libs/my-lib": {
+              "targets": {
+                "typecheck": {
+                  "cache": true,
+                  "command": "tsc --build --emitDeclarationOnly",
+                  "dependsOn": [
+                    "^typecheck",
+                  ],
+                  "inputs": [
+                    "production",
+                    "^production",
+                  ],
+                  "metadata": {
+                    "description": "Runs type-checking for the project.",
+                    "help": {
+                      "command": "npx tsc --build --help",
+                      "example": {
+                        "args": [
+                          "--force",
+                        ],
+                      },
+                    },
+                    "technologies": [
+                      "typescript",
+                    ],
+                  },
+                  "options": {
+                    "cwd": "libs/my-lib",
+                  },
+                  "outputs": [],
+                  "syncGenerators": [
+                    "@nx/js:typescript-sync",
+                  ],
+                },
+              },
+            },
+          },
+        }
+      `);
+    });
+
+    it('should create both typecheck and build targets with custom compiler option (tsgo)', async () => {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+        'libs/my-lib/tsconfig.json': JSON.stringify({ files: [] }),
+        'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
+        'libs/my-lib/package.json': `{ "main": "dist/index.js" }`,
+      });
+      expect(
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
+          compiler: 'tsgo',
+          build: {
+            configName: 'tsconfig.lib.json',
+          },
+        })
+      ).toMatchInlineSnapshot(`
+        {
+          "projects": {
+            "libs/my-lib": {
+              "targets": {
+                "build": {
+                  "cache": true,
+                  "command": "tsgo --build tsconfig.lib.json",
+                  "dependsOn": [
+                    "^build",
+                  ],
+                  "inputs": [
+                    "production",
+                    "^production",
+                  ],
+                  "metadata": {
+                    "description": "Builds the project with \`tsc\`.",
+                    "help": {
+                      "command": "npx tsgo --build --help",
+                      "example": {
+                        "args": [
+                          "--force",
+                        ],
+                      },
+                    },
+                    "technologies": [
+                      "typescript",
+                    ],
+                  },
+                  "options": {
+                    "cwd": "libs/my-lib",
+                  },
+                  "outputs": [
+                    "{projectRoot}/dist",
+                  ],
+                  "syncGenerators": [
+                    "@nx/js:typescript-sync",
+                  ],
+                },
+                "typecheck": {
+                  "cache": true,
+                  "command": "tsgo --build --emitDeclarationOnly",
+                  "dependsOn": [
+                    "build",
+                    "^typecheck",
+                  ],
+                  "inputs": [
+                    "production",
+                    "^production",
+                  ],
+                  "metadata": {
+                    "description": "Runs type-checking for the project.",
+                    "help": {
+                      "command": "npx tsgo --build --help",
+                      "example": {
+                        "args": [
+                          "--force",
+                        ],
+                      },
+                    },
+                    "technologies": [
+                      "typescript",
+                    ],
+                  },
+                  "options": {
+                    "cwd": "libs/my-lib",
+                  },
+                  "outputs": [],
+                  "syncGenerators": [
+                    "@nx/js:typescript-sync",
+                  ],
+                },
+              },
+            },
+          },
+        }
+      `);
+    });
+
     it('should not create typecheck target for a project level tsconfig.json file if set to false in plugin options', async () => {
       // Sibling package.json
       configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
@@ -3045,6 +3353,66 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                     "description": "Builds the project with \`tsc\`.",
                     "help": {
                       "command": "npx tsc --build --help",
+                      "example": {
+                        "args": [
+                          "--force",
+                        ],
+                      },
+                    },
+                    "technologies": [
+                      "typescript",
+                    ],
+                  },
+                  "options": {
+                    "cwd": "libs/my-lib",
+                  },
+                  "outputs": [
+                    "{projectRoot}/dist",
+                  ],
+                  "syncGenerators": [
+                    "@nx/js:typescript-sync",
+                  ],
+                },
+              },
+            },
+          },
+        }
+      `);
+    });
+
+    it('should create a build target with custom compiler option (tsgo)', async () => {
+      configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+        'libs/my-lib/tsconfig.json': `{}`,
+        'libs/my-lib/tsconfig.lib.json': `{"compilerOptions": {"outDir": "dist"}}`,
+        'libs/my-lib/package.json': `{ "main": "dist/index.js" }`,
+      });
+      expect(
+        await invokeCreateNodesOnMatchingFiles(configFiles, context, {
+          compiler: 'tsgo',
+          typecheck: false,
+          build: {
+            configName: 'tsconfig.lib.json',
+          },
+        })
+      ).toMatchInlineSnapshot(`
+        {
+          "projects": {
+            "libs/my-lib": {
+              "targets": {
+                "build": {
+                  "cache": true,
+                  "command": "tsgo --build tsconfig.lib.json",
+                  "dependsOn": [
+                    "^build",
+                  ],
+                  "inputs": [
+                    "production",
+                    "^production",
+                  ],
+                  "metadata": {
+                    "description": "Builds the project with \`tsc\`.",
+                    "help": {
+                      "command": "npx tsgo --build --help",
                       "example": {
                         "args": [
                           "--force",

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -45,6 +45,7 @@ import {
 } from './util';
 
 export interface TscPluginOptions {
+  compiler?: 'tsc' | 'tsgo';
   typecheck?:
     | boolean
     | {
@@ -63,6 +64,7 @@ export interface TscPluginOptions {
 }
 
 interface NormalizedPluginOptions {
+  compiler: 'tsc' | 'tsgo';
   typecheck:
     | false
     | {
@@ -493,8 +495,9 @@ function buildTscTargets(
       config.project
     );
     const targetName = options.typecheck.targetName;
+    const compiler = options.compiler;
     if (!targets[targetName]) {
-      let command = `tsc --build --emitDeclarationOnly${
+      let command = `${compiler} --build --emitDeclarationOnly${
         options.verboseOutput ? ' --verbose' : ''
       }`;
       if (
@@ -557,7 +560,7 @@ function buildTscTargets(
           technologies: ['typescript'],
           description: 'Runs type-checking for the project.',
           help: {
-            command: `${pmc.exec} tsc --build --help`,
+            command: `${pmc.exec} ${compiler} --build --help`,
             example: {
               args: ['--force'],
             },
@@ -584,10 +587,11 @@ function buildTscTargets(
       config.project
     );
     const targetName = options.build.targetName;
+    const compiler = options.compiler;
 
     targets[targetName] = {
       dependsOn: [`^${targetName}`],
-      command: `tsc --build ${options.build.configName}${
+      command: `${compiler} --build ${options.build.configName}${
         options.verboseOutput ? ' --verbose' : ''
       }`,
       options: { cwd: config.project.root },
@@ -612,7 +616,7 @@ function buildTscTargets(
         technologies: ['typescript'],
         description: 'Builds the project with `tsc`.',
         help: {
-          command: `${pmc.exec} tsc --build --help`,
+          command: `${pmc.exec} ${compiler} --build --help`,
           example: {
             args: ['--force'],
           },
@@ -1364,6 +1368,9 @@ function readTsConfig(
 function normalizePluginOptions(
   pluginOptions: TscPluginOptions = {}
 ): NormalizedPluginOptions {
+  const defaultCompiler = 'tsc';
+  const compiler = pluginOptions.compiler ?? defaultCompiler;
+
   const defaultTypecheckTargetName = 'typecheck';
   let typecheck: NormalizedPluginOptions['typecheck'] = {
     targetName: defaultTypecheckTargetName,
@@ -1403,6 +1410,7 @@ function normalizePluginOptions(
   }
 
   return {
+    compiler,
     typecheck,
     build,
     verboseOutput: pluginOptions.verboseOutput ?? false,


### PR DESCRIPTION
Adds a 'compiler' option to the @nx/js/typescript plugin configuration, with options 'tsc' and 'tsgo'. Affects both typecheck and build targets.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The `@nx/js/typescript` plugin always uses `tsc` as the compiler, with no way to use the native `tsgo` preview.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
The `@nx/js/typescript` plugin can be configured to use `tsgo` for building and typechecking.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related discussion #32591.
