### PR TITLE
feat(core): add decorative banners for Nx Cloud CNW completion message

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -470,19 +470,13 @@ async function normalizeArgsMiddleware(
 
       let nxCloud: string;
       let completionMessageKey: string | undefined;
-      const flowVariant = getFlowVariant();
 
       if (argv.skipGit === true) {
         nxCloud = 'skip';
         completionMessageKey = undefined;
-      } else if (flowVariant === '2') {
-        // Variant 2: Skip cloud prompt, auto-connect
-        // Respect --nxCloud=skip if explicitly provided
-        nxCloud = argv.nxCloud === 'skip' ? 'skip' : 'yes';
-        completionMessageKey =
-          nxCloud === 'skip' ? undefined : getCompletionMessageKeyForVariant();
       } else {
-        // Variants 0 & 1: Show cloud prompt (different copy based on variant)
+        // Always show cloud prompt with "full platform" message (CLOUD-4147)
+        // Flow variant only affects completion banners, not this prompt
         nxCloud = await determineNxCloudV2(argv);
         completionMessageKey =
           nxCloud === 'skip' ? undefined : getCompletionMessageKeyForVariant();
@@ -497,7 +491,6 @@ async function normalizeArgsMiddleware(
         defaultBase: 'main',
         aiAgents,
         ghAvailable,
-        skipCloudConnect: flowVariant === '2',
       });
 
       await recordStat({

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -2,12 +2,7 @@ import * as yargs from 'yargs';
 import * as enquirer from 'enquirer';
 import * as chalk from 'chalk';
 
-import {
-  getFlowVariant,
-  MessageKey,
-  messages,
-  shouldShowCloudPrompt,
-} from '../utils/nx/ab-testing';
+import { MessageKey, messages } from '../utils/nx/ab-testing';
 import { deduceDefaultBase } from '../utils/git/default-base';
 import { isGitAvailable } from '../utils/git/git';
 import {
@@ -50,44 +45,22 @@ export async function determineNxCloudV2(
     return 'skip';
   }
 
-  // Variant 2: Skip prompt and auto-connect
-  if (!shouldShowCloudPrompt()) {
-    return 'github';
-  }
-
-  // Variants 0 & 1: Show cloud prompt with different copy
-  const variant = getFlowVariant();
-  const promptConfig =
-    variant === '1'
-      ? {
-          name: 'nxCloud',
-          message: 'Would you like remote caching to make your build faster?',
-          type: 'autocomplete',
-          choices: [
-            { value: 'yes', name: 'Yes' },
-            { value: 'skip', name: 'Skip' },
-          ],
-          initial: 0,
-          hint: () => chalk.dim('\n(can be disabled any time)'),
-          footer: () =>
-            chalk.dim(
-              '\nRead more about remote caching at https://nx.dev/ci/features/remote-cache'
-            ),
-        }
-      : {
-          name: 'nxCloud',
-          message: 'Try the full Nx platform?',
-          type: 'autocomplete',
-          choices: [
-            { value: 'yes', name: 'Yes' },
-            { value: 'skip', name: 'Skip' },
-          ],
-          initial: 0,
-          footer: () =>
-            chalk.dim(
-              '\nAutomatically fix broken PRs, 70% faster CI: https://nx.dev/nx-cloud'
-            ),
-        };
+  // Locked to "full platform" messaging (CLOUD-4147)
+  // Flow variant only affects completion banners, not this prompt
+  const promptConfig = {
+    name: 'nxCloud',
+    message: 'Try the full Nx platform?',
+    type: 'autocomplete',
+    choices: [
+      { value: 'yes', name: 'Yes' },
+      { value: 'skip', name: 'Skip' },
+    ],
+    initial: 0,
+    footer: () =>
+      chalk.dim(
+        '\nAutomatically fix broken PRs, 70% faster CI: https://nx.dev/nx-cloud'
+      ),
+  };
 
   const result = await enquirer.prompt<{ nxCloud: 'github' | 'skip' }>([
     promptConfig as any, // types in enquirer are not up to date

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.spec.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.spec.ts
@@ -1,0 +1,92 @@
+import { isEnterpriseCloudUrl, getBannerVariant } from './ab-testing';
+
+describe('ab-testing', () => {
+  describe('isEnterpriseCloudUrl', () => {
+    it('should return false for cloud.nx.app', () => {
+      expect(isEnterpriseCloudUrl('https://cloud.nx.app/connect/abc123')).toBe(
+        false
+      );
+    });
+
+    it('should return false for eu.nx.app', () => {
+      expect(isEnterpriseCloudUrl('https://eu.nx.app/connect/abc123')).toBe(
+        false
+      );
+    });
+
+    it('should return false for staging.nx.app', () => {
+      expect(
+        isEnterpriseCloudUrl('https://staging.nx.app/connect/abc123')
+      ).toBe(false);
+    });
+
+    it('should return false for snapshot.nx.app', () => {
+      expect(
+        isEnterpriseCloudUrl('https://snapshot.nx.app/connect/abc123')
+      ).toBe(false);
+    });
+
+    it('should return true for enterprise URLs', () => {
+      expect(
+        isEnterpriseCloudUrl('https://enterprise.company.com/connect/abc123')
+      ).toBe(true);
+      expect(
+        isEnterpriseCloudUrl('https://nx.acme-corp.com/connect/abc123')
+      ).toBe(true);
+    });
+
+    it('should return false for undefined/null', () => {
+      expect(isEnterpriseCloudUrl(undefined)).toBe(false);
+      expect(isEnterpriseCloudUrl('')).toBe(false);
+    });
+
+    it('should return false for invalid URLs', () => {
+      expect(isEnterpriseCloudUrl('not-a-url')).toBe(false);
+    });
+  });
+
+  describe('getBannerVariant', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      jest.resetModules();
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('should return 0 for docs generation', () => {
+      process.env.NX_GENERATE_DOCS_PROCESS = 'true';
+      // Re-import to get fresh module state
+      const { getBannerVariant: freshGetBannerVariant } = jest.requireActual(
+        './ab-testing'
+      ) as typeof import('./ab-testing');
+      expect(freshGetBannerVariant('https://cloud.nx.app/connect/abc')).toBe(
+        '0'
+      );
+    });
+
+    it('should return 0 for enterprise URLs', () => {
+      expect(
+        getBannerVariant('https://enterprise.company.com/connect/abc')
+      ).toBe('0');
+    });
+
+    it('should respect NX_CNW_FLOW_VARIANT env variable', () => {
+      process.env.NX_CNW_FLOW_VARIANT = '2';
+      const { getBannerVariant: freshGetBannerVariant } = jest.requireActual(
+        './ab-testing'
+      ) as typeof import('./ab-testing');
+      expect(freshGetBannerVariant('https://cloud.nx.app/connect/abc')).toBe(
+        '2'
+      );
+    });
+
+    it('should return a valid variant (0, 1, 2, or 3) for standard URLs', () => {
+      const variant = getBannerVariant('https://cloud.nx.app/connect/abc');
+      expect(['0', '1', '2', '3']).toContain(variant);
+    });
+  });
+});

--- a/packages/create-nx-workspace/src/utils/nx/messages.spec.ts
+++ b/packages/create-nx-workspace/src/utils/nx/messages.spec.ts
@@ -292,129 +292,109 @@ describe('Nx Cloud Messages', () => {
     });
   });
 
-  describe('Platform Promo Messages', () => {
-    it('should show promo title and subtext when user has pushed', () => {
+  describe('Banner Variant Messages (CLOUD-4147)', () => {
+    it('variant 0 should show plain link message', () => {
       const message = getCompletionMessage(
-        'platform-promo',
-        'https://nx.app/setup/123',
-        VcsPushStatus.PushedToVcs
+        'platform-setup',
+        'https://cloud.nx.app/connect/abc123',
+        VcsPushStatus.PushedToVcs,
+        'myworkspace',
+        '0'
       );
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Connect your repo to enable remote caching and self-healing CI at: https://nx.app/setup/123",
-            "",
-            "Remote caching · Self-healing CI · Task distribution",
+            "Go to Nx Cloud and finish the setup: https://cloud.nx.app/connect/abc123",
           ],
-          "title": "Want faster builds?",
+          "title": "Your platform setup is almost complete.",
         }
       `);
     });
 
-    it('should show promo message with generic cloud URL when pushed without URL', () => {
+    it('variant 1 should show "Try the full Nx platform" banner', () => {
       const message = getCompletionMessage(
-        'platform-promo',
-        null,
-        VcsPushStatus.PushedToVcs
+        'platform-setup',
+        'https://cloud.nx.app/connect/abc123',
+        VcsPushStatus.PushedToVcs,
+        'myworkspace',
+        '1'
       );
-      expect(message).toMatchInlineSnapshot(`
-        {
-          "bodyLines": [
-            "Connect your repo at https://cloud.nx.app to enable remote caching and self-healing CI.",
-            "",
-            "Remote caching · Self-healing CI · Task distribution",
-          ],
-          "title": "Want faster builds?",
-        }
-      `);
+      expect(message.title).toBe('Your platform setup is almost complete.');
+      expect(message.bodyLines.length).toBeGreaterThan(1);
+      expect(message.bodyLines.join('\n')).toContain(
+        'Try the full Nx platform'
+      );
+      expect(message.bodyLines.join('\n')).toContain(
+        'https://cloud.nx.app/connect/abc123'
+      );
+      expect(message.bodyLines.join('\n')).toContain('Remote caching');
     });
 
-    it('should instruct user to push repo first when they opted out of pushing', () => {
+    it('variant 2 should show "Unlock 70% faster CI" banner', () => {
       const message = getCompletionMessage(
-        'platform-promo',
-        'https://nx.app/setup/123',
-        VcsPushStatus.OptedOutOfPushingToVcs,
-        'myworkspace'
+        'platform-setup',
+        'https://cloud.nx.app/connect/abc123',
+        VcsPushStatus.PushedToVcs,
+        'myworkspace',
+        '2'
       );
-      expect(message).toMatchInlineSnapshot(`
-        {
-          "bodyLines": [
-            "Connect your repo (https://github.com/new?name=myworkspace) to enable remote caching and self-healing CI at: https://nx.app/setup/123",
-            "",
-            "Remote caching · Self-healing CI · Task distribution",
-          ],
-          "title": "Want faster builds?",
-        }
-      `);
+      expect(message.title).toBe('Your platform setup is almost complete.');
+      expect(message.bodyLines.length).toBeGreaterThan(1);
+      expect(message.bodyLines.join('\n')).toContain('Unlock 70% faster CI');
+      expect(message.bodyLines.join('\n')).toContain(
+        'https://cloud.nx.app/connect/abc123'
+      );
     });
 
-    it('should show connect message with cloud URL when failed to push and no URL', () => {
+    it('variant 3 should show "Reclaim your team\'s focus" banner', () => {
       const message = getCompletionMessage(
-        'platform-promo',
-        null,
-        VcsPushStatus.FailedToPushToVcs,
-        'myworkspace'
+        'platform-setup',
+        'https://cloud.nx.app/connect/abc123',
+        VcsPushStatus.PushedToVcs,
+        'myworkspace',
+        '3'
       );
-      expect(message).toMatchInlineSnapshot(`
-        {
-          "bodyLines": [
-            "Connect your repo (https://github.com/new?name=myworkspace) to enable remote caching and self-healing CI at https://cloud.nx.app",
-            "",
-            "Remote caching · Self-healing CI · Task distribution",
-          ],
-          "title": "Want faster builds?",
-        }
-      `);
+      expect(message.title).toBe('Your platform setup is almost complete.');
+      expect(message.bodyLines.length).toBeGreaterThan(1);
+      expect(message.bodyLines.join('\n')).toContain(
+        "Reclaim your team's focus"
+      );
+      expect(message.bodyLines.join('\n')).toContain(
+        'https://cloud.nx.app/connect/abc123'
+      );
+      expect(message.bodyLines.join('\n')).toContain('Self-healing CI');
     });
 
-    it('should use generic GitHub URL when workspaceName is not provided', () => {
-      const message = getCompletionMessage(
-        'platform-promo',
-        'https://nx.app/setup/123',
-        VcsPushStatus.FailedToPushToVcs
-      );
-      expect(message).toMatchInlineSnapshot(`
-        {
-          "bodyLines": [
-            "Connect your repo (https://github.com/new) to enable remote caching and self-healing CI at: https://nx.app/setup/123",
-            "",
-            "Remote caching · Self-healing CI · Task distribution",
-          ],
-          "title": "Want faster builds?",
-        }
-      `);
-    });
-
-    it('should always include subtext in body lines', () => {
-      const scenarios = [
-        { url: 'https://nx.app/setup/123', pushed: VcsPushStatus.PushedToVcs },
-        { url: null, pushed: VcsPushStatus.PushedToVcs },
-        {
-          url: 'https://nx.app/setup/123',
-          pushed: VcsPushStatus.FailedToPushToVcs,
-        },
-        { url: null, pushed: VcsPushStatus.FailedToPushToVcs },
-        {
-          url: 'https://nx.app/setup/123',
-          pushed: VcsPushStatus.OptedOutOfPushingToVcs,
-        },
-        { url: null, pushed: VcsPushStatus.OptedOutOfPushingToVcs },
-      ];
-
-      scenarios.forEach(({ url, pushed }) => {
+    it('should fall back to plain link when URL is null (all variants)', () => {
+      const variants = ['0', '1', '2', '3'] as const;
+      variants.forEach((variant) => {
         const message = getCompletionMessage(
-          'platform-promo',
-          url,
-          pushed,
-          'myworkspace'
+          'platform-setup',
+          null,
+          VcsPushStatus.PushedToVcs,
+          'myworkspace',
+          variant
         );
-        expect(message.title).toBe('Want faster builds?');
-        expect(message.bodyLines).toHaveLength(3);
-        expect(message.bodyLines[1]).toBe('');
-        expect(message.bodyLines[2]).toBe(
-          'Remote caching \u00b7 Self-healing CI \u00b7 Task distribution'
+        // All variants fall back to plain message when URL is null
+        expect(message.bodyLines).toHaveLength(1);
+        expect(message.bodyLines[0]).toBe(
+          'Return to Nx Cloud and finish the setup.'
         );
       });
+    });
+
+    it('should default to variant 0 when bannerVariant is not provided', () => {
+      const message = getCompletionMessage(
+        'platform-setup',
+        'https://cloud.nx.app/connect/abc123',
+        VcsPushStatus.PushedToVcs,
+        'myworkspace'
+        // no bannerVariant - defaults to '0'
+      );
+      expect(message.bodyLines).toHaveLength(1);
+      expect(message.bodyLines[0]).toContain(
+        'Go to Nx Cloud and finish the setup:'
+      );
     });
   });
 

--- a/packages/create-nx-workspace/src/utils/nx/messages.ts
+++ b/packages/create-nx-workspace/src/utils/nx/messages.ts
@@ -1,26 +1,86 @@
 import { VcsPushStatus } from '../git/git';
 
+/**
+ * Banner variants for the completion message experiment (CLOUD-4147).
+ * - '0': Plain link (control) - always used for enterprise URLs
+ * - '1': "Try the full Nx platform" decorative banner
+ * - '2': "Unlock 70% faster CI" decorative banner
+ * - '3': "Reclaim your team's focus" decorative banner
+ */
+export type BannerVariant = '0' | '1' | '2' | '3';
+
+/**
+ * Generates the decorative ASCII art banner for Nx Cloud.
+ * Line widths are carefully calculated to align properly.
+ */
+function generateDecorativeBanner(
+  headline: string,
+  url: string,
+  subtext: string
+): string[] {
+  // Fixed banner structure - pad content to fit within the box
+  // Total inner width is 60 characters
+  const innerWidth = 60;
+
+  const padCenter = (text: string, width: number): string => {
+    const padding = width - text.length;
+    const leftPad = Math.floor(padding / 2);
+    const rightPad = padding - leftPad;
+    return ' '.repeat(leftPad) + text + ' '.repeat(rightPad);
+  };
+
+  const line1 = padCenter('', innerWidth);
+  const line2 = padCenter(`- ${headline} -`, innerWidth);
+  const line3 = padCenter(url, innerWidth);
+  const line4 = padCenter(subtext, innerWidth);
+
+  return [
+    ` ${'_'.repeat(innerWidth + 1)}  ____   ___   __   `,
+    ` \\${line1}\\ \\   \\  \\  \\  \\ \\`,
+    `  \\${line2}\\ \\   \\  \\  \\  \\ \\`,
+    `   \\${line3}\\ \\   \\  \\  \\  \\ \\`,
+    `    \\${line4}\\ \\   \\  \\  \\  \\ \\ `,
+    `     \\${'_'.repeat(innerWidth)}\\ \\___\\  \\__\\  \\_\\`,
+  ];
+}
+
+/**
+ * Get banner lines based on the variant.
+ * Returns empty array for variant 0 (plain link).
+ */
+function getBannerLines(variant: BannerVariant, url: string): string[] {
+  switch (variant) {
+    case '1':
+      return generateDecorativeBanner(
+        'Try the full Nx platform',
+        url,
+        'Remote caching * Distribution * Self-healing CI'
+      );
+    case '2':
+      return generateDecorativeBanner(
+        'Unlock 70% faster CI',
+        url,
+        'Remote caching & Distribution'
+      );
+    case '3':
+      return generateDecorativeBanner(
+        "Reclaim your team's focus",
+        url,
+        'Self-healing CI + Remote caching'
+      );
+    default:
+      return [];
+  }
+}
+
 function getSetupMessage(
   url: string | null,
   pushedToVcs: VcsPushStatus,
-  workspaceName?: string,
-  isPromo?: boolean
+  workspaceName?: string
 ): string {
   const githubUrl = workspaceName
     ? `https://github.com/new?name=${encodeURIComponent(workspaceName)}`
     : 'https://github.com/new';
-
-  if (isPromo) {
-    if (pushedToVcs === VcsPushStatus.PushedToVcs) {
-      return url
-        ? `Connect your repo to enable remote caching and self-healing CI at: ${url}`
-        : 'Connect your repo at https://cloud.nx.app to enable remote caching and self-healing CI.';
-    }
-
-    return url
-      ? `Connect your repo (${githubUrl}) to enable remote caching and self-healing CI at: ${url}`
-      : `Connect your repo (${githubUrl}) to enable remote caching and self-healing CI at https://cloud.nx.app`;
-  }
 
   if (pushedToVcs === VcsPushStatus.PushedToVcs) {
     return url
@@ -48,10 +108,6 @@ const completionMessages = {
   'platform-setup': {
     title: 'Your platform setup is almost complete.',
   },
-  'platform-promo': {
-    title: 'Want faster builds?',
-    subtext: 'Remote caching \u00b7 Self-healing CI \u00b7 Task distribution',
-  },
 } as const;
 
 export type CompletionMessageKey = keyof typeof completionMessages;
@@ -60,18 +116,26 @@ export function getCompletionMessage(
   completionMessageKey: CompletionMessageKey | undefined,
   url: string | null,
   pushedToVcs: VcsPushStatus,
-  workspaceName?: string
+  workspaceName?: string,
+  bannerVariant?: BannerVariant
 ): { title: string; bodyLines: string[] } {
   const key = completionMessageKey ?? 'ci-setup';
   const messageConfig = completionMessages[key];
-  const isPromo = key === 'platform-promo';
+  const variant = bannerVariant ?? '0';
 
-  const bodyLines = [getSetupMessage(url, pushedToVcs, workspaceName, isPromo)];
-
-  if ('subtext' in messageConfig && messageConfig.subtext) {
-    bodyLines.push('');
-    bodyLines.push(messageConfig.subtext);
+  // For decorative banner variants (1, 2, 3), show the banner instead of plain text
+  if (variant !== '0' && url) {
+    const bannerLines = getBannerLines(variant, url);
+    if (bannerLines.length > 0) {
+      return {
+        title: messageConfig.title,
+        bodyLines: [...bannerLines, ''],
+      };
+    }
   }
+
+  // Variant 0 (control) or fallback: plain link message
+  const bodyLines = [getSetupMessage(url, pushedToVcs, workspaceName)];
 
   return {
     title: messageConfig.title,

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -5,7 +5,7 @@ import {
   getSkippedCloudMessage,
   CompletionMessageKey,
 } from './messages';
-import { getFlowVariant } from './ab-testing';
+import { getBannerVariant, getFlowVariant } from './ab-testing';
 import * as ora from 'ora';
 
 export type NxCloud =
@@ -115,11 +115,15 @@ export async function getNxCloudInfo(
   workspaceName?: string
 ) {
   const out = new CLIOutput(false);
+  // Get the banner variant based on the cloud URL
+  // Enterprise URLs automatically get variant 0 (plain link)
+  const bannerVariant = getBannerVariant(connectCloudUrl);
   const message = getCompletionMessage(
     completionMessageKey,
     connectCloudUrl,
     pushedToVcs,
-    workspaceName
+    workspaceName,
+    bannerVariant
   );
   out.success(message);
   return out.getOutput();


### PR DESCRIPTION
## Current Behavior

After completing the CNW (Create Nx Workspace) flow with Nx Cloud, users see a plain text completion message with a link to finish setup.

## Expected Behavior

Users now see one of four completion message variants controlled by `NX_CNW_FLOW_VARIANT`:
- **Variant 0**: Plain link (control) - always used for enterprise URLs
- **Variant 1**: "Try the full Nx platform" decorative ASCII banner
- **Variant 2**: "Unlock 70% faster CI" decorative ASCII banner
- **Variant 3**: "Reclaim your team's focus" decorative ASCII banner

Key changes:
- Added enterprise URL detection (non-standard Nx Cloud URLs always get variant 0)
- Locked the cloud prompt to always show "Try the full Nx platform?" (no longer varies by flow variant)
- Flow variant now only affects the completion banner, not the prompt
- Added `snapshot.nx.app` to standard Nx Cloud hosts
- Removed variant 2 auto-connect behavior (all variants now prompt)

## Screenshots
Variant 0:
<img width="1392" height="1065" alt="variant0" src="https://github.com/user-attachments/assets/0b18686e-1481-4fc0-995e-1577052887ff" />

Variant 1:
<img width="1392" height="1065" alt="variant1" src="https://github.com/user-attachments/assets/e5909e2e-e1d8-4d04-9721-ba6186d06891" />

Variant 2:
<img width="1392" height="1065" alt="variant2" src="https://github.com/user-attachments/assets/7e9f819f-e3c0-44d7-9760-0cab1d5dd9ac" />

Variant 3:
<img width="1392" height="1065" alt="variant3" src="https://github.com/user-attachments/assets/83f0499f-d807-4dc8-9390-c7eec93590a9" />


## Related Issue(s)

Closes CLOUD-4147