### PR TITLE
fix(linter): allow for wildcards paths in enforce-module-boundaries rule

### DIFF
--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
@@ -348,9 +348,8 @@ export default ESLintUtils.RuleCreator(
                     // Step 2: Get the path relative to project path (which is the workspace root in practice)
                     // Example: absoluteImportPath='/root/libs/models/user', projectPath='/root'
                     //          => workspaceRelativePath='libs/models/user'
-                    const workspaceRelativePath = relative(
-                      projectPath,
-                      absoluteImportPath
+                    const workspaceRelativePath = normalizePath(
+                      relative(projectPath, absoluteImportPath)
                     );
 
                     // Step 3: Extract the dynamic part after the base path


### PR DESCRIPTION
closed #32190

## Current Behavior

eslint crashes when tsconfig.base.json path includes a * and you have an import going to that project
## Expected Behavior
The plugin shouldn't crash and it should auto fix to a working import

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
https://github.com/nrwl/nx/issues/32190

Fixes #32190
