### PR TITLE
feat(bundling): support rollup nested export

### DIFF
--- a/packages/js/src/plugins/rollup/type-definitions.ts
+++ b/packages/js/src/plugins/rollup/type-definitions.ts
@@ -1,6 +1,6 @@
 // nx-ignore-next-line
 import type { OutputBundle } from 'rollup'; // only used  for types
-import { relative } from 'path';
+import { relative, dirname } from 'path';
 import { stripIndents } from '@nx/devkit';
 
 //NOTE: This is here so we can share between `@nx/rollup` and `@nx/vite`.
@@ -46,7 +46,7 @@ export function typeDefinitions(options: { projectRoot: string }) {
           '.d.ts'
         );
 
-        const relativeSourceDtsName = JSON.stringify('./' + entrySourceDtsName);
+        const relativeSourceDtsName = JSON.stringify('./' + relative(dirname(file.name), entrySourceDtsName));
         const dtsFileSource = hasDefaultExport
           ? stripIndents`
               export * from ${relativeSourceDtsName};

--- a/packages/js/src/plugins/rollup/type-definitions.ts
+++ b/packages/js/src/plugins/rollup/type-definitions.ts
@@ -46,7 +46,9 @@ export function typeDefinitions(options: { projectRoot: string }) {
           '.d.ts'
         );
 
-        const relativeSourceDtsName = JSON.stringify('./' + relative(dirname(file.name), entrySourceDtsName));
+        const relativeSourceDtsName = JSON.stringify(
+          './' + relative(dirname(file.name), entrySourceDtsName)
+        );
         const dtsFileSource = hasDefaultExport
           ? stripIndents`
               export * from ${relativeSourceDtsName};

