### PR TITLE
fix(core): resolve daemon client reconnect queue deadlock

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -1113,13 +1113,13 @@ export class DaemonClient {
 
       // Resend the pending message if one exists
       if (this.currentMessage && this.currentResolve && this.currentReject) {
-        // Decrement the queue counter that was incremented when the error occurred
-        this.queue.decrementQueueCounter();
-        // Retry the message through the normal queue
+        // Retry the message directly (not through the queue) to resolve the
+        // pending promise that the original queue entry is waiting on.
+        // This allows the original queue entry to complete naturally.
         const msg = this.currentMessage;
         const res = this.currentResolve;
         const rej = this.currentReject;
-        this.sendToDaemonViaQueue(msg).then(res, rej);
+        this.sendMessageToDaemon(msg).then(res, rej);
       }
     } else {
       // Failed to reconnect after all attempts, reject the pending request

--- a/packages/nx/src/utils/promised-based-queue.ts
+++ b/packages/nx/src/utils/promised-based-queue.ts
@@ -35,14 +35,4 @@ export class PromisedBasedQueue {
   isEmpty() {
     return this.counter === 0;
   }
-
-  /**
-   * Used to decrement the internal counter representing the number of active promises in the queue.
-   * This is useful for retrying a failed daemon message, as we want to be able to shut the daemon down
-   * without marking the promise that represents the failed message as settled. To do so, we store
-   * the promise in a separate variable and only resolve or reject it later.
-   */
-  decrementQueueCounter() {
-    this.counter--;
-  }
 }


### PR DESCRIPTION
## Current Behavior

When the daemon dies while processing a request, the reconnect logic adds the retry back to the promise-based queue. However, the original request is still blocked in the queue waiting for a response that will never come (the socket is dead). This creates a deadlock:

1. Original request (`fn1`) is blocked awaiting a promise that will never resolve
2. Retry request (`fn2`) is queued but can't execute until `fn1` completes
3. `fn1` can't complete because it's waiting on the dead socket

## Expected Behavior

When reconnecting after daemon death, the retry should resolve the pending promise that the original queue entry is waiting on, allowing the queue to proceed normally.

## Related Issue(s)

<!-- No specific issue, discovered during development -->

## Solution

Instead of re-queuing the retry through `sendToDaemonViaQueue` (which adds to the end of the queue), we now call `sendMessageToDaemon` directly. This resolves the pending promise that `fn1` is waiting on, allowing it to complete naturally and the queue to proceed.

Also removed the now-unused `decrementQueueCounter` method from `PromisedBasedQueue`.