### PR TITLE
fix(core): make process metrics registration in critical paths non-blocking

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -1012,11 +1012,13 @@ export class DaemonClient {
       this._daemonReady();
 
       daemonPid ??= getDaemonProcessIdSync();
-      await this.registerDaemonProcessWithMetricsService(daemonPid);
+      // Fire-and-forget - don't block daemon connection by waiting for metrics registration
+      this.registerDaemonProcessWithMetricsService(daemonPid);
     } else if (this._daemonStatus == DaemonStatus.CONNECTING) {
       await this._waitForDaemonReady;
       const daemonPid = getDaemonProcessIdSync();
-      await this.registerDaemonProcessWithMetricsService(daemonPid);
+      // Fire-and-forget - don't block daemon connection by waiting for metrics registration
+      this.registerDaemonProcessWithMetricsService(daemonPid);
     }
   }
 


### PR DESCRIPTION
## Current Behavior

On systems under heavy load, plugin loading can fail with:

```bash
Plugin Worker exited because no plugin was loaded within 10 seconds of starting up.
```

The initialization of the process metrics collection could potentially cause this by blocking the loading of the plugin.

## Expected Behavior

Process metrics initialization no longer blocks critical startup paths, allowing plugin loading to succeed regardless of system load.