### PR TITLE
fix(nx-dev): update broken /launch-nx links

### DIFF
--- a/docs/blog/2024-02-05-nx-18-project-crystal.md
+++ b/docs/blog/2024-02-05-nx-18-project-crystal.md
@@ -27,7 +27,7 @@ Table of Contents
 **Prefer a video? We've got you covered!**
 {% youtube src="https://www.youtube.com/embed/wADNsVItnsM?si=sQ3-Dlx6KBRBUMkE" title="What if Nx Plugins Were More Like VSCode Extensions" /%}
 
-Also, make sure to check out [Launch Nx Conf](/launch-nx) on Thursday, Feb 8th, where we'll have more in-depth talks about Project Crystal as well as other exciting features around Nx and Nx Cloud.
+Also, make sure to check out [Launch Nx Conf](/blog/launch-nx-week-recap) where we had more in-depth talks about Project Crystal as well as other exciting features around Nx and Nx Cloud.
 
 ---
 

--- a/docs/blog/2024-02-15-launch-week-recap.md
+++ b/docs/blog/2024-02-15-launch-week-recap.md
@@ -7,7 +7,7 @@ tags: [nx, nx-cloud, releases, changelog]
 description: 'Explore the major announcements from Launch Nx Week, including Nx 18.0, Project Crystal, Nuxt plugin, Nx Agents, and Tusky AI integration.'
 ---
 
-We just finished wrapping up [Launch Nx Week](/launch-nx), which ran from February 5–9, including a full conference on Thursday!
+We just finished wrapping up [Launch Nx Week](/blog/launch-nx-week-recap), which ran from February 5–9, including a full conference on Thursday!
 
 In this article, we're going to recap all the things launched during Launch Nx Conf, as well as all the talks given during the conference! Here's a set of links so you can fast-forward to the stuff you're most interested in if you want!
 

--- a/docs/changelog/18_0_0.md
+++ b/docs/changelog/18_0_0.md
@@ -1,6 +1,6 @@
 # Nx 18
 
-We were so excited about the features in Nx 18 that we created a whole [Launch Nx Week](/launch-nx) to share our excitement with you. During the launch week, we made the following announcements:
+We were so excited about the features in Nx 18 that we created a whole [Launch Nx Week](/blog/launch-nx-week-recap) to share our excitement with you. During the launch week, we made the following announcements:
 
 - [Project Crystal](/blog/what-if-nx-plugins-were-more-like-vscode-extensions) allows you to use inferred tasks
 - A new [`@nx/nuxt`](/blog/introducing-nx-nuxt-enhanced-nuxt-js-support-in-nx) plugin is available


### PR DESCRIPTION
## Current Behavior

The internal link checker reports 3 broken links pointing to `/launch-nx`:
- `/blog/2024-02-05-nx-18-project-crystal.md`
- `/blog/2024-02-15-launch-week-recap.md`
- `/changelog/18_0_0.md`

The `/launch-nx` page was a temporary page for the Nx 18 launch event in February 2024 and no longer exists.

## Expected Behavior

All internal links should point to valid pages. Links to the old launch page now redirect to the Launch Nx Week recap blog post.

## Related Issue(s)

Fixes the internal link checker errors.