### PR TITLE
feat(angular): support cypress component testing with zoneless projects

### DIFF
--- a/e2e/angular/src/cypress-component-tests-setup.ts
+++ b/e2e/angular/src/cypress-component-tests-setup.ts
@@ -19,7 +19,9 @@ export interface CypressComponentTestsSetup {
   buildableLibName: string;
 }
 
-export function setupCypressComponentTests(): CypressComponentTestsSetup {
+export function setupCypressComponentTests(
+  zoneless: boolean = true
+): CypressComponentTestsSetup {
   const projectName = newProject({
     name: uniq('cy-ng'),
     packages: ['@nx/angular'],
@@ -29,7 +31,7 @@ export function setupCypressComponentTests(): CypressComponentTestsSetup {
   const usedInAppLibName = uniq('cy-angular-lib');
   const buildableLibName = uniq('cy-angular-buildable-lib');
 
-  createApp(appName, ['--no-zoneless']);
+  createApp(appName, zoneless ? [] : ['--no-zoneless']);
   createLib(projectName, appName, usedInAppLibName);
   useLibInApp(projectName, appName, usedInAppLibName);
   createBuildableLib(projectName, buildableLibName);

--- a/e2e/angular/src/cypress-component-tests-zone-projects.test.ts
+++ b/e2e/angular/src/cypress-component-tests-zone-projects.test.ts
@@ -1,0 +1,42 @@
+import { runCLI, runE2ETests } from '@nx/e2e-utils';
+import {
+  setupCypressComponentTests,
+  cleanupCypressComponentTests,
+  CypressComponentTestsSetup,
+} from './cypress-component-tests-setup';
+
+describe('Angular Cypress Component Tests - Zone.js projects', () => {
+  let setup: CypressComponentTestsSetup;
+
+  beforeAll(async () => {
+    setup = setupCypressComponentTests(false);
+  });
+
+  afterAll(() => cleanupCypressComponentTests());
+
+  it('should successfully run for an app', () => {
+    const { appName } = setup;
+
+    runCLI(
+      `generate @nx/angular:cypress-component-configuration --project=${appName} --generate-tests --no-interactive`
+    );
+    if (runE2ETests('cypress')) {
+      expect(runCLI(`component-test ${appName}`)).toContain(
+        'All specs passed!'
+      );
+    }
+  }, 300_000);
+
+  it('should successfully run for a lib', () => {
+    const { usedInAppLibName } = setup;
+
+    runCLI(
+      `generate @nx/angular:cypress-component-configuration --project=${usedInAppLibName} --generate-tests --no-interactive`
+    );
+    if (runE2ETests('cypress')) {
+      expect(runCLI(`component-test ${usedInAppLibName}`)).toContain(
+        'All specs passed!'
+      );
+    }
+  }, 300_000);
+});

--- a/packages/cypress/migrations.json
+++ b/packages/cypress/migrations.json
@@ -108,6 +108,22 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "22.3.2": {
+      "version": "22.3.2-beta.0",
+      "requires": {
+        "cypress": ">=15.0.0 <15.8.0"
+      },
+      "packages": {
+        "cypress": {
+          "version": "^15.8.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@cypress/webpack-dev-server": {
+          "version": "^5.4.1",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/cypress/src/utils/versions.ts
+++ b/packages/cypress/src/utils/versions.ts
@@ -6,8 +6,8 @@ export const nxVersion = require('../../package.json').version;
 export const eslintPluginCypressVersion = '^3.5.0';
 export const typesNodeVersion = '20.19.9';
 export const cypressViteDevServerVersion = '^7.0.1';
-export const cypressVersion = '^15.6.0';
-export const cypressWebpackVersion = '^5.1.4';
+export const cypressVersion = '^15.8.0';
+export const cypressWebpackVersion = '^5.4.1';
 export const viteVersion = '^6.0.0';
 export const htmlWebpackPluginVersion = '^5.5.0';
 


### PR DESCRIPTION
## Current Behavior

Cypress Component Testing for zoneless Angular projects is not supported.

## Expected Behavior

Cypress Component Testing for zoneless Angular projects should be supported.