### PR TITLE
fix(core): tweak configure-ai-agents messaging

### DIFF
--- a/packages/nx/src/ai/constants.ts
+++ b/packages/nx/src/ai/constants.ts
@@ -29,6 +29,10 @@ export function claudeMdPath(root: string): string {
   return join(root, 'CLAUDE.md');
 }
 
+export function claudeMcpJsonPath(root: string): string {
+  return join(root, '.mcp.json');
+}
+
 export function opencodeMcpPath(root: string): string {
   return join(root, 'opencode.json');
 }


### PR DESCRIPTION
 ### Current Behavior                                                                                     
                                                                                                       
  The nx configure-ai-agents command output is minimal - just "AI agents set up successfully" with a   
  bullet list of agent names. Users don't understand what was actually configured (plugin vs MCP,      
  skills, which files were created/modified).                                                          
                                                                                                       
  ### Expected Behavior                                                                                    
                                                                                                       
  Clearer feedback about what gets configured for each agent:                                          
                                                                                                       
  Selection prompt improvements:                                                                       
  - Agents needing updates show (update available) tag                                                 
  - Footer always shows result state: what will be configured                                          
  - Agent-specific descriptions (e.g., "Installs Nx plugin (MCP + skills + agents). Updates            
  CLAUDE.md.")                                                                                         
                                                                                                       
  Post-configuration output:                                                                           
  - Compact summary per agent showing what was set up                                                  
  - Example: Claude Code: Nx plugin (MCP + skills + agents) + CLAUDE.md                                
                                                                                                       
  Claude .mcp.json cleanup:                                                                            
  - When configuring Claude, removes nx-mcp from .mcp.json since it's now handled by the plugin        
  - Deletes the file entirely if nx-mcp was the only entry                                             
                         