### PR TITLE
fix(js): correctly validate buildable packages when outDir is outside…

### DIFF
--- a/packages/js/src/plugins/typescript/util.ts
+++ b/packages/js/src/plugins/typescript/util.ts
@@ -178,12 +178,6 @@ function isAnyEntryPointPointingToOutDir(
   projectAbsolutePath: string
 ): boolean {
   const resolvedOutDir = resolve(projectAbsolutePath, outDir);
-  const relativePath = relative(projectAbsolutePath, resolvedOutDir);
-
-  // If outDir is outside project root: buildable
-  if (relativePath.startsWith('..')) {
-    return true;
-  }
 
   const isPathInsideOutDir = (path: string): boolean => {
     const normalizedPath = normalizePath(


### PR DESCRIPTION
… project root

Previously, `isAnyEntryPointPointingToOutDir` in the TypeScript plugin assumed that if `outDir` resolves to a path outside the project root, the package is automatically buildable. This caused incorrect behavior when users have base tsconfig in non-standard directories (like `.config/`), because TypeScript resolves `outDir` relative to the config file containing it.

The fix removes the short-circuit logic and always validates that package.json exports actually point to the resolved outDir.

Closes #34243

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
The `isAnyEntryPointPointingToOutDir` function in the `@nx/js/typescript` plugin assumes that if `outDir` resolves to a path outside the project root, the package is automatically buildable. This causes incorrect behavior when:

1. Users have base `tsconfig.json` in non-standard directories (like `.config/`)
2. The base config has `outDir: "dist"` which TypeScript resolves relative to the base config directory
3. The resolved `outDir` becomes `.config/dist` instead of `packages/mylib/dist`
4. The plugin incorrectly marks packages as buildable even when their `package.json` exports don't point to the actual output directory

## Expected Behavior
The plugin should always validate that `package.json` exports actually point to files inside the resolved `outDir`, regardless of whether the `outDir` is inside or outside the project root.

With this fix:
- Packages with exports pointing to the correct `outDir` are correctly identified as buildable
- Packages with exports pointing to source files (not `outDir`) are correctly identified as non-buildable
- Users with non-standard config directories (like `.config/`) get correct build target inference when they properly override `outDir` in their project's tsconfig

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #34243
