### PR TITLE
feat(angular): add migration to set `isolateModules: true` to jest tsconfig files

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -381,6 +381,14 @@
       },
       "description": "Update 'vitest' unit test runner option to 'vitest-analog' in generator defaults.",
       "factory": "./src/migrations/update-22-3-0/update-unit-test-runner-option"
+    },
+    "set-isolated-modules-22-3-0": {
+      "version": "22.3.0-beta.3",
+      "requires": {
+        "@angular/core": ">=21.0.0"
+      },
+      "description": "Set 'isolatedModules' to 'true' in TypeScript test configurations for Angular projects.",
+      "factory": "./src/migrations/update-22-3-0/set-isolated-modules"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/migrations/update-22-3-0/set-isolated-modules.md
+++ b/packages/angular/src/migrations/update-22-3-0/set-isolated-modules.md
@@ -1,0 +1,76 @@
+#### Set `isolatedModules` to `true` in TypeScript test configurations
+
+Sets the TypeScript `isolatedModules` compiler option to `true` in `tsconfig.spec.json` files for Angular projects using the Jest test runner.
+
+#### Examples
+
+The migration updates TypeScript test configuration files in Angular projects using the Jest test runner to set the `isolatedModules` compiler option:
+
+##### Before
+
+```jsonc {3-5}
+// apps/my-app/tsconfig.spec.json
+{
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec"
+  }
+}
+```
+
+##### After
+
+```jsonc {4-5}
+// apps/my-app/tsconfig.spec.json
+{
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec",
+    "isolatedModules": true
+  }
+}
+```
+
+If the value is already set to `true` or inherited from an extended tsconfig file, the migration will not modify the configuration:
+
+##### Before
+
+```jsonc {4}
+// tsconfig.json
+{
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}
+```
+
+```jsonc {4-6}
+// apps/my-app/tsconfig.spec.json
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec"
+  }
+}
+```
+
+##### After
+
+```jsonc {4}
+// tsconfig.json
+{
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}
+```
+
+```jsonc {4-6}
+// apps/my-app/tsconfig.spec.json
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/spec"
+  }
+}
+```
+
+The migration only processes TypeScript test configuration files (`tsconfig.spec.json` or custom test tsconfig files referenced by `@nx/jest:jest` tasks) in Angular projects.

--- a/packages/angular/src/migrations/update-22-3-0/set-isolated-modules.spec.ts
+++ b/packages/angular/src/migrations/update-22-3-0/set-isolated-modules.spec.ts
@@ -1,0 +1,268 @@
+import {
+  addProjectConfiguration,
+  readJson,
+  writeJson,
+  type ProjectConfiguration,
+  type ProjectGraph,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './set-isolated-modules';
+
+let projectGraph: ProjectGraph;
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual('@nx/devkit'),
+  createProjectGraphAsync: jest
+    .fn()
+    .mockImplementation(() => Promise.resolve(projectGraph)),
+}));
+
+describe('set-isolated-modules migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should set isolatedModules to true when not set', async () => {
+    addProject('app1', {
+      root: 'apps/app1',
+      sourceRoot: 'apps/app1/src',
+      targets: {
+        test: {
+          executor: '@angular-devkit/build-angular:karma',
+          options: {
+            tsConfig: 'apps/app1/tsconfig.spec.json',
+          },
+        },
+      },
+    });
+    writeJson(tree, 'apps/app1/tsconfig.spec.json', {
+      extends: './tsconfig.json',
+      compilerOptions: {},
+    });
+
+    await migration(tree);
+
+    const specConfig = readJson(tree, 'apps/app1/tsconfig.spec.json');
+    expect(specConfig.compilerOptions.isolatedModules).toBe(true);
+  });
+
+  it('should not modify when isolatedModules is already true', async () => {
+    addProject('app1', {
+      root: 'apps/app1',
+      sourceRoot: 'apps/app1/src',
+      targets: {
+        test: {
+          executor: '@angular-devkit/build-angular:karma',
+          options: {
+            tsConfig: 'apps/app1/tsconfig.spec.json',
+          },
+        },
+      },
+    });
+    writeJson(tree, 'apps/app1/tsconfig.spec.json', {
+      compilerOptions: {
+        isolatedModules: true,
+      },
+    });
+
+    await migration(tree);
+
+    const config = readJson(tree, 'apps/app1/tsconfig.spec.json');
+    expect(config.compilerOptions.isolatedModules).toBe(true);
+  });
+
+  it('should not modify when isolatedModules is inherited from parent tsconfig', async () => {
+    addProject('app1', {
+      root: 'apps/app1',
+      sourceRoot: 'apps/app1/src',
+      targets: {
+        test: {
+          executor: '@angular-devkit/build-angular:karma',
+          options: {
+            tsConfig: 'apps/app1/tsconfig.spec.json',
+          },
+        },
+      },
+    });
+    // Base tsconfig with isolatedModules: true at the workspace root
+    writeJson(tree, 'tsconfig.json', {
+      compilerOptions: {
+        isolatedModules: true,
+      },
+    });
+    // App tsconfig in apps folder
+    writeJson(tree, 'apps/tsconfig.json', {
+      extends: '../tsconfig.json',
+      compilerOptions: {},
+    });
+    // App-specific tsconfig extends the apps tsconfig (inherits the values)
+    writeJson(tree, 'apps/app1/tsconfig.spec.json', {
+      extends: '../tsconfig.json',
+      compilerOptions: {},
+    });
+
+    await migration(tree);
+
+    // Should not add duplicate settings since they're inherited
+    const config = readJson(tree, 'apps/app1/tsconfig.spec.json');
+    expect(config.compilerOptions.isolatedModules).toBeUndefined();
+  });
+
+  it('should update tsconfig.spec.json files in multiple projects', async () => {
+    addProject('app1', {
+      root: 'apps/app1',
+      sourceRoot: 'apps/app1/src',
+      targets: {
+        test: {
+          executor: '@angular-devkit/build-angular:karma',
+          options: {
+            tsConfig: 'apps/app1/tsconfig.spec.json',
+          },
+        },
+      },
+    });
+    writeJson(tree, 'apps/app1/tsconfig.spec.json', {
+      compilerOptions: {},
+    });
+
+    addProject('app2', {
+      root: 'apps/app2',
+      sourceRoot: 'apps/app2/src',
+      targets: {
+        test: {
+          executor: '@angular-devkit/build-angular:karma',
+          options: {
+            tsConfig: 'apps/app2/tsconfig.spec.json',
+          },
+        },
+      },
+    });
+    writeJson(tree, 'apps/app2/tsconfig.spec.json', {
+      compilerOptions: {},
+    });
+
+    await migration(tree);
+
+    const app1Config = readJson(tree, 'apps/app1/tsconfig.spec.json');
+    const app2Config = readJson(tree, 'apps/app2/tsconfig.spec.json');
+    expect(app1Config.compilerOptions.isolatedModules).toBe(true);
+    expect(app2Config.compilerOptions.isolatedModules).toBe(true);
+  });
+
+  it('should handle custom tsConfig paths from test target options', async () => {
+    addProject('app1', {
+      root: 'apps/app1',
+      sourceRoot: 'apps/app1/src',
+      targets: {
+        test: {
+          executor: '@nx/jest:jest',
+          options: {
+            tsConfig: 'apps/app1/tsconfig.spec.custom.json',
+          },
+        },
+      },
+    });
+    writeJson(tree, 'apps/app1/tsconfig.spec.custom.json', {
+      compilerOptions: {},
+    });
+
+    await migration(tree);
+
+    const config = readJson(tree, 'apps/app1/tsconfig.spec.custom.json');
+    expect(config.compilerOptions.isolatedModules).toBe(true);
+  });
+
+  it('should update tsconfig.spec.json even without test target', async () => {
+    addProject('lib1', {
+      root: 'libs/lib1',
+      sourceRoot: 'libs/lib1/src',
+      targets: {},
+    });
+    writeJson(tree, 'libs/lib1/tsconfig.spec.json', {
+      compilerOptions: {},
+    });
+
+    await migration(tree);
+
+    const specConfig = readJson(tree, 'libs/lib1/tsconfig.spec.json');
+    expect(specConfig.compilerOptions.isolatedModules).toBe(true);
+  });
+
+  it('should set isolatedModules when explicitly set to false', async () => {
+    addProject('app1', {
+      root: 'apps/app1',
+      sourceRoot: 'apps/app1/src',
+      targets: {
+        test: {
+          executor: '@angular-devkit/build-angular:karma',
+          options: {
+            tsConfig: 'apps/app1/tsconfig.spec.json',
+          },
+        },
+      },
+    });
+    writeJson(tree, 'apps/app1/tsconfig.spec.json', {
+      compilerOptions: {
+        isolatedModules: false,
+      },
+    });
+
+    await migration(tree);
+
+    const config = readJson(tree, 'apps/app1/tsconfig.spec.json');
+    expect(config.compilerOptions.isolatedModules).toBe(true);
+  });
+
+  it('should set isolatedModules when inherited value is false', async () => {
+    addProject('app1', {
+      root: 'apps/app1',
+      sourceRoot: 'apps/app1/src',
+      targets: {
+        test: {
+          executor: '@angular-devkit/build-angular:karma',
+          options: {
+            tsConfig: 'apps/app1/tsconfig.spec.json',
+          },
+        },
+      },
+    });
+    writeJson(tree, 'tsconfig.json', {
+      compilerOptions: {
+        isolatedModules: false,
+      },
+    });
+    writeJson(tree, 'apps/app1/tsconfig.spec.json', {
+      extends: '../../tsconfig.json',
+      compilerOptions: {},
+    });
+
+    await migration(tree);
+
+    const config = readJson(tree, 'apps/app1/tsconfig.spec.json');
+    expect(config.compilerOptions.isolatedModules).toBe(true);
+  });
+
+  function addProject(
+    projectName: string,
+    config: ProjectConfiguration,
+    dependencies: string[] = ['npm:@angular/core', 'npm:jest-preset-angular']
+  ): void {
+    projectGraph = {
+      dependencies: {
+        ...(projectGraph?.dependencies || {}),
+        [projectName]: dependencies.map((d) => ({
+          source: projectName,
+          target: d,
+          type: 'static',
+        })),
+      },
+      nodes: {
+        ...(projectGraph?.nodes || {}),
+        [projectName]: { data: config, name: projectName, type: 'app' },
+      },
+    };
+    addProjectConfiguration(tree, projectName, config);
+  }
+});

