### PR TITLE
fix(misc): send connectUrl in completion metadata

### DIFF
--- a/packages/create-nx-plugin/bin/create-nx-plugin.ts
+++ b/packages/create-nx-plugin/bin/create-nx-plugin.ts
@@ -163,6 +163,7 @@ async function main(parsedArgs: yargs.Arguments<CreateNxPluginArguments>) {
       nxCloudArg: parsedArgs.nxCloud ?? '',
       nxCloudArgRaw: rawArgs.nxCloud ?? '',
       pushedToVcs: '',
+      connectUrl: workspaceInfo.connectUrl ?? '',
     },
   });
 

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -386,6 +386,7 @@ async function main(parsedArgs: yargs.Arguments<Arguments>) {
       pushedToVcs: workspaceInfo.pushedToVcs ?? '',
       template: chosenTemplate ?? '',
       preset: chosenPreset ?? '',
+      connectUrl: workspaceInfo.connectUrl ?? '',
     },
   });
 

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -214,6 +214,7 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
     nxCloudInfo,
     directory,
     pushedToVcs,
+    connectUrl,
   };
 }
 


### PR DESCRIPTION
## Current Behavior

The `recordStat` telemetry for `create-nx-workspace` and `create-nx-plugin` completion events does not include the Nx Cloud connect URL.

## Expected Behavior

The connect URL (e.g., `https://cloud.nx.app/connect/{shortlinkId}`) is now included in the completion metadata sent to `/nx-cloud/stats`.

## Related Issue(s)

N/A - Internal telemetry enhancement