### PR TITLE
feat(maven): bump maven plugin version to 0.0.13

### DIFF
--- a/packages/maven/batch-runner-adapters/maven3/pom.xml
+++ b/packages/maven/batch-runner-adapters/maven3/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>batch-runner-adapters</artifactId>
-        <version>0.0.12</version>
+        <version>0.0.13</version>
     </parent>
 
     <artifactId>maven3-adapter</artifactId>

--- a/packages/maven/batch-runner-adapters/maven4/pom.xml
+++ b/packages/maven/batch-runner-adapters/maven4/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>batch-runner-adapters</artifactId>
-        <version>0.0.12</version>
+        <version>0.0.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/batch-runner-adapters/pom.xml
+++ b/packages/maven/batch-runner-adapters/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>nx-maven-parent</artifactId>
-        <version>0.0.12</version>
+        <version>0.0.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/batch-runner/pom.xml
+++ b/packages/maven/batch-runner/pom.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0          http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>nx-maven-parent</artifactId>
-        <version>0.0.12</version>
+        <version>0.0.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/maven-plugin/pom.xml
+++ b/packages/maven/maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.nx.maven</groupId>
     <artifactId>nx-maven-parent</artifactId>
-    <version>0.0.12</version>
+    <version>0.0.13</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/migrations.json
+++ b/packages/maven/migrations.json
@@ -30,6 +30,12 @@
       "version": "22.4.0-beta.0",
       "description": "Update Maven plugin version from 0.0.11 to 0.0.12 in pom.xml files",
       "factory": "./dist/migrations/0-0-12/update-pom-xml-version"
+    },
+    "update-0-0-13": {
+      "cli": "nx",
+      "version": "22.5.0-beta.5",
+      "description": "Update Maven plugin version from 0.0.12 to 0.0.13 in pom.xml files",
+      "factory": "./dist/migrations/0-0-13/update-pom-xml-version"
     }
   }
 }

--- a/packages/maven/migrations.json
+++ b/packages/maven/migrations.json
@@ -33,7 +33,7 @@
     },
     "update-0-0-13": {
       "cli": "nx",
-      "version": "22.5.0-beta.5",
+      "version": "22.5.0-beta.4",
       "description": "Update Maven plugin version from 0.0.12 to 0.0.13 in pom.xml files",
       "factory": "./dist/migrations/0-0-13/update-pom-xml-version"
     }

--- a/packages/maven/pom.xml
+++ b/packages/maven/pom.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0          http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>dev.nx.maven</groupId>
     <artifactId>nx-parent</artifactId>
-    <version>0.0.12</version>
+    <version>0.0.13</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/shared/pom.xml
+++ b/packages/maven/shared/pom.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0          http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>nx-maven-parent</artifactId>
-        <version>0.0.12</version>
+        <version>0.0.13</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/src/migrations/0-0-13/update-pom-xml-version.ts
+++ b/packages/maven/src/migrations/0-0-13/update-pom-xml-version.ts
@@ -1,0 +1,11 @@
+import { Tree } from '@nx/devkit';
+import { updateNxMavenPluginVersion } from '../../utils/pom-xml-updater';
+
+/**
+ * Migration for @nx/maven v0.0.13
+ * Updates the Maven plugin version to 0.0.13 in pom.xml files
+ */
+export default async function update(tree: Tree) {
+  // Update user pom.xml files
+  updateNxMavenPluginVersion(tree, '0.0.13');
+}

--- a/packages/maven/src/utils/versions.ts
+++ b/packages/maven/src/utils/versions.ts
@@ -1,2 +1,2 @@
 export const nxVersion = require('../../package.json').version;
-export const mavenPluginVersion = '0.0.12';
+export const mavenPluginVersion = '0.0.13';

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>dev.nx.maven</groupId>
   <artifactId>nx-parent</artifactId>
-  <version>0.0.12</version>
+  <version>0.0.13</version>
   <packaging>pom</packaging>
 
   <name>Nx Parent</name>

