### PR TITLE
fix(gradle): force gradle executor to always rerun tasks

### DIFF
--- a/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/GradleRunner.kt
+++ b/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/GradleRunner.kt
@@ -41,6 +41,7 @@ fun runTasksInParallel(
           "--continue",
           "-Dorg.gradle.daemon.idletimeout=0",
           "--parallel",
+          "--rerun",
           "-Dorg.gradle.workers.max=$workersMax")
 
   if (additionalArgs.isNotBlank()) {

--- a/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/GradleRunner.kt
+++ b/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/GradleRunner.kt
@@ -9,6 +9,20 @@ import java.io.ByteArrayOutputStream
 import org.gradle.tooling.BuildCancelledException
 import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.events.OperationType
+import org.gradle.tooling.model.build.BuildEnvironment
+import org.gradle.util.GradleVersion
+
+private val GRADLE_RERUN_MIN_VERSION = GradleVersion.version("7.6")
+
+fun getGradleVersion(connection: ProjectConnection): GradleVersion? {
+  return try {
+    val buildEnvironment = connection.getModel(BuildEnvironment::class.java)
+    GradleVersion.version(buildEnvironment.gradle.gradleVersion)
+  } catch (e: Exception) {
+    logger.warning("Failed to get Gradle version: ${e.message}")
+    null
+  }
+}
 
 fun runTasksInParallel(
     connection: ProjectConnection,
@@ -29,6 +43,13 @@ fun runTasksInParallel(
   val outputStream2 = ByteArrayOutputStream()
   val errorStream2 = ByteArrayOutputStream()
 
+  // --rerun used to skip Gradle caching since we use Nx caching
+  // Fall back to --rerun-tasks if version detection fails (null) or version is < 7.6
+  val gradleVersion = getGradleVersion(connection)
+  val rerunFlag =
+      if (gradleVersion != null && gradleVersion >= GRADLE_RERUN_MIN_VERSION) "--rerun"
+      else "--rerun-tasks"
+
   // --info is for terminal per task
   // --continue is for continue running tasks if one failed in a batch
   // --parallel is for performance
@@ -41,7 +62,7 @@ fun runTasksInParallel(
           "--continue",
           "-Dorg.gradle.daemon.idletimeout=0",
           "--parallel",
-          "--rerun",
+          rerunFlag,
           "-Dorg.gradle.workers.max=$workersMax")
 
   if (additionalArgs.isNotBlank()) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The Nx Plugin uses Nx as the backing mechanism, but Gradle still does some caching behind the scenes. When using Nx and Gradle's caching at the same time, there can be times where Gradle does not recognize input changes and will not execute tasks that it mistakenly deems unchanged. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Ensure that the batch executor always reruns tasks and is not impacted by the Gradle build cache.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes NXC-3649
