### PR TITLE
fix(maven): update Spring Boot to 4.0 and enable parent POM local install

### DIFF
--- a/e2e/maven/project.json
+++ b/e2e/maven/project.json
@@ -7,10 +7,18 @@
   "// targets": "to see all targets run: nx show project e2e-maven --web",
   "targets": {
     "e2e-local": {
-      "command": "echo 'Maven e2e tests disabled'"
+      "dependsOn": [
+        "@nx/nx-source:populate-local-registry-storage",
+        "@nx/nx-source:local-registry",
+        "nx-maven-plugin:install"
+      ]
     },
     "e2e-ci--**/**": {
-      "command": "echo 'Maven e2e tests disabled'"
+      "dependsOn": [
+        "@nx/nx-source:populate-local-registry-storage",
+        "@nx/nx-source:local-registry",
+        "nx-maven-plugin:install"
+      ]
     }
   }
 }

--- a/e2e/maven/src/utils/create-maven-project.ts
+++ b/e2e/maven/src/utils/create-maven-project.ts
@@ -92,7 +92,7 @@ export async function createMavenProject(
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring-boot.version>3.4.0</spring-boot.version>
+    <spring-boot.version>4.0.0</spring-boot.version>
   </properties>
 
   <dependencyManagement>
@@ -180,7 +180,7 @@ async function createModule(
     {
       type: 'maven-project',
       language: 'java',
-      bootVersion: '3.4.0',
+      bootVersion: '4.0.0',
       baseDir: moduleName,
       groupId: 'com.example',
       artifactId: moduleName,

--- a/packages/maven/batch-runner/pom.xml
+++ b/packages/maven/batch-runner/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>nx-maven-parent</artifactId>
-        <version>0.0.11</version>
+        <version>0.0.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/maven-plugin/pom.xml
+++ b/packages/maven/maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.nx.maven</groupId>
     <artifactId>nx-maven-parent</artifactId>
-    <version>0.0.11</version>
+    <version>0.0.12</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/migrations.json
+++ b/packages/maven/migrations.json
@@ -24,6 +24,12 @@
       "version": "22.2.0-beta.4",
       "description": "Update Maven plugin version from 0.0.10 to 0.0.11 in pom.xml files",
       "factory": "./dist/migrations/0-0-11/update-pom-xml-version"
+    },
+    "update-0-0-12": {
+      "cli": "nx",
+      "version": "22.4.0-beta.0",
+      "description": "Update Maven plugin version from 0.0.11 to 0.0.12 in pom.xml files",
+      "factory": "./dist/migrations/0-0-12/update-pom-xml-version"
     }
   }
 }

--- a/packages/maven/pom.xml
+++ b/packages/maven/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <!-- Skip deployment for this parent POM -->
-    <maven.install.skip>true</maven.install.skip>
+    <maven.install.skip>false</maven.install.skip>
     <maven.deploy.skip>true</maven.deploy.skip>
     <maven.gpg.skip>true</maven.gpg.skip>
   </properties>

--- a/packages/maven/pom.xml
+++ b/packages/maven/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>dev.nx.maven</groupId>
     <artifactId>nx-parent</artifactId>
-    <version>0.0.11</version>
+    <version>0.0.12</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/shared/pom.xml
+++ b/packages/maven/shared/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>nx-maven-parent</artifactId>
-        <version>0.0.11</version>
+        <version>0.0.12</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/src/migrations/0-0-12/update-pom-xml-version.ts
+++ b/packages/maven/src/migrations/0-0-12/update-pom-xml-version.ts
@@ -1,0 +1,11 @@
+import { Tree } from '@nx/devkit';
+import { updateNxMavenPluginVersion } from '../../utils/pom-xml-updater';
+
+/**
+ * Migration for @nx/maven v0.0.12
+ * Updates the Maven plugin version to 0.0.12 in pom.xml files
+ */
+export default async function update(tree: Tree) {
+  // Update user pom.xml files
+  updateNxMavenPluginVersion(tree, '0.0.12');
+}

--- a/packages/maven/src/utils/versions.ts
+++ b/packages/maven/src/utils/versions.ts
@@ -1,2 +1,2 @@
 export const nxVersion = require('../../package.json').version;
-export const mavenPluginVersion = '0.0.11';
+export const mavenPluginVersion = '0.0.12';

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>dev.nx.maven</groupId>
   <artifactId>nx-parent</artifactId>
-  <version>0.0.11</version>
+  <version>0.0.12</version>
   <packaging>pom</packaging>
 
   <name>Nx Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
   <properties>
     <!-- Skip deploying parent POM -->
     <maven.deploy.skip>true</maven.deploy.skip>
-    <maven.install.skip>true</maven.install.skip>
+    <maven.install.skip>false</maven.install.skip>
     <maven.gpg.skip>true</maven.gpg.skip>
 
     <!-- Build Properties -->

