### PR TITLE
feat(release): special-case 0.x versions for semver bumps

### DIFF
--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -1036,7 +1036,7 @@
         },
         "adjustSemverBumpsForZeroMajorVersion": {
           "type": "boolean",
-          "description": "Whether to apply the common convention for 0.x versions where breaking changes bump the minor version (instead of major), and new features bump the patch version (instead of minor). When enabled: 'major' bumps become 'minor' bumps for 0.x versions, 'minor' bumps become 'patch' bumps for 0.x versions. Versions 1.0.0 and above are unaffected. This is false by default for backward compatibility.",
+          "description": "Whether to strictly follow SemVer V2 spec for 0.x versions where breaking changes bump the minor version (instead of major), and new features bump the patch version (instead of minor). When enabled: 'major' bumps become 'minor' bumps for 0.x versions, 'minor' bumps become 'patch' bumps for 0.x versions. Versions 1.0.0 and above are unaffected. This is false by default for backward compatibility.",
           "default": false
         },
         "versionActions": {

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -1034,6 +1034,11 @@
             ]
           }
         },
+        "adjustSemverBumpsForZeroMajorVersion": {
+          "type": "boolean",
+          "description": "Whether to apply the common convention for 0.x versions where breaking changes bump the minor version (instead of major), and new features bump the patch version (instead of minor). When enabled: 'major' bumps become 'minor' bumps for 0.x versions, 'minor' bumps become 'patch' bumps for 0.x versions. Versions 1.0.0 and above are unaffected. This is false by default for backward compatibility.",
+          "default": false
+        },
         "versionActions": {
           "type": "string",
           "description": "The path to the version actions implementation to use for releasing all projects by default. This can also be overridden on the release group and project levels.",
@@ -1150,6 +1155,11 @@
               "optionalDependencies"
             ]
           }
