### PR TITLE
docs(misc): remove redundant checkout conditional for GHA DTE example

### DIFF
--- a/astro-docs/src/content/docs/guides/Nx Cloud/manual-dte.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/manual-dte.mdoc
@@ -40,16 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        name: Checkout [Pull Request]
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          # We need to fetch all branches and commits so that Nx affected has a base to compare against.
-          fetch-depth: 0
-          filter: tree:0
-
-      - uses: actions/checkout@v4
-        name: Checkout [Default Branch]
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           # We need to fetch all branches and commits so that Nx affected has a base to compare against.
           fetch-depth: 0


### PR DESCRIPTION
## Current Behavior

The GitHub Actions DTE example includes a redundant conditional checkout step that has separate configurations for pull request and default branch events, both performing the same checkout operation.

## Expected Behavior

The GitHub Actions example should use a single, simpler checkout configuration that works for both pull request and default branch events, removing redundant code.

## Related Issue(s)

This change simplifies the documentation example by removing redundant checkout steps while maintaining the same functionality.