### PR TITLE
fix(storybook): use helper to find correct version when pnpm catalogs are used

### DIFF
--- a/packages/eslint/src/utils/version-utils.ts
+++ b/packages/eslint/src/utils/version-utils.ts
@@ -1,8 +1,4 @@
-import {
-  getDependencyVersionFromPackageJson,
-  readJsonFile,
-  type Tree,
-} from '@nx/devkit';
+import { getDependencyVersionFromPackageJson, type Tree } from '@nx/devkit';
 import { checkAndCleanWithSemver } from '@nx/devkit/src/utils/semver';
 import { readModulePackageJson } from 'nx/src/devkit-internals';
 import { lt } from 'semver';
@@ -29,10 +25,8 @@ export function getInstalledPackageVersion(
       pkgName
     );
   } else {
-    const rootPackageJson = readJsonFile('package.json');
-    pkgVersionInRootPackageJson =
-      rootPackageJson.devDependencies?.[pkgName] ??
-      rootPackageJson.dependencies?.[pkgName];
+    // Use filesystem-based signature for pnpm catalog compatibility
+    pkgVersionInRootPackageJson = getDependencyVersionFromPackageJson(pkgName);
   }
 
   if (!pkgVersionInRootPackageJson) {

--- a/packages/storybook/src/utils/utilities.ts
+++ b/packages/storybook/src/utils/utilities.ts
@@ -1,4 +1,8 @@
-import { readJson, TargetConfiguration, Tree } from '@nx/devkit';
+import {
+  getDependencyVersionFromPackageJson,
+  TargetConfiguration,
+  Tree,
+} from '@nx/devkit';
 import { CompilerOptions } from 'typescript';
 import { statSync } from 'fs';
 import { findNodes } from '@nx/js';
@@ -52,12 +56,12 @@ export function getStorybookVersionToInstall(tree: Tree) {
 }
 
 export function storybookMajorVersion(tree?: Tree): number | undefined {
-  let foundStorybookPackageVersion: string;
+  let foundStorybookPackageVersion: string | null = null;
   if (tree) {
-    const rootPkgJson = readJson(tree, 'package.json');
-    foundStorybookPackageVersion =
-      rootPkgJson?.dependencies?.['storybook'] ||
-      rootPkgJson?.devDependencies?.['storybook'];
+    foundStorybookPackageVersion = getDependencyVersionFromPackageJson(
+      tree,
+      'storybook'
+    );
   }
   if (foundStorybookPackageVersion) {
     try {
@@ -78,12 +82,12 @@ export function storybookMajorVersion(tree?: Tree): number | undefined {
 }
 
 export function getInstalledStorybookVersion(tree?: Tree): string | undefined {
-  let foundStorybookPackageVersion: string;
+  let foundStorybookPackageVersion: string | null = null;
   if (tree) {
-    const rootPkgJson = readJson(tree, 'package.json');
-    foundStorybookPackageVersion =
-      rootPkgJson?.dependencies?.['storybook'] ||
-      rootPkgJson?.devDependencies?.['storybook'];
+    foundStorybookPackageVersion = getDependencyVersionFromPackageJson(
+      tree,
+      'storybook'
+    );
   }
   if (foundStorybookPackageVersion) {
     return foundStorybookPackageVersion;


### PR DESCRIPTION
  Current Behavior

  When using pnpm catalogs to manage dependency versions, the Storybook utilities and ESLint version-utils read package.json directly using readJson() or readJsonFile(). This approach doesn't resolve catalog references like catalog:default, causing version detection to fail or return incorrect values.

  For example, if package.json contains:
  {
    "devDependencies": {
      "storybook": "catalog:default"
    }
  }

  The current code would return "catalog:default" as the version string instead of resolving it to the actual version (e.g., "8.5.0").

  Expected Behavior

  Use the getDependencyVersionFromPackageJson() helper from @nx/devkit which properly handles pnpm catalog resolution. This ensures that version detection works correctly regardless of whether dependencies are specified directly or via pnpm catalogs.

  The helper:
  - Resolves catalog: references to their actual versions
  - Falls back gracefully when catalogs aren't in use
  - Maintains consistent behavior across different package managers

  Related Issue(s)

  Fixes issues with pnpm catalog compatibility in Storybook generators and ESLint utilities.

  Related to #29772