### PR TITLE
chore(repo): remove .deb file from accidental commit and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ test-results
 # .NET build output
 /packages/dotnet/analyzer/bin
 /packages/dotnet/analyzer/obj
+/*.deb


### PR DESCRIPTION
removes accidentally committed file