### PR TITLE
docs(misc): update footer with proper year

### DIFF
--- a/nx-dev/ui-common/src/lib/footer.tsx
+++ b/nx-dev/ui-common/src/lib/footer.tsx
@@ -373,7 +373,7 @@ export function Footer({
         </div>
         <div className="mt-20 border-t border-slate-200 p-2 dark:border-slate-800">
           <div className="flex items-center gap-1 text-sm text-slate-400 xl:justify-center">
-            <span>&copy; 2025 made with</span>
+            <span>&copy; {new Date().getFullYear()} made with</span>
             <HeartIcon className="inline h-4 w-4" />
             <span>by</span>
             <Link


### PR DESCRIPTION
This PR updates the `2025` in footer component to always be the current year during build.

<img width="474" height="186" alt="image" src="https://github.com/user-attachments/assets/a177d57d-e58a-411d-9002-9073b16ec007" />
