### PR TITLE
fix(misc): update banner validation to match Framer API format

### DIFF
--- a/astro-docs/src/components/layout/PageFrame.astro
+++ b/astro-docs/src/components/layout/PageFrame.astro
@@ -13,13 +13,10 @@ const githubStarsCount = Astro.locals.githubStarsCount ?? 0;
 const bannerCollection = await getCollection('banner');
 const bannerConfig = bannerCollection[0]?.data;
 
-// Check if banner is active
+// Check if banner is active based on activeUntil date
 function isBannerActive(config: typeof bannerConfig): boolean {
-  if (!config?.enabled) return false;
-  if (config.activeUntil) {
-    return new Date() < new Date(config.activeUntil);
-  }
-  return true;
+  if (!config?.activeUntil) return false;
+  return new Date() < new Date(config.activeUntil);
 }
 
 const showBanner = isBannerActive(bannerConfig);

--- a/astro-docs/src/content.config.ts
+++ b/astro-docs/src/content.config.ts
@@ -106,14 +106,14 @@ const banner = defineCollection({
   loader: file('src/content/banner.json'),
   schema: z.object({
     id: z.string(),
+    slug: z.string(),
     title: z.string(),
     description: z.string(),
     primaryCtaUrl: z.string(),
     primaryCtaText: z.string(),
     secondaryCtaUrl: z.string().optional(),
     secondaryCtaText: z.string().optional(),
-    enabled: z.boolean(),
-    activeUntil: z.string().optional(),
+    activeUntil: z.string(),
   }),
 });
 

--- a/scripts/documentation/prebuild-banner.mjs
+++ b/scripts/documentation/prebuild-banner.mjs
@@ -57,7 +57,9 @@ function validateBannerConfig(config) {
     return false;
   if (typeof config.primaryCtaText !== 'string' || !config.primaryCtaText)
     return false;
-  if (typeof config.enabled !== 'boolean') return false;
+  // activeUntil is required for determining when the banner expires
+  if (typeof config.activeUntil !== 'string' || !config.activeUntil)
+    return false;
   return true;
 }
 


### PR DESCRIPTION
## Current Behavior
The prebuild-banner script requires an `enabled` boolean field that the Framer API does not return, causing validation failures.

## Expected Behavior
Validation matches the actual API response format which uses `activeUntil` for determining banner visibility instead of `enabled`.

Closes #CLOUD-4071