### PR TITLE
feat(nx-dev): add scroll depth tracking for marketing pages

### DIFF
--- a/nx-dev/feature-analytics/src/index.ts
+++ b/nx-dev/feature-analytics/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/google-analytics';
+export * from './lib/use-window-scroll-depth';

--- a/nx-dev/feature-analytics/src/lib/use-window-scroll-depth.ts
+++ b/nx-dev/feature-analytics/src/lib/use-window-scroll-depth.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useRef, useCallback } from 'react';
+import { usePathname } from 'next/navigation';
+import { sendCustomEvent } from './google-analytics';
+
+function getScrollDepth(pct: number): 0 | 25 | 50 | 75 | 90 {
+  if (pct >= 0.9) return 90;
+  if (pct < 0.25) return 0;
+  if (pct < 0.5) return 25;
+  if (pct < 0.75) return 50;
+  return 75;
+}
+
+export function useWindowScrollDepth(): void {
+  const pathname = usePathname();
+  const scrollDepth = useRef(0);
+  const shouldTrackScroll = useRef(true);
+  const rafId = useRef<number | null>(null);
+
+  const handleScroll = useCallback(() => {
+    if (!shouldTrackScroll.current) return;
+    if (typeof window === 'undefined') return;
+
+    const scrollPercentage =
+      (window.scrollY + window.innerHeight) /
+      document.documentElement.scrollHeight;
+    const depth = getScrollDepth(scrollPercentage);
+
+    if (depth > scrollDepth.current) {
+      scrollDepth.current = depth;
+      sendCustomEvent(`scroll_${depth}`, 'scroll', pathname || '/');
+    }
+  }, [pathname]);
+
+  const throttledHandleScroll = useCallback(() => {
+    if (rafId.current !== null) return;
+
+    rafId.current = requestAnimationFrame(() => {
+      handleScroll();
+      rafId.current = null;
+    });
+  }, [handleScroll]);
+
+  useEffect(() => {
+    shouldTrackScroll.current = false;
+
+    const timeout = setTimeout(() => {
+      scrollDepth.current = 0;
+      shouldTrackScroll.current = true;
+    }, 500);
+
+    return () => clearTimeout(timeout);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    window.addEventListener('scroll', throttledHandleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', throttledHandleScroll);
+      if (rafId.current !== null) {
+        cancelAnimationFrame(rafId.current);
+      }
+    };
+  }, [throttledHandleScroll]);
+}

--- a/nx-dev/ui-common/src/lib/default-layout.tsx
+++ b/nx-dev/ui-common/src/lib/default-layout.tsx
@@ -1,7 +1,10 @@
+'use client';
+
 import { Footer } from './footer';
 import { Header } from './headers/header';
 import { PropsWithChildren } from 'react';
 import { ButtonLinkProps } from './button';
+import { useWindowScrollDepth } from '@nx/nx-dev-feature-analytics';
 
 export function DefaultLayout({
   isHome = false,
@@ -19,6 +22,8 @@ export function DefaultLayout({
   headerCTAConfig?: ButtonLinkProps[];
   scrollCTAConfig?: ButtonLinkProps[];
 } & PropsWithChildren): JSX.Element {
+  useWindowScrollDepth();
+
   return (
     <div className="w-full dark:bg-slate-950">
       {!hideHeader && (


### PR DESCRIPTION
## Current Behavior

Marketing pages (homepage, /react, /java, etc.) do not track scroll depth. Only docs pages have scroll tracking via the ScrollableContent component.

## Expected Behavior

Marketing pages now track scroll depth and fire scroll_0, scroll_25, scroll_50, scroll_75, scroll_90 events to Google Analytics, matching the existing docs page behavior.

## Related Issue(s)
Closes DOC-376
