### PR TITLE
fix(nx-dev): fix internal link check caching and remaining /launch-nx link

### DIFF
--- a/astro-docs/src/content/docs/reference/Nx Cloud/release-notes.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/release-notes.mdoc
@@ -538,7 +538,7 @@ This includes events such as when a workspace was created, when a new VCS integr
 
 ### 2402.27.3
 
-With this version you can take advantage of most features announced during our recent [launch week](/launch-nx).
+With this version you can take advantage of most features announced during our recent [launch week](/blog/launch-nx-week-recap).
 
 ##### Nx Agents
 

--- a/astro-docs/validate-links.ts
+++ b/astro-docs/validate-links.ts
@@ -11,7 +11,6 @@ const ignoredLinks = [
   '/docs/reference/nx/executors',
   'NxPowerpack-Trial-v1.1.pdf',
   '/blog/',
-  '/launch-nx',
   '/contact',
 ];
 

--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -33,8 +33,8 @@
       },
       "inputs": [
         "{workspaceRoot}/docs/**/*",
-        "{workspaceRoot}/dist/nx-dev/nx-dev/public/sitemap.xml",
-        "{workspaceRoot}/astro-docs/dist/sitemap-index.xml",
+        "{workspaceRoot}/dist/nx-dev/nx-dev/public/sitemap*.xml",
+        "{workspaceRoot}/astro-docs/dist/sitemap*.xml",
         "{workspaceRoot}/scripts/tsconfig.scripts.json",
         "{workspaceRoot}/scripts/documentation/internal-link-checker.ts"
       ]


### PR DESCRIPTION
## Current Behavior

1. The `check-links` task cache inputs only included `sitemap.xml` (the index
   file) and `sitemap-index.xml`, but not the actual `sitemap-0.xml` files that
   contain the URL data. This meant that when pages were added or removed, the
   cache wasn't properly invalidated - the check-links task would return a
   cached "passing" result even when broken links existed.

2. The `/launch-nx` page was removed in #34183 but one link in
   `astro-docs/src/content/docs/reference/Nx Cloud/release-notes.mdoc` still
   pointed to it. This link was masked by being in the `validate-links.ts`
   ignore list.

## Expected Behavior

1. The `check-links` task cache is invalidated when sitemap URLs change by
   using glob patterns (`sitemap*.xml`) to include all sitemap files.

2. All links point to valid pages. The `/launch-nx` link now redirects to
   `/blog/launch-nx-week-recap`.

## Changes

- **astro-docs/release-notes.mdoc**: Updated `/launch-nx` link to `/blog/launch-nx-week-recap`
- **astro-docs/validate-links.ts**: Removed `/launch-nx` from ignore list (no longer needed)
- **nx-dev/project.json**: Fixed cache inputs to use `sitemap*.xml` glob patterns

## Related Issue(s)

Fixes DOC-385

🤖 Generated with [Claude Code](https://claude.com/claude-code)