### PR TITLE
feat(core): add CnwError class for typed error handling in create-nx-workspace

### DIFF
--- a/packages/create-nx-plugin/bin/create-nx-plugin.ts
+++ b/packages/create-nx-plugin/bin/create-nx-plugin.ts
@@ -156,10 +156,14 @@ async function main(parsedArgs: yargs.Arguments<CreateNxPluginArguments>) {
     nxVersion,
     command: 'create-nx-plugin',
     useCloud: parsedArgs.nxCloud !== 'skip',
-    meta: [
-      messages.codeOfSelectedPromptMessage('setupCI'),
-      messages.codeOfSelectedPromptMessage('setupNxCloud'),
-    ],
+    meta: {
+      type: 'complete',
+      setupCIPrompt: messages.codeOfSelectedPromptMessage('setupCI'),
+      setupCloudPrompt: messages.codeOfSelectedPromptMessage('setupNxCloud'),
+      nxCloudArg: parsedArgs.nxCloud ?? '',
+      nxCloudArgRaw: rawArgs.nxCloud ?? '',
+      pushedToVcs: '',
+    },
   });
 
   if (parsedArgs.nxCloud && workspaceInfo.nxCloudInfo) {
@@ -181,7 +185,9 @@ async function normalizeArgsMiddleware(
     await recordStat({
       nxVersion,
       command: 'create-nx-plugin',
-      meta: ['start'],
+      meta: {
+        type: 'start',
+      },
       useCloud: argv.nxCloud !== 'skip',
     });
 

--- a/packages/create-nx-workspace/src/create-empty-workspace.ts
+++ b/packages/create-nx-workspace/src/create-empty-workspace.ts
@@ -2,8 +2,7 @@ import * as ora from 'ora';
 import { join } from 'path';
 import { CreateWorkspaceOptions } from './create-workspace-options';
 import { execAndWait } from './utils/child-process-utils';
-import { mapErrorToBodyLines } from './utils/error-utils';
-import { output } from './utils/output';
+import { CnwError } from './utils/error-utils';
 import {
   getPackageManagerCommand,
   getPackageManagerVersion,
@@ -76,15 +75,11 @@ export async function createEmptyWorkspace<T extends CreateWorkspaceOptions>(
     );
   } catch (e) {
     workspaceSetupSpinner.fail();
-    if (e instanceof Error) {
-      output.error({
-        title: `Failed to create a workspace.`,
-        bodyLines: mapErrorToBodyLines(e),
-      });
-    } else {
-      console.error(e);
-    }
-    process.exit(1);
+    const message = e instanceof Error ? e.message : String(e);
+    throw new CnwError(
+      'WORKSPACE_CREATION_FAILED',
+      `Failed to create a workspace: ${message}`
+    );
   } finally {
     workspaceSetupSpinner.stop();
   }

--- a/packages/create-nx-workspace/src/create-preset.ts
+++ b/packages/create-nx-workspace/src/create-preset.ts
@@ -1,5 +1,5 @@
 import { CreateWorkspaceOptions } from './create-workspace-options';
-import { output } from './utils/output';
+import { CnwError } from './utils/error-utils';
 import {
   getPackageManagerCommand,
   getPackageManagerVersion,
@@ -63,10 +63,6 @@ export async function createPreset<T extends CreateWorkspaceOptions>(
     );
     await spawnAndWait(exec, args, directory);
   } catch (e) {
-    output.error({
-      title: `Failed to apply preset: ${preset}`,
-      bodyLines: ['See above'],
-    });
-    process.exit(1);
+    throw new CnwError('PRESET_FAILED', `Failed to apply preset: ${preset}`);
   }
 }

--- a/packages/create-nx-workspace/src/create-sandbox.ts
+++ b/packages/create-nx-workspace/src/create-sandbox.ts
@@ -9,9 +9,8 @@ import {
   PackageManager,
 } from './utils/package-manager';
 import { execAndWait } from './utils/child-process-utils';
-import { output } from './utils/output';
 import { nxVersion } from './utils/nx/nx-version';
-import { mapErrorToBodyLines } from './utils/error-utils';
+import { CnwError } from './utils/error-utils';
 
 /**
  * Creates a temporary directory and installs Nx in it.
@@ -48,15 +47,11 @@ export async function createSandbox(packageManager: PackageManager) {
     installSpinner.succeed();
   } catch (e) {
     installSpinner.fail();
-    if (e instanceof Error) {
-      output.error({
-        title: `Failed to install dependencies`,
-        bodyLines: mapErrorToBodyLines(e),
-      });
-    } else {
-      console.error(e);
-    }
-    process.exit(1);
+    const message = e instanceof Error ? e.message : String(e);
+    throw new CnwError(
+      'SANDBOX_FAILED',
+      `Failed to install dependencies: ${message}`
+    );
   } finally {
     installSpinner.stop();
   }

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -7,7 +7,6 @@ import {
   messages,
   shouldUseTemplateFlow,
 } from '../utils/nx/ab-testing';
-import { output } from '../utils/output';
 import { deduceDefaultBase } from '../utils/git/default-base';
 import {
   detectInvokedPackageManager,
@@ -22,6 +21,7 @@ import {
   agentDisplayMap,
   supportedAgents,
 } from '../create-workspace-options';
+import { CnwError } from '../utils/error-utils';
 
 export async function determineNxCloud(
   parsedArgs: yargs.Arguments<{ nxCloud: NxCloud }>
@@ -210,11 +210,10 @@ export async function determineDefaultBase(
       ])
       .then((a) => {
         if (!a.DefaultBase) {
-          output.error({
-            title: 'Invalid branch name',
-            bodyLines: [`Branch name cannot be empty`],
-          });
-          process.exit(1);
+          throw new CnwError(
+            'INVALID_BRANCH_NAME',
+            'Branch name cannot be empty'
+          );
         }
         return a.DefaultBase;
       });
@@ -231,15 +230,12 @@ export async function determinePackageManager(
     if (packageManagerList.includes(packageManager as PackageManager)) {
       return packageManager as PackageManager;
     }
-    output.error({
-      title: 'Invalid package manager',
-      bodyLines: [
-        `Package manager must be one of ${stringifyCollection([
-          ...packageManagerList,
-        ])}`,
-      ],
-    });
-    process.exit(1);
+    throw new CnwError(
+      'INVALID_PACKAGE_MANAGER',
+      `Package manager must be one of ${stringifyCollection([
+        ...packageManagerList,
+      ])}`
+    );
   } else if (parsedArgs.allPrompts) {
     return enquirer
       .prompt<{ packageManager: PackageManager }>([

--- a/packages/create-nx-workspace/src/utils/ci/setup-ci.ts
+++ b/packages/create-nx-workspace/src/utils/ci/setup-ci.ts
@@ -1,8 +1,7 @@
 import * as ora from 'ora';
 
 import { execAndWait } from '../child-process-utils';
-import { mapErrorToBodyLines } from '../error-utils';
-import { output } from '../output';
+import { CnwError } from '../error-utils';
 import { getPackageManagerCommand, PackageManager } from '../package-manager';
 
 export async function setupCI(
@@ -21,16 +20,11 @@ export async function setupCI(
     return res;
   } catch (e) {
     ciSpinner.fail();
-    if (e instanceof Error) {
-      output.error({
-        title: `Failed to generate CI workflow`,
-        bodyLines: mapErrorToBodyLines(e),
-      });
-    } else {
-      console.error(e);
-    }
-
-    process.exit(1);
+    const message = e instanceof Error ? e.message : String(e);
+    throw new CnwError(
+      'CI_WORKFLOW_FAILED',
+      `Failed to generate CI workflow: ${message}`
+    );
   } finally {
     ciSpinner.stop();
   }

--- a/packages/create-nx-workspace/src/utils/error-utils.ts
+++ b/packages/create-nx-workspace/src/utils/error-utils.ts
@@ -1,3 +1,43 @@
+/**
+ * Error codes for CNW errors.
+ * These are used for telemetry and error tracking.
+ */
+export type CnwErrorCode =
+  | 'DIRECTORY_EXISTS'
+  | 'INVALID_WORKSPACE_NAME'
+  | 'INVALID_FOLDER_NAME'
+  | 'INVALID_BRANCH_NAME'
+  | 'INVALID_PACKAGE_MANAGER'
+  | 'INVALID_PRESET'
+  | 'INVALID_WORKSPACE_TYPE'
+  | 'INVALID_APP_NAME'
+  | 'PRESET_FAILED'
+  | 'SANDBOX_FAILED'
+  | 'TEMPLATE_CLONE_FAILED'
+  | 'CI_WORKFLOW_FAILED'
+  | 'WORKSPACE_CREATION_FAILED'
+  | 'ANGULAR_PREFIX_INVALID'
+  | 'UNKNOWN';
+
+/**
+ * Custom error class for CNW errors.
+ * Used for structured error reporting and telemetry.
+ */
+export class CnwError extends Error {
+  constructor(
+    public readonly code: CnwErrorCode,
+    message: string,
+    public readonly logFile?: string,
+    public readonly exitCode?: number
+  ) {
+    super(message);
+    this.name = 'CnwError';
+  }
+}
+
+/**
+ * @deprecated Use CnwError instead
+ */
 export class CreateNxWorkspaceError extends Error {
   constructor(
     public logMessage: string,
@@ -22,6 +62,8 @@ export function mapErrorToBodyLines(error: Error): string[] {
   const lines =
     error instanceof CreateNxWorkspaceError
       ? [`Exit code: ${error.code}`, `Log file: ${error.logFile}`]
+      : error instanceof CnwError && error.logFile
+      ? [`Log file: ${error.logFile}`]
       : [];
 
   if (process.env.NX_VERBOSE_LOGGING === 'true') {

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -253,6 +253,31 @@ function getCloudUrl(): string {
 }
 
 /**
+ * Meta payload types for recordStat telemetry.
+ */
+export interface RecordStatMetaStart {
+  type: 'start';
+  [key: string]: string;
+}
+
+export interface RecordStatMetaComplete {
+  type: 'complete';
+  [key: string]: string;
+}
+
+export interface RecordStatMetaError {
+  type: 'error';
+  errorCode: string;
+  errorMessage?: string;
+  errorFile?: string;
+}
+
+export type RecordStatMeta =
+  | RecordStatMetaStart
+  | RecordStatMetaComplete
+  | RecordStatMetaError;
+
+/**
  * We are incrementing a counter to track how often create-nx-workspace is used in CI
  * vs dev environments. No personal information is collected.
  */
@@ -260,7 +285,7 @@ export async function recordStat(opts: {
   command: string;
   nxVersion: string;
   useCloud: boolean;
-  meta: string[];
+  meta: RecordStatMeta;
 }) {
   try {
     if (!shouldRecordStats()) {
@@ -277,7 +302,7 @@ export async function recordStat(opts: {
         command: opts.command,
         isCI: isCI(),
         useCloud: opts.useCloud,
-        meta: [opts.nxVersion, ...opts.meta].filter((v) => !!v).join(','),
+        meta: JSON.stringify({ nxVersion: opts.nxVersion, ...opts.meta }),
       });
   } catch (e) {
     if (process.env.NX_VERBOSE_LOGGING === 'true') {

--- a/packages/create-nx-workspace/src/utils/template/clone-template.ts
+++ b/packages/create-nx-workspace/src/utils/template/clone-template.ts
@@ -2,15 +2,15 @@ import { execAndWait } from '../child-process-utils';
 import { existsSync } from 'fs';
 import { rm } from 'fs/promises';
 import { join } from 'path';
-import { output } from '../output';
-import { mapErrorToBodyLines } from '../error-utils';
+import { CnwError } from '../error-utils';
 
 export async function cloneTemplate(
   templateUrl: string,
   targetDirectory: string
 ): Promise<void> {
   if (existsSync(targetDirectory)) {
-    throw new Error(
+    throw new CnwError(
+      'DIRECTORY_EXISTS',
       `The directory '${targetDirectory}' already exists and is not empty. Choose a different name or remove the existing directory.`
     );
   }
@@ -27,14 +27,10 @@ export async function cloneTemplate(
       await rm(gitDir, { recursive: true, force: true });
     }
   } catch (e) {
-    if (e instanceof Error) {
-      output.error({
-        title: 'Failed to create starter workspace',
-        bodyLines: mapErrorToBodyLines(e),
-      });
-    } else {
-      console.error(e);
-    }
-    process.exit(1);
+    const message = e instanceof Error ? e.message : String(e);
+    throw new CnwError(
+      'TEMPLATE_CLONE_FAILED',
+      `Failed to create starter workspace: ${message}`
+    );
   }
 }


### PR DESCRIPTION
Replace process.exit(1) calls with typed CnwError exceptions for structured error reporting and telemetry tracking. Update recordStat meta to use typed JSON objects with named keys instead of arrays.

Examples of what's sent as `meta`.

```
{"type":"start","flowVariant":"1"}
{"type":"complete","flowVariant":"1","setupCIPrompt":"which-ci-provider","setupCloudPrompt":"cloud-v2-remote-cache-visit","nxCloudArg":"skip","nxCloudArgRaw":"","pushedToVcs":"SkippedGit","template":"nrwl/empty-template"}
{"type":"start","flowVariant":"1"}
{"type":"start","flowVariant":"0"}
{"type":"complete","flowVariant":"0","setupCIPrompt":"which-ci-provider","setupCloudPrompt":"enable-caching2","nxCloudArg":"skip","nxCloudArgRaw":"","pushedToVcs":"SkippedGit","template":"custom"}
{"type":"start","flowVariant":"1"}
{"type":"error","errorCode":"DIRECTORY_EXISTS"}
{"type":"start","flowVariant":"1"}
{"type":"error","errorCode":"DIRECTORY_EXISTS"}
{"type":"start","flowVariant":"1"}
{"type":"complete","flowVariant":"1","setupCIPrompt":"which-ci-provider","setupCloudPrompt":"cloud-v2-green-prs-visit","nxCloudArg":"yes","nxCloudArgRaw":"","pushedToVcs":"FailedToPushToVcs","template":"nrwl/empty-template"}
{"type":"start","flowVariant":"1"}
{"type":"complete","flowVariant":"1","setupCIPrompt":"which-ci-provider","setupCloudPrompt":"cloud-v2-fast-ci-visit","nxCloudArg":"yes","nxCloudArgRaw":"","pushedToVcs":"FailedToPushToVcs","template":"nrwl/empty-template"}
{"type":"start","flowVariant":"1"}
{"type":"start","flowVariant":"1"}
{"type":"complete","flowVariant":"1","setupCIPrompt":"which-ci-provider","setupCloudPrompt":"cloud-v2-green-prs-visit","nxCloudArg":"skip","nxCloudArgRaw":"","pushedToVcs":"SkippedGit","template":"nrwl/typescript-template"}
{"type":"start","flowVariant":"1"}
{"type":"error","errorCode":"WORKSPACE_CREATION_FAILED"}
```

Known errors like "directory exists" does not print stack trace:

<img width="1061" height="362" alt="image" src="https://github.com/user-attachments/assets/8f29f303-3839-4297-b789-d23ac3af6d52" />

Another known error (invalid custom preset):

<img width="1091" height="391" alt="image" src="https://github.com/user-attachments/assets/c7f6e586-42a8-493b-b595-f7d77743683f" />
