### PR TITLE
fix(js): make CopyAssetsHandler per-file logs opt-in via verbose mode

### DIFF
--- a/packages/js/src/utils/assets/copy-assets-handler.ts
+++ b/packages/js/src/utils/assets/copy-assets-handler.ts
@@ -57,7 +57,7 @@ export const defaultFileEventHandler = (events: FileEvent[]) => {
     }
     const eventDir = path.dirname(event.src);
     const relativeDest = path.relative(eventDir, event.dest);
-    logger.log(`\n${dim(relativeDest)}`);
+    logger.verbose(`\n${dim(relativeDest)}`);
   });
 };
 


### PR DESCRIPTION
The CopyAssetsHandler was logging every copied file to the console,
causing noisy output when a project copies many files. This could
cause build errors to be cut off in terminals with scroll limits.

Change logger.log() to logger.verbose() so per-file logging only
appears when --verbose is passed or NX_VERBOSE_LOGGING=true.

Fixes #33521

