### PR TITLE
feat(core): support dependency filesets with ^{projectRoot} syntax

### DIFF
--- a/astro-docs/src/content/docs/guides/Tasks & Caching/configure-inputs.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/configure-inputs.mdoc
@@ -443,6 +443,37 @@ With the above named inputs, Nx will behave in the following way:
 - When only test files are changed, Nx will restore previous compilation results from the cache and re-run the tests for the projects containing the test files
 - When any production files are changed, Nx will re-run the tests for the project as well as any projects which depend on it
 
+### Specifying Dependency File Patterns Directly
+
+Instead of defining a named input and referencing it with `^`, you can directly specify file patterns to consider from dependency projects using the `^{projectRoot}` syntax:
+
+```jsonc
+// nx.json
+{
+  "targetDefaults": {
+    "build": {
+      "inputs": [
+        "production",
+        "^{projectRoot}/src/**/*.ts", // Only consider .ts source files from dependencies
+      ],
+    },
+  },
+}
+```
+
+This is useful when you want fine-grained control over which files from dependencies affect a task's cache without creating a named input. For example, a `build` task might only need to consider `.ts` files from its dependencies rather than all production files.
+
+You can also use the object format with the `dependencies` property:
+
+```jsonc
+{
+  "inputs": [
+    "production",
+    { "fileset": "{projectRoot}/src/**/*.ts", "dependencies": true },
+  ],
+}
+```
+
 ### Consider the Version of a Language for all Tasks
 
 Many times, the version of the programming language being used will affect the behavior of all tasks for the workspace.

--- a/astro-docs/src/content/docs/reference/inputs.mdoc
+++ b/astro-docs/src/content/docs/reference/inputs.mdoc
@@ -64,7 +64,25 @@ Files listed in `.gitignore` are automatically excluded from inputs. Nx will not
 {% /aside %}
 
 Prefixing a source file input with `!` will exclude the files matching the pattern from the set of files used to calculate the hash.
-Prefixing a source file input with `^` means this entry applies to the project dependencies of the project, not the project itself.
+Prefixing a source file input with `^` means this entry applies to the project dependencies of the project, not the project itself. This allows you to specify exactly which files from dependency projects should be considered as inputs.
+
+```jsonc
+{
+  "inputs": [
+    "{projectRoot}/**/*.ts", // .ts files in the current project
+    "^{projectRoot}/**/*.ts", // .ts files in all dependency projects
+    "^{workspaceRoot}/tools/**/*", // workspace-level files, applied per dependency
+  ],
+}
+```
+
+You can also use the object format with the `dependencies` property to achieve the same result:
+
+```jsonc
+{
+  "inputs": [{ "fileset": "{projectRoot}/**/*.ts", "dependencies": true }],
+}
+```
 
 By default, Nx will use all files in a project as well as all files in the project's dependencies when computing a hash for tasks belonging to the project.
 This may cause Nx to rerun some tasks even when files irrelevant to the task have changed but it ensures that by default, Nx always re-runs the task when it should.
