### PR TITLE
fix(maven): fix Maven Central publishing for Maven 4

### DIFF
--- a/packages/maven/maven-plugin/pom.xml
+++ b/packages/maven/maven-plugin/pom.xml
@@ -42,7 +42,8 @@
   <properties>
     <!-- Enable install, deploy, and signing for this module -->
     <maven.install.skip>false</maven.install.skip>
-    <maven.deploy.skip>false</maven.deploy.skip>
+    <!-- Skip standard maven-deploy-plugin; we use central-publishing-maven-plugin instead -->
+    <maven.deploy.skip>true</maven.deploy.skip>
     <maven.gpg.skip>false</maven.gpg.skip>
   </properties>
 
@@ -330,6 +331,15 @@
           <plugin>
             <groupId>org.sonatype.central</groupId>
             <artifactId>central-publishing-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>publish-to-central</id>
+                <phase>deploy</phase>
+                <goals>
+                  <goal>publish</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -292,8 +292,7 @@
       <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.9.0</version>
-        <extensions>true</extensions>
+        <version>0.10.0</version>
         <configuration>
           <publishingServerId>central</publishingServerId>
         </configuration>
@@ -306,12 +305,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>
-      </plugin>
-
-      <!-- Activate central publishing plugin -->
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
## Current Behavior

The `central-publishing-maven-plugin` with `extensions=true` does not work with Maven 4. Running `./mvnw deploy -Prelease` completes the build but never triggers the deploy/publish phase - it stops at install.

This is a known issue tracked as [MNG-8584](https://issues.apache.org/jira/browse/MNG-8584).

## Expected Behavior

Running `./mvnw deploy -Prelease -pl packages/maven/maven-plugin -am` should publish the nx-maven-plugin to Maven Central.

## Related Issue(s)

Related to Maven 4 compatibility: https://issues.apache.org/jira/browse/MNG-8584

## Changes

- Add explicit execution binding for `central-publishing-maven-plugin` to the deploy phase (workaround for broken extensions mechanism in Maven 4)
- Remove `extensions=true` that doesn't work with Maven 4
- Update `central-publishing-maven-plugin` from 0.9.0 to 0.10.0
- Skip standard `maven-deploy-plugin` for nx-maven-plugin module (we use central-publishing instead)