### PR TITLE
docs(release): clarify ignorePatternsForPlanCheck syntax #30324

### DIFF
--- a/astro-docs/src/content/docs/guides/Nx Release/file-based-versioning-version-plans.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/file-based-versioning-version-plans.mdoc
@@ -170,7 +170,7 @@ By default, all files that have changed are considered, but you may not want all
 }
 ```
 
-{% aside type="warning" title="Important: Pattern Syntax" %}
+{% aside type="caution" title="Important: Pattern Syntax" %}
 
 The `ignorePatternsForPlanCheck` patterns follow [gitignore semantics](https://git-scm.com/docs/gitignore). When using negation patterns (patterns starting with `!`) to "un-ignore" certain files, be aware that:
 

--- a/astro-docs/src/content/docs/guides/Nx Release/file-based-versioning-version-plans.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/file-based-versioning-version-plans.mdoc
@@ -170,6 +170,33 @@ By default, all files that have changed are considered, but you may not want all
 }
 ```
 
+{% aside type="warning" title="Important: Pattern Syntax" %}
+
+The `ignorePatternsForPlanCheck` patterns follow [gitignore semantics](https://git-scm.com/docs/gitignore). When using negation patterns (patterns starting with `!`) to "un-ignore" certain files, be aware that:
+
+**Working patterns:**
+
+- `["**/*.spec.ts"]` - ignore all spec files
+- `["**/*.ts", "!**/src/**"]` - ignore all .ts files except those in src/ directories
+
+**Non-working patterns:**
+
+- `["*", "!src/"]` - this does NOT work as expected because `*` in gitignore matches at the root level and negation patterns cannot properly un-ignore nested paths
+
+If you want to ignore all files except those in specific directories, use file extension patterns instead of wildcards:
+
+```jsonc
+{
+  "release": {
+    "versionPlans": {
+      "ignorePatternsForPlanCheck": ["**/*.ts", "**/*.json", "!**/src/**"],
+    },
+  },
+}
+```
+
+{% /aside %}
+
 To see more details about the changed files that were detected and the filtering logic that was used to determine the ultimately changed projects behind the scenes, you can pass `--verbose` to the command:
 
 ```shell

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -353,6 +353,11 @@ export interface NxReleaseVersionPlansConfiguration {
   /**
    * Changes to files matching any of these optional patterns will be excluded from the affected project logic within the `nx release plan:check`
    * command. This is useful for ignoring files that are not relevant to the versioning process, such as documentation or configuration files.
+   *
+   * These patterns follow gitignore semantics. When using negation patterns (to "un-ignore" certain files), use specific file extension patterns
+   * rather than wildcards like `*` or `**`. For example:
+   * - Works: `["**\/*.ts", "!**\/src/**"]` - ignores all .ts files except those in src/ directories
+   * - Does NOT work as expected: `["*", "!src/"]` - negation won't properly un-ignore nested paths
    */
   ignorePatternsForPlanCheck?: string[];
 }

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -356,8 +356,8 @@ export interface NxReleaseVersionPlansConfiguration {
    *
    * These patterns follow gitignore semantics. When using negation patterns (to "un-ignore" certain files), use specific file extension patterns
    * rather than wildcards like `*` or `**`. For example:
-   * - Works: `["**/*.ts", "!**/src/**"]` - ignores all .ts files except those in src/ directories
-   * - Does NOT work as expected: `["*", "!src/"]` - negation won't properly un-ignore nested paths
+   * - Works: ["**\/*.ts", "!**\/src\/**"] - ignores all .ts files except those in src/ directories
+   * - Does NOT work as expected: ["*", "!src/"] - negation won't properly un-ignore nested paths
    */
   ignorePatternsForPlanCheck?: string[];
 }

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -356,7 +356,7 @@ export interface NxReleaseVersionPlansConfiguration {
    *
    * These patterns follow gitignore semantics. When using negation patterns (to "un-ignore" certain files), use specific file extension patterns
    * rather than wildcards like `*` or `**`. For example:
-   * - Works: `["**\/*.ts", "!**\/src/**"]` - ignores all .ts files except those in src/ directories
+   * - Works: `["**/*.ts", "!**/src/**"]` - ignores all .ts files except those in src/ directories
    * - Does NOT work as expected: `["*", "!src/"]` - negation won't properly un-ignore nested paths
    */
   ignorePatternsForPlanCheck?: string[];


### PR DESCRIPTION
## Current Behaviour

  The ignorePatternsForPlanCheck configuration option in nx.json for version plans lacks
  documentation about the pattern syntax. Users attempting to use negation patterns (e.g.,
  ["*", "!src/"]) may experience unexpected behavior because gitignore semantics don't work
  as intuitively expected with such patterns.

 ## Expected Behaviour

  The documentation and JSDoc comments now clearly explain:
  - That ignorePatternsForPlanCheck follows gitignore semantics
  - Working patterns like ["**/*.spec.ts"] and ["**/*.ts", "!**/src/**"]
  - Non-working patterns like ["*", "!src/"] and why they don't work as expected
  - Recommended approach of using file extension patterns instead of wildcards when trying to
   ignore all files except those in specific directories

 ## Related Issues

  Fixes #30324