### PR TITLE
chore(core): nx plugin submission @0zd0/nx-oxfmt

### DIFF
--- a/astro-docs/src/content/approved-community-plugins.json
+++ b/astro-docs/src/content/approved-community-plugins.json
@@ -548,5 +548,10 @@
     "name": "@berenddeboer/nx-biome",
     "description": "A self-inferring Nx plugin for using biome to format and lint projects. Supports --batch",
     "url": "https://github.com/berenddeboer/nx-plugins/tree/main/packages/nx-biome"
+  },
+  {
+    "name": "@0zd0/nx-oxfmt",
+    "description": "Nx plugin for oxfmt - the high-performance JavaScript/TypeScript formatter",
+    "url": "https://github.com/0zd0/nx-oxfmt"
   }
 ]


### PR DESCRIPTION
# Community Plugin Submission

## @0zd0/nx-oxfmt

The [plugin](https://github.com/0zd0/nx-oxfmt) provides integration with the new [Oxfmt](https://oxc.rs/docs/guide/usage/formatter.html) formatter in Rust, which replaces Prettier.

It consists of an `init` generator and an `fmt` executor with all parameters available to the CLI.
