### PR TITLE
fix(angular): ensure jest and jest-preset-angular are updated correctly for angular v21

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -2152,22 +2152,6 @@
           "alwaysAddToPackageJson": false
         }
       }
-    },
-    "22.3.0-jest": {
-      "version": "22.3.0-beta.0",
-      "requires": {
-        "@angular/compiler-cli": ">=19.0.0 <22.0.0",
-        "@angular/core": ">=19.0.0 <22.0.0",
-        "@angular/platform-browser": ">=19.0.0 <22.0.0",
-        "@angular/platform-browser-dynamic": ">=19.0.0 <22.0.0",
-        "jest": "^30.0.0"
-      },
-      "packages": {
-        "jest-preset-angular": {
-          "version": "~16.0.0",
-          "alwaysAddToPackageJson": false
-        }
-      }
     }
   }
 }

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -101,7 +101,7 @@
       }
     },
     "22.3.0": {
-      "version": "22.3.0-beta.0",
+      "version": "22.3.0-beta.3",
       "x-prompt": "Do you want to update the Jest version to v30?",
       "incompatibleWith": {
         "@angular-devkit/build-angular": "< 21.0.0"
@@ -144,6 +144,22 @@
         },
         "@swc/jest": {
           "version": "~0.2.38",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
+    "22.3.0-jest-preset-angular": {
+      "version": "22.3.0-beta.3",
+      "requires": {
+        "@angular/compiler-cli": ">=19.0.0 <22.0.0",
+        "@angular/core": ">=19.0.0 <22.0.0",
+        "@angular/platform-browser": ">=19.0.0 <22.0.0",
+        "@angular/platform-browser-dynamic": ">=19.0.0 <22.0.0",
+        "jest": "^30.0.0"
+      },
+      "packages": {
+        "jest-preset-angular": {
+          "version": "~16.0.0",
           "alwaysAddToPackageJson": false
         }
       }

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -101,11 +101,11 @@
     "migrations": "./migrations.json",
     "packageGroup": [
       "@nx/js",
-      "@nx/jest",
       "@nx/linter",
       "@nx/eslint",
       "@nx/workspace",
       "@nx/angular",
+      "@nx/jest",
       "@nx/cypress",
       "@nx/detox",
       "@nx/devkit",


### PR DESCRIPTION
## Current Behavior

There's a deadlock between the Angular and Jest package updates requirements (`requires` and `incompatibleWith`) that prevents updating Jest to v30 and `jest-preset-angular` to v16.

## Expected Behavior

Updating to Angular v21 should result in updating Jest to v30 and `jest-preset-angular` to v16.

This is ensured by moving the `jest-preset-angular` package update definition to the `@nx/jest` package and processing the `@nx/angular` package updates before `@nx/jest`. That way, by the time `@nx/jest` is processed, the migrator would have collected the Angular v21 updates, and the requirements will be met.