### PR TITLE
feat(core): share cache between git worktrees

### DIFF
--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -74,11 +74,16 @@ export function getCache(options: DefaultTasksRunnerOptions): DbCache | Cache {
 
 export class DbCache {
   private nxJson = readNxJson();
+  // Use cache directory for the database so it's shared between worktrees
+  // alongside the cache files. This is separate from workspaceDataDirectory
+  // which contains per-workspace daemon state.
+  // We pass linkTaskDetails=false because task_details table is in the
+  // workspace-data database, not the cache database.
   private cache = new NxCache(
     workspaceRoot,
     cacheDir,
-    getDbConnection(),
-    undefined,
+    getDbConnection({ directory: cacheDir }),
+    false, // linkTaskDetails - disable FK to task_details since it's in a different DB
     resolveMaxCacheSize(this.nxJson)
   );
 

--- a/packages/nx/src/utils/cache-directory.spec.ts
+++ b/packages/nx/src/utils/cache-directory.spec.ts
@@ -1,0 +1,166 @@
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { dirSync } from 'tmp';
+
+import {
+  isGitWorktree,
+  getMainRepoRoot,
+  cacheDirectoryForWorkspace,
+  workspaceDataDirectoryForWorkspace,
+} from './cache-directory';
+
+describe('cache-directory', () => {
+  describe('isGitWorktree', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = dirSync({ unsafeCleanup: true }).name;
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('should return false when .git does not exist', () => {
+      expect(isGitWorktree(tempDir)).toBe(false);
+    });
+
+    it('should return false when .git is a directory (main repo)', () => {
+      mkdirSync(join(tempDir, '.git'));
+      expect(isGitWorktree(tempDir)).toBe(false);
+    });
+
+    it('should return true when .git is a file (worktree)', () => {
+      writeFileSync(
+        join(tempDir, '.git'),
+        'gitdir: /some/path/.git/worktrees/branch'
+      );
+      expect(isGitWorktree(tempDir)).toBe(true);
+    });
+  });
+
+  describe('getMainRepoRoot', () => {
+    // Note: These tests require an actual git worktree setup.
+    // We test the basic case where the function is called on a non-git directory.
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = dirSync({ unsafeCleanup: true }).name;
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('should return null for non-git directory', () => {
+      expect(getMainRepoRoot(tempDir)).toBe(null);
+    });
+  });
+
+  describe('cacheDirectoryForWorkspace', () => {
+    const originalEnv = { ...process.env };
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = dirSync({ unsafeCleanup: true }).name;
+      // Reset env vars that affect cache directory
+      delete process.env.NX_CACHE_DIRECTORY;
+      delete process.env.CI;
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+      process.env = { ...originalEnv };
+    });
+
+    it('should return default cache directory for non-worktree', () => {
+      mkdirSync(join(tempDir, '.git')); // Main repo (directory, not file)
+      writeFileSync(join(tempDir, 'nx.json'), '{}');
+
+      const result = cacheDirectoryForWorkspace(tempDir);
+      expect(result).toBe(join(tempDir, '.nx', 'cache'));
+    });
+
+    it('should respect NX_CACHE_DIRECTORY env var', () => {
+      process.env.NX_CACHE_DIRECTORY = '/custom/cache/path';
+      writeFileSync(join(tempDir, 'nx.json'), '{}');
+
+      const result = cacheDirectoryForWorkspace(tempDir);
+      expect(result).toBe('/custom/cache/path');
+    });
+
+    it('should respect cacheDirectory in nx.json', () => {
+      mkdirSync(join(tempDir, '.git'));
+      writeFileSync(
+        join(tempDir, 'nx.json'),
+        JSON.stringify({ cacheDirectory: 'custom-cache' })
+      );
+
+      const result = cacheDirectoryForWorkspace(tempDir);
+      expect(result).toBe(join(tempDir, 'custom-cache'));
+    });
+
+    it('should skip worktree cache sharing in CI', () => {
+      process.env.CI = 'true';
+      // Simulate worktree by creating .git file
+      writeFileSync(
+        join(tempDir, '.git'),
+        'gitdir: /some/path/.git/worktrees/branch'
+      );
+      writeFileSync(join(tempDir, 'nx.json'), '{}');
+
+      const result = cacheDirectoryForWorkspace(tempDir);
+      // In CI, should fall back to local cache even if it's a worktree
+      expect(result).toBe(join(tempDir, '.nx', 'cache'));
+    });
+  });
+
+  describe('workspaceDataDirectoryForWorkspace', () => {
+    const originalEnv = { ...process.env };
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = dirSync({ unsafeCleanup: true }).name;
+      // Reset env vars that affect workspace data directory
+      delete process.env.NX_WORKSPACE_DATA_DIRECTORY;
+      delete process.env.NX_PROJECT_GRAPH_CACHE_DIRECTORY;
+      delete process.env.CI;
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+      process.env = { ...originalEnv };
+    });
+
+    it('should return default workspace data directory for non-worktree', () => {
+      mkdirSync(join(tempDir, '.git')); // Main repo (directory, not file)
+      writeFileSync(join(tempDir, 'nx.json'), '{}');
+
+      const result = workspaceDataDirectoryForWorkspace(tempDir);
+      expect(result).toBe(join(tempDir, '.nx', 'workspace-data'));
+    });
+
+    it('should respect NX_WORKSPACE_DATA_DIRECTORY env var', () => {
+      process.env.NX_WORKSPACE_DATA_DIRECTORY = '/custom/data/path';
+      writeFileSync(join(tempDir, 'nx.json'), '{}');
+
+      const result = workspaceDataDirectoryForWorkspace(tempDir);
+      expect(result).toBe('/custom/data/path');
+    });
+
+    it('should always use local workspace data directory even for worktrees', () => {
+      // Workspace-data is intentionally NOT shared between worktrees.
+      // The daemon tracks output hashes per-workspace, so sharing would
+      // cause incorrect cache hit detection.
+      writeFileSync(
+        join(tempDir, '.git'),
+        'gitdir: /some/path/.git/worktrees/branch'
+      );
+      writeFileSync(join(tempDir, 'nx.json'), '{}');
+
+      const result = workspaceDataDirectoryForWorkspace(tempDir);
+      // Should use local workspace-data, not shared with main repo
+      expect(result).toBe(join(tempDir, '.nx', 'workspace-data'));
+    });
+  });
+});

