### PR TITLE
feat(core): add variant 2 to CNW cloud prompts with promo message

### DIFF
--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -2,7 +2,12 @@ import * as yargs from 'yargs';
 import * as enquirer from 'enquirer';
 import * as chalk from 'chalk';
 
-import { MessageKey, messages } from '../utils/nx/ab-testing';
+import {
+  getFlowVariant,
+  MessageKey,
+  messages,
+  shouldShowCloudPrompt,
+} from '../utils/nx/ab-testing';
 import { deduceDefaultBase } from '../utils/git/default-base';
 import { isGitAvailable } from '../utils/git/git';
 import {
@@ -45,26 +50,47 @@ export async function determineNxCloudV2(
     return 'skip';
   }
 
-  // Show simplified prompt
-  const { message, choices, initial, footer, hint } =
-    messages.getPrompt('setupNxCloudV2');
+  // Variant 2: Skip prompt and auto-connect
+  if (!shouldShowCloudPrompt()) {
+    return 'github';
+  }
 
-  const promptConfig = {
-    name: 'nxCloud',
-    message,
-    type: 'autocomplete',
-    choices,
-    initial,
-  } as any; // types in enquirer are not up to date
-  if (footer) {
-    promptConfig.footer = () => footer;
-  }
-  if (hint) {
-    promptConfig.hint = () => hint;
-  }
+  // Variants 0 & 1: Show cloud prompt with different copy
+  const variant = getFlowVariant();
+  const promptConfig =
+    variant === '1'
+      ? {
+          name: 'nxCloud',
+          message: 'Would you like remote caching to make your build faster?',
+          type: 'autocomplete',
+          choices: [
+            { value: 'yes', name: 'Yes' },
+            { value: 'skip', name: 'Skip' },
+          ],
+          initial: 0,
+          hint: () => chalk.dim('\n(can be disabled any time)'),
+          footer: () =>
+            chalk.dim(
+              '\nRead more about remote caching at https://nx.dev/ci/features/remote-cache'
+            ),
+        }
+      : {
+          name: 'nxCloud',
+          message: 'Try the full Nx platform?',
+          type: 'autocomplete',
+          choices: [
+            { value: 'yes', name: 'Yes' },
+            { value: 'skip', name: 'Skip' },
+          ],
+          initial: 0,
+          footer: () =>
+            chalk.dim(
+              '\nAutomatically fix broken PRs, 70% faster CI: https://nx.dev/nx-cloud'
+            ),
+        };
 
   const result = await enquirer.prompt<{ nxCloud: 'github' | 'skip' }>([
-    promptConfig,
+    promptConfig as any, // types in enquirer are not up to date
   ]);
   return result.nxCloud;
 }

--- a/packages/create-nx-workspace/src/utils/nx/messages.spec.ts
+++ b/packages/create-nx-workspace/src/utils/nx/messages.spec.ts
@@ -292,6 +292,132 @@ describe('Nx Cloud Messages', () => {
     });
   });
 
