### PR TITLE
feat(release): ignore project scope for version bump

### DIFF
--- a/packages/nx/src/command-line/release/config/conventional-commits.ts
+++ b/packages/nx/src/command-line/release/config/conventional-commits.ts
@@ -2,6 +2,7 @@ import { NxReleaseConfig } from './config';
 
 export const DEFAULT_CONVENTIONAL_COMMITS_CONFIG: NxReleaseConfig['conventionalCommits'] =
   {
+    ignoreProjectScopeForVersionBump: false,
     types: {
       feat: {
         semverBump: 'minor',

--- a/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
+++ b/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
@@ -24,7 +24,8 @@ Promise<Map<string, SemverSpecifier | null>> {
   );
   return determineSemverChange(
     relevantCommits,
-    releaseConfig.conventionalCommits
+    releaseConfig.conventionalCommits,
+    releaseConfig.conventionalCommits?.ignoreProjectScopeForVersionBump
   );
 }
 

--- a/packages/nx/src/command-line/release/utils/semver.spec.ts
+++ b/packages/nx/src/command-line/release/utils/semver.spec.ts
@@ -237,5 +237,93 @@ describe('semver', () => {
         ).get('default')
       ).toEqual(null);
     });
+
+    it('should apply full semver bump to non-scoped commits when ignoreProjectScopeForVersionBump is true', () => {
+      expect(
+        determineSemverChange(
+          new Map([
+            [
+              'default',
+              [
+                { commit: fixCommit, isProjectScopedCommit: false },
+                {
+                  commit: featNonBreakingCommit,
+                  isProjectScopedCommit: false,
+                },
+                { commit: choreCommit, isProjectScopedCommit: false },
+              ],
+            ],
+          ]),
+          config,
+          true // ignoreProjectScopeForVersionBump enabled
+        ).get('default')
+      ).toEqual(SemverSpecifier.MINOR);
+    });
+
+    it('should still return major for breaking non-scoped commits when ignoreProjectScopeForVersionBump is true', () => {
+      expect(
+        determineSemverChange(
+          new Map([
+            [
+              'default',
+              [
+                { commit: fixCommit, isProjectScopedCommit: false },
+                { commit: featBreakingCommit, isProjectScopedCommit: false },
+              ],
+            ],
+          ]),
+          config,
+          true // ignoreProjectScopeForVersionBump enabled
+        ).get('default')
+      ).toEqual(SemverSpecifier.MAJOR);
+    });
+
+    it('should return patch for non-scoped patch commits when ignoreProjectScopeForVersionBump is true', () => {
+      expect(
+        determineSemverChange(
+          new Map([
+            [
+              'default',
+              [
+                { commit: fixCommit, isProjectScopedCommit: false },
+                { commit: choreCommit, isProjectScopedCommit: false },
+              ],
+            ],
+          ]),
+          config,
+          true // ignoreProjectScopeForVersionBump enabled
+        ).get('default')
+      ).toEqual(SemverSpecifier.PATCH);
+    });
+
+    it('should respect ignoreProjectScopeForVersionBump for individual projects', () => {
+      expect(
+        determineSemverChange(
+          new Map([
+            [
+              'project-a',
+              [
+                { commit: fixCommit, isProjectScopedCommit: false },
+                {
+                  commit: featNonBreakingCommit,
+                  isProjectScopedCommit: false,
+                },
+              ],
+            ],
+            [
+              'project-b',
+              [{ commit: fixCommit, isProjectScopedCommit: false }],
+            ],
+          ]),
+          config,
+          true // ignoreProjectScopeForVersionBump enabled
+        )
+      ).toEqual(
+        new Map([
+          ['project-a', SemverSpecifier.MINOR],
+          ['project-b', SemverSpecifier.PATCH],
+        ])
+      );
+    });
   });
 });

--- a/packages/nx/src/command-line/release/utils/semver.ts
+++ b/packages/nx/src/command-line/release/utils/semver.ts
@@ -34,15 +34,17 @@ export function determineSemverChange(
     string,
     { commit: GitCommit; isProjectScopedCommit: boolean }[]
   >,
-  config: NxReleaseConfig['conventionalCommits']
+  config: NxReleaseConfig['conventionalCommits'],
+  ignoreProjectScopeForVersionBump?: boolean
 ): Map<string, SemverSpecifier | null> {
   const semverChangePerProject: Map<string, SemverSpecifier | null> = new Map();
   for (const [projectName, relevantCommit] of relevantCommits) {
     let highestChange: SemverSpecifier | null = null;
 
     for (const { commit, isProjectScopedCommit } of relevantCommit) {
-      if (!isProjectScopedCommit) {
+      if (!isProjectScopedCommit && !ignoreProjectScopeForVersionBump) {
         // commit is relevant to the project, but not directly, report patch change to match side-effectful bump behavior in update dependents in release-group-processor
+        // unless ignoreProjectScopeForVersionBump is enabled, in which case we use the commit type's configured semver bump
         highestChange = Math.max(SemverSpecifier.PATCH, highestChange ?? 0);
         continue;
       }

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -320,6 +320,18 @@ export interface NxReleaseGitConfiguration {
 }
 
 export interface NxReleaseConventionalCommitsConfiguration {
+  /**
+   * When enabled, commits affecting a project will use their full semver bump
+   * even if the commit scope doesn't match the project name.
+   *
+   * By default (false), a commit like `feat(other-lib):` affecting a project as a dependency
+   * will be downgraded to a patch bump. When set to true, the same commit will apply its full
+   * semver bump (minor for feat, patch for fix, etc.).
+   *
+   * This is useful when your commit scopes don't map 1:1 with project names, or when you want
+   * any commit affecting a project to use its configured semver bump regardless of scope matching.
+   */
+  ignoreProjectScopeForVersionBump?: boolean;
   types?: Record<
     string,
     /**


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

Since Nx 22, when using conventional commits with independent project relationships, commits affecting a project require the scope to match the project name to apply the full semver bump. 

For example:
- `feat(my-lib): new feature` → **minor** bump for `my-lib` ✅
- `feat: new feature` → **minor** bump for affected projects ✅ 
- `feat(random-scope): new feature` → **patch** bump (downgraded) ❌

This behavior forces teams to use project names as scopes, which may not align with their preferred commit conventions (e.g., feature-based or functional scopes like `feat(auth): ...`, `feat(ui): ...`).

The changelog generation correctly identifies breaking changes regardless of scope matching, but the versioning logic downgrades non-matching scoped commits to patch bumps.

## Expected Behavior

With the new `ignoreProjectScopeForVersionBump` configuration option, teams can opt-in to use commit scopes freely without being constrained to match project names.

When `ignoreProjectScopeForVersionBump: true` is set in the conventional commits configuration:
- `feat(random-scope): new feature` → **minor** bump ✅
- `fix(whatever): bug fix` → **patch** bump ✅
- `feat(auth)!: breaking change` → **major** bump ✅

The versioning will be based solely on the commit type (feat, fix, etc.) and breaking change indicators, not on scope matching.

### Configuration Example

```json
{
  "release": {
    "version": {
      "conventionalCommits": true
    },
    "conventionalCommits": {
      "ignoreProjectScopeForVersionBump": true
    }
  }
}
```

### Related Issue(s)
Fixes #33686

### Implementation Details
- Added `ignoreProjectScopeForVersionBump` boolean option to `NxReleaseConventionalCommitsConfiguration`
- Modified `determineSemverChange()` to respect this configuration when determining version bumps
- Added default value (false) to maintain backward compatibility
- Added comprehensive unit tests to validate the new behavior
- Updated type definitions and documentation