### PR TITLE
chore(core): exclude handwritten files from native build outputs

### DIFF
--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -15,7 +15,7 @@
       "inputs": ["native"],
       "outputs": [
         "{projectRoot}/src/native/*.wasm",
-        "{projectRoot}/src/native/*.js",
+        "{projectRoot}/src/native/!(index|browser).js",
         "{projectRoot}/src/native/*.cjs",
         "{projectRoot}/src/native/*.mjs",
         "{projectRoot}/src/native/index.d.ts"
@@ -31,7 +31,7 @@
     "build-native": {
       "outputs": [
         "{projectRoot}/src/native/*.node",
-        "{projectRoot}/src/native/*.js",
+        "{projectRoot}/src/native/!(index|browser).js",
         "{projectRoot}/src/native/index.d.ts"
       ],
       "executor": "@monodon/rust:napi",


### PR DESCRIPTION
Exclude some handwritten files from the native build outputs. When those files are updated in isolation, the build can replace them with stale cached outputs. This is because they are not inputs of the native builds, but are incorrectly stored as outputs of the native builds.