### PR TITLE
fix(core): do not throw error if worker.stdout is not instanceof socket

### DIFF
--- a/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
@@ -506,17 +506,9 @@ async function startPluginWorker(name: string) {
   worker.unref();
   if (worker.stdout instanceof Socket) {
     worker.stdout.unref();
-  } else {
-    throw new Error(
-      `Expected worker.stdout to be an instance of Socket, but got ${getTypeName(worker.stdout)}`
-    );
   }
   if (worker.stderr instanceof Socket) {
     worker.stderr.unref();
-  } else {
-    throw new Error(
-      `Expected worker.stderr to be an instance of Socket, but got ${getTypeName(worker.stderr)}`
-    );
   }
 
   let attempts = 0;


### PR DESCRIPTION
deno worker.stdout is a Readable/Writeable. To provide better deno support an error should not be thrown

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
If `worker.stdout` or `worker.stderr` are not instanceof Socket then nx throws an error. This is problematic in Deno where `stdout` and `stderr` are Readable/Writable and not Socket.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
`startupPluginWorker` function should work in Deno runtime

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

- https://github.com/denoland/deno/issues/31961
- https://github.com/oven-sh/bun/issues/26505
