### PR TITLE
feat(bundling): replace rollup-plugin-postcss with inlined version

### DIFF
--- a/packages/rollup/.eslintrc.json
+++ b/packages/rollup/.eslintrc.json
@@ -46,6 +46,8 @@
               "typescript",
               "@swc/core", // Installed to workspace and only used in swc() plugin
               "postcss",
+              "postcss-modules", // Dynamically loaded in postcss plugin
+              "source-map-js", // Used for types only
               "@rollup/plugin-typescript"
             ]
           }

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -45,11 +45,11 @@
     "postcss-modules": "^6.0.1",
     "rollup": "^4.14.0",
     "rollup-plugin-typescript2": "^0.36.0",
-    "source-map-js": "^1.2.0",
     "tslib": "catalog:typescript"
   },
   "devDependencies": {
-    "nx": "workspace:*"
+    "nx": "workspace:*",
+    "source-map-js": "^1.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -38,12 +38,14 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-typescript": "^12.1.0",
     "autoprefixer": "^10.4.9",
+    "concat-with-sourcemaps": "^1.1.0",
     "picocolors": "catalog:",
     "picomatch": "catalog:",
     "postcss": "^8.4.38",
+    "postcss-modules": "^6.0.1",
     "rollup": "^4.14.0",
-    "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-typescript2": "^0.36.0",
+    "source-map-js": "^1.2.0",
     "tslib": "catalog:typescript"
   },
   "devDependencies": {

--- a/packages/rollup/src/plugins/postcss/index.ts
+++ b/packages/rollup/src/plugins/postcss/index.ts
@@ -1,0 +1,25 @@
+/**
+ * @nx/rollup PostCSS plugin
+ *
+ * An inlined, simplified version of rollup-plugin-postcss that:
+ * - Processes CSS files through PostCSS
+ * - Supports CSS preprocessors (Sass, Less, Stylus)
+ * - Supports CSS Modules
+ * - Can inject CSS into DOM or extract to separate files
+ *
+ * This replaces the external rollup-plugin-postcss dependency to avoid
+ * peer dependency conflicts and maintenance issues.
+ */
+
+export { postcss } from './postcss-plugin';
+export { postcss as default } from './postcss-plugin';
+
+export type {
+  PostCSSPluginOptions,
+  PostCSSModulesOptions,
+  FilterPattern,
+  UseOptions,
+  LessOptions,
+  SassOptions,
+  StylusOptions,
+} from './options';

--- a/packages/rollup/src/plugins/postcss/loaders/index.ts
+++ b/packages/rollup/src/plugins/postcss/loaders/index.ts
@@ -1,0 +1,115 @@
+import type {
+  Loader,
+  LoaderContext,
+  LoaderResult,
+  PostCSSLoaderOptions,
+  LessLoaderOptions,
+  SassLoaderOptions,
+  StylusLoaderOptions,
+} from './types';
+import { createPostCSSLoader } from './postcss-loader';
+import { createLessLoader } from './less-loader';
+import { createSassLoader } from './sass-loader';
+import { createStylusLoader } from './stylus-loader';
+import type { UseOptions } from '../options';
+
+export * from './types';
+export { createPostCSSLoader } from './postcss-loader';
+export { createLessLoader } from './less-loader';
+export { createSassLoader } from './sass-loader';
+export { createStylusLoader } from './stylus-loader';
+
+interface LoadersOptions {
+  /** PostCSS loader options */
+  postcss: PostCSSLoaderOptions;
+  /** Preprocessor options */
+  use: UseOptions;
+}
+
+/**
+ * Manages the chain of CSS loaders (preprocessors + PostCSS)
+ */
+export class Loaders {
+  private loaders: Loader[] = [];
+
+  constructor(options: LoadersOptions) {
+    // Register preprocessor loaders based on 'use' options
+    // These are registered first and process files before PostCSS
+    this.registerPreprocessors(options.use);
+
+    // Register the PostCSS loader last - it always processes
+    this.loaders.push(createPostCSSLoader(options.postcss));
+  }
+
+  /**
+   * Register preprocessor loaders based on the 'use' option
+   */
+  private registerPreprocessors(use: UseOptions): void {
+    // Less loader
+    if (use.less !== false) {
+      const lessOptions: LessLoaderOptions =
+        typeof use.less === 'object' ? use.less : {};
+      this.loaders.push(createLessLoader(lessOptions));
+    }
+
+    // Sass loader
+    if (use.sass !== false) {
+      const sassOptions: SassLoaderOptions =
+        typeof use.sass === 'object' ? use.sass : {};
+      this.loaders.push(createSassLoader(sassOptions));
+    }
+
+    // Stylus loader
+    if (use.stylus !== false) {
+      const stylusOptions: StylusLoaderOptions =
+        typeof use.stylus === 'object' ? use.stylus : {};
+      this.loaders.push(createStylusLoader(stylusOptions));
+    }
+  }
+
+  /**
+   * Check if any loader can process the given file
+   */
+  isSupported(filepath: string): boolean {
+    return this.loaders.some((loader) => this.matchesLoader(loader, filepath));
+  }
+
+  /**
+   * Check if a file matches a loader's test
+   */
+  private matchesLoader(loader: Loader, filepath: string): boolean {
+    if (typeof loader.test === 'function') {
+      return loader.test(filepath);
+    }
+    return loader.test.test(filepath);
+  }
+
+  /**
+   * Process a file through the loader chain
+   * Preprocessors run first (if matching), then PostCSS always runs
+   */
+  async process(code: string, context: LoaderContext): Promise<LoaderResult> {
+    let result: LoaderResult = { code };
+
+    // Process through each loader in order
+    for (const loader of this.loaders) {
+      // Skip non-matching loaders unless they always process
+      if (!loader.alwaysProcess && !this.matchesLoader(loader, context.id)) {
+        continue;
+      }
+
+      // Process with this loader
+      const loaderResult = await loader.process(result.code, context);
+
+      // Merge the result
+      result = {
+        ...result,
+        ...loaderResult,
+        // Preserve the map from the latest loader that produced one
+        map: loaderResult.map ?? result.map,
+      };
+    }
+
+    return result;
+  }
+}

--- a/packages/rollup/src/plugins/postcss/loaders/less-loader.ts
+++ b/packages/rollup/src/plugins/postcss/loaders/less-loader.ts
@@ -1,0 +1,94 @@
+import { promisify } from 'util';
+import type {
+  Loader,
+  LoaderContext,
+  LoaderResult,
+  LessLoaderOptions,
+} from './types';
+import { requireModule, humanizePath } from '../utils';
+
+interface LessStatic {
+  render(
+    input: string,
+    options: LessRenderOptions,
+    callback: (
+      error: Less.RenderError | null,
+      output: Less.RenderOutput | undefined
+    ) => void
+  ): void;
+}
+
+interface LessRenderOptions {
+  filename?: string;
+  sourceMap?: {
+    outputSourceFiles?: boolean;
+  };
+  javascriptEnabled?: boolean;
+  [key: string]: unknown;
+}
+
+declare namespace Less {
+  interface RenderError {
+    message: string;
+    filename?: string;
+    line?: number;
+    column?: number;
+  }
+
+  interface RenderOutput {
+    css: string;
+    map?: string;
+    imports: string[];
+  }
+}
+
+let less: LessStatic | undefined;
+
+/**
+ * Less preprocessor loader
+ * Compiles .less files to CSS
+ */
+export function createLessLoader(options: LessLoaderOptions = {}): Loader {
+  return {
+    name: 'less',
+    test: /\.less$/,
+
+    async process(code: string, context: LoaderContext): Promise<LoaderResult> {
+      if (!less) {
+        less = requireModule<LessStatic>('less', 'Less');
+      }
+
+      const render = promisify(less.render.bind(less));
+
+      const result = await render(code, {
+        ...options,
+        filename: context.id,
+        sourceMap: context.sourceMap
+          ? {
+              outputSourceFiles: true,
+            }
+          : undefined,
+      });
+
+      // Track dependencies
+      if (result.imports) {
+        for (const dep of result.imports) {
+          context.dependencies.add(dep);
+        }
+      }
+
+      let map: LoaderResult['map'];
+      if (result.map) {
+        map = JSON.parse(result.map);
+        if (map && map.sources) {
+          map.sources = map.sources.map(humanizePath);
+        }
+      }
+
+      return {
+        code: result.css,
+        map,
+      };
+    },
+  };
+}

--- a/packages/rollup/src/plugins/postcss/loaders/loaders.spec.ts
+++ b/packages/rollup/src/plugins/postcss/loaders/loaders.spec.ts
@@ -1,0 +1,198 @@
+import { Loaders } from './index';
+import type { LoaderContext } from './types';
+
+describe('Loaders', () => {
+  const createMockContext = (): LoaderContext => ({
+    id: '/path/to/file.css',
+    sourceMap: false,
+    dependencies: new Set(),
+    warn: jest.fn(),
+  });
+
+  describe('isSupported', () => {
+    it('should support CSS files', () => {
+      const loaders = new Loaders({
+        postcss: {
+          plugins: [],
+          modules: false,
+          autoModules: false,
+          extract: false,
+          inject: true,
+        },
+        use: {},
+      });
+
+      expect(loaders.isSupported('/path/to/styles.css')).toBe(true);
+    });
+
+    it('should support SCSS files', () => {
+      const loaders = new Loaders({
+        postcss: {
+          plugins: [],
+          modules: false,
+          autoModules: false,
+          extract: false,
+          inject: true,
+        },
+        use: {},
+      });
+
+      expect(loaders.isSupported('/path/to/styles.scss')).toBe(true);
+    });
+
+    it('should support SASS files', () => {
+      const loaders = new Loaders({
+        postcss: {
+          plugins: [],
+          modules: false,
+          autoModules: false,
+          extract: false,
+          inject: true,
+        },
+        use: {},
+      });
+
+      expect(loaders.isSupported('/path/to/styles.sass')).toBe(true);
+    });
+
+    it('should support Less files', () => {
+      const loaders = new Loaders({
+        postcss: {
+          plugins: [],
+          modules: false,
+          autoModules: false,
+          extract: false,
+          inject: true,
+        },
+        use: {},
+      });
+
+      expect(loaders.isSupported('/path/to/styles.less')).toBe(true);
+    });
+
+    it('should support Stylus files', () => {
+      const loaders = new Loaders({
+        postcss: {
+          plugins: [],
+          modules: false,
+          autoModules: false,
+          extract: false,
+          inject: true,
+        },
+        use: {},
+      });
+
+      expect(loaders.isSupported('/path/to/styles.styl')).toBe(true);
+      expect(loaders.isSupported('/path/to/styles.stylus')).toBe(true);
+    });
+
+    it('should not support JS files', () => {
+      const loaders = new Loaders({
+        postcss: {
+          plugins: [],
+          modules: false,
+          autoModules: false,
+          extract: false,
+          inject: true,
+        },
+        use: {},
+      });
+
+      expect(loaders.isSupported('/path/to/script.js')).toBe(false);
+    });
+
+    it('should not support TypeScript files', () => {
+      const loaders = new Loaders({
+        postcss: {
+          plugins: [],
+          modules: false,
+          autoModules: false,
+          extract: false,
+          inject: true,
+        },
+        use: {},
+      });
+
+      expect(loaders.isSupported('/path/to/script.ts')).toBe(false);
+    });
+  });
+
+  describe('process', () => {
+    it('should process plain CSS', async () => {
+      const loaders = new Loaders({
+        postcss: {
+          plugins: [],
+          modules: false,
+          autoModules: false,
+          extract: false,
+          inject: true,
+        },
+        use: {},
+      });
+
+      const context = createMockContext();
+      const result = await loaders.process('.foo { color: red; }', context);
+
+      expect(result).toBeDefined();
+      expect(result.code).toBeDefined();
+      expect(typeof result.code).toBe('string');
+    });
+
+    it('should generate inject code when inject is true', async () => {
+      const loaders = new Loaders({
+        postcss: {
+          plugins: [],
+          modules: false,
+          autoModules: false,
+          extract: false,
+          inject: true,
+        },
+        use: {},
+      });
+
+      const context = createMockContext();
+      const result = await loaders.process('.foo { color: red; }', context);
+
+      expect(result.code).toContain('styleInject');
+    });
+
+    it('should generate extract code when extract is true', async () => {
+      const loaders = new Loaders({
+        postcss: {
+          plugins: [],
+          modules: false,
+          autoModules: false,
+          extract: true,
+          inject: false,
+        },
+        use: {},
+      });
+
+      const context = createMockContext();
+      const result = await loaders.process('.foo { color: red; }', context);
+
+      expect(result.extracted).toBeDefined();
+      expect(result.extracted?.code).toContain('.foo');
+    });
+
+    it('should disable specific preprocessors when set to false', () => {
+      const loaders = new Loaders({
+        postcss: {
+          plugins: [],
+          modules: false,
+          autoModules: false,
+          extract: false,
+          inject: true,
+        },
+        use: {
+          less: false,
+          sass: false,
+          stylus: false,
+        },
+      });
+
+      // When preprocessors are disabled, the loaders should still support CSS
+      expect(loaders.isSupported('/path/to/styles.css')).toBe(true);
+    });
+  });
+});

--- a/packages/rollup/src/plugins/postcss/loaders/postcss-loader.ts
+++ b/packages/rollup/src/plugins/postcss/loaders/postcss-loader.ts
@@ -1,0 +1,224 @@
+import { basename } from 'path';
+import postcss, { type AcceptedPlugin, type ProcessOptions } from 'postcss';
+import type {
+  Loader,
+  LoaderContext,
+  LoaderResult,
+  PostCSSLoaderOptions,
+} from './types';
+import { humanizePath, safeIdentifier, STYLE_INJECT_PATH } from '../utils';
+
+/**
+ * Check if a file should use CSS modules based on its filename
+ */
+function shouldUseCSSModules(filepath: string, autoModules: boolean): boolean {
+  if (!autoModules) {
+    return false;
+  }
+  // Check for .module.xxx pattern
+  const filename = basename(filepath);
+  return /\.module\.[a-z]+$/i.test(filename);
+}
+
+/**
+ * PostCSS loader - processes CSS through PostCSS plugins
+ * This loader always runs last in the chain
+ */
+export function createPostCSSLoader(options: PostCSSLoaderOptions): Loader {
+  return {
+    name: 'postcss',
+    test: /\.(css|sss|pcss|sass|scss|less|styl|stylus)$/,
+    alwaysProcess: true,
+
+    async process(code: string, context: LoaderContext): Promise<LoaderResult> {
+      const { plugins, modules, autoModules, extract, inject } = options;
+
+      // Determine if CSS modules should be used
+      const shouldUseModules =
+        modules || shouldUseCSSModules(context.id, autoModules);
+
+      // Collect CSS module exports
+      let cssModuleExports: Record<string, string> | undefined;
+
+      // Build the PostCSS plugins array
+      const postcssPlugins: AcceptedPlugin[] = [...plugins];
+
+      // Add CSS modules plugin if needed
+      if (shouldUseModules) {
+        try {
+          const postcssModules = require('postcss-modules');
+          const modulesOptions = typeof modules === 'object' ? modules : {};
+
+          postcssPlugins.unshift(
+            postcssModules({
+              ...modulesOptions,
+              getJSON(
+                _cssFilename: string,
+                json: Record<string, string>,
+                _outputFilename: string
+              ) {
+                cssModuleExports = json;
+              },
+            })
+          );
+        } catch {
+          throw new Error(
+            'You need to install "postcss-modules" package in order to use CSS Modules.'
+          );
+        }
+      }
+
+      // Process with PostCSS
+      const processOptions: ProcessOptions = {
+        from: context.id,
+        to: context.id,
+        map: context.sourceMap
+          ? {
+              inline: context.sourceMap === 'inline',
+              annotation: false,
+              sourcesContent: true,
+            }
+          : false,
+      };
+
+      const result = await postcss(postcssPlugins).process(
+        code,
+        processOptions
+      );
+
+      // Track dependencies from PostCSS messages
+      for (const message of result.messages) {
+        if (message.type === 'dependency') {
+          context.dependencies.add(message.file);
+        }
+      }
+
+      // Emit warnings
+      for (const warning of result.warnings()) {
+        context.warn(warning.toString());
+      }
+
+      // Get the source map
+      let map: LoaderResult['map'];
+      if (result.map) {
+        map = result.map.toJSON() as unknown as LoaderResult['map'];
+        if (map?.sources) {
+          map.sources = map.sources.map(humanizePath);
+        }
+      }
+
+      // If extracting CSS, return the extracted content
+      if (extract) {
+        return {
+          code: generateModuleCode(cssModuleExports),
+          map: undefined,
+          extracted: {
+            code: result.css,
+            map,
+          },
+          exports: cssModuleExports,
+        };
+      }
+
+      // If injecting CSS, return code that injects at runtime
+      if (inject) {
+        return {
+          code: generateInjectCode(
+            result.css,
+            context.id,
+            inject,
+            cssModuleExports
+          ),
+          map: undefined,
+          exports: cssModuleExports,
+        };
+      }
+
+      // Otherwise return the CSS as a string export
+      return {
+        code: generateModuleCode(cssModuleExports, result.css),
+        map,
+        exports: cssModuleExports,
+      };
+    },
+  };
+}
+
+/**
+ * Generate JavaScript module code for CSS exports
+ */
+function generateModuleCode(
+  exports?: Record<string, string>,
+  css?: string
+): string {
+  const lines: string[] = [];
+
+  if (exports && Object.keys(exports).length > 0) {
+    // Export each class name
+    for (const [key, value] of Object.entries(exports)) {
+      const safeName = safeIdentifier(key);
+      lines.push(`export var ${safeName} = ${JSON.stringify(value)};`);
+    }
+
+    // Default export is the full exports object
+    lines.push(`export default ${JSON.stringify(exports)};`);
+  } else if (css !== undefined) {
+    // Export the CSS string as default
+    lines.push(`export default ${JSON.stringify(css)};`);
+  } else {
+    // Empty export
+    lines.push(`export default {};`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Generate JavaScript code that injects CSS at runtime
+ */
+function generateInjectCode(
+  css: string,
+  id: string,
+  inject:
+    | boolean
+    | Record<string, unknown>
+    | ((cssVar: string, id: string) => string),
+  exports?: Record<string, string>
+): string {
+  const lines: string[] = [];
+
+  // Import style-inject
+  lines.push(`import styleInject from '${STYLE_INJECT_PATH}';`);
+  lines.push('');
+
+  // CSS string variable
+  lines.push(`var css = ${JSON.stringify(css)};`);
+  lines.push('');
+
+  // Inject the CSS
+  if (typeof inject === 'function') {
+    // Custom inject function
+    lines.push(`(${inject.toString()})('css', ${JSON.stringify(id)});`);
+  } else if (typeof inject === 'object') {
+    // Inject with options
+    lines.push(`styleInject(css, ${JSON.stringify(inject)});`);
+  } else {
+    // Default inject
+    lines.push(`styleInject(css);`);
+  }
+
+  lines.push('');
+
+  // Export CSS module classes if any
+  if (exports && Object.keys(exports).length > 0) {
+    for (const [key, value] of Object.entries(exports)) {
+      const safeName = safeIdentifier(key);
+      lines.push(`export var ${safeName} = ${JSON.stringify(value)};`);
+    }
+    lines.push(`export default ${JSON.stringify(exports)};`);
+  } else {
+    lines.push(`export default css;`);
+  }
+
+  return lines.join('\n');
+}

--- a/packages/rollup/src/plugins/postcss/loaders/postcss-loader.ts
+++ b/packages/rollup/src/plugins/postcss/loaders/postcss-loader.ts
@@ -198,7 +198,7 @@ function generateInjectCode(
   // Inject the CSS
   if (typeof inject === 'function') {
     // Custom inject function
-    lines.push(`(${inject.toString()})('css', ${JSON.stringify(id)});`);
+    lines.push(`(${inject.toString()})(css, ${JSON.stringify(id)});`);
   } else if (typeof inject === 'object') {
     // Inject with options
     lines.push(`styleInject(css, ${JSON.stringify(inject)});`);

--- a/packages/rollup/src/plugins/postcss/loaders/sass-loader.ts
+++ b/packages/rollup/src/plugins/postcss/loaders/sass-loader.ts
@@ -1,0 +1,254 @@
+import { dirname, resolve, basename, join } from 'path';
+import type {
+  Loader,
+  LoaderContext,
+  LoaderResult,
+  SassLoaderOptions,
+} from './types';
+import { loadModule, humanizePath } from '../utils';
+
+interface SassOptions {
+  file?: string;
+  data?: string;
+  includePaths?: string[];
+  sourceMap?: boolean;
+  outFile?: string;
+  sourceMapContents?: boolean;
+  importer?: SassImporter | SassImporter[];
+  [key: string]: unknown;
+}
+
+interface SassResult {
+  css: Buffer;
+  map?: Buffer;
+  stats: {
+    includedFiles: string[];
+  };
+}
+
+type SassImporter = (
+  url: string,
+  prev: string,
+  done: (result: { file: string } | { contents: string } | Error | null) => void
+) => void | { file: string } | { contents: string } | Error | null;
+
+interface SassStatic {
+  render(
+    options: SassOptions,
+    callback: (error: Error | null, result: SassResult) => void
+  ): void;
+  renderSync(options: SassOptions): SassResult;
+}
+
+interface ModernSassStatic {
+  compile(path: string, options?: ModernSassOptions): ModernSassResult;
+  compileString(source: string, options?: ModernSassOptions): ModernSassResult;
+}
+
+interface ModernSassOptions {
+  loadPaths?: string[];
+  sourceMap?: boolean;
+  importers?: ModernSassImporter[];
+  [key: string]: unknown;
+}
+
+interface ModernSassImporter {
+  findFileUrl?(
+    url: string,
+    context: { containingUrl: URL | null }
+  ): URL | null | Promise<URL | null>;
+}
+
+interface ModernSassResult {
+  css: string;
+  sourceMap?: {
+    sources: string[];
+    [key: string]: unknown;
+  };
+  loadedUrls: URL[];
+}
+
+let sassModule: SassStatic | ModernSassStatic | undefined;
+let isModernSass = false;
+
+/**
+ * Get the sass module, trying modern sass first, then node-sass
+ */
+function getSassModule(): SassStatic | ModernSassStatic {
+  if (sassModule) {
+    return sassModule;
+  }
+
+  // Try modern sass first
+  const modernSass = loadModule<ModernSassStatic>('sass');
+  if (modernSass && typeof modernSass.compile === 'function') {
+    sassModule = modernSass;
+    isModernSass = true;
+    return sassModule;
+  }
+
+  // Try legacy sass (or node-sass)
+  const legacySass =
+    loadModule<SassStatic>('sass') || loadModule<SassStatic>('node-sass');
+  if (legacySass && typeof legacySass.render === 'function') {
+    sassModule = legacySass;
+    isModernSass = false;
+    return sassModule;
+  }
+
+  throw new Error(
+    'You need to install "sass" or "node-sass" package in order to process Sass files.'
+  );
+}
+
+/**
+ * Resolve a module import (handles ~ prefix for node_modules)
+ */
+function resolveModuleImport(url: string, prev: string): string | null {
+  if (!url.startsWith('~')) {
+    return null;
+  }
+
+  const modulePath = url.slice(1);
+  const prevDir = dirname(prev);
+
+  // Try to resolve from node_modules
+  const paths = [
+    join(prevDir, 'node_modules', modulePath),
+    join(process.cwd(), 'node_modules', modulePath),
+  ];
+
+  // Also try partial file (with underscore prefix)
+  const dir = dirname(modulePath);
+  const file = basename(modulePath);
+  const partialPaths = [
+    join(prevDir, 'node_modules', dir, `_${file}`),
+    join(process.cwd(), 'node_modules', dir, `_${file}`),
+  ];
+
+  // Try all paths with various extensions
+  const extensions = ['', '.scss', '.sass', '.css'];
+
+  for (const basePath of [...partialPaths, ...paths]) {
+    for (const ext of extensions) {
+      const fullPath = basePath + ext;
+      try {
+        require.resolve(fullPath);
+        return fullPath;
+      } catch {
+        // Continue trying
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Sass/SCSS preprocessor loader
+ * Compiles .sass and .scss files to CSS
+ */
+export function createSassLoader(options: SassLoaderOptions = {}): Loader {
+  return {
+    name: 'sass',
+    test: /\.(sass|scss)$/,
+
+    async process(code: string, context: LoaderContext): Promise<LoaderResult> {
+      const sass = getSassModule();
+      const { implementation: _, ...sassOptions } = options;
+
+      if (isModernSass) {
+        // Modern sass (Dart Sass) with compile API
+        const modernSass = sass as ModernSassStatic;
+
+        const result = modernSass.compileString(code, {
+          ...sassOptions,
+          loadPaths: [dirname(context.id), process.cwd(), 'node_modules'],
+          sourceMap: !!context.sourceMap,
+          importers: [
+            {
+              findFileUrl(url: string) {
+                const resolved = resolveModuleImport(url, context.id);
+                if (resolved) {
+                  return new URL(`file://${resolve(resolved)}`);
+                }
+                return null;
+              },
+            },
+          ],
+        });
+
+        // Track dependencies
+        for (const loadedUrl of result.loadedUrls) {
+          if (loadedUrl.protocol === 'file:') {
+            context.dependencies.add(loadedUrl.pathname);
+          }
+        }
+
+        let map: LoaderResult['map'];
+        if (result.sourceMap) {
+          map = result.sourceMap as unknown as LoaderResult['map'];
+          if (map?.sources) {
+            map.sources = map.sources.map(humanizePath);
+          }
+        }
+
+        return {
+          code: result.css,
+          map,
+        };
+      } else {
+        // Legacy sass/node-sass with render API
+        const legacySass = sass as SassStatic;
+
+        return new Promise((resolvePromise, reject) => {
+          legacySass.render(
+            {
+              ...sassOptions,
+              data: code,
+              file: context.id,
+              includePaths: [dirname(context.id), process.cwd()],
+              sourceMap: !!context.sourceMap,
+              outFile: context.id,
+              sourceMapContents: true,
+              importer: (url, prev, done) => {
+                const resolved = resolveModuleImport(url, prev);
+                if (resolved) {
+                  done({ file: resolved });
+                } else {
+                  done(null);
+                }
+              },
+            },
+            (error, result) => {
+              if (error) {
+                reject(error);
+                return;
+              }
+
+              // Track dependencies
+              if (result.stats.includedFiles) {
+                for (const dep of result.stats.includedFiles) {
+                  context.dependencies.add(dep);
+                }
+              }
+
+              let map: LoaderResult['map'];
+              if (result.map) {
+                map = JSON.parse(result.map.toString());
+                if (map?.sources) {
+                  map.sources = map.sources.map(humanizePath);
+                }
+              }
+
+              resolvePromise({
+                code: result.css.toString(),
+                map,
+              });
+            }
+          );
+        });
+      }
+    },
+  };
+}

--- a/packages/rollup/src/plugins/postcss/loaders/stylus-loader.ts
+++ b/packages/rollup/src/plugins/postcss/loaders/stylus-loader.ts
@@ -1,0 +1,90 @@
+import { dirname } from 'path';
+import type {
+  Loader,
+  LoaderContext,
+  LoaderResult,
+  StylusLoaderOptions,
+} from './types';
+import { requireModule, humanizePath } from '../utils';
+
+interface StylusStatic {
+  (code: string): StylusRenderer;
+}
+
+interface StylusRenderer {
+  set(key: string, value: unknown): this;
+  render(callback: (error: Error | null, css: string) => void): void;
+  deps(): string[];
+  sourcemap:
+    | {
+        sources: string[];
+        [key: string]: unknown;
+      }
+    | undefined;
+}
+
+let stylus: StylusStatic | undefined;
+
+/**
+ * Stylus preprocessor loader
+ * Compiles .styl and .stylus files to CSS
+ */
+export function createStylusLoader(options: StylusLoaderOptions = {}): Loader {
+  return {
+    name: 'stylus',
+    test: /\.(styl|stylus)$/,
+
+    async process(code: string, context: LoaderContext): Promise<LoaderResult> {
+      if (!stylus) {
+        stylus = requireModule<StylusStatic>('stylus', 'Stylus');
+      }
+
+      const renderer = stylus(code);
+
+      // Set options
+      renderer.set('filename', context.id);
+      renderer.set('paths', [dirname(context.id), process.cwd()]);
+
+      if (context.sourceMap) {
+        renderer.set('sourcemap', {
+          comment: false,
+          inline: false,
+          basePath: process.cwd(),
+        });
+      }
+
+      // Apply additional options
+      for (const [key, value] of Object.entries(options)) {
+        renderer.set(key, value);
+      }
+
+      return new Promise((resolve, reject) => {
+        renderer.render((error, css) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          // Track dependencies
+          const deps = renderer.deps();
+          for (const dep of deps) {
+            context.dependencies.add(dep);
+          }
+
+          let map: LoaderResult['map'];
+          if (renderer.sourcemap) {
+            map = renderer.sourcemap as unknown as LoaderResult['map'];
+            if (map?.sources) {
+              map.sources = map.sources.map(humanizePath);
+            }
+          }
+
+          resolve({
+            code: css,
+            map,
+          });
+        });
+      });
+    },
+  };
+}

--- a/packages/rollup/src/plugins/postcss/loaders/types.ts
+++ b/packages/rollup/src/plugins/postcss/loaders/types.ts
@@ -1,0 +1,101 @@
+import type { RawSourceMap } from 'source-map-js';
+import type { PostCSSModulesOptions } from '../options';
+import type { AcceptedPlugin } from 'postcss';
+
+/**
+ * Context passed to each loader during processing
+ */
+export interface LoaderContext {
+  /** Absolute path to the file being processed */
+  id: string;
+  /** Whether source maps are enabled */
+  sourceMap: boolean | 'inline';
+  /** Set of file dependencies (for watch mode) */
+  dependencies: Set<string>;
+  /** Function to emit warnings */
+  warn: (message: string) => void;
+}
+
+/**
+ * Result returned from a loader
+ */
+export interface LoaderResult {
+  /** Processed CSS/code */
+  code: string;
+  /** Source map (if generated) */
+  map?: RawSourceMap;
+  /** Extracted CSS content (for extraction mode) */
+  extracted?: {
+    /** CSS content */
+    code: string;
+    /** CSS source map */
+    map?: RawSourceMap;
+  };
+  /** CSS module exports (class name mappings) */
+  exports?: Record<string, string>;
+}
+
+/**
+ * Interface for CSS loaders (preprocessors and PostCSS)
+ */
+export interface Loader {
+  /** Unique name for this loader */
+  name: string;
+  /** Test to determine if this loader should process a file */
+  test: RegExp | ((filepath: string) => boolean);
+  /** Whether this loader should always process files (like postcss-loader) */
+  alwaysProcess?: boolean;
+  /** Process the file and return the result */
+  process(
+    code: string,
+    context: LoaderContext,
+    options?: Record<string, unknown>
+  ): Promise<LoaderResult>;
+}
+
+/**
+ * Options for the PostCSS loader
+ */
+export interface PostCSSLoaderOptions {
+  /** PostCSS plugins to apply */
+  plugins: AcceptedPlugin[];
+  /** CSS modules options */
+  modules: boolean | PostCSSModulesOptions;
+  /** Auto-detect CSS modules from .module.xxx files */
+  autoModules: boolean;
+  /** Extract CSS to separate file instead of injecting */
+  extract: boolean | string;
+  /** Inject CSS into DOM */
+  inject:
+    | boolean
+    | Record<string, unknown>
+    | ((cssVar: string, id: string) => string);
+}
+
+/**
+ * Options for the Less loader
+ */
+export interface LessLoaderOptions {
+  /** Enable inline JavaScript in Less files */
+  javascriptEnabled?: boolean;
+  /** Additional Less options */
+  [key: string]: unknown;
+}
+
+/**
+ * Options for the Sass loader
+ */
+export interface SassLoaderOptions {
+  /** Sass implementation to use */
+  implementation?: string;
+  /** Additional Sass options */
+  [key: string]: unknown;
+}
+
+/**
+ * Options for the Stylus loader
+ */
+export interface StylusLoaderOptions {
+  /** Additional Stylus options */
+  [key: string]: unknown;
+}

--- a/packages/rollup/src/plugins/postcss/options.spec.ts
+++ b/packages/rollup/src/plugins/postcss/options.spec.ts
@@ -1,0 +1,80 @@
+import { normalizeOptions } from './options';
+
+describe('normalizeOptions', () => {
+  it('should return defaults when no options provided', () => {
+    const result = normalizeOptions();
+
+    expect(result.inject).toBe(true);
+    expect(result.extract).toBe(false);
+    expect(result.autoModules).toBe(false);
+    expect(result.modules).toBe(false);
+    expect(result.plugins).toEqual([]);
+    expect(result.use).toEqual({});
+    expect(result.extensions).toEqual(['.css', '.sss', '.pcss']);
+    expect(result.sourceMap).toBe(false);
+  });
+
+  it('should preserve provided options', () => {
+    const result = normalizeOptions({
+      inject: false,
+      extract: true,
+      autoModules: true,
+      sourceMap: 'inline',
+    });
+
+    expect(result.inject).toBe(false);
+    expect(result.extract).toBe(true);
+    expect(result.autoModules).toBe(true);
+    expect(result.sourceMap).toBe('inline');
+  });
+
+  it('should handle extract as string', () => {
+    const result = normalizeOptions({
+      extract: 'styles.css',
+    });
+
+    expect(result.extract).toBe('styles.css');
+  });
+
+  it('should handle modules as object', () => {
+    const modulesOptions = {
+      generateScopedName: '[name]__[local]___[hash:base64:5]',
+    };
+    const result = normalizeOptions({
+      modules: modulesOptions,
+    });
+
+    expect(result.modules).toEqual(modulesOptions);
+  });
+
+  it('should preserve plugins array', () => {
+    const mockPlugin = { postcssPlugin: 'test' };
+    const result = normalizeOptions({
+      plugins: [mockPlugin as any],
+    });
+
+    expect(result.plugins).toEqual([mockPlugin]);
+  });
+
+  it('should preserve use options for preprocessors', () => {
+    const result = normalizeOptions({
+      use: {
+        less: { javascriptEnabled: true },
+        sass: { implementation: 'sass' },
+      },
+    });
+
+    expect(result.use).toEqual({
+      less: { javascriptEnabled: true },
+      sass: { implementation: 'sass' },
+    });
+  });
+
+  it('should handle custom extensions', () => {
+    const result = normalizeOptions({
+      extensions: ['.css', '.scss'],
+    });
+
+    expect(result.extensions).toEqual(['.css', '.scss']);
+  });
+});

--- a/packages/rollup/src/plugins/postcss/options.ts
+++ b/packages/rollup/src/plugins/postcss/options.ts
@@ -1,0 +1,150 @@
+import type { AcceptedPlugin } from 'postcss';
+
+export type FilterPattern = string | RegExp | (string | RegExp)[];
+
+export interface PostCSSModulesOptions {
+  /** Generate scoped names */
+  generateScopedName?:
+    | string
+    | ((name: string, filename: string, css: string) => string);
+  /** Scope behaviour */
+  scopeBehaviour?: 'global' | 'local';
+  /** Global module paths */
+  globalModulePaths?: RegExp[];
+  /** Export globals */
+  exportGlobals?: boolean;
+  /** Hash prefix */
+  hashPrefix?: string;
+  /** Locate imports */
+  localsConvention?: 'camelCase' | 'camelCaseOnly' | 'dashes' | 'dashesOnly';
+}
+
+export interface LessOptions {
+  /** Enable inline JavaScript in Less files */
+  javascriptEnabled?: boolean;
+  /** Additional Less options */
+  [key: string]: unknown;
+}
+
+export interface SassOptions {
+  /** Sass implementation to use ('sass' or 'node-sass') */
+  implementation?: string;
+  /** Additional Sass options */
+  [key: string]: unknown;
+}
+
+export interface StylusOptions {
+  /** Additional Stylus options */
+  [key: string]: unknown;
+}
+
+export interface UseOptions {
+  sass?: SassOptions | false;
+  less?: LessOptions | false;
+  stylus?: StylusOptions | false;
+}
+
+export interface PostCSSPluginOptions {
+  /**
+   * Inject CSS as <style> tag to <head>
+   * @default true
+   */
+  inject?:
+    | boolean
+    | Record<string, unknown>
+    | ((cssVar: string, id: string) => string);
+
+  /**
+   * Extract CSS to a separate file
+   * - `true`: Extract to `[name].css`
+   * - `string`: Extract to the specified path
+   * @default false
+   */
+  extract?: boolean | string;
+
+  /**
+   * Automatically enable CSS modules for `.module.xxx` files
+   * @default false
+   */
+  autoModules?: boolean;
+
+  /**
+   * Enable CSS modules
+   * - `true`: Enable with default options
+   * - `object`: Enable with custom options
+   * @default false
+   */
+  modules?: boolean | PostCSSModulesOptions;
+
+  /**
+   * PostCSS plugins to apply
+   */
+  plugins?: AcceptedPlugin[];
+
+  /**
+   * Preprocessor options
+   */
+  use?: UseOptions;
+
+  /**
+   * Files to include
+   * @default [/\.css$/, /\.sss$/, /\.pcss$/]
+   */
+  include?: FilterPattern;
+
+  /**
+   * Files to exclude
+   * @default /node_modules/
+   */
+  exclude?: FilterPattern;
+
+  /**
+   * Generate source maps
+   * - `true`: Generate external source maps
+   * - `'inline'`: Generate inline source maps
+   * @default false
+   */
+  sourceMap?: boolean | 'inline';
+
+  /**
+   * File extensions to process
+   * @default ['.css', '.sss', '.pcss']
+   */
+  extensions?: string[];
+}
+
+/**
+ * Internal options after normalization
+ */
+export interface NormalizedPostCSSOptions extends PostCSSPluginOptions {
+  inject:
+    | boolean
+    | Record<string, unknown>
+    | ((cssVar: string, id: string) => string);
+  extract: boolean | string;
+  autoModules: boolean;
+  modules: boolean | PostCSSModulesOptions;
+  plugins: AcceptedPlugin[];
+  use: UseOptions;
+  extensions: string[];
+  sourceMap: boolean | 'inline';
+}
+
+/**
+ * Normalize plugin options with defaults
+ */
+export function normalizeOptions(
+  options: PostCSSPluginOptions = {}
+): NormalizedPostCSSOptions {
+  return {
+    ...options,
+    inject: options.inject ?? true,
+    extract: options.extract ?? false,
+    autoModules: options.autoModules ?? false,
+    modules: options.modules ?? false,
+    plugins: options.plugins ?? [],
+    use: options.use ?? {},
+    extensions: options.extensions ?? ['.css', '.sss', '.pcss'],
+    sourceMap: options.sourceMap ?? false,
+  };
+}

--- a/packages/rollup/src/plugins/postcss/postcss-plugin.spec.ts
+++ b/packages/rollup/src/plugins/postcss/postcss-plugin.spec.ts
@@ -1,0 +1,262 @@
+import { postcss } from './postcss-plugin';
+import type { Plugin, PluginContext } from 'rollup';
+
+describe('postcss plugin', () => {
+  describe('plugin initialization', () => {
+    it('should return a plugin with correct name', () => {
+      const plugin = postcss();
+      expect(plugin.name).toBe('postcss');
+    });
+
+    it('should have required hooks', () => {
+      const plugin = postcss();
+      expect(plugin.resolveId).toBeDefined();
+      expect(plugin.load).toBeDefined();
+      expect(plugin.transform).toBeDefined();
+      expect(plugin.augmentChunkHash).toBeDefined();
+      expect(plugin.generateBundle).toBeDefined();
+    });
+  });
+
+  describe('resolveId', () => {
+    it('should resolve style-inject virtual module', () => {
+      const plugin = postcss();
+      const resolveId = plugin.resolveId as Function;
+
+      expect(resolveId('style-inject')).toBe('\0style-inject');
+    });
+
+    it('should return null for other modules', () => {
+      const plugin = postcss();
+      const resolveId = plugin.resolveId as Function;
+
+      expect(resolveId('some-other-module')).toBeNull();
+      expect(resolveId('./styles.css')).toBeNull();
+    });
+  });
+
+  describe('load', () => {
+    it('should load style-inject virtual module', () => {
+      const plugin = postcss();
+      const load = plugin.load as Function;
+
+      const result = load('\0style-inject');
+      expect(result).toContain('function styleInject');
+      expect(result).toContain('export default styleInject');
+    });
+
+    it('should return null for other modules', () => {
+      const plugin = postcss();
+      const load = plugin.load as Function;
+
+      expect(load('some-other-module')).toBeNull();
+      expect(load('./styles.css')).toBeNull();
+    });
+  });
+
+  describe('transform', () => {
+    let mockContext: Partial<PluginContext>;
+
+    beforeEach(() => {
+      mockContext = {
+        warn: jest.fn(),
+        addWatchFile: jest.fn(),
+      };
+    });
+
+    it('should skip non-CSS files', async () => {
+      const plugin = postcss();
+      const transform = plugin.transform as Function;
+
+      const result = await transform.call(
+        mockContext,
+        'const x = 1;',
+        '/path/to/file.js'
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should skip files in node_modules by default', async () => {
+      const plugin = postcss();
+      const transform = plugin.transform as Function;
+
+      const result = await transform.call(
+        mockContext,
+        '.foo { color: red; }',
+        '/path/to/node_modules/pkg/style.css'
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('should process CSS files', async () => {
+      const plugin = postcss();
+      const transform = plugin.transform as Function;
+
+      const result = await transform.call(
+        mockContext,
+        '.foo { color: red; }',
+        '/path/to/styles.css'
+      );
+
+      expect(result).toBeDefined();
+      expect(result.code).toBeDefined();
+      expect(typeof result.code).toBe('string');
+    });
+
+    it('should generate injection code when inject is true', async () => {
+      const plugin = postcss({ inject: true, extract: false });
+      const transform = plugin.transform as Function;
+
+      const result = await transform.call(
+        mockContext,
+        '.foo { color: red; }',
+        '/path/to/styles.css'
+      );
+
+      expect(result.code).toContain("import styleInject from 'style-inject'");
+      expect(result.code).toContain('styleInject(css)');
+    });
+
+    it('should generate module exports when extract is true', async () => {
+      const plugin = postcss({ inject: false, extract: true });
+      const transform = plugin.transform as Function;
+
+      const result = await transform.call(
+        mockContext,
+        '.foo { color: red; }',
+        '/path/to/styles.css'
+      );
+
+      expect(result.code).toContain('export default');
+      expect(result.code).not.toContain('styleInject');
+    });
+
+    it('should process .scss files', async () => {
+      const plugin = postcss();
+      const transform = plugin.transform as Function;
+
+      // Note: This test will only pass if sass is installed
+      // In CI, we might need to mock the sass loader
+      try {
+        const result = await transform.call(
+          mockContext,
+          '$color: red; .foo { color: $color; }',
+          '/path/to/styles.scss'
+        );
+        expect(result).toBeDefined();
+      } catch (e) {
+        // Sass not installed - this is expected in unit tests
+        expect((e as Error).message).toContain('sass');
+      }
+    });
+
+    it('should process .less files', async () => {
+      const plugin = postcss({
+        use: { less: { javascriptEnabled: true } },
+      });
+      const transform = plugin.transform as Function;
+
+      // Note: This test will only pass if less is installed
+      try {
+        const result = await transform.call(
+          mockContext,
+          '@color: red; .foo { color: @color; }',
+          '/path/to/styles.less'
+        );
+        expect(result).toBeDefined();
+      } catch (e) {
+        // Less not installed - this is expected in unit tests
+        expect((e as Error).message).toContain('less');
+      }
+    });
+  });
+
+  describe('CSS Modules', () => {
+    let mockContext: Partial<PluginContext>;
+
+    beforeEach(() => {
+      mockContext = {
+        warn: jest.fn(),
+        addWatchFile: jest.fn(),
+      };
+    });
+
+    it('should auto-detect CSS modules from .module.css files', async () => {
+      const plugin = postcss({ autoModules: true });
+      const transform = plugin.transform as Function;
+
+      try {
+        const result = await transform.call(
+          mockContext,
+          '.foo { color: red; }',
+          '/path/to/styles.module.css'
+        );
+
+        expect(result).toBeDefined();
+        expect(result.code).toBeDefined();
+      } catch (e) {
+        // postcss-modules not installed - this is expected
+        expect((e as Error).message).toContain('postcss-modules');
+      }
+    });
+
+    it('should not use CSS modules for regular CSS files when autoModules is true', async () => {
+      const plugin = postcss({ autoModules: true, inject: false });
+      const transform = plugin.transform as Function;
+
+      const result = await transform.call(
+        mockContext,
+        '.foo { color: red; }',
+        '/path/to/styles.css'
+      );
+
+      expect(result).toBeDefined();
+      // Regular CSS should just export the CSS string
+      expect(result.code).toContain('export default');
+    });
+  });
+
+  describe('file filtering', () => {
+    let mockContext: Partial<PluginContext>;
+
+    beforeEach(() => {
+      mockContext = {
+        warn: jest.fn(),
+        addWatchFile: jest.fn(),
+      };
+    });
+
+    it('should process files matching include pattern', async () => {
+      const plugin = postcss({
+        include: ['**/custom/**/*.css'],
+        exclude: undefined,
+      });
+      const transform = plugin.transform as Function;
+
+      const result = await transform.call(
+        mockContext,
+        '.foo { color: red; }',
+        '/path/custom/styles.css'
+      );
+
+      expect(result).toBeDefined();
+    });
+
+    it('should respect custom extensions', async () => {
+      const plugin = postcss({
+        extensions: ['.mycss'],
+      });
+      const transform = plugin.transform as Function;
+
+      // Should not process .css when not in extensions
+      const cssResult = await transform.call(
+        mockContext,
+        '.foo { color: red; }',
+        '/path/to/styles.css'
+      );
+      expect(cssResult).toBeNull();
+    });
+  });
+});

--- a/packages/rollup/src/plugins/postcss/postcss-plugin.ts
+++ b/packages/rollup/src/plugins/postcss/postcss-plugin.ts
@@ -1,0 +1,360 @@
+import { basename, extname, relative } from 'path';
+import type { Plugin, PluginContext, SourceMapInput } from 'rollup';
+import type {
+  PostCSSPluginOptions,
+  FilterPattern,
+  NormalizedPostCSSOptions,
+} from './options';
+import { normalizeOptions } from './options';
+import { Loaders } from './loaders';
+import type { LoaderResult } from './loaders';
+import {
+  normalizePath,
+  styleInjectCode,
+  STYLE_INJECT_ID,
+  STYLE_INJECT_PATH,
+} from './utils';
+
+// Use require for modules that don't have proper ES module exports
+const Concat = require('concat-with-sourcemaps');
+const picomatch = require('picomatch');
+
+interface ExtractedCSS {
+  id: string;
+  code: string;
+  map?: LoaderResult['map'];
+}
+
+/**
+ * Convert a source map from loader format to Rollup format
+ */
+function toRollupSourceMap(
+  map: LoaderResult['map']
+): SourceMapInput | undefined {
+  if (!map) return undefined;
+  // Rollup expects version as number, but source-map-js uses string
+  // Convert to Rollup-compatible format
+  return {
+    ...map,
+    version:
+      typeof map.version === 'string' ? parseInt(map.version, 10) : map.version,
+  } as SourceMapInput;
+}
+
+/**
+ * Create a file filter from include/exclude patterns
+ */
+function createFilter(
+  include?: FilterPattern,
+  exclude?: FilterPattern
+): (id: string) => boolean {
+  const includeMatchers = include
+    ? (Array.isArray(include) ? include : [include]).map((p) =>
+        typeof p === 'string' ? picomatch(p) : (id: string) => p.test(id)
+      )
+    : [];
+
+  const excludeMatchers = exclude
+    ? (Array.isArray(exclude) ? exclude : [exclude]).map((p) =>
+        typeof p === 'string' ? picomatch(p) : (id: string) => p.test(id)
+      )
+    : [];
+
+  return (id: string) => {
+    const normalizedId = normalizePath(id);
+
+    // If exclude matches, reject
+    if (
+      excludeMatchers.length > 0 &&
+      excludeMatchers.some((m) => m(normalizedId))
+    ) {
+      return false;
+    }
+
+    // If include is specified, only accept if it matches
+    if (includeMatchers.length > 0) {
+      return includeMatchers.some((m) => m(normalizedId));
+    }
+
+    // Default: accept all
+    return true;
+  };
+}
+
+/**
+ * Get the output filename for extracted CSS
+ */
+function getExtractedFilename(
+  extract: boolean | string,
+  chunkName: string
+): string {
+  if (typeof extract === 'string') {
+    return extract;
+  }
+  return `${chunkName}.css`;
+}
+
+/**
+ * Recursively get the import order for CSS files
+ * This ensures CSS is concatenated in the correct dependency order
+ */
+function getRecursiveImportOrder(
+  id: string,
+  moduleGraph: Map<string, Set<string>>,
+  visited = new Set<string>()
+): string[] {
+  if (visited.has(id)) {
+    return [];
+  }
+  visited.add(id);
+
+  const imports = moduleGraph.get(id);
+  if (!imports) {
+    return [id];
+  }
+
+  const result: string[] = [];
+  for (const importId of imports) {
+    result.push(...getRecursiveImportOrder(importId, moduleGraph, visited));
+  }
+  result.push(id);
+
+  return result;
+}
+
+/**
+ * PostCSS Rollup plugin
+ *
+ * Processes CSS files through PostCSS and optional preprocessors (Sass, Less, Stylus).
+ * Supports CSS injection into the DOM or extraction to separate files.
+ */
+export function postcss(pluginOptions: PostCSSPluginOptions = {}): Plugin {
+  const options: NormalizedPostCSSOptions = normalizeOptions(pluginOptions);
+
+  // Create file filter
+  const defaultExtensions = [
+    '.css',
+    '.sss',
+    '.pcss', // CSS formats
+    '.scss',
+    '.sass', // Sass
+    '.less', // Less
+    '.styl',
+    '.stylus', // Stylus
+  ];
+
+  const extensions = options.extensions ?? defaultExtensions;
+
+  const filter = createFilter(
+    options.include ?? extensions.map((ext) => `**/*${ext}`),
+    options.exclude ?? /node_modules/
+  );
+
+  // Initialize the loaders
+  const loaders = new Loaders({
+    postcss: {
+      plugins: options.plugins,
+      modules: options.modules,
+      autoModules: options.autoModules,
+      extract: options.extract,
+      inject: options.inject,
+    },
+    use: options.use,
+  });
+
+  // Storage for extracted CSS (when extract is enabled)
+  const extracted = new Map<string, ExtractedCSS>();
+
+  // Track module dependencies for correct CSS ordering
+  const moduleGraph = new Map<string, Set<string>>();
+
+  return {
+    name: 'postcss',
+
+    /**
+     * Resolve the virtual style-inject module
+     */
+    resolveId(source: string) {
+      if (source === STYLE_INJECT_PATH) {
+        return STYLE_INJECT_ID;
+      }
+      return null;
+    },
+
+    /**
+     * Load the virtual style-inject module
+     */
+    load(id: string) {
+      if (id === STYLE_INJECT_ID) {
+        return styleInjectCode;
+      }
+      return null;
+    },
+
+    /**
+     * Transform CSS files
+     */
+    async transform(this: PluginContext, code: string, id: string) {
+      // Skip non-CSS files
+      if (!filter(id)) {
+        return null;
+      }
+
+      const ext = extname(id);
+      if (!extensions.includes(ext)) {
+        return null;
+      }
+
+      // Track dependencies for this module
+      const deps = new Set<string>();
+      moduleGraph.set(id, deps);
+
+      // Process through the loader chain
+      const result = await loaders.process(code, {
+        id,
+        sourceMap: options.sourceMap,
+        dependencies: deps,
+        warn: (message: string) => this.warn(message),
+      });
+
+      // Add watch dependencies
+      for (const dep of deps) {
+        this.addWatchFile(dep);
+      }
+
+      // Store extracted CSS if in extract mode
+      if (result.extracted) {
+        extracted.set(id, {
+          id,
+          code: result.extracted.code,
+          map: result.extracted.map,
+        });
+      }
+
+      return {
+        code: result.code,
+        map: toRollupSourceMap(result.map) ?? { mappings: '' },
+      };
+    },
+
+    /**
+     * Include extracted CSS in chunk hash
+     */
+    augmentChunkHash(chunk) {
+      if (!options.extract || extracted.size === 0) {
+        return;
+      }
+
+      // Find CSS files that belong to this chunk
+      const chunkCSS: string[] = [];
+      for (const moduleId of Object.keys(chunk.modules)) {
+        const css = extracted.get(moduleId);
+        if (css) {
+          chunkCSS.push(css.code);
+        }
+      }
+
+      if (chunkCSS.length > 0) {
+        return chunkCSS.join(':');
+      }
+    },
+
+    /**
+     * Generate the extracted CSS files
+     */
+    async generateBundle(this: PluginContext, outputOptions, bundle) {
+      if (!options.extract || extracted.size === 0) {
+        return;
+      }
+
+      // Group extracted CSS by chunk
+      const cssPerChunk = new Map<string, ExtractedCSS[]>();
+
+      for (const [chunkId, chunk] of Object.entries(bundle)) {
+        if (chunk.type !== 'chunk') {
+          continue;
+        }
+
+        const chunkModules = Object.keys(chunk.modules);
+        const cssForChunk: ExtractedCSS[] = [];
+
+        // Get the import order for CSS files in this chunk
+        const orderedModules: string[] = [];
+        for (const moduleId of chunkModules) {
+          orderedModules.push(
+            ...getRecursiveImportOrder(moduleId, moduleGraph)
+          );
+        }
+
+        // Remove duplicates while preserving order
+        const seen = new Set<string>();
+        const uniqueModules = orderedModules.filter((id) => {
+          if (seen.has(id)) return false;
+          seen.add(id);
+          return true;
+        });
+
+        // Collect CSS in dependency order
+        for (const moduleId of uniqueModules) {
+          const css = extracted.get(moduleId);
+          if (css) {
+            cssForChunk.push(css);
+          }
+        }
+
+        if (cssForChunk.length > 0) {
+          cssPerChunk.set(chunkId, cssForChunk);
+        }
+      }
+
+      // Emit CSS files for each chunk
+      for (const [chunkId, cssFiles] of cssPerChunk) {
+        const chunk = bundle[chunkId];
+        if (chunk.type !== 'chunk') continue;
+
+        const chunkName = chunk.name || basename(chunkId, extname(chunkId));
+        const cssFilename = getExtractedFilename(options.extract, chunkName);
+
+        // Concatenate CSS files with source maps
+        const concat = new Concat(!!options.sourceMap, cssFilename, '\n');
+
+        for (const css of cssFiles) {
+          const relativePath = relative(process.cwd(), css.id);
+          concat.add(
+            relativePath,
+            css.code,
+            css.map ? JSON.stringify(css.map) : undefined
+          );
+        }
+
+        // Emit the CSS file
+        const cssContent = concat.content.toString();
+        const cssMap = concat.sourceMap;
+
+        // Determine if source map should be inline or separate
+        let finalCSS = cssContent;
+        if (options.sourceMap === 'inline' && cssMap) {
+          const mapBase64 = Buffer.from(cssMap).toString('base64');
+          finalCSS += `\n/*# sourceMappingURL=data:application/json;base64,${mapBase64} */`;
+        } else if (options.sourceMap && cssMap) {
+          // Add source map reference
+          finalCSS += `\n/*# sourceMappingURL=${cssFilename}.map */`;
+
+          // Emit source map file
+          this.emitFile({
+            type: 'asset',
+            fileName: `${cssFilename}.map`,
+            source: cssMap,
+          });
+        }
+
+        // Emit CSS file
+        this.emitFile({
+          type: 'asset',
+          fileName: cssFilename,
+          source: finalCSS,
+        });
+      }
+    },
+  };
+}

--- a/packages/rollup/src/plugins/postcss/postcss-plugin.ts
+++ b/packages/rollup/src/plugins/postcss/postcss-plugin.ts
@@ -312,8 +312,14 @@ export function postcss(pluginOptions: PostCSSPluginOptions = {}): Plugin {
         const chunk = bundle[chunkId];
         if (chunk.type !== 'chunk') continue;
 
-        const chunkName = chunk.name || basename(chunkId, extname(chunkId));
-        const cssFilename = getExtractedFilename(options.extract, chunkName);
+        // Use the actual chunk filename to derive CSS filename
+        // This preserves patterns like index.esm.js -> index.esm.css
+        const chunkFileName = chunk.fileName;
+        const chunkBaseName = basename(chunkFileName, extname(chunkFileName));
+        const cssFilename = getExtractedFilename(
+          options.extract,
+          chunkBaseName
+        );
 
         // Concatenate CSS files with source maps
         const concat = new Concat(!!options.sourceMap, cssFilename, '\n');

--- a/packages/rollup/src/plugins/postcss/types/concat-with-sourcemaps.d.ts
+++ b/packages/rollup/src/plugins/postcss/types/concat-with-sourcemaps.d.ts
@@ -1,0 +1,29 @@
+declare module 'concat-with-sourcemaps' {
+  class Concat {
+    constructor(
+      generateSourceMap: boolean,
+      outputFileName: string,
+      separator?: string
+    );
+
+    /**
+     * Add a file to the output
+     * @param filePath - Relative path to the file
+     * @param content - File content
+     * @param sourceMap - Source map JSON string (optional)
+     */
+    add(filePath: string, content: string | Buffer, sourceMap?: string): void;
+
+    /**
+     * The concatenated content
+     */
+    readonly content: Buffer;
+
+    /**
+     * The combined source map (as JSON string)
+     */
+    readonly sourceMap: string | undefined;
+  }
+
+  export = Concat;
+}

--- a/packages/rollup/src/plugins/postcss/utils/index.ts
+++ b/packages/rollup/src/plugins/postcss/utils/index.ts
@@ -1,0 +1,8 @@
+export { normalizePath, humanizePath } from './normalize-path';
+export { loadModule, requireModule } from './load-module';
+export { safeIdentifier, escapeClassNameDashes } from './safe-identifier';
+export {
+  styleInjectCode,
+  STYLE_INJECT_ID,
+  STYLE_INJECT_PATH,
+} from './style-inject';

--- a/packages/rollup/src/plugins/postcss/utils/load-module.ts
+++ b/packages/rollup/src/plugins/postcss/utils/load-module.ts
@@ -1,0 +1,37 @@
+import { resolve } from 'path';
+
+/**
+ * Load a module with fallback to loading from cwd
+ * This allows preprocessors like sass, less, stylus to be loaded from
+ * either the plugin's node_modules or the project's node_modules
+ */
+export function loadModule<T = unknown>(moduleId: string): T | undefined {
+  try {
+    // First try to load from the plugin's node_modules
+    return require(moduleId) as T;
+  } catch {
+    // If that fails, try to load from the current working directory
+    try {
+      const modulePath = resolve(process.cwd(), 'node_modules', moduleId);
+      return require(modulePath) as T;
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+/**
+ * Load a module and throw an error if it's not found
+ */
+export function requireModule<T = unknown>(
+  moduleId: string,
+  feature: string
+): T {
+  const module = loadModule<T>(moduleId);
+  if (!module) {
+    throw new Error(
+      `You need to install "${moduleId}" package in order to process ${feature} files.`
+    );
+  }
+  return module;
+}

--- a/packages/rollup/src/plugins/postcss/utils/normalize-path.spec.ts
+++ b/packages/rollup/src/plugins/postcss/utils/normalize-path.spec.ts
@@ -1,0 +1,27 @@
+import { normalizePath } from './normalize-path';
+
+describe('normalizePath', () => {
+  it('should convert backslashes to forward slashes', () => {
+    expect(normalizePath('path\\to\\file.css')).toBe('path/to/file.css');
+  });
+
+  it('should handle multiple consecutive backslashes', () => {
+    expect(normalizePath('path\\\\to\\\\file.css')).toBe('path/to/file.css');
+  });
+
+  it('should return empty string for undefined input', () => {
+    expect(normalizePath(undefined)).toBe('');
+  });
+
+  it('should return empty string for empty string input', () => {
+    expect(normalizePath('')).toBe('');
+  });
+
+  it('should not modify paths with only forward slashes', () => {
+    expect(normalizePath('path/to/file.css')).toBe('path/to/file.css');
+  });
+
+  it('should handle mixed slashes', () => {
+    expect(normalizePath('path/to\\file.css')).toBe('path/to/file.css');
+  });
+});

--- a/packages/rollup/src/plugins/postcss/utils/normalize-path.ts
+++ b/packages/rollup/src/plugins/postcss/utils/normalize-path.ts
@@ -1,0 +1,18 @@
+/**
+ * Normalize file path to use forward slashes (POSIX style)
+ * This ensures consistent path handling across Windows and Unix systems
+ */
+export function normalizePath(path: string | undefined): string {
+  if (!path) {
+    return '';
+  }
+  return path.replace(/\\+/g, '/');
+}
+
+/**
+ * Convert an absolute path to a human-readable relative path from cwd
+ */
+export function humanizePath(filepath: string): string {
+  const { relative } = require('path');
+  return normalizePath(relative(process.cwd(), filepath));
+}

--- a/packages/rollup/src/plugins/postcss/utils/safe-identifier.spec.ts
+++ b/packages/rollup/src/plugins/postcss/utils/safe-identifier.spec.ts
@@ -1,0 +1,52 @@
+import { safeIdentifier, escapeClassNameDashes } from './safe-identifier';
+
+describe('escapeClassNameDashes', () => {
+  it('should convert dashes to camelCase', () => {
+    expect(escapeClassNameDashes('my-class')).toBe('myClass');
+  });
+
+  it('should handle multiple dashes', () => {
+    expect(escapeClassNameDashes('my-very-long-class')).toBe('myVeryLongClass');
+  });
+
+  it('should handle consecutive dashes', () => {
+    expect(escapeClassNameDashes('my--class')).toBe('myClass');
+  });
+
+  it('should not modify names without dashes', () => {
+    expect(escapeClassNameDashes('myClass')).toBe('myClass');
+  });
+});
+
+describe('safeIdentifier', () => {
+  it('should convert dashes to camelCase', () => {
+    expect(safeIdentifier('my-class')).toBe('myClass');
+  });
+
+  it('should prefix with underscore if starts with digit', () => {
+    expect(safeIdentifier('123class')).toBe('_123class');
+  });
+
+  it('should prefix reserved words with underscore', () => {
+    expect(safeIdentifier('class')).toBe('_class');
+    expect(safeIdentifier('export')).toBe('_export');
+    expect(safeIdentifier('import')).toBe('_import');
+    expect(safeIdentifier('default')).toBe('_default');
+  });
+
+  it('should replace invalid characters with underscores', () => {
+    expect(safeIdentifier('my.class')).toBe('my_class');
+    expect(safeIdentifier('my@class')).toBe('my_class');
+  });
+
+  it('should handle complex class names', () => {
+    // -123 becomes 123 (dash removal with next char capitalized, but 1 stays as 1)
+    expect(safeIdentifier('my-class-123')).toBe('myClass123');
+  });
+
+  it('should not modify valid identifiers', () => {
+    expect(safeIdentifier('myClass')).toBe('myClass');
+    expect(safeIdentifier('_private')).toBe('_private');
+    expect(safeIdentifier('$special')).toBe('$special');
+  });
+});

--- a/packages/rollup/src/plugins/postcss/utils/safe-identifier.ts
+++ b/packages/rollup/src/plugins/postcss/utils/safe-identifier.ts
@@ -1,0 +1,93 @@
+/**
+ * Convert a CSS class name to a valid JavaScript identifier
+ * This is used when generating exports for CSS modules
+ */
+
+/**
+ * Reserved JavaScript keywords that cannot be used as identifiers
+ */
+const RESERVED_WORDS = new Set([
+  'break',
+  'case',
+  'catch',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'finally',
+  'for',
+  'function',
+  'if',
+  'in',
+  'instanceof',
+  'new',
+  'return',
+  'switch',
+  'this',
+  'throw',
+  'try',
+  'typeof',
+  'var',
+  'void',
+  'while',
+  'with',
+  'class',
+  'const',
+  'enum',
+  'export',
+  'extends',
+  'import',
+  'super',
+  'implements',
+  'interface',
+  'let',
+  'package',
+  'private',
+  'protected',
+  'public',
+  'static',
+  'yield',
+  'null',
+  'true',
+  'false',
+]);
+
+/**
+ * Check if a string starts with a digit
+ */
+function startsWithDigit(str: string): boolean {
+  return /^\d/.test(str);
+}
+
+/**
+ * Escape dashes in class names to make them valid JS identifiers
+ * e.g., "my-class" -> "myClass"
+ */
+export function escapeClassNameDashes(name: string): string {
+  return name.replace(/-+(\w)/g, (_, char) => char.toUpperCase());
+}
+
+/**
+ * Convert a CSS class name to a safe JavaScript identifier
+ */
+export function safeIdentifier(name: string): string {
+  // First escape dashes
+  let safeName = escapeClassNameDashes(name);
+
+  // If it starts with a digit, prefix with underscore
+  if (startsWithDigit(safeName)) {
+    safeName = '_' + safeName;
+  }
+
+  // If it's a reserved word, prefix with underscore
+  if (RESERVED_WORDS.has(safeName)) {
+    safeName = '_' + safeName;
+  }
+
+  // Replace any remaining invalid characters with underscores
+  safeName = safeName.replace(/[^a-zA-Z0-9_$]/g, '_');
+
+  return safeName;
+}

--- a/packages/rollup/src/plugins/postcss/utils/style-inject.ts
+++ b/packages/rollup/src/plugins/postcss/utils/style-inject.ts
@@ -1,0 +1,55 @@
+/**
+ * Inlined style-inject module
+ * Original: https://github.com/nicolo-ribaudo/style-inject
+ *
+ * This module is used at runtime to inject CSS into the DOM when
+ * the `inject` option is enabled and `extract` is disabled.
+ */
+
+/**
+ * The style-inject runtime code that gets injected into the bundle
+ * This is the ES module version that will be imported at runtime
+ */
+export const styleInjectCode = `
+function styleInject(css, ref) {
+  if (ref === void 0) ref = {};
+  var insertAt = ref.insertAt;
+
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = document.createElement('style');
+  style.type = 'text/css';
+
+  if (insertAt === 'top') {
+    if (head.firstChild) {
+      head.insertBefore(style, head.firstChild);
+    } else {
+      head.appendChild(style);
+    }
+  } else {
+    head.appendChild(style);
+  }
+
+  if (style.styleSheet) {
+    style.styleSheet.cssText = css;
+  } else {
+    style.appendChild(document.createTextNode(css));
+  }
+}
+
+export { styleInject };
+export default styleInject;
+`.trim();
+
+/**
+ * Virtual module ID for style-inject
+ */
+export const STYLE_INJECT_ID = '\0style-inject';
+
+/**
+ * Path that will be used in imports
+ */
+export const STYLE_INJECT_PATH = 'style-inject';

--- a/packages/rollup/src/plugins/with-nx/with-nx.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx.ts
@@ -38,7 +38,9 @@ const commonjs = require('@rollup/plugin-commonjs');
 const image = require('@rollup/plugin-image');
 
 const json = require('@rollup/plugin-json');
-const postcss = require('rollup-plugin-postcss');
+
+// Use our inlined postcss plugin instead of external rollup-plugin-postcss
+import { postcss } from '../postcss';
 
 const fileExtensions = ['.js', '.jsx', '.ts', '.tsx'];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4055,9 +4055,6 @@ importers:
       rollup-plugin-typescript2:
         specifier: ^0.36.0
         version: 0.36.0(rollup@4.44.2)(typescript@5.9.2)
-      source-map-js:
-        specifier: ^1.2.0
-        version: 1.2.1
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
@@ -4065,6 +4062,9 @@ importers:
       nx:
         specifier: workspace:*
         version: link:../nx
+      source-map-js:
+        specifier: ^1.2.0
+        version: 1.2.1
 
   packages/rsbuild:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4034,6 +4034,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.9
         version: 10.4.21(postcss@8.5.3)
+      concat-with-sourcemaps:
+        specifier: ^1.1.0
+        version: 1.1.0
       picocolors:
         specifier: 'catalog:'
         version: 1.1.1
@@ -4043,15 +4046,18 @@ importers:
       postcss:
         specifier: ^8.4.38
         version: 8.5.3
+      postcss-modules:
+        specifier: ^6.0.1
+        version: 6.0.1(postcss@8.5.3)
       rollup:
         specifier: ^4.14.0
         version: 4.44.2
-      rollup-plugin-postcss:
-        specifier: ^4.0.2
-        version: 4.0.2(postcss@8.5.3)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.9.2))
       rollup-plugin-typescript2:
         specifier: ^0.36.0
         version: 0.36.0(rollup@4.44.2)(typescript@5.9.2)
+      source-map-js:
+        specifier: ^1.2.0
+        version: 1.2.1
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
@@ -49847,14 +49853,6 @@ snapshots:
       postcss: 8.5.3
       ts-node: 10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@20.19.19)(typescript@5.9.2)
 
-  postcss-load-config@3.1.4(postcss@8.5.3)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.9.2)):
-    dependencies:
-      lilconfig: 2.1.0
-      yaml: 1.10.2
-    optionalDependencies:
-      postcss: 8.5.3
-      ts-node: 10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.9.2)
-
   postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@20.19.19)(typescript@5.9.2)):
     dependencies:
       lilconfig: 3.1.3
@@ -52038,25 +52036,6 @@ snapshots:
       pify: 5.0.0
       postcss: 8.5.3
       postcss-load-config: 3.1.4(postcss@8.5.3)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(@types/node@20.19.19)(typescript@5.9.2))
-      postcss-modules: 4.3.1(postcss@8.5.3)
-      promise.series: 0.2.0
-      resolve: 1.22.10
-      rollup-pluginutils: 2.8.2
-      safe-identifier: 0.4.2
-      style-inject: 0.3.0
-    transitivePeerDependencies:
-      - ts-node
-
-  rollup-plugin-postcss@4.0.2(postcss@8.5.3)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.9.2)):
-    dependencies:
-      chalk: 4.1.2
-      concat-with-sourcemaps: 1.1.0
-      cssnano: 5.1.15(postcss@8.5.3)
-      import-cwd: 3.0.0
-      p-queue: 6.6.2
-      pify: 5.0.0
-      postcss: 8.5.3
-      postcss-load-config: 3.1.4(postcss@8.5.3)(ts-node@10.9.1(@swc/core@1.5.7(@swc/helpers@0.5.17))(@types/node@24.2.0)(typescript@5.9.2))
       postcss-modules: 4.3.1(postcss@8.5.3)
       promise.series: 0.2.0
       resolve: 1.22.10


### PR DESCRIPTION
## Current Behavior
The `rollup-plugin-postcss` has not released a new version in 4 years.
The deps it depends on are outdated and starting to cause problems with peer-dep conflicts.

## Expected Behavior
Recreate the plugin within the `@nx/rollup` package to maintain the functionality/behaviour and manage dependencies ourselves.

## Related Issue(s)

Closes NXC-3644
