### PR TITLE
fix(core): display task output in TUI when native command runner is disabled

### DIFF
--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -997,6 +997,12 @@ export class TaskOrchestrator {
         return true;
       }
 
+      // When TUI is enabled, we need to use pipe output capture to support
+      // progressive output streaming via the onOutput callback
+      if (this.tuiEnabled) {
+        return true;
+      }
+
       const { schema } = getExecutorForTask(task, this.projectGraph);
 
       return (


### PR DESCRIPTION
## Current Behavior

When `NX_NATIVE_COMMAND_RUNNER=false` is set, tasks running in the TUI don't display any output in the terminal pane. The pane remains empty even though the task is running.

## Expected Behavior

Task output is displayed in the TUI terminal pane regardless of the `NX_NATIVE_COMMAND_RUNNER` setting.

## Related Issues

Fixes #32803 