### PR TITLE
fix(maven): include pom.xml and ancestor pom files as inputs for all targets

### DIFF
--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt
@@ -92,7 +92,7 @@ class NxProjectAnalyzerMojo : AbstractMojo() {
     // Create shared component instances ONCE for all projects (major optimization)
 
     val pathFormatter = PathFormatter()
-    val mojoAnalyzer = MojoAnalyzer(sharedExpressionResolver, pathFormatter, gitIgnoreClassifier)
+    val mojoAnalyzer = MojoAnalyzer(sharedExpressionResolver, pathFormatter, gitIgnoreClassifier, workspaceRoot)
 
     val sharedTestClassDiscovery = TestClassDiscovery()
 

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/cache/CacheConfig.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/cache/CacheConfig.kt
@@ -29,7 +29,6 @@ data class CacheConfig(
             defaultInputs = listOf(
                 PathPattern("src/main/**/*", recursive = true),
                 PathPattern("src/test/**/*", recursive = true),
-                PathPattern("pom.xml"),
                 PathPattern("*.properties")
             ),
             defaultOutputs = listOf(

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/utils/PathFormatter.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/utils/PathFormatter.kt
@@ -26,6 +26,12 @@ class PathFormatter {
     return "{projectRoot}/$relativePath"
   }
 
+  fun toWorkspacePath(path: File, workspaceRoot: File): String {
+    val relativePath = path.canonicalFile.relativeTo(workspaceRoot.canonicalFile)
+
+    return "{workspaceRoot}/$relativePath"
+  }
+
   fun normalizeRelativePath(path: String): String = path.takeIf { it.isNotEmpty() } ?: "."
 }
 


### PR DESCRIPTION
## Current Behavior

- `pom.xml` is only included as an input when a mojo uses default inputs
- Mojos with specific input configurations (like `maven-compiler-plugin:compile`) don't get `pom.xml` in their inputs
- Parent `pom.xml` files aren't tracked as inputs

This can lead to stale cache hits when:
1. `pom.xml` changes but a mojo has specific input config
2. A parent `pom.xml` changes (affecting inherited properties, dependency versions, plugin config)

## Expected Behavior

- Every target should include its own `pom.xml` as an input
- Every target should include ancestor `pom.xml` files (within the workspace) as inputs
- Cache should invalidate when any relevant `pom.xml` changes

## Related Issue(s)

N/A - discovered during code review

## Changes

- **CacheConfig.kt**: Removed `pom.xml` from `defaultInputs` (now always added explicitly)
- **MojoAnalyzer.kt**: Added `workspaceRoot` parameter and logic to walk up the parent chain, adding all in-workspace ancestor `pom.xml` files as inputs
- **NxProjectAnalyzerMojo.kt**: Pass `workspaceRoot` to `MojoAnalyzer`