### PR TITLE
docs(misc): push toc to the right side to match the alignment of the left sidebar

### DIFF
--- a/astro-docs/src/styles/global.css
+++ b/astro-docs/src/styles/global.css
@@ -408,6 +408,13 @@ h6:hover .anchor-link {
   border-inline-start: none;
 }
 
+@media (min-width: 84rem) {
+  .right-sidebar-panel {
+    display: flex;
+    justify-content: flex-end;
+  }
+}
+
 .content-panel + .content-panel {
   border-top: 0;
 }


### PR DESCRIPTION
This PR aligns the TOC to the right side of the page so the spacing is more balanced.

<img width="2672" height="1527" alt="image" src="https://github.com/user-attachments/assets/ef00906a-3788-47fb-a71d-230b3d69c201" />

Similar to other docs like React:

<img width="2672" height="1527" alt="image" src="https://github.com/user-attachments/assets/e9a1cd81-f716-4e09-b148-be80a93b7aee" />


---

## Other screen widths

1400px:

<img width="1424" height="1025" alt="Screenshot 2026-01-30 at 12 11 57 PM" src="https://github.com/user-attachments/assets/d9fc5029-4942-4e32-b2f2-4c66ebcb21df" />

1000px (TOC hidden):


<img width="1145" height="1019" alt="Screenshot 2026-01-30 at 12 12 10 PM" src="https://github.com/user-attachments/assets/ce1cd890-193a-42d7-bb4f-3259146845a8" />
