### PR TITLE
feat(core): add hints and status messages to the tui

### DIFF
--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -97,6 +97,11 @@
           ],
           "description": "Whether to exit the TUI automatically after all tasks finish. If set to `true`, the TUI will exit immediately. If set to `false` the TUI will not automatically exit. If set to a number, an interruptible countdown popup will be shown for that many seconds before the TUI exits.",
           "default": 3
+        },
+        "suppressHints": {
+          "type": "boolean",
+          "description": "Whether to suppress hint popups that provide guidance for unhandled keys.",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -876,6 +876,11 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
      * - If set to a number, an interruptible countdown popup will be shown for that many seconds before the TUI exits.
      */
     autoExit?: boolean | number;
+    /**
+     * Whether to suppress hint popups that provide guidance for unhandled keys.
+     * Defaults to `false` (hints are shown).
+     */
+    suppressHints?: boolean;
   };
 }
 

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -498,6 +498,7 @@ export interface TuiCliArgs {
 
 export interface TuiConfig {
   autoExit?: boolean | number | undefined
+  suppressHints?: boolean
 }
 
 export interface UpdatedWorkspaceFiles {

--- a/packages/nx/src/native/tui/action.rs
+++ b/packages/nx/src/native/tui/action.rs
@@ -36,4 +36,5 @@ pub enum Action {
     SendConsoleMessage(String),
     ConsoleMessengerAvailable(bool),
     EndCommand,
+    ShowHint(String),
 }

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -1494,10 +1494,11 @@ impl App {
                 if matches!(task_status, TaskStatus::NotStarted | TaskStatus::Skipped) {
                     // Task is pending - handle keys in dependency view
                     if let Some(dep_state) = &mut self.dependency_view_states[pane_idx] {
-                        if dep_state.handle_key_event(key) {
-                            return Ok(()); // Key was handled by dependency view
+                        if let Some(action) = dep_state.handle_key_event(key) {
+                            self.dispatch_action(action);
                         }
                     }
+                    return Ok(());
                 } else {
                     // Task is running/completed - handle keys in terminal pane
                     let terminal_pane_data = &mut self.terminal_pane_data[pane_idx];

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -1086,13 +1086,16 @@ impl App {
                 self.handle_end_command();
             }
             Action::ShowHint(message) => {
-                if let Some(hint_popup) = self
-                    .components
-                    .iter_mut()
-                    .find_map(|c| c.as_any_mut().downcast_mut::<HintPopup>())
-                {
-                    hint_popup.show(message.clone());
-                    self.update_focus(Focus::HintPopup);
+                // Only show hints if not suppressed by config
+                if !self.tui_config.suppress_hints {
+                    if let Some(hint_popup) = self
+                        .components
+                        .iter_mut()
+                        .find_map(|c| c.as_any_mut().downcast_mut::<HintPopup>())
+                    {
+                        hint_popup.show(message.clone());
+                        self.update_focus(Focus::HintPopup);
+                    }
                 }
             }
             _ => {}

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -28,6 +28,7 @@ use super::components::Component;
 use super::components::countdown_popup::CountdownPopup;
 use super::components::dependency_view::{DependencyView, DependencyViewState};
 use super::components::help_popup::HelpPopup;
+use super::components::hint_popup::HintPopup;
 use super::components::layout_manager::{
     LayoutAreas, LayoutManager, PaneArrangement, TaskListVisibility,
 };
@@ -44,6 +45,9 @@ use super::utils::normalize_newlines;
 use crate::native::ide::nx_console::messaging::NxConsoleMessageConnection;
 use crate::native::tui::graph_utils::get_failed_dependencies;
 use crate::native::utils::time::current_timestamp_millis;
+
+/// Duration before status messages in terminal panes are automatically cleared
+const STATUS_MESSAGE_DURATION: std::time::Duration = std::time::Duration::from_secs(3);
 
 pub struct App {
     pub components: Vec<Box<dyn Component>>,
@@ -87,6 +91,7 @@ pub enum Focus {
     MultipleOutput(usize),
     HelpPopup,
     CountdownPopup,
+    HintPopup,
 }
 
 impl App {
@@ -120,11 +125,13 @@ impl App {
         );
         let help_popup = HelpPopup::new();
         let countdown_popup = CountdownPopup::new();
+        let hint_popup = HintPopup::new();
 
         let components: Vec<Box<dyn Component>> = vec![
             Box::new(tasks_list),
             Box::new(help_popup),
             Box::new(countdown_popup),
+            Box::new(hint_popup),
         ];
 
         let main_terminal_pane_data = TerminalPaneData::new();
@@ -519,6 +526,22 @@ impl App {
                     return Ok(false);
                 }
 
+                // If hint popup is open, only ESC dismisses it
+                if matches!(self.focus, Focus::HintPopup) {
+                    if let Some(hint_popup) = self
+                        .components
+                        .iter_mut()
+                        .find_map(|c| c.as_any_mut().downcast_mut::<HintPopup>())
+                    {
+                        if key.code == KeyCode::Esc {
+                            hint_popup.hide();
+                            self.update_focus(self.previous_focus);
+                        }
+                        // All other keys are consumed while hint popup is visible
+                    }
+                    return Ok(false);
+                }
+
                 if let Some(tasks_list) = self
                     .components
                     .iter_mut()
@@ -781,6 +804,9 @@ impl App {
                                 Focus::CountdownPopup => {
                                     // Countdown popup has its own key handling above
                                 }
+                                Focus::HintPopup => {
+                                    // Hint popup has its own key handling above
+                                }
                             }
                         }
                     }
@@ -822,6 +848,30 @@ impl App {
                             messenger.update_running_tasks(&tasks_list.tasks, &self.pty_instances)
                         })
                 });
+
+                // Auto-dismiss hint popup after duration elapsed
+                if let Some(hint_popup) = self
+                    .components
+                    .iter_mut()
+                    .find_map(|c| c.as_any_mut().downcast_mut::<HintPopup>())
+                {
+                    if hint_popup.should_auto_dismiss() {
+                        hint_popup.hide();
+                        // Restore focus if hint popup was focused
+                        if matches!(self.focus, Focus::HintPopup) {
+                            self.update_focus(self.previous_focus);
+                        }
+                    }
+                }
+
+                // Clear expired status messages from terminal panes
+                for terminal_pane_data in &mut self.terminal_pane_data {
+                    if let Some((_, shown_at)) = &terminal_pane_data.status_message {
+                        if shown_at.elapsed() > STATUS_MESSAGE_DURATION {
+                            terminal_pane_data.status_message = None;
+                        }
+                    }
+                }
             }
             // Quit immediately
             Action::Quit => {
@@ -999,18 +1049,29 @@ impl App {
                         }
                     }
 
-                    // Draw the help popup and countdown popup
-                    let (first_part, second_part) = self.components.split_at_mut(2);
-                    let help_popup = first_part[1]
-                        .as_any_mut()
-                        .downcast_mut::<HelpPopup>()
-                        .unwrap();
-                    let countdown_popup = second_part[0]
-                        .as_any_mut()
-                        .downcast_mut::<CountdownPopup>()
-                        .unwrap();
-                    let _ = help_popup.draw(f, frame_area);
-                    let _ = countdown_popup.draw(f, frame_area);
+                    // Draw the popups (help, countdown, interstitial)
+                    // Draw each popup sequentially to avoid multiple mutable borrows
+                    if let Some(help_popup) = self
+                        .components
+                        .iter_mut()
+                        .find_map(|c| c.as_any_mut().downcast_mut::<HelpPopup>())
+                    {
+                        let _ = help_popup.draw(f, frame_area);
+                    }
+                    if let Some(countdown_popup) = self
+                        .components
+                        .iter_mut()
+                        .find_map(|c| c.as_any_mut().downcast_mut::<CountdownPopup>())
+                    {
+                        let _ = countdown_popup.draw(f, frame_area);
+                    }
+                    if let Some(hint_popup) = self
+                        .components
+                        .iter_mut()
+                        .find_map(|c| c.as_any_mut().downcast_mut::<HintPopup>())
+                    {
+                        let _ = hint_popup.draw(f, frame_area);
+                    }
                 })
                 .ok();
             }
