### PR TITLE
feat(angular-rspack): add tailwind and postcss config to component stylesheet bundler

### DIFF
--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -2,9 +2,15 @@ import { RsbuildConfig } from '@rsbuild/core';
 import * as ts from 'typescript';
 import { InlineStyleLanguage, FileReplacement, type Sass } from '../models';
 import { loadCompilerCli } from '../utils';
-import { ComponentStylesheetBundler } from '@angular/build/private';
+import {
+  ComponentStylesheetBundler,
+  findTailwindConfiguration,
+  generateSearchDirectories,
+  loadPostcssConfiguration,
+} from '@angular/build/private';
 import { transformSupportedBrowsersToTargets } from '../utils/targets-from-browsers';
 import { getSupportedBrowsers } from '@angular/build/private';
+import { createRequire } from 'node:module';
 
 export interface StylesheetTransformResult {
   contents: string;
@@ -60,6 +66,26 @@ export async function setupCompilation(
 
   const compilerOptions = tsCompilerOptions;
 
+  const searchDirectories = await generateSearchDirectories([options.root]);
+  const postcssConfiguration =
+    await loadPostcssConfiguration(searchDirectories);
+  // Skip tailwind configuration if postcss is customized
+  let tailwindConfiguration;
+  if (!postcssConfiguration) {
+    const tailwindConfigPath = findTailwindConfiguration(searchDirectories);
+    if (tailwindConfigPath) {
+      const resolver = createRequire(tailwindConfigPath);
+      try {
+        tailwindConfiguration = {
+          file: tailwindConfigPath,
+          package: resolver.resolve('tailwindcss'),
+        };
+      } catch (e) {
+        // Tailwind config found but package not installed - warning already shown by Angular build
+      }
+    }
+  }
+
   const componentStylesheetBundler = new ComponentStylesheetBundler(
     {
       workspaceRoot: options.root,
@@ -80,6 +106,8 @@ export async function setupCompilation(
       ),
       includePaths: options.includePaths,
       sass: options.sass,
+      postcssConfiguration,
+      tailwindConfiguration,
     },
     options.inlineStyleLanguage,
     false


### PR DESCRIPTION
# Current Behavior
The Angular Rspack compiler's `ComponentStylesheetBundler` does not receive Tailwind or PostCSS configuration. This means Tailwind directives (like `@apply`, `@tailwind`) in component stylesheets are not processed, resulting in broken styles.

# Expected Behavior
Component stylesheets should support Tailwind CSS and PostCSS configurations, matching the behavior of the standard Angular CLI build process.

# Related Issue(s)
https://github.com/nrwl/nx/issues/34098