### PR TITLE
fix(misc): deprecate setup-tailwind generators

### DIFF
--- a/packages/angular/generators.json
+++ b/packages/angular/generators.json
@@ -161,7 +161,8 @@
     "setup-tailwind": {
       "factory": "./src/generators/setup-tailwind/setup-tailwind",
       "schema": "./src/generators/setup-tailwind/schema.json",
-      "description": "Configures Tailwind CSS for an application or a buildable/publishable library."
+      "description": "Configures Tailwind CSS for an application or a buildable/publishable library.",
+      "x-deprecated": "Generating Tailwind configuration is no longer maintained. This generator will be removed in Nx 23."
     },
     "stories": {
       "factory": "./src/generators/stories/stories",

--- a/packages/angular/src/generators/setup-tailwind/setup-tailwind.ts
+++ b/packages/angular/src/generators/setup-tailwind/setup-tailwind.ts
@@ -1,6 +1,7 @@
 import {
   formatFiles,
   GeneratorCallback,
+  logger,
   readProjectConfiguration,
   Tree,
 } from '@nx/devkit';
@@ -18,6 +19,10 @@ export async function setupTailwindGenerator(
   tree: Tree,
   rawOptions: GeneratorOptions
 ): Promise<GeneratorCallback> {
+  logger.warn(
+    `The 'setup-tailwind' generator is deprecated. Generating Tailwind configuration is no longer maintained. This generator will be removed in Nx 23.`
+  );
+
   const options = normalizeOptions(rawOptions);
   const project = readProjectConfiguration(tree, options.project);
 

--- a/packages/next/src/generators/setup-tailwind/setup-tailwind.ts
+++ b/packages/next/src/generators/setup-tailwind/setup-tailwind.ts
@@ -23,6 +23,10 @@ export async function setupTailwindGenerator(
   tree: Tree,
   options: SetupTailwindOptions
 ) {
+  logger.warn(
+    `The 'setup-tailwind' generator is deprecated. Generating Tailwind configuration is no longer maintained. This generator will be removed in Nx 23.`
+  );
+
   const tasks: GeneratorCallback[] = [];
   const project = readProjectConfiguration(tree, options.project);
 

--- a/packages/react/generators.json
+++ b/packages/react/generators.json
@@ -90,7 +90,8 @@
       "factory": "./src/generators/setup-tailwind/setup-tailwind#setupTailwindGenerator",
       "schema": "./src/generators/setup-tailwind/schema.json",
       "description": "Set up Tailwind configuration for a project.",
-      "hidden": false
+      "hidden": false,
+      "x-deprecated": "Generating Tailwind configuration is no longer maintained. This generator will be removed in Nx 23."
     },
     "setup-ssr": {
       "factory": "./src/generators/setup-ssr/setup-ssr#setupSsrGenerator",

--- a/packages/react/src/generators/setup-tailwind/setup-tailwind.ts
+++ b/packages/react/src/generators/setup-tailwind/setup-tailwind.ts
@@ -23,6 +23,10 @@ export async function setupTailwindGenerator(
   tree: Tree,
   options: SetupTailwindOptions
 ) {
+  logger.warn(
+    `The 'setup-tailwind' generator is deprecated. Generating Tailwind configuration is no longer maintained. This generator will be removed in Nx 23.`
+  );
+
   const tasks: GeneratorCallback[] = [];
   const project = readProjectConfiguration(tree, options.project);
 

--- a/packages/remix/generators.json
+++ b/packages/remix/generators.json
@@ -69,7 +69,8 @@
     "setup-tailwind": {
       "implementation": "./src/generators/setup-tailwind/setup-tailwind.impl",
       "schema": "./src/generators/setup-tailwind/schema.json",
-      "description": "Generates a TailwindCSS configuration for the Remix application"
+      "description": "Generates a TailwindCSS configuration for the Remix application",
+      "x-deprecated": "Generating Tailwind configuration is no longer maintained. This generator will be removed in Nx 23."
     },
     "storybook-configuration": {
       "implementation": "./src/generators/storybook-configuration/storybook-configuration.impl#remixStorybookConfiguration",

--- a/packages/remix/src/generators/setup-tailwind/setup-tailwind.impl.ts
+++ b/packages/remix/src/generators/setup-tailwind/setup-tailwind.impl.ts
@@ -4,6 +4,7 @@ import {
   generateFiles,
   installPackagesTask,
   joinPathFragments,
+  logger,
   readProjectConfiguration,
   stripIndents,
   type Tree,
@@ -21,6 +22,10 @@ export default async function setupTailwind(
   tree: Tree,
   options: SetupTailwindSchema
 ) {
+  logger.warn(
+    `The 'setup-tailwind' generator is deprecated. Generating Tailwind configuration is no longer maintained. This generator will be removed in Nx 23.`
+  );
+
   const project = readProjectConfiguration(tree, options.project);
 
   generateFiles(tree, joinPathFragments(__dirname, 'files'), project.root, {

--- a/packages/vue/generators.json
+++ b/packages/vue/generators.json
@@ -32,7 +32,8 @@
     "setup-tailwind": {
       "factory": "./src/generators/setup-tailwind/setup-tailwind",
       "schema": "./src/generators/setup-tailwind/schema.json",
-      "description": "Set up Tailwind configuration for a project."
+      "description": "Set up Tailwind configuration for a project.",
+      "x-deprecated": "Generating Tailwind configuration is no longer maintained. This generator will be removed in Nx 23."
     },
     "storybook-configuration": {
       "factory": "./src/generators/storybook-configuration/configuration#storybookConfigurationGeneratorInternal",

--- a/packages/vue/src/generators/setup-tailwind/setup-tailwind.ts
+++ b/packages/vue/src/generators/setup-tailwind/setup-tailwind.ts
@@ -3,6 +3,7 @@ import {
   addDependenciesToPackageJson,
   formatFiles,
   generateFiles,
+  logger,
   readProjectConfiguration,
 } from '@nx/devkit';
 
@@ -19,6 +20,10 @@ export async function setupTailwindGenerator(
   tree: Tree,
   options: SetupTailwindOptions
 ): Promise<void | GeneratorCallback> {
+  logger.warn(
+    `The 'setup-tailwind' generator is deprecated. Generating Tailwind configuration is no longer maintained. This generator will be removed in Nx 23.`
+  );
+
   let installTask: GeneratorCallback | undefined = undefined;
   const project = readProjectConfiguration(tree, options.project);
 


### PR DESCRIPTION
The setup-tailwind generators are deprecated as generating Tailwind
configuration is no longer maintained. This adds deprecation metadata
to generators.json and runtime warnings when the generators are invoked.

Affected packages: @nx/angular, @nx/react, @nx/next, @nx/remix, @nx/vue

These generators will be removed in Nx 23.

For adding Tailwind support, people can follow the official Tailwind guides. We also
- updated our [angular](https://nx.dev/docs/technologies/angular/guides/using-tailwind-css-with-angular-projects) and [react](https://nx.dev/docs/technologies/react/guides/using-tailwind-css-in-react) docs and have a [blog post](https://nx.dev/blog/setup-tailwind-4-angular-nx-workspace) about it with more info.

Closes NXC-3714
