### PR TITLE
fix(angular-rspack): exclude .json files from JS/TS regex patterns

### DIFF
--- a/packages/angular-rspack-compiler/src/utils/regex-filters.spec.ts
+++ b/packages/angular-rspack-compiler/src/utils/regex-filters.spec.ts
@@ -16,7 +16,7 @@ describe('TS_ALL_EXT_REGEX', () => {
     expect(filename).toMatch(TS_ALL_EXT_REGEX);
   });
 
-  it.each([['file.js'], ['file.cjs'], ['file.mjs'], ['file']])(
+  it.each([['file.js'], ['file.cjs'], ['file.mjs'], ['file'], ['file.json']])(
     'should not match other files',
     (filename) => {
       expect(filename).not.toMatch(TS_ALL_EXT_REGEX);
@@ -35,12 +35,17 @@ describe('JS_ALL_EXT_REGEX', () => {
     expect(filename).toMatch(JS_ALL_EXT_REGEX);
   });
 
-  it.each([['file.tsx'], ['file.ts'], ['file.cts'], ['file.mts'], ['file']])(
-    'should not match other files',
-    (filename) => {
-      expect(filename).not.toMatch(JS_ALL_EXT_REGEX);
-    }
-  );
+  it.each([
+    ['file.tsx'],
+    ['file.ts'],
+    ['file.cts'],
+    ['file.mts'],
+    ['file'],
+    ['file.json'],
+    ['package.json'],
+  ])('should not match other files', (filename) => {
+    expect(filename).not.toMatch(JS_ALL_EXT_REGEX);
+  });
 });
 
 describe('isStandardJsFile', () => {

--- a/packages/angular-rspack-compiler/src/utils/regex-filters.ts
+++ b/packages/angular-rspack-compiler/src/utils/regex-filters.ts
@@ -1,5 +1,5 @@
-export const TS_ALL_EXT_REGEX = /\.[cm]?(ts)[^x]?\??/;
-export const JS_ALL_EXT_REGEX = /\.[cm]?(js)[^x]?\??/;
+export const TS_ALL_EXT_REGEX = /\.[cm]?tsx?(\?|$)/;
+export const JS_ALL_EXT_REGEX = /\.[cm]?jsx?(\?|$)/;
 export const JS_EXT_REGEX = /\.[cm]?js$/;
 
 export function isStandardJsFile(filename: string) {


### PR DESCRIPTION
## Current Behavior

When importing a `package.json` file in an Angular application built with `@nx/angular-rspack`, the build fails with a Babel syntax error if the `package.json` contains `@angular/*` dependencies:

```
SyntaxError: /path/to/package.json: Missing semicolon. (2:10)

  1 | {
> 2 |     "name": "@org/app",
    |           ^
  3 |     "version": "4.0.2",
  4 |     "dependencies": {
  5 |         "@angular/platform-browser": "20.3.7",
```

This happens because the `JS_ALL_EXT_REGEX` pattern `/\.[cm]?(js)[^x]?\??/` incorrectly matches `.json` files. When the JSON file content contains `@angular` strings, the `angular-partial-transform-loader` attempts to process it through Babel, which fails because JSON is not valid JavaScript.

**Root cause:** The regex `[^x]?` (optional character that is NOT 'x') allows `.json` to match because 'o' is not 'x'.

## Expected Behavior
- `.json` files should NOT match `JS_ALL_EXT_REGEX` or `TS_ALL_EXT_REGEX`
- Importing `package.json` in Angular applications should work correctly
- All existing matches for `.js`, `.jsx`, `.mjs`, `.cjs` (and TypeScript equivalents) should continue to work

## Related Issue(s)
https://github.com/nrwl/nx/issues/32649