--- a/packages/js/src/plugins/rollup/type-definitions.ts
+++ b/packages/js/src/plugins/rollup/type-definitions.ts
@@ -47,7 +47,7 @@ export function typeDefinitions(options: { projectRoot: string }) {
         );
 
         const relativeSourceDtsName = JSON.stringify(
-          './' + relative(dirname(file.name), entrySourceDtsName)
+          './' + relative(dirname(file.fileName), entrySourceDtsName)
         );
         const dtsFileSource = hasDefaultExport
           ? stripIndents`

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -137,6 +137,13 @@
       },
       "x-priority": "important"
     },
+    "additionalEntryPointsRootDir": {
+      "type": "array",
+      "description": "Root dir for the additional entry-points. If provided, the paths in `additionalEntryPoints` are relative to this root dir.",
+      "items": {
+        "type": "string"
+      }
+    },
     "buildLibsFromSource": {
       "type": "boolean",
       "description": "Read buildable libraries from source instead of building them separately.",

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -138,11 +138,8 @@
       "x-priority": "important"
     },
     "additionalEntryPointsRootDir": {
-      "type": "array",
-      "description": "Root dir for the additional entry-points. If provided, the paths in `additionalEntryPoints` are relative to this root dir.",
-      "items": {
-        "type": "string"
-      }
+      "type": "string",
+      "description": "Root dir for the additional entry-points. If provided, the paths in `additionalEntryPoints` are relative to this root dir."
     },
     "buildLibsFromSource": {
       "type": "boolean",

--- a/packages/rollup/src/plugins/package-json/generate-package-json.ts
+++ b/packages/rollup/src/plugins/package-json/generate-package-json.ts
@@ -20,8 +20,8 @@ export function generatePackageJson(
 ): Plugin {
   return {
     name: pluginName,
-    writeBundle: () => {
-      updatePackageJson(options, packageJson);
+    writeBundle: (rollupOptions, bundle) => {
+      updatePackageJson(options, packageJson, bundle);
     },
   };
 }

--- a/packages/rollup/src/plugins/package-json/update-package-json.spec.ts
+++ b/packages/rollup/src/plugins/package-json/update-package-json.spec.ts
@@ -24,7 +24,8 @@ describe('updatePackageJson', () => {
           generateExportsField: true,
           format: ['esm'],
         },
-        {} as unknown as PackageJson
+        {} as unknown as PackageJson,
+        {}
       );
 
       expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
@@ -53,7 +54,8 @@ describe('updatePackageJson', () => {
           generateExportsField: true,
           format: ['cjs'],
         },
-        {} as unknown as PackageJson
+        {} as unknown as PackageJson,
+        {}
       );
 
       expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
@@ -78,7 +80,8 @@ describe('updatePackageJson', () => {
           generateExportsField: true,
           format: ['esm', 'cjs'],
         },
-        {} as unknown as PackageJson
+        {} as unknown as PackageJson,
+        {}
       );
 
       expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
@@ -115,7 +118,8 @@ describe('updatePackageJson', () => {
               types: './some/custom/path/foo.d.ts',
             },
           },
-        } as unknown as PackageJson
+        } as unknown as PackageJson,
+        {}
       );
 
       expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
@@ -149,7 +153,8 @@ describe('updatePackageJson', () => {
           ...commonOptions,
           format: ['esm'],
         },
-        {} as unknown as PackageJson
+        {} as unknown as PackageJson,
+        {}
       );
 
       expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
@@ -170,7 +175,8 @@ describe('updatePackageJson', () => {
           ...commonOptions,
           format: ['cjs'],
         },
-        {} as unknown as PackageJson
+        {} as unknown as PackageJson,
+        {}
       );
 
       expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
@@ -190,7 +196,8 @@ describe('updatePackageJson', () => {
           ...commonOptions,
           format: ['esm', 'cjs'],
         },
-        {} as unknown as PackageJson
+        {} as unknown as PackageJson,
+        {}
       );
 
       expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
@@ -214,7 +221,8 @@ describe('updatePackageJson', () => {
           exports: {
             './foo': './foo.esm.js',
           },
-        } as unknown as PackageJson
+        } as unknown as PackageJson,
+        {}
       );
 
       expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
@@ -245,7 +253,8 @@ describe('updatePackageJson', () => {
           exports: {
             './foo': './foo.esm.js',
           },
-        } as unknown as PackageJson
+        } as unknown as PackageJson,
+        {}
       );
 
       expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
@@ -272,7 +281,8 @@ describe('updatePackageJson', () => {
           exports: {
             './foo': './foo.esm.js',
           },
-        } as unknown as PackageJson
+        } as unknown as PackageJson,
+        {}
       );
 
       expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {
@@ -301,7 +311,8 @@ describe('updatePackageJson', () => {
           exports: {
             './foo': './foo.esm.js',
           },
-        } as unknown as PackageJson
+        } as unknown as PackageJson,
+        {}
       );
 
       expect(utils.writeJsonFile).toHaveBeenCalledWith(expect.anything(), {

--- a/packages/rollup/src/plugins/package-json/update-package-json.ts
+++ b/packages/rollup/src/plugins/package-json/update-package-json.ts
@@ -29,10 +29,13 @@ export function updatePackageJson(
   }
 
   if (hasEsmFormat) {
-    const esmExports = getExports({
-      ...options,
-      fileExt: '.esm.js',
-    }, bundle);
+    const esmExports = getExports(
+      {
+        ...options,
+        fileExt: '.esm.js',
+      },
+      bundle
+    );
 
     packageJson.module = esmExports['.'];
 
@@ -56,10 +59,13 @@ export function updatePackageJson(
   }
 
   if (hasCjsFormat) {
-    const cjsExports = getExports({
-      ...options,
-      fileExt: '.cjs.js',
-    }, bundle);
+    const cjsExports = getExports(
+      {
+        ...options,
+        fileExt: '.cjs.js',
+      },
+      bundle
+    );
 
     packageJson.main = cjsExports['.'];
 
@@ -128,17 +134,28 @@ interface Exports {
   [name: string]: string;
 }
 
-function getExports(options: {
-  main?: string;
-  fileExt: string;
-  outputFileName?: string;
-  additionalEntryPoints?: string[];
-}, bundle: OutputBundle): Exports {
+function getExports(
+  options: {
+    main?: string;
+    fileExt: string;
+    outputFileName?: string;
+    additionalEntryPoints?: string[];
+  },
+  bundle: OutputBundle
+): Exports {
   const exports: Exports = {};
 
-  const exportMapping = new Map(Object.entries(bundle)
-    .filter((entry): entry is [string, OutputChunk] => entry[1].type === 'chunk' && entry[1].facadeModuleId != null)
-    .map(([key, value]) => [relative(workspaceRoot, value.facadeModuleId), { path: key, name: value.name }]))
+  const exportMapping = new Map(
+    Object.entries(bundle)
+      .filter(
+        (entry): entry is [string, OutputChunk] =>
+          entry[1].type === 'chunk' && entry[1].facadeModuleId != null
+      )
+      .map(([key, value]) => [
+        relative(workspaceRoot, value.facadeModuleId),
+        { path: key, name: value.name },
+      ])
+  );
 
   // Users may provide custom input option and skip the main field.
   if (options.main) {
@@ -150,7 +167,7 @@ function getExports(options: {
 
   if (options.additionalEntryPoints) {
     for (const file of options.additionalEntryPoints) {
-      const mapping = exportMapping.get(file)
+      const mapping = exportMapping.get(file);
       if (mapping != null) {
         exports['./' + mapping.name] = './' + mapping.path;
       } else {

--- a/packages/rollup/src/plugins/package-json/update-package-json.ts
+++ b/packages/rollup/src/plugins/package-json/update-package-json.ts
@@ -168,7 +168,7 @@ function getExports(
   if (options.additionalEntryPoints) {
     for (const file of options.additionalEntryPoints) {
       const mapping = exportMapping.get(file);
-      if (mapping != null) {
+      if (mapping != null && mapping.path.endsWith(options.fileExt)) {
         exports['./' + mapping.name] = './' + mapping.path;
       } else {
         const { name: fileName } = parse(file);

--- a/packages/rollup/src/plugins/with-nx/normalize-options.ts
+++ b/packages/rollup/src/plugins/with-nx/normalize-options.ts
@@ -29,6 +29,7 @@ export function normalizeOptions(
       options.additionalEntryPoints,
       workspaceRoot
     ),
+    additionalEntryPointsRootDir: options.additionalEntryPointsRootDir ? resolve(workspaceRoot, options.additionalEntryPointsRootDir) : undefined,
     allowJs: options.allowJs ?? false,
     assets: options.assets
       ? normalizeAssets(options.assets, workspaceRoot, sourceRoot)

--- a/packages/rollup/src/plugins/with-nx/normalize-options.ts
+++ b/packages/rollup/src/plugins/with-nx/normalize-options.ts
@@ -29,7 +29,9 @@ export function normalizeOptions(
       options.additionalEntryPoints,
       workspaceRoot
     ),
-    additionalEntryPointsRootDir: options.additionalEntryPointsRootDir ? resolve(workspaceRoot, options.additionalEntryPointsRootDir) : undefined,
+    additionalEntryPointsRootDir: options.additionalEntryPointsRootDir
+      ? resolve(workspaceRoot, options.additionalEntryPointsRootDir)
+      : undefined,
     allowJs: options.allowJs ?? false,
     assets: options.assets
       ? normalizeAssets(options.assets, workspaceRoot, sourceRoot)

--- a/packages/rollup/src/plugins/with-nx/with-nx-options.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx-options.ts
@@ -4,6 +4,11 @@ export interface RollupWithNxPluginOptions {
    * */
   additionalEntryPoints?: string[];
   /**
+   * Root dir for the additional entry-points.
+   * If provided, the paths in `additionalEntryPoints` are relative to this root dir.
+   * */
+  additionalEntryPointsRootDir?: string;
+  /**
    * Allow JavaScript files to be compiled.
    */
   allowJs?: boolean;

--- a/packages/rollup/src/plugins/with-nx/with-nx.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx.ts
@@ -21,7 +21,7 @@ import { getBabelInputPlugin } from '@rollup/plugin-babel';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import * as autoprefixer from 'autoprefixer';
 import { existsSync } from 'node:fs';
-import { dirname, join, parse } from 'node:path';
+import { dirname, join, parse, relative } from 'node:path';
 import { PackageJson } from 'nx/src/utils/package-json';
 import * as rollup from 'rollup';
 import { analyze } from '../analyze';
@@ -356,7 +356,9 @@ function createInput(
     join(workspaceRoot, options.main)
   );
   options.additionalEntryPoints?.forEach((entry) => {
-    input[parse(entry).name] = normalizePath(join(workspaceRoot, entry));
+    const path = normalizePath(join(workspaceRoot, entry))
+    const inputName = options.additionalEntryPointsRootDir ? relative(options.additionalEntryPointsRootDir, entry) : parse(entry).name
+    input[inputName] = path;
   });
   return input;
 }

--- a/packages/rollup/src/plugins/with-nx/with-nx.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx.ts
@@ -356,8 +356,10 @@ function createInput(
     join(workspaceRoot, options.main)
   );
   options.additionalEntryPoints?.forEach((entry) => {
-    const path = normalizePath(join(workspaceRoot, entry))
-    const inputName = options.additionalEntryPointsRootDir ? relative(options.additionalEntryPointsRootDir, entry) : parse(entry).name
+    const path = normalizePath(join(workspaceRoot, entry));
+    const inputName = options.additionalEntryPointsRootDir
+      ? relative(options.additionalEntryPointsRootDir, entry)
+      : parse(entry).name;
     input[inputName] = path;
   });
   return input;


### PR DESCRIPTION

## Current Behavior


nested additionalEntryPoints are all moved to the root or the library

## Expected Behavior


additionalEntryPoints path should be kept when bundling a library

## Related Issue(s)



Fixes https://github.com/nrwl/nx/discussions/33789