@@ -1023,6 +1084,16 @@ impl App {
             }
             Action::EndCommand => {
                 self.handle_end_command();
+            }
+            Action::ShowHint(message) => {
+                if let Some(hint_popup) = self
+                    .components
+                    .iter_mut()
+                    .find_map(|c| c.as_any_mut().downcast_mut::<HintPopup>())
+                {
+                    hint_popup.show(message.clone());
+                    self.update_focus(Focus::HintPopup);
+                }
             }
             _ => {}
         }
@@ -1228,6 +1299,7 @@ impl App {
             }
             Focus::HelpPopup => Focus::TaskList,
             Focus::CountdownPopup => Focus::TaskList,
+            Focus::HintPopup => Focus::TaskList,
         };
 
         self.update_focus(focus);
@@ -1293,6 +1365,7 @@ impl App {
             }
             Focus::HelpPopup => Focus::TaskList,
             Focus::CountdownPopup => Focus::TaskList,
+            Focus::HintPopup => Focus::TaskList,
         };
 
         self.update_focus(focus);

--- a/packages/nx/src/native/tui/components.rs
+++ b/packages/nx/src/native/tui/components.rs
@@ -13,6 +13,7 @@ pub mod countdown_popup;
 pub mod dependency_view;
 pub mod help_popup;
 pub mod help_text;
