### PR TITLE
fix(core): convert filePath to an absolute path before typescript resolves the module

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -146,17 +146,11 @@ export class TargetProjectLocator {
     }
 
     if (this.tsConfig.config) {
-      // Convert to an absolute file path because TypeScript's module resolution won't
-      // properly walk up the directory tree (toward the workspace root) when given a relative path.
-      const absolutePath = isAbsolute(filePath)
-        ? filePath
-        : this.getAbsolutePath(filePath);
-
       // TODO: this can be removed once we rework resolveImportWithRequire below
       // to properly handle ESM (exports, imports, conditions)
       const resolvedProject = this.resolveImportWithTypescript(
         importExpr,
-        absolutePath
+        filePath
       );
       if (resolvedProject) {
         return resolvedProject;
@@ -423,6 +417,11 @@ export class TargetProjectLocator {
     filePath: string
   ): string | undefined {
     let resolvedModule: string;
+    if (!isAbsolute(filePath)) {
+      // Convert to an absolute file path because TypeScript's module resolution won't
+      // properly walk up the directory tree (toward the workspace root) when given a relative path.
+      filePath = this.getAbsolutePath(filePath);
+    }
     const projectName = findProjectForPath(filePath, this.projectRootMappings);
     const cacheScope = projectName
       ? // fall back to the project name if the project root can't be determined

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -1,5 +1,5 @@
 import { isBuiltin } from 'node:module';
-import { dirname, join, posix, relative } from 'node:path';
+import { dirname, join, posix, relative, isAbsolute } from 'node:path';
 import { clean, satisfies } from 'semver';
 import type {
   ProjectGraphExternalNode,
@@ -146,11 +146,17 @@ export class TargetProjectLocator {
     }
 
     if (this.tsConfig.config) {
+      // Convert to an absolute file path because TypeScript's module resolution won't
+      // properly walk up the directory tree (toward the workspace root) when given a relative path.
+      const absolutePath = isAbsolute(filePath)
+        ? filePath
+        : this.getAbsolutePath(filePath);
+
       // TODO: this can be removed once we rework resolveImportWithRequire below
       // to properly handle ESM (exports, imports, conditions)
       const resolvedProject = this.resolveImportWithTypescript(
         importExpr,
-        filePath
+        absolutePath
       );
       if (resolvedProject) {
         return resolvedProject;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
TypeScript’s module resolution stop at project's root when resolving modules.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
TypeScript’s module resolution will walk up to the workspace root when resolving modules

## Changes Made
Convert the filePath to an absolute path inside findProjectFromImport before calling resolveImportWithTypescript, because TypeScript’s module resolution will not correctly traverse up the directory tree toward the workspace root when given a relative path.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #33985
