### PR TITLE
fix(core): clean up stale socket files before listening

### DIFF
--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -10,7 +10,11 @@ import { stripIndents } from '../utils/strip-indents';
 import { BatchMessageType } from './batch/batch-messages';
 import { DefaultTasksRunnerOptions } from './default-tasks-runner';
 import { getProcessMetricsService } from './process-metrics-service';
-import { PseudoTerminal, PseudoTtyProcess } from './pseudo-terminal';
+import {
+  createPseudoTerminal as createPseudoTerminalWithShutdown,
+  PseudoTerminal,
+  PseudoTtyProcess,
+} from './pseudo-terminal';
 import { BatchProcess } from './running-tasks/batch-process';
 import {
   NodeChildProcessWithDirectOutput,
@@ -187,7 +191,8 @@ export class ForkedProcessTaskRunner {
   }
 
   private async createPseudoTerminal() {
-    const terminal = new PseudoTerminal(new RustPseudoTerminal());
+    // Use the helper to ensure shutdown callbacks are registered
+    const terminal = createPseudoTerminalWithShutdown(true);
 
     await terminal.init();
 

--- a/packages/nx/src/tasks-runner/pseudo-ipc.spec.ts
+++ b/packages/nx/src/tasks-runner/pseudo-ipc.spec.ts
@@ -1,0 +1,56 @@
+import { PseudoIPCServer } from './pseudo-ipc';
+import { existsSync, writeFileSync, unlinkSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+describe('PseudoIPCServer', () => {
+  const testSocketDir = join(tmpdir(), 'nx-pseudo-ipc-test');
+  let socketPath: string;
+
+  beforeAll(() => {
+    try {
+      mkdirSync(testSocketDir, { recursive: true });
+    } catch {}
+  });
+
+  beforeEach(() => {
+    socketPath = join(testSocketDir, `test-${process.pid}-${Date.now()}.sock`);
+  });
+
+  afterEach(() => {
+    try {
+      unlinkSync(socketPath);
+    } catch {}
+  });
+
+  it('should clean up stale socket file before listening', async () => {
+    // Create a fake stale socket file
+    writeFileSync(socketPath, '');
+    expect(existsSync(socketPath)).toBe(true);
+
+    const server = new PseudoIPCServer(socketPath);
+    await server.init();
+
+    // Should have successfully listened (stale file was cleaned up)
+    // The socket file should exist again (created by the server)
+    expect(existsSync(socketPath)).toBe(true);
+
+    server.close();
+  });
+
+  it('should work when no stale socket file exists', async () => {
+    // Ensure no file exists
+    try {
+      unlinkSync(socketPath);
+    } catch {}
+    expect(existsSync(socketPath)).toBe(false);
+
+    const server = new PseudoIPCServer(socketPath);
+    await server.init();
+
+    // Should have successfully listened
+    expect(existsSync(socketPath)).toBe(true);
+
+    server.close();
+  });
+});


### PR DESCRIPTION
## Current Behavior

When running Nx tasks in CI environments (e.g., Buildkite) where the host's /tmp is mounted to containers, intermittent EADDRINUSE errors occur in PseudoIPCServer.init(). This happens because:

1. PseudoIPCServer doesn't clean up its Unix socket file before calling listen()
2. ForkedProcessTaskRunner.createPseudoTerminal() instantiates PseudoTerminal directly instead of using the createPseudoTerminal() helper, bypassing shutdown callback registration

When a new container starts with the same PID as a previous run (PID recycling), it generates the same socket path and hits EADDRINUSE because the stale socket file still exists.

## Expected Behavior

No EADDRINUSE errors should occur. The PseudoIPCServer should defensively remove any stale socket file before attempting to listen, similar to how the daemon server handles this.

## Related Issue(s)

Fixes #34233