### PR TITLE
fix(core): consolidate GitHub URL messaging when gh push fails

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -352,6 +352,12 @@ process.on('SIGINT', async () => {
   const { directory, connectUrl } = getInterruptedWorkspaceState();
 
   if (directory) {
+    const path = require('path');
+    const workspaceName = path.basename(directory);
+    const githubUrl = `https://github.com/new?name=${encodeURIComponent(
+      workspaceName
+    )}`;
+
     console.log(''); // New line after ^C
     output.log({
       title: 'Workspace creation interrupted',
@@ -359,7 +365,7 @@ process.on('SIGINT', async () => {
         `Your workspace was created at: ${directory}`,
         '',
         'To complete the setup:',
-        '  1. Ensure your repo is pushed (e.g. https://github.com/new)',
+        `  1. Ensure your repo is pushed (e.g. ${githubUrl})`,
         connectUrl
           ? `  2. Connect to Nx Cloud: ${connectUrl}`
           : '  2. Connect to Nx Cloud: Run "nx connect"',

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -205,7 +205,8 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
     nxCloudInfo = await getNxCloudInfo(
       connectUrl,
       pushedToVcs,
-      options.completionMessageKey
+      options.completionMessageKey,
+      name
     );
   } else if (isTemplate && nxCloud === 'skip') {
     // Show nx connect message when user skips cloud in template flow

--- a/packages/create-nx-workspace/src/utils/git/git.ts
+++ b/packages/create-nx-workspace/src/utils/git/git.ts
@@ -278,30 +278,14 @@ export async function pushToGitHub(
     });
     return VcsPushStatus.PushedToVcs;
   } catch (e) {
-    const isVerbose =
-      options.verbose || process.env.NX_VERBOSE_LOGGING === 'true';
-    const errorMessage = e instanceof Error ? e.message : String(e);
-
     // Error code 127 means gh wasn't installed
     // GitHubPushSkippedError means user hasn't opted in or we couldn't authenticate
     const title =
       e instanceof GitHubPushSkippedError || (e as any)?.code === 127
         ? 'Push your workspace to GitHub.'
-        : 'Could not push. Push repo to complete setup.';
+        : 'Could not push.';
 
-    const createRepoUrl = `https://github.com/new?name=${encodeURIComponent(
-      options.name
-    )}`;
-    output.log({
-      title,
-      bodyLines: isVerbose
-        ? [
-            `Go to ${createRepoUrl} and push this workspace.`,
-            'Error details:',
-            errorMessage,
-          ]
-        : [`Go to ${createRepoUrl} and push this workspace.`],
-    });
+    output.log({ title });
     return VcsPushStatus.FailedToPushToVcs;
   }
 }

--- a/packages/create-nx-workspace/src/utils/nx/messages.spec.ts
+++ b/packages/create-nx-workspace/src/utils/nx/messages.spec.ts
@@ -39,12 +39,13 @@ describe('Nx Cloud Messages', () => {
       const message = getCompletionMessage(
         'ci-setup',
         'https://nx.app/setup/123',
-        VcsPushStatus.OptedOutOfPushingToVcs
+        VcsPushStatus.OptedOutOfPushingToVcs,
+        'myworkspace'
       );
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
+            "Push your repo (https://github.com/new?name=myworkspace), then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
           ],
           "title": "Your CI setup is almost complete.",
         }
@@ -55,12 +56,13 @@ describe('Nx Cloud Messages', () => {
       const message = getCompletionMessage(
         'ci-setup',
         'https://nx.app/setup/123',
-        VcsPushStatus.FailedToPushToVcs
+        VcsPushStatus.FailedToPushToVcs,
+        'myworkspace'
       );
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
+            "Push your repo (https://github.com/new?name=myworkspace), then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
           ],
           "title": "Your CI setup is almost complete.",
         }
@@ -71,12 +73,13 @@ describe('Nx Cloud Messages', () => {
       const message = getCompletionMessage(
         'ci-setup',
         null,
-        VcsPushStatus.FailedToPushToVcs
+        VcsPushStatus.FailedToPushToVcs,
+        'myworkspace'
       );
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then return to Nx Cloud and finish the setup.",
+            "Push your repo (https://github.com/new?name=myworkspace), then return to Nx Cloud and finish the setup.",
           ],
           "title": "Your CI setup is almost complete.",
         }
@@ -87,12 +90,29 @@ describe('Nx Cloud Messages', () => {
       const message = getCompletionMessage(
         'ci-setup',
         null,
-        VcsPushStatus.OptedOutOfPushingToVcs
+        VcsPushStatus.OptedOutOfPushingToVcs,
+        'myworkspace'
       );
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then return to Nx Cloud and finish the setup.",
+            "Push your repo (https://github.com/new?name=myworkspace), then return to Nx Cloud and finish the setup.",
+          ],
+          "title": "Your CI setup is almost complete.",
+        }
+      `);
+    });
+
+    it('should use generic GitHub URL when workspaceName is not provided', () => {
+      const message = getCompletionMessage(
+        'ci-setup',
+        'https://nx.app/setup/123',
+        VcsPushStatus.FailedToPushToVcs
+      );
+      expect(message).toMatchInlineSnapshot(`
+        {
+          "bodyLines": [
+            "Push your repo (https://github.com/new), then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
           ],
           "title": "Your CI setup is almost complete.",
         }
@@ -137,12 +157,13 @@ describe('Nx Cloud Messages', () => {
       const message = getCompletionMessage(
         'cache-setup',
         'https://nx.app/setup/456',
-        VcsPushStatus.OptedOutOfPushingToVcs
+        VcsPushStatus.OptedOutOfPushingToVcs,
+        'myworkspace'
       );
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/456",
+            "Push your repo (https://github.com/new?name=myworkspace), then go to Nx Cloud and finish the setup: https://nx.app/setup/456",
           ],
           "title": "Your remote cache setup is almost complete.",
         }
@@ -153,12 +174,13 @@ describe('Nx Cloud Messages', () => {
       const message = getCompletionMessage(
         'cache-setup',
         'https://nx.app/setup/456',
-        VcsPushStatus.FailedToPushToVcs
+        VcsPushStatus.FailedToPushToVcs,
+        'myworkspace'
       );
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/456",
+            "Push your repo (https://github.com/new?name=myworkspace), then go to Nx Cloud and finish the setup: https://nx.app/setup/456",
           ],
           "title": "Your remote cache setup is almost complete.",
         }
@@ -169,12 +191,13 @@ describe('Nx Cloud Messages', () => {
       const message = getCompletionMessage(
         'cache-setup',
         null,
-        VcsPushStatus.FailedToPushToVcs
+        VcsPushStatus.FailedToPushToVcs,
+        'myworkspace'
       );
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then return to Nx Cloud and finish the setup.",
+            "Push your repo (https://github.com/new?name=myworkspace), then return to Nx Cloud and finish the setup.",
           ],
           "title": "Your remote cache setup is almost complete.",
         }
@@ -185,12 +208,13 @@ describe('Nx Cloud Messages', () => {
       const message = getCompletionMessage(
         'cache-setup',
         null,
-        VcsPushStatus.OptedOutOfPushingToVcs
+        VcsPushStatus.OptedOutOfPushingToVcs,
+        'myworkspace'
       );
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then return to Nx Cloud and finish the setup.",
+            "Push your repo (https://github.com/new?name=myworkspace), then return to Nx Cloud and finish the setup.",
           ],
           "title": "Your remote cache setup is almost complete.",
         }
@@ -211,12 +235,14 @@ describe('Nx Cloud Messages', () => {
       const messageNotPushedWithUrl = getCompletionMessage(
         'cache-setup',
         'https://nx.app/setup/456',
-        VcsPushStatus.FailedToPushToVcs
+        VcsPushStatus.FailedToPushToVcs,
+        'myworkspace'
       );
       const messageNotPushedWithoutUrl = getCompletionMessage(
         'cache-setup',
         null,
-        VcsPushStatus.FailedToPushToVcs
+        VcsPushStatus.FailedToPushToVcs,
+        'myworkspace'
       );
 
       expect(messageWithUrl.bodyLines).toHaveLength(1);
@@ -242,7 +268,12 @@ describe('Nx Cloud Messages', () => {
       ];
 
       scenarios.forEach(({ url, pushed }) => {
-        const message = getCompletionMessage('cache-setup', url, pushed);
+        const message = getCompletionMessage(
+          'cache-setup',
+          url,
+          pushed,
+          'myworkspace'
+        );
         expect(message.title).toBe(
           'Your remote cache setup is almost complete.'
         );

--- a/packages/create-nx-workspace/src/utils/nx/messages.ts
+++ b/packages/create-nx-workspace/src/utils/nx/messages.ts
@@ -2,7 +2,8 @@ import { VcsPushStatus } from '../git/git';
 
 function getSetupMessage(
   url: string | null,
-  pushedToVcs: VcsPushStatus
+  pushedToVcs: VcsPushStatus,
+  workspaceName?: string
 ): string {
   if (pushedToVcs === VcsPushStatus.PushedToVcs) {
     return url
@@ -10,10 +11,14 @@ function getSetupMessage(
       : 'Return to Nx Cloud and finish the setup.';
   }
 
-  // Default case: FailedToPushToVcs
+  // User needs to push first
+  const githubUrl = workspaceName
+    ? `https://github.com/new?name=${encodeURIComponent(workspaceName)}`
+    : 'https://github.com/new';
+
   const action = url ? 'go' : 'return';
   const urlSuffix = url ? `: ${url}` : '.';
-  return `Push your repo, then ${action} to Nx Cloud and finish the setup${urlSuffix}`;
+  return `Push your repo (${githubUrl}), then ${action} to Nx Cloud and finish the setup${urlSuffix}`;
 }
 
 /**
@@ -37,13 +42,14 @@ export type CompletionMessageKey = keyof typeof completionMessages;
 export function getCompletionMessage(
   completionMessageKey: CompletionMessageKey | undefined,
   url: string | null,
-  pushedToVcs: VcsPushStatus
+  pushedToVcs: VcsPushStatus,
+  workspaceName?: string
 ): { title: string; bodyLines: string[] } {
   const key = completionMessageKey ?? 'ci-setup';
 
   return {
     title: completionMessages[key].title,
-    bodyLines: [getSetupMessage(url, pushedToVcs)],
+    bodyLines: [getSetupMessage(url, pushedToVcs, workspaceName)],
   };
 }
 

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -111,13 +111,15 @@ export async function createNxCloudOnboardingUrl(
 export async function getNxCloudInfo(
   connectCloudUrl: string,
   pushedToVcs: VcsPushStatus,
-  completionMessageKey?: CompletionMessageKey
+  completionMessageKey?: CompletionMessageKey,
+  workspaceName?: string
 ) {
   const out = new CLIOutput(false);
   const message = getCompletionMessage(
     completionMessageKey,
     connectCloudUrl,
-    pushedToVcs
+    pushedToVcs,
+    workspaceName
   );
   out.success(message);
   return out.getOutput();


### PR DESCRIPTION
When `gh repo create` fails, users see two redundant messages. This consolidates them into a single message with the helpful `?name=...` parameter in the GitHub URL.

BEFORE: (We show `Could not push. Push repo to complete setup.` and then `Push your repo (https://github.com/new)...` again at the end)

<img width="1209" height="560" alt="image" src="https://github.com/user-attachments/assets/e22c012c-8e0f-4ff9-a6c2-de8267b69b5d" />

AFTER: (Only show `Could not push` as an info log, and then complete setup is shown only once at the end)

<img width="1250" height="591" alt="image" src="https://github.com/user-attachments/assets/3dc075c7-4418-4373-a07a-1b95f71b3b87" />

Closes NXC-3754
