### PR TITLE
fix(core): follow symlinks when expanding cache outputs

### DIFF
--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -45,6 +45,7 @@ where
 
     // Use WalkDir instead of ignore::WalkBuilder because it's faster
     WalkDir::new(&base_dir)
+        .follow_links(true)
         .into_iter()
         .filter_entry(move |entry| {
             let path = entry.path().to_string_lossy();


### PR DESCRIPTION
When cache outputs include glob patterns like .next/*.json along with symlinked directories like .next/standalone, the walker was not following symlinks, causing files inside symlinked directories to not be found during cache operations.

This resulted in incomplete caching and potential 'File exists (os error 17)' errors when Nx tried to handle the incomplete cache state.

The fix enables symlink following in nx_walker_sync by adding follow_links(true) to the WalkDir configuration. This ensures that when outputs like .next/standalone are symlinks to directories, the files within those directories are properly discovered and cached.

Fixes #34013
