### PR TITLE
fix(vitest): prevent config double-merge causing array duplication

### DIFF
--- a/packages/vitest/src/executors/test/schema.d.ts
+++ b/packages/vitest/src/executors/test/schema.d.ts
@@ -4,4 +4,5 @@ export interface VitestExecutorOptions {
   testFiles?: string[];
   watch?: boolean;
   mode?: string;
+  runMode?: 'test' | 'benchmark';
 }

--- a/packages/vitest/src/executors/test/schema.json
+++ b/packages/vitest/src/executors/test/schema.json
@@ -19,7 +19,13 @@
     },
     "mode": {
       "type": "string",
-      "description": "Mode for Vite."
+      "description": "Vite mode for loading configuration."
+    },
+    "runMode": {
+      "type": "string",
+      "description": "Vitest execution mode.",
+      "enum": ["test", "benchmark"],
+      "default": "test"
     },
     "testFiles": {
       "aliases": ["testFile"],

--- a/packages/vitest/src/executors/test/vitest.impl.ts
+++ b/packages/vitest/src/executors/test/vitest.impl.ts
@@ -35,7 +35,7 @@ export async function* vitestExecutor(
   const cliFilters = options.testFiles ?? [];
 
   const ctx = await startVitest(
-    resolvedOptions['mode'] ?? 'test',
+    options.runMode ?? 'test',
     cliFilters,
     resolvedOptions
   );


### PR DESCRIPTION
## Current Behavior

Running `nx test` with Vitest browser mode fails with error:

> "The browser configuration must have a 'name' property"

Array configs like `browser.instances` and `reporters` get duplicated, breaking tests.

## Expected Behavior

Vitest browser mode and array configurations work correctly without duplication.

## Related Issue(s)

Fixes #33591