### PR TITLE
fix(react): remove file-loader dependency and update svgr migration

### DIFF
--- a/packages/next/.eslintrc.json
+++ b/packages/next/.eslintrc.json
@@ -101,7 +101,6 @@
               // require.resovle is used for these
               "@babel/plugin-proposal-decorators",
               "tailwindcss",
-              "file-loader",
               "@svgr/webpack",
               // since `with-nx.ts` is included in the prod build, we need to use `require('@nx/next')` instead of proper relative imports
               "@nx/next"

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -39,7 +39,6 @@
     "@babel/plugin-proposal-decorators": "^7.22.7",
     "@svgr/webpack": "^8.1.0",
     "copy-webpack-plugin": "^10.2.4",
-    "file-loader": "^6.2.0",
     "ignore": "^5.0.4",
     "semver": "catalog:",
     "tslib": "catalog:typescript",

--- a/packages/next/src/migrations/update-22-0-0/add-svgr-to-next-config.spec.ts
+++ b/packages/next/src/migrations/update-22-0-0/add-svgr-to-next-config.spec.ts
@@ -185,31 +185,36 @@ module.exports = composePlugins(...plugins)(nextConfig);
         const originalWebpack = config.webpack;
         // @ts-ignore
         config.webpack = (webpackConfig, ctx) => {
-          // Add SVGR support
+          // Add SVGR support with webpack 5 asset modules
           webpackConfig.module.rules.push({
             test: /.svg$/,
-            issuer: { not: /.(css|scss|sass)$/ },
-            resourceQuery: {
-              not: [
-                /__next_metadata__/,
-                /__next_metadata_route__/,
-                /__next_metadata_image_meta__/,
-              ],
-            },
-            use: [
+            oneOf: [
               {
-                loader: require.resolve('@svgr/webpack'),
-                options: {
-                  svgo: false,
-                  titleProp: true,
-                  ref: true,
+                resourceQuery: /url/,
+                type: 'asset/resource',
+                generator: {
+                  filename: 'static/media/[name].[hash][ext]',
                 },
               },
               {
-                loader: require.resolve('file-loader'),
-                options: {
-                  name: 'static/media/[name].[hash].[ext]',
+                issuer: { not: /.(css|scss|sass)$/ },
+                resourceQuery: {
+                  not: [
+                    /__next_metadata__/,
+                    /__next_metadata_route__/,
+                    /__next_metadata_image_meta__/,
+                  ],
                 },
+                use: [
+                  {
+                    loader: require.resolve('@svgr/webpack'),
+                    options: {
+                      svgo: false,
+                      titleProp: true,
+                      ref: true,
+                    },
+                  },
+                ],
               },
             ],
           });
@@ -282,31 +287,36 @@ module.exports = composePlugins(...plugins)(nextConfig);
         const originalWebpack = config.webpack;
         // @ts-ignore
         config.webpack = (webpackConfig, ctx) => {
-          // Add SVGR support
+          // Add SVGR support with webpack 5 asset modules
           webpackConfig.module.rules.push({
             test: /.svg$/,
-            issuer: { not: /.(css|scss|sass)$/ },
-            resourceQuery: {
-              not: [
-                /__next_metadata__/,
-                /__next_metadata_route__/,
-                /__next_metadata_image_meta__/,
-              ],
-            },
-            use: [
+            oneOf: [
               {
-                loader: require.resolve('@svgr/webpack'),
-                options: {
-                  svgo: true,
-                  titleProp: false,
-                  ref: false,
+                resourceQuery: /url/,
+                type: 'asset/resource',
+                generator: {
+                  filename: 'static/media/[name].[hash][ext]',
                 },
               },
               {
-                loader: require.resolve('file-loader'),
-                options: {
-                  name: 'static/media/[name].[hash].[ext]',
+                issuer: { not: /.(css|scss|sass)$/ },
+                resourceQuery: {
+                  not: [
+                    /__next_metadata__/,
+                    /__next_metadata_route__/,
+                    /__next_metadata_image_meta__/,
+                  ],
                 },
+                use: [
+                  {
+                    loader: require.resolve('@svgr/webpack'),
+                    options: {
+                      svgo: true,
+                      titleProp: false,
+                      ref: false,
+                    },
+                  },
+                ],
               },
             ],
           });
@@ -375,31 +385,36 @@ module.exports = composePlugins(...plugins)(nextConfig);
         const originalWebpack = config.webpack;
         // @ts-ignore
         config.webpack = (webpackConfig, ctx) => {
-          // Add SVGR support
+          // Add SVGR support with webpack 5 asset modules
           webpackConfig.module.rules.push({
             test: /.svg$/,
-            issuer: { not: /.(css|scss|sass)$/ },
-            resourceQuery: {
-              not: [
-                /__next_metadata__/,
-                /__next_metadata_route__/,
-                /__next_metadata_image_meta__/,
-              ],
-            },
-            use: [
+            oneOf: [
               {
-                loader: require.resolve('@svgr/webpack'),
-                options: {
-                  svgo: false,
-                  titleProp: true,
-                  ref: true,
+                resourceQuery: /url/,
+                type: 'asset/resource',
+                generator: {
+                  filename: 'static/media/[name].[hash][ext]',
                 },
               },
               {
-                loader: require.resolve('file-loader'),
-                options: {
-                  name: 'static/media/[name].[hash].[ext]',
+                issuer: { not: /.(css|scss|sass)$/ },
+                resourceQuery: {
+                  not: [
+                    /__next_metadata__/,
+                    /__next_metadata_route__/,
+                    /__next_metadata_image_meta__/,
+                  ],
                 },
+                use: [
+                  {
+                    loader: require.resolve('@svgr/webpack'),
+                    options: {
+                      svgo: false,
+                      titleProp: true,
+                      ref: true,
+                    },
+                  },
+                ],
               },
             ],
           });
@@ -500,31 +515,36 @@ module.exports = composePlugins(...plugins)(nextConfig);
         const originalWebpack = config.webpack;
         // @ts-ignore
         config.webpack = (webpackConfig, ctx) => {
-          // Add SVGR support
+          // Add SVGR support with webpack 5 asset modules
           webpackConfig.module.rules.push({
             test: /.svg$/,
-            issuer: { not: /.(css|scss|sass)$/ },
-            resourceQuery: {
-              not: [
-                /__next_metadata__/,
-                /__next_metadata_route__/,
-                /__next_metadata_image_meta__/,
-              ],
-            },
-            use: [
+            oneOf: [
               {
-                loader: require.resolve('@svgr/webpack'),
-                options: {
-                  svgo: false,
-                  titleProp: true,
-                  ref: true,
+                resourceQuery: /url/,
+                type: 'asset/resource',
+                generator: {
+                  filename: 'static/media/[name].[hash][ext]',
                 },
               },
               {
-                loader: require.resolve('file-loader'),
-                options: {
-                  name: 'static/media/[name].[hash].[ext]',
+                issuer: { not: /.(css|scss|sass)$/ },
+                resourceQuery: {
+                  not: [
+                    /__next_metadata__/,
+                    /__next_metadata_route__/,
+                    /__next_metadata_image_meta__/,
+                  ],
                 },
+                use: [
+                  {
+                    loader: require.resolve('@svgr/webpack'),
+                    options: {
+                      svgo: false,
+                      titleProp: true,
+                      ref: true,
+                    },
+                  },
+                ],
               },
             ],
           });
@@ -599,31 +619,36 @@ module.exports = composePlugins(...plugins)(nextConfig);
         const originalWebpack = config.webpack;
         // @ts-ignore
         config.webpack = (webpackConfig, ctx) => {
-          // Add SVGR support
+          // Add SVGR support with webpack 5 asset modules
           webpackConfig.module.rules.push({
             test: /.svg$/,
-            issuer: { not: /.(css|scss|sass)$/ },
-            resourceQuery: {
-              not: [
-                /__next_metadata__/,
-                /__next_metadata_route__/,
-                /__next_metadata_image_meta__/,
-              ],
-            },
-            use: [
+            oneOf: [
               {
-                loader: require.resolve('@svgr/webpack'),
-                options: {
-                  svgo: false,
-                  titleProp: true,
-                  ref: true,
+                resourceQuery: /url/,
+                type: 'asset/resource',
+                generator: {
+                  filename: 'static/media/[name].[hash][ext]',
                 },
               },
               {
-                loader: require.resolve('file-loader'),
-                options: {
-                  name: 'static/media/[name].[hash].[ext]',
+                issuer: { not: /.(css|scss|sass)$/ },
+                resourceQuery: {
+                  not: [
+                    /__next_metadata__/,
+                    /__next_metadata_route__/,
+                    /__next_metadata_image_meta__/,
+                  ],
                 },
+                use: [
+                  {
+                    loader: require.resolve('@svgr/webpack'),
+                    options: {
+                      svgo: false,
+                      titleProp: true,
+                      ref: true,
+                    },
+                  },
+                ],
               },
             ],
           });
@@ -692,31 +717,36 @@ module.exports = composePlugins(...plugins)(nextConfig);
         const originalWebpack = config.webpack;
         // @ts-ignore
         config.webpack = (webpackConfig, ctx) => {
-          // Add SVGR support
+          // Add SVGR support with webpack 5 asset modules
           webpackConfig.module.rules.push({
             test: /.svg$/,
-            issuer: { not: /.(css|scss|sass)$/ },
-            resourceQuery: {
-              not: [
-                /__next_metadata__/,
-                /__next_metadata_route__/,
-                /__next_metadata_image_meta__/,
-              ],
-            },
-            use: [
+            oneOf: [
               {
-                loader: require.resolve('@svgr/webpack'),
-                options: {
-                  svgo: false,
-                  titleProp: true,
-                  ref: true,
+                resourceQuery: /url/,
+                type: 'asset/resource',
+                generator: {
+                  filename: 'static/media/[name].[hash][ext]',
                 },
               },
               {
-                loader: require.resolve('file-loader'),
-                options: {
-                  name: 'static/media/[name].[hash].[ext]',
+                issuer: { not: /.(css|scss|sass)$/ },
+                resourceQuery: {
+                  not: [
+                    /__next_metadata__/,
+                    /__next_metadata_route__/,
+                    /__next_metadata_image_meta__/,
+                  ],
                 },
+                use: [
+                  {
+                    loader: require.resolve('@svgr/webpack'),
+                    options: {
+                      svgo: false,
+                      titleProp: true,
+                      ref: true,
+                    },
+                  },
+                ],
               },
             ],
           });

--- a/packages/react/.eslintrc.json
+++ b/packages/react/.eslintrc.json
@@ -78,7 +78,6 @@
               "babel-plugin-emotion",
               "babel-plugin-styled-components",
               "css-loader",
-              "file-loader",
               "less-loader",
               "react-refresh",
               "rollup",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "@phenomnomnominal/tsquery": "catalog:typescript",
     "@svgr/webpack": "^8.0.1",
-    "file-loader": "^6.2.0",
     "minimatch": "catalog:",
     "picocolors": "catalog:",
     "tslib": "catalog:typescript",

--- a/packages/react/src/migrations/update-22-0-0/add-svgr-to-webpack-config.spec.ts
+++ b/packages/react/src/migrations/update-22-0-0/add-svgr-to-webpack-config.spec.ts
@@ -107,20 +107,25 @@ module.exports = composePlugins(
               config.module.rules.splice(svgLoaderIdx, 1);
             }
 
-            // Add SVGR loader
+            // Add SVGR loader with webpack 5 asset modules
             config.module.rules.push({
               test: /\\.svg$/,
-              issuer: /\\.(js|ts|md)x?$/,
-              use: [
+              oneOf: [
                 {
-                  loader: require.resolve('@svgr/webpack'),
-                  options,
+                  resourceQuery: /url/,
+                  type: 'asset/resource',
+                  generator: {
+                    filename: '[name].[hash][ext]',
+                  },
                 },
                 {
-                  loader: require.resolve('file-loader'),
-                  options: {
-                    name: '[name].[hash].[ext]',
-                  },
+                  issuer: /\\.(js|ts|md)x?$/,
+                  use: [
+                    {
+                      loader: require.resolve('@svgr/webpack'),
+                      options,
+                    },
+                  ],
                 },
               ],
             });
@@ -202,20 +207,25 @@ module.exports = composePlugins(
               config.module.rules.splice(svgLoaderIdx, 1);
             }
 
-            // Add SVGR loader
+            // Add SVGR loader with webpack 5 asset modules
             config.module.rules.push({
               test: /\\.svg$/,
-              issuer: /\\.(js|ts|md)x?$/,
-              use: [
+              oneOf: [
                 {
-                  loader: require.resolve('@svgr/webpack'),
-                  options,
+                  resourceQuery: /url/,
+                  type: 'asset/resource',
+                  generator: {
+                    filename: '[name].[hash][ext]',
+                  },
                 },
                 {
-                  loader: require.resolve('file-loader'),
-                  options: {
-                    name: '[name].[hash].[ext]',
-                  },
+                  issuer: /\\.(js|ts|md)x?$/,
+                  use: [
+                    {
+                      loader: require.resolve('@svgr/webpack'),
+                      options,
+                    },
+                  ],
                 },
               ],
             });
@@ -352,20 +362,25 @@ module.exports = composePlugins(
               config.module.rules.splice(svgLoaderIdx, 1);
             }
 
-            // Add SVGR loader
+            // Add SVGR loader with webpack 5 asset modules
             config.module.rules.push({
               test: /\\.svg$/,
-              issuer: /\\.(js|ts|md)x?$/,
-              use: [
+              oneOf: [
                 {
-                  loader: require.resolve('@svgr/webpack'),
-                  options,
+                  resourceQuery: /url/,
+                  type: 'asset/resource',
+                  generator: {
+                    filename: '[name].[hash][ext]',
+                  },
                 },
                 {
-                  loader: require.resolve('file-loader'),
-                  options: {
-                    name: '[name].[hash].[ext]',
-                  },
+                  issuer: /\\.(js|ts|md)x?$/,
+                  use: [
+                    {
+                      loader: require.resolve('@svgr/webpack'),
+                      options,
+                    },
+                  ],
                 },
               ],
             });
@@ -445,20 +460,25 @@ module.exports = config;
               config.module.rules.splice(svgLoaderIdx, 1);
             }
 
-            // Add SVGR loader
+            // Add SVGR loader with webpack 5 asset modules
             config.module.rules.push({
               test: /\\.svg$/,
-              issuer: /\\.(js|ts|md)x?$/,
-              use: [
+              oneOf: [
                 {
-                  loader: require.resolve('@svgr/webpack'),
-                  options,
+                  resourceQuery: /url/,
+                  type: 'asset/resource',
+                  generator: {
+                    filename: '[name].[hash][ext]',
+                  },
                 },
                 {
-                  loader: require.resolve('file-loader'),
-                  options: {
-                    name: '[name].[hash].[ext]',
-                  },
+                  issuer: /\\.(js|ts|md)x?$/,
+                  use: [
+                    {
+                      loader: require.resolve('@svgr/webpack'),
+                      options,
+                    },
+                  ],
                 },
               ],
             });
@@ -538,20 +558,25 @@ export default config;
               config.module.rules.splice(svgLoaderIdx, 1);
             }
 
-            // Add SVGR loader
+            // Add SVGR loader with webpack 5 asset modules
             config.module.rules.push({
               test: /\\.svg$/,
-              issuer: /\\.(js|ts|md)x?$/,
-              use: [
+              oneOf: [
                 {
-                  loader: require.resolve('@svgr/webpack'),
-                  options,
+                  resourceQuery: /url/,
+                  type: 'asset/resource',
+                  generator: {
+                    filename: '[name].[hash][ext]',
+                  },
                 },
                 {
-                  loader: require.resolve('file-loader'),
-                  options: {
-                    name: '[name].[hash].[ext]',
-                  },
+                  issuer: /\\.(js|ts|md)x?$/,
+                  use: [
+                    {
+                      loader: require.resolve('@svgr/webpack'),
+                      options,
+                    },
+                  ],
                 },
               ],
             });
@@ -632,20 +657,25 @@ export default composePlugins(
               config.module.rules.splice(svgLoaderIdx, 1);
             }
 
-            // Add SVGR loader
+            // Add SVGR loader with webpack 5 asset modules
             config.module.rules.push({
               test: /\\.svg$/,
-              issuer: /\\.(js|ts|md)x?$/,
-              use: [
+              oneOf: [
                 {
-                  loader: require.resolve('@svgr/webpack'),
-                  options,
+                  resourceQuery: /url/,
+                  type: 'asset/resource',
+                  generator: {
+                    filename: '[name].[hash][ext]',
+                  },
                 },
                 {
-                  loader: require.resolve('file-loader'),
-                  options: {
-                    name: '[name].[hash].[ext]',
-                  },
+                  issuer: /\\.(js|ts|md)x?$/,
+                  use: [
+                    {
+                      loader: require.resolve('@svgr/webpack'),
+                      options,
+                    },
+                  ],
                 },
               ],
             });
@@ -817,20 +847,25 @@ module.exports = {
                     ),
                 );
 
-                // Add SVGR loader with both default and named exports
+                // Add SVGR loader with webpack 5 asset modules
                 compiler.options.module.rules.push({
                   test: /.svg$/,
-                  issuer: /.[jt]sx?$/,
-                  use: [
+                  oneOf: [
                     {
-                      loader: require.resolve('@svgr/webpack'),
-                      options,
+                      resourceQuery: /url/,
+                      type: 'asset/resource',
+                      generator: {
+                        filename: '[name].[hash][ext]',
+                      },
                     },
                     {
-                      loader: require.resolve('file-loader'),
-                      options: {
-                        name: '[name].[hash].[ext]',
-                      },
+                      issuer: /.[jt]sx?$/,
+                      use: [
+                        {
+                          loader: require.resolve('@svgr/webpack'),
+                          options,
+                        },
+                      ],
                     },
                   ],
                 });
@@ -978,20 +1013,25 @@ module.exports = {
                     ),
                 );
 
-                // Add SVGR loader with both default and named exports
+                // Add SVGR loader with webpack 5 asset modules
                 compiler.options.module.rules.push({
                   test: /.svg$/,
-                  issuer: /.[jt]sx?$/,
-                  use: [
+                  oneOf: [
                     {
-                      loader: require.resolve('@svgr/webpack'),
-                      options,
+                      resourceQuery: /url/,
+                      type: 'asset/resource',
+                      generator: {
+                        filename: '[name].[hash][ext]',
+                      },
                     },
                     {
-                      loader: require.resolve('file-loader'),
-                      options: {
-                        name: '[name].[hash].[ext]',
-                      },
+                      issuer: /.[jt]sx?$/,
+                      use: [
+                        {
+                          loader: require.resolve('@svgr/webpack'),
+                          options,
+                        },
+                      ],
                     },
                   ],
                 });
@@ -1095,20 +1135,25 @@ module.exports = webpackConfig;
                     ),
                 );
 
-                // Add SVGR loader with both default and named exports
+                // Add SVGR loader with webpack 5 asset modules
                 compiler.options.module.rules.push({
                   test: /.svg$/,
-                  issuer: /.[jt]sx?$/,
-                  use: [
+                  oneOf: [
                     {
-                      loader: require.resolve('@svgr/webpack'),
-                      options,
+                      resourceQuery: /url/,
+                      type: 'asset/resource',
+                      generator: {
+                        filename: '[name].[hash][ext]',
+                      },
                     },
                     {
-                      loader: require.resolve('file-loader'),
-                      options: {
-                        name: '[name].[hash].[ext]',
-                      },
+                      issuer: /.[jt]sx?$/,
+                      use: [
+                        {
+                          loader: require.resolve('@svgr/webpack'),
+                          options,
+                        },
+                      ],
                     },
                   ],
                 });
@@ -1210,20 +1255,25 @@ export default webpackConfig;
                     ),
                 );
 
-                // Add SVGR loader with both default and named exports
+                // Add SVGR loader with webpack 5 asset modules
                 compiler.options.module.rules.push({
                   test: /.svg$/,
-                  issuer: /.[jt]sx?$/,
-                  use: [
+                  oneOf: [
                     {
-                      loader: require.resolve('@svgr/webpack'),
-                      options,
+                      resourceQuery: /url/,
+                      type: 'asset/resource',
+                      generator: {
+                        filename: '[name].[hash][ext]',
+                      },
                     },
                     {
-                      loader: require.resolve('file-loader'),
-                      options: {
-                        name: '[name].[hash].[ext]',
-                      },
+                      issuer: /.[jt]sx?$/,
+                      use: [
+                        {
+                          loader: require.resolve('@svgr/webpack'),
+                          options,
+                        },
+                      ],
                     },
                   ],
                 });
@@ -1325,20 +1375,25 @@ export default {
                     ),
                 );
 
-                // Add SVGR loader with both default and named exports
+                // Add SVGR loader with webpack 5 asset modules
                 compiler.options.module.rules.push({
                   test: /.svg$/,
-                  issuer: /.[jt]sx?$/,
-                  use: [
+                  oneOf: [
                     {
-                      loader: require.resolve('@svgr/webpack'),
-                      options,
+                      resourceQuery: /url/,
+                      type: 'asset/resource',
+                      generator: {
+                        filename: '[name].[hash][ext]',
+                      },
                     },
                     {
-                      loader: require.resolve('file-loader'),
-                      options: {
-                        name: '[name].[hash].[ext]',
-                      },
+                      issuer: /.[jt]sx?$/,
+                      use: [
+                        {
+                          loader: require.resolve('@svgr/webpack'),
+                          options,
+                        },
+                      ],
                     },
                   ],
                 });
@@ -1552,20 +1607,25 @@ module.exports = composePlugins(withNx(), withReact(), (config) => config);
               config.module.rules.splice(svgLoaderIdx, 1);
             }
 
-            // Add SVGR loader
+            // Add SVGR loader with webpack 5 asset modules
             config.module.rules.push({
               test: /\\.svg$/,
-              issuer: /\\.(js|ts|md)x?$/,
-              use: [
+              oneOf: [
                 {
-                  loader: require.resolve('@svgr/webpack'),
-                  options,
+                  resourceQuery: /url/,
+                  type: 'asset/resource',
+                  generator: {
+                    filename: '[name].[hash][ext]',
+                  },
                 },
                 {
-                  loader: require.resolve('file-loader'),
-                  options: {
-                    name: '[name].[hash].[ext]',
-                  },
+                  issuer: /\\.(js|ts|md)x?$/,
+                  use: [
+                    {
+                      loader: require.resolve('@svgr/webpack'),
+                      options,
+                    },
+                  ],
                 },
               ],
             });
@@ -1610,20 +1670,25 @@ module.exports = composePlugins(withNx(), withReact(), (config) => config);
                     ),
                 );
 
-                // Add SVGR loader with both default and named exports
+                // Add SVGR loader with webpack 5 asset modules
                 compiler.options.module.rules.push({
                   test: /.svg$/,
-                  issuer: /.[jt]sx?$/,
-                  use: [
+                  oneOf: [
                     {
-                      loader: require.resolve('@svgr/webpack'),
-                      options,
+                      resourceQuery: /url/,
+                      type: 'asset/resource',
+                      generator: {
+                        filename: '[name].[hash][ext]',
+                      },
                     },
                     {
-                      loader: require.resolve('file-loader'),
-                      options: {
-                        name: '[name].[hash].[ext]',
-                      },
+                      issuer: /.[jt]sx?$/,
+                      use: [
+                        {
+                          loader: require.resolve('@svgr/webpack'),
+                          options,
+                        },
+                      ],
                     },
                   ],
                 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3523,9 +3523,6 @@ importers:
       copy-webpack-plugin:
         specifier: ^10.2.4
         version: 10.2.4(webpack@5.104.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3)))
-      file-loader:
-        specifier: ^6.2.0
-        version: 6.2.0(webpack@5.104.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3)))
       ignore:
         specifier: ^5.0.4
         version: 5.3.2
@@ -3861,9 +3858,6 @@ importers:
       express:
         specifier: ^4.21.2
         version: 4.21.2
-      file-loader:
-        specifier: ^6.2.0
-        version: 6.2.0(webpack@5.104.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3)))
       http-proxy-middleware:
         specifier: ^3.0.5
         version: 3.0.5
@@ -43522,12 +43516,6 @@ snapshots:
       loader-utils: 2.0.3
       schema-utils: 3.3.0
       webpack: 5.101.3(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.25.0)(webpack-cli@5.1.4)
-
-  file-loader@6.2.0(webpack@5.104.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3))):
-    dependencies:
-      loader-utils: 2.0.3
-      schema-utils: 3.3.0
-      webpack: 5.104.1(@swc/core@1.5.7(@swc/helpers@0.5.11))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3))
 
   file-type@16.5.4:
     dependencies:


### PR DESCRIPTION
## Current Behavior
The migration for svgr requires using file-loader which is unmaintained.

## Expected Behavior
Use asset/resource instead of file-loader

## Related Issue(s)

CLOSES NXC-3667
