### PR TITLE
fix(core): prevent command injection in getNpmPackageVersion

### DIFF
--- a/packages/workspace/src/generators/utils/get-npm-package-version.ts
+++ b/packages/workspace/src/generators/utils/get-npm-package-version.ts
@@ -1,15 +1,29 @@
+// Valid npm package names: optional @scope/ prefix, then URL-safe chars (A-Za-z0-9 . - _ ~)
+// Must not start with . or _ per npm rules. Uppercase allowed for legacy packages.
+const validNpmPackageNameRegex =
+  /^(@[a-zA-Z0-9~-][a-zA-Z0-9._~-]*\/)?[a-zA-Z0-9~-][a-zA-Z0-9._~-]*$/;
+
 export function getNpmPackageVersion(
   packageName: string,
   packageVersion?: string
 ): string | null {
+  if (!validNpmPackageNameRegex.test(packageName)) {
+    throw new Error(
+      `Invalid npm package name: "${packageName}". Package names can only contain URL-safe characters (letters, digits, hyphens, dots, underscores, and tildes).`
+    );
+  }
+
   try {
-    const version = require('child_process').execSync(
-      `npm view ${packageName}${
-        packageVersion ? '@' + packageVersion : ''
-      } version --json`,
+    const packageSpec = packageVersion
+      ? `${packageName}@${packageVersion}`
+      : packageName;
+    // Use npm.cmd on Windows since execFileSync without a shell can't run .cmd files
+    const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+    const version = require('child_process').execFileSync(
+      npmBin,
+      ['view', packageSpec, 'version', '--json'],
       {
         stdio: ['pipe', 'pipe', 'ignore'],
-
         windowsHide: false,
       }
     );


### PR DESCRIPTION
## Current Behavior

The `getNpmPackageVersion` function in `packages/workspace/src/generators/utils/get-npm-package-version.ts` uses `execSync` with direct string interpolation of the `packageName` parameter. When a user runs `create-nx-workspace` with a custom `--preset` value that doesn't match a known preset, the value flows unsanitized into a shell command:

```js
execSync(`npm view ${packageName}... version --json`)
```

This allows arbitrary command execution via shell metacharacters (e.g., `--preset='pkg$(malicious command)'`).

## Expected Behavior

User-supplied package names are validated against a strict npm package name regex before being passed to any shell command. The function now uses `execFileSync` with an args array instead of `execSync` with string interpolation, providing defense in depth:

1. **Input validation** — rejects anything that isn't a valid npm package name
2. **Safe execution** — arguments are passed as an array so Node.js handles escaping, rather than concatenating into a raw shell string