### PR TITLE
fix(js): display pnpm publish errors without requiring --verbose

### DIFF
--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -205,11 +205,19 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
               )
             ) {
               console.error('npm dist-tag add error:');
+              // npm returns error.summary and error.detail
               if (stdoutData.error?.summary) {
                 console.error(stdoutData.error.summary);
               }
               if (stdoutData.error?.detail) {
                 console.error(stdoutData.error.detail);
+              }
+              // pnpm returns error.code and error.message
+              if (stdoutData.error?.code && !stdoutData.error?.summary) {
+                console.error(`Error code: ${stdoutData.error.code}`);
+              }
+              if (stdoutData.error?.message && !stdoutData.error?.summary) {
+                console.error(stdoutData.error.message);
               }
 
               if (context.isVerbose) {
@@ -375,11 +383,19 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
       const stdoutData = JSON.parse(err.stdout?.toString() || '{}');
 
       console.error(`${pm} publish error:`);
+      // npm returns error.summary and error.detail
       if (stdoutData.error?.summary) {
         console.error(stdoutData.error.summary);
       }
       if (stdoutData.error?.detail) {
         console.error(stdoutData.error.detail);
+      }
+      // pnpm returns error.code and error.message
+      if (stdoutData.error?.code && !stdoutData.error?.summary) {
+        console.error(`Error code: ${stdoutData.error.code}`);
+      }
+      if (stdoutData.error?.message && !stdoutData.error?.summary) {
+        console.error(stdoutData.error.message);
       }
 
       if (context.isVerbose) {


### PR DESCRIPTION
The release-publish executor was only displaying npm-style errors (error.summary
and error.detail), but pnpm returns errors with a different format (error.code
and error.message). This caused pnpm publish errors to be invisible unless users
passed the --verbose flag.

This fix adds handling for pnpm's error format so that error messages are
properly displayed to users without requiring --verbose.

Fixes 33537
