### PR TITLE
fix(misc): remove CNW A/B testing flow branching

### DIFF
--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -2,11 +2,7 @@ import * as yargs from 'yargs';
 import * as enquirer from 'enquirer';
 import * as chalk from 'chalk';
 
-import {
-  MessageKey,
-  messages,
-  shouldUseTemplateFlow,
-} from '../utils/nx/ab-testing';
+import { MessageKey, messages } from '../utils/nx/ab-testing';
 import { deduceDefaultBase } from '../utils/git/default-base';
 import { isGitAvailable } from '../utils/git/git';
 import {
@@ -128,8 +124,8 @@ export async function determineTemplate(
   if (parsedArgs.template) return parsedArgs.template;
   if (parsedArgs.preset) return 'custom';
   if (!parsedArgs.interactive || isCI()) return 'custom';
-  // A/B test: shouldUseTemplateFlow() determines if user sees template or preset flow
-  if (!shouldUseTemplateFlow()) return 'custom';
+  // Docs generation needs preset flow to document all presets
+  if (process.env.NX_GENERATE_DOCS_PROCESS === 'true') return 'custom';
   // Template flow requires git for cloning - fall back to custom preset if git is not available
   if (!isGitAvailable()) return 'custom';
   const { template } = await enquirer.prompt<{ template: string }>([

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -58,22 +58,6 @@ function getFlowVariantInternal(): string {
 }
 
 /**
- * Determines whether to use the new template flow (1) or old preset flow (0).
- * - NX_CNW_FLOW_VARIANT=0 forces preset flow
- * - NX_CNW_FLOW_VARIANT=1 forces template flow
- * - NX_GENERATE_DOCS_PROCESS=true forces preset flow (for docs generation)
- * - Otherwise, uses cached value (7 days) or randomly assigns
- */
-export function shouldUseTemplateFlow(): boolean {
-  if (process.env.NX_GENERATE_DOCS_PROCESS === 'true') {
-    flowVariantCache = '0';
-    return false;
-  }
-
-  return getFlowVariantInternal() === '1';
-}
-
-/**
  * Returns the flow variant for tracking (0 = preset, 1 = template).
  */
 export function getFlowVariant(): string {

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -95,18 +95,7 @@ export async function createNxCloudOnboardingUrl(
       ? 'create-nx-workspace-success-cache-setup'
       : 'create-nx-workspace-success-ci-setup';
 
-  // Meta: "start" or "start-v2" prefix, with prompt code
-  // For template flow (variant 1): use specific prompt code from setupNxCloudV2
-  // For preset flow (variant 0): use visit codes based on nxCloud value
-  const flowVariant = getFlowVariant();
-  const prefix = flowVariant === '1' ? 'start-v2' : 'start';
-  const promptCode =
-    flowVariant === '1'
-      ? messages.codeOfSelectedPromptMessage('setupNxCloudV2')
-      : '';
-  const code =
-    promptCode || (nxCloud === 'yes' ? 'remote-cache-visit' : 'ci-setup-visit');
-  const meta = `${prefix}-${code}`;
+  const meta = messages.codeOfSelectedPromptMessage('setupNxCloudV2');
 
   return createNxCloudOnboardingURL(
     source,


### PR DESCRIPTION
This PR removes the variant check for deciding whether to use GitHub templates for CNW. Moving forward, the first-level options are all `nrwl/*` templates. The `Custom` option allows users to go back to the previous presets.