### PR TITLE
fix(devkit): allow null values in JSON schema validation

### DIFF
--- a/packages/nx/src/utils/params.spec.ts
+++ b/packages/nx/src/utils/params.spec.ts
@@ -1201,6 +1201,91 @@ describe('params', () => {
         });
       });
 
+      describe('null', () => {
+        it('should accept null when type is null', () => {
+          const schema = {
+            properties: {
+              a: {
+                type: 'null',
+              },
+            },
+          };
+          expect(() =>
+            validateOptsAgainstSchema({ a: null }, schema)
+          ).not.toThrow();
+        });
+
+        it('should reject null when type is not null', () => {
+          const schema = {
+            properties: {
+              a: {
+                type: 'string',
+              },
+            },
+          };
+          expect(() =>
+            validateOptsAgainstSchema({ a: null }, schema)
+          ).toThrow();
+        });
+
+        it('should accept null when type array includes null', () => {
+          const schema = {
+            properties: {
+              a: {
+                type: ['string', 'null'],
+              },
+            },
+          };
+          expect(() =>
+            validateOptsAgainstSchema({ a: null }, schema)
+          ).not.toThrow();
+        });
+
+        it('should accept string when type array includes string and null', () => {
+          const schema = {
+            properties: {
+              a: {
+                type: ['string', 'null'],
+              },
+            },
+          };
+          expect(() =>
+            validateOptsAgainstSchema({ a: 'test' }, schema)
+          ).not.toThrow();
+        });
+
+        it('should reject null when type array does not include null', () => {
+          const schema = {
+            properties: {
+              a: {
+                type: ['string', 'boolean'],
+              },
+            },
+          };
+          expect(() =>
+            validateOptsAgainstSchema({ a: null }, schema)
+          ).toThrow();
+        });
+
+        it('should accept null in nested objects when schema allows it', () => {
+          const schema = {
+            properties: {
+              a: {
+                type: 'object',
+                properties: {
+                  b: {
+                    type: ['string', 'null'],
+                  },
+                },
+              },
+            },
+          };
+          expect(() =>
+            validateOptsAgainstSchema({ a: { b: null } }, schema)
+          ).not.toThrow();
+        });
+      });
+
       describe('number', () => {
         it('should handle validating multiples of', () => {
           const schema = {

--- a/packages/nx/src/utils/params.ts
+++ b/packages/nx/src/utils/params.ts
@@ -490,6 +490,16 @@ function validateProperty(
     value.forEach((valueInArray) =>
       validateProperty(propName, valueInArray, schema.items || {}, definitions)
     );
+  } else if (value === null) {
+    // Special handling for null since typeof null === 'object' in JavaScript
+    // null is valid if schema.type is 'null' or if it's an array containing 'null'
+    if (Array.isArray(schema.type)) {
+      if (!schema.type.includes('null')) {
+        throwInvalidSchema(propName, schema);
+      }
+    } else if (schema.type !== 'null') {
+      throwInvalidSchema(propName, schema);
+    }
   } else {
     if (schema.type !== 'object') throwInvalidSchema(propName, schema);
     validateObject(value, schema, definitions);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Schema validation (done, for instance, when calling an executor) fails when an option has value "null" and schema accepts null values. I had it in a custom executor for `nx-release-publish`, that understands that `nxReleaseVersionData` is implicitly passed, so I define its schema:
```json
"newVersion": {
  "type": ["string", "null"],
  "description": "The new version of the project, null if no changes detected"
}
```

My code calls `getReleaseClient().releaseVersion(options)`, which gets me a `projectsVersionData` object with version info. It contains `null` values (allowed). I then pass it, and ends up in:
```typescript
 // nx/src/tasks-runner/task-orchestrator.ts:531-539                                                                                                                                                                      
  const combinedOptions = combineOptionsForExecutor(                                                                                                                                                                       
      task.overrides,  // ← Contains nxReleaseVersionData with null values                                                                                                                                                 
      task.target.configuration,                                                                                                                                                                                           
      targetConfiguration,                                                                                                                                                                                                 
      schema,           // ← Schema from executor                                                                                                                                                                          
      task.target.project,                                                                                                                                                                                                 
      relativeCwd,                                                                                                                                                                                                         
      isVerbose                                                                                                                                                                                                            
  );
```

which fails inside:
```typescript
 // nx/src/utils/params.js:126-201                                                                                                                                                                                        
  function validateObject(opts, schema, definitions) {                                                                                                                                                                     
      // Line 191-200: Iterate through all properties                                                                                                                                                                      
      Object.keys(opts).forEach((p) => {                                                                                                                                                                                   
          validateProperty(                                                                                                                                                                                                
              p,                              // "nxReleaseVersionData"                                                                                                                                                    
              opts[p],                        // { foo: { newVersion: null, ... }}                                                                                                                                         
              (schema.properties ?? {})[p],   // schema for nxReleaseVersionData                                                                                                                                           
              definitions                                                                                                                                                                                                  
          );                                                                                                                                                                                                               
      });                                                                                                                                                                                                                  
  }
  ```

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

`null` values should be considered, as they are valid in JSON schemas. It was probably not considered, because we never think that `typeof null === "object"`, but it's unfortunately the case.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

I will create one

Fixes https://github.com/nrwl/nx/issues/34169
