### PR TITLE
fix(maven): maven batch runner to use tcp-based communication

### DIFF
--- a/packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/NxMavenBatchRunner.kt
+++ b/packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/NxMavenBatchRunner.kt
@@ -16,7 +16,7 @@ private val log = run {
     System.setProperty("maven.logger.showLogName", "false")
     System.setProperty("maven.logger.levelInBrackets", "true")
     System.setProperty("maven.logger.defaultLogLevel", "info")
-    // Log to stdout (stderr is used for NX_RESULT streaming)
+    // NOTE: We use --raw-streams in ResidentMavenExecutor to prevent recursion
     System.setProperty("maven.logger.logFile", "System.out")
     // Enable colored output (jansi.force needed when stdout isn't a TTY)
     System.setProperty("style.color", "always")

--- a/packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/cli/ArgParser.kt
+++ b/packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/cli/ArgParser.kt
@@ -12,6 +12,7 @@ object ArgParser {
     fun parseArgs(args: Array<String>): MavenBatchOptions {
         var workspaceRoot = ""
         var verbose = false
+        var communicationPort: Int? = null
 
         var i = 0
         while (i < args.size) {
@@ -21,6 +22,12 @@ object ArgParser {
                 }
                 args[i].startsWith("--workspaceRoot=") -> {
                     workspaceRoot = args[i].substringAfter("=")
+                }
+                args[i] == "--communicationPort" && i + 1 < args.size -> {
+                    communicationPort = args[++i].toIntOrNull()
+                }
+                args[i].startsWith("--communicationPort=") -> {
+                    communicationPort = args[i].substringAfter("=").toIntOrNull()
                 }
                 args[i] == "--verbose" -> {
                     verbose = true
@@ -36,8 +43,16 @@ object ArgParser {
             throw IllegalArgumentException("workspaceRoot is required")
         }
 
+        if (communicationPort == null) {
+            throw IllegalArgumentException("communicationPort is required")
+        }
+
         // Read combined payload from stdin (taskGraph, tasks, and args)
         val stdinJson = System.`in`.bufferedReader().readText()
+
+        if (verbose) {
+            println("[DEBUG] Read stdin payload, size: ${stdinJson.length} bytes")
+        }
 
         // Parse the combined payload
         val payload = if (stdinJson.isNotEmpty() && stdinJson != "{}") {
@@ -107,7 +122,8 @@ object ArgParser {
             taskOptions = tasksMap,
             args = argsList,
             verbose = verbose,
-            taskGraph = taskGraph
+            taskGraph = taskGraph,
+            communicationPort = communicationPort
         )
     }
 }

--- a/packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/data/MavenBatchOptions.kt
+++ b/packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/data/MavenBatchOptions.kt
@@ -5,7 +5,8 @@ data class MavenBatchOptions(
     val taskOptions: Map<String, MavenBatchTask>,
     val args: List<String> = emptyList(),
     val verbose: Boolean = false,
-    val taskGraph: TaskGraph? = null
+    val taskGraph: TaskGraph? = null,
+    val communicationPort: Int? = null
 )
 
 data class MavenBatchTask(

--- a/packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/runner/ResidentMavenExecutor.kt
+++ b/packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/runner/ResidentMavenExecutor.kt
@@ -191,6 +191,13 @@ class ResidentMavenExecutor(
       allArguments.addAll(goals)
       allArguments.addAll(arguments)
 
+      // Prevent Maven 4 from redirecting System.out/System.err to its logger,
+      // which causes a StackOverflowError when maven.logger.logFile is System.out.
+      // We already capture output via stdOut/stdErr in ParserRequest.
+      if (!allArguments.contains("--raw-streams")) {
+        allArguments.add("--raw-streams")
+      }
+
       log.debug("Executing Maven with goals: $goals, arguments: $arguments from directory: $workingDir")
 
       // Create a message builder factory for formatting output

--- a/packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/runner/ResultEmitter.kt
+++ b/packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/runner/ResultEmitter.kt
@@ -1,0 +1,65 @@
+package dev.nx.maven.runner
+
+import com.google.gson.Gson
+import dev.nx.maven.data.TaskResult
+import org.slf4j.LoggerFactory
+import java.io.PrintWriter
+import java.net.Socket
+
+/**
+ * Interface for emitting task results to the parent process.
+ */
+interface ResultEmitter {
+    fun emit(taskId: String, result: TaskResult)
+    fun close() {}
+}
+
+/**
+ * TCP-based result emitter.
+ * Connects to a local port and sends JSON results as single lines.
+ */
+class TcpResultEmitter(port: Int, private val gson: Gson) : ResultEmitter {
+    private val log = LoggerFactory.getLogger(TcpResultEmitter::class.java)
+    private var socket: Socket? = null
+    private var writer: PrintWriter? = null
+
+    init {
+        try {
+            log.debug("Connecting to result communication port: $port")
+            socket = Socket("127.0.0.1", port)
+            writer = PrintWriter(socket!!.getOutputStream(), true)
+            log.debug("Connected to result communication port: $port")
+        } catch (e: Exception) {
+            log.error("Failed to connect to result communication port $port: ${e.message}", e)
+        }
+    }
+
+    override fun emit(taskId: String, result: TaskResult) {
+        val currentWriter = writer
+        if (currentWriter != null) {
+            val resultData = mapOf(
+                "task" to taskId,
+                "result" to mapOf(
+                    "success" to result.success,
+                    "terminalOutput" to result.terminalOutput,
+                    "startTime" to result.startTime,
+                    "endTime" to result.endTime
+                )
+            )
+            val json = gson.toJson(resultData)
+            currentWriter.println(json)
+        } else {
+            log.warn("Cannot emit result for $taskId: TCP writer is null")
+        }
+    }
+
+    override fun close() {
+        try {
+            writer?.close()
+            socket?.close()
+            log.debug("Closed result communication socket")
+        } catch (e: Exception) {
+            log.error("Error closing result communication socket: ${e.message}")
+        }
+    }
+}


### PR DESCRIPTION
## Current Behavior
Maven plugin executions can sometimes lead to stackoverflow error, if a plugin is writing to stdout

In my current setup, I am facing this issue however I am not able to add a reproducer
It is a multi-module project where in one of the modules I am using maven-shade-plugin

When I am including this module, I see this error while excluding this plugin works fine. However I can't even pin-point that shading is the issue here. But I observed this and it can affect other plugins too.

With batch implementation either the execution usually gets stuck with this error

## Expected Behavior
Stackover error should not come even when any plugin is writing using System.out / System.err as maven logger tries to redirect these to its maven logger

### Root Cause
1. `NxMavenBatchRunner` configures Maven's logger to write to `System.out` via `System.setProperty("maven.logger.logFile", "System.out")`.
2. When running in resident/embedded mode, Maven 4's `LookupInvoker` attempts to capture all `System.out` output by redirecting it to a `LoggingOutputStream`.
3. `LoggingOutputStream` turns everything written to it into a log event (`logger.info()`).
4. `MavenBaseLogger` (the logger implementation) handles this event by writing to its configured log file, which is `System.out`.
5. Since `System.out` is now the `LoggingOutputStream` from step 2, it causes infinite recursion.

### Solution
The fix involves disabling Maven 4's automatic redirection of standard streams when running in the resident executor. This is achieved by adding the `--raw-streams` flag to the Maven arguments. In "raw streams" mode, Maven 4 leaves `System.out` and `System.err` untouched, allowing the runner to manage them directly (which it already does by passing `stdOut` and `stdErr` to the `ParserRequest`).

Moreover currently we are using System.err for IPC which is also seems like a fragile setup. Moreover when using `--raw-parser`, the NX_RESULT logs are also printed on console which adds noise.

Introduced `TcpResultEmitter` for transmitting task result data via a TCP socket instead of using `System.err`. This along with `--raw-parser` eliminates the issue without adding noise to the console and makes setup more robust.

### Changes
- Modified `packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/runner/ResidentMavenExecutor.kt` to automatically add `--raw-streams` to the arguments if not already present.
- Updated `packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/NxMavenBatchRunner.kt` with a comment explaining the logging configuration and its interaction with `--raw-streams`.
- Introduced `TcpResultEmitter` for transmitting task result data via a TCP socket
- Replaced `stderr`-based result streaming with a TCP server in Node.js batch implementation
- Updated CLI and argument parsing to require a `--communicationPort` for the connection
- Ensured resource cleanup by properly managing socket and server lifecycle

## Related Issue(s)

Fixes #34038
