### PR TITLE
fix(graph): serve full project graph when navigating from PDV

### DIFF
--- a/graph/client/src/app/routes.tsx
+++ b/graph/client/src/app/routes.tsx
@@ -30,7 +30,10 @@ export function getRoutesForEnvironment() {
   }
 }
 
-const workspaceDataLoader = async (selectedWorkspaceId: string) => {
+const workspaceDataLoader = async (
+  selectedWorkspaceId: string,
+  requestFull = false
+) => {
   const workspaceInfo = appConfig.workspaces.find(
     (graph) => graph.id === selectedWorkspaceId
   );
@@ -43,7 +46,8 @@ const workspaceDataLoader = async (selectedWorkspaceId: string) => {
 
   const projectGraph: ProjectGraphClientResponse =
     await projectGraphDataService.getProjectGraph(
-      workspaceInfo.projectGraphUrl
+      workspaceInfo.projectGraphUrl,
+      requestFull
     );
 
   const targetsSet = new Set<string>();
@@ -291,7 +295,7 @@ export const devRoutes: RouteObject[] = [
         loader: async ({ params }) => {
           const selectedWorkspaceId =
             params.selectedWorkspaceId ?? appConfig.defaultWorkspaceId;
-          return workspaceDataLoader(selectedWorkspaceId);
+          return workspaceDataLoader(selectedWorkspaceId, true);
         },
         children: childRoutes,
       },
@@ -314,7 +318,7 @@ export const releaseRoutes: RouteObject[] = [
     id: 'selectedWorkspace',
     loader: async () => {
       const selectedWorkspaceId = appConfig.defaultWorkspaceId;
-      return workspaceDataLoader(selectedWorkspaceId);
+      return workspaceDataLoader(selectedWorkspaceId, true);
     },
     shouldRevalidate: () => {
       return false;

--- a/graph/shared/src/lib/project-graph-data-service/fetch-project-graph-service.ts
+++ b/graph/shared/src/lib/project-graph-data-service/fetch-project-graph-service.ts
@@ -16,8 +16,12 @@ export class FetchProjectGraphService implements ProjectGraphService {
     return response.json();
   }
 
-  async getProjectGraph(url: string): Promise<ProjectGraphClientResponse> {
-    const request = new Request(url, { mode: 'no-cors' });
+  async getProjectGraph(
+    url: string,
+    requestFull = false
+  ): Promise<ProjectGraphClientResponse> {
+    const requestUrl = requestFull ? `${url}?full=true` : url;
+    const request = new Request(requestUrl, { mode: 'no-cors' });
 
     const response = await fetch(request);
 

--- a/graph/shared/src/lib/project-graph-data-service/get-project-graph-data-service.ts
+++ b/graph/shared/src/lib/project-graph-data-service/get-project-graph-data-service.ts
@@ -12,7 +12,10 @@ let projectGraphService: ProjectGraphService;
 
 export interface ProjectGraphService {
   getHash: () => Promise<string>;
-  getProjectGraph: (url: string) => Promise<ProjectGraphClientResponse>;
+  getProjectGraph: (
+    url: string,
+    requestFull?: boolean
+  ) => Promise<ProjectGraphClientResponse>;
   getTaskGraph: (url: string) => Promise<TaskGraphClientResponse>;
   getSpecificTaskGraph?: (
     url: string,


### PR DESCRIPTION
`nx show project` creates partial graph filtered by focus. clicking 'view in graph' should fetch full graph, not the cached partial one.

- add isFilteredGraph tracking on server
- handle ?full=true query param to regenerate full graph
- client requests full graph when loading projects/tasks view
- file watcher respects current filter state
