### PR TITLE
fix(expo): set projectRoot to workspaceRoot for Expo SDK 54+ compatibility

### DIFF
--- a/packages/expo/plugins/metro-resolver.ts
+++ b/packages/expo/plugins/metro-resolver.ts
@@ -142,7 +142,14 @@ function pnpmResolver(
       exportsConditionNames,
       mainFields
     );
-    const lookupStartPath = dirname(context.originModulePath);
+    let lookupStartPath = dirname(context.originModulePath);
+
+    // Defensive: ensure path is within workspace root.
+    // Handles Expo SDK 54+ where originModulePath may be project-relative.
+    if (!lookupStartPath.startsWith(workspaceRoot)) {
+      lookupStartPath = workspaceRoot;
+    }
+
     const filePath = pnpmResolve.resolveSync(
       {},
       lookupStartPath,

--- a/packages/expo/plugins/with-nx-metro.ts
+++ b/packages/expo/plugins/with-nx-metro.ts
@@ -74,6 +74,9 @@ export function withNxMetro(userConfig: MetroConfig, opts: WithNxOptions = {}) {
   );
 
   const nxConfig: MetroConfig = {
+    // Set projectRoot to workspaceRoot to ensure originModulePath is
+    // workspace-relative. This is required for Expo SDK 54+ compatibility.
+    projectRoot: workspaceRoot,
     resolver: {
       resolveRequest: getResolveRequest(
         extensions,


### PR DESCRIPTION
Expo CLI 54.0.12+ changed how originModulePath is determined in Metro
resolvers - from workspace root to project root. This caused the Nx
custom resolver to double-path modules when resolving workspace libraries.

This fix:
- Adds projectRoot: workspaceRoot to the Metro config to ensure
  originModulePath remains workspace-relative
- Adds defensive path normalization in pnpmResolver to handle edge cases

Fixes #33597
