### PR TITLE
fix(core): ensure consistent yarn optional dependency hashing

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/yarn-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/yarn-parser.spec.ts
@@ -1087,31 +1087,31 @@ __metadata:
 
         expect(graph.externalNodes).toMatchInlineSnapshot(`
           {
-            "npm:@babel/runtime@7.26.0": {
+            "npm:@babel/runtime": {
               "data": {
                 "hash": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
                 "packageName": "@babel/runtime",
                 "version": "7.26.0",
               },
-              "name": "npm:@babel/runtime@7.26.0",
+              "name": "npm:@babel/runtime",
               "type": "npm",
             },
-            "npm:@docusaurus/core@3.7.0": {
+            "npm:@docusaurus/core": {
               "data": {
                 "hash": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
                 "packageName": "@docusaurus/core",
                 "version": "3.7.0",
               },
-              "name": "npm:@docusaurus/core@3.7.0",
+              "name": "npm:@docusaurus/core",
               "type": "npm",
             },
-            "npm:@docusaurus/module-type-aliases@3.7.0": {
+            "npm:@docusaurus/module-type-aliases": {
               "data": {
                 "hash": "sha512-g7WdPqDNaqA60CmBrr0cORTrsOit77hbsTj7xE2l71YhBn79sxdm7WMK7wfhcaafkbpIh7jv5ef5TOpf1Xv9Lg==",
                 "packageName": "@docusaurus/module-type-aliases",
                 "version": "3.7.0",
               },
-              "name": "npm:@docusaurus/module-type-aliases@3.7.0",
+              "name": "npm:@docusaurus/module-type-aliases",
               "type": "npm",
             },
             "npm:react-helmet-async": {

--- a/packages/nx/src/plugins/js/lock-file/yarn-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/yarn-parser.ts
@@ -185,7 +185,14 @@ function getNodes(
 
   const externalNodes: Record<string, ProjectGraphExternalNode> = {};
   for (const [packageName, versionMap] of nodes.entries()) {
-    const hoistedNode = findHoistedNode(packageName, versionMap, combinedDeps);
+    // If there's only one version of a package, treat it as hoisted
+    // This ensures deterministic hashing across environments for packages
+    // like optional platform-specific dependencies (e.g., @nx/nx-darwin-arm64)
+    const hoistedNode: ProjectGraphExternalNode =
+      versionMap.size === 1
+        ? versionMap.values().next().value
+        : findHoistedNode(packageName, versionMap, combinedDeps);
+
     if (hoistedNode) {
       hoistedNode.name = `npm:${packageName}`;
     }


### PR DESCRIPTION
## Current Behavior

For optional packages that are not installed when using yarn, we currently add the package version to the key for the hash. NPM and PNPM do not do this.

The results in inconsistent hashes for package dependencies when running in different environments. For example, trying to use the cache created in CI on linux on a mac where native dependencies are used.

**yarn on arm mac**

_note how the key has the version in it for the linux and x64 versions that are not installed_
```
$ nx test foo | grep @nx/nx-
...
        "npm:@nx/nx-darwin-x64@22.3.3": "14042642002999097748",
        "npm:@nx/nx-linux-x64-gnu@22.3.3": "12169496858981304476",
        "npm:@nx/nx-darwin-arm64": "1683411334940043113", 
```

**npm on arm mac**

```
$ nx test foo | grep @nx/nx-
...
        "npm:@nx/nx-darwin-x64": "14042642002999097748",
        "npm:@nx/nx-darwin-arm64": "1683411334940043113",
"9980946580833020728",
        "npm:@nx/nx-linux-x64-gnu": "12169496858981304476",
```


**pnpm on arm mac**
```
$ nx test foo | grep @nx/nx-
...
        "npm:@nx/nx-darwin-arm64": "1683411334940043113",
        "npm:@nx/nx-darwin-x64": "14042642002999097748",
        "npm:@nx/nx-linux-x64-gnu": "12169496858981304476",
```


## Expected Behavior

Optional dependencies should be handled the same way from a hashing perspective as installed dependencies.

**yarn on arm mac**

```
$ nx test foo | grep @nx/nx-
...
        "npm:@nx/nx-darwin-x64": "14042642002999097748",
        "npm:@nx/nx-linux-x64-gnu": "12169496858981304476",
        "npm:@nx/nx-darwin-arm64": "1683411334940043113", 
```
