### PR TITLE
fix(core): track all task outputs regardless of path depth

### DIFF
--- a/packages/nx/src/utils/collapse-expanded-outputs.spec.ts
+++ b/packages/nx/src/utils/collapse-expanded-outputs.spec.ts
@@ -101,4 +101,36 @@ describe('collapseExpandedOutputs', () => {
 
     expect(res).toEqual(['dist/apps/app1']);
   });
+
+  it('should preserve shallow paths when deep paths cause collapse', () => {
+    const outputs = [
+      'dist/libs/mylib/esm/src/file1.js',
+      'dist/libs/mylib/esm/src/file2.js',
+      'dist/libs/mylib/esm/src/file3.js',
+      'dist/libs/mylib/esm/src/file4.js',
+      'libs/mylib/src/generated.ts',
+    ];
+    const res = collapseExpandedOutputs(outputs);
+
+    expect(res).toContain('dist/libs/mylib/esm/src');
+    expect(res).toContain('libs/mylib/src/generated.ts');
+    expect(res).toHaveLength(2);
+  });
+
+  it('should preserve multiple shallow paths at different depths', () => {
+    const outputs = [
+      'dist/deep/nested/path/a.js',
+      'dist/deep/nested/path/b.js',
+      'dist/deep/nested/path/c.js',
+      'dist/deep/nested/path/d.js',
+      'shallow/file.txt',
+      'medium/depth/file.txt',
+    ];
+    const res = collapseExpandedOutputs(outputs);
+
+    expect(res).toContain('dist/deep/nested/path');
+    expect(res).toContain('shallow/file.txt');
+    expect(res).toContain('medium/depth/file.txt');
+    expect(res).toHaveLength(3);
+  });
 });

--- a/packages/nx/src/utils/collapse-expanded-outputs.ts
+++ b/packages/nx/src/utils/collapse-expanded-outputs.ts
@@ -5,7 +5,21 @@ import { dirname } from 'path';
  */
 const MAX_OUTPUTS_TO_CHECK_HASHES = 3;
 
+/**
+ * Collapses a list of file paths into a smaller set of parent directories
+ * when there are too many outputs to efficiently track individually.
+ *
+ * This prevents creating too many hash files by:
+ * 1. Building a tree structure of all path components
+ * 2. Finding the "collapse level" - the deepest level before exceeding MAX_OUTPUTS_TO_CHECK_HASHES
+ * 3. Returning parent paths at/above collapse level, while preserving leaf paths that terminate early
+ */
 export function collapseExpandedOutputs(expandedOutputs: string[]) {
+  // Small output sets don't need collapsing
+  if (expandedOutputs.length <= MAX_OUTPUTS_TO_CHECK_HASHES) {
+    return [...expandedOutputs];
+  }
+
   const tree: Set<string>[] = [];
 
   // Create a Tree of directories/files
@@ -25,21 +39,42 @@ export function collapseExpandedOutputs(expandedOutputs: string[]) {
     }
   }
 
-  // Find a level in the tree that has too many outputs
-  if (tree.length === 0) {
-    return [];
-  }
-
-  let j = 0;
-  let level = tree[j];
-  for (j = 0; j < tree.length; j++) {
-    level = tree[j];
-    if (level.size > MAX_OUTPUTS_TO_CHECK_HASHES) {
+  // Find collapse level: the level before the first level with too many outputs
+  let collapseLevel = tree.length - 1;
+  for (let j = 0; j < tree.length; j++) {
+    if (tree[j].size > MAX_OUTPUTS_TO_CHECK_HASHES) {
+      collapseLevel = Math.max(0, j - 1);
       break;
     }
   }
 
-  // Return the level before the level with too many outputs
-  // If the first level has too many outputs, return that one.
-  return Array.from(tree[Math.max(0, j - 1)]);
+  // Collect paths, preserving leaf paths that terminate before collapse level
+  const result = new Set<string>();
+
+  // Convert sets to arrays once for faster iteration
+  const levelArrays: string[][] = [];
+  for (let i = 0; i <= collapseLevel + 1 && i < tree.length; i++) {
+    levelArrays[i] = Array.from(tree[i]);
+  }
+
+  for (let level = 0; level <= collapseLevel; level++) {
+    const nextLevelArray = levelArrays[level + 1];
+    for (const path of levelArrays[level]) {
+      let hasChildren = false;
+      if (nextLevelArray) {
+        for (const child of nextLevelArray) {
+          if (child.startsWith(path + '/')) {
+            hasChildren = true;
+            break;
+          }
+        }
+      }
+      // Include path if it's at collapse level or doesn't have children (leaf)
+      if (level === collapseLevel || !hasChildren) {
+        result.add(path);
+      }
+    }
+  }
+
+  return Array.from(result);
 }


### PR DESCRIPTION
## Current Behavior

When a task has outputs at different path depths, some outputs may not be tracked. This causes:

- Deleted output files not being detected
- Cache restoration being skipped with message "existing outputs match the cache, left as is"
- Files not being restored even though they exist in cache

## Expected Behavior

All task outputs are tracked regardless of their path depth, ensuring:

- Deleted outputs are correctly detected
- Cache restoration happens when outputs are missing