### PR TITLE
feat(angular): add migration to replace `jest-preset-angular/setup-jest` imports

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -389,6 +389,14 @@
       },
       "description": "Set 'isolatedModules' to 'true' in TypeScript test configurations for Angular projects.",
       "factory": "./src/migrations/update-22-3-0/set-isolated-modules"
+    },
+    "update-jest-preset-angular-setup": {
+      "version": "22.3.0-beta.3",
+      "requires": {
+        "@angular/core": ">=21.0.0"
+      },
+      "description": "Replace 'jest-preset-angular/setup-jest' imports with the new 'setupZoneTestEnv' function.",
+      "factory": "./src/migrations/update-22-3-0/update-jest-preset-angular-setup"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/migrations/update-22-3-0/update-jest-preset-angular-setup.md
+++ b/packages/angular/src/migrations/update-22-3-0/update-jest-preset-angular-setup.md
@@ -1,0 +1,21 @@
+#### Update Jest Preset Angular Setup
+
+Replaces the removed `jest-preset-angular/setup-jest` import with the new `setupZoneTestEnv` function from `jest-preset-angular/setup-env/zone`.
+
+Starting with `jest-preset-angular` v15, the `setup-jest` files have been removed and replaced with explicit setup functions. The old `setup-jest` import only supported zone-based testing (zoneless support was added in v14.3.0 with the new `setupZonelessTestEnv` function), so all projects using the removed import are migrated to use `setupZoneTestEnv`.
+
+#### Examples
+
+##### Before
+
+```ts title="apps/my-app/src/test-setup.ts"
+import 'jest-preset-angular/setup-jest';
+```
+
+##### After
+
+```ts title="apps/my-app/src/test-setup.ts"
+import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();
+```

--- a/packages/angular/src/migrations/update-22-3-0/update-jest-preset-angular-setup.spec.ts
+++ b/packages/angular/src/migrations/update-22-3-0/update-jest-preset-angular-setup.spec.ts
@@ -1,0 +1,289 @@
+import {
+  addProjectConfiguration,
+  writeJson,
+  type ProjectConfiguration,
+  type ProjectGraph,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './update-jest-preset-angular-setup';
+
+let projectGraph: ProjectGraph;
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual('@nx/devkit'),
+  createProjectGraphAsync: () => Promise.resolve(projectGraph),
+  formatFiles: jest.fn(),
+}));
+
+describe('update-jest-preset-angular-setup migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    projectGraph = { dependencies: {}, nodes: {} };
+    writeJson(tree, 'package.json', {
+      dependencies: {},
+      devDependencies: { 'jest-preset-angular': '~16.0.0' },
+    });
+  });
+
+  describe('import replacement', () => {
+    it('should replace import with single quotes', async () => {
+      addProject(tree, 'app1', { root: 'apps/app1' });
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `import 'jest-preset-angular/setup-jest';`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/src/test-setup.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+        setupZoneTestEnv();"
+      `);
+    });
+
+    it('should replace import with double quotes', async () => {
+      addProject(tree, 'app1', { root: 'apps/app1' });
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `import "jest-preset-angular/setup-jest";`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/src/test-setup.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+        setupZoneTestEnv();"
+      `);
+    });
+
+    it('should replace import with .js extension', async () => {
+      addProject(tree, 'app1', { root: 'apps/app1' });
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `import 'jest-preset-angular/setup-jest.js';`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/src/test-setup.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+        setupZoneTestEnv();"
+      `);
+    });
+
+    it('should replace import with .mjs extension and preserve the extension', async () => {
+      addProject(tree, 'app1', { root: 'apps/app1' });
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `import 'jest-preset-angular/setup-jest.mjs';`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/src/test-setup.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone/index.mjs';
+
+        setupZoneTestEnv();"
+      `);
+    });
+
+    it('should replace require syntax and preserve it', async () => {
+      addProject(tree, 'app1', { root: 'apps/app1' });
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `require('jest-preset-angular/setup-jest');`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/src/test-setup.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { setupZoneTestEnv } = require('jest-preset-angular/setup-env/zone');
+
+        setupZoneTestEnv();"
+      `);
+    });
+  });
+
+  describe('content preservation', () => {
+    it('should preserve content before the import', async () => {
+      addProject(tree, 'app1', { root: 'apps/app1' });
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `// Jest setup file
+import 'zone.js';
+import 'zone.js/testing';
+import 'jest-preset-angular/setup-jest';`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/src/test-setup.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "// Jest setup file
+        import 'zone.js';
+        import 'zone.js/testing';
+        import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+        setupZoneTestEnv();"
+      `);
+    });
+
+    it('should preserve content after the import', async () => {
+      addProject(tree, 'app1', { root: 'apps/app1' });
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `import 'jest-preset-angular/setup-jest';
+
+// Additional test setup
+globalThis.someGlobal = 'test';`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/src/test-setup.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+        setupZoneTestEnv();
+        // Additional test setup
+        globalThis.someGlobal = 'test';"
+      `);
+    });
+  });
+
+  describe('skip scenarios', () => {
+    it('should not modify files already using the new format', async () => {
+      addProject(tree, 'app1', { root: 'apps/app1' });
+      const originalContent = `import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+setupZoneTestEnv();`;
+      tree.write('apps/app1/src/test-setup.ts', originalContent);
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/src/test-setup.ts', 'utf-8')).toBe(
+        originalContent
+      );
+    });
+
+    it('should skip non-.ts files', async () => {
+      addProject(tree, 'app1', { root: 'apps/app1' });
+      const originalContent = `import 'jest-preset-angular/setup-jest';`;
+      tree.write('apps/app1/src/setup.js', originalContent);
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/src/setup.js', 'utf-8')).toBe(
+        originalContent
+      );
+    });
+
+    it('should skip projects without jest-preset-angular dependency', async () => {
+      addProject(tree, 'app1', { root: 'apps/app1' }, ['npm:@angular/core']);
+      const originalContent = `import 'jest-preset-angular/setup-jest';`;
+      tree.write('apps/app1/src/test-setup.ts', originalContent);
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/src/test-setup.ts', 'utf-8')).toBe(
+        originalContent
+      );
+    });
+  });
+
+  describe('multiple projects', () => {
+    it('should process multiple projects', async () => {
+      addProject(tree, 'app1', { root: 'apps/app1' });
+      addProject(tree, 'app2', { root: 'apps/app2' });
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `import 'jest-preset-angular/setup-jest';`
+      );
+      tree.write(
+        'apps/app2/src/test-setup.ts',
+        `import 'jest-preset-angular/setup-jest';`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/src/test-setup.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+        setupZoneTestEnv();"
+      `);
+      expect(tree.read('apps/app2/src/test-setup.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+        setupZoneTestEnv();"
+      `);
+    });
+
+    it('should process both apps and libraries', async () => {
+      addProject(tree, 'app1', { root: 'apps/app1' });
+      addProject(tree, 'lib1', { root: 'libs/lib1' });
+      tree.write(
+        'apps/app1/src/test-setup.ts',
+        `import 'jest-preset-angular/setup-jest';`
+      );
+      tree.write(
+        'libs/lib1/src/test-setup.ts',
+        `import 'jest-preset-angular/setup-jest';`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('apps/app1/src/test-setup.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+        setupZoneTestEnv();"
+      `);
+      expect(tree.read('libs/lib1/src/test-setup.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { setupZoneTestEnv } from 'jest-preset-angular/setup-env/zone';
+
+        setupZoneTestEnv();"
+      `);
+    });
+  });
+});
+
+function addProject(
+  tree: Tree,
+  projectName: string,
+  config: Partial<ProjectConfiguration>,
+  dependencies: string[] = ['npm:@angular/core', 'npm:jest-preset-angular']
+): void {
+  const fullConfig: ProjectConfiguration = {
+    root: config.root || `apps/${projectName}`,
+    ...config,
+  };
+
+  projectGraph = {
+    dependencies: {
+      ...projectGraph.dependencies,
+      [projectName]: dependencies.map((d) => ({
+        source: projectName,
+        target: d,
+        type: 'static',
+      })),
+    },
+    nodes: {
+      ...projectGraph.nodes,
+      [projectName]: { data: fullConfig, name: projectName, type: 'app' },
+    },
+  };
+  addProjectConfiguration(tree, projectName, fullConfig);
+}

--- a/packages/angular/src/migrations/update-22-3-0/update-jest-preset-angular-setup.ts
+++ b/packages/angular/src/migrations/update-22-3-0/update-jest-preset-angular-setup.ts
@@ -1,0 +1,79 @@
+import { formatFiles, visitNotIgnoredFiles, type Tree } from '@nx/devkit';
+import { getProjectsFilteredByDependencies } from '../utils/projects';
+
+export default async function (tree: Tree) {
+  const projects = await getProjectsFilteredByDependencies([
+    'npm:jest-preset-angular',
+  ]);
+
+  if (!projects.length) {
+    return;
+  }
+
+  // The old 'jest-preset-angular/setup-jest' import only supported zone-based testing.
+  // Zoneless support was added in jest-preset-angular v14.3.0 with the new
+  // setupZonelessTestEnv function. Therefore, all projects using the old import
+  // were zone-based and should be migrated to setupZoneTestEnv.
+
+  // Regex patterns to match removed imports
+  // Matches: import 'jest-preset-angular/setup-jest'; (with optional .js/.mjs extension)
+  // Captures .mjs extension in group 3 to preserve it in the replacement
+  const setupJestImportRegex =
+    /^(\s*)import\s+(['"`])jest-preset-angular\/setup-jest(?:\.js)?(\.mjs)?\2;?\s*$/gm;
+  // Matches: require('jest-preset-angular/setup-jest'); (with optional .js extension)
+  // Note: .mjs is not supported with require() so we don't capture it
+  const setupJestRequireRegex =
+    /^(\s*)require\s*\(\s*(['"`])jest-preset-angular\/setup-jest(?:\.js)?\2\s*\)\s*;?\s*$/gm;
+
+  for (const project of projects) {
+    visitNotIgnoredFiles(tree, project.data.root, (file) => {
+      if (!file.endsWith('.ts')) {
+        return;
+      }
+
+      let content = tree.read(file, 'utf-8');
+      if (!content.includes('jest-preset-angular/setup-jest')) {
+        return;
+      }
+
+      let wasUpdated = false;
+
+      // Replace import statements, preserving .mjs extension if present
+      setupJestImportRegex.lastIndex = 0;
+      if (setupJestImportRegex.test(content)) {
+        setupJestImportRegex.lastIndex = 0;
+        content = content.replace(
+          setupJestImportRegex,
+          (_match, _leadingWhitespace, _quote, mjsExt) => {
+            const modulePath = mjsExt
+              ? 'jest-preset-angular/setup-env/zone/index.mjs'
+              : 'jest-preset-angular/setup-env/zone';
+            return `import { setupZoneTestEnv } from '${modulePath}';
+
+setupZoneTestEnv();`;
+          }
+        );
+        wasUpdated = true;
+      }
+
+      // Replace require statements, keeping require syntax
+      setupJestRequireRegex.lastIndex = 0;
+      if (setupJestRequireRegex.test(content)) {
+        setupJestRequireRegex.lastIndex = 0;
+        content = content.replace(
+          setupJestRequireRegex,
+          `const { setupZoneTestEnv } = require('jest-preset-angular/setup-env/zone');
+
+setupZoneTestEnv();`
+        );
+        wasUpdated = true;
+      }
+
+      if (wasUpdated) {
+        tree.write(file, content);
+      }
+    });
+  }
+
+  await formatFiles(tree);
+}


### PR DESCRIPTION
Replaces the removed `jest-preset-angular/setup-jest` import with the new `setupZoneTestEnv` function from `jest-preset-angular/setup-env/zone`.