### PR TITLE
fix(core): hide already-installed nx packages from suggestion list during nx import

### DIFF
--- a/packages/nx/src/command-line/import/import.ts
+++ b/packages/nx/src/command-line/import/import.ts
@@ -9,6 +9,8 @@ import { output } from '../../utils/output';
 const createSpinner = require('ora');
 import { detectPlugins } from '../init/init-v2';
 import { readNxJson } from '../../config/nx-json';
+import { readJsonFile } from '../../utils/fileutils';
+import { PackageJson } from '../../utils/package-json';
 import { workspaceRoot } from '../../utils/workspace-root';
 import {
   addPackagePathToWorkspaces,
@@ -263,8 +265,15 @@ export async function importHandler(options: ImportOptions) {
 
   resetWorkspaceContext();
 
+  let packageJson: PackageJson | null;
+  try {
+    packageJson = readJsonFile<PackageJson>('package.json');
+  } catch {
+    packageJson = null;
+  }
   const { plugins, updatePackageScripts } = await detectPlugins(
     nxJson,
+    packageJson,
     options.interactive,
     true
   );

--- a/packages/nx/src/command-line/init/init-v2.spec.ts
+++ b/packages/nx/src/command-line/init/init-v2.spec.ts
@@ -1,0 +1,78 @@
+import { detectPlugins } from './init-v2';
+
+// Mock dependencies
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  existsSync: jest.fn((path: string) => {
+    if (path === 'package.json') return true;
+    return false;
+  }),
+}));
+
+jest.mock('../../utils/fileutils', () => ({
+  readJsonFile: jest.fn(),
+  fileExists: jest.fn(() => false),
+}));
+
+import { readJsonFile } from '../../utils/fileutils';
+const mockReadJsonFile = readJsonFile as jest.Mock;
+
+jest.mock('../../utils/workspace-context', () => ({
+  globWithWorkspaceContextSync: jest.fn(() => []),
+}));
+
+jest.mock('../../utils/output', () => ({
+  output: { log: jest.fn() },
+}));
+
+describe('detectPlugins', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not suggest a plugin that is already installed as an npm dependency', async () => {
+    const packageJson = {
+      name: 'test',
+      version: '1.0.0',
+      dependencies: { vite: '^5.0.0' },
+      devDependencies: { '@nx/vite': '19.0.0' },
+    };
+    mockReadJsonFile.mockReturnValue(packageJson);
+
+    const result = await detectPlugins({ plugins: [] }, packageJson, false);
+
+    expect(result.plugins).not.toContain('@nx/vite');
+  });
+
+  it('should suggest a plugin when the tool is installed but the nx plugin is not', async () => {
+    const packageJson = {
+      name: 'test',
+      version: '1.0.0',
+      dependencies: { vite: '^5.0.0' },
+      devDependencies: {},
+    };
+    mockReadJsonFile.mockReturnValue(packageJson);
+
+    const result = await detectPlugins({ plugins: [] }, packageJson, false);
+
+    expect(result.plugins).toContain('@nx/vite');
+  });
+
+  it('should not suggest a plugin already listed in nx.json plugins', async () => {
+    const packageJson = {
+      name: 'test',
+      version: '1.0.0',
+      dependencies: { vite: '^5.0.0' },
+      devDependencies: {},
+    };
+    mockReadJsonFile.mockReturnValue(packageJson);
+
+    const result = await detectPlugins(
+      { plugins: ['@nx/vite'] },
+      packageJson,
+      false
+    );
+
+    expect(result.plugins).not.toContain('@nx/vite');
+  });
+});


### PR DESCRIPTION
## Current Behavior
If something is in `package.json#dependencies`, we still suggest it to be `nx add`-ed during `nx import`

## Expected Behavior
If a plugin is already installed, we don't suggest it anymore