### PR TITLE
chore(maven): bump Maven plugin version to 0.0.12

### DIFF
--- a/packages/maven/batch-runner/pom.xml
+++ b/packages/maven/batch-runner/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>nx-maven-parent</artifactId>
-        <version>0.0.11</version>
+        <version>0.0.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/maven-plugin/pom.xml
+++ b/packages/maven/maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.nx.maven</groupId>
     <artifactId>nx-maven-parent</artifactId>
-    <version>0.0.11</version>
+    <version>0.0.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/migrations.json
+++ b/packages/maven/migrations.json
@@ -24,6 +24,12 @@
       "version": "22.2.0-beta.4",
       "description": "Update Maven plugin version from 0.0.10 to 0.0.11 in pom.xml files",
       "factory": "./dist/migrations/0-0-11/update-pom-xml-version"
+    },
+    "update-0-0-12": {
+      "cli": "nx",
+      "version": "22.4.0-beta.0",
+      "description": "Update Maven plugin version from 0.0.11 to 0.0.12 in pom.xml files",
+      "factory": "./dist/migrations/0-0-12/update-pom-xml-version"
     }
   }
 }

--- a/packages/maven/pom.xml
+++ b/packages/maven/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>dev.nx.maven</groupId>
     <artifactId>nx-parent</artifactId>
-    <version>0.0.11</version>
+    <version>0.0.12</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/shared/pom.xml
+++ b/packages/maven/shared/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>nx-maven-parent</artifactId>
-        <version>0.0.11</version>
+        <version>0.0.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/src/migrations/0-0-12/update-pom-xml-version.ts
+++ b/packages/maven/src/migrations/0-0-12/update-pom-xml-version.ts
@@ -1,0 +1,11 @@
+import { Tree } from '@nx/devkit';
+import { updateNxMavenPluginVersion } from '../../utils/pom-xml-updater';
+
+/**
+ * Migration for @nx/maven v0.0.12
+ * Updates the Maven plugin version to 0.0.12 in pom.xml files
+ */
+export default async function update(tree: Tree) {
+  // Update user pom.xml files
+  updateNxMavenPluginVersion(tree, '0.0.12');
+}

--- a/packages/maven/src/utils/versions.ts
+++ b/packages/maven/src/utils/versions.ts
@@ -1,2 +1,2 @@
 export const nxVersion = require('../../package.json').version;
-export const mavenPluginVersion = '0.0.11';
+export const mavenPluginVersion = '0.0.12';

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>dev.nx.maven</groupId>
   <artifactId>nx-parent</artifactId>
-  <version>0.0.11</version>
+  <version>0.0.12</version>
   <packaging>pom</packaging>
 
   <name>Nx Parent</name>

