### PR TITLE
docs(misc): update Turborepo documentation with visualization details

### DIFF
--- a/astro-docs/src/content/docs/guides/Adopting Nx/from-turborepo.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/from-turborepo.mdoc
@@ -71,7 +71,7 @@ Turborepo forces you to manually annotated your non-JavaScript packages, Nx unde
 Being able to visually explore your workspace is crucial for large monorepos:
 
 - **Nx**: Rich, interactive visualizer, both locally via the `nx graph` CLI and for every pull request via Nx Cloud. (More [in the docs](/docs/features/explore-graph))
-- **Turborepo**: Basic graphviz image export
+- **Turborepo**: [Robust browser-based graph visualizations](https://turborepo.com/docs/reference/devtools) and [Graphviz image exports](https://turborepo.com/docs/reference/run#--graph-file-name)
 
 #### IDE/Developer Tools
 

--- a/astro-docs/src/content/docs/guides/Adopting Nx/from-turborepo.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/from-turborepo.mdoc
@@ -71,7 +71,7 @@ Turborepo forces you to manually annotated your non-JavaScript packages, Nx unde
 Being able to visually explore your workspace is crucial for large monorepos:
 
 - **Nx**: Rich, interactive visualizer, both locally via the `nx graph` CLI and for every pull request via Nx Cloud. (More [in the docs](/docs/features/explore-graph))
-- **Turborepo**: [Robust browser-based graph visualizations](https://turborepo.com/docs/reference/devtools) and [Graphviz image exports](https://turborepo.com/docs/reference/run#--graph-file-name)
+- **Turborepo**: [Browser-based graph visualizations](https://turborepo.com/docs/reference/devtools) and [Graphviz image exports](https://turborepo.com/docs/reference/run#--graph-file-name)
 
 #### IDE/Developer Tools
 


### PR DESCRIPTION
Updated Turborepo section to include robust browser-based graph visualizations and Graphviz image exports.