### PR TITLE
feat(core): kill and restart tasks from the tui

### DIFF
--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -327,6 +327,35 @@ export declare export declare function isAiAgent(): boolean
 
 export declare export declare function isEditorInstalled(editor: SupportedEditor): boolean
 
+/**
+ * Event emitted by the TUI to control task execution
+ *
+ * Contains an event type and optional task_id for task-specific events.
+ */
+export interface LifecycleEvent {
+  /** The type of lifecycle event */
+  eventType: LifecycleEventType
+  /** The task ID (required for RerunTask and KillTask, None for bulk operations) */
+  taskId?: string
+}
+
+/**
+ * Event types that can be emitted by the TUI to control task execution
+ *
+ * These event types flow from the TUI (Rust) to the TaskOrchestrator (TypeScript).
+ * The TypeScript side registers a handler via `registerLifecycleEventHandler`.
+ */
+export declare const enum LifecycleEventType {
+  /** Re-run a completed task or restart a running task */
+  RerunTask = 'RerunTask',
+  /** Kill a running task without re-running */
+  KillTask = 'KillTask',
+  /** Re-run all failed tasks */
+  RerunAllFailed = 'RerunAllFailed',
+  /** Kill all currently running tasks */
+  KillAllRunning = 'KillAllRunning'
+}
+
 export declare export declare function logDebug(message: string): void
 
 /** Combined metadata for groups and processes */

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -20,6 +20,13 @@ export declare class AppLifeCycle {
   registerRunningTaskWithEmptyParser(taskId: string): void
   appendTaskOutput(taskId: string, output: string, isPtyOutput: boolean): void
   setTaskStatus(taskId: string, status: TaskStatus): void
+  /**
+   * Get the current status of a task from the TUI state
+   *
+   * This is used by JavaScript to check if a task is being restarted
+   * before treating an exit as a failure. Returns None if task not found.
+   */
+  getTaskStatus(taskId: string): TaskStatus | null
   registerForcedShutdownCallback(forcedShutdownCallback: () => any): void
   __setCloudMessage(message: string): Promise<void>
   setEstimatedTaskTimings(timings: Record<string, number>): void
@@ -513,7 +520,8 @@ export declare const enum TaskStatus {
   NotStarted = 6,
   InProgress = 7,
   Shared = 8,
-  Stopped = 9
+  Stopped = 9,
+  Restarting = 10
 }
 
 export interface TaskTarget {

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -23,6 +23,16 @@ export declare class AppLifeCycle {
   registerForcedShutdownCallback(forcedShutdownCallback: () => any): void
   __setCloudMessage(message: string): Promise<void>
   setEstimatedTaskTimings(timings: Record<string, number>): void
+  /**
+   * Register a handler for lifecycle events emitted by the TUI
+   *
+   * The handler is called when users trigger task control actions:
+   * - RerunTask: Re-run a completed task or restart a running task
+   * - KillTask: Kill a running task
+   * - RerunAllFailed: Re-run all failed tasks
+   * - KillAllRunning: Kill all running tasks
+   */
+  registerLifecycleEventHandler(handler: (arg: LifecycleEvent) => any): void
 }
 
 export declare class ChildProcess {

--- a/packages/nx/src/native/native-bindings.js
+++ b/packages/nx/src/native/native-bindings.js
@@ -398,6 +398,7 @@ module.exports.installNxConsoleForEditor = nativeBinding.installNxConsoleForEdit
 module.exports.IS_WASM = nativeBinding.IS_WASM
 module.exports.isAiAgent = nativeBinding.isAiAgent
 module.exports.isEditorInstalled = nativeBinding.isEditorInstalled
+module.exports.LifecycleEventType = nativeBinding.LifecycleEventType
 module.exports.logDebug = nativeBinding.logDebug
 module.exports.parseTaskStatus = nativeBinding.parseTaskStatus
 module.exports.remove = nativeBinding.remove

--- a/packages/nx/src/native/tui/action.rs
+++ b/packages/nx/src/native/tui/action.rs
@@ -38,4 +38,18 @@ pub enum Action {
     EndCommand,
     ShowHint(String),
     SwitchMode(TuiMode),
+
+    // Task control actions
+    RerunSelectedTask,
+    KillSelectedTask,
+    RerunAllFailed,
+    KillAllRunning,
+
+    // Confirmation dialog actions
+    ShowConfirmDialog {
+        action: Box<Action>,
+        message: String,
+    },
+    ConfirmAction(Box<Action>),
+    CancelConfirmDialog,
 }

--- a/packages/nx/src/native/tui/components.rs
+++ b/packages/nx/src/native/tui/components.rs
@@ -9,6 +9,7 @@ use super::{
     tui::{Event, Frame},
 };
 
+pub mod confirm_dialog;
 pub mod countdown_popup;
 pub mod dependency_view;
 pub mod help_popup;

--- a/packages/nx/src/native/tui/components/confirm_dialog.rs
+++ b/packages/nx/src/native/tui/components/confirm_dialog.rs
@@ -1,0 +1,237 @@
+use color_eyre::eyre::Result;
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    Frame,
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph},
+};
+use std::any::Any;
+
+use crate::native::tui::action::Action;
+use crate::native::tui::theme::THEME;
+
+use super::Component;
+
+/// A modal confirmation dialog for destructive actions
+///
+/// Displays a centered dialog with a message and Yes/No buttons.
+/// Defaults to "No" for safety. Supports keyboard navigation and shortcuts.
+pub struct ConfirmDialog {
+    visible: bool,
+    message: String,
+    pending_action: Option<Action>,
+    selected_yes: bool, // false = No selected (default for safety)
+}
+
+impl ConfirmDialog {
+    /// Create a new confirmation dialog
+    pub fn new() -> Self {
+        Self {
+            visible: false,
+            message: String::new(),
+            pending_action: None,
+            selected_yes: false, // Default to No for safety
+        }
+    }
+
+    /// Show the dialog with a message and action to execute if confirmed
+    ///
+    /// # Arguments
+    /// * `message` - The confirmation message to display
+    /// * `action` - The action to execute if user confirms
+    pub fn show(&mut self, message: String, action: Action) {
+        self.visible = true;
+        self.message = message;
+        self.pending_action = Some(action);
+        self.selected_yes = false; // Always default to No for safety
+    }
+
+    /// Hide the dialog
+    pub fn hide(&mut self) {
+        self.visible = false;
+        self.pending_action = None;
+    }
+
+    /// Returns true if the dialog is currently visible
+    pub fn is_visible(&self) -> bool {
+        self.visible
+    }
+
+    /// Handle a key event
+    ///
+    /// Returns `Some(Action)` if the dialog should close:
+    /// - `ConfirmAction(action)` if user confirmed
+    /// - `CancelConfirmDialog` if user cancelled
+    pub fn handle_key(&mut self, key: KeyEvent) -> Option<Action> {
+        match key.code {
+            // Navigation between Yes/No
+            KeyCode::Left | KeyCode::Right | KeyCode::Tab => {
+                self.selected_yes = !self.selected_yes;
+                None
+            }
+            // Confirm selection
+            KeyCode::Enter => {
+                if self.selected_yes {
+                    self.pending_action
+                        .take()
+                        .map(|a| Action::ConfirmAction(Box::new(a)))
+                } else {
+                    Some(Action::CancelConfirmDialog)
+                }
+            }
+            // Shortcuts
+            KeyCode::Char('y') | KeyCode::Char('Y') => self
+                .pending_action
+                .take()
+                .map(|a| Action::ConfirmAction(Box::new(a))),
+            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                Some(Action::CancelConfirmDialog)
+            }
+            _ => None,
+        }
+    }
+
+    /// Render the dialog centered on screen
+    pub fn render(&self, f: &mut Frame<'_>, area: Rect) {
+        // Add a safety check to prevent rendering outside buffer bounds
+        if area.height == 0
+            || area.width == 0
+            || area.x >= f.area().width
+            || area.y >= f.area().height
+        {
+            return;
+        }
+
+        // Ensure area is entirely within frame bounds
+        let safe_area = Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width.min(f.area().width.saturating_sub(area.x)),
+            height: area.height.min(f.area().height.saturating_sub(area.y)),
+        };
+
+        // Calculate dialog dimensions
+        let dialog_height: u16 = 7;
+        let dialog_width: u16 = 50;
+
+        // Make sure we don't exceed the available area
+        let dialog_height = dialog_height.min(safe_area.height.saturating_sub(4));
+        let dialog_width = dialog_width.min(safe_area.width.saturating_sub(4));
+
+        // Center the dialog
+        let x = safe_area.x + (safe_area.width.saturating_sub(dialog_width)) / 2;
+        let y = safe_area.y + (safe_area.height.saturating_sub(dialog_height)) / 2;
+        let dialog_area = Rect::new(x, y, dialog_width, dialog_height);
+
+        // Clear the area behind the dialog
+        f.render_widget(Clear, dialog_area);
+
+        // Create the dialog block
+        let block = Block::default()
+            .title(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    " NX ",
+                    Style::default()
+                        .add_modifier(Modifier::BOLD)
+                        .bg(THEME.warning)
+                        .fg(THEME.primary_fg),
+                ),
+                Span::styled("  Confirm  ", Style::default().fg(THEME.primary_fg)),
+            ]))
+            .title_alignment(Alignment::Left)
+            .borders(Borders::ALL)
+            .border_type(BorderType::Plain)
+            .border_style(Style::default().fg(THEME.warning))
+            .padding(Padding::proportional(1));
+
+        let inner = block.inner(dialog_area);
+
+        // Layout: message on top, buttons at bottom
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Min(1),    // Message
+                Constraint::Length(1), // Spacer
+                Constraint::Length(1), // Buttons
+            ])
+            .split(inner);
+
+        // Render the block
+        f.render_widget(block, dialog_area);
+
+        // Render message
+        let message = Paragraph::new(self.message.clone())
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(THEME.primary_fg));
+        f.render_widget(message, chunks[0]);
+
+        // Render buttons
+        let yes_style = if self.selected_yes {
+            Style::default()
+                .fg(THEME.primary_fg)
+                .bg(THEME.success)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(THEME.secondary_fg)
+        };
+
+        let no_style = if !self.selected_yes {
+            Style::default()
+                .fg(THEME.primary_fg)
+                .bg(THEME.error)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(THEME.secondary_fg)
+        };
+
+        let buttons = Line::from(vec![
+            Span::raw("  "),
+            Span::styled(" Yes (y) ", yes_style),
+            Span::raw("   "),
+            Span::styled(" No (n) ", no_style),
+            Span::raw("  "),
+        ]);
+
+        let buttons_para = Paragraph::new(buttons).alignment(Alignment::Center);
+        f.render_widget(buttons_para, chunks[2]);
+    }
+
+    /// Get a reference to the pending action
+    pub fn pending_action(&self) -> Option<&Action> {
+        self.pending_action.as_ref()
+    }
+}
+
+impl Default for ConfirmDialog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Component for ConfirmDialog {
+    fn handle_key_event(&mut self, key: KeyEvent) -> Result<Option<Action>> {
+        if self.visible {
+            Ok(self.handle_key(key))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn draw(&mut self, f: &mut Frame<'_>, rect: Rect) -> Result<()> {
+        if self.visible {
+            self.render(f, rect);
+        }
+        Ok(())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}

--- a/packages/nx/src/native/tui/inline_app.rs
+++ b/packages/nx/src/native/tui/inline_app.rs
@@ -203,6 +203,12 @@ impl InlineApp {
         match action {
             Action::RerunSelectedTask => {
                 if let Some(task_id) = self.selected_task.clone() {
+                    // Set status to Restarting BEFORE emitting the lifecycle event
+                    // This prevents race conditions where the process exits before
+                    // JavaScript can set the restarting flag
+                    // Note: Confirmation dialog is only shown for running tasks,
+                    // so if we reach here, the task is running
+                    self.update_task_status(task_id.clone(), TaskStatus::Restarting);
                     self.core
                         .emit_lifecycle_event(LifecycleEvent::rerun_task(task_id));
                 }

--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -522,6 +522,19 @@ impl AppLifeCycle {
         self.with_app(|app| app.update_task_status(task_id, status));
     }
 
+    /// Get the current status of a task from the TUI state
+    ///
+    /// This is used by JavaScript to check if a task is being restarted
+    /// before treating an exit as a failure. Returns None if task not found.
+    #[napi]
+    pub fn get_task_status(&self, task_id: String) -> Option<TaskStatus> {
+        self.with_app(|app| {
+            let shared_state = app.get_shared_state();
+            let state = shared_state.lock();
+            state.get_task_status(&task_id)
+        })
+    }
+
     // This method is excluded from test builds because it uses ThreadsafeFunction
     // which requires Node.js runtime symbols.
     #[cfg(not(test))]

--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -21,10 +21,10 @@ use super::app::App;
 use super::components::tasks_list::TaskStatus;
 use super::config::{AutoExit, TuiCliArgs as RustTuiCliArgs, TuiConfig as RustTuiConfig};
 use super::inline_app::InlineApp;
+use super::lifecycle_event::LifecycleEvent;
 #[cfg(not(test))]
 use super::tui::Tui;
 use super::tui_app::TuiApp;
-use super::lifecycle_event::LifecycleEvent;
 use super::tui_state::TuiState;
 
 #[napi(object)]
@@ -564,7 +564,9 @@ impl AppLifeCycle {
         handler: ThreadsafeFunction<LifecycleEvent, ErrorStrategy::Fatal>,
     ) -> napi::Result<()> {
         self.with_app(|app| {
-            app.get_shared_state().lock().set_lifecycle_event_handler(handler);
+            app.get_shared_state()
+                .lock()
+                .set_lifecycle_event_handler(handler);
         });
         Ok(())
     }

--- a/packages/nx/src/native/tui/lifecycle_event.rs
+++ b/packages/nx/src/native/tui/lifecycle_event.rs
@@ -1,0 +1,64 @@
+use napi_derive::napi;
+
+/// Event types that can be emitted by the TUI to control task execution
+///
+/// These event types flow from the TUI (Rust) to the TaskOrchestrator (TypeScript).
+/// The TypeScript side registers a handler via `registerLifecycleEventHandler`.
+#[napi(string_enum)]
+#[derive(Debug, PartialEq, Eq)]
+pub enum LifecycleEventType {
+    /// Re-run a completed task or restart a running task
+    RerunTask,
+    /// Kill a running task without re-running
+    KillTask,
+    /// Re-run all failed tasks
+    RerunAllFailed,
+    /// Kill all currently running tasks
+    KillAllRunning,
+}
+
+/// Event emitted by the TUI to control task execution
+///
+/// Contains an event type and optional task_id for task-specific events.
+#[napi(object)]
+#[derive(Debug, Clone)]
+pub struct LifecycleEvent {
+    /// The type of lifecycle event
+    pub event_type: LifecycleEventType,
+    /// The task ID (required for RerunTask and KillTask, None for bulk operations)
+    pub task_id: Option<String>,
+}
+
+impl LifecycleEvent {
+    /// Create a RerunTask event for a specific task
+    pub fn rerun_task(task_id: String) -> Self {
+        Self {
+            event_type: LifecycleEventType::RerunTask,
+            task_id: Some(task_id),
+        }
+    }
+
+    /// Create a KillTask event for a specific task
+    pub fn kill_task(task_id: String) -> Self {
+        Self {
+            event_type: LifecycleEventType::KillTask,
+            task_id: Some(task_id),
+        }
+    }
+
+    /// Create a RerunAllFailed event
+    pub fn rerun_all_failed() -> Self {
+        Self {
+            event_type: LifecycleEventType::RerunAllFailed,
+            task_id: None,
+        }
+    }
+
+    /// Create a KillAllRunning event
+    pub fn kill_all_running() -> Self {
+        Self {
+            event_type: LifecycleEventType::KillAllRunning,
+            task_id: None,
+        }
+    }
+}

--- a/packages/nx/src/native/tui/mod.rs
+++ b/packages/nx/src/native/tui/mod.rs
@@ -6,6 +6,7 @@ pub mod escape_sequences;
 pub mod graph_utils;
 pub mod inline_app;
 pub mod lifecycle;
+pub mod lifecycle_event;
 pub mod pty;
 pub mod scroll_momentum;
 pub mod status_icons;
@@ -18,6 +19,7 @@ pub mod tui_state;
 pub mod utils;
 
 pub use inline_app::InlineApp;
+pub use lifecycle_event::{LifecycleEvent, LifecycleEventType};
 pub use tui_app::TuiApp;
 pub use tui_core::TuiCore;
 pub use tui_state::TuiState;

--- a/packages/nx/src/native/tui/status_icons.rs
+++ b/packages/nx/src/native/tui/status_icons.rs
@@ -39,6 +39,16 @@ pub fn get_status_icon(status: TaskStatus, throbber_counter: usize) -> Span<'sta
                 Style::default().fg(THEME.info).add_modifier(Modifier::BOLD),
             )
         }
+        TaskStatus::Restarting => {
+            let throbber_chars = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+            let throbber_char = throbber_chars[throbber_counter % throbber_chars.len()];
+            Span::styled(
+                format!("  {}  ", throbber_char),
+                Style::default()
+                    .fg(THEME.warning)
+                    .add_modifier(Modifier::BOLD),
+            )
+        }
         TaskStatus::Stopped => Span::styled(
             "  ◼  ",
             Style::default()
@@ -68,6 +78,10 @@ pub fn get_status_char(status: TaskStatus, throbber_counter: usize) -> char {
             let throbber_chars = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
             throbber_chars[throbber_counter % throbber_chars.len()]
         }
+        TaskStatus::Restarting => {
+            let throbber_chars = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+            throbber_chars[throbber_counter % throbber_chars.len()]
+        }
         TaskStatus::Stopped => '◼',
         TaskStatus::NotStarted => '·',
     }
@@ -91,6 +105,9 @@ pub fn get_status_style(status: TaskStatus) -> Style {
         TaskStatus::InProgress | TaskStatus::Shared => {
             Style::default().fg(THEME.info).add_modifier(Modifier::BOLD)
         }
+        TaskStatus::Restarting => Style::default()
+            .fg(THEME.warning)
+            .add_modifier(Modifier::BOLD),
         TaskStatus::Stopped | TaskStatus::NotStarted => Style::default()
             .fg(THEME.secondary_fg)
             .add_modifier(Modifier::BOLD),

--- a/packages/nx/src/native/tui/utils.rs
+++ b/packages/nx/src/native/tui/utils.rs
@@ -148,7 +148,7 @@ pub fn get_task_status_style(status: TaskStatus) -> Style {
         | TaskStatus::LocalCache
         | TaskStatus::RemoteCache => THEME.success,
         TaskStatus::Failure => THEME.error,
-        TaskStatus::Skipped => THEME.warning,
+        TaskStatus::Skipped | TaskStatus::Restarting => THEME.warning,
         TaskStatus::InProgress | TaskStatus::Shared => THEME.info,
         TaskStatus::NotStarted | TaskStatus::Stopped => THEME.secondary_fg,
     })
@@ -190,6 +190,12 @@ pub fn get_task_status_icon(status: TaskStatus, padding: usize) -> Span<'static>
             pad_symbol("●", padding),
             Style::default().fg(THEME.info).add_modifier(Modifier::BOLD),
         ),
+        TaskStatus::Restarting => Span::styled(
+            pad_symbol("↻", padding),
+            Style::default()
+                .fg(THEME.warning)
+                .add_modifier(Modifier::BOLD),
+        ),
         TaskStatus::Stopped => Span::styled(
             pad_symbol("◼", padding),
             Style::default()
@@ -227,7 +233,7 @@ pub fn sort_task_items(tasks: &mut [TaskItem], highlighted_names: &HashSet<Strin
             }
 
             match status {
-                TaskStatus::InProgress | TaskStatus::Shared => 0,
+                TaskStatus::InProgress | TaskStatus::Shared | TaskStatus::Restarting => 0,
                 TaskStatus::Failure => 2,
                 TaskStatus::Success
                 | TaskStatus::LocalCacheKeptExisting
@@ -660,7 +666,7 @@ mod tests {
             let status_to_category = |status: &TaskStatus, _: &str| -> u8 {
                 // In this test we're using an empty highlighted list
                 match status {
-                    TaskStatus::InProgress | TaskStatus::Shared => 0,
+                    TaskStatus::InProgress | TaskStatus::Shared | TaskStatus::Restarting => 0,
                     TaskStatus::Failure => 2,
                     TaskStatus::Success
                     | TaskStatus::LocalCacheKeptExisting

--- a/packages/nx/src/tasks-runner/life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycle.ts
@@ -68,6 +68,8 @@ export interface LifeCycle {
 
   setTaskStatus?(taskId: string, status: NativeTaskStatus): void;
 
+  getTaskStatus?(taskId: string): NativeTaskStatus | undefined;
+
   registerForcedShutdownCallback?(callback: () => void): void;
 
   setEstimatedTaskTimings?(timings: Record<string, number>): void;
@@ -188,6 +190,18 @@ export class CompositeLifeCycle implements LifeCycle {
         l.setTaskStatus(taskId, status);
       }
     }
+  }
+
+  getTaskStatus(taskId: string): NativeTaskStatus | undefined {
+    for (let l of this.lifeCycles) {
+      if (l.getTaskStatus) {
+        const status = l.getTaskStatus(taskId);
+        if (status !== undefined) {
+          return status;
+        }
+      }
+    }
+    return undefined;
   }
 
   registerForcedShutdownCallback(callback: () => void): void {

--- a/packages/nx/src/tasks-runner/life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycle.ts
@@ -1,4 +1,5 @@
 import { Task } from '../config/task-graph';
+import type { LifecycleEvent } from '../native';
 import { ExternalObject, TaskStatus as NativeTaskStatus } from '../native';
 import { RunningTask } from './running-tasks/running-task';
 import { TaskStatus } from './tasks-runner';
@@ -70,6 +71,10 @@ export interface LifeCycle {
   registerForcedShutdownCallback?(callback: () => void): void;
 
   setEstimatedTaskTimings?(timings: Record<string, number>): void;
+
+  registerLifecycleEventHandler?(
+    handler: (event: LifecycleEvent) => void
+  ): void;
 }
 
 export class CompositeLifeCycle implements LifeCycle {
@@ -197,6 +202,16 @@ export class CompositeLifeCycle implements LifeCycle {
     for (let l of this.lifeCycles) {
       if (l.setEstimatedTaskTimings) {
         l.setEstimatedTaskTimings(timings);
+      }
+    }
+  }
+
+  registerLifecycleEventHandler(
+    handler: (event: LifecycleEvent) => void
+  ): void {
+    for (const l of this.lifeCycles) {
+      if (l.registerLifecycleEventHandler) {
+        l.registerLifecycleEventHandler(handler);
       }
     }
   }


### PR DESCRIPTION
> [!NOTE]
> This work represents a spike of how we could go about restarting tasks from the TUI. In the future, we'd like to revisit and finish this out. The end goal is to be able to watch tasks from the tui, restart them on file changes, etc, but the minimal impl of restarting tasks manually does also have some value.

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
To restart a task that is running (or failed) from the TUI, you must fully exit the Nx command and reload it.

## Expected Behavior
There are keybinds to restart or kill tasks

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
