### PR TITLE
fix(js): prevent crash when terminating task using the `@nx/js:swc` executor

### DIFF
--- a/packages/js/src/executors/swc/swc.impl.ts
+++ b/packages/js/src/executors/swc/swc.impl.ts
@@ -132,8 +132,8 @@ export async function* swcExecutor(
 
   if (options.watch) {
     let disposeFn: () => void;
-    process.on('SIGINT', () => disposeFn());
-    process.on('SIGTERM', () => disposeFn());
+    process.on('SIGINT', () => disposeFn?.());
+    process.on('SIGTERM', () => disposeFn?.());
 
     return yield* compileSwcWatch(context, options, async () => {
       const assetResult = await copyAssets(options, context);


### PR DESCRIPTION
## Current Behavior

When terminating a task using the `@nx/js:swc` executor before it ever got to execute its post-compilation logic, a `TypeError: disposeFn is not a function` error is thrown.

## Expected Behavior

Terminating a task using the `@nx/js:swc` executor should not error.

## Related Issue(s)

Fixes #31938 