### PR TITLE
fix(nest): ensure library is generated with correct outputPath for TS Soln #32060

### DIFF
--- a/packages/nest/src/generators/library/lib/add-project.ts
+++ b/packages/nest/src/generators/library/lib/add-project.ts
@@ -10,6 +10,13 @@ export function addProject(tree: Tree, options: NormalizedOptions): void {
     return;
   }
 
+  // For TS solution setup, the build target is inferred by @nx/js/typescript plugin.
+  // The @nx/js:library generator already handles setting up the correct configuration.
+  if (options.isUsingTsSolutionsConfig) {
+    return;
+  }
+
+  // For non-TS solution setup, add the build target with the correct output path
   const project = readProjectConfiguration(tree, options.projectName);
   project.targets ??= {};
   project.targets.build = {


### PR DESCRIPTION
## Current Behavior
NestJs libraries are generated with output path pointing to workspace level dist folder. With TS Soln setups, we expect the dist folder to be local to the project.

## Expected Behavior
Ensure the outputPath generated is correct

## Related Issue(s)

Fixes #32060
