### PR TITLE
fix(js): allow copying generated Prisma client (asset) from 'node_modules'

### DIFF
--- a/packages/angular/src/plugins/plugin.spec.ts
+++ b/packages/angular/src/plugins/plugin.spec.ts
@@ -1,5 +1,5 @@
 import type { CreateNodesContextV2 } from '@nx/devkit';
-import { mkdirSync, rmdirSync } from 'node:fs';
+import { mkdirSync, rmSync } from 'node:fs';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { createNodesV2, type AngularProjectConfiguration } from './plugin';
 
@@ -30,7 +30,7 @@ describe('@nx/angular/plugin', () => {
   afterEach(() => {
     jest.resetModules();
     tempFs.cleanup();
-    rmdirSync('tmp/project-graph-cache', { recursive: true });
+    rmSync('tmp/project-graph-cache', { recursive: true, force: true });
   });
 
   it('should infer tasks from multiple projects in angular.json', async () => {

--- a/packages/eslint/src/plugins/plugin.spec.ts
+++ b/packages/eslint/src/plugins/plugin.spec.ts
@@ -2,7 +2,7 @@ import { CreateNodesContextV2 } from '@nx/devkit';
 import { minimatch } from 'minimatch';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { createNodesV2, EslintPluginOptions } from './plugin';
-import { mkdirSync, rmdirSync } from 'fs';
+import { mkdirSync, rmSync } from 'fs';
 
 jest.mock('nx/src/utils/cache-directory', () => ({
   ...jest.requireActual('nx/src/utils/cache-directory'),
@@ -39,7 +39,7 @@ describe('@nx/eslint/plugin', () => {
     jest.resetModules();
     tempFs.cleanup();
     tempFs = null;
-    rmdirSync('tmp/project-graph-cache', { recursive: true });
+    rmSync('tmp/project-graph-cache', { recursive: true, force: true });
   });
 
   it('should not create any nodes when there are no eslint configs', async () => {

--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -1,7 +1,7 @@
 import { detectPackageManager, type CreateNodesContextV2 } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import picomatch = require('picomatch');
-import { mkdirSync, rmdirSync } from 'node:fs';
+import { mkdirSync, rmSync } from 'node:fs';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { getLockFileName } from 'nx/src/plugins/js/lock-file/lock-file';
 import { setupWorkspaceContext } from 'nx/src/utils/workspace-context';
@@ -46,7 +46,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
     tempFs.cleanup();
     process.chdir(cwd);
     process.env.NX_CACHE_PROJECT_GRAPH = originalCacheProjectGraph;
-    rmdirSync('tmp/project-graph-cache', { recursive: true });
+    rmSync('tmp/project-graph-cache', { recursive: true, force: true });
   });
 
   it('should handle missing lock file', async () => {

--- a/packages/js/src/utils/assets/copy-assets-handler.ts
+++ b/packages/js/src/utils/assets/copy-assets-handler.ts
@@ -140,7 +140,7 @@ export class CopyAssetsHandler {
           dot: true, // enable hidden files
           expandDirectories: false,
           // Ignore common directories that should not be copied or processed
-          ignore: ['**/node_modules/**', '**/.git/**'],
+          ignore: ['**/.git/**'],
         });
 
         this.callback(this.filesToEvent(files, ag));


### PR DESCRIPTION
Removed 'node_modules' from the ignore list for asset copying.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Updating Nx to v22 breaks my app. Some projects use generated Prisma clients which, because of how Prisma binaries work, have to be generated to `node_modules` in order to work both locally and in Docker context.
With Nx v22 Prisma client is not copied when project is built using `@nx/esbuild:esbuild` (or any other executor supporting `assets` property) without any error or warning. It took mi couple of hours to pinpoint the exact line of code responsible for this. `node_modules` dir is hardcoded there without any possibility to be overridden.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Prisma client can be copied from `node_modules` to project output directory when building. 
Ignoring `node_modules` is removed **or can be overridden**. I'm open to any solution which will let me update Nx in my repository.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
