### PR TITLE
fix(core): add back ability to create `cache_outputs` table without a foreign key

### DIFF
--- a/packages/nx/src/native/db/initialize.rs
+++ b/packages/nx/src/native/db/initialize.rs
@@ -1,4 +1,3 @@
-use crate::native::cache::cache::SCHEMA as CACHE_SCHEMA;
 use crate::native::db::connection::NxDbConnection;
 use crate::native::tasks::details::SCHEMA as TASK_DETAILS_SCHEMA;
 use crate::native::tasks::running_tasks_service::SCHEMA as RUNNING_TASKS_SCHEMA;
@@ -123,7 +122,7 @@ fn create_all_tables(c: &mut NxDbConnection) -> anyhow::Result<()> {
 
         // Tables with FK dependencies
         conn.execute_batch(TASK_HISTORY_SCHEMA)?;
-        conn.execute_batch(CACHE_SCHEMA)?;
+        // TODO: cache_outputs table is created by NxCache with conditional FK constraint
 
         Ok(())
     })?;


### PR DESCRIPTION
Add back the ability to create the `cache_outputs` table without a foreign key to `task_details`. Nx Cloud still needs this.