### PR TITLE
docs(nx-dev): migrate color variants to contrast design

### DIFF
--- a/nx-dev/feature-ai/src/lib/feed-container.tsx
+++ b/nx-dev/feature-ai/src/lib/feed-container.tsx
@@ -136,7 +136,7 @@ export function FeedContainer(): JSX.Element {
                 <div
                   className={cx(
                     'left0 fixed bottom-0 right-0 w-full px-4 py-4 lg:px-0 lg:py-6',
-                    'bg-gradient-to-t from-white via-white/75 dark:from-slate-900 dark:via-slate-900/75'
+                    'bg-gradient-to-t from-white via-white/75 dark:from-zinc-900 dark:via-zinc-900/75'
                   )}
                 >
                   <Prompt

--- a/nx-dev/feature-ai/src/lib/feed/feed-answer.tsx
+++ b/nx-dev/feature-ai/src/lib/feed/feed-answer.tsx
@@ -51,7 +51,7 @@ export function FeedAnswer({
 
   return (
     <>
-      <div className="grid h-12 w-12 items-center justify-center rounded-full bg-white text-slate-900 ring-1 ring-slate-200 dark:bg-slate-900 dark:text-white dark:ring-slate-700">
+      <div className="grid h-12 w-12 items-center justify-center rounded-full bg-white text-zinc-900 ring-1 ring-zinc-200 dark:bg-zinc-900 dark:text-white dark:ring-zinc-700">
         <svg
           role="img"
           viewBox="0 0 24 24"
@@ -65,23 +65,20 @@ export function FeedAnswer({
       </div>
       <div className="min-w-0 flex-1">
         <div>
-          <div className="flex items-center gap-2 text-lg text-slate-900 dark:text-slate-100">
+          <div className="flex items-center gap-2 text-lg text-zinc-900 dark:text-zinc-100">
             Nx Assistant
           </div>
-          <p className="mt-0.5 flex items-center gap-x-1 text-sm text-slate-500">
-            <ChatGptLogo
-              className="h-4 w-4 text-slate-400"
-              aria-hidden="true"
-            />{' '}
+          <p className="mt-0.5 flex items-center gap-x-1 text-sm text-zinc-500">
+            <ChatGptLogo className="h-4 w-4 text-zinc-400" aria-hidden="true" />{' '}
             AI powered
           </p>
         </div>
-        <div className="prose prose-slate dark:prose-invert mt-2 w-full max-w-none 2xl:max-w-4xl">
+        <div className="prose prose-zinc dark:prose-invert mt-2 w-full max-w-none 2xl:max-w-4xl">
           {!isFirst && callout}
           {renderMarkdown(normalizedContent, { filePath: '' }).node}
         </div>
         {!isFirst && (
-          <div className="text-md group flex-1 gap-4 text-slate-400 transition hover:text-slate-500 md:flex md:items-center md:justify-end">
+          <div className="text-md group flex-1 gap-4 text-zinc-400 transition hover:text-zinc-500 md:flex md:items-center md:justify-end">
             {feedbackStatement ? (
               <p className="italic group-hover:flex">
                 {feedbackStatement === 'good'
@@ -96,7 +93,7 @@ export function FeedAnswer({
             <div className="flex gap-4">
               <button
                 className={cx(
-                  'p-1 transition-all hover:rotate-12 hover:text-blue-500 disabled:cursor-not-allowed dark:hover:text-sky-500',
+                  'p-1 transition-all hover:rotate-12 hover:text-blue-500 disabled:cursor-not-allowed dark:hover:text-blue-500',
                   { 'text-blue-500': feedbackStatement === 'bad' }
                 )}
                 disabled={!!feedbackStatement}
@@ -108,7 +105,7 @@ export function FeedAnswer({
               </button>
               <button
                 className={cx(
-                  'p-1 transition-all hover:rotate-12 hover:text-blue-500 disabled:cursor-not-allowed dark:hover:text-sky-500',
+                  'p-1 transition-all hover:rotate-12 hover:text-blue-500 disabled:cursor-not-allowed dark:hover:text-blue-500',
                   { 'text-blue-500': feedbackStatement === 'good' }
                 )}
                 disabled={!!feedbackStatement}

--- a/nx-dev/feature-ai/src/lib/feed/feed-question.tsx
+++ b/nx-dev/feature-ai/src/lib/feed/feed-question.tsx
@@ -1,7 +1,7 @@
 export function FeedQuestion({ content }: { content: string }) {
   return (
     <div className="flex w-full justify-end">
-      <p className="whitespace-pre-wrap break-words rounded-lg bg-blue-500 px-4 py-2 text-base text-white selection:bg-sky-900 dark:bg-sky-500">
+      <p className="whitespace-pre-wrap break-words rounded-lg bg-blue-500 px-4 py-2 text-base text-white selection:bg-blue-900 dark:bg-blue-500">
         {content}
       </p>
     </div>

--- a/nx-dev/feature-ai/src/lib/loading-state.tsx
+++ b/nx-dev/feature-ai/src/lib/loading-state.tsx
@@ -1,6 +1,6 @@
 export function LoadingState(): JSX.Element {
   return (
-    <div className="flex w-full items-center justify-center gap-4 px-4 py-2 text-blue-500 transition duration-150 ease-in-out dark:text-sky-500">
+    <div className="flex w-full items-center justify-center gap-4 px-4 py-2 text-blue-500 transition duration-150 ease-in-out dark:text-blue-500">
       <svg
         className="h-5 w-5 animate-spin"
         xmlns="http://www.w3.org/2000/svg"

--- a/nx-dev/feature-ai/src/lib/prompt.tsx
+++ b/nx-dev/feature-ai/src/lib/prompt.tsx
@@ -62,7 +62,7 @@ export function Prompt({
     <form
       ref={formRef}
       onSubmit={handleSubmit}
-      className="relative mx-auto flex max-w-3xl gap-2 rounded-md border border-slate-300 bg-white px-2 py-2 shadow-lg dark:border-slate-900 dark:bg-slate-700"
+      className="relative mx-auto flex max-w-3xl gap-2 rounded-md border border-zinc-300 bg-white px-2 py-2 shadow-lg dark:border-zinc-900 dark:bg-zinc-700"
     >
       <div
         className={cx(
@@ -74,7 +74,7 @@ export function Prompt({
           <Button
             variant="secondary"
             size="small"
-            className={cx('bg-white dark:bg-slate-900')}
+            className={cx('bg-white dark:bg-zinc-900')}
             onClick={handleStopGenerating}
           >
             <StopIcon aria-hidden="true" className="h-5 w-5" />
@@ -85,7 +85,7 @@ export function Prompt({
           <Button
             variant="secondary"
             size="small"
-            className={cx('bg-white dark:bg-slate-900')}
+            className={cx('bg-white dark:bg-zinc-900')}
             onClick={handleNewChat}
           >
             <XMarkIcon aria-hidden="true" className="h-5 w-5" />
@@ -96,7 +96,7 @@ export function Prompt({
           <Button
             variant="secondary"
             size="small"
-            className={cx('bg-white dark:bg-slate-900')}
+            className={cx('bg-white dark:bg-zinc-900')}
             onClick={onRegenerate}
           >
             <ArrowPathIcon aria-hidden="true" className="h-5 w-5" />
@@ -123,14 +123,14 @@ export function Prompt({
           name="query"
           maxLength={500}
           disabled={isGenerating}
-          className="block w-full resize-none border-none bg-transparent p-0 py-3 pl-2 text-sm placeholder-slate-500 focus-within:outline-none focus:placeholder-slate-400 focus:outline-none focus:ring-0 disabled:cursor-not-allowed dark:text-white dark:focus:placeholder-slate-300"
+          className="block w-full resize-none border-none bg-transparent p-0 py-3 pl-2 text-sm placeholder-zinc-500 focus-within:outline-none focus:placeholder-zinc-400 focus:outline-none focus:ring-0 disabled:cursor-not-allowed dark:text-white dark:focus:placeholder-zinc-300"
           placeholder="How does caching work?"
           rows={1}
         />
       </div>
       <div className="flex">
         <Button
-          variant="primary"
+          variant="contrast"
           size="small"
           type="submit"
           disabled={isGenerating}

--- a/nx-dev/feature-ai/src/lib/sidebar/activity-limit-reached.tsx
+++ b/nx-dev/feature-ai/src/lib/sidebar/activity-limit-reached.tsx
@@ -2,16 +2,16 @@ import { InformationCircleIcon } from '@heroicons/react/24/outline';
 
 export function ActivityLimitReached(): JSX.Element {
   return (
-    <div className="rounded-md bg-slate-50 p-4 shadow-sm ring-1 ring-slate-100 dark:bg-slate-800/40 dark:ring-slate-700">
+    <div className="rounded-md bg-zinc-50 p-4 shadow-sm ring-1 ring-zinc-100 dark:bg-zinc-800/40 dark:ring-zinc-700">
       <div className="flex">
         <div className="flex-shrink-0">
           <InformationCircleIcon
-            className="h-5 w-5 text-slate-500 dark:text-slate-300"
+            className="h-5 w-5 text-zinc-500 dark:text-zinc-300"
             aria-hidden="true"
           />
         </div>
         <div className="ml-3 flex-1 md:flex md:justify-between">
-          <p className="text-sm text-slate-700 dark:text-slate-400">
+          <p className="text-sm text-zinc-700 dark:text-zinc-400">
             You've reached the maximum message history limit. Previous messages
             will be removed.
           </p>

--- a/nx-dev/feature-ai/src/lib/sidebar/sidebar-container.tsx
+++ b/nx-dev/feature-ai/src/lib/sidebar/sidebar-container.tsx
@@ -3,7 +3,7 @@ import { ReactNode } from 'react';
 export function SidebarContainer({ children }: { children: ReactNode[] }) {
   return (
     <div id="sidebar" data-testid="sidebar">
-      <div className="hidden h-full w-72 flex-col border-r border-slate-200 md:flex dark:border-slate-700 dark:bg-slate-900">
+      <div className="hidden h-full w-72 flex-col border-r border-zinc-200 md:flex dark:border-zinc-700 dark:bg-zinc-900">
         <div className="relative flex flex-col gap-4 overflow-y-scroll p-4">
           {...children}
         </div>

--- a/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/doc-viewer.tsx
@@ -135,7 +135,7 @@ export function DocViewer({
                   ref={ref}
                   data-document="main"
                   className={cx(
-                    'prose prose-slate dark:prose-invert w-full max-w-none 2xl:max-w-4xl',
+                    'prose prose-zinc dark:prose-invert w-full max-w-none 2xl:max-w-4xl',
                     { 'xl:max-w-2xl': !hideTableOfContent }
                   )}
                 >
@@ -146,7 +146,7 @@ export function DocViewer({
                 <div>
                   <div
                     className={cx(
-                      'sticky top-2 z-20 ml-[max(2rem,calc(50%-8rem))] hidden w-60 space-y-6 overflow-y-auto bg-white text-sm xl:block dark:bg-slate-900'
+                      'sticky top-2 z-20 ml-[max(2rem,calc(50%-8rem))] hidden w-60 space-y-6 overflow-y-auto bg-white text-sm xl:block dark:bg-zinc-900'
                     )}
                   >
                     {widgetData.githubStarsCount > 0 && (
@@ -163,18 +163,18 @@ export function DocViewer({
                       document={document}
                     >
                       <>
-                        <div className="my-4 flex items-center justify-center space-x-2 rounded-md border border-slate-200 pl-2 pr-2 hover:border-slate-400 dark:border-slate-700 print:hidden">
+                        <div className="my-4 flex items-center justify-center space-x-2 rounded-md border border-zinc-200 pl-2 pr-2 hover:border-zinc-400 dark:border-zinc-700 print:hidden">
                           <button
                             type="button"
                             aria-label="Give feedback on this page"
                             title="Give feedback of this page"
-                            className="whitespace-nowrap border-transparent px-4 py-2 font-bold hover:text-slate-900 dark:hover:text-sky-400"
+                            className="whitespace-nowrap border-transparent px-4 py-2 font-bold hover:text-zinc-900 dark:hover:text-blue-400"
                             onClick={() => setShowFeedback(true)}
                           >
                             Feedback
                           </button>
                         </div>
-                        <div className="my-4 flex items-center justify-center space-x-2 rounded-md border border-slate-200 pl-2 pr-2 hover:border-slate-400 dark:border-slate-700 print:hidden">
+                        <div className="my-4 flex items-center justify-center space-x-2 rounded-md border border-zinc-200 pl-2 pr-2 hover:border-zinc-400 dark:border-zinc-700 print:hidden">
                           {document.filePath ? (
                             <a
                               aria-hidden="true"
@@ -190,7 +190,7 @@ export function DocViewer({
                               target="_blank"
                               rel="noreferrer"
                               title="Edit this page on GitHub"
-                              className="whitespace-nowrap border-transparent px-4 py-2 font-bold hover:text-slate-900 dark:hover:text-sky-400"
+                              className="whitespace-nowrap border-transparent px-4 py-2 font-bold hover:text-zinc-900 dark:hover:text-blue-400"
                             >
                               Edit this page
                             </a>
@@ -207,7 +207,7 @@ export function DocViewer({
             <div
               data-document="related"
               className={cx(
-                'prose prose-slate dark:prose-invert w-full max-w-none pt-8 2xl:max-w-4xl',
+                'prose prose-zinc dark:prose-invert w-full max-w-none pt-8 2xl:max-w-4xl',
                 { 'xl:max-w-2xl': !hideTableOfContent }
               )}
             >
@@ -221,7 +221,7 @@ export function DocViewer({
               hideTableOfContent ? '' : 'xl:hidden'
             }`}
           >
-            <div className="ml-4 flex h-0.5 w-full flex-grow rounded bg-slate-50 dark:bg-slate-800/60" />
+            <div className="ml-4 flex h-0.5 w-full flex-grow rounded bg-zinc-50 dark:bg-zinc-800/60" />
             <div className="relative z-0 inline-flex flex-shrink-0 rounded-md shadow-sm">
               <button
                 type="button"
@@ -230,7 +230,7 @@ export function DocViewer({
                 className={`relative inline-flex items-center rounded-l-md ${
                   // If there is no file path for this page then don't show edit button.
                   document.filePath ? '' : 'rounded-r-md'
-                }border border-slate-200 bg-white px-4 py-2 text-xs font-medium text-slate-600 focus-within:ring-blue-500 hover:bg-slate-50 focus:z-10 focus:outline-none focus:ring-1 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-400 dark:focus-within:ring-sky-500 dark:hover:bg-slate-800`}
+                }border border-zinc-200 bg-white px-4 py-2 text-xs font-medium text-zinc-600 focus-within:ring-blue-500 hover:bg-zinc-50 focus:z-10 focus:outline-none focus:ring-1 dark:border-zinc-700 dark:bg-zinc-800/60 dark:text-zinc-400 dark:focus-within:ring-blue-500 dark:hover:bg-zinc-800`}
                 onClick={() => setShowFeedback(true)}
               >
                 Feedback
@@ -247,7 +247,7 @@ export function DocViewer({
                   target="_blank"
                   rel="noreferrer"
                   title="Edit this page on GitHub"
-                  className="relative -ml-px inline-flex items-center rounded-r-md border border-slate-200 bg-white px-4 py-2 text-xs font-medium text-slate-600 focus-within:ring-blue-500 hover:bg-slate-50 focus:z-10 focus:outline-none focus:ring-1 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-400 dark:focus-within:ring-sky-500 dark:hover:bg-slate-800"
+                  className="relative -ml-px inline-flex items-center rounded-r-md border border-zinc-200 bg-white px-4 py-2 text-xs font-medium text-zinc-600 focus-within:ring-blue-500 hover:bg-zinc-50 focus:z-10 focus:outline-none focus:ring-1 dark:border-zinc-700 dark:bg-zinc-800/60 dark:text-zinc-400 dark:focus-within:ring-blue-500 dark:hover:bg-zinc-800"
                 >
                   Edit this page
                 </a>

--- a/nx-dev/feature-doc-viewer/src/lib/related-documents-section.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/related-documents-section.tsx
@@ -40,12 +40,12 @@ const iconMap: { [key: string]: JSX.Element } = {
 
 function CategoryBox({ category }: { category: RelatedDocumentsCategory }) {
   return (
-    <div className="rounded-lg border border-slate-200 bg-white/60 p-5 dark:border-slate-800/40 dark:bg-slate-800/60">
+    <div className="rounded-lg border border-zinc-200 bg-white/60 p-5 dark:border-zinc-800/40 dark:bg-zinc-800/60">
       <h4 className="mt-0 flex items-center pb-2 text-xl font-bold">
         {iconMap[category.id] ?? iconMap.default}
         {category.name}
       </h4>
-      <ul className="list-none divide-y divide-slate-300 pl-0 dark:divide-slate-700">
+      <ul className="list-none divide-y divide-zinc-300 pl-0 dark:divide-zinc-700">
         {category.relatedDocuments.map((d) => (
           <li
             key={d.id}
@@ -53,11 +53,11 @@ function CategoryBox({ category }: { category: RelatedDocumentsCategory }) {
           >
             <Link
               href={d.path}
-              className="flex flex-grow items-center justify-between no-underline transition-colors ease-out hover:text-blue-700 hover:underline dark:text-sky-500 dark:hover:text-sky-400"
+              className="flex flex-grow items-center justify-between no-underline transition-colors ease-out hover:text-blue-700 hover:underline dark:text-blue-500 dark:hover:text-blue-400"
               prefetch={false}
             >
               <span>{d.name}</span>
-              <ArrowRightIcon className="h-4 w-4 text-slate-500 dark:text-slate-400" />
+              <ArrowRightIcon className="h-4 w-4 text-zinc-500 dark:text-zinc-400" />
             </Link>
           </li>
         ))}

--- a/nx-dev/feature-doc-viewer/src/lib/table-of-contents.tsx
+++ b/nx-dev/feature-doc-viewer/src/lib/table-of-contents.tsx
@@ -86,9 +86,9 @@ export function TableOfContents({
                   <Link
                     href={href}
                     className={cx(
-                      'block w-full border-l-4 border-slate-200 py-1 pl-3 transition hover:border-slate-500 dark:border-slate-700/40 dark:hover:border-slate-700',
+                      'block w-full border-l-4 border-zinc-200 py-1 pl-3 transition hover:border-zinc-500 dark:border-zinc-700/40 dark:hover:border-zinc-700',
                       {
-                        'border-slate-500 bg-slate-50 dark:border-slate-700 dark:bg-slate-800/60':
+                        'border-zinc-500 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800/60':
                           activeId === item.id && !item.highlightColor,
                         // region Highlight Color
                         'border-blue-200 bg-blue-50 hover:border-blue-500 dark:border-blue-700/40 dark:bg-blue-800/40 dark:hover:border-blue-700':

--- a/nx-dev/feature-feedback/src/lib/feedback-dialog.tsx
+++ b/nx-dev/feature-feedback/src/lib/feedback-dialog.tsx
@@ -93,10 +93,10 @@ function FeedbackDialog({
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <DialogPanel className="relative w-full max-w-2xl transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-slate-900">
+              <DialogPanel className="relative w-full max-w-2xl transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all dark:bg-zinc-900">
                 <DialogTitle
                   as="h3"
-                  className="bg-white p-4 text-center text-lg font-medium leading-6 text-slate-700 dark:bg-slate-900 dark:text-slate-400"
+                  className="bg-white p-4 text-center text-lg font-medium leading-6 text-zinc-700 dark:bg-zinc-900 dark:text-zinc-400"
                 >
                   What is on your mind?
                   <button className={styles.closebutton} onClick={closeDialog}>
@@ -154,7 +154,7 @@ function FeedbackDialog({
                       htmlFor="idea"
                       tabIndex={0}
                       onKeyDown={(e) => keydownHandler(e)}
-                      className="inline-flex w-full cursor-pointer items-center justify-between rounded-lg border border-gray-200 bg-white p-5 text-gray-500 hover:bg-slate-50 focus:outline-none focus:ring-1 peer-checked:border-sky-500 peer-checked:text-sky-500 dark:border-gray-700 dark:bg-gray-800 dark:text-slate-400 dark:focus-within:ring-sky-500 dark:hover:bg-slate-800 dark:hover:text-gray-300 dark:peer-checked:text-sky-500"
+                      className="inline-flex w-full cursor-pointer items-center justify-between rounded-lg border border-gray-200 bg-white p-5 text-gray-500 hover:bg-zinc-50 focus:outline-none focus:ring-1 peer-checked:border-blue-500 peer-checked:text-blue-500 dark:border-gray-700 dark:bg-gray-800 dark:text-zinc-400 dark:focus-within:ring-blue-500 dark:hover:bg-zinc-800 dark:hover:text-gray-300 dark:peer-checked:text-blue-500"
                     >
                       <div className="block">
                         <div className="w-full text-lg font-semibold">Idea</div>
@@ -242,10 +242,10 @@ function FeedbackDialog({
                         onClick={submitFeedback}
                         disabled={formDisabled}
                         className={cx(
-                          'rounded-md border border-slate-200 bg-white px-4 py-2 text-base font-medium text-slate-600 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-400',
+                          'rounded-md border border-zinc-200 bg-white px-4 py-2 text-base font-medium text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800/60 dark:text-zinc-400',
                           { 'cursor-not-allowed': formDisabled },
                           {
-                            'focus-within:ring-blue-500 hover:bg-slate-50 focus:z-10 focus:outline-none focus:ring-1 dark:focus-within:ring-sky-500 dark:hover:bg-slate-800':
+                            'focus-within:ring-blue-500 hover:bg-zinc-50 focus:z-10 focus:outline-none focus:ring-1 dark:focus-within:ring-blue-500 dark:hover:bg-zinc-800':
                               !formDisabled,
                           }
                         )}

--- a/nx-dev/feature-package-schema-viewer/src/lib/content.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/content.tsx
@@ -129,7 +129,7 @@ export function Content({
           <div
             aria-hidden="true"
             data-tooltip="Schema type"
-            className="relative inline-flex rounded-md border border-slate-200 bg-slate-50 px-4 py-2 text-xs font-medium uppercase dark:border-slate-700 dark:bg-slate-800/60"
+            className="relative inline-flex rounded-md border border-zinc-200 bg-zinc-50 px-4 py-2 text-xs font-medium uppercase dark:border-zinc-700 dark:bg-zinc-800/60"
           >
             {schemaViewModel.type}
           </div>
@@ -157,7 +157,7 @@ export function Content({
             href={schemaViewModel.packageUrl}
             title="See package information"
             className={cx(
-              'relative inline-flex items-center rounded-l-md border border-slate-200 bg-white px-4 py-2 text-xs font-medium text-slate-600 focus-within:ring-blue-500 hover:bg-slate-50 focus:z-10 focus:outline-none focus:ring-1 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-400 dark:focus-within:ring-sky-500 dark:hover:bg-slate-800',
+              'relative inline-flex items-center rounded-l-md border border-zinc-200 bg-white px-4 py-2 text-xs font-medium text-zinc-600 focus-within:ring-blue-500 hover:bg-zinc-50 focus:z-10 focus:outline-none focus:ring-1 dark:border-zinc-700 dark:bg-zinc-800/60 dark:text-zinc-400 dark:focus-within:ring-blue-500 dark:hover:bg-zinc-800',
               schemaViewModel.packageName.startsWith('@nx/powerpack')
                 ? 'rounded-md'
                 : 'rounded-l-md'
@@ -173,7 +173,7 @@ export function Content({
               target="_blank"
               rel="noreferrer"
               title="See this schema on GitHub"
-              className="relative -ml-px inline-flex items-center rounded-r-md border border-slate-200 bg-white px-4 py-2 text-xs font-medium text-slate-600 focus-within:ring-blue-500 hover:bg-slate-50 focus:z-10 focus:outline-none focus:ring-1 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-400 dark:focus-within:ring-sky-500 dark:hover:bg-slate-800"
+              className="relative -ml-px inline-flex items-center rounded-r-md border border-zinc-200 bg-white px-4 py-2 text-xs font-medium text-zinc-600 focus-within:ring-blue-500 hover:bg-zinc-50 focus:z-10 focus:outline-none focus:ring-1 dark:border-zinc-700 dark:bg-zinc-800/60 dark:text-zinc-400 dark:focus-within:ring-blue-500 dark:hover:bg-zinc-800"
             >
               <svg
                 className="mr-2 h-4 w-4"
@@ -237,7 +237,7 @@ export function Content({
       {/* We remove the top description on sub property lookup */}
       {!schemaViewModel.subReference && (
         <>
-          <div className="prose prose-slate dark:prose-invert max-w-none">
+          <div className="prose prose-zinc dark:prose-invert max-w-none">
             {vm.markdown.header}
             {vm.markdown.customContent}
             {vm.markdown.usageAndExamples}
@@ -269,7 +269,7 @@ export function Content({
                       setPresets(p.keys);
                     }}
                     type="button"
-                    className="relative inline-flex items-center rounded-md border border-slate-200 bg-white px-4 py-2 text-xs font-medium text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-400 dark:hover:bg-slate-800"
+                    className="relative inline-flex items-center rounded-md border border-zinc-200 bg-white px-4 py-2 text-xs font-medium text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800/60 dark:text-zinc-400 dark:hover:bg-zinc-800"
                   >
                     {p.name}
                   </button>
@@ -278,7 +278,7 @@ export function Content({
                   <button
                     onClick={() => setPresets([])}
                     type="button"
-                    className="relative inline-flex items-center rounded-md border border-slate-200 bg-white px-4 py-2 text-xs font-medium text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-400 dark:hover:bg-slate-800"
+                    className="relative inline-flex items-center rounded-md border border-zinc-200 bg-white px-4 py-2 text-xs font-medium text-zinc-600 hover:bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800/60 dark:text-zinc-400 dark:hover:bg-zinc-800"
                   >
                     Reset <XCircleIcon className="ml-1.5 h-4 w-4" />
                   </button>
@@ -286,7 +286,7 @@ export function Content({
               </div>
             </>
           )}
-          <div className="rounded-md border border-slate-200 p-0.5 dark:border-slate-700">
+          <div className="rounded-md border border-zinc-200 p-0.5 dark:border-zinc-700">
             <SchemaEditor
               packageName={schemaViewModel.packageName}
               schemaName={schemaViewModel.schemaMetadata.name}

--- a/nx-dev/feature-package-schema-viewer/src/lib/migration-viewer.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/migration-viewer.tsx
@@ -21,7 +21,7 @@ export function MigrationViewer({
       <summary className="cursor-pointer">
         <Heading3 title={schema.name}></Heading3>
       </summary>
-      <div className="prose prose-slate dark:prose-invert mb-6 ml-5">
+      <div className="prose prose-zinc dark:prose-invert mb-6 ml-5">
         <p>{schema.description}</p>
         <div className="my-1">
           <strong>Version</strong>: {schema.version}

--- a/nx-dev/feature-package-schema-viewer/src/lib/package-schema-list.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/package-schema-list.tsx
@@ -125,7 +125,7 @@ export function PackageSchemaList({
 
             <div className="h-12">{/* SPACER */}</div>
             <Heading2 title={'Migrations'} />
-            <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+            <ul className="divide-y divide-zinc-100 dark:divide-zinc-800">
               {!!filesAndLabels.length
                 ? filesAndLabels.map((schema) =>
                     typeof schema === 'string' ? (

--- a/nx-dev/feature-package-schema-viewer/src/lib/package-schema-sub-list.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/package-schema-sub-list.tsx
@@ -116,7 +116,7 @@ export function PackageSchemaSubList({
             ) : null}
 
             {vm.type === 'migration' ? (
-              <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+              <ul className="divide-y divide-zinc-100 dark:divide-zinc-800">
                 {filesAndLabels.map((schema) =>
                   typeof schema === 'string' ? (
                     <VersionLabelListItem
@@ -142,7 +142,7 @@ export function PackageSchemaSubList({
 
 export const VersionLabelListItem = ({ label }: { label: string }) => {
   return label ? (
-    <li className="relative flex px-1 pt-2 transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-slate-50 dark:focus-within:ring-sky-500 dark:hover:bg-slate-800/60">
+    <li className="relative flex px-1 pt-2 transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-zinc-50 dark:focus-within:ring-blue-500 dark:hover:bg-zinc-800/60">
       <div className="pt-2">
         <span className="text-sm font-bold">
           <Heading2 title={label} />

--- a/nx-dev/feature-package-schema-viewer/src/lib/parameter-view.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/parameter-view.tsx
@@ -24,13 +24,13 @@ export const ParameterView = (props: {
         {props.alias && (
           <span
             data-tooltip="Property alias"
-            className="relative -top-0.5 inline-flex rounded-md px-2 text-xs font-semibold leading-5 dark:bg-slate-700"
+            className="relative -top-0.5 inline-flex rounded-md px-2 text-xs font-semibold leading-5 dark:bg-zinc-700"
           >
             {props.alias}
           </span>
         )}
         {props.required && (
-          <span className="relative -top-0.5 inline-flex rounded-md bg-slate-100 px-2 text-xs font-semibold uppercase leading-5 dark:bg-slate-700">
+          <span className="relative -top-0.5 inline-flex rounded-md bg-zinc-100 px-2 text-xs font-semibold uppercase leading-5 dark:bg-zinc-700">
             Required
           </span>
         )}
@@ -68,7 +68,7 @@ export const ParameterView = (props: {
       )}
     </div>
 
-    <div className="prose prose-slate dark:prose-invert -mt-4 max-w-none">
+    <div className="prose prose-zinc dark:prose-invert -mt-4 max-w-none">
       {
         renderMarkdown(props.description, {
           filePath: '',
@@ -78,7 +78,7 @@ export const ParameterView = (props: {
 
     {props.deprecated &&
     typeof (props.schema as any)['x-deprecated'] === 'string' ? (
-      <div className="prose prose-slate dark:prose-invert mt-2 rounded-md bg-red-100 px-4 text-red-800 dark:bg-red-800 dark:text-red-100">
+      <div className="prose prose-zinc dark:prose-invert mt-2 rounded-md bg-red-100 px-4 text-red-800 dark:bg-red-800 dark:text-red-100">
         {
           renderMarkdown(String((props.schema as any)['x-deprecated']), {
             filePath: '',

--- a/nx-dev/feature-package-schema-viewer/src/lib/ui/headings.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/ui/headings.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 export const Heading1 = ({ title }: { title: string }) => (
   <h1
     id={slugify(title)}
-    className="group mb-5 text-4xl font-extrabold tracking-tight text-slate-900 dark:text-slate-100"
+    className="group mb-5 text-4xl font-extrabold tracking-tight text-zinc-900 dark:text-zinc-100"
   >
     <span>{title}</span>
     <Link aria-hidden="true" tabIndex={-1} href={'#' + slugify(title)}>
@@ -20,7 +20,7 @@ export const Heading1 = ({ title }: { title: string }) => (
 export const Heading2 = ({ title }: { title: string }) => (
   <h2
     id={slugify(title)}
-    className="group mb-5 text-2xl font-bold tracking-tight text-slate-800 dark:text-slate-200"
+    className="group mb-5 text-2xl font-bold tracking-tight text-zinc-800 dark:text-zinc-200"
   >
     <span>{title}</span>
     <Link aria-hidden="true" tabIndex={-1} href={'#' + slugify(title)}>
@@ -35,7 +35,7 @@ export const Heading2 = ({ title }: { title: string }) => (
 export const Heading3 = ({ title }: { title: string }) => (
   <h3
     id={slugify(title)}
-    className="group text-xl font-semibold tracking-tight text-slate-700 dark:text-slate-300"
+    className="group text-xl font-semibold tracking-tight text-zinc-700 dark:text-zinc-300"
   >
     <span>{title}</span>
     <Link aria-hidden="true" tabIndex={-1} href={'#' + slugify(title)}>

--- a/nx-dev/feature-package-schema-viewer/src/lib/ui/package-reference.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/ui/package-reference.tsx
@@ -16,7 +16,7 @@ export function DocumentList({
   documents: DocumentMetadata[];
 }): JSX.Element {
   return (
-    <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+    <ul className="divide-y divide-zinc-100 dark:divide-zinc-800">
       {!!documents.length ? (
         documents.map((guide) => (
           <DocumentListItem key={guide.id} document={guide} />
@@ -36,9 +36,9 @@ function DocumentListItem({
   return (
     <li
       key={document.name}
-      className="relative flex px-2 py-2 transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-slate-50 dark:focus-within:ring-sky-500 dark:hover:bg-slate-800/60"
+      className="relative flex px-2 py-2 transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-zinc-50 dark:focus-within:ring-blue-500 dark:hover:bg-zinc-800/60"
     >
-      <div className="flex-shrink-0 self-start rounded-lg border-slate-200 bg-slate-100 p-2 dark:border-slate-600 dark:bg-slate-700">
+      <div className="flex-shrink-0 self-start rounded-lg border-zinc-200 bg-zinc-100 p-2 dark:border-zinc-600 dark:bg-zinc-700">
         <DocumentIcon className="h-5 w-5" role="img" />
       </div>
       <div className="ml-3 py-2">
@@ -61,7 +61,7 @@ export function SchemaList({
   type: 'executor' | 'generator';
 }): JSX.Element {
   return (
-    <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+    <ul className="divide-y divide-zinc-100 dark:divide-zinc-800">
       {!!files.length ? (
         files.map((schema) => (
           <SchemaListItem key={schema.name} file={schema} />
@@ -77,9 +77,9 @@ function SchemaListItem({ file }: { file: FileMetadata }): JSX.Element {
   return (
     <li
       key={file.name}
-      className="relative flex px-2 py-2 transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-slate-50 dark:focus-within:ring-sky-500 dark:hover:bg-slate-800/60"
+      className="relative flex px-2 py-2 transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-zinc-50 dark:focus-within:ring-blue-500 dark:hover:bg-zinc-800/60"
     >
-      <div className="flex-shrink-0 self-start rounded-lg border-slate-200 bg-slate-100 p-2 dark:border-slate-600 dark:bg-slate-700">
+      <div className="flex-shrink-0 self-start rounded-lg border-zinc-200 bg-zinc-100 p-2 dark:border-zinc-600 dark:bg-zinc-700">
         {file.type === 'executor' ? (
           <CpuChipIcon className="h-5 w-5" role="img" />
         ) : (
@@ -99,7 +99,7 @@ function SchemaListItem({ file }: { file: FileMetadata }): JSX.Element {
             </span>
           )}
         </p>
-        <div className="prose prose-slate dark:prose-invert prose-sm">
+        <div className="prose prose-zinc dark:prose-invert prose-sm">
           {
             renderMarkdown(file.description, {
               filePath: '',
@@ -117,10 +117,10 @@ function EmptyList({
   type: 'executor' | 'generator' | 'document';
 }): JSX.Element {
   return (
-    <li className="relative flex px-2 py-2 transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-slate-50 dark:focus-within:ring-sky-500 dark:hover:bg-slate-800/60">
-      <div className="flex-shrink-0 self-start rounded-lg border-slate-200 bg-slate-100 p-2 dark:border-slate-600 dark:bg-slate-700">
+    <li className="relative flex px-2 py-2 transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-zinc-50 dark:focus-within:ring-blue-500 dark:hover:bg-zinc-800/60">
+      <div className="flex-shrink-0 self-start rounded-lg border-zinc-200 bg-zinc-100 p-2 dark:border-zinc-600 dark:bg-zinc-700">
         <InformationCircleIcon
-          className="h-5 w-5 flex-shrink-0 rounded-md border-slate-200 bg-slate-50 dark:bg-slate-700 dark:bg-slate-800"
+          className="h-5 w-5 flex-shrink-0 rounded-md border-zinc-200 bg-zinc-50 dark:bg-zinc-700 dark:bg-zinc-800"
           role="img"
         />
       </div>
@@ -136,7 +136,7 @@ function EmptyList({
             {type} available for this package yet!
           </Link>
         </p>
-        <div className="prose prose-slate dark:prose-invert prose-sm">
+        <div className="prose prose-zinc dark:prose-invert prose-sm">
           <a
             href="https://github.com/nrwl/nx/discussions"
             target="_blank"

--- a/nx-dev/feature-package-schema-viewer/src/lib/ui/top.layout.tsx
+++ b/nx-dev/feature-package-schema-viewer/src/lib/ui/top.layout.tsx
@@ -11,7 +11,7 @@ export function TopSchemaLayout({
     <div className="mb-8 flex w-full items-center space-x-2">
       <div className="w-full flex-grow">
         <div
-          className="relative inline-flex rounded-md border border-slate-200 bg-slate-50 px-4 py-2 text-xs font-medium uppercase dark:border-slate-700 dark:bg-slate-800/60"
+          className="relative inline-flex rounded-md border border-zinc-200 bg-zinc-50 px-4 py-2 text-xs font-medium uppercase dark:border-zinc-700 dark:bg-zinc-800/60"
           aria-hidden="true"
           data-tooltip="Installable Package"
         >
@@ -26,7 +26,7 @@ export function TopSchemaLayout({
             rel="noreferrer"
             aria-hidden="true"
             title="See package on GitHub"
-            className="relative inline-flex items-center rounded-md border border-slate-200 bg-slate-50 px-4 py-2 text-xs font-medium dark:border-slate-700 dark:bg-slate-800/60"
+            className="relative inline-flex items-center rounded-md border border-zinc-200 bg-zinc-50 px-4 py-2 text-xs font-medium dark:border-zinc-700 dark:bg-zinc-800/60"
           >
             <svg
               className="mr-2 h-4 w-4"

--- a/nx-dev/feature-search/src/lib/algolia-search.tsx
+++ b/nx-dev/feature-search/src/lib/algolia-search.tsx
@@ -92,15 +92,15 @@ export function AlgoliaSearch({
           type="button"
           ref={searchButtonRef}
           onClick={handleOpen}
-          className="flex w-full items-center rounded-md bg-white px-2 py-1.5 text-sm leading-4 ring-1 ring-slate-300 transition dark:bg-slate-700 dark:ring-slate-900"
+          className="flex w-full items-center rounded-md bg-white px-2 py-1.5 text-sm leading-4 ring-1 ring-zinc-300 transition dark:bg-zinc-700 dark:ring-zinc-900"
         >
           <MagnifyingGlassIcon className="h-4 w-4 flex-none" />
-          <span className="mx-3 inline-flex text-xs text-slate-300 md:text-sm dark:text-slate-400">
+          <span className="mx-3 inline-flex text-xs text-zinc-300 md:text-sm dark:text-zinc-400">
             Search
           </span>
           <span
             style={{ opacity: browserDetected ? '1' : '0' }}
-            className="ml-auto hidden flex-none rounded-md border border-slate-200 bg-slate-50 px-1 py-0.5 text-xs font-semibold text-slate-500 md:block dark:border-slate-700 dark:bg-slate-800/60"
+            className="ml-auto hidden flex-none rounded-md border border-zinc-200 bg-zinc-50 px-1 py-0.5 text-xs font-semibold text-zinc-500 md:block dark:border-zinc-700 dark:bg-zinc-800/60"
           >
             <span className="sr-only">Press </span>
             <kbd className="font-sans">
@@ -122,7 +122,7 @@ export function AlgoliaSearch({
         >
           <span
             style={{ opacity: browserDetected ? '1' : '0' }}
-            className="ml-auto block flex-none rounded-md border border-slate-200 bg-slate-50/60 px-1 py-0.5 text-xs font-semibold text-slate-400 transition hover:text-slate-500 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-500 dark:hover:text-slate-400"
+            className="ml-auto block flex-none rounded-md border border-zinc-200 bg-zinc-50/60 px-1 py-0.5 text-xs font-semibold text-zinc-400 transition hover:text-zinc-500 dark:border-zinc-700 dark:bg-zinc-800/60 dark:text-zinc-500 dark:hover:text-zinc-400"
           >
             <span className="sr-only">Press </span>
             <kbd className="font-sans">

--- a/nx-dev/nx-dev/app/layout.tsx
+++ b/nx-dev/nx-dev/app/layout.tsx
@@ -119,7 +119,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           }}
         />
       </head>
-      <body className="h-full bg-white text-slate-700 antialiased selection:bg-blue-500 selection:text-white dark:bg-slate-900 dark:text-slate-400 dark:selection:bg-sky-500">
+      <body className="h-full bg-white text-zinc-700 antialiased selection:bg-blue-500 selection:text-white dark:bg-zinc-900 dark:text-zinc-400 dark:selection:bg-blue-500">
         <GlobalSearchHandler />
         {children}
         {bannerCollection.map((bannerConfig) => {

--- a/nx-dev/nx-dev/app/resources/page.tsx
+++ b/nx-dev/nx-dev/app/resources/page.tsx
@@ -15,7 +15,7 @@ interface ResourceCardProps {
 
 function Hero(): JSX.Element {
   return (
-    <section className="relative overflow-hidden py-16 dark:from-slate-900 dark:to-slate-950">
+    <section className="relative overflow-hidden py-16 dark:from-zinc-900 dark:to-zinc-950">
       <div className="mx-auto max-w-3xl text-center">
         <SectionHeading
           as="h1"
@@ -27,7 +27,7 @@ function Hero(): JSX.Element {
         <SectionHeading
           as="p"
           variant="subtitle"
-          className="mx-auto mt-6 max-w-3xl text-xl text-slate-600 dark:text-slate-400"
+          className="mx-auto mt-6 max-w-3xl text-xl text-zinc-600 dark:text-zinc-400"
         >
           Learning ⋅ Events ⋅ Company
         </SectionHeading>
@@ -41,8 +41,8 @@ function ResourceCard({ item }: ResourceCardProps) {
     <a href={item.href} className="block h-full transform-gpu">
       <div
         className={cx(
-          'group relative h-full w-full overflow-hidden rounded-2xl border border-slate-200 bg-white p-8',
-          'dark:border-slate-800 dark:bg-slate-900 dark:hover:border-blue-900 dark:hover:shadow-blue-900/20',
+          'group relative h-full w-full overflow-hidden rounded-2xl border border-zinc-200 bg-white p-8',
+          'dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-blue-900 dark:hover:shadow-blue-900/20',
           'before:absolute before:inset-0 before:z-0 before:bg-gradient-to-br before:from-blue-50 before:to-transparent before:opacity-0 before:transition-opacity',
           'transition-all duration-300 ease-out',
           'hover:-translate-y-2 hover:border-blue-200 hover:shadow-xl hover:shadow-blue-100/50',
@@ -51,15 +51,15 @@ function ResourceCard({ item }: ResourceCardProps) {
       >
         <div className="relative z-10">
           {item.icon && (
-            <div className="mb-6 flex h-14 w-14 items-center justify-center rounded-xl bg-blue-50 group-hover:bg-blue-100 dark:bg-slate-800 dark:group-hover:bg-blue-900">
+            <div className="mb-6 flex h-14 w-14 items-center justify-center rounded-xl bg-blue-50 group-hover:bg-blue-100 dark:bg-zinc-800 dark:group-hover:bg-blue-900">
               <item.icon className="h-8 w-8 text-blue-600 transition-transform duration-300 group-hover:scale-110 dark:text-blue-400" />
             </div>
           )}
-          <p className="text-xl font-medium text-slate-900 transition-colors duration-200 dark:text-slate-100">
+          <p className="text-xl font-medium text-zinc-900 transition-colors duration-200 dark:text-zinc-100">
             {item.name}
           </p>
           {item.description && (
-            <p className="mt-3 text-slate-600 transition-colors duration-200 dark:text-slate-400">
+            <p className="mt-3 text-zinc-600 transition-colors duration-200 dark:text-zinc-400">
               {item.description}
             </p>
           )}

--- a/nx-dev/nx-dev/pages/404.tsx
+++ b/nx-dev/nx-dev/pages/404.tsx
@@ -45,7 +45,7 @@ export function FourOhFour(): JSX.Element {
                   src={illustrationUrl}
                   className="drop-shadow"
                 />
-                <h1 className="mt-4 text-4xl font-extrabold tracking-tight text-slate-900 sm:text-6xl lg:ml-8 dark:text-slate-100">
+                <h1 className="mt-4 text-4xl font-extrabold tracking-tight text-zinc-900 sm:text-6xl lg:ml-8 dark:text-zinc-100">
                   <span className="sr-only">404 - </span>Page not found!
                 </h1>
               </div>

--- a/nx-dev/nx-dev/pages/500.tsx
+++ b/nx-dev/nx-dev/pages/500.tsx
@@ -22,7 +22,7 @@ export default function FiveOhOh(): JSX.Element {
                   src="/images/illustrations/500.svg"
                   className="drop-shadow"
                 />
-                <h1 className="mt-4 text-4xl font-extrabold tracking-tight text-slate-900 sm:text-6xl lg:ml-8 dark:text-slate-100">
+                <h1 className="mt-4 text-4xl font-extrabold tracking-tight text-zinc-900 sm:text-6xl lg:ml-8 dark:text-zinc-100">
                   <div className="sr-only">500 - </div>Internal Server Error!
                 </h1>
               </div>

--- a/nx-dev/nx-dev/pages/_document.tsx
+++ b/nx-dev/nx-dev/pages/_document.tsx
@@ -43,7 +43,7 @@ export default function Document(): ReactElement {
           }}
         />
       </Head>
-      <body className="h-full bg-white text-slate-700 antialiased selection:bg-blue-500 selection:text-white dark:bg-slate-900 dark:text-slate-400 dark:selection:bg-sky-500">
+      <body className="h-full bg-white text-zinc-700 antialiased selection:bg-blue-500 selection:text-white dark:bg-zinc-900 dark:text-zinc-400 dark:selection:bg-blue-500">
         <Main />
         <NextScript />
       </body>

--- a/nx-dev/nx-dev/pages/changelog.tsx
+++ b/nx-dev/nx-dev/pages/changelog.tsx
@@ -225,7 +225,7 @@ export default function Changelog(props: ChangeLogProps): JSX.Element {
             <Breadcrumbs path={router.asPath} />
           </div>
           <header className="mt-0">
-            <h1 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-5xl dark:text-slate-100">
+            <h1 className="text-3xl font-semibold tracking-tight text-zinc-900 sm:text-5xl dark:text-zinc-100">
               Nx Changelog
             </h1>
             <p className="mt-4">
@@ -249,10 +249,10 @@ export default function Changelog(props: ChangeLogProps): JSX.Element {
                     'absolute left-0 top-0 hidden w-6 justify-center sm:flex'
                   )}
                 >
-                  <div className="w-px bg-slate-200 dark:bg-slate-700" />
+                  <div className="w-px bg-zinc-200 dark:bg-zinc-700" />
                 </div>
                 <div className="relative mt-1 hidden h-6 w-6 flex-none items-center justify-center sm:flex">
-                  <div className="h-2 w-2 rounded-full bg-slate-100 ring-1 ring-slate-300 dark:bg-slate-600 dark:ring-slate-500" />
+                  <div className="h-2 w-2 rounded-full bg-zinc-100 ring-1 ring-zinc-300 dark:bg-zinc-600 dark:ring-zinc-500" />
                 </div>
                 <div
                   id={changelog.version}
@@ -264,7 +264,7 @@ export default function Changelog(props: ChangeLogProps): JSX.Element {
                       href={`https://github.com/nrwl/nx/releases/tag/${changelog.version}`}
                       target="_blank"
                       rel="noreferrer"
-                      className="text-xl font-medium leading-5 text-slate-900 hover:underline dark:text-slate-100"
+                      className="text-xl font-medium leading-5 text-zinc-900 hover:underline dark:text-zinc-100"
                     >
                       <TagIcon
                         className="inline-flex h-4 w-4"
@@ -276,7 +276,7 @@ export default function Changelog(props: ChangeLogProps): JSX.Element {
                       <LinkIcon className="mb-1 ml-2 inline h-5 w-5 opacity-0 group-hover:opacity-100" />
                     </Link>
                   </p>
-                  <p className="py-0.5 text-xs leading-5 text-slate-400 dark:text-slate-500">
+                  <p className="py-0.5 text-xs leading-5 text-zinc-400 dark:text-zinc-500">
                     <time
                       dateTime={convertToDate(
                         changelog.date
@@ -288,7 +288,7 @@ export default function Changelog(props: ChangeLogProps): JSX.Element {
                 </div>
                 {/* CONTAINER */}
                 <div className="flex flex-grow flex-col gap-8 md:ml-12">
-                  <div className="prose prose-slate dark:prose-invert max-w-none">
+                  <div className="prose prose-zinc dark:prose-invert max-w-none">
                     {changelog.content}
                   </div>
                   {changelog.patches.length > 0 && (
@@ -299,7 +299,7 @@ export default function Changelog(props: ChangeLogProps): JSX.Element {
                           href={`https://github.com/nrwl/nx/releases/tag/${version}`}
                           target="_blank"
                           rel="noreferrer"
-                          className="inline-flex items-center rounded-md bg-slate-50 px-2 py-1 text-xs font-medium text-slate-600 ring-1 ring-inset ring-slate-500/10 hover:underline dark:bg-slate-600/30 dark:text-slate-500 dark:ring-slate-700"
+                          className="inline-flex items-center rounded-md bg-zinc-50 px-2 py-1 text-xs font-medium text-zinc-600 ring-1 ring-inset ring-zinc-500/10 hover:underline dark:bg-zinc-600/30 dark:text-zinc-500 dark:ring-zinc-700"
                         >
                           {version}
                         </a>

--- a/nx-dev/nx-dev/pages/community.tsx
+++ b/nx-dev/nx-dev/pages/community.tsx
@@ -60,7 +60,7 @@ export default function Community(): JSX.Element {
         <div className="w-full">
           <div
             id="connect-with-us"
-            className="py-18 bg-slate-50 dark:bg-slate-800/40"
+            className="py-18 bg-zinc-50 dark:bg-zinc-800/40"
           >
             <ConnectWithUs />
           </div>
@@ -81,7 +81,7 @@ export default function Community(): JSX.Element {
                   </SectionHeading>
                 </header>
                 <div className="mt-8 flex gap-16 font-normal">
-                  <p className="max-w-xl text-lg text-slate-700 dark:text-slate-400">
+                  <p className="max-w-xl text-lg text-zinc-700 dark:text-zinc-400">
                     These friendly people promote Nx in the community by
                     publishing content and sharing their expertise. They also
                     gather feedback from the community to help improve Nx.

--- a/nx-dev/nx-dev/pages/company.tsx
+++ b/nx-dev/nx-dev/pages/company.tsx
@@ -38,7 +38,7 @@ export function Company(): JSX.Element {
               as="h2"
               variant="subtitle"
               id="trusted"
-              className="scroll-mt-24 font-medium tracking-tight text-slate-950 sm:text-3xl dark:text-white"
+              className="scroll-mt-24 font-medium tracking-tight text-zinc-950 sm:text-3xl dark:text-white"
             >
               Trusted by leading OSS projects and Fortune 500 companies.
             </SectionHeading>

--- a/nx-dev/nx-dev/pages/customers.tsx
+++ b/nx-dev/nx-dev/pages/customers.tsx
@@ -18,7 +18,7 @@ export function Customers(): JSX.Element {
   const scrollCTAConfig: ButtonLinkProps[] = [
     {
       href: '/contact/sales',
-      variant: 'primary',
+      variant: 'contrast',
       size: 'small',
       target: '_blank',
       title: 'Book a demo',

--- a/nx-dev/nx-dev/pages/enterprise/index.tsx
+++ b/nx-dev/nx-dev/pages/enterprise/index.tsx
@@ -36,7 +36,7 @@ export function Enterprise(): ReactElement {
   const scrollCTAConfig: ButtonLinkProps[] = [
     {
       href: '/enterprise/trial',
-      variant: 'primary',
+      variant: 'contrast',
       size: 'small',
       title: 'Request a free trial',
       children: 'Request a free trial',

--- a/nx-dev/nx-dev/pages/index.tsx
+++ b/nx-dev/nx-dev/pages/index.tsx
@@ -43,7 +43,7 @@ export default function Index(): JSX.Element {
         <div className="mt-32 lg:mt-56">
           <Problem />
         </div>
-        <div className="bg-white/50 bg-[url(/images/home/wave.svg)] bg-cover bg-center py-32 bg-blend-soft-light lg:py-56 dark:bg-slate-900/50 dark:bg-[url(/images/home/wave-dark.svg)] dark:bg-blend-darken">
+        <div className="bg-white/50 bg-[url(/images/home/wave.svg)] bg-cover bg-center py-32 bg-blend-soft-light lg:py-56 dark:bg-zinc-900/50 dark:bg-[url(/images/home/wave-dark.svg)] dark:bg-blend-darken">
           <Solution />
         </div>
 

--- a/nx-dev/nx-dev/pages/solutions/engineering.tsx
+++ b/nx-dev/nx-dev/pages/solutions/engineering.tsx
@@ -21,7 +21,7 @@ export function EnterpriseSolutionsEngineering(): ReactElement {
   const scrollCTAConfig: ButtonLinkProps[] = [
     {
       href: '/contact/sales',
-      variant: 'primary',
+      variant: 'contrast',
       size: 'small',
       title: 'Talk to our team',
       children: 'Talk to our team',

--- a/nx-dev/nx-dev/pages/solutions/leadership.tsx
+++ b/nx-dev/nx-dev/pages/solutions/leadership.tsx
@@ -22,7 +22,7 @@ export function EnterpriseSolutionsLeadership(): ReactElement {
   const scrollCTAConfig: ButtonLinkProps[] = [
     {
       href: '/contact/sales',
-      variant: 'primary',
+      variant: 'contrast',
       size: 'small',
       title: 'Talk to our team',
       children: 'Talk to our team',

--- a/nx-dev/nx-dev/pages/solutions/management.tsx
+++ b/nx-dev/nx-dev/pages/solutions/management.tsx
@@ -22,7 +22,7 @@ export function EnterpriseSolutionsManagement(): ReactElement {
   const scrollCTAConfig: ButtonLinkProps[] = [
     {
       href: '/contact/sales',
-      variant: 'primary',
+      variant: 'contrast',
       size: 'small',
       title: 'Talk to our team',
       children: 'Talk to our team',

--- a/nx-dev/nx-dev/pages/solutions/platform.tsx
+++ b/nx-dev/nx-dev/pages/solutions/platform.tsx
@@ -22,7 +22,7 @@ export function EnterpriseSolutionsPlatform(): ReactElement {
   const scrollCTAConfig: ButtonLinkProps[] = [
     {
       href: '/contact/sales',
-      variant: 'primary',
+      variant: 'contrast',
       size: 'small',
       title: 'Talk to our team',
       children: 'Talk to our team',

--- a/nx-dev/nx-dev/pages/whitepaper-fast-ci.tsx
+++ b/nx-dev/nx-dev/pages/whitepaper-fast-ci.tsx
@@ -104,7 +104,7 @@ export function WhitePaperFastCI(): ReactElement {
                     </ButtonLink>
                   </div>
 
-                  <figure className="mt-16 rounded-lg bg-slate-100 p-4 pl-8 dark:bg-slate-800">
+                  <figure className="mt-16 rounded-lg bg-zinc-100 p-4 pl-8 dark:bg-zinc-800">
                     <blockquote className="text-base/7">
                       <p>
                         “The decision to jump to Nx Cloud was really something
@@ -124,13 +124,13 @@ export function WhitePaperFastCI(): ReactElement {
                         <div className="font-semibold">
                           Justin Schwartzenberger
                         </div>
-                        <div className="text-slate-500">
+                        <div className="text-zinc-500">
                           Principal Software Engineer, SiriusXM
                         </div>
                       </div>
                       <SiriusxmAlternateIcon
                         aria-hidden="true"
-                        className="ml-auto size-10 rounded text-[#0000EB] dark:bg-slate-200"
+                        className="ml-auto size-10 rounded text-[#0000EB] dark:bg-zinc-200"
                       />
                     </figcaption>
                   </figure>
@@ -156,7 +156,7 @@ export function WhitePaperFastCI(): ReactElement {
                     />
                   </div>
                 </section>
-                <section className="flex-1 rounded-xl border border-slate-200 bg-white p-8 md:self-start dark:border-slate-800/40">
+                <section className="flex-1 rounded-xl border border-zinc-200 bg-white p-8 md:self-start dark:border-zinc-800/40">
                   <HubspotForm
                     region="na1"
                     portalId="2757427"

--- a/nx-dev/ui-ai-landing-page/src/lib/call-to-action.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/call-to-action.tsx
@@ -26,7 +26,7 @@ export function CallToAction(): ReactElement {
         <svg
           x="50%"
           y={0}
-          className="overflow-visible fill-slate-200/20 dark:fill-slate-800/20"
+          className="overflow-visible fill-zinc-200/20 dark:fill-zinc-800/20"
         >
           <path
             d="M-200 0h201v201h-201Z M600 0h201v201h-201Z M-400 600h201v201h-201Z M200 800h201v201h-201Z"
@@ -57,7 +57,7 @@ export function CallToAction(): ReactElement {
 
       {/* Content */}
       <div className="mx-auto max-w-3xl text-center">
-        <h2 className="text-3xl font-medium tracking-tight text-slate-950 sm:text-5xl dark:text-white">
+        <h2 className="text-3xl font-medium tracking-tight text-zinc-950 sm:text-5xl dark:text-white">
           Transform your AI assistant in minutes
         </h2>
         <div className="mt-10 flex items-center justify-center gap-x-6">
@@ -65,7 +65,7 @@ export function CallToAction(): ReactElement {
             href={'/docs/features/enhance-ai#setting-up-nx-mcp'}
             title="Get started with Nx AI integration"
             prefetch={false}
-            className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
+            className="rounded-md bg-zinc-950 px-3.5 py-2.5 text-sm font-semibold text-zinc-100 shadow-sm hover:bg-zinc-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-100"
           >
             Start here{' '}
             <span

--- a/nx-dev/ui-ai-landing-page/src/lib/features.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/features.tsx
@@ -12,7 +12,7 @@ export function Features(): ReactElement {
             Make your AI assistant workspace-aware
           </SectionHeading>
 
-          <p className="mt-4 text-lg text-slate-500 dark:text-slate-400">
+          <p className="mt-4 text-lg text-zinc-500 dark:text-zinc-400">
             Transform your LLM from context-blind to architecture-aware with
             complete workspace intelligence.
           </p>
@@ -276,8 +276,8 @@ function FeatureCard({
     <a href={href} className="block h-full transform-gpu">
       <div
         className={cx(
-          'group relative h-full w-full overflow-hidden rounded-lg border border-slate-200 bg-white p-6',
-          'dark:border-slate-800 dark:bg-slate-900 dark:hover:border-blue-900 dark:hover:shadow-blue-900/20',
+          'group relative h-full w-full overflow-hidden rounded-lg border border-zinc-200 bg-white p-6',
+          'dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-blue-900 dark:hover:shadow-blue-900/20',
           'before:absolute before:inset-0 before:z-0 before:bg-gradient-to-br before:from-blue-50 before:to-transparent before:opacity-0 before:transition-opacity',
           'transition-all duration-300 ease-out',
           'hover:-translate-y-2 hover:border-blue-200 hover:shadow-xl hover:shadow-blue-100/50',
@@ -285,11 +285,11 @@ function FeatureCard({
         )}
       >
         <div className="relative z-10">
-          <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-50 text-blue-600 transition-transform duration-300 group-hover:scale-110 dark:bg-slate-800 dark:text-blue-400 dark:group-hover:bg-blue-900">
+          <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-50 text-blue-600 transition-transform duration-300 group-hover:scale-110 dark:bg-zinc-800 dark:text-blue-400 dark:group-hover:bg-blue-900">
             {icon}
           </div>
           <h3 className="mb-2 text-lg font-medium">{title}</h3>
-          <p className="text-slate-500 dark:text-slate-400">{description}</p>
+          <p className="text-zinc-500 dark:text-zinc-400">{description}</p>
         </div>
       </div>
     </a>

--- a/nx-dev/ui-ai-landing-page/src/lib/hero.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/hero.tsx
@@ -197,7 +197,7 @@ export function Hero(): JSX.Element {
             <div className="relative">
               <div className="absolute bottom-0 start-0 -z-10 -translate-x-14 translate-y-10">
                 <svg
-                  className="h-auto max-w-40 text-slate-200 dark:text-slate-800"
+                  className="h-auto max-w-40 text-zinc-200 dark:text-zinc-800"
                   width="696"
                   height="653"
                   viewBox="0 0 696 653"
@@ -370,8 +370,7 @@ export function Hero(): JSX.Element {
                       {
                         'bg-blue-50 ring-2 ring-blue-500 dark:bg-blue-950/50 dark:ring-blue-400':
                           isSelected,
-                        'hover:bg-slate-100 dark:hover:bg-slate-800':
-                          !isSelected,
+                        'hover:bg-zinc-100 dark:hover:bg-zinc-800': !isSelected,
                       }
                     )}
                   >
@@ -398,7 +397,7 @@ export function Hero(): JSX.Element {
                           'relative text-base font-medium leading-6 transition-colors',
                           isSelected
                             ? 'text-blue-900 dark:text-blue-100'
-                            : 'text-slate-900 group-hover:text-blue-600 dark:text-slate-100 dark:group-hover:text-blue-400'
+                            : 'text-zinc-900 group-hover:text-blue-600 dark:text-zinc-100 dark:group-hover:text-blue-400'
                         )}
                       >
                         {feature.title}
@@ -420,7 +419,7 @@ export function Hero(): JSX.Element {
                           'mt-2 text-sm leading-6 transition-colors',
                           isSelected
                             ? 'text-blue-700 dark:text-blue-200'
-                            : 'text-slate-600 dark:text-slate-400'
+                            : 'text-zinc-600 dark:text-zinc-400'
                         )}
                       >
                         {feature.description}
@@ -439,7 +438,7 @@ export function Hero(): JSX.Element {
             >
               <ButtonLink
                 href={'/docs/features/enhance-ai#setting-up-nx-mcp'}
-                variant="primary"
+                variant="contrast"
                 size="default"
                 title="Enhance your AI assistant"
                 onClick={() =>

--- a/nx-dev/ui-ai-landing-page/src/lib/new/ai-hero.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/new/ai-hero.tsx
@@ -27,7 +27,7 @@ export function AiHero(): ReactElement {
             <ButtonLink
               href={'/docs/getting-started/ai-setup'}
               title="Nx AI Integration"
-              variant="primary"
+              variant="contrast"
               size="small"
             >
               Integrate Nx with your Coding Assistant
@@ -36,7 +36,7 @@ export function AiHero(): ReactElement {
           <div className="mt-8 flex flex-wrap items-center gap-4">
             <a
               href="#while-coding"
-              className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-2 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+              className="inline-flex items-center gap-1.5 rounded-full bg-zinc-100 px-2 py-1.5 text-xs font-medium text-zinc-700 hover:bg-zinc-200 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
               aria-label="Jump to While Coding section"
             >
               <CodeBracketIcon aria-hidden="true" className="size-4 shrink-0" />
@@ -44,7 +44,7 @@ export function AiHero(): ReactElement {
             </a>
             <a
               href="#while-running-ci"
-              className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-2 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+              className="inline-flex items-center gap-1.5 rounded-full bg-zinc-100 px-2 py-1.5 text-xs font-medium text-zinc-700 hover:bg-zinc-200 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
               aria-label="Jump to While Running CI section"
             >
               <ServerStackIcon aria-hidden="true" className="size-4 shrink-0" />
@@ -52,7 +52,7 @@ export function AiHero(): ReactElement {
             </a>
             <a
               href="#while-scaling-your-organization"
-              className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-2 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+              className="inline-flex items-center gap-1.5 rounded-full bg-zinc-100 px-2 py-1.5 text-xs font-medium text-zinc-700 hover:bg-zinc-200 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
               aria-label="Jump to Scaling Your Organization section"
             >
               <UserGroupIcon aria-hidden="true" className="size-4 shrink-0" />

--- a/nx-dev/ui-ai-landing-page/src/lib/new/feature-card.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/new/feature-card.tsx
@@ -50,7 +50,7 @@ export function FeatureCard({
   return (
     <div key={id} className="flex flex-col">
       <dt className="text-base/7 font-semibold">
-        <div className="relative mb-6 aspect-video max-h-52 w-full overflow-hidden rounded-xl bg-slate-200 dark:bg-slate-700/60">
+        <div className="relative mb-6 aspect-video max-h-52 w-full overflow-hidden rounded-xl bg-zinc-200 dark:bg-zinc-700/60">
           <Image
             src={imageUrl}
             alt={`Thumbnail for ${title}`}

--- a/nx-dev/ui-ai-landing-page/src/lib/new/nx-power-ai.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/new/nx-power-ai.tsx
@@ -32,7 +32,7 @@ export function NxPowerAi({
           <li className="relative isolate flex aspect-square h-20 items-center justify-center">
             <HexagonShape
               aria-hidden="true"
-              className="absolute inset-0 z-0 text-slate-50/90 drop-shadow-sm dark:text-white/5"
+              className="absolute inset-0 z-0 text-zinc-50/90 drop-shadow-sm dark:text-white/5"
             />
           </li>
           <li className="relative isolate flex aspect-square h-20 items-center justify-center">
@@ -48,7 +48,7 @@ export function NxPowerAi({
           <li className="relative isolate flex aspect-square h-20 items-center justify-center">
             <HexagonShape
               aria-hidden="true"
-              className="absolute inset-0 z-0 text-slate-50/90 drop-shadow-sm dark:text-white/5"
+              className="absolute inset-0 z-0 text-zinc-50/90 drop-shadow-sm dark:text-white/5"
             />
           </li>
           <li className="invisible aspect-square" />
@@ -57,7 +57,7 @@ export function NxPowerAi({
           <li className="flex aspect-square translate-x-1/2 items-center justify-center">
             <HexagonShape
               aria-hidden="true"
-              className="absolute inset-0 z-0 text-slate-50/90 drop-shadow-sm dark:text-white/5"
+              className="absolute inset-0 z-0 text-zinc-50/90 drop-shadow-sm dark:text-white/5"
             />
           </li>
           <li className="relative isolate flex aspect-square h-20 translate-x-1/2 items-center justify-center">
@@ -83,7 +83,7 @@ export function NxPowerAi({
           <li className="flex aspect-square translate-x-1/2 items-center justify-center">
             <HexagonShape
               aria-hidden="true"
-              className="absolute inset-0 z-0 text-slate-50/90 drop-shadow-sm dark:text-white/5"
+              className="absolute inset-0 z-0 text-zinc-50/90 drop-shadow-sm dark:text-white/5"
             />
           </li>
           <li className="invisible"></li>
@@ -93,7 +93,7 @@ export function NxPowerAi({
           <li className="relative isolate flex aspect-square h-20 items-center justify-center">
             <HexagonShape
               aria-hidden="true"
-              className="absolute inset-0 z-0 text-slate-50/90 drop-shadow-sm dark:text-white/5"
+              className="absolute inset-0 z-0 text-zinc-50/90 drop-shadow-sm dark:text-white/5"
             />
           </li>
           <li className="relative isolate flex aspect-square h-20 items-center justify-center">
@@ -109,7 +109,7 @@ export function NxPowerAi({
           <li className="relative isolate flex aspect-square h-20 items-center justify-center">
             <HexagonShape
               aria-hidden="true"
-              className="absolute inset-0 z-0 text-slate-50/90 drop-shadow-sm dark:text-white/5"
+              className="absolute inset-0 z-0 text-zinc-50/90 drop-shadow-sm dark:text-white/5"
             />
           </li>
           <li className="invisible" />
@@ -119,20 +119,20 @@ export function NxPowerAi({
       {/* Steps List */}
       <div className="relative mt-12 space-y-2">
         {/* Active Step */}
-        <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 shadow-sm backdrop-blur-sm dark:border-slate-800/40 dark:bg-slate-800/60">
+        <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-4 shadow-sm backdrop-blur-sm dark:border-zinc-800/40 dark:bg-zinc-800/60">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-3">
-              <div className="flex size-5 items-center justify-center rounded-full border border-white/25 bg-gradient-to-br from-slate-200 to-slate-300 dark:border-slate-900 dark:from-slate-700 dark:to-slate-800">
-                <div className="size-2 rounded-full bg-white dark:bg-slate-900" />
+              <div className="flex size-5 items-center justify-center rounded-full border border-white/25 bg-gradient-to-br from-zinc-200 to-zinc-300 dark:border-zinc-900 dark:from-zinc-700 dark:to-zinc-800">
+                <div className="size-2 rounded-full bg-white dark:bg-zinc-900" />
               </div>
               <div className="flex-1">
-                <p className="font-mono text-xs leading-tight text-slate-900 dark:text-slate-100">
+                <p className="font-mono text-xs leading-tight text-zinc-900 dark:text-zinc-100">
                   Generating a fix for test "ui-profile:test:save-preferences"
                 </p>
               </div>
             </div>
             <div className="flex items-center space-x-2">
-              <span className="text-xs text-slate-600 dark:text-slate-400">
+              <span className="text-xs text-zinc-600 dark:text-zinc-400">
                 Working...
               </span>
               <span className="relative flex size-1.5">
@@ -144,20 +144,20 @@ export function NxPowerAi({
         </div>
 
         {/* Completed Step */}
-        <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 opacity-50 shadow-sm backdrop-blur-sm dark:border-slate-800/40 dark:bg-slate-800/60">
+        <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-4 opacity-50 shadow-sm backdrop-blur-sm dark:border-zinc-800/40 dark:bg-zinc-800/60">
           <div className="flex items-center justify-between gap-4">
             <div className="flex grow items-center space-x-3">
-              <div className="flex size-5 items-center justify-center rounded-full border border-white/25 bg-gradient-to-br from-slate-200 to-slate-300 dark:border-slate-900 dark:from-slate-700 dark:to-slate-800">
-                <div className="size-2 rounded-full bg-white dark:bg-slate-900" />
+              <div className="flex size-5 items-center justify-center rounded-full border border-white/25 bg-gradient-to-br from-zinc-200 to-zinc-300 dark:border-zinc-900 dark:from-zinc-700 dark:to-zinc-800">
+                <div className="size-2 rounded-full bg-white dark:bg-zinc-900" />
               </div>
 
               <div className="w-full grow space-y-1">
-                <div className="h-1 w-8 rounded-sm bg-slate-800/15 dark:bg-slate-200/35" />
-                <div className="h-1 w-1/2 rounded-sm bg-slate-500/10 dark:bg-slate-400/35" />
+                <div className="h-1 w-8 rounded-sm bg-zinc-800/15 dark:bg-zinc-200/35" />
+                <div className="h-1 w-1/2 rounded-sm bg-zinc-500/10 dark:bg-zinc-400/35" />
               </div>
             </div>
             <div className="flex items-center space-x-2">
-              <span className="text-xs text-slate-600 dark:text-slate-300">
+              <span className="text-xs text-zinc-600 dark:text-zinc-300">
                 Done
               </span>
               <div className="size-1.5 rounded-full bg-green-500 shadow-sm" />
@@ -166,13 +166,13 @@ export function NxPowerAi({
         </div>
 
         {/* Pending Step */}
-        <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 opacity-40 shadow-sm backdrop-blur-sm dark:border-slate-800/40 dark:bg-slate-800/60">
+        <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-4 opacity-40 shadow-sm backdrop-blur-sm dark:border-zinc-800/40 dark:bg-zinc-800/60">
           <div className="flex items-center space-x-3">
-            <div className="flex size-5 items-center justify-center rounded-full border border-white/25 bg-gradient-to-br from-slate-200 to-slate-300 dark:border-slate-900 dark:from-slate-700 dark:to-slate-800">
-              <div className="size-2 rounded-full bg-white dark:bg-slate-900" />
+            <div className="flex size-5 items-center justify-center rounded-full border border-white/25 bg-gradient-to-br from-zinc-200 to-zinc-300 dark:border-zinc-900 dark:from-zinc-700 dark:to-zinc-800">
+              <div className="size-2 rounded-full bg-white dark:bg-zinc-900" />
             </div>
             <div className="flex-1">
-              <div className="h-1 w-16 rounded-sm bg-slate-400/20" />
+              <div className="h-1 w-16 rounded-sm bg-zinc-400/20" />
             </div>
           </div>
         </div>

--- a/nx-dev/ui-ai-landing-page/src/lib/new/play-button.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/new/play-button.tsx
@@ -57,7 +57,7 @@ export function PlayButton({
         initial="initial"
         whileHover="hover"
         variants={parent}
-        className="relative isolate flex size-20 cursor-pointer items-center justify-center gap-6 rounded-full border-2 border-slate-100 bg-white/10 p-6 text-white antialiased backdrop-blur-xl"
+        className="relative isolate flex size-20 cursor-pointer items-center justify-center gap-6 rounded-full border-2 border-zinc-100 bg-white/10 p-6 text-white antialiased backdrop-blur-xl"
       >
         <PlayIcon aria-hidden="true" className="absolute left-6 top-6 size-8" />
         <motion.div variants={child} className="absolute left-20 top-4 w-48">

--- a/nx-dev/ui-ai-landing-page/src/lib/new/while-coding.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/new/while-coding.tsx
@@ -100,7 +100,7 @@ export function WhileCoding(): ReactElement {
       className="mx-auto max-w-7xl scroll-mt-32 px-6 lg:px-8"
     >
       <div className="max-w-2xl">
-        <div className="h-8 w-36 border-t-2 border-blue-500 dark:border-sky-500" />
+        <div className="h-8 w-36 border-t-2 border-blue-500 dark:border-blue-500" />
         <SectionHeading as="h2" variant="title" id="while-coding-title">
           While Coding
         </SectionHeading>

--- a/nx-dev/ui-ai-landing-page/src/lib/new/while-running-ci.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/new/while-running-ci.tsx
@@ -65,7 +65,7 @@ export function WhileRunningCi(): ReactElement {
   const [openVideoUrl, setOpenVideoUrl] = useState<string | null>(null);
 
   return (
-    <div className="relative bg-slate-50 py-32 dark:bg-slate-800">
+    <div className="relative bg-zinc-50 py-32 dark:bg-zinc-800">
       <div
         id="while-running-ci"
         className="mx-auto max-w-7xl scroll-mt-32 px-6 lg:px-8"

--- a/nx-dev/ui-ai-landing-page/src/lib/problem-statement.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/problem-statement.tsx
@@ -15,7 +15,7 @@ export function ProblemStatement({
             Your AI assistant is blind to your workspace architecture
           </SectionHeading>
 
-          <p className="mt-4 text-lg text-slate-500 dark:text-slate-400">
+          <p className="mt-4 text-lg text-zinc-500 dark:text-zinc-400">
             As monorepos scale, AI tools become progressively less effective
             without true workspace understanding.
           </p>
@@ -24,7 +24,7 @@ export function ProblemStatement({
         <div className="grid grid-cols-1 gap-x-8 gap-y-4 md:grid-cols-2">
           {/* Left Column - Problems */}
           <div>
-            <h3 className="mb-3 text-lg font-bold text-slate-900 dark:text-white">
+            <h3 className="mb-3 text-lg font-bold text-zinc-900 dark:text-white">
               The challenges
             </h3>
 
@@ -50,10 +50,10 @@ export function ProblemStatement({
                   </svg>
                 </div>
                 <div>
-                  <h4 className="mb-1 text-sm font-medium leading-tight text-slate-900 dark:text-slate-100">
+                  <h4 className="mb-1 text-sm font-medium leading-tight text-zinc-900 dark:text-zinc-100">
                     Limited context
                   </h4>
-                  <p className="text-sm text-slate-600 dark:text-slate-300">
+                  <p className="text-sm text-zinc-600 dark:text-zinc-300">
                     LLMs only see individual files, missing the architectural
                     relationships in large monorepos.
                   </p>
@@ -77,10 +77,10 @@ export function ProblemStatement({
                   </svg>
                 </div>
                 <div>
-                  <h4 className="mb-1 text-sm font-medium leading-tight text-slate-900 dark:text-slate-100">
+                  <h4 className="mb-1 text-sm font-medium leading-tight text-zinc-900 dark:text-zinc-100">
                     Inconsistent output
                   </h4>
-                  <p className="text-sm text-slate-600 dark:text-slate-300">
+                  <p className="text-sm text-zinc-600 dark:text-zinc-300">
                     AI generates code that doesn't follow team standards or may
                     break components it can't see.
                   </p>
@@ -106,10 +106,10 @@ export function ProblemStatement({
                   </svg>
                 </div>
                 <div>
-                  <h4 className="mb-1 text-sm font-medium leading-tight text-slate-900 dark:text-slate-100">
+                  <h4 className="mb-1 text-sm font-medium leading-tight text-zinc-900 dark:text-zinc-100">
                     No workspace awareness
                   </h4>
-                  <p className="text-sm text-slate-600 dark:text-slate-300">
+                  <p className="text-sm text-zinc-600 dark:text-zinc-300">
                     AI can't understand project dependencies, ownership, or
                     cross-project integration points.
                   </p>
@@ -136,10 +136,10 @@ export function ProblemStatement({
                   </svg>
                 </div>
                 <div>
-                  <h4 className="mb-1 text-sm font-medium leading-tight text-slate-900 dark:text-slate-100">
+                  <h4 className="mb-1 text-sm font-medium leading-tight text-zinc-900 dark:text-zinc-100">
                     Manual context burden
                   </h4>
-                  <p className="text-sm text-slate-600 dark:text-slate-300">
+                  <p className="text-sm text-zinc-600 dark:text-zinc-300">
                     Developers must repeatedly provide the same contextual
                     information about project structure.
                   </p>
@@ -150,7 +150,7 @@ export function ProblemStatement({
 
           {/* Right Column - Solutions */}
           <div>
-            <h3 className="mb-3 text-lg font-bold text-slate-900 dark:text-white">
+            <h3 className="mb-3 text-lg font-bold text-zinc-900 dark:text-white">
               How Nx helps
             </h3>
 
@@ -176,10 +176,10 @@ export function ProblemStatement({
                   </svg>
                 </div>
                 <div>
-                  <h4 className="mb-1 text-sm font-medium leading-tight text-slate-900 dark:text-slate-100">
+                  <h4 className="mb-1 text-sm font-medium leading-tight text-zinc-900 dark:text-zinc-100">
                     Architectural awareness
                   </h4>
-                  <p className="text-sm text-slate-600 dark:text-slate-300">
+                  <p className="text-sm text-zinc-600 dark:text-zinc-300">
                     Move from file-level to workspace-level understanding with
                     rich project relationship metadata.
                   </p>
@@ -203,10 +203,10 @@ export function ProblemStatement({
                   </svg>
                 </div>
                 <div>
-                  <h4 className="mb-1 text-sm font-medium leading-tight text-slate-900 dark:text-slate-100">
+                  <h4 className="mb-1 text-sm font-medium leading-tight text-zinc-900 dark:text-zinc-100">
                     Predictable + intelligent
                   </h4>
-                  <p className="text-sm text-slate-600 dark:text-slate-300">
+                  <p className="text-sm text-zinc-600 dark:text-zinc-300">
                     Combine consistent generators with AI customization that
                     follows team standards.
                   </p>
@@ -241,10 +241,10 @@ export function ProblemStatement({
                   </svg>
                 </div>
                 <div>
-                  <h4 className="mb-1 text-sm font-medium leading-tight text-slate-900 dark:text-slate-100">
+                  <h4 className="mb-1 text-sm font-medium leading-tight text-zinc-900 dark:text-zinc-100">
                     Integrated workflows
                   </h4>
-                  <p className="text-sm text-slate-600 dark:text-slate-300">
+                  <p className="text-sm text-zinc-600 dark:text-zinc-300">
                     Connect editor, terminal, CI, and AI for truly context-aware
                     assistance across your entire workspace.
                   </p>
@@ -290,10 +290,10 @@ export function ProblemStatement({
                   </svg>
                 </div>
                 <div>
-                  <h4 className="mb-1 text-sm font-medium leading-tight text-slate-900 dark:text-slate-100">
+                  <h4 className="mb-1 text-sm font-medium leading-tight text-zinc-900 dark:text-zinc-100">
                     Up-to-Date Documentation
                   </h4>
-                  <p className="text-sm text-slate-600 dark:text-slate-300">
+                  <p className="text-sm text-zinc-600 dark:text-zinc-300">
                     Access current docs and best practices for accurate,
                     workspace-specific guidance.
                   </p>

--- a/nx-dev/ui-ai-landing-page/src/lib/technical-implementation.tsx
+++ b/nx-dev/ui-ai-landing-page/src/lib/technical-implementation.tsx
@@ -13,7 +13,7 @@ export function TechnicalImplementation({
 }: TechnicalImplementationProps): JSX.Element {
   return (
     <section
-      className={`bg-gradient-to-b from-white to-slate-50 py-12 dark:from-slate-900 dark:to-slate-800 ${
+      className={`bg-gradient-to-b from-white to-zinc-50 py-12 dark:from-zinc-900 dark:to-zinc-800 ${
         className || ''
       }`}
     >
@@ -21,7 +21,7 @@ export function TechnicalImplementation({
         <div className="mb-12 grid grid-cols-1 gap-8 md:grid-cols-2 lg:gap-12">
           {/* Left Side - Title and How It Works */}
           <div className="flex flex-col justify-center">
-            <h2 className="mb-8 text-left text-3xl font-bold text-slate-900 md:text-4xl dark:text-white">
+            <h2 className="mb-8 text-left text-3xl font-bold text-zinc-900 md:text-4xl dark:text-white">
               Powered by Nx workspace intelligence
             </h2>
 
@@ -31,7 +31,7 @@ export function TechnicalImplementation({
                   <span className="text-lg font-semibold">1</span>
                 </div>
                 <div className="flex-1 pt-1">
-                  <p className="text-slate-600 dark:text-slate-300">
+                  <p className="text-zinc-600 dark:text-zinc-300">
                     Nx daemon runs in the background, maintaining up-to-date
                     workspace metadata
                   </p>
@@ -43,7 +43,7 @@ export function TechnicalImplementation({
                   <span className="text-lg font-semibold">2</span>
                 </div>
                 <div className="flex-1 pt-1">
-                  <p className="text-slate-600 dark:text-slate-300">
+                  <p className="text-zinc-600 dark:text-zinc-300">
                     This rich contextual data is processed and optimized for AI
                     consumption
                   </p>
@@ -55,7 +55,7 @@ export function TechnicalImplementation({
                   <span className="text-lg font-semibold">3</span>
                 </div>
                 <div className="flex-1 pt-1">
-                  <p className="text-slate-600 dark:text-slate-300">
+                  <p className="text-zinc-600 dark:text-zinc-300">
                     Nx Console exposes the data to your AI assistant via an MCP
                   </p>
                 </div>
@@ -82,16 +82,16 @@ export function TechnicalImplementation({
           {/* Flow diagram with connected boxes */}
           <div className="grid grid-cols-1 gap-6 md:grid-cols-3 lg:gap-8">
             {/* Nx Console Box */}
-            <div className="relative rounded-xl border border-slate-200 bg-slate-50 p-6 shadow-md dark:border-slate-700 dark:bg-slate-800/50">
+            <div className="relative rounded-xl border border-zinc-200 bg-zinc-50 p-6 shadow-md dark:border-zinc-700 dark:bg-zinc-800/50">
               <div className="mb-4 flex items-center">
                 <div className="mr-4 flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white">
                   <NxConsoleSmallIcon className="h-24 w-24" />
                 </div>
-                <h4 className="text-xl font-bold text-slate-900 dark:text-white">
+                <h4 className="text-xl font-bold text-zinc-900 dark:text-white">
                   Start with Nx Console
                 </h4>
               </div>
-              <p className="text-slate-600 dark:text-slate-300">
+              <p className="text-zinc-600 dark:text-zinc-300">
                 Install the Nx Console Extension, available for VSCode, Cursor,
                 and IntelliJ.
               </p>
@@ -132,16 +132,16 @@ export function TechnicalImplementation({
             </div>
 
             {/* MCP Box */}
-            <div className="relative rounded-xl border border-slate-200 bg-slate-50 p-6 shadow-md dark:border-slate-700 dark:bg-slate-800/50">
+            <div className="relative rounded-xl border border-zinc-200 bg-zinc-50 p-6 shadow-md dark:border-zinc-700 dark:bg-zinc-800/50">
               <div className="mb-4 flex items-center">
                 <div className="mr-4 flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full bg-indigo-500 text-white">
                   <ModelContextProtocolIcon className="h-8 w-8" />
                 </div>
-                <h4 className="text-xl font-bold text-slate-900 dark:text-white">
+                <h4 className="text-xl font-bold text-zinc-900 dark:text-white">
                   Nx MCP
                 </h4>
               </div>
-              <p className="text-slate-600 dark:text-slate-300">
+              <p className="text-zinc-600 dark:text-zinc-300">
                 Nx Console automatically registers its MCP server or you can
                 configure it in any MCP compatible client.
               </p>
@@ -182,7 +182,7 @@ export function TechnicalImplementation({
             </div>
 
             {/* Enhanced LLM Workflow Box */}
-            <div className="rounded-xl border border-slate-200 bg-slate-50 p-6 shadow-md dark:border-slate-700 dark:bg-slate-800/50">
+            <div className="rounded-xl border border-zinc-200 bg-zinc-50 p-6 shadow-md dark:border-zinc-700 dark:bg-zinc-800/50">
               <div className="mb-4 flex items-center">
                 <div className="mr-4 flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-full bg-blue-600 text-white">
                   <svg
@@ -200,11 +200,11 @@ export function TechnicalImplementation({
                     />
                   </svg>
                 </div>
-                <h4 className="text-xl font-bold text-slate-900 dark:text-white">
+                <h4 className="text-xl font-bold text-zinc-900 dark:text-white">
                   Enhanced LLM workflow
                 </h4>
               </div>
-              <p className="text-slate-600 dark:text-slate-300">
+              <p className="text-zinc-600 dark:text-zinc-300">
                 Your existing AI tools understand your workspace architecture
                 without changing your development habits.
               </p>

--- a/nx-dev/ui-blog/src/lib/author-detail.tsx
+++ b/nx-dev/ui-blog/src/lib/author-detail.tsx
@@ -8,7 +8,7 @@ interface AuthorDetailProps {
 
 export default function AuthorDetail({ author }: AuthorDetailProps) {
   return (
-    <div className="space-between invisible absolute left-[65%] right-0 z-30 mt-2 flex w-60 translate-x-[-50%] items-center gap-4 rounded bg-slate-50 p-4 text-sm text-slate-700 opacity-0 shadow-lg ring-1 ring-slate-200 transition-all delay-75 duration-300 ease-in-out md:group-hover:visible md:group-hover:opacity-100 dark:bg-slate-900 dark:text-slate-400 dark:ring-slate-800">
+    <div className="space-between invisible absolute left-[65%] right-0 z-30 mt-2 flex w-60 translate-x-[-50%] items-center gap-4 rounded bg-zinc-50 p-4 text-sm text-zinc-700 opacity-0 shadow-lg ring-1 ring-zinc-200 transition-all delay-75 duration-300 ease-in-out md:group-hover:visible md:group-hover:opacity-100 dark:bg-zinc-900 dark:text-zinc-400 dark:ring-zinc-800">
       <span>
         <Image
           alt={author.name}
@@ -18,7 +18,7 @@ export default function AuthorDetail({ author }: AuthorDetailProps) {
           height="40"
           decoding="async"
           src={`/documentation/blog/images/authors/${author.name}.jpeg`}
-          className="rounded-full ring-1 ring-white grayscale dark:ring-slate-900"
+          className="rounded-full ring-1 ring-white grayscale dark:ring-zinc-900"
         />
       </span>
       <span className="text-balance">{author.name}</span>

--- a/nx-dev/ui-blog/src/lib/authors.tsx
+++ b/nx-dev/ui-blog/src/lib/authors.tsx
@@ -21,7 +21,7 @@ export function BlogAuthors({
             height="48"
             decoding="async"
             src={`/documentation/blog/images/authors/${author.name}.jpeg`}
-            className="relative inline-block h-6 w-6 rounded-full ring-1 ring-white grayscale dark:ring-slate-900"
+            className="relative inline-block h-6 w-6 rounded-full ring-1 ring-white grayscale dark:ring-zinc-900"
           />
           {showAuthorDetails && <AuthorDetail author={author} />}
         </div>

--- a/nx-dev/ui-blog/src/lib/blog-container.tsx
+++ b/nx-dev/ui-blog/src/lib/blog-container.tsx
@@ -77,7 +77,7 @@ export function BlogContainer({ blogPosts, tags }: BlogContainerProps) {
           <header className="mb-8 mt-20">
             <h1
               id="blog-title"
-              className="text-xl font-semibold tracking-tight text-slate-900 md:text-2xl dark:text-slate-100"
+              className="text-xl font-semibold tracking-tight text-zinc-900 md:text-2xl dark:text-zinc-100"
             >
               {selectedFilterHeading}
             </h1>
@@ -100,7 +100,7 @@ export function BlogContainer({ blogPosts, tags }: BlogContainerProps) {
         <FeaturedBlogs blogs={firstFiveBlogs} />
         {!!remainingBlogs.length && (
           <>
-            <div className="mx-auto mb-8 mt-20 flex items-center justify-between border-b-2 border-slate-300 pb-3 text-sm dark:border-slate-700">
+            <div className="mx-auto mb-8 mt-20 flex items-center justify-between border-b-2 border-zinc-300 pb-3 text-sm dark:border-zinc-700">
               <h2 className="font-semibold">All blogs</h2>
               <div className="flex gap-2">
                 <Link
@@ -108,14 +108,14 @@ export function BlogContainer({ blogPosts, tags }: BlogContainerProps) {
                   aria-label="RSS feed"
                   prefetch={false}
                 >
-                  <RssIcon className="h-5 w-5 text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200" />
+                  <RssIcon className="h-5 w-5 text-zinc-600 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200" />
                 </Link>
                 <Link
                   href="/blog/atom.xml"
                   aria-label="Atom feed"
                   prefetch={false}
                 >
-                  <AtSymbolIcon className="h-5 w-5 text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200" />
+                  <AtSymbolIcon className="h-5 w-5 text-zinc-600 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200" />
                 </Link>
               </div>
             </div>

--- a/nx-dev/ui-blog/src/lib/blog-details.tsx
+++ b/nx-dev/ui-blog/src/lib/blog-details.tsx
@@ -48,7 +48,7 @@ export function BlogDetails({ post, allPosts }: BlogDetailsProps) {
         <div className="mx-auto flex justify-between px-4">
           <Link
             href="/blog"
-            className="flex w-20 shrink-0 items-center gap-2 text-slate-400 hover:text-slate-800 dark:text-slate-600 dark:hover:text-slate-200"
+            className="flex w-20 shrink-0 items-center gap-2 text-zinc-400 hover:text-zinc-800 dark:text-zinc-600 dark:hover:text-zinc-200"
             prefetch={false}
           >
             <ChevronLeftIcon className="h-3 w-3" />
@@ -56,7 +56,7 @@ export function BlogDetails({ post, allPosts }: BlogDetailsProps) {
           </Link>
           <div className="flex max-w-sm flex-1 grow items-center justify-end gap-2">
             <BlogAuthors authors={post.authors} />
-            <span className="text-sm text-slate-400 dark:text-slate-600">
+            <span className="text-sm text-zinc-400 dark:text-zinc-600">
               {formattedDate}
             </span>
           </div>
@@ -64,7 +64,7 @@ export function BlogDetails({ post, allPosts }: BlogDetailsProps) {
 
         {/* Title */}
         <header className="mx-auto mb-16 mt-8 px-4">
-          <h1 className="text-center text-4xl font-semibold text-slate-900 dark:text-white">
+          <h1 className="text-center text-4xl font-semibold text-zinc-900 dark:text-white">
             {post.title}
           </h1>
         </header>
@@ -120,7 +120,7 @@ export function BlogDetails({ post, allPosts }: BlogDetailsProps) {
             )}
             <div
               data-document="main"
-              className="prose prose-lg prose-slate dark:prose-invert w-full max-w-none"
+              className="prose prose-lg prose-zinc dark:prose-invert w-full max-w-none"
             >
               {node}
             </div>
@@ -137,10 +137,10 @@ export function BlogDetails({ post, allPosts }: BlogDetailsProps) {
 
       {/* Related Posts Section */}
       {post.tags.length > 0 && relatedPosts.length > 0 && (
-        <section className="mt-24 border-b border-t border-slate-200 bg-slate-50 py-24 sm:py-32 dark:border-slate-800 dark:bg-slate-900">
+        <section className="mt-24 border-b border-t border-zinc-200 bg-zinc-50 py-24 sm:py-32 dark:border-zinc-800 dark:bg-zinc-900">
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             <div className="mx-auto max-w-2xl lg:mx-0 lg:max-w-none">
-              <h2 className="mb-8 flex items-center gap-3 text-2xl font-semibold text-slate-900 dark:text-white">
+              <h2 className="mb-8 flex items-center gap-3 text-2xl font-semibold text-zinc-900 dark:text-white">
                 {primaryTopic ? (
                   <>
                     <primaryTopic.icon className="h-7 w-7" />

--- a/nx-dev/ui-blog/src/lib/blog-entry.tsx
+++ b/nx-dev/ui-blog/src/lib/blog-entry.tsx
@@ -10,7 +10,7 @@ export interface BlogEntryProps {
 
 export function BlogEntry({ post, overrideLink }: BlogEntryProps) {
   return (
-    <div className="relative flex h-full transform-gpu flex-col overflow-hidden rounded-2xl border border-slate-200 shadow transition-all duration-300 ease-in-out hover:scale-[1.02] hover:shadow-lg dark:border-slate-800">
+    <div className="relative flex h-full transform-gpu flex-col overflow-hidden rounded-2xl border border-zinc-200 shadow transition-all duration-300 ease-in-out hover:scale-[1.02] hover:shadow-lg dark:border-zinc-800">
       {post.cover_image && (
         <div className="aspect-[1.7] w-full">
           <Image
@@ -28,7 +28,7 @@ export function BlogEntry({ post, overrideLink }: BlogEntryProps) {
         <Link
           href={overrideLink ? overrideLink : `/blog/${post.slug}`}
           title={post.title}
-          className="text-balance text-lg font-semibold text-slate-900 dark:text-white"
+          className="text-balance text-lg font-semibold text-zinc-900 dark:text-white"
           prefetch={false}
         >
           <span className="absolute inset-0" aria-hidden="true" />

--- a/nx-dev/ui-blog/src/lib/episode-player.tsx
+++ b/nx-dev/ui-blog/src/lib/episode-player.tsx
@@ -65,13 +65,13 @@ export function EpisodePlayer({
         </div>
         <div className="flex basis-1/2 flex-wrap justify-end gap-6 sm:gap-4">
           <button
-            className="flex shrink-0 items-center gap-2 text-slate-400 hover:text-slate-800 dark:text-slate-600 dark:hover:text-slate-200"
+            className="flex shrink-0 items-center gap-2 text-zinc-400 hover:text-zinc-800 dark:text-zinc-600 dark:hover:text-zinc-200"
             onClick={() => setViewType(getOpposite(viewType))}
           >
             Switch to {getOpposite(viewType) === 'audio' ? 'Audio' : 'Video'}
           </button>
           <Link
-            className="flex shrink-0 items-center gap-2 text-slate-400 hover:text-slate-800 dark:text-slate-600 dark:hover:text-slate-200"
+            className="flex shrink-0 items-center gap-2 text-zinc-400 hover:text-zinc-800 dark:text-zinc-600 dark:hover:text-zinc-200"
             href="/podcast"
           >
             More Podcasts
@@ -124,7 +124,7 @@ export function PlatformLinks({
           return (
             <li
               key={platform.name}
-              className="inline-block cursor-pointer place-items-center rounded-2xl border border-slate-100 bg-white p-4 text-slate-600 transition-all hover:scale-[1.02] hover:text-slate-950 dark:border-slate-800/60 dark:bg-slate-950 dark:text-slate-400 dark:hover:text-white"
+              className="inline-block cursor-pointer place-items-center rounded-2xl border border-zinc-100 bg-white p-4 text-zinc-600 transition-all hover:scale-[1.02] hover:text-zinc-950 dark:border-zinc-800/60 dark:bg-zinc-950 dark:text-zinc-400 dark:hover:text-white"
             >
               <a
                 href={platform.url}

--- a/nx-dev/ui-blog/src/lib/filters.tsx
+++ b/nx-dev/ui-blog/src/lib/filters.tsx
@@ -85,7 +85,7 @@ export function Filters({
                 aria-label={`Filter by ${filter.label}`}
                 scroll={false}
                 prefetch={false}
-                className="flex items-center justify-center gap-2 rounded-full border border-slate-400 bg-white px-2.5 py-1.5 font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 hover:text-slate-600 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+                className="flex items-center justify-center gap-2 rounded-full border border-zinc-400 bg-white px-2.5 py-1.5 font-medium text-zinc-700 shadow-sm transition hover:bg-zinc-50 hover:text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700"
                 onClick={() => setSelectedFilterHeading(filter.heading)}
               >
                 {filter.icon && (
@@ -101,7 +101,7 @@ export function Filters({
       <div className="relative lg:hidden">
         <Menu as="div" className="inline-block text-left">
           <MenuButton
-            className="inline-flex w-full justify-center rounded-md border border-slate-400 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 hover:text-slate-600 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+            className="inline-flex w-full justify-center rounded-md border border-zinc-400 bg-white px-3 py-1.5 text-sm font-medium text-zinc-700 shadow-sm transition hover:bg-zinc-50 hover:text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700"
             aria-label="Select filter topic"
           >
             Topics
@@ -121,7 +121,7 @@ export function Filters({
           >
             <MenuItems
               as="ul"
-              className="absolute right-0 z-[31] mt-2 flex w-56 origin-top-right flex-col gap-4 rounded-md bg-white p-4 shadow-lg ring-1 ring-black/5 focus:outline-none dark:bg-slate-800 dark:text-white"
+              className="absolute right-0 z-[31] mt-2 flex w-56 origin-top-right flex-col gap-4 rounded-md bg-white p-4 shadow-lg ring-1 ring-black/5 focus:outline-none dark:bg-zinc-800 dark:text-white"
               aria-label="Filter topics"
             >
               {filters

--- a/nx-dev/ui-blog/src/lib/more-blogs.tsx
+++ b/nx-dev/ui-blog/src/lib/more-blogs.tsx
@@ -24,10 +24,10 @@ export function MoreBlogs({ blogs }: MoreBlogsProps) {
             <Link
               href={`/blog/${post.slug}`}
               key={post.slug}
-              className="relative flex items-center gap-6 border-b border-slate-200 py-5 text-sm before:absolute before:inset-x-[-16px] before:inset-y-[-2px] before:z-[-1] before:rounded-xl before:bg-slate-200 before:opacity-0 last:border-0 before:hover:opacity-100 dark:border-slate-800 dark:before:bg-slate-800/50"
+              className="relative flex items-center gap-6 border-b border-zinc-200 py-5 text-sm before:absolute before:inset-x-[-16px] before:inset-y-[-2px] before:z-[-1] before:rounded-xl before:bg-zinc-200 before:opacity-0 last:border-0 before:hover:opacity-100 dark:border-zinc-800 dark:before:bg-zinc-800/50"
               prefetch={false}
             >
-              <span className="w-1/2 flex-none text-balance font-medium text-slate-500 sm:w-5/12 dark:text-white">
+              <span className="w-1/2 flex-none text-balance font-medium text-zinc-500 sm:w-5/12 dark:text-white">
                 {post.title}
               </span>
               <span className="w-1/2 flex-none sm:w-3/12">

--- a/nx-dev/ui-brands/src/lib/lerna-brand.tsx
+++ b/nx-dev/ui-brands/src/lib/lerna-brand.tsx
@@ -26,13 +26,13 @@ export function LernaBrand() {
               in a way that confuses Nrwl with another brand.
             </SectionDescription>
           </header>
-          <h4 className="mt-4 text-lg leading-8 text-slate-700 sm:text-xl dark:text-slate-300">
+          <h4 className="mt-4 text-lg leading-8 text-zinc-700 sm:text-xl dark:text-zinc-300">
             Spelling
           </h4>
-          <p className="mt-2 text-base text-slate-700 dark:text-slate-400">
+          <p className="mt-2 text-base text-zinc-700 dark:text-zinc-400">
             The preferred written format is Lerna. <br /> For social media
             usage,
-            <span className="mx-1 inline-flex items-center rounded-full bg-slate-100 px-3 py-0.5 text-sm font-medium text-slate-800 dark:bg-slate-700 dark:text-slate-300">
+            <span className="mx-1 inline-flex items-center rounded-full bg-zinc-100 px-3 py-0.5 text-sm font-medium text-zinc-800 dark:bg-zinc-700 dark:text-zinc-300">
               #Lerna
             </span>{' '}
             is an accepted format.
@@ -53,9 +53,9 @@ export function LernaBrand() {
           </ButtonLink>
         </div>
         <div aria-hidden="true">
-          <div className="w-full rounded-md border border-slate-100 bg-slate-50/20 p-4 dark:border-slate-800 dark:bg-slate-800/60">
-            <div className="grid grid-cols-1 items-center justify-items-center rounded-sm bg-white p-2 ring-1 ring-slate-50 dark:bg-slate-800/80 dark:ring-slate-800">
-              <LernaIcon className="m-16 h-36 w-36 text-slate-900 dark:text-slate-100" />
+          <div className="w-full rounded-md border border-zinc-100 bg-zinc-50/20 p-4 dark:border-zinc-800 dark:bg-zinc-800/60">
+            <div className="grid grid-cols-1 items-center justify-items-center rounded-sm bg-white p-2 ring-1 ring-zinc-50 dark:bg-zinc-800/80 dark:ring-zinc-800">
+              <LernaIcon className="m-16 h-36 w-36 text-zinc-900 dark:text-zinc-100" />
             </div>
           </div>
         </div>

--- a/nx-dev/ui-brands/src/lib/nx-brand.tsx
+++ b/nx-dev/ui-brands/src/lib/nx-brand.tsx
@@ -26,12 +26,12 @@ export function NxBrand() {
               a way that confuses Nx with another brand.
             </SectionDescription>
           </header>
-          <h4 className="mt-4 text-lg leading-8 text-slate-700 sm:text-xl dark:text-slate-300">
+          <h4 className="mt-4 text-lg leading-8 text-zinc-700 sm:text-xl dark:text-zinc-300">
             Spelling
           </h4>
-          <p className="mt-2 text-base text-slate-700 dark:text-slate-400">
+          <p className="mt-2 text-base text-zinc-700 dark:text-zinc-400">
             The preferred written format is Nx. <br /> For social media usage,
-            <span className="mx-1 inline-flex items-center rounded-full bg-slate-100 px-3 py-0.5 text-sm font-medium text-slate-800 dark:bg-slate-700 dark:text-slate-300">
+            <span className="mx-1 inline-flex items-center rounded-full bg-zinc-100 px-3 py-0.5 text-sm font-medium text-zinc-800 dark:bg-zinc-700 dark:text-zinc-300">
               #NxDevTools
             </span>{' '}
             is an accepted format.
@@ -51,9 +51,9 @@ export function NxBrand() {
           </ButtonLink>
         </div>
         <div aria-hidden="true">
-          <div className="w-full rounded-md border border-slate-100 bg-slate-50/20 p-4 dark:border-slate-800 dark:bg-slate-800/60">
-            <div className="grid grid-cols-1 items-center justify-items-center rounded-sm bg-white p-2 ring-1 ring-slate-50 dark:bg-slate-800/80 dark:ring-slate-800">
-              <NxIcon className="m-20 h-28 w-28 text-slate-900 dark:text-slate-100" />
+          <div className="w-full rounded-md border border-zinc-100 bg-zinc-50/20 p-4 dark:border-zinc-800 dark:bg-zinc-800/60">
+            <div className="grid grid-cols-1 items-center justify-items-center rounded-sm bg-white p-2 ring-1 ring-zinc-50 dark:bg-zinc-800/80 dark:ring-zinc-800">
+              <NxIcon className="m-20 h-28 w-28 text-zinc-900 dark:text-zinc-100" />
             </div>
           </div>
         </div>

--- a/nx-dev/ui-brands/src/lib/nx-cloud.tsx
+++ b/nx-dev/ui-brands/src/lib/nx-cloud.tsx
@@ -26,13 +26,13 @@ export function NxCloudBrand() {
               a way that confuses Nx with another brand.
             </SectionDescription>
           </header>
-          <h4 className="mt-4 text-lg leading-8 text-slate-700 sm:text-xl dark:text-slate-300">
+          <h4 className="mt-4 text-lg leading-8 text-zinc-700 sm:text-xl dark:text-zinc-300">
             Spelling
           </h4>
-          <p className="mt-2 text-base text-slate-700 dark:text-slate-400">
+          <p className="mt-2 text-base text-zinc-700 dark:text-zinc-400">
             The preferred written format is Nx Cloud. <br /> For social media
             usage,
-            <span className="mx-1 inline-flex items-center rounded-full bg-slate-100 px-3 py-0.5 text-sm font-medium text-slate-800 dark:bg-slate-700 dark:text-slate-300">
+            <span className="mx-1 inline-flex items-center rounded-full bg-zinc-100 px-3 py-0.5 text-sm font-medium text-zinc-800 dark:bg-zinc-700 dark:text-zinc-300">
               #NxCloud
             </span>{' '}
             is an accepted format.
@@ -53,9 +53,9 @@ export function NxCloudBrand() {
           </ButtonLink>
         </div>
         <div aria-hidden="true">
-          <div className="w-full rounded-md border border-slate-100 bg-slate-50/20 p-4 dark:border-slate-800 dark:bg-slate-800/60">
-            <div className="grid grid-cols-1 items-center justify-items-center rounded-sm bg-white p-2 ring-1 ring-slate-50 dark:bg-slate-800/80 dark:ring-slate-800">
-              <NxCloudIcon className="m-20 h-28 w-28 text-slate-900 dark:text-slate-100" />
+          <div className="w-full rounded-md border border-zinc-100 bg-zinc-50/20 p-4 dark:border-zinc-800 dark:bg-zinc-800/60">
+            <div className="grid grid-cols-1 items-center justify-items-center rounded-sm bg-white p-2 ring-1 ring-zinc-50 dark:bg-zinc-800/80 dark:ring-zinc-800">
+              <NxCloudIcon className="m-20 h-28 w-28 text-zinc-900 dark:text-zinc-100" />
             </div>
           </div>
         </div>

--- a/nx-dev/ui-brands/src/lib/nx-console-brand.tsx
+++ b/nx-dev/ui-brands/src/lib/nx-console-brand.tsx
@@ -26,13 +26,13 @@ export function NxConsoleBrand() {
               Nx, or in a way that confuses Nx with another brand.
             </SectionDescription>
           </header>
-          <h4 className="mt-4 text-lg leading-8 text-slate-700 sm:text-xl dark:text-slate-300">
+          <h4 className="mt-4 text-lg leading-8 text-zinc-700 sm:text-xl dark:text-zinc-300">
             Spelling
           </h4>
-          <p className="mt-2 text-base text-slate-700 dark:text-slate-400">
+          <p className="mt-2 text-base text-zinc-700 dark:text-zinc-400">
             The preferred written format is Nx Console. <br /> For social media
             usage,
-            <span className="mx-1 inline-flex items-center rounded-full bg-slate-100 px-3 py-0.5 text-sm font-medium text-slate-800 dark:bg-slate-700 dark:text-slate-300">
+            <span className="mx-1 inline-flex items-center rounded-full bg-zinc-100 px-3 py-0.5 text-sm font-medium text-zinc-800 dark:bg-zinc-700 dark:text-zinc-300">
               #NxConsole
             </span>{' '}
             is an accepted format.
@@ -53,9 +53,9 @@ export function NxConsoleBrand() {
           </ButtonLink>
         </div>
         <div aria-hidden="true">
-          <div className="w-full rounded-md border border-slate-100 bg-slate-50/20 p-4 dark:border-slate-800 dark:bg-slate-800/60">
-            <div className="grid grid-cols-1 items-center justify-items-center rounded-sm bg-white p-2 ring-1 ring-slate-50 dark:bg-slate-800/80 dark:ring-slate-800">
-              <NxConsoleIcon className="m-16 h-40 w-40 text-slate-900 dark:text-slate-100" />
+          <div className="w-full rounded-md border border-zinc-100 bg-zinc-50/20 p-4 dark:border-zinc-800 dark:bg-zinc-800/60">
+            <div className="grid grid-cols-1 items-center justify-items-center rounded-sm bg-white p-2 ring-1 ring-zinc-50 dark:bg-zinc-800/80 dark:ring-zinc-800">
+              <NxConsoleIcon className="m-16 h-40 w-40 text-zinc-900 dark:text-zinc-100" />
             </div>
           </div>
         </div>

--- a/nx-dev/ui-careers/src/lib/current-openings.tsx
+++ b/nx-dev/ui-careers/src/lib/current-openings.tsx
@@ -9,10 +9,10 @@ export async function CurrentOpenings({ jobs }: CurrentOpeningsProps) {
   return (
     <section
       id="current-openings"
-      className="border-b border-t border-slate-100 bg-slate-50/40 dark:border-slate-800 dark:bg-slate-800/60"
+      className="border-b border-t border-zinc-100 bg-zinc-50/40 dark:border-zinc-800 dark:bg-zinc-800/60"
     >
       <div className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8 lg:py-24">
-        <div className="relative mx-auto max-w-lg divide-y divide-slate-100 lg:max-w-7xl dark:divide-slate-700">
+        <div className="relative mx-auto max-w-lg divide-y divide-zinc-100 lg:max-w-7xl dark:divide-zinc-700">
           <header className="max-w-prose">
             <SectionHeading as="h2" variant="title" className="mt-4">
               Current Openings
@@ -23,9 +23,9 @@ export async function CurrentOpenings({ jobs }: CurrentOpeningsProps) {
             {jobs.map((post) => (
               <div
                 key={post.title}
-                className="relative mt-2 block rounded-lg border border-transparent p-4 transition hover:border-slate-100 hover:shadow-sm dark:hover:border-slate-700"
+                className="relative mt-2 block rounded-lg border border-transparent p-4 transition hover:border-zinc-100 hover:shadow-sm dark:hover:border-zinc-700"
               >
-                <p className="text-lg font-semibold leading-8 tracking-tight text-slate-800 dark:text-slate-200">
+                <p className="text-lg font-semibold leading-8 tracking-tight text-zinc-800 dark:text-zinc-200">
                   {post.title}
                 </p>
                 <p className="mt-3 text-base">
@@ -44,7 +44,7 @@ export async function CurrentOpenings({ jobs }: CurrentOpeningsProps) {
             ))}
             {!jobs.length ? (
               <div className="mt-2 block">
-                <p className="text-lg font-semibold leading-8 tracking-tight text-slate-800 dark:text-slate-200">
+                <p className="text-lg font-semibold leading-8 tracking-tight text-zinc-800 dark:text-zinc-200">
                   There are no job openings at this time.
                 </p>
               </div>

--- a/nx-dev/ui-careers/src/lib/what-we-offer.tsx
+++ b/nx-dev/ui-careers/src/lib/what-we-offer.tsx
@@ -57,10 +57,10 @@ export function WhatWeOffer(): JSX.Element {
             <div key={feature.name} className="relative">
               <dt>
                 <CheckIcon
-                  className="absolute mt-1 h-6 w-6 text-blue-500 dark:text-sky-500"
+                  className="absolute mt-1 h-6 w-6 text-blue-500 dark:text-blue-500"
                   aria-hidden="true"
                 />
-                <p className="ml-10 text-lg font-semibold leading-8 tracking-tight text-slate-800 dark:text-slate-200">
+                <p className="ml-10 text-lg font-semibold leading-8 tracking-tight text-zinc-800 dark:text-zinc-200">
                   {feature.name}
                 </p>
               </dt>

--- a/nx-dev/ui-careers/src/lib/why-join-nx.tsx
+++ b/nx-dev/ui-careers/src/lib/why-join-nx.tsx
@@ -46,14 +46,14 @@ export function WhyJoinNx(): JSX.Element {
             <div key={feature.name}>
               <dt>
                 <feature.icon
-                  className="h-8 w-8 text-blue-500 dark:text-sky-500"
+                  className="h-8 w-8 text-blue-500 dark:text-blue-500"
                   aria-hidden="true"
                 />
-                <p className="mt-4 text-lg font-semibold leading-8 tracking-tight text-slate-800 dark:text-slate-200">
+                <p className="mt-4 text-lg font-semibold leading-8 tracking-tight text-zinc-800 dark:text-zinc-200">
                   {feature.name}
                 </p>
               </dt>
-              <dd className="mt-2 text-slate-500 dark:text-slate-400">
+              <dd className="mt-2 text-zinc-500 dark:text-zinc-400">
                 <p className="text-base leading-7">{feature.description}</p>
               </dd>
             </div>

--- a/nx-dev/ui-cloud/src/lib/call-to-action.tsx
+++ b/nx-dev/ui-cloud/src/lib/call-to-action.tsx
@@ -24,7 +24,7 @@ export function CallToAction(): ReactElement {
         <svg
           x="50%"
           y={0}
-          className="overflow-visible fill-slate-200/20 dark:fill-slate-800/20"
+          className="overflow-visible fill-zinc-200/20 dark:fill-zinc-800/20"
         >
           <path
             d="M-200 0h201v201h-201Z M600 0h201v201h-201Z M-400 600h201v201h-201Z M200 800h201v201h-201Z"
@@ -55,7 +55,7 @@ export function CallToAction(): ReactElement {
 
       {/* Content */}
       <div className="mx-auto max-w-4xl text-center">
-        <h2 className="text-3xl font-medium tracking-tight text-slate-950 sm:text-5xl dark:text-white">
+        <h2 className="text-3xl font-medium tracking-tight text-zinc-950 sm:text-5xl dark:text-white">
           Don't Let Your CI Slow You Down
         </h2>
         <p className="mt-12 text-xl">
@@ -66,7 +66,7 @@ export function CallToAction(): ReactElement {
             href="https://cloud.nx.app/get-started"
             title="Get started now"
             prefetch={false}
-            className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
+            className="rounded-md bg-zinc-950 px-3.5 py-2.5 text-sm font-semibold text-zinc-100 shadow-sm hover:bg-zinc-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-100"
           >
             Start here{' '}
             <span

--- a/nx-dev/ui-cloud/src/lib/ci-bottleneck-animation.tsx
+++ b/nx-dev/ui-cloud/src/lib/ci-bottleneck-animation.tsx
@@ -23,7 +23,7 @@ const Card = forwardRef<
     <div
       ref={ref}
       className={cx(
-        'rounded-lg border border-slate-200 bg-slate-50 p-4 shadow-sm backdrop-blur-sm dark:border-slate-800/40 dark:bg-slate-800/60',
+        'rounded-lg border border-zinc-200 bg-zinc-50 p-4 shadow-sm backdrop-blur-sm dark:border-zinc-800/40 dark:bg-zinc-800/60',
         className
       )}
       onMouseEnter={onMouseEnter}
@@ -57,7 +57,7 @@ export function CiBottleneckAnimation(): ReactElement {
               className="border-green-400/60 bg-green-400/40 dark:border-green-800/60 dark:bg-green-800/40"
             >
               <div className="flex items-center justify-between">
-                <div className="flex items-center space-x-3 text-slate-900 dark:text-slate-100">
+                <div className="flex items-center space-x-3 text-zinc-900 dark:text-zinc-100">
                   <ServerStackIcon
                     aria-hidden="true"
                     className="size-5 shrink-0"
@@ -75,7 +75,7 @@ export function CiBottleneckAnimation(): ReactElement {
               className="border-green-400/60 bg-green-400/40 dark:border-green-800/60 dark:bg-green-800/40"
             >
               <div className="flex items-center justify-between">
-                <div className="flex items-center space-x-3 text-slate-900 dark:text-slate-100">
+                <div className="flex items-center space-x-3 text-zinc-900 dark:text-zinc-100">
                   <UserPlusIcon
                     aria-hidden="true"
                     className="size-5 shrink-0"
@@ -95,7 +95,7 @@ export function CiBottleneckAnimation(): ReactElement {
               className="border-green-400/60 bg-green-400/40 dark:border-green-800/60 dark:bg-green-800/40"
             >
               <div className="flex items-center justify-between">
-                <div className="flex items-center space-x-3 text-slate-900 dark:text-slate-100">
+                <div className="flex items-center space-x-3 text-zinc-900 dark:text-zinc-100">
                   <WrenchScrewdriverIcon
                     aria-hidden="true"
                     className="size-5 shrink-0"
@@ -114,9 +114,9 @@ export function CiBottleneckAnimation(): ReactElement {
           <div className="flex flex-col items-center">
             <Card
               ref={ciBottleneck}
-              className="relative bg-white dark:border-slate-800/60 dark:bg-slate-950"
+              className="relative bg-white dark:border-zinc-800/60 dark:bg-zinc-950"
             >
-              <span className="absolute -bottom-8 right-0 hidden items-center gap-x-1.5 rounded-md bg-white px-2 py-1 text-xs font-medium text-slate-400 ring-1 ring-inset ring-slate-200 sm:inline-flex dark:bg-slate-950 dark:ring-slate-800/60">
+              <span className="absolute -bottom-8 right-0 hidden items-center gap-x-1.5 rounded-md bg-white px-2 py-1 text-xs font-medium text-zinc-400 ring-1 ring-inset ring-zinc-200 sm:inline-flex dark:bg-zinc-950 dark:ring-zinc-800/60">
                 <span className="relative flex size-1.5">
                   <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-orange-400/80 opacity-75" />
                   <span className="relative inline-flex size-1.5 rounded-full bg-orange-500/80" />
@@ -124,7 +124,7 @@ export function CiBottleneckAnimation(): ReactElement {
                 Queue increasing
               </span>
               <div className="flex items-center justify-between">
-                <div className="flex items-center space-x-3 text-slate-900 dark:text-slate-100">
+                <div className="flex items-center space-x-3 text-zinc-900 dark:text-zinc-100">
                   <FunnelIcon aria-hidden="true" className="size-5 shrink-0" />
                   <div className="flex-1">
                     <p className="font-mono text-xs leading-tight">
@@ -143,7 +143,7 @@ export function CiBottleneckAnimation(): ReactElement {
               className="border-red-400/60 bg-red-400/40 dark:border-red-800/60 dark:bg-red-800/40"
             >
               <div className="flex items-center justify-between">
-                <div className="flex items-center space-x-3 text-slate-900 dark:text-slate-100">
+                <div className="flex items-center space-x-3 text-zinc-900 dark:text-zinc-100">
                   <ClockIcon aria-hidden="true" className="size-5 shrink-0" />
                   <div className="flex-1">
                     <p className="font-mono text-xs leading-tight">

--- a/nx-dev/ui-cloud/src/lib/ci-bottleneck.tsx
+++ b/nx-dev/ui-cloud/src/lib/ci-bottleneck.tsx
@@ -13,7 +13,7 @@ export function CiBottleneck(): ReactElement {
   return (
     <section
       id="ci-bottleneck"
-      className="scroll-mt-24 border-b border-t border-slate-200 bg-slate-50 py-24 sm:py-32 dark:border-slate-800 dark:bg-slate-900"
+      className="scroll-mt-24 border-b border-t border-zinc-200 bg-zinc-50 py-24 sm:py-32 dark:border-zinc-800 dark:bg-zinc-900"
     >
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-3xl text-center">
@@ -45,7 +45,7 @@ export function CiBottleneck(): ReactElement {
                 key={stat.id}
                 className="flex flex-col bg-white p-8 dark:bg-white/5"
               >
-                <dt className="text-sm/6 font-semibold text-slate-700 dark:text-slate-300">
+                <dt className="text-sm/6 font-semibold text-zinc-700 dark:text-zinc-300">
                   {stat.name}
                 </dt>
                 <dd className="order-first text-3xl font-semibold tracking-tight text-black dark:text-white">

--- a/nx-dev/ui-cloud/src/lib/customer-metrics.tsx
+++ b/nx-dev/ui-cloud/src/lib/customer-metrics.tsx
@@ -32,13 +32,13 @@ export function CustomerMetrics(): ReactElement {
                 }}
                 className="group relative block rounded-2xl"
               >
-                <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-white/60 opacity-0 backdrop-blur-sm transition duration-300 group-hover:opacity-100 dark:bg-slate-950/60">
-                  <div className="flex items-center gap-2 text-lg font-semibold text-slate-950 drop-shadow dark:text-white">
+                <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-white/60 opacity-0 backdrop-blur-sm transition duration-300 group-hover:opacity-100 dark:bg-zinc-950/60">
+                  <div className="flex items-center gap-2 text-lg font-semibold text-zinc-950 drop-shadow dark:text-white">
                     <PlayIcon className="size-8" />
                     Watch the interview
                   </div>
                 </div>
-                <figure className="relative rounded-2xl bg-white shadow-lg ring-1 ring-slate-900/5 dark:bg-slate-800">
+                <figure className="relative rounded-2xl bg-white shadow-lg ring-1 ring-zinc-900/5 dark:bg-zinc-800">
                   <blockquote className="p-6 text-lg font-semibold tracking-tight text-black dark:text-white">
                     <p>
                       The number of hours we spent trying to manage CI before,
@@ -50,15 +50,15 @@ export function CustomerMetrics(): ReactElement {
                       it fast."
                     </p>
                   </blockquote>
-                  <figcaption className="flex flex-wrap items-center gap-x-4 gap-y-4 border-t border-slate-900/10 px-6 py-4 sm:flex-nowrap dark:border-slate-100/10">
+                  <figcaption className="flex flex-wrap items-center gap-x-4 gap-y-4 border-t border-zinc-900/10 px-6 py-4 sm:flex-nowrap dark:border-zinc-100/10">
                     <img
                       alt="Nicolas Beaussart image"
                       src="https://avatars.githubusercontent.com/u/7281023?v=4"
-                      className="size-10 rounded-full bg-slate-50"
+                      className="size-10 rounded-full bg-zinc-50"
                     />
                     <div className="flex-auto">
                       <div className="font-semibold">Nicolas Beaussart</div>
-                      <div className="text-slate-600 dark:text-slate-500">
+                      <div className="text-zinc-600 dark:text-zinc-500">
                         Staff Platform Engineer, Payfit
                       </div>
                     </div>
@@ -86,19 +86,19 @@ export function CustomerMetrics(): ReactElement {
             </div>
             <div className="lg:flex lg:flex-auto lg:justify-center">
               <dl className="flex flex-col justify-center gap-8 sm:flex-row lg:flex-col xl:w-80">
-                <div className="flex flex-col-reverse gap-y-1 border-slate-200 pl-4 text-center sm:border-l sm:text-left dark:border-slate-800">
+                <div className="flex flex-col-reverse gap-y-1 border-zinc-200 pl-4 text-center sm:border-l sm:text-left dark:border-zinc-800">
                   <dt className="text-base/7">faster CI</dt>
                   <dd className="[text-shadow:1px 1px 0 white;] te text-5xl font-semibold tracking-tight text-black dark:text-white">
                     70%
                   </dd>
                 </div>
-                <div className="flex flex-col-reverse gap-y-1 border-slate-200 pl-4 text-center sm:border-l sm:text-left dark:border-slate-800">
+                <div className="flex flex-col-reverse gap-y-1 border-zinc-200 pl-4 text-center sm:border-l sm:text-left dark:border-zinc-800">
                   <dt className="text-base/7">less compute used</dt>
                   <dd className="text-5xl font-semibold tracking-tight text-black dark:text-white">
                     60%
                   </dd>
                 </div>
-                <div className="flex flex-col-reverse gap-y-1 border-slate-200 pl-4 text-center sm:border-l sm:text-left dark:border-slate-800">
+                <div className="flex flex-col-reverse gap-y-1 border-zinc-200 pl-4 text-center sm:border-l sm:text-left dark:border-zinc-800">
                   <dt className="text-base/7">reduction in infra costs</dt>
                   <dd className="text-5xl font-semibold tracking-tight text-black dark:text-white">
                     75%

--- a/nx-dev/ui-cloud/src/lib/faq.tsx
+++ b/nx-dev/ui-cloud/src/lib/faq.tsx
@@ -161,7 +161,7 @@ export function Faq(): ReactElement {
               Check out our most commonly asked questions.
             </SectionHeading>
 
-            <p className="text-md mt-4 text-slate-400 dark:text-slate-600">
+            <p className="text-md mt-4 text-zinc-400 dark:text-zinc-600">
               <Link
                 href="/contact"
                 title="Reach out to the team"
@@ -186,14 +186,14 @@ export function Faq(): ReactElement {
             }))}
           />
           <div className="mt-12 lg:col-span-2 lg:mt-0">
-            <dl className="mt-6 space-y-6 divide-y divide-slate-100 dark:divide-slate-800">
+            <dl className="mt-6 space-y-6 divide-y divide-zinc-100 dark:divide-zinc-800">
               {faqs.map((faq) => (
                 <Disclosure as="div" key={faq.question} className="pt-6">
                   {({ open }) => (
                     <>
                       <dt className="text-lg">
-                        <DisclosureButton className="flex w-full items-start justify-between text-left text-slate-400">
-                          <span className="font-medium text-slate-800 dark:text-slate-300">
+                        <DisclosureButton className="flex w-full items-start justify-between text-left text-zinc-400">
+                          <span className="font-medium text-zinc-800 dark:text-zinc-300">
                             {faq.question}
                           </span>
                           <span className="ml-6 flex h-7 items-center">
@@ -217,7 +217,7 @@ export function Faq(): ReactElement {
                       >
                         <DisclosurePanel
                           as="dd"
-                          className="mt-2 pr-12 text-base text-slate-500 dark:text-slate-400"
+                          className="mt-2 pr-12 text-base text-zinc-500 dark:text-zinc-400"
                         >
                           {faq.answerUi}
                         </DisclosurePanel>

--- a/nx-dev/ui-cloud/src/lib/features.tsx
+++ b/nx-dev/ui-cloud/src/lib/features.tsx
@@ -5,7 +5,7 @@ export function Features(): ReactElement {
   return (
     <section
       id="features"
-      className="scroll-mt-24 border-b border-t border-slate-200 bg-slate-50 py-24 sm:py-32 dark:border-slate-800 dark:bg-slate-900"
+      className="scroll-mt-24 border-b border-t border-zinc-200 bg-zinc-50 py-24 sm:py-32 dark:border-zinc-800 dark:bg-zinc-900"
     >
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-3xl text-center">
@@ -19,14 +19,14 @@ export function Features(): ReactElement {
         </div>
         <div className="mx-auto mt-12 grid max-w-5xl grid-cols-1 gap-4 sm:mt-16 md:grid-cols-2">
           <div className="relative">
-            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 lg:rounded-tl-[calc(2rem+1px)] dark:bg-slate-950 dark:ring-white/10">
+            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 lg:rounded-tl-[calc(2rem+1px)] dark:bg-zinc-950 dark:ring-white/10">
               <img
                 alt="Nx Replay: remote caching"
                 src="/images/enterprise/nx-replay.avif"
                 className="h-80 object-cover object-center"
               />
               <div className="relative p-10 pt-4">
-                <h3 className="text-lg font-medium tracking-tight text-slate-950 dark:text-white">
+                <h3 className="text-lg font-medium tracking-tight text-zinc-950 dark:text-white">
                   Secure Remote Cache
                 </h3>
                 <p className="mt-2 max-w-lg text-sm/6">
@@ -38,14 +38,14 @@ export function Features(): ReactElement {
             </div>
           </div>
           <div className="relative">
-            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 lg:rounded-tr-[calc(2rem+1px)] dark:bg-slate-950 dark:ring-white/10">
+            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 lg:rounded-tr-[calc(2rem+1px)] dark:bg-zinc-950 dark:ring-white/10">
               <img
                 alt="Nx flaky task detection & rerun"
                 src="/images/enterprise/nx-flaky-tasks-detection.avif"
                 className="h-80 object-cover"
               />
               <div className="relative p-10 pt-4">
-                <h3 className="text-lg font-medium tracking-tight text-slate-950 dark:text-white">
+                <h3 className="text-lg font-medium tracking-tight text-zinc-950 dark:text-white">
                   Self-Healing CI
                 </h3>
                 <p className="mt-2 max-w-lg text-sm/6">
@@ -57,14 +57,14 @@ export function Features(): ReactElement {
             </div>
           </div>
           <div className="relative">
-            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 dark:bg-slate-950 dark:ring-white/10">
+            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 dark:bg-zinc-950 dark:ring-white/10">
               <img
                 alt="Nx Atomizer: split large tasks & E2E in chunks"
                 src="/images/enterprise/nx-atomizer.avif"
                 className="h-80 object-cover object-center"
               />
               <div className="relative p-10 pt-4">
-                <h3 className="text-lg font-medium tracking-tight text-slate-950 dark:text-white">
+                <h3 className="text-lg font-medium tracking-tight text-zinc-950 dark:text-white">
                   E2E Test Splitting
                 </h3>
                 <p className="mt-2 max-w-lg text-sm/6">
@@ -76,14 +76,14 @@ export function Features(): ReactElement {
             </div>
           </div>
           <div className="relative">
-            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 dark:bg-slate-950 dark:ring-white/10">
+            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 dark:bg-zinc-950 dark:ring-white/10">
               <img
                 alt="Nx Agents: simple & fast task distribution"
                 src="/images/enterprise/nx-agents.avif"
                 className="h-80 object-cover object-center"
               />
               <div className="relative p-10 pt-4">
-                <h3 className="text-lg font-medium tracking-tight text-slate-950 dark:text-white">
+                <h3 className="text-lg font-medium tracking-tight text-zinc-950 dark:text-white">
                   Distributed Task Execution
                 </h3>
                 <p className="mt-2 max-w-lg text-sm/6">
@@ -95,7 +95,7 @@ export function Features(): ReactElement {
             </div>
           </div>
           <div className="relative">
-            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 lg:rounded-bl-[calc(2rem+1px)] dark:bg-slate-800 dark:ring-white/10">
+            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 lg:rounded-bl-[calc(2rem+1px)] dark:bg-zinc-800 dark:ring-white/10">
               <img
                 alt="Nx Agents: simple & fast task distribution"
                 src="/images/enterprise/visibility.avif"
@@ -103,11 +103,11 @@ export function Features(): ReactElement {
               />
               <div className="relative p-10 pt-4">
                 <div className="absolute -top-10 left-10">
-                  <span className="inline-flex items-center rounded-md bg-slate-400/10 px-2 py-1 text-xs font-medium text-slate-400 ring-1 ring-inset ring-slate-400/20">
+                  <span className="inline-flex items-center rounded-md bg-zinc-400/10 px-2 py-1 text-xs font-medium text-zinc-400 ring-1 ring-inset ring-zinc-400/20">
                     Enterprise
                   </span>
                 </div>
-                <h3 className="text-lg font-medium tracking-tight text-slate-950 dark:text-white">
+                <h3 className="text-lg font-medium tracking-tight text-zinc-950 dark:text-white">
                   See Dependencies Across Teams & Repositories
                 </h3>
                 <p className="mt-2 max-w-lg text-sm/6">
@@ -121,7 +121,7 @@ export function Features(): ReactElement {
             </div>
           </div>
           <div className="relative">
-            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 lg:rounded-br-[calc(2rem+1px)] dark:bg-slate-800 dark:ring-white/10">
+            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 lg:rounded-br-[calc(2rem+1px)] dark:bg-zinc-800 dark:ring-white/10">
               <img
                 alt="Nx Atomizer: split large tasks & E2E in chunks"
                 src="/images/enterprise/conformance.avif"
@@ -129,11 +129,11 @@ export function Features(): ReactElement {
               />
               <div className="relative p-10 pt-4">
                 <div className="absolute -top-10 left-10">
-                  <span className="inline-flex items-center rounded-md bg-slate-400/10 px-2 py-1 text-xs font-medium text-slate-400 ring-1 ring-inset ring-slate-400/20">
+                  <span className="inline-flex items-center rounded-md bg-zinc-400/10 px-2 py-1 text-xs font-medium text-zinc-400 ring-1 ring-inset ring-zinc-400/20">
                     Enterprise
                   </span>
                 </div>
-                <h3 className="text-lg font-medium tracking-tight text-slate-950 dark:text-white">
+                <h3 className="text-lg font-medium tracking-tight text-zinc-950 dark:text-white">
                   Streamline Onboarding & Governance
                 </h3>
                 <p className="mt-2 max-w-lg text-sm/6">

--- a/nx-dev/ui-cloud/src/lib/get-started.tsx
+++ b/nx-dev/ui-cloud/src/lib/get-started.tsx
@@ -12,14 +12,14 @@ export function GetStarted(): ReactElement {
               as="h2"
               variant="title"
               id="get-started-title"
-              className="text-white dark:text-slate-950"
+              className="text-white dark:text-zinc-950"
             >
               Get Started
             </SectionHeading>
             <SectionHeading
               as="p"
               variant="subtitle"
-              className="mt-8 text-white dark:text-slate-950"
+              className="mt-8 text-white dark:text-zinc-950"
             >
               In 5 minutes, you'll see the difference.
             </SectionHeading>

--- a/nx-dev/ui-cloud/src/lib/hero/nx-cloud-hero-video.tsx
+++ b/nx-dev/ui-cloud/src/lib/hero/nx-cloud-hero-video.tsx
@@ -18,7 +18,7 @@ export function NxCloudHeroVideo(): ReactElement {
                 <div className="h-20 w-20 bg-[radial-gradient(var(--blue-500)_40%,transparent_60%)] opacity-[0.8] dark:bg-[radial-gradient(var(--pink-500)_40%,transparent_60%)]" />
               </MovingBorder>
             </div>
-            <picture className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-xl border border-slate-100 bg-slate-50 antialiased backdrop-blur-xl dark:border-slate-900 dark:bg-slate-900/[0.8]">
+            <picture className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-xl border border-zinc-100 bg-zinc-50 antialiased backdrop-blur-xl dark:border-zinc-900 dark:bg-zinc-900/[0.8]">
               <Image
                 src="/images/cloud/nrwl-ocean.avif"
                 alt="App screenshot: overview"

--- a/nx-dev/ui-cloud/src/lib/hero/play-button.tsx
+++ b/nx-dev/ui-cloud/src/lib/hero/play-button.tsx
@@ -51,14 +51,14 @@ export function PlayButton({
     >
       <div className="absolute inset-0">
         <MovingBorder duration={5000} rx="5%" ry="5%">
-          <div className="size-20 bg-[radial-gradient(var(--blue-500)_40%,transparent_60%)] opacity-[0.8] dark:bg-[radial-gradient(var(--sky-500)_40%,transparent_60%)]" />
+          <div className="size-20 bg-[radial-gradient(var(--blue-500)_40%,transparent_60%)] opacity-[0.8] dark:bg-[radial-gradient(var(--blue-500)_40%,transparent_60%)]" />
         </MovingBorder>
       </div>
       <motion.div
         initial="initial"
         whileHover="hover"
         variants={parent}
-        className="relative isolate flex size-20 cursor-pointer items-center justify-center gap-6 rounded-full border-2 border-slate-100 bg-white/10 p-6 text-slate-950 antialiased backdrop-blur-xl"
+        className="relative isolate flex size-20 cursor-pointer items-center justify-center gap-6 rounded-full border-2 border-zinc-100 bg-white/10 p-6 text-zinc-950 antialiased backdrop-blur-xl"
       >
         <PlayIcon aria-hidden="true" className="absolute left-6 top-6 size-8" />
         <motion.div variants={child} className="absolute left-20 top-4 w-48">

--- a/nx-dev/ui-cloud/src/lib/nx-cloud-hero.tsx
+++ b/nx-dev/ui-cloud/src/lib/nx-cloud-hero.tsx
@@ -139,7 +139,7 @@ export function NxCloudHero(): ReactElement {
               <ButtonLink
                 href="https://cloud.nx.app/get-started"
                 title="Nx AI Integration"
-                variant="primary"
+                variant="contrast"
                 size="default"
                 onClick={() =>
                   sendCustomEvent(

--- a/nx-dev/ui-cloud/src/lib/pricing.tsx
+++ b/nx-dev/ui-cloud/src/lib/pricing.tsx
@@ -10,7 +10,7 @@ export function Pricing(): ReactElement {
   return (
     <section
       id="plans"
-      className="scroll-mt-24 border-b border-t border-slate-200 bg-slate-50 py-24 sm:py-32 dark:border-slate-800 dark:bg-slate-900"
+      className="scroll-mt-24 border-b border-t border-zinc-200 bg-zinc-50 py-24 sm:py-32 dark:border-zinc-800 dark:bg-zinc-900"
     >
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <header className="mx-auto max-w-4xl text-center">
@@ -39,9 +39,9 @@ export function Pricing(): ReactElement {
           <div className="isolate -mt-16 grid max-w-full grid-cols-1 gap-6 sm:mx-auto lg:mt-0 lg:grid-cols-3 xl:-mx-4 xl:gap-8">
             {/*HOBBY*/}
             <div>
-              <div className="rounded-lg border-2 border-blue-500 bg-white p-6 dark:border-sky-500 dark:bg-slate-950">
+              <div className="rounded-lg border-2 border-blue-500 bg-white p-6 dark:border-blue-500 dark:bg-zinc-950">
                 <div className="flex items-center gap-x-2">
-                  <h4 className="text-xl font-semibold leading-8 text-slate-950 dark:text-white">
+                  <h4 className="text-xl font-semibold leading-8 text-zinc-950 dark:text-white">
                     Hobby
                   </h4>
                   <span className="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10 dark:bg-blue-400/10 dark:text-blue-400 dark:ring-blue-400/30">
@@ -53,7 +53,7 @@ export function Pricing(): ReactElement {
                   product. No credit card required.
                 </p>
                 <p className="mt-4 pb-5 leading-5">
-                  <span className="text-3xl font-semibold text-slate-950 dark:text-white">
+                  <span className="text-3xl font-semibold text-zinc-950 dark:text-white">
                     $0
                   </span>
                 </p>
@@ -63,7 +63,7 @@ export function Pricing(): ReactElement {
                     aria-describedby="hobby-plan"
                     title="Start now"
                     size="default"
-                    variant="primary"
+                    variant="contrast"
                     onClick={() =>
                       sendCustomEvent(
                         'start-hobby-plan-click',
@@ -76,21 +76,21 @@ export function Pricing(): ReactElement {
                     Start now
                   </ButtonLink>
                 </div>
-                <ul className="mt-4 divide-y divide-slate-200 text-sm dark:divide-slate-800">
+                <ul className="mt-4 divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
                   <li className="py-2.5">
                     <span className="font-medium">Included for free</span>
                   </li>
                   <li className="flex items-center justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>50,000 monthly credits</span>
                   </li>
                   <li className="flex items-center justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <Link
                       href="/ai"
@@ -111,7 +111,7 @@ export function Pricing(): ReactElement {
                   <li className="flex items-center justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>
                       Remote caching with{' '}
@@ -135,7 +135,7 @@ export function Pricing(): ReactElement {
                   <li className="flex items-center justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>
                       Distributed task execution with{' '}
@@ -163,9 +163,9 @@ export function Pricing(): ReactElement {
             </div>
 
             {/*TEAM*/}
-            <div className="rounded-lg border border-slate-200 bg-white p-6 dark:border-slate-800 dark:bg-slate-950">
+            <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-950">
               <div className="flex items-center gap-x-2">
-                <h4 className="text-xl font-semibold leading-8 text-slate-950 dark:text-white">
+                <h4 className="text-xl font-semibold leading-8 text-zinc-950 dark:text-white">
                   Team
                 </h4>
               </div>
@@ -173,7 +173,7 @@ export function Pricing(): ReactElement {
                 Start free, pay as you grow. Billed on the first of each month.
               </p>
               <p className="mt-4 leading-5">
-                <span className="text-3xl font-semibold text-slate-950 dark:text-white">
+                <span className="text-3xl font-semibold text-zinc-950 dark:text-white">
                   $19
                 </span>
                 <span className="text-lg"> per Active Contributor¹</span>{' '}
@@ -203,35 +203,35 @@ export function Pricing(): ReactElement {
                   Free to start
                 </ButtonLink>
               </div>
-              <ul className="mt-4 divide-y divide-slate-200 text-sm dark:divide-slate-800">
+              <ul className="mt-4 divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
                 <li className="py-2.5">
                   <span className="font-medium">Included for free</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>5 active contributors¹</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>50,000 monthly credits</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>10 concurrent CI connections</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <Link
                     href="/ai"
@@ -252,7 +252,7 @@ export function Pricing(): ReactElement {
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>Email support</span>
                 </li>
@@ -262,35 +262,35 @@ export function Pricing(): ReactElement {
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <PlusIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>$19 per active contributor¹ / month</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <PlusIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>$5.50 per 10,000 credits</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <PlusIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>$2.25 per concurrent CI connection</span>
                 </li>
               </ul>
-              <p className="mt-4 text-xs text-slate-500">
+              <p className="mt-4 text-xs text-zinc-500">
                 ¹Any person or actor that has triggered a CI Pipeline Execution
                 within the current billing cycle. Up to 50 active contributors.
               </p>
             </div>
 
             {/* ENTERPRISE */}
-            <div className="rounded-lg border border-slate-200 bg-slate-50/60 p-6 dark:border-slate-800 dark:bg-slate-900">
+            <div className="rounded-lg border border-zinc-200 bg-zinc-50/60 p-6 dark:border-zinc-800 dark:bg-zinc-900">
               <div className="flex items-center gap-x-2">
-                <h4 className="text-xl font-semibold leading-8 text-slate-950 dark:text-white">
+                <h4 className="text-xl font-semibold leading-8 text-zinc-950 dark:text-white">
                   Enterprise
                 </h4>
               </div>
@@ -299,7 +299,7 @@ export function Pricing(): ReactElement {
                 & payment options available.
               </p>
               <p className="mt-4 pb-5 leading-5">
-                <span className="text-3xl font-semibold text-slate-950 dark:text-white">
+                <span className="text-3xl font-semibold text-zinc-950 dark:text-white">
                   Custom
                 </span>
               </p>
@@ -322,28 +322,28 @@ export function Pricing(): ReactElement {
                   Request a trial
                 </ButtonLink>
               </div>
-              <ul className="mt-4 divide-y divide-slate-200 text-sm dark:divide-slate-800">
+              <ul className="mt-4 divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
                 <li className="py-2.5">
                   <span className="font-medium">Includes</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>Volume discounts on credits available</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>White glove onboarding</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>
                     <Link
@@ -367,7 +367,7 @@ export function Pricing(): ReactElement {
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>
                     Work hand-in-hand with the Nx team for continual improvement
@@ -376,7 +376,7 @@ export function Pricing(): ReactElement {
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>
                     Run on the Nx Cloud servers in any region or run fully
@@ -386,14 +386,14 @@ export function Pricing(): ReactElement {
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>SSO / SAML Login</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>Premium Support and SLAs available</span>
                 </li>

--- a/nx-dev/ui-cloud/src/lib/security.tsx
+++ b/nx-dev/ui-cloud/src/lib/security.tsx
@@ -41,7 +41,7 @@ export function Security(): ReactElement {
               and other regulated industries. Don't compromise.
             </SectionHeading>
             <div className="mt-8 flex flex-wrap items-center gap-4 md:gap-8">
-              <div className="flex w-52 shrink-0 items-center gap-2 rounded-xl px-2 py-1 text-xs text-slate-950 ring-1 ring-slate-200 dark:text-slate-50 dark:ring-slate-700">
+              <div className="flex w-52 shrink-0 items-center gap-2 rounded-xl px-2 py-1 text-xs text-zinc-950 ring-1 ring-zinc-200 dark:text-zinc-50 dark:ring-zinc-700">
                 <svg
                   role="img"
                   xmlns="http://www.w3.org/2000/svg"

--- a/nx-dev/ui-cloud/src/lib/time-to-green.tsx
+++ b/nx-dev/ui-cloud/src/lib/time-to-green.tsx
@@ -25,7 +25,7 @@ export function TimeToGreen(): ReactElement {
         <h3 className="text-xl font-semibold">Average Time To Green</h3>
 
         <div className="mt-2">
-          <div className="relative grid grid-cols-1 rounded-lg bg-slate-50 text-xs font-medium text-slate-900 ring-1 ring-slate-200 sm:h-12 sm:grid-cols-12 dark:bg-slate-900 dark:text-slate-100 dark:ring-white/10">
+          <div className="relative grid grid-cols-1 rounded-lg bg-zinc-50 text-xs font-medium text-zinc-900 ring-1 ring-zinc-200 sm:h-12 sm:grid-cols-12 dark:bg-zinc-900 dark:text-zinc-100 dark:ring-white/10">
             <div className="flex h-12 items-center justify-center rounded-t-lg bg-blue-400/40 sm:col-span-2 sm:h-auto sm:rounded-l-lg sm:rounded-r-none dark:bg-blue-600/40">
               <span className="px-2">Write Code</span>
             </div>
@@ -50,7 +50,7 @@ export function TimeToGreen(): ReactElement {
           <h3 className="text-xl font-semibold">Time To Green with Nx Cloud</h3>
           <div className="mt-2 grid grid-cols-1 sm:h-12 sm:grid-cols-12">
             <div className="col-span-4 grid grid-cols-1 sm:grid-cols-6">
-              <div className="grid grid-cols-1 rounded-lg bg-slate-50 text-xs font-medium text-slate-900 ring-1 ring-slate-200 sm:col-span-5 sm:grid-cols-10 dark:bg-slate-900 dark:text-slate-100 dark:ring-white/10">
+              <div className="grid grid-cols-1 rounded-lg bg-zinc-50 text-xs font-medium text-zinc-900 ring-1 ring-zinc-200 sm:col-span-5 sm:grid-cols-10 dark:bg-zinc-900 dark:text-zinc-100 dark:ring-white/10">
                 <div className="flex h-12 items-center justify-center rounded-t-lg bg-blue-400/40 sm:col-span-6 sm:h-auto sm:rounded-l-lg sm:rounded-r-none dark:bg-blue-600/40">
                   <span className="px-2">Write Code</span>
                 </div>

--- a/nx-dev/ui-commands/src/lib/inline-command.tsx
+++ b/nx-dev/ui-commands/src/lib/inline-command.tsx
@@ -39,13 +39,10 @@ export function InlineCommand({
       >
         <button
           type="button"
-          className="font-input-mono duration-180 flex w-full flex-none items-center justify-center space-x-2 rounded-md border border-slate-300 bg-white py-1 text-sm leading-6 text-slate-400 transition-colors hover:text-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-300 focus:ring-offset-2 focus:ring-offset-white sm:max-w-full sm:space-x-4 sm:px-3"
+          className="font-input-mono duration-180 flex w-full flex-none items-center justify-center space-x-2 rounded-md border border-zinc-300 bg-white py-1 text-sm leading-6 text-zinc-400 transition-colors hover:text-zinc-800 focus:outline-none focus:ring-2 focus:ring-zinc-300 focus:ring-offset-2 focus:ring-offset-white sm:max-w-full sm:space-x-4 sm:px-3"
         >
-          <span className="flex items-center overflow-auto text-slate-800">
-            <span
-              className="hidden text-slate-500 sm:inline"
-              aria-hidden="true"
-            >
+          <span className="flex items-center overflow-auto text-zinc-800">
+            <span className="hidden text-zinc-500 sm:inline" aria-hidden="true">
               $
             </span>
             <SyntaxHighlighter

--- a/nx-dev/ui-common/src/lib/announcement-banner.tsx
+++ b/nx-dev/ui-common/src/lib/announcement-banner.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 export function AnnouncementBanner(): JSX.Element {
   return (
-    <div className="group relative border border-y border-slate-200 bg-slate-50/40 transition hover:bg-slate-50 dark:border-slate-800/40 dark:bg-slate-800/60 dark:hover:bg-slate-800">
+    <div className="group relative border border-y border-zinc-200 bg-zinc-50/40 transition hover:bg-zinc-50 dark:border-zinc-800/40 dark:bg-zinc-800/60 dark:hover:bg-zinc-800">
       <div className="mx-auto max-w-7xl px-3 py-3 sm:px-6 lg:px-8">
         <div className="text-center">
           <p className="text-sm font-medium">
@@ -22,7 +22,7 @@ export function AnnouncementBanner(): JSX.Element {
             <span className="ml-2 inline-block">
               <Link
                 href="https://monorepo.world?utm_source=nx.dev"
-                className="font-semibold text-blue-500 underline dark:text-sky-500"
+                className="font-semibold text-blue-500 underline dark:text-blue-500"
               >
                 <span className="absolute inset-0" aria-hidden="true" />
                 Join us!

--- a/nx-dev/ui-common/src/lib/breadcrumbs.tsx
+++ b/nx-dev/ui-common/src/lib/breadcrumbs.tsx
@@ -82,15 +82,15 @@ export function Breadcrumbs({
               <div className="flex items-center">
                 {!!index && (
                   <ChevronRightIcon
-                    className="h-5 w-5 flex-shrink-0 text-slate-500"
+                    className="h-5 w-5 flex-shrink-0 text-zinc-500"
                     aria-hidden="true"
                   />
                 )}
                 <a
                   href={crumb.href}
                   className={classNames(
-                    'text-sm font-medium hover:text-slate-600',
-                    crumb.current ? 'text-slate-600' : 'text-slate-400',
+                    'text-sm font-medium hover:text-zinc-600',
+                    crumb.current ? 'text-zinc-600' : 'text-zinc-400',
                     !!index ? 'ml-4' : ''
                   )}
                   aria-current={crumb.current ? 'page' : undefined}

--- a/nx-dev/ui-common/src/lib/button.tsx
+++ b/nx-dev/ui-common/src/lib/button.tsx
@@ -25,11 +25,11 @@ export type ButtonLinkProps = ButtonProps & {
 
 const variantStyles: Record<AllowedVariants, string> = {
   primary:
-    'bg-blue-500 dark:bg-sky-500 text-white group-hover:bg-blue-600 dark:group-hover:bg-sky-600 group-focus:ring-2 group-focus:ring-blue-500 dark:group-focus:ring-sky-500 focus:group-ring-offset-2',
+    'bg-blue-500 dark:bg-blue-500 text-white group-hover:bg-blue-600 dark:group-hover:bg-blue-600 group-focus:ring-2 group-focus:ring-blue-500 dark:group-focus:ring-blue-500 focus:group-ring-offset-2',
   secondary:
-    'border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-200 group-hover:bg-slate-50 dark:group-hover:bg-slate-700 group-focus:ring-2 group-focus:ring-blue-500 dark:group-focus:ring-sky-500 focus:ring-offset-2',
+    'border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 text-zinc-700 dark:text-zinc-200 group-hover:bg-zinc-50 dark:group-hover:bg-zinc-700 group-focus:ring-2 group-focus:ring-blue-500 dark:group-focus:ring-blue-500 focus:ring-offset-2',
   contrast:
-    'bg-slate-950 dark:bg-white text-slate-100 dark:text-slate-950 group-hover:bg-slate-800 dark:group-hover:bg-slate-100 group-focus:ring-2 group-focus:ring-blue-500 dark:group-focus:ring-sky-500 focus:ring-offset-2',
+    'bg-zinc-950 dark:bg-white text-zinc-100 dark:text-zinc-950 group-hover:bg-zinc-800 dark:group-hover:bg-zinc-100 group-focus:ring-2 group-focus:ring-blue-500 dark:group-focus:ring-blue-500 focus:ring-offset-2',
 };
 const sizes: Record<AllowedSizes, string> = {
   large: 'space-x-4 px-4 py-2 text-lg',
@@ -52,7 +52,7 @@ function getLayoutClassName(className = ''): string {
  */
 function ButtonInner({
   children,
-  variant = 'primary',
+  variant = 'contrast',
   size = 'default',
   rounded = 'default',
 }: ButtonProps): JSX.Element {
@@ -79,7 +79,7 @@ function ButtonInner({
 export function Button({
   children,
   className = '',
-  variant = 'primary',
+  variant = 'contrast',
   size = 'large',
   rounded = 'default',
   ...props
@@ -102,7 +102,7 @@ export const ButtonLink = forwardRef(function (
     className = '',
     href,
     size = 'default',
-    variant = 'primary',
+    variant = 'contrast',
     title = '',
     ...props
   }: ButtonLinkProps,

--- a/nx-dev/ui-common/src/lib/call-to-action.tsx
+++ b/nx-dev/ui-common/src/lib/call-to-action.tsx
@@ -34,7 +34,7 @@ export function CallToAction({
         <svg
           x="50%"
           y={0}
-          className="overflow-visible fill-slate-200/20 dark:fill-slate-800/20"
+          className="overflow-visible fill-zinc-200/20 dark:fill-zinc-800/20"
         >
           <path
             d="M-200 0h201v201h-201Z M600 0h201v201h-201Z M-400 600h201v201h-201Z M200 800h201v201h-201Z"
@@ -63,7 +63,7 @@ export function CallToAction({
       <div className="mx-auto max-w-2xl text-center">
         <h2
           id="cta"
-          className="text-3xl font-medium tracking-tight text-slate-950 sm:text-5xl dark:text-white"
+          className="text-3xl font-medium tracking-tight text-zinc-950 sm:text-5xl dark:text-white"
         >
           Ready to
           <br />
@@ -74,7 +74,7 @@ export function CallToAction({
             href={mainActionLink}
             title={mainActionTitle}
             prefetch={false}
-            className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
+            className="rounded-md bg-zinc-950 px-3.5 py-2.5 text-sm font-semibold text-zinc-100 shadow-sm hover:bg-zinc-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-100"
           >
             {mainActionLinkText}
           </Link>
@@ -82,7 +82,7 @@ export function CallToAction({
             href="/contact"
             title="Get in touch"
             prefetch={false}
-            className="group text-sm font-semibold leading-6 text-slate-950 dark:text-white"
+            className="group text-sm font-semibold leading-6 text-zinc-950 dark:text-white"
             onClick={() => sendCustomEvent('contact-click', 'footer-cta', '')}
           >
             Contact us{' '}

--- a/nx-dev/ui-common/src/lib/champion-card.tsx
+++ b/nx-dev/ui-common/src/lib/champion-card.tsx
@@ -15,28 +15,28 @@ export interface Champion {
 
 export function ChampionCard({ data }: { data: Champion }): JSX.Element {
   return (
-    <figure className="relative flex flex-col justify-between rounded-lg border border-slate-200 bg-white/40 p-4 text-sm shadow-sm transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-white dark:border-slate-800/40 dark:bg-slate-800/60 dark:hover:bg-slate-800">
+    <figure className="relative flex flex-col justify-between rounded-lg border border-zinc-200 bg-white/40 p-4 text-sm shadow-sm transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-white dark:border-zinc-800/40 dark:bg-zinc-800/60 dark:hover:bg-zinc-800">
       <figcaption className="flex items-center space-x-4">
         <img
           src={data.imageUrl}
           alt={data.name}
-          className="h-12 w-12 flex-none rounded-full border border-slate-200 bg-slate-800/40 object-cover dark:border-slate-800/40 dark:bg-slate-200"
+          className="h-12 w-12 flex-none rounded-full border border-zinc-200 bg-zinc-800/40 object-cover dark:border-zinc-800/40 dark:bg-zinc-200"
           loading="lazy"
         />
         <div className="flex-auto">
-          <div className="font-semibold text-slate-500 dark:text-slate-300">
+          <div className="font-semibold text-zinc-500 dark:text-zinc-300">
             <a target="_blank" rel="noreferrer" href={data.contact[0].link}>
               <span className="absolute inset-0"></span>
               {data.name}
             </a>
           </div>
-          <div className="mt-0.5 text-xs text-slate-400 dark:text-slate-500">
+          <div className="mt-0.5 text-xs text-zinc-400 dark:text-zinc-500">
             <MapIcon className="inline h-4 w-4" /> {data.location}
           </div>
         </div>
       </figcaption>
       <p className="mt-4">{data.expertise}</p>
-      <div className="ml mt-4 inline text-xs text-slate-400 dark:text-slate-500">
+      <div className="ml mt-4 inline text-xs text-zinc-400 dark:text-zinc-500">
         <ChatBubbleLeftIcon className="inline h-4 w-4" />{' '}
         {data.contact[0].label}
       </div>

--- a/nx-dev/ui-common/src/lib/champion-perks.tsx
+++ b/nx-dev/ui-common/src/lib/champion-perks.tsx
@@ -28,7 +28,7 @@ export function ChampionPerks(): JSX.Element {
   return (
     <article
       id="making-of-champion"
-      className="relative bg-slate-50 py-28 dark:bg-slate-800/40"
+      className="relative bg-zinc-50 py-28 dark:bg-zinc-800/40"
     >
       <div className="mx-auto max-w-7xl px-4 sm:grid sm:grid-cols-2 sm:gap-8 sm:px-6 lg:px-8">
         <div>
@@ -46,7 +46,7 @@ export function ChampionPerks(): JSX.Element {
             </SectionHeading>
           </header>
           <div className="mt-8 flex gap-16 font-normal">
-            <p className="max-w-xl text-lg text-slate-700 dark:text-slate-400">
+            <p className="max-w-xl text-lg text-zinc-700 dark:text-zinc-400">
               If you love Nx and want other people to love Nx too, you may have
               the makings of an Nx Champion.
             </p>
@@ -59,7 +59,7 @@ export function ChampionPerks(): JSX.Element {
             <dt>
               <div className="relative flex h-12 w-12">
                 <CheckBadgeIcon
-                  className="h-8 w-8 text-blue-500 dark:text-sky-500"
+                  className="h-8 w-8 text-blue-500 dark:text-blue-500"
                   aria-hidden="true"
                 />
                 <HeartIcon
@@ -71,12 +71,12 @@ export function ChampionPerks(): JSX.Element {
                   aria-hidden="true"
                 />
               </div>
-              <p className="relative mt-4 text-base font-medium leading-6 text-slate-900 dark:text-slate-100">
-                <span className="absolute -left-4 h-full w-0.5 bg-blue-500 dark:bg-sky-500"></span>
+              <p className="relative mt-4 text-base font-medium leading-6 text-zinc-900 dark:text-zinc-100">
+                <span className="absolute -left-4 h-full w-0.5 bg-blue-500 dark:bg-blue-500"></span>
                 Recognition as a Leader
               </p>
             </dt>
-            <dd className="mt-2 text-base text-slate-500 dark:text-slate-400">
+            <dd className="mt-2 text-base text-zinc-500 dark:text-zinc-400">
               You'll be listed in the Nx Champion directory above, receive
               branded swag for yourself and Nx stickers to give away.
             </dd>
@@ -85,7 +85,7 @@ export function ChampionPerks(): JSX.Element {
             <dt>
               <div className="relative flex h-12 w-12">
                 <NewspaperIcon
-                  className="h-8 w-8 text-blue-500 dark:text-sky-500"
+                  className="h-8 w-8 text-blue-500 dark:text-blue-500"
                   aria-hidden="true"
                 />
                 <VideoCameraIcon
@@ -97,12 +97,12 @@ export function ChampionPerks(): JSX.Element {
                   aria-hidden="true"
                 />
               </div>
-              <p className="relative mt-4 text-base font-medium leading-6 text-slate-900 dark:text-slate-100">
-                <span className="absolute -left-4 h-full w-0.5 bg-blue-500 dark:bg-sky-500"></span>
+              <p className="relative mt-4 text-base font-medium leading-6 text-zinc-900 dark:text-zinc-100">
+                <span className="absolute -left-4 h-full w-0.5 bg-blue-500 dark:bg-blue-500"></span>
                 Content Promotion
               </p>
             </dt>
-            <dd className="mt-2 text-base text-slate-500 dark:text-slate-400">
+            <dd className="mt-2 text-base text-zinc-500 dark:text-zinc-400">
               You can collaborate with other Nx Champions to improve your blog
               posts and videos. Nx will promote your content on our social media
               channels.
@@ -112,7 +112,7 @@ export function ChampionPerks(): JSX.Element {
             <dt>
               <div className="relative flex h-12 w-12">
                 <KeyIcon
-                  className="h-8 w-8 text-blue-500 dark:text-sky-500"
+                  className="h-8 w-8 text-blue-500 dark:text-blue-500"
                   aria-hidden="true"
                 />
                 <LightBulbIcon
@@ -124,12 +124,12 @@ export function ChampionPerks(): JSX.Element {
                   aria-hidden="true"
                 />
               </div>
-              <p className="relative mt-4 text-base font-medium leading-6 text-slate-900 dark:text-slate-100">
-                <span className="absolute -left-4 h-full w-0.5 bg-blue-500 dark:bg-sky-500"></span>
+              <p className="relative mt-4 text-base font-medium leading-6 text-zinc-900 dark:text-zinc-100">
+                <span className="absolute -left-4 h-full w-0.5 bg-blue-500 dark:bg-blue-500"></span>
                 Special Access
               </p>
             </dt>
-            <dd className="mt-2 text-base text-slate-500 dark:text-slate-400">
+            <dd className="mt-2 text-base text-zinc-500 dark:text-zinc-400">
               You'll have a dedicated Discord channel with the Nx team and
               monthly video calls with Nx team members to share feedback and
               brainstorm content ideas.
@@ -139,7 +139,7 @@ export function ChampionPerks(): JSX.Element {
             <dt>
               <div className="relative flex h-12 w-12">
                 <UserGroupIcon
-                  className="h-8 w-8 text-blue-500 dark:text-sky-500"
+                  className="h-8 w-8 text-blue-500 dark:text-blue-500"
                   aria-hidden="true"
                 />
                 <UsersIcon
@@ -151,15 +151,15 @@ export function ChampionPerks(): JSX.Element {
                   aria-hidden="true"
                 />
               </div>
-              <p className="relative mt-4 text-base font-medium leading-6 text-slate-900 dark:text-slate-100">
-                <span className="absolute -left-4 h-full w-0.5 bg-blue-500 dark:bg-sky-500"></span>
+              <p className="relative mt-4 text-base font-medium leading-6 text-zinc-900 dark:text-zinc-100">
+                <span className="absolute -left-4 h-full w-0.5 bg-blue-500 dark:bg-blue-500"></span>
                 Join the Program
               </p>
             </dt>
-            <dd className="mt-2 text-base text-slate-500 dark:text-slate-400">
+            <dd className="mt-2 text-base text-zinc-500 dark:text-zinc-400">
               When you're ready to join, fill out the{' '}
               <a
-                className="text-slate-900 underline dark:text-slate-100"
+                className="text-zinc-900 underline dark:text-zinc-100"
                 href="https://forms.gle/wYd9mC3ka64ki96G7"
               >
                 application form

--- a/nx-dev/ui-common/src/lib/course-video.tsx
+++ b/nx-dev/ui-common/src/lib/course-video.tsx
@@ -17,7 +17,7 @@ export function CourseVideo({
 }: CourseVideoProps): JSX.Element {
   return (
     <div className="not-prose mx-auto max-w-4xl pt-4">
-      <div className="overflow-hidden rounded-xl bg-slate-50 shadow-sm ring-1 ring-slate-900/5 dark:bg-slate-800/50 dark:ring-slate-700/50">
+      <div className="overflow-hidden rounded-xl bg-zinc-50 shadow-sm ring-1 ring-zinc-900/5 dark:bg-zinc-800/50 dark:ring-zinc-700/50">
         <div className="aspect-video w-full">
           <YouTube
             src={videoUrl}
@@ -28,12 +28,12 @@ export function CourseVideo({
         </div>
         <div className="px-6 py-4">
           <div className="flex flex-col items-center gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <h3 className="text-center text-xl font-medium text-slate-900 sm:text-left dark:text-white">
+            <h3 className="text-center text-xl font-medium text-zinc-900 sm:text-left dark:text-white">
               {courseTitle}
             </h3>
             <ButtonLink
               href={courseUrl}
-              variant="primary"
+              variant="contrast"
               size="small"
               title={`Watch the full "${courseTitle}" course`}
               className="whitespace-nowrap"

--- a/nx-dev/ui-common/src/lib/default-layout.tsx
+++ b/nx-dev/ui-common/src/lib/default-layout.tsx
@@ -25,7 +25,7 @@ export function DefaultLayout({
   useWindowScrollDepth();
 
   return (
-    <div className="w-full dark:bg-slate-950">
+    <div className="w-full dark:bg-zinc-950">
       {!hideHeader && (
         <Header
           ctaButtons={headerCTAConfig}

--- a/nx-dev/ui-common/src/lib/flip-card.tsx
+++ b/nx-dev/ui-common/src/lib/flip-card.tsx
@@ -45,15 +45,15 @@ export function FlipCard({
       >
         <div
           className={cx(
-            'preserve-3d relative h-full w-full content-center rounded-lg border-2 bg-white/60 shadow-sm transition duration-200 focus-within:ring-offset-2 dark:bg-slate-800/90',
+            'preserve-3d relative h-full w-full content-center rounded-lg border-2 bg-white/60 shadow-sm transition duration-200 focus-within:ring-offset-2 dark:bg-zinc-800/90',
             isFlippable && isFlipped
-              ? 'my-rotate-y-180 bg-white dark:bg-slate-800'
+              ? 'my-rotate-y-180 bg-white dark:bg-zinc-800'
               : '',
             isFlippable
               ? isFlipped
-                ? 'border-blue-400 dark:border-slate-800'
-                : 'border-blue-400 hover:[transform:rotateY(10deg)] dark:border-slate-800'
-              : 'border-1 border-slate-300 dark:border-slate-800'
+                ? 'border-blue-400 dark:border-zinc-800'
+                : 'border-blue-400 hover:[transform:rotateY(10deg)] dark:border-zinc-800'
+              : 'border-1 border-zinc-300 dark:border-zinc-800'
           )}
         >
           <FlipCardFront>{fullDate}</FlipCardFront>
@@ -76,7 +76,7 @@ export function FlipCardBack({ children }: { children: ReactNode }) {
   return (
     <FlipCardContext.Consumer>
       {() => (
-        <div className="my-rotate-y-180 backface-hidden h-full w-full overflow-hidden rounded-md bg-white text-3xl text-slate-900 dark:bg-slate-800 dark:text-slate-100">
+        <div className="my-rotate-y-180 backface-hidden h-full w-full overflow-hidden rounded-md bg-white text-3xl text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
           <div className="p-4 text-sm sm:text-sm md:text-sm lg:text-lg">
             {children}
           </div>

--- a/nx-dev/ui-common/src/lib/footer.tsx
+++ b/nx-dev/ui-common/src/lib/footer.tsx
@@ -198,7 +198,7 @@ export function Footer({
   };
   return (
     <footer
-      className={`bg-white dark:bg-slate-950 ${className}`}
+      className={`bg-white dark:bg-zinc-950 ${className}`}
       aria-labelledby="footer-heading"
     >
       <h2 id="footer-heading" className="sr-only">
@@ -206,7 +206,7 @@ export function Footer({
       </h2>
       <div className="mx-auto max-w-7xl px-4 pt-12 transition-opacity sm:px-6 lg:px-8 lg:pt-16 lg:opacity-50 lg:hover:opacity-100">
         <div className="xl:grid xl:grid-cols-3 xl:gap-8">
-          <div className="space-y-4 text-slate-700 xl:col-span-1 dark:text-slate-300">
+          <div className="space-y-4 text-zinc-700 xl:col-span-1 dark:text-zinc-300">
             <svg
               className="h-14 subpixel-antialiased"
               role="img"
@@ -225,7 +225,7 @@ export function Footer({
                   href={item.href}
                   title={item.label}
                   prefetch={false}
-                  className="text-sm text-slate-500 no-underline hover:text-slate-600 dark:hover:text-slate-400"
+                  className="text-sm text-zinc-500 no-underline hover:text-zinc-600 dark:hover:text-zinc-400"
                 >
                   <span className="sr-only">{item.name}</span>
                   <item.icon className="h-6 w-6" aria-hidden="true" />
@@ -241,7 +241,7 @@ export function Footer({
                     title={item.name}
                     target="_blank"
                     rel="noreferer"
-                    className="text-slate-500 no-underline hover:text-slate-600 dark:hover:text-slate-400"
+                    className="text-zinc-500 no-underline hover:text-zinc-600 dark:hover:text-zinc-400"
                   >
                     {item.name}
                   </a>
@@ -251,7 +251,7 @@ export function Footer({
                     href={prefixHref(item.href)}
                     title={item.name}
                     prefetch={false}
-                    className="text-slate-500 no-underline hover:text-slate-600 dark:hover:text-slate-400"
+                    className="text-zinc-500 no-underline hover:text-zinc-600 dark:hover:text-zinc-400"
                   >
                     {item.name}
                   </Link>
@@ -267,7 +267,7 @@ export function Footer({
           <div className="mt-12 grid grid-cols-2 gap-8 xl:col-span-2 xl:mt-0">
             <div className="md:grid md:grid-cols-2 md:gap-8">
               <div>
-                <h3 className="text-sm font-semibold uppercase tracking-wider text-slate-400">
+                <h3 className="text-sm font-semibold uppercase tracking-wider text-zinc-400">
                   Resources
                 </h3>
                 <ul role="list" className="mt-4 space-y-4 p-0">
@@ -279,7 +279,7 @@ export function Footer({
                           target="_blank"
                           title={item.name}
                           rel="noreferer"
-                          className="text-sm text-slate-500 no-underline hover:text-slate-600 dark:hover:text-slate-400"
+                          className="text-sm text-zinc-500 no-underline hover:text-zinc-600 dark:hover:text-zinc-400"
                         >
                           {item.name}
                         </a>
@@ -288,7 +288,7 @@ export function Footer({
                           href={prefixHref(item.href)}
                           prefetch={false}
                           title={item.name}
-                          className="text-sm text-slate-500 no-underline hover:text-slate-600 dark:hover:text-slate-400"
+                          className="text-sm text-zinc-500 no-underline hover:text-zinc-600 dark:hover:text-zinc-400"
                         >
                           {item.name}
                         </Link>
@@ -298,7 +298,7 @@ export function Footer({
                 </ul>
               </div>
               <div className="mt-12 md:mt-0">
-                <h3 className="text-sm font-semibold uppercase tracking-wider text-slate-400">
+                <h3 className="text-sm font-semibold uppercase tracking-wider text-zinc-400">
                   Solutions
                 </h3>
                 <ul role="list" className="mt-4 space-y-4 p-0">
@@ -308,7 +308,7 @@ export function Footer({
                         href={prefixHref(item.href)}
                         prefetch={false}
                         title={item.name}
-                        className="text-sm text-slate-500 no-underline hover:text-slate-600 dark:hover:text-slate-400"
+                        className="text-sm text-zinc-500 no-underline hover:text-zinc-600 dark:hover:text-zinc-400"
                       >
                         {item.name}
                       </Link>
@@ -319,7 +319,7 @@ export function Footer({
             </div>
             <div className="md:grid md:grid-cols-2 md:gap-8">
               <div>
-                <h3 className="text-sm font-semibold uppercase tracking-wider text-slate-400">
+                <h3 className="text-sm font-semibold uppercase tracking-wider text-zinc-400">
                   Nx Cloud
                 </h3>
                 <ul role="list" className="mt-4 space-y-4 p-0">
@@ -331,7 +331,7 @@ export function Footer({
                           title={item.name}
                           target="_blank"
                           rel="noreferer"
-                          className="text-sm text-slate-500 no-underline hover:text-slate-600 dark:hover:text-slate-400"
+                          className="text-sm text-zinc-500 no-underline hover:text-zinc-600 dark:hover:text-zinc-400"
                         >
                           {item.name}
                         </a>
@@ -340,7 +340,7 @@ export function Footer({
                           href={prefixHref(item.href)}
                           prefetch={false}
                           title={item.name}
-                          className="text-sm text-slate-500 no-underline hover:text-slate-600 dark:hover:text-slate-400"
+                          className="text-sm text-zinc-500 no-underline hover:text-zinc-600 dark:hover:text-zinc-400"
                         >
                           {item.name}
                         </Link>
@@ -350,7 +350,7 @@ export function Footer({
                 </ul>
               </div>
               <div className="mt-12 md:mt-0">
-                <h3 className="text-sm font-semibold uppercase tracking-wider text-slate-400">
+                <h3 className="text-sm font-semibold uppercase tracking-wider text-zinc-400">
                   Company
                 </h3>
                 <ul role="list" className="mt-4 space-y-4 p-0">
@@ -360,7 +360,7 @@ export function Footer({
                         href={prefixHref(item.href)}
                         prefetch={false}
                         title={item.name}
-                        className="text-sm text-slate-500 no-underline hover:text-slate-600 dark:hover:text-slate-400"
+                        className="text-sm text-zinc-500 no-underline hover:text-zinc-600 dark:hover:text-zinc-400"
                       >
                         {item.name}
                       </Link>
@@ -371,8 +371,8 @@ export function Footer({
             </div>
           </div>
         </div>
-        <div className="mt-20 border-t border-slate-200 p-2 dark:border-slate-800">
-          <div className="flex items-center gap-1 text-sm text-slate-400 xl:justify-center">
+        <div className="mt-20 border-t border-zinc-200 p-2 dark:border-zinc-800">
+          <div className="flex items-center gap-1 text-sm text-zinc-400 xl:justify-center">
             <span>&copy; {new Date().getFullYear()} made with</span>
             <HeartIcon className="inline h-4 w-4" />
             <span>by</span>
@@ -380,7 +380,7 @@ export function Footer({
               href={prefixHref('/company')}
               prefetch={false}
               title="Company"
-              className="inline-flex items-center text-slate-500 no-underline hover:text-slate-600 dark:hover:text-slate-400"
+              className="inline-flex items-center text-zinc-500 no-underline hover:text-zinc-600 dark:hover:text-zinc-400"
             >
               <svg
                 role="img"

--- a/nx-dev/ui-common/src/lib/github-star-widget.tsx
+++ b/nx-dev/ui-common/src/lib/github-star-widget.tsx
@@ -38,7 +38,7 @@ export function GitHubStarWidget({
   };
 
   return (
-    <div className="relative mx-2 flex items-center justify-center gap-2 rounded-md bg-slate-950 p-2 text-xs text-white transition hover:bg-slate-900 dark:bg-slate-100 dark:text-slate-950 dark:hover:bg-white print:hidden">
+    <div className="relative mx-2 flex items-center justify-center gap-2 rounded-md bg-zinc-950 p-2 text-xs text-white transition hover:bg-zinc-900 dark:bg-zinc-100 dark:text-zinc-950 dark:hover:bg-white print:hidden">
       <div className="flex items-center gap-2">
         <GithubIcon aria-hidden="true" className="h-4 w-4" />
         <span className="font-semibold">{formatStars(starsCount)}</span>
@@ -47,7 +47,7 @@ export function GitHubStarWidget({
         href="https://github.com/nrwl/nx"
         target="_blank"
         rel="noreferrer noopener"
-        className="flex items-center gap-2 border-transparent font-bold text-white no-underline dark:text-slate-950"
+        className="flex items-center gap-2 border-transparent font-bold text-white no-underline dark:text-zinc-950"
         onClick={() => handleClick('githubstars_buttonclick')}
       >
         <span className="absolute inset-0" />

--- a/nx-dev/ui-common/src/lib/headers/default-menu-item.tsx
+++ b/nx-dev/ui-common/src/lib/headers/default-menu-item.tsx
@@ -21,8 +21,8 @@ export function DefaultMenuItem({
       className={cx(
         'relative flex flex-1 gap-4 rounded-lg px-2 py-4 transition duration-150 ease-in-out',
         item.isHighlight
-          ? 'bg-slate-50 hover:bg-slate-100 dark:bg-slate-800/80 dark:hover:bg-slate-700/60'
-          : 'hover:bg-slate-50 dark:hover:bg-slate-800/60',
+          ? 'bg-zinc-50 hover:bg-zinc-100 dark:bg-zinc-800/80 dark:hover:bg-zinc-700/60'
+          : 'hover:bg-zinc-50 dark:hover:bg-zinc-800/60',
         className
       )}
       {...rest}
@@ -35,19 +35,19 @@ export function DefaultMenuItem({
           href={item.href}
           title={item.name}
           target={hasExternalLink ? '_blank' : '_self'}
-          className="text-sm font-medium text-slate-900 dark:text-slate-200"
+          className="text-sm font-medium text-zinc-900 dark:text-zinc-200"
           prefetch={false}
         >
           {item.name}
           {item.isNew ? (
-            <span className="float-right inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10 dark:bg-blue-400/10 dark:text-sky-400 dark:ring-sky-400/30">
+            <span className="float-right inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10 dark:bg-blue-400/10 dark:text-blue-400 dark:ring-blue-400/30">
               new
             </span>
           ) : null}
           <span className="absolute inset-0" />
         </Link>
         {item.description ? (
-          <p className="mt-0.5 text-xs text-slate-400 dark:text-slate-500">
+          <p className="mt-0.5 text-xs text-zinc-400 dark:text-zinc-500">
             {item.description}
           </p>
         ) : null}

--- a/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
@@ -43,8 +43,8 @@ function Menu({ tabs }: { tabs: any[] }): ReactElement {
             href={tab.href}
             className={cx(
               tab.current
-                ? 'border-blue-500 text-blue-600 dark:border-sky-500 dark:text-sky-500'
-                : 'border-transparent hover:text-slate-900 dark:hover:text-sky-400',
+                ? 'border-blue-500 text-blue-600 dark:border-blue-500 dark:text-blue-500'
+                : 'border-transparent hover:text-zinc-900 dark:hover:text-blue-400',
               'whitespace-nowrap border-b-2 py-2 text-sm font-medium'
             )}
             aria-current={tab.current ? 'page' : undefined}
@@ -218,7 +218,7 @@ export function DocumentationHeader({
   ];
 
   return (
-    <div className="border-b border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-800/60 print:hidden">
+    <div className="border-b border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-800/60 print:hidden">
       <div className="mx-auto flex w-full items-center gap-4 lg:px-8 lg:py-4">
         {/*MOBILE MENU*/}
         <div className="flex w-full items-center lg:hidden">
@@ -244,7 +244,7 @@ export function DocumentationHeader({
         <div className="flex items-center gap-4">
           <Link
             href="/"
-            className="flex flex-grow items-center px-4 text-slate-900 lg:px-0 dark:text-white"
+            className="flex flex-grow items-center px-4 text-zinc-900 lg:px-0 dark:text-white"
             prefetch={false}
             onContextMenu={handleContextMenu}
           >
@@ -255,7 +255,7 @@ export function DocumentationHeader({
           </Link>
           <Link
             href={docsUrl}
-            className="ml-2 hidden items-center px-4 text-slate-900 lg:flex lg:px-0 dark:text-white"
+            className="ml-2 hidden items-center px-4 text-zinc-900 lg:flex lg:px-0 dark:text-white"
             prefetch={false}
             onClick={() =>
               sendCustomEvent(
@@ -282,7 +282,7 @@ export function DocumentationHeader({
             <Link
               href="/blog"
               title="Blog"
-              className="hidden px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
+              className="hidden px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
               prefetch={false}
             >
               Blog
@@ -293,19 +293,19 @@ export function DocumentationHeader({
                 <>
                   <PopoverButton
                     className={cx(
-                      open ? 'text-blue-500 dark:text-sky-500' : '',
-                      'group inline-flex items-center px-3 py-2 font-medium leading-tight outline-0 dark:text-slate-200'
+                      open ? 'text-blue-500 dark:text-blue-500' : '',
+                      'group inline-flex items-center px-3 py-2 font-medium leading-tight outline-0 dark:text-zinc-200'
                     )}
                   >
-                    <span className="transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-sky-500">
+                    <span className="transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-blue-500">
                       Resources
                     </span>
                     <ChevronDownIcon
                       className={cx(
                         open
-                          ? 'rotate-180 transform text-blue-500 dark:text-sky-500'
+                          ? 'rotate-180 transform text-blue-500 dark:text-blue-500'
                           : '',
-                        'ml-2 h-3 w-3 transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-sky-500'
+                        'ml-2 h-3 w-3 transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-blue-500'
                       )}
                       aria-hidden="true"
                     />
@@ -327,11 +327,11 @@ export function DocumentationHeader({
                 </>
               )}
             </Popover>
-            <div className="hidden h-6 w-px bg-slate-200 md:block dark:bg-slate-700" />
+            <div className="hidden h-6 w-px bg-zinc-200 md:block dark:bg-zinc-700" />
             <Link
               href="/ai"
               title="AI"
-              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
+              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
               prefetch={false}
             >
               AI
@@ -339,16 +339,16 @@ export function DocumentationHeader({
             <Link
               href="/nx-cloud"
               title="Nx Cloud"
-              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
+              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
               prefetch={false}
             >
               Nx Cloud
             </Link>
-            <div className="hidden h-6 w-px bg-slate-200 md:block dark:bg-slate-700" />
+            <div className="hidden h-6 w-px bg-zinc-200 md:block dark:bg-zinc-700" />
             <Link
               href="/enterprise"
               title="Enterprise"
-              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
+              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
               prefetch={false}
             >
               Enterprise
@@ -379,7 +379,7 @@ export function DocumentationHeader({
             <ButtonLink
               href="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=documentation-header&utm_campaign=try-nx-cloud"
               title="Try Nx Cloud for free"
-              variant="primary"
+              variant="contrast"
               size="small"
               onClick={() =>
                 sendCustomEvent(

--- a/nx-dev/ui-common/src/lib/headers/header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/header.tsx
@@ -104,7 +104,7 @@ export function Header({
     },
     {
       href: 'https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=header',
-      variant: 'primary',
+      variant: 'contrast',
       size: 'small',
       target: '_blank',
       title: 'Try Nx Cloud for free',
@@ -133,13 +133,13 @@ export function Header({
         }}
       />
       {/*DESKTOP*/}
-      <div className="mx-auto mt-2 hidden w-full max-w-7xl items-center justify-between space-x-10 rounded-xl border border-slate-200/40 bg-white/70 px-4 py-2 shadow-sm backdrop-blur-xl backdrop-saturate-150 lg:flex dark:border-slate-800/60 dark:bg-slate-950/40">
+      <div className="mx-auto mt-2 hidden w-full max-w-7xl items-center justify-between space-x-10 rounded-xl border border-zinc-200/40 bg-white/70 px-4 py-2 shadow-sm backdrop-blur-xl backdrop-saturate-150 lg:flex dark:border-zinc-800/60 dark:bg-zinc-950/40">
         {/*PRIMARY NAVIGATION*/}
         <div className="flex flex-shrink-0 text-sm">
           {/*LOGO*/}
           <Link
             href="/"
-            className="mr-4 flex items-center text-slate-900 dark:text-white"
+            className="mr-4 flex items-center text-zinc-900 dark:text-white"
             prefetch={false}
             onContextMenu={handleContextMenu}
           >
@@ -156,7 +156,7 @@ export function Header({
             <Link
               href={docsUrl}
               title="Documentation"
-              className="hidden px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
+              className="hidden px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
               prefetch={false}
               onClick={() =>
                 sendCustomEvent(
@@ -171,7 +171,7 @@ export function Header({
             <Link
               href="/blog"
               title="Blog"
-              className="hidden px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
+              className="hidden px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
               prefetch={false}
             >
               Blog
@@ -182,19 +182,19 @@ export function Header({
                 <>
                   <PopoverButton
                     className={cx(
-                      open ? 'text-blue-500 dark:text-sky-500' : '',
-                      'group inline-flex items-center px-3 py-2 font-medium leading-tight outline-0 dark:text-slate-200'
+                      open ? 'text-blue-500 dark:text-blue-500' : '',
+                      'group inline-flex items-center px-3 py-2 font-medium leading-tight outline-0 dark:text-zinc-200'
                     )}
                   >
-                    <span className="transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-sky-500">
+                    <span className="transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-blue-500">
                       Solutions
                     </span>
                     <ChevronDownIcon
                       className={cx(
                         open
-                          ? 'rotate-180 transform text-blue-500 dark:text-sky-500'
+                          ? 'rotate-180 transform text-blue-500 dark:text-blue-500'
                           : '',
-                        'ml-2 h-3 w-3 transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-sky-500'
+                        'ml-2 h-3 w-3 transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-blue-500'
                       )}
                       aria-hidden="true"
                     />
@@ -228,19 +228,19 @@ export function Header({
                 <>
                   <PopoverButton
                     className={cx(
-                      open ? 'text-blue-500 dark:text-sky-500' : '',
-                      'group inline-flex items-center px-3 py-2 font-medium leading-tight outline-0 dark:text-slate-200'
+                      open ? 'text-blue-500 dark:text-blue-500' : '',
+                      'group inline-flex items-center px-3 py-2 font-medium leading-tight outline-0 dark:text-zinc-200'
                     )}
                   >
-                    <span className="transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-sky-500">
+                    <span className="transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-blue-500">
                       Resources
                     </span>
                     <ChevronDownIcon
                       className={cx(
                         open
-                          ? 'rotate-180 transform text-blue-500 dark:text-sky-500'
+                          ? 'rotate-180 transform text-blue-500 dark:text-blue-500'
                           : '',
-                        'ml-2 h-3 w-3 transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-sky-500'
+                        'ml-2 h-3 w-3 transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-blue-500'
                       )}
                       aria-hidden="true"
                     />
@@ -262,11 +262,11 @@ export function Header({
                 </>
               )}
             </Popover>
-            <div className="hidden h-6 w-px bg-slate-200 md:block dark:bg-slate-700" />
+            <div className="hidden h-6 w-px bg-zinc-200 md:block dark:bg-zinc-700" />
             <Link
               href="/ai"
               title="AI"
-              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
+              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
               prefetch={false}
               onClick={() =>
                 sendCustomEvent('ai-click', 'header-cta', 'page-header')
@@ -277,7 +277,7 @@ export function Header({
             <Link
               href="/nx-cloud"
               title="Nx Cloud"
-              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
+              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
               prefetch={false}
               onClick={() =>
                 sendCustomEvent('nx-cloud-click', 'header-cta', 'page-header')
@@ -288,7 +288,7 @@ export function Header({
             <Link
               href="/nx-cloud#plans"
               title="Nx Cloud Pricing"
-              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
+              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
               prefetch={false}
               onClick={() =>
                 sendCustomEvent('pricing-click', 'header-cta', 'page-header')
@@ -296,12 +296,12 @@ export function Header({
             >
               Pricing
             </Link>
-            <div className="hidden h-6 w-px bg-slate-200 md:block dark:bg-slate-700" />
+            <div className="hidden h-6 w-px bg-zinc-200 md:block dark:bg-zinc-700" />
             {/*ENTERPRISE*/}
             <Link
               href="/enterprise"
               title="Nx for Enterprises"
-              className="hidden gap-2 px-3 py-2 font-semibold leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
+              className="hidden gap-2 px-3 py-2 font-semibold leading-tight hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
               prefetch={false}
               onClick={() =>
                 sendCustomEvent('enterprise-click', 'header-cta', 'page-header')
@@ -367,7 +367,7 @@ export function Header({
           {/*LOGO*/}
           <Link
             href="/"
-            className="flex items-center text-slate-900 dark:text-white"
+            className="flex items-center text-zinc-900 dark:text-white"
             prefetch={false}
           >
             <span className="sr-only">Nx</span>
@@ -417,13 +417,13 @@ export function Header({
                   leaveTo="translate-x-full"
                 >
                   <DialogPanel className="pointer-events-auto w-screen">
-                    <div className="flex h-full flex-col overflow-y-scroll bg-white py-6 shadow-xl dark:bg-slate-900">
+                    <div className="flex h-full flex-col overflow-y-scroll bg-white py-6 shadow-xl dark:bg-zinc-900">
                       <div className="px-4 sm:px-6">
                         <div className="flex items-start justify-between">
                           <DialogTitle>
                             <Link
                               href="/"
-                              className="flex items-center text-slate-900 dark:text-white"
+                              className="flex items-center text-zinc-900 dark:text-white"
                               prefetch={false}
                             >
                               <svg
@@ -442,7 +442,7 @@ export function Header({
                           <div className="ml-3 flex h-7 items-center">
                             <button
                               type="button"
-                              className="dark:hovers:text-sky-500 relative rounded-md text-slate-600 hover:text-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:text-slate-400 dark:focus:ring-sky-500"
+                              className="dark:hovers:text-blue-500 relative rounded-md text-zinc-600 hover:text-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:text-zinc-400 dark:focus:ring-blue-500"
                               onClick={() => setIsOpen(!isOpen)}
                             >
                               <span className="absolute -inset-2.5" />
@@ -471,7 +471,7 @@ export function Header({
                           >
                             <ButtonLink
                               href="https://cloud.nx.app/get-started"
-                              variant="primary"
+                              variant="contrast"
                               size="small"
                               target="_blank"
                               title="Try Nx Cloud for free"
@@ -508,11 +508,11 @@ export function Header({
                           )}
                         </div>
 
-                        <div className="mt-4 divide-y divide-slate-200 border-b border-slate-200 dark:divide-slate-800 dark:border-slate-800">
+                        <div className="mt-4 divide-y divide-zinc-200 border-b border-zinc-200 dark:divide-zinc-800 dark:border-zinc-800">
                           <Link
                             href={docsUrl}
                             title="Documentation"
-                            className="block py-4 font-medium leading-tight hover:text-blue-500 dark:text-slate-200 dark:hover:text-sky-500"
+                            className="block py-4 font-medium leading-tight hover:text-blue-500 dark:text-zinc-200 dark:hover:text-blue-500"
                             prefetch={false}
                             onClick={() =>
                               sendCustomEvent(
@@ -527,7 +527,7 @@ export function Header({
                           <Link
                             href="/blog"
                             title="Blog"
-                            className="block py-4 font-medium leading-tight hover:text-blue-500 dark:text-slate-200 dark:hover:text-sky-500"
+                            className="block py-4 font-medium leading-tight hover:text-blue-500 dark:text-zinc-200 dark:hover:text-blue-500"
                             prefetch={false}
                           >
                             Blog
@@ -539,8 +539,8 @@ export function Header({
                                 <DisclosureButton
                                   className={cx(
                                     open
-                                      ? 'text-blue-500 dark:text-sky-500'
-                                      : 'tex-slate-800 dark:text-slate-200',
+                                      ? 'text-blue-500 dark:text-blue-500'
+                                      : 'tex-zinc-800 dark:text-zinc-200',
                                     'flex w-full items-center justify-between py-4 text-left text-base font-medium focus:outline-none'
                                   )}
                                 >
@@ -549,9 +549,9 @@ export function Header({
                                     aria-hidden="true"
                                     className={cx(
                                       open
-                                        ? 'rotate-180 transform text-blue-500 dark:text-sky-500'
-                                        : 'tex-slate-800 dark:text-slate-200',
-                                      'h-3 w-3 transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-sky-500'
+                                        ? 'rotate-180 transform text-blue-500 dark:text-blue-500'
+                                        : 'tex-zinc-800 dark:text-zinc-200',
+                                      'h-3 w-3 transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-blue-500'
                                     )}
                                   />
                                 </DisclosureButton>
@@ -582,8 +582,8 @@ export function Header({
                                 <DisclosureButton
                                   className={cx(
                                     open
-                                      ? 'text-blue-500 dark:text-sky-500'
-                                      : 'tex-slate-800 dark:text-slate-200',
+                                      ? 'text-blue-500 dark:text-blue-500'
+                                      : 'tex-zinc-800 dark:text-zinc-200',
                                     'flex w-full items-center justify-between py-4 text-left text-base font-medium focus:outline-none'
                                   )}
                                 >
@@ -592,9 +592,9 @@ export function Header({
                                     aria-hidden="true"
                                     className={cx(
                                       open
-                                        ? 'rotate-180 transform text-blue-500 dark:text-sky-500'
-                                        : 'tex-slate-800 dark:text-slate-200',
-                                      'h-3 w-3 transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-sky-500'
+                                        ? 'rotate-180 transform text-blue-500 dark:text-blue-500'
+                                        : 'tex-zinc-800 dark:text-zinc-200',
+                                      'h-3 w-3 transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-blue-500'
                                     )}
                                   />
                                 </DisclosureButton>
@@ -617,7 +617,7 @@ export function Header({
                           <Link
                             href="/ai"
                             title="AI"
-                            className="flex w-full gap-2 py-4 font-medium leading-tight hover:text-blue-500 dark:text-slate-200 dark:hover:text-sky-500"
+                            className="flex w-full gap-2 py-4 font-medium leading-tight hover:text-blue-500 dark:text-zinc-200 dark:hover:text-blue-500"
                             prefetch={false}
                             onClick={() =>
                               sendCustomEvent(
@@ -632,7 +632,7 @@ export function Header({
                           <Link
                             href="/nx-cloud"
                             title="Nx Cloud"
-                            className="flex w-full gap-2 py-4 font-medium leading-tight hover:text-blue-500 dark:text-slate-200 dark:hover:text-sky-500"
+                            className="flex w-full gap-2 py-4 font-medium leading-tight hover:text-blue-500 dark:text-zinc-200 dark:hover:text-blue-500"
                             prefetch={false}
                             onClick={() =>
                               sendCustomEvent(
@@ -647,7 +647,7 @@ export function Header({
                           <Link
                             href="/nx-cloud#plans"
                             title="Nx Cloud Pricing"
-                            className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-slate-200 dark:hover:text-sky-500"
+                            className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
                             prefetch={false}
                             onClick={() =>
                               sendCustomEvent(
@@ -665,8 +665,8 @@ export function Header({
                                 <DisclosureButton
                                   className={cx(
                                     open
-                                      ? 'text-blue-500 dark:text-sky-500'
-                                      : 'tex-slate-800 dark:text-slate-200',
+                                      ? 'text-blue-500 dark:text-blue-500'
+                                      : 'tex-zinc-800 dark:text-zinc-200',
                                     'flex w-full items-center justify-between py-4 text-left text-base font-medium focus:outline-none'
                                   )}
                                 >
@@ -675,9 +675,9 @@ export function Header({
                                     aria-hidden="true"
                                     className={cx(
                                       open
-                                        ? 'rotate-180 transform text-blue-500 dark:text-sky-500'
-                                        : 'tex-slate-800 dark:text-slate-200',
-                                      'h-3 w-3 transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-sky-500'
+                                        ? 'rotate-180 transform text-blue-500 dark:text-blue-500'
+                                        : 'tex-zinc-800 dark:text-zinc-200',
+                                      'h-3 w-3 transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-blue-500'
                                     )}
                                   />
                                 </DisclosureButton>
@@ -700,7 +700,7 @@ export function Header({
                           <Link
                             href="/contact"
                             title="Contact"
-                            className="block py-4 font-medium leading-tight hover:text-blue-500 dark:text-slate-200 dark:hover:text-sky-500"
+                            className="block py-4 font-medium leading-tight hover:text-blue-500 dark:text-zinc-200 dark:hover:text-blue-500"
                             prefetch={false}
                             onClick={() =>
                               sendCustomEvent(

--- a/nx-dev/ui-common/src/lib/headers/mobile-menu-item.tsx
+++ b/nx-dev/ui-common/src/lib/headers/mobile-menu-item.tsx
@@ -20,7 +20,7 @@ export function MobileMenuItem({
     <Tag
       className={cx(
         'items-top relative flex flex-1 gap-2 rounded-lg py-3',
-        item.isHighlight ? 'bg-slate-50 px-2 dark:bg-slate-800/80' : '',
+        item.isHighlight ? 'bg-zinc-50 px-2 dark:bg-zinc-800/80' : '',
         className
       )}
       {...rest}
@@ -33,19 +33,19 @@ export function MobileMenuItem({
           href={item.href}
           title={item.name}
           target={hasExternalLink ? '_blank' : '_self'}
-          className="text-sm font-medium text-slate-900 dark:text-slate-200"
+          className="text-sm font-medium text-zinc-900 dark:text-zinc-200"
           prefetch={false}
         >
           {item.name}
           {item.isNew ? (
-            <span className="float-right inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10 dark:bg-blue-400/10 dark:text-sky-400 dark:ring-sky-400/30">
+            <span className="float-right inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10 dark:bg-blue-400/10 dark:text-blue-400 dark:ring-blue-400/30">
               new
             </span>
           ) : null}
           <span className="absolute inset-0" />
         </Link>
         {item.description ? (
-          <p className="mt-0.5 text-xs text-slate-400 dark:text-slate-500">
+          <p className="mt-0.5 text-xs text-zinc-400 dark:text-zinc-500">
             {item.description}
           </p>
         ) : null}

--- a/nx-dev/ui-common/src/lib/headers/sections-menu.tsx
+++ b/nx-dev/ui-common/src/lib/headers/sections-menu.tsx
@@ -7,12 +7,12 @@ export function SectionsMenu({
   sections: Record<string, MenuItem[]>;
 }): JSX.Element {
   return (
-    <div className="flex flex-col gap-2 overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
-      <div className="divide-y divide-slate-200 dark:divide-slate-800">
+    <div className="flex flex-col gap-2 overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-zinc-200 dark:bg-zinc-900 dark:ring-zinc-800">
+      <div className="divide-y divide-zinc-200 dark:divide-zinc-800">
         {Object.keys(sections).map((section) => (
           <div key={section}>
             {section ? (
-              <h5 className="px-4 pt-6 text-sm text-slate-500 dark:text-slate-400">
+              <h5 className="px-4 pt-6 text-sm text-zinc-500 dark:text-zinc-400">
                 {section}
               </h5>
             ) : undefined}

--- a/nx-dev/ui-common/src/lib/headers/two-columns-menu.tsx
+++ b/nx-dev/ui-common/src/lib/headers/two-columns-menu.tsx
@@ -3,7 +3,7 @@ import { DefaultMenuItem } from './default-menu-item';
 
 export function TwoColumnsMenu({ items }: { items: MenuItem[] }): JSX.Element {
   return (
-    <div className="flex flex-col gap-2 overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-slate-200 dark:bg-slate-900 dark:ring-slate-800">
+    <div className="flex flex-col gap-2 overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-zinc-200 dark:bg-zinc-900 dark:ring-zinc-800">
       <div className="grid grid-cols-2 gap-2 p-2">
         {items
           .filter((i) => !i.isHighlight)

--- a/nx-dev/ui-common/src/lib/live-stream-notifier.tsx
+++ b/nx-dev/ui-common/src/lib/live-stream-notifier.tsx
@@ -42,13 +42,13 @@ export function LiveStreamNotifier(): ReactElement | null {
         damping: 30,
         mass: 1,
       }}
-      className="fixed bottom-0 left-0 right-0 z-30 w-full overflow-hidden bg-slate-950 text-white shadow-lg md:bottom-4 md:left-auto md:right-4 md:w-[512px] md:rounded-lg"
+      className="fixed bottom-0 left-0 right-0 z-30 w-full overflow-hidden bg-zinc-950 text-white shadow-lg md:bottom-4 md:left-auto md:right-4 md:w-[512px] md:rounded-lg"
       style={{ originY: 1 }}
     >
       <div className="relative p-4">
         <button
           onClick={closeNotifier}
-          className="absolute right-2 top-2 rounded-full p-1 hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-white"
+          className="absolute right-2 top-2 rounded-full p-1 hover:bg-zinc-800 focus:outline-none focus:ring-2 focus:ring-white"
         >
           <XMarkIcon className="size-5" aria-hidden="true" />
           <span className="sr-only">Close</span>

--- a/nx-dev/ui-common/src/lib/plugin-card.tsx
+++ b/nx-dev/ui-common/src/lib/plugin-card.tsx
@@ -28,7 +28,7 @@ export function PluginCard({
   nxVersion,
 }: PluginCardProps): JSX.Element {
   return (
-    <div className="focus-within:ring-focus-within:ring-blue-500 relative flex w-full rounded-lg border border-slate-200 bg-white shadow-sm transition hover:bg-slate-50 dark:border-slate-900 dark:bg-slate-800/60 dark:focus-within:ring-sky-500 dark:hover:bg-slate-800">
+    <div className="focus-within:ring-focus-within:ring-blue-500 relative flex w-full rounded-lg border border-zinc-200 bg-white shadow-sm transition hover:bg-zinc-50 dark:border-zinc-900 dark:bg-zinc-800/60 dark:focus-within:ring-blue-500 dark:hover:bg-zinc-800">
       <div className="flex w-full flex-col px-4 py-3">
         <h3 className="mb-4 flex items-center font-semibold leading-tight">
           <svg

--- a/nx-dev/ui-common/src/lib/sidebar-container.tsx
+++ b/nx-dev/ui-common/src/lib/sidebar-container.tsx
@@ -103,11 +103,11 @@ export function SidebarContainer({
         toggleNav={toggleNav}
         navIsOpen={navIsOpen}
       />
-      <div className="hidden h-full w-72 flex-col border-r border-slate-200 md:flex dark:border-slate-700 dark:bg-slate-900">
+      <div className="hidden h-full w-72 flex-col border-r border-zinc-200 md:flex dark:border-zinc-700 dark:bg-zinc-900">
         <div className="relative flex flex-grow overflow-y-scroll p-4">
           <Sidebar menu={menuWithAngularRspack} />
         </div>
-        {/*<div className="relative flex flex-col space-y-1 border-t border-slate-200 px-4 py-2 dark:border-slate-700">*/}
+        {/*<div className="relative flex flex-col space-y-1 border-t border-zinc-200 px-4 py-2 dark:border-zinc-700">*/}
         {/*  // another section.*/}
         {/*</div>*/}
       </div>

--- a/nx-dev/ui-common/src/lib/sidebar.tsx
+++ b/nx-dev/ui-common/src/lib/sidebar.tsx
@@ -63,7 +63,7 @@ function SidebarSection({ section }: { section: MenuSection }): JSX.Element {
       {section.hideSectionHeader ? null : (
         <h4
           data-testid={`section-h4:${section.id}`}
-          className="mb-3 mt-8 border-b border-solid border-slate-200 pb-2 text-xl font-bold dark:border-slate-700 dark:text-slate-100"
+          className="mb-3 mt-8 border-b border-solid border-zinc-200 pb-2 text-xl font-bold dark:border-zinc-700 dark:text-zinc-100"
         >
           {section.name}
         </h4>
@@ -142,8 +142,8 @@ function SidebarSectionItems({
           'group flex items-center py-2',
           '-ml-1 px-1',
           !isNested
-            ? 'text-base text-slate-800 lg:text-base dark:text-slate-200'
-            : 'text-sm text-slate-800 lg:text-sm dark:text-slate-200',
+            ? 'text-base text-zinc-800 lg:text-base dark:text-zinc-200'
+            : 'text-sm text-zinc-800 lg:text-sm dark:text-zinc-200',
           firstLevel ? 'font-semibold' : '',
           item.disableCollapsible ? 'cursor-text' : 'cursor-pointer'
         )}
@@ -195,7 +195,7 @@ function SidebarSectionItems({
               className={cx(
                 'relative',
                 item.id !== 'technologies'
-                  ? 'border-l border-slate-300 pl-2 pl-3 transition-colors duration-150 dark:border-slate-600'
+                  ? 'border-l border-zinc-300 pl-2 pl-3 transition-colors duration-150 dark:border-zinc-600'
                   : ''
               )}
             >
@@ -214,13 +214,13 @@ function SidebarSectionItems({
                 <Link
                   href={subItem.path}
                   className={cx(
-                    'relative block py-1 text-slate-500 transition-colors duration-200 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-300'
+                    'relative block py-1 text-zinc-500 transition-colors duration-200 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-300'
                   )}
                   prefetch={false}
                 >
                   <span
                     className={cx('relative', {
-                      'text-md font-medium text-blue-500 dark:text-sky-500':
+                      'text-md font-medium text-blue-500 dark:text-blue-500':
                         isActiveLink,
                     })}
                   >
@@ -245,7 +245,7 @@ function CollapsibleIcon({
     <svg
       xmlns="http://www.w3.org/2000/svg"
       className={cx(
-        'w-3.5 text-slate-600 transition-all dark:text-slate-400',
+        'w-3.5 text-zinc-600 transition-all dark:text-zinc-400',
         !isCollapsed && 'rotate-90 transform'
       )}
       fill="none"
@@ -361,9 +361,9 @@ export function SidebarMobile({
             leaveFrom="translate-x-0"
             leaveTo="-translate-x-full"
           >
-            <DialogPanel className="relative flex w-full flex-col overflow-y-auto bg-white dark:bg-slate-900">
+            <DialogPanel className="relative flex w-full flex-col overflow-y-auto bg-white dark:bg-zinc-900">
               {/*HEADER*/}
-              <div className="flex w-full items-center border-b border-slate-200 bg-slate-50 p-4 lg:hidden dark:border-slate-700 dark:bg-slate-800/60">
+              <div className="flex w-full items-center border-b border-zinc-200 bg-zinc-50 p-4 lg:hidden dark:border-zinc-700 dark:bg-zinc-800/60">
                 {/*CLOSE BUTTON*/}
                 <button
                   type="button"
@@ -379,7 +379,7 @@ export function SidebarMobile({
                 <div className="ml-auto flex items-center">
                   <Link
                     href="/"
-                    className="flex flex-grow items-center px-4 text-slate-900 lg:px-0 dark:text-white"
+                    className="flex flex-grow items-center px-4 text-zinc-900 lg:px-0 dark:text-white"
                     prefetch={false}
                   >
                     <span className="sr-only">Nx</span>
@@ -389,7 +389,7 @@ export function SidebarMobile({
               </div>
               <div className="p-4">
                 {/*SECTIONS*/}
-                <div className="mt-5 divide-y divide-slate-200">
+                <div className="mt-5 divide-y divide-zinc-200">
                   <div className="grid w-full shrink-0 grid-cols-3 items-center justify-between">
                     {sections.general.map((section) => (
                       <Link
@@ -397,8 +397,8 @@ export function SidebarMobile({
                         href={section.href}
                         className={cx(
                           section.current
-                            ? 'text-blue-600 dark:text-sky-500'
-                            : 'hover:text-slate-900 dark:hover:text-sky-400',
+                            ? 'text-blue-600 dark:text-blue-500'
+                            : 'hover:text-zinc-900 dark:hover:text-blue-400',
                           'whitespace-nowrap p-4 text-center text-sm font-medium'
                         )}
                         aria-current={section.current ? 'page' : undefined}
@@ -415,8 +415,8 @@ export function SidebarMobile({
                         href={section.href}
                         className={cx(
                           section.current
-                            ? 'text-blue-600 dark:text-sky-500'
-                            : 'hover:text-slate-900 dark:hover:text-sky-400',
+                            ? 'text-blue-600 dark:text-blue-500'
+                            : 'hover:text-zinc-900 dark:hover:text-blue-400',
                           'whitespace-nowrap p-4 text-center text-sm font-medium'
                         )}
                         aria-current={section.current ? 'page' : undefined}

--- a/nx-dev/ui-common/src/lib/square-dotted-pattern.tsx
+++ b/nx-dev/ui-common/src/lib/square-dotted-pattern.tsx
@@ -24,7 +24,7 @@ export const SquareDottedPattern: FC<SVGProps<SVGSVGElement>> = (props) => (
             y={0}
             width={4}
             height={4}
-            className="text-slate-200 dark:text-slate-800"
+            className="text-zinc-200 dark:text-zinc-800"
             fill="currentColor"
           />
         </pattern>
@@ -56,7 +56,7 @@ export const SquareDottedPattern: FC<SVGProps<SVGSVGElement>> = (props) => (
             y={0}
             width={4}
             height={4}
-            className="text-slate-200 dark:text-slate-800"
+            className="text-zinc-200 dark:text-zinc-800"
             fill="currentColor"
           />
         </pattern>
@@ -88,7 +88,7 @@ export const SquareDottedPattern: FC<SVGProps<SVGSVGElement>> = (props) => (
             y={0}
             width={4}
             height={4}
-            className="text-slate-200 dark:text-slate-800"
+            className="text-zinc-200 dark:text-zinc-800"
             fill="currentColor"
           />
         </pattern>

--- a/nx-dev/ui-common/src/lib/testimonial-card.tsx
+++ b/nx-dev/ui-common/src/lib/testimonial-card.tsx
@@ -8,25 +8,25 @@ interface Testimonial {
 
 export function TestimonialCard({ data }: { data: Testimonial }): JSX.Element {
   return (
-    <figure className="relative flex flex-col-reverse rounded-lg border border-slate-200 bg-white/40 p-4 text-sm shadow-sm transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-white dark:border-slate-800/40 dark:bg-slate-800/60 dark:hover:bg-slate-800">
-      <blockquote className="mt-4 text-slate-600 dark:text-slate-400">
+    <figure className="relative flex flex-col-reverse rounded-lg border border-zinc-200 bg-white/40 p-4 text-sm shadow-sm transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-white dark:border-zinc-800/40 dark:bg-zinc-800/60 dark:hover:bg-zinc-800">
+      <blockquote className="mt-4 text-zinc-600 dark:text-zinc-400">
         <p>{data.content}</p>
       </blockquote>
       <figcaption className="flex items-center space-x-4">
         <img
           src={data.imageUrl}
           alt={data.author}
-          className="h-12 w-12 flex-none rounded-full border border-slate-200 object-cover dark:border-slate-800/40"
+          className="h-12 w-12 flex-none rounded-full border border-zinc-200 object-cover dark:border-zinc-800/40"
           loading="lazy"
         />
         <div className="flex-auto">
-          <div className="font-semibold text-slate-500 dark:text-slate-300">
+          <div className="font-semibold text-zinc-500 dark:text-zinc-300">
             <a target="_blank" rel="noreferrer" href={data.link}>
               <span className="absolute inset-0"></span>
               {data.author}
             </a>
           </div>
-          <div className="mt-0.5 text-xs text-slate-400 dark:text-slate-500">
+          <div className="mt-0.5 text-xs text-zinc-400 dark:text-zinc-500">
             {data.title}
           </div>
         </div>

--- a/nx-dev/ui-common/src/lib/testimonials.tsx
+++ b/nx-dev/ui-common/src/lib/testimonials.tsx
@@ -17,8 +17,8 @@ export function Testimonials(): JSX.Element {
         </SectionHeading>
       </header>
       <div className="md:px-62 mx-auto grid max-w-7xl grid-cols-1 items-stretch gap-8 px-4 py-12 md:grid-cols-3 lg:px-8 lg:py-16">
-        <div className="rounded-xl bg-slate-50 p-10 dark:bg-slate-800/60">
-          <ChatBubbleLeftEllipsisIcon className="h-8 w-8 text-blue-500 dark:text-sky-500" />
+        <div className="rounded-xl bg-zinc-50 p-10 dark:bg-zinc-800/60">
+          <ChatBubbleLeftEllipsisIcon className="h-8 w-8 text-blue-500 dark:text-blue-500" />
           <p className="mt-4">
             "It made it possible to remove our hand-rolled code and to use a
             well-maintained and streamlined solution, increasing performance
@@ -28,8 +28,8 @@ export function Testimonials(): JSX.Element {
           <div className="mt-8 font-semibold">Nitin Vericherla</div>
           <div className="mt-0.5 text-sm">UI Architect at Synapse Wireless</div>
         </div>
-        <div className="rounded-xl bg-slate-50 p-10 dark:bg-slate-800/60">
-          <ChatBubbleLeftEllipsisIcon className="h-8 w-8 text-blue-500 dark:text-sky-500" />
+        <div className="rounded-xl bg-zinc-50 p-10 dark:bg-zinc-800/60">
+          <ChatBubbleLeftEllipsisIcon className="h-8 w-8 text-blue-500 dark:text-blue-500" />
           <p className="mt-4">
             "By updating to the latest Lerna version and enabling Nx caching, we
             were able to reduce CI build times by ~35% - a great time saving for
@@ -41,8 +41,8 @@ export function Testimonials(): JSX.Element {
             Senior Software Engineer at Sentry
           </div>
         </div>
-        <div className="rounded-xl bg-slate-50 p-10 dark:bg-slate-800/60">
-          <ChatBubbleLeftEllipsisIcon className="h-8 w-8 text-blue-500 dark:text-sky-500" />
+        <div className="rounded-xl bg-zinc-50 p-10 dark:bg-zinc-800/60">
+          <ChatBubbleLeftEllipsisIcon className="h-8 w-8 text-blue-500 dark:text-blue-500" />
           <p className="mt-4">
             "Since we are using NxCloud, we saw our CI times reduced by 83%!
             That means our teams are not waiting hours for their PR to be merged

--- a/nx-dev/ui-common/src/lib/trusted-by.tsx
+++ b/nx-dev/ui-common/src/lib/trusted-by.tsx
@@ -35,7 +35,7 @@ export function TrustedBy({
           as="h2"
           variant="subtitle"
           id="trusted"
-          className="scroll-mt-24 font-medium tracking-tight text-slate-950 sm:text-3xl dark:text-white"
+          className="scroll-mt-24 font-medium tracking-tight text-zinc-950 sm:text-3xl dark:text-white"
         >
           Trusted by leading OSS projects and Fortune 500 companies.
         </SectionHeading>
@@ -49,67 +49,67 @@ export function TrustedBy({
         <div className="grid grid-cols-3 place-items-center items-center gap-6 transition-all sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8">
           <MicrosoftIcon
             aria-hidden="true"
-            className="h-10 w-10 text-slate-950 dark:text-white"
+            className="h-10 w-10 text-zinc-950 dark:text-white"
           />
           <AwsIcon
             aria-hidden="true"
-            className="h-14 w-14 text-slate-950 dark:text-white"
+            className="h-14 w-14 text-zinc-950 dark:text-white"
           />
           <AdobeIcon
             aria-hidden="true"
-            className="h-10 w-10 text-slate-950 dark:text-white"
+            className="h-10 w-10 text-zinc-950 dark:text-white"
           />
           <IntelIcon
             aria-hidden="true"
-            className="hidden h-16 w-16 text-slate-950 sm:block dark:text-white"
+            className="hidden h-16 w-16 text-zinc-950 sm:block dark:text-white"
           />
           <CiscoIcon
             aria-hidden="true"
-            className="hidden h-16 w-16 text-slate-950 md:block dark:text-white"
+            className="hidden h-16 w-16 text-zinc-950 md:block dark:text-white"
           />
           <VmwareIcon
             aria-hidden="true"
-            className="hidden h-24 w-24 text-slate-950 md:block dark:text-white"
+            className="hidden h-24 w-24 text-zinc-950 md:block dark:text-white"
           />
           <FedExIcon
             aria-hidden="true"
-            className="hidden h-20 w-20 text-slate-950 md:block dark:text-white"
+            className="hidden h-20 w-20 text-zinc-950 md:block dark:text-white"
           />
           <HiltonIcon
             aria-hidden="true"
-            className="hidden h-20 w-20 text-slate-950 md:block dark:text-white"
+            className="hidden h-20 w-20 text-zinc-950 md:block dark:text-white"
           />
           <SevenElevenIcon
             aria-hidden="true"
-            className="hidden h-10 w-10 text-slate-950 lg:block dark:text-white"
+            className="hidden h-10 w-10 text-zinc-950 lg:block dark:text-white"
           />
           <RedBullIcon
             aria-hidden="true"
-            className="hidden h-20 w-20 text-slate-950 lg:block dark:text-white"
+            className="hidden h-20 w-20 text-zinc-950 lg:block dark:text-white"
           />
           <StorybookIcon
             aria-hidden="true"
-            className="h-10 w-10 text-slate-950 dark:text-white"
+            className="h-10 w-10 text-zinc-950 dark:text-white"
           />
           <StrapiIcon
             aria-hidden="true"
-            className="hidden h-10 w-10 text-slate-950 lg:block dark:text-white"
+            className="hidden h-10 w-10 text-zinc-950 lg:block dark:text-white"
           />
           <CypressIcon
             aria-hidden="true"
-            className="hidden h-12 w-12 text-slate-950 sm:block dark:text-white"
+            className="hidden h-12 w-12 text-zinc-950 sm:block dark:text-white"
           />
           <SentryIcon
             aria-hidden="true"
-            className="h-16 w-16 text-slate-950 dark:text-white"
+            className="h-16 w-16 text-zinc-950 dark:text-white"
           />
           <RxJSIcon
             aria-hidden="true"
-            className="hidden h-10 w-10 text-slate-950 lg:block dark:text-white"
+            className="hidden h-10 w-10 text-zinc-950 lg:block dark:text-white"
           />
           <ShopifyIcon
             aria-hidden="true"
-            className="h-10 w-10 text-slate-950 dark:text-white"
+            className="h-10 w-10 text-zinc-950 dark:text-white"
           />
         </div>
 
@@ -118,7 +118,7 @@ export function TrustedBy({
             href={`/customers?utm_source=${utmSource}&utm_medium=website&utm_campaign=${utmCampaign}&utm_content=our_customers`}
             title="Our customers"
             prefetch={false}
-            className="group font-semibold leading-6 text-slate-950 transition-all duration-200 dark:text-white"
+            className="group font-semibold leading-6 text-zinc-950 transition-all duration-200 dark:text-white"
           >
             Learn about our customers{' '}
             <span

--- a/nx-dev/ui-common/src/lib/typography.tsx
+++ b/nx-dev/ui-common/src/lib/typography.tsx
@@ -21,11 +21,11 @@ type Description = {
 
 const variants: Record<AllowedVariants, string> = {
   title:
-    'text-3xl font-bold tracking-tight text-slate-950 dark:text-white sm:text-5xl',
+    'text-3xl font-bold tracking-tight text-zinc-950 dark:text-white sm:text-5xl',
   display:
-    'text-5xl font-semibold tracking-tight text-balance text-slate-950 dark:text-white sm:text-7xl',
+    'text-5xl font-semibold tracking-tight text-balance text-zinc-950 dark:text-white sm:text-7xl',
   subtitle:
-    'text-lg font-medium text-pretty sm:text-xl/8 text-slate-700 dark:text-slate-300',
+    'text-lg font-medium text-pretty sm:text-xl/8 text-zinc-700 dark:text-zinc-300',
 };
 
 export function SectionHeading({
@@ -52,7 +52,7 @@ export function SectionDescription({
   const Tag = as;
   return (
     <Tag
-      className={cx('text-slate-700 dark:text-slate-400', className)}
+      className={cx('text-zinc-700 dark:text-zinc-400', className)}
       {...rest}
     >
       {children}
@@ -77,7 +77,7 @@ export function TextLink({
       {...props}
       className={cx(
         className,
-        'font-bold text-blue-600 underline decoration-blue-600/50 transition hover:text-black hover:decoration-blue-600 dark:text-sky-500 dark:decoration-sky-500/50 dark:hover:text-white dark:hover:decoration-sky-500'
+        'font-bold text-blue-600 underline decoration-blue-600/50 transition hover:text-black hover:decoration-blue-600 dark:text-blue-500 dark:decoration-blue-500/50 dark:hover:text-white dark:hover:decoration-blue-500'
       )}
     />
   );
@@ -91,7 +91,7 @@ export function TextLinkHighlight({
       {...props}
       className={cx(
         className,
-        'rounded bg-black px-1 py-0.5 font-bold text-white transition hover:bg-blue-600 dark:bg-white dark:text-black dark:hover:bg-sky-500'
+        'rounded bg-black px-1 py-0.5 font-bold text-white transition hover:bg-blue-600 dark:bg-white dark:text-black dark:hover:bg-blue-500'
       )}
     />
   );
@@ -104,7 +104,7 @@ export function Strong({
   return (
     <strong
       {...props}
-      className={cx(className, 'font-bold text-slate-950 dark:text-slate-100')}
+      className={cx(className, 'font-bold text-zinc-950 dark:text-zinc-100')}
     />
   );
 }
@@ -118,7 +118,7 @@ export function Code({
       {...props}
       className={cx(
         className,
-        'rounded border border-slate-950/10 bg-slate-950/[2.5%] px-0.5 text-sm font-medium text-slate-950 sm:text-[0.8125rem] dark:border-white/20 dark:bg-white/5 dark:text-white'
+        'rounded border border-zinc-950/10 bg-zinc-950/[2.5%] px-0.5 text-sm font-medium text-zinc-950 sm:text-[0.8125rem] dark:border-white/20 dark:bg-white/5 dark:text-white'
       )}
     />
   );

--- a/nx-dev/ui-common/src/lib/version-picker.tsx
+++ b/nx-dev/ui-common/src/lib/version-picker.tsx
@@ -36,13 +36,13 @@ export function VersionPicker(): JSX.Element {
               <div className="relative">
                 <ListboxButton
                   className={
-                    'relative w-full cursor-pointer rounded-lg border-slate-200 py-2 pr-6 text-left font-medium focus:outline-none focus-visible:border-blue-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-blue-300 sm:text-sm dark:border-slate-700'
+                    'relative w-full cursor-pointer rounded-lg border-zinc-200 py-2 pr-6 text-left font-medium focus:outline-none focus-visible:border-blue-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-blue-300 sm:text-sm dark:border-zinc-700'
                   }
                 >
                   <span className="block">{selected.label}</span>
                   <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center">
                     <ChevronUpDownIcon
-                      className="h-5 w-5 text-slate-500"
+                      className="h-5 w-5 text-zinc-500"
                       aria-hidden="true"
                     />
                   </span>
@@ -59,13 +59,13 @@ export function VersionPicker(): JSX.Element {
                 >
                   <ListboxOptions
                     static
-                    className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-sm bg-white py-1 pl-0 text-base shadow-md focus:outline-none sm:text-sm dark:bg-slate-800/90 dark:focus-within:ring-sky-500"
+                    className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-sm bg-white py-1 pl-0 text-base shadow-md focus:outline-none sm:text-sm dark:bg-zinc-800/90 dark:focus-within:ring-blue-500"
                   >
                     {versionOptions.map((item, idx) => (
                       <ListboxOption
                         key={idx}
                         className={() =>
-                          `relative cursor-pointer select-none list-none hover:bg-slate-50 dark:hover:bg-slate-800`
+                          `relative cursor-pointer select-none list-none hover:bg-zinc-50 dark:hover:bg-zinc-800`
                         }
                         value={item}
                       >

--- a/nx-dev/ui-common/src/lib/video-player/video-player.tsx
+++ b/nx-dev/ui-common/src/lib/video-player/video-player.tsx
@@ -47,14 +47,14 @@ const VARIANT_STYLES: Record<
       'bg-[radial-gradient(var(--blue-500)_40%,transparent_60%)] opacity-[0.8] dark:bg-[radial-gradient(var(--pink-500)_40%,transparent_60%)]',
     textColor: 'text-white',
     backgroundColor: 'bg-white/10',
-    borderColor: 'border-slate-100',
+    borderColor: 'border-zinc-100',
   },
   'blue-white-spin': {
     gradient:
       'bg-[conic-gradient(from_90deg_at_50%_50%,#FFFFFF_0%,#3B82F6_50%,#FFFFFF_100%)] dark:bg-[conic-gradient(from_90deg_at_50%_50%,#FFFFFF_0%,#0EA5E9_50%,#FFFFFF_100%)]',
-    textColor: 'text-slate-950',
+    textColor: 'text-zinc-950',
     backgroundColor: 'bg-white/70',
-    borderColor: 'border-slate-100',
+    borderColor: 'border-zinc-100',
   },
 };
 

--- a/nx-dev/ui-common/src/lib/webinar-notifier.tsx
+++ b/nx-dev/ui-common/src/lib/webinar-notifier.tsx
@@ -65,13 +65,13 @@ export function WebinarNotifier({
         damping: 30,
         mass: 1,
       }}
-      className="fixed bottom-0 left-0 right-0 z-30 w-full overflow-hidden bg-slate-950 text-white shadow-lg md:bottom-4 md:left-auto md:right-4 md:w-[512px] md:rounded-lg"
+      className="fixed bottom-0 left-0 right-0 z-30 w-full overflow-hidden bg-zinc-950 text-white shadow-lg md:bottom-4 md:left-auto md:right-4 md:w-[512px] md:rounded-lg"
       style={{ originY: 1 }}
     >
       <div className="relative p-4">
         <button
           onClick={closeNotifier}
-          className="absolute right-2 top-2 flex h-9 w-9 cursor-pointer items-center justify-center !rounded-full bg-transparent p-1 hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-white"
+          className="absolute right-2 top-2 flex h-9 w-9 cursor-pointer items-center justify-center !rounded-full bg-transparent p-1 hover:bg-zinc-800 focus:outline-none focus:ring-2 focus:ring-white"
         >
           <XMarkIcon className="size-5" aria-hidden="true" />
           <span className="sr-only">Close</span>
@@ -96,7 +96,7 @@ export function WebinarNotifier({
                   target="_blank"
                   title={secondaryCtaText}
                   rel="noopener noreferrer"
-                  className="inline-flex items-center justify-center gap-2 rounded-lg border border-slate-700 bg-slate-800 px-2 py-2 text-sm font-semibold text-white no-underline transition hover:bg-slate-700 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 md:px-4"
+                  className="inline-flex items-center justify-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800 px-2 py-2 text-sm font-semibold text-white no-underline transition hover:bg-zinc-700 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 md:px-4"
                 >
                   <ArrowTopRightOnSquareIcon
                     aria-hidden="true"

--- a/nx-dev/ui-common/src/lib/youtube.component.tsx
+++ b/nx-dev/ui-common/src/lib/youtube.component.tsx
@@ -124,7 +124,7 @@ export function YouTube(props: YouTubeProps): JSX.Element {
               {
                 'rounded-lg shadow-lg': !props.disableRoundedCorners,
               },
-              'aspect-video border-2 border-slate-200 hover:border-slate-500 dark:border-slate-700/40 dark:hover:border-slate-700'
+              'aspect-video border-2 border-zinc-200 hover:border-zinc-500 dark:border-zinc-700/40 dark:hover:border-zinc-700'
             )}
           />
         </a>
@@ -141,7 +141,7 @@ export function YouTube(props: YouTubeProps): JSX.Element {
         />
       )}
       {props.caption && (
-        <p className="mx-auto pt-0 text-slate-500 md:w-1/2 dark:text-slate-400">
+        <p className="mx-auto pt-0 text-zinc-500 md:w-1/2 dark:text-zinc-400">
           {props.caption}
         </p>
       )}

--- a/nx-dev/ui-community/src/lib/connect-with-us.tsx
+++ b/nx-dev/ui-community/src/lib/connect-with-us.tsx
@@ -34,7 +34,7 @@ export function ConnectWithUs(): JSX.Element {
       <div className="relative flex-none lg:w-7/12 xl:w-7/12">
         <div className="relative flex flex-col space-y-6 md:flex-row md:space-x-6 md:space-y-0">
           <div className="space-y-6 md:mt-24 md:w-1/2">
-            <div className="group relative rounded-lg border border-slate-200 bg-white/60 p-5 transition duration-200 ease-out hover:border-indigo-300 dark:border-slate-800/40 dark:bg-slate-800/60 dark:hover:border-indigo-900 dark:hover:bg-slate-800">
+            <div className="group relative rounded-lg border border-zinc-200 bg-white/60 p-5 transition duration-200 ease-out hover:border-indigo-300 dark:border-zinc-800/40 dark:bg-zinc-800/60 dark:hover:border-indigo-900 dark:hover:bg-zinc-800">
               <div className="relative m-2 mb-6 inline-flex h-10 w-10 items-center justify-center">
                 <div className="absolute inset-0 -m-2 rotate-6 transform rounded-3xl bg-indigo-300 transition duration-200 ease-out group-hover:-rotate-3 group-hover:scale-105 dark:bg-indigo-900" />
                 <div className="absolute inset-0 -rotate-6 transform rounded-2xl bg-[#5865F2] bg-opacity-75 shadow-inner transition duration-200 ease-out group-hover:rotate-2 group-hover:scale-105" />
@@ -59,7 +59,7 @@ export function ConnectWithUs(): JSX.Element {
                 </p>
               </a>
             </div>
-            <div className="group relative rounded-lg border border-slate-200 bg-white/60 p-5 transition duration-200 ease-out hover:border-red-300 dark:border-slate-800/40 dark:bg-slate-800/60 dark:hover:border-red-900 dark:hover:bg-slate-800">
+            <div className="group relative rounded-lg border border-zinc-200 bg-white/60 p-5 transition duration-200 ease-out hover:border-red-300 dark:border-zinc-800/40 dark:bg-zinc-800/60 dark:hover:border-red-900 dark:hover:bg-zinc-800">
               <div className="relative m-2 mb-6 inline-flex h-10 w-10 items-center justify-center">
                 <div className="absolute inset-0 -m-2 rotate-6 transform rounded-3xl bg-red-300 transition duration-200 ease-out group-hover:-rotate-3 group-hover:scale-105 dark:bg-red-900" />
                 <div className="absolute inset-0 -rotate-6 transform rounded-2xl bg-[#FF0000] bg-opacity-75 shadow-inner transition duration-200 ease-out group-hover:rotate-2 group-hover:scale-105" />
@@ -90,7 +90,7 @@ export function ConnectWithUs(): JSX.Element {
                 </p>
               </a>
             </div>
-            <div className="group relative rounded-lg border border-slate-200 bg-white/60 p-5 transition duration-200 ease-out hover:border-green-300 dark:border-slate-800/40 dark:bg-slate-800/60 dark:hover:border-green-900 dark:hover:bg-slate-800">
+            <div className="group relative rounded-lg border border-zinc-200 bg-white/60 p-5 transition duration-200 ease-out hover:border-green-300 dark:border-zinc-800/40 dark:bg-zinc-800/60 dark:hover:border-green-900 dark:hover:bg-zinc-800">
               <div className="relative m-2 mb-6 inline-flex h-10 w-10 items-center justify-center">
                 <div className="absolute inset-0 -m-2 rotate-6 transform rounded-3xl bg-green-300 transition duration-200 ease-out group-hover:-rotate-3 group-hover:scale-105 dark:bg-green-800" />
                 <div className="absolute inset-0 -rotate-6 transform rounded-2xl bg-green-500 bg-opacity-75 shadow-inner transition duration-200 ease-out group-hover:rotate-2 group-hover:scale-105" />
@@ -114,9 +114,9 @@ export function ConnectWithUs(): JSX.Element {
             </div>
           </div>
           <div className="space-y-6 md:w-1/2">
-            <div className="group relative rounded-lg border border-slate-200 bg-white/60 p-5 transition duration-200 ease-out hover:border-slate-300 dark:border-slate-800/40 dark:bg-slate-800/60 dark:hover:border-slate-900 dark:hover:bg-slate-800">
+            <div className="group relative rounded-lg border border-zinc-200 bg-white/60 p-5 transition duration-200 ease-out hover:border-zinc-300 dark:border-zinc-800/40 dark:bg-zinc-800/60 dark:hover:border-zinc-900 dark:hover:bg-zinc-800">
               <div className="relative m-2 mb-6 inline-flex h-10 w-10 items-center justify-center">
-                <div className="absolute inset-0 -m-2 rotate-6 transform rounded-3xl bg-slate-300 transition duration-200 ease-out group-hover:-rotate-3 group-hover:scale-105 dark:bg-slate-800" />
+                <div className="absolute inset-0 -m-2 rotate-6 transform rounded-3xl bg-zinc-300 transition duration-200 ease-out group-hover:-rotate-3 group-hover:scale-105 dark:bg-zinc-800" />
                 <div className="absolute inset-0 -rotate-6 transform rounded-2xl bg-[#000000] bg-opacity-75 shadow-inner transition duration-200 ease-out group-hover:rotate-2 group-hover:scale-105" />
                 <svg
                   fill="currentColor"
@@ -145,7 +145,7 @@ export function ConnectWithUs(): JSX.Element {
               </a>
             </div>
 
-            <div className="group relative rounded-lg border border-slate-200 bg-white/60 p-5 transition duration-200 ease-out hover:border-blue-300 dark:border-slate-800/40 dark:bg-slate-800/60 dark:hover:border-blue-900 dark:hover:bg-slate-800">
+            <div className="group relative rounded-lg border border-zinc-200 bg-white/60 p-5 transition duration-200 ease-out hover:border-blue-300 dark:border-zinc-800/40 dark:bg-zinc-800/60 dark:hover:border-blue-900 dark:hover:bg-zinc-800">
               <div className="relative m-2 mb-6 inline-flex h-10 w-10 items-center justify-center">
                 <div className="absolute inset-0 -m-2 rotate-6 transform rounded-3xl bg-blue-300 transition duration-200 ease-out group-hover:-rotate-3 group-hover:scale-105 dark:bg-blue-800" />
                 <div className="absolute inset-0 -rotate-6 transform rounded-2xl bg-[#0285FF] bg-opacity-75 shadow-inner transition duration-200 ease-out group-hover:rotate-2 group-hover:scale-105" />
@@ -176,7 +176,7 @@ export function ConnectWithUs(): JSX.Element {
               </a>
             </div>
 
-            <div className="group relative rounded-lg border border-slate-200 bg-white/60 p-5 transition duration-200 ease-out hover:border-blue-300 dark:border-slate-800/40 dark:bg-slate-800/60 dark:hover:border-blue-900 dark:hover:bg-slate-800">
+            <div className="group relative rounded-lg border border-zinc-200 bg-white/60 p-5 transition duration-200 ease-out hover:border-blue-300 dark:border-zinc-800/40 dark:bg-zinc-800/60 dark:hover:border-blue-900 dark:hover:bg-zinc-800">
               <div className="relative m-2 mb-6 inline-flex h-10 w-10 items-center justify-center">
                 <div className="absolute inset-0 -m-2 rotate-6 transform rounded-3xl bg-blue-300 transition duration-200 ease-out group-hover:-rotate-3 group-hover:scale-105 dark:bg-blue-900" />
                 <div className="absolute inset-0 -rotate-6 transform rounded-2xl bg-[#0077B5] bg-opacity-75 shadow-inner transition duration-200 ease-out group-hover:rotate-2 group-hover:scale-105" />

--- a/nx-dev/ui-community/src/lib/plugin-directory.tsx
+++ b/nx-dev/ui-community/src/lib/plugin-directory.tsx
@@ -103,13 +103,13 @@ export function PluginDirectory({
           </label>
           <div className="relative">
             <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-              <MagnifyingGlassIcon className="h-5 w-5 text-slate-500" />
+              <MagnifyingGlassIcon className="h-5 w-5 text-zinc-500" />
             </div>
             <input
               id="search"
               ref={searchRef}
               name="search"
-              className="block w-full rounded-md border border-slate-300 bg-white py-2 pl-10 pr-3 text-sm placeholder-slate-500 transition focus:placeholder-slate-400 dark:border-slate-900 dark:bg-slate-700"
+              className="block w-full rounded-md border border-zinc-300 bg-white py-2 pl-10 pr-3 text-sm placeholder-zinc-500 transition focus:placeholder-zinc-400 dark:border-zinc-900 dark:bg-zinc-700"
               placeholder="Quick search"
               onChange={(event) =>
                 setModifiers({ ...modifiers, term: event.target.value })
@@ -121,7 +121,7 @@ export function PluginDirectory({
             <div className="mr-1 py-1">Order by:</div>
             <div className="flex flex-wrap gap-1">
               <button
-                className="rounded-sm border border-slate-200 bg-white px-1 py-1 font-semibold transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:hover:bg-slate-700"
+                className="rounded-sm border border-zinc-200 bg-white px-1 py-1 font-semibold transition hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-800 dark:hover:bg-zinc-700"
                 onClick={() => setOrderBy('lastPublishDate')}
               >
                 <ClockIcon className="mr-0.5 inline-block h-4 w-4 align-bottom"></ClockIcon>
@@ -136,7 +136,7 @@ export function PluginDirectory({
                 ) : null}
               </button>
               <button
-                className="rounded-sm border border-slate-200 bg-white px-1 py-1 font-semibold transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:hover:bg-slate-700"
+                className="rounded-sm border border-zinc-200 bg-white px-1 py-1 font-semibold transition hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-800 dark:hover:bg-zinc-700"
                 onClick={() => setOrderBy('npmDownloads')}
               >
                 <ArrowDownTrayIcon className="mr-0.5 inline-block h-4 w-4 align-bottom"></ArrowDownTrayIcon>
@@ -151,7 +151,7 @@ export function PluginDirectory({
                 ) : null}
               </button>
               <button
-                className="rounded-sm border border-slate-200 bg-white px-1 py-1 font-semibold transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:hover:bg-slate-700"
+                className="rounded-sm border border-zinc-200 bg-white px-1 py-1 font-semibold transition hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-800 dark:hover:bg-zinc-700"
                 onClick={() => setOrderBy('githubStars')}
               >
                 <StarIcon className="mr-0.5 inline-block h-4 w-4 align-bottom"></StarIcon>
@@ -166,7 +166,7 @@ export function PluginDirectory({
                 ) : null}
               </button>
               <button
-                className="rounded-sm border border-slate-200 bg-white px-1 py-1 font-semibold transition hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:hover:bg-slate-700"
+                className="rounded-sm border border-zinc-200 bg-white px-1 py-1 font-semibold transition hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-800 dark:hover:bg-zinc-700"
                 onClick={() => setOrderBy('nxVersion')}
               >
                 {/* Nx Logo */}

--- a/nx-dev/ui-company/src/lib/co-founders.tsx
+++ b/nx-dev/ui-company/src/lib/co-founders.tsx
@@ -24,7 +24,7 @@ const coFounders = [
 export function CoFounders(): JSX.Element {
   return (
     <section>
-      <div className="slate-100 border border-y bg-slate-50/40 dark:border-slate-800 dark:bg-slate-800/60">
+      <div className="zinc-100 border border-y bg-zinc-50/40 dark:border-zinc-800 dark:bg-zinc-800/60">
         <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8 lg:py-24">
           <div className="space-y-12 lg:grid lg:grid-cols-3 lg:gap-8 lg:space-y-0">
             <div className="space-y-5 sm:space-y-4">
@@ -48,10 +48,10 @@ export function CoFounders(): JSX.Element {
                       <div>
                         <div className="space-y-4">
                           <div className="space-y-1 text-lg font-medium leading-6">
-                            <h3 className="font-semi-bold leading-8 tracking-tight text-slate-800 dark:text-slate-200">
+                            <h3 className="font-semi-bold leading-8 tracking-tight text-zinc-800 dark:text-zinc-200">
                               {coFounder.name}
                             </h3>
-                            <p className="text-slate-500 dark:text-slate-600">
+                            <p className="text-zinc-500 dark:text-zinc-600">
                               {coFounder.title}
                             </p>
                           </div>
@@ -60,7 +60,7 @@ export function CoFounders(): JSX.Element {
                               <a
                                 title="X"
                                 href={coFounder.social.url}
-                                className="text-slate-500 dark:text-slate-600"
+                                className="text-zinc-500 dark:text-zinc-600"
                               >
                                 <span className="sr-only">X</span>
                                 <coFounder.social.icon className="h-5 w-5" />

--- a/nx-dev/ui-company/src/lib/hero.tsx
+++ b/nx-dev/ui-company/src/lib/hero.tsx
@@ -52,12 +52,12 @@ export function Hero(): JSX.Element {
             return (
               <div key={statement.title}>
                 <dt>
-                  <statement.icon className="h-8 w-8 text-blue-500 dark:text-sky-500" />
-                  <p className="mt-4 text-lg font-semibold leading-8 tracking-tight text-slate-800 dark:text-slate-200">
+                  <statement.icon className="h-8 w-8 text-blue-500 dark:text-blue-500" />
+                  <p className="mt-4 text-lg font-semibold leading-8 tracking-tight text-zinc-800 dark:text-zinc-200">
                     {statement.title}
                   </p>
                 </dt>
-                <dd className="mt-4 text-slate-500 dark:text-slate-400">
+                <dd className="mt-4 text-zinc-500 dark:text-zinc-400">
                   <p className="leading 7 text-base">{statement.description}</p>
                 </dd>
               </div>

--- a/nx-dev/ui-company/src/lib/the-team.tsx
+++ b/nx-dev/ui-company/src/lib/the-team.tsx
@@ -207,7 +207,7 @@ export function TheTeam(): ReactElement {
                     <div className="space-y-2">
                       <div className="text-xs font-medium lg:text-sm">
                         <h3>{teamMember.name}</h3>
-                        <p className="text-slate-400 dark:text-slate-600">
+                        <p className="text-zinc-400 dark:text-zinc-600">
                           {teamMember.title}
                         </p>
                       </div>

--- a/nx-dev/ui-contact/src/lib/contact-links.tsx
+++ b/nx-dev/ui-contact/src/lib/contact-links.tsx
@@ -26,7 +26,7 @@ export function ContactLinks(): JSX.Element {
               <title>GitHub</title>
               <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
             </svg>
-            <h4 className="text-lg font-medium text-slate-700 dark:text-slate-300">
+            <h4 className="text-lg font-medium text-zinc-700 dark:text-zinc-300">
               Contribute on GitHub
             </h4>
           </div>
@@ -38,7 +38,7 @@ export function ContactLinks(): JSX.Element {
             rel="noreferrer"
             target="_blank"
             title="Nx GitHub"
-            className="mt-2 flex items-center gap-2 text-sm text-slate-500 transition hover:text-slate-800 dark:hover:text-slate-400"
+            className="mt-2 flex items-center gap-2 text-sm text-zinc-500 transition hover:text-zinc-800 dark:hover:text-zinc-400"
           >
             <span>Contribute on GitHub</span>
             <ArrowUpRightIcon aria-hidden="true" className="h-3 w-3" />
@@ -47,7 +47,7 @@ export function ContactLinks(): JSX.Element {
         <div>
           <div className="flex items-center gap-2">
             <AcademicCapIcon aria-hidden="true" className="h-4 w-4" />
-            <h4 className="text-lg font-medium text-slate-700 dark:text-slate-300">
+            <h4 className="text-lg font-medium text-zinc-700 dark:text-zinc-300">
               Documentation
             </h4>
           </div>
@@ -57,7 +57,7 @@ export function ContactLinks(): JSX.Element {
           <Link
             href={'/docs/getting-started/intro'}
             title="Nx documentation"
-            className="mt-2 flex items-center gap-2 text-sm text-slate-500 transition hover:text-slate-800 dark:hover:text-slate-400"
+            className="mt-2 flex items-center gap-2 text-sm text-zinc-500 transition hover:text-zinc-800 dark:hover:text-zinc-400"
             prefetch={false}
           >
             <span>Nx docs</span>
@@ -77,7 +77,7 @@ export function ContactLinks(): JSX.Element {
               <title>YouTube</title>
               <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
             </svg>
-            <h4 className="text-lg font-medium text-slate-700 dark:text-slate-300">
+            <h4 className="text-lg font-medium text-zinc-700 dark:text-zinc-300">
               Livestreams on Youtube
             </h4>
           </div>
@@ -89,7 +89,7 @@ export function ContactLinks(): JSX.Element {
             rel="noreferrer"
             target="_blank"
             title="Nx Youtube channel"
-            className="mt-2 flex items-center gap-2 text-sm text-slate-500 transition hover:text-slate-800 dark:hover:text-slate-400"
+            className="mt-2 flex items-center gap-2 text-sm text-zinc-500 transition hover:text-zinc-800 dark:hover:text-zinc-400"
           >
             <span>Join the Nx Youtube channel</span>
             <ArrowUpRightIcon aria-hidden="true" className="h-3 w-3" />
@@ -108,7 +108,7 @@ export function ContactLinks(): JSX.Element {
               <title>X</title>
               <path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" />
             </svg>
-            <h4 className="text-lg font-medium text-slate-700 dark:text-slate-300">
+            <h4 className="text-lg font-medium text-zinc-700 dark:text-zinc-300">
               Follow us on X
             </h4>
           </div>
@@ -121,7 +121,7 @@ export function ContactLinks(): JSX.Element {
             rel="noreferrer"
             target="_blank"
             title="Nx Official X account"
-            className="mt-2 flex items-center gap-2 text-sm text-slate-500 transition hover:text-slate-800 dark:hover:text-slate-400"
+            className="mt-2 flex items-center gap-2 text-sm text-zinc-500 transition hover:text-zinc-800 dark:hover:text-zinc-400"
           >
             <span>
               Follow <span className="font-medium">@nxdevtools</span>
@@ -142,7 +142,7 @@ export function ContactLinks(): JSX.Element {
               <title>Bluesky</title>
               <path d="M12 10.8c-1.087-2.114-4.046-6.053-6.798-7.995C2.566.944 1.561 1.266.902 1.565.139 1.908 0 3.08 0 3.768c0 .69.378 5.65.624 6.479.815 2.736 3.713 3.66 6.383 3.364.136-.02.275-.039.415-.056-.138.022-.276.04-.415.056-3.912.58-7.387 2.005-2.83 7.078 5.013 5.19 6.87-1.113 7.823-4.308.953 3.195 2.05 9.271 7.733 4.308 4.267-4.308 1.172-6.498-2.74-7.078a8.741 8.741 0 0 1-.415-.056c.14.017.279.036.415.056 2.67.297 5.568-.628 6.383-3.364.246-.828.624-5.79.624-6.478 0-.69-.139-1.861-.902-2.206-.659-.298-1.664-.62-4.3 1.24C16.046 4.748 13.087 8.687 12 10.8Z" />
             </svg>
-            <h4 className="text-lg font-medium text-slate-700 dark:text-slate-300">
+            <h4 className="text-lg font-medium text-zinc-700 dark:text-zinc-300">
               Follow us on Bluesky
             </h4>
           </div>
@@ -155,7 +155,7 @@ export function ContactLinks(): JSX.Element {
             rel="noreferrer"
             target="_blank"
             title="Nx Official Bluesky account"
-            className="mt-2 flex items-center gap-2 text-sm text-slate-500 transition hover:text-slate-800 dark:hover:text-slate-400"
+            className="mt-2 flex items-center gap-2 text-sm text-zinc-500 transition hover:text-zinc-800 dark:hover:text-zinc-400"
           >
             <span>
               Follow <span className="font-medium">@nx.dev</span>
@@ -166,7 +166,7 @@ export function ContactLinks(): JSX.Element {
         <div>
           <div className="flex items-center gap-2">
             <EnvelopeIcon aria-hidden="true" className="h-4 w-4" />
-            <h4 className="text-lg font-medium text-slate-700 dark:text-slate-300">
+            <h4 className="text-lg font-medium text-zinc-700 dark:text-zinc-300">
               Nx monthly newsletter
             </h4>
           </div>
@@ -179,7 +179,7 @@ export function ContactLinks(): JSX.Element {
             rel="noreferrer"
             target="_blank"
             title="Nx monthly newsletter"
-            className="mt-2 flex items-center gap-2 text-sm text-slate-500 transition hover:text-slate-800 dark:hover:text-slate-400"
+            className="mt-2 flex items-center gap-2 text-sm text-zinc-500 transition hover:text-zinc-800 dark:hover:text-zinc-400"
           >
             <span>Subscribe to Nx newsletter</span>
             <ArrowUpRightIcon aria-hidden="true" className="h-3 w-3" />
@@ -188,7 +188,7 @@ export function ContactLinks(): JSX.Element {
         <div>
           <div className="flex items-center gap-2">
             <BuildingOffice2Icon aria-hidden="true" className="h-4 w-4" />
-            <h4 className="text-lg font-medium text-slate-700 dark:text-slate-300">
+            <h4 className="text-lg font-medium text-zinc-700 dark:text-zinc-300">
               Company
             </h4>
           </div>
@@ -199,7 +199,7 @@ export function ContactLinks(): JSX.Element {
           <Link
             href="/company"
             title="Nx the company"
-            className="mt-2 flex items-center gap-2 text-sm text-slate-500 transition hover:text-slate-800 dark:hover:text-slate-400"
+            className="mt-2 flex items-center gap-2 text-sm text-zinc-500 transition hover:text-zinc-800 dark:hover:text-zinc-400"
           >
             <span>Nx the company</span>
             <ChevronRightIcon aria-hidden="true" className="h-3 w-3" />

--- a/nx-dev/ui-contact/src/lib/how-can-we-help.tsx
+++ b/nx-dev/ui-contact/src/lib/how-can-we-help.tsx
@@ -16,13 +16,13 @@ export function HowCanWeHelp(): JSX.Element {
           </SectionHeading>
         </div>
         <div className="mx-auto mt-16 grid max-w-5xl grid-cols-1 gap-4 md:grid-cols-2">
-          <section className="rounded-xl border border-slate-200 bg-slate-50/20 p-8 dark:border-slate-800/40 dark:bg-slate-800/60">
+          <section className="rounded-xl border border-zinc-200 bg-zinc-50/20 p-8 dark:border-zinc-800/40 dark:bg-zinc-800/60">
             <div className="flex items-center gap-2">
               <ChevronRightIcon
                 aria-hidden="true"
                 className="h-5 w-5 shrink-0"
               />
-              <h3 className="text-xl font-medium text-slate-700 dark:text-slate-300">
+              <h3 className="text-xl font-medium text-zinc-700 dark:text-zinc-300">
                 Talk to Sales
               </h3>
             </div>
@@ -32,7 +32,7 @@ export function HowCanWeHelp(): JSX.Element {
             </p>
             <ButtonLink
               href="/contact/sales"
-              variant="primary"
+              variant="contrast"
               size="default"
               title="Talk to our sales team"
               className="mt-6"
@@ -40,13 +40,13 @@ export function HowCanWeHelp(): JSX.Element {
               Reach out to sales
             </ButtonLink>
           </section>
-          <section className="rounded-xl border border-slate-200 bg-slate-50/20 p-8 dark:border-slate-800/40 dark:bg-slate-800/60">
+          <section className="rounded-xl border border-zinc-200 bg-zinc-50/20 p-8 dark:border-zinc-800/40 dark:bg-zinc-800/60">
             <div className="flex items-center gap-2">
               <ChevronRightIcon
                 aria-hidden="true"
                 className="h-5 w-5 shrink-0"
               />
-              <h3 className="text-xl font-medium text-slate-700 dark:text-slate-300">
+              <h3 className="text-xl font-medium text-zinc-700 dark:text-zinc-300">
                 Learn more about Nx Cloud
               </h3>
             </div>
@@ -56,7 +56,7 @@ export function HowCanWeHelp(): JSX.Element {
             </p>
             <ButtonLink
               href="/contact/engineering"
-              variant="primary"
+              variant="contrast"
               size="default"
               title="Talk to our engineering team"
               className="mt-6"
@@ -64,13 +64,13 @@ export function HowCanWeHelp(): JSX.Element {
               Reach out to engineers
             </ButtonLink>
           </section>
-          <section className="rounded-xl border border-slate-200 bg-slate-50/20 p-8 dark:border-slate-800/40 dark:bg-slate-800/60">
+          <section className="rounded-xl border border-zinc-200 bg-zinc-50/20 p-8 dark:border-zinc-800/40 dark:bg-zinc-800/60">
             <div className="flex items-center gap-2">
               <ChatBubbleLeftRightIcon
                 aria-hidden="true"
                 className="h-5 w-5 shrink-0"
               />
-              <h3 className="text-lg font-medium text-slate-700 dark:text-slate-300">
+              <h3 className="text-lg font-medium text-zinc-700 dark:text-zinc-300">
                 Question about Nx
               </h3>
             </div>
@@ -92,10 +92,10 @@ export function HowCanWeHelp(): JSX.Element {
               <ArrowUpRightIcon aria-hidden="true" className="h-3 w-3" />
             </ButtonLink>
           </section>
-          <section className="rounded-xl border border-slate-200 bg-slate-50/20 p-8 dark:border-slate-800/40 dark:bg-slate-800/60">
+          <section className="rounded-xl border border-zinc-200 bg-zinc-50/20 p-8 dark:border-zinc-800/40 dark:bg-zinc-800/60">
             <div className="flex items-center gap-2">
               <NxCloudIcon aria-hidden="true" className="h-5 w-5 shrink-0" />
-              <h3 className="text-lg font-medium text-slate-700 dark:text-slate-300">
+              <h3 className="text-lg font-medium text-zinc-700 dark:text-zinc-300">
                 Nx Cloud support
               </h3>
             </div>

--- a/nx-dev/ui-contact/src/lib/nx-labs.tsx
+++ b/nx-dev/ui-contact/src/lib/nx-labs.tsx
@@ -120,7 +120,7 @@ export function NxLabsContact(): ReactElement {
               </div>
             </div>
           </section>
-          <section className="flex-1 self-start rounded-xl border border-slate-200 bg-white p-8 dark:border-slate-800/40">
+          <section className="flex-1 self-start rounded-xl border border-zinc-200 bg-white p-8 dark:border-zinc-800/40">
             <HubspotForm
               calendlyFormId="e0d476c6-2a39-4cd3-91bc-e9bff0d0f75d"
               formId="d5710d48-85de-4b17-ab97-4c22c25a8f02"
@@ -131,7 +131,7 @@ export function NxLabsContact(): ReactElement {
             />
           </section>
         </div>
-        <figure className="mx-auto mt-12 max-w-4xl border-l border-slate-200 pl-8 dark:border-slate-800">
+        <figure className="mx-auto mt-12 max-w-4xl border-l border-zinc-200 pl-8 dark:border-zinc-800">
           <blockquote className="text-base/7">
             <p>
               “Nx’s professional services team was instrumental in helping us
@@ -148,7 +148,7 @@ export function NxLabsContact(): ReactElement {
             />
             <div>
               <div className="font-semibold">Wayne Kaskie</div>
-              <div className="text-slate-500">Front End Architect, Zipari</div>
+              <div className="text-zinc-500">Front End Architect, Zipari</div>
             </div>
             <ZipariIcon
               aria-hidden="true"

--- a/nx-dev/ui-contact/src/lib/talk-to-our-engineering-team.tsx
+++ b/nx-dev/ui-contact/src/lib/talk-to-our-engineering-team.tsx
@@ -38,7 +38,7 @@ export function TalkToOurEngineeringTeam(): ReactElement {
               start the discussion on a shared Slack.
             </p>
 
-            <figure className="mt-12 border-l border-slate-200 pl-8 dark:border-slate-800">
+            <figure className="mt-12 border-l border-zinc-200 pl-8 dark:border-zinc-800">
               <blockquote className="text-base/7">
                 <p>
                   “The decision to jump to Nx Cloud was really something we
@@ -56,7 +56,7 @@ export function TalkToOurEngineeringTeam(): ReactElement {
                 />
                 <div>
                   <div className="font-semibold">Justin Schwartzenberger</div>
-                  <div className="text-slate-500">
+                  <div className="text-zinc-500">
                     Principal Software Engineer, SiriusXM
                   </div>
                 </div>
@@ -118,7 +118,7 @@ export function TalkToOurEngineeringTeam(): ReactElement {
               </div>
             </div>
           </section>
-          <section className="flex-1 self-start rounded-xl border border-slate-200 bg-white p-8 dark:border-slate-800/40">
+          <section className="flex-1 self-start rounded-xl border border-zinc-200 bg-white p-8 dark:border-zinc-800/40">
             <HubspotForm
               region="na1"
               portalId="2757427"

--- a/nx-dev/ui-contact/src/lib/talk-to-our-team.tsx
+++ b/nx-dev/ui-contact/src/lib/talk-to-our-team.tsx
@@ -86,7 +86,7 @@ export function TalkToOurTeam(): ReactElement {
               </VideoPlayerProvider>
             </div>
 
-            <figure className="mt-12 rounded-lg bg-slate-100 p-4 pl-8 dark:bg-slate-800">
+            <figure className="mt-12 rounded-lg bg-zinc-100 p-4 pl-8 dark:bg-zinc-800">
               <blockquote className="text-base/7">
                 <p>
                   “Nx means tooling and efficiency around our software
@@ -102,18 +102,18 @@ export function TalkToOurTeam(): ReactElement {
                 />
                 <div>
                   <div className="font-semibold">Justin Schwartzenberger</div>
-                  <div className="text-slate-500">
+                  <div className="text-zinc-500">
                     Principal Software Engineer, SiriusXM
                   </div>
                 </div>
                 <SiriusxmAlternateIcon
                   aria-hidden="true"
-                  className="ml-auto size-10 rounded text-[#0000EB] dark:bg-slate-200"
+                  className="ml-auto size-10 rounded text-[#0000EB] dark:bg-zinc-200"
                 />
               </figcaption>
             </figure>
           </section>
-          <section className="w-full flex-1 rounded-xl border border-slate-200 bg-white p-8 md:self-start dark:border-slate-800/40">
+          <section className="w-full flex-1 rounded-xl border border-zinc-200 bg-white p-8 md:self-start dark:border-zinc-800/40">
             <HubspotForm
               calendlyFormId="436b5997-6d7f-4220-8726-0ac417eb8f54"
               formId="2e492124-843c-4a6d-87fe-93db27ab4323"

--- a/nx-dev/ui-courses/src/lib/course-details.tsx
+++ b/nx-dev/ui-courses/src/lib/course-details.tsx
@@ -22,7 +22,7 @@ export function CourseDetails({ course }: CourseDetailsProps) {
       <div className="mb-4">
         <Link
           href="/courses"
-          className="group inline-flex items-center text-sm leading-6 text-slate-950 dark:text-white"
+          className="group inline-flex items-center text-sm leading-6 text-zinc-950 dark:text-white"
           prefetch={false}
         >
           <span
@@ -37,7 +37,7 @@ export function CourseDetails({ course }: CourseDetailsProps) {
 
       <div className="mb-8 flex items-center justify-between">
         <div className="course-title-section">
-          <h1 className="text-2xl font-bold tracking-tight text-slate-950 sm:text-5xl dark:text-white">
+          <h1 className="text-2xl font-bold tracking-tight text-zinc-950 sm:text-5xl dark:text-white">
             {course.title}
           </h1>
           <div className="mt-4 flex items-center gap-x-2">
@@ -52,7 +52,7 @@ export function CourseDetails({ course }: CourseDetailsProps) {
           <ButtonLink
             href={`/courses/${course.id}/${course.lessons[0].id}`}
             title="Start the course"
-            variant="primary"
+            variant="contrast"
             size="default"
           >
             Start Learning
@@ -62,7 +62,7 @@ export function CourseDetails({ course }: CourseDetailsProps) {
           <ButtonLink
             href={course.repository}
             title="Code"
-            variant="contrast"
+            variant="secondary"
             size="default"
           >
             <GitHubIcon className="mr-2 inline-block h-5 w-5" />
@@ -73,7 +73,7 @@ export function CourseDetails({ course }: CourseDetailsProps) {
 
       <div className="mt-8 flex flex-col gap-8 md:flex-row">
         <div className="course-description md:w-2/3">
-          <div className="prose prose-lg prose-slate dark:prose-invert w-full max-w-none 2xl:max-w-4xl">
+          <div className="prose prose-lg prose-zinc dark:prose-invert w-full max-w-none 2xl:max-w-4xl">
             {node}
           </div>
         </div>

--- a/nx-dev/ui-courses/src/lib/lesson-player.tsx
+++ b/nx-dev/ui-courses/src/lib/lesson-player.tsx
@@ -35,8 +35,7 @@ const LessonsList = ({
             {
               'bg-blue-50 text-blue-900 dark:bg-blue-900/20 dark:text-blue-100':
                 item.id === lesson.id,
-              'hover:bg-slate-100 dark:hover:bg-slate-800':
-                item.id !== lesson.id,
+              'hover:bg-zinc-100 dark:hover:bg-zinc-800': item.id !== lesson.id,
             }
           )}
           prefetch={false}
@@ -44,7 +43,7 @@ const LessonsList = ({
           <span
             className={cx('inline-block min-w-[2rem] flex-shrink-0 text-sm', {
               'text-blue-600 dark:text-blue-400': item.id === lesson.id,
-              'text-slate-400 dark:text-slate-500': item.id !== lesson.id,
+              'text-zinc-400 dark:text-zinc-500': item.id !== lesson.id,
             })}
           >
             {(index + 1).toString()}
@@ -53,14 +52,14 @@ const LessonsList = ({
             <span
               className={cx('', {
                 'font-semibold': item.id === lesson.id,
-                'text-slate-700 dark:text-slate-300': item.id !== lesson.id,
+                'text-zinc-700 dark:text-zinc-300': item.id !== lesson.id,
               })}
             >
               {item.title}
             </span>
           </span>
           {item.duration && (
-            <span className="ml-2 flex items-center gap-1 text-xs text-slate-400 dark:text-slate-500">
+            <span className="ml-2 flex items-center gap-1 text-xs text-zinc-400 dark:text-zinc-500">
               <svg
                 className="h-3 w-3"
                 fill="none"
@@ -95,14 +94,14 @@ export function LessonPlayer({ course, lesson }: LessonPlayerProps) {
       <Header />
       <div className="flex h-screen w-full pt-20">
         {/* Left Panel - Course Info & Lessons (Hidden on mobile) */}
-        <div className="hidden lg:flex lg:w-80 lg:flex-none lg:flex-col lg:border-r lg:border-slate-200 lg:dark:border-slate-700">
-          <div className="border-b border-slate-200 p-6 dark:border-slate-700">
-            <div className="text-sm font-medium text-slate-500 dark:text-slate-400">
+        <div className="hidden lg:flex lg:w-80 lg:flex-none lg:flex-col lg:border-r lg:border-zinc-200 lg:dark:border-zinc-700">
+          <div className="border-b border-zinc-200 p-6 dark:border-zinc-700">
+            <div className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
               Course by {course.authors[0].name}
             </div>
             <Link
               href={`/courses/${course.id}`}
-              className="mt-1 block text-xl font-bold text-slate-900 hover:text-blue-600 dark:text-white dark:hover:text-blue-400"
+              className="mt-1 block text-xl font-bold text-zinc-900 hover:text-blue-600 dark:text-white dark:hover:text-blue-400"
             >
               {course.title}
             </Link>
@@ -113,9 +112,9 @@ export function LessonPlayer({ course, lesson }: LessonPlayerProps) {
         </div>
 
         {/* Center/Right Panel - Video & Content */}
-        <div className="wide:w-[45%] wide:flex-none wide:overflow-y-visible wide:border-r wide:border-slate-200 wide:dark:border-slate-700 flex flex-1 flex-col overflow-y-auto">
+        <div className="wide:w-[45%] wide:flex-none wide:overflow-y-visible wide:border-r wide:border-zinc-200 wide:dark:border-zinc-700 flex flex-1 flex-col overflow-y-auto">
           {/* Video Section */}
-          <div className="flex-none border-b border-slate-200 dark:border-slate-700">
+          <div className="flex-none border-b border-zinc-200 dark:border-zinc-700">
             {lesson.videoUrl ? (
               <div className="aspect-video">
                 <YouTube
@@ -126,8 +125,8 @@ export function LessonPlayer({ course, lesson }: LessonPlayerProps) {
                 />
               </div>
             ) : (
-              <div className="flex aspect-video items-center justify-center bg-slate-100 dark:bg-slate-800">
-                <p className="text-slate-500 dark:text-slate-400">
+              <div className="flex aspect-video items-center justify-center bg-zinc-100 dark:bg-zinc-800">
+                <p className="text-zinc-500 dark:text-zinc-400">
                   No video available for this lesson
                 </p>
               </div>
@@ -135,21 +134,21 @@ export function LessonPlayer({ course, lesson }: LessonPlayerProps) {
           </div>
 
           {/* Mobile Course Title and Lessons List */}
-          <div className="flex-none border-b border-slate-200 lg:hidden dark:border-slate-700">
+          <div className="flex-none border-b border-zinc-200 lg:hidden dark:border-zinc-700">
             <div className="p-4">
-              <div className="text-sm font-medium text-slate-500 dark:text-slate-400">
+              <div className="text-sm font-medium text-zinc-500 dark:text-zinc-400">
                 Course by {course.authors[0].name}
               </div>
               <div className="flex items-center justify-between">
                 <Link
                   href={`/courses/${course.id}`}
-                  className="mt-1 block text-xl font-bold text-slate-900 hover:text-blue-600 dark:text-white dark:hover:text-blue-400"
+                  className="mt-1 block text-xl font-bold text-zinc-900 hover:text-blue-600 dark:text-white dark:hover:text-blue-400"
                 >
                   {course.title}
                 </Link>
                 <button
                   onClick={() => setIsExpanded(!isExpanded)}
-                  className="flex items-center text-sm text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
+                  className="flex items-center text-sm text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-200"
                 >
                   {isExpanded ? 'Hide' : 'Show'} lessons
                   <svg
@@ -174,7 +173,7 @@ export function LessonPlayer({ course, lesson }: LessonPlayerProps) {
               </div>
             </div>
             {isExpanded && (
-              <div className="border-t border-slate-200 bg-slate-50 p-4 dark:border-slate-700 dark:bg-slate-800/50">
+              <div className="border-t border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-800/50">
                 <LessonsList course={course} lesson={lesson} />
               </div>
             )}
@@ -183,10 +182,10 @@ export function LessonPlayer({ course, lesson }: LessonPlayerProps) {
           {/* Content Section (Hidden on wide screens) */}
           <div className="wide:hidden flex-1">
             <div className="mx-auto max-w-4xl px-8 py-6">
-              <h1 className="mb-6 text-3xl font-bold text-slate-900 dark:text-white">
+              <h1 className="mb-6 text-3xl font-bold text-zinc-900 dark:text-white">
                 {lesson.title}
               </h1>
-              <div className="prose prose-slate prose-lg dark:prose-invert max-w-none">
+              <div className="prose prose-zinc prose-lg dark:prose-invert max-w-none">
                 {lessonContent}
               </div>
             </div>
@@ -196,10 +195,10 @@ export function LessonPlayer({ course, lesson }: LessonPlayerProps) {
         {/* Right Panel - Lesson Content (wide screens Only) */}
         <div className="wide:block wide:flex-1 wide:overflow-y-auto hidden">
           <div className="mx-auto max-w-3xl px-8 py-6">
-            <h1 className="mb-6 text-3xl font-bold text-slate-900 dark:text-white">
+            <h1 className="mb-6 text-3xl font-bold text-zinc-900 dark:text-white">
               {lesson.title}
             </h1>
-            <div className="prose prose-slate prose-lg dark:prose-invert max-w-none">
+            <div className="prose prose-zinc prose-lg dark:prose-invert max-w-none">
               {lessonContent}
             </div>
           </div>

--- a/nx-dev/ui-courses/src/lib/lessons-list.tsx
+++ b/nx-dev/ui-courses/src/lib/lessons-list.tsx
@@ -12,12 +12,12 @@ export function LessonsList({
   return (
     <nav className="toc">
       <div className="flex items-center justify-between">
-        <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+        <h3 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
           Contents
         </h3>
-        <div className="flex items-center gap-2 text-sm text-slate-500">
+        <div className="flex items-center gap-2 text-sm text-zinc-500">
           <span>{course.lessons.length} Lessons</span>
-          <span className="text-slate-300 dark:text-slate-600">•</span>
+          <span className="text-zinc-300 dark:text-zinc-600">•</span>
           <span className="flex items-center gap-1">
             <svg
               className="h-3 w-3"
@@ -36,21 +36,21 @@ export function LessonsList({
           </span>
         </div>
       </div>
-      <div className="mt-4 rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700/50 dark:bg-slate-900">
+      <div className="mt-4 rounded-lg border border-zinc-200 bg-white p-4 dark:border-zinc-700/50 dark:bg-zinc-900">
         <ul className="flex flex-col space-y-3">
           {course.lessons.map((courseLesson, index) => (
             <li key={courseLesson.id}>
               <Link
                 href={`/courses/${course.id}/${courseLesson.id}`}
                 className={cx('group flex transition', {
-                  'text-slate-900 dark:text-slate-100':
+                  'text-zinc-900 dark:text-zinc-100':
                     lesson && courseLesson.id === lesson.id,
-                  'text-slate-700 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200':
+                  'text-zinc-700 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-200':
                     !(lesson && courseLesson.id === lesson.id),
                 })}
                 prefetch={false}
               >
-                <span className="inline-block min-w-[2rem] flex-shrink-0 text-sm font-medium text-slate-400 dark:text-slate-600">
+                <span className="inline-block min-w-[2rem] flex-shrink-0 text-sm font-medium text-zinc-400 dark:text-zinc-600">
                   {(index + 1).toString().padStart(1, '0')}
                 </span>
                 <span className="text-[15px] font-medium leading-normal">

--- a/nx-dev/ui-customers/src/lib/customer-icon-grid.tsx
+++ b/nx-dev/ui-customers/src/lib/customer-icon-grid.tsx
@@ -21,7 +21,7 @@ const CustomerIconGrid: FC<CustomerIconGridProps> = ({ icons }) => {
             href={customerIcon.url}
             target="_blank"
             rel="noopener noreferrer"
-            className={`flex items-center justify-center border-slate-200/20 p-12 shadow-[0_0px_1px_0_rgba(226,232,240,0.2)] transition hover:bg-slate-100/20 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white`}
+            className={`flex items-center justify-center border-zinc-200/20 p-12 shadow-[0_0px_1px_0_rgba(226,232,240,0.2)] transition hover:bg-zinc-100/20 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white`}
           >
             <customerIcon.icon
               aria-hidden="true"

--- a/nx-dev/ui-customers/src/lib/customer-testimonial-carousel.tsx
+++ b/nx-dev/ui-customers/src/lib/customer-testimonial-carousel.tsx
@@ -249,10 +249,10 @@ export function CustomerTestimonialCarousel(): ReactElement {
           <div className="flex h-full flex-col justify-center space-y-8">
             {currentTestimonial.metrics?.map((metric, index) => (
               <div key={index} className="space-y-2">
-                <div className="border-l-2 border-blue-900/70 pl-4 text-3xl font-bold text-slate-700 dark:border-sky-300/60 dark:text-slate-200">
+                <div className="border-l-2 border-blue-900/70 pl-4 text-3xl font-bold text-zinc-700 dark:border-blue-300/60 dark:text-zinc-200">
                   {metric.value}
                 </div>
-                <div className="text-balance pl-[18px] text-lg text-slate-500 dark:text-slate-400">
+                <div className="text-balance pl-[18px] text-lg text-zinc-500 dark:text-zinc-400">
                   {metric.label}
                 </div>
               </div>
@@ -267,7 +267,7 @@ export function CustomerTestimonialCarousel(): ReactElement {
             <button
               disabled={currentIndex === 0}
               title={`See ${testimonials[currentIndex - 1]?.company}`}
-              className="flex h-12 w-12 items-center justify-center rounded-full p-2 transition hover:text-slate-950 disabled:pointer-events-none disabled:opacity-0 md:hidden dark:hover:text-white"
+              className="flex h-12 w-12 items-center justify-center rounded-full p-2 transition hover:text-zinc-950 disabled:pointer-events-none disabled:opacity-0 md:hidden dark:hover:text-white"
               onClick={() => {
                 setCurrentIndex(
                   (currentIndex - 1 + testimonials.length) % testimonials.length
@@ -307,7 +307,7 @@ export function CustomerTestimonialCarousel(): ReactElement {
             </div>
             {/* Next Button - Mobile only */}
             <button
-              className="flex h-12 w-12 items-center justify-center rounded-full p-2 transition hover:text-slate-950 disabled:pointer-events-none disabled:opacity-0 md:hidden dark:hover:text-white"
+              className="flex h-12 w-12 items-center justify-center rounded-full p-2 transition hover:text-zinc-950 disabled:pointer-events-none disabled:opacity-0 md:hidden dark:hover:text-white"
               disabled={currentIndex === testimonials.length - 1}
               title={`Next ${testimonials[currentIndex + 1]?.company}`}
               onClick={() => {
@@ -332,7 +332,7 @@ export function CustomerTestimonialCarousel(): ReactElement {
                 className={`h-1.5 rounded-full transition-all duration-300 ${
                   index === currentIndex
                     ? 'w-12 bg-blue-500'
-                    : 'w-4 bg-slate-200 dark:bg-slate-700'
+                    : 'w-4 bg-zinc-200 dark:bg-zinc-700'
                 }`}
               />
             ))}
@@ -347,9 +347,9 @@ export function CustomerTestimonialCarousel(): ReactElement {
             onClick={() => setCurrentIndex(i)}
             key={`logo-${i}`}
             title={company}
-            className={`relative grid h-full w-full place-items-center border border-slate-200/15 transition-all dark:border-slate-800/20 ${
+            className={`relative grid h-full w-full place-items-center border border-zinc-200/15 transition-all dark:border-zinc-800/20 ${
               i !== currentIndex &&
-              'text-slate-400 hover:text-slate-500 dark:text-slate-700 dark:hover:text-slate-500'
+              'text-zinc-400 hover:text-zinc-500 dark:text-zinc-700 dark:hover:text-zinc-500'
             }`}
           >
             <span className="sr-only">{company} Logo</span>
@@ -365,7 +365,7 @@ export function CustomerTestimonialCarousel(): ReactElement {
             {i === currentIndex && !isOpen && (
               <div className="absolute left-0 top-0 h-[2px] w-full overflow-hidden bg-gray-300/80 transition-all">
                 <div
-                  className="animate-progress h-full w-full bg-blue-600/80 dark:bg-sky-600/80"
+                  className="animate-progress h-full w-full bg-blue-600/80 dark:bg-blue-600/80"
                   style={{ animationDuration: `${slideLogoTimeOut}ms` }}
                 />
               </div>

--- a/nx-dev/ui-customers/src/lib/enterprise-customers.tsx
+++ b/nx-dev/ui-customers/src/lib/enterprise-customers.tsx
@@ -267,7 +267,7 @@ export function EnterpriseCustomers(): ReactElement {
           <CustomerIconGrid icons={firstCustomerIcons} />
         </div>
 
-        <div className="col-span-2 border-y border-slate-200 bg-slate-50 py-24 sm:py-32 md:col-span-4 dark:border-slate-800 dark:bg-slate-900">
+        <div className="col-span-2 border-y border-zinc-200 bg-zinc-50 py-24 sm:py-32 md:col-span-4 dark:border-zinc-800 dark:bg-zinc-900">
           <div className="mx-auto">
             <CustomerTestimonialCarousel />
           </div>

--- a/nx-dev/ui-customers/src/lib/hero.tsx
+++ b/nx-dev/ui-customers/src/lib/hero.tsx
@@ -8,7 +8,7 @@ export function Hero(): ReactElement {
     <section>
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-3xl text-center">
-          <p className="mx-auto max-w-3xl text-3xl font-normal tracking-tight text-slate-700 sm:text-4xl dark:text-slate-400">
+          <p className="mx-auto max-w-3xl text-3xl font-normal tracking-tight text-zinc-700 sm:text-4xl dark:text-zinc-400">
             We empower our clients to
           </p>
           <SectionHeading
@@ -22,7 +22,7 @@ export function Hero(): ReactElement {
             <ButtonLink
               href="https://cloud.nx.app/get-started"
               title="Get started now"
-              variant="primary"
+              variant="contrast"
               size="default"
               onClick={() =>
                 sendCustomEvent('get-started-click', 'hero', 'customers')

--- a/nx-dev/ui-customers/src/lib/oss-projects.tsx
+++ b/nx-dev/ui-customers/src/lib/oss-projects.tsx
@@ -32,7 +32,7 @@ export function OssProjects(): JSX.Element {
               rel="noreferrer"
               href="https://github.com/tanstack"
               target="_blank"
-              className="flex items-center justify-center border border-slate-200/20 p-12 transition hover:bg-slate-100/25 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white"
+              className="flex items-center justify-center border border-zinc-200/20 p-12 transition hover:bg-zinc-100/25 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white"
             >
               <TanstackIcon aria-hidden="true" className="h-14 w-14" />
             </a>
@@ -40,7 +40,7 @@ export function OssProjects(): JSX.Element {
               rel="noreferrer"
               href="https://redwoodjs.com/"
               target="_blank"
-              className="flex cursor-pointer items-center justify-center border-y border-slate-200/20 p-12 transition hover:bg-slate-100/25 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white"
+              className="flex cursor-pointer items-center justify-center border-y border-zinc-200/20 p-12 transition hover:bg-zinc-100/25 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white"
             >
               <RedwoodJsIcon aria-hidden="true" className="h-12 w-12" />
             </a>
@@ -48,7 +48,7 @@ export function OssProjects(): JSX.Element {
               href="https://github.com/epicweb-dev/epicshop"
               rel="noreferrer"
               target="_blank"
-              className="flex items-center justify-center border border-slate-200/20 p-12 transition hover:bg-slate-100/25 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white"
+              className="flex items-center justify-center border border-zinc-200/20 p-12 transition hover:bg-zinc-100/25 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white"
             >
               <EpicWebIcon aria-hidden="true" className="h-12 w-12" />
             </a>
@@ -56,7 +56,7 @@ export function OssProjects(): JSX.Element {
               rel="noreferrer"
               href="https://github.com/storybookjs/storybook"
               target="_blank"
-              className="flex items-center justify-center border-y border-r border-slate-200/20 p-12 transition hover:bg-slate-100/25 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white"
+              className="flex items-center justify-center border-y border-r border-zinc-200/20 p-12 transition hover:bg-zinc-100/25 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white"
             >
               <StorybookIcon aria-hidden="true" className="h-12 w-12" />
             </a>
@@ -64,7 +64,7 @@ export function OssProjects(): JSX.Element {
               rel="noreferrer"
               href="https://lerna.js.org"
               target="_blank"
-              className="flex items-center justify-center border-x border-b border-slate-200/20 p-12 transition hover:bg-slate-100/25 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white"
+              className="flex items-center justify-center border-x border-b border-zinc-200/20 p-12 transition hover:bg-zinc-100/25 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white"
             >
               <LernaIcon aria-hidden="true" className="h-20 w-20" />
             </a>
@@ -72,7 +72,7 @@ export function OssProjects(): JSX.Element {
               rel="noreferrer"
               href="https://github.com/ReactiveX/rxjs"
               target="_blank"
-              className="flex items-center justify-center border-b border-slate-200/20 p-12 transition hover:bg-slate-100/25 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white"
+              className="flex items-center justify-center border-b border-zinc-200/20 p-12 transition hover:bg-zinc-100/25 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white"
             >
               <RxJSIcon aria-hidden="true" className="h-12 w-12" />
             </a>
@@ -80,7 +80,7 @@ export function OssProjects(): JSX.Element {
               rel="noreferrer"
               href="https://github.com/getsentry/sentry-javascript"
               target="_blank"
-              className="flex items-center justify-center border-x border-b border-slate-200/20 p-12 transition hover:bg-slate-100/25 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white"
+              className="flex items-center justify-center border-x border-b border-zinc-200/20 p-12 transition hover:bg-zinc-100/25 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white"
             >
               <SentryIcon aria-hidden="true" className="h-16 w-16" />
             </a>
@@ -88,7 +88,7 @@ export function OssProjects(): JSX.Element {
               rel="noreferrer"
               href="https://github.com/mui/material-ui"
               target="_blank"
-              className="flex items-center justify-center border-b border-r border-slate-200/20 p-12 transition hover:bg-slate-100/25 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white"
+              className="flex items-center justify-center border-b border-r border-zinc-200/20 p-12 transition hover:bg-zinc-100/25 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white"
             >
               <MuiIcon aria-hidden="true" className="h-12 w-12" />
             </a>
@@ -97,7 +97,7 @@ export function OssProjects(): JSX.Element {
               rel="noreferrer"
               href="https://github.com/aws-amplify/amplify-cli"
               target="_blank"
-              className="flex items-center justify-center border-x border-b border-slate-200/20 p-12 transition hover:bg-slate-100/25 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white"
+              className="flex items-center justify-center border-x border-b border-zinc-200/20 p-12 transition hover:bg-zinc-100/25 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white"
             >
               <AwsIcon aria-hidden="true" className="h-16 w-16" />
             </a>
@@ -105,7 +105,7 @@ export function OssProjects(): JSX.Element {
               href="https://github.com/Shopify/cli"
               rel="noreferrer"
               target="_blank"
-              className="flex items-center justify-center border-b border-slate-200/20 p-12 transition hover:bg-slate-100/20 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white"
+              className="flex items-center justify-center border-b border-zinc-200/20 p-12 transition hover:bg-zinc-100/20 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white"
             >
               <ShopifyIcon aria-hidden="true" className="h-12 w-12" />
             </a>
@@ -113,7 +113,7 @@ export function OssProjects(): JSX.Element {
               href="https://github.com/electron/forge"
               rel="noreferrer"
               target="_blank"
-              className="flex items-center justify-center border-x border-b border-slate-200/20 p-12 transition hover:bg-slate-100/20 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white"
+              className="flex items-center justify-center border-x border-b border-zinc-200/20 p-12 transition hover:bg-zinc-100/20 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white"
             >
               <ElectronIcon aria-hidden="true" className="h-14 w-14" />
             </a>
@@ -121,7 +121,7 @@ export function OssProjects(): JSX.Element {
               rel="noreferrer"
               href="https://github.com/strapi/strapi"
               target="_blank"
-              className="flex items-center justify-center border-b border-r border-slate-200/20 p-12 transition hover:bg-slate-100/25 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white"
+              className="flex items-center justify-center border-b border-r border-zinc-200/20 p-12 transition hover:bg-zinc-100/25 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white"
             >
               <StrapiIcon aria-hidden="true" className="h-12 w-12" />
             </a>
@@ -130,7 +130,7 @@ export function OssProjects(): JSX.Element {
               href="https://github.com/typescript-eslint/typescript-eslint"
               rel="noreferrer"
               target="_blank"
-              className="flex items-center justify-center border-x border-b border-slate-200/20 p-12 transition hover:bg-slate-100/20 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white"
+              className="flex items-center justify-center border-x border-b border-zinc-200/20 p-12 transition hover:bg-zinc-100/20 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white"
             >
               <TypescriptEslintIcon aria-hidden="true" className="h-14 w-14" />
             </a>
@@ -138,7 +138,7 @@ export function OssProjects(): JSX.Element {
               href="https://github.com/cypress-io/cypress"
               rel="noreferrer"
               target="_blank"
-              className="flex items-center justify-center border-b border-slate-200/20 p-12 transition hover:bg-slate-100/20 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white"
+              className="flex items-center justify-center border-b border-zinc-200/20 p-12 transition hover:bg-zinc-100/20 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white"
             >
               <CypressIcon aria-hidden="true" className="h-14 w-14" />
             </a>
@@ -146,7 +146,7 @@ export function OssProjects(): JSX.Element {
               href="https://github.com/microsoft/fluentui"
               rel="noreferrer"
               target="_blank"
-              className="flex items-center justify-center border-x border-b border-slate-200/20 p-12 transition hover:bg-slate-100/20 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white"
+              className="flex items-center justify-center border-x border-b border-zinc-200/20 p-12 transition hover:bg-zinc-100/20 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white"
             >
               <MicrosoftIcon aria-hidden="true" className="h-12 w-12" />
             </a>
@@ -154,7 +154,7 @@ export function OssProjects(): JSX.Element {
               href="https://github.com/TryGhost/Ghost"
               rel="noreferrer"
               target="_blank"
-              className="flex items-center justify-center border-b border-r border-slate-200/20 p-12 transition hover:bg-slate-100/20 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white"
+              className="flex items-center justify-center border-b border-r border-zinc-200/20 p-12 transition hover:bg-zinc-100/20 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white"
             >
               <GhostIcon aria-hidden="true" className="h-14 w-14" />
             </a>

--- a/nx-dev/ui-enterprise/src/lib/call-to-action.tsx
+++ b/nx-dev/ui-enterprise/src/lib/call-to-action.tsx
@@ -28,7 +28,7 @@ export function CallToAction(): ReactElement {
         <svg
           x="50%"
           y={0}
-          className="overflow-visible fill-slate-200/20 dark:fill-slate-800/20"
+          className="overflow-visible fill-zinc-200/20 dark:fill-zinc-800/20"
         >
           <path
             d="M-200 0h201v201h-201Z M600 0h201v201h-201Z M-400 600h201v201h-201Z M200 800h201v201h-201Z"
@@ -57,7 +57,7 @@ export function CallToAction(): ReactElement {
       <div className="mx-auto max-w-2xl text-center">
         <h2
           id="section-cta-heading"
-          className="text-3xl font-medium tracking-tight text-slate-950 sm:text-5xl dark:text-white"
+          className="text-3xl font-medium tracking-tight text-zinc-950 sm:text-5xl dark:text-white"
         >
           Get your hands dirty and try it out for yourself.
         </h2>
@@ -74,7 +74,7 @@ export function CallToAction(): ReactElement {
                 'enterprise'
               )
             }
-            className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
+            className="rounded-md bg-zinc-950 px-3.5 py-2.5 text-sm font-semibold text-zinc-100 shadow-sm hover:bg-zinc-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-100"
           >
             Request a free trial
           </Link>

--- a/nx-dev/ui-enterprise/src/lib/customer-logos.tsx
+++ b/nx-dev/ui-enterprise/src/lib/customer-logos.tsx
@@ -83,7 +83,7 @@ export function CustomerLogos(): ReactElement {
   return (
     <section
       id="customer-logos"
-      className="group/canvas relative mx-auto flex max-w-7xl overflow-hidden text-slate-950 dark:text-slate-100"
+      className="group/canvas relative mx-auto flex max-w-7xl overflow-hidden text-zinc-950 dark:text-zinc-100"
     >
       <Marquee className="w-full justify-center overflow-hidden [--duration:240s] [--gap:6rem]">
         {icons.map((e, idx) => (
@@ -94,9 +94,9 @@ export function CustomerLogos(): ReactElement {
           />
         ))}
       </Marquee>
-      <div className="absolute bottom-0 left-0 top-0 w-1/3 max-w-60 bg-gradient-to-r from-white to-white/0 dark:from-slate-950 dark:to-slate-950/0"></div>
-      <div className="absolute bottom-0 right-0 top-0 w-1/3 max-w-60 bg-gradient-to-r from-white/0 to-white dark:from-slate-950/0 dark:to-slate-950"></div>
-      <div className="absolute inset-0 grid grid-cols-1 place-items-center bg-white/60 opacity-0 backdrop-blur-sm transition-all duration-200 group-hover/canvas:opacity-100 dark:bg-slate-950/60">
+      <div className="absolute bottom-0 left-0 top-0 w-1/3 max-w-60 bg-gradient-to-r from-white to-white/0 dark:from-zinc-950 dark:to-zinc-950/0"></div>
+      <div className="absolute bottom-0 right-0 top-0 w-1/3 max-w-60 bg-gradient-to-r from-white/0 to-white dark:from-zinc-950/0 dark:to-zinc-950"></div>
+      <div className="absolute inset-0 grid grid-cols-1 place-items-center bg-white/60 opacity-0 backdrop-blur-sm transition-all duration-200 group-hover/canvas:opacity-100 dark:bg-zinc-950/60">
         <Link
           href="/customers"
           title="See our customers"

--- a/nx-dev/ui-enterprise/src/lib/customer-metrics.tsx
+++ b/nx-dev/ui-enterprise/src/lib/customer-metrics.tsx
@@ -7,7 +7,7 @@ import { PlayIcon } from '@heroicons/react/24/outline';
 
 export function CustomerMetrics(): ReactElement {
   return (
-    <section className="border-b border-t border-slate-200 bg-slate-50 py-24 sm:py-32 dark:border-slate-800 dark:bg-slate-900">
+    <section className="border-b border-t border-zinc-200 bg-zinc-50 py-24 sm:py-32 dark:border-zinc-800 dark:bg-zinc-900">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-2xl lg:mx-0 lg:max-w-none">
           <div className="mt-6 flex flex-col-reverse gap-x-8 gap-y-20 lg:flex-row lg:items-center">
@@ -23,13 +23,13 @@ export function CustomerMetrics(): ReactElement {
                 }}
                 className="group relative block rounded-2xl"
               >
-                <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-white/60 opacity-0 backdrop-blur-sm transition duration-300 group-hover:opacity-100 dark:bg-slate-950/60">
-                  <div className="flex items-center gap-2 text-lg font-semibold text-slate-950 drop-shadow dark:text-white">
+                <div className="absolute inset-0 z-10 flex items-center justify-center rounded-2xl bg-white/60 opacity-0 backdrop-blur-sm transition duration-300 group-hover:opacity-100 dark:bg-zinc-950/60">
+                  <div className="flex items-center gap-2 text-lg font-semibold text-zinc-950 drop-shadow dark:text-white">
                     <PlayIcon className="size-8" />
                     Watch the interview
                   </div>
                 </div>
-                <figure className="relative rounded-2xl bg-white shadow-lg ring-1 ring-slate-900/5 dark:bg-slate-800">
+                <figure className="relative rounded-2xl bg-white shadow-lg ring-1 ring-zinc-900/5 dark:bg-zinc-800">
                   <blockquote className="p-6 text-lg font-semibold tracking-tight text-black dark:text-white">
                     <p>
                       Engineers will run a test command and expect it to run for
@@ -38,15 +38,15 @@ export function CustomerMetrics(): ReactElement {
                       fast?"
                     </p>
                   </blockquote>
-                  <figcaption className="flex flex-wrap items-center gap-x-4 gap-y-4 border-t border-slate-900/10 px-6 py-4 sm:flex-nowrap dark:border-slate-100/10">
+                  <figcaption className="flex flex-wrap items-center gap-x-4 gap-y-4 border-t border-zinc-900/10 px-6 py-4 sm:flex-nowrap dark:border-zinc-100/10">
                     <img
                       alt="pavlo grosse"
                       src="https://avatars.githubusercontent.com/u/2219064?v=4"
-                      className="size-10 flex-none rounded-full bg-slate-50"
+                      className="size-10 flex-none rounded-full bg-zinc-50"
                     />
                     <div className="flex-auto">
                       <div className="font-semibold">Pavlo Grosse</div>
-                      <div className="text-slate-600 dark:text-slate-500">
+                      <div className="text-zinc-600 dark:text-zinc-500">
                         Senior Software Engineer, Hetzner Cloud
                       </div>
                     </div>
@@ -82,19 +82,19 @@ export function CustomerMetrics(): ReactElement {
             </div>
             <div className="lg:flex lg:flex-auto lg:justify-center">
               <dl className="flex flex-col justify-center gap-8 sm:flex-row lg:flex-col xl:w-80">
-                <div className="flex flex-col-reverse gap-y-1 border-slate-200 pl-4 text-center sm:border-l sm:text-left dark:border-slate-800">
+                <div className="flex flex-col-reverse gap-y-1 border-zinc-200 pl-4 text-center sm:border-l sm:text-left dark:border-zinc-800">
                   <dt className="text-base/7">faster CI</dt>
                   <dd className="[text-shadow:1px 1px 0 white;] te text-5xl font-semibold tracking-tight text-black dark:text-white">
                     70%
                   </dd>
                 </div>
-                <div className="flex flex-col-reverse gap-y-1 border-slate-200 pl-4 text-center sm:border-l sm:text-left dark:border-slate-800">
+                <div className="flex flex-col-reverse gap-y-1 border-zinc-200 pl-4 text-center sm:border-l sm:text-left dark:border-zinc-800">
                   <dt className="text-base/7">less compute used</dt>
                   <dd className="text-5xl font-semibold tracking-tight text-black dark:text-white">
                     60%
                   </dd>
                 </div>
-                <div className="flex flex-col-reverse gap-y-1 border-slate-200 pl-4 text-center sm:border-l sm:text-left dark:border-slate-800">
+                <div className="flex flex-col-reverse gap-y-1 border-zinc-200 pl-4 text-center sm:border-l sm:text-left dark:border-zinc-800">
                   <dt className="text-base/7">reduction in infra costs</dt>
                   <dd className="text-5xl font-semibold tracking-tight text-black dark:text-white">
                     75%

--- a/nx-dev/ui-enterprise/src/lib/download-case-study.tsx
+++ b/nx-dev/ui-enterprise/src/lib/download-case-study.tsx
@@ -7,7 +7,7 @@ export interface DownloadCaseStudyProps {
   buttonHref: string;
   buttonText?: string;
   buttonCTA?: 'Download' | 'Read more';
-  variant?: 'primary' | 'secondary';
+  variant?: 'primary' | 'secondary' | 'contrast';
 }
 
 export function DownloadCaseStudy({
@@ -16,12 +16,12 @@ export function DownloadCaseStudy({
   buttonHref,
   buttonCTA = 'Download',
   buttonText = 'Download (pdf)',
-  variant = 'primary',
+  variant = 'contrast',
 }: DownloadCaseStudyProps): ReactElement {
   return (
-    <div className="flex h-full flex-col border border-slate-100 bg-white shadow sm:rounded-lg dark:border-slate-800/60 dark:bg-slate-950">
+    <div className="flex h-full flex-col border border-zinc-100 bg-white shadow sm:rounded-lg dark:border-zinc-800/60 dark:bg-zinc-950">
       <div className="flex flex-1 flex-col px-4 py-5 sm:p-6">
-        <h3 className="text-base font-semibold leading-6 text-slate-900 dark:text-slate-100">
+        <h3 className="text-base font-semibold leading-6 text-zinc-900 dark:text-zinc-100">
           {title}
         </h3>
         <div className="mt-2 max-w-xl flex-1 text-sm">

--- a/nx-dev/ui-enterprise/src/lib/enterprise-layout.tsx
+++ b/nx-dev/ui-enterprise/src/lib/enterprise-layout.tsx
@@ -10,7 +10,7 @@ export function EnterpriseLayout({
   scrollCTAConfig?: ButtonLinkProps[];
 } & PropsWithChildren): ReactElement {
   return (
-    <div className="w-full dark:bg-slate-950">
+    <div className="w-full dark:bg-zinc-950">
       <Header ctaButtons={headerCTAConfig} scrollCtaButtons={scrollCTAConfig} />
       <main data-document="main">{children}</main>
       <Footer />

--- a/nx-dev/ui-enterprise/src/lib/hero.tsx
+++ b/nx-dev/ui-enterprise/src/lib/hero.tsx
@@ -6,7 +6,7 @@ import { WebinarSection } from './webinar-section';
 export function Hero(): ReactElement {
   return (
     <section className="relative overflow-hidden">
-      <div className="relative isolate h-[868px] border-b border-slate-200 dark:border-slate-800">
+      <div className="relative isolate h-[868px] border-b border-zinc-200 dark:border-zinc-800">
         <img
           alt="hero illustration"
           src="/images/enterprise/hero-light.avif"
@@ -49,7 +49,7 @@ export function Hero(): ReactElement {
               <ButtonLink
                 href="/enterprise/trial"
                 title="Request a free trial"
-                variant="primary"
+                variant="contrast"
                 size="default"
                 onClick={() =>
                   sendCustomEvent(

--- a/nx-dev/ui-enterprise/src/lib/hetzner-cloud-testimonial.tsx
+++ b/nx-dev/ui-enterprise/src/lib/hetzner-cloud-testimonial.tsx
@@ -17,7 +17,7 @@ import { sendCustomEvent } from '@nx/nx-dev-feature-analytics';
 
 export function HetznerCloudTestimonial(): ReactElement {
   return (
-    <div className="border-b border-t border-slate-200 bg-slate-50 py-24 sm:py-32 dark:border-slate-800 dark:bg-slate-900">
+    <div className="border-b border-t border-zinc-200 bg-zinc-50 py-24 sm:py-32 dark:border-zinc-800 dark:bg-zinc-900">
       <section
         id="hetzner-cloud-testimonial"
         className="z-0 mx-auto max-w-7xl scroll-mt-20 px-4 sm:px-6 lg:px-8"
@@ -39,7 +39,7 @@ export function HetznerCloudTestimonial(): ReactElement {
             <div className="relative">
               <div className="absolute bottom-0 start-0 -translate-x-14 translate-y-10">
                 <svg
-                  className="h-auto max-w-40 text-slate-200 dark:text-slate-800"
+                  className="h-auto max-w-40 text-zinc-200 dark:text-zinc-800"
                   width="696"
                   height="653"
                   viewBox="0 0 696 653"
@@ -132,7 +132,7 @@ export function HetznerCloudTestimonial(): ReactElement {
           <figure>
             <blockquote className="relative">
               <svg
-                className="absolute start-0 top-0 size-24 -translate-x-8 -translate-y-4 transform text-slate-200 dark:text-slate-800"
+                className="absolute start-0 top-0 size-24 -translate-x-8 -translate-y-4 transform text-zinc-200 dark:text-zinc-800"
                 width="16"
                 height="16"
                 viewBox="0 0 16 16"
@@ -147,11 +147,11 @@ export function HetznerCloudTestimonial(): ReactElement {
               </svg>
 
               <div className="relative z-10">
-                <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-200">
+                <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-neutral-200">
                   Featured client
                 </p>
 
-                <p className="text-xl font-medium italic text-slate-800 md:text-2xl md:leading-normal xl:text-3xl xl:leading-normal dark:text-neutral-200">
+                <p className="text-xl font-medium italic text-zinc-800 md:text-2xl md:leading-normal xl:text-3xl xl:leading-normal dark:text-neutral-200">
                   Nx is speed and scalability. Before we only had a few features
                   and CI was slow and now it’s fast with way more features.
                   That’s a huge win for us.
@@ -166,7 +166,7 @@ export function HetznerCloudTestimonial(): ReactElement {
                 />
                 <div className="flex-auto">
                   <div className="text-base font-semibold">Pavlo Grosse</div>
-                  <div className="text-xs text-slate-600 dark:text-slate-500">
+                  <div className="text-xs text-zinc-600 dark:text-zinc-500">
                     Senior Software Engineer, Hetzner Cloud
                   </div>
                 </div>

--- a/nx-dev/ui-enterprise/src/lib/make-your-ci-fast.tsx
+++ b/nx-dev/ui-enterprise/src/lib/make-your-ci-fast.tsx
@@ -13,7 +13,7 @@ export function MakeYourCiFast(): ReactElement {
         </SectionHeading>
         <div className="mt-10 grid grid-cols-1 gap-4 sm:mt-16 lg:grid-cols-6">
           <div className="relative lg:col-span-2">
-            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 lg:rounded-tl-[calc(2rem+1px)] dark:bg-slate-950 dark:ring-white/10">
+            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 lg:rounded-tl-[calc(2rem+1px)] dark:bg-zinc-950 dark:ring-white/10">
               <img
                 alt="Nx Replay: remote caching"
                 src="/images/enterprise/nx-replay.avif"
@@ -21,11 +21,11 @@ export function MakeYourCiFast(): ReactElement {
               />
               <div className="relative p-10 pt-4">
                 <div className="absolute -top-10 left-10">
-                  <span className="inline-flex items-center rounded-md bg-slate-400/10 px-2 py-1 text-xs font-medium text-slate-400 ring-1 ring-inset ring-slate-400/20">
+                  <span className="inline-flex items-center rounded-md bg-zinc-400/10 px-2 py-1 text-xs font-medium text-zinc-400 ring-1 ring-inset ring-zinc-400/20">
                     Nx Replay
                   </span>
                 </div>
-                <h3 className="text-lg font-medium tracking-tight text-slate-950 dark:text-white">
+                <h3 className="text-lg font-medium tracking-tight text-zinc-950 dark:text-white">
                   Never build the same code twice
                 </h3>
                 <p className="mt-2 max-w-lg text-sm/6">
@@ -37,7 +37,7 @@ export function MakeYourCiFast(): ReactElement {
             </div>
           </div>
           <div className="relative lg:col-span-2">
-            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 dark:bg-slate-950 dark:ring-white/10">
+            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 dark:bg-zinc-950 dark:ring-white/10">
               <img
                 alt="Nx flaky task detection & rerun"
                 src="/images/enterprise/nx-flaky-tasks-detection.avif"
@@ -45,11 +45,11 @@ export function MakeYourCiFast(): ReactElement {
               />
               <div className="relative p-10 pt-4">
                 <div className="absolute -top-10 left-10">
-                  <span className="inline-flex items-center rounded-md bg-slate-400/10 px-2 py-1 text-xs font-medium text-slate-400 ring-1 ring-inset ring-slate-400/20">
+                  <span className="inline-flex items-center rounded-md bg-zinc-400/10 px-2 py-1 text-xs font-medium text-zinc-400 ring-1 ring-inset ring-zinc-400/20">
                     Flaky task retries
                   </span>
                 </div>
-                <h3 className="text-lg font-medium tracking-tight text-slate-950 dark:text-white">
+                <h3 className="text-lg font-medium tracking-tight text-zinc-950 dark:text-white">
                   One less thing to debug
                 </h3>
                 <p className="mt-2 max-w-lg text-sm/6">
@@ -61,7 +61,7 @@ export function MakeYourCiFast(): ReactElement {
             </div>
           </div>
           <div className="relative lg:col-span-2">
-            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 lg:rounded-tr-[calc(2rem+1px)] dark:bg-slate-950 dark:ring-white/10">
+            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 lg:rounded-tr-[calc(2rem+1px)] dark:bg-zinc-950 dark:ring-white/10">
               <img
                 alt="Nx Atomizer: split large tasks & E2E in chunks"
                 src="/images/enterprise/nx-atomizer.avif"
@@ -69,11 +69,11 @@ export function MakeYourCiFast(): ReactElement {
               />
               <div className="relative p-10 pt-4">
                 <div className="absolute -top-10 left-10">
-                  <span className="inline-flex items-center rounded-md bg-slate-400/10 px-2 py-1 text-xs font-medium text-slate-400 ring-1 ring-inset ring-slate-400/20">
+                  <span className="inline-flex items-center rounded-md bg-zinc-400/10 px-2 py-1 text-xs font-medium text-zinc-400 ring-1 ring-inset ring-zinc-400/20">
                     Atomizer
                   </span>
                 </div>
-                <h3 className="text-lg font-medium tracking-tight text-slate-950 dark:text-white">
+                <h3 className="text-lg font-medium tracking-tight text-zinc-950 dark:text-white">
                   Break tasks down, to speed tests up
                 </h3>
                 <p className="mt-2 max-w-lg text-sm/6">
@@ -86,7 +86,7 @@ export function MakeYourCiFast(): ReactElement {
             </div>
           </div>
           <div className="relative lg:col-span-3">
-            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 lg:rounded-bl-[calc(2rem+1px)] dark:bg-slate-950 dark:ring-white/10">
+            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 lg:rounded-bl-[calc(2rem+1px)] dark:bg-zinc-950 dark:ring-white/10">
               <img
                 alt="Nx Agents: simple & fast task distribution"
                 src="/images/enterprise/nx-agents.avif"
@@ -94,11 +94,11 @@ export function MakeYourCiFast(): ReactElement {
               />
               <div className="relative p-10 pt-4">
                 <div className="absolute -top-10 left-10">
-                  <span className="inline-flex items-center rounded-md bg-slate-400/10 px-2 py-1 text-xs font-medium text-slate-400 ring-1 ring-inset ring-slate-400/20">
+                  <span className="inline-flex items-center rounded-md bg-zinc-400/10 px-2 py-1 text-xs font-medium text-zinc-400 ring-1 ring-inset ring-zinc-400/20">
                     Nx Agents
                   </span>
                 </div>
-                <h3 className="text-lg font-medium tracking-tight text-slate-950 dark:text-white">
+                <h3 className="text-lg font-medium tracking-tight text-zinc-950 dark:text-white">
                   Machines, make it fast!
                 </h3>
                 <p className="mt-2 max-w-lg text-sm/6">
@@ -111,7 +111,7 @@ export function MakeYourCiFast(): ReactElement {
             </div>
           </div>
           <div className="relative lg:col-span-3">
-            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 lg:rounded-br-[calc(2rem+1px)] dark:bg-slate-950 dark:ring-white/10">
+            <div className="relative flex h-full flex-col overflow-hidden rounded-[calc(theme(borderRadius.lg)+1px)] bg-white shadow ring-1 ring-black/5 lg:rounded-br-[calc(2rem+1px)] dark:bg-zinc-950 dark:ring-white/10">
               <img
                 alt="Partner with the Nx Team for guidances"
                 src="/images/enterprise/nx-partnership.avif"
@@ -119,11 +119,11 @@ export function MakeYourCiFast(): ReactElement {
               />
               <div className="relative p-10 pt-4">
                 <div className="absolute -top-10 left-10">
-                  <span className="inline-flex items-center rounded-md bg-slate-400/10 px-2 py-1 text-xs font-medium text-slate-400 ring-1 ring-inset ring-slate-400/20">
+                  <span className="inline-flex items-center rounded-md bg-zinc-400/10 px-2 py-1 text-xs font-medium text-zinc-400 ring-1 ring-inset ring-zinc-400/20">
                     Partnership
                   </span>
                 </div>
-                <h3 className="text-lg font-medium tracking-tight text-slate-950 dark:text-white">
+                <h3 className="text-lg font-medium tracking-tight text-zinc-950 dark:text-white">
                   Always thinking a step ahead for you
                 </h3>
                 <p className="mt-2 max-w-lg text-sm/6">

--- a/nx-dev/ui-enterprise/src/lib/scale-your-organization.tsx
+++ b/nx-dev/ui-enterprise/src/lib/scale-your-organization.tsx
@@ -23,7 +23,7 @@ export function ScaleYourOrganization(): ReactElement {
               src="/images/enterprise/neurons-dark.avif"
               width={2111}
               height={921}
-              className="hidden w-[48rem] max-w-none rounded-xl shadow-xl ring-1 ring-slate-400/10 sm:w-[57rem] md:-mr-4 lg:mr-0 dark:block"
+              className="hidden w-[48rem] max-w-none rounded-xl shadow-xl ring-1 ring-zinc-400/10 sm:w-[57rem] md:-mr-4 lg:mr-0 dark:block"
             />
           </div>
           <div className="lg:ml-auto lg:pl-4 lg:pt-4">
@@ -42,7 +42,7 @@ export function ScaleYourOrganization(): ReactElement {
                 </Strong>
                 .
               </SectionHeading>
-              <figure className="mt-12 border-l border-slate-200 pl-8 dark:border-slate-800">
+              <figure className="mt-12 border-l border-zinc-200 pl-8 dark:border-zinc-800">
                 <blockquote className="text-base/7">
                   <p>
                     “Nx means tooling and efficiency around our software
@@ -58,7 +58,7 @@ export function ScaleYourOrganization(): ReactElement {
                   />
                   <div>
                     <div className="font-semibold">Justin Schwartzenberger</div>
-                    <div className="text-slate-500">
+                    <div className="text-zinc-500">
                       Principal Software Engineer, SiriusXM
                     </div>
                   </div>
@@ -80,10 +80,10 @@ export function ScaleYourOrganization(): ReactElement {
               </div>
               <div className="relative flex gap-x-4">
                 <div className="absolute -bottom-6 left-0 top-0 flex w-6 justify-center">
-                  <div className="w-px bg-slate-200 dark:bg-slate-800" />
+                  <div className="w-px bg-zinc-200 dark:bg-zinc-800" />
                 </div>
-                <div className="relative mt-1 flex size-6 flex-none items-center justify-center bg-white dark:bg-slate-950">
-                  <div className="size-1.5 rounded-full bg-slate-100 ring-1 ring-slate-300 dark:bg-slate-800 dark:ring-slate-600" />
+                <div className="relative mt-1 flex size-6 flex-none items-center justify-center bg-white dark:bg-zinc-950">
+                  <div className="size-1.5 rounded-full bg-zinc-100 ring-1 ring-zinc-300 dark:bg-zinc-800 dark:ring-zinc-600" />
                 </div>
                 <div className="flex flex-col pb-10">
                   <dt className="text-base font-semibold leading-7 text-black dark:text-white">
@@ -117,10 +117,10 @@ export function ScaleYourOrganization(): ReactElement {
               </div>
               <div className="group/section relative flex gap-x-4">
                 <div className="absolute -bottom-6 left-0 top-0 flex w-6 justify-center">
-                  <div className="w-px bg-slate-200 dark:bg-slate-800" />
+                  <div className="w-px bg-zinc-200 dark:bg-zinc-800" />
                 </div>
-                <div className="relative mt-1 flex size-6 flex-none items-center justify-center bg-white dark:bg-slate-950">
-                  <div className="size-1.5 rounded-full bg-slate-100 ring-1 ring-slate-300 dark:bg-slate-800 dark:ring-slate-600" />
+                <div className="relative mt-1 flex size-6 flex-none items-center justify-center bg-white dark:bg-zinc-950">
+                  <div className="size-1.5 rounded-full bg-zinc-100 ring-1 ring-zinc-300 dark:bg-zinc-800 dark:ring-zinc-600" />
                 </div>
                 <div className="flex flex-col pb-10">
                   <dt className="text-base font-semibold leading-7 text-black dark:text-white">
@@ -179,10 +179,10 @@ export function ScaleYourOrganization(): ReactElement {
               </div>
               <div className="relative flex gap-x-4">
                 <div className="absolute -bottom-6 left-0 top-0 flex w-6 justify-center">
-                  <div className="w-px bg-slate-200 dark:bg-slate-800" />
+                  <div className="w-px bg-zinc-200 dark:bg-zinc-800" />
                 </div>
-                <div className="relative mt-1 flex size-6 flex-none items-center justify-center bg-white dark:bg-slate-950">
-                  <div className="size-1.5 rounded-full bg-slate-100 ring-1 ring-slate-300 dark:bg-slate-800 dark:ring-slate-600" />
+                <div className="relative mt-1 flex size-6 flex-none items-center justify-center bg-white dark:bg-zinc-950">
+                  <div className="size-1.5 rounded-full bg-zinc-100 ring-1 ring-zinc-300 dark:bg-zinc-800 dark:ring-zinc-600" />
                 </div>
                 <div className="flex flex-col pb-10">
                   <dt className="text-base font-semibold leading-7 text-black dark:text-white">
@@ -249,7 +249,7 @@ export function ScaleOrganizationIntro(): ReactElement {
         <svg
           x="50%"
           y={0}
-          className="overflow-visible fill-slate-200/20 dark:fill-slate-800/60"
+          className="overflow-visible fill-zinc-200/20 dark:fill-zinc-800/60"
         >
           <path
             d="M-200 0h201v201h-201Z M600 0h201v201h-201Z M-400 600h201v201h-201Z M200 800h201v201h-201Z"

--- a/nx-dev/ui-enterprise/src/lib/security.tsx
+++ b/nx-dev/ui-enterprise/src/lib/security.tsx
@@ -32,7 +32,7 @@ export function Security(): ReactElement {
             </p>
 
             <div className="mt-16 flex flex-wrap items-center gap-4">
-              <div className="flex w-52 shrink-0 items-center gap-2 rounded-xl px-2 py-1 text-xs text-slate-950 ring-1 ring-slate-200 dark:text-slate-50 dark:ring-slate-700">
+              <div className="flex w-52 shrink-0 items-center gap-2 rounded-xl px-2 py-1 text-xs text-zinc-950 ring-1 ring-zinc-200 dark:text-zinc-50 dark:ring-zinc-700">
                 <svg
                   role="img"
                   xmlns="http://www.w3.org/2000/svg"
@@ -60,7 +60,7 @@ export function Security(): ReactElement {
             <div className="mt-8 flex gap-4">
               <ServerStackIcon aria-hidden="true" className="size-6 shrink-0" />
               <div>
-                <h4 className="relative text-base font-medium leading-6 text-slate-900 dark:text-slate-100">
+                <h4 className="relative text-base font-medium leading-6 text-zinc-900 dark:text-zinc-100">
                   Dedicated infrastructure
                 </h4>
                 <p className="mt-2">
@@ -74,7 +74,7 @@ export function Security(): ReactElement {
             <div className="mt-8 flex gap-4">
               <ShieldCheckIcon aria-hidden="true" className="size-6 shrink-0" />
               <div>
-                <h4 className="relative text-base font-medium leading-6 text-slate-900 dark:text-slate-100">
+                <h4 className="relative text-base font-medium leading-6 text-zinc-900 dark:text-zinc-100">
                   Application security
                 </h4>
                 <p className="mt-2">
@@ -91,7 +91,7 @@ export function Security(): ReactElement {
                 className="size-6 shrink-0"
               />
               <div>
-                <h4 className="relative text-base font-medium leading-6 text-slate-900 dark:text-slate-100">
+                <h4 className="relative text-base font-medium leading-6 text-zinc-900 dark:text-zinc-100">
                   US & EU instances available
                 </h4>
                 <p className="mt-2">
@@ -108,7 +108,7 @@ export function Security(): ReactElement {
                 className="size-6 shrink-0"
               />
               <div>
-                <h4 className="relative text-base font-medium leading-6 text-slate-900 dark:text-slate-100">
+                <h4 className="relative text-base font-medium leading-6 text-zinc-900 dark:text-zinc-100">
                   Enterprise-grade CI security
                 </h4>
                 <p className="mt-2">

--- a/nx-dev/ui-enterprise/src/lib/security/build-for-enterprise.tsx
+++ b/nx-dev/ui-enterprise/src/lib/security/build-for-enterprise.tsx
@@ -61,7 +61,7 @@ export function BuiltForEnterprise(): ReactElement {
               secure.
             </SectionHeading>
 
-            <figure className="mt-16 rounded-lg bg-slate-100 p-4 pl-8 dark:bg-slate-800">
+            <figure className="mt-16 rounded-lg bg-zinc-100 p-4 pl-8 dark:bg-zinc-800">
               <blockquote className="text-base/7">
                 <p>
                   “Nx is the tool that helps gain speed and trust on the overall
@@ -77,7 +77,7 @@ export function BuiltForEnterprise(): ReactElement {
                 />
                 <div>
                   <div className="font-semibold">Nicolas Beaussart</div>
-                  <div className="text-slate-500">
+                  <div className="text-zinc-500">
                     Staff Platform Engineer, Payfit
                   </div>
                 </div>

--- a/nx-dev/ui-enterprise/src/lib/security/cache-poisoning-protection.tsx
+++ b/nx-dev/ui-enterprise/src/lib/security/cache-poisoning-protection.tsx
@@ -54,7 +54,7 @@ export function CachePoisoningProtection(): ReactElement {
 
             <ul className="mt-4 space-y-4 text-base leading-7">
               <li className="relative pl-9">
-                <span className="inline font-semibold text-slate-950 dark:text-white">
+                <span className="inline font-semibold text-zinc-950 dark:text-white">
                   <ServerIcon
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"
@@ -67,7 +67,7 @@ export function CachePoisoningProtection(): ReactElement {
                 main.
               </li>
               <li className="relative pl-9">
-                <span className="inline font-semibold text-slate-950 dark:text-white">
+                <span className="inline font-semibold text-zinc-950 dark:text-white">
                   <FingerPrintIcon
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"
@@ -78,7 +78,7 @@ export function CachePoisoningProtection(): ReactElement {
                 or process that created them.
               </li>
               <li className="relative pl-9">
-                <span className="inline font-semibold text-slate-950 dark:text-white">
+                <span className="inline font-semibold text-zinc-950 dark:text-white">
                   <LinkSlashIcon
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"

--- a/nx-dev/ui-enterprise/src/lib/security/call-to-action.tsx
+++ b/nx-dev/ui-enterprise/src/lib/security/call-to-action.tsx
@@ -28,7 +28,7 @@ export function SecurityCallToAction(): ReactElement {
         <svg
           x="50%"
           y={0}
-          className="overflow-visible fill-slate-200/20 dark:fill-slate-800/20"
+          className="overflow-visible fill-zinc-200/20 dark:fill-zinc-800/20"
         >
           <path
             d="M-200 0h201v201h-201Z M600 0h201v201h-201Z M-400 600h201v201h-201Z M200 800h201v201h-201Z"
@@ -57,7 +57,7 @@ export function SecurityCallToAction(): ReactElement {
       <div className="mx-auto max-w-2xl text-center">
         <h2
           id="section-cta-heading"
-          className="text-3xl font-medium tracking-tight text-slate-950 sm:text-5xl dark:text-white"
+          className="text-3xl font-medium tracking-tight text-zinc-950 sm:text-5xl dark:text-white"
         >
           Security that scales <br className="hidden lg:block" /> with your team
         </h2>
@@ -74,7 +74,7 @@ export function SecurityCallToAction(): ReactElement {
                   'enterprise-security'
                 )
               }
-              className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
+              className="rounded-md bg-zinc-950 px-3.5 py-2.5 text-sm font-semibold text-zinc-100 shadow-sm hover:bg-zinc-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-100"
             >
               Talk to an expert
             </Link>

--- a/nx-dev/ui-enterprise/src/lib/security/ci-access.tsx
+++ b/nx-dev/ui-enterprise/src/lib/security/ci-access.tsx
@@ -49,7 +49,7 @@ export function CiAccess(): ReactElement {
             </SectionDescription>
             <ul className="mt-4 space-y-4 text-base leading-7">
               <li className="relative pl-9">
-                <span className="inline font-semibold text-slate-950 dark:text-white">
+                <span className="inline font-semibold text-zinc-950 dark:text-white">
                   <ArrowPathIcon
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"
@@ -58,7 +58,7 @@ export function CiAccess(): ReactElement {
                 </span>
               </li>
               <li className="relative pl-9">
-                <span className="inline font-semibold text-slate-950 dark:text-white">
+                <span className="inline font-semibold text-zinc-950 dark:text-white">
                   <ArrowsUpDownIcon
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"

--- a/nx-dev/ui-enterprise/src/lib/security/failing-compliance.tsx
+++ b/nx-dev/ui-enterprise/src/lib/security/failing-compliance.tsx
@@ -48,14 +48,14 @@ export function FailingCompliance(): ReactElement {
             </SectionDescription>
 
             <div className="mt-6 flex justify-center">
-              <div className="max-w-sm rounded-lg border border-slate-200 bg-white p-4 shadow-lg dark:border-slate-800 dark:bg-slate-800/60">
+              <div className="max-w-sm rounded-lg border border-zinc-200 bg-white p-4 shadow-lg dark:border-zinc-800 dark:bg-zinc-800/60">
                 <div className="flex items-start">
                   <ShieldExclamationIcon
                     aria-hidden="true"
                     className="size-5 flex-shrink-0 text-red-500 dark:text-white"
                   />
                   <div className="ml-4 flex-1">
-                    <p className="text-sm font-medium text-slate-900 dark:text-white">
+                    <p className="text-sm font-medium text-zinc-900 dark:text-white">
                       <abbr
                         title="Cache Race-condition Exploit Enables Poisoning"
                         className="cursor-help"
@@ -64,7 +64,7 @@ export function FailingCompliance(): ReactElement {
                       </abbr>{' '}
                       (CVE-2025-36852)
                     </p>
-                    <p className="mt-1 text-xs text-slate-600 dark:text-slate-400">
+                    <p className="mt-1 text-xs text-zinc-600 dark:text-zinc-400">
                       Critical Cache Poisoning Vulnerability Affects Multiple
                       Build Systems.
                     </p>
@@ -120,7 +120,7 @@ export function FailingCompliance(): ReactElement {
 
             <ul className="mt-6 space-y-4 text-base leading-7">
               <li className="relative pl-9">
-                <span className="inline font-semibold text-slate-950 dark:text-white">
+                <span className="inline font-semibold text-zinc-950 dark:text-white">
                   <ExclamationTriangleIcon
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"
@@ -132,7 +132,7 @@ export function FailingCompliance(): ReactElement {
                 2 compliance.
               </li>
               <li className="relative pl-9">
-                <span className="inline font-semibold text-slate-950 dark:text-white">
+                <span className="inline font-semibold text-zinc-950 dark:text-white">
                   <ExclamationTriangleIcon
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"
@@ -143,7 +143,7 @@ export function FailingCompliance(): ReactElement {
                 HIPAA mandates for protecting ePHI.
               </li>
               <li className="relative pl-9">
-                <span className="inline font-semibold text-slate-950 dark:text-white">
+                <span className="inline font-semibold text-zinc-950 dark:text-white">
                   <ExclamationTriangleIcon
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"
@@ -154,7 +154,7 @@ export function FailingCompliance(): ReactElement {
                 internal/external audit cycles.
               </li>
               <li className="relative pl-9">
-                <span className="inline font-semibold text-slate-950 dark:text-white">
+                <span className="inline font-semibold text-zinc-950 dark:text-white">
                   <ExclamationTriangleIcon
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"
@@ -165,7 +165,7 @@ export function FailingCompliance(): ReactElement {
                 data classification, monitoring, and secure U.S. hosting.
               </li>
               <li className="relative pl-9">
-                <span className="inline font-semibold text-slate-950 dark:text-white">
+                <span className="inline font-semibold text-zinc-950 dark:text-white">
                   <ExclamationTriangleIcon
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"
@@ -191,7 +191,7 @@ export function FailingCompliance(): ReactElement {
               </SectionDescription>
               <ButtonLink
                 href="/contact/sales"
-                variant="primary"
+                variant="contrast"
                 size="default"
                 title="Talk to an expert"
                 className="mt-4"

--- a/nx-dev/ui-enterprise/src/lib/security/personal-access.tsx
+++ b/nx-dev/ui-enterprise/src/lib/security/personal-access.tsx
@@ -46,7 +46,7 @@ export function PersonalAccess(): ReactElement {
 
             <ul className="mt-4 space-y-4 text-base leading-7">
               <li className="relative pl-9">
-                <span className="inline font-semibold text-slate-950 dark:text-white">
+                <span className="inline font-semibold text-zinc-950 dark:text-white">
                   <IdentificationIcon
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"
@@ -55,7 +55,7 @@ export function PersonalAccess(): ReactElement {
                 </span>
               </li>
               <li className="relative pl-9">
-                <span className="inline font-semibold text-slate-950 dark:text-white">
+                <span className="inline font-semibold text-zinc-950 dark:text-white">
                   <LinkSlashIcon
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"

--- a/nx-dev/ui-enterprise/src/lib/security/why-ci-security-matters.tsx
+++ b/nx-dev/ui-enterprise/src/lib/security/why-ci-security-matters.tsx
@@ -42,7 +42,7 @@ export function WhyCiSecurityMatters(): ReactElement {
             <div className="mt-10 text-center">
               <ButtonLink
                 href="/enterprise"
-                variant="primary"
+                variant="contrast"
                 size="default"
                 title="Learn about Nx Cloud for Enterprises"
               >
@@ -53,7 +53,7 @@ export function WhyCiSecurityMatters(): ReactElement {
           <div>
             <ul className="mt-12 space-y-4 text-base leading-7">
               <li className="relative pl-9">
-                <span className="inline font-semibold text-slate-950 dark:text-white">
+                <span className="inline font-semibold text-zinc-950 dark:text-white">
                   <BugAntIcon
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"
@@ -63,7 +63,7 @@ export function WhyCiSecurityMatters(): ReactElement {
                 — if left unprotected
               </li>
               <li className="relative pl-9">
-                <span className="inline font-semibold text-slate-950 dark:text-white">
+                <span className="inline font-semibold text-zinc-950 dark:text-white">
                   <EyeSlashIcon
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"
@@ -72,7 +72,7 @@ export function WhyCiSecurityMatters(): ReactElement {
                 </span>
               </li>
               <li className="relative pl-9">
-                <span className="inline font-semibold text-slate-950 dark:text-white">
+                <span className="inline font-semibold text-zinc-950 dark:text-white">
                   <DocumentCheckIcon
                     aria-hidden="true"
                     className="absolute left-1 top-1 h-5 w-5"

--- a/nx-dev/ui-enterprise/src/lib/solutions/engineering/all-speed-no-stress.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/engineering/all-speed-no-stress.tsx
@@ -107,7 +107,7 @@ export function AllSpeedNoStress(): ReactElement {
       className="mx-auto max-w-7xl scroll-mt-32 px-6 lg:px-8"
     >
       <div className="mx-auto max-w-2xl lg:mx-0">
-        <div className="h-8 w-36 border-t-2 border-blue-500 dark:border-sky-500" />
+        <div className="h-8 w-36 border-t-2 border-blue-500 dark:border-blue-500" />
         <SectionHeading as="h2" variant="title" id="all-speed-no-stress-title">
           All speed no stress
         </SectionHeading>
@@ -120,7 +120,7 @@ export function AllSpeedNoStress(): ReactElement {
           {features.map((feature) => (
             <div key={feature.name} className="flex flex-col">
               <dt className="text-base/7 font-semibold">
-                <div className="mb-6 flex size-10 items-center justify-center rounded-lg bg-blue-500 dark:bg-sky-500">
+                <div className="mb-6 flex size-10 items-center justify-center rounded-lg bg-blue-500 dark:bg-blue-500">
                   <feature.icon
                     aria-hidden="true"
                     className="size-6 text-white"

--- a/nx-dev/ui-enterprise/src/lib/solutions/engineering/solutions-engineering-hero.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/engineering/solutions-engineering-hero.tsx
@@ -27,7 +27,7 @@ export function SolutionsEngineeringHero(): ReactElement {
             className="mt-8 text-pretty tracking-tight"
           >
             Build confidently, ship faster{' '}
-            <span className="rounded-lg bg-gradient-to-r from-blue-500 to-sky-500 bg-clip-text text-transparent">
+            <span className="rounded-lg bg-gradient-to-r from-blue-500 to-blue-500 bg-clip-text text-transparent">
               without waiting on your tools
             </span>
           </SectionHeading>
@@ -43,7 +43,7 @@ export function SolutionsEngineeringHero(): ReactElement {
             <ButtonLink
               href="/contact/sales"
               title="Talk to our team"
-              variant="primary"
+              variant="contrast"
               size="default"
               onClick={() =>
                 sendCustomEvent(

--- a/nx-dev/ui-enterprise/src/lib/solutions/engineering/solutions-engineering-testimonials.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/engineering/solutions-engineering-testimonials.tsx
@@ -11,7 +11,7 @@ import { SectionHeading } from '@nx/nx-dev-ui-common';
 
 export function SolutionsEngineeringTestimonials(): ReactElement {
   return (
-    <div className="border border-slate-100 bg-slate-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8 dark:border-slate-900 dark:bg-slate-900/[0.8]">
+    <div className="border border-zinc-100 bg-zinc-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8 dark:border-zinc-900 dark:bg-zinc-900/[0.8]">
       <div className="mx-auto max-w-5xl text-center">
         <SectionHeading as="h2" variant="title" id="testimonials">
           Don't just take our word for it.
@@ -22,7 +22,7 @@ export function SolutionsEngineeringTestimonials(): ReactElement {
         </SectionHeading>
       </div>
       <div className="mx-auto grid max-w-7xl gap-8 lg:grid-cols-3">
-        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-slate-950">
+        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-zinc-950">
           <blockquote className="text-base/7">
             <p>
               “Using Nx Cloud, our CI times have reduced by 83%! Our teams are
@@ -38,7 +38,7 @@ export function SolutionsEngineeringTestimonials(): ReactElement {
             />
             <div>
               <div className="font-semibold">Laurent Delamare</div>
-              <div className="text-slate-500">Senior Engineer, VMware</div>
+              <div className="text-zinc-500">Senior Engineer, VMware</div>
             </div>
             <VmwareIcon
               aria-hidden="true"
@@ -46,7 +46,7 @@ export function SolutionsEngineeringTestimonials(): ReactElement {
             />
           </figcaption>
         </figure>
-        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-slate-950">
+        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-zinc-950">
           <blockquote className="text-base/7">
             <p>
               "Engineers will run a test command and expect it to run for 20
@@ -62,7 +62,7 @@ export function SolutionsEngineeringTestimonials(): ReactElement {
             />
             <div>
               <div className="font-semibold">Pavlo Grosse</div>
-              <div className="text-slate-500">
+              <div className="text-zinc-500">
                 Senior Engineer, Hetzner Cloud
               </div>
             </div>
@@ -73,7 +73,7 @@ export function SolutionsEngineeringTestimonials(): ReactElement {
             />
           </figcaption>
         </figure>
-        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-slate-950">
+        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-zinc-950">
           <blockquote className="text-base/7">
             <p>
               "Maintaining our own CI was not efficient. With Nx Cloud our
@@ -89,7 +89,7 @@ export function SolutionsEngineeringTestimonials(): ReactElement {
             />
             <div>
               <div className="font-semibold">Sid Govindaraju</div>
-              <div className="text-slate-500">Engineering Manager, UKG</div>
+              <div className="text-zinc-500">Engineering Manager, UKG</div>
             </div>
             <UkgIcon
               aria-hidden="true"

--- a/nx-dev/ui-enterprise/src/lib/solutions/leadership/scale-safely.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/leadership/scale-safely.tsx
@@ -53,7 +53,7 @@ export function ScaleSafely(): ReactElement {
       className="mx-auto max-w-7xl scroll-mt-32 px-6 lg:px-8"
     >
       <div className="mx-auto max-w-2xl lg:mx-0">
-        <div className="h-8 w-36 border-t-2 border-blue-500 dark:border-sky-500" />
+        <div className="h-8 w-36 border-t-2 border-blue-500 dark:border-blue-500" />
         <SectionHeading as="h2" variant="title" id="scale-safely-title">
           Scale Safely
         </SectionHeading>
@@ -67,7 +67,7 @@ export function ScaleSafely(): ReactElement {
           {features.map((feature) => (
             <div key={feature.name} className="flex flex-col">
               <dt className="text-base/7 font-semibold">
-                <div className="mb-6 flex size-10 items-center justify-center rounded-lg bg-blue-500 dark:bg-sky-500">
+                <div className="mb-6 flex size-10 items-center justify-center rounded-lg bg-blue-500 dark:bg-blue-500">
                   <feature.icon
                     aria-hidden="true"
                     className="size-6 text-white"

--- a/nx-dev/ui-enterprise/src/lib/solutions/leadership/solutions-leadership-hero.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/leadership/solutions-leadership-hero.tsx
@@ -62,7 +62,7 @@ function PlayButton({
         initial="initial"
         whileHover="hover"
         variants={parent}
-        className="relative isolate flex size-20 cursor-pointer items-center justify-center gap-6 rounded-full border-2 border-slate-100 bg-white/10 p-6 text-white antialiased backdrop-blur-xl"
+        className="relative isolate flex size-20 cursor-pointer items-center justify-center gap-6 rounded-full border-2 border-zinc-100 bg-white/10 p-6 text-white antialiased backdrop-blur-xl"
       >
         <PlayIcon aria-hidden="true" className="absolute left-6 top-6 size-8" />
         <motion.div variants={child} className="absolute left-20 top-4 w-48">
@@ -90,7 +90,7 @@ export function SolutionsLeadershipHero(): ReactElement {
           >
             Fast Delivery <br className="lg:block" /> Low Risk
             <br className="lg:block" />
-            <span className="rounded-lg bg-gradient-to-r from-blue-500 to-sky-500 bg-clip-text text-transparent">
+            <span className="rounded-lg bg-gradient-to-r from-blue-500 to-blue-500 bg-clip-text text-transparent">
               High ROI
             </span>
           </SectionHeading>
@@ -107,7 +107,7 @@ export function SolutionsLeadershipHero(): ReactElement {
             <ButtonLink
               href="/contact/sales"
               title="Talk to our team"
-              variant="primary"
+              variant="contrast"
               size="default"
               onClick={() =>
                 sendCustomEvent(

--- a/nx-dev/ui-enterprise/src/lib/solutions/leadership/solutions-leadership-testimonials.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/leadership/solutions-leadership-testimonials.tsx
@@ -9,7 +9,7 @@ import { SectionHeading } from '@nx/nx-dev-ui-common';
 
 export function SolutionsLeadershipTestimonials(): ReactElement {
   return (
-    <div className="border border-slate-100 bg-slate-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8 dark:border-slate-900 dark:bg-slate-900/[0.8]">
+    <div className="border border-zinc-100 bg-zinc-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8 dark:border-zinc-900 dark:bg-zinc-900/[0.8]">
       <div className="mx-auto max-w-5xl text-center">
         <SectionHeading as="h2" variant="title" id="testimonials">
           Don't just take our word for it.
@@ -20,7 +20,7 @@ export function SolutionsLeadershipTestimonials(): ReactElement {
         </SectionHeading>
       </div>
       <div className="mx-auto grid max-w-7xl gap-8 lg:grid-cols-3">
-        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-slate-950">
+        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-zinc-950">
           <blockquote className="text-base/7">
             <p>
               "The hours we spent manually load balancing in CircleCI was
@@ -36,7 +36,7 @@ export function SolutionsLeadershipTestimonials(): ReactElement {
             />
             <div>
               <div className="font-semibold">Nicolas Beaussart</div>
-              <div className="text-slate-500">
+              <div className="text-zinc-500">
                 Staff Platform Engineer, Payfit
               </div>
             </div>
@@ -46,7 +46,7 @@ export function SolutionsLeadershipTestimonials(): ReactElement {
             />
           </figcaption>
         </figure>
-        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-slate-950">
+        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-zinc-950">
           <blockquote className="text-base/7">
             <p>
               “Nx means tooling and efficiency around our software development
@@ -62,18 +62,18 @@ export function SolutionsLeadershipTestimonials(): ReactElement {
             />
             <div>
               <div className="font-semibold">Justin Schwartzenberger</div>
-              <div className="text-slate-500">
+              <div className="text-zinc-500">
                 Principal Software Engineer, SiriusXM
               </div>
             </div>
             <SiriusxmAlternateIcon
               aria-hidden="true"
-              className="ml-auto size-10 shrink-0 rounded text-[#0000EB] dark:bg-slate-200"
+              className="ml-auto size-10 shrink-0 rounded text-[#0000EB] dark:bg-zinc-200"
             />
           </figcaption>
         </figure>
 
-        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-slate-950">
+        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-zinc-950">
           <blockquote className="text-base/7">
             <p>
               "We leverage Nx to share code, UX, and styles. All teams decided
@@ -89,7 +89,7 @@ export function SolutionsLeadershipTestimonials(): ReactElement {
             />
             <div>
               <div className="font-semibold">Amir Toole</div>
-              <div className="text-slate-500">VP of Engineering, Caseware</div>
+              <div className="text-zinc-500">VP of Engineering, Caseware</div>
             </div>
             <CasewareIcon
               aria-hidden="true"

--- a/nx-dev/ui-enterprise/src/lib/solutions/management/keep-teams-aligned.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/management/keep-teams-aligned.tsx
@@ -79,7 +79,7 @@ export function KeepTeamsAligned(): ReactElement {
       className="mx-auto max-w-7xl scroll-mt-32 px-6 lg:px-8"
     >
       <div className="mx-auto max-w-2xl lg:mx-0">
-        <div className="h-8 w-36 border-t-2 border-blue-500 dark:border-sky-500" />
+        <div className="h-8 w-36 border-t-2 border-blue-500 dark:border-blue-500" />
         <SectionHeading as="h2" variant="title" id="keep-teams-aligned-title">
           Keep Teams Aligned
         </SectionHeading>
@@ -93,7 +93,7 @@ export function KeepTeamsAligned(): ReactElement {
           {features.map((feature) => (
             <div key={feature.name} className="flex flex-col">
               <dt className="text-base/7 font-semibold">
-                <div className="mb-6 flex size-10 items-center justify-center rounded-lg bg-blue-500 dark:bg-sky-500">
+                <div className="mb-6 flex size-10 items-center justify-center rounded-lg bg-blue-500 dark:bg-blue-500">
                   <feature.icon
                     aria-hidden="true"
                     className="size-6 text-white"

--- a/nx-dev/ui-enterprise/src/lib/solutions/management/solutions-management-hero.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/management/solutions-management-hero.tsx
@@ -27,7 +27,7 @@ export function SolutionsManagementHero(): ReactElement {
             className="mt-8 text-pretty tracking-tight"
           >
             Standardize, scale,{' '}
-            <span className="rounded-lg bg-gradient-to-r from-blue-500 to-sky-500 bg-clip-text text-transparent">
+            <span className="rounded-lg bg-gradient-to-r from-blue-500 to-blue-500 bg-clip-text text-transparent">
               ship faster with less waste
             </span>
           </SectionHeading>
@@ -43,7 +43,7 @@ export function SolutionsManagementHero(): ReactElement {
             <ButtonLink
               href="/contact/sales"
               title="Talk to our team"
-              variant="primary"
+              variant="contrast"
               size="default"
               onClick={() =>
                 sendCustomEvent(

--- a/nx-dev/ui-enterprise/src/lib/solutions/management/solutions-management-testimonials.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/management/solutions-management-testimonials.tsx
@@ -8,7 +8,7 @@ import { SectionHeading } from '@nx/nx-dev-ui-common';
 
 export function SolutionsManagementTestimonials(): ReactElement {
   return (
-    <div className="border border-slate-100 bg-slate-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8 dark:border-slate-900 dark:bg-slate-900/[0.8]">
+    <div className="border border-zinc-100 bg-zinc-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8 dark:border-zinc-900 dark:bg-zinc-900/[0.8]">
       <div className="mx-auto max-w-5xl text-center">
         <SectionHeading as="h2" variant="title" id="testimonials">
           Don't just take our word for it.
@@ -19,7 +19,7 @@ export function SolutionsManagementTestimonials(): ReactElement {
         </SectionHeading>
       </div>
       <div className="mx-auto grid max-w-7xl gap-8 lg:grid-cols-3">
-        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-slate-950">
+        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-zinc-950">
           <blockquote className="text-base/7">
             <p>
               “Nx means tooling and efficiency around our software development
@@ -35,17 +35,17 @@ export function SolutionsManagementTestimonials(): ReactElement {
             />
             <div>
               <div className="font-semibold">Justin Schwartzenberger</div>
-              <div className="text-slate-500">
+              <div className="text-zinc-500">
                 Principal Software Engineer, SiriusXM
               </div>
             </div>
             <SiriusxmAlternateIcon
               aria-hidden="true"
-              className="ml-auto size-10 shrink-0 rounded text-[#0000EB] dark:bg-slate-200"
+              className="ml-auto size-10 shrink-0 rounded text-[#0000EB] dark:bg-zinc-200"
             />
           </figcaption>
         </figure>
-        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-slate-950">
+        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-zinc-950">
           <blockquote className="text-base/7">
             <p>
               "A year ago, to deploy a feature, it took 2-5 days. Now the same
@@ -61,7 +61,7 @@ export function SolutionsManagementTestimonials(): ReactElement {
             />
             <div>
               <div className="font-semibold">Nicolas Beaussart</div>
-              <div className="text-slate-500">
+              <div className="text-zinc-500">
                 Staff Platform Engineer, Payfit
               </div>
             </div>
@@ -71,7 +71,7 @@ export function SolutionsManagementTestimonials(): ReactElement {
             />
           </figcaption>
         </figure>
-        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-slate-950">
+        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-zinc-950">
           <blockquote className="text-base/7">
             <p>
               "Nx is speed and scalability - with the set of features we had 3
@@ -87,7 +87,7 @@ export function SolutionsManagementTestimonials(): ReactElement {
             />
             <div>
               <div className="font-semibold">Pavlo Grosse</div>
-              <div className="text-slate-500">
+              <div className="text-zinc-500">
                 Senior Engineer, Hetzner Cloud
               </div>
             </div>

--- a/nx-dev/ui-enterprise/src/lib/solutions/platform/easy-to-adapt-easy-to-maintain.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/platform/easy-to-adapt-easy-to-maintain.tsx
@@ -76,7 +76,7 @@ export function EasyToAdoptEasyToMaintain(): ReactElement {
       className="mx-auto max-w-7xl scroll-mt-32 px-6 lg:px-8"
     >
       <div className="mx-auto max-w-2xl lg:mx-0">
-        <div className="h-8 w-36 border-t-2 border-blue-500 dark:border-sky-500" />
+        <div className="h-8 w-36 border-t-2 border-blue-500 dark:border-blue-500" />
         <SectionHeading
           as="h2"
           variant="title"
@@ -94,7 +94,7 @@ export function EasyToAdoptEasyToMaintain(): ReactElement {
           {features.map((feature) => (
             <div key={feature.name} className="flex flex-col">
               <dt className="text-base/7 font-semibold">
-                <div className="mb-6 flex size-10 items-center justify-center rounded-lg bg-blue-500 dark:bg-sky-500">
+                <div className="mb-6 flex size-10 items-center justify-center rounded-lg bg-blue-500 dark:bg-blue-500">
                   <feature.icon
                     aria-hidden="true"
                     className="size-6 text-white"

--- a/nx-dev/ui-enterprise/src/lib/solutions/platform/solutions-platform-hero.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/platform/solutions-platform-hero.tsx
@@ -27,7 +27,7 @@ export function SolutionsPlatformHero(): ReactElement {
             className="mt-8 text-pretty tracking-tight"
           >
             CI that works out of the box –{' '}
-            <span className="rounded-lg bg-gradient-to-r from-blue-500 to-sky-500 bg-clip-text text-transparent">
+            <span className="rounded-lg bg-gradient-to-r from-blue-500 to-blue-500 bg-clip-text text-transparent">
               stays reliable at scale
             </span>
           </SectionHeading>
@@ -44,7 +44,7 @@ export function SolutionsPlatformHero(): ReactElement {
             <ButtonLink
               href="/contact/sales"
               title="Talk to our team"
-              variant="primary"
+              variant="contrast"
               size="default"
               onClick={() =>
                 sendCustomEvent(

--- a/nx-dev/ui-enterprise/src/lib/solutions/platform/solutions-platform-testimonials.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/platform/solutions-platform-testimonials.tsx
@@ -9,7 +9,7 @@ import { SectionHeading } from '@nx/nx-dev-ui-common';
 
 export function SolutionsPlatformTestimonials(): ReactElement {
   return (
-    <div className="border border-slate-100 bg-slate-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8 dark:border-slate-900 dark:bg-slate-900/[0.8]">
+    <div className="border border-zinc-100 bg-zinc-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8 dark:border-zinc-900 dark:bg-zinc-900/[0.8]">
       <div className="mx-auto max-w-5xl text-center">
         <SectionHeading as="h2" variant="title" id="testimonials">
           Don't just take our word for it.
@@ -20,7 +20,7 @@ export function SolutionsPlatformTestimonials(): ReactElement {
         </SectionHeading>
       </div>
       <div className="mx-auto grid max-w-7xl gap-12 lg:grid-cols-3">
-        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-slate-950">
+        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-zinc-950">
           <blockquote className="text-base/7">
             <p>
               “Nx means tooling and efficiency around our software development
@@ -36,17 +36,17 @@ export function SolutionsPlatformTestimonials(): ReactElement {
             />
             <div>
               <div className="font-semibold">Justin Schwartzenberger</div>
-              <div className="text-slate-500">
+              <div className="text-zinc-500">
                 Principal Software Engineer, SiriusXM
               </div>
             </div>
             <SiriusxmAlternateIcon
               aria-hidden="true"
-              className="ml-auto size-10 rounded text-[#0000EB] dark:bg-slate-200"
+              className="ml-auto size-10 rounded text-[#0000EB] dark:bg-zinc-200"
             />
           </figcaption>
         </figure>
-        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-slate-950">
+        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-zinc-950">
           <blockquote className="text-base/7">
             <p>
               "A year ago, to deploy a feature, it took 2-5 days. Now the same
@@ -62,7 +62,7 @@ export function SolutionsPlatformTestimonials(): ReactElement {
             />
             <div>
               <div className="font-semibold">Nicolas Beaussart</div>
-              <div className="text-slate-500">
+              <div className="text-zinc-500">
                 Staff Platform Engineer, Payfit
               </div>
             </div>
@@ -72,7 +72,7 @@ export function SolutionsPlatformTestimonials(): ReactElement {
             />
           </figcaption>
         </figure>
-        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-slate-950">
+        <figure className="mt-16 flex flex-col justify-between rounded-lg bg-white p-4 pl-8 dark:bg-zinc-950">
           <blockquote className="text-base/7">
             <p>
               “We got requests from other feature teams saying they wanted to
@@ -89,7 +89,7 @@ export function SolutionsPlatformTestimonials(): ReactElement {
             />
             <div>
               <div className="font-semibold">Sid Govindaraju</div>
-              <div className="text-slate-500">Engineering Manager, UKG</div>
+              <div className="text-zinc-500">Engineering Manager, UKG</div>
             </div>
             <UkgIcon
               aria-hidden="true"

--- a/nx-dev/ui-enterprise/src/lib/solutions/solutions-bottom-call-to-action.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/solutions-bottom-call-to-action.tsx
@@ -29,7 +29,7 @@ export function SolutionsBottomCallToAction(): ReactElement {
         <svg
           x="50%"
           y={0}
-          className="overflow-visible fill-slate-200/20 dark:fill-slate-800/20"
+          className="overflow-visible fill-zinc-200/20 dark:fill-zinc-800/20"
         >
           <path
             d="M-200 0h201v201h-201Z M600 0h201v201h-201Z M-400 600h201v201h-201Z M200 800h201v201h-201Z"
@@ -77,7 +77,7 @@ export function SolutionsBottomCallToAction(): ReactElement {
                   'enterprise-security'
                 )
               }
-              className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
+              className="rounded-md bg-zinc-950 px-3.5 py-2.5 text-sm font-semibold text-zinc-100 shadow-sm hover:bg-zinc-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-100"
             >
               Talk to our team
             </Link>

--- a/nx-dev/ui-enterprise/src/lib/solutions/solutions-faq.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/solutions-faq.tsx
@@ -83,7 +83,7 @@ export function SolutionsFaq(): ReactElement {
               Got questions? We've got answers.
             </SectionHeading>
 
-            <p className="text-md mt-4 text-slate-400 dark:text-slate-600">
+            <p className="text-md mt-4 text-zinc-400 dark:text-zinc-600">
               <Link
                 href="/contact"
                 title="Reach out to the team"
@@ -109,14 +109,14 @@ export function SolutionsFaq(): ReactElement {
             }))}
           />
           <div className="mt-12 lg:col-span-2 lg:mt-0">
-            <dl className="mt-6 space-y-6 divide-y divide-slate-100 dark:divide-slate-800">
+            <dl className="mt-6 space-y-6 divide-y divide-zinc-100 dark:divide-zinc-800">
               {faqs.map((faq) => (
                 <Disclosure as="div" key={faq.question} className="pt-6">
                   {({ open }) => (
                     <>
                       <dt className="text-lg">
-                        <DisclosureButton className="flex w-full items-start justify-between text-left text-slate-400">
-                          <span className="font-medium text-slate-800 dark:text-slate-300">
+                        <DisclosureButton className="flex w-full items-start justify-between text-left text-zinc-400">
+                          <span className="font-medium text-zinc-800 dark:text-zinc-300">
                             {faq.question}
                           </span>
                           <span className="ml-6 flex h-7 items-center">
@@ -140,7 +140,7 @@ export function SolutionsFaq(): ReactElement {
                       >
                         <DisclosurePanel
                           as="dd"
-                          className="mt-2 pr-12 text-base text-slate-500 dark:text-slate-400"
+                          className="mt-2 pr-12 text-base text-zinc-500 dark:text-zinc-400"
                         >
                           {faq.answerUi}
                         </DisclosurePanel>

--- a/nx-dev/ui-enterprise/src/lib/solutions/solutions-top-call-to-action.tsx
+++ b/nx-dev/ui-enterprise/src/lib/solutions/solutions-top-call-to-action.tsx
@@ -3,7 +3,7 @@ import { SectionHeading, Strong } from '@nx/nx-dev-ui-common';
 
 export function SolutionsTopCallToAction(): ReactElement {
   return (
-    <div className="border border-slate-100 bg-slate-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8 dark:border-slate-900 dark:bg-slate-900/[0.8]">
+    <div className="border border-zinc-100 bg-zinc-50 px-6 py-24 sm:px-6 sm:py-32 lg:px-8 dark:border-zinc-900 dark:bg-zinc-900/[0.8]">
       <div className="mx-auto max-w-3xl text-center">
         <SectionHeading as="h2" variant="title" id="unlock-peak-performance">
           Unlock Peak Performance for <br className="lg:block" /> Your

--- a/nx-dev/ui-enterprise/src/lib/testimonial-carousel.tsx
+++ b/nx-dev/ui-enterprise/src/lib/testimonial-carousel.tsx
@@ -53,7 +53,7 @@ export function Carousel({
       </CarouselRoot>
 
       {/* Partner logos section - now linked to carousel items */}
-      <div className="mt-12 flex items-center justify-center divide-x divide-slate-200 dark:divide-slate-700">
+      <div className="mt-12 flex items-center justify-center divide-x divide-zinc-200 dark:divide-zinc-700">
         {iterableItems.map((item, index) => (
           <button
             key={item.id + '-logo'}
@@ -107,8 +107,8 @@ export function TestimonialCarousel(): ReactElement {
                     }}
                   />
                   <div className="absolute inset-0 bg-gradient-to-r from-[#0F6FDE] via-[#0F6FDE] via-70% to-[#0F6FDE]/40" />
-                  <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/60 opacity-0 backdrop-blur-sm transition duration-300 group-hover:opacity-100 dark:bg-slate-950/60">
-                    <div className="flex items-center gap-2 text-lg font-semibold text-slate-950 drop-shadow dark:text-white">
+                  <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/60 opacity-0 backdrop-blur-sm transition duration-300 group-hover:opacity-100 dark:bg-zinc-950/60">
+                    <div className="flex items-center gap-2 text-lg font-semibold text-zinc-950 drop-shadow dark:text-white">
                       <PlayIcon className="size-8" />
                       Watch the interview
                     </div>
@@ -135,7 +135,7 @@ export function TestimonialCarousel(): ReactElement {
                           <img
                             alt="avatar"
                             src="https://avatars.githubusercontent.com/u/7281023?v=4"
-                            className="size-14 rounded-full bg-slate-50"
+                            className="size-14 rounded-full bg-zinc-50"
                           />
                           <div className="text-base">
                             <div className="font-semibold">
@@ -182,8 +182,8 @@ export function TestimonialCarousel(): ReactElement {
                     }}
                   />
                   <div className="absolute inset-0 bg-gradient-to-r from-[#005151] via-[#005151] via-55% to-[#005151]/40" />
-                  <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/60 opacity-0 backdrop-blur-sm transition duration-300 group-hover:opacity-100 dark:bg-slate-950/60">
-                    <div className="flex items-center gap-2 text-lg font-semibold text-slate-950 drop-shadow dark:text-white">
+                  <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/60 opacity-0 backdrop-blur-sm transition duration-300 group-hover:opacity-100 dark:bg-zinc-950/60">
+                    <div className="flex items-center gap-2 text-lg font-semibold text-zinc-950 drop-shadow dark:text-white">
                       <PlayIcon className="size-8" />
                       Watch the interview
                     </div>
@@ -203,7 +203,7 @@ export function TestimonialCarousel(): ReactElement {
                           <img
                             alt=""
                             src="https://avatars.githubusercontent.com/u/6657673?v=4"
-                            className="size-14 rounded-full bg-slate-50"
+                            className="size-14 rounded-full bg-zinc-50"
                           />
                           <div className="text-base">
                             <div className="font-semibold">Sid Govindaraju</div>

--- a/nx-dev/ui-enterprise/src/lib/trial-nx-enterprise.tsx
+++ b/nx-dev/ui-enterprise/src/lib/trial-nx-enterprise.tsx
@@ -32,7 +32,7 @@ export function TrialNxEnterprise(): ReactElement {
         </div>
         <div className="mx-auto mt-16 flex max-w-5xl flex-col gap-12 md:flex-row lg:gap-8">
           <section className="flex-1">
-            <h3 className="text-3xl font-bold tracking-tight text-slate-950 dark:text-white">
+            <h3 className="text-3xl font-bold tracking-tight text-zinc-950 dark:text-white">
               Much more than a simple trial
             </h3>
 
@@ -121,7 +121,7 @@ export function TrialNxEnterprise(): ReactElement {
               />
             </div>
           </section>
-          <section className="flex-1 rounded-xl border border-slate-200 bg-white p-8 md:self-start dark:border-slate-800/40">
+          <section className="flex-1 rounded-xl border border-zinc-200 bg-white p-8 md:self-start dark:border-zinc-800/40">
             <HubspotForm
               formId="e7f05c82-b56c-4a31-8cf8-a53ca8d69c5b"
               calendlyFormId="fd9d9be5-55cd-4b49-874b-ee54deb141f1"
@@ -132,7 +132,7 @@ export function TrialNxEnterprise(): ReactElement {
             />
           </section>
         </div>
-        <figure className="mx-auto mt-16 max-w-4xl rounded-lg bg-slate-100 p-4 pl-8 dark:bg-slate-800">
+        <figure className="mx-auto mt-16 max-w-4xl rounded-lg bg-zinc-100 p-4 pl-8 dark:bg-zinc-800">
           <blockquote className="text-base/7">
             <p>
               “They asked me a few years ago, ‘Do you want to trial Nx
@@ -150,7 +150,7 @@ export function TrialNxEnterprise(): ReactElement {
             />
             <div>
               <div className="font-semibold">Amir Toole</div>
-              <div className="text-slate-500">VP of Engineering, Caseware</div>
+              <div className="text-zinc-500">VP of Engineering, Caseware</div>
             </div>
             <CasewareIcon
               aria-hidden="true"

--- a/nx-dev/ui-enterprise/src/lib/vmware-testimonial.tsx
+++ b/nx-dev/ui-enterprise/src/lib/vmware-testimonial.tsx
@@ -17,7 +17,7 @@ export function VmwareTestimonial(): ReactElement {
           </p>
 
           <p className="mt-4 text-right md:text-lg">
-            <span className="font-semibold text-sky-500">
+            <span className="font-semibold text-blue-500">
               Laurent Delamare,
             </span>{' '}
             <span className="text-neutral-500">Senior Engineer</span>

--- a/nx-dev/ui-fence/src/lib/fence.tsx
+++ b/nx-dev/ui-fence/src/lib/fence.tsx
@@ -198,14 +198,14 @@ export function Fence({
               <button
                 type="button"
                 className={
-                  'not-prose flex border border-slate-200 bg-slate-50/50 p-2 opacity-0 transition-opacity group-hover:opacity-100 dark:border-slate-700 dark:bg-slate-800/60' +
+                  'not-prose flex border border-zinc-200 bg-zinc-50/50 p-2 opacity-0 transition-opacity group-hover:opacity-100 dark:border-zinc-700 dark:bg-zinc-800/60' +
                   ((highlightOptions && highlightOptions[0]) || isWithinTab
                     ? ''
                     : ' rounded-tr-lg')
                 }
               >
                 {copied ? (
-                  <ClipboardDocumentCheckIcon className="h-5 w-5 text-blue-500 dark:text-sky-500" />
+                  <ClipboardDocumentCheckIcon className="h-5 w-5 text-blue-500 dark:text-blue-500" />
                 ) : (
                   <ClipboardDocumentIcon className="h-5 w-5" />
                 )}

--- a/nx-dev/ui-fence/src/lib/fences/code-output.tsx
+++ b/nx-dev/ui-fence/src/lib/fences/code-output.tsx
@@ -13,12 +13,12 @@ export function CodeOutput({
   return (
     <div
       className={cx(
-        'hljs not-prose w-full overflow-x-auto border-slate-200 bg-slate-50/50 font-mono text-sm dark:border-slate-700 dark:bg-slate-800/60',
+        'hljs not-prose w-full overflow-x-auto border-zinc-200 bg-zinc-50/50 font-mono text-sm dark:border-zinc-700 dark:bg-zinc-800/60',
         isWithinTab ? 'border-b border-t' : 'rounded-lg border'
       )}
     >
       {!!fileName && (
-        <div className="flex border-b border-slate-200 bg-slate-50 px-4 py-2 italic text-slate-400 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-500">
+        <div className="flex border-b border-zinc-200 bg-zinc-50 px-4 py-2 italic text-zinc-400 dark:border-zinc-700 dark:bg-zinc-800/80 dark:text-zinc-500">
           {fileName}
         </div>
       )}

--- a/nx-dev/ui-fence/src/lib/fences/terminal-shell.tsx
+++ b/nx-dev/ui-fence/src/lib/fences/terminal-shell.tsx
@@ -8,8 +8,8 @@ export function TerminalShellWrapper({
   children: ReactNode;
 }): JSX.Element {
   return (
-    <div className="hljs not-prose w-full overflow-x-auto rounded-lg border border-slate-200 bg-slate-50/50 font-mono text-sm dark:border-slate-700 dark:bg-slate-800/60">
-      <div className="relative flex justify-center border-b border-slate-200 bg-slate-100/50 p-2 text-slate-400 dark:border-slate-700 dark:bg-slate-700/50 dark:text-slate-500">
+    <div className="hljs not-prose w-full overflow-x-auto rounded-lg border border-zinc-200 bg-zinc-50/50 font-mono text-sm dark:border-zinc-700 dark:bg-zinc-800/60">
+      <div className="relative flex justify-center border-b border-zinc-200 bg-zinc-100/50 p-2 text-zinc-400 dark:border-zinc-700 dark:bg-zinc-700/50 dark:text-zinc-500">
         <div className="absolute left-2 top-3 flex items-center gap-2">
           <span className="h-2 w-2 rounded-full bg-red-400 dark:bg-red-600" />
           <span className="h-2 w-2 rounded-full bg-yellow-400 dark:bg-yellow-600" />

--- a/nx-dev/ui-fence/src/lib/selector.tsx
+++ b/nx-dev/ui-fence/src/lib/selector.tsx
@@ -28,7 +28,7 @@ export function Selector<T = {}>(props: SelectorProps<T>): JSX.Element {
             <div className="relative">
               <ListboxButton
                 className={
-                  'relative w-full cursor-pointer border border-slate-200 py-2 pl-3 pr-10 text-left font-medium focus:outline-none focus-visible:border-blue-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-blue-300 sm:text-sm dark:border-slate-700' +
+                  'relative w-full cursor-pointer border border-zinc-200 py-2 pl-3 pr-10 text-left font-medium focus:outline-none focus-visible:border-blue-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-blue-300 sm:text-sm dark:border-zinc-700' +
                   (props.className ? ` ${props.className}` : '')
                 }
               >
@@ -40,7 +40,7 @@ export function Selector<T = {}>(props: SelectorProps<T>): JSX.Element {
                 </span>
                 <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
                   <ChevronUpDownIcon
-                    className="h-5 w-5 text-slate-500"
+                    className="h-5 w-5 text-zinc-500"
                     aria-hidden="true"
                   />
                 </span>
@@ -57,13 +57,13 @@ export function Selector<T = {}>(props: SelectorProps<T>): JSX.Element {
               >
                 <ListboxOptions
                   static
-                  className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-sm bg-white py-1 pl-0 text-base shadow-md focus:outline-none sm:text-sm dark:bg-slate-800/60 dark:focus-within:ring-sky-500"
+                  className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-sm bg-white py-1 pl-0 text-base shadow-md focus:outline-none sm:text-sm dark:bg-zinc-800/60 dark:focus-within:ring-blue-500"
                 >
                   {props.items.map((item, personIdx) => (
                     <ListboxOption
                       key={personIdx}
                       className={() =>
-                        `relative cursor-pointer select-none list-none px-3 py-2 hover:bg-slate-50 dark:hover:bg-slate-800`
+                        `relative cursor-pointer select-none list-none px-3 py-2 hover:bg-zinc-50 dark:hover:bg-zinc-800`
                       }
                       value={item}
                     >

--- a/nx-dev/ui-gradle/src/lib/call-to-action.tsx
+++ b/nx-dev/ui-gradle/src/lib/call-to-action.tsx
@@ -27,7 +27,7 @@ export function CallToAction(): ReactElement {
         <svg
           x="50%"
           y={0}
-          className="overflow-visible fill-slate-200/20 dark:fill-slate-800/20"
+          className="overflow-visible fill-zinc-200/20 dark:fill-zinc-800/20"
         >
           <path
             d="M-200 0h201v201h-201Z M600 0h201v201h-201Z M-400 600h201v201h-201Z M200 800h201v201h-201Z"
@@ -58,7 +58,7 @@ export function CallToAction(): ReactElement {
 
       {/* Content */}
       <div className="mx-auto max-w-2xl text-center">
-        <h2 className="text-3xl font-medium tracking-tight text-slate-950 sm:text-5xl dark:text-white">
+        <h2 className="text-3xl font-medium tracking-tight text-zinc-950 sm:text-5xl dark:text-white">
           Learn More
         </h2>
         <p className="mt-8">
@@ -70,7 +70,7 @@ export function CallToAction(): ReactElement {
             href="/docs/technologies/java/gradle/introduction"
             title="Get started with Gradle"
             prefetch={false}
-            className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
+            className="rounded-md bg-zinc-950 px-3.5 py-2.5 text-sm font-semibold text-zinc-100 shadow-sm hover:bg-zinc-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-100"
           >
             @nx/gradle Docs{' '}
             <span
@@ -85,7 +85,7 @@ export function CallToAction(): ReactElement {
             href="/docs/technologies/java/maven/introduction"
             title="Get started with Maven"
             prefetch={false}
-            className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
+            className="rounded-md bg-zinc-950 px-3.5 py-2.5 text-sm font-semibold text-zinc-100 shadow-sm hover:bg-zinc-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-100"
           >
             @nx/maven Docs{' '}
             <span

--- a/nx-dev/ui-gradle/src/lib/feature-sections.tsx
+++ b/nx-dev/ui-gradle/src/lib/feature-sections.tsx
@@ -88,7 +88,7 @@ function FeatureSection({
 }: FeatureSectionProps): ReactElement {
   return (
     <div
-      className={`feature-section flex flex-col overflow-hidden rounded-2xl bg-white shadow ring-1 ring-black/5 dark:bg-slate-950 dark:ring-white/10`}
+      className={`feature-section flex flex-col overflow-hidden rounded-2xl bg-white shadow ring-1 ring-black/5 dark:bg-zinc-950 dark:ring-white/10`}
     >
       <div className="h-0 w-full md:h-72">
         <img
@@ -99,13 +99,13 @@ function FeatureSection({
       </div>
       <div className="relative flex flex-1 flex-col justify-center p-8 lg:p-10">
         <div>
-          <span className="mb-3 inline-flex items-center rounded-full bg-slate-400/10 px-3 py-1 text-sm font-medium text-slate-600 ring-1 ring-inset ring-slate-400/20 dark:text-slate-300">
+          <span className="mb-3 inline-flex items-center rounded-full bg-zinc-400/10 px-3 py-1 text-sm font-medium text-zinc-600 ring-1 ring-inset ring-zinc-400/20 dark:text-zinc-300">
             {tag}
           </span>
-          <h3 className="mt-2 text-xl font-medium tracking-tight text-slate-950 lg:text-2xl dark:text-white">
+          <h3 className="mt-2 text-xl font-medium tracking-tight text-zinc-950 lg:text-2xl dark:text-white">
             {title}
           </h3>
-          <p className="mt-4 text-base/relaxed text-slate-600 dark:text-slate-300">
+          <p className="mt-4 text-base/relaxed text-zinc-600 dark:text-zinc-300">
             {description}
           </p>
           <div className="mt-6">

--- a/nx-dev/ui-gradle/src/lib/features.tsx
+++ b/nx-dev/ui-gradle/src/lib/features.tsx
@@ -9,7 +9,7 @@ export function Features(): ReactElement {
         Features
       </SectionHeading>
 
-      <p className="mt-4 text-lg text-slate-500 dark:text-slate-400">
+      <p className="mt-4 text-lg text-zinc-500 dark:text-zinc-400">
         The Nx Plugin for Java integrates seamlessly with your existing Gradle
         and Maven builds, adding powerful capabilities to your workflow.
       </p>
@@ -256,8 +256,8 @@ function FeatureCard({
     <a href={href} className="block h-full transform-gpu">
       <div
         className={cx(
-          'group relative h-full w-full overflow-hidden rounded-lg border border-slate-200 bg-white p-6',
-          'dark:border-slate-800 dark:bg-slate-900 dark:hover:border-blue-900 dark:hover:shadow-blue-900/20',
+          'group relative h-full w-full overflow-hidden rounded-lg border border-zinc-200 bg-white p-6',
+          'dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-blue-900 dark:hover:shadow-blue-900/20',
           'before:absolute before:inset-0 before:z-0 before:bg-gradient-to-br before:from-blue-50 before:to-transparent before:opacity-0 before:transition-opacity',
           'transition-all duration-300 ease-out',
           'hover:-translate-y-2 hover:border-blue-200 hover:shadow-xl hover:shadow-blue-100/50',
@@ -265,11 +265,11 @@ function FeatureCard({
         )}
       >
         <div className="relative z-10">
-          <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-50 text-blue-600 transition-transform duration-300 group-hover:scale-110 dark:bg-slate-800 dark:text-blue-400 dark:group-hover:bg-blue-900">
+          <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-50 text-blue-600 transition-transform duration-300 group-hover:scale-110 dark:bg-zinc-800 dark:text-blue-400 dark:group-hover:bg-blue-900">
             {icon}
           </div>
           <h3 className="mb-2 text-lg font-medium">{title}</h3>
-          <p className="text-slate-500 dark:text-slate-400">{description}</p>
+          <p className="text-zinc-500 dark:text-zinc-400">{description}</p>
         </div>
       </div>
     </a>

--- a/nx-dev/ui-gradle/src/lib/hero.tsx
+++ b/nx-dev/ui-gradle/src/lib/hero.tsx
@@ -15,7 +15,7 @@ export function Hero(): ReactElement {
       <div className="mx-auto max-w-2xl text-center">
         {/* Logo displayed above the title */}
         <div className="mb-6 flex justify-center">
-          <div className="rounded-full bg-slate-100 p-4 dark:bg-slate-800">
+          <div className="rounded-full bg-zinc-100 p-4 dark:bg-zinc-800">
             <JavaIcon className="h-20 w-20" />
           </div>
         </div>
@@ -32,7 +32,7 @@ export function Hero(): ReactElement {
         <div className="mt-10 flex flex-col items-center justify-center gap-6 sm:flex-row">
           <ButtonLink
             href="https://nx.dev/getting-started/tutorials/gradle-tutorial"
-            variant="primary"
+            variant="contrast"
             size="default"
             title="Get Started"
           >
@@ -43,7 +43,7 @@ export function Hero(): ReactElement {
             href="https://github.com/nrwl/nx-recipes/tree/main/gradle"
             target="_blank"
             rel="noopener noreferrer"
-            className="group inline-flex items-center text-sm font-semibold leading-6 text-slate-800 dark:text-white"
+            className="group inline-flex items-center text-sm font-semibold leading-6 text-zinc-800 dark:text-white"
           >
             View Example Project{' '}
             <span
@@ -62,10 +62,10 @@ export function Hero(): ReactElement {
 export function GettingStarted(): ReactElement {
   return (
     <section className="relative py-16 sm:py-24">
-      <div className="absolute inset-0 bg-white dark:bg-slate-900"></div>
+      <div className="absolute inset-0 bg-white dark:bg-zinc-900"></div>
       <div className="relative mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <h2 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl dark:text-white">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 sm:text-4xl dark:text-white">
             Add Nx To An Existing Project
           </h2>
           <p className="mt-8">Nx supports both Gradle and Maven</p>
@@ -102,7 +102,7 @@ export function GettingStarted(): ReactElement {
             href="https://github.com/nrwl/nx-recipes/tree/main/gradle"
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-6 py-3 font-medium text-slate-900 shadow-sm transition-all hover:-translate-y-1 hover:border-blue-400 hover:shadow-md dark:border-slate-700 dark:bg-slate-800 dark:text-white dark:hover:border-blue-500"
+            className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-6 py-3 font-medium text-zinc-900 shadow-sm transition-all hover:-translate-y-1 hover:border-blue-400 hover:shadow-md dark:border-zinc-700 dark:bg-zinc-800 dark:text-white dark:hover:border-blue-500"
           >
             <svg
               className="h-5 w-5"
@@ -135,15 +135,15 @@ function GetStartedCard({
   description,
 }: GetStartedCardProps): ReactElement {
   return (
-    <div className="h-full rounded-xl border border-slate-200 bg-white p-6 shadow-sm transition-all hover:shadow-md dark:border-slate-700 dark:bg-slate-800">
-      <h3 className="text-lg font-medium text-slate-900 dark:text-white">
+    <div className="h-full rounded-xl border border-zinc-200 bg-white p-6 shadow-sm transition-all hover:shadow-md dark:border-zinc-700 dark:bg-zinc-800">
+      <h3 className="text-lg font-medium text-zinc-900 dark:text-white">
         {title}
       </h3>
-      <div className="mt-3 overflow-hidden rounded-md bg-slate-800 px-4 py-3 text-sm text-white dark:bg-slate-950">
+      <div className="mt-3 overflow-hidden rounded-md bg-zinc-800 px-4 py-3 text-sm text-white dark:bg-zinc-950">
         <code style={{ whiteSpace: 'pre-line' }}>{command}</code>
       </div>
       <p
-        className="mt-3 text-sm text-slate-600 dark:text-slate-300"
+        className="mt-3 text-sm text-zinc-600 dark:text-zinc-300"
         dangerouslySetInnerHTML={{ __html: description }}
       ></p>
     </div>

--- a/nx-dev/ui-home/src/lib/ci-for-monorepos.tsx
+++ b/nx-dev/ui-home/src/lib/ci-for-monorepos.tsx
@@ -25,7 +25,7 @@ import { ReactNode } from 'react';
 
 export function CiForMonorepos(): JSX.Element {
   return (
-    <section className="bg-slate-50 py-32 shadow-inner sm:py-40 dark:bg-slate-900">
+    <section className="bg-zinc-50 py-32 shadow-inner sm:py-40 dark:bg-zinc-900">
       <article className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="max-w-5xl">
           <SectionHeading
@@ -105,7 +105,7 @@ export function Card({
   return (
     <div
       className={cx(
-        'relative h-full w-full overflow-hidden rounded-2xl border border-slate-100 bg-white p-6 dark:border-slate-800/60 dark:bg-slate-950',
+        'relative h-full w-full overflow-hidden rounded-2xl border border-zinc-100 bg-white p-6 dark:border-zinc-800/60 dark:bg-zinc-950',
         className
       )}
     >
@@ -137,7 +137,7 @@ export function CornerBlur({
   return (
     <div
       className={cx(
-        'absolute bottom-0 left-0 z-0 size-72 -translate-x-1/2 translate-y-1/2 rounded-full bg-slate-50 blur-2xl dark:bg-slate-900',
+        'absolute bottom-0 left-0 z-0 size-72 -translate-x-1/2 translate-y-1/2 rounded-full bg-zinc-50 blur-2xl dark:bg-zinc-900',
         className
       )}
     />
@@ -150,10 +150,10 @@ export function ApplicationCard(): JSX.Element {
       <Card>
         <PulseLine />
         <CornerBlur />
-        <p className="text-2xl text-slate-900 dark:text-slate-100">
+        <p className="text-2xl text-zinc-900 dark:text-zinc-100">
           Powerful and elegant UI
         </p>
-        <p className="mt-2 text-slate-600 dark:text-slate-400">
+        <p className="mt-2 text-zinc-600 dark:text-zinc-400">
           An application built for monorepo CI, so you can quickly find what
           failed, debug and move on.
         </p>
@@ -163,7 +163,7 @@ export function ApplicationCard(): JSX.Element {
             target="_blank"
             rel="noopener"
             title="See Nx Cloud live demo"
-            className="group font-semibold leading-6 text-slate-950 dark:text-white"
+            className="group font-semibold leading-6 text-zinc-950 dark:text-white"
           >
             View a live demo{' '}
             <span
@@ -174,7 +174,7 @@ export function ApplicationCard(): JSX.Element {
             </span>
           </a>
         </div>
-        <div className="absolute bottom-0 left-4 h-[345px] w-full overflow-hidden rounded-xl border border-slate-200 dark:bg-slate-800">
+        <div className="absolute bottom-0 left-4 h-[345px] w-full overflow-hidden rounded-xl border border-zinc-200 dark:bg-zinc-800">
           <VideoPlayerProvider videoUrl="https://www.youtube.com/embed/4VI-q943J3o?si=3tR-EkCKLfLvHYzL">
             <VideoPlayer>
               <VideoPlayerThumbnail
@@ -208,15 +208,15 @@ export function ProjectsCreatedEveryMonth(): JSX.Element {
       <Card className="relative">
         <div className="flex flex-col justify-between text-center drop-shadow">
           <div>
-            <span className="text-9xl font-bold text-slate-950 dark:text-white">
+            <span className="text-9xl font-bold text-zinc-950 dark:text-white">
               <AnimateValue num={20} suffix="k" once />
             </span>
             <br />
-            <span className="text-4xl font-semibold text-slate-950 dark:text-white">
+            <span className="text-4xl font-semibold text-zinc-950 dark:text-white">
               new projects
             </span>
           </div>
-          <span className="text-2xl font-semibold text-slate-600 dark:text-slate-400">
+          <span className="text-2xl font-semibold text-zinc-600 dark:text-zinc-400">
             every month
           </span>
         </div>
@@ -224,7 +224,7 @@ export function ProjectsCreatedEveryMonth(): JSX.Element {
           <ButtonLink
             href="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=homepage_links&utm_campaign=try-nx-cloud"
             title="Get started with Nx Cloud"
-            variant="primary"
+            variant="contrast"
             size="large"
             target="_blank"
             rel="nofollow"
@@ -243,39 +243,39 @@ export function HalveYouBill(): JSX.Element {
   return (
     <div className="col-span-2 h-[415px] sm:h-[360px] md:col-span-1">
       <Card>
-        <p className="text-2xl text-slate-900 dark:text-slate-100">
+        <p className="text-2xl text-zinc-900 dark:text-zinc-100">
           Halve your CI bill
         </p>
-        <p className="mt-2 text-slate-600 dark:text-slate-400">
+        <p className="mt-2 text-zinc-600 dark:text-zinc-400">
           Nx Cloud not only makes your runs{' '}
-          <span className="font-semibold text-slate-800 dark:text-slate-200">
+          <span className="font-semibold text-zinc-800 dark:text-zinc-200">
             30% to 70% faster
           </span>
           , but also significantly cheaper.
         </p>
         <div className="mt-6">
           <div className="flex items-center">
-            <div className="w-28 shrink-0 border-r-2 border-slate-200 py-3 pr-2 text-right text-slate-700 transition duration-200 dark:border-slate-800 dark:text-slate-300">
+            <div className="w-28 shrink-0 border-r-2 border-zinc-200 py-3 pr-2 text-right text-zinc-700 transition duration-200 dark:border-zinc-800 dark:text-zinc-300">
               CI
             </div>
             <div className="flex-grow py-1.5 font-semibold">
-              <div className="w-full flex-grow items-center justify-end rounded-r-lg border border-l-0 border-slate-200 bg-slate-100 px-4 py-2 text-right text-slate-900 transition duration-200 dark:border-slate-800 dark:bg-slate-700 dark:text-white">
+              <div className="w-full flex-grow items-center justify-end rounded-r-lg border border-l-0 border-zinc-200 bg-zinc-100 px-4 py-2 text-right text-zinc-900 transition duration-200 dark:border-zinc-800 dark:bg-zinc-700 dark:text-white">
                 <span className="drop-shadow-sm">$6k</span>
               </div>
             </div>
           </div>
           <div className="flex items-center">
-            <div className="w-28 shrink-0 border-r-2 border-slate-200 py-3 pr-2 text-right font-medium text-slate-700 transition duration-200 dark:border-slate-800 dark:text-slate-300">
+            <div className="w-28 shrink-0 border-r-2 border-zinc-200 py-3 pr-2 text-right font-medium text-zinc-700 transition duration-200 dark:border-zinc-800 dark:text-zinc-300">
               CI + Nx Cloud
             </div>
             <div className="flex-grow py-1.5 font-semibold">
-              <div className="w-1/2 rounded-r-lg border border-l-0 border-slate-200 bg-gradient-to-r from-emerald-500 to-green-500 px-4 py-2 text-right text-white transition duration-200 dark:border-slate-800">
+              <div className="w-1/2 rounded-r-lg border border-l-0 border-zinc-200 bg-gradient-to-r from-emerald-500 to-green-500 px-4 py-2 text-right text-white transition duration-200 dark:border-zinc-800">
                 <span className="drop-shadow-sm">$3.2k</span>
               </div>
             </div>
           </div>
         </div>
-        <p className="z-10 mt-6 text-xs text-slate-400 transition duration-200 dark:text-slate-600">
+        <p className="z-10 mt-6 text-xs text-zinc-400 transition duration-200 dark:text-zinc-600">
           <span className="underline">Cost per month for CI compute.</span> Data
           collected based on a typical month of CI runs measured on the Nx OSS
           monorepo.
@@ -292,10 +292,10 @@ export function IntegratesToYouCurrentCiProvider(): JSX.Element {
     <div className="col-span-2 h-fit sm:h-[225px]">
       <Card>
         <div className="relative z-20">
-          <p className="text-2xl text-slate-900 dark:text-slate-100">
+          <p className="text-2xl text-zinc-900 dark:text-zinc-100">
             Works with your current CI
           </p>
-          <p className="mt-2 max-w-md text-slate-600 dark:text-slate-400">
+          <p className="mt-2 max-w-md text-zinc-600 dark:text-zinc-400">
             Use your current CI provider, export your compute and slash your CI
             bill by using Nx Agents to save time, improve performance and
             ramp-up your developer experience.
@@ -305,7 +305,7 @@ export function IntegratesToYouCurrentCiProvider(): JSX.Element {
               href="/ci/recipes/set-up?utm_source=homepage&utm_medium=website&utm_campaign=homepage_links&utm_content=cta_ci_for_monorepos"
               title="Add Nx Cloud to your CI workflow"
               prefetch={false}
-              className="group font-semibold leading-6 text-slate-950 dark:text-white"
+              className="group font-semibold leading-6 text-zinc-950 dark:text-white"
             >
               Enable faster CI with a single line of code{' '}
               <span
@@ -398,10 +398,10 @@ export function AiSection(): JSX.Element {
           />
         </div>
         <div className="grow">
-          <p className="text-2xl text-slate-900 dark:text-slate-100">
+          <p className="text-2xl text-zinc-900 dark:text-zinc-100">
             AI for your CI
           </p>
-          <p className="mt-2text-slate-600 dark:text-slate-400">
+          <p className="mt-2text-zinc-600 dark:text-zinc-400">
             Identify and <Strong> resolve task failures</Strong> instantly with
             intelligent explanations and actionable solutions. Set your desired
             CI run time, and Nx Cloud will match it. Our{' '}
@@ -415,7 +415,7 @@ export function AiSection(): JSX.Element {
               href="/ci/concepts/nx-cloud-ai?utm_source=homepage&utm_medium=website&utm_campaign=homepage_links&utm_content=cta_ci_for_monorepos"
               title="Add AI to your CI with Nx Cloud"
               prefetch={false}
-              className="group font-semibold leading-6 text-slate-950 dark:text-white"
+              className="group font-semibold leading-6 text-zinc-950 dark:text-white"
             >
               Learn more{' '}
               <span

--- a/nx-dev/ui-home/src/lib/features/feature-container.tsx
+++ b/nx-dev/ui-home/src/lib/features/feature-container.tsx
@@ -15,18 +15,18 @@ export function FeatureContainer({
   return (
     <div className="flex items-stretch">
       <div className="flex flex-col items-center">
-        <div className="sticky top-20 hidden h-[3rem] w-[3rem] items-center justify-center rounded-full bg-slate-200 shadow-xl md:flex dark:bg-slate-800">
+        <div className="sticky top-20 hidden h-[3rem] w-[3rem] items-center justify-center rounded-full bg-zinc-200 shadow-xl md:flex dark:bg-zinc-800">
           {icon === 'code' && (
-            <CodeBracketIcon className="h-6 w-6 text-slate-400" />
+            <CodeBracketIcon className="h-6 w-6 text-zinc-400" />
           )}
           {icon === 'command-line' && (
-            <CommandLineIcon className="h-6 w-6 text-slate-400" />
+            <CommandLineIcon className="h-6 w-6 text-zinc-400" />
           )}
           {icon === 'user-plus' && (
-            <UserPlusIcon className="h-6 w-6 text-slate-400" />
+            <UserPlusIcon className="h-6 w-6 text-zinc-400" />
           )}
         </div>
-        <div className="hidden h-full w-[3px] bg-gradient-to-b from-slate-200 via-purple-500 to-slate-50 md:block dark:from-slate-800 dark:via-purple-500 dark:to-slate-900"></div>
+        <div className="hidden h-full w-[3px] bg-gradient-to-b from-zinc-200 via-purple-500 to-zinc-50 md:block dark:from-zinc-800 dark:via-purple-500 dark:to-zinc-900"></div>
       </div>
       <div className="mb-32 mt-1 md:ml-16">{children}</div>
     </div>

--- a/nx-dev/ui-home/src/lib/features/features-call-to-action.tsx
+++ b/nx-dev/ui-home/src/lib/features/features-call-to-action.tsx
@@ -11,7 +11,7 @@ export function FeaturesCallToAction(): ReactElement {
           as="h3"
           variant="subtitle"
           id="from-code-to-deployment-in-record-time"
-          className="scroll-mt-24 text-center text-4xl font-bold tracking-tight text-slate-950 sm:text-5xl dark:text-white"
+          className="scroll-mt-24 text-center text-4xl font-bold tracking-tight text-zinc-950 sm:text-5xl dark:text-white"
         >
           From{' '}
           <span className="rounded-lg bg-gradient-to-r from-cyan-500 to-blue-500 bg-clip-text text-transparent">
@@ -19,27 +19,27 @@ export function FeaturesCallToAction(): ReactElement {
           </span>{' '}
           in record time
         </SectionHeading>
-        <p className="mt-6 text-center text-lg text-slate-600 dark:text-slate-400">
+        <p className="mt-6 text-center text-lg text-zinc-600 dark:text-zinc-400">
           Every minute wasted is a minute not shipping value to users. Your{' '}
           <strong>Time to Green</strong>—the critical window from commit to
           merge-ready PR—relies on having intelligent tooling and seamless
           automation.
         </p>
-        <div className="divide-2 mt-12 grid grid-cols-2 justify-stretch divide-white/20 rounded-lg bg-slate-950/90 ring-8 ring-slate-950/50 md:grid-cols-4 md:divide-x md:divide-solid dark:divide-slate-950/20 dark:bg-white dark:ring-white/20">
+        <div className="divide-2 mt-12 grid grid-cols-2 justify-stretch divide-white/20 rounded-lg bg-zinc-950/90 ring-8 ring-zinc-950/50 md:grid-cols-4 md:divide-x md:divide-solid dark:divide-zinc-950/20 dark:bg-white dark:ring-white/20">
           <FeaturedStat
             stat="50%"
             description="reduction in Time to Green"
-            className="border-b border-r border-white/20 md:border-0 dark:border-slate-950/20"
+            className="border-b border-r border-white/20 md:border-0 dark:border-zinc-950/20"
           />
           <FeaturedStat
             stat="70%"
             description="faster CI"
-            className="border-b border-white/20 md:border-0 dark:border-slate-950/20"
+            className="border-b border-white/20 md:border-0 dark:border-zinc-950/20"
           />
           <FeaturedStat
             stat="90%"
             description="fewer flaky test failures"
-            className="border-r border-white/20 dark:border-slate-950/20"
+            className="border-r border-white/20 dark:border-zinc-950/20"
           />
           <FeaturedStat stat="40%" description="fewer CI failures" />
         </div>
@@ -49,7 +49,7 @@ export function FeaturesCallToAction(): ReactElement {
               'https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=homepage_links&utm_campaign=try-nx-cloud'
             }
             title={'Get started with Nx'}
-            variant="primary"
+            variant="contrast"
             size="default"
           >
             Get started
@@ -58,7 +58,7 @@ export function FeaturesCallToAction(): ReactElement {
             href="/nx-cloud"
             title="Find out more about Nx Cloud"
             prefetch={false}
-            className="group font-semibold leading-6 text-slate-950 dark:text-white"
+            className="group font-semibold leading-6 text-zinc-950 dark:text-white"
           >
             Learn more{' '}
             <span
@@ -85,10 +85,10 @@ export function FeaturedStat({
 } & ComponentProps<'div'>): ReactElement {
   return (
     <div className={cx('flex flex-col p-8 text-center', className)} {...props}>
-      <div className="mb-1 text-5xl font-extrabold text-white dark:text-slate-800">
+      <div className="mb-1 text-5xl font-extrabold text-white dark:text-zinc-800">
         {stat}
       </div>
-      <div className="text-base text-slate-200 dark:text-slate-600">
+      <div className="text-base text-zinc-200 dark:text-zinc-600">
         {description}
       </div>
     </div>

--- a/nx-dev/ui-home/src/lib/features/features-while-coding.tsx
+++ b/nx-dev/ui-home/src/lib/features/features-while-coding.tsx
@@ -12,7 +12,7 @@ export function FeaturesWhileCoding(): ReactElement {
           as="h3"
           variant="subtitle"
           id="features-while-coding"
-          className="scroll-mt-24 text-2xl font-medium tracking-tight text-slate-950 sm:text-3xl dark:text-white"
+          className="scroll-mt-24 text-2xl font-medium tracking-tight text-zinc-950 sm:text-3xl dark:text-white"
         >
           While Coding
         </SectionHeading>
@@ -90,7 +90,7 @@ export function FeaturesWhileCoding(): ReactElement {
                 }
                 title="Find out about Nx"
                 prefetch={false}
-                className="group font-semibold leading-6 text-slate-950 dark:text-white"
+                className="group font-semibold leading-6 text-zinc-950 dark:text-white"
               >
                 Learn more about Nx{' '}
                 <span

--- a/nx-dev/ui-home/src/lib/features/features-while-running-ci.tsx
+++ b/nx-dev/ui-home/src/lib/features/features-while-running-ci.tsx
@@ -12,7 +12,7 @@ export function FeaturesWhileRunningCI(): ReactElement {
           as="h3"
           variant="subtitle"
           id="features-while-running-ci"
-          className="scroll-mt-24 text-2xl font-medium tracking-tight text-slate-950 sm:text-3xl dark:text-white"
+          className="scroll-mt-24 text-2xl font-medium tracking-tight text-zinc-950 sm:text-3xl dark:text-white"
         >
           While Running CI
         </SectionHeading>
@@ -66,7 +66,7 @@ export function FeaturesWhileRunningCI(): ReactElement {
                 href="/nx-cloud?utm_medium=website&utm_campaign=homepage_links&utm_content=features"
                 title="Add Nx Cloud to your CI workflow"
                 prefetch={false}
-                className="group font-semibold leading-6 text-slate-950 dark:text-white"
+                className="group font-semibold leading-6 text-zinc-950 dark:text-white"
               >
                 Learn more about Nx Cloud{' '}
                 <span

--- a/nx-dev/ui-home/src/lib/features/features-while-scaling-your-organization.tsx
+++ b/nx-dev/ui-home/src/lib/features/features-while-scaling-your-organization.tsx
@@ -11,7 +11,7 @@ export function FeaturesWhileScalingYourOrganization(): ReactElement {
           as="h3"
           variant="subtitle"
           id="features-while-scaling-your-organization"
-          className="scroll-mt-24 text-2xl font-medium tracking-tight text-slate-950 sm:text-3xl dark:text-white"
+          className="scroll-mt-24 text-2xl font-medium tracking-tight text-zinc-950 sm:text-3xl dark:text-white"
         >
           While Scaling
         </SectionHeading>

--- a/nx-dev/ui-home/src/lib/features/features.tsx
+++ b/nx-dev/ui-home/src/lib/features/features.tsx
@@ -7,7 +7,7 @@ import { FeaturesCallToAction } from './features-call-to-action';
 
 export function Features(): ReactElement {
   return (
-    <section className="scroll-mt-24 border-b border-t border-slate-200 bg-slate-50 py-24 sm:py-32 dark:border-slate-800 dark:bg-slate-900">
+    <section className="scroll-mt-24 border-b border-t border-zinc-200 bg-zinc-50 py-24 sm:py-32 dark:border-zinc-800 dark:bg-zinc-900">
       <article className="mx-auto max-w-7xl px-6 lg:px-8">
         <SectionHeading as="h2" variant="title" id="" className="scroll-mt-24">
           Build Products,

--- a/nx-dev/ui-home/src/lib/hero/hero.tsx
+++ b/nx-dev/ui-home/src/lib/hero/hero.tsx
@@ -41,7 +41,7 @@ export function Hero(): ReactElement {
             <ButtonLink
               href="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=homepage_links&utm_campaign=try-nx-cloud"
               title="Get started with Nx & Nx Cloud"
-              variant="primary"
+              variant="contrast"
               size="default"
               onClick={() =>
                 sendCustomEvent('get-started-click', 'hero', 'homepage')

--- a/nx-dev/ui-home/src/lib/hero/nx-hero-video.tsx
+++ b/nx-dev/ui-home/src/lib/hero/nx-hero-video.tsx
@@ -18,7 +18,7 @@ export function NxHeroVideo(): ReactElement {
             </MovingBorder>
           </div>
           <div
-            className="relative w-full overflow-hidden rounded-xl border border-slate-100 bg-slate-50 antialiased backdrop-blur-xl dark:border-slate-900 dark:bg-slate-900/[0.8]"
+            className="relative w-full overflow-hidden rounded-xl border border-zinc-100 bg-zinc-50 antialiased backdrop-blur-xl dark:border-zinc-900 dark:bg-zinc-900/[0.8]"
             style={{ aspectRatio: '16/9' }}
           >
             {isPlaying ? (

--- a/nx-dev/ui-home/src/lib/hero/play-button.tsx
+++ b/nx-dev/ui-home/src/lib/hero/play-button.tsx
@@ -51,14 +51,14 @@ export function PlayButton({
     >
       <div className="absolute inset-0">
         <MovingBorder duration={5000} rx="5%" ry="5%">
-          <div className="size-20 bg-[radial-gradient(var(--blue-500)_40%,transparent_60%)] opacity-[0.8] dark:bg-[radial-gradient(var(--sky-500)_40%,transparent_60%)]" />
+          <div className="size-20 bg-[radial-gradient(var(--blue-500)_40%,transparent_60%)] opacity-[0.8] dark:bg-[radial-gradient(var(--blue-500)_40%,transparent_60%)]" />
         </MovingBorder>
       </div>
       <motion.div
         initial="initial"
         whileHover="hover"
         variants={parent}
-        className="relative isolate flex size-20 cursor-pointer items-center justify-center gap-6 rounded-full border-2 border-slate-100 bg-white/10 p-6 text-slate-950 antialiased backdrop-blur-xl"
+        className="relative isolate flex size-20 cursor-pointer items-center justify-center gap-6 rounded-full border-2 border-zinc-100 bg-white/10 p-6 text-zinc-950 antialiased backdrop-blur-xl"
       >
         <PlayIcon aria-hidden="true" className="absolute left-6 top-6 size-8" />
         <motion.div variants={child} className="absolute left-20 top-4 w-48">

--- a/nx-dev/ui-home/src/lib/hetzner-cloud-testimonial.tsx
+++ b/nx-dev/ui-home/src/lib/hetzner-cloud-testimonial.tsx
@@ -26,7 +26,7 @@ export function HetznerCloudTestimonial(): ReactElement {
           as="h2"
           variant="subtitle"
           id="trusted"
-          className="scroll-mt-24 text-center font-medium tracking-tight text-slate-950 sm:text-3xl dark:text-white"
+          className="scroll-mt-24 text-center font-medium tracking-tight text-zinc-950 sm:text-3xl dark:text-white"
         >
           Trusted by leading OSS projects and Fortune 500 companies.
         </SectionHeading>
@@ -69,7 +69,7 @@ export function HetznerCloudTestimonial(): ReactElement {
           <figure>
             <blockquote className="relative">
               <svg
-                className="absolute start-0 top-0 size-12 -translate-x-8 -translate-y-4 transform text-slate-200 dark:text-slate-800"
+                className="absolute start-0 top-0 size-12 -translate-x-8 -translate-y-4 transform text-zinc-200 dark:text-zinc-800"
                 width="16"
                 height="16"
                 viewBox="0 0 16 16"
@@ -84,11 +84,11 @@ export function HetznerCloudTestimonial(): ReactElement {
               </svg>
 
               <div className="relative z-10">
-                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-neutral-200">
+                <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-neutral-200">
                   Featured client
                 </p>
 
-                <p className="mt-2 text-xl font-medium italic text-slate-800 md:leading-normal dark:text-neutral-200">
+                <p className="mt-2 text-xl font-medium italic text-zinc-800 md:leading-normal dark:text-neutral-200">
                   Nx is speed and scalability. Before we only had a few features
                   and CI was slow and now it’s fast with way more features.
                   That’s a huge win for us.
@@ -103,7 +103,7 @@ export function HetznerCloudTestimonial(): ReactElement {
                 />
                 <div className="flex-auto">
                   <div className="text-base font-semibold">Pavlo Grosse</div>
-                  <div className="text-xs text-slate-600 dark:text-slate-500">
+                  <div className="text-xs text-zinc-600 dark:text-zinc-500">
                     Senior Software Engineer, Hetzner Cloud
                   </div>
                 </div>

--- a/nx-dev/ui-home/src/lib/monorepo-ai-support.tsx
+++ b/nx-dev/ui-home/src/lib/monorepo-ai-support.tsx
@@ -78,7 +78,7 @@ export function MonorepoAiSupport(): ReactElement {
             className="hidden max-w-[40%] lg:max-w-[45%] dark:block"
           />
         </div>
-        <div className="relative hidden text-slate-500 lg:block">
+        <div className="relative hidden text-zinc-500 lg:block">
           <ProjectGraph />
 
           <ReactIcon
@@ -111,7 +111,7 @@ export function MonorepoAiSupport(): ReactElement {
           />
         </div>
         <div className="hidden flex-col items-center justify-center sm:flex">
-          <div className="relative text-slate-100 dark:text-slate-950">
+          <div className="relative text-zinc-100 dark:text-zinc-950">
             <Image
               src="/images/home/nx-ai.avif"
               width={1200}
@@ -134,34 +134,34 @@ export function MonorepoAiSupport(): ReactElement {
           </div>
         </div>
         <div className="relative flex flex-col items-center justify-center gap-6">
-          <div className="flex w-full flex-col rounded-lg border-slate-200 bg-white px-4 py-2 opacity-85 shadow-sm transition-all hover:opacity-100 dark:bg-slate-900">
+          <div className="flex w-full flex-col rounded-lg border-zinc-200 bg-white px-4 py-2 opacity-85 shadow-sm transition-all hover:opacity-100 dark:bg-zinc-900">
             <div className="flex items-center space-x-2">
-              <span className="text-xs font-semibold text-slate-800 dark:text-slate-200">
+              <span className="text-xs font-semibold text-zinc-800 dark:text-zinc-200">
                 Instant impact analysis
               </span>
             </div>
-            <p className="mt-1.5 text-sm font-normal text-slate-900 dark:text-white">
+            <p className="mt-1.5 text-sm font-normal text-zinc-900 dark:text-white">
               If I update this shared library, what downstream projects will
               break?
             </p>
           </div>
-          <div className="flex w-full flex-col rounded-lg border-slate-200 bg-white px-4 py-2 opacity-85 shadow-sm transition-all hover:opacity-100 dark:bg-slate-900">
+          <div className="flex w-full flex-col rounded-lg border-zinc-200 bg-white px-4 py-2 opacity-85 shadow-sm transition-all hover:opacity-100 dark:bg-zinc-900">
             <div className="flex items-center space-x-2">
-              <span className="text-xs font-semibold text-slate-800 dark:text-slate-200">
+              <span className="text-xs font-semibold text-zinc-800 dark:text-zinc-200">
                 Ownership clarity
               </span>
             </div>
-            <p className="mt-1.5 text-sm font-normal text-slate-900 dark:text-white">
+            <p className="mt-1.5 text-sm font-normal text-zinc-900 dark:text-white">
               Who maintains this module, and what other teams rely on it?
             </p>
           </div>
-          <div className="flex w-full flex-col rounded-lg border-slate-200 bg-white px-4 py-2 opacity-85 shadow-sm transition-all hover:opacity-100 dark:bg-slate-900">
+          <div className="flex w-full flex-col rounded-lg border-zinc-200 bg-white px-4 py-2 opacity-85 shadow-sm transition-all hover:opacity-100 dark:bg-zinc-900">
             <div className="flex items-center space-x-2">
-              <span className="text-xs font-semibold text-slate-800 dark:text-slate-200">
+              <span className="text-xs font-semibold text-zinc-800 dark:text-zinc-200">
                 Cross-stack reasoning
               </span>
             </div>
-            <p className="mt-1.5 text-sm font-normal text-slate-900 dark:text-white">
+            <p className="mt-1.5 text-sm font-normal text-zinc-900 dark:text-white">
               How does this frontend change impact our backend services?
             </p>
           </div>

--- a/nx-dev/ui-home/src/lib/problem.tsx
+++ b/nx-dev/ui-home/src/lib/problem.tsx
@@ -6,7 +6,7 @@ export function Problem(): ReactElement {
   return (
     <section
       id="problem"
-      className="relative scroll-mt-24 border-b border-t border-slate-200 bg-slate-50 py-24 sm:py-32 dark:border-slate-800 dark:bg-slate-900"
+      className="relative scroll-mt-24 border-b border-t border-zinc-200 bg-zinc-50 py-24 sm:py-32 dark:border-zinc-800 dark:bg-zinc-900"
     >
       <div
         className="pointer-events-none absolute inset-x-0 top-10 flex transform-gpu justify-center overflow-hidden blur-3xl"

--- a/nx-dev/ui-home/src/lib/smarter-tools-for-monorepos.tsx
+++ b/nx-dev/ui-home/src/lib/smarter-tools-for-monorepos.tsx
@@ -46,7 +46,7 @@ import {
 
 export function SmarterToolsForMonorepos(): JSX.Element {
   return (
-    <section className="bg-slate-50 py-32 shadow-inner sm:py-40 dark:bg-slate-900">
+    <section className="bg-zinc-50 py-32 shadow-inner sm:py-40 dark:bg-zinc-900">
       <article className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="max-w-5xl">
           <SectionHeading
@@ -297,7 +297,7 @@ export function SmarterToolsForMonorepos(): JSX.Element {
                   title="Nx video tutorials"
                   className="h-full w-full p-2 sm:p-4"
                 >
-                  <FitText className="text-slate-950 dark:text-white">
+                  <FitText className="text-zinc-950 dark:text-white">
                     Video tutorials
                   </FitText>
                 </Link>
@@ -370,7 +370,7 @@ export function SmarterToolsForMonorepos(): JSX.Element {
                         className="h-[156px] w-[136px]"
                       />
                     </motion.div>
-                    <FitText className="text-slate-950 dark:text-white">
+                    <FitText className="text-zinc-950 dark:text-white">
                       Plugins
                     </FitText>
                   </div>
@@ -411,19 +411,19 @@ export function SmarterToolsForMonorepos(): JSX.Element {
                   href="/getting-started/editor-setup?utm_medium=website&utm_campaign=homepage_links&utm_content=cta_smarter_tools_techlink"
                   prefetch={false}
                   title="Webstorm plugin"
-                  className="flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-xs transition dark:border-slate-800 dark:bg-slate-900"
+                  className="flex items-center gap-2 rounded-full border border-zinc-200 bg-zinc-50 px-4 py-2 text-xs transition dark:border-zinc-800 dark:bg-zinc-900"
                 >
                   <JetBrainsIcon aria-hidden="true" className="size-3" />{' '}
                   JetBrains
                 </Link>
-                <FitText className="text-slate-950 dark:text-white">
+                <FitText className="text-zinc-950 dark:text-white">
                   Editor Integration
                 </FitText>
                 <Link
                   href="/getting-started/editor-setup?utm_medium=website&utm_campaign=homepage_links&utm_content=cta_smarter_tools_techlink"
                   prefetch={false}
                   title="VSCode plugin"
-                  className="flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-xs dark:border-slate-800 dark:bg-slate-900"
+                  className="flex items-center gap-2 rounded-full border border-zinc-200 bg-zinc-50 px-4 py-2 text-xs dark:border-zinc-800 dark:bg-zinc-900"
                 >
                   <VisualStudioCodeIcon aria-hidden="true" className="size-3" />{' '}
                   VS Code
@@ -625,7 +625,7 @@ export function SmarterToolsForMonorepos(): JSX.Element {
                   className="h-[156px] w-[136px]"
                 />
               </motion.div>
-              <FitText className="text-slate-950 dark:text-white">
+              <FitText className="text-zinc-950 dark:text-white">
                 Plugins
               </FitText>
             </div>
@@ -1071,8 +1071,8 @@ const Card = ({
   return (
     <div
       className={cx(
-        'relative col-span-1 row-span-1 grid grid-cols-1 place-items-center rounded-2xl border border-slate-100 bg-white dark:border-slate-800/60 dark:bg-slate-950',
-        'text-slate-600 transition hover:text-slate-950 dark:text-slate-400 dark:hover:text-white',
+        'relative col-span-1 row-span-1 grid grid-cols-1 place-items-center rounded-2xl border border-zinc-100 bg-white dark:border-zinc-800/60 dark:bg-zinc-950',
+        'text-zinc-600 transition hover:text-zinc-950 dark:text-zinc-400 dark:hover:text-white',
         className
       )}
     >

--- a/nx-dev/ui-home/src/lib/solution.tsx
+++ b/nx-dev/ui-home/src/lib/solution.tsx
@@ -43,7 +43,7 @@ export function Solution(): ReactElement {
             description="across teams with repo-aware dependency management"
           />
         </ul>
-        <p className="mt-12 text-balance text-3xl font-normal tracking-tight text-slate-950 sm:text-5xl dark:text-white">
+        <p className="mt-12 text-balance text-3xl font-normal tracking-tight text-zinc-950 sm:text-5xl dark:text-white">
           Works with <strong>any</strong> tech stack. Works with{' '}
           <strong>any</strong> CI provider.
         </p>
@@ -159,7 +159,7 @@ function StatCard({
     indigo:
       'from-indigo-100 to-indigo-300 dark:from-indigo-950 dark:to-indigo-900',
     blue: 'from-blue-100 to-blue-300 dark:from-blue-950 dark:to-blue-900',
-    sky: 'from-sky-100 to-sky-300 dark:from-sky-950 dark:to-sky-900',
+    sky: 'from-blue-100 to-blue-300 dark:from-blue-950 dark:to-blue-900',
     cyan: 'from-cyan-100 to-cyan-300 dark:from-cyan-950 dark:to-cyan-900',
   };
 
@@ -174,7 +174,7 @@ function StatCard({
       <div className="mb-8 flex-grow font-semibold dark:text-white/50">
         {description}
       </div>
-      <div className="mt-auto flex items-center gap-2 text-slate-950 dark:text-white">
+      <div className="mt-auto flex items-center gap-2 text-zinc-950 dark:text-white">
         {company === 'Caseware' && (
           <CasewareIcon aria-hidden="true" className="size-10" />
         )}

--- a/nx-dev/ui-home/src/lib/statistics.tsx
+++ b/nx-dev/ui-home/src/lib/statistics.tsx
@@ -33,11 +33,11 @@ export function Statistics(): JSX.Element {
               key={stat.id}
               className="mx-auto flex max-w-sm flex-col gap-y-2"
             >
-              <dt className="text-base leading-7 text-slate-600 dark:text-slate-400">
+              <dt className="text-base leading-7 text-zinc-600 dark:text-zinc-400">
                 {stat.name}
               </dt>
-              <dd className="order-first text-3xl font-semibold tracking-tight text-slate-950 dark:text-white">
-                <span className="text-blue-500 dark:text-sky-500">
+              <dd className="order-first text-3xl font-semibold tracking-tight text-zinc-950 dark:text-white">
+                <span className="text-blue-500 dark:text-blue-500">
                   {stat.prefix}
                   {stat.value}
                   {stat.suffix}

--- a/nx-dev/ui-home/src/lib/team-and-community.tsx
+++ b/nx-dev/ui-home/src/lib/team-and-community.tsx
@@ -86,7 +86,7 @@ export function TeamAndCommunity(): ReactElement {
         </div>
         <div className="mt-8 grid grid-cols-2 gap-12 sm:grid-cols-3 sm:gap-8 lg:grid-cols-6 lg:gap-6">
           <div>
-            <div className="group/item relative flex items-center gap-2 rounded-xl border border-slate-100 p-4 transition hover:text-slate-950 dark:border-slate-800/60 dark:hover:text-white">
+            <div className="group/item relative flex items-center gap-2 rounded-xl border border-zinc-100 p-4 transition hover:text-zinc-950 dark:border-zinc-800/60 dark:hover:text-white">
               <XIcon aria-hidden="true" className="size-6 shrink-0" />
               <a href="https://x.com/NxDevTools" className="grow text-base">
                 <span className="absolute inset-0" />
@@ -99,7 +99,7 @@ export function TeamAndCommunity(): ReactElement {
             </div>
           </div>
           <div>
-            <div className="group/item relative flex items-center gap-2 rounded-xl border border-slate-100 p-4 transition hover:text-slate-950 dark:border-slate-800/60 dark:hover:text-white">
+            <div className="group/item relative flex items-center gap-2 rounded-xl border border-zinc-100 p-4 transition hover:text-zinc-950 dark:border-zinc-800/60 dark:hover:text-white">
               <NewspaperIcon aria-hidden="true" className="size-6 shrink-0" />
               <Link href="/blog" className="grow text-base">
                 <span className="absolute inset-0" />
@@ -112,7 +112,7 @@ export function TeamAndCommunity(): ReactElement {
             </div>
           </div>
           <div>
-            <div className="group/item relative flex items-center gap-2 rounded-xl border border-slate-100 p-4 transition hover:text-slate-950 dark:border-slate-800/60 dark:hover:text-white">
+            <div className="group/item relative flex items-center gap-2 rounded-xl border border-zinc-100 p-4 transition hover:text-zinc-950 dark:border-zinc-800/60 dark:hover:text-white">
               <YoutubeIcon aria-hidden="true" className="size-6 shrink-0" />
               <a
                 href="https://youtube.com/@nxdevtools"
@@ -129,7 +129,7 @@ export function TeamAndCommunity(): ReactElement {
           </div>
 
           <div>
-            <div className="group/item relative flex items-center gap-2 rounded-xl border border-slate-100 p-4 transition hover:text-slate-950 dark:border-slate-800/60 dark:hover:text-white">
+            <div className="group/item relative flex items-center gap-2 rounded-xl border border-zinc-100 p-4 transition hover:text-zinc-950 dark:border-zinc-800/60 dark:hover:text-white">
               <DiscordIcon aria-hidden="true" className="size-6 shrink-0" />
               <a
                 href="https://go.nx.dev/community?utm_medium=website&utm_campaign=homepage_links&utm_content=cta_team_and_community"
@@ -146,7 +146,7 @@ export function TeamAndCommunity(): ReactElement {
           </div>
 
           <div>
-            <div className="group/item relative flex items-center gap-2 rounded-xl border border-slate-100 p-4 transition dark:border-slate-800/60 dark:hover:text-white">
+            <div className="group/item relative flex items-center gap-2 rounded-xl border border-zinc-100 p-4 transition dark:border-zinc-800/60 dark:hover:text-white">
               <MicrophoneIcon aria-hidden="true" className="size-6 shrink-0" />
               <Link
                 href="https://podcasters.spotify.com/pod/show/enterprise-software"
@@ -166,7 +166,7 @@ export function TeamAndCommunity(): ReactElement {
           </div>
 
           <div>
-            <div className="group/item relative flex items-center gap-2 rounded-xl border border-slate-100 p-4 transition dark:border-slate-800/60 dark:hover:text-white">
+            <div className="group/item relative flex items-center gap-2 rounded-xl border border-zinc-100 p-4 transition dark:border-zinc-800/60 dark:hover:text-white">
               <ComputerDesktopIcon
                 aria-hidden="true"
                 className="size-6 shrink-0"

--- a/nx-dev/ui-home/src/lib/work-better-achieve-more-ship-quicker.tsx
+++ b/nx-dev/ui-home/src/lib/work-better-achieve-more-ship-quicker.tsx
@@ -58,7 +58,7 @@ export function WorkBetterAchieveMoreShipQuicker(): JSX.Element {
           <ButtonLink
             href="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=homepage_links&utm_campaign=try-nx-cloud"
             title="Get started"
-            variant="primary"
+            variant="contrast"
             size="large"
           >
             Try Nx for yourself
@@ -67,7 +67,7 @@ export function WorkBetterAchieveMoreShipQuicker(): JSX.Element {
       </div>
 
       <div className="mt-12 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:gap-32">
-        <div className="group/card rounded-2xl border border-slate-100 bg-slate-50/30 p-6 transition-all duration-500 dark:border-slate-800/60 dark:bg-black">
+        <div className="group/card rounded-2xl border border-zinc-100 bg-zinc-50/30 p-6 transition-all duration-500 dark:border-zinc-800/60 dark:bg-black">
           <SectionHeading
             as="h3"
             variant="title"
@@ -90,7 +90,7 @@ export function WorkBetterAchieveMoreShipQuicker(): JSX.Element {
             className="translation-all hidden max-w-full duration-500 group-hover/card:brightness-200 dark:block"
           />
         </div>
-        <div className="group/card rounded-2xl border border-slate-100 bg-slate-50/30 p-6 transition-all duration-500 dark:border-slate-800/60 dark:bg-black">
+        <div className="group/card rounded-2xl border border-zinc-100 bg-zinc-50/30 p-6 transition-all duration-500 dark:border-zinc-800/60 dark:bg-black">
           <SectionHeading
             as="h3"
             variant="title"

--- a/nx-dev/ui-markdoc/src/lib/graphs/project-graph.tsx
+++ b/nx-dev/ui-markdoc/src/lib/graphs/project-graph.tsx
@@ -111,18 +111,18 @@ function NxDevProjectGraphInner({
 
       <NxGraphElementPanel
         element={element}
-        panelContainerClassName="border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900"
-        panelHeaderClassName="border-slate-300 dark:border-slate-700"
-        panelContentContainerClassName="divide-slate-300 dark:divide-slate-700"
+        panelContainerClassName="border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900"
+        panelHeaderClassName="border-zinc-300 dark:border-zinc-700"
+        panelContentContainerClassName="divide-zinc-300 dark:divide-zinc-700"
         header={{
           project: (element, { open, close }) => (
             <NxGraphProjectNodePanelHeader
               element={element}
               open={open}
               close={close}
-              badgeClassName="bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 border-slate-300 dark:border-slate-600 uppercase"
-              elementNameClassName="text-slate-900 dark:text-slate-100"
-              closeButtonClassName="hover:bg-slate-100 dark:hover:bg-slate-700"
+              badgeClassName="bg-zinc-100 dark:bg-zinc-700 text-zinc-700 dark:text-zinc-300 border-zinc-300 dark:border-zinc-600 uppercase"
+              elementNameClassName="text-zinc-900 dark:text-zinc-100"
+              closeButtonClassName="hover:bg-zinc-100 dark:hover:bg-zinc-700"
             />
           ),
           'composite-project': (element, { open, close }) => (
@@ -130,9 +130,9 @@ function NxDevProjectGraphInner({
               element={element}
               open={open}
               close={close}
-              badgeClassName="bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 border-slate-300 dark:border-slate-600 uppercase"
-              elementNameClassName="text-slate-900 dark:text-slate-100"
-              closeButtonClassName="hover:bg-slate-100 dark:hover:bg-slate-700"
+              badgeClassName="bg-zinc-100 dark:bg-zinc-700 text-zinc-700 dark:text-zinc-300 border-zinc-300 dark:border-zinc-600 uppercase"
+              elementNameClassName="text-zinc-900 dark:text-zinc-100"
+              closeButtonClassName="hover:bg-zinc-100 dark:hover:bg-zinc-700"
             />
           ),
         }}
@@ -141,35 +141,35 @@ function NxDevProjectGraphInner({
           project: (element) => (
             <NxGraphProjectNodePanelContent
               element={element}
-              sectionHeadingClassName="text-slate-900 dark:text-slate-100"
-              sectionTextClassName="text-slate-700 dark:text-slate-300"
-              tagBadgeClassName="bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 border-slate-300 dark:border-slate-600"
-              actionButtonClassName="bg-slate-100/60 dark:bg-slate-700/60 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-900 dark:hover:text-slate-100 border-slate-300 dark:border-slate-600"
+              sectionHeadingClassName="text-zinc-900 dark:text-zinc-100"
+              sectionTextClassName="text-zinc-700 dark:text-zinc-300"
+              tagBadgeClassName="bg-zinc-100 dark:bg-zinc-700 text-zinc-700 dark:text-zinc-300 border-zinc-300 dark:border-zinc-600"
+              actionButtonClassName="bg-zinc-100/60 dark:bg-zinc-700/60 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700 hover:text-zinc-900 dark:hover:text-zinc-100 border-zinc-300 dark:border-zinc-600"
               cancelActionButtonClassName="bg-red-500 dark:bg-red-600 text-white hover:bg-red-600 dark:hover:bg-red-700 border-red-500 dark:border-red-600"
-              dependencyItemClassName="text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700"
-              dependentItemClassName="text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700"
-              emptyItemListClassName="text-slate-600 dark:text-slate-400"
-              traceAlgorithmButtonClassName="bg-slate-100/60 dark:bg-slate-700/60 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-900 dark:hover:text-slate-100 border-slate-300 dark:border-slate-600"
-              traceAlgorithmActiveButtonClassName="bg-sky-500 dark:bg-sky-600 text-white hover:bg-sky-600 dark:hover:bg-sky-700 border-sky-500 dark:border-sky-600"
-              traceableProjectItemClassName="text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 justify-between"
-              traceableProjectSelectedItemClassName="bg-sky-500/10 dark:bg-sky-600/10 text-slate-900 dark:text-slate-100"
+              dependencyItemClassName="text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700"
+              dependentItemClassName="text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700"
+              emptyItemListClassName="text-zinc-600 dark:text-zinc-400"
+              traceAlgorithmButtonClassName="bg-zinc-100/60 dark:bg-zinc-700/60 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700 hover:text-zinc-900 dark:hover:text-zinc-100 border-zinc-300 dark:border-zinc-600"
+              traceAlgorithmActiveButtonClassName="bg-blue-500 dark:bg-blue-600 text-white hover:bg-blue-600 dark:hover:bg-blue-700 border-blue-500 dark:border-blue-600"
+              traceableProjectItemClassName="text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700 justify-between"
+              traceableProjectSelectedItemClassName="bg-blue-500/10 dark:bg-blue-600/10 text-zinc-900 dark:text-zinc-100"
             />
           ),
           'composite-project': (element) => (
             <NxGraphCompositeProjectNodePanelContent
               element={element}
-              sectionHeadingClassName="text-slate-900 dark:text-slate-100"
-              sectionTextClassName="text-slate-700 dark:text-slate-300"
-              actionButtonClassName="bg-slate-100/60 dark:bg-slate-700/60 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-900 dark:hover:text-slate-100 border-slate-300 dark:border-slate-600"
+              sectionHeadingClassName="text-zinc-900 dark:text-zinc-100"
+              sectionTextClassName="text-zinc-700 dark:text-zinc-300"
+              actionButtonClassName="bg-zinc-100/60 dark:bg-zinc-700/60 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700 hover:text-zinc-900 dark:hover:text-zinc-100 border-zinc-300 dark:border-zinc-600"
               cancelActionButtonClassName="bg-red-500 dark:bg-red-600 text-white hover:bg-red-600 dark:hover:bg-red-700 border-red-500 dark:border-red-600"
-              confirmActionButtonClassName="bg-sky-500 dark:bg-sky-600 text-white hover:bg-sky-600 dark:hover:bg-sky-700 border-sky-500 dark:border-sky-600"
-              multiselectContainerClassName="text-slate-700 dark:text-slate-300"
-              multiselectFilterInputClassName="bg-white dark:bg-slate-800 border-slate-300 dark:border-slate-600 text-slate-900 dark:text-slate-100 focus:border-sky-500 dark:focus:border-sky-400"
-              multiselectEmptyStateClassName="text-slate-600 dark:text-slate-400"
-              multiselectListItemClassName="hover:bg-slate-100 dark:hover:bg-slate-700"
-              multiselectCheckboxClassName="border-slate-300 dark:border-slate-600 accent-sky-500"
-              multiselectLabelClassName="text-slate-700 dark:text-slate-300"
-              multiselectSectionHeaderClassName="text-slate-900 dark:text-slate-100 border-slate-300 dark:border-slate-700"
+              confirmActionButtonClassName="bg-blue-500 dark:bg-blue-600 text-white hover:bg-blue-600 dark:hover:bg-blue-700 border-blue-500 dark:border-blue-600"
+              multiselectContainerClassName="text-zinc-700 dark:text-zinc-300"
+              multiselectFilterInputClassName="bg-white dark:bg-zinc-800 border-zinc-300 dark:border-zinc-600 text-zinc-900 dark:text-zinc-100 focus:border-blue-500 dark:focus:border-blue-400"
+              multiselectEmptyStateClassName="text-zinc-600 dark:text-zinc-400"
+              multiselectListItemClassName="hover:bg-zinc-100 dark:hover:bg-zinc-700"
+              multiselectCheckboxClassName="border-zinc-300 dark:border-zinc-600 accent-blue-500"
+              multiselectLabelClassName="text-zinc-700 dark:text-zinc-300"
+              multiselectSectionHeaderClassName="text-zinc-900 dark:text-zinc-100 border-zinc-300 dark:border-zinc-700"
             />
           ),
         }}

--- a/nx-dev/ui-markdoc/src/lib/graphs/task-graph.tsx
+++ b/nx-dev/ui-markdoc/src/lib/graphs/task-graph.tsx
@@ -92,18 +92,18 @@ export function NxDevTaskGraphInner({
 
       <NxGraphElementPanel
         element={element}
-        panelContainerClassName="border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900"
-        panelHeaderClassName="border-slate-300 dark:border-slate-700"
-        panelContentContainerClassName="divide-slate-300 dark:divide-slate-700"
+        panelContainerClassName="border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900"
+        panelHeaderClassName="border-zinc-300 dark:border-zinc-700"
+        panelContentContainerClassName="divide-zinc-300 dark:divide-zinc-700"
         header={{
           task: (element, { open, close }) => (
             <NxGraphTaskNodePanelHeader
               element={element}
               open={open}
               close={close}
-              elementNameClassName="text-slate-900 dark:text-slate-100"
-              closeButtonClassName="hover:bg-slate-100 dark:hover:bg-slate-700"
-              taskFlagBadgeClassName="bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-300 border-slate-300 dark:border-slate-600"
+              elementNameClassName="text-zinc-900 dark:text-zinc-100"
+              closeButtonClassName="hover:bg-zinc-100 dark:hover:bg-zinc-700"
+              taskFlagBadgeClassName="bg-zinc-100 dark:bg-zinc-700 text-zinc-700 dark:text-zinc-300 border-zinc-300 dark:border-zinc-600"
             />
           ),
         }}
@@ -112,19 +112,19 @@ export function NxDevTaskGraphInner({
           task: (element) => (
             <NxGraphTaskNodePanelContent
               element={element}
-              sectionHeadingClassName="text-slate-900 dark:text-slate-100"
-              sectionTextClassName="text-slate-700 dark:text-slate-300"
-              actionButtonClassName="bg-slate-100/60 dark:bg-slate-700/60 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-900 dark:hover:text-slate-100 border-slate-300 dark:border-slate-600"
-              sectionListContainerClassName="border-slate-200 dark:border-slate-700"
-              sectionListSectionClassName="bg-slate-50 dark:bg-slate-800"
-              sectionListHeaderClassName="text-slate-700 dark:text-slate-300 bg-slate-200 dark:bg-slate-800"
-              sectionListHeaderLabelClassName="text-slate-600 dark:text-slate-400"
-              sectionListItemsClassName="divide-slate-200 dark:divide-slate-600"
-              sectionListItemClassName="bg-slate-50 dark:bg-slate-700"
-              sectionListItemLabelClassName="text-slate-900 dark:text-slate-100"
-              loadingSkeletonHeaderClassName="bg-slate-200 dark:bg-slate-600"
-              loadingSkeletonItemClassName="bg-slate-100 dark:bg-slate-700"
-              loadingSkeletonListClassName="bg-slate-50 dark:bg-slate-800"
+              sectionHeadingClassName="text-zinc-900 dark:text-zinc-100"
+              sectionTextClassName="text-zinc-700 dark:text-zinc-300"
+              actionButtonClassName="bg-zinc-100/60 dark:bg-zinc-700/60 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100 dark:hover:bg-zinc-700 hover:text-zinc-900 dark:hover:text-zinc-100 border-zinc-300 dark:border-zinc-600"
+              sectionListContainerClassName="border-zinc-200 dark:border-zinc-700"
+              sectionListSectionClassName="bg-zinc-50 dark:bg-zinc-800"
+              sectionListHeaderClassName="text-zinc-700 dark:text-zinc-300 bg-zinc-200 dark:bg-zinc-800"
+              sectionListHeaderLabelClassName="text-zinc-600 dark:text-zinc-400"
+              sectionListItemsClassName="divide-zinc-200 dark:divide-zinc-600"
+              sectionListItemClassName="bg-zinc-50 dark:bg-zinc-700"
+              sectionListItemLabelClassName="text-zinc-900 dark:text-zinc-100"
+              loadingSkeletonHeaderClassName="bg-zinc-200 dark:bg-zinc-600"
+              loadingSkeletonItemClassName="bg-zinc-100 dark:bg-zinc-700"
+              loadingSkeletonListClassName="bg-zinc-50 dark:bg-zinc-800"
             />
           ),
         }}

--- a/nx-dev/ui-markdoc/src/lib/nodes/link.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/nodes/link.component.tsx
@@ -17,7 +17,7 @@ export function CustomLink(props: any) {
       rel={target === '_blank' ? 'noreferrer' : undefined}
       className={cx(
         props.className,
-        'text-blue-600 transition-colors ease-out hover:text-blue-700 dark:text-sky-500 dark:hover:text-sky-400'
+        'text-blue-600 transition-colors ease-out hover:text-blue-700 dark:text-blue-500 dark:hover:text-blue-400'
       )}
     >
       {props.children}

--- a/nx-dev/ui-markdoc/src/lib/tags/call-to-action.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/call-to-action.component.tsx
@@ -21,30 +21,30 @@ const variantClasses: Record<
   }
 > = {
   default: {
-    container: 'bg-slate-50 dark:bg-slate-800/60',
-    accent: 'bg-blue-500 dark:bg-sky-500',
+    container: 'bg-zinc-50 dark:bg-zinc-800/60',
+    accent: 'bg-blue-500 dark:bg-blue-500',
     hoverText: 'hover:text-white',
     expandBg: 'group-hover:w-full',
   },
   gradient: {
     container:
-      'bg-gradient-to-r from-blue-500 via-sky-400 to-blue-500 dark:from-sky-600 dark:via-blue-500 dark:to-sky-600',
+      'bg-gradient-to-r from-blue-500 via-blue-400 to-blue-500 dark:from-blue-600 dark:via-blue-500 dark:to-blue-600',
     accent: 'dark:bg-white bg-blue-500',
-    hoverText: 'hover:text-sky-100 dark:hover:text-slate-900 text-white',
+    hoverText: 'hover:text-blue-100 dark:hover:text-zinc-900 text-white',
     expandBg: 'group-hover:w-full',
   },
   inverted: {
-    container: 'bg-slate-800 dark:bg-slate-100',
-    accent: 'bg-sky-400 dark:bg-blue-600',
+    container: 'bg-zinc-800 dark:bg-zinc-100',
+    accent: 'bg-blue-400 dark:bg-blue-600',
     hoverText:
-      'hover:text-slate-900 dark:hover:text-white text-white dark:text-slate-900',
+      'hover:text-zinc-900 dark:hover:text-white text-white dark:text-zinc-900',
     expandBg: 'group-hover:w-full',
   },
   'gradient-alt': {
     container:
-      'bg-gradient-to-br from-blue-600 via-sky-400 to-blue-300 dark:from-blue-800 dark:via-sky-600 dark:to-blue-400',
-    accent: 'bg-blue-800 dark:bg-sky-500',
-    hoverText: 'hover:text-blue-100 dark:hover:text-sky-200 text-white',
+      'bg-gradient-to-br from-blue-600 via-blue-400 to-blue-300 dark:from-blue-800 dark:via-blue-600 dark:to-blue-400',
+    accent: 'bg-blue-800 dark:bg-blue-500',
+    hoverText: 'hover:text-blue-100 dark:hover:text-blue-200 text-white',
     expandBg: 'group-hover:w-full',
   },
   simple: {

--- a/nx-dev/ui-markdoc/src/lib/tags/callout.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/callout.component.tsx
@@ -34,14 +34,14 @@ const typeMap: Record<
   note: {
     icon: (
       <InformationCircleIcon
-        className="h-5 w-5 text-slate-500 dark:text-slate-300"
+        className="h-5 w-5 text-zinc-500 dark:text-zinc-300"
         aria-hidden="true"
       />
     ),
-    backgroundColor: 'bg-slate-50 dark:bg-slate-800/40',
-    borderColor: 'border-slate-200 dark:border-slate-700',
-    titleColor: 'text-slate-600 dark:text-slate-300',
-    textColor: 'text-slate-700 dark:text-slate-400',
+    backgroundColor: 'bg-zinc-50 dark:bg-zinc-800/40',
+    borderColor: 'border-zinc-200 dark:border-zinc-700',
+    titleColor: 'text-zinc-600 dark:text-zinc-300',
+    textColor: 'text-zinc-700 dark:text-zinc-400',
   },
   announcement: {
     icon: (

--- a/nx-dev/ui-markdoc/src/lib/tags/cards.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/cards.component.tsx
@@ -85,7 +85,7 @@ export function Cards({
       {moreLink && (
         <div className="col-span-full mt-2 flex justify-end">
           <Link
-            className="group flex items-center whitespace-nowrap border-transparent px-4 py-0 text-sm font-semibold no-underline transition-all duration-200 ease-in-out hover:text-slate-900 dark:hover:text-sky-400"
+            className="group flex items-center whitespace-nowrap border-transparent px-4 py-0 text-sm font-semibold no-underline transition-all duration-200 ease-in-out hover:text-zinc-900 dark:hover:text-blue-400"
             href={moreLink}
             prefetch={false}
           >
@@ -129,7 +129,7 @@ export function LinkCard({
     <Link
       key={title}
       href={url}
-      className="no-prose relative col-span-1 mx-auto flex w-full max-w-md flex-col items-center rounded-md border border-slate-200 bg-slate-50/40 p-4 text-center font-semibold shadow-sm transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-slate-100 dark:border-slate-800/40 dark:bg-slate-800/60 dark:hover:bg-slate-800"
+      className="no-prose relative col-span-1 mx-auto flex w-full max-w-md flex-col items-center rounded-md border border-zinc-200 bg-zinc-50/40 p-4 text-center font-semibold shadow-sm transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-zinc-100 dark:border-zinc-800/40 dark:bg-zinc-800/60 dark:hover:bg-zinc-800"
       style={{ textDecorationLine: 'none' }}
       prefetch={false}
     >
@@ -162,13 +162,13 @@ export function LinkCard({
         className={cx({ 'pt-4': !!icon }, { 'pt-2': appearance === 'small' })}
       >
         {appearance === 'small' && type ? null : (
-          <div className="mb-1 text-xs font-medium uppercase text-slate-600 dark:text-slate-300">
+          <div className="mb-1 text-xs font-medium uppercase text-zinc-600 dark:text-zinc-300">
             {type}
           </div>
         )}
         <h3
           className={cx(
-            'm-0 text-lg font-semibold text-slate-900 dark:text-white',
+            'm-0 text-lg font-semibold text-zinc-900 dark:text-white',
             { 'text-sm font-normal': appearance === 'small' }
           )}
         >
@@ -208,7 +208,7 @@ export function Card({
       key={title}
       href={url}
       title={title}
-      className="not-content group flex flex-col items-stretch rounded-md border border-slate-200 bg-slate-50/40 text-sm no-underline shadow-sm transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-slate-50 dark:border-slate-800/40 dark:bg-slate-800/60 dark:hover:bg-slate-800"
+      className="not-content group flex flex-col items-stretch rounded-md border border-zinc-200 bg-zinc-50/40 text-sm no-underline shadow-sm transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-zinc-50 dark:border-zinc-800/40 dark:bg-zinc-800/60 dark:hover:bg-zinc-800"
       prefetch={false}
     >
       {!!hasYoutubeId && (
@@ -221,13 +221,13 @@ export function Card({
         </div>
       )}
       <div className="relative flex flex-col p-3 pr-8">
-        <h3 className="m-0 flex items-center text-base font-bold text-slate-900 dark:text-white">
+        <h3 className="m-0 flex items-center text-base font-bold text-zinc-900 dark:text-white">
           <span className="absolute inset-0" aria-hidden="true"></span>
           {!hasYoutubeId ? iconMap[type] : null}
           {title}
         </h3>
         {description ? (
-          <p className="mt-2 w-full text-sm font-normal text-slate-600 no-underline dark:text-slate-300">
+          <p className="mt-2 w-full text-sm font-normal text-zinc-600 no-underline dark:text-zinc-300">
             {description}
           </p>
         ) : null}

--- a/nx-dev/ui-markdoc/src/lib/tags/github-repository.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/github-repository.component.tsx
@@ -10,9 +10,9 @@ export function GithubRepository({
   title,
 }: GithubRepositoryProps): JSX.Element {
   return (
-    <div className="not-content not-prose group relative mx-auto my-12 flex w-full max-w-md items-center gap-3 overflow-hidden rounded-lg bg-slate-50 shadow-md transition hover:text-white dark:bg-slate-800/60">
-      <div className="absolute inset-0 z-0 w-2 bg-blue-500 transition-all duration-150 group-hover:w-full dark:bg-sky-500"></div>
-      <div className="w-2 bg-blue-500 dark:bg-sky-500"></div>
+    <div className="not-content not-prose group relative mx-auto my-12 flex w-full max-w-md items-center gap-3 overflow-hidden rounded-lg bg-zinc-50 shadow-md transition hover:text-white dark:bg-zinc-800/60">
+      <div className="absolute inset-0 z-0 w-2 bg-blue-500 transition-all duration-150 group-hover:w-full dark:bg-blue-500"></div>
+      <div className="w-2 bg-blue-500 dark:bg-blue-500"></div>
 
       <div className="z-10 flex flex-grow items-center py-3">
         <svg

--- a/nx-dev/ui-markdoc/src/lib/tags/graph.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/graph.component.tsx
@@ -7,7 +7,7 @@ export function Loading() {
   return (
     <div className="flex h-[450px] w-full items-center justify-center">
       <div
-        className="spinner-border inline-block h-8 w-8 animate-spin rounded-full border-4 border-slate-200 border-r-slate-400 dark:border-slate-700 dark:border-r-slate-500"
+        className="spinner-border inline-block h-8 w-8 animate-spin rounded-full border-4 border-zinc-200 border-r-zinc-400 dark:border-zinc-700 dark:border-r-zinc-500"
         role="status"
       >
         <span className="sr-only">Loading...</span>
@@ -101,9 +101,9 @@ export function Graph({
   }
 
   return parsedProps ? (
-    <div className="not-content mt-4 w-full place-content-center overflow-hidden rounded-md ring-1 ring-slate-200 dark:ring-slate-700">
+    <div className="not-content mt-4 w-full place-content-center overflow-hidden rounded-md ring-1 ring-zinc-200 dark:ring-zinc-700">
       {title ? (
-        <div className="relative flex justify-center border-b border-slate-200 bg-slate-100/50 p-2 font-bold dark:border-slate-700 dark:bg-slate-700/50">
+        <div className="relative flex justify-center border-b border-zinc-200 bg-zinc-100/50 p-2 font-bold dark:border-zinc-700 dark:bg-zinc-700/50">
           {title}
         </div>
       ) : null}

--- a/nx-dev/ui-markdoc/src/lib/tags/iframe.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/iframe.component.tsx
@@ -10,7 +10,7 @@ export function Iframe(props: IframeProps) {
       {...props}
       title={props.title}
       frameBorder="0"
-      className="not-content rounded-lg border border-slate-200 shadow-lg dark:border-slate-700"
+      className="not-content rounded-lg border border-zinc-200 shadow-lg dark:border-zinc-700"
     />
   );
 }

--- a/nx-dev/ui-markdoc/src/lib/tags/install-nx-console.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/install-nx-console.component.tsx
@@ -3,9 +3,9 @@ import { ChevronRightIcon } from '@heroicons/react/24/outline';
 export const InstallNxConsole = () => (
   <div className="not-content my-12 grid grid-cols-1 gap-6 lg:grid-cols-2 lg:gap-16">
     {/* VSCode */}
-    <div className="not-prose group relative mx-auto flex w-full max-w-md items-center gap-4 overflow-hidden rounded-lg bg-slate-50 shadow-md transition hover:text-white dark:bg-slate-800/60">
-      <div className="absolute inset-0 z-0 w-2 bg-blue-500 transition-all duration-150 group-hover:w-full dark:bg-sky-500" />
-      <div className="w-2 bg-blue-500 dark:bg-sky-500" />
+    <div className="not-prose group relative mx-auto flex w-full max-w-md items-center gap-4 overflow-hidden rounded-lg bg-zinc-50 shadow-md transition hover:text-white dark:bg-zinc-800/60">
+      <div className="absolute inset-0 z-0 w-2 bg-blue-500 transition-all duration-150 group-hover:w-full dark:bg-blue-500" />
+      <div className="w-2 bg-blue-500 dark:bg-blue-500" />
 
       <div className="z-10 flex flex-grow items-center gap-4 py-3">
         <svg
@@ -37,9 +37,9 @@ export const InstallNxConsole = () => (
       <ChevronRightIcon className="mr-4 h-6 w-6 flex-shrink-0 transition-all group-hover:translate-x-3" />
     </div>
     {/* JetBrains */}
-    <div className="not-prose group relative mx-auto flex w-full max-w-md items-center gap-4 overflow-hidden rounded-lg bg-slate-50 shadow-md transition hover:text-white dark:bg-slate-800/60">
-      <div className="absolute inset-0 z-0 w-2 bg-blue-500 transition-all duration-150 group-hover:w-full dark:bg-sky-500" />
-      <div className="w-2 bg-blue-500 dark:bg-sky-500" />
+    <div className="not-prose group relative mx-auto flex w-full max-w-md items-center gap-4 overflow-hidden rounded-lg bg-zinc-50 shadow-md transition hover:text-white dark:bg-zinc-800/60">
+      <div className="absolute inset-0 z-0 w-2 bg-blue-500 transition-all duration-150 group-hover:w-full dark:bg-blue-500" />
+      <div className="w-2 bg-blue-500 dark:bg-blue-500" />
 
       <div className="z-10 flex flex-grow items-center gap-4 py-3">
         <svg

--- a/nx-dev/ui-markdoc/src/lib/tags/metrics-cta.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/metrics-cta.tsx
@@ -8,13 +8,13 @@ import { sendCustomEvent } from '@nx/nx-dev-feature-analytics';
 export function MetricsCTA() {
   return (
     <div className="not-prose flex flex-col space-y-3">
-      <h3 className="text-lg font-semibold text-slate-900 dark:text-white">
+      <h3 className="text-lg font-semibold text-zinc-900 dark:text-white">
         Ready to get started?
       </h3>
       <ButtonLink
         href="/contact/sales"
         title="Reach out"
-        variant="primary"
+        variant="contrast"
         size="default"
         onClick={() =>
           sendCustomEvent(

--- a/nx-dev/ui-markdoc/src/lib/tags/metrics.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/metrics.component.tsx
@@ -21,10 +21,10 @@ export function Metrics({
               key={index}
               className="flex flex-col items-center space-y-1 text-center"
             >
-              <div className="text-2xl font-bold text-slate-700 dark:text-slate-200">
+              <div className="text-2xl font-bold text-zinc-700 dark:text-zinc-200">
                 {metric.value}
               </div>
-              <div className="text-sm leading-snug text-slate-500 dark:text-slate-400">
+              <div className="text-sm leading-snug text-zinc-500 dark:text-zinc-400">
                 {metric.label}
               </div>
             </div>
@@ -38,10 +38,10 @@ export function Metrics({
     <div className="not-content space-y-8">
       {metrics.map((metric, index) => (
         <div key={index} className="flex flex-col space-y-2">
-          <div className="text-4xl font-bold text-slate-700 dark:text-slate-200">
+          <div className="text-4xl font-bold text-zinc-700 dark:text-zinc-200">
             {metric.value}
           </div>
-          <div className="text-sm leading-snug text-slate-500 dark:text-slate-400">
+          <div className="text-sm leading-snug text-zinc-500 dark:text-zinc-400">
             {metric.label}
           </div>
         </div>

--- a/nx-dev/ui-markdoc/src/lib/tags/personas.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/personas.component.tsx
@@ -203,7 +203,7 @@ export function Persona({
   const ui = typeMap[type];
 
   return (
-    <section className="not-content relative flex overflow-hidden rounded-md border border-slate-200 bg-slate-50 p-4 transition hover:bg-slate-50/40 dark:border-slate-800/40 dark:bg-slate-800/60 dark:hover:bg-slate-800">
+    <section className="not-content relative flex overflow-hidden rounded-md border border-zinc-200 bg-zinc-50 p-4 transition hover:bg-zinc-50/40 dark:border-zinc-800/40 dark:bg-zinc-800/60 dark:hover:bg-zinc-800">
       <div className="flex-shrink-0">{ui.image}</div>
       <div className="ml-4">
         {title && <h5 className="mt-0 text-base font-medium">{title}</h5>}

--- a/nx-dev/ui-markdoc/src/lib/tags/pill.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/pill.component.tsx
@@ -8,7 +8,7 @@ export type PillProps = {
 
 export function Pill({ url, children, ...rest }: PillProps): JSX.Element {
   return (
-    <span className="not-content group relative mb-2 mr-2 inline-flex rounded-md border border-slate-200 bg-slate-50/40 text-sm shadow-sm transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-slate-50 dark:border-slate-800/40 dark:bg-slate-800/60 dark:hover:bg-slate-800">
+    <span className="not-content group relative mb-2 mr-2 inline-flex rounded-md border border-zinc-200 bg-zinc-50/40 text-sm shadow-sm transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:bg-zinc-50 dark:border-zinc-800/40 dark:bg-zinc-800/60 dark:hover:bg-zinc-800">
       <span className="flex flex-col p-3">
         <Link
           href={url}

--- a/nx-dev/ui-markdoc/src/lib/tags/project-details.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/project-details.component.tsx
@@ -17,7 +17,7 @@ export function Loading() {
   return (
     <div className="flex h-[450px] w-full items-center justify-center">
       <div
-        className="spinner-border inline-block h-8 w-8 animate-spin rounded-full border-4 border-slate-200 border-r-slate-400 dark:border-slate-700 dark:border-r-slate-500"
+        className="spinner-border inline-block h-8 w-8 animate-spin rounded-full border-4 border-zinc-200 border-r-zinc-400 dark:border-zinc-700 dark:border-r-zinc-500"
         role="status"
       >
         <span className="sr-only">Loading...</span>
@@ -115,9 +115,9 @@ export function ProjectDetails({
   }
 
   return parsedProps ? (
-    <div className="not-content w-full place-content-center overflow-hidden rounded-md ring-1 ring-slate-200 dark:ring-slate-700">
+    <div className="not-content w-full place-content-center overflow-hidden rounded-md ring-1 ring-zinc-200 dark:ring-zinc-700">
       {title && (
-        <div className="relative flex justify-center border-b border-slate-200 bg-slate-100/50 p-2 font-bold dark:border-slate-700 dark:bg-slate-700/50">
+        <div className="relative flex justify-center border-b border-zinc-200 bg-zinc-100/50 p-2 font-bold dark:border-zinc-700 dark:bg-zinc-700/50">
           {title}
         </div>
       )}

--- a/nx-dev/ui-markdoc/src/lib/tags/short-embed.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/short-embed.tsx
@@ -102,7 +102,7 @@ export function ShortEmbeds({
           leaveFrom="opacity-100 translate-y-0"
           leaveTo="opacity-0 translate-y-full"
         >
-          <div className="coding relative mt-12 flex h-full w-full flex-col rounded-xl border border-slate-200 bg-slate-50 p-2 leading-normal text-slate-800 subpixel-antialiased shadow-xl dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
+          <div className="coding relative mt-12 flex h-full w-full flex-col rounded-xl border border-zinc-200 bg-zinc-50 p-2 leading-normal text-zinc-800 subpixel-antialiased shadow-xl dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200">
             <Button
               size="small"
               variant="secondary"
@@ -135,7 +135,7 @@ export function ShortEmbeds({
                             setUserInteraction(true);
                             setCurrentVideo(config);
                           }}
-                          className="flex h-24 overflow-hidden rounded-lg border border-slate-200 bg-white/40 text-sm shadow-sm transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:cursor-pointer hover:bg-white dark:border-slate-800/40 dark:bg-slate-800/60 dark:hover:bg-slate-800"
+                          className="flex h-24 overflow-hidden rounded-lg border border-zinc-200 bg-white/40 text-sm shadow-sm transition focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-offset-2 hover:cursor-pointer hover:bg-white dark:border-zinc-800/40 dark:bg-zinc-800/60 dark:hover:bg-zinc-800"
                         >
                           <div className="w-32 shrink-0">
                             <img

--- a/nx-dev/ui-markdoc/src/lib/tags/side-by-side.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/side-by-side.component.tsx
@@ -11,7 +11,7 @@ export function SideBySide({ align, children }: SideBySideProps) {
   return (
     <div
       className={cx(
-        'not-prose grid divide-x divide-solid divide-slate-50 md:grid-cols-2 dark:divide-slate-800',
+        'not-prose grid divide-x divide-solid divide-zinc-50 md:grid-cols-2 dark:divide-zinc-800',
         align === 'top' ? 'items-start' : 'items-center'
       )}
     >

--- a/nx-dev/ui-markdoc/src/lib/tags/stackblitz-button.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/stackblitz-button.component.tsx
@@ -12,9 +12,9 @@ export function StackblitzButton({
   const resolvedUrl = url.replace('https://', '');
 
   return (
-    <div className="not-content not-prose group relative mx-auto my-12 flex w-full max-w-md items-center gap-3 overflow-hidden rounded-lg bg-slate-50 shadow-md transition hover:text-white dark:bg-slate-800/60">
-      <div className="absolute inset-0 z-0 w-2 bg-blue-500 transition-all duration-150 group-hover:w-full dark:bg-sky-500"></div>
-      <div className="w-2 bg-blue-500 dark:bg-sky-500"></div>
+    <div className="not-content not-prose group relative mx-auto my-12 flex w-full max-w-md items-center gap-3 overflow-hidden rounded-lg bg-zinc-50 shadow-md transition hover:text-white dark:bg-zinc-800/60">
+      <div className="absolute inset-0 z-0 w-2 bg-blue-500 transition-all duration-150 group-hover:w-full dark:bg-blue-500"></div>
+      <div className="w-2 bg-blue-500 dark:bg-blue-500"></div>
 
       <div className="z-10 flex flex-grow items-center py-3">
         <svg

--- a/nx-dev/ui-markdoc/src/lib/tags/steps.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/steps.component.tsx
@@ -15,13 +15,13 @@ export function Steps({ children }: StepsProps) {
           {/* Vertical line connecting steps */}
           {index < stepsCount - 1 && (
             <div
-              className="absolute left-5 top-10 h-full w-0.5 bg-slate-200 dark:bg-slate-700"
+              className="absolute left-5 top-10 h-full w-0.5 bg-zinc-200 dark:bg-zinc-700"
               aria-hidden="true"
             />
           )}
 
           {/* Step number circle */}
-          <div className="relative z-10 flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white dark:bg-sky-500">
+          <div className="relative z-10 flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-500 text-white dark:bg-blue-500">
             <span className="text-sm font-semibold">{index + 1}</span>
           </div>
 
@@ -49,9 +49,9 @@ export function Step({ title, children }: StepProps) {
   };
 
   return (
-    <div className="prose prose-slate dark:prose-invert max-w-none">
+    <div className="prose prose-zinc dark:prose-invert max-w-none">
       {title && (
-        <h3 className="mt-0 text-lg font-semibold text-slate-900 dark:text-slate-100">
+        <h3 className="mt-0 text-lg font-semibold text-zinc-900 dark:text-zinc-100">
           {title}
         </h3>
       )}

--- a/nx-dev/ui-markdoc/src/lib/tags/svg-animation.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/svg-animation.component.tsx
@@ -41,12 +41,12 @@ export function SvgAnimation({
   }, [src]);
 
   return (
-    <div className="w-full rounded-md border border-slate-100 bg-slate-50/20 p-4 dark:border-slate-800 dark:bg-slate-800/60">
+    <div className="w-full rounded-md border border-zinc-100 bg-zinc-50/20 p-4 dark:border-zinc-800 dark:bg-zinc-800/60">
       <object
         ref={objectRef}
         type="image/svg+xml"
         title={title}
-        className="rounded-sm bg-white p-2 ring-1 ring-slate-50 dark:bg-slate-800/80 dark:ring-slate-800"
+        className="rounded-sm bg-white p-2 ring-1 ring-zinc-50 dark:bg-zinc-800/80 dark:ring-zinc-800"
       >
         {title}
       </object>

--- a/nx-dev/ui-markdoc/src/lib/tags/table-of-contents.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/table-of-contents.component.tsx
@@ -46,8 +46,8 @@ export function TableOfContents({
   }
 
   return (
-    <nav className="toc not-prose mb-8 rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900/50">
-      <p className="mb-3 text-sm font-semibold text-slate-900 dark:text-slate-100">
+    <nav className="toc not-prose mb-8 rounded-lg border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/50">
+      <p className="mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
         Table of Contents
       </p>
       <ul className="space-y-2 text-sm">
@@ -58,7 +58,7 @@ export function TableOfContents({
           >
             <a
               href={`#${heading.id}`}
-              className="text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200"
+              className="text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-200"
             >
               {heading.text}
             </a>

--- a/nx-dev/ui-markdoc/src/lib/tags/tabs.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/tabs.component.tsx
@@ -66,8 +66,8 @@ export function Tabs({ labels, children }: TabsProps) {
             className={cx(
               'whitespace-nowrap border-b-2 p-2 text-sm font-medium',
               label === currentTab
-                ? 'border-blue-500 text-slate-800 dark:border-sky-500 dark:text-slate-300'
-                : 'border-transparent text-slate-500 hover:border-blue-500 hover:text-slate-800 dark:text-slate-400 dark:hover:border-sky-500 dark:hover:text-slate-300'
+                ? 'border-blue-500 text-zinc-800 dark:border-blue-500 dark:text-zinc-300'
+                : 'border-transparent text-zinc-500 hover:border-blue-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:border-blue-500 dark:hover:text-zinc-300'
             )}
           >
             {label}
@@ -76,7 +76,7 @@ export function Tabs({ labels, children }: TabsProps) {
       </nav>
       <div
         className={cx(
-          'border border-slate-200 pb-2 pl-4 pr-4 pt-2 dark:border-slate-700',
+          'border border-zinc-200 pb-2 pl-4 pr-4 pt-2 dark:border-zinc-700',
           currentTab === labels[0]
             ? 'rounded-b-md rounded-tr-md'
             : 'rounded-b-md rounded-t-md'
@@ -108,7 +108,7 @@ export function Tab({ label, children }: TabProps) {
 
   return (
     <div
-      className="prose prose-slate dark:prose-invert mt-2 max-w-none"
+      className="prose prose-zinc dark:prose-invert mt-2 max-w-none"
       hidden={!isActive}
     >
       {isActive && passPropsToChildren(children)}

--- a/nx-dev/ui-markdoc/src/lib/tags/testimonial.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/testimonial.component.tsx
@@ -35,7 +35,7 @@ export function Testimonial({
     <figure className="not-content not-prose">
       <blockquote className="relative pt-6">
         <svg
-          className="absolute start-0 top-0 size-24 -translate-x-8 -translate-y-4 transform text-slate-200 dark:text-slate-800"
+          className="absolute start-0 top-0 size-24 -translate-x-8 -translate-y-4 transform text-zinc-200 dark:text-zinc-800"
           width="16"
           height="16"
           viewBox="0 0 16 16"
@@ -50,7 +50,7 @@ export function Testimonial({
         </svg>
 
         <div className="relative z-10">
-          <div className="text-xl font-medium italic text-slate-800 md:text-2xl md:leading-normal xl:text-3xl xl:leading-normal dark:text-neutral-200">
+          <div className="text-xl font-medium italic text-zinc-800 md:text-2xl md:leading-normal xl:text-3xl xl:leading-normal dark:text-neutral-200">
             {children}
           </div>
         </div>
@@ -63,7 +63,7 @@ export function Testimonial({
           />
           <div className="flex-auto">
             <div className="text-base font-semibold">{name}</div>
-            <div className="text-xs text-slate-600 dark:text-slate-500">
+            <div className="text-xs text-zinc-600 dark:text-zinc-500">
               {title}
             </div>
           </div>

--- a/nx-dev/ui-markdoc/src/lib/tags/video-link.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/video-link.component.tsx
@@ -37,9 +37,9 @@ export function VideoLink({ text, link }: VideoLinkProps) {
         rel="noopener noreferrer"
         className="flex items-center space-x-2 border-transparent !text-inherit !no-underline dark:text-white"
       >
-        <div className="flex items-center justify-between space-x-2 rounded-md border border-slate-200 py-1 pl-2 pl-3 pr-2 transition hover:border-slate-500 dark:border-slate-700/40 dark:hover:border-slate-700">
+        <div className="flex items-center justify-between space-x-2 rounded-md border border-zinc-200 py-1 pl-2 pl-3 pr-2 transition hover:border-zinc-500 dark:border-zinc-700/40 dark:hover:border-zinc-700">
           {youtubeIcon}
-          <span className="text-md font-semibold hover:text-slate-900 dark:hover:text-sky-400">
+          <span className="text-md font-semibold hover:text-zinc-900 dark:hover:text-blue-400">
             {text || 'Jump to section in video'}
           </span>
         </div>

--- a/nx-dev/ui-markdoc/src/lib/tags/video-player.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/video-player.component.tsx
@@ -60,7 +60,7 @@ export function VideoPlayer({
 }: VideoPlayerProps): JSX.Element {
   return (
     <div className="not-content mb-4 overflow-x-auto">
-      <div className="rounded-lg border border-slate-200 bg-slate-50/50 dark:border-slate-700 dark:bg-slate-800/60">
+      <div className="rounded-lg border border-zinc-200 bg-zinc-50/50 dark:border-zinc-700 dark:bg-zinc-800/60">
         <div
           className={
             showDescription && alt
@@ -89,7 +89,7 @@ export function VideoPlayer({
           )}
         </div>
         {showDescription && alt && (
-          <div className="py-2 text-center text-sm text-slate-600 dark:text-slate-400">
+          <div className="py-2 text-center text-sm text-zinc-600 dark:text-zinc-400">
             {alt}
           </div>
         )}

--- a/nx-dev/ui-partners/src/lib/call-to-action.tsx
+++ b/nx-dev/ui-partners/src/lib/call-to-action.tsx
@@ -33,7 +33,7 @@ export function CallToAction({
         <svg
           x="50%"
           y={0}
-          className="overflow-visible fill-slate-200/20 dark:fill-slate-800/20"
+          className="overflow-visible fill-zinc-200/20 dark:fill-zinc-800/20"
         >
           <path
             d="M-200 0h201v201h-201Z M600 0h201v201h-201Z M-400 600h201v201h-201Z M200 800h201v201h-201Z"
@@ -62,7 +62,7 @@ export function CallToAction({
       <div className="mx-auto max-w-2xl text-center">
         <h2
           id="cta"
-          className="text-3xl font-medium tracking-tight text-slate-950 sm:text-5xl dark:text-white"
+          className="text-3xl font-medium tracking-tight text-zinc-950 sm:text-5xl dark:text-white"
         >
           Become a Partner
         </h2>
@@ -77,7 +77,7 @@ export function CallToAction({
             href={mainActionLink}
             title={mainActionTitle}
             prefetch={false}
-            className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
+            className="rounded-md bg-zinc-950 px-3.5 py-2.5 text-sm font-semibold text-zinc-100 shadow-sm hover:bg-zinc-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-100"
           >
             {mainActionLinkText}
           </Link>
@@ -85,7 +85,7 @@ export function CallToAction({
             href="/contact"
             title="Get in touch"
             prefetch={false}
-            className="group text-sm font-semibold leading-6 text-slate-950 dark:text-white"
+            className="group text-sm font-semibold leading-6 text-zinc-950 dark:text-white"
           >
             Contact us{' '}
             <span

--- a/nx-dev/ui-partners/src/lib/partner-icon-grid.tsx
+++ b/nx-dev/ui-partners/src/lib/partner-icon-grid.tsx
@@ -21,7 +21,7 @@ const PartnerIconGrid: FC<PartnerIconGridProps> = ({ icons }) => {
             href={partnerIcon.url}
             target="_blank"
             rel="noopener noreferrer"
-            className={`flex items-center justify-center border-slate-200/20 p-12 shadow-[0_0px_1px_0_rgba(226,232,240,0.2)] transition hover:bg-slate-100/20 hover:text-slate-950 dark:border-slate-800/20 dark:hover:border-slate-600/20 dark:hover:bg-slate-600/10 dark:hover:text-white`}
+            className={`flex items-center justify-center border-zinc-200/20 p-12 shadow-[0_0px_1px_0_rgba(226,232,240,0.2)] transition hover:bg-zinc-100/20 hover:text-zinc-950 dark:border-zinc-800/20 dark:hover:border-zinc-600/20 dark:hover:bg-zinc-600/10 dark:hover:text-white`}
           >
             <partnerIcon.icon
               aria-hidden="true"

--- a/nx-dev/ui-partners/src/lib/partner.tsx
+++ b/nx-dev/ui-partners/src/lib/partner.tsx
@@ -15,18 +15,18 @@ export const Partner: FC<{
       target="_blank"
       className={
         'group flex flex-col items-center justify-center border shadow-md transition' +
-        ' border-slate-400/50 bg-white hover:border-slate-800/50 hover:bg-slate-200/50 hover:text-slate-950' +
-        ' dark:border-slate-400/20 dark:bg-slate-950 dark:hover:border-slate-100/20 dark:hover:bg-slate-950/50 dark:hover:text-white'
+        ' border-zinc-400/50 bg-white hover:border-zinc-800/50 hover:bg-zinc-200/50 hover:text-zinc-950' +
+        ' dark:border-zinc-400/20 dark:bg-zinc-950 dark:hover:border-zinc-100/20 dark:hover:bg-zinc-950/50 dark:hover:text-white'
       }
     >
-      <div className="flex h-[130px] w-full items-center justify-center border-b border-slate-400/20 bg-white p-12 pb-4 pt-8 group-hover:bg-white/20 dark:bg-slate-200 dark:group-hover:bg-slate-50">
+      <div className="flex h-[130px] w-full items-center justify-center border-b border-zinc-400/20 bg-white p-12 pb-4 pt-8 group-hover:bg-white/20 dark:bg-zinc-200 dark:group-hover:bg-zinc-50">
         {logo}
       </div>
       <div className="flex-grow p-8">
         <div className="mb-4">
           <strong>{name}</strong>
-          <p className="block min-h-14 text-sm text-slate-500">{tagline}</p>
-          <div className="my-2 text-sm text-slate-500">({location})</div>
+          <p className="block min-h-14 text-sm text-zinc-500">{tagline}</p>
+          <div className="my-2 text-sm text-zinc-500">({location})</div>
         </div>
         <div>
           {capabilities.map((capability) => (

--- a/nx-dev/ui-partners/src/lib/partners-list.tsx
+++ b/nx-dev/ui-partners/src/lib/partners-list.tsx
@@ -126,7 +126,7 @@ export function PartnersList(): JSX.Element {
 
   return (
     <section>
-      <div className="col-span-2 border-y border-slate-200 bg-slate-50 px-6 py-8 md:col-span-4 lg:py-16 dark:border-slate-800 dark:bg-slate-900">
+      <div className="col-span-2 border-y border-zinc-200 bg-zinc-50 px-6 py-8 md:col-span-4 lg:py-16 dark:border-zinc-800 dark:bg-zinc-900">
         <div className="mx-auto max-w-7xl text-center">
           <dl className="grid grid-cols-1 justify-between gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
             {partners.map((partner) => (

--- a/nx-dev/ui-podcast/src/lib/hero.tsx
+++ b/nx-dev/ui-podcast/src/lib/hero.tsx
@@ -15,7 +15,7 @@ export function Hero(): JSX.Element {
               architects of enterprise software.
             </SectionHeading>
             <div className="flex flex-col gap-3 text-lg">
-              <p className="font-medium text-slate-950 dark:text-white">
+              <p className="font-medium text-zinc-950 dark:text-white">
                 Available On:{' '}
               </p>
               <ListenOn />
@@ -24,7 +24,7 @@ export function Hero(): JSX.Element {
         </div>
         <div className="hidden lg:col-span-3 lg:col-start-10 lg:block">
           <img
-            className="aspect[1/1] rounded-lg border-8 border-slate-800/50 object-cover dark:border-white"
+            className="aspect[1/1] rounded-lg border-8 border-zinc-800/50 object-cover dark:border-white"
             src="/images/podcast/podcast-hero.avif"
             alt="Illustration of a microphone"
           />

--- a/nx-dev/ui-podcast/src/lib/listen-on.tsx
+++ b/nx-dev/ui-podcast/src/lib/listen-on.tsx
@@ -35,7 +35,7 @@ export function ListenOn(): JSX.Element {
         return (
           <li
             key={platform.name}
-            className="inline-block cursor-pointer place-items-center rounded-2xl border border-slate-100 bg-white p-4 text-slate-600 transition-all hover:scale-[1.02] hover:text-slate-950 dark:border-slate-800/60 dark:bg-slate-950 dark:text-slate-400 dark:hover:text-white"
+            className="inline-block cursor-pointer place-items-center rounded-2xl border border-zinc-100 bg-white p-4 text-zinc-600 transition-all hover:scale-[1.02] hover:text-zinc-950 dark:border-zinc-800/60 dark:bg-zinc-950 dark:text-zinc-400 dark:hover:text-white"
           >
             <a
               href={platform.url}

--- a/nx-dev/ui-podcast/src/lib/podcast-list-item.tsx
+++ b/nx-dev/ui-podcast/src/lib/podcast-list-item.tsx
@@ -16,10 +16,10 @@ export function PodcastListItem({ podcast, episode }: PodcastListItemProps) {
     <Link
       href={`/blog/${podcast.slug}`}
       key={podcast.slug}
-      className="relative flex items-center gap-6 border-b border-slate-200 py-5 text-sm before:absolute before:inset-x-[-16px] before:inset-y-[-2px] before:z-[-1] before:rounded-xl before:bg-slate-200 before:opacity-0 last:border-0 before:hover:opacity-100 dark:border-slate-800 dark:before:bg-slate-800/50"
+      className="relative flex items-center gap-6 border-b border-zinc-200 py-5 text-sm before:absolute before:inset-x-[-16px] before:inset-y-[-2px] before:z-[-1] before:rounded-xl before:bg-zinc-200 before:opacity-0 last:border-0 before:hover:opacity-100 dark:border-zinc-800 dark:before:bg-zinc-800/50"
       prefetch={false}
     >
-      <span className="w-1/2 flex-none text-balance text-slate-500 sm:w-8/12 dark:text-white">
+      <span className="w-1/2 flex-none text-balance text-zinc-500 sm:w-8/12 dark:text-white">
         {podcast.title}
       </span>
       <span className="hidden w-2/12 flex-none sm:inline-block">

--- a/nx-dev/ui-podcast/src/lib/podcast-list.tsx
+++ b/nx-dev/ui-podcast/src/lib/podcast-list.tsx
@@ -8,13 +8,13 @@ export interface PodcastListProps {
 export function PodcastList({ podcasts }: PodcastListProps): JSX.Element {
   return podcasts.length < 1 ? (
     <div>
-      <h2 className="mt-32 text-center text-xl font-semibold text-slate-500 sm:text-2xl xl:mb-24 dark:text-white">
+      <h2 className="mt-32 text-center text-xl font-semibold text-zinc-500 sm:text-2xl xl:mb-24 dark:text-white">
         No podcasts as yet but stay tuned!
       </h2>
     </div>
   ) : (
     <div className="mx-auto max-w-7xl px-8">
-      <div className="mb-8 mt-20 border-b-2 border-slate-300 pb-3 text-sm dark:border-slate-700">
+      <div className="mb-8 mt-20 border-b-2 border-zinc-300 pb-3 text-sm dark:border-zinc-700">
         <h2 className="font-semibold">Podcasts</h2>
       </div>
       <div>

--- a/nx-dev/ui-powerpack/src/lib/call-to-action.tsx
+++ b/nx-dev/ui-powerpack/src/lib/call-to-action.tsx
@@ -25,7 +25,7 @@ export function CallToAction(): ReactElement {
         <svg
           x="50%"
           y={0}
-          className="overflow-visible fill-slate-200/20 dark:fill-slate-800/20"
+          className="overflow-visible fill-zinc-200/20 dark:fill-zinc-800/20"
         >
           <path
             d="M-200 0h201v201h-201Z M600 0h201v201h-201Z M-400 600h201v201h-201Z M200 800h201v201h-201Z"
@@ -54,7 +54,7 @@ export function CallToAction(): ReactElement {
       <div className="mx-auto max-w-2xl text-center">
         <h2
           id="cta"
-          className="text-3xl font-medium tracking-tight text-slate-950 sm:text-5xl dark:text-white"
+          className="text-3xl font-medium tracking-tight text-zinc-950 sm:text-5xl dark:text-white"
         >
           Ready to enhance your CLI?
         </h2>
@@ -63,7 +63,7 @@ export function CallToAction(): ReactElement {
             href="/contact/sales"
             title="Get in touch"
             prefetch={false}
-            className="group text-sm font-semibold leading-6 text-slate-950 dark:text-white"
+            className="group text-sm font-semibold leading-6 text-zinc-950 dark:text-white"
             onClick={() =>
               sendCustomEvent(
                 'contact-sales-click',

--- a/nx-dev/ui-powerpack/src/lib/get-started.tsx
+++ b/nx-dev/ui-powerpack/src/lib/get-started.tsx
@@ -36,7 +36,7 @@ export function GetStarted(): ReactElement {
                   y={0}
                   width={4}
                   height={4}
-                  className="text-slate-100 dark:text-slate-800/60"
+                  className="text-zinc-100 dark:text-zinc-800/60"
                   fill="currentColor"
                 />
               </pattern>
@@ -69,7 +69,7 @@ export function GetStarted(): ReactElement {
                   y={0}
                   width={4}
                   height={4}
-                  className="text-slate-100 dark:text-slate-800/60"
+                  className="text-zinc-100 dark:text-zinc-800/60"
                   fill="currentColor"
                 />
               </pattern>
@@ -82,13 +82,13 @@ export function GetStarted(): ReactElement {
           </svg>
           <div className="space-y-6 lg:space-y-12">
             <div className="flex flex-col items-center lg:flex-row lg:items-start lg:gap-6">
-              <div className="mb-4 flex size-10 place-items-center rounded-full p-4 shadow-sm ring-1 ring-slate-200 lg:mb-0 dark:ring-slate-800/60">
-                <span className="text-lg text-slate-900 dark:text-slate-100">
+              <div className="mb-4 flex size-10 place-items-center rounded-full p-4 shadow-sm ring-1 ring-zinc-200 lg:mb-0 dark:ring-zinc-800/60">
+                <span className="text-lg text-zinc-900 dark:text-zinc-100">
                   1
                 </span>
               </div>
               <div className="text-center lg:text-left">
-                <h4 className="relative text-base font-medium leading-6 text-slate-900 dark:text-slate-100">
+                <h4 className="relative text-base font-medium leading-6 text-zinc-900 dark:text-zinc-100">
                   Receive an Nx Powerpack license
                 </h4>
                 <p className="mt-2">
@@ -99,13 +99,13 @@ export function GetStarted(): ReactElement {
             </div>
 
             <div className="flex flex-col items-center lg:flex-row lg:items-start lg:gap-6">
-              <div className="mb-4 flex size-10 place-items-center rounded-full p-4 shadow-sm ring-1 ring-slate-200 lg:mb-0 dark:ring-slate-800/60">
-                <span className="text-lg text-slate-900 dark:text-slate-100">
+              <div className="mb-4 flex size-10 place-items-center rounded-full p-4 shadow-sm ring-1 ring-zinc-200 lg:mb-0 dark:ring-zinc-800/60">
+                <span className="text-lg text-zinc-900 dark:text-zinc-100">
                   2
                 </span>
               </div>
               <div className="text-center lg:text-left">
-                <h4 className="relative text-base font-medium leading-6 text-slate-900 dark:text-slate-100">
+                <h4 className="relative text-base font-medium leading-6 text-zinc-900 dark:text-zinc-100">
                   Activate Nx Powerpack right from your terminal
                 </h4>
                 <p className="mt-2">
@@ -124,13 +124,13 @@ export function GetStarted(): ReactElement {
             </div>
 
             <div className="flex flex-col items-center lg:flex-row lg:items-start lg:gap-6">
-              <div className="mb-4 flex size-10 place-items-center rounded-full p-4 shadow-sm ring-1 ring-slate-200 lg:mb-0 dark:ring-slate-800/60">
-                <span className="text-lg text-slate-900 dark:text-slate-100">
+              <div className="mb-4 flex size-10 place-items-center rounded-full p-4 shadow-sm ring-1 ring-zinc-200 lg:mb-0 dark:ring-zinc-800/60">
+                <span className="text-lg text-zinc-900 dark:text-zinc-100">
                   3
                 </span>
               </div>
               <div className="text-center lg:text-left">
-                <h4 className="relative text-base font-medium leading-6 text-slate-900 dark:text-slate-100">
+                <h4 className="relative text-base font-medium leading-6 text-zinc-900 dark:text-zinc-100">
                   Install Powerpack plugins
                 </h4>
                 <p className="mt-2">

--- a/nx-dev/ui-powerpack/src/lib/hero.tsx
+++ b/nx-dev/ui-powerpack/src/lib/hero.tsx
@@ -62,7 +62,7 @@ export function Hero(): ReactElement {
           <div className="fixed inset-0 bg-black/25 backdrop-blur-sm" />
           <div className="fixed inset-0 overflow-y-auto">
             <div className="flex min-h-full items-center justify-center p-4 text-center">
-              <DialogPanel className="relative w-auto transform overflow-hidden rounded-2xl border border-slate-950 bg-slate-950 text-left align-middle shadow-xl transition-all focus:outline-none">
+              <DialogPanel className="relative w-auto transform overflow-hidden rounded-2xl border border-zinc-950 bg-zinc-950 text-left align-middle shadow-xl transition-all focus:outline-none">
                 <iframe
                   width="812"
                   height="456"

--- a/nx-dev/ui-powerpack/src/lib/powerpack-features.tsx
+++ b/nx-dev/ui-powerpack/src/lib/powerpack-features.tsx
@@ -36,8 +36,8 @@ export function PowerpackFeatures(): ReactElement {
     <section className="relative isolate">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="relative flex justify-center">
-          <div className="pointer-events-auto w-fit justify-between gap-x-6 bg-slate-950 px-6 py-2.5 sm:rounded-xl sm:py-3 sm:pl-4 sm:pr-3.5 dark:bg-white">
-            <p className="text-sm/6 text-white dark:text-slate-950">
+          <div className="pointer-events-auto w-fit justify-between gap-x-6 bg-zinc-950 px-6 py-2.5 sm:rounded-xl sm:py-3 sm:pl-4 sm:pr-3.5 dark:bg-white">
+            <p className="text-sm/6 text-white dark:text-zinc-950">
               <strong className="font-semibold">
                 Looking for self-hosted caching?
               </strong>
@@ -52,7 +52,7 @@ export function PowerpackFeatures(): ReactElement {
               <Link
                 href="/remote-cache"
                 title="Self-hosted cache storage"
-                className="text-white dark:text-slate-950"
+                className="text-white dark:text-zinc-950"
               >
                 <span className="absolute inset-0" />
                 <span aria-hidden="true">&rarr;</span>
@@ -61,7 +61,7 @@ export function PowerpackFeatures(): ReactElement {
           </div>
         </div>
         <div className="mt-32 grid grid-cols-1 gap-8 lg:grid-cols-2">
-          {/*<div className="flex max-w-full flex-col gap-16 bg-white/50 px-6 py-16 ring-1 ring-slate-200 sm:rounded-3xl sm:p-8 md:col-span-full lg:mx-0 lg:max-w-full lg:flex-row lg:items-center lg:py-16 xl:px-16 dark:bg-white/5 dark:ring-white/10">
+          {/*<div className="flex max-w-full flex-col gap-16 bg-white/50 px-6 py-16 ring-1 ring-zinc-200 sm:rounded-3xl sm:p-8 md:col-span-full lg:mx-0 lg:max-w-full lg:flex-row lg:items-center lg:py-16 xl:px-16 dark:bg-white/5 dark:ring-white/10">
             <div className="xl:max-w-xl">
               <SectionHeading
                 as="h2"
@@ -101,7 +101,7 @@ export function PowerpackFeatures(): ReactElement {
             </div>
           </div>*/}
 
-          <div className="flex flex-col gap-16 bg-white/50 px-6 py-16 ring-1 ring-slate-200 sm:rounded-3xl sm:p-8 lg:mx-0 lg:max-w-none lg:justify-between lg:py-16 xl:px-16 dark:bg-white/5 dark:ring-white/10">
+          <div className="flex flex-col gap-16 bg-white/50 px-6 py-16 ring-1 ring-zinc-200 sm:rounded-3xl sm:p-8 lg:mx-0 lg:max-w-none lg:justify-between lg:py-16 xl:px-16 dark:bg-white/5 dark:ring-white/10">
             <div className="max-w-2xl">
               <SectionHeading
                 as="h2"
@@ -137,7 +137,7 @@ export function PowerpackFeatures(): ReactElement {
               </ButtonLink>
             </div>
           </div>
-          <div className="flex flex-col gap-16 bg-white/50 px-6 py-16 ring-1 ring-slate-200 sm:rounded-3xl sm:p-8 lg:mx-0 lg:max-w-none lg:justify-between lg:py-16 xl:px-16 dark:bg-white/5 dark:ring-white/10">
+          <div className="flex flex-col gap-16 bg-white/50 px-6 py-16 ring-1 ring-zinc-200 sm:rounded-3xl sm:p-8 lg:mx-0 lg:max-w-none lg:justify-between lg:py-16 xl:px-16 dark:bg-white/5 dark:ring-white/10">
             <div className="max-w-2xl">
               <SectionHeading
                 as="h2"
@@ -177,7 +177,7 @@ export function PowerpackFeatures(): ReactElement {
               </ButtonLink>
             </div>
           </div>
-          <div className="flex max-w-full flex-col gap-16 bg-slate-50/80 px-6 py-16 ring-1 ring-slate-200 sm:rounded-3xl sm:p-8 lg:col-span-2 lg:mx-0 lg:max-w-full lg:flex-row lg:items-center lg:py-16 xl:px-16 dark:bg-white/15 dark:ring-white/10">
+          <div className="flex max-w-full flex-col gap-16 bg-zinc-50/80 px-6 py-16 ring-1 ring-zinc-200 sm:rounded-3xl sm:p-8 lg:col-span-2 lg:mx-0 lg:max-w-full lg:flex-row lg:items-center lg:py-16 xl:px-16 dark:bg-white/15 dark:ring-white/10">
             <div className="relative hidden h-full w-64 shrink-0 overflow-hidden lg:block">
               <img
                 src="/images/powerpack/trust-secure-light.avif"
@@ -219,7 +219,7 @@ export function PowerpackFeatures(): ReactElement {
               </div>
             </div>
           </div>
-          <div className="flex flex-col gap-16 bg-slate-50/80 px-6 py-16 ring-1 ring-slate-200 sm:rounded-3xl sm:p-8 lg:mx-0 lg:max-w-none lg:justify-between lg:py-16 xl:px-16 dark:bg-white/15 dark:ring-white/10">
+          <div className="flex flex-col gap-16 bg-zinc-50/80 px-6 py-16 ring-1 ring-zinc-200 sm:rounded-3xl sm:p-8 lg:mx-0 lg:max-w-none lg:justify-between lg:py-16 xl:px-16 dark:bg-white/15 dark:ring-white/10">
             <div className="max-w-2xl">
               <SectionHeading
                 as="h2"
@@ -240,7 +240,7 @@ export function PowerpackFeatures(): ReactElement {
               </p>
             </div>
           </div>
-          <div className="flex flex-col gap-16 bg-slate-50/80 px-6 py-16 ring-1 ring-slate-200 sm:rounded-3xl sm:p-8 lg:mx-0 lg:max-w-none lg:justify-between lg:py-16 xl:px-16 dark:bg-white/15 dark:ring-white/10">
+          <div className="flex flex-col gap-16 bg-zinc-50/80 px-6 py-16 ring-1 ring-zinc-200 sm:rounded-3xl sm:p-8 lg:mx-0 lg:max-w-none lg:justify-between lg:py-16 xl:px-16 dark:bg-white/15 dark:ring-white/10">
             <div className="max-w-2xl">
               <SectionHeading
                 as="h2"
@@ -296,7 +296,7 @@ const Card = forwardRef<
     <div
       ref={ref}
       className={cx(
-        'z-10 flex items-center gap-2 rounded-md border border-slate-200 bg-white p-2 py-2 shadow-sm dark:border-white/10 dark:bg-slate-950',
+        'z-10 flex items-center gap-2 rounded-md border border-zinc-200 bg-white p-2 py-2 shadow-sm dark:border-white/10 dark:bg-zinc-950',
         className
       )}
       onMouseEnter={onMouseEnter}
@@ -415,15 +415,15 @@ export function CustomRemoteCacheAnimation(): ReactElement {
         <div className="flex w-full justify-center">
           <Card
             ref={nxRef}
-            className="size-18 relative p-3 transition hover:bg-slate-50 dark:hover:bg-slate-800"
+            className="size-18 relative p-3 transition hover:bg-zinc-50 dark:hover:bg-zinc-800"
           >
             <NxIcon
               aria-hidden="true"
-              className="size-10 text-slate-900 dark:text-white"
+              className="size-10 text-zinc-900 dark:text-white"
             />
             <CircleStackIcon
               aria-hidden="true"
-              className="absolute bottom-1 right-1 size-4 text-slate-900 dark:text-white"
+              className="absolute bottom-1 right-1 size-4 text-zinc-900 dark:text-white"
             />
           </Card>
         </div>
@@ -439,15 +439,15 @@ export function CustomRemoteCacheAnimation(): ReactElement {
               setSelected(null);
             }}
             className={cx(
-              'relative transition hover:bg-slate-50 dark:hover:bg-slate-800',
-              { 'bg-slate-50 dark:bg-slate-800': selected === 'aws' }
+              'relative transition hover:bg-zinc-50 dark:hover:bg-zinc-800',
+              { 'bg-zinc-50 dark:bg-zinc-800': selected === 'aws' }
             )}
           >
             <AmazonS3Icon aria-hidden="true" className="size-4" />
             <Link
               href="/nx-api/powerpack-s3-cache"
               title="Learn how to configure Amazon S3 caching"
-              className="text-center text-xs text-slate-900 dark:text-white"
+              className="text-center text-xs text-zinc-900 dark:text-white"
             >
               <span className="absolute inset-0" />
               Amazon S3
@@ -464,15 +464,15 @@ export function CustomRemoteCacheAnimation(): ReactElement {
               setSelected(null);
             }}
             className={cx(
-              'relative transition hover:bg-slate-50 dark:hover:bg-slate-800',
-              { 'bg-slate-50 dark:bg-slate-800': selected === 'minio' }
+              'relative transition hover:bg-zinc-50 dark:hover:bg-zinc-800',
+              { 'bg-zinc-50 dark:bg-zinc-800': selected === 'minio' }
             )}
           >
             <MinIOIcon aria-hidden="true" className="size-4" />
             <Link
               href="/nx-api/powerpack-s3-cache"
               title="Learn how to configure Amazon S3 caching"
-              className="text-center text-xs text-slate-900 dark:text-white"
+              className="text-center text-xs text-zinc-900 dark:text-white"
             >
               <span className="absolute inset-0" />
               MinIO
@@ -489,8 +489,8 @@ export function CustomRemoteCacheAnimation(): ReactElement {
               setSelected(null);
             }}
             className={cx(
-              'relative transition hover:bg-slate-50 dark:hover:bg-slate-800',
-              { 'bg-slate-50 dark:bg-slate-800': selected === 'networkDrive' }
+              'relative transition hover:bg-zinc-50 dark:hover:bg-zinc-800',
+              { 'bg-zinc-50 dark:bg-zinc-800': selected === 'networkDrive' }
             )}
           >
             <ServerIcon aria-hidden="true" className="size-4" />
@@ -498,7 +498,7 @@ export function CustomRemoteCacheAnimation(): ReactElement {
             <Link
               href="/nx-api/powerpack-shared-fs-cache"
               title="Learn how to configure network drive caching"
-              className="text-center text-xs text-slate-900 dark:text-white"
+              className="text-center text-xs text-zinc-900 dark:text-white"
             >
               <span className="absolute inset-0" />
               Network Drive
@@ -515,8 +515,8 @@ export function CustomRemoteCacheAnimation(): ReactElement {
               setSelected(null);
             }}
             className={cx(
-              'relative transition hover:bg-slate-50 dark:hover:bg-slate-800',
-              { 'bg-slate-50 dark:bg-slate-800': selected === 'gcp' }
+              'relative transition hover:bg-zinc-50 dark:hover:bg-zinc-800',
+              { 'bg-zinc-50 dark:bg-zinc-800': selected === 'gcp' }
             )}
           >
             <GoogleCloudIcon aria-hidden="true" className="size-4" />
@@ -524,7 +524,7 @@ export function CustomRemoteCacheAnimation(): ReactElement {
             <Link
               href="/nx-api/powerpack-gcs-cache"
               title="Learn how to configure Google Storage caching"
-              className="text-center text-xs text-slate-900 dark:text-white"
+              className="text-center text-xs text-zinc-900 dark:text-white"
             >
               <span className="absolute inset-0" />
               GCP
@@ -541,8 +541,8 @@ export function CustomRemoteCacheAnimation(): ReactElement {
               setSelected(null);
             }}
             className={cx(
-              'relative transition hover:bg-slate-50 dark:hover:bg-slate-800',
-              { 'bg-slate-50 dark:bg-slate-800': selected === 'azure' }
+              'relative transition hover:bg-zinc-50 dark:hover:bg-zinc-800',
+              { 'bg-zinc-50 dark:bg-zinc-800': selected === 'azure' }
             )}
           >
             <AzureDevOpsIcon aria-hidden="true" className="size-4" />
@@ -550,7 +550,7 @@ export function CustomRemoteCacheAnimation(): ReactElement {
             <Link
               href="/nx-api/powerpack-azure-cache"
               title="Learn how to configure Azure Blob Storage caching"
-              className="text-center text-xs text-slate-900 dark:text-white"
+              className="text-center text-xs text-zinc-900 dark:text-white"
             >
               <span className="absolute inset-0" />
               Azure

--- a/nx-dev/ui-powerpack/src/lib/powerpack-pricing.tsx
+++ b/nx-dev/ui-powerpack/src/lib/powerpack-pricing.tsx
@@ -5,12 +5,12 @@ import { ButtonLink } from '@nx/nx-dev-ui-common';
 export function PowerpackPricing() {
   return (
     <aside>
-      {/*<h4 className="text-lg font-medium leading-6 text-slate-900 dark:text-slate-100">*/}
+      {/*<h4 className="text-lg font-medium leading-6 text-zinc-900 dark:text-zinc-100">*/}
       {/*  Nx Powerpack license subscription*/}
       {/*</h4>*/}
 
       <div className="flex flex-col gap-2">
-        <div className="group relative flex w-full items-center justify-between gap-8 rounded-md border border-slate-200 bg-white px-6 py-4 transition hover:bg-white/90 hover:shadow dark:border-slate-800/60 dark:bg-slate-900/60 dark:hover:bg-slate-900/100">
+        <div className="group relative flex w-full items-center justify-between gap-8 rounded-md border border-zinc-200 bg-white px-6 py-4 transition hover:bg-white/90 hover:shadow dark:border-zinc-800/60 dark:bg-zinc-900/60 dark:hover:bg-zinc-900/100">
           <a
             href="https://cloud.nx.app/powerpack/purchase?utm_source=nx-website&utm_medium=referral&utm_campaign=powerpack-landing-page&utm_content=cta-button&utm_term=purchase-powerpack-annually"
             title="Buy your license"
@@ -19,7 +19,7 @@ export function PowerpackPricing() {
             <span className="absolute inset-0" />
 
             <ArrowRightIcon aria-hidden="true" className="size-4" />
-            <span className="text-sm font-medium leading-none text-slate-900 dark:text-slate-50">
+            <span className="text-sm font-medium leading-none text-zinc-900 dark:text-zinc-50">
               Billed annually
             </span>
             <span className="inline-flex items-center gap-x-1 whitespace-nowrap rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-900 ring-1 ring-inset ring-blue-500/30 dark:bg-blue-400/10 dark:text-blue-400 dark:ring-blue-400/30">
@@ -27,17 +27,17 @@ export function PowerpackPricing() {
             </span>
           </a>
           <p className="text-base">
-            <span className="font-semibold text-slate-950 dark:text-white">
+            <span className="font-semibold text-zinc-950 dark:text-white">
               $250
             </span>
-            <span className="text-xs text-slate-500 dark:text-slate-400">
+            <span className="text-xs text-zinc-500 dark:text-zinc-400">
               /seat
             </span>
           </p>
         </div>
       </div>
       <div className="mt-4 flex flex-col gap-2">
-        <div className="group relative flex w-full items-center justify-between gap-8 rounded-md border border-slate-200 bg-white px-6 py-4 transition hover:bg-white/90 hover:shadow dark:border-slate-800/60 dark:bg-slate-900/60 dark:hover:bg-slate-900/100">
+        <div className="group relative flex w-full items-center justify-between gap-8 rounded-md border border-zinc-200 bg-white px-6 py-4 transition hover:bg-white/90 hover:shadow dark:border-zinc-800/60 dark:bg-zinc-900/60 dark:hover:bg-zinc-900/100">
           <a
             href="https://cloud.nx.app/powerpack/purchase?utm_source=nx-website&utm_medium=referral&utm_campaign=powerpack-landing-page&utm_content=cta-button&utm_term=purchase-powerpack-monthly"
             title="Buy your license"
@@ -45,15 +45,15 @@ export function PowerpackPricing() {
           >
             <span className="absolute inset-0" />
             <ArrowRightIcon aria-hidden="true" className="size-4" />
-            <span className="text-sm font-medium leading-none text-slate-900 dark:text-slate-50">
+            <span className="text-sm font-medium leading-none text-zinc-900 dark:text-zinc-50">
               Billed monthly
             </span>
           </a>
           <p className="text-base">
-            <span className="font-semibold text-slate-950 dark:text-white">
+            <span className="font-semibold text-zinc-950 dark:text-white">
               $26
             </span>
-            <span className="text-xs text-slate-500 dark:text-slate-400">
+            <span className="text-xs text-zinc-500 dark:text-zinc-400">
               /seat
             </span>
           </p>
@@ -63,7 +63,7 @@ export function PowerpackPricing() {
         <ButtonLink
           href="https://cloud.nx.app/powerpack/purchase?utm_source=nx-website&utm_medium=referral&utm_campaign=powerpack-landing-page&utm_content=cta-button&utm_term=buy-powerpack-license"
           title="Talk to the engineering team"
-          variant="primary"
+          variant="contrast"
           size="default"
         >
           Buy your Nx Powerpack license

--- a/nx-dev/ui-pricing/src/lib/credit-pricing.tsx
+++ b/nx-dev/ui-pricing/src/lib/credit-pricing.tsx
@@ -110,14 +110,14 @@ export function CreditPricing(): ReactElement {
             {nonComputeItems.map((project) => (
               <li
                 key={project.name}
-                className="col-span-1 flex overflow-hidden rounded-md border border-slate-200 shadow-sm dark:border-slate-800"
+                className="col-span-1 flex overflow-hidden rounded-md border border-zinc-200 shadow-sm dark:border-zinc-800"
               >
-                <div className="flex flex-1 items-center justify-between bg-white dark:bg-slate-900">
+                <div className="flex flex-1 items-center justify-between bg-white dark:bg-zinc-900">
                   <div className="flex-1 px-4 py-2 text-sm">
-                    <span className="font-medium text-slate-900 dark:text-slate-100">
+                    <span className="font-medium text-zinc-900 dark:text-zinc-100">
                       {project.name}
                     </span>
-                    <p className="text-xs text-slate-500">
+                    <p className="text-xs text-zinc-500">
                       {project.description}
                     </p>
                   </div>
@@ -146,17 +146,17 @@ export function CreditPricing(): ReactElement {
             {linuxAmd64.map((project) => (
               <li
                 key={project.name}
-                className="col-span-1 flex overflow-hidden rounded-md border border-slate-200 shadow-sm dark:border-slate-800"
+                className="col-span-1 flex overflow-hidden rounded-md border border-zinc-200 shadow-sm dark:border-zinc-800"
               >
-                <div className="flex w-16 shrink-0 items-center justify-center border-r border-slate-200 bg-slate-50 text-sm font-medium dark:border-slate-800 dark:bg-slate-800">
+                <div className="flex w-16 shrink-0 items-center justify-center border-r border-zinc-200 bg-zinc-50 text-sm font-medium dark:border-zinc-800 dark:bg-zinc-800">
                   {project.icon}
                 </div>
-                <div className="flex flex-1 items-center justify-between truncate bg-white dark:bg-slate-900">
+                <div className="flex flex-1 items-center justify-between truncate bg-white dark:bg-zinc-900">
                   <div className="flex-1 truncate px-4 py-2 text-sm">
-                    <span className="font-medium text-slate-900 dark:text-slate-100">
+                    <span className="font-medium text-zinc-900 dark:text-zinc-100">
                       {project.name}
                     </span>
-                    <p className="text-xs text-slate-500">
+                    <p className="text-xs text-zinc-500">
                       {project.description}
                     </p>
                   </div>
@@ -183,17 +183,17 @@ export function CreditPricing(): ReactElement {
             {linuxArm64.map((project) => (
               <li
                 key={project.name}
-                className="col-span-1 flex overflow-hidden rounded-md border border-slate-200 shadow-sm dark:border-slate-800"
+                className="col-span-1 flex overflow-hidden rounded-md border border-zinc-200 shadow-sm dark:border-zinc-800"
               >
-                <div className="flex w-16 shrink-0 items-center justify-center border-r border-slate-200 bg-slate-50 text-sm font-medium dark:border-slate-800 dark:bg-slate-800">
+                <div className="flex w-16 shrink-0 items-center justify-center border-r border-zinc-200 bg-zinc-50 text-sm font-medium dark:border-zinc-800 dark:bg-zinc-800">
                   {project.icon}
                 </div>
-                <div className="flex flex-1 items-center justify-between truncate bg-white dark:bg-slate-900">
+                <div className="flex flex-1 items-center justify-between truncate bg-white dark:bg-zinc-900">
                   <div className="flex-1 truncate px-4 py-2 text-sm">
-                    <span className="font-medium text-slate-900 dark:text-slate-100">
+                    <span className="font-medium text-zinc-900 dark:text-zinc-100">
                       {project.name}
                     </span>
-                    <p className="text-xs text-slate-500">
+                    <p className="text-xs text-zinc-500">
                       {project.description}
                     </p>
                   </div>
@@ -215,17 +215,17 @@ export function CreditPricing(): ReactElement {
             {windows.map((project) => (
               <li
                 key={project.name}
-                className="col-span-1 flex overflow-hidden rounded-md border border-slate-200 shadow-sm dark:border-slate-800"
+                className="col-span-1 flex overflow-hidden rounded-md border border-zinc-200 shadow-sm dark:border-zinc-800"
               >
-                <div className="flex w-16 shrink-0 items-center justify-center border-r border-slate-200 bg-slate-50 text-sm font-medium dark:border-slate-800 dark:bg-slate-800">
+                <div className="flex w-16 shrink-0 items-center justify-center border-r border-zinc-200 bg-zinc-50 text-sm font-medium dark:border-zinc-800 dark:bg-zinc-800">
                   {project.icon}
                 </div>
-                <div className="flex flex-1 items-center justify-between truncate bg-white dark:bg-slate-900">
+                <div className="flex flex-1 items-center justify-between truncate bg-white dark:bg-zinc-900">
                   <div className="flex-1 truncate px-4 py-2 text-sm">
-                    <span className="font-medium text-slate-900 dark:text-slate-100">
+                    <span className="font-medium text-zinc-900 dark:text-zinc-100">
                       {project.name}
                     </span>
-                    <p className="text-xs text-slate-500">
+                    <p className="text-xs text-zinc-500">
                       {project.description}
                     </p>
                   </div>

--- a/nx-dev/ui-pricing/src/lib/faq.tsx
+++ b/nx-dev/ui-pricing/src/lib/faq.tsx
@@ -127,7 +127,7 @@ export function Faq(): ReactElement {
               Check out our most commonly asked questions.
             </SectionHeading>
 
-            <p className="text-md mt-4 text-slate-400 dark:text-slate-600">
+            <p className="text-md mt-4 text-zinc-400 dark:text-zinc-600">
               <Link
                 href="/contact/sales"
                 title="Reach out to the team"
@@ -152,14 +152,14 @@ export function Faq(): ReactElement {
             }))}
           />
           <div className="mt-12 lg:col-span-2 lg:mt-0">
-            <dl className="mt-6 space-y-6 divide-y divide-slate-100 dark:divide-slate-800">
+            <dl className="mt-6 space-y-6 divide-y divide-zinc-100 dark:divide-zinc-800">
               {faqs.map((faq) => (
                 <Disclosure as="div" key={faq.question} className="pt-6">
                   {({ open }) => (
                     <>
                       <dt className="text-lg">
-                        <DisclosureButton className="flex w-full items-start justify-between text-left text-slate-400">
-                          <span className="font-medium text-slate-800 dark:text-slate-300">
+                        <DisclosureButton className="flex w-full items-start justify-between text-left text-zinc-400">
+                          <span className="font-medium text-zinc-800 dark:text-zinc-300">
                             {faq.question}
                           </span>
                           <span className="ml-6 flex h-7 items-center">
@@ -182,7 +182,7 @@ export function Faq(): ReactElement {
                         leaveTo="transform -translate-y-6 opacity-0"
                       >
                         <DisclosurePanel as="dd" className="mt-2 pr-12">
-                          <p className="text-base text-slate-500 dark:text-slate-400">
+                          <p className="text-base text-zinc-500 dark:text-zinc-400">
                             {faq.answer}
                           </p>
                         </DisclosurePanel>

--- a/nx-dev/ui-pricing/src/lib/oss.tsx
+++ b/nx-dev/ui-pricing/src/lib/oss.tsx
@@ -4,7 +4,7 @@ import { ReactElement } from 'react';
 export function Oss(): ReactElement {
   return (
     <section id="oss" className="isolate">
-      <div className="mx-auto max-w-4xl bg-slate-50/80 px-6 py-16 ring-1 ring-slate-200 sm:rounded-3xl sm:p-8 lg:py-16 xl:px-16 dark:bg-slate-800/60 dark:ring-white/10">
+      <div className="mx-auto max-w-4xl bg-zinc-50/80 px-6 py-16 ring-1 ring-zinc-200 sm:rounded-3xl sm:p-8 lg:py-16 xl:px-16 dark:bg-zinc-800/60 dark:ring-white/10">
         <div className="mx-auto max-w-2xl text-center">
           <SectionHeading as="h2" variant="title">
             Open Source maintainers <br /> and authors?

--- a/nx-dev/ui-pricing/src/lib/plans-display.tsx
+++ b/nx-dev/ui-pricing/src/lib/plans-display.tsx
@@ -33,9 +33,9 @@ export function PlansDisplay(): ReactElement {
           <div className="isolate -mt-16 grid max-w-full grid-cols-1 gap-6 sm:mx-auto lg:mt-0 lg:grid-cols-3 xl:-mx-4 xl:gap-8">
             {/*HOBBY*/}
             <div>
-              <div className="rounded-lg border-2 border-blue-500 bg-white p-6 dark:border-sky-500 dark:bg-slate-950">
+              <div className="rounded-lg border-2 border-blue-500 bg-white p-6 dark:border-blue-500 dark:bg-zinc-950">
                 <div className="flex items-center gap-x-2">
-                  <h4 className="text-xl font-semibold leading-8 text-slate-950 dark:text-white">
+                  <h4 className="text-xl font-semibold leading-8 text-zinc-950 dark:text-white">
                     Hobby
                   </h4>
                   <span className="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10 dark:bg-blue-400/10 dark:text-blue-400 dark:ring-blue-400/30">
@@ -47,7 +47,7 @@ export function PlansDisplay(): ReactElement {
                   product. No credit card required.
                 </p>
                 <p className="mt-4 pb-5 leading-5">
-                  <span className="text-3xl font-semibold text-slate-950 dark:text-white">
+                  <span className="text-3xl font-semibold text-zinc-950 dark:text-white">
                     $0
                   </span>
                 </p>
@@ -57,7 +57,7 @@ export function PlansDisplay(): ReactElement {
                     aria-describedby="hobby-plan"
                     title="Start now"
                     size="default"
-                    variant="primary"
+                    variant="contrast"
                     onClick={() =>
                       sendCustomEvent(
                         'start-hobby-plan-click',
@@ -70,21 +70,21 @@ export function PlansDisplay(): ReactElement {
                     Start now
                   </ButtonLink>
                 </div>
-                <ul className="mt-4 divide-y divide-slate-200 text-sm dark:divide-slate-800">
+                <ul className="mt-4 divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
                   <li className="py-2.5">
                     <span className="font-medium">Included for free</span>
                   </li>
                   <li className="flex items-center justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>50,000 monthly credits</span>
                   </li>
                   <li className="flex items-center justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <Link
                       href="/ai"
@@ -105,7 +105,7 @@ export function PlansDisplay(): ReactElement {
                   <li className="flex items-center justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>
                       Remote caching with{' '}
@@ -129,7 +129,7 @@ export function PlansDisplay(): ReactElement {
                   <li className="flex items-center justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>
                       Distributed task execution with{' '}
@@ -157,9 +157,9 @@ export function PlansDisplay(): ReactElement {
             </div>
 
             {/*TEAM*/}
-            <div className="rounded-lg border border-slate-200 bg-white p-6 dark:border-slate-800 dark:bg-slate-950">
+            <div className="rounded-lg border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-950">
               <div className="flex items-center gap-x-2">
-                <h4 className="text-xl font-semibold leading-8 text-slate-950 dark:text-white">
+                <h4 className="text-xl font-semibold leading-8 text-zinc-950 dark:text-white">
                   Team
                 </h4>
               </div>
@@ -167,7 +167,7 @@ export function PlansDisplay(): ReactElement {
                 Start free, pay as you grow. Billed on the first of each month.
               </p>
               <p className="mt-4 leading-5">
-                <span className="text-3xl font-semibold text-slate-950 dark:text-white">
+                <span className="text-3xl font-semibold text-zinc-950 dark:text-white">
                   $19
                 </span>
                 <span className="text-lg"> per Active Contributor¹</span>{' '}
@@ -197,35 +197,35 @@ export function PlansDisplay(): ReactElement {
                   Free to start
                 </ButtonLink>
               </div>
-              <ul className="mt-4 divide-y divide-slate-200 text-sm dark:divide-slate-800">
+              <ul className="mt-4 divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
                 <li className="py-2.5">
                   <span className="font-medium">Included for free</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>5 active contributors¹</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>50,000 monthly credits</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>10 concurrent CI connections</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <Link
                     href="/ai"
@@ -246,7 +246,7 @@ export function PlansDisplay(): ReactElement {
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>Email support</span>
                 </li>
@@ -256,35 +256,35 @@ export function PlansDisplay(): ReactElement {
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <PlusIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>$19 per active contributor¹ / month</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <PlusIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>$5.50 per 10,000 credits</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <PlusIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>$2.25 per concurrent CI connection</span>
                 </li>
               </ul>
-              <p className="mt-4 text-xs text-slate-500">
+              <p className="mt-4 text-xs text-zinc-500">
                 ¹Any person or actor that has triggered a CI Pipeline Execution
                 within the current billing cycle. Up to 30 active contributors.
               </p>
             </div>
 
             {/* ENTERPRISE */}
-            <div className="rounded-lg border border-slate-200 bg-slate-50/60 p-6 dark:border-slate-800 dark:bg-slate-900">
+            <div className="rounded-lg border border-zinc-200 bg-zinc-50/60 p-6 dark:border-zinc-800 dark:bg-zinc-900">
               <div className="flex items-center gap-x-2">
-                <h4 className="text-xl font-semibold leading-8 text-slate-950 dark:text-white">
+                <h4 className="text-xl font-semibold leading-8 text-zinc-950 dark:text-white">
                   Enterprise
                 </h4>
               </div>
@@ -293,7 +293,7 @@ export function PlansDisplay(): ReactElement {
                 & payment options available.
               </p>
               <p className="mt-4 pb-5 leading-5">
-                <span className="text-3xl font-semibold text-slate-950 dark:text-white">
+                <span className="text-3xl font-semibold text-zinc-950 dark:text-white">
                   Custom
                 </span>
               </p>
@@ -316,28 +316,28 @@ export function PlansDisplay(): ReactElement {
                   Request a trial
                 </ButtonLink>
               </div>
-              <ul className="mt-4 divide-y divide-slate-200 text-sm dark:divide-slate-800">
+              <ul className="mt-4 divide-y divide-zinc-200 text-sm dark:divide-zinc-800">
                 <li className="py-2.5">
                   <span className="font-medium">Includes</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>Volume discounts on credits available</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>White glove onboarding</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>
                     <Link
@@ -361,7 +361,7 @@ export function PlansDisplay(): ReactElement {
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>
                     Work hand-in-hand with the Nx team for continual improvement
@@ -370,7 +370,7 @@ export function PlansDisplay(): ReactElement {
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>
                     Run on the Nx Cloud servers in any region or run fully
@@ -380,14 +380,14 @@ export function PlansDisplay(): ReactElement {
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>SSO / SAML Login</span>
                 </li>
                 <li className="flex items-center justify-start gap-x-2 py-2.5">
                   <CheckCircleIcon
                     aria-hidden="true"
-                    className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                    className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                   />
                   <span>Premium Support and SLAs available</span>
                 </li>

--- a/nx-dev/ui-pricing/src/lib/trial-callout.tsx
+++ b/nx-dev/ui-pricing/src/lib/trial-callout.tsx
@@ -13,7 +13,7 @@ export function TrialCallout({
   return (
     <section id="start-trial" className="scroll-mt-24">
       <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
-        <div className="relative isolate overflow-hidden bg-white px-6 pt-16 shadow-2xl ring-1 ring-slate-200 sm:rounded-3xl sm:px-16 md:pt-24 lg:flex lg:gap-x-20 lg:px-24 lg:pt-0 dark:bg-slate-900 dark:ring-slate-800">
+        <div className="relative isolate overflow-hidden bg-white px-6 pt-16 shadow-2xl ring-1 ring-zinc-200 sm:rounded-3xl sm:px-16 md:pt-24 lg:flex lg:gap-x-20 lg:px-24 lg:pt-0 dark:bg-zinc-900 dark:ring-zinc-800">
           <svg
             viewBox="0 0 1024 1024"
             aria-hidden="true"
@@ -34,7 +34,7 @@ export function TrialCallout({
             </defs>
           </svg>
           <div className="mx-auto max-w-md text-center lg:mx-0 lg:flex-auto lg:py-32 lg:text-left">
-            <h2 className="texxt-slate-950 text-balance text-3xl font-semibold tracking-tight sm:text-4xl dark:text-white">
+            <h2 className="texxt-zinc-950 text-balance text-3xl font-semibold tracking-tight sm:text-4xl dark:text-white">
               Start a Trial
             </h2>
             <p className="mt-6 text-pretty text-lg/8">
@@ -45,7 +45,7 @@ export function TrialCallout({
             <div className="mt-4 flex items-center justify-center gap-x-6 lg:justify-start">
               <ButtonLink
                 href="https://cloud.nx.app"
-                variant="primary"
+                variant="contrast"
                 size="default"
                 title="Start free trial"
                 onClick={() =>
@@ -71,7 +71,7 @@ export function TrialCallout({
                     'trial-callout'
                   )
                 }
-                className="font-semibold text-blue-500 dark:text-sky-500"
+                className="font-semibold text-blue-500 dark:text-blue-500"
               >
                 reach out to us and we'll help you get started with a trial
               </Link>{' '}
@@ -86,7 +86,7 @@ export function TrialCallout({
               height={1622}
               loading="eager"
               priority
-              className="absolute left-0 top-0 w-[57rem] max-w-none rounded-md bg-white/5 ring-1 ring-slate-950/10"
+              className="absolute left-0 top-0 w-[57rem] max-w-none rounded-md bg-white/5 ring-1 ring-zinc-950/10"
             />
           </div>
         </div>

--- a/nx-dev/ui-react/src/lib/call-to-action.tsx
+++ b/nx-dev/ui-react/src/lib/call-to-action.tsx
@@ -27,7 +27,7 @@ export function CallToAction(): ReactElement {
         <svg
           x="50%"
           y={0}
-          className="overflow-visible fill-slate-200/20 dark:fill-slate-800/20"
+          className="overflow-visible fill-zinc-200/20 dark:fill-zinc-800/20"
         >
           <path
             d="M-200 0h201v201h-201Z M600 0h201v201h-201Z M-400 600h201v201h-201Z M200 800h201v201h-201Z"
@@ -59,10 +59,10 @@ export function CallToAction(): ReactElement {
       {/* Content */}
       <div className="mx-auto max-w-2xl text-center">
         <div className="mb-8 flex justify-center">
-          <ReactIcon className="h-24 w-24 text-slate-900 dark:text-white" />
+          <ReactIcon className="h-24 w-24 text-zinc-900 dark:text-white" />
         </div>
 
-        <h2 className="text-3xl font-medium tracking-tight text-slate-950 sm:text-5xl dark:text-white">
+        <h2 className="text-3xl font-medium tracking-tight text-zinc-950 sm:text-5xl dark:text-white">
           Get Started With Nx React
         </h2>
         <p className="mt-8">
@@ -74,7 +74,7 @@ export function CallToAction(): ReactElement {
             href="/nx-api/react/documents/overview"
             title="Get started with the tutorial"
             prefetch={false}
-            className="rounded-md bg-slate-950 px-3.5 py-2.5 text-sm font-semibold text-slate-100 shadow-sm hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-slate-900 dark:hover:bg-slate-100"
+            className="rounded-md bg-zinc-950 px-3.5 py-2.5 text-sm font-semibold text-zinc-100 shadow-sm hover:bg-zinc-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white dark:bg-white dark:text-zinc-900 dark:hover:bg-zinc-100"
           >
             Read the Docs{' '}
             <span

--- a/nx-dev/ui-react/src/lib/feature-sections.tsx
+++ b/nx-dev/ui-react/src/lib/feature-sections.tsx
@@ -88,7 +88,7 @@ function FeatureSection({
 }: FeatureSectionProps): ReactElement {
   return (
     <div
-      className={`feature-section flex flex-col overflow-hidden rounded-2xl bg-white shadow ring-1 ring-black/5 dark:bg-slate-950 dark:ring-white/10`}
+      className={`feature-section flex flex-col overflow-hidden rounded-2xl bg-white shadow ring-1 ring-black/5 dark:bg-zinc-950 dark:ring-white/10`}
     >
       <div className="h-0 w-full md:h-72">
         <img
@@ -99,13 +99,13 @@ function FeatureSection({
       </div>
       <div className="relative flex flex-1 flex-col justify-center p-8 lg:p-10">
         <div>
-          <span className="mb-3 inline-flex items-center rounded-full bg-slate-400/10 px-3 py-1 text-sm font-medium text-slate-600 ring-1 ring-inset ring-slate-400/20 dark:text-slate-300">
+          <span className="mb-3 inline-flex items-center rounded-full bg-zinc-400/10 px-3 py-1 text-sm font-medium text-zinc-600 ring-1 ring-inset ring-zinc-400/20 dark:text-zinc-300">
             {tag}
           </span>
-          <h3 className="mt-2 text-xl font-medium tracking-tight text-slate-950 lg:text-2xl dark:text-white">
+          <h3 className="mt-2 text-xl font-medium tracking-tight text-zinc-950 lg:text-2xl dark:text-white">
             {title}
           </h3>
-          <p className="mt-4 text-base/relaxed text-slate-600 dark:text-slate-300">
+          <p className="mt-4 text-base/relaxed text-zinc-600 dark:text-zinc-300">
             {description}
           </p>
           <div className="mt-6">

--- a/nx-dev/ui-react/src/lib/features.tsx
+++ b/nx-dev/ui-react/src/lib/features.tsx
@@ -9,7 +9,7 @@ export function Features(): ReactElement {
         Features
       </SectionHeading>
 
-      <p className="mt-4 text-lg text-slate-500 dark:text-slate-400">
+      <p className="mt-4 text-lg text-zinc-500 dark:text-zinc-400">
         Nx allows you to take existing React projects and add powerful
         capabilities to your workflow.
       </p>
@@ -256,8 +256,8 @@ function FeatureCard({
     <a href={href} className="block h-full transform-gpu">
       <div
         className={cx(
-          'group relative h-full w-full overflow-hidden rounded-lg border border-slate-200 bg-white p-6',
-          'dark:border-slate-800 dark:bg-slate-900 dark:hover:border-blue-900 dark:hover:shadow-blue-900/20',
+          'group relative h-full w-full overflow-hidden rounded-lg border border-zinc-200 bg-white p-6',
+          'dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-blue-900 dark:hover:shadow-blue-900/20',
           'before:absolute before:inset-0 before:z-0 before:bg-gradient-to-br before:from-blue-50 before:to-transparent before:opacity-0 before:transition-opacity',
           'transition-all duration-300 ease-out',
           'hover:-translate-y-2 hover:border-blue-200 hover:shadow-xl hover:shadow-blue-100/50',
@@ -265,11 +265,11 @@ function FeatureCard({
         )}
       >
         <div className="relative z-10">
-          <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-50 text-blue-600 transition-transform duration-300 group-hover:scale-110 dark:bg-slate-800 dark:text-blue-400 dark:group-hover:bg-blue-900">
+          <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-50 text-blue-600 transition-transform duration-300 group-hover:scale-110 dark:bg-zinc-800 dark:text-blue-400 dark:group-hover:bg-blue-900">
             {icon}
           </div>
           <h3 className="mb-2 text-lg font-medium">{title}</h3>
-          <p className="text-slate-500 dark:text-slate-400">{description}</p>
+          <p className="text-zinc-500 dark:text-zinc-400">{description}</p>
         </div>
       </div>
     </a>

--- a/nx-dev/ui-react/src/lib/hero.tsx
+++ b/nx-dev/ui-react/src/lib/hero.tsx
@@ -15,7 +15,7 @@ export function Hero(): ReactElement {
       <div className="mx-auto max-w-2xl text-center">
         {/* Logo displayed above the title */}
         <div className="mb-6 flex justify-center">
-          <div className="rounded-full bg-slate-100 p-4 dark:bg-slate-800">
+          <div className="rounded-full bg-zinc-100 p-4 dark:bg-zinc-800">
             <ReactIcon className="h-20 w-20" />
           </div>
         </div>
@@ -40,7 +40,7 @@ export function Hero(): ReactElement {
         <div className="mt-10 flex flex-col items-center justify-center gap-6 sm:flex-row">
           <ButtonLink
             href={'/docs/getting-started/tutorials/react-monorepo-tutorial'}
-            variant="primary"
+            variant="contrast"
             size="default"
             title="Get Started"
           >
@@ -51,7 +51,7 @@ export function Hero(): ReactElement {
             href="https://github.com/nrwl/nx-recipes/tree/main/react-monorepo"
             target="_blank"
             rel="noopener noreferrer"
-            className="group inline-flex items-center text-sm font-semibold leading-6 text-slate-800 dark:text-white"
+            className="group inline-flex items-center text-sm font-semibold leading-6 text-zinc-800 dark:text-white"
           >
             View Example Project{' '}
             <span
@@ -70,10 +70,10 @@ export function Hero(): ReactElement {
 export function GettingStarted(): ReactElement {
   return (
     <section className="relative py-16 sm:py-24">
-      <div className="absolute inset-0 bg-white dark:bg-slate-900"></div>
+      <div className="absolute inset-0 bg-white dark:bg-zinc-900"></div>
       <div className="relative mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
-          <h2 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl dark:text-white">
+          <h2 className="text-3xl font-bold tracking-tight text-zinc-900 sm:text-4xl dark:text-white">
             Add Nx To An Existing Project
           </h2>
         </div>
@@ -103,7 +103,7 @@ export function GettingStarted(): ReactElement {
             href="https://github.com/nrwl/nx-recipes/tree/main/react-monorepo"
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-6 py-3 font-medium text-slate-900 shadow-sm transition-all hover:-translate-y-1 hover:border-blue-400 hover:shadow-md dark:border-slate-700 dark:bg-slate-800 dark:text-white dark:hover:border-blue-500"
+            className="flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-6 py-3 font-medium text-zinc-900 shadow-sm transition-all hover:-translate-y-1 hover:border-blue-400 hover:shadow-md dark:border-zinc-700 dark:bg-zinc-800 dark:text-white dark:hover:border-blue-500"
           >
             <svg
               className="h-5 w-5"
@@ -136,15 +136,15 @@ function GetStartedCard({
   description,
 }: GetStartedCardProps): ReactElement {
   return (
-    <div className="h-full rounded-xl border border-slate-200 bg-white p-6 shadow-sm transition-all hover:shadow-md dark:border-slate-700 dark:bg-slate-800">
-      <h3 className="text-lg font-medium text-slate-900 dark:text-white">
+    <div className="h-full rounded-xl border border-zinc-200 bg-white p-6 shadow-sm transition-all hover:shadow-md dark:border-zinc-700 dark:bg-zinc-800">
+      <h3 className="text-lg font-medium text-zinc-900 dark:text-white">
         {title}
       </h3>
-      <div className="mt-3 overflow-hidden rounded-md bg-slate-800 px-4 py-3 text-sm text-white dark:bg-slate-950">
+      <div className="mt-3 overflow-hidden rounded-md bg-zinc-800 px-4 py-3 text-sm text-white dark:bg-zinc-950">
         <code style={{ whiteSpace: 'pre-line' }}>{command}</code>
       </div>
       <p
-        className="mt-3 text-sm text-slate-600 dark:text-slate-300"
+        className="mt-3 text-sm text-zinc-600 dark:text-zinc-300"
         dangerouslySetInnerHTML={{ __html: description }}
       ></p>
     </div>

--- a/nx-dev/ui-react/src/lib/nx-benefits-video/nx-benefits-video.tsx
+++ b/nx-dev/ui-react/src/lib/nx-benefits-video/nx-benefits-video.tsx
@@ -21,7 +21,7 @@ export function NxBenefitsVideo(): ReactElement {
   const thumbnailUrl = computeThumbnailURL(videoUrl);
 
   return (
-    <div className="border-b border-t border-slate-200 bg-slate-50 py-16 sm:py-8 dark:border-slate-800 dark:bg-slate-900">
+    <div className="border-b border-t border-zinc-200 bg-zinc-50 py-16 sm:py-8 dark:border-zinc-800 dark:bg-zinc-900">
       <section
         id="nx-benefits-video"
         className="z-0 mx-auto max-w-7xl scroll-mt-20 px-4 sm:px-6 lg:px-8"
@@ -31,7 +31,7 @@ export function NxBenefitsVideo(): ReactElement {
             <div className="relative">
               <div className="absolute bottom-0 start-0 -translate-x-14 translate-y-10">
                 <svg
-                  className="h-auto max-w-40 text-slate-200 dark:text-slate-800"
+                  className="h-auto max-w-40 text-zinc-200 dark:text-zinc-800"
                   width="696"
                   height="653"
                   viewBox="0 0 696 653"
@@ -124,13 +124,13 @@ export function NxBenefitsVideo(): ReactElement {
               href="https://nx.dev/recipes/adopting-nx/adding-to-monorepo"
               className="group block"
             >
-              <div className="mt-8 flex gap-4 rounded-lg p-3 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800">
+              <div className="mt-8 flex gap-4 rounded-lg p-3 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-800">
                 <BoltIcon
                   aria-hidden="true"
                   className="size-6 shrink-0 text-blue-500"
                 />
                 <div>
-                  <h4 className="relative text-base font-medium leading-6 text-slate-900 group-hover:text-blue-500 dark:text-slate-100 dark:group-hover:text-blue-400">
+                  <h4 className="relative text-base font-medium leading-6 text-zinc-900 group-hover:text-blue-500 dark:text-zinc-100 dark:group-hover:text-blue-400">
                     Add Nx to any existing monorepo
                     <span className="ml-1 opacity-0 transition-opacity group-hover:opacity-100">
                       →
@@ -149,13 +149,13 @@ export function NxBenefitsVideo(): ReactElement {
               href="https://nx.dev/features/cache-task-results"
               className="group block"
             >
-              <div className="mt-8 flex gap-4 rounded-lg p-3 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800">
+              <div className="mt-8 flex gap-4 rounded-lg p-3 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-800">
                 <RocketLaunchIcon
                   aria-hidden="true"
                   className="size-6 shrink-0 text-blue-500"
                 />
                 <div>
-                  <h4 className="relative text-base font-medium leading-6 text-slate-900 group-hover:text-blue-500 dark:text-slate-100 dark:group-hover:text-blue-400">
+                  <h4 className="relative text-base font-medium leading-6 text-zinc-900 group-hover:text-blue-500 dark:text-zinc-100 dark:group-hover:text-blue-400">
                     Immediate speed and efficiency gains
                     <span className="ml-1 opacity-0 transition-opacity group-hover:opacity-100">
                       →
@@ -171,13 +171,13 @@ export function NxBenefitsVideo(): ReactElement {
             </a>
 
             <a href="https://nx.dev/plugin-registry" className="group block">
-              <div className="mt-8 flex gap-4 rounded-lg p-3 transition-colors hover:bg-slate-100 dark:hover:bg-slate-800">
+              <div className="mt-8 flex gap-4 rounded-lg p-3 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-800">
                 <PuzzlePieceIcon
                   aria-hidden="true"
                   className="size-6 shrink-0 text-blue-500"
                 />
                 <div>
-                  <h4 className="relative text-base font-medium leading-6 text-slate-900 group-hover:text-blue-500 dark:text-slate-100 dark:group-hover:text-blue-400">
+                  <h4 className="relative text-base font-medium leading-6 text-zinc-900 group-hover:text-blue-500 dark:text-zinc-100 dark:group-hover:text-blue-400">
                     Enhanced developer experience
                     <span className="ml-1 opacity-0 transition-opacity group-hover:opacity-100">
                       →

--- a/nx-dev/ui-remote-cache/src/lib/faq.tsx
+++ b/nx-dev/ui-remote-cache/src/lib/faq.tsx
@@ -188,7 +188,7 @@ export function Faq(): ReactElement {
               Check out our most commonly asked questions.
             </SectionHeading>
 
-            <p className="text-md mt-4 text-slate-400 dark:text-slate-600">
+            <p className="text-md mt-4 text-zinc-400 dark:text-zinc-600">
               <Link
                 href="/contact"
                 title="Reach out to the team"
@@ -206,14 +206,14 @@ export function Faq(): ReactElement {
             }))}
           />
           <div className="mt-12 lg:col-span-2 lg:mt-0">
-            <dl className="mt-6 space-y-6 divide-y divide-slate-100 dark:divide-slate-800">
+            <dl className="mt-6 space-y-6 divide-y divide-zinc-100 dark:divide-zinc-800">
               {faqs.map((faq) => (
                 <Disclosure as="div" key={faq.question} className="pt-6">
                   {({ open }) => (
                     <>
                       <dt className="text-lg">
-                        <DisclosureButton className="flex w-full items-start justify-between text-left text-slate-400">
-                          <span className="font-medium text-slate-800 dark:text-slate-300">
+                        <DisclosureButton className="flex w-full items-start justify-between text-left text-zinc-400">
+                          <span className="font-medium text-zinc-800 dark:text-zinc-300">
                             {faq.question}
                           </span>
                           <span className="ml-6 flex h-7 items-center">
@@ -237,7 +237,7 @@ export function Faq(): ReactElement {
                       >
                         <DisclosurePanel
                           as="dd"
-                          className="mt-2 pr-12 text-base text-slate-500 dark:text-slate-400"
+                          className="mt-2 pr-12 text-base text-zinc-500 dark:text-zinc-400"
                         >
                           {faq.answerUi}
                         </DisclosurePanel>

--- a/nx-dev/ui-remote-cache/src/lib/remote-cache-solutions.tsx
+++ b/nx-dev/ui-remote-cache/src/lib/remote-cache-solutions.tsx
@@ -25,12 +25,12 @@ export function RemoteCacheSolutions(): ReactElement {
           <div className="-mt-16 grid max-w-full grid-cols-1 gap-12 sm:mx-auto lg:mt-0 lg:grid-cols-3 xl:-mx-4">
             {/* NX CLOUD */}
             <div>
-              <div className="relative rounded-xl border-2 border-blue-500 bg-white p-8 dark:border-sky-500 dark:bg-slate-950">
+              <div className="relative rounded-xl border-2 border-blue-500 bg-white p-8 dark:border-blue-500 dark:bg-zinc-950">
                 <span className="absolute left-1/2 top-0 inline-flex -translate-x-1/2 -translate-y-6 transform items-center rounded-t-md bg-blue-500 px-2 py-1 text-xs font-medium text-white ring-1 ring-inset">
                   Recommended
                 </span>
                 <div className="flex items-center gap-x-2">
-                  <h4 className="text-xl font-semibold leading-8 text-slate-950 dark:text-white">
+                  <h4 className="text-xl font-semibold leading-8 text-zinc-950 dark:text-white">
                     Nx Cloud remote cache
                   </h4>
                 </div>
@@ -43,7 +43,7 @@ export function RemoteCacheSolutions(): ReactElement {
                     aria-describedby="nx-cloud-remote-cache"
                     title="Start caching your builds with Nx Cloud"
                     size="default"
-                    variant="primary"
+                    variant="contrast"
                     onClick={() =>
                       sendCustomEvent(
                         'manage-remote-cache-with-nx-cloud',
@@ -57,18 +57,18 @@ export function RemoteCacheSolutions(): ReactElement {
                   </ButtonLink>
                 </div>
 
-                <ul className="mt-4 divide-y divide-slate-200 border-t border-slate-200 text-sm dark:divide-slate-800 dark:border-slate-800">
+                <ul className="mt-4 divide-y divide-zinc-200 border-t border-zinc-200 text-sm dark:divide-zinc-800 dark:border-zinc-800">
                   <li className="flex items-start justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>Free plans available, no credit card required</span>
                   </li>
                   <li className="flex items-start justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>
                       Secure against cache poisoning (
@@ -86,7 +86,7 @@ export function RemoteCacheSolutions(): ReactElement {
                   <li className="flex items-start justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>
                       SOC 2 compliant (
@@ -103,14 +103,14 @@ export function RemoteCacheSolutions(): ReactElement {
                   <li className="flex items-start justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>Zero configuration</span>
                   </li>
                   <li className="flex items-start justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>
                       Hosted on Nx Cloud servers or on-premise with{' '}
@@ -127,7 +127,7 @@ export function RemoteCacheSolutions(): ReactElement {
                   <li className="flex items-start justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>
                       Enterprise grade access management and key revocation
@@ -136,14 +136,14 @@ export function RemoteCacheSolutions(): ReactElement {
                   <li className="flex items-start justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>Support</span>
                   </li>
                   <li className="flex items-start justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>
                       Includes access to advanced CI features: distributed task
@@ -156,9 +156,9 @@ export function RemoteCacheSolutions(): ReactElement {
             </div>
             {/*OFFICIAL PLUGINS*/}
             <div>
-              <div className="rounded-xl border border-slate-200 bg-white p-8 dark:border-slate-800 dark:bg-slate-950">
+              <div className="rounded-xl border border-zinc-200 bg-white p-8 dark:border-zinc-800 dark:bg-zinc-950">
                 <div className="flex items-center gap-x-2">
-                  <h4 className="text-xl font-semibold leading-8 text-slate-950 dark:text-white">
+                  <h4 className="text-xl font-semibold leading-8 text-zinc-950 dark:text-white">
                     Self-hosted cache
                   </h4>
                 </div>
@@ -172,7 +172,7 @@ export function RemoteCacheSolutions(): ReactElement {
                     aria-describedby="official-plugins"
                     title="Free official remote cache plugins"
                     size="default"
-                    variant="primary"
+                    variant="contrast"
                     onClick={() =>
                       sendCustomEvent(
                         'learn-more-self-hosted-cache-plugins',
@@ -185,7 +185,7 @@ export function RemoteCacheSolutions(): ReactElement {
                     Learn more
                   </ButtonLink>
                 </div>
-                <ul className="mt-4 divide-y divide-slate-200 border-t border-slate-200 text-sm dark:divide-slate-800 dark:border-slate-800">
+                <ul className="mt-4 divide-y divide-zinc-200 border-t border-zinc-200 text-sm dark:divide-zinc-800 dark:border-zinc-800">
                   <li className="flex items-start justify-start gap-x-2 py-2.5">
                     <ExclamationCircleIcon
                       aria-hidden="true"
@@ -212,28 +212,28 @@ export function RemoteCacheSolutions(): ReactElement {
                   <li className="flex items-start justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>Free for all users</span>
                   </li>
                   <li className="flex items-start justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>Supports Amazon S3, MinIO, GCP, Azure</span>
                   </li>
                   <li className="flex items-start justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>Supports shared network drives</span>
                   </li>
                   <li className="flex items-start justify-start gap-x-2 py-2.5">
                     <CheckCircleIcon
                       aria-hidden="true"
-                      className="h-6 w-5 flex-none text-blue-600 dark:text-sky-500"
+                      className="h-6 w-5 flex-none text-blue-600 dark:text-blue-500"
                     />
                     <span>
                       Simple migration path from existing 3rd party plugins
@@ -244,9 +244,9 @@ export function RemoteCacheSolutions(): ReactElement {
             </div>
             {/*OPENAPI*/}
             <div>
-              <div className="rounded-xl border border-slate-200 bg-white p-8 dark:border-slate-800 dark:bg-slate-950">
+              <div className="rounded-xl border border-zinc-200 bg-white p-8 dark:border-zinc-800 dark:bg-zinc-950">
                 <div className="flex items-center gap-x-2">
-                  <h4 className="text-xl font-semibold leading-8 text-slate-950 dark:text-white">
+                  <h4 className="text-xl font-semibold leading-8 text-zinc-950 dark:text-white">
                     Build your own
                   </h4>
                 </div>
@@ -262,7 +262,7 @@ export function RemoteCacheSolutions(): ReactElement {
                     aria-describedby="open-api"
                     title="Remote cache api specs"
                     size="default"
-                    variant="primary"
+                    variant="contrast"
                     onClick={() =>
                       sendCustomEvent(
                         'build-your-own-openapi',

--- a/nx-dev/ui-resources/src/lib/filters.tsx
+++ b/nx-dev/ui-resources/src/lib/filters.tsx
@@ -55,8 +55,8 @@ export function Filters({ selectedFilter, filters }: FiltersProps) {
                 aria-current={isActive ? 'true' : undefined}
                 className={`flex items-center justify-center gap-2 rounded-full border px-2.5 py-1.5 font-medium shadow-sm transition ${
                   isActive
-                    ? 'border-blue-500 bg-blue-500 text-white hover:bg-blue-600 dark:border-sky-500 dark:bg-sky-500 dark:hover:bg-sky-600'
-                    : 'border-slate-400 bg-white text-slate-700 hover:bg-slate-50 hover:text-slate-600 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700'
+                    ? 'border-blue-500 bg-blue-500 text-white hover:bg-blue-600 dark:border-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600'
+                    : 'border-zinc-400 bg-white text-zinc-700 hover:bg-zinc-50 hover:text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700'
                 }`}
               >
                 {filter.icon && (
@@ -73,7 +73,7 @@ export function Filters({ selectedFilter, filters }: FiltersProps) {
       <div className="relative lg:hidden">
         <Menu as="div" className="inline-block text-left">
           <MenuButton
-            className="inline-flex w-full justify-center rounded-md border border-slate-400 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 hover:text-slate-600 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+            className="inline-flex w-full justify-center rounded-md border border-zinc-400 bg-white px-3 py-1.5 text-sm font-medium text-zinc-700 shadow-sm transition hover:bg-zinc-50 hover:text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700"
             aria-label="Select filter category"
           >
             Categories
@@ -93,7 +93,7 @@ export function Filters({ selectedFilter, filters }: FiltersProps) {
           >
             <MenuItems
               as="ul"
-              className="absolute right-0 z-[31] mt-2 flex w-56 origin-top-right flex-col gap-4 rounded-md bg-white p-4 shadow-lg ring-1 ring-black/5 focus:outline-none dark:bg-slate-800 dark:text-white"
+              className="absolute right-0 z-[31] mt-2 flex w-56 origin-top-right flex-col gap-4 rounded-md bg-white p-4 shadow-lg ring-1 ring-black/5 focus:outline-none dark:bg-zinc-800 dark:text-white"
               aria-label="Filter categories"
             >
               {filters.map((filter) => {
@@ -103,7 +103,7 @@ export function Filters({ selectedFilter, filters }: FiltersProps) {
                     <Link
                       className={`flex items-center gap-2 ${
                         isActive
-                          ? 'font-semibold text-blue-600 dark:text-sky-400'
+                          ? 'font-semibold text-blue-600 dark:text-blue-400'
                           : ''
                       }`}
                       href={updateFilter(filter.value)}

--- a/nx-dev/ui-resources/src/lib/resource-card.tsx
+++ b/nx-dev/ui-resources/src/lib/resource-card.tsx
@@ -8,9 +8,9 @@ interface ResourceCardProps {
 
 export function ResourceCard({ resource }: ResourceCardProps) {
   return (
-    <article className="group relative flex h-full flex-row overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm transition hover:shadow-md dark:border-slate-800 dark:bg-slate-900">
+    <article className="group relative flex h-full flex-row overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-sm transition hover:shadow-md dark:border-zinc-800 dark:bg-zinc-900">
       {/* Cover Image */}
-      <div className="relative flex min-w-[140px] max-w-[240px] shrink-0 items-center overflow-hidden bg-slate-100 dark:bg-slate-800">
+      <div className="relative flex min-w-[140px] max-w-[240px] shrink-0 items-center overflow-hidden bg-zinc-100 dark:bg-zinc-800">
         <img
           src={resource.coverImage}
           alt={resource.title}
@@ -31,13 +31,13 @@ export function ResourceCard({ resource }: ResourceCardProps) {
         </div>
 
         {/* Title */}
-        <h3 className="mb-2 text-base font-semibold text-slate-900 dark:text-slate-100">
+        <h3 className="mb-2 text-base font-semibold text-zinc-900 dark:text-zinc-100">
           {resource.title}
         </h3>
 
         {/* Description */}
         {resource.description && (
-          <p className="mb-3 text-sm text-slate-600 dark:text-slate-400">
+          <p className="mb-3 text-sm text-zinc-600 dark:text-zinc-400">
             {resource.description}
           </p>
         )}
@@ -46,7 +46,7 @@ export function ResourceCard({ resource }: ResourceCardProps) {
         <div>
           <Link
             href={resource.downloadUrl}
-            className="inline-flex items-center gap-1.5 rounded-md bg-blue-500 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-blue-600 dark:bg-sky-500 dark:hover:bg-sky-600"
+            className="inline-flex items-center gap-1.5 rounded-md bg-blue-500 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-blue-600 dark:bg-blue-500 dark:hover:bg-blue-600"
             aria-label={`Download ${resource.title}`}
           >
             <ArrowDownTrayIcon className="h-4 w-4" />

--- a/nx-dev/ui-resources/src/lib/resource-container.tsx
+++ b/nx-dev/ui-resources/src/lib/resource-container.tsx
@@ -40,11 +40,11 @@ export function ResourceContainer({ resources }: ResourceContainerProps) {
         <header className="mb-8 mt-20">
           <h1
             id="resources-title"
-            className="text-3xl font-semibold tracking-tight text-slate-900 md:text-5xl dark:text-slate-100"
+            className="text-3xl font-semibold tracking-tight text-zinc-900 md:text-5xl dark:text-zinc-100"
           >
             {selectedFilterHeading}
           </h1>
-          <p className="mt-2 text-slate-600 dark:text-slate-400">
+          <p className="mt-2 text-zinc-600 dark:text-zinc-400">
             Download whitepapers, books, case studies, and cheatsheets to learn
             more about Nx and modern development practices.
           </p>
@@ -59,7 +59,7 @@ export function ResourceContainer({ resources }: ResourceContainerProps) {
           <ResourceGrid resources={filteredList} />
         ) : (
           <div className="py-12 text-center">
-            <p className="text-slate-600 dark:text-slate-400">
+            <p className="text-zinc-600 dark:text-zinc-400">
               No resources found in this category.
             </p>
           </div>

--- a/nx-dev/ui-resources/src/lib/resource-grid.tsx
+++ b/nx-dev/ui-resources/src/lib/resource-grid.tsx
@@ -80,10 +80,10 @@ export function ResourceGrid({ resources }: ResourceGridProps) {
         return (
           <section key={category}>
             <div className="mb-6">
-              <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+              <h2 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">
                 {CATEGORY_LABELS[category]}
               </h2>
-              <div className="mt-2 h-px bg-slate-200 dark:bg-slate-700" />
+              <div className="mt-2 h-px bg-zinc-200 dark:bg-zinc-700" />
             </div>
             <div className="mx-auto grid auto-rows-fr grid-cols-1 gap-5 lg:grid-cols-2">
               {sortedCategoryResources.map((resource) => (

--- a/nx-dev/ui-sponsor-card/src/lib/sponsor-card.tsx
+++ b/nx-dev/ui-sponsor-card/src/lib/sponsor-card.tsx
@@ -21,7 +21,7 @@ export function SponsorCard(data: Sponsor): JSX.Element {
       </div>
       <div className="md:col-span-2">
         <h5 className="font-input-mono mb-3">{data.name}</h5>
-        <p className="text-slate-400">{data.description}</p>
+        <p className="text-zinc-400">{data.description}</p>
       </div>
     </figure>
   );

--- a/nx-dev/ui-theme/src/lib/theme-switcher.component.tsx
+++ b/nx-dev/ui-theme/src/lib/theme-switcher.component.tsx
@@ -75,7 +75,7 @@ export function ThemeSwitcher(): JSX.Element {
             leaveFrom="transform opacity-100 scale-100"
             leaveTo="transform opacity-0 scale-95"
           >
-            <ListboxOptions className="absolute -right-10 top-full z-50 mt-2 w-36 origin-top-right divide-y divide-slate-100 rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none dark:divide-slate-800 dark:bg-slate-900 dark:ring-white/5">
+            <ListboxOptions className="absolute -right-10 top-full z-50 mt-2 w-36 origin-top-right divide-y divide-zinc-100 rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none dark:divide-zinc-800 dark:bg-zinc-900 dark:ring-white/5">
               {availableThemes.map((t) => (
                 <ListboxOption key={t.value} value={t.value} as={Fragment}>
                   {({ focus, selected }) => (
@@ -83,9 +83,9 @@ export function ThemeSwitcher(): JSX.Element {
                       className={cx(
                         'flex cursor-pointer items-center gap-2 px-4 py-2 text-sm',
                         {
-                          'bg-slate-100 dark:bg-slate-800/60': focus,
-                          'text-blue-500 dark:text-sky-500': focus || selected,
-                          'text-slate-700 dark:text-slate-400': !focus,
+                          'bg-zinc-100 dark:bg-zinc-800/60': focus,
+                          'text-blue-500 dark:text-blue-500': focus || selected,
+                          'text-zinc-700 dark:text-zinc-400': !focus,
                         }
                       )}
                     >

--- a/nx-dev/ui-video-courses/src/lib/course-hero.tsx
+++ b/nx-dev/ui-video-courses/src/lib/course-hero.tsx
@@ -3,7 +3,7 @@ import { JSX } from 'react';
 
 export function CourseHero(): JSX.Element {
   return (
-    <section className="relative overflow-hidden py-16 dark:from-slate-900 dark:to-slate-950">
+    <section className="relative overflow-hidden py-16 dark:from-zinc-900 dark:to-zinc-950">
       <div className="mx-auto max-w-3xl text-center">
         <SectionHeading as="h1" variant="display">
           Nx Video Courses

--- a/nx-dev/ui-video-courses/src/lib/course-overview.tsx
+++ b/nx-dev/ui-video-courses/src/lib/course-overview.tsx
@@ -21,8 +21,8 @@ export function CourseOverview({ courses }: CourseOverviewProps): JSX.Element {
             >
               <div
                 className={cx(
-                  'group relative h-full w-full overflow-hidden rounded-2xl border border-slate-200 bg-white p-8',
-                  'dark:border-slate-800 dark:bg-slate-900 dark:hover:border-blue-900 dark:hover:shadow-blue-900/20',
+                  'group relative h-full w-full overflow-hidden rounded-2xl border border-zinc-200 bg-white p-8',
+                  'dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-blue-900 dark:hover:shadow-blue-900/20',
                   'before:absolute before:inset-0 before:z-0 before:bg-gradient-to-br before:from-blue-50 before:to-transparent before:opacity-0 before:transition-opacity',
                   'transition-all duration-300 ease-out',
                   'hover:-translate-y-2 hover:border-blue-200 hover:shadow-xl hover:shadow-blue-100/50',
@@ -30,15 +30,15 @@ export function CourseOverview({ courses }: CourseOverviewProps): JSX.Element {
                 )}
               >
                 <div className="relative z-10">
-                  <p className="text-2xl font-semibold text-slate-900 transition-colors duration-200 dark:text-slate-100">
+                  <p className="text-2xl font-semibold text-zinc-900 transition-colors duration-200 dark:text-zinc-100">
                     {course.title}
                   </p>
 
-                  <div className="mt-2 flex items-center gap-2 text-sm font-medium text-slate-400 dark:text-slate-500">
+                  <div className="mt-2 flex items-center gap-2 text-sm font-medium text-zinc-400 dark:text-zinc-500">
                     {course.authors?.[0]?.name && (
                       <>
                         <span>{course.authors[0].name}</span>
-                        <span className="text-slate-300 dark:text-slate-600">
+                        <span className="text-zinc-300 dark:text-zinc-600">
                           •
                         </span>
                       </>
@@ -48,9 +48,7 @@ export function CourseOverview({ courses }: CourseOverviewProps): JSX.Element {
                         ? `${course.lessons.length} lessons`
                         : `${course.lessonCount} lessons`}
                     </span>
-                    <span className="text-slate-300 dark:text-slate-600">
-                      •
-                    </span>
+                    <span className="text-zinc-300 dark:text-zinc-600">•</span>
                     {course.lessons.length > 0 && (
                       <span className="flex items-center gap-1">
                         <ClockIcon className="h-3 w-3" />
@@ -60,7 +58,7 @@ export function CourseOverview({ courses }: CourseOverviewProps): JSX.Element {
                   </div>
 
                   <div className="mt-4">
-                    <p className="text-[15px] leading-relaxed text-slate-600 transition-colors duration-200 dark:text-slate-400">
+                    <p className="text-[15px] leading-relaxed text-zinc-600 transition-colors duration-200 dark:text-zinc-400">
                       {course.description}
                     </p>
                   </div>

--- a/nx-dev/ui-webinar/src/lib/webinar-list-item.tsx
+++ b/nx-dev/ui-webinar/src/lib/webinar-list-item.tsx
@@ -26,10 +26,10 @@ export function WebinarListItem({ webinar, episode }: WebinarListItemProps) {
   return (
     <div
       key={webinar.slug}
-      className="border-b border-slate-200 py-5 text-sm last:border-0 dark:border-slate-800 dark:before:bg-slate-800/50"
+      className="border-b border-zinc-200 py-5 text-sm last:border-0 dark:border-zinc-800 dark:before:bg-zinc-800/50"
     >
       <Link href={link} prefetch={false}>
-        <h3 className="text-balance text-lg text-slate-500 sm:w-8/12 dark:text-white">
+        <h3 className="text-balance text-lg text-zinc-500 sm:w-8/12 dark:text-white">
           {webinar.title}
         </h3>
       </Link>
@@ -44,7 +44,7 @@ export function WebinarListItem({ webinar, episode }: WebinarListItemProps) {
       </span>
       <p className="my-2">{webinar.description}</p>
       <Link href={link} prefetch={false}>
-        <span className="my-4 text-balance text-slate-500 sm:w-8/12 dark:text-white">
+        <span className="my-4 text-balance text-zinc-500 sm:w-8/12 dark:text-white">
           {webinar.status === 'Past - Ungated'
             ? 'Watch the recording'
             : 'Sign up to view the recording'}

--- a/nx-dev/ui-webinar/src/lib/webinar-list.tsx
+++ b/nx-dev/ui-webinar/src/lib/webinar-list.tsx
@@ -11,7 +11,7 @@ export interface WebinarListProps {
 export function WebinarList({ webinars }: WebinarListProps): JSX.Element {
   return webinars.length < 1 ? (
     <div>
-      <h2 className="mt-32 text-center text-xl font-semibold text-slate-500 sm:text-2xl xl:mb-24 dark:text-white">
+      <h2 className="mt-32 text-center text-xl font-semibold text-zinc-500 sm:text-2xl xl:mb-24 dark:text-white">
         No webinars as yet but stay tuned!
       </h2>
     </div>
@@ -42,7 +42,7 @@ export function WebinarList({ webinars }: WebinarListProps): JSX.Element {
                 <Link
                   href={webinar.registrationUrl || `/blog/${webinar.slug}`}
                   title={webinar.title}
-                  className="text-balance text-2xl font-semibold text-slate-900 dark:text-white"
+                  className="text-balance text-2xl font-semibold text-zinc-900 dark:text-white"
                   prefetch={false}
                 >
                   {webinar.title}
@@ -60,7 +60,7 @@ export function WebinarList({ webinars }: WebinarListProps): JSX.Element {
                   </div>
                 )}
               </div>
-              <div className="relative hidden h-full flex-1 transform-gpu flex-col overflow-hidden rounded-2xl border border-slate-200 shadow transition-all duration-300 ease-in-out hover:scale-[1.02] hover:shadow-lg lg:flex dark:border-slate-800">
+              <div className="relative hidden h-full flex-1 transform-gpu flex-col overflow-hidden rounded-2xl border border-zinc-200 shadow transition-all duration-300 ease-in-out hover:scale-[1.02] hover:shadow-lg lg:flex dark:border-zinc-800">
                 {webinar.cover_image && (
                   <div className="aspect-[1.7] w-full">
                     <Image
@@ -77,7 +77,7 @@ export function WebinarList({ webinars }: WebinarListProps): JSX.Element {
             </div>
           );
         })}
-      <div className="mt-20 border-b-2 border-slate-300 pb-3 text-lg dark:border-slate-700">
+      <div className="mt-20 border-b-2 border-zinc-300 pb-3 text-lg dark:border-zinc-700">
         <h2 className="font-semibold">Past Webinars</h2>
       </div>
       <div>


### PR DESCRIPTION
This design refresh emphasizes the contrast variant aesthetic across all hero sections, pricing cards, and primary call-to-actions.

- Change 47 instances of variant="primary" to variant="contrast"
- Update ui-courses to use variant="secondary" for GitHub link
- Prefer high-contrast inverted style for primary CTAs
- Maintain proper visual hierarchy with secondary actions
- Replace all slate-* classes with zinc-* equivalents (1,158 instances)
- Replace all sky-* classes with blue-* equivalents (210 instances)
- Update opacity variants, gradients, rings, and borders
- Maintain full dark mode compatibility
