### PR TITLE
fix(linter): handle variable references in replaceOverride

### DIFF
--- a/packages/eslint/src/generators/utils/flat-config/ast-utils.spec.ts
+++ b/packages/eslint/src/generators/utils/flat-config/ast-utils.spec.ts
@@ -681,22 +681,22 @@ export default [
 
         export default [
             {
-              "files": [
-                "my-lib/**/*.ts",
-                "my-lib/**/*.tsx"
-              ],
-              "rules": {
-                "my-rule": "error"
-              }
+                files: [
+                    "my-lib/**/*.ts",
+                    "my-lib/**/*.tsx"
+                ],
+                rules: {
+              "my-rule": "error"
+            }
             },
             {
-              "files": [
-                "my-lib/**/*.ts",
-                "my-lib/**/*.js"
-              ],
-              "rules": {
-                "my-rule": "error"
-              }
+                files: [
+                    "my-lib/**/*.ts",
+                    "my-lib/**/*.js"
+                ],
+                rules: {
+              "my-rule": "error"
+            }
             },
             {
                 files: [
@@ -752,14 +752,14 @@ export default [
 
         export default [
             {
-              "files": [
-                "my-lib/**/*.ts",
-                "my-lib/**/*.tsx"
-              ],
-              "rules": {
-                "my-ts-rule": "error",
-                "my-new-rule": "error"
-              }
+                files: [
+                    "my-lib/**/*.ts",
+                    "my-lib/**/*.tsx"
+                ],
+                rules: {
+              "my-ts-rule": "error",
+              "my-new-rule": "error"
+            }
             },
             {
                 files: [
@@ -808,15 +808,129 @@ export default [
         export default [
             ...compat.config({ extends: ["plugin:@nx/typescript"] }).map(config => ({
             ...config,
-              "files": [
+            files: [
                 "my-lib/**/*.ts",
                 "my-lib/**/*.tsx"
-              ],
-              "rules": {
-                "my-ts-rule": "error",
-                "my-new-rule": "error"
-              }
+            ],
+            rules: {
+              "my-ts-rule": "error",
+              "my-new-rule": "error"
+            }
           }),
+        ];"
+      `);
+    });
+
+    it('should update files while preserving variable references (ESM)', () => {
+      const content = `
+import pluginPackageJson from "eslint-plugin-package-json";
+import jsoncParser from "jsonc-eslint-parser";
+
+export default [
+    {
+        files: ["package.json"],
+        plugins: { "package-json": pluginPackageJson },
+        languageOptions: {
+            parser: jsoncParser,
+        },
+        rules: {
+            '@nx/nx-plugin-checks': 'error'
+        }
+    }
+];`;
+
+      const result = replaceOverride(
+        content,
+        '',
+        (o) =>
+          Object.keys(o.rules ?? {}).includes('@nx/nx-plugin-checks') ||
+          Object.keys(o.rules ?? {}).includes('@nrwl/nx/nx-plugin-checks'),
+        (o) => {
+          const files = Array.isArray(o.files) ? o.files : [o.files];
+          return {
+            ...o,
+            files: [...files, './migrations.json'],
+          };
+        }
+      );
+
+      // Property-level AST update: only files is modified, plugins with variable refs is preserved
+      expect(result).toMatchInlineSnapshot(`
+        "
+        import pluginPackageJson from "eslint-plugin-package-json";
+        import jsoncParser from "jsonc-eslint-parser";
+
+        export default [
+            {
+                files: [
+              "package.json",
+              "./migrations.json"
+            ],
+                plugins: { "package-json": pluginPackageJson },
+                languageOptions: {
+                    parser: jsoncParser,
+                },
+                rules: {
+                    '@nx/nx-plugin-checks': 'error'
+                }
+            }
+        ];"
+      `);
+    });
+
+    it('should update files while preserving variable references (CJS)', () => {
+      const content = `
+const pluginPackageJson = require("eslint-plugin-package-json");
+const jsoncParser = require("jsonc-eslint-parser");
+
+module.exports = [
+    {
+        files: ["package.json"],
+        plugins: { "package-json": pluginPackageJson },
+        languageOptions: {
+            parser: jsoncParser,
+        },
+        rules: {
+            '@nx/nx-plugin-checks': 'error'
+        }
+    }
+];`;
+
+      const result = replaceOverride(
+        content,
+        '',
+        (o) =>
+          Object.keys(o.rules ?? {}).includes('@nx/nx-plugin-checks') ||
+          Object.keys(o.rules ?? {}).includes('@nrwl/nx/nx-plugin-checks'),
+        (o) => {
+          const files = Array.isArray(o.files) ? o.files : [o.files];
+          return {
+            ...o,
+            files: [...files, './migrations.json'],
+          };
+        }
+      );
+
+      // Property-level AST update: only files is modified, plugins with variable refs is preserved
+      expect(result).toMatchInlineSnapshot(`
+        "
+        const pluginPackageJson = require("eslint-plugin-package-json");
+        const jsoncParser = require("jsonc-eslint-parser");
+
+        module.exports = [
+            {
+                files: [
+              "package.json",
+              "./migrations.json"
+            ],
+                plugins: { "package-json": pluginPackageJson },
+                languageOptions: {
+                    parser: jsoncParser,
+                },
+                rules: {
+                    '@nx/nx-plugin-checks': 'error'
+                }
+            }
         ];"
       `);
     });

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -830,6 +830,7 @@ describe('app', () => {
                 '**/*.cjs',
                 '**/*.mjs',
               ],
+              // Override or add rules here
               rules: {
                 '@next/next/no-html-link-for-pages': ['error', './pages'],
               },


### PR DESCRIPTION
The migration generator (`@nx/plugin:migration`) fails when due to ESLint flat config not being parsed correctly, leading to an error.

This happens because `replaceOverride` uses `parseTextToJson` to parse the config, which fails for non-JSON-serializable JavaScript expressions.

This PR fixes the issue by using AST parsing, like we did for `hasOverrides` here https://github.com/nrwl/nx/pull/33548.

Fixes #34010