### PR TITLE
fix(core): clean up daemon workspace data directory on nx reset --onl…

### DIFF
--- a/packages/nx/src/command-line/reset/command-object.ts
+++ b/packages/nx/src/command-line/reset/command-object.ts
@@ -24,7 +24,7 @@ export const yargsResetCommand: CommandModule<
       })
       .option('onlyDaemon', {
         description:
-          'Stops the Nx Daemon, it will be restarted fresh when the next Nx command is run.',
+          'Stops the Nx Daemon and clears its workspace data, it will be restarted fresh when the next Nx command is run.',
         type: 'boolean',
       })
       .option('onlyCloud', {

--- a/packages/nx/src/command-line/reset/reset.ts
+++ b/packages/nx/src/command-line/reset/reset.ts
@@ -119,7 +119,10 @@ function cleanupDaemonWorkspaceData() {
     INCREMENTAL_BACKOFF_FIRST_DELAY,
     INCREMENTAL_BACKOFF_MAX_DURATION,
     () => {
-      rmSync(DAEMON_DIR_FOR_CURRENT_WORKSPACE, { recursive: true, force: true });
+      rmSync(DAEMON_DIR_FOR_CURRENT_WORKSPACE, {
+        recursive: true,
+        force: true,
+      });
     }
   );
 }


### PR DESCRIPTION
Previously, `nx reset --onlyDaemon` would only stop the daemon process but not clean up the daemon files in `.nx/workspace-data/d`. This change ensures the daemon workspace data directory is also removed when using the `--onlyDaemon` flag, consistent with the behavior of a full reset.
