### PR TITLE
fix(testing): ensure jest v30 migration is run

### DIFF
--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -34,6 +34,14 @@
       "version": "22.2.0-beta.2",
       "description": "Convert jest.config.ts files from ESM to CJS syntax (export default -> module.exports, import -> require) for projects using CommonJS resolution to ensure correct loading under Node.js type-stripping.",
       "implementation": "./src/migrations/update-22-2-0/convert-jest-config-to-cjs"
+    },
+    "replace-removed-matcher-aliases-v22-3": {
+      "version": "22.3.2-beta.0",
+      "requires": {
+        "jest": ">=30.0.0"
+      },
+      "description": "Replace removed matcher aliases in Jest v30 with their corresponding matcher",
+      "implementation": "./src/migrations/update-21-3-0/replace-removed-matcher-aliases"
     }
   },
   "packageJsonUpdates": {


### PR DESCRIPTION
## Current Behavior

The `replace-removed-matcher-aliases` migration from `@nx/jest` is not run when migrating to Angular v21 (and updating Jest to v30). That migration targets the original package update for Jest v30 (Nx 21.3.0), which was incompatible with Angular < 21, so it wouldn't have run for Angular workspaces at the time. Now that Angular is being updated to v21, Jest is updated to v30, but the migration generator is not running.

## Expected Behavior

The `replace-removed-matcher-aliases` migration from `@nx/jest` should run when migrating to Angular v21 (and updating Jest to v30).