### PR TITLE
fix(node): use @swc/helpers instead of tslib when compiler is swc

### DIFF
--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -726,7 +726,7 @@ describe('lib', () => {
       expect(readJson(tree, 'mylib/package.json')).toMatchInlineSnapshot(`
         {
           "dependencies": {
-            "tslib": "^2.3.0",
+            "@swc/helpers": "~0.5.11",
           },
           "exports": {
             ".": {
@@ -741,6 +741,7 @@ describe('lib', () => {
           "module": "./dist/index.js",
           "name": "@proj/mylib",
           "nx": {
+            "sourceRoot": "mylib/src",
             "targets": {
               "build": {
                 "executor": "@nx/js:swc",


### PR DESCRIPTION
When using `@nx/node:library` generator with `--compiler=swc`, the generator
was incorrectly adding `tslib` as a dependency instead of `@swc/helpers`.

This change fixes two issues:
1. Pass the correct bundler (matching the compiler) to jsLibraryGenerator
   so it adds the correct helper dependency to the project's package.json
2. Update ensureDependencies to only add tslib when compiler is tsc

Fixes #31202
