### PR TITLE
fix(core): prioritize nx installation path in getNxRequirePaths

### DIFF
--- a/packages/nx/src/utils/installation-directory.ts
+++ b/packages/nx/src/utils/installation-directory.ts
@@ -6,5 +6,5 @@ export function getNxInstallationPath(root: string = workspaceRoot) {
 }
 
 export function getNxRequirePaths(root: string = workspaceRoot) {
-  return [root, getNxInstallationPath(root)];
+  return [getNxInstallationPath(root), root];
 }


### PR DESCRIPTION
## Current Behavior

`getNxRequirePaths` returns paths in the order `[root, getNxInstallationPath(root)]`, which means the workspace root is checked first when resolving modules.

## Expected Behavior

The nx installation path (`.nx/installation`) should be prioritized and checked first before falling back to the workspace root. This ensures that modules from the nx installation directory take precedence.

## Related Issue(s)

N/A