### PR TITLE
fix(vite): handle sophisticated vite plugins

### DIFF
--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -23,6 +23,7 @@ import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { deriveGroupNameFromTarget } from 'nx/src/utils/plugins';
 import { loadViteDynamicImport } from '../utils/executor-utils';
 import picomatch = require('picomatch');
+import type { ResolvedConfig } from 'vite';
 
 const pmc = getPackageManagerCommand();
 
@@ -219,6 +220,7 @@ async function buildViteTargets(
     {
       configFile: absoluteConfigFilePath,
       mode: 'development',
+      root: projectRoot,
     },
     'build'
   );
@@ -596,7 +598,7 @@ function serveStaticTarget(
 }
 
 function getOutputs(
-  viteBuildConfig: Record<string, any> | undefined,
+  viteBuildConfig: ResolvedConfig | undefined,
   projectRoot: string,
   workspaceRoot: string
 ): {
@@ -615,10 +617,12 @@ function getOutputs(
     'dist'
   );
 
-  const isBuildable =
+  const isBuildable = Boolean(
     build?.lib ||
-    build?.rollupOptions?.input ||
-    existsSync(join(workspaceRoot, projectRoot, 'index.html'));
+      viteBuildConfig?.builder?.buildApp ||
+      build?.rollupOptions?.input ||
+      existsSync(join(workspaceRoot, projectRoot, 'index.html'))
+  );
 
   const hasServeConfig = Boolean(server?.host || server?.port);
 


### PR DESCRIPTION
## Current Behavior
With Vite now providing additional options (environments etc) for framework authors, vite.config files can be much more simple for the user.
However, this often assumes that the `root` property will be set and provided during `Vite CLI` invocation.

When we run `resolveConfig` to determine inputs and outputs, we do not set this `root` and expect the user to have it in their vite config file.
For some plugins/frameworks such as Tanstack Start - this causes the plugin to error.

The `isBuildable` conditions is also not inclusive enough and can skip projects that should be marked as buildable.

## Expected Behavior
Ensure that sophisticated vite plugins are supported with Nx

## Related Issue(s)

CLOSES NXC-3637
