### PR TITLE
fix(nx-dev): fix double-counting and exclude assets from page tracking

### DIFF
--- a/astro-docs/netlify/edge-functions/track-asset-requests.ts
+++ b/astro-docs/netlify/edge-functions/track-asset-requests.ts
@@ -101,5 +101,5 @@ export default async function handler(
 }
 
 export const config = {
-  path: ['/*.txt', '/**/*.txt', '/*.md', '/**/*.md'],
+  path: ['/**/*.txt', '/**/*.md'],
 };

--- a/astro-docs/netlify/edge-functions/track-page-requests.ts
+++ b/astro-docs/netlify/edge-functions/track-page-requests.ts
@@ -103,11 +103,27 @@ export default async function handler(
 export const config = {
   path: ['/docs/*'],
   excludedPath: [
+    // Text/code files (handled by track-asset-requests or not tracked)
     '/docs/*.md',
     '/docs/*.js',
     '/docs/*.txt',
+    // Images
+    '/docs/*.svg',
+    '/docs/*.png',
+    '/docs/*.jpg',
+    '/docs/*.jpeg',
+    '/docs/*.gif',
+    '/docs/*.webp',
+    '/docs/*.ico',
     '/docs/images/*',
-    // _astro and other asset paths
+    '/docs/og/*',
+    // Fonts
+    '/docs/fonts/*',
+    '/docs/*.woff',
+    '/docs/*.woff2',
+    // Search index (pagefind)
+    '/docs/pagefind/*',
+    // Astro build assets
     '/docs/_*',
   ],
 };


### PR DESCRIPTION
## Current Behavior

1. **track-asset-requests** runs twice per request due to redundant path patterns:
   ```typescript
   path: ["/*.txt", "/**/*.txt", "/*.md", "/**/*.md"]
   ```
   The `/**/*` pattern already matches root level files, so `/*` is redundant.

2. **track-page-requests** runs on many asset requests even though it only tracks HTML page views:
   - Font files: `/docs/fonts/*.woff2`, `/docs/*.woff`
   - Images: `/docs/*.svg`, `/docs/*.png`, `/docs/og/*`
   - Pagefind search index: `/docs/pagefind/*`

## Expected Behavior

1. Asset tracking should fire only once per request
2. Page tracking should exclude all non-HTML assets at Netlify level (zero compute)

## Changes

### track-asset-requests.ts
Simplified path patterns:
```typescript
path: ["/**/*.txt", "/**/*.md"]
```

### track-page-requests.ts
Added comprehensive exclusions:

| Category | Exclusions |
|----------|------------|
| Images | `.svg`, `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.ico`, `/images/*`, `/og/*` |
| Fonts | `/fonts/*`, `.woff`, `.woff2` |
| Search | `/pagefind/*` |

## Related Issue(s)

Fixes DOC-395