### PR TITLE
fix(maven): use project from options instead of target

### DIFF
--- a/packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/runner/MavenInvokerRunner.kt
+++ b/packages/maven/batch-runner/src/main/kotlin/dev/nx/maven/runner/MavenInvokerRunner.kt
@@ -164,8 +164,8 @@ class MavenInvokerRunner(private val workspaceRoot: File, private val options: M
       }
 
       // Extract unique project selectors from executed tasks
-      val uniqueProjectSelectors = options.taskGraph?.tasks?.values
-        ?.map { it.target.project }
+      val uniqueProjectSelectors = options.taskGraph?.tasks
+        ?.map { (taskId, task) -> options.taskOptions[taskId]?.project ?: task.target.project }
         ?.toSet() ?: emptySet()
 
       if (uniqueProjectSelectors.isEmpty()) {

--- a/packages/maven/src/executors/maven/maven-batch.impl.ts
+++ b/packages/maven/src/executors/maven/maven-batch.impl.ts
@@ -66,8 +66,8 @@ function buildTasks(
   const tasks: Record<string, TaskData> = {};
   for (const taskId of Object.keys(taskGraph.tasks)) {
     const task = taskGraph.tasks[taskId];
-    const projectName = task.target.project;
     const options = inputs[taskId];
+    const projectName = options.project ?? task.target.project;
     tasks[taskId] = buildTaskData(options, projectName);
   }
   return tasks;

--- a/packages/maven/src/executors/maven/maven.impl.ts
+++ b/packages/maven/src/executors/maven/maven.impl.ts
@@ -65,7 +65,7 @@ export default async function mavenExecutor(
   context: ExecutorContext
 ): Promise<{ success: boolean }> {
   const mavenExecutable = detectMavenExecutable(workspaceRoot);
-  const projectName = context.projectName;
+  const projectName = options.project ?? context.projectName;
   const useMaven4 = isMaven4(workspaceRoot);
   const args = buildMavenArgs(options, projectName, useMaven4);
 

--- a/packages/maven/src/executors/maven/schema.ts
+++ b/packages/maven/src/executors/maven/schema.ts
@@ -2,5 +2,6 @@ export interface MavenExecutorSchema {
   phase?: string;
   goals?: string[] | string;
   args?: string[] | string;
+  project?: string;
   __unparsed__?: string[];
 }


### PR DESCRIPTION
## Current Behavior
Customising project name doesn't work for java projects, it uses the one inferred by the plugin

It doesn't impact the graph building logic of nx, just the part where the options are sent to maven for execution

## Expected Behavior
We should be allowed to customize the project names generated by the maven plugin as they can be too complex to be used in real-world for building daily

### Changes
* Used project from options which is added by nx-maven-plugin version > 0.0.11, this is the original project name generated by the plugin
* Fallback to the older format in case someone is not using the latest version of nx-maven-plugin

## Related Issue(s)

Fixes #34060
