### PR TITLE
docs(misc): add "Copy page" button to copy markdown content

### DIFF
--- a/astro-docs/astro.config.mjs
+++ b/astro-docs/astro.config.mjs
@@ -91,6 +91,7 @@ export default defineConfig({
         './src/plugins/sidebar-icons.middleware.ts',
         './src/plugins/og.middleware.ts',
         './src/plugins/github-stars.middleware.ts',
+        './src/plugins/raw-content.middleware.ts',
       ],
       markdown: {
         // this breaks the renderMarkdown function in the plugin loader due to starlight path normalization

--- a/astro-docs/src/components/CopyPageButton.astro
+++ b/astro-docs/src/components/CopyPageButton.astro
@@ -1,0 +1,124 @@
+---
+export interface Props {
+  content: string;
+}
+
+const { content } = Astro.props;
+// Generate a unique ID for this instance
+const id = `copy-content-${Math.random().toString(36).slice(2, 9)}`;
+---
+
+<copy-page-button data-content-id={id}>
+  <button
+    type="button"
+    class="copy-page-btn"
+  >
+    <svg class="icon-default" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 7.5V6.108c0-1.135.845-2.098 1.976-2.192.373-.03.748-.057 1.123-.08M15.75 18H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08M15.75 18.75v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5A3.375 3.375 0 0 0 6.375 7.5H5.25m11.9-3.664A2.251 2.251 0 0 0 15 2.25h-1.5a2.251 2.251 0 0 0-2.15 1.586m5.8 0c.065.21.1.433.1.664v.75h-6V4.5c0-.231.035-.454.1-.664M6.75 7.5H4.875c-.621 0-1.125.504-1.125 1.125v12c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V16.5a9 9 0 0 0-9-9Z" />
+    </svg>
+    <svg class="icon-copied" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+    </svg>
+    <span class="label">Copy page</span>
+  </button>
+  <script type="application/json" id={id} set:html={JSON.stringify(content)} />
+</copy-page-button>
+
+<style>
+  .copy-page-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: var(--sl-text-xs);
+    color: var(--sl-color-gray-3);
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    transition: color 0.2s;
+  }
+
+  .copy-page-btn:hover {
+    color: var(--sl-color-white);
+  }
+
+  .copy-page-btn svg {
+    width: 1rem;
+    height: 1rem;
+    flex-shrink: 0;
+  }
+
+  .copy-page-btn .icon-copied {
+    display: none;
+  }
+
+  .copy-page-btn.copied .icon-default {
+    display: none;
+  }
+
+  .copy-page-btn.copied .icon-copied {
+    display: block;
+  }
+</style>
+
+<script>
+  class CopyPageButtonElement extends HTMLElement {
+    private button: HTMLButtonElement | null = null;
+    private timeout: number | null = null;
+    private content: string | null = null;
+
+    constructor() {
+      super();
+      this.button = this.querySelector('button');
+
+      // Get content from the JSON script tag
+      const contentId = this.dataset.contentId;
+      if (contentId) {
+        const scriptTag = this.querySelector(`#${contentId}`);
+        if (scriptTag?.textContent) {
+          try {
+            this.content = JSON.parse(scriptTag.textContent);
+          } catch (e) {
+            console.error('Failed to parse copy content:', e);
+          }
+        }
+      }
+    }
+
+    connectedCallback() {
+      this.button?.addEventListener('click', this.handleClick);
+    }
+
+    disconnectedCallback() {
+      this.button?.removeEventListener('click', this.handleClick);
+      if (this.timeout) {
+        clearTimeout(this.timeout);
+      }
+    }
+
+    private handleClick = async () => {
+      if (!this.content) return;
+
+      try {
+        await navigator.clipboard.writeText(this.content);
+        this.showCopiedState();
+      } catch (err) {
+        console.error('Failed to copy:', err);
+      }
+    };
+
+    private showCopiedState() {
+      this.button?.classList.add('copied');
+
+      if (this.timeout) {
+        clearTimeout(this.timeout);
+      }
+
+      this.timeout = window.setTimeout(() => {
+        this.button?.classList.remove('copied');
+      }, 3000);
+    }
+  }
+
+  customElements.define('copy-page-button', CopyPageButtonElement);
+</script>

--- a/astro-docs/src/components/layout/TableOfContents.astro
+++ b/astro-docs/src/components/layout/TableOfContents.astro
@@ -2,9 +2,11 @@
 // recreated from https://github.com/withastro/starlight/blob/main/packages/starlight/components/TableOfContents.astro
 import TableOfContentsList from './TableOfContentsList.astro';
 import { GitHubStarWidget } from '@nx/nx-dev-ui-common';
+import CopyPageButton from '../CopyPageButton.astro';
 
 const { toc } = Astro.locals.starlightRoute;
 const githubStarsCount = Astro.locals.githubStarsCount ?? 0;
+const rawContent = Astro.locals.rawContent;
 ---
 
 {
@@ -19,6 +21,11 @@ const githubStarsCount = Astro.locals.githubStarsCount ?? 0;
           <TableOfContentsList toc={toc.items} />
         </div>
       </nav>
+      {rawContent && (
+        <div class="copy-page-button-container">
+          <CopyPageButton content={rawContent} />
+        </div>
+      )}
     </custom-toc>
   )
 }
