### PR TITLE
fix(js): avoid duplicate `@nx/js/typescript` plugin entries for non-buildable libs

### DIFF
--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -2272,7 +2272,7 @@ describe('lib', () => {
       ]);
     });
 
-    it('should exclude a non-buildable library from a plugin registration when it has a build target', async () => {
+    it('should not change the plugin registration for a non-buildable library when it has build options without skipBuildCheck', async () => {
       updateJson(tree, 'nx.json', (json) => {
         json.plugins ??= [];
         json.plugins.push({
@@ -2297,6 +2297,36 @@ describe('lib', () => {
           plugin: '@nx/js/typescript',
           options: {
             build: { targetName: 'build' },
+          },
+        },
+      ]);
+    });
+
+    it('should exclude a non-buildable library from a plugin registration when it has build options with skipBuildCheck', async () => {
+      updateJson(tree, 'nx.json', (json) => {
+        json.plugins ??= [];
+        json.plugins.push({
+          plugin: '@nx/js/typescript',
+          options: {
+            build: { targetName: 'build', skipBuildCheck: true },
+          },
+        });
+        return json;
+      });
+
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        directory: 'packages/my-lib',
+        bundler: 'none',
+        unitTestRunner: 'none',
+        linter: 'none',
+      });
+
+      expect(readJson(tree, 'nx.json').plugins).toStrictEqual([
+        {
+          plugin: '@nx/js/typescript',
+          options: {
+            build: { targetName: 'build', skipBuildCheck: true },
           },
           exclude: ['packages/my-lib/*'],
         },


### PR DESCRIPTION
## Current Behavior

When adding a non-buildable JS library (`bundler: 'none'`) to a workspace with an existing `@nx/js/typescript` plugin registration that has build options configured, a duplicate plugin entry is unnecessarily created in `nx.json`.

## Expected Behavior

Non-buildable libraries reuse the existing plugin registration when `skipBuildCheck: true` is not specified, thereby avoiding duplicate entries in `nx.json`. The `@nx/js/typescript` plugin will infer the project as non-buildable because the library's `package.json` will have entry points pointing to source files, so there's no need for a separate plugin registration.

## Related Issue(s)

Fixes #33981