### PR TITLE
fix(core): fix CNW git amend and README marker handling

### DIFF
--- a/packages/create-nx-workspace/src/utils/template/update-readme.spec.ts
+++ b/packages/create-nx-workspace/src/utils/template/update-readme.spec.ts
@@ -67,13 +67,14 @@ More content.`;
     `);
   });
 
-  it('should strip markers and content when no connect URL provided', () => {
+  it('should strip markers but keep content when no connect URL provided', () => {
     const content = `# My Workspace
 
 Some intro content.
 
 <!-- BEGIN: nx-cloud -->
-Placeholder content to remove.
+## Try the full Nx platform
+🚀 If you haven't connected to Nx Cloud yet, complete your setup here.
 <!-- END: nx-cloud -->
 
 ## Other Section
@@ -86,6 +87,9 @@ More content.`;
       "# My Workspace
 
       Some intro content.
+
+      ## Try the full Nx platform
+      🚀 If you haven't connected to Nx Cloud yet, complete your setup here.
 
       ## Other Section
 


### PR DESCRIPTION
This PR fixes two issues:
1. When the README changes are amended, there's an edge case where we don't have a commit to amend (e.g. `--skipGit`), and this fails the entire CNW flow.
2. When user opts out of Cloud, we strip the entire `<!-- BEGIN: nx-cloud -->` block in README rather than just the comments and leaving the content.

Closes NXC-3812