### PR TITLE
feat(nx-dev): add llms-full.txt and HTTP Link headers for LLM discovery

### DIFF
--- a/astro-docs/netlify.toml
+++ b/astro-docs/netlify.toml
@@ -21,6 +21,11 @@ path = "/*.md"
 function = "track-asset-requests"
 path = "/**/*.md"
 
+# Edge Function to add HTTP Link headers for LLM resource discovery
+[[edge_functions]]
+function = "add-link-headers"
+path = "/docs/*"
+
 # Permanent redirects (301 by default)
 
 # Storybook docs consolidation

--- a/astro-docs/netlify/edge-functions/add-link-headers.ts
+++ b/astro-docs/netlify/edge-functions/add-link-headers.ts
@@ -1,0 +1,68 @@
+import type { Context } from 'https://edge.netlify.com';
+
+/**
+ * Netlify Edge Function to add HTTP Link headers to docs pages.
+ * This advertises the availability of raw markdown and LLM-friendly resources.
+ *
+ * Headers added:
+ * - Link to .md version of current page
+ * - Link to llms.txt (documentation index)
+ * - Link to llms-full.txt (concatenated full docs)
+ *
+ * See: https://llmstxt.org/
+ */
+export default async function handler(
+  request: Request,
+  context: Context
+): Promise<Response> {
+  // Early exit: Only process requests that want HTML (saves edge function costs)
+  // Browsers and HTML-consuming tools send Accept: text/html
+  const acceptHeader = request.headers.get('accept') || '';
+  if (!acceptHeader.includes('text/html')) {
+    return context.next();
+  }
+
+  const url = new URL(request.url);
+  const pathname = url.pathname;
+
+  // Skip non-page paths (assets, API endpoints, etc.)
+  if (
+    pathname.endsWith('.md') ||
+    pathname.endsWith('.txt') ||
+    pathname.includes('/og/') ||
+    pathname.includes('/_') ||
+    pathname.includes('/assets/')
+  ) {
+    return context.next();
+  }
+
+  const response = await context.next();
+
+  const contentType = response.headers.get('content-type') || '';
+  if (!contentType.includes('text/html')) {
+    return response;
+  }
+
+  // e.g. /docs/getting-started/intro -> /docs/getting-started/intro.md
+  const mdPath = pathname.replace(/\/?$/, '.md');
+
+  const linkHeader = [
+    `<${mdPath}>; rel="alternate"; type="text/markdown"`,
+    `</docs/llms.txt>; rel="alternate"; type="text/markdown"; title="LLM Index"`,
+    `</docs/llms-full.txt>; rel="alternate"; type="text/markdown"; title="Full Documentation"`,
+  ].join(', ');
+
+  // Netlify Edge Function responses are immutable, so create a new Response
+  const newHeaders = new Headers(response.headers);
+  newHeaders.set('Link', linkHeader);
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: newHeaders,
+  });
+}
+
+export const config = {
+  path: ['/docs/*'],
+};

