### PR TITLE
docs(nx-dev): make sure cli nested sub commands are parsed

### DIFF
--- a/astro-docs/src/plugins/utils/generate-plugin-markdown.ts
+++ b/astro-docs/src/plugins/utils/generate-plugin-markdown.ts
@@ -265,7 +265,7 @@ nx generate ${fullItemName} ${positionalArgs
         const defaultValue = getPropertyDefault(property);
         const isRequired = required.includes(propName);
 
-        const optionName = `\`${propName}\``;
+        const optionName = `\`--${propName}\``;
 
         if (isRequired) {
           type += ' [**required**]';

--- a/astro-docs/src/plugins/utils/generate-plugin-markdown.ts
+++ b/astro-docs/src/plugins/utils/generate-plugin-markdown.ts
@@ -279,14 +279,14 @@ nx generate ${fullItemName} ${positionalArgs
   }
 
   markdown += `
-     ## Getting Help
+## Getting Help
 
-     You can get help for any generator by adding the \`--help\` flag:
+You can get help for any generator by adding the \`--help\` flag:
 
-     \`\`\`bash
-     nx generate ${packageName}:<generator> --help
-     \`\`\`
-     `;
+\`\`\`bash
+nx generate ${packageName}:<generator> --help
+\`\`\`
+`;
 
   return markdown;
 }


### PR DESCRIPTION
commands like nx release and nx show were missing sub commands. make sure they are now correctly parsed.

<img width="224" height="162" alt="image" src="https://github.com/user-attachments/assets/f51c12f2-9926-44a1-a3c0-57de565434bd" />


also, fixed the "getting help" for plugin docs being rendered incorrectly. and add double dash `--` to the plugin option docs to match rest of docs.


<img width="874" height="634" alt="image" src="https://github.com/user-attachments/assets/be7a58a3-0ea0-41d5-8ba6-98cfa0210a95" />
