### PR TITLE
fix(core): disallow `Vitest & Angular` unit test runner when bundler is not `esbuild` in cnw

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -1294,11 +1294,15 @@ async function determineAngularOptions(
           name: 'unitTestRunner',
           skip: !parsedArgs.interactive || isCI(),
           choices: [
-            {
-              name: 'vitest-angular',
-              message:
-                'Vitest & Angular [ https://vitest.dev/ & https://angular.dev ]',
-            },
+            ...(bundler === 'esbuild'
+              ? [
+                  {
+                    name: 'vitest-angular',
+                    message:
+                      'Vitest & Angular [ https://vitest.dev/ & https://angular.dev ]',
+                  },
+                ]
+              : []),
             {
               name: 'vitest-analog',
               message:


### PR DESCRIPTION
## Current Behavior

The `create-nx-workspace` incorrectly offers `Vitest & Angular` as a valid unit test runner choice when the bundler is something other than `esbuild`.

## Expected Behavior

The `create-nx-workspace` should only offer `Vitest & Angular` as a valid unit test runner choice when the bundler is `esbuild`.

## Related Issue(s)

Fixes #34014 
