### PR TITLE
fix(repo): install correct Rust target for x86_64 macOS build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,7 +123,7 @@ jobs:
           - host: macos-latest
             target: x86_64-apple-darwin
             setup: |-
-              rustup target add aarch64-apple-darwin
+              rustup target add x86_64-apple-darwin
             build: |
               pnpm nx run-many --target=build-native -- --target=x86_64-apple-darwin
           - host: windows-latest


### PR DESCRIPTION
## Current Behavior

The publish workflow was installing `aarch64-apple-darwin` Rust target but attempting to build for `x86_64-apple-darwin`, causing the build to fail with:

```
error[E0463]: can't find crate for `core`
  = note: the `x86_64-apple-darwin` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-apple-darwin`
```

## Expected Behavior

The workflow should install the correct Rust target (`x86_64-apple-darwin`) before attempting to build for it.

## Related Issue(s)

N/A - Bug found during publish workflow debugging