### PR TITLE
feat(core): add failed project listing environment variable

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
@@ -398,11 +398,11 @@ export async function createRunManyDynamicOutputRenderer({
           .forEach((arg) => taskOverridesRows.push(arg));
       }
 
-      const numFailedToPrint = 5;
-      const failedTasksForPrinting = Array.from(failedTasks).slice(
+      const numFailedToPrint = parseInt(process.env['NX_FAILED_TASKS_TO_PRINT'] || '5', 10);
+      const failedTasksForPrinting = numFailedToPrint > 0 ? Array.from(failedTasks).slice(
         0,
         numFailedToPrint
-      );
+      ) : Array.from(failedTasks);
       const failureSummaryRows = [
         output.applyNxPrefix(
           'red',

--- a/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
@@ -490,11 +490,11 @@ export function getTuiTerminalSummaryLifeCycle({
           );
         }
         if (totalFailedTasks > 0) {
-          const numFailedToPrint = 5;
-          const failedTasksForPrinting = Array.from(failedTasks).slice(
+          const numFailedToPrint = parseInt(process.env['NX_FAILED_TASKS_TO_PRINT'] || '5', 10);
+          const failedTasksForPrinting = numFailedToPrint > 0 ? Array.from(failedTasks).slice(
             0,
             numFailedToPrint
-          );
+          ) : Array.from(failedTasks);
           failureSummaryRows.push(
             `${LEFT_PAD}${output.colors.red(
               figures.cross


### PR DESCRIPTION
This adds `NX_FAILED_TASKS_TO_PRINT` as an environment variable controlling how many projects are shown when a command fails. 0 or less removes the limit

## Current Behavior
Right now, when some number of projects fail an `nx` command at most 5 items are shown and the rest are hidden

## Expected Behavior
Now, by specifying `NX_FAILED_TASKS_TO_PRINT` environment variable as a positive number (or 0 for no limit) that limit can be increased

