### PR TITLE
fix(js): resolve nx binary from workspace root in node executor

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -296,7 +296,7 @@ export async function* nodeExecutor(
         let childProcess: ChildProcess = null;
         const whenReady = new Promise<{ success: boolean }>(async (resolve) => {
           childProcess = fork(
-            require.resolve('nx'),
+            require.resolve('nx/bin/nx.js'),
             [
               'run',
               `${context.projectName}:${buildTarget.target}${


### PR DESCRIPTION
## Current Behavior

When running `nx serve` with a NestJS project (and other node apps using `runBuildTargetDependencies`), the node executor attempts to resolve the `nx` binary using `require.resolve('nx')`. This fails with because `nx/package.json` does no longer has a `main` field.

## Expected Behavior

The node executor should correctly resolve and use the `nx` binary from the workspace where it's always installed.

This is fixed by using `nx/bin/nx.js` instead of just `nx` -- as we do in other places.

## Related Issue(s)

Fixes #33776