+  describe('Platform Promo Messages', () => {
+    it('should show promo title and subtext when user has pushed', () => {
+      const message = getCompletionMessage(
+        'platform-promo',
+        'https://nx.app/setup/123',
+        VcsPushStatus.PushedToVcs
+      );
+      expect(message).toMatchInlineSnapshot(`
+        {
+          "bodyLines": [
+            "Connect your repo to enable remote caching and self-healing CI at: https://nx.app/setup/123",
+            "",
+            "Remote caching · Self-healing CI · Task distribution",
+          ],
+          "title": "Want faster builds?",
+        }
+      `);
+    });
+
+    it('should show promo message with generic cloud URL when pushed without URL', () => {
+      const message = getCompletionMessage(
+        'platform-promo',
+        null,
+        VcsPushStatus.PushedToVcs
+      );
+      expect(message).toMatchInlineSnapshot(`
+        {
+          "bodyLines": [
+            "Connect your repo at https://cloud.nx.app to enable remote caching and self-healing CI.",
+            "",
+            "Remote caching · Self-healing CI · Task distribution",
+          ],
+          "title": "Want faster builds?",
+        }
+      `);
+    });
+
+    it('should instruct user to push repo first when they opted out of pushing', () => {
+      const message = getCompletionMessage(
+        'platform-promo',
+        'https://nx.app/setup/123',
+        VcsPushStatus.OptedOutOfPushingToVcs,
+        'myworkspace'
+      );
+      expect(message).toMatchInlineSnapshot(`
+        {
+          "bodyLines": [
+            "Connect your repo (https://github.com/new?name=myworkspace) to enable remote caching and self-healing CI at: https://nx.app/setup/123",
+            "",
+            "Remote caching · Self-healing CI · Task distribution",
+          ],
+          "title": "Want faster builds?",
+        }
+      `);
+    });
+
+    it('should show connect message with cloud URL when failed to push and no URL', () => {
+      const message = getCompletionMessage(
+        'platform-promo',
+        null,
+        VcsPushStatus.FailedToPushToVcs,
+        'myworkspace'
+      );
+      expect(message).toMatchInlineSnapshot(`
+        {
+          "bodyLines": [
+            "Connect your repo (https://github.com/new?name=myworkspace) to enable remote caching and self-healing CI at https://cloud.nx.app",
+            "",
+            "Remote caching · Self-healing CI · Task distribution",
+          ],
+          "title": "Want faster builds?",
+        }
+      `);
+    });
+
+    it('should use generic GitHub URL when workspaceName is not provided', () => {
+      const message = getCompletionMessage(
+        'platform-promo',
+        'https://nx.app/setup/123',
+        VcsPushStatus.FailedToPushToVcs
+      );
+      expect(message).toMatchInlineSnapshot(`
+        {
+          "bodyLines": [
+            "Connect your repo (https://github.com/new) to enable remote caching and self-healing CI at: https://nx.app/setup/123",
+            "",
+            "Remote caching · Self-healing CI · Task distribution",
+          ],
+          "title": "Want faster builds?",
+        }
+      `);
+    });
+
+    it('should always include subtext in body lines', () => {
+      const scenarios = [
+        { url: 'https://nx.app/setup/123', pushed: VcsPushStatus.PushedToVcs },
+        { url: null, pushed: VcsPushStatus.PushedToVcs },
+        {
+          url: 'https://nx.app/setup/123',
+          pushed: VcsPushStatus.FailedToPushToVcs,
+        },
+        { url: null, pushed: VcsPushStatus.FailedToPushToVcs },
+        {
+          url: 'https://nx.app/setup/123',
+          pushed: VcsPushStatus.OptedOutOfPushingToVcs,
+        },
+        { url: null, pushed: VcsPushStatus.OptedOutOfPushingToVcs },
+      ];
+
+      scenarios.forEach(({ url, pushed }) => {
+        const message = getCompletionMessage(
+          'platform-promo',
+          url,
+          pushed,
+          'myworkspace'
+        );
+        expect(message.title).toBe('Want faster builds?');
+        expect(message.bodyLines).toHaveLength(3);
+        expect(message.bodyLines[1]).toBe('');
+        expect(message.bodyLines[2]).toBe(
+          'Remote caching \u00b7 Self-healing CI \u00b7 Task distribution'
+        );
+      });
+    });
+  });
+
   describe('Default Messages', () => {
     it('should default to ci-setup when no key is provided', () => {
       const message = getCompletionMessage(


### PR DESCRIPTION
This PR uses three variants for CNW for prompting for Cloud/platform connection.

- Variant 0: Shows "Try the full Nx platform?" prompt → platform-setup completion
- Variant 1: Shows "Would you like remote caching..." prompt → cache-setup completion
- Variant 2: No prompt → platform-promo completion with "Want faster builds?"

Both template and custom flows use the same messages and prompts.


### Skip (all) -- No changes


<img width="1392" height="994" alt="cnw_all_skip_completion" src="https://github.com/user-attachments/assets/1579df01-fc36-4324-bc74-19efc18f78af" />

### Variant 0 (full platform)

Template prompt:

<img width="1392" height="994" alt="cnw_template_variant_0_prompt" src="https://github.com/user-attachments/assets/d02e9ddc-fd25-4f6f-ac61-6f6d518fe338" />

Template completion:

<img width="1392" height="994" alt="cnw_template_variant_0_completion" src="https://github.com/user-attachments/assets/12e459a0-962c-4724-82fa-a4f5a3b6fbd8" />

Custom prompt:

<img width="1392" height="994" alt="cnw_custom_variant_0_prompt" src="https://github.com/user-attachments/assets/8143832a-a85e-43b4-81eb-15074c223476" />

Custom completion:

<img width="1392" height="994" alt="cnw_custom_variant_0_completion" src="https://github.com/user-attachments/assets/036ef6f9-4977-459a-bbd2-502670a12d01" />

### Variant 1 (remote cache)

Template prompt:

<img width="1392" height="994" alt="cnw_template_variant_1_prompt" src="https://github.com/user-attachments/assets/f69b540f-7e48-46ae-99e5-f53657176424" />

Template completion:

<img width="1392" height="994" alt="cnw_template_variant_1_completion" src="https://github.com/user-attachments/assets/04c17847-b0f2-4e37-b7d2-5556aa14f510" />

Custom prompt:

<img width="1392" height="994" alt="cnw_custom_variant_1_prompt" src="https://github.com/user-attachments/assets/abdb38b2-611e-458b-85c0-7b89cd1b827e" />


Custom completion:

<img width="1348" height="950" alt="cnw_custom_variant_1_completion" src="https://github.com/user-attachments/assets/e7d35ddb-e8ac-4ad1-889e-9fff89538900" />

## Variant 2 (no prompt)

Template completion:

<img width="1392" height="994" alt="cnw_template_variant_2_completion" src="https://github.com/user-attachments/assets/07050989-a56c-46eb-a0c3-8730916856ff" />

Custom completion:

<img width="1392" height="994" alt="cnw_custom_variant_2_completion" src="https://github.com/user-attachments/assets/94000828-37b2-4059-a13b-0d36972cfd3e" />

## Related Issue(s)

Closes CLOUD-4189