@@ -205,6 +223,16 @@ You can reference named inputs from specific projects or from project dependenci
 ```
 
 The `projects` property can be a string or an array of strings specifying which project(s) to reference the named input from. Using just the string name (e.g., `"production"`) is shorthand for referencing the named input from the current project. Prefixing with `^` (e.g., `"^production"`) references the named input from all project dependencies.
+
+{% aside type="note" title="^ with filesets vs named inputs" %}
+The `^` prefix behaves differently depending on what follows it:
+
+- `^{projectRoot}/**/*.ts` — treated as a **dependency fileset**, hashing matching files in each dependency project
+- `^{workspaceRoot}/tools/**/*` — treated as a **dependency fileset** with workspace-level files
+- `^production` — treated as a **named input reference**, resolving the `production` named input for each dependency project
+
+In short, if the value after `^` starts with `{projectRoot}` or `{workspaceRoot}`, it is a fileset applied to dependencies. Otherwise, it is interpreted as a named input reference.
+{% /aside %}
 
 ## Named Inputs
 

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -560,8 +560,13 @@
               "fileset": {
                 "type": "string",
                 "description": "A glob"
+              },
+              "dependencies": {
+                "type": "boolean",
+                "description": "Include files matching the fileset for all the project dependencies of this target."
               }
             },
+            "required": ["fileset"],
             "additionalProperties": false
           },
           {

--- a/packages/nx/schemas/project-schema.json
+++ b/packages/nx/schemas/project-schema.json
@@ -216,8 +216,13 @@
               "fileset": {
                 "type": "string",
                 "description": "A glob used to determine a fileset."
+              },
+              "dependencies": {
+                "type": "boolean",
+                "description": "Include files matching the fileset for all the project dependencies of this target."
               }
             },
+            "required": ["fileset"],
             "additionalProperties": false
           },
           {

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -208,6 +208,7 @@ export type InputDefinition =
   | { input: string; dependencies: true }
   | { input: string }
   | { fileset: string }
+  | { fileset: string; dependencies: true }
   | { runtime: string }
   | { externalDependencies: string[] }
   | { dependentTasksOutputFiles: string; transitive?: boolean }

--- a/packages/nx/src/hasher/task-hasher.spec.ts
+++ b/packages/nx/src/hasher/task-hasher.spec.ts
@@ -1,8 +1,193 @@
 // This must come before the Hasher import
 
-import { expandNamedInput, filterUsingGlobPatterns } from './task-hasher';
+import {
+  expandNamedInput,
+  filterUsingGlobPatterns,
+  splitInputsIntoSelfAndDependencies,
+} from './task-hasher';
 
 describe('TaskHasher', () => {
+  describe('splitInputsIntoSelfAndDependencies', () => {
+    it('should identify ^{projectRoot}/**/*.ts as a dependency fileset', () => {
+      const result = splitInputsIntoSelfAndDependencies(
+        ['^{projectRoot}/**/*.ts'],
+        {}
+      );
+      expect(result.depsFilesets).toEqual([
+        { fileset: '{projectRoot}/**/*.ts', dependencies: true },
+      ]);
+      expect(result.depsInputs).toEqual([]);
+      expect(result.selfInputs).toEqual([]);
+    });
+
+    it('should identify ^{workspaceRoot}/tools/**/* as a dependency fileset', () => {
+      const result = splitInputsIntoSelfAndDependencies(
+        ['^{workspaceRoot}/tools/**/*'],
+        {}
+      );
+      expect(result.depsFilesets).toEqual([
+        { fileset: '{workspaceRoot}/tools/**/*', dependencies: true },
+      ]);
+      expect(result.depsInputs).toEqual([]);
+      expect(result.selfInputs).toEqual([]);
+    });
+
+    it('should identify ^namedInput as a named input reference (regression test)', () => {
+      const result = splitInputsIntoSelfAndDependencies(['^production'], {
+        production: ['{projectRoot}/**/*.ts', '!{projectRoot}/**/*.spec.ts'],
+      });
+      expect(result.depsInputs).toEqual([
+        { input: 'production', dependencies: true },
+      ]);
+      expect(result.depsFilesets).toEqual([]);
+      expect(result.selfInputs).toEqual([]);
+    });
+
+    it('should handle { fileset: "...", dependencies: true } object form', () => {
+      const result = splitInputsIntoSelfAndDependencies(
+        [{ fileset: '{projectRoot}/**/*.ts', dependencies: true }],
+        {}
+      );
+      expect(result.depsFilesets).toEqual([
+        { fileset: '{projectRoot}/**/*.ts', dependencies: true },
+      ]);
+      expect(result.depsInputs).toEqual([]);
+      expect(result.selfInputs).toEqual([]);
+    });
+
+    it('should handle mixed inputs correctly', () => {
+      const result = splitInputsIntoSelfAndDependencies(
+        [
+          '{projectRoot}/**/*.ts', // self input
+          '^{projectRoot}/**/*.json', // dependency fileset
+          '^production', // dependency named input
+          { fileset: '{workspaceRoot}/config/*', dependencies: true }, // object form dependency fileset
+          { input: 'default', dependencies: true }, // object form dependency named input
+        ],
+        {
+          production: ['{projectRoot}/**/*.ts'],
+        }
+      );
+
+      expect(result.selfInputs).toEqual([{ fileset: '{projectRoot}/**/*.ts' }]);
+      expect(result.depsFilesets).toEqual([
+        { fileset: '{projectRoot}/**/*.json', dependencies: true },
+        { fileset: '{workspaceRoot}/config/*', dependencies: true },
+      ]);
+      expect(result.depsInputs).toEqual([
+        { input: 'production', dependencies: true },
+        { input: 'default', dependencies: true },
+      ]);
+    });
+
+    it('should not treat ^{projectRoot} filesets as named inputs', () => {
+      // Verify that ^{projectRoot}/**/*.ts is not expanded as if it were a named input
+      const result = splitInputsIntoSelfAndDependencies(
+        ['^{projectRoot}/**/*.ts'],
+        {
+          // Even if there's a named input that could theoretically match, it shouldn't be used
+          '{projectRoot}/**/*.ts': ['{projectRoot}/src/**/*.ts'],
+        }
+      );
+
+      // Should be a depsFileset, not expanded via namedInputs
+      expect(result.depsFilesets).toEqual([
+        { fileset: '{projectRoot}/**/*.ts', dependencies: true },
+      ]);
+      expect(result.selfInputs).toEqual([]);
+    });
+
+    it('should treat ^!{projectRoot} as a named input reference (not a dependency fileset)', () => {
+      // Note: Negated patterns like ^!{projectRoot}/**/*.spec.ts are currently
+      // treated as named input references because after stripping the ^,
+      // the rest (!{projectRoot}...) doesn't start with {projectRoot} or {workspaceRoot}
+      const result = splitInputsIntoSelfAndDependencies(
+        ['^!{projectRoot}/**/*.spec.ts'],
+        {}
+      );
+      // This is treated as a named input reference, not a dependency fileset
+      expect(result.depsInputs).toEqual([
+        { input: '!{projectRoot}/**/*.spec.ts', dependencies: true },
+      ]);
+      expect(result.depsFilesets).toEqual([]);
+      expect(result.selfInputs).toEqual([]);
+    });
+
+    it('should handle multiple dependency filesets in one inputs array', () => {
+      const result = splitInputsIntoSelfAndDependencies(
+        [
+          '^{projectRoot}/**/*.ts',
+          '^{projectRoot}/**/*.json',
+          '^{workspaceRoot}/shared/**/*',
+        ],
+        {}
+      );
+      expect(result.depsFilesets).toEqual([
+        { fileset: '{projectRoot}/**/*.ts', dependencies: true },
+        { fileset: '{projectRoot}/**/*.json', dependencies: true },
+        { fileset: '{workspaceRoot}/shared/**/*', dependencies: true },
+      ]);
+      expect(result.depsInputs).toEqual([]);
+      expect(result.selfInputs).toEqual([]);
+    });
+
+    it('should handle self and dependency filesets together', () => {
+      const result = splitInputsIntoSelfAndDependencies(
+        [
+          '{projectRoot}/**/*.ts', // self input
+          '^{projectRoot}/**/*.ts', // dependency fileset (same pattern but for deps)
+        ],
+        {}
+      );
+      expect(result.selfInputs).toEqual([{ fileset: '{projectRoot}/**/*.ts' }]);
+      expect(result.depsFilesets).toEqual([
+        { fileset: '{projectRoot}/**/*.ts', dependencies: true },
+      ]);
+      expect(result.depsInputs).toEqual([]);
+    });
+
+    it('should handle empty namedInputs (undefined equivalent)', () => {
+      const result = splitInputsIntoSelfAndDependencies(
+        ['{projectRoot}/**/*.ts', '^{projectRoot}/**/*.json'],
+        {}
+      );
+      expect(result.selfInputs).toEqual([{ fileset: '{projectRoot}/**/*.ts' }]);
+      expect(result.depsFilesets).toEqual([
+        { fileset: '{projectRoot}/**/*.json', dependencies: true },
+      ]);
+      expect(result.depsInputs).toEqual([]);
+    });
+
+    it('should treat { fileset: "..." } without dependencies as a self input', () => {
+      const result = splitInputsIntoSelfAndDependencies(
+        [{ fileset: '{projectRoot}/**/*.ts' }],
+        {}
+      );
+      // When dependencies is not specified, it should be treated as a self input
+      expect(result.selfInputs).toEqual([{ fileset: '{projectRoot}/**/*.ts' }]);
+      expect(result.depsFilesets).toEqual([]);
+      expect(result.depsInputs).toEqual([]);
+    });
+
+    it('should treat object form without dependencies property as a self input (not a dependency fileset)', () => {
+      // Verify that the object form { fileset: ... } without dependencies: true
+      // is NOT treated as a dependency fileset
+      const result = splitInputsIntoSelfAndDependencies(
+        [
+          { fileset: '{projectRoot}/**/*.ts' }, // no dependencies property
+          { fileset: '{projectRoot}/**/*.json', dependencies: true }, // explicit dependencies: true
+        ],
+        {}
+      );
+      // The first should be a self input, the second should be a deps fileset
+      expect(result.selfInputs).toEqual([{ fileset: '{projectRoot}/**/*.ts' }]);
+      expect(result.depsFilesets).toEqual([
+        { fileset: '{projectRoot}/**/*.json', dependencies: true },
+      ]);
+      expect(result.depsInputs).toEqual([]);
+    });
+  });
+
   describe('expandNamedInput', () => {
     it('should expand named inputs', () => {
       const expanded = expandNamedInput('c', {

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -261,6 +261,7 @@ export interface FileMap {
 
 export interface FileSetInput {
   fileset: string
+  dependencies?: boolean
 }
 
 export declare export declare function findImports(projectFileMap: Record<string, Array<string>>): Array<ImportResult>

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -358,7 +358,7 @@ impl HashPlanner {
         let (project_file_sets, workspace_file_sets): (Vec<&str>, Vec<&str>) = self_inputs
             .iter()
             .filter_map(|input| match input {
-                Input::FileSet(file_set) => Some(file_set),
+                Input::FileSet { fileset, .. } => Some(*fileset),
                 _ => None,
             })
             .partition(|file_set| {

--- a/packages/nx/src/native/tasks/inputs.rs
+++ b/packages/nx/src/native/tasks/inputs.rs
@@ -47,25 +47,49 @@ pub(super) fn get_inputs_for_dependency<'a>(
     nx_json: &'a NxJson,
     named_input: &'a Input,
 ) -> anyhow::Result<Option<SplitInputs<'a>>> {
-    let Input::Inputs { input, .. } = named_input else {
-        return Ok(None);
-    };
+    match named_input {
+        Input::Inputs { input, .. } => {
+            let inputs = get_named_inputs(nx_json, project);
+            let (self_inputs, deps_outputs): (Vec<Input>, Vec<Input>) =
+                expand_named_input(input, &inputs)?
+                    .into_iter()
+                    .partition(|i| !(matches!(i, Input::DepsOutputs { .. })));
+            let deps_inputs = vec![Input::Inputs {
+                input,
+                dependencies: true,
+            }];
 
-    let inputs = get_named_inputs(nx_json, project);
-    let (self_inputs, deps_outputs): (Vec<Input>, Vec<Input>) = expand_named_input(input, &inputs)?
-        .into_iter()
-        .partition(|i| !(matches!(i, Input::DepsOutputs { .. })));
-    let deps_inputs = vec![Input::Inputs {
-        input,
-        dependencies: true,
-    }];
+            Ok(Some(SplitInputs {
+                deps_outputs,
+                deps_inputs,
+                self_inputs,
+                project_inputs: vec![],
+            }))
+        }
+        Input::FileSet {
+            fileset,
+            dependencies: true,
+        } => {
+            // For dependency filesets, we apply the same fileset to the dependency
+            // and continue recursively with the same pattern
+            let self_inputs = vec![Input::FileSet {
+                fileset,
+                dependencies: false,
+            }];
+            let deps_inputs = vec![Input::FileSet {
+                fileset,
+                dependencies: true,
+            }];
 
-    Ok(Some(SplitInputs {
-        deps_outputs,
-        deps_inputs,
-        self_inputs,
-        project_inputs: vec![],
-    }))
+            Ok(Some(SplitInputs {
+                deps_outputs: vec![],
+                deps_inputs,
+                self_inputs,
+                project_inputs: vec![],
+            }))
+        }
+        _ => Ok(None),
+    }
 }
 
 fn split_inputs_into_self_and_deps<'a>(
@@ -74,7 +98,10 @@ fn split_inputs_into_self_and_deps<'a>(
 ) -> anyhow::Result<SplitInputs<'a>> {
     let inputs = inputs.unwrap_or_else(|| {
         vec![
-            Input::FileSet("{projectRoot}/**/*"),
+            Input::FileSet {
+                fileset: "{projectRoot}/**/*",
+                dependencies: false,
+            },
             Input::Inputs {
                 input: "default",
                 dependencies: true,
@@ -96,12 +123,18 @@ fn split_inputs_into_self_and_deps<'a>(
                 Input::Inputs {
                     dependencies: true, ..
                 } => acc.0.push(input),
+                Input::FileSet {
+                    dependencies: true, ..
+                } => acc.0.push(input),
                 Input::Inputs {
                     dependencies: false,
                     ..
                 }
                 | Input::String(_)
-                | Input::FileSet(_)
+                | Input::FileSet {
+                    dependencies: false,
+                    ..
+                }
                 | Input::Runtime(_)
                 | Input::Environment(_)
                 | Input::DepsOutputs { .. }
@@ -149,16 +182,25 @@ pub(super) fn expand_single_project_inputs<'a>(
                     expanded.extend(expand_named_input(s, named_inputs)?);
                 } else {
                     validate_file_set(s)?;
-                    expanded.push(Input::FileSet(s));
+                    expanded.push(Input::FileSet {
+                        fileset: s,
+                        dependencies: false,
+                    });
                 }
             }
             Input::Inputs {
                 input,
                 dependencies: false,
             } => expanded.extend(expand_named_input(input, named_inputs)?),
-            Input::FileSet(fileset) => {
+            Input::FileSet {
+                fileset,
+                dependencies: false,
+            } => {
                 validate_file_set(fileset)?;
-                expanded.push(Input::FileSet(fileset));
+                expanded.push(Input::FileSet {
+                    fileset,
+                    dependencies: false,
+                });
             }
             Input::Runtime(runtime) => expanded.push(Input::Runtime(runtime)),
             Input::Environment(env) => expanded.push(Input::Environment(env)),
@@ -175,6 +217,9 @@ pub(super) fn expand_single_project_inputs<'a>(
             Input::WorkingDirectory(mode) => expanded.push(Input::WorkingDirectory(mode)),
             Input::Projects { .. }
             | Input::Inputs {
+                dependencies: true, ..
+            }
+            | Input::FileSet {
                 dependencies: true, ..
             } => {
                 anyhow::bail!(
@@ -225,7 +270,13 @@ pub(super) fn get_named_inputs<'a>(
 ) -> HashMap<&'a str, Vec<Input<'a>>> {
     let mut collected_named_inputs: HashMap<&str, Vec<Input>> = HashMap::new();
 
-    collected_named_inputs.insert("default", vec![Input::FileSet("{projectRoot}/**/*")]);
+    collected_named_inputs.insert(
+        "default",
+        vec![Input::FileSet {
+            fileset: "{projectRoot}/**/*",
+            dependencies: false,
+        }],
+    );
 
     let iterable_structs = [&nx_json.named_inputs, &project.named_inputs];
     for named_inputs in iterable_structs.into_iter().flatten() {


### PR DESCRIPTION
## Current Behavior
`^` and `dependencies: true` only work for fileset inputs

## Expected Behavior
Adds support for inputs of the form `^{projectRoot}/**/*.ts` as syntactic sugar for specifying a fileset input that should be collected from dependency projects.

Previously, only named inputs could use the `^` prefix to include dependencies (e.g., `^production`). Now filesets can also use this syntax directly without needing to define a named input first.

Examples:
- `^{projectRoot}/**/*.ts` - include .ts files from all dependencies
- `^{workspaceRoot}/tools/**/*` - include workspace tools from dependencies
- `{ fileset: '{projectRoot}/**/*.ts', dependencies: true }` - object form

Detection is deterministic: if the string after `^` starts with `{projectRoot}` or `{workspaceRoot}`, it's treated as a dependency fileset; otherwise, it's treated as a named input reference.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
