### PR TITLE
feat(webpack): add support for merging externals to NxAppWebpackPlugin

### DIFF
--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -370,7 +370,7 @@ function applyNxDependentConfig(
     plugins.push(new StatsJsonPlugin());
   }
 
-  const externals = options.mergeExternals ? config.externals : [];
+  const externals = options.mergeExternals && Array.isArray(config.externals) ? config.externals : [];
   if (options.target === 'node' && options.externalDependencies === 'all') {
     const modulesDir = `${options.root}/node_modules`;
 

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -370,7 +370,10 @@ function applyNxDependentConfig(
     plugins.push(new StatsJsonPlugin());
   }
 
-  const externals = options.mergeExternals && Array.isArray(config.externals) ? config.externals : [];
+  const externals =
+    options.mergeExternals && Array.isArray(config.externals)
+      ? [...config.externals]
+      : [];
   if (options.target === 'node' && options.externalDependencies === 'all') {
     const modulesDir = `${options.root}/node_modules`;
 

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -370,7 +370,7 @@ function applyNxDependentConfig(
     plugins.push(new StatsJsonPlugin());
   }
 
-  const externals = [];
+  const externals = options.mergeExternals ? config.externals : [];
   if (options.target === 'node' && options.externalDependencies === 'all') {
     const modulesDir = `${options.root}/node_modules`;
 

--- a/packages/webpack/src/plugins/nx-webpack-plugin/nx-app-webpack-plugin-options.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/nx-app-webpack-plugin-options.ts
@@ -92,6 +92,11 @@ export interface NxAppWebpackPluginOptions {
    */
   externalDependencies?: 'all' | 'none' | string[];
   /**
+   * Weather to combine plugin externals config with the existing webpack external config.
+   * Default is `false`.
+   */
+  mergeExternals?: boolean;
+  /**
    * Extract CSS as an external file. Default is `true`.
    */
   extractCss?: boolean;

--- a/packages/webpack/src/plugins/nx-webpack-plugin/nx-app-webpack-plugin-options.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/nx-app-webpack-plugin-options.ts
@@ -92,7 +92,7 @@ export interface NxAppWebpackPluginOptions {
    */
   externalDependencies?: 'all' | 'none' | string[];
   /**
-   * Weather to combine plugin externals config with the existing webpack external config.
+   * Whether to combine plugin externals config with the existing webpack external config.
    * Default is `false`.
    */
   mergeExternals?: boolean;


### PR DESCRIPTION
This pull request introduces a new option to the Nx Webpack plugin that allows users to control whether the plugin should merge its external dependencies configuration with any existing Webpack externals configuration. This provides greater flexibility when customizing how external dependencies are handled during the build process.

Configuration enhancements:

* Added a new `mergeExternals` boolean option to the `NxAppWebpackPluginOptions` interface, allowing users to specify whether to combine the plugin's externals configuration with the existing Webpack config.
* Updated the logic in `apply-base-config.ts` so that the `externals` array is set based on the new `mergeExternals` option, defaulting to not merging unless specified.