### PR TITLE
fix(gradle): enforce that only one gradle task can be passed into gradle executor

### DIFF
--- a/packages/gradle/src/executors/gradle/gradle.impl.ts
+++ b/packages/gradle/src/executors/gradle/gradle.impl.ts
@@ -24,6 +24,12 @@ export default async function gradleExecutor(
   ); // find gradlew near project root
   gradlewPath = join(context.root, gradlewPath);
 
+  if (options.taskName && options.taskName?.includes(' ')) {
+    throw new Error(
+      `Task "${options.taskName}" contains spaces. Only a single Gradle task is allowed per executor invocation.`
+    );
+  }
+
   let args =
     typeof options.args === 'string'
       ? options.args.trim().split(' ')


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

The Gradle executor accepts a taskName option that *should not* contain multiple space-separated tasks. When multiple tasks are provided, the batch runner misinterprets the space-separated string as containing project names rather than treating it as a single task argument, leading to execution errors and confusion.

This only occurs if the taskName is manually overridden and should not occur when task names are generated by the project graph plugin.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The Gradle executor now validates that taskName contains only a single task without spaces. If multiple tasks are passed, it throws a clear error message: "Task '[taskName]' contains spaces. Only a single Gradle task is allowed per executor invocation." This prevents the batch runner from misinterpreting the task name and provides immediate feedback to users about the correct usage.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
