### PR TITLE
chore(misc): fix release script to check GITHUB_ACTIONS not NODE_AUTH_TOKEN

### DIFF
--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -74,7 +74,8 @@ const VALID_AUTHORS_FOR_LATEST = [
   };
 
   // Intended for creating a github release which triggers the publishing workflow
-  if (!options.local && !process.env.NODE_AUTH_TOKEN) {
+  // This runs locally (not in CI) to create the GitHub release that triggers the actual publish workflow
+  if (!options.local && !process.env.GITHUB_ACTIONS) {
     // For this important use-case it makes sense to always have full logs
     isVerboseLogging = true;
 


### PR DESCRIPTION
The check should be for `GITHUB_ACTIONS` since that is the intention. The token may not be set due to Trusted Publisher flow.