### PR TITLE
fix(core): avoid panic when inline tui can't init

### DIFF
--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -542,7 +542,7 @@ impl App {
                 if matches!(key.code, KeyCode::F(11))
                     && !matches!(self.focus, Focus::CountdownPopup)
                 {
-                    self.try_switch_to_inline_mode();
+                    self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
                     return Ok(false);
                 }
 
@@ -744,9 +744,7 @@ impl App {
                                     // swap to inline tui mode focusing that task
                                     KeyCode::Enter => {
                                         // dispatch action to switch to inline mode with focused task
-                                        if let Focus::MultipleOutput(_pane_idx) = self.focus {
-                                            self.try_switch_to_inline_mode();
-                                        }
+                                        self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
                                     }
                                     _ => {
                                         // Forward other keys for interactivity, scrolling (j/k) etc
@@ -1264,22 +1262,6 @@ impl App {
     /// Dispatches an action to the action tx for other components to handle however they see fit
     fn dispatch_action(&self, action: Action) {
         self.core.dispatch_action(action);
-    }
-
-    /// Attempts to switch to inline mode, showing a hint if unavailable
-    ///
-    /// Inline mode requires stdin to be a TTY for cursor position queries.
-    /// In environments like git hooks where stdin is redirected, inline mode
-    /// would hang waiting for terminal responses. This method shows a helpful
-    /// hint instead of silently failing.
-    fn try_switch_to_inline_mode(&self) {
-        if tui::Tui::is_stdin_interactive() {
-            self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
-        } else {
-            self.dispatch_action(Action::ShowHint(
-                "Inline mode is not available in this environment (stdin is not a TTY)".to_string(),
-            ));
-        }
     }
 
     fn recalculate_layout_areas(&mut self) {


### PR DESCRIPTION
## Current Behavior
if inline tui init fails, we panic

## Expected Behavior
If inline tui init fails, inline mode is disabled. We show the reason its disabled when someone tries to use it.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
