### PR TITLE
fix(gradle): use tooling api compatible flags

### DIFF
--- a/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/BuildListener.kt
+++ b/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/BuildListener.kt
@@ -9,6 +9,12 @@ import org.gradle.tooling.events.task.TaskFinishEvent
 import org.gradle.tooling.events.task.TaskStartEvent
 import org.gradle.tooling.events.task.TaskSuccessResult
 
+/**
+ * Normalizes a Gradle task path by removing the leading colon. Gradle events use paths like
+ * `:project:task` but Nx uses `project:task`.
+ */
+fun normalizeTaskPath(taskPath: String): String = taskPath.trimStart(':')
+
 fun buildListener(
     tasks: Map<String, GradleTask>,
     taskStartTimes: MutableMap<String, Long>,
@@ -18,7 +24,7 @@ fun buildListener(
     is TaskStartEvent -> {
       val taskPath = event.descriptor.taskPath
       tasks.entries
-          .find { it.value.taskName == taskPath }
+          .find { normalizeTaskPath(it.value.taskName) == normalizeTaskPath(taskPath) }
           ?.key
           ?.let { nxTaskId ->
             taskStartTimes[nxTaskId] = event.eventTime
@@ -30,7 +36,7 @@ fun buildListener(
       val taskPath = event.descriptor.taskPath
       val success = getTaskFinishEventSuccess(event, taskPath)
       tasks.entries
-          .find { it.value.taskName == taskPath }
+          .find { normalizeTaskPath(it.value.taskName) == normalizeTaskPath(taskPath) }
           ?.key
           ?.let { nxTaskId ->
             val endTime = event.result.endTime

--- a/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/BuildListener.kt
+++ b/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/BuildListener.kt
@@ -16,12 +16,13 @@ fun buildListener(
 ): (ProgressEvent) -> Unit = { event ->
   when (event) {
     is TaskStartEvent -> {
+      val taskPath = event.descriptor.taskPath
       tasks.entries
-          .find { it.value.taskName == event.descriptor.taskPath }
+          .find { it.value.taskName == taskPath }
           ?.key
           ?.let { nxTaskId ->
             taskStartTimes[nxTaskId] = event.eventTime
-            logger.info("🏁 Task start: $nxTaskId ${event.descriptor.taskPath}")
+            logger.info("🏁 Task start: $nxTaskId $taskPath")
           }
     }
 

--- a/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/GradleRunner.kt
+++ b/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/GradleRunner.kt
@@ -9,20 +9,7 @@ import java.io.ByteArrayOutputStream
 import org.gradle.tooling.BuildCancelledException
 import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.events.OperationType
-import org.gradle.tooling.model.build.BuildEnvironment
-import org.gradle.util.GradleVersion
 
-private val GRADLE_RERUN_MIN_VERSION = GradleVersion.version("7.6")
-
-fun getGradleVersion(connection: ProjectConnection): GradleVersion? {
-  return try {
-    val buildEnvironment = connection.getModel(BuildEnvironment::class.java)
-    GradleVersion.version(buildEnvironment.gradle.gradleVersion)
-  } catch (e: Exception) {
-    logger.warning("Failed to get Gradle version: ${e.message}")
-    null
-  }
-}
 
 fun runTasksInParallel(
     connection: ProjectConnection,
@@ -43,13 +30,7 @@ fun runTasksInParallel(
   val outputStream2 = ByteArrayOutputStream()
   val errorStream2 = ByteArrayOutputStream()
 
-  // --rerun used to skip Gradle caching since we use Nx caching
-  // Fall back to --rerun-tasks if version detection fails (null) or version is < 7.6
-  val gradleVersion = getGradleVersion(connection)
-  val rerunFlag =
-      if (gradleVersion != null && gradleVersion >= GRADLE_RERUN_MIN_VERSION) "--rerun"
-      else "--rerun-tasks"
-
+  // --rerun-tasks used to skip Gradle caching since we use Nx caching
   // --info is for terminal per task
   // --continue is for continue running tasks if one failed in a batch
   // --parallel is for performance
@@ -62,7 +43,7 @@ fun runTasksInParallel(
           "--continue",
           "-Dorg.gradle.daemon.idletimeout=0",
           "--parallel",
-          rerunFlag,
+          "--rerun-tasks",
           "-Dorg.gradle.workers.max=$workersMax")
 
   if (additionalArgs.isNotBlank()) {

--- a/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/GradleRunner.kt
+++ b/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/GradleRunner.kt
@@ -10,7 +10,6 @@ import org.gradle.tooling.BuildCancelledException
 import org.gradle.tooling.ProjectConnection
 import org.gradle.tooling.events.OperationType
 
-
 fun runTasksInParallel(
     connection: ProjectConnection,
     tasks: Map<String, GradleTask>,

--- a/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/TestListener.kt
+++ b/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/TestListener.kt
@@ -20,9 +20,7 @@ fun testListener(
         val success = getTaskFinishEventSuccess(event, taskPath)
 
         tasks.entries
-            .filter {
-              it.value.taskName == taskPath
-            }
+            .filter { it.value.taskName == taskPath }
             .map { it.key }
             .forEach { nxTaskId ->
               testTaskStatus.computeIfAbsent(nxTaskId) { success }

--- a/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/TestListener.kt
+++ b/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/TestListener.kt
@@ -22,9 +22,9 @@ fun testListener(
         tasks.entries
             .filter {
               it.value.taskName == taskPath
-            } // Filters the entries to keep only matching ones
+            }
             .map { it.key }
-            .forEach { nxTaskId -> // Iterate over the filtered entries
+            .forEach { nxTaskId ->
               testTaskStatus.computeIfAbsent(nxTaskId) { success }
               testEndTimes.computeIfAbsent(nxTaskId) { event.result.endTime }
             }

--- a/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/TestListener.kt
+++ b/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/TestListener.kt
@@ -20,7 +20,7 @@ fun testListener(
         val success = getTaskFinishEventSuccess(event, taskPath)
 
         tasks.entries
-            .filter { it.value.taskName == taskPath }
+            .filter { normalizeTaskPath(it.value.taskName) == normalizeTaskPath(taskPath) }
             .map { it.key }
             .forEach { nxTaskId ->
               testTaskStatus.computeIfAbsent(nxTaskId) { success }

--- a/packages/gradle/src/executors/gradle/gradle.impl.ts
+++ b/packages/gradle/src/executors/gradle/gradle.impl.ts
@@ -34,6 +34,9 @@ export default async function gradleExecutor(
     args.push(`--tests`, options.testClassName);
   }
 
+  // Skip Gradle caching since we use Nx caching
+  args.push('--rerun-tasks');
+
   // Pass any additional options not defined in the schema as gradle arguments
   const knownOptions = new Set([
     'taskName',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

--rerun is not tooling api compatible and therefore will break usage of the batch executor. Replaced the flag with --rerun-tasks.

Also updated the build and test listeners so that we normalize the task paths that we use between Gradle and Nx. There were cases where gradle prepended `:` to its task paths, which did not match what Nx was using.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
