### PR TITLE
feat(core): improve AI agent rules for CLAUDE.md generation

### DIFF
--- a/packages/nx/src/ai/set-up-ai-agents/get-agent-rules.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/get-agent-rules.ts
@@ -2,10 +2,21 @@ export function getAgentRules(nxCloud: boolean) {
   return `
 # General Guidelines for working with Nx
 
+- For navigating/exploring the workspace, invoke the \`nx-workspace\` skill first - it has patterns for querying projects, targets, and dependencies
 - When running tasks (for example build, lint, test, e2e, etc.), always prefer running the task through \`nx\` (i.e. \`nx run\`, \`nx run-many\`, \`nx affected\`) instead of using the underlying tooling directly
+- Prefix nx commands with the workspace's package manager (e.g., \`pnpm nx build\`, \`npm exec nx test\`) - avoids using globally installed CLI
 - You have access to the Nx MCP server and its tools, use them to help the user
-- For understanding the workspace structure, projects, or available tasks, use the \`/nx-workspace\` skill which provides guidance on exploring Nx workspaces
-- For questions around nx configuration, best practices or if you're unsure, use the \`nx_docs\` MCP tool to get relevant, up-to-date docs. Always use this instead of assuming things about nx configuration
 - For Nx plugin best practices, check \`node_modules/@nx/<plugin>/PLUGIN.md\`. Not all plugins have this file - proceed without it if unavailable.
+- NEVER guess CLI flags - always check nx_docs or \`--help\` first when unsure
+
+## Scaffolding & Generators
+
+- For scaffolding tasks (creating apps, libs, project structure, setup), ALWAYS invoke the \`nx-generate\` skill FIRST before exploring or calling MCP tools
+
+## When to use nx_docs
+
+- USE for: advanced config options, unfamiliar flags, migration guides, plugin configuration, edge cases
+- DON'T USE for: basic generator syntax (\`nx g @nx/react:app\`), standard commands, things you already know
+- The \`nx-generate\` skill handles generator discovery internally - don't call nx_docs just to look up generator syntax
 `;
 }


### PR DESCRIPTION
## Summary

Updates the generated CLAUDE.md content with improved guidance for AI agents working with Nx workspaces.

**Changes:**
- Add "nx-workspace skill first" for workspace navigation
- Add "prefix nx commands with package manager" rule
- Add "NEVER guess CLI flags" rule
- Add "Scaffolding & Generators" section (invoke nx-generate skill first)
- Add "When to use nx_docs" guidance (USE for advanced config, DON'T USE for basic syntax)

## Why These Changes

Based on testing with repeated scaffolding tasks, agents were:

| Issue | Fix |
|-------|-----|
| Calling `nx_docs` for basic generator syntax | Added clear guidance on when to use/not use nx_docs |
| Guessing CLI flags incorrectly (e.g., `nx sync --apply`) | Added "never guess flags" rule |
| Using global nx CLI causing version mismatches | Added package manager prefix rule |
| Not invoking nx-generate skill on scaffolding tasks | Added explicit "Scaffolding & Generators" section |

## Related

Companion PR with skill improvements: https://github.com/nrwl/nx-ai-agents-config/pull/26