### PR TITLE
fix(linter): honor `setParserOptionsProject` in flat config

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -701,6 +701,85 @@ describe('app', () => {
           }
         `);
       });
+
+      it('should set parserOptions.project when enabled (eslintrc)', async () => {
+        await generateApp(appTree, 'my-app', {
+          linter: 'eslint',
+          setParserOptionsProject: true,
+        });
+
+        const eslintConfig = readJson(appTree, 'my-app/.eslintrc.json');
+        expect(eslintConfig.overrides[0].parserOptions.project).toEqual([
+          'my-app/tsconfig.*?.json',
+        ]);
+      });
+
+      it('should set parserOptions.project when enabled (flat config)', async () => {
+        appTree.write('eslint.config.cjs', '');
+
+        await generateApp(appTree, 'my-app', {
+          linter: 'eslint',
+          setParserOptionsProject: true,
+        });
+
+        const eslintConfig = appTree.read('my-app/eslint.config.cjs', 'utf-8');
+        expect(eslintConfig).toMatchInlineSnapshot(`
+          "const nx = require("@nx/eslint-plugin");
+          const baseConfig = require("../eslint.config.cjs");
+
+          module.exports = [
+              ...baseConfig,
+              {
+                  files: [
+                      "**/*.ts",
+                      "**/*.tsx",
+                      "**/*.js",
+                      "**/*.jsx"
+                  ],
+                  languageOptions: {
+                      parserOptions: {
+                          project: [
+                              "my-app/tsconfig.*?.json"
+                          ]
+                      }
+                  }
+              },
+              ...nx.configs["flat/angular"],
+              ...nx.configs["flat/angular-template"],
+              {
+                  files: [
+                      "**/*.ts"
+                  ],
+                  rules: {
+                      "@angular-eslint/directive-selector": [
+                          "error",
+                          {
+                              type: "attribute",
+                              prefix: "app",
+                              style: "camelCase"
+                          }
+                      ],
+                      "@angular-eslint/component-selector": [
+                          "error",
+                          {
+                              type: "element",
+                              prefix: "app",
+                              style: "kebab-case"
+                          }
+                      ]
+                  }
+              },
+              {
+                  files: [
+                      "**/*.html"
+                  ],
+                  // Override or add rules here
+                  rules: {}
+              }
+          ];
+          "
+        `);
+      });
     });
 
     describe('none', () => {

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -1260,6 +1260,73 @@ describe('lib', () => {
         `);
       });
 
