### PR TITLE
fix(core): disable ignore filters for outputs expansion

### DIFF
--- a/packages/nx/src/native/cache/expand_outputs.rs
+++ b/packages/nx/src/native/cache/expand_outputs.rs
@@ -313,6 +313,20 @@ mod test {
     }
 
     #[test]
+    fn should_get_files_for_outputs_when_gitignore_hides_files() {
+        let temp = TempDir::new().unwrap();
+        temp.child("out/.gitignore").write_str("*").unwrap();
+        temp.child("out/visible.txt").write_str("content").unwrap();
+
+        let entries = vec!["out".to_string()];
+        let mut result = get_files_for_outputs(temp.display().to_string(), entries).unwrap();
+        result.sort();
+
+        assert!(result.contains(&"out/visible.txt".to_string()));
+        assert!(result.contains(&"out/.gitignore".to_string()));
+    }
+
+    #[test]
     #[ignore]
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     fn should_not_leak_threads() {

--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -191,6 +191,9 @@ where
         }
 
         walker.add_custom_ignore_filename(".nxignore");
+    } else {
+        // Don't filter out ignored files
+        walker.standard_filters(false);
     }
 
     // We should make sure to always ignore node_modules and the .git folder


### PR DESCRIPTION
## Current Behavior

When a task output directory contains a nested `.gitignore` that hides its contents, Nx can treat the outputs as already present and skip restoring them from cache. This can result in generated files being missing from disk, even though the cache entry is valid.

## Expected Behavior

Nx should restore cached outputs regardless of ignore rules inside the output directory.

## Related Issue(s)

Fixes #32620 
