### PR TITLE
feat(gradle): add env vars to skip gradle and maven plugin computation

### DIFF
--- a/astro-docs/netlify.toml
+++ b/astro-docs/netlify.toml
@@ -1,3 +1,9 @@
+# Disable gradle and maven plugins on Netlify
+# (Netlify only supports Java 8 but these plugins require Java 17)
+[build.environment]
+NX_GRADLE_DISABLE = "true"
+NX_MAVEN_DISABLE = "true"
+
 # Permanent redirects (301 by default)
 
 # Storybook docs consolidation

--- a/astro-docs/src/content/docs/reference/environment-variables.mdoc
+++ b/astro-docs/src/content/docs/reference/environment-variables.mdoc
@@ -53,6 +53,16 @@ The following environment variables are ones that you can set to change the beha
 | `NX_FORMAT_SORT_TSCONFIG_PATHS`    | boolean        | If set to `true`, generators will sort the TypeScript path mappings in the root tsconfig file.                                                                                                                                      |
 | `NX_SKIP_VSCODE_EXTENSION_INSTALL` | boolean        | If set to `true`, skips the automatic installation of the Nx Console extension for supported editors. Set this in environments where the temp file that we store this information in otherwise isn't accessible.                    |
 
+## Plugin Environment Variables
+
+The following environment variables can be used to disable specific Nx plugins. This is useful in CI environments where the required tooling (e.g., Java) is not available.
+
+| Property            | Type    | Description                                                                                                    |
+| ------------------- | ------- | -------------------------------------------------------------------------------------------------------------- |
+| `NX_DOTNET_DISABLE` | boolean | If set to `true`, disables the `@nx/dotnet` plugin. Useful in environments where .NET SDK is not available.    |
+| `NX_GRADLE_DISABLE` | boolean | If set to `true`, disables the `@nx/gradle` plugin. Useful in environments where Java/Gradle is not available. |
+| `NX_MAVEN_DISABLE`  | boolean | If set to `true`, disables the `@nx/maven` plugin. Useful in environments where Java/Maven is not available.   |
+
 Nx will set the following environment variables so they can be accessible within the process even outside of executors and generators.
 
 | Property                       | Type    | Description                                                                                                                                               |

--- a/packages/gradle/plugin.ts
+++ b/packages/gradle/plugin.ts
@@ -1,2 +1,9 @@
-export { createDependencies } from './src/plugin/dependencies';
-export { createNodesV2 } from './src/plugin/nodes';
+import { createDependencies as _createDependencies } from './src/plugin/dependencies';
+import { createNodesV2 as _createNodesV2 } from './src/plugin/nodes';
+
+const isDisabled = process.env.NX_GRADLE_DISABLE === 'true';
+
+export const name = isDisabled ? '@nx/gradle [disabled]' : '@nx/gradle';
+export const createNodesV2 = isDisabled ? undefined : _createNodesV2;
+export const createNodes = createNodesV2;
+export const createDependencies = isDisabled ? undefined : _createDependencies;

--- a/packages/gradle/src/plugin/nodes.ts
+++ b/packages/gradle/src/plugin/nodes.ts
@@ -145,11 +145,6 @@ export const createNodesV2: CreateNodesV2<GradlePluginOptions> = [
       const normalizedOptions = normalizeOptions(options);
 
       for (const gradleFilePath of allBuildFiles) {
-        // Skip on Vercel and Netlify
-        if (process.env.VERCEL || process.env.NETLIFY) {
-          continue;
-        }
-
         const projectRoot = dirname(gradleFilePath);
         const hash = await calculateHashForCreateNodes(
           projectRoot,
@@ -216,12 +211,6 @@ export const makeCreateNodesForGradleConfigFile =
     options: GradlePluginOptions | undefined,
     context: CreateNodesContextV2
   ) => {
-    // Vercel does not allow JAVA_VERSION to be set, skip on Vercel
-    if (process.env.VERCEL) return {};
-
-    // Netlify only supports Java 8 but we require 17, skip on Netlify
-    if (process.env.NETLIFY) return {};
-
     const projectRoot = dirname(gradleFilePath);
     options = normalizeOptions(options);
 

--- a/packages/gradle/src/plugin/utils/get-project-graph-lines.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-lines.ts
@@ -1,18 +1,12 @@
 import { AggregateCreateNodesError, output, workspaceRoot } from '@nx/devkit';
 import { execGradleAsync, newLineSeparator } from '../../utils/exec-gradle';
 import { GradlePluginOptions } from './gradle-plugin-options';
-import { dirname } from 'node:path';
 
 export async function getNxProjectGraphLines(
   gradlewFile: string,
   gradleConfigHash: string,
   gradlePluginOptions: GradlePluginOptions
 ): Promise<string[]> {
-  if (process.env.VERCEL) {
-    // skip on Vercel
-    return [];
-  }
-
   let nxProjectGraphBuffer: Buffer;
 
   const gradlePluginOptionsArgs =

--- a/packages/maven/src/index.ts
+++ b/packages/maven/src/index.ts
@@ -1,2 +1,9 @@
-export { createNodes, createNodes as createNodesV2 } from './plugins/nodes';
-export { createDependencies } from './plugins/dependencies';
+import { createNodes as _createNodes } from './plugins/nodes';
+import { createDependencies as _createDependencies } from './plugins/dependencies';
+
+const isDisabled = process.env.NX_MAVEN_DISABLE === 'true';
+
+export const name = isDisabled ? '@nx/maven [disabled]' : '@nx/maven';
+export const createNodes = isDisabled ? undefined : _createNodes;
+export const createNodesV2 = createNodes;
+export const createDependencies = isDisabled ? undefined : _createDependencies;

--- a/packages/maven/src/plugins/nodes.ts
+++ b/packages/maven/src/plugins/nodes.ts
@@ -36,22 +36,6 @@ export const createNodes: CreateNodesV2<MavenPluginOptions> = [
       return [];
     }
 
-    // Vercel does not allow JAVA_VERSION to be set, skip on Vercel
-    if (process.env.VERCEL) {
-      console.error(
-        `VERCEL environment detected, skipping maven plugin computation.`
-      );
-      return [];
-    }
-
-    // Netlify only supports Java 8, skip on Netlify
-    if (process.env.NETLIFY) {
-      console.error(
-        `NETLIFY environment detected, skipping maven plugin computation.`
-      );
-      return [];
-    }
-
     // Get cache path based on options
     const optionsHash = hashObject(opts);
     const cachePath = getCachePath(context.workspaceRoot, optionsHash);


### PR DESCRIPTION

## Current Behavior
the plugins are disabled on vercel and netlify but there's no easy way to disable them otherwise.

## Expected Behavior
there's an env var to disable each of the plugins: `NX_GRADLE_DISABLE` / `NX_MAVEN_DISABLE` just like there is one for dotnet.
