### PR TITLE
feat(core): add preferBatch executor option

### DIFF
--- a/e2e/gradle/src/gradle-plugin-v1.test.ts
+++ b/e2e/gradle/src/gradle-plugin-v1.test.ts
@@ -36,14 +36,14 @@ describe('Gradle Plugin V1', () => {
       });
       afterAll(() => cleanupProject());
 
-      it('should build', () => {
+      it('should build without batch mode', () => {
         const projects = runCLI(`show projects`);
         expect(projects).toContain('app');
         expect(projects).toContain('list');
         expect(projects).toContain('utilities');
         expect(projects).toContain(gradleProjectName);
 
-        const buildOutput = runCLI('build app', { verbose: true });
+        const buildOutput = runCLI('build app --no-batch', { verbose: true });
         expect(buildOutput).toContain('nx run list:build');
         expect(buildOutput).toContain(':list:classes');
         expect(buildOutput).toContain('nx run utilities:build');
@@ -56,7 +56,7 @@ describe('Gradle Plugin V1', () => {
         );
       });
 
-      it('should track dependencies for new app', () => {
+      it('should track dependencies for new app without batch mode', () => {
         if (type === 'groovy') {
           createFile(
             `app2/build.gradle`,
@@ -94,7 +94,7 @@ dependencies {
           }
         );
 
-        let buildOutput = runCLI('build app2', { verbose: true });
+        let buildOutput = runCLI('build app2 --no-batch', { verbose: true });
         // app2 depends on app
         expect(buildOutput).toContain('nx run app:build');
         expect(buildOutput).toContain(':app:classes');

--- a/e2e/gradle/src/gradle.test.ts
+++ b/e2e/gradle/src/gradle.test.ts
@@ -23,14 +23,14 @@ describe('Gradle', () => {
       });
       afterAll(() => cleanupProject());
 
-      it('should build', () => {
+      it('should build without batch mode', () => {
         const projects = runCLI(`show projects`);
         expect(projects).toContain('app');
         expect(projects).toContain('list');
         expect(projects).toContain('utilities');
         expect(projects).toContain(gradleProjectName);
 
-        let buildOutput = runCLI('build app', { verbose: true });
+        let buildOutput = runCLI('build app --no-batch', { verbose: true });
         expect(buildOutput).toContain(':list:classes');
         expect(buildOutput).toContain(':utilities:classes');
 
@@ -48,7 +48,7 @@ describe('Gradle', () => {
         expect(bootJarOutput).toContain(':app:bootJar');
       });
 
-      it('should track dependencies for new app', () => {
+      it('should track dependencies for new app without batch mode', () => {
         if (type === 'groovy') {
           createFile(
             `app2/build.gradle`,
@@ -86,7 +86,7 @@ dependencies {
           }
         );
 
-        let buildOutput = runCLI('build app2', { verbose: true });
+        let buildOutput = runCLI('build app2 --no-batch', { verbose: true });
         // app2 depends on app
         expect(buildOutput).toContain(':app:classes');
         expect(buildOutput).toContain(':list:classes');
@@ -109,8 +109,12 @@ dependencies {
         });
 
         expect(() => {
-          runCLI('run app:test-ci--MessageUtilsTest', { verbose: true });
-          runCLI('run list:test-ci--LinkedListTest', { verbose: true });
+          runCLI('run app:test-ci--MessageUtilsTest --no-batch', {
+            verbose: true,
+          });
+          runCLI('run list:test-ci--LinkedListTest --no-batch', {
+            verbose: true,
+          });
         }).not.toThrow();
       });
 
@@ -153,7 +157,7 @@ dependencies {
         expect(output).toContain('gradle-classes');
 
         // Verify prefixed target works
-        const buildOutput = runCLI('run app:gradle-build');
+        const buildOutput = runCLI('run app:gradle-build --no-batch');
         expect(buildOutput).toContain('BUILD SUCCESSFUL');
       });
 

--- a/e2e/maven/src/maven.test.ts
+++ b/e2e/maven/src/maven.test.ts
@@ -46,9 +46,9 @@ describe('Maven', () => {
     expect(output).toContain('- install-ci:');
   });
 
-  it('should build Maven project with dependencies', () => {
+  it('should build Maven project with dependencies without batch mode', () => {
     // Build app which depends on lib, which depends on utils
-    let buildOutput = runCLI('run app:install', { verbose: true });
+    let buildOutput = runCLI('run app:install --no-batch', { verbose: true });
 
     // Should build dependencies first
     expect(buildOutput).toContain('BUILD SUCCESS');
@@ -60,8 +60,8 @@ describe('Maven', () => {
     );
   });
 
-  it('should run tests for Maven project', () => {
-    const testOutput = runCLI('run utils:test', { verbose: true });
+  it('should run tests for Maven project without batch mode', () => {
+    const testOutput = runCLI('run utils:test --no-batch', { verbose: true });
     expect(testOutput).toContain('BUILD SUCCESS');
   });
 
@@ -118,7 +118,7 @@ describe('Maven', () => {
     expect(output).toContain('- mvn-install-ci:');
 
     // Verify prefixed target works
-    const buildOutput = runCLI('run app:mvn-compile');
+    const buildOutput = runCLI('run app:mvn-compile --no-batch');
     expect(buildOutput).toContain('BUILD SUCCESS');
   });
 });

--- a/packages/gradle/executors.json
+++ b/packages/gradle/executors.json
@@ -4,7 +4,8 @@
       "batchImplementation": "./src/executors/gradle/gradle-batch.impl",
       "implementation": "./src/executors/gradle/gradle.impl",
       "schema": "./src/executors/gradle/schema.json",
-      "description": "Runs gradle tasks via the Gradle Tooling API or by invoking gradlew."
+      "description": "Runs gradle tasks via the Gradle Tooling API or by invoking gradlew.",
+      "preferBatch": true
     }
   }
 }

--- a/packages/maven/executors.json
+++ b/packages/maven/executors.json
@@ -5,7 +5,8 @@
       "implementation": "./dist/executors/maven/maven.impl",
       "batchImplementation": "./dist/executors/maven/maven-batch.impl",
       "schema": "./dist/executors/maven/schema.json",
-      "description": "Runs Maven phases and goals via Maven executable."
+      "description": "Runs Maven phases and goals via Maven executable.",
+      "preferBatch": true
     }
   }
 }

--- a/packages/nx/src/command-line/run/executor-utils.ts
+++ b/packages/nx/src/command-line/run/executor-utils.ts
@@ -102,6 +102,7 @@ export function getExecutorInformation(
       schema,
       implementationFactory,
       batchImplementationFactory,
+      preferBatch: executorConfig.preferBatch,
       hasherFactory,
       isNgCompat,
       isNxExecutor: !isNgCompat,
@@ -127,6 +128,7 @@ function readExecutorJson(
   executorConfig: {
     implementation: string;
     batchImplementation?: string;
+    preferBatch?: boolean;
     schema: string;
     hasher?: string;
   };

--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -201,9 +201,11 @@ export function withBatch(yargs: Argv) {
     type: 'boolean',
     describe: 'Run task(s) in batches for executors which support batches.',
     coerce: (v) => {
-      return v || process.env.NX_BATCH_MODE === 'true';
+      if (v !== undefined) return v;
+      if (process.env.NX_BATCH_MODE === 'true') return true;
+      return undefined; // Let preferBatch decide
     },
-    default: false,
+    default: undefined,
   }) as any;
 }
 

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -42,6 +42,7 @@ export interface ExecutorJsonEntryConfig {
   schema: string;
   implementation: string;
   batchImplementation?: string;
+  preferBatch?: boolean;
   description?: string;
   hasher?: string;
 }
@@ -128,6 +129,7 @@ export interface ExecutorConfig {
   hasherFactory?: () => CustomHasher;
   implementationFactory: () => Executor;
   batchImplementationFactory?: () => TaskGraphExecutor;
+  preferBatch?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Current Behavior

Batch mode is binary:
- `--batch` flag → batch ALL executors that support it
- No flag → batch NOTHING

This means users of gradle/maven must always remember to pass `--batch` to get the performance benefits.

## Expected Behavior

Plugin authors can now set `preferBatch: true` in their executor config to indicate batch mode should be used by default. Users can still opt-out with `--no-batch`.

Three states:
- `--batch` → batch everything
- `--no-batch` → batch nothing  
- (not specified) → use each executor's `preferBatch` preference

| `--batch` flag | `preferBatch` | Result |
|----------------|---------------|--------|
| `true`         | any           | Batch  |
| `false`        | any           | No batch |
| not set        | `true`        | Batch  |
| not set        | `false`/undefined | No batch |

## Changes

- Added `preferBatch?: boolean` to `ExecutorJsonEntryConfig` and `ExecutorConfig` interfaces
- Updated `--batch` default from `false` to `undefined` to allow `preferBatch` to decide
- Modified batch scheduling logic to respect `preferBatch`
- Enabled `preferBatch: true` for gradle and maven executors
- Added 5 unit tests covering all `preferBatch` scenarios

## Related Issue(s)

<!-- Link any related issues here -->