+      it('should set parserOptions.project when enabled (flat config)', async () => {
+        tree.write('eslint.config.cjs', '');
+
+        await runLibraryGeneratorWithOpts({
+          linter: 'eslint',
+          setParserOptionsProject: true,
+        });
+
+        const eslintConfig = tree.read('my-lib/eslint.config.cjs', 'utf-8');
+        expect(eslintConfig).toMatchInlineSnapshot(`
+          "const nx = require("@nx/eslint-plugin");
+          const baseConfig = require("../eslint.config.cjs");
+
+          module.exports = [
+              ...baseConfig,
+              {
+                  files: [
+                      "**/*.ts",
+                      "**/*.tsx",
+                      "**/*.js",
+                      "**/*.jsx"
+                  ],
+                  languageOptions: {
+                      parserOptions: {
+                          project: [
+                              "my-lib/tsconfig.*?.json"
+                          ]
+                      }
+                  }
+              },
+              ...nx.configs["flat/angular"],
+              ...nx.configs["flat/angular-template"],
+              {
+                  files: [
+                      "**/*.ts"
+                  ],
+                  rules: {
+                      "@angular-eslint/directive-selector": [
+                          "error",
+                          {
+                              type: "attribute",
+                              prefix: "lib",
+                              style: "camelCase"
+                          }
+                      ],
+                      "@angular-eslint/component-selector": [
+                          "error",
+                          {
+                              type: "element",
+                              prefix: "lib",
+                              style: "kebab-case"
+                          }
+                      ]
+                  }
+              },
+              {
+                  files: [
+                      "**/*.html"
+                  ],
+                  // Override or add rules here
+                  rules: {}
+              }
+          ];
+          "
+        `);
+      });
+
       it('should add valid eslint JSON configuration which extends from Nx presets (eslintrc)', async () => {
         // ACT
         await runLibraryGeneratorWithOpts({ linter: 'eslint' });
@@ -1315,6 +1382,18 @@ describe('lib', () => {
             ],
           }
         `);
+      });
+
+      it('should set parserOptions.project when enabled (eslintrc)', async () => {
+        await runLibraryGeneratorWithOpts({
+          linter: 'eslint',
+          setParserOptionsProject: true,
+        });
+
+        const eslintConfig = readJson(tree, 'my-lib/.eslintrc.json');
+        expect(eslintConfig.overrides[0].parserOptions.project).toEqual([
+          'my-lib/tsconfig.*?.json',
+        ]);
       });
 
       it('should add dependency checks to buildable libs', async () => {

--- a/packages/eslint/src/generators/lint-project/lint-project.spec.ts
+++ b/packages/eslint/src/generators/lint-project/lint-project.spec.ts
@@ -415,6 +415,47 @@ describe('@nx/eslint:lint-project', () => {
     process.env.ESLINT_USE_FLAT_CONFIG = originalEslintUseFlatConfigVal;
   });
 
+  it('should set parserOptions.project in flat config when enabled', async () => {
+    const originalEslintUseFlatConfigVal = process.env.ESLINT_USE_FLAT_CONFIG;
+    process.env.ESLINT_USE_FLAT_CONFIG = 'true';
+
+    await lintProjectGenerator(tree, {
+      ...defaultOptions,
+      linter: 'eslint',
+      project: 'test-lib',
+      setParserOptionsProject: true,
+      skipFormat: true,
+      eslintConfigFormat: 'mjs',
+    });
+
+    expect(tree.read('libs/test-lib/eslint.config.mjs', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import baseConfig from "../../eslint.config.mjs";
+
+      export default [
+          ...baseConfig,
+          {
+              files: [
+                  "**/*.ts",
+                  "**/*.tsx",
+                  "**/*.js",
+                  "**/*.jsx"
+              ],
+              languageOptions: {
+                  parserOptions: {
+                      project: [
+                          "libs/test-lib/tsconfig.*?.json"
+                      ]
+                  }
+              }
+          }
+      ];
+      "
+    `);
+
+    process.env.ESLINT_USE_FLAT_CONFIG = originalEslintUseFlatConfigVal;
+  });
+
   it('should generate a eslint config (legacy)', async () => {
     await lintProjectGenerator(tree, {
       ...defaultOptions,

--- a/packages/eslint/src/generators/lint-project/lint-project.ts
+++ b/packages/eslint/src/generators/lint-project/lint-project.ts
@@ -246,8 +246,21 @@ function createEsLintConfiguration(
   const overrides: Linter.ConfigOverride<Linter.RulesRecord>[] = useFlatConfig(
     tree
   )
-    ? // For flat configs, we don't need to generate different overrides for each file. Users should add their own overrides as needed.
-      []
+    ? // For flat configs, keep generated overrides minimal; only add parserOptions when explicitly requested.
+      [
+        ...(setParserOptionsProject
+          ? [
+              {
+                files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+                languageOptions: {
+                  parserOptions: {
+                    project: [`${projectConfig.root}/tsconfig.*?.json`],
+                  },
+                },
+              } as unknown as Linter.ConfigOverride<Linter.RulesRecord>,
+            ]
+          : []),
+      ]
     : [
         {
           files: ['*.ts', '*.tsx', '*.js', '*.jsx'],


### PR DESCRIPTION
## Current Behavior

When generating Angular apps/libs with `setParserOptionsProject`, the ESLint flat config output did not include the project-level `parserOptions.project`, so type-aware lint rules still fail unless users edit the config manually.

## Expected Behavior

Enabling `setParserOptionsProject` produces the appropriate project-level `parserOptions.project` configuration in both flat ESLint config and legacy `.eslintrc.json`, so type-aware linting works out of the box.

## Related Issue(s)

Fixes #33944