+pub mod hint_popup;
 pub mod layout_manager;
 pub mod task_selection_manager;
 pub mod tasks_list;

--- a/packages/nx/src/native/tui/components/hint_popup.rs
+++ b/packages/nx/src/native/tui/components/hint_popup.rs
@@ -1,0 +1,157 @@
+use color_eyre::eyre::Result;
+use ratatui::{
+    Frame,
+    layout::{Alignment, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph},
+};
+use std::any::Any;
+use std::time::{Duration, Instant};
+
+use crate::native::tui::theme::THEME;
+
+use super::Component;
+
+/// Default duration before the hint popup auto-dismisses
+const AUTO_DISMISS_DURATION: Duration = Duration::from_secs(5);
+/// Default popup dimensions
+const POPUP_HEIGHT: u16 = 7;
+const POPUP_WIDTH: u16 = 80;
+
+/// A reusable popup component for displaying contextual hints and guidance to users.
+/// Used to show informational messages that auto-dismiss after a configurable duration
+/// or when the user presses ESC.
+pub struct HintPopup {
+    visible: bool,
+    message: String,
+    shown_at: Option<Instant>,
+    auto_dismiss_duration: Duration,
+}
+
+impl HintPopup {
+    pub fn new() -> Self {
+        Self {
+            visible: false,
+            message: String::new(),
+            shown_at: None,
+            auto_dismiss_duration: AUTO_DISMISS_DURATION,
+        }
+    }
+
+    /// Shows the popup with the given message
+    pub fn show(&mut self, message: String) {
+        self.visible = true;
+        self.message = message;
+        self.shown_at = Some(Instant::now());
+    }
+
+    /// Hides the popup
+    pub fn hide(&mut self) {
+        self.visible = false;
+        self.shown_at = None;
+    }
+
+    /// Returns true if the popup is currently visible
+    pub fn is_visible(&self) -> bool {
+        self.visible
+    }
+
+    /// Returns true if the popup should be auto-dismissed based on elapsed time
+    pub fn should_auto_dismiss(&self) -> bool {
+        self.shown_at
+            .is_some_and(|t| t.elapsed() >= self.auto_dismiss_duration)
+    }
+
+    pub fn render(&mut self, f: &mut Frame<'_>, area: Rect) {
+        // Add a safety check to prevent rendering outside buffer bounds
+        if area.height == 0
+            || area.width == 0
+            || area.x >= f.area().width
+            || area.y >= f.area().height
+        {
+            return;
+        }
+
+        // Ensure area is entirely within frame bounds
+        let safe_area = Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width.min(f.area().width.saturating_sub(area.x)),
+            height: area.height.min(f.area().height.saturating_sub(area.y)),
+        };
+
+        // Make sure we don't exceed the available area
+        let popup_height = POPUP_HEIGHT.min(safe_area.height.saturating_sub(4));
+        let popup_width = POPUP_WIDTH.min(safe_area.width.saturating_sub(4));
+
+        // Calculate the top-left position to center the popup
+        let popup_x = safe_area.x + (safe_area.width.saturating_sub(popup_width)) / 2;
+        let popup_y = safe_area.y + (safe_area.height.saturating_sub(popup_height)) / 2;
+
+        // Create popup area with fixed dimensions
+        let popup_area = Rect::new(popup_x, popup_y, popup_width, popup_height);
+
+        let content = vec![Line::from(vec![Span::styled(
+            &self.message,
+            Style::default().fg(THEME.primary_fg),
+        )])];
+
+        // Build dismiss hint for bottom border
+        let dismiss_hint = Line::from(vec![
+            Span::styled("  Press ", Style::default().fg(THEME.secondary_fg)),
+            Span::styled("ESC", Style::default().fg(THEME.info)),
+            Span::styled(" to dismiss  ", Style::default().fg(THEME.secondary_fg)),
+        ]);
+
+        let block = Block::default()
+            .title(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    " NX ",
+                    Style::default()
+                        .add_modifier(Modifier::BOLD)
+                        .bg(THEME.info)
+                        .fg(THEME.primary_fg),
+                ),
+                Span::styled("  ", Style::default().fg(THEME.primary_fg)),
+            ]))
+            .title_alignment(Alignment::Left)
+            .title_bottom(dismiss_hint.alignment(Alignment::Right))
+            .borders(Borders::ALL)
+            .border_type(BorderType::Plain)
+            .border_style(Style::default().fg(THEME.info))
+            .padding(Padding::proportional(1));
+
+        let popup = Paragraph::new(content)
+            .block(block)
+            .wrap(ratatui::widgets::Wrap { trim: true });
+
+        // Render popup
+        f.render_widget(Clear, popup_area);
+        f.render_widget(popup, popup_area);
+    }
+}
+
+impl Default for HintPopup {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Component for HintPopup {
+    fn draw(&mut self, f: &mut Frame<'_>, rect: Rect) -> Result<()> {
+        if self.visible {
+            self.render(f, rect);
+        }
+        Ok(())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}

--- a/packages/nx/src/native/tui/components/hint_popup.rs
+++ b/packages/nx/src/native/tui/components/hint_popup.rs
@@ -14,7 +14,7 @@ use crate::native::tui::theme::THEME;
 use super::Component;
 
 /// Default duration before the hint popup auto-dismisses
-const AUTO_DISMISS_DURATION: Duration = Duration::from_secs(5);
+const AUTO_DISMISS_DURATION: Duration = Duration::from_secs(2);
 /// Default popup dimensions
 const POPUP_HEIGHT: u16 = 7;
 const POPUP_WIDTH: u16 = 80;

--- a/packages/nx/src/native/tui/components/terminal_pane.rs
+++ b/packages/nx/src/native/tui/components/terminal_pane.rs
@@ -129,6 +129,13 @@ impl TerminalPaneData {
                     self.set_interactive(true);
                     return Ok(None);
                 }
+                // Show hint when 'i' is pressed but task can't be interactive
+                KeyCode::Char('i') if !self.can_be_interactive => {
+                    return Ok(Some(Action::ShowHint(
+                        "This task does not support interactive mode. Only in-progress tasks that accept input can be interactive."
+                            .to_string(),
+                    )));
+                }
                 KeyCode::Char('a')
                     if key.modifiers.contains(KeyModifiers::CONTROL) && !self.is_interactive =>
                 {

--- a/packages/nx/src/native/tui/config.rs
+++ b/packages/nx/src/native/tui/config.rs
@@ -40,11 +40,16 @@ impl AutoExit {
 
 pub struct TuiConfig {
     pub auto_exit: AutoExit,
+    pub suppress_hints: bool,
 }
 
 impl TuiConfig {
     /// Creates a new TuiConfig from nx.json config properties and CLI args
-    pub fn new(auto_exit: Option<AutoExit>, cli_args: &TuiCliArgs) -> Self {
+    pub fn new(
+        auto_exit: Option<AutoExit>,
+        suppress_hints: Option<bool>,
+        cli_args: &TuiCliArgs,
+    ) -> Self {
         // Default to 3-second countdown if nothing is specified
         let final_auto_exit = match auto_exit {
             Some(config) => config,
@@ -57,6 +62,7 @@ impl TuiConfig {
         };
         Self {
             auto_exit: final_auto_exit,
+            suppress_hints: suppress_hints.unwrap_or(false),
         }
     }
 }

--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -44,6 +44,7 @@ impl From<TuiCliArgs> for RustTuiCliArgs {
 pub struct TuiConfig {
     #[napi(ts_type = "boolean | number | undefined")]
     pub auto_exit: Option<Either<bool, u32>>,
+    pub suppress_hints: Option<bool>,
 }
 
 impl From<(TuiConfig, &RustTuiCliArgs)> for RustTuiConfig {
@@ -53,7 +54,11 @@ impl From<(TuiConfig, &RustTuiCliArgs)> for RustTuiConfig {
             Either::B(int_value) => AutoExit::Integer(int_value),
         });
         // Pass the converted JSON config value(s) and cli_args to instantiate the config with
-        RustTuiConfig::new(js_auto_exit, rust_tui_cli_args)
+        RustTuiConfig::new(
+            js_auto_exit,
+            js_tui_config.suppress_hints,
+            rust_tui_cli_args,
+        )
     }
 }
 


### PR DESCRIPTION
## Current Behavior

When users press unhandled keys in the TUI (e.g., pressing `i` on a completed task, or typing in a non-interactive terminal pane), nothing happens and there's no feedback explaining why.

Similarly, when users press certain key bindings like `c` to copy output, the action succeeds but there's no visual confirmation.

## Expected Behavior

### Hint Popups for Unhandled Keys

Users now see helpful hint popups when pressing keys that don't work in the current context:

- Pressing `i`, `c`, or `Ctrl+A` in the dependency view (task hasn't started yet)
- Pressing `i` on a task that doesn't support interactive mode
- Pressing character keys in a terminal pane that's not in interactive mode

The hints explain what's happening and guide users on how to proceed.

### Status Messages for "Invisible" Actions

When users perform actions without obvious visual feedback, a status message now appears in the terminal pane's bottom border:

- `Output copied` when pressing `c` to copy
- `Sent to assistant` when pressing `Ctrl+A`

### Configuration Option

Users who prefer not to see hint popups can disable them in `nx.json`:

```json
{
  "tui": {
    "suppressHints": true
  }
}
```