### PR TITLE
fix(core): improve package-json createNode performance

### DIFF
--- a/packages/nx/plugins/package-json.ts
+++ b/packages/nx/plugins/package-json.ts
@@ -2,6 +2,7 @@ import { createNodesFromFiles, NxPluginV2 } from '../src/project-graph/plugins';
 import { workspaceRoot } from '../src/utils/workspace-root';
 import {
   buildPackageJsonWorkspacesMatcher,
+  buildPackageJsonPatterns,
   createNodeFromPackageJson,
 } from '../src/plugins/package-json';
 import { workspaceDataDirectory } from '../src/utils/cache-directory';
@@ -34,10 +35,11 @@ const plugin: NxPluginV2 = {
     (configFiles, options, context) => {
       const cache = readPackageJsonConfigurationCache();
 
-      const isInPackageJsonWorkspaces = buildPackageJsonWorkspacesMatcher(
-        context.workspaceRoot,
-        (f) => readJsonFile(join(context.workspaceRoot, f))
+      const patterns = buildPackageJsonPatterns(context.workspaceRoot, (f) =>
+        readJsonFile(join(context.workspaceRoot, f))
       );
+      const isInPackageJsonWorkspaces =
+        buildPackageJsonWorkspacesMatcher(patterns);
 
       const result = createNodesFromFiles(
         (packageJsonPath) =>

--- a/packages/nx/src/plugins/package-json/create-nodes.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.ts
@@ -47,13 +47,12 @@ export const createNodesV2: CreateNodesV2 = [
       process.env.NX_INFER_ALL_PACKAGE_JSONS !== 'true' ||
       configFiles.includes('package.json')
     ) {
-      const { positivePatterns, negativePatterns } = buildPackageJsonPatterns(
+      const patterns = buildPackageJsonPatterns(
         context.workspaceRoot,
         readJson
       );
       isInPackageJsonWorkspaces = buildPackageJsonWorkspacesMatcher(
-        positivePatterns,
-        negativePatterns
+        patterns
       );
     }
     const isNextToProjectJson = (packageJsonPath: string) => {

--- a/packages/nx/src/plugins/package-json/create-nodes.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.ts
@@ -28,22 +28,34 @@ import {
   readPackageJsonConfigurationCache,
 } from '../../../plugins/package-json';
 
+const globPatterns = combineGlobPatterns(
+  'package.json',
+  '**/package.json',
+  'project.json',
+  '**/project.json'
+);
+
 export const createNodesV2: CreateNodesV2 = [
-  combineGlobPatterns(
-    'package.json',
-    '**/package.json',
-    'project.json',
-    '**/project.json'
-  ),
+  globPatterns,
   (configFiles, _, context) => {
     const { packageJsons, projectJsonRoots } = splitConfigFiles(configFiles);
 
     const readJson = (f) => readJsonFile(join(context.workspaceRoot, f));
-    const isInPackageJsonWorkspaces =
-      process.env.NX_INFER_ALL_PACKAGE_JSONS === 'true' &&
-      !configFiles.includes('package.json')
-        ? () => true
-        : buildPackageJsonWorkspacesMatcher(context.workspaceRoot, readJson);
+    let isInPackageJsonWorkspaces = (p: string) => true;
+
+    if (
+      process.env.NX_INFER_ALL_PACKAGE_JSONS !== 'true' ||
+      configFiles.includes('package.json')
+    ) {
+      const { positivePatterns, negativePatterns } = buildPackageJsonPatterns(
+        context.workspaceRoot,
+        readJson
+      );
+      isInPackageJsonWorkspaces = buildPackageJsonWorkspacesMatcher(
+        positivePatterns,
+        negativePatterns
+      );
+    }
     const isNextToProjectJson = (packageJsonPath: string) => {
       return projectJsonRoots.has(dirname(packageJsonPath));
     };
@@ -93,8 +105,7 @@ function splitConfigFiles(configFiles: readonly string[]): {
 
   return { packageJsons, projectJsonRoots };
 }
-
-export function buildPackageJsonWorkspacesMatcher(
+export function buildPackageJsonPatterns(
   workspaceRoot: string,
   readJson: (path: string) => any
 ) {
@@ -103,9 +114,20 @@ export function buildPackageJsonWorkspacesMatcher(
     readJson
   );
 
-  const negativePatterns = patterns.filter((p) => p.startsWith('!'));
-  const positivePatterns = patterns.filter((p) => !p.startsWith('!'));
+  const negativePatterns: string[] = [];
+  const positivePatterns: string[] = [];
+  const positivePatternLookup: Record<string, boolean> = {};
+  const negativePatternLookup: Record<string, boolean> = {};
 
+  for (const pattern of patterns) {
+    if (pattern.startsWith('!')) {
+      negativePatterns.push(pattern);
+      negativePatternLookup[pattern.slice(1)] = true;
+    } else {
+      positivePatterns.push(pattern);
+      positivePatternLookup[pattern] = true;
+    }
+  }
   if (
     // There are some negative patterns
     negativePatterns.length > 0 &&
@@ -117,8 +139,26 @@ export function buildPackageJsonWorkspacesMatcher(
     positivePatterns.push('**/package.json');
   }
 
-  return (p: string) =>
-    positivePatterns.some((positive) => minimatch(p, positive)) &&
+  return {
+    positive: positivePatterns,
+    positiveLookup: positivePatternLookup,
+    negative: negativePatterns,
+    negativeLookup: negativePatternLookup,
+  };
+}
+type PackageJsonPatterns = {
+  positive: string[];
+  positiveLookup: Record<string, boolean>;
+  negative: string[];
+  negativeLookup: Record<string, boolean>;
+};
+export function buildPackageJsonWorkspacesMatcher(
+  patterns: PackageJsonPatterns
+) {
+  return (p) =>
+    // use lookup to avoid unnecessary minimatch calls
+    (patterns.positiveLookup[p] ||
+      patterns.positive.some((positive) => minimatch(p, positive))) &&
     /**
      * minimatch will return true if the given p is NOT excluded by the negative pattern.
      *
@@ -128,7 +168,8 @@ export function buildPackageJsonWorkspacesMatcher(
      * Therefore, we need to ensure that every negative pattern returns true to validate that the given p is not
      * excluded by any of the negative patterns.
      */
-    negativePatterns.every((negative) => minimatch(p, negative));
+    !patterns.negativeLookup[p] &&
+    patterns.negative.every((negative) => minimatch(p, negative));
 }
 
 export function createNodeFromPackageJson(

--- a/packages/nx/src/plugins/package-json/create-nodes.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.ts
@@ -51,9 +51,7 @@ export const createNodesV2: CreateNodesV2 = [
         context.workspaceRoot,
         readJson
       );
-      isInPackageJsonWorkspaces = buildPackageJsonWorkspacesMatcher(
-        patterns
-      );
+      isInPackageJsonWorkspaces = buildPackageJsonWorkspacesMatcher(patterns);
     }
     const isNextToProjectJson = (packageJsonPath: string) => {
       return projectJsonRoots.has(dirname(packageJsonPath));
@@ -107,7 +105,7 @@ function splitConfigFiles(configFiles: readonly string[]): {
 export function buildPackageJsonPatterns(
   workspaceRoot: string,
   readJson: (path: string) => any
-) {
+): PackageJsonPatterns {
   const patterns = getGlobPatternsFromPackageManagerWorkspaces(
     workspaceRoot,
     readJson


### PR DESCRIPTION
On test repo, the `package-json:createNodes:isInPackageManagerWorkspacesTime` takes:
- Before the PR: 2356ms
- With PR: 23ms

This is achieved by avoiding unnecessary use of `minimatch` when a direct string comparison is sufficient.

It also makes creation and logging of entire graph come down from `23.6s` down to `18.5s`

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
