### PR TITLE
fix(angular-rspack): stats serialization and configuration

### DIFF
--- a/packages/angular-rspack/src/lib/config/create-config.spec.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.spec.ts
@@ -332,6 +332,37 @@ describe('createConfig', () => {
       }
     );
 
+    it('should merge user stats options via rspackConfigOverrides', async () => {
+      const config = await createConfig({
+        options: configBase,
+        rspackConfigOverrides: {
+          stats: { all: false, chunks: false },
+        },
+      });
+
+      expect(config[0].stats).toEqual(
+        expect.objectContaining({ all: false, chunks: false })
+      );
+    });
+
+    it('should allow user to fully override stats options', async () => {
+      const customStats = {
+        all: false,
+        assets: true,
+        errors: true,
+        warnings: true,
+      };
+
+      const config = await createConfig({
+        options: configBase,
+        rspackConfigOverrides: {
+          stats: customStats,
+        },
+      });
+
+      expect(config[0].stats).toEqual(expect.objectContaining(customStats));
+    });
+
     it('should successfully merge multiple configurations', () => {
       const config = handleConfigurations(
         {

--- a/packages/angular-rspack/src/lib/utils/stats.ts
+++ b/packages/angular-rspack/src/lib/utils/stats.ts
@@ -469,7 +469,7 @@ export function rspackStatsLogger(
   statOptions: StatsOptions,
   budgetFailures?: BudgetCalculatorResult[]
 ): void {
-  const json = stats.toJson();
+  const json = stats.toJson(statOptions);
   console.log(statsToString(stats, json, statOptions, budgetFailures));
 
   if (typeof stats !== 'object') {


### PR DESCRIPTION
# Current Behavior
1. **Performance bottleneck**: `statsValue.toJson()` is called with no options, causing full serialization of all stats data on every build. This is expensive and unnecessary when only budget checking is needed.
2. **Redundant work**: Budget checking code runs even when no budgets are configured or when targeting server platform.
3. **User stats config ignored**: Custom stats configuration provided via `rspackConfigOverrides` is not respected by the stats logger.
4. **Double serialization**: `rspackStatsLogger` calls `stats.toJson()` without passing the stats options, ignoring user preferences.

# Expected Behavior
1. Only serialize what's needed for budget checking (`assets` and `chunks`), significantly reducing overhead.
2. Early exit when budgets are not configured or on server platform, skipping expensive `toJson()` entirely.
3. User's stats configuration is merged with defaults and respected throughout the build output.
4. `rspackStatsLogger` uses the provided `statOptions` when serializing stats.

# Related Issue(s)
Fixes https://github.com/nrwl/nx/issues/34145