--- a/packages/nx/src/utils/cache-directory.ts
+++ b/packages/nx/src/utils/cache-directory.ts
@@ -1,5 +1,6 @@
-import { existsSync } from 'fs';
+import { existsSync, statSync } from 'fs';
 import { isAbsolute, join } from 'path';
+import { execSync } from 'child_process';
 import { NxJsonConfiguration } from '../config/nx-json';
 import { readJsonFile } from './fileutils';
 import { workspaceRoot } from './workspace-root';
@@ -24,6 +25,158 @@ function absolutePath(root: string, path: string): string {
   }
 }
 
+// ============================================================
+// Worktree detection and cache sharing
+// ============================================================
+
+/**
+ * Check if .git is a file (worktree) or directory (main repo).
+ * Git worktrees have a .git file containing `gitdir: /path/to/main/.git/worktrees/{name}`
+ */
+export function isGitWorktree(root: string): boolean {
+  const gitPath = join(root, '.git');
+
+  if (!existsSync(gitPath)) {
+    return false;
+  }
+
+  try {
+    return statSync(gitPath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get git version to check for worktree support (requires 2.5+)
+ */
+function getGitVersion(): { major: number; minor: number } | null {
+  try {
+    const output = execSync('git --version', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    const match = output.match(/git version (\d+)\.(\d+)/);
+    if (!match) {
+      return null;
+    }
+
+    return {
+      major: parseInt(match[1], 10),
+      minor: parseInt(match[2], 10),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if git version supports worktrees (2.5+)
+ */
+function gitSupportsWorktrees(): boolean {
+  const version = getGitVersion();
+  if (!version) {
+    return false;
+  }
+  return version.major > 2 || (version.major === 2 && version.minor >= 5);
+}
+
+/**
+ * Get the main repository root from a worktree using git rev-parse --git-common-dir.
+ * Returns the path without the trailing /.git
+ */
+export function getMainRepoRoot(worktreeRoot: string): string | null {
+  try {
+    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+      cwd: worktreeRoot,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+
+    // Make absolute if relative
+    const absoluteGitDir = gitCommonDir.startsWith('/')
+      ? gitCommonDir
+      : join(worktreeRoot, gitCommonDir);
+
+    // Strip /.git suffix to get main repo root
+    return absoluteGitDir.replace(/[/\\]\.git\/?$/, '');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check skip conditions for worktree cache sharing.
+ * Returns the reason if should skip, null otherwise.
+ */
+function shouldSkipWorktreeCacheSharing(): {
+  skip: boolean;
+  reason?: string;
+  silent?: boolean;
+} {
+  // Skip silently in CI (Cloud Agents can't access local worktree cache)
+  if (process.env.CI) {
+    return { skip: true, reason: 'CI environment', silent: true };
+  }
+
+  // Skip silently if custom cache directory is already set
+  if (process.env.NX_CACHE_DIRECTORY) {
+    return { skip: true, reason: 'NX_CACHE_DIRECTORY is set', silent: true };
+  }
+
+  // Skip with warning if git is too old
+  if (!gitSupportsWorktrees()) {
+    return {
+      skip: true,
+      reason: 'Git version does not support worktrees (requires 2.5+)',
+      silent: false,
+    };
+  }
+
+  return { skip: false };
+}
+
+/**
+ * Resolve the main repo root for worktree sharing.
+ * Returns the main repo root if in a worktree, null otherwise.
+ */
+function resolveWorktreeMainRoot(root: string): string | null {
+  const skipCheck = shouldSkipWorktreeCacheSharing();
+  if (skipCheck.skip) {
+    if (!skipCheck.silent && process.env.NX_VERBOSE_LOGGING) {
+      console.warn(
+        `Worktree cache sharing disabled: ${skipCheck.reason}. Worktrees will use independent caches.`
+      );
+    }
+    return null;
+  }
+
+  if (!isGitWorktree(root)) {
+    return null; // Not a worktree, use normal cache
+  }
+
+  const mainRepoRoot = getMainRepoRoot(root);
+  if (!mainRepoRoot) {
+    return null; // Failed to resolve, fall back to local cache
+  }
+
+  // Verify main repo still exists
+  if (!existsSync(mainRepoRoot)) {
+    throw new Error(
+      `Cannot access shared cache: The main repository may have been moved or deleted.\n` +
+        `Worktree path: ${root}\n` +
+        `Expected main repo: ${mainRepoRoot}`
+    );
+  }
+
+  return mainRepoRoot;
+}
+
+// ============================================================
+// Cache directory resolution
+// ============================================================
+
 function cacheDirectory(root: string, cacheDirectory: string) {
   const cacheDirFromEnv = process.env.NX_CACHE_DIRECTORY;
   if (cacheDirFromEnv) {
@@ -31,9 +184,15 @@ function cacheDirectory(root: string, cacheDirectory: string) {
   }
   if (cacheDirectory) {
     return absolutePath(root, cacheDirectory);
-  } else {
-    return defaultCacheDirectory(root);
   }
+
+  // Check for worktree and resolve shared cache
+  const mainRepoRoot = resolveWorktreeMainRoot(root);
+  if (mainRepoRoot) {
+    return join(mainRepoRoot, '.nx', 'cache');
+  }
+
+  return defaultCacheDirectory(root);
 }
 
 function pickCacheDirectory(
@@ -83,6 +242,10 @@ export const workspaceDataDirectory =
   workspaceDataDirectoryForWorkspace(workspaceRoot);
 
 export function workspaceDataDirectoryForWorkspace(workspaceRoot: string) {
+  // Note: We intentionally do NOT share workspace-data between worktrees.
+  // The daemon runs per-workspace and tracks output hashes in memory.
+  // Sharing the daemon directory would cause incorrect cache hit detection.
+  // Only the cache directory (cacheDir) is shared between worktrees.
   return absolutePath(
     workspaceRoot,
     process.env.NX_WORKSPACE_DATA_DIRECTORY ??


### PR DESCRIPTION
## Current Behavior
Each git worktree maintains its own `.nx/cache`, leading to duplicated cache entries, missed cache hits, and increased disk usage.

## Expected Behavior
Worktrees automatically share the main repository's `.nx/cache`:
- Detect worktrees by checking if `.git` is a file (not directory)
- Resolve main repo path via `git rev-parse --git-common-dir`
- Share cache files AND cache database between worktrees
- Keep daemon state (`workspace-data`) per-workspace to avoid output hash tracking conflicts

Skip conditions (silent): CI environment, NX_CACHE_DIRECTORY set
Skip conditions (warn): Git version < 2.5

## Demo

https://www.loom.com/share/583f80ef14d34383909aafa0bd06de6b

## Related Issue(s)
Closes NXC-3806
