### PR TITLE
fix(core): restore linkTaskDetails param for backwards compatibility

### DIFF
--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -48,6 +48,8 @@ impl NxCache {
         workspace_root: String,
         cache_path: String,
         db_connection: External<NxDbConnection>,
+        // Unused parameter kept for backwards compatibility with Nx Cloud
+        _link_task_details: Option<bool>,
         max_cache_size: Option<i64>,
     ) -> anyhow::Result<Self> {
         let cache_path = PathBuf::from(&cache_path);

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -69,7 +69,7 @@ export declare class ImportResult {
 
 export declare class NxCache {
   cacheDirectory: string
-  constructor(workspaceRoot: string, cachePath: string, dbConnection: ExternalObject<NxDbConnection>, maxCacheSize?: number | undefined | null)
+  constructor(workspaceRoot: string, cachePath: string, dbConnection: ExternalObject<NxDbConnection>, linkTaskDetails?: boolean | undefined | null, maxCacheSize?: number | undefined | null)
   get(hash: string): CachedResult | null
   put(hash: string, terminalOutput: string, outputs: Array<string>, code: number): void
   applyRemoteCacheResults(hash: string, result: CachedResult, outputs?: Array<string> | undefined | null): void

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -78,6 +78,7 @@ export class DbCache {
     workspaceRoot,
     cacheDir,
     getDbConnection(),
+    undefined,
     resolveMaxCacheSize(this.nxJson)
   );
 


### PR DESCRIPTION
## Current Behavior

The `linkTaskDetails` parameter was removed from the `NxCache` constructor in #33843, which broke Nx Cloud since it still passes this parameter.

## Expected Behavior

The `NxCache` constructor should accept the `linkTaskDetails` parameter (even if unused) to maintain backwards compatibility with Nx Cloud.

## Related Issue(s)

Fixes https://github.com/nrwl/nx/commit/ed09ee1daed597b7be60255f0cebe52efdd1ae69#r172894152