--- a/tools/workspace-plugin/src/generators/bump-maven-version/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/bump-maven-version/generator.spec.ts
@@ -12,7 +12,7 @@ describe('bump-maven-version generator', () => {
   <version>0.0.8</version>
 </project>`;
 
-  const mockMavenPluginPomXml = `<?xml version="1.0" encoding="UTF-8"?>
+  const mockMavenParentPomXml = `<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0">
   <parent>
     <groupId>dev.nx</groupId>
@@ -20,8 +20,42 @@ describe('bump-maven-version generator', () => {
     <version>0.0.8</version>
   </parent>
   <groupId>dev.nx.maven</groupId>
+  <artifactId>nx-maven-parent</artifactId>
+  <packaging>pom</packaging>
+</project>`;
+
+  const mockMavenPluginPomXml = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <parent>
+    <groupId>dev.nx.maven</groupId>
+    <artifactId>nx-maven-parent</artifactId>
+    <version>0.0.8</version>
+  </parent>
+  <groupId>dev.nx.maven</groupId>
   <artifactId>nx-maven-plugin</artifactId>
   <version>\${project.parent.version}</version>
+</project>`;
+
+  const mockSharedPomXml = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <parent>
+    <groupId>dev.nx.maven</groupId>
+    <artifactId>nx-maven-parent</artifactId>
+    <version>0.0.8</version>
+  </parent>
+  <groupId>dev.nx.maven</groupId>
+  <artifactId>nx-maven-shared</artifactId>
+</project>`;
+
+  const mockBatchRunnerPomXml = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <parent>
+    <groupId>dev.nx.maven</groupId>
+    <artifactId>nx-maven-parent</artifactId>
+    <version>0.0.8</version>
+  </parent>
+  <groupId>dev.nx.maven</groupId>
+  <artifactId>maven-batch-runner</artifactId>
 </project>`;
 
   const mockVersionsTs = `export const nxVersion = require('../../package.json').version;
@@ -45,7 +79,10 @@ export const mavenPluginVersion = '0.0.8';`;
 
     // Setup mock files
     tree.write('pom.xml', mockPomXml);
+    tree.write('packages/maven/pom.xml', mockMavenParentPomXml);
     tree.write('packages/maven/maven-plugin/pom.xml', mockMavenPluginPomXml);
+    tree.write('packages/maven/shared/pom.xml', mockSharedPomXml);
+    tree.write('packages/maven/batch-runner/pom.xml', mockBatchRunnerPomXml);
     tree.write('packages/maven/src/utils/versions.ts', mockVersionsTs);
     tree.write(
       'packages/maven/migrations.json',

--- a/tools/workspace-plugin/src/generators/bump-maven-version/generator.ts
+++ b/tools/workspace-plugin/src/generators/bump-maven-version/generator.ts
@@ -124,7 +124,11 @@ export default async function runGenerator(
     logger.info('Updating /pom.xml...');
     updateXmlVersion(tree, 'pom.xml', newVersion, true);
 
-    // 2. Update maven-plugin pom.xml
+    // 2. Update packages/maven/pom.xml
+    logger.info('Updating packages/maven/pom.xml...');
+    updateXmlVersion(tree, 'packages/maven/pom.xml', newVersion, false);
+
+    // 3. Update maven-plugin pom.xml
     logger.info('Updating packages/maven/maven-plugin/pom.xml...');
     updateXmlVersion(
       tree,
@@ -133,7 +137,20 @@ export default async function runGenerator(
       false
     );
 
-    // 3. Update versions.ts
+    // 4. Update shared pom.xml
+    logger.info('Updating packages/maven/shared/pom.xml...');
+    updateXmlVersion(tree, 'packages/maven/shared/pom.xml', newVersion, false);
+
+    // 5. Update batch-runner pom.xml
+    logger.info('Updating packages/maven/batch-runner/pom.xml...');
+    updateXmlVersion(
+      tree,
+      'packages/maven/batch-runner/pom.xml',
+      newVersion,
+      false
+    );
+
+    // 6. Update versions.ts
     logger.info('Updating packages/maven/src/utils/versions.ts...');
     const versionsFile = tree.read(
       'packages/maven/src/utils/versions.ts',
@@ -150,7 +167,7 @@ export default async function runGenerator(
 
     tree.write('packages/maven/src/utils/versions.ts', updatedVersionsFile);
 
-    // 4. Update migrations.json
+    // 7. Update migrations.json
     logger.info('Updating packages/maven/migrations.json...');
     const migrationsJsonPath = 'packages/maven/migrations.json';
     const migrationEntry = {
@@ -175,7 +192,7 @@ export default async function runGenerator(
 
     updateJson(tree, migrationsJsonPath, migrationEntry[migrationsJsonPath]);
 
-    // 5. Create migration file
+    // 8. Create migration file
     logger.info(`Creating migration file in ${migrationsDir}...`);
     const migrationContent = `import { Tree } from '@nx/devkit';
 import { updateNxMavenPluginVersion } from '../../utils/pom-xml-updater';


### PR DESCRIPTION
## Current Behavior

The Maven plugin version is currently at 0.0.11.

## Expected Behavior

This PR bumps the Maven plugin version to 0.0.12 and creates a migration for Nx 22.4.0-beta.0. This allows users to automatically update their pom.xml files when they upgrade to the next version of Nx.

## Related Issue(s)

N/A - Version bump