### PR TITLE
fix(vitest): skip target inference for root workspace configs with projects

### DIFF
--- a/packages/vitest/src/plugins/plugin.ts
+++ b/packages/vitest/src/plugins/plugin.ts
@@ -193,6 +193,14 @@ async function buildVitestTargets(
     'build'
   );
 
+  // If this is a root workspace config file with projects property, don't infer targets.
+  // The root config is just an orchestrator - the actual tests live in the individual project configs.
+  const isWorkspaceRoot = projectRoot === '.';
+  const hasProjectsProperty = Array.isArray(viteBuildConfig?.test?.projects);
+  if (isWorkspaceRoot && hasProjectsProperty) {
+    return { targets: {}, metadata: {}, projectType: 'library' };
+  }
+
   let metadata: ProjectConfiguration['metadata'] = {};
 
   const { testOutputs, hasTest } = getOutputs(


### PR DESCRIPTION
When a vitest config file is at the workspace root and contains a
`projects` property in the test configuration, the plugin now skips
inferring test targets for that config. This is because root workspace
configs act as orchestrators - the actual tests live in the individual
project configs referenced by `projects`.

Fixes #32471
