### PR TITLE
fix(core): allow dte to handle continuous tasks termination

### DIFF
--- a/packages/nx/src/tasks-runner/init-tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/init-tasks-runner.ts
@@ -144,7 +144,7 @@ async function createOrchestrator(
   const orchestrator = new TaskOrchestrator(
     hasher,
     null,
-    [],
+    tasks,
     projectGraph,
     taskGraph,
     nxJson,


### PR DESCRIPTION
## Current Behavior

When running a task graph with continuous tasks and one of them is terminated, the reverse continuous task deps that have no other tasks that depend on them are also automatically terminated. This is fine in a non-DTE context, but when running in a DTE context, the DTE task runner must own the lifecycle of the continuous tasks, and Nx shouldn't automatically terminate them.

## Expected Behavior

Nx shouldn't automatically terminate continuous tasks when running in a DTE context.