### PR TITLE
fix(core): display shared running tasks in the in progress section of the tui

### DIFF
--- a/packages/nx/src/native/tui/components/snapshots/nx__native__tui__components__tasks_list__tests__shared_task_grouped_with_in_progress_section.snap
+++ b/packages/nx/src/native/tui/components/snapshots/nx__native__tui__components__tasks_list__tests__shared_task_grouped_with_in_progress_section.snap
@@ -1,0 +1,19 @@
+---
+source: packages/nx/src/native/tui/components/tasks_list.rs
+expression: terminal.backend()
+---
+"                                                                                                                        "
+" NX    Running Test Tasks...                                                                            Cache   Duration"
+" │                                                                                                                      "
+">│⠋    task1                                                                                              ...       <1ms"
+" │⠋    task3                                                                                                -        ..."
+" └                                                                                                                      "
+"  ✔    task2                                                                                                -        ..."
+"                                                                                                                        "
+"                                                                                                                        "
+"                                                                                                                        "
+"                                                                                                                        "
+"                                                                                                                        "
+"                                                                                                                        "
+"                                                                                                                        "
+"                                    quit: q  help: ?  navigate: ↑ ↓  filter: /  pin output: 1 or 2  show output: <enter>"


### PR DESCRIPTION
## Current Behavior

Shared running tasks (tasks running in another process) do not appear in the In Progress section of the TUI. They show the throbber as being in progress, but are located in the Pending/Completed section.

## Expected Behavior

Shared running tasks (tasks running in another process) should appear in the In Progress section of the TUI.