### PR TITLE
fix(testing): add timeout to runCommandUntil to prevent hanging tests

### DIFF
--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -8,7 +8,6 @@ assignment-rules:
   - projects:
       - e2e-gradle
       - e2e-node
-      - e2e-angular
       - e2e-react
       - e2e-next
       - e2e-plugin
@@ -17,6 +16,13 @@ assignment-rules:
     run-on:
       - agent: linux-extra-large
         parallelism: 2
+  - projects:
+      - e2e-angular
+    targets:
+      - e2e-ci**
+    run-on:
+      - agent: linux-extra-large
+        parallelism: 1
 
   - projects:
       - nx

--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -7,6 +7,11 @@ distribute-on:
 assignment-rules:
   - projects:
       - e2e-gradle
+      - e2e-node
+      - e2e-angular
+      - e2e-react
+      - e2e-next
+      - e2e-plugin
     targets:
       - e2e-ci**
     run-on:
@@ -29,9 +34,7 @@ assignment-rules:
 
   - projects:
       - e2e-release
-      - e2e-angular
-      - e2e-react
-      - e2e-next
+      - e2e-nuxt
       - e2e-web
       - e2e-eslint
       - e2e-remix

--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -1,5 +1,9 @@
 distribute-on:
-  default: auto linux-large, 3 linux-extra-large
+  extra-small-changeset: 8 linux-large, 3 linux-extra-large
+  small-changeset: 10 linux-large, 4 linux-extra-large
+  medium-changeset: 12 linux-large, 4 linux-extra-large
+  large-changeset: 14 linux-large, 5 linux-extra-large
+  extra-large-changeset: 16 linux-large, 6 linux-extra-large
 assignment-rules:
   - projects:
       - e2e-gradle

--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -1,9 +1,9 @@
 distribute-on:
   extra-small-changeset: 8 linux-large, 3 linux-extra-large
-  small-changeset: 10 linux-large, 4 linux-extra-large
-  medium-changeset: 12 linux-large, 4 linux-extra-large
-  large-changeset: 14 linux-large, 5 linux-extra-large
-  extra-large-changeset: 16 linux-large, 6 linux-extra-large
+  small-changeset: 8 linux-large, 4 linux-extra-large
+  medium-changeset: 8 linux-large, 5 linux-extra-large
+  large-changeset: 10 linux-large, 6 linux-extra-large
+  extra-large-changeset: 12 linux-large, 6 linux-extra-large
 assignment-rules:
   - projects:
       - e2e-gradle
@@ -16,7 +16,7 @@ assignment-rules:
       - e2e-ci**
     run-on:
       - agent: linux-extra-large
-        parallelism: 1
+        parallelism: 2
 
   - projects:
       - nx
@@ -51,7 +51,7 @@ assignment-rules:
       - agent: linux-large
         parallelism: 1
       - agent: linux-extra-large
-        parallelism: 1
+        parallelism: 2
 
   # All other e2e tests can run in parallel
   - targets:

--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -1,14 +1,12 @@
 distribute-on:
-  extra-small-changeset: 8 linux-large, 3 linux-extra-large
-  small-changeset: 8 linux-large, 4 linux-extra-large
-  medium-changeset: 8 linux-large, 5 linux-extra-large
-  large-changeset: 10 linux-large, 6 linux-extra-large
-  extra-large-changeset: 12 linux-large, 6 linux-extra-large
+  extra-small-changeset: 6 linux-large, 3 linux-extra-large
+  small-changeset: 6 linux-large, 4 linux-extra-large
+  medium-changeset: 6 linux-large, 5 linux-extra-large
+  large-changeset: 6 linux-large, 6 linux-extra-large
+  extra-large-changeset: 8 linux-large, 8 linux-extra-large
 assignment-rules:
   - projects:
       - e2e-gradle
-      - e2e-node
-      - e2e-react
       - e2e-next
       - e2e-plugin
     targets:
@@ -18,6 +16,8 @@ assignment-rules:
         parallelism: 2
   - projects:
       - e2e-angular
+      - e2e-node
+      - e2e-react
     targets:
       - e2e-ci**
     run-on:

--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -47,6 +47,7 @@ assignment-rules:
       - e2e-cypress
       - e2e-docker
       - e2e-js
+      - e2e-nx
       - e2e-nx-init
       - e2e-dotnet
       - e2e-workspace-create