--- a/packages/angular/src/migrations/update-22-3-0/set-isolated-modules.ts
+++ b/packages/angular/src/migrations/update-22-3-0/set-isolated-modules.ts
@@ -1,0 +1,78 @@
+import {
+  formatFiles,
+  joinPathFragments,
+  type Tree,
+  updateJson,
+} from '@nx/devkit';
+import { readCompilerOptionsFromTsConfig } from '../../generators/utils/tsconfig-utils';
+import { allProjectTargets, allTargetOptions } from '../../utils/targets';
+import { getProjectsFilteredByDependencies } from '../utils/projects';
+
+type TsConfig = {
+  compilerOptions?: {
+    isolatedModules?: boolean;
+  };
+};
+
+export default async function (tree: Tree) {
+  const uniqueSpecTsConfigs = new Set<string>();
+
+  const projects = await getProjectsFilteredByDependencies([
+    'npm:@angular/core',
+    'npm:jest-preset-angular',
+  ]);
+
+  for (const graphNode of projects) {
+    const projectRoot = graphNode.data.root;
+
+    // add tsconfig.spec.json if it exists
+    const specTsConfigPath = joinPathFragments(
+      projectRoot,
+      'tsconfig.spec.json'
+    );
+    if (tree.exists(specTsConfigPath)) {
+      uniqueSpecTsConfigs.add(specTsConfigPath);
+    }
+
+    // look for tsConfig in @nx/jest:jest tasks in case there are any
+    // custom test tsconfig files
+    for (const [, target] of allProjectTargets(graphNode.data)) {
+      if (target.executor !== '@nx/jest:jest') {
+        continue;
+      }
+
+      for (const [, options] of allTargetOptions<{ tsConfig?: string }>(
+        target
+      )) {
+        if (
+          typeof options?.tsConfig === 'string' &&
+          tree.exists(options.tsConfig)
+        ) {
+          uniqueSpecTsConfigs.add(options.tsConfig);
+        }
+      }
+    }
+  }
+
+  for (const tsConfig of uniqueSpecTsConfigs) {
+    setIsolatedModules(tree, tsConfig);
+  }
+
+  await formatFiles(tree);
+}
+
+function setIsolatedModules(tree: Tree, tsConfigPath: string): void {
+  const compilerOptions = readCompilerOptionsFromTsConfig(tree, tsConfigPath);
+
+  if (compilerOptions.isolatedModules === true) {
+    // already set to true
+    return;
+  }
+
+  // set isolatedModules to true
+  updateJson<TsConfig>(tree, tsConfigPath, (json) => {
+    json.compilerOptions ??= {};
+    json.compilerOptions.isolatedModules = true;
+    return json;
+  });
+}


### PR DESCRIPTION
## Current Behavior

When upgrading to Angular 21 with Jest, users may encounter TypeScript compilation issues because their `tsconfig.spec.json` files don't have `isolatedModules: true` set, which is required for compatibility with Jest and `jest-preset-angular`.

## Expected Behavior

After running `nx migrate`, Angular projects using Jest will automatically have `isolatedModules: true` added to their `tsconfig.spec.json` files (or custom test tsconfig files referenced by `@nx/jest:jest` tasks) if not already set or inherited from a parent tsconfig.