### PR TITLE
fix(nx-dev): make sure canonical urls are always nx.dev

### DIFF
--- a/astro-docs/astro.config.mjs
+++ b/astro-docs/astro.config.mjs
@@ -22,7 +22,7 @@ const PUBLIC_CONFIG = {
 export default defineConfig({
   base: BASE,
   vite: { plugins: [tailwindcss()] },
-  // Allow this to be configured per environment
+  // Allow this to be configured per environment for robots.txt detection
   // Note: this happens during build time so we don't use `import.meta.env`
   site: process.env.NX_DEV_URL ?? 'https://nx.dev',
   image: {
@@ -92,6 +92,7 @@ export default defineConfig({
         './src/plugins/og.middleware.ts',
         './src/plugins/github-stars.middleware.ts',
         './src/plugins/raw-content.middleware.ts',
+        './src/plugins/canonical.middleware.ts',
       ],
       markdown: {
         // this breaks the renderMarkdown function in the plugin loader due to starlight path normalization

--- a/astro-docs/src/plugins/canonical.middleware.ts
+++ b/astro-docs/src/plugins/canonical.middleware.ts
@@ -1,0 +1,25 @@
+import { defineRouteMiddleware } from '@astrojs/starlight/route-data';
+
+const CANONICAL_DOMAIN = 'https://nx.dev';
+
+export const onRequest = defineRouteMiddleware((context) => {
+  const { head } = context.locals.starlightRoute;
+  const pathname = context.url.pathname;
+
+  const canonicalUrl = new URL(pathname, CANONICAL_DOMAIN).href;
+
+  const existingCanonicalIndex = head.findIndex(
+    (entry) => entry.tag === 'link' && entry.attrs?.rel === 'canonical'
+  );
+
+  const canonicalEntry = {
+    tag: 'link' as const,
+    attrs: { rel: 'canonical', href: canonicalUrl },
+  };
+
+  if (existingCanonicalIndex !== -1) {
+    head[existingCanonicalIndex] = canonicalEntry;
+  } else {
+    head.push(canonicalEntry);
+  }
+});


### PR DESCRIPTION
make sure canonical always points to nx.dev and not a subdomain preview incase they're index.
<img width="1728" height="863" alt="image" src="https://github.com/user-attachments/assets/8e7d91c1-277b-4a2a-91ec-732f7f4f37ae" />
also confirm that robots.txt still has deny for non prod builds. 

this is done via middleware since canonical url is controlled via astro config 'site' property. which is used to control other aspects that we do want to be preview URL domains (like navigation). so we have a middleware to always override the url to match prod.

also nextjs side was already overriding this in `_app.tsx`
