### PR TITLE
chore(repo): add copy-built-package script

### DIFF
--- a/scripts/copy-built-package.ts
+++ b/scripts/copy-built-package.ts
@@ -1,0 +1,185 @@
+import fs, { existsSync } from 'fs';
+import { readJsonSync } from 'fs-extra';
+import { dirname, join, relative } from 'path';
+import { globSync } from 'tinyglobby';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+const packages = globSync(`packages/*/package.json`).map(
+  (p) => readJsonSync(p).name
+);
+
+// Progress display utilities
+function getProgressBar(current: number, total: number, width = 40): string {
+  const percentage = total > 0 ? current / total : 0;
+  const filled = Math.round(width * percentage);
+  const empty = width - filled;
+  return `${'█'.repeat(filled)}${'░'.repeat(empty)}`;
+}
+
+function truncateStart(str: string, maxLen: number): string {
+  if (str.length <= maxLen) return str;
+  return '...' + str.slice(-(maxLen - 3));
+}
+
+class ProgressDisplay {
+  private current = 0;
+  private total: number;
+  private lastFile = '';
+  private initialized: boolean = false;
+
+  constructor(total: number) {
+    this.total = total;
+  }
+
+  insertBefore(str: string) {
+    process.stdout.write('\x1b[J');
+    console.log(str);
+  }
+
+  row(maxWidth: number, minGap: number, ...parts: string[]): string {
+    const totalPartsLength = parts.reduce((sum, part) => sum + part.length, 0);
+    const calculatedGap = (maxWidth - totalPartsLength) / (parts.length - 1);
+    if (calculatedGap < minGap) {
+      const neededReduction = (minGap - calculatedGap) * (parts.length - 1);
+      parts[0] = truncateStart(parts[0], parts[0].length - neededReduction);
+    }
+    return parts.join(' '.repeat(Math.max(calculatedGap, minGap)));
+  }
+
+  update(file: string, message?: string): void {
+    this.current++;
+    this.lastFile = file;
+
+    // Move cursor up 3 lines and clear each line
+    if (this.initialized) {
+      process.stdout.write('\x1b[2F');
+    } else {
+      this.initialized = true;
+    }
+
+    if (message) {
+      this.insertBefore(message);
+    }
+    this.renderCurrentStatus();
+  }
+
+  private renderCurrentStatus() {
+    const termWidth = process.stdout.columns || 80;
+    const progressBar = getProgressBar(this.current, this.total, termWidth);
+
+    // Line 1: Most recently copied file
+    process.stdout.write(
+      this.row(
+        termWidth,
+        4,
+        this.lastFile,
+        `[${this.current} / ${this.total}]\n`
+      )
+    );
+    // Line 2: Progress bar
+    process.stdout.write(`${progressBar}\x1b[K\n`);
+  }
+
+  finish(): void {
+    // Add a newline after completion to separate from next output
+    process.stdout.write('\n');
+  }
+}
+
+yargs(hideBin(process.argv)).command({
+  command: '$0',
+  builder: (yargs) =>
+    yargs
+      .option('package', {
+        type: 'string',
+        choices: packages,
+        description: 'The package to copy the build outputs from',
+        demandOption: true,
+      })
+      .option('repo', {
+        type: 'string',
+        description: 'The root path of the repo to copy the built packages to',
+        demandOption: true,
+      }),
+  handler: (argv) => {
+    console.log(
+      `Copying ${argv.package} to ${argv.repo}/node_modules/${argv.package}`
+    );
+    copyBuiltPackage(argv.package, argv.repo);
+  },
+}).argv;
+
+function copyBuiltPackage(pkg: string, outputWorkspace: string) {
+  const pkgRoot = join('packages', pkg);
+  const pathInDist = join(__dirname, '../dist', pkgRoot);
+  const copyRoot = existsSync(pathInDist) ? pathInDist : pkgRoot;
+
+  if (copyRoot === pkgRoot) {
+    console.warn(`No build artifacts in "${pathInDist}, checking project root`);
+  }
+
+  // Copy all files from dist/packages/<pkg> to the output package root
+  const files = globSync(`**/*.js`, {
+    cwd: copyRoot,
+    dot: true,
+    ignore: ['**/node_modules/**'],
+  });
+
+  if (!files.length) {
+    throw new Error(
+      `Unable to find built artifacts for ${pkg}. Did you forget to build?`
+    );
+  }
+
+  const outputPkgRoot = join(outputWorkspace, 'node_modules', pkg);
+  fs.mkdirSync(outputPkgRoot, { recursive: true });
+
+  // Get native files count for accurate total
+  const nativeFiles = getNativeFiles(pkg);
+  const totalFiles = files.length + nativeFiles.length;
+  const progress = new ProgressDisplay(totalFiles);
+
+  files.forEach((file) => {
+    const destFile = join(outputPkgRoot, file);
+    const destDir = dirname(destFile);
+    const copySrc = join(copyRoot, file);
+    const relativeFilePath = relative(copyRoot, copySrc);
+    progress.update(relativeFilePath, `Writing: ${destFile}`);
+    fs.mkdirSync(destDir, { recursive: true });
+    fs.copyFileSync(copySrc, destFile);
+  });
+
+  // Copy native files
+  copyNativeFiles(pkg, outputPkgRoot, nativeFiles, progress);
+  progress.finish();
+}
+
+function getNativeFiles(pkg: string): string[] {
+  const copyRoot = join(__dirname, '../packages', pkg);
+  return globSync(`**/*.{node,wasm,js,mjs,cjs}`, {
+    ignore: [
+      '**/node_modules/**',
+      'src/command-line/migrate/run-migration-process.js',
+    ],
+    cwd: copyRoot,
+  });
+}
+
+function copyNativeFiles(
+  pkg: string,
+  outputPkgRoot: string,
+  nativeFiles: string[],
+  progress: ProgressDisplay
+) {
+  const copyRoot = join(__dirname, '../packages', pkg);
+  nativeFiles.forEach((file) => {
+    const destFile = join(outputPkgRoot, file);
+    const destDir = dirname(destFile);
+    const copySrc = join(copyRoot, file);
+    const relativeFilePath = relative(copyRoot, copySrc);
+    progress.update(relativeFilePath, `Writing: ${destFile}`);
+    fs.mkdirSync(destDir, { recursive: true });
+    fs.copyFileSync(copySrc, destFile);
+  });
+}


### PR DESCRIPTION
Adds a sm utility script to ease quickly checking changes against local repos. Not a replacement for local registry + install, but good for quick checks