### PR TITLE
feat(core): add Nx Cloud connect URL to template README

### DIFF
--- a/packages/create-nx-workspace/src/utils/template/update-readme.spec.ts
+++ b/packages/create-nx-workspace/src/utils/template/update-readme.spec.ts
@@ -1,0 +1,119 @@
+import { updateReadmeContent } from './update-readme';
+
+describe('updateReadmeContent', () => {
+  it('should return original content if markers are not present and no URL', () => {
+    const content = '# My Workspace';
+    const result = updateReadmeContent(content, undefined);
+    expect(result).toBe(content);
+  });
+
+  it('should return original content if markers are not present', () => {
+    const content = '# My Workspace\n\nSome content here.';
+    const result = updateReadmeContent(
+      content,
+      'https://cloud.nx.app/connect/abc123'
+    );
+    expect(result).toBe(content);
+  });
+
+  it('should return original content if END marker is missing', () => {
+    const content = '# My Workspace\n\n<!-- BEGIN: nx-cloud -->\nSome content.';
+    const result = updateReadmeContent(
+      content,
+      'https://cloud.nx.app/connect/abc123'
+    );
+    expect(result).toBe(content);
+  });
+
+  it('should return original content if BEGIN marker is missing', () => {
+    const content = '# My Workspace\n\n<!-- END: nx-cloud -->\nSome content.';
+    const result = updateReadmeContent(
+      content,
+      'https://cloud.nx.app/connect/abc123'
+    );
+    expect(result).toBe(content);
+  });
+
+  it('should strip markers and insert section with connect URL', () => {
+    const content = `# My Workspace
+
+Some intro content.
+
+<!-- BEGIN: nx-cloud -->
+Old placeholder content here.
+<!-- END: nx-cloud -->
+
+## Other Section
+
+More content.`;
+
+    const result = updateReadmeContent(
+      content,
+      'https://cloud.nx.app/connect/abc123'
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "# My Workspace
+
+      Some intro content.
+
+      ## Finish your Nx platform setup
+
+      🚀 [Finish setting up your workspace](https://cloud.nx.app/connect/abc123) to get faster builds with remote caching, distributed task execution, and self-healing CI. [Learn more about Nx Cloud](https://nx.dev/ci/intro/why-nx-cloud).
+
+      ## Other Section
+
+      More content."
+    `);
+  });
+
+  it('should strip markers and content when no connect URL provided', () => {
+    const content = `# My Workspace
+
+Some intro content.
+
+<!-- BEGIN: nx-cloud -->
+Placeholder content to remove.
+<!-- END: nx-cloud -->
+
+## Other Section
+
+More content.`;
+
+    const result = updateReadmeContent(content, undefined);
+
+    expect(result).toMatchInlineSnapshot(`
+      "# My Workspace
+
+      Some intro content.
+
+      ## Other Section
+
+      More content."
+    `);
+  });
+
+  it('should handle markers with empty content between them', () => {
+    const content = `# Test
+
+<!-- BEGIN: nx-cloud -->
+<!-- END: nx-cloud -->
+
+Footer.`;
+
+    const result = updateReadmeContent(
+      content,
+      'https://staging.nx.app/connect/pkjwpKplOJ'
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "# Test
+
+      ## Finish your Nx platform setup
+
+      🚀 [Finish setting up your workspace](https://staging.nx.app/connect/pkjwpKplOJ) to get faster builds with remote caching, distributed task execution, and self-healing CI. [Learn more about Nx Cloud](https://nx.dev/ci/intro/why-nx-cloud).
+
+      Footer."
+    `);
+  });
+});

--- a/packages/create-nx-workspace/src/utils/template/update-readme.ts
+++ b/packages/create-nx-workspace/src/utils/template/update-readme.ts
@@ -1,0 +1,118 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'path';
+import { execAndWait } from '../child-process-utils';
+
+const BEGIN_MARKER = '<!-- BEGIN: nx-cloud -->';
+const END_MARKER = '<!-- END: nx-cloud -->';
+
+const CLOUD_SETUP_SECTION = `## Finish your Nx platform setup
+
+🚀 [Finish setting up your workspace]({{CONNECT_URL}}) to get faster builds with remote caching, distributed task execution, and self-healing CI. [Learn more about Nx Cloud](https://nx.dev/ci/intro/why-nx-cloud).
+`;
+
+/**
+ * Updates README content by processing the nx-cloud marker section.
+ * - If connectUrl is provided: replaces markers and content with the connect URL section
+ * - If connectUrl is undefined: removes markers and their content entirely
+ *
+ * This ensures users never see the raw <!-- BEGIN/END: nx-cloud --> markers in their README.
+ *
+ * @param readmeContent - The current README content
+ * @param connectUrl - The Nx Cloud connect URL (optional)
+ * @returns The updated README content with markers processed, or original if markers not found
+ */
+export function updateReadmeContent(
+  readmeContent: string,
+  connectUrl: string | undefined
+): string {
+  const beginIndex = readmeContent.indexOf(BEGIN_MARKER);
+  const endIndex = readmeContent.indexOf(END_MARKER);
+
+  if (beginIndex === -1 || endIndex === -1 || beginIndex >= endIndex) {
+    return readmeContent;
+  }
+
+  // If no connect URL, remove the markers and placeholder content entirely
+  if (!connectUrl) {
+    // Remove the marker section and surrounding newlines to avoid extra blank lines
+    // Skip one newline before BEGIN marker (if present)
+    const beforeBegin =
+      beginIndex > 0 && readmeContent[beginIndex - 1] === '\n'
+        ? beginIndex - 1
+        : beginIndex;
+    // Skip one newline after END marker (if present)
+    const afterEnd = endIndex + END_MARKER.length;
+    const skipTrailing =
+      readmeContent[afterEnd] === '\n' ? afterEnd + 1 : afterEnd;
+
+    return (
+      readmeContent.slice(0, beforeBegin) + readmeContent.slice(skipTrailing)
+    );
+  }
+
+  const section = CLOUD_SETUP_SECTION.replace('{{CONNECT_URL}}', connectUrl);
+
+  // Strip the markers - only include the section content
+  // Also skip one trailing newline after END marker since section already has one
+  const afterEnd = endIndex + END_MARKER.length;
+  const skipNewline =
+    readmeContent[afterEnd] === '\n' ? afterEnd + 1 : afterEnd;
+
+  return (
+    readmeContent.slice(0, beginIndex) +
+    section +
+    readmeContent.slice(skipNewline)
+  );
+}
+
+/**
+ * Updates the README.md file in the given directory with the Nx Cloud connect URL.
+ * This is a convenience wrapper around updateReadmeContent that handles file I/O.
+ *
+ * @param directory - The workspace directory containing README.md
+ * @param connectUrl - The Nx Cloud connect URL
+ * @returns true if the file was modified, false otherwise
+ */
+export function addConnectUrlToReadme(
+  directory: string,
+  connectUrl: string | undefined
+): boolean {
+  const readmePath = join(directory, 'README.md');
+  if (!existsSync(readmePath)) {
+    return false;
+  }
+
+  const content = readFileSync(readmePath, 'utf-8');
+  const updated = updateReadmeContent(content, connectUrl);
+
+  if (updated !== content) {
+    writeFileSync(readmePath, updated);
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Commits README.md changes, either by amending the initial commit or creating a new one.
+ * - If already pushed to VCS: creates a new commit (to avoid requiring force push)
+ * - If not pushed: amends the initial commit (cleaner history)
+ *
+ * @param directory - The workspace directory
+ * @param alreadyPushed - Whether the repo was already pushed to VCS
+ */
+export async function amendOrCommitReadme(
+  directory: string,
+  alreadyPushed: boolean
+): Promise<void> {
+  await execAndWait('git add README.md', directory);
+  if (alreadyPushed) {
+    await execAndWait(
+      'git commit -m "chore: add Nx Cloud setup link to README"',
+      directory
+    );
+    await execAndWait('git push', directory);
+  } else {
+    await execAndWait('git commit --amend --no-edit', directory);
+  }
+}


### PR DESCRIPTION
## Current Behavior
Template-generated workspaces use a generic link in the README instead of a per-workspace short link for Nx Cloud setup.

## Expected Behavior
When users opt into Nx Cloud (or are auto-connected via variant 2), the template README is updated with a personalized connect URL section that helps them finish setting up their workspace.

---
BEFORE: 

<img width="762" height="460" alt="image" src="https://github.com/user-attachments/assets/58900071-1727-49d1-aa19-279c488b5037" />


AFTER: 

<img width="1032" height="599" alt="image" src="https://github.com/user-attachments/assets/a6e3a122-5807-4ba2-90dd-441e41a3280e" />

---

## Related Issue(s)
Closes NXC-3783