### PR TITLE
docs(misc): filter out non-existing image requests and also only track HTML page views when requested with "Accept: text/html"

### DIFF
--- a/astro-docs/netlify/edge-functions/track-asset-requests.ts
+++ b/astro-docs/netlify/edge-functions/track-asset-requests.ts
@@ -102,6 +102,6 @@ export default async function handler(
 
 export const config = {
   path: ['/**/*.txt', '/**/*.md'],
-  // Something is adding .png.md to get image paths, exclude those.
-  excludedPath: ['/docs/og/*'],
+  // Something is adding .png.md and .svg.md to get image paths, exclude those.
+  excludedPath: ['/docs/og/*', '/docs/*.svg.md', '/docs/*.png.md'],
 };


### PR DESCRIPTION
We're getting requests to `favicon.svg.md` that are being tracked, ignore these. Also for the server page views, we should only count them if `text/html` is in the accept  header. Browsers will send these, and AI agents, curl, etc. do not. This allows us to compare browser traffic vs AI/curl traffic more accurately.