### PR TITLE
fix(core): only init inline view if able to run

### DIFF
--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -542,7 +542,7 @@ impl App {
                 if matches!(key.code, KeyCode::F(11))
                     && !matches!(self.focus, Focus::CountdownPopup)
                 {
-                    self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
+                    self.try_switch_to_inline_mode();
                     return Ok(false);
                 }
 
@@ -745,9 +745,7 @@ impl App {
                                     KeyCode::Enter => {
                                         // dispatch action to switch to inline mode with focused task
                                         if let Focus::MultipleOutput(_pane_idx) = self.focus {
-                                            self.dispatch_action(Action::SwitchMode(
-                                                TuiMode::Inline,
-                                            ));
+                                            self.try_switch_to_inline_mode();
                                         }
                                     }
                                     _ => {
@@ -1266,6 +1264,22 @@ impl App {
     /// Dispatches an action to the action tx for other components to handle however they see fit
     fn dispatch_action(&self, action: Action) {
         self.core.dispatch_action(action);
+    }
+
+    /// Attempts to switch to inline mode, showing a hint if unavailable
+    ///
+    /// Inline mode requires stdin to be a TTY for cursor position queries.
+    /// In environments like git hooks where stdin is redirected, inline mode
+    /// would hang waiting for terminal responses. This method shows a helpful
+    /// hint instead of silently failing.
+    fn try_switch_to_inline_mode(&self) {
+        if tui::Tui::is_stdin_interactive() {
+            self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
+        } else {
+            self.dispatch_action(Action::ShowHint(
+                "Inline mode is not available in this environment (stdin is not a TTY)".to_string(),
+            ));
+        }
     }
 
     fn recalculate_layout_areas(&mut self) {

--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -176,6 +176,22 @@ fn switch_mode(
 ) -> Option<TuiMode> {
     debug!("Switching to {:?} mode", target_mode);
 
+    // Inline mode requires cursor position queries which hang when stdin is not a TTY.
+    // This happens in git hooks where stderr is a TTY but stdin is redirected.
+    // In this case, show a hint to the user and stay in fullscreen mode instead of hanging.
+    // See: https://github.com/crossterm-rs/crossterm/issues/692
+    if target_mode == TuiMode::Inline && !super::tui::Tui::is_stdin_interactive() {
+        debug!(
+            "Cannot switch to inline mode: stdin is not a TTY. \
+             Staying in fullscreen mode to avoid hanging on cursor position query."
+        );
+        // Show hint to inform user why inline mode is unavailable
+        let _ = action_tx.send(Action::ShowHint(
+            "Inline mode is not available in this environment (stdin is not a TTY)".to_string(),
+        ));
+        return Some(tui.current_mode);
+    }
+
     // Save UI state before switching (for full-screen mode persistence)
     // and get the task to display in inline mode
     let (shared_state, focused_task) = {

--- a/scripts/copy-built-package.ts
+++ b/scripts/copy-built-package.ts
@@ -1,4 +1,5 @@
-import fs, { existsSync } from 'fs';
+import { hash } from 'crypto';
+import fs, { existsSync, readFileSync } from 'fs';
 import { readJsonSync } from 'fs-extra';
 import { dirname, join, relative } from 'path';
 import { globSync } from 'tinyglobby';
@@ -9,17 +10,47 @@ const packages = globSync(`packages/*/package.json`).map(
   (p) => readJsonSync(p).name
 );
 
+const centerStringInWidth = (str: string, width: number): string => {
+  const padding = Math.max(0, width - str.length);
+  const padStart = Math.floor(padding / 2);
+  const padEnd = padding - padStart;
+  return ' '.repeat(padStart) + str + ' '.repeat(padEnd);
+};
+
 // Progress display utilities
 function getProgressBar(current: number, total: number, width = 40): string {
   const percentage = total > 0 ? current / total : 0;
   const filled = Math.round(width * percentage);
   const empty = width - filled;
-  return `${'█'.repeat(filled)}${'░'.repeat(empty)}`;
+  return '█'.repeat(filled) + '░'.repeat(empty);
 }
 
 function truncateStart(str: string, maxLen: number): string {
   if (str.length <= maxLen) return str;
   return '...' + str.slice(-(maxLen - 3));
+}
+
+let progressDisplayInstance: ProgressDisplay | null = null;
+
+function asciiBlock(w: number, px: number, py: number, text: string) {
+  const lines = text.split('\n');
+  const contentWidth = w - px * 2 - 2;
+  const paddedLines = lines.map((line) => {
+    const truncatedLine =
+      line.length > contentWidth
+        ? line.slice(0, contentWidth - 3) + '...'
+        : line;
+    return centerStringInWidth(truncatedLine, w - 2);
+  });
+  const emptyLine = ' '.repeat(w - 2);
+  const blockLines = [
+    '┌' + '─'.repeat(w - 2) + '┐',
+    ...Array(py).fill('│' + emptyLine + '│'),
+    ...paddedLines.map((line) => '│' + line + '│'),
+    ...Array(py).fill('│' + emptyLine + '│'),
+    '└' + '─'.repeat(w - 2) + '┘',
+  ];
+  return blockLines;
 }
 
 class ProgressDisplay {
@@ -30,6 +61,7 @@ class ProgressDisplay {
 
   constructor(total: number) {
     this.total = total;
+    progressDisplayInstance = this;
   }
 
   insertBefore(str: string) {
@@ -66,19 +98,29 @@ class ProgressDisplay {
 
   private renderCurrentStatus() {
     const termWidth = process.stdout.columns || 80;
-    const progressBar = getProgressBar(this.current, this.total, termWidth);
+    const adjustedTermWidth = termWidth - Math.floor(0.2 * termWidth);
+    const progressBar = getProgressBar(
+      this.current,
+      this.total,
+      adjustedTermWidth
+    );
 
     // Line 1: Most recently copied file
     process.stdout.write(
-      this.row(
-        termWidth,
-        4,
-        this.lastFile,
-        `[${this.current} / ${this.total}]\n`
-      )
+      centerStringInWidth(
+        this.row(
+          adjustedTermWidth,
+          4,
+          this.lastFile,
+          `[${this.current} / ${this.total}]`
+        ),
+        termWidth
+      ) + '\x1b[K\n'
     );
     // Line 2: Progress bar
-    process.stdout.write(`${progressBar}\x1b[K\n`);
+    process.stdout.write(
+      centerStringInWidth(progressBar, termWidth) + '\x1b[K\n'
+    );
   }
 
   finish(): void {
@@ -103,8 +145,18 @@ yargs(hideBin(process.argv)).command({
         demandOption: true,
       }),
   handler: (argv) => {
+    const termWidth = process.stdout.columns || 80;
+    const renderWidth = termWidth - termWidth * 0.2;
+    console.log();
     console.log(
-      `Copying ${argv.package} to ${argv.repo}/node_modules/${argv.package}`
+      asciiBlock(
+        renderWidth,
+        2,
+        1,
+        `Copying ${argv.package} to ${argv.repo}/node_modules/${argv.package}`
+      )
+        .map((line) => centerStringInWidth(line, termWidth))
+        .join('\n')
     );
     copyBuiltPackage(argv.package, argv.repo);
   },
@@ -145,9 +197,9 @@ function copyBuiltPackage(pkg: string, outputWorkspace: string) {
     const destDir = dirname(destFile);
     const copySrc = join(copyRoot, file);
     const relativeFilePath = relative(copyRoot, copySrc);
-    progress.update(relativeFilePath, `Writing: ${destFile}`);
+    progress.update(relativeFilePath);
     fs.mkdirSync(destDir, { recursive: true });
-    fs.copyFileSync(copySrc, destFile);
+    safeCopyFileSync(copySrc, destFile);
   });
 
   // Copy native files
@@ -178,8 +230,30 @@ function copyNativeFiles(
     const destDir = dirname(destFile);
     const copySrc = join(copyRoot, file);
     const relativeFilePath = relative(copyRoot, copySrc);
-    progress.update(relativeFilePath, `Writing: ${destFile}`);
+    progress.update(relativeFilePath);
     fs.mkdirSync(destDir, { recursive: true });
-    fs.copyFileSync(copySrc, destFile);
+    safeCopyFileSync(copySrc, destFile);
   });
+}
+
+function safeCopyFileSync(src: string, dest: string) {
+  const sha = hash('sha256', readFileSync(src));
+  for (let i = 0; i < 3; i++) {
+    try {
+      fs.copyFileSync(src, dest);
+      const destSha = hash('sha256', readFileSync(dest));
+      if (sha === destSha) {
+        return;
+      } else {
+        progressDisplayInstance?.insertBefore(
+          `Hash mismatch when copying ${src} to ${dest}, retrying...`
+        );
+      }
+    } catch (e) {
+      progressDisplayInstance?.insertBefore(
+        `Error copying file ${src} to ${dest}: ${(e as Error).message}, retrying...`
+      );
+    }
+  }
+  throw new Error(`Failed to copy ${src} to ${dest} after 3 attempts.`);
 }


### PR DESCRIPTION
## Current Behavior
The inline tui runs some terminal escape codes to check cursor position, these break when stdin isn't a tty (like in a git hook)

## Expected Behavior
The inline tui is disabled if stdin isn't a tty

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
