### PR TITLE
fix(core): add pnpm/yarn support for CNW templates

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -16,6 +16,7 @@ import { nxVersion } from '../src/utils/nx/nx-version';
 
 import { yargsDecorator } from './decorator';
 import { getPackageNameFromThirdPartyPreset } from '../src/utils/preset/get-third-party-preset';
+import { detectInvokedPackageManager } from '../src/utils/package-manager';
 import {
   determineAiAgents,
   determineDefaultBase,
@@ -377,7 +378,7 @@ async function normalizeArgsMiddleware(
     chosenTemplate = template;
 
     if (template !== 'custom') {
-      // Template flow - uses npm and 'main' branch by default
+      // Template flow - uses detected package manager (from invoking command) and 'main' branch by default
       argv.template = template;
       const aiAgents = await determineAiAgents(argv);
       const nxCloud =
@@ -390,7 +391,7 @@ async function normalizeArgsMiddleware(
         nxCloud,
         useGitHub: nxCloud !== 'skip',
         completionMessageKey,
-        packageManager: 'npm',
+        packageManager: detectInvokedPackageManager(),
         defaultBase: 'main',
         aiAgents,
       });

--- a/packages/create-nx-workspace/src/utils/package-manager.spec.ts
+++ b/packages/create-nx-workspace/src/utils/package-manager.spec.ts
@@ -1,0 +1,98 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { workspacesToPnpmYaml, findWorkspacePackages } from './package-manager';
+
+describe('workspacesToPnpmYaml', () => {
+  it('should convert single workspace glob to yaml', () => {
+    expect(workspacesToPnpmYaml(['packages/*'])).toMatchInlineSnapshot(`
+      "packages:
+        - 'packages/*'
+      "
+    `);
+  });
+
+  it('should convert multiple workspace globs to yaml', () => {
+    expect(workspacesToPnpmYaml(['packages/*', 'apps/*']))
+      .toMatchInlineSnapshot(`
+      "packages:
+        - 'packages/*'
+        - 'apps/*'
+      "
+    `);
+  });
+
+  it('should handle empty array', () => {
+    expect(workspacesToPnpmYaml([])).toMatchInlineSnapshot(`
+      "packages:
+
+      "
+    `);
+  });
+});
+
+describe('findWorkspacePackages', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cnw-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should find packages in packages directory', () => {
+    mkdirSync(join(tempDir, 'packages', 'pkg-a'), { recursive: true });
+    mkdirSync(join(tempDir, 'packages', 'pkg-b'), { recursive: true });
+    writeFileSync(
+      join(tempDir, 'packages', 'pkg-a', 'package.json'),
+      JSON.stringify({ name: '@myorg/pkg-a' })
+    );
+    writeFileSync(
+      join(tempDir, 'packages', 'pkg-b', 'package.json'),
+      JSON.stringify({ name: '@myorg/pkg-b' })
+    );
+
+    const result = findWorkspacePackages(tempDir);
+    expect(result).toEqual(['@myorg/pkg-a', '@myorg/pkg-b']);
+  });
+
+  it('should find packages in packages, libs, and apps directories', () => {
+    mkdirSync(join(tempDir, 'packages', 'pkg'), { recursive: true });
+    mkdirSync(join(tempDir, 'libs', 'lib'), { recursive: true });
+    mkdirSync(join(tempDir, 'apps', 'app'), { recursive: true });
+    writeFileSync(
+      join(tempDir, 'packages', 'pkg', 'package.json'),
+      JSON.stringify({ name: '@myorg/pkg' })
+    );
+    writeFileSync(
+      join(tempDir, 'libs', 'lib', 'package.json'),
+      JSON.stringify({ name: '@myorg/lib' })
+    );
+    writeFileSync(
+      join(tempDir, 'apps', 'app', 'package.json'),
+      JSON.stringify({ name: '@myorg/app' })
+    );
+
+    const result = findWorkspacePackages(tempDir);
+    expect(result).toEqual(['@myorg/app', '@myorg/lib', '@myorg/pkg']);
+  });
+
+  it('should return empty array when no packages found', () => {
+    const result = findWorkspacePackages(tempDir);
+    expect(result).toEqual([]);
+  });
+
+  it('should skip directories without package.json', () => {
+    mkdirSync(join(tempDir, 'packages', 'no-pkg'), { recursive: true });
+    mkdirSync(join(tempDir, 'packages', 'has-pkg'), { recursive: true });
+    writeFileSync(
+      join(tempDir, 'packages', 'has-pkg', 'package.json'),
+      JSON.stringify({ name: 'has-pkg' })
+    );
+
+    const result = findWorkspacePackages(tempDir);
+    expect(result).toEqual(['has-pkg']);
+  });
+});


### PR DESCRIPTION
Currently the template flow will only set up `npm`, even if you run `yarn create` or `pnpx create-nx-workspace`. This PR adds support back for other package managers.