### PR TITLE
fix(web): ensure vitest config file is created

### DIFF
--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -579,7 +579,7 @@ describe('app', () => {
         unitTestRunner: 'vitest',
         addPlugin: true,
       });
-      expect(tree.exists('my-webpack-app/vite.config.mts')).toBeTruthy();
+      expect(tree.exists('my-webpack-app/vitest.config.mts')).toBeTruthy();
       expect(tree.exists('my-webpack-app/jest.config.cts')).toBeFalsy();
       expect(
         readJson(tree, 'my-webpack-app/tsconfig.spec.json').compilerOptions

--- a/packages/web/src/generators/application/application.ts
+++ b/packages/web/src/generators/application/application.ts
@@ -412,6 +412,8 @@ export async function applicationGeneratorInternal(host: Tree, schema: Schema) {
         inSourceTests: options.inSourceTests,
         useEsmExtension: true,
       },
+      true,
+      undefined,
       true
     );
   }


### PR DESCRIPTION
`@nx/web:app` generator is incorrectly calling `createOrEditViteConfig` when bundler != vite and unitTestRunner = vitest.

Ensure it is using the correct file