### PR TITLE
fix(core): only run nx console background check if daemon is active

### DIFF
--- a/packages/nx/bin/init-local.ts
+++ b/packages/nx/bin/init-local.ts
@@ -125,7 +125,7 @@ function shouldDelegateToAngularCLI() {
 
 async function ensureNxConsoleInstalledViaDaemon(): Promise<void> {
   // Only proceed if daemon is available
-  if (!daemonClient.enabled()) {
+  if (!daemonClient.enabled() || !(await daemonClient.isServerAvailable())) {
     return;
   }
 


### PR DESCRIPTION

## Current Behavior
running commands while the nx daemon is disabled will check the nx console status - which sends a message to the daemon and thus enables it. 
This can cause weird race conditions.

## Expected Behavior
As it's a non-critical check, we should only send messages to the daemon if it's running.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