+        },
+        "adjustSemverBumpsForZeroMajorVersion": {
+          "type": "boolean",
+          "description": "Whether to apply the common convention for 0.x versions where breaking changes bump the minor version (instead of major), and new features bump the patch version (instead of minor). When enabled: 'major' bumps become 'minor' bumps for 0.x versions, 'minor' bumps become 'patch' bumps for 0.x versions. Versions 1.0.0 and above are unaffected. This is false by default for backward compatibility.",
+          "default": false
         },
         "versionActions": {
           "type": "string",

--- a/packages/nx/src/command-line/release/config/config.spec.ts
+++ b/packages/nx/src/command-line/release/config/config.spec.ts
@@ -310,6 +310,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -331,6 +332,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -524,6 +526,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -545,6 +548,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -741,6 +745,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -762,6 +767,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -989,6 +995,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -1010,6 +1017,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -1221,6 +1229,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -1242,6 +1251,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -1461,6 +1471,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -1482,6 +1493,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -1702,6 +1714,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -1723,6 +1736,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -1923,6 +1937,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -1944,6 +1959,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -2144,6 +2160,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -2165,6 +2182,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -2375,6 +2393,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -2396,6 +2415,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -2600,6 +2620,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -2637,6 +2658,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -2658,6 +2680,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -2860,6 +2883,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -2881,6 +2905,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -3075,6 +3100,7 @@ describe('createNxReleaseConfig()', () => {
                 },
                 "releaseTagPatternRequireSemver": true,
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -3102,6 +3128,7 @@ describe('createNxReleaseConfig()', () => {
                 },
                 "releaseTagPatternRequireSemver": false,
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -3123,6 +3150,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -3332,6 +3360,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -3364,6 +3393,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -3385,6 +3415,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -3596,6 +3627,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -3628,6 +3660,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -3649,6 +3682,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -3863,6 +3897,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -3895,6 +3930,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -3916,6 +3952,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -4138,6 +4175,7 @@ describe('createNxReleaseConfig()', () => {
                 },
                 "releaseTagPatternPreferDockerVersion": true,
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -4171,6 +4209,7 @@ describe('createNxReleaseConfig()', () => {
                 },
                 "releaseTagPatternPreferDockerVersion": false,
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -4204,6 +4243,7 @@ describe('createNxReleaseConfig()', () => {
                 },
                 "releaseTagPatternPreferDockerVersion": "both",
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -4225,6 +4265,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -4426,6 +4467,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -4447,6 +4489,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -4646,6 +4689,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -4667,6 +4711,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -4869,6 +4914,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -4890,6 +4936,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -5088,6 +5135,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -5109,6 +5157,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -5310,6 +5359,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "nx run-many -t build -p lib-a",
                   "logUnchangedProjects": true,
@@ -5331,6 +5381,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -5524,6 +5575,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -5551,6 +5603,7 @@ describe('createNxReleaseConfig()', () => {
                 },
                 "releaseTagPatternRequireSemver": true,
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -5572,6 +5625,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -5765,6 +5819,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -5792,6 +5847,7 @@ describe('createNxReleaseConfig()', () => {
                 },
                 "releaseTagPatternStrictPreid": false,
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -5813,6 +5869,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -6033,6 +6090,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -6054,6 +6112,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -6267,6 +6326,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -6288,6 +6348,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -6486,6 +6547,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -6507,6 +6569,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -6708,6 +6771,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -6732,6 +6796,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -6951,6 +7016,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -6972,6 +7038,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -7170,6 +7237,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -7191,6 +7259,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -7405,6 +7474,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -7427,6 +7497,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -7617,6 +7688,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -7638,6 +7710,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -7869,6 +7942,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -7890,6 +7964,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -8111,6 +8186,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -8132,6 +8208,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -8331,6 +8408,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -8352,6 +8430,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -8556,6 +8635,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -8577,6 +8657,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -8784,6 +8865,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -8805,6 +8887,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -9012,6 +9095,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -9033,6 +9117,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -9241,6 +9326,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -9262,6 +9348,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -9548,6 +9635,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -9569,6 +9657,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -9793,6 +9882,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -9814,6 +9904,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -10204,6 +10295,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -10225,6 +10317,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -10422,6 +10515,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -10443,6 +10537,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -10676,6 +10771,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -10697,6 +10793,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -10906,6 +11003,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -10927,6 +11025,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -11139,6 +11238,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -11160,6 +11260,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -11373,6 +11474,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -11394,6 +11496,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -11610,6 +11713,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -11631,6 +11735,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -11872,6 +11977,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -11898,6 +12004,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -11935,6 +12042,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -11956,6 +12064,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -12200,6 +12309,7 @@ describe('createNxReleaseConfig()', () => {
                 },
                 "releaseTagPattern": "{projectName}-{version}",
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -12221,6 +12331,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -12461,6 +12572,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -12482,6 +12594,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -12703,6 +12816,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -12724,6 +12838,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -13166,6 +13281,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -13187,6 +13303,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -13598,6 +13715,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -13625,6 +13743,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -13646,6 +13765,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -13832,6 +13952,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -13853,6 +13974,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -14053,6 +14175,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "currentVersionResolver": "git-tag",
                   "groupPreVersionCommand": "",
@@ -14075,6 +14198,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": "git-tag",
               "git": {
@@ -14271,6 +14395,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "currentVersionResolver": "registry",
                   "groupPreVersionCommand": "",
@@ -14293,6 +14418,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": "registry",
               "git": {
@@ -14491,6 +14617,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": true,
                   "currentVersionResolver": "git-tag",
                   "groupPreVersionCommand": "",
@@ -14514,6 +14641,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": true,
               "currentVersionResolver": "git-tag",
               "git": {
@@ -14719,6 +14847,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "fallbackCurrentVersionResolver": "disk",
                   "groupPreVersionCommand": "",
@@ -14741,6 +14870,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": true,
               "currentVersionResolver": "git-tag",
               "fallbackCurrentVersionResolver": "disk",
@@ -14945,6 +15075,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -14967,6 +15098,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -15168,6 +15300,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -15194,6 +15327,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -15395,6 +15529,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -15422,6 +15557,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -15443,6 +15579,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -15640,6 +15777,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -15671,6 +15809,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -15692,6 +15831,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -15889,6 +16029,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -15915,6 +16056,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -15937,6 +16079,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {
@@ -16136,6 +16279,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -16162,6 +16306,7 @@ describe('createNxReleaseConfig()', () => {
                   "strictPreid": true,
                 },
                 "version": {
+                  "adjustSemverBumpsForZeroMajorVersion": false,
                   "conventionalCommits": false,
                   "groupPreVersionCommand": "",
                   "logUnchangedProjects": true,
@@ -16188,6 +16333,7 @@ describe('createNxReleaseConfig()', () => {
               "strictPreid": true,
             },
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": false,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "git": {

--- a/packages/nx/src/command-line/release/config/config.ts
+++ b/packages/nx/src/command-line/release/config/config.ts
@@ -378,6 +378,9 @@ export async function createNxReleaseConfig(
         userConfig.version?.preserveMatchingDependencyRanges ?? true,
       logUnchangedProjects: userConfig.version?.logUnchangedProjects ?? true,
       updateDependents: userConfig.version?.updateDependents ?? 'always',
+      // TODO(v23): change the default value of this to true
+      adjustSemverBumpsForZeroMajorVersion:
+        userConfig.version?.adjustSemverBumpsForZeroMajorVersion ?? false,
     } as DeepRequired<NxReleaseConfiguration['version']>,
     changelog: {
       git: changelogGitDefaults,

--- a/packages/nx/src/command-line/release/config/filter-release-groups.spec.ts
+++ b/packages/nx/src/command-line/release/config/filter-release-groups.spec.ts
@@ -189,6 +189,7 @@ describe('filterReleaseGroups()', () => {
             },
             "resolvedVersionPlans": false,
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": undefined,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "currentVersionResolverMetadata": undefined,
@@ -226,6 +227,7 @@ describe('filterReleaseGroups()', () => {
             },
             "resolvedVersionPlans": false,
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": undefined,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "currentVersionResolverMetadata": undefined,
@@ -267,6 +269,7 @@ describe('filterReleaseGroups()', () => {
             },
             "resolvedVersionPlans": false,
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": undefined,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "currentVersionResolverMetadata": undefined,
@@ -306,6 +309,7 @@ describe('filterReleaseGroups()', () => {
             },
             "resolvedVersionPlans": false,
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": undefined,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "currentVersionResolverMetadata": undefined,
@@ -482,6 +486,7 @@ describe('filterReleaseGroups()', () => {
             },
             "resolvedVersionPlans": false,
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": undefined,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "currentVersionResolverMetadata": undefined,
@@ -523,6 +528,7 @@ describe('filterReleaseGroups()', () => {
             },
             "resolvedVersionPlans": false,
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": undefined,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "currentVersionResolverMetadata": undefined,
@@ -620,6 +626,7 @@ describe('filterReleaseGroups()', () => {
             },
             "resolvedVersionPlans": false,
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": undefined,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "currentVersionResolverMetadata": undefined,
@@ -661,6 +668,7 @@ describe('filterReleaseGroups()', () => {
             },
             "resolvedVersionPlans": false,
             "version": {
+              "adjustSemverBumpsForZeroMajorVersion": undefined,
               "conventionalCommits": false,
               "currentVersionResolver": undefined,
               "currentVersionResolverMetadata": undefined,

--- a/packages/nx/src/command-line/release/config/filter-release-groups.spec.ts
+++ b/packages/nx/src/command-line/release/config/filter-release-groups.spec.ts
@@ -357,6 +357,7 @@ describe('filterReleaseGroups()', () => {
             logUnchangedProjects: undefined,
             versionActions: undefined,
             versionActionsOptions: undefined,
+            adjustSemverBumpsForZeroMajorVersion: undefined,
           },
           releaseTag: {
             pattern: '',

--- a/packages/nx/src/command-line/release/utils/release-graph.ts
+++ b/packages/nx/src/command-line/release/utils/release-graph.ts
@@ -35,6 +35,7 @@ export interface FinalConfigForProject {
   versionPrefix: NxReleaseVersionConfiguration['versionPrefix'];
   preserveLocalDependencyProtocols: NxReleaseVersionConfiguration['preserveLocalDependencyProtocols'];
   preserveMatchingDependencyRanges: NxReleaseVersionConfiguration['preserveMatchingDependencyRanges'];
+  adjustSemverBumpsForZeroMajorVersion: NxReleaseVersionConfiguration['adjustSemverBumpsForZeroMajorVersion'];
   versionActionsOptions: NxReleaseVersionConfiguration['versionActionsOptions'];
   manifestRootsToUpdate: Array<
     Exclude<
@@ -888,6 +889,17 @@ Valid values are: ${validReleaseVersionPrefixes
       true;
 
     /**
+     * adjustSemverBumpsForZeroMajorVersion
+     *
+     * TODO(v23): change the default value of this to true
+     * This is false by default for backward compatibility.
+     */
+    const adjustSemverBumpsForZeroMajorVersion =
+      projectVersionConfig?.adjustSemverBumpsForZeroMajorVersion ??
+      releaseGroupVersionConfig?.adjustSemverBumpsForZeroMajorVersion ??
+      false;
+
+    /**
      * fallbackCurrentVersionResolver, defaults to disk when performing a first release, otherwise undefined
      */
     const fallbackCurrentVersionResolver =
@@ -931,6 +943,7 @@ Valid values are: ${validReleaseVersionPrefixes
       versionPrefix,
       preserveLocalDependencyProtocols,
       preserveMatchingDependencyRanges,
+      adjustSemverBumpsForZeroMajorVersion,
       versionActionsOptions,
       manifestRootsToUpdate,
       dockerOptions,

--- a/packages/nx/src/command-line/release/utils/semver.spec.ts
+++ b/packages/nx/src/command-line/release/utils/semver.spec.ts
@@ -75,6 +75,68 @@ describe('semver', () => {
         `"Invalid semver version specifier "foo" provided. Please provide either a valid semver version or a valid semver version keyword."`
       );
     });
+
+    describe('0.x version handling', () => {
+      describe('0.x.y versions (shift bumps down)', () => {
+        it('should bump 0.1.0 + major to 0.2.0', () => {
+          expect(deriveNewSemverVersion('0.1.0', 'major')).toBe('0.2.0');
+        });
+
+        it('should bump 0.1.0 + minor to 0.1.1', () => {
+          expect(deriveNewSemverVersion('0.1.0', 'minor')).toBe('0.1.1');
+        });
+
+        it('should bump 0.1.0 + patch to 0.1.1', () => {
+          expect(deriveNewSemverVersion('0.1.0', 'patch')).toBe('0.1.1');
+        });
+
+        it('should bump 0.0.1 + major to 0.1.0', () => {
+          expect(deriveNewSemverVersion('0.0.1', 'major')).toBe('0.1.0');
+        });
+
+        it('should bump 0.0.1 + minor to 0.0.2', () => {
+          expect(deriveNewSemverVersion('0.0.1', 'minor')).toBe('0.0.2');
+        });
+
+        it('should bump 0.0.1 + patch to 0.0.2', () => {
+          expect(deriveNewSemverVersion('0.0.1', 'patch')).toBe('0.0.2');
+        });
+      });
+
+      describe('1.x.y+ versions (no change)', () => {
+        it('should bump 1.0.0 + major to 2.0.0', () => {
+          expect(deriveNewSemverVersion('1.0.0', 'major')).toBe('2.0.0');
+        });
+
+        it('should bump 1.0.0 + minor to 1.1.0', () => {
+          expect(deriveNewSemverVersion('1.0.0', 'minor')).toBe('1.1.0');
+        });
+
+        it('should bump 1.0.0 + patch to 1.0.1', () => {
+          expect(deriveNewSemverVersion('1.0.0', 'patch')).toBe('1.0.1');
+        });
+      });
+
+      describe('prerelease specifiers (consistent with 0.x shift)', () => {
+        it('should shift premajor to preminor for 0.x versions', () => {
+          expect(deriveNewSemverVersion('0.1.0', 'premajor')).toBe('0.2.0-0');
+        });
+
+        it('should shift preminor to prepatch for 0.x versions', () => {
+          expect(deriveNewSemverVersion('0.1.0', 'preminor')).toBe('0.1.1-0');
+        });
+
+        it('should not adjust prepatch for 0.x versions', () => {
+          expect(deriveNewSemverVersion('0.1.0', 'prepatch')).toBe('0.1.1-0');
+        });
+
+        it('should not adjust prerelease for 0.x versions', () => {
+          expect(deriveNewSemverVersion('0.1.0-0', 'prerelease')).toBe(
+            '0.1.0-1'
+          );
+        });
+      });
+    });
   });
   // tests for determineSemverChange()
   describe('determineSemverChange()', () => {

--- a/packages/nx/src/command-line/release/utils/semver.spec.ts
+++ b/packages/nx/src/command-line/release/utils/semver.spec.ts
@@ -77,63 +77,112 @@ describe('semver', () => {
     });
 
     describe('0.x version handling', () => {
-      describe('0.x.y versions (shift bumps down)', () => {
-        it('should bump 0.1.0 + major to 0.2.0', () => {
-          expect(deriveNewSemverVersion('0.1.0', 'major')).toBe('0.2.0');
-        });
-
-        it('should bump 0.1.0 + minor to 0.1.1', () => {
-          expect(deriveNewSemverVersion('0.1.0', 'minor')).toBe('0.1.1');
-        });
-
-        it('should bump 0.1.0 + patch to 0.1.1', () => {
+      describe('default behavior (adjustSemverBumpsForZeroMajorVersion: false)', () => {
+        it('should use standard semver for 0.x versions by default', () => {
+          // Without the option, standard semver rules apply
+          expect(deriveNewSemverVersion('0.1.0', 'major')).toBe('1.0.0');
+          expect(deriveNewSemverVersion('0.1.0', 'minor')).toBe('0.2.0');
           expect(deriveNewSemverVersion('0.1.0', 'patch')).toBe('0.1.1');
-        });
-
-        it('should bump 0.0.1 + major to 0.1.0', () => {
-          expect(deriveNewSemverVersion('0.0.1', 'major')).toBe('0.1.0');
-        });
-
-        it('should bump 0.0.1 + minor to 0.0.2', () => {
-          expect(deriveNewSemverVersion('0.0.1', 'minor')).toBe('0.0.2');
-        });
-
-        it('should bump 0.0.1 + patch to 0.0.2', () => {
+          expect(deriveNewSemverVersion('0.0.1', 'major')).toBe('1.0.0');
+          expect(deriveNewSemverVersion('0.0.1', 'minor')).toBe('0.1.0');
           expect(deriveNewSemverVersion('0.0.1', 'patch')).toBe('0.0.2');
         });
-      });
 
-      describe('1.x.y+ versions (no change)', () => {
-        it('should bump 1.0.0 + major to 2.0.0', () => {
-          expect(deriveNewSemverVersion('1.0.0', 'major')).toBe('2.0.0');
-        });
-
-        it('should bump 1.0.0 + minor to 1.1.0', () => {
-          expect(deriveNewSemverVersion('1.0.0', 'minor')).toBe('1.1.0');
-        });
-
-        it('should bump 1.0.0 + patch to 1.0.1', () => {
-          expect(deriveNewSemverVersion('1.0.0', 'patch')).toBe('1.0.1');
-        });
-      });
-
-      describe('prerelease specifiers (consistent with 0.x shift)', () => {
-        it('should shift premajor to preminor for 0.x versions', () => {
-          expect(deriveNewSemverVersion('0.1.0', 'premajor')).toBe('0.2.0-0');
-        });
-
-        it('should shift preminor to prepatch for 0.x versions', () => {
-          expect(deriveNewSemverVersion('0.1.0', 'preminor')).toBe('0.1.1-0');
-        });
-
-        it('should not adjust prepatch for 0.x versions', () => {
+        it('should use standard semver for prerelease specifiers on 0.x versions by default', () => {
+          expect(deriveNewSemverVersion('0.1.0', 'premajor')).toBe('1.0.0-0');
+          expect(deriveNewSemverVersion('0.1.0', 'preminor')).toBe('0.2.0-0');
           expect(deriveNewSemverVersion('0.1.0', 'prepatch')).toBe('0.1.1-0');
-        });
-
-        it('should not adjust prerelease for 0.x versions', () => {
           expect(deriveNewSemverVersion('0.1.0-0', 'prerelease')).toBe(
             '0.1.0-1'
           );
+        });
+      });
+
+      describe('adjustSemverBumpsForZeroMajorVersion: true', () => {
+        const opts = { adjustSemverBumpsForZeroMajorVersion: true };
+
+        describe('0.x.y versions (shift bumps down)', () => {
+          it('should bump 0.1.0 + major to 0.2.0', () => {
+            expect(
+              deriveNewSemverVersion('0.1.0', 'major', undefined, opts)
+            ).toBe('0.2.0');
+          });
+
+          it('should bump 0.1.0 + minor to 0.1.1', () => {
+            expect(
+              deriveNewSemverVersion('0.1.0', 'minor', undefined, opts)
+            ).toBe('0.1.1');
+          });
+
+          it('should bump 0.1.0 + patch to 0.1.1', () => {
+            expect(
+              deriveNewSemverVersion('0.1.0', 'patch', undefined, opts)
+            ).toBe('0.1.1');
+          });
+
+          it('should bump 0.0.1 + major to 0.1.0', () => {
+            expect(
+              deriveNewSemverVersion('0.0.1', 'major', undefined, opts)
+            ).toBe('0.1.0');
+          });
+
+          it('should bump 0.0.1 + minor to 0.0.2', () => {
+            expect(
+              deriveNewSemverVersion('0.0.1', 'minor', undefined, opts)
+            ).toBe('0.0.2');
+          });
+
+          it('should bump 0.0.1 + patch to 0.0.2', () => {
+            expect(
+              deriveNewSemverVersion('0.0.1', 'patch', undefined, opts)
+            ).toBe('0.0.2');
+          });
+        });
+
+        describe('1.x.y+ versions (no change)', () => {
+          it('should bump 1.0.0 + major to 2.0.0', () => {
+            expect(
+              deriveNewSemverVersion('1.0.0', 'major', undefined, opts)
+            ).toBe('2.0.0');
+          });
+
+          it('should bump 1.0.0 + minor to 1.1.0', () => {
+            expect(
+              deriveNewSemverVersion('1.0.0', 'minor', undefined, opts)
+            ).toBe('1.1.0');
+          });
+
+          it('should bump 1.0.0 + patch to 1.0.1', () => {
+            expect(
+              deriveNewSemverVersion('1.0.0', 'patch', undefined, opts)
+            ).toBe('1.0.1');
+          });
+        });
+
+        describe('prerelease specifiers (consistent with 0.x shift)', () => {
+          it('should shift premajor to preminor for 0.x versions', () => {
+            expect(
+              deriveNewSemverVersion('0.1.0', 'premajor', undefined, opts)
+            ).toBe('0.2.0-0');
+          });
+
+          it('should shift preminor to prepatch for 0.x versions', () => {
+            expect(
+              deriveNewSemverVersion('0.1.0', 'preminor', undefined, opts)
+            ).toBe('0.1.1-0');
+          });
+
+          it('should not adjust prepatch for 0.x versions', () => {
+            expect(
+              deriveNewSemverVersion('0.1.0', 'prepatch', undefined, opts)
+            ).toBe('0.1.1-0');
+          });
+
+          it('should not adjust prerelease for 0.x versions', () => {
+            expect(
+              deriveNewSemverVersion('0.1.0-0', 'prerelease', undefined, opts)
+            ).toBe('0.1.0-1');
+          });
         });
       });
     });

--- a/packages/nx/src/command-line/release/utils/semver.ts
+++ b/packages/nx/src/command-line/release/utils/semver.ts
@@ -3,7 +3,7 @@
  * https://github.com/unjs/changelogen
  */
 
-import { RELEASE_TYPES, ReleaseType, inc, valid } from 'semver';
+import { major, RELEASE_TYPES, ReleaseType, inc, valid } from 'semver';
 import { NxReleaseConfig } from '../config/config';
 import { GitCommit } from './git';
 
@@ -63,6 +63,42 @@ export function determineSemverChange(
   return semverChangePerProject;
 }
 
+/**
+ * For 0.x versions, shifts semver bump types down to follow
+ * the common convention where breaking changes bump minor, and
+ * new features bump patch.
+ *
+ * - 'major' -> 'minor'
+ * - 'premajor' -> 'preminor'
+ * - 'minor' -> 'patch'
+ * - 'preminor' -> 'prepatch'
+ * - 'patch' -> 'patch' (unchanged)
+ * - 'prepatch' -> 'prepatch' (unchanged)
+ * - 'prerelease' -> 'prerelease' (unchanged)
+ */
+function adjustSpecifierForZeroMajorVersion(
+  specifier: string,
+  currentVersion: string
+): string {
+  // Only adjust for 0.x versions
+  if (major(currentVersion) !== 0) {
+    return specifier;
+  }
+
+  switch (specifier) {
+    case 'major':
+      return 'minor';
+    case 'premajor':
+      return 'preminor';
+    case 'minor':
+      return 'patch';
+    case 'preminor':
+      return 'prepatch';
+    default:
+      return specifier;
+  }
+}
+
 export function deriveNewSemverVersion(
   currentSemverVersion: string,
   semverSpecifier: string,
@@ -76,8 +112,17 @@ export function deriveNewSemverVersion(
 
   let newVersion = semverSpecifier;
   if (isRelativeVersionKeyword(semverSpecifier)) {
-    // Derive the new version from the current version combined with the new version specifier.
-    const derivedVersion = inc(currentSemverVersion, semverSpecifier, preid);
+    // Adjust for 0.x versions
+    const adjustedSpecifier = adjustSpecifierForZeroMajorVersion(
+      semverSpecifier,
+      currentSemverVersion
+    );
+    // Derive the new version from the current version combined with the adjusted version specifier.
+    const derivedVersion = inc(
+      currentSemverVersion,
+      adjustedSpecifier as ReleaseType,
+      preid
+    );
     if (!derivedVersion) {
       throw new Error(
         `Unable to derive new version from current version "${currentSemverVersion}" and version specifier "${semverSpecifier}"`

--- a/packages/nx/src/command-line/release/utils/semver.ts
+++ b/packages/nx/src/command-line/release/utils/semver.ts
@@ -102,7 +102,8 @@ function adjustSpecifierForZeroMajorVersion(
 export function deriveNewSemverVersion(
   currentSemverVersion: string,
   semverSpecifier: string,
-  preid?: string
+  preid?: string,
+  options?: { adjustSemverBumpsForZeroMajorVersion?: boolean }
 ) {
   if (!valid(currentSemverVersion)) {
     throw new Error(
@@ -112,11 +113,13 @@ export function deriveNewSemverVersion(
 
   let newVersion = semverSpecifier;
   if (isRelativeVersionKeyword(semverSpecifier)) {
-    // Adjust for 0.x versions
-    const adjustedSpecifier = adjustSpecifierForZeroMajorVersion(
-      semverSpecifier,
-      currentSemverVersion
-    );
+    // Adjust for 0.x versions if explicitly enabled
+    const adjustedSpecifier = options?.adjustSemverBumpsForZeroMajorVersion
+      ? adjustSpecifierForZeroMajorVersion(
+          semverSpecifier,
+          currentSemverVersion
+        )
+      : semverSpecifier;
     // Derive the new version from the current version combined with the adjusted version specifier.
     const derivedVersion = inc(
       currentSemverVersion,

--- a/packages/nx/src/command-line/release/utils/test/test-utils.ts
+++ b/packages/nx/src/command-line/release/utils/test/test-utils.ts
@@ -17,5 +17,6 @@ export function createVersionConfig() {
     logUnchangedProjects: undefined,
     versionActions: undefined,
     versionActionsOptions: undefined,
+    adjustSemverBumpsForZeroMajorVersion: undefined,
   };
 }

--- a/packages/nx/src/command-line/release/version/release-version.spec.ts
+++ b/packages/nx/src/command-line/release/version/release-version.spec.ts
@@ -228,17 +228,17 @@ describe('releaseVersionGenerator (ported tests)', () => {
                 "type": "static",
               },
             ],
-            "newVersion": "1.0.0",
+            "newVersion": "0.1.0",
           },
           "project-with-dependency-on-my-pkg": {
             "currentVersion": "0.0.1",
             "dependentProjects": [],
-            "newVersion": "1.0.0",
+            "newVersion": "0.1.0",
           },
           "project-with-devDependency-on-my-pkg": {
             "currentVersion": "0.0.1",
             "dependentProjects": [],
-            "newVersion": "1.0.0",
+            "newVersion": "0.1.0",
           },
         },
       }
@@ -323,13 +323,13 @@ describe('releaseVersionGenerator (ported tests)', () => {
       expect(readJson(tree, 'my-app/package.json')).toMatchInlineSnapshot(`
         {
           "dependencies": {
-            "my-lib-1": "1.0.0",
+            "my-lib-1": "0.1.0",
           },
           "devDependencies": {
-            "my-lib-2": "1.0.0",
+            "my-lib-2": "0.1.0",
           },
           "name": "my-app",
-          "version": "1.0.0",
+          "version": "0.1.0",
         }
       `);
     });
@@ -363,7 +363,8 @@ describe('releaseVersionGenerator (ported tests)', () => {
         filters,
         userGivenSpecifier: 'major',
       });
-      expect(readJson(tree, 'my-lib/package.json').version).toEqual('1.0.0');
+      // 0.0.1 + major = 0.1.0 (0.x versioning: major bumps minor)
+      expect(readJson(tree, 'my-lib/package.json').version).toEqual('0.1.0');
 
       await releaseVersionGeneratorForTest(tree, {
         nxReleaseConfig,
@@ -371,7 +372,8 @@ describe('releaseVersionGenerator (ported tests)', () => {
         filters,
         userGivenSpecifier: 'minor',
       });
-      expect(readJson(tree, 'my-lib/package.json').version).toEqual('1.1.0');
+      // 0.1.0 + minor = 0.1.1 (0.x versioning: minor bumps patch)
+      expect(readJson(tree, 'my-lib/package.json').version).toEqual('0.1.1');
 
       await releaseVersionGeneratorForTest(tree, {
         nxReleaseConfig,
@@ -379,7 +381,8 @@ describe('releaseVersionGenerator (ported tests)', () => {
         filters,
         userGivenSpecifier: 'patch',
       });
-      expect(readJson(tree, 'my-lib/package.json').version).toEqual('1.1.1');
+      // 0.1.1 + patch = 0.1.2
+      expect(readJson(tree, 'my-lib/package.json').version).toEqual('0.1.2');
 
       await releaseVersionGeneratorForTest(tree, {
         nxReleaseConfig,
@@ -419,7 +422,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
       expect(readJson(tree, 'my-lib/package.json')).toMatchInlineSnapshot(`
         {
           "name": "my-lib",
-          "version": "1.0.0",
+          "version": "0.1.0",
         }
       `);
 
@@ -427,10 +430,10 @@ describe('releaseVersionGenerator (ported tests)', () => {
         .toMatchInlineSnapshot(`
         {
           "dependencies": {
-            "my-lib": "1.0.0",
+            "my-lib": "0.1.0",
           },
           "name": "project-with-dependency-on-my-pkg",
-          "version": "1.0.0",
+          "version": "0.1.0",
         }
       `);
       expect(
@@ -438,10 +441,10 @@ describe('releaseVersionGenerator (ported tests)', () => {
       ).toMatchInlineSnapshot(`
         {
           "devDependencies": {
-            "my-lib": "1.0.0",
+            "my-lib": "0.1.0",
           },
           "name": "project-with-devDependency-on-my-pkg",
-          "version": "1.0.0",
+          "version": "0.1.0",
         }
       `);
     });
@@ -486,10 +489,11 @@ describe('releaseVersionGenerator (ported tests)', () => {
           userGivenSpecifier: undefined,
         });
 
+        // 0.0.1 + minor = 0.0.2 (0.x versioning: minor bumps patch)
         expect(readJson(tree, 'my-lib/package.json')).toMatchInlineSnapshot(`
           {
             "name": "my-lib",
-            "version": "0.1.0",
+            "version": "0.0.2",
           }
         `);
 
@@ -497,7 +501,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
           .toMatchInlineSnapshot(`
           {
             "dependencies": {
-              "my-lib": "0.1.0",
+              "my-lib": "0.0.2",
             },
             "name": "project-with-dependency-on-my-pkg",
             "version": "0.0.2",
@@ -508,7 +512,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
         ).toMatchInlineSnapshot(`
           {
             "devDependencies": {
-              "my-lib": "0.1.0",
+              "my-lib": "0.0.2",
             },
             "name": "project-with-devDependency-on-my-pkg",
             "version": "1.2.3",

--- a/packages/nx/src/command-line/release/version/release-version.spec.ts
+++ b/packages/nx/src/command-line/release/version/release-version.spec.ts
@@ -195,6 +195,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
         {
           version: {
             specifierSource: 'prompt',
+            adjustSemverBumpsForZeroMajorVersion: true,
           },
         }
       );
@@ -263,6 +264,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
           {
             version: {
               specifierSource: 'prompt',
+              adjustSemverBumpsForZeroMajorVersion: true,
             },
           }
         );
@@ -309,6 +311,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
           {
             version: {
               specifierSource: 'prompt',
+              adjustSemverBumpsForZeroMajorVersion: true,
             },
           }
         );
@@ -351,6 +354,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
           {
             version: {
               specifierSource: 'prompt',
+              adjustSemverBumpsForZeroMajorVersion: true,
             },
           }
         );
@@ -408,6 +412,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
           {
             version: {
               specifierSource: 'prompt',
+              adjustSemverBumpsForZeroMajorVersion: true,
             },
           }
         );
@@ -478,6 +483,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
             {
               version: {
                 specifierSource: 'prompt',
+                adjustSemverBumpsForZeroMajorVersion: true,
               },
             }
           );
@@ -534,6 +540,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
             {
               version: {
                 specifierSource: 'prompt',
+                adjustSemverBumpsForZeroMajorVersion: true,
               },
             }
           );
@@ -591,6 +598,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
               {
                 version: {
                   specifierSource: 'prompt',
+                  adjustSemverBumpsForZeroMajorVersion: true,
                   // No value for updateDependents, should default to 'always'
                 },
               },
@@ -680,6 +688,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
               {
                 version: {
                   specifierSource: 'prompt',
+                  adjustSemverBumpsForZeroMajorVersion: true,
                   updateDependents: 'never',
                 },
               },
@@ -742,6 +751,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
               {
                 version: {
                   specifierSource: 'prompt',
+                  adjustSemverBumpsForZeroMajorVersion: true,
                   updateDependents: 'auto',
                 },
               },
@@ -804,6 +814,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
               {
                 version: {
                   specifierSource: 'prompt',
+                  adjustSemverBumpsForZeroMajorVersion: true,
                 },
               }
             );
@@ -878,6 +889,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
           {
             version: {
               specifierSource: 'prompt',
+              adjustSemverBumpsForZeroMajorVersion: true,
             },
           }
         );
@@ -962,6 +974,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
         await createNxReleaseConfigAndPopulateWorkspace(tree, graphDefinition, {
           version: {
             specifierSource: 'prompt',
+            adjustSemverBumpsForZeroMajorVersion: true,
             versionPrefix: '',
             preserveMatchingDependencyRanges: false,
           },
@@ -1026,6 +1039,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
         await createNxReleaseConfigAndPopulateWorkspace(tree, graphDefinition, {
           version: {
             specifierSource: 'prompt',
+            adjustSemverBumpsForZeroMajorVersion: true,
             versionPrefix: '^',
             preserveMatchingDependencyRanges: false,
           },
@@ -1090,6 +1104,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
         await createNxReleaseConfigAndPopulateWorkspace(tree, graphDefinition, {
           version: {
             specifierSource: 'prompt',
+            adjustSemverBumpsForZeroMajorVersion: true,
             versionPrefix: '~',
             preserveMatchingDependencyRanges: false,
           },
@@ -1154,6 +1169,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
         await createNxReleaseConfigAndPopulateWorkspace(tree, graphDefinition, {
           version: {
             specifierSource: 'prompt',
+            adjustSemverBumpsForZeroMajorVersion: true,
             versionPrefix: 'auto',
             preserveMatchingDependencyRanges: false,
           },
@@ -1218,6 +1234,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
         await createNxReleaseConfigAndPopulateWorkspace(tree, graphDefinition, {
           version: {
             specifierSource: 'prompt',
+            adjustSemverBumpsForZeroMajorVersion: true,
             // No value, should default to "auto"
             versionPrefix: undefined,
             preserveMatchingDependencyRanges: false,
@@ -1285,6 +1302,7 @@ describe('releaseVersionGenerator (ported tests)', () => {
         await createNxReleaseConfigAndPopulateWorkspace(tree, graphDefinition, {
           version: {
             specifierSource: 'prompt',
+            adjustSemverBumpsForZeroMajorVersion: true,
             versionPrefix: '$' as any,
           },
         });
@@ -1924,6 +1942,7 @@ Valid values are: "auto", "", "~", "^", "="`,
           {
             version: {
               specifierSource: 'prompt',
+              adjustSemverBumpsForZeroMajorVersion: true,
               preserveLocalDependencyProtocols: true,
             },
           },
@@ -1998,6 +2017,7 @@ Valid values are: "auto", "", "~", "^", "="`,
           {
             version: {
               specifierSource: 'prompt',
+              adjustSemverBumpsForZeroMajorVersion: true,
               preserveLocalDependencyProtocols: true,
             },
           },
@@ -2076,6 +2096,7 @@ Valid values are: "auto", "", "~", "^", "="`,
         {
           version: {
             specifierSource: 'prompt',
+            adjustSemverBumpsForZeroMajorVersion: true,
           },
         },
         undefined,

--- a/packages/nx/src/command-line/release/version/resolve-current-version.spec.ts
+++ b/packages/nx/src/command-line/release/version/resolve-current-version.spec.ts
@@ -24,6 +24,7 @@ describe('resolveCurrentVersion', () => {
       versionPrefix: 'auto',
       preserveLocalDependencyProtocols: true,
       preserveMatchingDependencyRanges: false,
+      adjustSemverBumpsForZeroMajorVersion: undefined,
       manifestRootsToUpdate: [],
       versionActionsOptions: {},
       dockerOptions: {

--- a/packages/nx/src/command-line/release/version/version-actions.ts
+++ b/packages/nx/src/command-line/release/version/version-actions.ts
@@ -332,7 +332,11 @@ It is also possible that the project is being processed because of a dependency 
     const newVersion = deriveNewSemverVersion(
       currentVersion,
       newVersionInput,
-      preid
+      preid,
+      {
+        adjustSemverBumpsForZeroMajorVersion:
+          this.finalConfigForProject.adjustSemverBumpsForZeroMajorVersion,
+      }
     );
 
     const newVersionInputText = isRelativeVersionKeyword(newVersionInput)

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -214,7 +214,7 @@ export interface NxReleaseVersionConfiguration {
       >;
   // TODO(v23): change the default value of this to true
   /**
-   * Whether to apply the common convention for 0.x versions where breaking changes
+   * Whether to strictly follow SemVer V2 spec for 0.x versions where breaking changes
    * bump the minor version (instead of major), and new features bump the patch version
    * (instead of minor).
    *

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -212,6 +212,23 @@ export interface NxReleaseVersionConfiguration {
         | 'peerDependencies'
         | 'optionalDependencies'
       >;
+  // TODO(v23): change the default value of this to true
+  /**
+   * Whether to apply the common convention for 0.x versions where breaking changes
+   * bump the minor version (instead of major), and new features bump the patch version
+   * (instead of minor).
+   *
+   * When enabled:
+   * - 'major' bumps become 'minor' bumps for 0.x versions
+   * - 'minor' bumps become 'patch' bumps for 0.x versions
+   * - 'premajor' becomes 'preminor' for 0.x versions
+   * - 'preminor' becomes 'prepatch' for 0.x versions
+   *
+   * Versions 1.0.0 and above are unaffected.
+   *
+   * This is false by default for backward compatibility.
+   */
+  adjustSemverBumpsForZeroMajorVersion?: boolean;
 }
 
 export interface NxReleaseChangelogConfiguration {


### PR DESCRIPTION
For 0.x versions, shift semver bump types down to follow the common
convention where breaking changes bump minor, and new features bump patch:

- major -> minor
- premajor -> preminor
- minor -> patch
- preminor -> prepatch
- patch -> patch (unchanged)

This ensures that `nx release` with a breaking change on a 0.x package
(e.g., 0.1.0) bumps to 0.2.0 instead of 1.0.0.

Fixes NXC-3638
