### PR TITLE
fix(module-federation): check port availability before starting remote proxies

### DIFF
--- a/packages/module-federation/src/executors/utils/start-remote-iterators.ts
+++ b/packages/module-federation/src/executors/utils/start-remote-iterators.ts
@@ -100,7 +100,7 @@ export async function startRemoteIterators(
     : startStaticRemotesFileServer(staticRemotesConfig, context, options);
 
   isServer
-    ? startSsrRemoteProxies(
+    ? await startSsrRemoteProxies(
         staticRemotesConfig,
         mappedLocationsOfStaticRemotes,
         options.ssl
@@ -108,9 +108,10 @@ export async function startRemoteIterators(
               pathToCert: options.sslCert,
               pathToKey: options.sslKey,
             }
-          : undefined
+          : undefined,
+        options.host
       )
-    : startRemoteProxies(
+    : await startRemoteProxies(
         staticRemotesConfig,
         mappedLocationsOfStaticRemotes,
         options.ssl
@@ -118,7 +119,8 @@ export async function startRemoteIterators(
               pathToCert: options.sslCert,
               pathToKey: options.sslKey,
             }
-          : undefined
+          : undefined,
+        options.host
       );
 
   return {

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/angular/nx-module-federation-dev-server-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/angular/nx-module-federation-dev-server-plugin.ts
@@ -70,10 +70,16 @@ export class NxModuleFederationDevServerPlugin implements RspackPluginInstance {
               workspaceRoot,
               this._options.devServerConfig.staticRemotesPort
             );
-            startRemoteProxies(staticRemotesConfig, mappedLocationOfRemotes, {
-              pathToCert: this._options.devServerConfig.sslCert,
-              pathToKey: this._options.devServerConfig.sslCert,
-            });
+            await startRemoteProxies(
+              staticRemotesConfig,
+              mappedLocationOfRemotes,
+              {
+                pathToCert: this._options.devServerConfig.sslCert,
+                pathToKey: this._options.devServerConfig.sslCert,
+              },
+              false,
+              this._options.devServerConfig.host
+            );
 
             new DefinePlugin({
               'process.env.NX_MF_DEV_REMOTES': process.env.NX_MF_DEV_REMOTES,

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/angular/nx-module-federation-ssr-dev-server-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/angular/nx-module-federation-ssr-dev-server-plugin.ts
@@ -74,14 +74,15 @@ export class NxModuleFederationSSRDevServerPlugin
               workspaceRoot,
               this._options.devServerConfig.staticRemotesPort
             );
-            startRemoteProxies(
+            await startRemoteProxies(
               staticRemotesConfig,
               mappedLocationOfRemotes,
               {
                 pathToCert: this._options.devServerConfig.sslCert,
                 pathToKey: this._options.devServerConfig.sslCert,
               },
-              true
+              true,
+              this._options.devServerConfig.host
             );
 
             new DefinePlugin({

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-dev-server-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-dev-server-plugin.ts
@@ -70,10 +70,16 @@ export class NxModuleFederationDevServerPlugin implements RspackPluginInstance {
               workspaceRoot,
               this._options.devServerConfig.staticRemotesPort
             );
-            startRemoteProxies(staticRemotesConfig, mappedLocationOfRemotes, {
-              pathToCert: this._options.devServerConfig.sslCert,
-              pathToKey: this._options.devServerConfig.sslCert,
-            });
+            await startRemoteProxies(
+              staticRemotesConfig,
+              mappedLocationOfRemotes,
+              {
+                pathToCert: this._options.devServerConfig.sslCert,
+                pathToKey: this._options.devServerConfig.sslCert,
+              },
+              false,
+              this._options.devServerConfig.host
+            );
 
             new DefinePlugin({
               'process.env.NX_MF_DEV_REMOTES': process.env.NX_MF_DEV_REMOTES,

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-ssr-dev-server-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-ssr-dev-server-plugin.ts
@@ -74,14 +74,15 @@ export class NxModuleFederationSSRDevServerPlugin
               workspaceRoot,
               this._options.devServerConfig.staticRemotesPort
             );
-            startRemoteProxies(
+            await startRemoteProxies(
               staticRemotesConfig,
               mappedLocationOfRemotes,
               {
                 pathToCert: this._options.devServerConfig.sslCert,
                 pathToKey: this._options.devServerConfig.sslCert,
               },
-              true
+              true,
+              this._options.devServerConfig.host
             );
 
             new DefinePlugin({

--- a/packages/module-federation/src/utils/index.ts
+++ b/packages/module-federation/src/utils/index.ts
@@ -6,5 +6,6 @@ export * from './models';
 export * from './normalize-project-name';
 export * from './get-remotes-for-host';
 export * from './parse-static-remotes-config';
+export * from './port-utils';
 export * from './start-remote-proxies';
 export * from './start-ssr-remote-proxies';

--- a/packages/module-federation/src/utils/port-utils.ts
+++ b/packages/module-federation/src/utils/port-utils.ts
@@ -1,0 +1,17 @@
+import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
+
+/**
+ * Check if a port is already in use by attempting to connect to it.
+ * Uses waitForPortOpen with retries: 0 for an immediate check.
+ */
+export async function isPortInUse(
+  port: number,
+  host: string = '127.0.0.1'
+): Promise<boolean> {
+  try {
+    await waitForPortOpen(port, { retries: 0, host });
+    return true; // Port is open/in use
+  } catch {
+    return false; // Port is not in use
+  }
+}

--- a/packages/module-federation/src/utils/start-remote-proxies.ts
+++ b/packages/module-federation/src/utils/start-remote-proxies.ts
@@ -2,11 +2,13 @@ import type { Express } from 'express';
 import { logger } from '@nx/devkit';
 import { StaticRemotesConfig } from './parse-static-remotes-config';
 import { existsSync, readFileSync } from 'fs';
+import { isPortInUse } from './port-utils';
 
-export function startRemoteProxies(
+export async function startRemoteProxies(
   staticRemotesConfig: StaticRemotesConfig,
   mappedLocationsOfRemotes: Record<string, string>,
-  sslOptions?: { pathToCert: string; pathToKey: string }
+  sslOptions?: { pathToCert: string; pathToKey: string },
+  host: string = '127.0.0.1'
 ) {
   const { createProxyMiddleware } = require('http-proxy-middleware');
   const express = require('express');
@@ -29,7 +31,22 @@ export function startRemoteProxies(
   const https = require('https');
 
   logger.info(`NX Starting static remotes proxies...`);
+  let startedProxies = 0;
+  let skippedProxies = 0;
+
   for (const app of staticRemotesConfig.remotes) {
+    const port = staticRemotesConfig.config[app].port;
+
+    // Check if the port is already in use (another MF dev server may have already started a proxy)
+    const portInUse = await isPortInUse(port, host);
+    if (portInUse) {
+      logger.info(
+        `NX Skipping proxy for ${app} on port ${port} - port already in use (likely served by another process)`
+      );
+      skippedProxies++;
+      continue;
+    }
+
     const expressProxy: Express = express();
     expressProxy.use(
       createProxyMiddleware({
@@ -40,9 +57,17 @@ export function startRemoteProxies(
     );
     const proxyServer = (sslCert ? https : http)
       .createServer({ cert: sslCert, key: sslKey }, expressProxy)
-      .listen(staticRemotesConfig.config[app].port);
+      .listen(port);
     process.on('SIGTERM', () => proxyServer.close());
     process.on('exit', () => proxyServer.close());
+    startedProxies++;
   }
-  logger.info(`NX Static remotes proxies started successfully`);
+
+  if (skippedProxies > 0) {
+    logger.info(
+      `NX Static remotes proxies: started ${startedProxies}, skipped ${skippedProxies} (already running)`
+    );
+  } else {
+    logger.info(`NX Static remotes proxies started successfully`);
+  }
 }


### PR DESCRIPTION
When multiple MF dev servers run concurrently and share the same remote,
they would both attempt to start proxies on the same port, causing
EADDRINUSE errors.

This fix checks if a port is already in use before attempting to start
a proxy. If the port is occupied (likely by another MF dev server that
started earlier), the proxy is skipped for that remote since it's
already being served.

Uses the existing `waitForPortOpen` utility with retries: 0 to perform
an immediate check.

Fixes #33470
