### PR TITLE
fix(gradle): resolve dependencies after capturing project tasks

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectDependencyUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectDependencyUtils.kt
@@ -19,8 +19,11 @@ private fun buildDependenciesForProject(project: Project): Set<Dependency> {
   val sourcePath = project.projectDir.absolutePath
   val sourceFilePath = project.buildFile.takeIf { it.exists() }?.absolutePath ?: ""
 
+  // Create a snapshot of configurations to avoid ConcurrentModificationException
+  // with Kotlin Multiplatform which adds configurations dynamically
   project.configurations
-      .matching { it.isCanBeResolved }
+      .filter { it.isCanBeResolved }
+      .toList()
       .forEach { conf ->
         try {
           conf.incoming.resolutionResult.allDependencies.forEach { dependency ->

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
@@ -18,16 +18,7 @@ fun createNodeForProject(
   val logger = project.logger
   logger.info("${Date()} ${project.name} createNodeForProject: get nodes and dependencies")
 
-  // Initialize dependencies with an empty Set to prevent null issues
-  val dependencies: MutableSet<Dependency> =
-      try {
-        getDependenciesForProject(project)
-      } catch (e: Exception) {
-        logger.info(
-            "${Date()} ${project.name} createNodeForProject: get dependencies error: ${e.message}")
-        mutableSetOf()
-      }
-  logger.info("${Date()} ${project.name} createNodeForProject: got dependencies")
+  val dependencies: MutableSet<Dependency> = mutableSetOf()
 
   // Initialize nodes and externalNodes with empty maps to prevent null issues
   var nodes: Map<String, ProjectNode>
@@ -37,6 +28,15 @@ fun createNodeForProject(
     val gradleTargets: GradleTargets =
         processTargetsForProject(
             project, dependencies, targetNameOverrides, workspaceRoot, atomized, targetNamePrefix)
+
+    try {
+      val configDependencies = getDependenciesForProject(project)
+      dependencies.addAll(configDependencies)
+      logger.info("${Date()} ${project.name} createNodeForProject: got configuration dependencies")
+    } catch (e: Exception) {
+      logger.info(
+          "${Date()} ${project.name} createNodeForProject: get dependencies error: ${e.message}")
+    }
     val projectRoot = project.projectDir.path
 
     // Read project-level nx config if it exists
@@ -112,13 +112,17 @@ fun processTargetsForProject(
   val ciTestTargetBaseName = targetNameOverrides["ciTestTargetName"]?.let { applyPrefix(it) }
   val testTargetName = applyPrefix(targetNameOverrides.getOrDefault("testTargetName", "test"))
 
-  val testTasks = project.tasks.withType(Test::class.java)
+  // Create a snapshot of test tasks to avoid ConcurrentModificationException
+  // with Kotlin Multiplatform which adds tasks dynamically
+  val testTasks = project.tasks.withType(Test::class.java).toList()
   val hasCiTestTarget = ciTestTargetBaseName != null && testTasks.isNotEmpty() && atomized
 
   logger.info(
       "${project.name}: hasCiTestTarget = $hasCiTestTarget (ciTestTargetName=$ciTestTargetBaseName, testTasks.size=${testTasks.size}, atomized=$atomized)")
 
-  project.tasks.forEach { task ->
+  // Create a snapshot of all tasks to avoid ConcurrentModificationException
+  // with Kotlin Multiplatform which adds tasks dynamically
+  project.tasks.toList().forEach { task ->
     try {
       val now = Date()
       logger.info("$now ${project.name}: Processing task ${task.path}")


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When processing Kotlin Multiplatform (KMP) projects, the Nx Gradle plugin encounters ConcurrentModificationException errors because KMP dynamically modifies the Gradle project's task and configuration containers during dependency resolution. The plugin was resolving configuration dependencies before processing tasks, which triggered KMP's hierarchy finalization and dynamic task creation while the plugin was still iterating over these collections.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Gradle plugin should handle Kotlin Multiplatform projects without errors by:
  1. Processing tasks before resolving configuration dependencies, preventing KMP from modifying task containers during iteration
  2. Creating immutable snapshots of task and configuration collections before iteration to avoid concurrent modification issues

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes NXC-3633
