### PR TITLE
fix(core): pass more error detail for CNW

### DIFF
--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -268,14 +268,21 @@ export interface RecordStatMetaComplete {
 export interface RecordStatMetaError {
   type: 'error';
   errorCode: string;
+  flowVariant?: string;
   errorMessage?: string;
   errorFile?: string;
+}
+
+export interface RecordStatMetaCancel {
+  type: 'cancel';
+  flowVariant?: string;
 }
 
 export type RecordStatMeta =
   | RecordStatMetaStart
   | RecordStatMetaComplete
-  | RecordStatMetaError;
+  | RecordStatMetaError
+  | RecordStatMetaCancel;
 
 /**
  * We are incrementing a counter to track how often create-nx-workspace is used in CI


### PR DESCRIPTION
We're missing messages and variant when errors happen during CNW. This will help us track down potential problems.

We also want to know when CNW is cancelled in order to know that we're not missing any events.