### PR TITLE
fix(core): remove shellapi from winapi featureset to minimize AV false positives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,6 +2635,7 @@ dependencies = [
  "watchexec-filterer-ignore",
  "watchexec-signals",
  "winapi",
+ "winres",
  "wrap-ansi",
  "xxhash-rust",
 ]
@@ -4416,6 +4417,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5577,6 +5587,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "winres"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
+dependencies = [
+ "toml",
 ]
 
 [[package]]

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -71,7 +71,10 @@ static_assertions = "1.1"
 wrap-ansi = "0.1"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["fileapi", "psapi", "shellapi"] }
+winapi = { version = "0.3", features = ["fileapi", "psapi"] }
+
+[target.'cfg(windows)'.build-dependencies]
+winres = "0.1"
 
 [target.'cfg(all(not(windows), not(target_family = "wasm")))'.dependencies]
 mio = "1.0"

--- a/packages/nx/build.rs
+++ b/packages/nx/build.rs
@@ -2,4 +2,26 @@ extern crate napi_build;
 
 fn main() {
     napi_build::setup();
+
+    // Embed Windows resource metadata to establish binary legitimacy
+    // and reduce false positive detections from security software
+    #[cfg(windows)]
+    {
+        let mut res = winres::WindowsResource::new();
+        res.set("ProductName", "Nx Build System")
+            .set(
+                "FileDescription",
+                "Nx Native Module - High-performance build system operations",
+            )
+            .set("CompanyName", "Nrwl")
+            .set("LegalCopyright", "Copyright (c) Nrwl. MIT License.")
+            .set("OriginalFilename", "nx.node")
+            .set("InternalName", "nx");
+
+        if let Err(e) = res.compile() {
+            // Don't fail the build if resource compilation fails
+            // (e.g., when cross-compiling from non-Windows)
+            eprintln!("cargo:warning=Failed to compile Windows resources: {}", e);
+        }
+    }
 }

--- a/packages/nx/build.rs
+++ b/packages/nx/build.rs
@@ -8,12 +8,12 @@ fn main() {
     #[cfg(windows)]
     {
         let mut res = winres::WindowsResource::new();
-        res.set("ProductName", "Nx Build System")
+        res.set("ProductName", "Nx")
             .set(
                 "FileDescription",
                 "Nx Native Module - High-performance build system operations",
             )
-            .set("CompanyName", "Nrwl")
+            .set("CompanyName", "Nx")
             .set("LegalCopyright", "Copyright (c) Nrwl. MIT License.")
             .set("OriginalFilename", "nx.node")
             .set("InternalName", "nx");


### PR DESCRIPTION
## Current Behavior
There's a chance that windows can falsely flag our native binaries as a threat. We do not use the shellapi feature from winapi.

## Expected Behavior
We hope that removing this API doesn't break things, and the threat messaging goes away	

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #https://github.com/nrwl/nx/issues/34186
