### PR TITLE
fix(misc): fix gitlab ci workflow for new repos and merge requests

### DIFF
--- a/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
+++ b/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
@@ -722,6 +722,7 @@ exports[`CI Workflow generator connected to nxCloud with bun should generate git
 "image: node:20
 variables:
   CI: 'true'
+  GIT_DEPTH: 0
 
 # Main job
 CI:
@@ -739,8 +740,8 @@ CI:
     # - bunx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
     - bun install --no-cache
-    - NX_HEAD=$CI_COMMIT_SHA
-    - NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$CI_COMMIT_BEFORE_SHA}
+    - export NX_HEAD=$CI_COMMIT_SHA
+    - export NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)}
 
     # Prepend any command with "nx record --" to record its logs to Nx Cloud
     # - bun nx record -- echo Hello World
@@ -1202,6 +1203,7 @@ exports[`CI Workflow generator connected to nxCloud with npm should generate git
 "image: node:20
 variables:
   CI: 'true'
+  GIT_DEPTH: 0
 
 # Main job
 CI:
@@ -1217,8 +1219,8 @@ CI:
     # - npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
     - npm ci
-    - NX_HEAD=$CI_COMMIT_SHA
-    - NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$CI_COMMIT_BEFORE_SHA}
+    - export NX_HEAD=$CI_COMMIT_SHA
+    - export NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)}
 
     # Prepend any command with "nx record --" to record its logs to Nx Cloud
     # - npx nx record -- echo Hello World
@@ -1719,6 +1721,7 @@ exports[`CI Workflow generator connected to nxCloud with pnpm should generate gi
 "image: node:20
 variables:
   CI: 'true'
+  GIT_DEPTH: 0
 
 # Main job
 CI:
@@ -1736,8 +1739,8 @@ CI:
     # - pnpm dlx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
     - pnpm install --frozen-lockfile
-    - NX_HEAD=$CI_COMMIT_SHA
-    - NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$CI_COMMIT_BEFORE_SHA}
+    - export NX_HEAD=$CI_COMMIT_SHA
+    - export NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)}
 
     # Prepend any command with "nx record --" to record its logs to Nx Cloud
     # - pnpm exec nx record -- echo Hello World
@@ -2201,6 +2204,7 @@ exports[`CI Workflow generator connected to nxCloud with yarn should generate gi
 "image: node:20
 variables:
   CI: 'true'
+  GIT_DEPTH: 0
 
 # Main job
 CI:
@@ -2216,8 +2220,8 @@ CI:
     # - npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
     - yarn install --frozen-lockfile
-    - NX_HEAD=$CI_COMMIT_SHA
-    - NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$CI_COMMIT_BEFORE_SHA}
+    - export NX_HEAD=$CI_COMMIT_SHA
+    - export NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)}
 
     # Prepend any command with "nx record --" to record its logs to Nx Cloud
     # - yarn nx record -- echo Hello World
@@ -2954,6 +2958,7 @@ exports[`CI Workflow generator not connected to nxCloud with bun should generate
 "image: node:20
 variables:
   CI: 'true'
+  GIT_DEPTH: 0
 
 # Main job
 CI:
@@ -2971,8 +2976,8 @@ CI:
     # - bunx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
     - bun install --no-cache
-    - NX_HEAD=$CI_COMMIT_SHA
-    - NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$CI_COMMIT_BEFORE_SHA}
+    - export NX_HEAD=$CI_COMMIT_SHA
+    - export NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)}
 
     # Prepend any command with "nx record --" to record its logs to Nx Cloud
     # - bun nx record -- echo Hello World
@@ -3436,6 +3441,7 @@ exports[`CI Workflow generator not connected to nxCloud with npm should generate
 "image: node:20
 variables:
   CI: 'true'
+  GIT_DEPTH: 0
 
 # Main job
 CI:
@@ -3451,8 +3457,8 @@ CI:
     # - npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
     - npm ci
-    - NX_HEAD=$CI_COMMIT_SHA
-    - NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$CI_COMMIT_BEFORE_SHA}
+    - export NX_HEAD=$CI_COMMIT_SHA
+    - export NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)}
 
     # Prepend any command with "nx record --" to record its logs to Nx Cloud
     # - npx nx record -- echo Hello World
