### PR TITLE
fix(core): provide actionable feedback when running migrations and pre-install fails with npm peer dep errors

### DIFF
--- a/packages/nx/src/command-line/migrate/command-object.ts
+++ b/packages/nx/src/command-line/migrate/command-object.ts
@@ -78,6 +78,12 @@ function withMigrationOptions(yargs: Argv) {
       type: 'boolean',
       default: false,
     })
+    .option('skipInstall', {
+      describe:
+        'Skip installing packages before running migrations. Useful when the installation needs to be performed manually (e.g., to resolve peer dependency conflicts).',
+      type: 'boolean',
+      default: false,
+    })
     .check(
       ({ createCommits, commitPrefix, from, excludeAppliedMigrations }) => {
         if (!createCommits && commitPrefix !== defaultCommitPrefix) {

--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -10,6 +10,7 @@ import * as packageMgrUtils from '../../utils/package-manager';
 
 import {
   formatCommandFailure,
+  isNpmPeerDepsError,
   Migrator,
   normalizeVersion,
   parseMigrationsOptions,
@@ -2092,6 +2093,54 @@ describe('Migration', () => {
         parent: { version: '2.0.0', addToPackageJson: false },
         child: { version: '2.0.0', addToPackageJson: false },
       });
+    });
+  });
+
+  describe('isNpmPeerDepsError', () => {
+    it('should detect the npm 7-9 ERESOLVE code line', () => {
+      const stderr = [
+        'npm ERR! code ERESOLVE',
+        'npm ERR! ERESOLVE unable to resolve dependency tree',
+      ].join('\n');
+      expect(isNpmPeerDepsError(stderr)).toBe(true);
+    });
+
+    it('should detect the npm 10+ ERESOLVE code line', () => {
+      const stderr = [
+        'npm error code ERESOLVE',
+        'npm error ERESOLVE could not resolve',
+      ].join('\n');
+      expect(isNpmPeerDepsError(stderr)).toBe(true);
+    });
+
+    it('should fall back to phrase matching when ERESOLVE is absent', () => {
+      expect(
+        isNpmPeerDepsError('npm ERR! Unable to resolve dependency tree')
+      ).toBe(true);
+      expect(
+        isNpmPeerDepsError('Could not resolve dependency: peer react@"^18"')
+      ).toBe(true);
+      expect(
+        isNpmPeerDepsError('Conflicting peer dependency: typescript@5.0.0')
+      ).toBe(true);
+    });
+
+    it('should not match unrelated npm errors', () => {
+      expect(
+        isNpmPeerDepsError('npm ERR! code ENOENT\nnpm ERR! path ./missing')
+      ).toBe(false);
+      expect(
+        isNpmPeerDepsError(
+          'network timeout fetching https://registry.npmjs.org'
+        )
+      ).toBe(false);
+      expect(isNpmPeerDepsError('')).toBe(false);
+    });
+
+    it('should not match substrings of unrelated words', () => {
+      // `\bERESOLVE\b` must not match arbitrary identifiers that merely contain
+      // the letters (e.g. a hypothetical "PREERESOLVED" token).
+      expect(isNpmPeerDepsError('some PREERESOLVED cache entry')).toBe(false);
     });
   });
 });

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -56,8 +56,6 @@ import {
   createTempNpmDirectory,
   detectPackageManager,
   getPackageManagerCommand,
-  PackageManager,
-  PackageManagerCommands,
   packageRegistryPack,
   packageRegistryView,
   resolvePackageVersionUsingRegistry,
@@ -1694,15 +1692,13 @@ function showConnectToCloudMessage() {
   }
 }
 
