### PR TITLE
fix(maven): include migrations.json in published package

### DIFF
--- a/packages/maven/package.json
+++ b/packages/maven/package.json
@@ -33,6 +33,7 @@
     "dist",
     "generators.json",
     "executors.json",
+    "migrations.json",
     "!dist/tsconfig.lib.tsbuildinfo"
   ],
   "keywords": [


### PR DESCRIPTION
## Current Behavior

The `migrations.json` file in the `@nx/maven` package is not included in the `files` array in `package.json`. This means when the package is published to npm, the migrations file is not included, preventing users from running migrations.

## Expected Behavior

The `migrations.json` file should be included in the published package so that Nx can discover and run migrations when users upgrade.

## Related Issue(s)

N/A - discovered during development