### PR TITLE
chore(repo): enable verbose logging and bust cache for CI debugging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
     env:
       NX_E2E_CI_CACHE_KEY: e2e-github-linux
       NX_DAEMON: 'true'
-      NX_PERF_LOGGING: 'false'
-      NX_VERBOSE_LOGGING: 'false'
-      NX_NATIVE_LOGGING: 'false'
+      NX_PERF_LOGGING: 'true'
+      NX_VERBOSE_LOGGING: 'true'
+      NX_NATIVE_LOGGING: 'debug'
       NX_E2E_RUN_E2E: 'true'
       NX_CI_EXECUTION_ENV: 'linux'
       NX_CLOUD_NO_TIMEOUTS: 'true'

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -4,7 +4,9 @@ common-env-vars: &common-env-vars
   GIT_COMMITTER_EMAIL: test@test.com
   GIT_COMMITTER_NAME: Test
   SELECTED_PM: 'pnpm'
-  NX_NATIVE_LOGGING: 'nx::native::db'
+  NX_NATIVE_LOGGING: 'debug'
+  NX_VERBOSE_LOGGING: 'true'
+  NX_PERF_LOGGING: 'true'
   # These are need for build and link validation for next.js and astro apps
   NEXT_PUBLIC_ASTRO_URL: 'https://master--nx-docs.netlify.app'
   NX_DEV_URL: 'https://canary.nx.dev'

--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -2,6 +2,9 @@ distribute-on:
   default: auto linux-large, 3 linux-extra-large
 assignment-rules:
   - projects:
+      - e2e-angular
+      - e2e-react
+      - e2e-node
       - e2e-gradle
     targets:
       - e2e-ci**

--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -1,5 +1,5 @@
 distribute-on:
-  default: auto linux-large, 3 linux-extra-large
+  default: auto linux-large, 6 linux-extra-large
 assignment-rules:
   - projects:
       - e2e-angular

--- a/nx.json
+++ b/nx.json
@@ -346,7 +346,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 6,
+  "bust": 7,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true

--- a/nx.json
+++ b/nx.json
@@ -346,7 +346,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 5,
+  "bust": 6,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true

--- a/nx.json
+++ b/nx.json
@@ -346,7 +346,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 3,
+  "bust": 5,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true


### PR DESCRIPTION
## Current Behavior

CI has been hanging and we need to investigate the root cause.

## Expected Behavior

With verbose logging enabled, we should be able to see detailed output to diagnose the hanging issue.

## Changes

- Enabled `NX_PERF_LOGGING`, `NX_VERBOSE_LOGGING` in CI workflow
- Set `NX_NATIVE_LOGGING` to `trace` for detailed native logging
- Incremented cache bust to `4` to force fresh task execution

**Note:** This is a temporary debugging PR. The logging flags should be reverted once the issue is identified.