### PR TITLE
fix(web): update e2e test regex for SWC decorator metadata

### DIFF
--- a/e2e/web/src/web.test.ts
+++ b/e2e/web/src/web.test.ts
@@ -215,7 +215,7 @@ describe('Web Components Applications', () => {
     runCLI(`build ${appName}`);
 
     expect(readFile(`dist/apps/${appName}/main.js`)).toMatch(
-      /Foo=.*?_decorate/
+      /class Foo.*_ts_metadata/
     );
   }, 120000);
 


### PR DESCRIPTION
## Current Behavior

The e2e test `should emit decorator metadata when using --compiler=swc` fails because the regex `/Foo=.*?_decorate/` expects the old transpiled output format where classes were assigned to variables.

## Expected Behavior

The test should pass by matching the current SWC output format which uses native ES class syntax.

## Solution

Updated the regex from `/Foo=.*?_decorate/` to `/class Foo.*_ts_metadata/` which:
- Matches `class Foo` (native ES class syntax)
- Verifies `_ts_metadata` is present (decorator metadata)