-function runInstall(nxWorkspaceRoot?: string) {
-  let packageManager: PackageManager;
-  let pmCommands: PackageManagerCommands;
-  if (nxWorkspaceRoot) {
-    packageManager = detectPackageManager(nxWorkspaceRoot);
-    pmCommands = getPackageManagerCommand(packageManager, nxWorkspaceRoot);
-  } else {
-    pmCommands = getPackageManagerCommand();
-  }
+function runInstall(
+  nxWorkspaceRoot?: string,
+  phase: 'pre-migration' | 'post-migration' = 'pre-migration'
+) {
+  const cwd = nxWorkspaceRoot ?? process.cwd();
+  const packageManager = detectPackageManager(cwd);
+  const pmCommands = getPackageManagerCommand(packageManager, cwd);
 
   const installCommand = `${pmCommands.install} ${
     pmCommands.ignoreScriptsFlag ?? ''
@@ -1710,11 +1706,79 @@ function runInstall(nxWorkspaceRoot?: string) {
   output.log({
     title: `Running '${installCommand}' to make sure necessary packages are installed`,
   });
-  execSync(installCommand, {
-    stdio: [0, 1, 2],
-    windowsHide: true,
-    cwd: nxWorkspaceRoot ?? process.cwd(),
-  });
+
+  try {
+    execSync(installCommand, {
+      // For npm, capture stderr to detect peer dependency errors
+      stdio:
+        packageManager === 'npm' ? ['inherit', 'inherit', 'pipe'] : 'inherit',
+      windowsHide: true,
+      cwd,
+    });
+  } catch (e) {
+    if (packageManager === 'npm') {
+      const stderr = e.stderr?.toString().trim() || '';
+      if (isNpmPeerDepsError(stderr)) {
+        logNpmPeerDepsError(phase, stderr || e.message);
+        // Exit immediately to ensure the error message is the last thing displayed to the user
+        process.exit(1);
+      }
+      console.error(stderr);
+    }
+    throw e;
+  }
+}
+
+function isNpmPeerDepsError(stderr: string): boolean {
+  const lowerStderr = stderr.toLowerCase();
+  return (
+    lowerStderr.includes('eresolve') ||
+    lowerStderr.includes('unable to resolve dependency tree') ||
+    lowerStderr.includes('could not resolve dependency') ||
+    lowerStderr.includes('conflicting peer dependency')
+  );
+}
+
+function logNpmPeerDepsError(
+  phase: 'pre-migration' | 'post-migration',
+  error: string
+): void {
+  const peerDepsResolutionSteps = [
+    'Recommended approaches (in order of preference):',
+    '',
+    '1. Use "overrides" in package.json to force compatible versions across the dependency tree and run: npm install',
+    '   (see https://docs.npmjs.com/cli/configuring-npm/package-json#overrides)',
+    '2. Run: npm install --legacy-peer-deps',
+    '   (bypasses peer dependency resolution; use with caution)',
+    '3. Run: npm install --force',
+    '   (last resort; may produce broken installs)',
+  ];
+
+  if (phase === 'pre-migration') {
+    output.error({
+      title: 'Installation failed due to peer dependency conflicts',
+      bodyLines: [error],
+    });
+    output.error({
+      title: 'You need to resolve the peer dependency conflicts',
+      bodyLines: [
+        ...peerDepsResolutionSteps,
+        '',
+        'After resolving the peer dependency conflicts, run the migrations with:',
+        '   NX_MIGRATE_SKIP_INSTALL=true nx migrate --run-migrations',
+      ],
+    });
+  } else {
+    output.error({
+      title: 'Installation failed due to peer dependency conflicts',
+      bodyLines: [error],
+    });
+    output.error({
+      title:
+        'Migrations have completed, but installing updated dependencies failed',
+      bodyLines: peerDepsResolutionSteps,
+    });
+  }
 }
 
 export async function executeMigrations(
@@ -1793,7 +1857,7 @@ class ChangedDepInstaller {
   public installDepsIfChanged() {
     const currentDeps = getStringifiedPackageJsonDeps(this.root);
     if (this.initialDeps !== currentDeps) {
-      runInstall(this.root);
+      runInstall(this.root, 'post-migration');
     }
     this.initialDeps = currentDeps;
   }

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -1,5 +1,5 @@
 import * as pc from 'picocolors';
-import { exec, execSync, type StdioOptions } from 'child_process';
+import { exec, execSync, spawn, type StdioOptions } from 'child_process';
 import { prompt } from 'enquirer';
 import { handleImport } from '../../utils/handle-import';
 import { dirname, join } from 'path';
@@ -1694,8 +1694,8 @@ function showConnectToCloudMessage() {
 
 function runInstall(
   nxWorkspaceRoot?: string,
-  phase: 'pre-migration' | 'post-migration' = 'pre-migration'
-) {
+  phase: MigrationInstallPhase = 'pre-migration'
+): Promise<void> {
   const cwd = nxWorkspaceRoot ?? process.cwd();
   const packageManager = detectPackageManager(cwd);
   const pmCommands = getPackageManagerCommand(packageManager, cwd);
@@ -1707,76 +1707,121 @@ function runInstall(
     title: `Running '${installCommand}' to make sure necessary packages are installed`,
   });
 
-  try {
-    execSync(installCommand, {
-      // For npm, capture stderr to detect peer dependency errors
-      stdio:
-        packageManager === 'npm' ? ['inherit', 'inherit', 'pipe'] : 'inherit',
+  return new Promise<void>((resolve, reject) => {
+    // For npm, pipe stderr so we can detect peer dependency errors while still
+    // mirroring it live to the user's terminal. Other package managers inherit
+    // stderr directly since we don't need to inspect their output.
+    const shouldCaptureStderr = packageManager === 'npm';
+    const child = spawn(installCommand, {
+      shell: true,
+      stdio: ['inherit', 'inherit', shouldCaptureStderr ? 'pipe' : 'inherit'],
       windowsHide: true,
       cwd,
     });
-  } catch (e) {
-    if (packageManager === 'npm') {
-      const stderr = e.stderr?.toString().trim() || '';
-      if (isNpmPeerDepsError(stderr)) {
-        logNpmPeerDepsError(phase, stderr || e.message);
-        // Exit immediately to ensure the error message is the last thing displayed to the user
-        process.exit(1);
+
+    const stderrChunks: Buffer[] = [];
+    child.stderr?.on('data', (chunk: Buffer) => {
+      process.stderr.write(chunk);
+      stderrChunks.push(chunk);
+    });
+
+    child.on('error', reject);
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
       }
-      console.error(stderr);
-    }
-    throw e;
+
+      if (shouldCaptureStderr) {
+        const stderr = Buffer.concat(stderrChunks).toString().trim();
+        if (isNpmPeerDepsError(stderr)) {
+          // Log the remediation guidance here so every caller of `runInstall`
+          // (CLI migrate, `nx repair`, single-migration runner, etc.) surfaces
+          // it consistently. Top-level callers catch `NpmPeerDepsInstallError`
+          // and return a non-zero exit code without re-logging.
+          logNpmPeerDepsError(phase);
+          reject(new NpmPeerDepsInstallError());
+          return;
+        }
+      }
+
+      reject(new Error(`Command failed: ${installCommand}`));
+    });
+  });
+}
+
+type MigrationInstallPhase = 'pre-migration' | 'post-migration';
+
+class NpmPeerDepsInstallError extends Error {
+  constructor() {
+    super('npm install failed due to peer dependency conflicts.');
+    this.name = 'NpmPeerDepsInstallError';
   }
 }
 
-function isNpmPeerDepsError(stderr: string): boolean {
+/**
+ * Detects npm peer-dependency resolution failures. Keyed on the `ERESOLVE`
+ * error code, which npm consistently emits for this class of failure across
+ * v7+ (`npm ERR! code ERESOLVE` / `npm error code ERESOLVE`). Falls back to a
+ * small set of stable phrases in case the code line is missing from the
+ * captured output.
+ */
+export function isNpmPeerDepsError(stderr: string): boolean {
+  if (/\bERESOLVE\b/.test(stderr)) {
+    return true;
+  }
   const lowerStderr = stderr.toLowerCase();
   return (
-    lowerStderr.includes('eresolve') ||
     lowerStderr.includes('unable to resolve dependency tree') ||
     lowerStderr.includes('could not resolve dependency') ||
     lowerStderr.includes('conflicting peer dependency')
   );
 }
 
-function logNpmPeerDepsError(
-  phase: 'pre-migration' | 'post-migration',
-  error: string
-): void {
+function logNpmPeerDepsError(phase: MigrationInstallPhase): void {
   const peerDepsResolutionSteps = [
     'Recommended approaches (in order of preference):',
     '',
-    '1. Use "overrides" in package.json to force compatible versions across the dependency tree and run: npm install',
-    '   (see https://docs.npmjs.com/cli/configuring-npm/package-json#overrides)',
-    '2. Run: npm install --legacy-peer-deps',
+    '1. Use "overrides" in package.json to force compatible versions across the dependency tree.',
+    '   See https://docs.npmjs.com/cli/configuring-npm/package-json#overrides',
+    '2. Persist legacy peer deps resolution in the project ".npmrc":',
+    '   npm config set legacy-peer-deps=true --location=project',
     '   (bypasses peer dependency resolution; use with caution)',
-    '3. Run: npm install --force',
-    '   (last resort; may produce broken installs)',
+    '3. As a last resort, force the installation by running "npm install --force".',
+    '   (does not persist and may produce broken installs)',
+  ];
+  const manualInstallHint = [
+    'If you installed the dependencies manually, pass "--skip-install" to avoid re-installing them:',
+    '   nx migrate --run-migrations --skip-install',
   ];
 
   if (phase === 'pre-migration') {
     output.error({
-      title: 'Installation failed due to peer dependency conflicts',
-      bodyLines: [error],
-    });
-    output.error({
-      title: 'You need to resolve the peer dependency conflicts',
+      title:
+        'You need to resolve the peer dependency conflicts before the migration can continue',
       bodyLines: [
         ...peerDepsResolutionSteps,
         '',
-        'After resolving the peer dependency conflicts, run the migrations with:',
-        '   NX_MIGRATE_SKIP_INSTALL=true nx migrate --run-migrations',
+        'Once the conflicts are resolved, re-run the migrations:',
+        '   nx migrate --run-migrations',
+        '',
+        ...manualInstallHint,
       ],
     });
   } else {
     output.error({
-      title: 'Installation failed due to peer dependency conflicts',
-      bodyLines: [error],
-    });
-    output.error({
       title:
-        'Migrations have completed, but installing updated dependencies failed',
-      bodyLines: peerDepsResolutionSteps,
+        'Some migrations have been applied, but installing the updated dependencies failed',
+      bodyLines: [
+        ...peerDepsResolutionSteps,
+        '',
+        'Once the conflicts are resolved, run "npm install" to install the updated dependencies.',
+        'If the migration was interrupted before completing, re-run the remaining migrations:',
+        '   nx migrate --run-migrations',
+        '',
+        ...manualInstallHint,
+      ],
     });
   }
 }
@@ -1791,9 +1836,10 @@ export async function executeMigrations(
   }[],
   isVerbose: boolean,
   shouldCreateCommits: boolean,
-  commitPrefix: string
+  commitPrefix: string,
+  shouldSkipInstall = false
 ) {
-  const changedDepInstaller = new ChangedDepInstaller(root);
+  const changedDepInstaller = new ChangedDepInstaller(root, shouldSkipInstall);
 
   const migrationsWithNoChanges: typeof migrations = [];
   const sortedMigrations = migrations.sort((a, b) => {
@@ -1833,15 +1879,21 @@ export async function executeMigrations(
       }
       logger.info(`---------------------------------------------------------`);
     } catch (e) {
-      output.error({
-        title: `Failed to run ${m.name} from ${m.package}. This workspace is NOT up to date!`,
-      });
+      if (!(e instanceof NpmPeerDepsInstallError)) {
+        output.error({
+          title: `Failed to run ${m.name} from ${m.package}. This workspace is NOT up to date!`,
+        });
+      }
       throw e;
     }
   }
 
   if (!shouldCreateCommits) {
-    changedDepInstaller.installDepsIfChanged();
+    await changedDepInstaller.installDepsIfChanged();
+  }
+
+  if (changedDepInstaller.skippedInstall) {
+    logSkippedPostMigrationInstall(root);
   }
 
   return { migrationsWithNoChanges, nextSteps: allNextSteps };
@@ -1849,18 +1901,39 @@ export async function executeMigrations(
 
 class ChangedDepInstaller {
   private initialDeps: string;
+  private _skippedInstall = false;
 
-  constructor(private readonly root: string) {
+  constructor(
+    private readonly root: string,
+    private readonly shouldSkipInstall = false
+  ) {
     this.initialDeps = getStringifiedPackageJsonDeps(root);
   }
 
-  public installDepsIfChanged() {
+  public get skippedInstall(): boolean {
+    return this._skippedInstall;
+  }
+
+  public async installDepsIfChanged(): Promise<void> {
     const currentDeps = getStringifiedPackageJsonDeps(this.root);
     if (this.initialDeps !== currentDeps) {
-      runInstall(this.root, 'post-migration');
+      if (this.shouldSkipInstall) {
+        this._skippedInstall = true;
+      } else {
+        await runInstall(this.root, 'post-migration');
+      }
     }
     this.initialDeps = currentDeps;
   }
+}
+
+function logSkippedPostMigrationInstall(root: string): void {
+  const packageManager = detectPackageManager(root);
+  const installCommand = getPackageManagerCommand(packageManager, root).install;
+  output.warn({
+    title: 'Migrations updated your dependencies, but the install was skipped',
+    bodyLines: [`Run "${installCommand}" to install the updated dependencies.`],
+  });
 }
 
 export async function runNxOrAngularMigration(
@@ -1874,7 +1947,7 @@ export async function runNxOrAngularMigration(
   isVerbose: boolean,
   shouldCreateCommits: boolean,
   commitPrefix: string,
-  installDepsIfChanged?: () => void,
+  installDepsIfChanged?: () => Promise<void>,
   handleInstallDeps = false
 ): Promise<{ changes: FileChange[]; nextSteps: string[] }> {
   if (!installDepsIfChanged) {
@@ -1931,7 +2004,7 @@ export async function runNxOrAngularMigration(
   }
 
   if (shouldCreateCommits) {
-    installDepsIfChanged();
+    await installDepsIfChanged();
 
     const commitMessage = `${commitPrefix}${migration.name}`;
     try {
@@ -1951,7 +2024,7 @@ export async function runNxOrAngularMigration(
     }
     // if we are running this function alone, we need to install deps internally
   } else if (handleInstallDeps) {
-    installDepsIfChanged();
+    await installDepsIfChanged();
   }
 
   return { changes, nextSteps };
@@ -1963,10 +2036,11 @@ async function runMigrations(
   args: string[],
   isVerbose: boolean,
   shouldCreateCommits = false,
-  commitPrefix: string
+  commitPrefix: string,
+  shouldSkipInstall = false
 ) {
-  if (!process.env.NX_MIGRATE_SKIP_INSTALL) {
-    runInstall();
+  if (!shouldSkipInstall && !process.env.NX_MIGRATE_SKIP_INSTALL) {
+    await runInstall();
   }
 
   if (!__dirname.startsWith(workspaceRoot)) {
@@ -2018,7 +2092,8 @@ async function runMigrations(
     migrations,
     isVerbose,
     shouldCreateCommits,
-    commitPrefix
+    commitPrefix,
+    shouldSkipInstall
   );
 
   if (migrationsWithNoChanges.length < migrations.length) {
@@ -2097,14 +2172,25 @@ export async function migrate(
     if (opts.type === 'generateMigrations') {
       await generateMigrationsJsonAndUpdatePackageJson(root, opts);
     } else {
-      return runMigrations(
-        root,
-        opts,
-        rawArgs,
-        args['verbose'],
-        args['createCommits'],
-        args['commitPrefix']
-      );
+      try {
+        return await runMigrations(
+          root,
+          opts,
+          rawArgs,
+          args['verbose'],
+          args['createCommits'],
+          args['commitPrefix'],
+          args['skipInstall']
+        );
+      } catch (e) {
+        // The remediation guidance is already logged by `runInstall`; swallow
+        // the error here so `handleErrors` doesn't print a noisy stack after
+        // the friendly output.
+        if (e instanceof NpmPeerDepsInstallError) {
+          return 1;
+        }
+        throw e;
+      }
     }
   });
 }


### PR DESCRIPTION
## Current Behavior

When running `nx migrate --run-migrations` in a workspace with `npm` as the package manager, sometimes the automatic package installation performed by the command can fail due to peer dependency constraint violations. In such cases, no actionable feedback is provided to the user to help resolve the issue.

## Expected Behavior

When running `nx migrate --run-migrations` in a workspace with `npm` as the package manager, and the automatic package installation performed by the command fails, Nx should provide actionable feedback to resolve the issue and to re-run the command while skipping the package installation.

## Related Issue(s)

Fixes #33942 