@@ -3955,6 +3961,7 @@ exports[`CI Workflow generator not connected to nxCloud with pnpm should generat
 "image: node:20
 variables:
   CI: 'true'
+  GIT_DEPTH: 0
 
 # Main job
 CI:
@@ -3972,8 +3979,8 @@ CI:
     # - pnpm dlx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
     - pnpm install --frozen-lockfile
-    - NX_HEAD=$CI_COMMIT_SHA
-    - NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$CI_COMMIT_BEFORE_SHA}
+    - export NX_HEAD=$CI_COMMIT_SHA
+    - export NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)}
 
     # Prepend any command with "nx record --" to record its logs to Nx Cloud
     # - pnpm exec nx record -- echo Hello World
@@ -4439,6 +4446,7 @@ exports[`CI Workflow generator not connected to nxCloud with yarn should generat
 "image: node:20
 variables:
   CI: 'true'
+  GIT_DEPTH: 0
 
 # Main job
 CI:
@@ -4454,8 +4462,8 @@ CI:
     # - npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
     - yarn install --frozen-lockfile
-    - NX_HEAD=$CI_COMMIT_SHA
-    - NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$CI_COMMIT_BEFORE_SHA}
+    - export NX_HEAD=$CI_COMMIT_SHA
+    - export NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)}
 
     # Prepend any command with "nx record --" to record its logs to Nx Cloud
     # - yarn nx record -- echo Hello World

--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
@@ -591,6 +591,7 @@ describe('CI Workflow generator', () => {
         "image: node:20
         variables:
           CI: 'true'
+          GIT_DEPTH: 0
 
         # Main job
         CI:
@@ -606,8 +607,8 @@ describe('CI Workflow generator', () => {
             # - npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
             - npm ci
-            - NX_HEAD=$CI_COMMIT_SHA
-            - NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$CI_COMMIT_BEFORE_SHA}
+            - export NX_HEAD=$CI_COMMIT_SHA
+            - export NX_BASE=\${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)}
 
             # Prepend any command with "nx record --" to record its logs to Nx Cloud
             # - npx nx record -- echo Hello World

--- a/packages/workspace/src/generators/ci-workflow/files/gitlab/.gitlab-ci.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/gitlab/.gitlab-ci.yml__tmpl__
@@ -1,12 +1,13 @@
 image: node:20
 variables:
   CI: 'true'
+  GIT_DEPTH: 0
 
 # Main job
 <%= workflowName %>:
   interruptible: true
   only:
-    - main
+    - <%= mainBranch %>
     - merge_requests
   script:
     <% if(packageManager == 'pnpm'){ %>
@@ -24,8 +25,8 @@ variables:
     - <%= packageManagerInstall %><% if(hasCypress){ %>
     - <%= packageManagerPrefix %> cypress install<% } %><% if(hasPlaywright){ %>
     - <%= packageManagerPrefix %> playwright install --with-deps<% } %><% if(!useRunMany){ %>
-    - NX_HEAD=$CI_COMMIT_SHA
-    - NX_BASE=${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$CI_COMMIT_BEFORE_SHA}<% } %>
+    - export NX_HEAD=$CI_COMMIT_SHA
+    - export NX_BASE=${CI_MERGE_REQUEST_DIFF_BASE_SHA:-$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)}<% } %>
 
 <% for (const command of commands) { %><% if (command.comments) { %><% for (const comment of command.comments) { %>
     # <%- comment %><% } %><% } %><% if (command.command && !command.alwaysRun) { %>


### PR DESCRIPTION
## Current Behavior

The generated GitLab CI workflow (`nx generate @nx/workspace:ci-workflow --ci=gitlab`) fails on new repositories with errors like:

fatal: ambiguous argument 'HEAD~1': unknown revision or path not in the working tree.


This happens because:
1. GitLab's default shallow clone doesn't have full git history
2. `CI_COMMIT_BEFORE_SHA` is always `0000000000000000000000000000000000000000` for merge requests and first commits
3. Environment variables `NX_HEAD` and `NX_BASE` weren't exported, so Nx couldn't read them

## Expected Behavior

The GitLab CI workflow should work correctly on:
- New repositories with no previous commits
- Merge request pipelines
- Main branch push pipelines

## Related Issue(s)

Fixes https://linear.app/nxdev/issue/NXC-3707

## Changes Made

1. **Added `GIT_DEPTH: 0`** - Fetches full git history instead of shallow clone
2. **Changed `only` branch to use template variable** - Uses `<%= mainBranch %>` instead of hardcoded `main`
3. **Fixed `NX_BASE` and `NX_HEAD` exports** - Added `export` keyword and improved fallback logic:
   - Uses `CI_MERGE_REQUEST_DIFF_BASE_SHA` for merge requests
   - Falls back to `HEAD~1` for regular commits
   - Falls back to `HEAD` for initial commits (no parent)

## Testing

Verified on real GitLab CI at `gitlab.com/AgentEnder/nx-gitlab-ci-test`:
- ✅ Main branch push pipeline passed
- ✅ Merge request pipeline passed
