### PR TITLE
chore(repo): fix nightlies

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -20,6 +20,8 @@ jobs:
     if: ${{ github.repository_owner == 'nrwl' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
+    env:
+      NODE_VERSION: ${{ matrix.node_version }}
     strategy:
       matrix:
         os:
@@ -53,11 +55,10 @@ jobs:
 
       - name: Setup dev tools with mise
         uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
-        env:
-          NODE_VERSION: ${{ matrix.node_version }}
 
       - name: Enable corepack and install pnpm
         run: |
+          npm install -g corepack@latest
           corepack enable
           corepack prepare --activate
 
@@ -137,6 +138,8 @@ jobs:
       contents: read
     runs-on: ${{ matrix.os }}
     timeout-minutes: 200 # <- cap each job to 200 minutes
+    env:
+      NODE_VERSION: ${{ matrix.node_version }}
     strategy:
       matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix)}} # Load matrix from previous job
       fail-fast: false
@@ -154,11 +157,10 @@ jobs:
 
       - name: Setup dev tools with mise
         uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
-        env:
-          NODE_VERSION: ${{ matrix.node_version }}
 
       - name: Enable corepack and install pnpm
         run: |
+          npm install -g corepack@latest
           corepack enable
           corepack prepare --activate
 


### PR DESCRIPTION
NODE_VERSION was set only on the mise-action step, so subsequent steps defaulted to the wrong node version and corepack couldn't create the pnpm shim.

Also update corepack first, otherwise you might run into intermittent integrity check issues: 
- https://github.com/nodejs/corepack/issues/612
- https://vercel.com/kb/guide/corepack-errors-github-actions

---

  Before (NODE_VERSION at step-level):

  1. mise-action runs with NODE_VERSION=20
    - mise installs Node 20
    - mise adds /home/runner/.local/share/mise/installs/node/20.x.x/bin/ to PATH
  2. corepack enable runs - NODE_VERSION is NOT set anymore (step env is gone)
    - corepack shim calls mise
    - mise reads mise.toml template: node = "{{ env['NODE_VERSION'] | default(value='24.11.0') }}"
    - NODE_VERSION is unset → defaults to 24.11.0
    - mise runs corepack from Node 24's install
    - corepack creates pnpm shim in Node 24's bin directory
  3. pnpm install runs
    - PATH has Node 20's bin (from step 1)
    - pnpm is in Node 24's bin (from step 2)
    - pnpm not found!

  After (NODE_VERSION at job-level):

  1. mise-action runs with NODE_VERSION=20 (from job env)
    - mise installs Node 20, adds its bin to PATH
  2. corepack enable runs - NODE_VERSION=20 is still set
    - corepack shim calls mise
    - mise sees NODE_VERSION=20
    - corepack runs from Node 20's install
    - pnpm shim created in Node 20's bin
  3. pnpm install runs
    - PATH has Node 20's bin ✓
    - pnpm is in Node 20's bin ✓
    - Works!
---

Closes NXC-3620