### PR TITLE
docs(misc): remove banner.enabled check since we only use banner.activeUntil

### DIFF
--- a/nx-dev/nx-dev/app/layout.tsx
+++ b/nx-dev/nx-dev/app/layout.tsx
@@ -125,9 +125,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         {bannerCollection.map((bannerConfig) => {
           // Check if banner is active
           const isActive =
-            bannerConfig.enabled &&
-            (!bannerConfig.activeUntil ||
-              new Date() < new Date(bannerConfig.activeUntil));
+            bannerConfig.activeUntil &&
+            new Date() < new Date(bannerConfig.activeUntil);
           if (!isActive) return null;
           return (
             <WebinarNotifier

--- a/nx-dev/nx-dev/lib/banner.json
+++ b/nx-dev/nx-dev/lib/banner.json
@@ -1,1 +1,14 @@
-[]
+[
+  {
+    "id": "banner",
+    "activeUntil": "2026-01-14T00:00:00.000Z",
+    "description": "This is the first banner's description.",
+    "slug": "main-event",
+    "primaryCtaText": "Register now!",
+    "primaryCtaUrl": "https://nx.dev",
+    "title": "This is the first banner's title",
+    "secondaryCtaText": "",
+    "secondaryCtaUrl": "",
+    "_generated": "2026-01-13T16:53:11.357Z"
+  }
+]

--- a/nx-dev/nx-dev/pages/_app.tsx
+++ b/nx-dev/nx-dev/pages/_app.tsx
@@ -102,9 +102,8 @@ export default function CustomApp({
       {bannerCollection.map((bannerConfig) => {
         // Check if banner is active
         const isActive =
-          bannerConfig.enabled &&
-          (!bannerConfig.activeUntil ||
-            new Date() < new Date(bannerConfig.activeUntil));
+          bannerConfig.activeUntil &&
+          new Date() < new Date(bannerConfig.activeUntil);
         if (!isActive) return null;
         return (
           <WebinarNotifier


### PR DESCRIPTION
This PR removes the `enabled` check for webinar banner since we don't have the prop in Framer CMS.

## Local verification using https://ready-knowledge-238309.framer.app/api/banners

Pages router:
<img width="2670" height="1527" alt="image" src="https://github.com/user-attachments/assets/b7dfb6c1-6c2a-4f73-8efa-64a66d61ef0c" />

App router (blog):

<img width="2670" height="1527" alt="image" src="https://github.com/user-attachments/assets/6df2bd12-06d4-4d22-bc45-3c772067b6fa" />
