### PR TITLE
fix(core): convert * to workspace:* for pnpm/yarn/bun in CNW

### DIFF
--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -228,6 +228,7 @@ export function runCreateWorkspace(
   name: string,
   {
     preset,
+    template,
     appName,
     style,
     base,
@@ -249,7 +250,8 @@ export function runCreateWorkspace(
     framework,
     prefix,
   }: {
-    preset: string;
+    preset?: string;
+    template?: string;
     appName?: string;
     style?: string;
     base?: string;
@@ -272,6 +274,15 @@ export function runCreateWorkspace(
     prefix?: string;
   }
 ) {
+  if (preset && template) {
+    throw new Error(
+      'Cannot specify both preset and template. Use one or the other.'
+    );
+  }
+  if (!preset && !template) {
+    throw new Error('Must specify either preset or template.');
+  }
+
   projName = name;
 
   const pm = getPackageManagerCommand({ packageManager });
@@ -279,7 +290,14 @@ export function runCreateWorkspace(
   // Needed for bun workarounds, see below
   const registry = execSync('npm config get registry').toString().trim();
 
-  let command = `${pm.createWorkspace} ${name} --preset=${preset} --nxCloud=skip --no-interactive`;
+  let command = `${pm.createWorkspace} ${name} --nxCloud=skip --no-interactive`;
+
+  if (preset) {
+    command += ` --preset=${preset}`;
+  }
+  if (template) {
+    command += ` --template=${template}`;
+  }
 
   if (appName) {
     command += ` --appName=${appName}`;
@@ -618,8 +636,8 @@ export function newLernaWorkspace({
         packageManager === 'pnpm'
           ? ' --workspace-root'
           : packageManager === 'yarn'
-          ? ' -W'
-          : ''
+            ? ' -W'
+            : ''
       }`,
       {
         cwd: tmpProjPath(),

--- a/e2e/workspace-create/src/create-nx-workspace-base-templates.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace-base-templates.test.ts
@@ -1,0 +1,32 @@
+import {
+  cleanupProject,
+  runCLI,
+  runCreateWorkspace,
+  uniq,
+} from '@nx/e2e-utils';
+
+describe('create-nx-workspace --template', () => {
+  afterEach(() => cleanupProject());
+
+  const templates = [
+    'nrwl/empty-template',
+    'nrwl/typescript-template',
+  ] as const;
+
+  describe.each(['npm', 'pnpm'] as const)('with %s', (packageManager) => {
+    it.each(templates)(
+      'should clone %s and run lint,test,build',
+      (template) => {
+        const wsName = uniq('template');
+
+        runCreateWorkspace(wsName, {
+          template,
+          packageManager,
+        });
+
+        expect(() => runCLI('run-many -t lint,test,build')).not.toThrow();
+      },
+      600_000
+    );
+  });
+});

--- a/e2e/workspace-create/src/create-nx-workspace-react-template.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace-react-template.test.ts
@@ -1,0 +1,29 @@
+import {
+  cleanupProject,
+  runCLI,
+  runCreateWorkspace,
+  uniq,
+} from '@nx/e2e-utils';
+
+describe('create-nx-workspace --template', () => {
+  afterEach(() => cleanupProject());
+
+  const templates = ['nrwl/react-template'] as const;
+
+  describe.each(['npm', 'pnpm'] as const)('with %s', (packageManager) => {
+    it.each(templates)(
+      'should clone %s and run lint,test,build',
+      (template) => {
+        const wsName = uniq('template');
+
+        runCreateWorkspace(wsName, {
+          template,
+          packageManager,
+        });
+
+        expect(() => runCLI('run-many -t lint,test,build')).not.toThrow();
+      },
+      600_000
+    );
+  });
+});

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -447,7 +447,7 @@ async function normalizeArgsMiddleware(
     chosenTemplate = template;
 
     if (template !== 'custom') {
-      // Template flow - uses detected package manager (from invoking command) and 'main' branch by default
+      // Template flow - respects CLI arg, otherwise uses detected package manager (from invoking command)
       argv.template = template;
       const aiAgents = await determineAiAgents(argv);
       const nxCloud =
@@ -456,7 +456,7 @@ async function normalizeArgsMiddleware(
         nxCloud === 'skip'
           ? undefined
           : messages.completionMessageOfSelectedPrompt('setupNxCloudV2');
-      packageManager = detectInvokedPackageManager();
+      packageManager = argv.packageManager ?? detectInvokedPackageManager();
       Object.assign(argv, {
         nxCloud,
         useGitHub: nxCloud !== 'skip',

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -8,6 +8,7 @@ import {
   shouldUseTemplateFlow,
 } from '../utils/nx/ab-testing';
 import { deduceDefaultBase } from '../utils/git/default-base';
+import { isGitAvailable } from '../utils/git/git';
 import {
   detectInvokedPackageManager,
   PackageManager,
@@ -129,6 +130,8 @@ export async function determineTemplate(
   if (!parsedArgs.interactive || isCI()) return 'custom';
   // A/B test: shouldUseTemplateFlow() determines if user sees template or preset flow
   if (!shouldUseTemplateFlow()) return 'custom';
+  // Template flow requires git for cloning - fall back to custom preset if git is not available
+  if (!isGitAvailable()) return 'custom';
   const { template } = await enquirer.prompt<{ template: string }>([
     {
       name: 'template',

--- a/packages/create-nx-workspace/src/utils/git/git.ts
+++ b/packages/create-nx-workspace/src/utils/git/git.ts
@@ -30,6 +30,19 @@ export async function checkGitVersion(): Promise<string | null | undefined> {
   }
 }
 
+/**
+ * Synchronously checks if git is available on the system.
+ * Returns true if git command can be executed, false otherwise.
+ */
+export function isGitAvailable(): boolean {
+  try {
+    execSync('git --version', { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function getGitHubUsername(directory: string): Promise<string> {
   const result = await execAndWait('gh api user --jq .login', directory);
   const username = result.stdout.trim();

--- a/packages/create-nx-workspace/src/utils/package-manager.spec.ts
+++ b/packages/create-nx-workspace/src/utils/package-manager.spec.ts
@@ -1,7 +1,18 @@
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  readFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { workspacesToPnpmYaml, findWorkspacePackages } from './package-manager';
+import {
+  workspacesToPnpmYaml,
+  findWorkspacePackages,
+  findAllWorkspacePackageJsons,
+  convertStarToWorkspaceProtocol,
+} from './package-manager';
 
 describe('workspacesToPnpmYaml', () => {
   it('should convert single workspace glob to yaml', () => {
@@ -94,5 +105,177 @@ describe('findWorkspacePackages', () => {
 
     const result = findWorkspacePackages(tempDir);
     expect(result).toEqual(['has-pkg']);
+  });
+
+  it('should find packages with 2-level nesting', () => {
+    // Level 1: libs/utils/package.json
+    mkdirSync(join(tempDir, 'libs', 'utils'), { recursive: true });
+    writeFileSync(
+      join(tempDir, 'libs', 'utils', 'package.json'),
+      JSON.stringify({ name: '@myorg/utils' })
+    );
+
+    // Level 2: libs/shared/models/package.json
+    mkdirSync(join(tempDir, 'libs', 'shared', 'models'), { recursive: true });
+    writeFileSync(
+      join(tempDir, 'libs', 'shared', 'models', 'package.json'),
+      JSON.stringify({ name: '@myorg/shared-models' })
+    );
+
+    // Level 2: libs/shared/ui/package.json
+    mkdirSync(join(tempDir, 'libs', 'shared', 'ui'), { recursive: true });
+    writeFileSync(
+      join(tempDir, 'libs', 'shared', 'ui', 'package.json'),
+      JSON.stringify({ name: '@myorg/shared-ui' })
+    );
+
+    const result = findWorkspacePackages(tempDir);
+    expect(result).toEqual([
+      '@myorg/shared-models',
+      '@myorg/shared-ui',
+      '@myorg/utils',
+    ]);
+  });
+});
+
+describe('findAllWorkspacePackageJsons', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cnw-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should find package.json files at both nesting levels', () => {
+    // Level 1
+    mkdirSync(join(tempDir, 'packages', 'pkg-a'), { recursive: true });
+    writeFileSync(
+      join(tempDir, 'packages', 'pkg-a', 'package.json'),
+      JSON.stringify({ name: 'pkg-a' })
+    );
+
+    // Level 2
+    mkdirSync(join(tempDir, 'libs', 'shared', 'models'), { recursive: true });
+    writeFileSync(
+      join(tempDir, 'libs', 'shared', 'models', 'package.json'),
+      JSON.stringify({ name: 'models' })
+    );
+
+    const result = findAllWorkspacePackageJsons(tempDir);
+    expect(result).toContain(
+      join(tempDir, 'packages', 'pkg-a', 'package.json')
+    );
+    expect(result).toContain(
+      join(tempDir, 'libs', 'shared', 'models', 'package.json')
+    );
+  });
+});
+
+describe('convertStarToWorkspaceProtocol', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'cnw-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should convert "*" to "workspace:*" in dependencies', () => {
+    mkdirSync(join(tempDir, 'libs', 'utils'), { recursive: true });
+    writeFileSync(
+      join(tempDir, 'libs', 'utils', 'package.json'),
+      JSON.stringify({
+        name: '@myorg/utils',
+        dependencies: {
+          '@myorg/shared': '*',
+          lodash: '^4.0.0',
+        },
+      })
+    );
+
+    convertStarToWorkspaceProtocol(tempDir);
+
+    const result = JSON.parse(
+      readFileSync(join(tempDir, 'libs', 'utils', 'package.json'), 'utf-8')
+    );
+    expect(result.dependencies['@myorg/shared']).toBe('workspace:*');
+    expect(result.dependencies['lodash']).toBe('^4.0.0');
+  });
+
+  it('should convert "*" to "workspace:*" in devDependencies', () => {
+    mkdirSync(join(tempDir, 'apps', 'web'), { recursive: true });
+    writeFileSync(
+      join(tempDir, 'apps', 'web', 'package.json'),
+      JSON.stringify({
+        name: '@myorg/web',
+        devDependencies: {
+          '@myorg/testing': '*',
+          jest: '^29.0.0',
+        },
+      })
+    );
+
+    convertStarToWorkspaceProtocol(tempDir);
+
+    const result = JSON.parse(
+      readFileSync(join(tempDir, 'apps', 'web', 'package.json'), 'utf-8')
+    );
+    expect(result.devDependencies['@myorg/testing']).toBe('workspace:*');
+    expect(result.devDependencies['jest']).toBe('^29.0.0');
+  });
+
+  it('should handle 2-level nested packages', () => {
+    mkdirSync(join(tempDir, 'libs', 'shared', 'models'), { recursive: true });
+    writeFileSync(
+      join(tempDir, 'libs', 'shared', 'models', 'package.json'),
+      JSON.stringify({
+        name: '@myorg/shared-models',
+        dependencies: {
+          '@myorg/utils': '*',
+        },
+      })
+    );
+
+    convertStarToWorkspaceProtocol(tempDir);
+
+    const result = JSON.parse(
+      readFileSync(
+        join(tempDir, 'libs', 'shared', 'models', 'package.json'),
+        'utf-8'
+      )
+    );
+    expect(result.dependencies['@myorg/utils']).toBe('workspace:*');
+  });
+
+  it('should not modify package.json without "*" dependencies', () => {
+    mkdirSync(join(tempDir, 'packages', 'core'), { recursive: true });
+    const originalContent = JSON.stringify(
+      {
+        name: '@myorg/core',
+        dependencies: {
+          lodash: '^4.0.0',
+        },
+      },
+      null,
+      2
+    );
+    writeFileSync(
+      join(tempDir, 'packages', 'core', 'package.json'),
+      originalContent
+    );
+
+    convertStarToWorkspaceProtocol(tempDir);
+
+    const result = readFileSync(
+      join(tempDir, 'packages', 'core', 'package.json'),
+      'utf-8'
+    );
+    // Should remain unchanged (no trailing newline added)
+    expect(result).toBe(originalContent);
   });
 });

--- a/packages/create-nx-workspace/src/utils/package-manager.ts
+++ b/packages/create-nx-workspace/src/utils/package-manager.ts
@@ -15,10 +15,10 @@ export function detectPackageManager(dir: string = ''): PackageManager {
   return existsSync(join(dir, 'bun.lockb')) || existsSync(join(dir, 'bun.lock'))
     ? 'bun'
     : existsSync(join(dir, 'yarn.lock'))
-    ? 'yarn'
-    : existsSync(join(dir, 'pnpm-lock.yaml'))
-    ? 'pnpm'
-    : 'npm';
+      ? 'yarn'
+      : existsSync(join(dir, 'pnpm-lock.yaml'))
+        ? 'pnpm'
+        : 'npm';
 }
 
 /**
@@ -99,8 +99,9 @@ export function generatePackageManagerFiles(
   const [pmMajor] = getPackageManagerVersion(packageManager).split('.');
   switch (packageManager) {
     case 'pnpm':
-      // pnpm doesn't support "workspaces" in package.json, needs pnpm-workspace.yaml
+      // pnpm doesn't support "workspaces" in package.json
       convertToWorkspaceYaml(root);
+      convertStarToWorkspaceProtocol(root);
       break;
     case 'yarn':
       if (+pmMajor >= 2) {
@@ -111,7 +112,12 @@ export function generatePackageManagerFiles(
         // avoids errors when using nested yarn projects
         writeFileSync(join(root, 'yarn.lock'), '');
       }
+      convertStarToWorkspaceProtocol(root);
       break;
+    case 'bun':
+      convertStarToWorkspaceProtocol(root);
+      break;
+    // npm handles "*" natively, no conversion needed
   }
 }
 
@@ -122,12 +128,6 @@ export function workspacesToPnpmYaml(workspaces: string[]): string {
   return `packages:\n${workspaces.map((p) => `  - '${p}'`).join('\n')}\n`;
 }
 
-/**
- * Converts package.json "workspaces" field to pnpm-workspace.yaml
- * and removes the workspaces field from package.json.
- * Also adds workspace packages as devDependencies since pnpm doesn't
- * automatically symlink workspace packages like npm/yarn.
- */
 function convertToWorkspaceYaml(root: string): void {
   const packageJsonPath = join(root, 'package.json');
   if (!existsSync(packageJsonPath)) {
@@ -146,44 +146,103 @@ function convertToWorkspaceYaml(root: string): void {
     workspacesToPnpmYaml(workspaces)
   );
 
-  // Find all workspace packages and add as devDependencies
-  const workspacePackages = findWorkspacePackages(root);
-  if (workspacePackages.length > 0) {
-    packageJson.devDependencies = packageJson.devDependencies || {};
-    for (const pkg of workspacePackages) {
-      packageJson.devDependencies[pkg] = 'workspace:*';
-    }
-  }
-
-  // Remove workspaces from package.json
   delete packageJson.workspaces;
   writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
 }
 
 /**
- * Finds all package names from packages, libs, and apps directories.
+ * Converts "*" dependencies to "workspace:*" in all workspace package.json files.
+ * This is needed for pnpm, yarn, and bun to properly symlink workspace packages.
  */
-export function findWorkspacePackages(root: string): string[] {
-  const packages: string[] = [];
+export function convertStarToWorkspaceProtocol(root: string): void {
+  for (const pkgJsonPath of findAllWorkspacePackageJsons(root)) {
+    try {
+      const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+      let updated = false;
+
+      for (const deps of [pkgJson.dependencies, pkgJson.devDependencies]) {
+        if (!deps) continue;
+        for (const [dep, version] of Object.entries(deps)) {
+          if (version === '*') {
+            deps[dep] = 'workspace:*';
+            updated = true;
+          }
+        }
+      }
+
+      if (updated) {
+        writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n');
+      }
+    } catch {
+      // Skip invalid package.json files
+    }
+  }
+}
+
+export function findAllWorkspacePackageJsons(
+  root: string,
+  maxDepth: number = 2
+): string[] {
+  const results: string[] = [];
 
   for (const dir of ['packages', 'libs', 'apps']) {
     const fullPath = join(root, dir);
-    if (!existsSync(fullPath)) continue;
+    if (existsSync(fullPath)) {
+      findPackageJsonsRecursive(fullPath, 1, maxDepth, results);
+    }
+  }
 
-    const entries = readdirSync(fullPath, { withFileTypes: true });
+  return results;
+}
+
+function findPackageJsonsRecursive(
+  dir: string,
+  currentDepth: number,
+  maxDepth: number,
+  results: string[]
+): void {
+  if (currentDepth > maxDepth) {
+    return;
+  }
+
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true });
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
-      const pkgJsonPath = join(fullPath, entry.name, 'package.json');
+
+      const entryPath = join(dir, entry.name);
+      const pkgJsonPath = join(entryPath, 'package.json');
+
       if (existsSync(pkgJsonPath)) {
-        try {
-          const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
-          if (pkgJson.name) {
-            packages.push(pkgJson.name);
-          }
-        } catch {
-          // Skip invalid package.json files
-        }
+        results.push(pkgJsonPath);
       }
+
+      if (currentDepth < maxDepth) {
+        findPackageJsonsRecursive(
+          entryPath,
+          currentDepth + 1,
+          maxDepth,
+          results
+        );
+      }
+    }
+  } catch {
+    // Skip unreadable directories
+  }
+}
+
+export function findWorkspacePackages(root: string): string[] {
+  const packages: string[] = [];
+  const packageJsonPaths = findAllWorkspacePackageJsons(root);
+
+  for (const pkgJsonPath of packageJsonPaths) {
+    try {
+      const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+      if (pkgJson.name) {
+        packages.push(pkgJson.name);
+      }
+    } catch {
+      // Skip invalid package.json files
     }
   }
 


### PR DESCRIPTION
Templates use `"*"` for workspace dependencies in individual package.json files. This works for npm but breaks pnpm, yarn, and bun which require the `workspace:` protocol for proper symlinking.

For pnpm, yarn, and bun: automatically convert `"*"` dependencies to `"workspace:*"` in all workspace package.json files. npm is left unchanged since it handles `"*"` natively.

Also adds support for 2-level nested projects (e.g., `libs/shared/models/package.json`).