--- a/tools/workspace-plugin/src/generators/bump-maven-version/generator.spec.ts
+++ b/tools/workspace-plugin/src/generators/bump-maven-version/generator.spec.ts
@@ -58,6 +58,37 @@ describe('bump-maven-version generator', () => {
   <artifactId>maven-batch-runner</artifactId>
 </project>`;
 
+  const mockBatchRunnerAdaptersPomXml = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <parent>
+    <groupId>dev.nx.maven</groupId>
+    <artifactId>nx-maven-parent</artifactId>
+    <version>0.0.8</version>
+  </parent>
+  <artifactId>batch-runner-adapters</artifactId>
+  <packaging>pom</packaging>
+</project>`;
+
+  const mockMaven3AdapterPomXml = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <parent>
+    <groupId>dev.nx.maven</groupId>
+    <artifactId>batch-runner-adapters</artifactId>
+    <version>0.0.8</version>
+  </parent>
+  <artifactId>maven3-adapter</artifactId>
+</project>`;
+
+  const mockMaven4AdapterPomXml = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <parent>
+    <groupId>dev.nx.maven</groupId>
+    <artifactId>batch-runner-adapters</artifactId>
+    <version>0.0.8</version>
+  </parent>
+  <artifactId>maven4-adapter</artifactId>
+</project>`;
+
   const mockVersionsTs = `export const nxVersion = require('../../package.json').version;
 export const mavenPluginVersion = '0.0.8';`;
 
@@ -83,6 +114,18 @@ export const mavenPluginVersion = '0.0.8';`;
     tree.write('packages/maven/maven-plugin/pom.xml', mockMavenPluginPomXml);
     tree.write('packages/maven/shared/pom.xml', mockSharedPomXml);
     tree.write('packages/maven/batch-runner/pom.xml', mockBatchRunnerPomXml);
+    tree.write(
+      'packages/maven/batch-runner-adapters/pom.xml',
+      mockBatchRunnerAdaptersPomXml
+    );
+    tree.write(
+      'packages/maven/batch-runner-adapters/maven3/pom.xml',
+      mockMaven3AdapterPomXml
+    );
+    tree.write(
+      'packages/maven/batch-runner-adapters/maven4/pom.xml',
+      mockMaven4AdapterPomXml
+    );
     tree.write('packages/maven/src/utils/versions.ts', mockVersionsTs);
     tree.write(
       'packages/maven/migrations.json',

--- a/tools/workspace-plugin/src/generators/bump-maven-version/generator.ts
+++ b/tools/workspace-plugin/src/generators/bump-maven-version/generator.ts
@@ -150,6 +150,35 @@ export default async function runGenerator(
       false
     );
 
+    // 5b. Update batch-runner-adapters pom.xml files
+    logger.info('Updating packages/maven/batch-runner-adapters/pom.xml...');
+    updateXmlVersion(
+      tree,
+      'packages/maven/batch-runner-adapters/pom.xml',
+      newVersion,
+      false
+    );
+
+    logger.info(
+      'Updating packages/maven/batch-runner-adapters/maven3/pom.xml...'
+    );
+    updateXmlVersion(
+      tree,
+      'packages/maven/batch-runner-adapters/maven3/pom.xml',
+      newVersion,
+      false
+    );
+
+    logger.info(
+      'Updating packages/maven/batch-runner-adapters/maven4/pom.xml...'
+    );
+    updateXmlVersion(
+      tree,
+      'packages/maven/batch-runner-adapters/maven4/pom.xml',
+      newVersion,
+      false
+    );
+
     // 6. Update versions.ts
     logger.info('Updating packages/maven/src/utils/versions.ts...');
     const versionsFile = tree.read(


### PR DESCRIPTION
## Current Behavior

The Maven plugin version is `0.0.12` across all pom.xml files and the versions.ts constant. The `bump-maven-version` generator does not update the `batch-runner-adapters` pom files, causing version mismatches.

## Expected Behavior

The Maven plugin version is bumped to `0.0.13` in **all** pom.xml files (including batch-runner-adapters), with a migration created for users upgrading to Nx `22.5.0-beta.4`. The bump generator now includes the batch-runner-adapters pom files so future bumps won't miss them.

### Changes
- Updated version from `0.0.12` to `0.0.13` in all pom.xml files (root, maven, maven-plugin, shared, batch-runner, batch-runner-adapters, maven3-adapter, maven4-adapter)
- Updated `mavenPluginVersion` constant in `packages/maven/src/utils/versions.ts`
- Added `update-0-0-13` migration entry in `packages/maven/migrations.json` targeting Nx `22.5.0-beta.4`
- Created migration file `packages/maven/src/migrations/0-0-13/update-pom-xml-version.ts`
- Fixed `bump-maven-version` generator to include `batch-runner-adapters` pom files