### PR TITLE
docs(misc): ignore /docs/og/*.png.md paths

### DIFF
--- a/astro-docs/netlify/edge-functions/track-asset-requests.ts
+++ b/astro-docs/netlify/edge-functions/track-asset-requests.ts
@@ -102,4 +102,6 @@ export default async function handler(
 
 export const config = {
   path: ['/**/*.txt', '/**/*.md'],
+  // Something is adding .png.md to get image paths, exclude those.
+  excludedPath: ['/docs/og/*'],
 };


### PR DESCRIPTION
This PR excludes `/docs/og/*` paths from assets tracking. This is likely added by some crawler and is additional compute/noise that we don't care about.

<img width="1354" height="86" alt="image" src="https://github.com/user-attachments/assets/6bfda816-0d26-46b3-b432-ae96e5976c37" />