--- a/tools/workspace-plugin/src/generators/bump-maven-version/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/bump-maven-version/generator.spec.ts
@@ -12,7 +12,7 @@ describe('bump-maven-version generator', () => {
   <version>0.0.8</version>
 </project>`;
 
-  const mockMavenPluginPomXml = `<?xml version="1.0" encoding="UTF-8"?>
+  const mockMavenParentPomXml = `<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0">
   <parent>
     <groupId>dev.nx</groupId>
@@ -20,8 +20,42 @@ describe('bump-maven-version generator', () => {
     <version>0.0.8</version>
   </parent>
   <groupId>dev.nx.maven</groupId>
+  <artifactId>nx-maven-parent</artifactId>
+  <packaging>pom</packaging>
+</project>`;
+
+  const mockMavenPluginPomXml = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <parent>
+    <groupId>dev.nx.maven</groupId>
+    <artifactId>nx-maven-parent</artifactId>
+    <version>0.0.8</version>
+  </parent>
+  <groupId>dev.nx.maven</groupId>
   <artifactId>nx-maven-plugin</artifactId>
   <version>\${project.parent.version}</version>
+</project>`;
+
+  const mockSharedPomXml = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <parent>
+    <groupId>dev.nx.maven</groupId>
+    <artifactId>nx-maven-parent</artifactId>
+    <version>0.0.8</version>
+  </parent>
+  <groupId>dev.nx.maven</groupId>
+  <artifactId>nx-maven-shared</artifactId>
+</project>`;
+
+  const mockBatchRunnerPomXml = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <parent>
+    <groupId>dev.nx.maven</groupId>
+    <artifactId>nx-maven-parent</artifactId>
+    <version>0.0.8</version>
+  </parent>
+  <groupId>dev.nx.maven</groupId>
+  <artifactId>maven-batch-runner</artifactId>
 </project>`;
 
   const mockVersionsTs = `export const nxVersion = require('../../package.json').version;
@@ -45,7 +79,10 @@ export const mavenPluginVersion = '0.0.8';`;
 
     // Setup mock files
     tree.write('pom.xml', mockPomXml);
+    tree.write('packages/maven/pom.xml', mockMavenParentPomXml);
     tree.write('packages/maven/maven-plugin/pom.xml', mockMavenPluginPomXml);
+    tree.write('packages/maven/shared/pom.xml', mockSharedPomXml);
+    tree.write('packages/maven/batch-runner/pom.xml', mockBatchRunnerPomXml);
     tree.write('packages/maven/src/utils/versions.ts', mockVersionsTs);
     tree.write(
       'packages/maven/migrations.json',

--- a/tools/workspace-plugin/src/generators/bump-maven-version/generator.ts
+++ b/tools/workspace-plugin/src/generators/bump-maven-version/generator.ts
@@ -124,7 +124,11 @@ export default async function runGenerator(
     logger.info('Updating /pom.xml...');
     updateXmlVersion(tree, 'pom.xml', newVersion, true);
 
-    // 2. Update maven-plugin pom.xml
+    // 2. Update packages/maven/pom.xml
+    logger.info('Updating packages/maven/pom.xml...');
+    updateXmlVersion(tree, 'packages/maven/pom.xml', newVersion, false);
+
+    // 3. Update maven-plugin pom.xml
     logger.info('Updating packages/maven/maven-plugin/pom.xml...');
     updateXmlVersion(
       tree,
@@ -133,7 +137,20 @@ export default async function runGenerator(
       false
     );
 
-    // 3. Update versions.ts
+    // 4. Update shared pom.xml
+    logger.info('Updating packages/maven/shared/pom.xml...');
+    updateXmlVersion(tree, 'packages/maven/shared/pom.xml', newVersion, false);
+
+    // 5. Update batch-runner pom.xml
+    logger.info('Updating packages/maven/batch-runner/pom.xml...');
+    updateXmlVersion(
+      tree,
+      'packages/maven/batch-runner/pom.xml',
+      newVersion,
+      false
+    );
+
+    // 6. Update versions.ts
     logger.info('Updating packages/maven/src/utils/versions.ts...');
     const versionsFile = tree.read(
       'packages/maven/src/utils/versions.ts',
@@ -150,7 +167,7 @@ export default async function runGenerator(
 
     tree.write('packages/maven/src/utils/versions.ts', updatedVersionsFile);
 
-    // 4. Update migrations.json
+    // 7. Update migrations.json
     logger.info('Updating packages/maven/migrations.json...');
     const migrationsJsonPath = 'packages/maven/migrations.json';
     const migrationEntry = {
@@ -175,7 +192,7 @@ export default async function runGenerator(
 
     updateJson(tree, migrationsJsonPath, migrationEntry[migrationsJsonPath]);
 
-    // 5. Create migration file
+    // 8. Create migration file
     logger.info(`Creating migration file in ${migrationsDir}...`);
     const migrationContent = `import { Tree } from '@nx/devkit';
 import { updateNxMavenPluginVersion } from '../../utils/pom-xml-updater';


### PR DESCRIPTION
## Current Behavior

Maven e2e tests fail with two issues:
1. Spring Initializr rejects Spring Boot 3.4.0 (now requires >=3.5.0)
2. Parent POMs (`nx-parent` and `nx-maven-parent`) aren't installed locally, causing Maven to fail when resolving `nx-maven-plugin:0.0.12` since it's not yet published to Maven Central

## Expected Behavior

Maven e2e tests pass successfully by:
1. Using Spring Boot 4.0.0 which is supported by Spring Initializr
2. Installing parent POMs to local Maven repository so the plugin can resolve its dependencies

## Related Issue(s)

Fixes the CI failures in maven e2e tests after the 0.0.12 version bump.