### PR TITLE
feat(core): support cwd specific hashes

### DIFF
--- a/astro-docs/src/content/docs/reference/inputs.mdoc
+++ b/astro-docs/src/content/docs/reference/inputs.mdoc
@@ -7,7 +7,7 @@ filter: 'type:References'
 ---
 
 When Nx [computes the hash for a given operation](/docs/concepts/how-caching-works), it takes into account the `inputs` of the target.
-The `inputs` are a list of **file sets**, **runtime** inputs and **environment variables** that affect the output of the target.
+The `inputs` are a list of **file sets**, **runtime** inputs, **environment variables**, and **working directory** that affect the output of the target.
 If any of the `inputs` change, the cache is invalidated and the target is re-run.
 
 ## Types of Inputs
@@ -87,6 +87,23 @@ You can use a Runtime input to provide a script which will output the informatio
 ```
 
 This kind of input is often used to include versions of tools used to run the task. You should ensure that these scripts work on any platform where the workspace is used. Avoid using `.sh` or `.bat` files as these will not work across Windows and \*nix operating systems.
+
+### Working Directory
+
+Some tasks may behave differently depending on which directory they are run from. Nx can include the current working directory in the computation hash to ensure that tasks are re-run when the working directory changes. Working directory inputs are defined like this:
+
+```jsonc
+{
+  "inputs": [
+    { "workingDirectory": "relative" }, // Hash the path relative to workspace root
+  ],
+}
+```
+
+The `workingDirectory` input accepts two values:
+
+- `"relative"` - Hashes the relative path from the workspace root to the current working directory. This is useful when tasks should be invalidated when run from different subdirectories within the workspace.
+- `"absolute"` - Hashes the full absolute path of the current working directory. This is useful when tasks depend on the exact location on the filesystem. Notably, this will invalidate cache entries if the repository is cloned to a different location on the filesystem, such as between CI and local development environments.
 
 ### External Dependencies
 

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Build.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Build.cs
@@ -55,7 +55,7 @@ public static partial class TargetBuilder
             },
             DependsOn = [$"^{targetName}"],
             Cache = true,
-            Inputs = [productionInput, $"^{productionInput}"],
+            Inputs = [productionInput, $"^{productionInput}", new { workingDirectory = "absolute" }],
             Outputs =
             [
                 $"{outputPrefix}/{outputPath}",

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Pack.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Pack.cs
@@ -49,7 +49,7 @@ public static partial class TargetBuilder
             },
             DependsOn = [buildReleaseTarget],
             Cache = true,
-            Inputs = ["default", $"^{productionInput}"],
+            Inputs = ["default", $"^{productionInput}", new { workingDirectory = "absolute" }],
             Outputs = [$"{outputPrefix}/{packageOutputPath}/*.nupkg"],
             Metadata = new TargetMetadata
             {

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Publish.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Publish.cs
@@ -52,7 +52,7 @@ public static partial class TargetBuilder
             },
             DependsOn = [buildReleaseTarget],
             Cache = true,
-            Inputs = ["default", $"^{productionInput}"],
+            Inputs = ["default", $"^{productionInput}", new { workingDirectory = "absolute" }],
             Outputs = [$"{outputPrefix}/{publishDir}"],
             Metadata = new TargetMetadata
             {

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Test.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Test.cs
@@ -42,6 +42,7 @@ public static partial class TargetBuilder
             [
                 "default",
                 $"^{productionInput}",
+                new { workingDirectory = "absolute" },
                 // new { externalDependencies = externalDeps }
             ],
             Outputs = [$"{outputPrefix}/{testResultsDir}"],

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -46,6 +46,9 @@
     "semver": "catalog:",
     "tslib": "catalog:typescript"
   },
+  "devDependencies": {
+    "nx": "workspace:*"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/eslint-plugin/tsconfig.lib.json
+++ b/packages/eslint-plugin/tsconfig.lib.json
@@ -22,6 +22,9 @@
     },
     {
       "path": "../devkit/tsconfig.lib.json"
+    },
+    {
+      "path": "../nx/tsconfig.lib.json"
     }
   ]
 }

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -42,6 +42,9 @@
     "metro-config": ">= 0.82.0",
     "metro-resolver": ">= 0.82.0"
   },
+  "devDependencies": {
+    "nx": "workspace:*"
+  },
   "optionalDependencies": {
     "@nx/detox": "workspace:*",
     "@nx/rollup": "workspace:*"

--- a/packages/expo/tsconfig.lib.json
+++ b/packages/expo/tsconfig.lib.json
@@ -27,6 +27,9 @@
     },
     {
       "path": "../detox/tsconfig.lib.json"
+    },
+    {
+      "path": "../nx/tsconfig.lib.json"
     }
   ]
 }

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -211,7 +211,8 @@ export type InputDefinition =
   | { runtime: string }
   | { externalDependencies: string[] }
   | { dependentTasksOutputFiles: string; transitive?: boolean }
-  | { env: string };
+  | { env: string }
+  | { workingDirectory: 'relative' | 'absolute' };
 
 /**
  * Target's configuration

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -337,7 +337,8 @@ export class DaemonClient {
     runnerOptions: any,
     tasks: Task[],
     taskGraph: TaskGraph,
-    env: NodeJS.ProcessEnv
+    env: NodeJS.ProcessEnv,
+    cwd: string
   ): Promise<Hash[]> {
     return this.sendToDaemonViaQueue({
       type: 'HASH_TASKS',
@@ -348,6 +349,7 @@ export class DaemonClient {
           : env,
       tasks,
       taskGraph,
+      cwd,
     });
   }
 

--- a/packages/nx/src/daemon/server/handle-hash-tasks.ts
+++ b/packages/nx/src/daemon/server/handle-hash-tasks.ts
@@ -16,6 +16,7 @@ export async function handleHashTasks(payload: {
   env: any;
   tasks: Task[];
   taskGraph: TaskGraph;
+  cwd: string;
 }) {
   const {
     error,
@@ -48,7 +49,8 @@ export async function handleHashTasks(payload: {
   const response = await storedHasher.hashTasks(
     payload.tasks,
     payload.taskGraph,
-    payload.env
+    payload.env,
+    payload.cwd
   );
   return {
     response,

--- a/packages/nx/src/hasher/native-task-hasher-impl.ts
+++ b/packages/nx/src/hasher/native-task-hasher-impl.ts
@@ -65,10 +65,11 @@ export class NativeTaskHasherImpl implements TaskHasherImpl {
   async hashTask(
     task: Task,
     taskGraph: TaskGraph,
-    env: NodeJS.ProcessEnv
+    env: NodeJS.ProcessEnv,
+    cwd?: string
   ): Promise<PartialHash> {
     const plans = this.planner.getPlansReference([task.id], taskGraph);
-    const hashes = this.hasher.hashPlans(plans, env);
+    const hashes = this.hasher.hashPlans(plans, env, cwd ?? process.cwd());
 
     return hashes[task.id];
   }
@@ -76,13 +77,14 @@ export class NativeTaskHasherImpl implements TaskHasherImpl {
   async hashTasks(
     tasks: Task[],
     taskGraph: TaskGraph,
-    env: NodeJS.ProcessEnv
+    env: NodeJS.ProcessEnv,
+    cwd?: string
   ): Promise<PartialHash[]> {
     const plans = this.planner.getPlansReference(
       tasks.map((t) => t.id),
       taskGraph
     );
-    const hashes = this.hasher.hashPlans(plans, env);
+    const hashes = this.hasher.hashPlans(plans, env, cwd ?? process.cwd());
     return tasks.map((t) => hashes[t.id]);
   }
 }

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -51,7 +51,8 @@ export interface TaskHasher {
   hashTask(
     task: Task,
     taskGraph: TaskGraph,
-    env: NodeJS.ProcessEnv
+    env: NodeJS.ProcessEnv,
+    cwd?: string
   ): Promise<Hash>;
 
   /**
@@ -68,7 +69,8 @@ export interface TaskHasher {
   hashTasks(
     tasks: Task[],
     taskGraph: TaskGraph,
-    env: NodeJS.ProcessEnv
+    env: NodeJS.ProcessEnv,
+    cwd?: string
   ): Promise<Hash[]>;
 }
 
@@ -76,14 +78,15 @@ export interface TaskHasherImpl {
   hashTasks(
     tasks: Task[],
     taskGraph: TaskGraph,
-    env: NodeJS.ProcessEnv
+    env: NodeJS.ProcessEnv,
+    cwd?: string
   ): Promise<PartialHash[]>;
 
   hashTask(
     task: Task,
     taskGraph: TaskGraph,
     env: NodeJS.ProcessEnv,
-    visited?: string[]
+    cwd?: string
   ): Promise<PartialHash>;
 }
 
@@ -104,7 +107,8 @@ export class DaemonBasedTaskHasher implements TaskHasher {
       this.runnerOptions,
       tasks,
       taskGraph,
-      env ?? process.env
+      env ?? process.env,
+      process.cwd()
     );
   }
 
@@ -118,7 +122,8 @@ export class DaemonBasedTaskHasher implements TaskHasher {
         this.runnerOptions,
         [task],
         taskGraph,
-        env ?? process.env
+        env ?? process.env,
+        process.cwd()
       )
     )[0];
   }
@@ -147,12 +152,14 @@ export class InProcessTaskHasher implements TaskHasher {
   async hashTasks(
     tasks: Task[],
     taskGraph?: TaskGraph,
-    env?: NodeJS.ProcessEnv
+    env?: NodeJS.ProcessEnv,
+    cwd?: string
   ): Promise<Hash[]> {
     const hashes = await this.taskHasher.hashTasks(
       tasks,
       taskGraph,
-      env ?? process.env
+      env ?? process.env,
+      cwd ?? process.cwd()
     );
     return tasks.map((task, index) =>
       this.createHashDetails(task, hashes[index])
@@ -162,12 +169,14 @@ export class InProcessTaskHasher implements TaskHasher {
   async hashTask(
     task: Task,
     taskGraph?: TaskGraph,
-    env?: NodeJS.ProcessEnv
+    env?: NodeJS.ProcessEnv,
+    cwd?: string
   ): Promise<Hash> {
     const res = await this.taskHasher.hashTask(
       task,
       taskGraph,
-      env ?? process.env
+      env ?? process.env,
+      cwd ?? process.cwd()
     );
     return this.createHashDetails(task, res);
   }
@@ -373,7 +382,8 @@ export function expandSingleProjectInputs(
         (d as any).env ||
         (d as any).runtime ||
         (d as any).externalDependencies ||
-        (d as any).dependentTasksOutputFiles
+        (d as any).dependentTasksOutputFiles ||
+        (d as any).workingDirectory
       ) {
         expanded.push(d);
       } else {

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -156,7 +156,7 @@ export declare class TaskDetails {
 
 export declare class TaskHasher {
   constructor(workspaceRoot: string, projectGraph: ExternalObject<ProjectGraph>, projectFileMap: ExternalObject<ProjectFiles>, allWorkspaceFiles: ExternalObject<Array<FileData>>, tsConfig: Buffer, tsConfigPaths: Record<string, Array<string>>, options?: HasherOptions | undefined | null)
-  hashPlans(hashPlans: ExternalObject<Record<string, Array<HashInstruction>>>, jsEnv: Record<string, string>): NapiDashMap
+  hashPlans(hashPlans: ExternalObject<Record<string, Array<HashInstruction>>>, jsEnv: Record<string, string>, cwd: string): NapiDashMap
 }
 
 export declare class Watcher {
@@ -511,6 +511,10 @@ export declare export declare function validateOutputs(outputs: Array<string>): 
 export interface WatchEvent {
   path: string
   type: EventType
+}
+
+export interface WorkingDirectoryInput {
+  workingDirectory: string
 }
 
 /** Public NAPI error codes that are for Node */

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -1,7 +1,7 @@
 use crate::native::logger::enable_logger;
 use crate::native::tasks::{
     dep_outputs::get_dep_output,
-    types::{HashInstruction, TaskGraph},
+    types::{CwdMode, HashInstruction, TaskGraph},
 };
 use crate::native::types::{Input, NxJson};
 use crate::native::{
@@ -391,6 +391,13 @@ impl HashPlanner {
         let runtime_and_env_inputs = self_inputs.iter().filter_map(|i| match i {
             Input::Runtime(runtime) => Some(HashInstruction::Runtime(runtime.to_string())),
             Input::Environment(env) => Some(HashInstruction::Environment(env.to_string())),
+            Input::WorkingDirectory(mode) => {
+                let cwd_mode = match mode.to_lowercase().as_str() {
+                    "absolute" => CwdMode::Absolute,
+                    _ => CwdMode::Relative,
+                };
+                Some(HashInstruction::Cwd(cwd_mode))
+            }
             _ => None,
         });
 

--- a/packages/nx/src/native/tasks/hashers.rs
+++ b/packages/nx/src/native/tasks/hashers.rs
@@ -1,3 +1,4 @@
+mod hash_cwd;
 mod hash_env;
 mod hash_external;
 mod hash_project_config;
@@ -7,6 +8,7 @@ mod hash_task_output;
 mod hash_tsconfig;
 mod hash_workspace_files;
 
+pub use hash_cwd::*;
 pub use hash_env::*;
 pub use hash_external::*;
 pub use hash_project_config::*;

--- a/packages/nx/src/native/tasks/hashers/hash_cwd.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_cwd.rs
@@ -1,0 +1,64 @@
+use crate::native::hasher::hash;
+use crate::native::tasks::types::CwdMode;
+use std::path::Path;
+
+pub fn hash_cwd(workspace_root: &Path, cwd: &Path, mode: CwdMode) -> String {
+    let path_to_hash = match mode {
+        CwdMode::Absolute => cwd.to_string_lossy().into_owned(),
+        CwdMode::Relative => cwd
+            .strip_prefix(workspace_root)
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_else(|_| cwd.to_string_lossy().into_owned()),
+    };
+    hash(path_to_hash.as_bytes())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn should_hash_absolute_cwd() {
+        let workspace_root = PathBuf::from("/home/user/workspace");
+        let cwd = PathBuf::from("/home/user/workspace/packages/my-app");
+
+        let hash_result = hash_cwd(&workspace_root, &cwd, CwdMode::Absolute);
+
+        // Hash of the full absolute path
+        assert_eq!(hash_result, hash(b"/home/user/workspace/packages/my-app"));
+    }
+
+    #[test]
+    fn should_hash_relative_cwd() {
+        let workspace_root = PathBuf::from("/home/user/workspace");
+        let cwd = PathBuf::from("/home/user/workspace/packages/my-app");
+
+        let hash_result = hash_cwd(&workspace_root, &cwd, CwdMode::Relative);
+
+        // Hash of the relative path from workspace root
+        assert_eq!(hash_result, hash(b"packages/my-app"));
+    }
+
+    #[test]
+    fn should_fallback_to_absolute_when_cwd_not_under_workspace() {
+        let workspace_root = PathBuf::from("/home/user/workspace");
+        let cwd = PathBuf::from("/other/path/somewhere");
+
+        let hash_result = hash_cwd(&workspace_root, &cwd, CwdMode::Relative);
+
+        // Falls back to absolute path when strip_prefix fails
+        assert_eq!(hash_result, hash(b"/other/path/somewhere"));
+    }
+
+    #[test]
+    fn should_hash_workspace_root_as_empty_relative() {
+        let workspace_root = PathBuf::from("/home/user/workspace");
+        let cwd = PathBuf::from("/home/user/workspace");
+
+        let hash_result = hash_cwd(&workspace_root, &cwd, CwdMode::Relative);
+
+        // When cwd is workspace root, relative path is empty
+        assert_eq!(hash_result, hash(b""));
+    }
+}

--- a/packages/nx/src/native/tasks/inputs.rs
+++ b/packages/nx/src/native/tasks/inputs.rs
@@ -105,7 +105,8 @@ fn split_inputs_into_self_and_deps<'a>(
                 | Input::Runtime(_)
                 | Input::Environment(_)
                 | Input::DepsOutputs { .. }
-                | Input::ExternalDependency(_) => {
+                | Input::ExternalDependency(_)
+                | Input::WorkingDirectory(_) => {
                     acc.1.push(input);
                 }
                 Input::Projects { .. } => {
@@ -171,6 +172,7 @@ pub(super) fn expand_single_project_inputs<'a>(
                 transitive: *transitive,
                 dependent_tasks_output_files,
             }),
+            Input::WorkingDirectory(mode) => expanded.push(Input::WorkingDirectory(mode)),
             Input::Projects { .. }
             | Input::Inputs {
                 dependencies: true, ..

--- a/packages/nx/src/native/tasks/types.rs
+++ b/packages/nx/src/native/tasks/types.rs
@@ -44,10 +44,17 @@ pub struct TaskGraph {
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub enum CwdMode {
+    Absolute,
+    Relative,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub enum HashInstruction {
     WorkspaceFileSet(Vec<String>),
     Runtime(String),
     Environment(String),
+    Cwd(CwdMode),
     ProjectFileSet(String, Vec<String>),
     ProjectConfiguration(String),
     TsConfiguration(String),
@@ -76,6 +83,15 @@ impl ToNapiValue for HashInstruction {
     }
 }
 
+impl fmt::Display for CwdMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            CwdMode::Absolute => write!(f, "absolute"),
+            CwdMode::Relative => write!(f, "relative"),
+        }
+    }
+}
+
 impl fmt::Display for HashInstruction {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
@@ -90,6 +106,7 @@ impl fmt::Display for HashInstruction {
                     format!("workspace:[{}]", file_set.join(",")),
                 HashInstruction::Runtime(runtime) => format!("runtime:{}", runtime),
                 HashInstruction::Environment(env) => format!("env:{}", env),
+                HashInstruction::Cwd(mode) => format!("cwd:{}", mode),
                 HashInstruction::TaskOutput(task_output, dep_outputs) => {
                     let dep_outputs = dep_outputs.join(",");
                     format!("{task_output}:{dep_outputs}")

--- a/packages/nx/src/native/types/inputs.rs
+++ b/packages/nx/src/native/types/inputs.rs
@@ -1,5 +1,5 @@
 use napi::Either;
-use napi::bindgen_prelude::Either7;
+use napi::bindgen_prelude::Either8;
 
 #[napi(object)]
 pub struct InputsInput {
@@ -34,7 +34,12 @@ pub struct DepsOutputsInput {
     pub transitive: Option<bool>,
 }
 
-pub(crate) type JsInputs = Either7<
+#[napi(object)]
+pub struct WorkingDirectoryInput {
+    pub working_directory: String,
+}
+
+pub(crate) type JsInputs = Either8<
     InputsInput,
     String,
     FileSetInput,
@@ -42,12 +47,13 @@ pub(crate) type JsInputs = Either7<
     EnvironmentInput,
     ExternalDependenciesInput,
     DepsOutputsInput,
+    WorkingDirectoryInput,
 >;
 
 impl<'a> From<&'a JsInputs> for Input<'a> {
     fn from(value: &'a JsInputs) -> Self {
         match value {
-            Either7::A(inputs) => {
+            Either8::A(inputs) => {
                 if let Some(projects) = &inputs.projects {
                     Input::Projects {
                         input: &inputs.input,
@@ -63,7 +69,7 @@ impl<'a> From<&'a JsInputs> for Input<'a> {
                     }
                 }
             }
-            Either7::B(string) => {
+            Either8::B(string) => {
                 if let Some(input) = string.strip_prefix('^') {
                     Input::Inputs {
                         input,
@@ -73,16 +79,19 @@ impl<'a> From<&'a JsInputs> for Input<'a> {
                     Input::String(string)
                 }
             }
-            Either7::C(file_set) => Input::FileSet(&file_set.fileset),
-            Either7::D(runtime) => Input::Runtime(&runtime.runtime),
-            Either7::E(environment) => Input::Environment(&environment.env),
-            Either7::F(external_dependencies) => {
+            Either8::C(file_set) => Input::FileSet(&file_set.fileset),
+            Either8::D(runtime) => Input::Runtime(&runtime.runtime),
+            Either8::E(environment) => Input::Environment(&environment.env),
+            Either8::F(external_dependencies) => {
                 Input::ExternalDependency(&external_dependencies.external_dependencies)
             }
-            Either7::G(deps_outputs) => Input::DepsOutputs {
+            Either8::G(deps_outputs) => Input::DepsOutputs {
                 transitive: deps_outputs.transitive.unwrap_or(false),
                 dependent_tasks_output_files: &deps_outputs.dependent_tasks_output_files,
             },
+            Either8::H(working_directory) => {
+                Input::WorkingDirectory(&working_directory.working_directory)
+            }
         }
     }
 }
@@ -106,4 +115,5 @@ pub(crate) enum Input<'a> {
         projects: Vec<&'a str>,
         input: &'a str,
     },
+    WorkingDirectory(&'a str),
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -42,6 +42,9 @@
     "metro-config": ">= 0.82.0",
     "metro-resolver": ">= 0.82.0"
   },
+  "devDependencies": {
+    "nx": "workspace:*"
+  },
   "optionalDependencies": {
     "@nx/detox": "workspace:*",
     "@nx/rollup": "workspace:*"

--- a/packages/react-native/tsconfig.lib.json
+++ b/packages/react-native/tsconfig.lib.json
@@ -26,6 +26,9 @@
     },
     {
       "path": "../rollup/tsconfig.lib.json"
+    },
+    {
+      "path": "../nx/tsconfig.lib.json"
     }
   ]
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -55,6 +55,7 @@
     "@nx/vite": "workspace:*",
     "@nx/vitest": "workspace:*",
     "@nx/webpack": "workspace:*",
+    "@nx/storybook": "workspace:*",
     "nx": "workspace:*"
   },
   "optionalDependencies": {

--- a/packages/react/tsconfig.lib.json
+++ b/packages/react/tsconfig.lib.json
@@ -17,9 +17,6 @@
   "include": ["**/*.ts", "**/*.json"],
   "references": [
     {
-      "path": "../vitest/tsconfig.lib.json"
-    },
-    {
       "path": "../rollup/tsconfig.lib.json"
     },
     {
@@ -41,7 +38,13 @@
       "path": "../nx/tsconfig.lib.json"
     },
     {
+      "path": "../storybook/tsconfig.lib.json"
+    },
+    {
       "path": "../webpack/tsconfig.lib.json"
+    },
+    {
+      "path": "../vitest/tsconfig.lib.json"
     },
     {
       "path": "../rsbuild/tsconfig.lib.json"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3182,6 +3182,10 @@ importers:
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
+    devDependencies:
+      nx:
+        specifier: workspace:*
+        version: link:../nx
 
   packages/expo:
     dependencies:
@@ -3218,6 +3222,10 @@ importers:
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
+    devDependencies:
+      nx:
+        specifier: workspace:*
+        version: link:../nx
     optionalDependencies:
       '@nx/detox':
         specifier: workspace:*
@@ -3896,6 +3904,9 @@ importers:
       '@nx/rsbuild':
         specifier: workspace:*
         version: link:../rsbuild
+      '@nx/storybook':
+        specifier: workspace:*
+        version: link:../storybook
       '@nx/vitest':
         specifier: workspace:*
         version: link:../vitest
@@ -3951,6 +3962,10 @@ importers:
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
+    devDependencies:
+      nx:
+        specifier: workspace:*
+        version: link:../nx
     optionalDependencies:
       '@nx/detox':
         specifier: workspace:*


### PR DESCRIPTION
## Current Behavior
There is no straight-forward way to use the cwd as part of a tasks hash

## Expected Behavior
You can use `{workingDirectory: 'absolute'}` to factor the working directory into the hash

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #33684
