### PR TITLE
fix(core): nx should show help for run-one when using project short names

### DIFF
--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -1,26 +1,26 @@
+import { calculateDefaultProjectName } from '../../config/calculate-default-project-name';
+import { readNxJson } from '../../config/configuration';
+import { NxJsonConfiguration } from '../../config/nx-json';
+import {
+  ProjectGraph,
+  ProjectGraphProjectNode,
+} from '../../config/project-graph';
+import { TargetDependencyConfig } from '../../config/workspace-json-project-json';
+import {
+  createProjectGraphAsync,
+  readProjectsConfigurationFromProjectGraph,
+} from '../../project-graph/project-graph';
 import { runCommand } from '../../tasks-runner/run-command';
 import {
   readGraphFileFromGraphArg,
   splitArgsIntoNxArgsAndOverrides,
 } from '../../utils/command-line-utils';
-import { connectToNxCloudIfExplicitlyAsked } from '../nx-cloud/connect/connect-to-nx-cloud';
-import {
-  createProjectGraphAsync,
-  readProjectsConfigurationFromProjectGraph,
-} from '../../project-graph/project-graph';
-import {
-  ProjectGraph,
-  ProjectGraphProjectNode,
-} from '../../config/project-graph';
-import { NxJsonConfiguration } from '../../config/nx-json';
-import { workspaceRoot } from '../../utils/workspace-root';
-import { splitTarget } from '../../utils/split-target';
-import { output } from '../../utils/output';
-import { TargetDependencyConfig } from '../../config/workspace-json-project-json';
-import { readNxJson } from '../../config/configuration';
-import { calculateDefaultProjectName } from '../../config/calculate-default-project-name';
-import { generateGraph } from '../graph/graph';
 import { findMatchingProjects } from '../../utils/find-matching-projects';
+import { output } from '../../utils/output';
+import { splitTarget } from '../../utils/split-target';
+import { workspaceRoot } from '../../utils/workspace-root';
+import { generateGraph } from '../graph/graph';
+import { connectToNxCloudIfExplicitlyAsked } from '../nx-cloud/connect/connect-to-nx-cloud';
 
 export async function runOne(
   cwd: string,
@@ -56,14 +56,22 @@ export async function runOne(
     nxJson
   );
 
+  const { projects, projectName } = getProjects(projectGraph, opts.project);
+
   if (nxArgs.help) {
-    await (await import('./run')).printTargetRunHelp(opts, workspaceRoot);
+    await (
+      await import('./run')
+    ).printTargetRunHelp(
+      {
+        ...opts,
+        project: projectName,
+      },
+      workspaceRoot
+    );
     process.exit(0);
   }
 
   await connectToNxCloudIfExplicitlyAsked(nxArgs);
-
-  const { projects, projectName } = getProjects(projectGraph, opts.project);
 
   if (nxArgs.graph) {
     const projectNames = projects.map((t) => t.name);


### PR DESCRIPTION
## Current Behavior
Given a project name like `:foo`, you can run tasks like `nx test foo` (note `foo` vs `:foo`), but passing --help throws an error

## Expected Behavior
`--help` works the same with the shortname vs full name

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