--- a/e2e/angular/src/module-federation-lib.test.ts
+++ b/e2e/angular/src/module-federation-lib.test.ts
@@ -86,8 +86,10 @@ describe('Angular Module Federation - Federated Libraries', () => {
     expect(buildRemoteOutput).toContain('Successfully ran target build');
 
     if (runE2ETests('cypress')) {
-      const e2eProcess = await runCommandUntil(`e2e ${host}-e2e`, (output) =>
-        output.includes('All specs passed!')
+      const e2eProcess = await runCommandUntil(
+        `e2e ${host}-e2e`,
+        (output) => output.includes('All specs passed!'),
+        { timeout: 120000 }
       );
       await killProcessAndPorts(e2eProcess.pid, hostPort, hostPort + 1);
     }
@@ -175,8 +177,10 @@ describe('Angular Module Federation - Federated Libraries', () => {
     expect(buildRemoteOutput).toContain('Successfully ran target build');
 
     if (runE2ETests('cypress')) {
-      const e2eProcess = await runCommandUntil(`e2e ${host}-e2e`, (output) =>
-        output.includes('All specs passed!')
+      const e2eProcess = await runCommandUntil(
+        `e2e ${host}-e2e`,
+        (output) => output.includes('All specs passed!'),
+        { timeout: 120000 }
       );
       await killProcessAndPorts(e2eProcess.pid, hostPort, hostPort + 1);
     }

--- a/e2e/angular/src/module-federation-ssr.test.ts
+++ b/e2e/angular/src/module-federation-ssr.test.ts
@@ -88,8 +88,13 @@ test('renders remotes', async ({ page }) => {
 });`
     );
     if (runE2ETests()) {
-      const e2eProcess = await runCommandUntil(`e2e ${host}-e2e`, (output) =>
-        output.includes(`Successfully ran target e2e for project ${host}-e2e`)
+      const e2eProcess = await runCommandUntil(
+        `e2e ${host}-e2e`,
+        (output) =>
+          output.includes(
+            `Successfully ran target e2e for project ${host}-e2e`
+          ),
+        { timeout: 120000 }
       );
       await killProcessAndPorts(e2eProcess.pid);
     }

--- a/e2e/node/src/node-esm-support.test.ts
+++ b/e2e/node/src/node-esm-support.test.ts
@@ -151,7 +151,8 @@ describe('Node.js Framework ESM Support', () => {
         `serve ${expressApp}`,
         (output) => {
           return output.includes('Express ESM serve ready on port');
-        }
+        },
+        { timeout: 120000 }
       );
 
       await promisifiedTreeKill(serveProcess.pid, 'SIGKILL');
@@ -269,7 +270,8 @@ describe('Node.js Framework ESM Support', () => {
         `serve ${fastifyApp}`,
         (output) => {
           return output.includes('Fastify ESM serve ready on port');
-        }
+        },
+        { timeout: 120000 }
       );
 
       await promisifiedTreeKill(serveProcess.pid, 'SIGKILL');
@@ -386,7 +388,8 @@ describe('Node.js Framework ESM Support', () => {
         `serve ${koaApp}`,
         (output) => {
           return output.includes('Koa ESM serve ready on port');
-        }
+        },
+        { timeout: 120000 }
       );
 
       await promisifiedTreeKill(serveProcess.pid, 'SIGKILL');
@@ -444,7 +447,8 @@ describe('Node.js Framework ESM Support', () => {
         `serve ${nestApp}`,
         (output) => {
           return output.includes('Nest ESM server ready on port');
-        }
+        },
+        { timeout: 120000 }
       );
       await promisifiedTreeKill(serveProcess.pid, 'SIGKILL');
     }, 600000);
@@ -496,7 +500,8 @@ describe('Node.js Framework ESM Support', () => {
         `serve ${nestApp}`,
         (output) => {
           return output.includes('Nest ESM serve ready on port');
-        }
+        },
+        { timeout: 120000 }
       );
 
       await promisifiedTreeKill(serveProcess.pid, 'SIGKILL');

--- a/e2e/node/src/node.test.ts
+++ b/e2e/node/src/node.test.ts
@@ -209,6 +209,7 @@ module.exports = {
         return output.includes(`foobar: test foo bar`);
       },
       {
+        timeout: 120000,
         env: {
           NX_DAEMON: 'true',
         },
@@ -271,8 +272,8 @@ module.exports = {
     const p = await runCommandUntil(
       `serve ${nodeapp}`,
       (output) => output.includes(`Listening at http://localhost:${port}`),
-
       {
+        timeout: 120000,
         env: {
           NX_DAEMON: 'true',
         },
@@ -328,6 +329,7 @@ module.exports = {
         return output.includes(`listening on ws://localhost:${port}`);
       },
       {
+        timeout: 120000,
         env: {
           NX_DAEMON: 'true',
         },
@@ -395,6 +397,7 @@ module.exports = {
         return output.includes('Hello World');
       },
       {
+        timeout: 120000,
         env: {
           NX_DAEMON: 'true',
         },

--- a/e2e/react/src/module-federation/core-rspack-basic-playwright.test.ts
+++ b/e2e/react/src/module-federation/core-rspack-basic-playwright.test.ts
@@ -69,7 +69,8 @@ describe('React Rspack Module Federation - Basic - Playwright', () => {
     if (runE2ETests()) {
       const e2eResultsSwc = await runCommandUntil(
         `e2e ${shell}-e2e`,
-        (output) => output.includes('Successfully ran target e2e for project')
+        (output) => output.includes('Successfully ran target e2e for project'),
+        { timeout: 120000 }
       );
 
       await killProcessAndPorts(e2eResultsSwc.pid, readPort(shell));

--- a/e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts
@@ -75,7 +75,8 @@ describe('React Module Federation - Webpack Basic - Playwright', () => {
       );
       const e2eResultsSwc = await runCommandUntil(
         `e2e ${shell}-e2e`,
-        (output) => output.includes('Successfully ran target e2e for project')
+        (output) => output.includes('Successfully ran target e2e for project'),
+        { timeout: 120_000 }
       );
       console.log(
         `[core-webpack-basic-playwright] e2e (swc) completed with PID ${e2eResultsSwc.pid}`
@@ -96,6 +97,7 @@ describe('React Module Federation - Webpack Basic - Playwright', () => {
         `e2e ${shell}-e2e`,
         (output) => output.includes('Successfully ran target e2e for project'),
         {
+          timeout: 120_000,
           env: { NX_PREFER_TS_NODE: 'true' },
         }
       );

--- a/e2e/react/src/module-federation/core-webpack-ssr.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-ssr.test.ts
@@ -63,8 +63,11 @@ describe('React Module Federation - Webpack SSR', () => {
       `generate @nx/react:host ${shell} --ssr --bundler=webpack --remotes=${remote1},${remote2},${remote3} --style=css --e2eTestRunner=cypress --no-interactive --skipFormat`
     );
 
-    const serveResult = await runCommandUntil(`serve ${shell}`, (output) =>
-      output.includes(`Nx SSR Static remotes proxies started successfully`)
+    const serveResult = await runCommandUntil(
+      `serve ${shell}`,
+      (output) =>
+        output.includes(`Nx SSR Static remotes proxies started successfully`),
+      { timeout: 120000 }
     );
 
     await killProcessAndPorts(serveResult.pid);
@@ -107,7 +110,8 @@ describe('React Module Federation - Webpack SSR', () => {
     if (runE2ETests()) {
       const hostE2eResults = await runCommandUntil(
         `e2e ${shell}-e2e --no-watch --verbose`,
-        (output) => output.includes('All specs passed!')
+        (output) => output.includes('All specs passed!'),
+        { timeout: 120000 }
       );
       await killProcessAndPorts(hostE2eResults.pid);
     }

--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -321,7 +321,6 @@ export function runCommandUntil(
       if (criteria(strippedOutput) && !complete) {
         complete = true;
         clearTimeout(timeoutId);
-        p.kill();
         res(p);
       }
     }

--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -305,7 +305,7 @@ export function runCommandUntil(
         complete = true;
         p.kill();
         logError(
-          `Original output:`,
+          `Output did not meet the criteria:`,
           output
             .split('\n')
             .map((l) => `    ${l}`)

--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -92,6 +92,9 @@ export default async function (globalConfig: Config.ConfigGlobals) {
 }
 
 function getPublishedVersion(): Promise<string | undefined> {
+  execSync(`npm config get registry`, {
+    stdio: 'inherit',
+  });
   return new Promise((resolve) => {
     // Resolve the published nx version from verdaccio
     exec(

--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -1,7 +1,7 @@
 import { Config } from '@jest/types';
 import { existsSync, removeSync } from 'fs-extra';
 import * as isCI from 'is-ci';
-import { exec } from 'node:child_process';
+import { exec, execSync } from 'node:child_process';
 import { join } from 'node:path';
 import { registerTsConfigPaths } from '../../packages/nx/src/plugins/js/utils/register';
 import { runLocalRelease } from '../../scripts/local-registry/populate-storage';

--- a/nx.json
+++ b/nx.json
@@ -346,7 +346,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 6,
+  "bust": 7,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true

--- a/nx.json
+++ b/nx.json
@@ -346,7 +346,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 5,
+  "bust": 6,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true

--- a/nx.json
+++ b/nx.json
@@ -346,7 +346,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 4,
+  "bust": 1,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true

--- a/nx.json
+++ b/nx.json
@@ -346,7 +346,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 2,
+  "bust": 3,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true

--- a/nx.json
+++ b/nx.json
@@ -346,7 +346,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 1,
+  "bust": 2,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true

--- a/nx.json
+++ b/nx.json
@@ -346,7 +346,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 3,
+  "bust": 4,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true

--- a/nx.json
+++ b/nx.json
@@ -346,7 +346,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 4,
+  "bust": 5,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true


### PR DESCRIPTION
## Current Behavior

The `runCommandUntil` e2e utility function waits indefinitely for the expected output to appear. If the output never appears (e.g., server fails to start, different output format, port conflict), the test hangs forever, causing CI jobs to run for hours before being killed.

## Expected Behavior

The function should timeout after a configurable duration and fail with a clear error message showing what output was received.

## Related Issue(s)

Fixes hanging e2e tests observed in CI (e.g., `e2e-node:e2e-ci--src/node-server.test.ts` hung for 1h 21m).

## Changes

- Added optional `timeout` parameter to `runCommandUntil` opts (default: 5 seconds)
- On timeout: kills the process, logs the collected output, and rejects with a clear error
- Existing call sites work unchanged; tests needing more startup time can pass `{ timeout: 30000 }`