### PR TITLE
Revert "feat(core): add A/B testing variant 1 to skip cloud prompt in CNW (#34106)"

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -46,7 +46,6 @@ import {
 } from '../src/utils/error-utils';
 import { existsSync } from 'fs';
 import { isCI } from '../src/utils/ci/is-ci';
-import { isGhCliAvailable } from '../src/utils/git/git';
 
 function extractErrorFile(error: Error): string | undefined {
   if (!error.stack) return undefined;
@@ -457,31 +456,12 @@ async function normalizeArgsMiddleware(
       // Template flow - respects CLI arg, otherwise uses detected package manager (from invoking command)
       argv.template = template;
       const aiAgents = await determineAiAgents(argv);
-
-      // Track GH CLI availability for telemetry
-      const ghAvailable = isGhCliAvailable();
-
-      let nxCloud: string;
-      let completionMessageKey: string | undefined;
-
-      if (argv.skipGit === true) {
-        nxCloud = 'skip';
-        completionMessageKey = undefined;
-      } else if (getFlowVariant() === '1') {
-        // Variant 1 (NXC-3628): Skip cloud prompt, always show platform link
-        // Respect --nxCloud=skip if explicitly provided
-        nxCloud = argv.nxCloud === 'skip' ? 'skip' : 'yes';
-        completionMessageKey =
-          nxCloud === 'skip' ? undefined : 'platform-setup';
-      } else {
-        // Variant 0: Current behavior - show cloud prompt
-        nxCloud = await determineNxCloudV2(argv);
-        completionMessageKey =
-          nxCloud === 'skip'
-            ? undefined
-            : messages.completionMessageOfSelectedPrompt('setupNxCloudV2');
-      }
-
+      const nxCloud =
+        argv.skipGit === true ? 'skip' : await determineNxCloudV2(argv);
+      const completionMessageKey =
+        nxCloud === 'skip'
+          ? undefined
+          : messages.completionMessageOfSelectedPrompt('setupNxCloudV2');
       packageManager = argv.packageManager ?? detectInvokedPackageManager();
       Object.assign(argv, {
         nxCloud,
@@ -490,8 +470,6 @@ async function normalizeArgsMiddleware(
         packageManager,
         defaultBase: 'main',
         aiAgents,
-        ghAvailable,
-        skipCloudConnect: getFlowVariant() === '1',
       });
 
       await recordStat({
@@ -505,7 +483,6 @@ async function normalizeArgsMiddleware(
           preset: '',
           nodeVersion: process.versions.node ?? '',
           packageManager,
-          ghAvailable: ghAvailable ? 'true' : 'false',
         },
       });
     } else {

--- a/packages/create-nx-workspace/src/create-workspace-options.ts
+++ b/packages/create-nx-workspace/src/create-workspace-options.ts
@@ -41,15 +41,6 @@ export interface CreateWorkspaceOptions {
   };
   cliName?: string; // Name of the CLI, used when displaying outputs. e.g. nx, Nx
   aiAgents?: Agent[]; // List of AI agents to configure
-  /**
-   * @description Skip cloud connection (variant 1 experiment - NXC-3628)
-   * @default false
-   */
-  skipCloudConnect?: boolean;
-  /**
-   * @description Whether GitHub CLI (gh) is available on the system (for telemetry)
-   */
-  ghAvailable?: boolean;
 }
 
 export const supportedAgents = [

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -108,8 +108,7 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
     }
 
     // Connect to Nx Cloud for template flow
-    // For variant 1 (NXC-3628): Skip connection, use GitHub flow for URL generation
-    if (nxCloud !== 'skip' && !options.skipCloudConnect) {
+    if (nxCloud !== 'skip') {
       await connectToNxCloudForTemplate(
         directory,
         'create-nx-workspace',
@@ -191,15 +190,7 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
   let connectUrl: string | undefined;
   let nxCloudInfo: string | undefined;
   if (nxCloud !== 'skip') {
-    // For variant 1 (skipCloudConnect=true): Skip readNxCloudToken() entirely
-    // - We didn't call connectToNxCloudForTemplate(), so no token exists
-    // - The spinner message "Checking Nx Cloud setup" would be misleading
-    // - createNxCloudOnboardingUrl() uses GitHub flow which sends accessToken: null
-    //
-    // For variant 0: Read the token as before (cloud was connected)
-    const token = options.skipCloudConnect
-      ? undefined
-      : readNxCloudToken(directory);
+    const token = readNxCloudToken(directory) as string;
 
     connectUrl = await createNxCloudOnboardingUrl(
       nxCloud,

--- a/packages/create-nx-workspace/src/utils/git/git.ts
+++ b/packages/create-nx-workspace/src/utils/git/git.ts
@@ -43,19 +43,6 @@ export function isGitAvailable(): boolean {
   }
 }
 
-/**
- * Synchronously checks if GitHub CLI (gh) is available on the system.
- * Returns true if gh command can be executed, false otherwise.
- */
-export function isGhCliAvailable(): boolean {
-  try {
-    execSync('gh --version', { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 async function getGitHubUsername(directory: string): Promise<string> {
   const result = await execAndWait('gh api user --jq .login', directory);
   const username = result.stdout.trim();

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -1,11 +1,5 @@
 import { execSync } from 'node:child_process';
-import {
-  existsSync,
-  readFileSync,
-  writeFileSync,
-  statSync,
-  unlinkSync,
-} from 'node:fs';
+import { existsSync, readFileSync, writeFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { isCI } from '../ci/is-ci';
@@ -22,15 +16,7 @@ function readCachedFlowVariant(): string | null {
   try {
     if (!existsSync(FLOW_VARIANT_CACHE_FILE)) return null;
     const stats = statSync(FLOW_VARIANT_CACHE_FILE);
-    if (Date.now() - stats.mtimeMs > FLOW_VARIANT_EXPIRY_MS) {
-      // Delete expired file so a new variant can be written
-      try {
-        unlinkSync(FLOW_VARIANT_CACHE_FILE);
-      } catch {
-        // Ignore delete errors
-      }
-      return null;
-    }
+    if (Date.now() - stats.mtimeMs > FLOW_VARIANT_EXPIRY_MS) return null;
     const value = readFileSync(FLOW_VARIANT_CACHE_FILE, 'utf-8').trim();
     return value === '0' || value === '1' ? value : null;
   } catch {
@@ -284,7 +270,6 @@ export interface RecordStatMetaPrecreate {
   preset: string;
   nodeVersion: string;
   packageManager: string;
-  ghAvailable?: string;
 }
 
 export type RecordStatMeta =

--- a/packages/create-nx-workspace/src/utils/nx/messages.spec.ts
+++ b/packages/create-nx-workspace/src/utils/nx/messages.spec.ts
@@ -44,7 +44,7 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo (https://github.com/new), then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
+            "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
           ],
           "title": "Your CI setup is almost complete.",
         }
@@ -60,7 +60,7 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo (https://github.com/new), then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
+            "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
           ],
           "title": "Your CI setup is almost complete.",
         }
@@ -76,7 +76,7 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo (https://github.com/new), then return to Nx Cloud and finish the setup.",
+            "Push your repo, then return to Nx Cloud and finish the setup.",
           ],
           "title": "Your CI setup is almost complete.",
         }
@@ -92,7 +92,7 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo (https://github.com/new), then return to Nx Cloud and finish the setup.",
+            "Push your repo, then return to Nx Cloud and finish the setup.",
           ],
           "title": "Your CI setup is almost complete.",
         }
@@ -142,7 +142,7 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo (https://github.com/new), then go to Nx Cloud and finish the setup: https://nx.app/setup/456",
+            "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/456",
           ],
           "title": "Your remote cache setup is almost complete.",
         }
@@ -158,7 +158,7 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo (https://github.com/new), then go to Nx Cloud and finish the setup: https://nx.app/setup/456",
+            "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/456",
           ],
           "title": "Your remote cache setup is almost complete.",
         }
@@ -174,7 +174,7 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo (https://github.com/new), then return to Nx Cloud and finish the setup.",
+            "Push your repo, then return to Nx Cloud and finish the setup.",
           ],
           "title": "Your remote cache setup is almost complete.",
         }
@@ -190,7 +190,7 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo (https://github.com/new), then return to Nx Cloud and finish the setup.",
+            "Push your repo, then return to Nx Cloud and finish the setup.",
           ],
           "title": "Your remote cache setup is almost complete.",
         }

--- a/packages/create-nx-workspace/src/utils/nx/messages.ts
+++ b/packages/create-nx-workspace/src/utils/nx/messages.ts
@@ -10,10 +10,10 @@ function getSetupMessage(
       : 'Return to Nx Cloud and finish the setup.';
   }
 
-  // User hasn't pushed - include github.com/new hint
+  // Default case: FailedToPushToVcs
   const action = url ? 'go' : 'return';
   const urlSuffix = url ? `: ${url}` : '.';
-  return `Push your repo (https://github.com/new), then ${action} to Nx Cloud and finish the setup${urlSuffix}`;
+  return `Push your repo, then ${action} to Nx Cloud and finish the setup${urlSuffix}`;
 }
 
 /**

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -5,7 +5,7 @@ import {
   getSkippedCloudMessage,
   CompletionMessageKey,
 } from './messages';
-import { getFlowVariant } from './ab-testing';
+import { getFlowVariant, messages } from './ab-testing';
 import * as ora from 'ora';
 
 export type NxCloud =
@@ -74,7 +74,7 @@ export function readNxCloudToken(directory: string) {
 
 export async function createNxCloudOnboardingUrl(
   nxCloud: NxCloud,
-  token: string | undefined,
+  token: string,
   directory: string,
   useGitHub?: boolean
 ): Promise<string> {
@@ -95,7 +95,7 @@ export async function createNxCloudOnboardingUrl(
       ? 'create-nx-workspace-success-cache-setup'
       : 'create-nx-workspace-success-ci-setup';
 
-  const meta = `variant-${getFlowVariant()}`;
+  const meta = messages.codeOfSelectedPromptMessage('setupNxCloudV2');
 
   return createNxCloudOnboardingURL(
     source,


### PR DESCRIPTION
## Current Behavior

The create-nx-workspace (CNW) command includes A/B testing variant 1 which skips the cloud prompt under certain conditions.

## Expected Behavior

Revert to the previous behavior where the cloud prompt flow is consistent without the A/B testing variant.

## Related Issue(s)

This reverts commit 2039a5e11937945dce9bf8586bcffa2cf834a9c9 from PR #34106.