### PR TITLE
fix(core): drain stdin on exit to prevent escape sequence leakage

### DIFF
--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -571,6 +571,10 @@ pub fn restore_terminal() -> napi::Result<()> {
     // Clear terminal progress indicator
     App::clear_terminal_progress();
 
+    // Drain pending terminal responses (e.g., OSC color query responses)
+    // to prevent escape sequences from leaking to the terminal on exit
+    super::tui::drain_stdin();
+
     if crossterm::terminal::is_raw_mode_enabled()? {
         crossterm::execute!(
             std::io::stderr(),

--- a/packages/nx/src/native/tui/tui.rs
+++ b/packages/nx/src/native/tui/tui.rs
@@ -3,7 +3,7 @@ use crate::native::tui::theme::THEME;
 use color_eyre::eyre::Result;
 use crossterm::{
     cursor,
-    event::{Event as CrosstermEvent, KeyEvent, KeyEventKind},
+    event::{self, Event as CrosstermEvent, KeyEvent, KeyEventKind},
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -51,6 +51,18 @@ pub struct Tui {
     pub frame_rate: f64,
     pub tick_rate: f64,
     pub current_mode: TuiMode,
+}
+
+/// Drain any pending input from stdin to prevent escape sequence leakage.
+/// This consumes terminal responses (e.g., from OSC color queries) that may
+/// arrive after a query was sent but before the response was fully read.
+pub(crate) fn drain_stdin() {
+    // Poll and consume any pending terminal events
+    // Note: Duration::ZERO can incorrectly return false with use-dev-tty feature
+    // See: https://github.com/crossterm-rs/crossterm/issues/839
+    while event::poll(Duration::from_millis(5)).unwrap_or(false) {
+        let _ = event::read();
+    }
 }
 
 impl Tui {
@@ -277,6 +289,10 @@ impl Tui {
     pub fn restore_terminal(&mut self) -> Result<()> {
         if crossterm::terminal::is_raw_mode_enabled()? {
             self.flush()?;
+
+            // Drain pending terminal responses (e.g., OSC color query responses)
+            // to prevent escape sequences from leaking to the terminal on exit
+            drain_stdin();
 
             // Only leave alternate screen if we're in full-screen mode
             match self.current_mode {

--- a/packages/nx/src/tasks-runner/is-tui-enabled.ts
+++ b/packages/nx/src/tasks-runner/is-tui-enabled.ts
@@ -29,8 +29,10 @@ export function shouldUseTui(
   skipCapabilityCheck = process.env.NX_TUI_SKIP_CAPABILITY_CHECK === 'true'
 ) {
   // If the current terminal/environment is not capable of displaying the TUI, we don't run it
+  const hasValidSize = process.stdout.columns > 0 && process.stdout.rows > 0;
   const isCapable =
-    skipCapabilityCheck || (process.stderr.isTTY && isUnicodeSupported());
+    skipCapabilityCheck ||
+    (process.stderr.isTTY && isUnicodeSupported() && hasValidSize);
 
   if (typeof nxArgs.tui === 'boolean') {
     if (nxArgs.tui && !isCapable) {


### PR DESCRIPTION
## Current Behavior

When exiting the TUI (especially via Ctrl+C), escape sequences leak to the terminal:
```
^[]11;rgb:2121/2121/2121^[\^[[55;1R^[[?62;22;52c
```

This happens because the TUI queries terminal background color via OSC 11 to detect dark/light mode. The terminal responds with an escape sequence, but if the program exits before fully consuming the response, it appears in the terminal output.

## Expected Behavior

Clean terminal state after TUI exits, with no escape sequence artifacts.

## Related Issue(s)

N/A - discovered during development

## Solution

Added `drain_stdin()` function that polls and consumes any pending terminal events before disabling raw mode. This clears any lingering OSC responses (like the background color query response) before the terminal is restored.

```rust
fn drain_stdin() {
    use std::time::Duration;
    while crossterm::event::poll(Duration::from_millis(5)).unwrap_or(false) {
        let _ = crossterm::event::read();
    }
}
```

The 5ms timeout is long enough to catch pending responses but short enough not to noticeably delay exit.