--- a/astro-docs/netlify/edge-functions/track-asset-requests.ts
+++ b/astro-docs/netlify/edge-functions/track-asset-requests.ts
@@ -86,10 +86,15 @@ export default async function handler(
   // Continue to serve the actual file
   const response = await context.next();
 
-  // Add header to indicate edge function processed this request
-  response.headers.set('x-nx-edge-function', 'track-asset-requests');
+  // Netlify Edge Function responses are immutable, so create a new Response
+  const newHeaders = new Headers(response.headers);
+  newHeaders.set('x-nx-edge-function', 'track-asset-requests');
 
-  return response;
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: newHeaders,
+  });
 }
 
 export const config = {

--- a/astro-docs/src/pages/llms-full.txt.ts
+++ b/astro-docs/src/pages/llms-full.txt.ts
@@ -1,0 +1,183 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const contentDocsDir = join(__dirname, '../content/docs');
+
+interface DocEntry {
+  slug: string;
+  title: string;
+  content: string;
+  section: string;
+}
+
+/**
+ * Strips YAML frontmatter from markdown content.
+ * Frontmatter is delimited by --- at the start of the file.
+ */
+function stripFrontmatter(content: string): string {
+  // Match frontmatter: starts with ---, ends with ---
+  const frontmatterRegex = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+  return content.replace(frontmatterRegex, '');
+}
+
+/**
+ * Generates llms-full.txt - a concatenated file of all Nx documentation.
+ * This file contains the full content of all docs for LLM consumption.
+ * See: https://llmstxt.org/
+ */
+export const GET: APIRoute = async ({ site }) => {
+  const siteUrl = site?.origin ?? 'https://nx.dev';
+  const entries: DocEntry[] = [];
+
+  // Preferred section order (same as llms.txt)
+  const sectionOrder = [
+    'quickstart',
+    'getting-started',
+    'concepts',
+    'features',
+    'guides',
+    'extending-nx',
+    'technologies',
+    'reference',
+    'enterprise',
+    'troubleshooting',
+  ];
+
+  // Section display names
+  const sectionNames: Record<string, string> = {
+    'getting-started': 'Getting Started',
+    concepts: 'Core Concepts',
+    features: 'Features',
+    guides: 'Guides',
+    'extending-nx': 'Extending Nx',
+    technologies: 'Technologies',
+    reference: 'Reference',
+    enterprise: 'Enterprise',
+    troubleshooting: 'Troubleshooting',
+    quickstart: 'Quickstart',
+  };
+
+  // Get all docs from the content collection (static .mdoc/.mdx files)
+  const docs = await getCollection('docs');
+
+  for (const doc of docs) {
+    const slug = doc.id;
+    const title = doc.data.title || slug.split('/').pop() || slug;
+    const section = slug.split('/')[0] || 'other';
+
+    // Try to get file path from doc.filePath, or try common extensions
+    let filePath = doc.filePath;
+    if (!filePath) {
+      const extensions = ['.mdoc', '.mdx', '.md'];
+      for (const ext of extensions) {
+        const testPath = join(contentDocsDir, doc.id + ext);
+        if (existsSync(testPath)) {
+          filePath = testPath;
+          break;
+        }
+      }
+    }
+
+    // Skip if no file path found or not readable
+    if (!filePath || !existsSync(filePath)) {
+      continue;
+    }
+
+    try {
+      const rawContent = readFileSync(filePath, 'utf-8');
+      const content = stripFrontmatter(rawContent);
+      entries.push({ slug, title, content, section });
+    } catch {
+      // Skip files that can't be read
+      continue;
+    }
+  }
+
+  // Get plugin docs (executors, generators for each plugin)
+  try {
+    const pluginDocs = await getCollection('plugin-docs');
+    for (const doc of pluginDocs) {
+      if (doc.data.slug && doc.body) {
+        const slug = doc.data.slug;
+        const section = slug.split('/')[0] || 'technologies';
+        entries.push({
+          slug,
+          title: doc.data.title || slug,
+          content: stripFrontmatter(doc.body),
+          section,
+        });
+      }
+    }
+  } catch {
+    // plugin-docs collection might not exist
+  }
+
+  // Note: Excluding nx-reference-packages (devkit API docs) for now
+  // to keep the file size under 2MB. These are highly technical
+  // and can be accessed individually via .md endpoints.
+
+  // Sort entries by section order, then by slug within section
+  entries.sort((a, b) => {
+    const sectionIndexA = sectionOrder.indexOf(a.section);
+    const sectionIndexB = sectionOrder.indexOf(b.section);
+    const orderA = sectionIndexA === -1 ? 999 : sectionIndexA;
+    const orderB = sectionIndexB === -1 ? 999 : sectionIndexB;
+
+    if (orderA !== orderB) {
+      return orderA - orderB;
+    }
+    return a.slug.localeCompare(b.slug);
+  });
+
+  // Generate the llms-full.txt content
+  const lines: string[] = [
+    '# Nx Documentation',
+    '',
+    '> Complete Nx documentation compiled into a single file for LLM consumption.',
+    '',
+    'Nx is a powerful, open source, technology-agnostic build platform designed to efficiently manage codebases of any scale. From small single projects to large enterprise monorepos, Nx provides intelligent task execution, caching, and CI optimization.',
+    '',
+    `This file was generated from ${entries.length} documentation pages.`,
+    `Individual pages are available at: ${siteUrl}/docs/{slug}.md`,
+    '',
+  ];
+
+  // Track current section for headers
+  let currentSection = '';
+
+  for (const entry of entries) {
+    // Add section header when section changes
+    if (entry.section !== currentSection) {
+      currentSection = entry.section;
+      const sectionName = sectionNames[currentSection] || currentSection;
+      lines.push('');
+      lines.push(`# ${sectionName}`);
+      lines.push('');
+    }
+
+    // URL encode spaces in the slug
+    const encodedSlug = entry.slug.replace(/ /g, '%20');
+    const sourceUrl = `${siteUrl}/docs/${encodedSlug}.md`;
+
+    lines.push('---');
+    lines.push(`<!-- source: ${sourceUrl} -->`);
+    lines.push(`## ${entry.title}`);
+    lines.push('');
+    lines.push(entry.content.trim());
+    lines.push('');
+  }
+
+  const content = lines.join('\n');
+
+  return new Response(content, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};

--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -25,7 +25,8 @@ module.exports = withNx({
   },
   async rewrites() {
     // Only configure rewrites if NEXT_PUBLIC_ASTRO_URL is set
-    const astroDocsUrl = process.env.NEXT_PUBLIC_ASTRO_URL;
+    // Remove trailing slash to prevent double slashes in rewrite destinations
+    const astroDocsUrl = process.env.NEXT_PUBLIC_ASTRO_URL?.replace(/\/$/, '');
 
     if (!astroDocsUrl) {
       // Skip rewrites if env var is not set
@@ -48,6 +49,10 @@ module.exports = withNx({
       {
         source: '/llms.txt',
         destination: `${astroDocsUrl}/docs/llms.txt`,
+      },
+      {
+        source: '/llms-full.txt',
+        destination: `${astroDocsUrl}/docs/llms-full.txt`,
       },
     ];
 


### PR DESCRIPTION
This PR adds:
1. `llms-full.txt` that is a full copy of our docs in markdown.
2. HTTP `Link` headers to our docs HTML pages so that they point to the `.md` (markdown) version, and also to `llms.txt` and `llms-full.txt`.

The `llms-full.txt` is currently at 2.7 MB, which is much less than other sites that are up to 5MB or more.

<img width="569" height="35" alt="Screenshot 2026-01-27 at 12 11 10 PM" src="https://github.com/user-attachments/assets/61be02b4-2813-4c39-951c-d831af83e823" />

First 100 lines of `llms-full.txt`:

````
# Nx Documentation

> Complete Nx documentation compiled into a single file for LLM consumption.

Nx is a powerful, open source, technology-agnostic build platform designed to efficiently manage codebases of any scale. From small single projects to large enterprise monorepos, Nx provides intelligent task execution, caching, and CI optimization.

This file was generated from 503 documentation pages.
Individual pages are available at: https://nx.dev/docs/{slug}.md


# Quickstart

---
<!-- source: https://nx.dev/docs/quickstart.md -->
## Quickstart with Nx

Get up and running with Nx in just a few minutes by following these simple steps.

{% steps %}

1. Install the Nx CLI

   Installing Nx globally is **optional** - you can use `npx` to run Nx commands without installing it globally, especially if you're working with Node.js projects.

   {% tabs syncKey="install-method" %}
   {% tabitem label="npm" %}

   ```shell
   npm add --global nx
   ```

   **Note:** You can also use Yarn, pnpm, or Bun

   {% /tabitem %}
   {% tabitem label="Homebrew (macOS, Linux)" %}

   ```shell
   brew install nx
   ```

   {% /tabitem %}
   {% tabitem label="Chocolatey (Windows)" %}

   ```shell
   choco install nx
   ```

   {% /tabitem %}
   {% tabitem label="apt (Ubuntu)" %}

   ```shell
   sudo add-apt-repository ppa:nrwl/nx
   sudo apt update
   sudo apt install nx
   ```

   {% /tabitem %}
   {% /tabs %}

2. Start fresh or add to existing project

   For JavaScript-based projects you can **start with a new workspace** using the following command:

   ```shell
   npx create-nx-workspace@latest
   ```

   **Add to an existing project: (recommended also for non-JS projects)**

   ```shell
   npx nx@latest init
   ```

   **Get the complete experience:**
   For a fully integrated development workflow with AI-powered CI features, [start directly from Nx Cloud](https://cloud.nx.app/get-started).

   Learn more: [Start New Project](/docs/getting-started/start-new-project) • [Add to Existing](/docs/getting-started/start-with-existing-project) • [Complete Nx Experience](https://cloud.nx.app/get-started)

3. Run Your First Commands

   Nx provides powerful task execution with built-in caching. Here are some essential commands:

   **Run a task for a single project:**

   ```shell
   nx build my-app
   nx test my-lib
   ```

   **Run tasks for multiple projects:**

   ```shell
   nx run-many -t build test lint
   ```

   Learn more: [Run Tasks](/docs/features/run-tasks) • [Cache Task Results](/docs/features/cache-task-results)

4. What's next?

   Now that you've experienced the Nx basics, choose how you want to continue:

````


## Related Issue(s)
Closes DOC-236