### PR TITLE
fix(core): improve plugin worker error messages and lifecycle timeouts

### DIFF
--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -237,7 +237,11 @@ describe('nx release - independent projects', () => {
       const versionWithGitActionsCLIOutput = runCLI(
         `release version 999.9.9-version-git-operations-test.2 -p ${pkg1} --git-commit --git-tag --verbose` // add verbose so we get richer output
       );
-      expect(versionWithGitActionsCLIOutput).toMatchInlineSnapshot(`
+      const filteredOutput = versionWithGitActionsCLIOutput.replace(
+        /\[plugin-(pool|worker)\].*\n/g,
+        ''
+      );
+      expect(filteredOutput).toMatchInlineSnapshot(`
 
         NX   Your filter "{project-name}" matched the following projects:
 
@@ -320,7 +324,11 @@ describe('nx release - independent projects', () => {
       const versionWithGitActionsConfigOutput = runCLI(
         `release version 999.9.9-version-git-operations-test.3 --verbose --gitTag` // add verbose so we get richer output
       );
-      expect(versionWithGitActionsConfigOutput).toMatchInlineSnapshot(`
+      const filteredConfigOutput = versionWithGitActionsConfigOutput.replace(
+        /\[plugin-(pool|worker)\].*\n/g,
+        ''
+      );
+      expect(filteredConfigOutput).toMatchInlineSnapshot(`
 
         NX   Running release version for project: {project-name}
 
@@ -516,7 +524,11 @@ describe('nx release - independent projects', () => {
       const versionWithGitActionsCLIOutput = runCLI(
         `release changelog 999.9.9-changelog-git-operations-test.1 -p ${pkg1} --verbose`
       );
-      expect(versionWithGitActionsCLIOutput).toMatchInlineSnapshot(`
+      const filteredChangelogOutput = versionWithGitActionsCLIOutput.replace(
+        /\[plugin-(pool|worker)\].*\n/g,
+        ''
+      );
+      expect(filteredChangelogOutput).toMatchInlineSnapshot(`
 
         NX   Your filter "{project-name}" matched the following projects:
 

--- a/e2e/release/src/independent-projects.workspaces.test.ts
+++ b/e2e/release/src/independent-projects.workspaces.test.ts
@@ -54,6 +54,8 @@ expect.addSnapshotSerializer({
         .replaceAll('pnpm install --lockfile-only', '{lock-file-command}')
         .replaceAll(getSelectedPackageManager(), '{package-manager}')
         .replaceAll(e2eRegistryUrl, '{registryUrl}')
+        // Filter out plugin worker verbose logs
+        .replaceAll(/\[plugin-(pool|worker)\].*\n/g, '')
         // We trim each line to reduce the chances of snapshot flakiness
         .split('\n')
         .map((r) => r.trim())

--- a/e2e/release/src/preserve-local-dependency-protocols.test.ts
+++ b/e2e/release/src/preserve-local-dependency-protocols.test.ts
@@ -47,6 +47,8 @@ expect.addSnapshotSerializer({
           /Integrity:\s*.*/g,
           'Integrity: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
         )
+        // Filter out plugin worker verbose logs
+        .replaceAll(/\[plugin-(pool|worker)\].*\n/g, '')
 
         .split('\n')
         .map((r) => r.trim())

--- a/e2e/release/src/version-plans-check.test.ts
+++ b/e2e/release/src/version-plans-check.test.ts
@@ -32,6 +32,8 @@ expect.addSnapshotSerializer({
         .replaceAll(/Test @[\w\d]+/g, 'Test @{COMMIT_AUTHOR}')
         // Normalize the version title date.
         .replaceAll(/\(\d{4}-\d{2}-\d{2}\)/g, '(YYYY-MM-DD)')
+        // Filter out plugin worker verbose logs
+        .replaceAll(/\[plugin-(pool|worker)\].*\n/g, '')
         // We trim each line to reduce the chances of snapshot flakiness
         .split('\n')
         .map((r) => r.trim())

--- a/e2e/release/src/version-plans-only-touched.test.ts
+++ b/e2e/release/src/version-plans-only-touched.test.ts
@@ -29,6 +29,8 @@ expect.addSnapshotSerializer({
         .replaceAll(/Test @[\w\d]+/g, 'Test @{COMMIT_AUTHOR}')
         // Normalize the version title date.
         .replaceAll(/\(\d{4}-\d{2}-\d{2}\)/g, '(YYYY-MM-DD)')
+        // Filter out plugin worker verbose logs
+        .replaceAll(/\[plugin-(pool|worker)\].*\n/g, '')
         // We trim each line to reduce the chances of snapshot flakiness
         .split('\n')
         .map((r) => r.trim())

--- a/packages/nx/src/project-graph/plugins/get-plugins.ts
+++ b/packages/nx/src/project-graph/plugins/get-plugins.ts
@@ -47,13 +47,34 @@ export async function getPlugins(
   }
 
   currentPluginsConfigurationHash = pluginsConfigurationHash;
-  const [defaultPlugins, specifiedPlugins] = await Promise.all([
+  const results = await Promise.allSettled([
     getOnlyDefaultPlugins(root),
     (pendingPluginsPromise ??= loadSpecifiedNxPlugins(
       pluginsConfiguration,
       root
     )),
   ]);
+
+  const errors: Error[] = [];
+  const defaultPlugins: LoadedNxPlugin[] = [];
+  const specifiedPlugins: LoadedNxPlugin[] = [];
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result.status === 'fulfilled') {
+      (i === 0 ? defaultPlugins : specifiedPlugins).push(...result.value);
+    } else {
+      errors.push(
+        result.reason instanceof Error
+          ? result.reason
+          : new Error(String(result.reason))
+      );
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new AggregateError(errors, errors.map((e) => e.message).join('\n'));
+  }
 
   loadedPlugins = specifiedPlugins.concat(defaultPlugins);
 
@@ -115,28 +136,58 @@ async function loadDefaultNxPlugins(root = workspaceRoot) {
   const plugins = getDefaultPlugins(root);
 
   const cleanupFunctions: Array<() => void> = [];
+  const results = await Promise.allSettled(
+    plugins.map(async (plugin) => {
+      performance.mark(`Load Nx Plugin: ${plugin} - start`);
+
+      const [loadedPluginPromise, cleanup] = await loadingMethod(plugin, root);
+
+      cleanupFunctions.push(cleanup);
+      const res = await loadedPluginPromise;
+      performance.mark(`Load Nx Plugin: ${plugin} - end`);
+      performance.measure(
+        `Load Nx Plugin: ${plugin}`,
+        `Load Nx Plugin: ${plugin} - start`,
+        `Load Nx Plugin: ${plugin} - end`
+      );
+
+      return res;
+    })
+  );
+
+  const defaultPluginResults: LoadedNxPlugin[] = [];
+  const errors: Array<{ pluginName: string; error: Error }> = [];
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result.status === 'fulfilled') {
+      defaultPluginResults.push(result.value);
+    } else {
+      errors.push({
+        pluginName: plugins[i],
+        error:
+          result.reason instanceof Error
+            ? result.reason
+            : new Error(String(result.reason)),
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    for (const fn of cleanupFunctions) {
+      fn();
+    }
+    const errorMessage = errors
+      .map((e) => `  - ${e.pluginName}: ${e.error.message}`)
+      .join('\n');
+    throw new AggregateError(
+      errors.map((e) => e.error),
+      `Failed to load ${errors.length} default Nx plugin(s):\n${errorMessage}`
+    );
+  }
+
   const ret = [
-    await Promise.all(
-      plugins.map(async (plugin) => {
-        performance.mark(`Load Nx Plugin: ${plugin} - start`);
-
-        const [loadedPluginPromise, cleanup] = await loadingMethod(
-          plugin,
-          root
-        );
-
-        cleanupFunctions.push(cleanup);
-        const res = await loadedPluginPromise;
-        performance.mark(`Load Nx Plugin: ${plugin} - end`);
-        performance.measure(
-          `Load Nx Plugin: ${plugin}`,
-          `Load Nx Plugin: ${plugin} - start`,
-          `Load Nx Plugin: ${plugin} - end`
-        );
-
-        return res;
-      })
-    ),
+    defaultPluginResults,
     () => {
       for (const fn of cleanupFunctions) {
         fn();
@@ -170,7 +221,7 @@ async function loadSpecifiedNxPlugins(
   pluginsConfigurations ??= [];
 
   const cleanupFunctions: Array<() => void> = [];
-  const plugins = await Promise.all(
+  const results = await Promise.allSettled(
     pluginsConfigurations.map(async (plugin, index) => {
       const pluginPath = typeof plugin === 'string' ? plugin : plugin.plugin;
       performance.mark(`Load Nx Plugin: ${pluginPath} - start`);
@@ -200,6 +251,40 @@ async function loadSpecifiedNxPlugins(
     'loadSpecifiedNxPlugins:start',
     'loadSpecifiedNxPlugins:end'
   );
+
+  const plugins: LoadedNxPlugin[] = [];
+  const errors: Array<{ pluginName: string; error: Error }> = [];
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    if (result.status === 'fulfilled') {
+      plugins.push(result.value);
+    } else {
+      const pluginConfig = pluginsConfigurations[i];
+      const pluginName =
+        typeof pluginConfig === 'string' ? pluginConfig : pluginConfig.plugin;
+      errors.push({
+        pluginName,
+        error:
+          result.reason instanceof Error
+            ? result.reason
+            : new Error(String(result.reason)),
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    for (const fn of cleanupFunctions) {
+      fn();
+    }
+    const errorMessage = errors
+      .map((e) => `  - ${e.pluginName}: ${e.error.message}`)
+      .join('\n');
+    throw new AggregateError(
+      errors.map((e) => e.error),
+      `Failed to load ${errors.length} Nx plugin(s):\n${errorMessage}`
+    );
+  }
 
   cleanupSpecifiedPlugins = () => {
     for (const fn of cleanupFunctions) {

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-pool.ts
@@ -4,6 +4,8 @@ import path = require('path');
 
 import { PluginConfiguration } from '../../../config/nx-json';
 
+import { logger } from '../../../utils/logger';
+
 import { getPluginOsSocketPath } from '../../../daemon/socket-utils';
 import { consumeMessagesFromSocket } from '../../../utils/consume-messages-from-socket';
 import type { LoadedNxPlugin } from '../loaded-nx-plugin';
@@ -186,6 +188,9 @@ function createWorkerHandler(
           const { name, createNodesPattern, include, exclude } = result;
           pluginName = name;
           pluginNames.set(worker, pluginName);
+          logger.verbose(
+            `[plugin-pool] loaded plugin "${name}" from worker (pid: ${worker.pid})`
+          );
           onload({
             name,
             include,
@@ -469,6 +474,10 @@ async function startPluginWorker(name: string) {
     }
   );
 
+  logger.verbose(
+    `[plugin-pool] spawned worker for "${name}" (pid: ${worker.pid}, socket: ${ipcPath})`
+  );
+
   // To make debugging easier and allow plugins to communicate things
   // like performance metrics, we pipe the stdout/stderr of the worker
   // to the main process.
@@ -527,6 +536,9 @@ async function startPluginWorker(name: string) {
       if (socket) {
         socket.unref();
         clearInterval(id);
+        logger.verbose(
+          `[plugin-pool] connected to worker for "${name}" (pid: ${worker.pid}) after ${attempts} attempt(s)`
+        );
         resolve({
           worker,
           socket,

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
@@ -2,13 +2,20 @@ import { performance } from 'node:perf_hooks';
 
 performance.mark(`plugin worker ${process.pid} code loading -- start`);
 
-import { consumeMessage, isPluginWorkerMessage } from './messaging';
-import { createSerializableError } from '../../../utils/serializable-error';
 import { consumeMessagesFromSocket } from '../../../utils/consume-messages-from-socket';
+import { createSerializableError } from '../../../utils/serializable-error';
 import type { LoadedNxPlugin } from '../loaded-nx-plugin';
+import { consumeMessage, isPluginWorkerMessage } from './messaging';
 
-import { createServer } from 'net';
 import { unlinkSync } from 'fs';
+import { createServer } from 'net';
+
+type Environment = Pick<
+  NodeJS.ProcessEnv,
+  'NX_PERF_LOGGING' | 'NX_PLUGIN_NO_TIMEOUTS'
+>;
+
+const environment: Environment = process.env as Environment;
 
 if (process.env.NX_PERF_LOGGING === 'true') {
   require('../../../utils/perf-logging');
@@ -23,22 +30,29 @@ performance.measure(
 
 global.NX_GRAPH_CREATION = true;
 global.NX_PLUGIN_WORKER = true;
-let connected = false;
 let plugin: LoadedNxPlugin;
 
 const socketPath = process.argv[2];
+const expectedPluginName = process.argv[3];
+
+let connectErrorTimeout = setErrorTimeout(
+  5000,
+  `The plugin worker for ${expectedPluginName} is exiting as it was not connected to within 5 seconds. ` +
+    'Plugin workers expect to receive a socket connection from the parent process shortly after being started. ' +
+    'If you are seeing this issue, please report it to the Nx team at https://github.com/nrwl/nx/issues.'
+);
 
 const server = createServer((socket) => {
-  connected = true;
+  connectErrorTimeout?.clear();
   // This handles cases where the host process was killed
   // after the worker connected but before the worker was
   // instructed to load the plugin.
-  const loadTimeout = setTimeout(() => {
-    console.error(
-      `Plugin Worker exited because no plugin was loaded within 10 seconds of starting up.`
-    );
-    process.exit(1);
-  }, 10000).unref();
+  let loadErrorTimeout = setErrorTimeout(
+    10_000,
+    `Plugin Worker for ${expectedPluginName} is exiting as it did not receive a load message within 10 seconds of connecting. ` +
+      'This likely indicates that the host process was terminated before the worker could be instructed to load the plugin. ' +
+      'If you are seeing this issue, please report it to the Nx team at https://github.com/nrwl/nx/issues.'
+  );
   socket.on(
     'data',
     consumeMessagesFromSocket((raw) => {
@@ -54,7 +68,7 @@ const server = createServer((socket) => {
           pluginPath,
           shouldRegisterTSTranspiler,
         }) => {
-          if (loadTimeout) clearTimeout(loadTimeout);
+          loadErrorTimeout?.clear();
           process.chdir(root);
           try {
             const { loadResolvedNxPluginAsync } = await import(
@@ -217,15 +231,26 @@ const server = createServer((socket) => {
 
 server.listen(socketPath);
 
-if (process.env.NX_PLUGIN_NO_TIMEOUTS !== 'true') {
-  setTimeout(() => {
-    if (!connected) {
-      console.error(
-        'The plugin worker is exiting as it was not connected to within 5 seconds.'
-      );
+function setErrorTimeout(
+  timeoutMs: number,
+  errorMessage: string
+): { clear: () => void } | undefined {
+  if (environment.NX_PLUGIN_NO_TIMEOUTS === 'true') {
+    return;
+  }
+  let cleared = false;
+  const timeout = setTimeout(() => {
+    if (!cleared) {
+      console.error(errorMessage);
       process.exit(1);
     }
-  }, 5000).unref();
+  }, timeoutMs).unref();
+  return {
+    clear: () => {
+      cleared = true;
+      clearTimeout(timeout);
+    },
+  };
 }
 
 const exitHandler = (exitCode: number) => () => {


### PR DESCRIPTION
## Current Behavior
Plugin workers occasionally fall over during the start up steps. 

## Expected Behavior
Improves some issues with the error handling when loading plugin workers and adds some more logs to help understand what's went wrong here.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
