### PR TITLE
fix(angular): install compatible vitest version for angular projects

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -1732,6 +1732,42 @@ describe('app', () => {
       `);
     });
 
+    it('should install vitest v3 when using vitest-analog with Angular v20', async () => {
+      updateJson(appTree, 'package.json', (json) => ({
+        ...json,
+        dependencies: {
+          ...json.dependencies,
+          '@angular/core': '~20.3.0',
+        },
+      }));
+
+      await generateApp(appTree, 'my-app', {
+        unitTestRunner: UnitTestRunner.VitestAnalog,
+      });
+
+      const { devDependencies } = readJson(appTree, 'package.json');
+      expect(devDependencies['vitest']).toBe(
+        backwardCompatibleVersions[20].vitestVersion
+      );
+      expect(devDependencies['jsdom']).toBe(
+        backwardCompatibleVersions[20].jsdomVersion
+      );
+    });
+
+    it('should install vitest v3 when using vitest-analog with Angular v19', async () => {
+      await generateApp(appTree, 'my-app', {
+        unitTestRunner: UnitTestRunner.VitestAnalog,
+      });
+
+      const { devDependencies } = readJson(appTree, 'package.json');
+      expect(devDependencies['vitest']).toBe(
+        backwardCompatibleVersions[19].vitestVersion
+      );
+      expect(devDependencies['jsdom']).toBe(
+        backwardCompatibleVersions[19].jsdomVersion
+      );
+    });
+
     describe('vitest-analog & angular < 21', () => {
       beforeEach(() => {
         updateJson(appTree, 'package.json', (json) => ({

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -13,6 +13,7 @@ import {
   updateNxJson,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { backwardCompatibleVersions } from '../../utils/backward-compatible-versions';
 import { createApp } from '../../utils/nx-devkit/testing';
 import { UnitTestRunner } from '../../utils/test-runners';
 import {
@@ -2020,6 +2021,50 @@ describe('lib', () => {
         export class MyLibModule {}
         "
       `);
+    });
+
+    it('should install vitest v3 when using vitest-analog with Angular v20', async () => {
+      updateJson(tree, 'package.json', (json) => ({
+        ...json,
+        dependencies: {
+          ...json.dependencies,
+          '@angular/core': '~20.3.0',
+        },
+      }));
+
+      await runLibraryGeneratorWithOpts({
+        unitTestRunner: UnitTestRunner.VitestAnalog,
+      });
+
+      const { devDependencies } = readJson(tree, 'package.json');
+      expect(devDependencies['vitest']).toBe(
+        backwardCompatibleVersions[20].vitestVersion
+      );
+      expect(devDependencies['jsdom']).toBe(
+        backwardCompatibleVersions[20].jsdomVersion
+      );
+    });
+
+    it('should install vitest v3 when using vitest-analog with Angular v19', async () => {
+      updateJson(tree, 'package.json', (json) => ({
+        ...json,
+        dependencies: {
+          ...json.dependencies,
+          '@angular/core': '~19.2.0',
+        },
+      }));
+
+      await runLibraryGeneratorWithOpts({
+        unitTestRunner: UnitTestRunner.VitestAnalog,
+      });
+
+      const { devDependencies } = readJson(tree, 'package.json');
+      expect(devDependencies['vitest']).toBe(
+        backwardCompatibleVersions[19].vitestVersion
+      );
+      expect(devDependencies['jsdom']).toBe(
+        backwardCompatibleVersions[19].jsdomVersion
+      );
     });
   });
 

--- a/packages/angular/src/utils/backward-compatible-versions.ts
+++ b/packages/angular/src/utils/backward-compatible-versions.ts
@@ -9,15 +9,8 @@ export type PackageVersionNames = Exclude<
 >;
 export type VersionMap = {
   21: Record<PackageVersionNames, string>;
-  20: Record<
-    Exclude<PackageVersionNames, 'jsdomVersion' | 'vitestVersion'>,
-    string
-  >;
-  19: Record<
-    | Exclude<PackageVersionNames, 'jsdomVersion' | 'vitestVersion'>
-    | 'angularRspackVersion',
-    string
-  >;
+  20: Record<PackageVersionNames, string>;
+  19: Record<PackageVersionNames | 'angularRspackVersion', string>;
 };
 
 export type PackageCompatVersions = VersionMap[SupportedVersion];
@@ -52,6 +45,8 @@ export const backwardCompatibleVersions: VersionMap = {
     jasmineMarblesVersion: '^0.9.2',
     jsoncEslintParserVersion: '^2.1.0',
     webpackMergeVersion: '^5.8.0',
+    vitestVersion: '^3.1.1',
+    jsdomVersion: '~22.1.0',
   },
   19: {
     angularVersion: '~19.2.0',
@@ -82,5 +77,7 @@ export const backwardCompatibleVersions: VersionMap = {
     jasmineMarblesVersion: '^0.9.2',
     jsoncEslintParserVersion: '^2.1.0',
     webpackMergeVersion: '^5.8.0',
+    vitestVersion: '^3.1.1',
+    jsdomVersion: '~22.1.0',
   },
 };

--- a/packages/vitest/src/generators/configuration/configuration.ts
+++ b/packages/vitest/src/generators/configuration/configuration.ts
@@ -110,6 +110,7 @@ export async function configurationGeneratorInternal(
     projectRoot: root,
     viteVersion: schema.viteVersion,
     skipPackageJson: schema.skipPackageJson,
+    keepExistingVersions: true,
   });
   tasks.push(initTask);
 


### PR DESCRIPTION
#### Current Behavior

When creating a new Nx workspace with Angular v20 and selecting Vitest as the unit test runner, the installation fails with an npm peer dependency conflict:

```bash
npm error ERESOLVE could not resolve
npm error peerOptional vitest@"^3.1.1" from @angular/build@20.3.13
npm error Found: vitest@4.0.15
```

## Expected Behavior

Workspace creation completes successfully when selecting Angular with Vitest as the unit test runner.

## Related Issue(s)

Fixes #33770