@@ -171,6 +178,13 @@ const githubStarsCount = Astro.locals.githubStarsCount ?? 0;
     /* GitHub star widget styling */
     .github-star-widget-container {
       margin-bottom: 1rem;
+    }
+
+    /* Copy page button styling - positioned after TOC with divider */
+    .copy-page-button-container {
+      padding-top: 1rem;
+      margin-top: 1rem;
+      border-top: 1px solid var(--sl-color-hairline);
     }
     
     /* Container with proper scrolling */

--- a/astro-docs/src/env.d.ts
+++ b/astro-docs/src/env.d.ts
@@ -5,5 +5,6 @@
 declare namespace App {
   interface Locals {
     githubStarsCount?: number;
+    rawContent?: string;
   }
 }

--- a/astro-docs/src/pages/reference/devkit/[...slug].astro
+++ b/astro-docs/src/pages/reference/devkit/[...slug].astro
@@ -14,6 +14,9 @@ if(!doc) {
 }
 
 const { Content, headings } = await render(doc);
+
+// Set raw content for the copy button
+Astro.locals.rawContent = doc.body;
 ---
 
 <StarlightPage

--- a/astro-docs/src/pages/reference/nx/[...slug].astro
+++ b/astro-docs/src/pages/reference/nx/[...slug].astro
@@ -30,6 +30,9 @@ const docType = doc.data.docType;
 
 // Capitalize the doc type for display
 const docTypeDisplay = docType.charAt(0).toUpperCase() + docType.slice(1);
+
+// Set raw content for the copy button
+Astro.locals.rawContent = doc.body;
 ---
 
 <StarlightPage

--- a/astro-docs/src/pages/reference/plugin/[...slug].astro
+++ b/astro-docs/src/pages/reference/plugin/[...slug].astro
@@ -30,6 +30,9 @@ const docType = doc.data.docType;
 
 // Capitalize the doc type for display
 const docTypeDisplay = docType.charAt(0).toUpperCase() + docType.slice(1);
+
+// Set raw content for the copy button
+Astro.locals.rawContent = doc.body;
 ---
 
 <StarlightPage

--- a/astro-docs/src/pages/reference/web/[...slug].astro
+++ b/astro-docs/src/pages/reference/web/[...slug].astro
@@ -30,6 +30,9 @@ const docType = doc.data.docType;
 
 // Capitalize the doc type for display
 const docTypeDisplay = docType.charAt(0).toUpperCase() + docType.slice(1);
+
+// Set raw content for the copy button
+Astro.locals.rawContent = doc.body;
 ---
 
 <StarlightPage

--- a/astro-docs/src/pages/reference/workspace/[...slug].astro
+++ b/astro-docs/src/pages/reference/workspace/[...slug].astro
@@ -30,6 +30,9 @@ const docType = doc.data.docType;
 
 // Capitalize the doc type for display
 const docTypeDisplay = docType.charAt(0).toUpperCase() + docType.slice(1);
+
+// Set raw content for the copy button
+Astro.locals.rawContent = doc.body;
 ---
 
 <StarlightPage

--- a/astro-docs/src/pages/technologies/[...slug].astro
+++ b/astro-docs/src/pages/technologies/[...slug].astro
@@ -29,6 +29,9 @@ const docType = doc.data.docType;
 
 // Capitalize the doc type for display
 const docTypeDisplay = docType.charAt(0).toUpperCase() + docType.slice(1);
+
+// Set raw content for the copy button (doc.body contains the raw markdown)
+Astro.locals.rawContent = doc.body;
 ---
 
 <StarlightPage

--- a/astro-docs/src/plugins/raw-content.middleware.ts
+++ b/astro-docs/src/plugins/raw-content.middleware.ts
@@ -1,0 +1,15 @@
+import { defineRouteMiddleware } from '@astrojs/starlight/route-data';
+import { readFileSync, existsSync } from 'node:fs';
+
+export const onRequest = defineRouteMiddleware((context) => {
+  const route = context.locals.starlightRoute;
+
+  // Only read raw content if the entry has a file path on disk
+  if (route?.entry?.filePath && existsSync(route.entry.filePath)) {
+    try {
+      context.locals.rawContent = readFileSync(route.entry.filePath, 'utf-8');
+    } catch (error) {
+      console.error('Failed to read raw content:', error);
+    }
+  }
+});


### PR DESCRIPTION
This PR adds a `Copy page` action under the ToC in the right sidebar.

<img width="608" height="861" alt="image" src="https://github.com/user-attachments/assets/9d3c7444-1163-4682-87dc-a399178e750d" />

The helps get the content into LLMs and AI agents.