### PR TITLE
fix(core): show the correct status for stopped continuous tasks

### DIFF
--- a/packages/nx/src/executors/run-commands/running-tasks.ts
+++ b/packages/nx/src/executors/run-commands/running-tasks.ts
@@ -507,7 +507,10 @@ class RunningNodeProcess implements RunningTask {
         cb(1, terminalOutput);
       }
     });
-    this.childProcess.on('exit', (code) => {
+    this.childProcess.on('exit', (code, signal) => {
+      if (code === null) {
+        code = signalToCode(signal);
+      }
       if (!this.readyWhenStatus.length || isReady(this.readyWhenStatus)) {
         const terminalOutput = this.terminalOutputChunks.join('');
         this.terminalOutputChunks = [];

--- a/packages/nx/src/native/tasks/task_history.rs
+++ b/packages/nx/src/native/tasks/task_history.rs
@@ -75,7 +75,7 @@ impl NxTaskHistory {
         self.db
             .prepare(
                 "SELECT hash from task_history
-                    WHERE hash IN rarray(?1)
+                    WHERE hash IN rarray(?1) AND status != 'stopped'
                     GROUP BY hash
                     HAVING COUNT(DISTINCT code) > 1
                 ",

--- a/packages/nx/src/native/tui/components/tasks_list.rs
+++ b/packages/nx/src/native/tui/components/tasks_list.rs
@@ -166,6 +166,7 @@ impl std::str::FromStr for TaskStatus {
             "success" => Ok(Self::Success),
             "failure" => Ok(Self::Failure),
             "skipped" => Ok(Self::Skipped),
+            "stopped" => Ok(Self::Stopped),
             "local-cache-kept-existing" => Ok(Self::LocalCacheKeptExisting),
             "local-cache" => Ok(Self::LocalCache),
             "remote-cache" => Ok(Self::RemoteCache),

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -3,8 +3,6 @@ import { writeFileSync } from 'fs';
 import { join } from 'path';
 import { ProjectGraph } from '../config/project-graph';
 import { Task, TaskGraph } from '../config/task-graph';
-import { RustPseudoTerminal } from '../native';
-import { signalToCode } from '../utils/exit-codes';
 import { output } from '../utils/output';
 import { stripIndents } from '../utils/strip-indents';
 import { BatchMessageType } from './batch/batch-messages';
@@ -437,23 +435,6 @@ export class ForkedProcessTaskRunner {
       this.cleanup();
       process.off('message', messageHandler);
     });
-    process.once('SIGINT', () => {
-      this.cleanup('SIGTERM');
-      process.off('message', messageHandler);
-      // we exit here because we don't need to write anything to cache.
-      process.exit(signalToCode('SIGINT'));
-    });
-    process.once('SIGTERM', () => {
-      this.cleanup('SIGTERM');
-      process.off('message', messageHandler);
-      // no exit here because we expect child processes to terminate which
-      // will store results to the cache and will terminate this process
-    });
-    process.once('SIGHUP', () => {
-      this.cleanup('SIGTERM');
-      process.off('message', messageHandler);
-      // no exit here because we expect child processes to terminate which
-      // will store results to the cache and will terminate this process
-    });
+    // Signal handlers removed - TaskOrchestrator owns signal handling
   }
 }

--- a/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
@@ -99,6 +99,9 @@ export function getTuiTerminalSummaryLifeCycle({
       totalCompletedTasks++;
       inProgressTasks.delete(task.id);
       tasksToTaskStatus[task.id] = status;
+      if (status === 'stopped') {
+        stoppedTasks.add(task.id);
+      }
 
       switch (status) {
         case 'remote-cache':

--- a/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
@@ -114,6 +114,8 @@ export function getTuiTerminalSummaryLifeCycle({
           totalFailedTasks++;
           failedTasks.add(task.id);
           break;
+        case 'stopped':
+          break;
       }
 
       // Store the final string directly — shares the same reference as

--- a/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
@@ -49,7 +49,9 @@ export function getTuiTerminalSummaryLifeCycle({
 
   const failedTasks = new Set<string>();
   const inProgressTasks = new Set<string>();
+  // Tasks ended with 'stopped' status (interrupted, didn't finish — counts as failure)
   const stoppedTasks = new Set<string>();
+  // Tasks shown with cyan stopped icon (includes fulfilled continuous tasks ended as 'success')
   const displayStoppedTasks = new Set<string>();
 
   // Chunks accumulated progressively during task execution
@@ -324,16 +326,7 @@ export function getTuiTerminalSummaryLifeCycle({
     for (const taskId of sortedTaskIds) {
       const taskStatus = tasksToTaskStatus[taskId];
       const terminalOutput = getTerminalOutput(taskId);
-      // Check stopped/display-stopped tasks first (before other status checks)
-      if (displayStoppedTasks.has(taskId)) {
-        output.logCommandOutput(taskId, taskStatus, terminalOutput);
-        output.addNewline();
-        checklistLines.push(
-          `${LEFT_PAD}${output.colors.cyan(
-            figures.squareSmallFilled
-          )}${SPACER}${output.colors.gray('nx run ')}${taskId}`
-        );
-      } else if (!taskStatus) {
+      if (displayStoppedTasks.has(taskId) || !taskStatus) {
         output.logCommandOutput(taskId, taskStatus, terminalOutput);
         output.addNewline();
         checklistLines.push(

--- a/packages/nx/src/tasks-runner/pseudo-terminal.ts
+++ b/packages/nx/src/tasks-runner/pseudo-terminal.ts
@@ -4,7 +4,7 @@ import { getForkedProcessOsSocketPath } from '../daemon/socket-utils';
 import { ChildProcess, IS_WASM, RustPseudoTerminal } from '../native';
 import { PseudoIPCServer } from './pseudo-ipc';
 import { RunningTask } from './running-tasks/running-task';
-import { codeToSignal } from '../utils/exit-codes';
+import { codeToSignal, messageToCode } from '../utils/exit-codes';
 
 // Register single event listeners for all pseudo-terminal instances
 const pseudoTerminalShutdownCallbacks: Array<(s: number) => void> = [];
@@ -221,25 +221,6 @@ export class PseudoTtyProcessWithSend extends PseudoTtyProcess {
 
   send(message: Serializable) {
     this.pseudoIpc.sendMessageToChild(this.id, message);
-  }
-}
-
-function messageToCode(message: string): number {
-  if (message.startsWith('Terminated by ')) {
-    switch (message.replace('Terminated by ', '').trim()) {
-      case 'Termination':
-        return 143;
-      case 'Interrupt':
-        return 130;
-      default:
-        return 128;
-    }
-  } else if (message.startsWith('Exited with code ')) {
-    return parseInt(message.replace('Exited with code ', '').trim());
-  } else if (message === 'Success') {
-    return 0;
-  } else {
-    return 1;
   }
 }
 

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -583,10 +583,7 @@ async function printConfigureAiAgentsDisclaimer(): Promise<void> {
   }
 }
 
-function didCommandComplete(
-  tasks: Task[],
-  taskResults: TaskResults
-): boolean {
+function didCommandComplete(tasks: Task[], taskResults: TaskResults): boolean {
   if (tasks.length === 0) return true;
 
   for (const task of tasks) {

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -22,7 +22,10 @@ import { getDbConnection } from '../utils/db-connection';
 import { output } from '../utils/output';
 import { combineOptionsForExecutor } from '../utils/params';
 import { workspaceRoot } from '../utils/workspace-root';
-import { signalToCode } from '../utils/exit-codes';
+import {
+  EXPECTED_TERMINATION_SIGNALS,
+  signalToCode,
+} from '../utils/exit-codes';
 import { Cache, DbCache, dbCacheEnabled, getCache } from './cache';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
 import { ForkedProcessTaskRunner } from './forked-process-task-runner';
@@ -817,8 +820,8 @@ export class TaskOrchestrator {
           this.runningContinuousTasks.delete(task.id);
 
           const wasIntentional = this.stoppingContinuousTasks.delete(task.id);
-          if (wasIntentional) {
-            // Intentional kill - success/Stopped
+          if (wasIntentional || EXPECTED_TERMINATION_SIGNALS.has(code)) {
+            // Terminated by user or orchestrator - success/Stopped
             await this.complete(
               [
                 {
@@ -901,8 +904,8 @@ export class TaskOrchestrator {
         }
 
         const wasIntentional = this.stoppingContinuousTasks.delete(task.id);
-        if (wasIntentional) {
-          // Intentional kill - success/Stopped
+        if (wasIntentional || EXPECTED_TERMINATION_SIGNALS.has(code)) {
+          // Terminated by user or orchestrator - success/Stopped
           await this.complete(
             [
               {

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -970,7 +970,8 @@ export class TaskOrchestrator {
               status !== 'local-cache' &&
               status !== 'local-cache-kept-existing' &&
               status !== 'remote-cache' &&
-              status !== 'skipped'
+              status !== 'skipped' &&
+              status !== 'stopped'
           )
           .map((result) => ({
             ...result,

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -96,7 +96,10 @@ export class TaskOrchestrator {
   private runningContinuousTasks = new Map<string, RunningTask>();
   private runningRunCommandsTasks = new Map<string, RunningTask>();
   private runningDiscreteTasks = new Map<string, RunningTask>();
-  private stoppingContinuousTasks = new Map<string, 'interrupted' | 'fulfilled'>();
+  private stoppingContinuousTasks = new Map<
+    string,
+    'interrupted' | 'fulfilled'
+  >();
   private stoppingDiscreteTasks = new Set<string>();
   private continuousTaskExitHandled = new Map<string, Promise<void>>();
 

--- a/packages/nx/src/tasks-runner/tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/tasks-runner.ts
@@ -9,6 +9,7 @@ export type TaskStatus =
   | 'success'
   | 'failure'
   | 'skipped'
+  | 'stopped'
   | 'local-cache-kept-existing'
   | 'local-cache'
   | 'remote-cache';

--- a/packages/nx/src/utils/child-process.ts
+++ b/packages/nx/src/utils/child-process.ts
@@ -13,6 +13,7 @@ import {
 } from './package-manager';
 import { workspaceRoot, workspaceRootInner } from './workspace-root';
 import { ChildProcess } from '../native';
+import { messageToCode } from './exit-codes';
 
 export function getRunNxBaseCommand(
   packageManagerCommand?: PackageManagerCommands,
@@ -88,25 +89,6 @@ export async function runNxAsync(
       child.stderr?.pipe(process.stderr);
     }
   });
-}
-
-function messageToCode(message: string): number {
-  if (message.startsWith('Terminated by ')) {
-    switch (message.replace('Terminated by ', '').trim()) {
-      case 'Termination':
-        return 143;
-      case 'Interrupt':
-        return 130;
-      default:
-        return 128;
-    }
-  } else if (message.startsWith('Exited with code ')) {
-    return parseInt(message.replace('Exited with code ', '').trim());
-  } else if (message === 'Success') {
-    return 0;
-  } else {
-    return 1;
-  }
 }
 
 export class PseudoTtyProcess {

--- a/packages/nx/src/utils/exit-codes.spec.ts
+++ b/packages/nx/src/utils/exit-codes.spec.ts
@@ -1,0 +1,62 @@
+import { messageToCode } from './exit-codes';
+
+describe('messageToCode', () => {
+  it('should return 0 for Success', () => {
+    expect(messageToCode('Success')).toBe(0);
+  });
+
+  it('should parse "Exited with code" messages', () => {
+    expect(messageToCode('Exited with code 0')).toBe(0);
+    expect(messageToCode('Exited with code 1')).toBe(1);
+    expect(messageToCode('Exited with code 127')).toBe(127);
+  });
+
+  it('should return 1 for unknown messages', () => {
+    expect(messageToCode('Something unexpected')).toBe(1);
+  });
+
+  describe('Terminated by signal (Linux exact match)', () => {
+    it('should handle Hangup', () => {
+      expect(messageToCode('Terminated by Hangup')).toBe(129);
+    });
+    it('should handle Interrupt', () => {
+      expect(messageToCode('Terminated by Interrupt')).toBe(130);
+    });
+    it('should handle Quit', () => {
+      expect(messageToCode('Terminated by Quit')).toBe(131);
+    });
+    it('should handle Abort', () => {
+      expect(messageToCode('Terminated by Abort')).toBe(134);
+    });
+    it('should handle Killed', () => {
+      expect(messageToCode('Terminated by Killed')).toBe(137);
+    });
+    it('should handle Terminated', () => {
+      expect(messageToCode('Terminated by Terminated')).toBe(143);
+    });
+    it('should return 128 for unknown signal', () => {
+      expect(messageToCode('Terminated by Unknown')).toBe(128);
+    });
+  });
+
+  describe('Terminated by signal (macOS strsignal format)', () => {
+    it('should handle "Hangup: 1"', () => {
+      expect(messageToCode('Terminated by Hangup: 1')).toBe(129);
+    });
+    it('should handle "Interrupt: 2"', () => {
+      expect(messageToCode('Terminated by Interrupt: 2')).toBe(130);
+    });
+    it('should handle "Quit: 3"', () => {
+      expect(messageToCode('Terminated by Quit: 3')).toBe(131);
+    });
+    it('should handle "Abort trap: 6"', () => {
+      expect(messageToCode('Terminated by Abort trap: 6')).toBe(134);
+    });
+    it('should handle "Killed: 9"', () => {
+      expect(messageToCode('Terminated by Killed: 9')).toBe(137);
+    });
+    it('should handle "Terminated: 15"', () => {
+      expect(messageToCode('Terminated by Terminated: 15')).toBe(143);
+    });
+  });
+});

--- a/packages/nx/src/utils/exit-codes.ts
+++ b/packages/nx/src/utils/exit-codes.ts
@@ -30,3 +30,30 @@ export function codeToSignal(code: number): NodeJS.Signals {
       return 'SIGTERM';
   }
 }
+
+// Exit codes from signals that indicate intentional termination (SIGHUP, SIGINT, SIGQUIT, SIGTERM).
+// Excludes SIGKILL (137) and SIGABRT (134) as those indicate abnormal termination.
+export const EXPECTED_TERMINATION_SIGNALS = new Set([129, 130, 131, 143]);
+
+/**
+ * Translates a pty exit message (e.g. "Terminated by Interrupt") to a numeric exit code.
+ * Handles both Linux exact-match and macOS strsignal formats (e.g. "Terminated by Hangup: 1").
+ */
+export function messageToCode(message: string): number {
+  if (message.startsWith('Terminated by ')) {
+    const signalDescription = message.replace('Terminated by ', '').trim();
+    if (signalDescription.startsWith('Hangup')) return 129;
+    if (signalDescription.startsWith('Interrupt')) return 130;
+    if (signalDescription.startsWith('Quit')) return 131;
+    if (signalDescription.startsWith('Abort')) return 134;
+    if (signalDescription.startsWith('Killed')) return 137;
+    if (signalDescription.startsWith('Terminated')) return 143;
+    return 128;
+  } else if (message.startsWith('Exited with code ')) {
+    return parseInt(message.replace('Exited with code ', '').trim());
+  } else if (message === 'Success') {
+    return 0;
+  } else {
+    return 1;
+  }
+}

--- a/packages/nx/src/utils/exit-codes.ts
+++ b/packages/nx/src/utils/exit-codes.ts
@@ -10,6 +10,8 @@ export function signalToCode(signal: NodeJS.Signals | null): number {
       return 128 + 2;
     case 'SIGTERM':
       return 128 + 15;
+    case 'SIGQUIT':
+      return 128 + 3;
     default:
       return 128;
   }
@@ -26,6 +28,8 @@ export function codeToSignal(code: number): NodeJS.Signals {
       return 'SIGINT';
     case 128 + 15:
       return 'SIGTERM';
+    case 128 + 3:
+      return 'SIGQUIT';
     default:
       return 'SIGTERM';
   }

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -311,16 +311,7 @@ class CLIOutput {
     }
   }
 
-  private addTaskStatus(
-    taskStatus:
-      | 'success'
-      | 'failure'
-      | 'skipped'
-      | 'local-cache-kept-existing'
-      | 'local-cache'
-      | 'remote-cache',
-    commandOutput: string
-  ) {
+  private addTaskStatus(taskStatus: TaskStatus, commandOutput: string) {
     if (taskStatus === 'local-cache') {
       return `${commandOutput}  ${pc.dim('[local cache]')}`;
     } else if (taskStatus === 'remote-cache') {


### PR DESCRIPTION
## Current Behavior

### 1. Continuous tasks missing from `postTasksExecution` hook

When running continuous tasks (e.g., `nx serve app`) and stopping them with Ctrl+C, the `postTasksExecution` lifecycle hook does not include them in `taskResults`. This breaks plugins that rely on post-run statistics (e.g., uploading task stats to DataDog).

### 2. Confusing TUI status when sibling continuous task exits

When multiple continuous tasks run together and one exits unexpectedly, its sibling is marked as "failed" even though it was intentionally terminated/stopped by the task orchestrator.

## Expected Behavior

1. All tasks, including continuous ones, are included in `taskResults` for the `postTasksExecution` hook
2. Continuous tasks that are intentionally stopped (because dependent tasks completed or during graceful shutdown) report as `success` with `Stopped` display status
3. Continuous tasks that exit unexpectedly (crash) report as `failure`
4. TUI summary shows correct status: success when all tasks completed successfully, square icon for stopped tasks

## Related Issue(s)

Fixes https://github.com/nrwl/nx/issues/33561

Supersedes:

- https://github.com/nrwl/nx/pull/33562
- https://github.com/nrwl/nx/pull/34132