### PR TITLE
fix(module-federation): skip non-npm external dependencies in getDependencies

### DIFF
--- a/packages/module-federation/src/utils/dependencies.ts
+++ b/packages/module-federation/src/utils/dependencies.ts
@@ -45,7 +45,9 @@ function collectDependencies(
   (projectGraph.dependencies[name] ?? []).forEach((dependency) => {
     if (dependency.target.startsWith('npm:')) {
       dependencies.npmPackages.add(dependency.target.replace('npm:', ''));
-    } else {
+    } else if (!dependency.target.includes(':')) {
+      // Only process as workspace library if it's not an external node.
+      // External nodes have prefixes like 'npm:', 'cargo:', etc.
       if (projectGraph.nodes[dependency.target]) {
         dependencies.workspaceLibraries.set(dependency.target, {
           name: dependency.target,
@@ -60,6 +62,7 @@ function collectDependencies(
         );
       }
     }
+    // Skip other external node types (cargo:, etc.)
   });
 
   return dependencies;


### PR DESCRIPTION
The getDependentPackagesForProject function was crashing when processing
projects with non-npm external nodes (e.g., cargo: prefixed nodes from
@monodon/rust plugin). The code only handled npm: prefixed externals and
treated everything else as workspace libraries, causing undefined access
errors when cargo externals were encountered.

This fix adds a check to skip external nodes that aren't npm-prefixed by
detecting the presence of a colon in the dependency target. Only npm:
prefixed externals are processed as npm packages, and other external
prefixes (cargo:, maven:, etc.) are now properly skipped.

Fixes #32819
