### PR TITLE
fix(react): set up module federation with webpack and ts soln correctly #31029

### DIFF
--- a/packages/react/src/generators/application/lib/add-project.ts
+++ b/packages/react/src/generators/application/lib/add-project.ts
@@ -51,6 +51,10 @@ export function addProject(host: Tree, options: NormalizedSchema) {
     }
     if (Object.keys(project.targets).length) {
       packageJson.nx ??= {};
+      packageJson.nx.sourceRoot = joinPathFragments(
+        options.appProjectRoot,
+        'src'
+      );
       packageJson.nx.targets = project.targets;
     }
     if (options.parsedTags?.length) {

--- a/packages/react/src/rules/update-module-federation-project.ts
+++ b/packages/react/src/rules/update-module-federation-project.ts
@@ -37,12 +37,14 @@ export function updateModuleFederationProject(
 
     projectConfig.targets.build.configurations ??= {};
 
-    projectConfig.targets.build.configurations.production = {
-      ...(projectConfig.targets.build.configurations?.production ?? {}),
-      webpackConfig: `${options.appProjectRoot}/webpack.config.prod.${
-        options.typescriptConfiguration && !options.js ? 'ts' : 'js'
-      }`,
-    };
+    if (!isUsingTsSolutionSetup(host)) {
+      projectConfig.targets.build.configurations.production = {
+        ...(projectConfig.targets.build.configurations?.production ?? {}),
+        webpackConfig: `${options.appProjectRoot}/webpack.config.prod.${
+          options.typescriptConfiguration && !options.js ? 'ts' : 'js'
+        }`,
+      };
+    }
   }
 
   // If host should be configured to use dynamic federation


### PR DESCRIPTION
 ## Current Behavior

  When generating a React Module Federation remote with webpack bundler in a TypeScript
  Solution setup, the generator incorrectly sets the production webpack config path in the
  project configuration. Additionally, the sourceRoot property is not being set in
  package.json for TS Solution setups, which causes issues with module federation's ability
  to locate source files correctly.

 ## Expected Behavior

  When using a TypeScript Solution setup:
  - The production webpack config should not be explicitly set in the build target's
  production configuration (it will be inferred correctly)
  - The sourceRoot property should be set in package.json under the nx configuration to
  properly identify the project's source directory
  - The typecheck target should be added as a dependency for both build and serve targets

 ## Related Issue(s)

  Fixes #31029