### PR TITLE
chore(repo): commit lint mention that commits should be lowercase

### DIFF
--- a/scripts/commit-lint.js
+++ b/scripts/commit-lint.js
@@ -95,6 +95,11 @@ if (require.main === module) {
       `possible scopes: ${result.allowedScopes} (if unsure use "core")`
     );
     console.log(
+      '\nThe commit subject must be lowercase, unless beginning with "Revert" or "Release".'
+    );
+    console.log('\n');
+
+    console.log(
       '\nEXAMPLE: \n' +
         'feat(nx): add an option to generate lazy-loadable modules\n' +
         'fix(core)!: breaking change should have exclamation mark\n'


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Commit linting does not mention requirement for commit message to be lowercase.
<!-- This is the behavior we have today -->

## Expected Behavior
Hook message should instruct user to use all lowercase for commit message. 
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
