### PR TITLE
docs(nx-cloud): remove broken on-premise auth-single-admin redirect

### DIFF
--- a/nx-dev/nx-dev/redirect-rules.js
+++ b/nx-dev/nx-dev/redirect-rules.js
@@ -457,10 +457,6 @@ const nxCloudUrls = {
     'https://github.com/nrwl/nx-cloud-helm',
   '/ci/recipes/on-premise': 'https://github.com/nrwl/nx-cloud-helm',
   '/ci/recipes/enterprise/on-premise': 'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/on-premise/auth-single-admin':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/enterprise/on-premise/auth-single-admin':
-    'https://github.com/nrwl/nx-cloud-helm',
   '/ci/recipes/enterprise/on-premise/ami-setup':
     'https://github.com/nrwl/nx-cloud-helm',
   '/ci/recipes/enterprise/on-premise/advanced-config':


### PR DESCRIPTION
## Current Behavior

The `/ci/recipes/enterprise/on-premise/auth-single-admin` and `/ci/recipes/on-premise/auth-single-admin` paths redirect to `https://github.com/nrwl/nx-cloud-helm`, but the documentation that should exist at these paths no longer has a target location.

## Expected Behavior

These redirect rules are removed so the broken links don't mislead users with incorrect redirects.

## Related Issue(s)

Fixes CLOUD-4007