### PR TITLE
fix(core): stabilizes project references in dependsOn and inputs when later plugins rename a project

### DIFF
--- a/e2e/nx/src/__snapshots__/extras.test.ts.snap
+++ b/e2e/nx/src/__snapshots__/extras.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Extra Nx Misc Tests task graph inputs should correctly expand default task inputs 1`] = `
 {
   "general": [
+    ".github/workflows/ci.yml",
     ".gitignore",
     "nx.json",
   ],

--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -1,5 +1,6 @@
 import { performance } from 'perf_hooks';
 
+import { join } from 'path';
 import { readNxJson } from '../config/nx-json';
 import { ProjectGraph } from '../config/project-graph';
 import {
@@ -8,7 +9,12 @@ import {
 } from '../config/workspace-json-project-json';
 import { daemonClient } from '../daemon/client/client';
 import { markDaemonAsDisabled, writeDaemonLogs } from '../daemon/tmp-dir';
+import { FileLock, IS_WASM } from '../native';
+import { workspaceDataDirectory } from '../utils/cache-directory';
+import { getCallSites } from '../utils/call-sites';
+import { DelayedSpinner } from '../utils/delayed-spinner';
 import { fileExists } from '../utils/fileutils';
+import { logger } from '../utils/logger';
 import { output } from '../utils/output';
 import { stripIndents } from '../utils/strip-indents';
 import { workspaceRoot } from '../utils/workspace-root';
@@ -29,18 +35,12 @@ import {
   readSourceMapsCache,
   writeCache,
 } from './nx-deps-cache';
+import { getPlugins } from './plugins/get-plugins';
 import { ConfigurationResult } from './utils/project-configuration-utils';
 import {
   retrieveProjectConfigurations,
   retrieveWorkspaceFiles,
 } from './utils/retrieve-workspace-files';
-import { getPlugins } from './plugins/get-plugins';
-import { logger } from '../utils/logger';
-import { FileLock, IS_WASM } from '../native';
-import { join } from 'path';
-import { workspaceDataDirectory } from '../utils/cache-directory';
-import { DelayedSpinner } from '../utils/delayed-spinner';
-import { getCallSites } from '../utils/call-sites';
 
 /**
  * Synchronously reads the latest cached copy of the workspace's ProjectGraph.

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -584,7 +584,18 @@ function mergeCreateNodesResults(
     // targets. Substitutors are keyed by the referenced name (not by root),
     // so registration requires no lookup and is safe regardless of whether
     // the referenced project has been processed yet.
-    projectNameManager.registerSubstitutorsForNodeResults(projectNodes);
+    try {
+      projectNameManager.registerSubstitutorsForNodeResults(projectNodes);
+    } catch (error) {
+      errors.push(
+        new MergeNodesError({
+          file,
+          pluginName,
+          error,
+          pluginIndex,
+        })
+      );
+    }
     Object.assign(externalNodes, pluginExternalNodes);
   }
 

--- a/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.spec.ts
@@ -1,0 +1,1020 @@
+import { ProjectConfiguration } from '../../../config/workspace-json-project-json';
+import { ProjectNameInNodePropsManager } from './name-substitution-manager';
+
+describe('ProjectNameInNodePropsManager', () => {
+  // ============== Helper Functions ==============
+
+  /**
+   * Helper to create a mock project configuration with common defaults.
+   * Uses 'any' to allow flexible test data without strict typing.
+   */
+  function createProject(
+    name: string,
+    root: string,
+    overrides: Record<string, any> = {}
+  ): Record<string, any> {
+    return {
+      name,
+      root,
+      ...overrides,
+    };
+  }
+
+  /**
+   * Helper to create a mock root map (projects keyed by root)
+   */
+  function createRootMap(
+    projects: Array<Record<string, any>>
+  ): Record<string, ProjectConfiguration> {
+    const map: Record<string, ProjectConfiguration> = {};
+    for (const project of projects) {
+      map[project.root] = { ...project } as ProjectConfiguration;
+    }
+    return map;
+  }
+
+  /**
+   * Helper to create a plugin result (projects keyed by root)
+   */
+  function createPluginResult(
+    projects: Array<Record<string, any>>
+  ): Record<string, any> {
+    const map: Record<string, any> = {};
+    for (const project of projects) {
+      map[project.root] = { ...project };
+    }
+    return map;
+  }
+
+  /**
+   * Helper to build a target with inputs that reference projects.
+   * Note: The InputDefinition type requires both 'input' and 'projects' properties.
+   */
+  function createTargetWithProjectInput(
+    projectsRef: string | string[]
+  ): Record<string, any> {
+    return {
+      inputs: [{ input: 'default', projects: projectsRef }],
+    };
+  }
+
+  /**
+   * Helper to build a target with dependsOn that reference projects
+   */
+  function createTargetWithDependsOn(
+    projectsRef: string | string[]
+  ): Record<string, any> {
+    return {
+      dependsOn: [{ target: 'build', projects: projectsRef }],
+    };
+  }
+
+  // ============== Basic Tests ==============
+
+  describe('basic functionality', () => {
+    it('should create an instance without errors', () => {
+      const manager = new ProjectNameInNodePropsManager();
+      expect(manager).toBeDefined();
+    });
+
+    it('should handle empty plugin results without errors', () => {
+      const manager = new ProjectNameInNodePropsManager();
+      manager.registerSubstitutorsForNodeResults({}, {});
+      manager.applySubstitutions({});
+      // No error should be thrown
+    });
+
+    it('should handle undefined plugin results', () => {
+      const manager = new ProjectNameInNodePropsManager();
+      manager.registerSubstitutorsForNodeResults(undefined, undefined);
+      // No error should be thrown
+    });
+  });
+
+  // ============== Input Projects Reference Tests ==============
+
+  describe('inputs with projects reference', () => {
+    it('should substitute a single project name in inputs.projects (string)', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      // Project A references project B by name in its inputs
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithProjectInput('project-b'),
+        },
+      });
+
+      const projectB = createProject('project-b', 'libs/b');
+
+      const pluginResultProjects = createPluginResult([projectA, projectB]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+
+      // Simulate project B's name being changed
+      manager.markDirty('libs/b');
+
+      const rootMap = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'project-b-renamed', root: 'libs/b' },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      // The input reference should now point to the new name
+      expect(projectA.targets.build.inputs[0].projects).toBe(
+        'project-b-renamed'
+      );
+    });
+
+    it('should substitute multiple project names in inputs.projects (array)', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      // Project A references projects B and C by name in its inputs
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithProjectInput(['project-b', 'project-c']),
+        },
+      });
+
+      const projectB = createProject('project-b', 'libs/b');
+      const projectC = createProject('project-c', 'libs/c');
+
+      const pluginResultProjects = createPluginResult([
+        projectA,
+        projectB,
+        projectC,
+      ]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+
+      // Simulate both projects being renamed
+      manager.markDirty('libs/b');
+      manager.markDirty('libs/c');
+
+      const rootMap = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'new-b', root: 'libs/b' },
+        { name: 'new-c', root: 'libs/c' },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      // Both references should be updated
+      const inputProjects = projectA.targets.build.inputs[0]
+        .projects as string[];
+      expect(inputProjects[0]).toBe('new-b');
+      expect(inputProjects[1]).toBe('new-c');
+    });
+
+    it('should not substitute "self" in inputs.projects', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithProjectInput('self'),
+        },
+      });
+
+      const pluginResultProjects = createPluginResult([projectA]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+
+      // Even if we mark this dirty, 'self' should not be substituted
+      manager.markDirty('libs/a');
+
+      const rootMap = createRootMap([
+        { name: 'renamed-a', root: 'libs/a', targets: projectA.targets },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      // 'self' should remain unchanged
+      expect(projectA.targets.build.inputs[0].projects).toBe('self');
+    });
+
+    it('should not substitute "dependencies" in inputs.projects', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithProjectInput('dependencies'),
+        },
+      });
+
+      const pluginResultProjects = createPluginResult([projectA]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+      manager.markDirty('libs/a');
+
+      const rootMap = createRootMap([
+        { name: 'renamed-a', root: 'libs/a', targets: projectA.targets },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      // 'dependencies' should remain unchanged
+      expect(projectA.targets.build.inputs[0].projects).toBe('dependencies');
+    });
+  });
+
+  // ============== DependsOn Projects Reference Tests ==============
+
+  describe('dependsOn with projects reference', () => {
+    it('should substitute a single project name in dependsOn.projects (string)', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithDependsOn('project-b'),
+        },
+      });
+
+      const projectB = createProject('project-b', 'libs/b');
+
+      const pluginResultProjects = createPluginResult([projectA, projectB]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+      manager.markDirty('libs/b');
+
+      const rootMap = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'project-b-renamed', root: 'libs/b' },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      expect(projectA.targets.build.dependsOn[0].projects).toBe(
+        'project-b-renamed'
+      );
+    });
+
+    it('should substitute multiple project names in dependsOn.projects (array)', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithDependsOn(['project-b', 'project-c']),
+        },
+      });
+
+      const projectB = createProject('project-b', 'libs/b');
+      const projectC = createProject('project-c', 'libs/c');
+
+      const pluginResultProjects = createPluginResult([
+        projectA,
+        projectB,
+        projectC,
+      ]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+      manager.markDirty('libs/b');
+      manager.markDirty('libs/c');
+
+      const rootMap = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'new-b', root: 'libs/b' },
+        { name: 'new-c', root: 'libs/c' },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      const dependsOnProjects = projectA.targets.build.dependsOn[0]
+        .projects as string[];
+      expect(dependsOnProjects[0]).toBe('new-b');
+      expect(dependsOnProjects[1]).toBe('new-c');
+    });
+
+    it('should not substitute "*" in dependsOn.projects', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithDependsOn('*'),
+        },
+      });
+
+      const pluginResultProjects = createPluginResult([projectA]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+      manager.markDirty('libs/a');
+
+      const rootMap = createRootMap([
+        { name: 'renamed-a', root: 'libs/a', targets: projectA.targets },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      expect(projectA.targets.build.dependsOn[0].projects).toBe('*');
+    });
+
+    it('should not substitute "self" in dependsOn.projects', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithDependsOn('self'),
+        },
+      });
+
+      const pluginResultProjects = createPluginResult([projectA]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+      manager.markDirty('libs/a');
+
+      const rootMap = createRootMap([
+        { name: 'renamed-a', root: 'libs/a', targets: projectA.targets },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      expect(projectA.targets.build.dependsOn[0].projects).toBe('self');
+    });
+
+    it('should not substitute "dependencies" in dependsOn.projects', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithDependsOn('dependencies'),
+        },
+      });
+
+      const pluginResultProjects = createPluginResult([projectA]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+      manager.markDirty('libs/a');
+
+      const rootMap = createRootMap([
+        { name: 'renamed-a', root: 'libs/a', targets: projectA.targets },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      expect(projectA.targets.build.dependsOn[0].projects).toBe('dependencies');
+    });
+
+    it('should not substitute glob patterns in dependsOn.projects array', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithDependsOn(['lib-*', 'project-b']),
+        },
+      });
+
+      const projectB = createProject('project-b', 'libs/b');
+
+      const pluginResultProjects = createPluginResult([projectA, projectB]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+      manager.markDirty('libs/b');
+
+      const rootMap = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'new-b', root: 'libs/b' },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      const dependsOnProjects = projectA.targets.build.dependsOn[0]
+        .projects as string[];
+      // Glob pattern should remain unchanged
+      expect(dependsOnProjects[0]).toBe('lib-*');
+      // Exact project name should be substituted
+      expect(dependsOnProjects[1]).toBe('new-b');
+    });
+  });
+
+  // ============== Multiple Plugin Calls Tests ==============
+
+  describe('multiple plugin calls', () => {
+    it('should handle registering substitutors from multiple plugin calls', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      // First plugin creates projects A and B, where A references B
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithProjectInput('project-b'),
+        },
+      });
+      const projectB = createProject('project-b', 'libs/b');
+
+      const firstPluginResult = createPluginResult([projectA, projectB]);
+
+      manager.registerSubstitutorsForNodeResults(firstPluginResult, {});
+
+      // Second plugin creates projects C and D, where C references D
+      const projectC = createProject('project-c', 'libs/c', {
+        targets: {
+          test: createTargetWithProjectInput('project-d'),
+        },
+      });
+      const projectD = createProject('project-d', 'libs/d');
+
+      const secondPluginResult = createPluginResult([projectC, projectD]);
+
+      manager.registerSubstitutorsForNodeResults(secondPluginResult, {});
+
+      // Mark both B and D as dirty
+      manager.markDirty('libs/b');
+      manager.markDirty('libs/d');
+
+      const rootMap = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'renamed-b', root: 'libs/b' },
+        { name: 'project-c', root: 'libs/c', targets: projectC.targets },
+        { name: 'renamed-d', root: 'libs/d' },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      // Both references should be updated
+      expect(projectA.targets.build.inputs[0].projects).toBe('renamed-b');
+      expect(projectC.targets.test.inputs[0].projects).toBe('renamed-d');
+    });
+
+    it('should handle cross-plugin references through merged configurations', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      // First plugin creates project B
+      const projectB = createProject('project-b', 'libs/b');
+      const firstPluginResult = createPluginResult([projectB]);
+      manager.registerSubstitutorsForNodeResults(firstPluginResult, {});
+
+      // Merged configurations now contain project B
+      const mergedConfigurations = createRootMap([
+        { name: 'project-b', root: 'libs/b' },
+      ]);
+
+      // Second plugin creates project A that references B (which is in merged configs)
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithProjectInput('project-b'),
+        },
+      });
+      const secondPluginResult = createPluginResult([projectA]);
+
+      manager.registerSubstitutorsForNodeResults(
+        secondPluginResult,
+        mergedConfigurations
+      );
+
+      // Mark B as dirty
+      manager.markDirty('libs/b');
+
+      const rootMap = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'renamed-b', root: 'libs/b' },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      expect(projectA.targets.build.inputs[0].projects).toBe('renamed-b');
+    });
+
+    it('should handle sequential registrations with overlapping projects', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      // Both plugins reference the same project
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithProjectInput('shared-lib'),
+        },
+      });
+
+      const projectB = createProject('project-b', 'libs/b', {
+        targets: {
+          test: createTargetWithDependsOn('shared-lib'),
+        },
+      });
+
+      const sharedLib = createProject('shared-lib', 'libs/shared');
+
+      // First call
+      const firstResult = createPluginResult([projectA, sharedLib]);
+      manager.registerSubstitutorsForNodeResults(firstResult, {});
+
+      // Merged configurations now contain shared-lib
+      const mergedAfterFirst = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'shared-lib', root: 'libs/shared' },
+      ]);
+
+      // Second call
+      const secondResult = createPluginResult([projectB]);
+      manager.registerSubstitutorsForNodeResults(
+        secondResult,
+        mergedAfterFirst
+      );
+
+      // Rename shared-lib
+      manager.markDirty('libs/shared');
+
+      const rootMap = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'project-b', root: 'libs/b', targets: projectB.targets },
+        { name: 'renamed-shared', root: 'libs/shared' },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      // Both references should be updated
+      expect(projectA.targets.build.inputs[0].projects).toBe('renamed-shared');
+      expect(projectB.targets.test.dependsOn[0].projects).toBe(
+        'renamed-shared'
+      );
+    });
+  });
+
+  // ============== Complex Scenarios ==============
+
+  describe('complex scenarios', () => {
+    it('should handle multiple targets with various reference types', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: {
+            inputs: [
+              { input: 'default', projects: 'project-b' },
+              { input: 'default', projects: ['project-c', 'project-d'] },
+            ],
+            dependsOn: [
+              { target: 'build', projects: 'project-b' },
+              { target: 'compile', projects: ['project-c', 'project-d'] },
+            ],
+          },
+          test: createTargetWithProjectInput('project-b'),
+          lint: createTargetWithDependsOn('project-c'),
+        },
+      });
+
+      const projectB = createProject('project-b', 'libs/b');
+      const projectC = createProject('project-c', 'libs/c');
+      const projectD = createProject('project-d', 'libs/d');
+
+      const pluginResultProjects = createPluginResult([
+        projectA,
+        projectB,
+        projectC,
+        projectD,
+      ]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+
+      // Rename all referenced projects
+      manager.markDirty('libs/b');
+      manager.markDirty('libs/c');
+      manager.markDirty('libs/d');
+
+      const rootMap = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'new-b', root: 'libs/b' },
+        { name: 'new-c', root: 'libs/c' },
+        { name: 'new-d', root: 'libs/d' },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      // Verify all substitutions
+      expect(projectA.targets.build.inputs[0].projects).toBe('new-b');
+      expect((projectA.targets.build.inputs[1].projects as string[])[0]).toBe(
+        'new-c'
+      );
+      expect((projectA.targets.build.inputs[1].projects as string[])[1]).toBe(
+        'new-d'
+      );
+      expect(projectA.targets.build.dependsOn[0].projects).toBe('new-b');
+      expect(
+        (projectA.targets.build.dependsOn[1].projects as string[])[0]
+      ).toBe('new-c');
+      expect(
+        (projectA.targets.build.dependsOn[1].projects as string[])[1]
+      ).toBe('new-d');
+      expect(projectA.targets.test.inputs[0].projects).toBe('new-b');
+      expect(projectA.targets.lint.dependsOn[0].projects).toBe('new-c');
+    });
+
+    it('should handle a project being renamed multiple times in sequence', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithProjectInput('project-b'),
+        },
+      });
+
+      const projectB = createProject('project-b', 'libs/b');
+
+      const pluginResultProjects = createPluginResult([projectA, projectB]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+
+      // First rename
+      manager.markDirty('libs/b');
+      const rootMap1 = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'first-rename', root: 'libs/b' },
+      ]);
+      manager.applySubstitutions(rootMap1);
+      expect(projectA.targets.build.inputs[0].projects).toBe('first-rename');
+
+      // Second rename (mark dirty again and apply with new name)
+      manager.markDirty('libs/b');
+      const rootMap2 = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'second-rename', root: 'libs/b' },
+      ]);
+      manager.applySubstitutions(rootMap2);
+      expect(projectA.targets.build.inputs[0].projects).toBe('second-rename');
+    });
+
+    it('should handle circular references (A -> B -> A)', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithProjectInput('project-b'),
+        },
+      });
+
+      const projectB = createProject('project-b', 'libs/b', {
+        targets: {
+          build: createTargetWithProjectInput('project-a'),
+        },
+      });
+
+      const pluginResultProjects = createPluginResult([projectA, projectB]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+
+      // Rename both projects
+      manager.markDirty('libs/a');
+      manager.markDirty('libs/b');
+
+      const rootMap = createRootMap([
+        { name: 'renamed-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'renamed-b', root: 'libs/b', targets: projectB.targets },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      // Both references should be updated
+      expect(projectA.targets.build.inputs[0].projects).toBe('renamed-b');
+      expect(projectB.targets.build.inputs[0].projects).toBe('renamed-a');
+    });
+
+    it('should handle large number of projects and references', () => {
+      const manager = new ProjectNameInNodePropsManager();
+      const projectCount = 50;
+      const projects: any[] = [];
+      const rootMap = createRootMap([]);
+
+      // Create many projects where each references the next
+      for (let i = 0; i < projectCount; i++) {
+        const nextIndex = (i + 1) % projectCount;
+        projects.push(
+          createProject(`project-${i}`, `libs/project-${i}`, {
+            targets: {
+              build: createTargetWithProjectInput(`project-${nextIndex}`),
+            },
+          })
+        );
+      }
+
+      const pluginResultProjects = createPluginResult(projects);
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+
+      // Mark all as dirty
+      for (let i = 0; i < projectCount; i++) {
+        manager.markDirty(`libs/project-${i}`);
+        rootMap[`libs/project-${i}`] = {
+          name: `renamed-${i}`,
+          root: `libs/project-${i}`,
+          targets: projects[i].targets,
+        };
+      }
+
+      manager.applySubstitutions(rootMap);
+
+      // Verify all substitutions
+      for (let i = 0; i < projectCount; i++) {
+        const nextIndex = (i + 1) % projectCount;
+        expect(projects[i].targets.build.inputs[0].projects).toBe(
+          `renamed-${nextIndex}`
+        );
+      }
+    });
+
+    it('should only substitute dirty roots', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithProjectInput('project-b'),
+          test: createTargetWithProjectInput('project-c'),
+        },
+      });
+
+      const projectB = createProject('project-b', 'libs/b');
+      const projectC = createProject('project-c', 'libs/c');
+
+      const pluginResultProjects = createPluginResult([
+        projectA,
+        projectB,
+        projectC,
+      ]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+
+      // Only mark B as dirty
+      manager.markDirty('libs/b');
+
+      const rootMap = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'renamed-b', root: 'libs/b' },
+        { name: 'renamed-c', root: 'libs/c' }, // C is renamed but not marked dirty
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      // B reference should be updated
+      expect(projectA.targets.build.inputs[0].projects).toBe('renamed-b');
+      // C reference should still have the original name (not marked dirty)
+      expect(projectA.targets.test.inputs[0].projects).toBe('project-c');
+    });
+  });
+
+  // ============== Edge Cases ==============
+
+  describe('edge cases', () => {
+    it('should handle projects without targets', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a');
+      const pluginResultProjects = createPluginResult([projectA]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+      manager.markDirty('libs/a');
+
+      const rootMap = createRootMap([{ name: 'renamed-a', root: 'libs/a' }]);
+
+      // Should not throw
+      manager.applySubstitutions(rootMap);
+    });
+
+    it('should handle targets without inputs or dependsOn', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: {
+            executor: 'nx:run-commands',
+            options: { command: 'echo hello' },
+          },
+        },
+      });
+
+      const pluginResultProjects = createPluginResult([projectA]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+      manager.markDirty('libs/a');
+
+      const rootMap = createRootMap([
+        { name: 'renamed-a', root: 'libs/a', targets: projectA.targets },
+      ]);
+
+      // Should not throw
+      manager.applySubstitutions(rootMap);
+    });
+
+    it('should handle inputs with non-projects entries', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: {
+            inputs: [
+              'default',
+              '{workspaceRoot}/.eslintrc.json',
+              { externalDependencies: ['eslint'] },
+              { input: 'default', projects: 'project-b' }, // Only this should be processed
+            ],
+          },
+        },
+      });
+
+      const projectB = createProject('project-b', 'libs/b');
+
+      const pluginResultProjects = createPluginResult([projectA, projectB]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+      manager.markDirty('libs/b');
+
+      const rootMap = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'renamed-b', root: 'libs/b' },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      // Only the projects reference should be updated
+      expect(projectA.targets.build.inputs[0]).toBe('default');
+      expect(projectA.targets.build.inputs[1]).toBe(
+        '{workspaceRoot}/.eslintrc.json'
+      );
+      expect(projectA.targets.build.inputs[2]).toEqual({
+        externalDependencies: ['eslint'],
+      });
+      expect(projectA.targets.build.inputs[3].projects).toBe('renamed-b');
+    });
+
+    it('should handle dependsOn with non-object entries', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: {
+            dependsOn: [
+              '^build', // String entry, not an object
+              { target: 'compile', projects: 'project-b' }, // Object entry
+            ],
+          },
+        },
+      });
+
+      const projectB = createProject('project-b', 'libs/b');
+
+      const pluginResultProjects = createPluginResult([projectA, projectB]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+      manager.markDirty('libs/b');
+
+      const rootMap = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'renamed-b', root: 'libs/b' },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      // String entry should remain unchanged
+      expect(projectA.targets.build.dependsOn[0]).toBe('^build');
+      // Object entry should have project substituted
+      expect(projectA.targets.build.dependsOn[1].projects).toBe('renamed-b');
+    });
+
+    it('should handle dependsOn without projects property', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: {
+            dependsOn: [
+              { target: 'build' }, // No projects property
+            ],
+          },
+        },
+      });
+
+      const pluginResultProjects = createPluginResult([projectA]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+      manager.markDirty('libs/a');
+
+      const rootMap = createRootMap([
+        { name: 'renamed-a', root: 'libs/a', targets: projectA.targets },
+      ]);
+
+      // Should not throw
+      manager.applySubstitutions(rootMap);
+      expect(projectA.targets.build.dependsOn[0].projects).toBeUndefined();
+    });
+
+    it('should handle referencing a non-existent project', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithProjectInput('non-existent'),
+        },
+      });
+
+      const pluginResultProjects = createPluginResult([projectA]);
+
+      // This should not throw, since the referenced project doesn't exist
+      // No substitutor will be registered for it
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+
+      const rootMap = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      // The reference should remain unchanged since no substitutor was registered
+      expect(projectA.targets.build.inputs[0].projects).toBe('non-existent');
+    });
+
+    it('should handle empty arrays in projects references', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: {
+            inputs: [{ input: 'default', projects: [] }],
+            dependsOn: [{ target: 'build', projects: [] }],
+          },
+        },
+      });
+
+      const pluginResultProjects = createPluginResult([projectA]);
+
+      manager.registerSubstitutorsForNodeResults(pluginResultProjects, {});
+      manager.markDirty('libs/a');
+
+      const rootMap = createRootMap([
+        { name: 'renamed-a', root: 'libs/a', targets: projectA.targets },
+      ]);
+
+      // Should not throw
+      manager.applySubstitutions(rootMap);
+    });
+  });
+
+  // ============== Integration with Merged Configurations ==============
+
+  describe('integration with merged configurations', () => {
+    it('should find projects in merged configurations when not in plugin result', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      // Project A references project B, but B is not in this plugin's result
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithProjectInput('existing-project'),
+        },
+      });
+
+      const pluginResultProjects = createPluginResult([projectA]);
+
+      // B exists in the merged configurations from previous plugins
+      const mergedConfigurations = createRootMap([
+        { name: 'existing-project', root: 'libs/existing' },
+      ]);
+
+      manager.registerSubstitutorsForNodeResults(
+        pluginResultProjects,
+        mergedConfigurations
+      );
+      manager.markDirty('libs/existing');
+
+      const rootMap = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'renamed-existing', root: 'libs/existing' },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      expect(projectA.targets.build.inputs[0].projects).toBe(
+        'renamed-existing'
+      );
+    });
+
+    it('should prefer plugin result over merged configurations', () => {
+      const manager = new ProjectNameInNodePropsManager();
+
+      // Project A references project B which exists in both plugin result and merged configs
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          build: createTargetWithProjectInput('project-b'),
+        },
+      });
+
+      // B in plugin result (at libs/b-new)
+      const projectBNew = createProject('project-b', 'libs/b-new');
+
+      const pluginResultProjects = createPluginResult([projectA, projectBNew]);
+
+      // B in merged configurations (at libs/b-old) - this should be ignored
+      const mergedConfigurations = createRootMap([
+        { name: 'project-b', root: 'libs/b-old' },
+      ]);
+
+      manager.registerSubstitutorsForNodeResults(
+        pluginResultProjects,
+        mergedConfigurations
+      );
+      manager.markDirty('libs/b-new');
+
+      const rootMap = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'renamed-b', root: 'libs/b-new' },
+        { name: 'project-b', root: 'libs/b-old' },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      // Should use the new location since it was found first in plugin result
+      expect(projectA.targets.build.inputs[0].projects).toBe('renamed-b');
+    });
+  });
+});

--- a/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.ts
@@ -1,169 +1,387 @@
 import { ProjectConfiguration } from '../../../config/workspace-json-project-json';
 import { isGlobPattern } from '../../../utils/globs';
 
-type ProjectNameSubstitutor<T = unknown> = (name: string) => void;
+// A substitutor receives the final resolved name of the project whose root
+// was marked dirty (i.e. the project that was renamed), and the final merged
+// configuration of the project that *holds the stale reference* so it can
+// update the appropriate field in-place.
+type ProjectNameSubstitutor = (
+  finalName: string,
+  ownerProjectConfig: ProjectConfiguration
+) => void;
+
+// Pairs a substitutor with the root of the project whose configuration it
+// will update. Stored together so applySubstitutions can look up
+// rootMap[ownerRoot] without passing the full map into each substitutor.
+type SubstitutorEntry = {
+  ownerRoot: string;
+  substitutor: ProjectNameSubstitutor;
+};
 
 /**
- * The idea here is:
- * - When we are recieving node results from createNodes,
- *   some node `A` may contain `dependsOn` or `inputs` blocks
- *   that reference a project (B) by name that was created by the
- *   same plugin.
- * - A later plugin may change the project name of `B` to `C`
- * - After the graph is built, this would leave `A` with a reference
- *   to project `B`, which no longer exists.
+ * Manages deferred project name substitutions across the plugin result
+ * merge phase of project graph construction.
  *
+ * ### Why this exists
  *
+ * When plugins return `createNodes` results, a node `A` may declare a
+ * `dependsOn` or `inputs` entry that references another project `B` by
+ * name. A *later* plugin is allowed to rename project `B` to `C`. After
+ * all plugin results are merged into the root map, node `A` would still
+ * hold a stale reference to the now-nonexistent name `B`.
+ *
+ * This class solves that by:
+ * 1. Scanning each plugin's results for project-name references in
+ *    `inputs` and `dependsOn` ({@link registerSubstitutorsForNodeResults}).
+ * 2. Recording a "substitutor" closure for each such reference, keyed by
+ *    the root directory of the referenced project.
+ * 3. When a project's name changes during the merge, marking that root as
+ *    dirty ({@link markDirty}).
+ * 4. After all results are merged, applying the substitutors for every
+ *    dirty root so that references are updated to the final name
+ *    ({@link applySubstitutions}).
  */
 export class ProjectNameInNodePropsManager {
-  private projectNameSubstitutors = new Map<string, ProjectNameSubstitutor[]>();
+  // Maps root directory -> set of substitutor entries that should run when
+  // the project at that root is renamed. Using a Set allows O(1) removal
+  // when a source-map key is overwritten by a later plugin registration.
+  private projectNameSubstitutors = new Map<string, Set<SubstitutorEntry>>();
+
+  // Tracks substitutor entries by (array path, index). This serves two purposes:
+  //
+  // 1. Per-index deduplication: if the same array index is registered again
+  //    (e.g. two plugin results contribute to the same position), the old
+  //    substitutor is evicted before the new one is added.
+  //
+  // 2. Tail-clearing: when a later plugin provides a shorter array at the
+  //    same path, splice removes all tail entries in one call without
+  //    needing to iterate from fromIndex to the end.
+  //
+  // Outer key: array path (e.g. "targets.build.inputs")
+  // Inner array: indexed by position; entries may be undefined for positions
+  //   that have no project-name reference (skipped during registration).
+  private substitutorsByArrayKey = new Map<
+    string,
+    Array<{ referencedRoot: string; entry: SubstitutorEntry } | undefined>
+  >();
+
+  // Roots whose project name changed during the merge phase. Only these
+  // roots need their substitutors executed in applySubstitutions.
   private dirtyRoots = new Set<string>();
 
-  constructor() {}
+  // Removes the substitutor registered at the given index of an array, if any.
+  // Used when re-registering for the same index (same position overwritten by
+  // a later plugin).
+  private clearSubstitutorAtIndex(arrayKey: string, index: number) {
+    const byIndex = this.substitutorsByArrayKey.get(arrayKey);
+    const existing = byIndex?.[index];
+    if (existing) {
+      this.projectNameSubstitutors
+        .get(existing.referencedRoot)
+        ?.delete(existing.entry);
+      byIndex[index] = undefined;
+    }
+  }
 
+  // Removes all substitutors at indices >= `fromIndex` for the given array
+  // path. Uses splice so the tail is dropped in one operation rather than
+  // iterating over each index individually.
+  private clearSubstitutorsFromIndex(arrayKey: string, fromIndex: number) {
+    const byIndex = this.substitutorsByArrayKey.get(arrayKey);
+    if (!byIndex) {
+      return;
+    }
+    const removed = byIndex.splice(fromIndex);
+    for (const item of removed) {
+      if (item) {
+        this.projectNameSubstitutors
+          .get(item.referencedRoot)
+          ?.delete(item.entry);
+      }
+    }
+  }
+
+  // Registers a new substitutor for the project at `referencedRoot`, tracked
+  // at (arrayKey, index) so it can be individually replaced or bulk-evicted
+  // when the array shrinks.
   private registerProjectNameSubstitutor(
-    root: string,
+    referencedRoot: string,
+    ownerRoot: string,
+    arrayKey: string,
+    index: number,
     substitutor: ProjectNameSubstitutor
   ) {
-    let subs = this.projectNameSubstitutors.get(root);
-    if (!subs) {
-      subs = [];
-      this.projectNameSubstitutors.set(root, subs);
+    // Evict any existing substitutor at this exact position first.
+    this.clearSubstitutorAtIndex(arrayKey, index);
+
+    let substitutorsForRoot = this.projectNameSubstitutors.get(referencedRoot);
+    if (!substitutorsForRoot) {
+      substitutorsForRoot = new Set();
+      this.projectNameSubstitutors.set(referencedRoot, substitutorsForRoot);
     }
-    subs.push(substitutor);
+
+    const entry: SubstitutorEntry = { ownerRoot, substitutor };
+    substitutorsForRoot.add(entry);
+
+    let byIndex = this.substitutorsByArrayKey.get(arrayKey);
+    if (!byIndex) {
+      byIndex = [];
+      this.substitutorsByArrayKey.set(arrayKey, byIndex);
+    }
+    byIndex[index] = { referencedRoot, entry };
   }
 
   /**
-   * Checks if results from a plugin may require substitutors given the known nodes.
+   * Scans `pluginResultProjects` for `inputs` and `dependsOn` entries that
+   * reference another project by name, and registers substitutors so those
+   * references are updated if the target project is later renamed.
    *
-   * PERF IMPACT:
-   *   - Loops through each result from the given plugin, and its targets
-   *   - If no targets have dependencies or inputs on another project's config,
-   *     that's it.
-   *   - If a target has a dependency or input that references another project name
-   *     - There's a minimal overhead to register + apply the substitutions
-   *     - If that projects from another plugin result, theres a larger impact
-   *       as we need to actually compute the name lookup table
+   * ### Performance notes
+   * - Iterates every target in every project result from the current plugin.
+   * - Builds a lazy name→project lookup of `mergedRootMap` only if an
+   *   inter-plugin reference is found (avoids the cost when unnecessary).
+   * - The actual substitutions are deferred until {@link applySubstitutions}.
    *
-   * @param pluginResultProjects The results from a single plugin
-   * @param mergedConfigurations The currently accumulated root map
+   * @param pluginResultProjects Projects from a single plugin's createNodes call.
+   * @param mergedRootMap The accumulated root map from all prior plugin results.
    */
   registerSubstitutorsForNodeResults(
     pluginResultProjects?: Record<
       string,
       Omit<ProjectConfiguration, 'root'> & Partial<ProjectConfiguration>
     >,
-    mergedConfigurations?: Record<string, ProjectConfiguration>
+    mergedRootMap?: Record<string, ProjectConfiguration>
   ) {
+    if (!pluginResultProjects) {
+      return;
+    }
+
+    // nameMap first checks the current plugin's own results (fast path for
+    // intra-plugin references), then falls back to the previously-merged
+    // results from earlier plugins (lazy to avoid unnecessary computation).
     const nameMap = new AggregateMap(
       rootMapToNameMap(pluginResultProjects),
-      new LazyMap(() => rootMapToNameMap(mergedConfigurations))
+      // to be clear, we use this so that if the current plugin
+      // only references projects that are defined by iteself,
+      // we don't need to build the name map for the merged root map at all
+      new LazyMap(() => rootMapToNameMap(mergedRootMap))
     );
 
-    for (const root in pluginResultProjects) {
-      const project = pluginResultProjects[root];
-
-      if (project.targets) {
-        for (const target in project.targets) {
-          const config = project.targets[target];
-          if (config.inputs) {
-            for (const input of config.inputs) {
-              if (typeof input === 'object' && 'projects' in input) {
-                const projects = input['projects'];
-                // This could be `self`, `dependencies`, or a project name
-                if (typeof projects === 'string') {
-                  if (projects === 'self' || projects === 'dependencies') {
-                    // This is a legacy syntax, but it **doesnt** reference
-                    // a project name, so we don't need to worry about it here
-                  } else {
-                    const project = nameMap.get(projects);
-                    if (project) {
-                      this.registerProjectNameSubstitutor(
-                        project.root,
-                        (name) => {
-                          input.projects = name;
-                        }
-                      );
-                    }
-                  }
-                } else {
-                  // this is an array of project names
-                  for (let i = 0; i < projects.length; i++) {
-                    const projectName = projects[i];
-                    const project = nameMap.get(projectName);
-                    if (project) {
-                      this.registerProjectNameSubstitutor(
-                        project.root,
-                        (name) => {
-                          projects[i] = name;
-                        }
-                      );
-                    }
-                  }
-                }
-              }
-            }
-          }
-
-          if (config.dependsOn) {
-            for (const dep of config.dependsOn) {
-              if (typeof dep === 'object' && dep.projects) {
-                const projects = dep.projects;
-                if (typeof projects === 'string') {
-                  if (!['*', 'self', 'dependencies'].includes(projects)) {
-                    const project = nameMap.get(projects);
-                    if (project) {
-                      this.registerProjectNameSubstitutor(
-                        project.root,
-                        (name) => {
-                          dep.projects = name;
-                        }
-                      );
-                    }
-                  }
-                } else {
-                  // array of project names or glob patterns?
-                  // ...to be totally correct here, we'd need to use
-                  // find matching projects... But that seems overkill
-                  // and likely to be perf sensitive. Lets assume these are full
-                  // names.
-                  for (let i = 0; i < dep.projects.length; i++) {
-                    const projectName = dep.projects[i];
-                    if (!isGlobPattern(projectName)) {
-                      const project = nameMap.get(projectName);
-                      if (project) {
-                        this.registerProjectNameSubstitutor(
-                          project.root,
-                          (name) => {
-                            projects[i] = name;
-                          }
-                        );
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+    for (const ownerRoot in pluginResultProjects) {
+      const project = pluginResultProjects[ownerRoot];
+      if (!project.targets) {
+        continue;
+      }
+      for (const targetName in project.targets) {
+        const targetConfig = project.targets[targetName];
+        if (targetConfig.inputs) {
+          this.registerSubstitutorsForInputs(
+            ownerRoot,
+            targetName,
+            targetConfig.inputs,
+            nameMap
+          );
+        }
+        if (targetConfig.dependsOn) {
+          this.registerSubstitutorsForDependsOn(
+            ownerRoot,
+            targetName,
+            targetConfig.dependsOn,
+            nameMap
+          );
         }
       }
     }
   }
 
-  markDirty(root: string) {
-    // It can't be dirty yet if there's no substitutors pointing at it
-    if (this.projectNameSubstitutors.has(root)) {
-      this.dirtyRoots.add(root);
+  // Registers substitutors for any project-name references found inside a
+  // target's `inputs` array. Substitutors are registered against the root of
+  // the *referenced* project, so they fire when that project is renamed.
+  // The substitutor closes over `ownerRoot` and the array index so it can
+  // navigate to the correct property in the final merged config.
+  private registerSubstitutorsForInputs(
+    ownerRoot: string,
+    targetName: string,
+    inputs: NonNullable<ProjectConfiguration['targets'][string]['inputs']>,
+    nameMap: AggregateMap<string, ProjectConfiguration>
+  ) {
+    const arrayKey = `targets.${targetName}.inputs`;
+    for (let i = 0; i < inputs.length; i++) {
+      const input = inputs[i];
+      if (typeof input !== 'object' || !('projects' in input)) {
+        continue;
+      }
+      const inputProjectNames = input['projects'];
+      if (typeof inputProjectNames === 'string') {
+        // `self` and `dependencies` are keywords, not project names.
+        if (
+          inputProjectNames === 'self' ||
+          inputProjectNames === 'dependencies'
+        ) {
+          continue;
+        }
+        const referencedProject = nameMap.get(inputProjectNames);
+        if (referencedProject) {
+          this.registerProjectNameSubstitutor(
+            referencedProject.root,
+            ownerRoot,
+            arrayKey,
+            i,
+            (finalName, ownerConfig) => {
+              const finalInput = ownerConfig.targets?.[targetName]?.inputs?.[i];
+              if (
+                finalInput &&
+                typeof finalInput === 'object' &&
+                'projects' in finalInput
+              ) {
+                (finalInput as { projects: string }).projects = finalName;
+              }
+            }
+          );
+        }
+      } else if (Array.isArray(inputProjectNames)) {
+        for (let j = 0; j < inputProjectNames.length; j++) {
+          const projectName = inputProjectNames[j];
+          const referencedProject = nameMap.get(projectName);
+          if (referencedProject) {
+            this.registerProjectNameSubstitutor(
+              referencedProject.root,
+              ownerRoot,
+              arrayKey,
+              i,
+              (finalName, ownerConfig) => {
+                const finalInput =
+                  ownerConfig.targets?.[targetName]?.inputs?.[i];
+                if (
+                  finalInput &&
+                  typeof finalInput === 'object' &&
+                  'projects' in finalInput
+                ) {
+                  (finalInput['projects'] as string[])[j] = finalName;
+                }
+              }
+            );
+          }
+        }
+      }
     }
+    // Evict any dangling substitutors at indices beyond the new array length —
+    // the array may have shrunk compared to a previous plugin's contribution.
+    this.clearSubstitutorsFromIndex(arrayKey, inputs.length);
   }
 
+  // Registers substitutors for any project-name references found inside a
+  // target's `dependsOn` array. Substitutors are registered against the root
+  // of the *referenced* project, so they fire when that project is renamed.
+  // The substitutor closes over `ownerRoot` and the array index so it can
+  // navigate to the correct property in the final merged config.
+  private registerSubstitutorsForDependsOn(
+    ownerRoot: string,
+    targetName: string,
+    dependsOn: NonNullable<
+      ProjectConfiguration['targets'][string]['dependsOn']
+    >,
+    nameMap: AggregateMap<string, ProjectConfiguration>
+  ) {
+    const arrayKey = `targets.${targetName}.dependsOn`;
+    for (let i = 0; i < dependsOn.length; i++) {
+      const dep = dependsOn[i];
+      if (typeof dep !== 'object' || !dep.projects) {
+        continue;
+      }
+      const depProjects = dep.projects;
+      if (typeof depProjects === 'string') {
+        // `*`, `self`, and `dependencies` are keywords, not project names.
+        if (['*', 'self', 'dependencies'].includes(depProjects)) {
+          continue;
+        }
+        const referencedProject = nameMap.get(depProjects);
+        if (referencedProject) {
+          this.registerProjectNameSubstitutor(
+            referencedProject.root,
+            ownerRoot,
+            arrayKey,
+            i,
+            (finalName, ownerConfig) => {
+              const finalDep =
+                ownerConfig.targets?.[targetName]?.dependsOn?.[i];
+              if (
+                finalDep &&
+                typeof finalDep === 'object' &&
+                'projects' in finalDep
+              ) {
+                (finalDep as { projects: string }).projects = finalName;
+              }
+            }
+          );
+        }
+      } else if (Array.isArray(depProjects)) {
+        // Glob patterns can match multiple projects and can't be resolved
+        // to a single root at this stage, so we skip them.
+        for (let j = 0; j < depProjects.length; j++) {
+          const projectName = depProjects[j];
+          if (isGlobPattern(projectName)) {
+            continue;
+          }
+          const referencedProject = nameMap.get(projectName);
+          if (referencedProject) {
+            this.registerProjectNameSubstitutor(
+              referencedProject.root,
+              ownerRoot,
+              arrayKey,
+              i,
+              (finalName, ownerConfig) => {
+                const finalDep =
+                  ownerConfig.targets?.[targetName]?.dependsOn?.[i];
+                if (
+                  finalDep &&
+                  typeof finalDep === 'object' &&
+                  'projects' in finalDep
+                ) {
+                  (finalDep['projects'] as string[])[j] = finalName;
+                }
+              }
+            );
+          }
+        }
+      }
+    }
+    // Evict any dangling substitutors at indices beyond the new array length —
+    // the array may have shrunk compared to a previous plugin's contribution.
+    this.clearSubstitutorsFromIndex(arrayKey, dependsOn.length);
+  }
+
+  /**
+   * Marks the project at `root` as having had its name changed. This causes
+   * all substitutors registered for that root to execute during
+   * {@link applySubstitutions}.
+   */
+  markDirty(root: string) {
+    this.dirtyRoots.add(root);
+  }
+
+  /**
+   * Executes all registered substitutors for dirty roots, updating stale
+   * project name references in the final merged `rootMap`. Should be called
+   * once after all plugin results have been merged.
+   */
   applySubstitutions(rootMap: Record<string, ProjectConfiguration>) {
     for (const root of this.dirtyRoots) {
-      const substitutions = this.projectNameSubstitutors.get(root);
-      if (substitutions) {
-        for (const substitution of substitutions) {
-          const currentName = rootMap[root].name;
-          substitution(currentName);
+      const substitutors = this.projectNameSubstitutors.get(root);
+      if (!substitutors) {
+        continue;
+      }
+      const finalName = rootMap[root]?.name;
+      if (!finalName) {
+        continue;
+      }
+      for (const { ownerRoot, substitutor } of substitutors) {
+        // Each entry stores the ownerRoot of the project holding the stale
+        // reference so we can look up its final merged config here, without
+        // passing the full rootMap into every substitutor.
+        const ownerConfig = rootMap[ownerRoot];
+        if (ownerConfig) {
+          substitutor(finalName, ownerConfig);
         }
       }
     }
@@ -171,12 +389,17 @@ export class ProjectNameInNodePropsManager {
 }
 
 function rootMapToNameMap(
-  rm: Record<
-    string,
-    Omit<ProjectConfiguration, 'root'> & Partial<ProjectConfiguration>
-  >
-) {
+  rm:
+    | Record<
+        string,
+        Omit<ProjectConfiguration, 'root'> & Partial<ProjectConfiguration>
+      >
+    | undefined
+): Map<string, ProjectConfiguration> {
   const map = new Map<string, ProjectConfiguration>();
+  if (!rm) {
+    return map;
+  }
   for (const root in rm) {
     const project = rm[root];
     if (project.name) {
@@ -192,7 +415,7 @@ class LazyMap<K, V> {
 
   constructor(private builder: () => Map<K, V>) {}
 
-  get(key: K): V | null {
+  get(key: K): V | undefined {
     if (!this.data) {
       this.data = this.builder();
     }

--- a/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.ts
@@ -244,6 +244,7 @@ export class ProjectNameInNodePropsManager {
           const projectName = inputProjectNames[j];
           const referencedProject = nameMap.get(projectName);
           if (referencedProject) {
+            const arrayIndex = j; // Capture j by value
             this.registerProjectNameSubstitutor(
               referencedProject.root,
               ownerRoot,
@@ -257,7 +258,7 @@ export class ProjectNameInNodePropsManager {
                   typeof finalInput === 'object' &&
                   'projects' in finalInput
                 ) {
-                  (finalInput['projects'] as string[])[j] = finalName;
+                  (finalInput['projects'] as string[])[arrayIndex] = finalName;
                 }
               }
             );
@@ -325,6 +326,7 @@ export class ProjectNameInNodePropsManager {
           }
           const referencedProject = nameMap.get(projectName);
           if (referencedProject) {
+            const arrayIndex = j; // Capture j by value
             this.registerProjectNameSubstitutor(
               referencedProject.root,
               ownerRoot,
@@ -338,7 +340,7 @@ export class ProjectNameInNodePropsManager {
                   typeof finalDep === 'object' &&
                   'projects' in finalDep
                 ) {
-                  (finalDep['projects'] as string[])[j] = finalName;
+                  (finalDep['projects'] as string[])[arrayIndex] = finalName;
                 }
               }
             );

--- a/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.ts
@@ -1,0 +1,217 @@
+import { ProjectConfiguration } from '../../../config/workspace-json-project-json';
+import { isGlobPattern } from '../../../utils/globs';
+
+type ProjectNameSubstitutor<T = unknown> = (name: string) => void;
+
+/**
+ * The idea here is:
+ * - When we are recieving node results from createNodes,
+ *   some node `A` may contain `dependsOn` or `inputs` blocks
+ *   that reference a project (B) by name that was created by the
+ *   same plugin.
+ * - A later plugin may change the project name of `B` to `C`
+ * - After the graph is built, this would leave `A` with a reference
+ *   to project `B`, which no longer exists.
+ *
+ *
+ */
+export class ProjectNameInNodePropsManager {
+  private projectNameSubstitutors = new Map<string, ProjectNameSubstitutor[]>();
+  private dirtyRoots = new Set<string>();
+
+  constructor() {}
+
+  private registerProjectNameSubstitutor(
+    root: string,
+    substitutor: ProjectNameSubstitutor
+  ) {
+    let subs = this.projectNameSubstitutors.get(root);
+    if (!subs) {
+      subs = [];
+      this.projectNameSubstitutors.set(root, subs);
+    }
+    subs.push(substitutor);
+  }
+
+  /**
+   * Checks if results from a plugin may require substitutors given the known nodes.
+   *
+   * PERF IMPACT:
+   *   - Loops through each result from the given plugin, and its targets
+   *   - If no targets have dependencies or inputs on another project's config,
+   *     that's it.
+   *   - If a target has a dependency or input that references another project name
+   *     - There's a minimal overhead to register + apply the substitutions
+   *     - If that projects from another plugin result, theres a larger impact
+   *       as we need to actually compute the name lookup table
+   *
+   * @param pluginResultProjects The results from a single plugin
+   * @param mergedConfigurations The currently accumulated root map
+   */
+  registerSubstitutorsForNodeResults(
+    pluginResultProjects?: Record<
+      string,
+      Omit<ProjectConfiguration, 'root'> & Partial<ProjectConfiguration>
+    >,
+    mergedConfigurations?: Record<string, ProjectConfiguration>
+  ) {
+    const nameMap = new AggregateMap(
+      rootMapToNameMap(pluginResultProjects),
+      new LazyMap(() => rootMapToNameMap(mergedConfigurations))
+    );
+
+    for (const root in pluginResultProjects) {
+      const project = pluginResultProjects[root];
+
+      if (project.targets) {
+        for (const target in project.targets) {
+          const config = project.targets[target];
+          if (config.inputs) {
+            for (const input of config.inputs) {
+              if (typeof input === 'object' && 'projects' in input) {
+                const projects = input['projects'];
+                // This could be `self`, `dependencies`, or a project name
+                if (typeof projects === 'string') {
+                  if (projects === 'self' || projects === 'dependencies') {
+                    // This is a legacy syntax, but it **doesnt** reference
+                    // a project name, so we don't need to worry about it here
+                  } else {
+                    const project = nameMap.get(projects);
+                    if (project) {
+                      this.registerProjectNameSubstitutor(
+                        project.root,
+                        (name) => {
+                          input.projects = name;
+                        }
+                      );
+                    }
+                  }
+                } else {
+                  // this is an array of project names
+                  for (let i = 0; i < projects.length; i++) {
+                    const projectName = projects[i];
+                    const project = nameMap.get(projectName);
+                    if (project) {
+                      this.registerProjectNameSubstitutor(
+                        project.root,
+                        (name) => {
+                          projects[i] = name;
+                        }
+                      );
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          if (config.dependsOn) {
+            for (const dep of config.dependsOn) {
+              if (typeof dep === 'object' && dep.projects) {
+                const projects = dep.projects;
+                if (typeof projects === 'string') {
+                  if (!['*', 'self', 'dependencies'].includes(projects)) {
+                    const project = nameMap.get(projects);
+                    if (project) {
+                      this.registerProjectNameSubstitutor(
+                        project.root,
+                        (name) => {
+                          dep.projects = name;
+                        }
+                      );
+                    }
+                  }
+                } else {
+                  // array of project names or glob patterns?
+                  // ...to be totally correct here, we'd need to use
+                  // find matching projects... But that seems overkill
+                  // and likely to be perf sensitive. Lets assume these are full
+                  // names.
+                  for (let i = 0; i < dep.projects.length; i++) {
+                    const projectName = dep.projects[i];
+                    if (!isGlobPattern(projectName)) {
+                      const project = nameMap.get(projectName);
+                      if (project) {
+                        this.registerProjectNameSubstitutor(
+                          project.root,
+                          (name) => {
+                            projects[i] = name;
+                          }
+                        );
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  markDirty(root: string) {
+    // It can't be dirty yet if there's no substitutors pointing at it
+    if (this.projectNameSubstitutors.has(root)) {
+      this.dirtyRoots.add(root);
+    }
+  }
+
+  applySubstitutions(rootMap: Record<string, ProjectConfiguration>) {
+    for (const root of this.dirtyRoots) {
+      const substitutions = this.projectNameSubstitutors.get(root);
+      if (substitutions) {
+        for (const substitution of substitutions) {
+          const currentName = rootMap[root].name;
+          substitution(currentName);
+        }
+      }
+    }
+  }
+}
+
+function rootMapToNameMap(
+  rm: Record<
+    string,
+    Omit<ProjectConfiguration, 'root'> & Partial<ProjectConfiguration>
+  >
+) {
+  const map = new Map<string, ProjectConfiguration>();
+  for (const root in rm) {
+    const project = rm[root];
+    if (project.name) {
+      project.root ??= root;
+      map.set(project.name, project as ProjectConfiguration);
+    }
+  }
+  return map;
+}
+
+class LazyMap<K, V> {
+  private data?: Map<K, V>;
+
+  constructor(private builder: () => Map<K, V>) {}
+
+  get(key: K): V | null {
+    if (!this.data) {
+      this.data = this.builder();
+    }
+    return this.data.get(key);
+  }
+}
+
+class AggregateMap<K, V> {
+  private readonly maps: Array<Map<K, V> | LazyMap<K, V>>;
+  constructor(...maps: Array<Map<K, V> | LazyMap<K, V>>) {
+    this.maps = maps;
+  }
+
+  get(key: K) {
+    for (const map of this.maps) {
+      const v = map.get(key);
+      if (v !== undefined) {
+        return v;
+      }
+    }
+  }
+}

--- a/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.ts
@@ -1,10 +1,9 @@
 import { ProjectConfiguration } from '../../../config/workspace-json-project-json';
 import { isGlobPattern } from '../../../utils/globs';
 
-// A substitutor receives the final resolved name of the project whose root
-// was marked dirty (i.e. the project that was renamed), and the final merged
-// configuration of the project that *holds the stale reference* so it can
-// update the appropriate field in-place.
+// A substitutor receives the final resolved name of the project that was
+// renamed, and the final merged configuration of the project that *holds
+// the stale reference* so it can update the appropriate field in-place.
 type ProjectNameSubstitutor = (
   finalName: string,
   ownerProjectConfig: ProjectConfiguration
@@ -33,48 +32,52 @@ type SubstitutorEntry = {
  * This class solves that by:
  * 1. Scanning each plugin's results for project-name references in
  *    `inputs` and `dependsOn` ({@link registerSubstitutorsForNodeResults}).
- * 2. Recording a "substitutor" closure for each such reference, keyed by
- *    the root directory of the referenced project.
- * 3. When a project's name changes during the merge, marking that root as
- *    dirty ({@link markDirty}).
- * 4. After all results are merged, applying the substitutors for every
- *    dirty root so that references are updated to the final name
+ *    Substitutors are indexed by the **referenced name as it appeared in
+ *    the plugin result** — no lookup into any project map is needed at
+ *    registration time.
+ * 2. When a project's name changes during the merge, recording that change
+ *    via {@link markDirty} so substitutors for the old name can be located.
+ * 3. After all results are merged, applying the substitutors for every
+ *    renamed project so that references are updated to the final name
  *    ({@link applySubstitutions}).
  */
 export class ProjectNameInNodePropsManager {
-  // Maps root directory -> set of substitutor entries that should run when
-  // the project at that root is renamed. Using a Set allows O(1) removal
-  // when a source-map key is overwritten by a later plugin registration.
+  // Maps the *referenced project name at registration time* → set of
+  // substitutor entries that should run when a project is renamed FROM
+  // that name. Keying by name (not root) means no project-map lookup is
+  // needed at registration time, and ordering between result entries does
+  // not matter.
   private projectNameSubstitutors = new Map<string, Set<SubstitutorEntry>>();
 
-  // Tracks substitutor entries by (array path, index, subIndex). This serves two purposes:
+  // Tracks substitutor entries by (array path, index, subIndex). This
+  // serves two purposes:
   //
-  // 1. Per-index deduplication: if the same array index is registered again
-  //    (e.g. two plugin results contribute to the same position), the old
-  //    substitutor is evicted before the new one is added.
+  // 1. Per-index deduplication: if the same array index is registered
+  //    again (e.g. two plugin results contribute to the same position),
+  //    the old substitutor is evicted before the new one is added.
   //
   // 2. Tail-clearing: when a later plugin provides a shorter array at the
-  //    same path, splice removes all tail entries in one call without
-  //    needing to iterate from fromIndex to the end.
+  //    same path, splice removes all tail entries in one call.
   //
-  // Outer key: array path (e.g. "targets.build.inputs")
-  // Inner array: indexed by position; each position is itself an array to handle
-  //   multiple project names within a single projects array (e.g., ['project-b', 'project-c']).
+  // Outer key: array path (e.g. "proj-a:targets.build.inputs")
+  // Inner array: indexed by position; each slot holds an array so that a
+  //   single `projects` array can hold multiple name references.
   private substitutorsByArrayKey = new Map<
     string,
     Array<
-      | Array<{ referencedRoot: string; entry: SubstitutorEntry } | undefined>
+      | Array<{ referencedName: string; entry: SubstitutorEntry } | undefined>
       | undefined
     >
   >();
 
-  // Roots whose project name changed during the merge phase. Only these
-  // roots need their substitutors executed in applySubstitutions.
-  private dirtyRoots = new Set<string>();
+  // Projects whose names changed during the merge phase. Key = root of the
+  // renamed project, value = its name *before* the rename. These are used
+  // in applySubstitutions to locate substitutors keyed by the old name.
+  private dirtyEntries = new Map<string, string>();
 
-  // Removes the substitutor registered at the given index (and optional subIndex) of an array, if any.
-  // Used when re-registering for the same index (same position overwritten by
-  // a later plugin).
+  // Removes the substitutor registered at the given index (and optional
+  // subIndex) of an array, if any. Used when re-registering for the same
+  // position (overwritten by a later plugin).
   private clearSubstitutorAtIndex(
     arrayKey: string,
     index: number,
@@ -87,34 +90,28 @@ export class ProjectNameInNodePropsManager {
     }
     if (subIndex === undefined) {
       // Clear the entire index entry (single project reference)
-      if (Array.isArray(atIndex)) {
-        // It's an array of substitutors, clear all
-        for (const item of atIndex) {
-          if (item) {
-            this.projectNameSubstitutors
-              .get(item.referencedRoot)
-              ?.delete(item.entry);
-          }
+      for (const item of atIndex) {
+        if (item) {
+          this.projectNameSubstitutors
+            .get(item.referencedName)
+            ?.delete(item.entry);
         }
       }
       byIndex[index] = undefined;
     } else {
       // Clear only the specific subIndex (within a projects array)
-      if (Array.isArray(atIndex)) {
-        const existing = atIndex[subIndex];
-        if (existing) {
-          this.projectNameSubstitutors
-            .get(existing.referencedRoot)
-            ?.delete(existing.entry);
-          atIndex[subIndex] = undefined;
-        }
+      const existing = atIndex[subIndex];
+      if (existing) {
+        this.projectNameSubstitutors
+          .get(existing.referencedName)
+          ?.delete(existing.entry);
+        atIndex[subIndex] = undefined;
       }
     }
   }
 
   // Removes all substitutors at indices >= `fromIndex` for the given array
-  // path. Uses splice so the tail is dropped in one operation rather than
-  // iterating over each index individually.
+  // path. Uses splice so the tail is dropped in one operation.
   private clearSubstitutorsFromIndex(arrayKey: string, fromIndex: number) {
     const byIndex = this.substitutorsByArrayKey.get(arrayKey);
     if (!byIndex) {
@@ -123,25 +120,22 @@ export class ProjectNameInNodePropsManager {
     const removed = byIndex.splice(fromIndex);
     for (const atIndex of removed) {
       if (atIndex) {
-        if (Array.isArray(atIndex)) {
-          // It's an array of substitutors (for projects arrays)
-          for (const item of atIndex) {
-            if (item) {
-              this.projectNameSubstitutors
-                .get(item.referencedRoot)
-                ?.delete(item.entry);
-            }
+        for (const item of atIndex) {
+          if (item) {
+            this.projectNameSubstitutors
+              .get(item.referencedName)
+              ?.delete(item.entry);
           }
         }
       }
     }
   }
 
-  // Registers a new substitutor for the project at `referencedRoot`, tracked
-  // at (arrayKey, index, subIndex) so it can be individually replaced or bulk-evicted
-  // when the array shrinks.
+  // Registers a new substitutor keyed by `referencedName` (the project name
+  // as it appears in the reference), tracked at (arrayKey, index, subIndex)
+  // for deduplication and tail-clearing.
   private registerProjectNameSubstitutor(
-    referencedRoot: string,
+    referencedName: string,
     ownerRoot: string,
     arrayKey: string,
     index: number,
@@ -151,14 +145,14 @@ export class ProjectNameInNodePropsManager {
     // Evict any existing substitutor at this exact position first.
     this.clearSubstitutorAtIndex(arrayKey, index, subIndex);
 
-    let substitutorsForRoot = this.projectNameSubstitutors.get(referencedRoot);
-    if (!substitutorsForRoot) {
-      substitutorsForRoot = new Set();
-      this.projectNameSubstitutors.set(referencedRoot, substitutorsForRoot);
+    let substitutorsForName = this.projectNameSubstitutors.get(referencedName);
+    if (!substitutorsForName) {
+      substitutorsForName = new Set();
+      this.projectNameSubstitutors.set(referencedName, substitutorsForName);
     }
 
     const entry: SubstitutorEntry = { ownerRoot, substitutor };
-    substitutorsForRoot.add(entry);
+    substitutorsForName.add(entry);
 
     let byIndex = this.substitutorsByArrayKey.get(arrayKey);
     if (!byIndex) {
@@ -167,17 +161,17 @@ export class ProjectNameInNodePropsManager {
     }
 
     if (subIndex === undefined) {
-      // Single project reference - store directly
-      byIndex[index] = [{ referencedRoot, entry }];
+      // Single project reference — store directly
+      byIndex[index] = [{ referencedName, entry }];
     } else {
-      // Multiple projects in an array - ensure the array exists and store at subIndex
+      // Multiple projects in an array — ensure the slot exists
       if (!byIndex[index]) {
         byIndex[index] = [];
       }
       const subArray = byIndex[index] as Array<
-        { referencedRoot: string; entry: SubstitutorEntry } | undefined
+        { referencedName: string; entry: SubstitutorEntry } | undefined
       >;
-      subArray[subIndex] = { referencedRoot, entry };
+      subArray[subIndex] = { referencedName, entry };
     }
   }
 
@@ -186,36 +180,22 @@ export class ProjectNameInNodePropsManager {
    * reference another project by name, and registers substitutors so those
    * references are updated if the target project is later renamed.
    *
-   * ### Performance notes
-   * - Iterates every target in every project result from the current plugin.
-   * - Builds a lazy name→project lookup of `mergedRootMap` only if an
-   *   inter-plugin reference is found (avoids the cost when unnecessary).
-   * - The actual substitutions are deferred until {@link applySubstitutions}.
+   * No lookup into any project map is performed — substitutors are simply
+   * keyed by whatever name appears in the reference. This means registration
+   * is safe to call at any point during the merge, regardless of whether the
+   * referenced project has been processed yet.
    *
    * @param pluginResultProjects Projects from a single plugin's createNodes call.
-   * @param mergedRootMap The accumulated root map from all prior plugin results.
    */
   registerSubstitutorsForNodeResults(
     pluginResultProjects?: Record<
       string,
       Omit<ProjectConfiguration, 'root'> & Partial<ProjectConfiguration>
-    >,
-    mergedRootMap?: Record<string, ProjectConfiguration>
+    >
   ) {
     if (!pluginResultProjects) {
       return;
     }
-
-    // nameMap first checks the current plugin's own results (fast path for
-    // intra-plugin references), then falls back to the previously-merged
-    // results from earlier plugins (lazy to avoid unnecessary computation).
-    const nameMap = new AggregateMap(
-      rootMapToNameMap(pluginResultProjects),
-      // to be clear, we use this so that if the current plugin
-      // only references projects that are defined by iteself,
-      // we don't need to build the name map for the merged root map at all
-      new LazyMap(() => rootMapToNameMap(mergedRootMap))
-    );
 
     for (const ownerRoot in pluginResultProjects) {
       const project = pluginResultProjects[ownerRoot];
@@ -228,32 +208,23 @@ export class ProjectNameInNodePropsManager {
           this.registerSubstitutorsForInputs(
             ownerRoot,
             targetName,
-            targetConfig.inputs,
-            nameMap
+            targetConfig.inputs
           );
         }
         if (targetConfig.dependsOn) {
           this.registerSubstitutorsForDependsOn(
             ownerRoot,
             targetName,
-            targetConfig.dependsOn,
-            nameMap
+            targetConfig.dependsOn
           );
         }
       }
     }
   }
 
-  // Registers substitutors for any project-name references found inside a
-  // target's `inputs` array. Substitutors are registered against the root of
-  // the *referenced* project, so they fire when that project is renamed.
-  // The substitutor closes over `ownerRoot` and the array index so it can
-  // navigate to the correct property in the final merged config.
-  // Factory methods for creating substitutors. Using factory functions instead
-  // of inline closures ensures that index variables (i, j) are captured as
-  // function parameters (always by value), preventing classic closure-over-
-  // loop-variable bugs where a shared `let` binding is mutated after the
-  // closure is created.
+  // Factory methods for creating substitutors. Using factory functions
+  // ensures that index variables (i, j) are captured as function parameters
+  // (always by value), preventing closure-over-loop-variable bugs.
 
   private createInputsStringSubstitutor(
     targetName: string,
@@ -316,8 +287,7 @@ export class ProjectNameInNodePropsManager {
   private registerSubstitutorsForInputs(
     ownerRoot: string,
     targetName: string,
-    inputs: NonNullable<ProjectConfiguration['targets'][string]['inputs']>,
-    nameMap: AggregateMap<string, ProjectConfiguration>
+    inputs: NonNullable<ProjectConfiguration['targets'][string]['inputs']>
   ) {
     const arrayKey = `${ownerRoot}:targets.${targetName}.inputs`;
     for (let i = 0; i < inputs.length; i++) {
@@ -334,30 +304,24 @@ export class ProjectNameInNodePropsManager {
         ) {
           continue;
         }
-        const referencedProject = nameMap.get(inputProjectNames);
-        if (referencedProject) {
-          this.registerProjectNameSubstitutor(
-            referencedProject.root,
-            ownerRoot,
-            arrayKey,
-            i,
-            this.createInputsStringSubstitutor(targetName, i)
-          );
-        }
+        this.registerProjectNameSubstitutor(
+          inputProjectNames,
+          ownerRoot,
+          arrayKey,
+          i,
+          this.createInputsStringSubstitutor(targetName, i)
+        );
       } else if (Array.isArray(inputProjectNames)) {
         for (let j = 0; j < inputProjectNames.length; j++) {
           const projectName = inputProjectNames[j];
-          const referencedProject = nameMap.get(projectName);
-          if (referencedProject) {
-            this.registerProjectNameSubstitutor(
-              referencedProject.root,
-              ownerRoot,
-              arrayKey,
-              i,
-              this.createInputsArraySubstitutor(targetName, i, j),
-              j // Pass subIndex for array elements
-            );
-          }
+          this.registerProjectNameSubstitutor(
+            projectName,
+            ownerRoot,
+            arrayKey,
+            i,
+            this.createInputsArraySubstitutor(targetName, i, j),
+            j // subIndex for array elements
+          );
         }
       }
     }
@@ -366,18 +330,10 @@ export class ProjectNameInNodePropsManager {
     this.clearSubstitutorsFromIndex(arrayKey, inputs.length);
   }
 
-  // Registers substitutors for any project-name references found inside a
-  // target's `dependsOn` array. Substitutors are registered against the root
-  // of the *referenced* project, so they fire when that project is renamed.
-  // The substitutor closes over `ownerRoot` and the array index so it can
-  // navigate to the correct property in the final merged config.
   private registerSubstitutorsForDependsOn(
     ownerRoot: string,
     targetName: string,
-    dependsOn: NonNullable<
-      ProjectConfiguration['targets'][string]['dependsOn']
-    >,
-    nameMap: AggregateMap<string, ProjectConfiguration>
+    dependsOn: NonNullable<ProjectConfiguration['targets'][string]['dependsOn']>
   ) {
     const arrayKey = `${ownerRoot}:targets.${targetName}.dependsOn`;
     for (let i = 0; i < dependsOn.length; i++) {
@@ -391,35 +347,29 @@ export class ProjectNameInNodePropsManager {
         if (['*', 'self', 'dependencies'].includes(depProjects)) {
           continue;
         }
-        const referencedProject = nameMap.get(depProjects);
-        if (referencedProject) {
-          this.registerProjectNameSubstitutor(
-            referencedProject.root,
-            ownerRoot,
-            arrayKey,
-            i,
-            this.createDependsOnStringSubstitutor(targetName, i)
-          );
-        }
+        this.registerProjectNameSubstitutor(
+          depProjects,
+          ownerRoot,
+          arrayKey,
+          i,
+          this.createDependsOnStringSubstitutor(targetName, i)
+        );
       } else if (Array.isArray(depProjects)) {
         // Glob patterns can match multiple projects and can't be resolved
-        // to a single root at this stage, so we skip them.
+        // to a single project name at this stage, so we skip them.
         for (let j = 0; j < depProjects.length; j++) {
           const projectName = depProjects[j];
           if (isGlobPattern(projectName)) {
             continue;
           }
-          const referencedProject = nameMap.get(projectName);
-          if (referencedProject) {
-            this.registerProjectNameSubstitutor(
-              referencedProject.root,
-              ownerRoot,
-              arrayKey,
-              i,
-              this.createDependsOnArraySubstitutor(targetName, i, j),
-              j // Pass subIndex for array elements
-            );
-          }
+          this.registerProjectNameSubstitutor(
+            projectName,
+            ownerRoot,
+            arrayKey,
+            i,
+            this.createDependsOnArraySubstitutor(targetName, i, j),
+            j // subIndex for array elements
+          );
         }
       }
     }
@@ -429,22 +379,22 @@ export class ProjectNameInNodePropsManager {
   }
 
   /**
-   * Marks the project at `root` as having had its name changed. This causes
-   * all substitutors registered for that root to execute during
+   * Records that the project at `root` was renamed from `previousName`.
+   * Substitutors registered for `previousName` will fire during
    * {@link applySubstitutions}.
    */
-  markDirty(root: string) {
-    this.dirtyRoots.add(root);
+  markDirty(root: string, previousName: string) {
+    this.dirtyEntries.set(root, previousName);
   }
 
   /**
-   * Executes all registered substitutors for dirty roots, updating stale
-   * project name references in the final merged `rootMap`. Should be called
-   * once after all plugin results have been merged.
+   * Executes all registered substitutors for renamed projects, updating
+   * stale project name references in the final merged `rootMap`. Should be
+   * called once after all plugin results have been merged.
    */
   applySubstitutions(rootMap: Record<string, ProjectConfiguration>) {
-    for (const root of this.dirtyRoots) {
-      const substitutors = this.projectNameSubstitutors.get(root);
+    for (const [root, previousName] of this.dirtyEntries) {
+      const substitutors = this.projectNameSubstitutors.get(previousName);
       if (!substitutors) {
         continue;
       }
@@ -454,63 +404,11 @@ export class ProjectNameInNodePropsManager {
       }
       for (const { ownerRoot, substitutor } of substitutors) {
         // Each entry stores the ownerRoot of the project holding the stale
-        // reference so we can look up its final merged config here, without
-        // passing the full rootMap into every substitutor.
+        // reference so we can look up its final merged config here.
         const ownerConfig = rootMap[ownerRoot];
         if (ownerConfig) {
           substitutor(finalName, ownerConfig);
         }
-      }
-    }
-  }
-}
-
-function rootMapToNameMap(
-  rm:
-    | Record<
-        string,
-        Omit<ProjectConfiguration, 'root'> & Partial<ProjectConfiguration>
-      >
-    | undefined
-): Map<string, ProjectConfiguration> {
-  const map = new Map<string, ProjectConfiguration>();
-  if (!rm) {
-    return map;
-  }
-  for (const root in rm) {
-    const project = rm[root];
-    if (project.name) {
-      project.root ??= root;
-      map.set(project.name, project as ProjectConfiguration);
-    }
-  }
-  return map;
-}
-
-class LazyMap<K, V> {
-  private data?: Map<K, V>;
-
-  constructor(private builder: () => Map<K, V>) {}
-
-  get(key: K): V | undefined {
-    if (!this.data) {
-      this.data = this.builder();
-    }
-    return this.data.get(key);
-  }
-}
-
-class AggregateMap<K, V> {
-  private readonly maps: Array<Map<K, V> | LazyMap<K, V>>;
-  constructor(...maps: Array<Map<K, V> | LazyMap<K, V>>) {
-    this.maps = maps;
-  }
-
-  get(key: K) {
-    for (const map of this.maps) {
-      const v = map.get(key);
-      if (v !== undefined) {
-        return v;
       }
     }
   }

--- a/packages/nx/src/project-graph/utils/project-configuration/source-maps.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/source-maps.ts
@@ -1,0 +1,130 @@
+/**
+ * Utilities for constructing source map keys used to track the origin
+ * of project configuration properties. Source map keys are dot-delimited
+ * paths into a ProjectConfiguration, e.g. `targets.build.inputs.0.projects`.
+ *
+ * Centralizing key construction here prevents typos and ensures consistent
+ * key shapes across the project graph build pipeline.
+ */
+
+/** Describes the file and plugin that contributed a given configuration property. */
+export type SourceInformation = [file: string | null, plugin: string];
+
+/** Maps each project root to a source map for its configuration properties. */
+export type ConfigurationSourceMaps = Record<
+  string,
+  Record<string, SourceInformation>
+>;
+
+/**
+ * Calls `callback` with the source map key for each index of `array` under
+ * `prefixKey`, producing keys like `${prefixKey}.0`, `${prefixKey}.1`, etc.
+ *
+ * Use this when you need the keys themselves — e.g. to register or clear
+ * entries in a name substitution manager — without necessarily writing to a
+ * source map.
+ *
+ * @param prefixKey The dot-delimited path prefix for the array (e.g. `"targets.build.inputs"`).
+ * @param array The array whose indices should be iterated.
+ * @param callback Called with the key for each index.
+ * @param startIndex Index to start from. Useful when appending to an existing array.
+ */
+export function forEachSourceMapKeyForArray(
+  prefixKey: string,
+  array: unknown[],
+  callback: (key: string, index: number) => void,
+  startIndex = 0
+): void {
+  for (let i = startIndex; i < array.length; i++) {
+    callback(`${prefixKey}.${i}`, i);
+  }
+}
+
+/**
+ * Records a single source map entry. Prefer this over direct bracket
+ * assignment to keep writes consistent with the rest of the source map API.
+ */
+export function recordSourceMapInfo(
+  sourceMap: Record<string, SourceInformation>,
+  key: string,
+  sourceInfo: SourceInformation
+): void {
+  sourceMap[key] = sourceInfo;
+}
+
+/**
+ * Convenience wrapper that records a source map entry for each index of
+ * `array` under `prefixKey`. Equivalent to calling {@link forEachSourceMapKeyForArray}
+ * and {@link recordSourceMapInfo} together.
+ *
+ * @param sourceMap The source map to write into.
+ * @param prefixKey The dot-delimited path prefix for the array (e.g. `"targets.build.inputs"`).
+ * @param array The array whose indices should be recorded.
+ * @param sourceInfo The source information to associate with each index key.
+ * @param startIndex Index to start writing from. Useful when appending to an existing array.
+ */
+export function recordSourceMapKeysByIndex(
+  sourceMap: Record<string, SourceInformation>,
+  prefixKey: string,
+  array: unknown[],
+  sourceInfo: SourceInformation,
+  startIndex = 0
+): void {
+  forEachSourceMapKeyForArray(
+    prefixKey,
+    array,
+    (key) => recordSourceMapInfo(sourceMap, key, sourceInfo),
+    startIndex
+  );
+}
+
+/**
+ * Builds a source map key for a target entry.
+ *
+ * @example
+ * // Returns "targets.build"
+ * targetSourceMapKey('build')
+ */
+export function targetSourceMapKey(targetName: string): string {
+  return `targets.${targetName}`;
+}
+
+/**
+ * Builds a source map key for a specific option within a target.
+ *
+ * @example
+ * // Returns "targets.build.options.outputPath"
+ * targetOptionSourceMapKey('build', 'outputPath')
+ */
+export function targetOptionSourceMapKey(
+  targetName: string,
+  optionKey: string
+): string {
+  return `targets.${targetName}.options.${optionKey}`;
+}
+
+/**
+ * Builds a source map key for a target's configurations section, optionally
+ * scoped to a specific configuration name and key within it.
+ *
+ * @example
+ * targetConfigurationsSourceMapKey('build')                         // "targets.build.configurations"
+ * targetConfigurationsSourceMapKey('build', 'production')           // "targets.build.configurations.production"
+ * targetConfigurationsSourceMapKey('build', 'production', 'outputHashing') // "targets.build.configurations.production.outputHashing"
+ */
+export function targetConfigurationsSourceMapKey(
+  targetName: string,
+  configurationName?: string,
+  configurationKey?: string
+): string {
+  let key = `targets.${targetName}.configurations`;
+  if (configurationName) {
+    key += `.${configurationName}`;
+  }
+  if (configurationKey) {
+    key += `.${configurationKey}`;
+  }
+  return key;
+}
+
+

--- a/packages/nx/src/project-graph/utils/project-configuration/source-maps.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/source-maps.ts
@@ -126,5 +126,3 @@ export function targetConfigurationsSourceMapKey(
   }
   return key;
 }
-
-


### PR DESCRIPTION
## Current Behavior
There's a bug currently where is a plugin returns a dependsOn dependency or input that directly references another project by name, and a later plugin renames that project, the dependsOn or input entry is left stale and pointing at a now non-existent project.

## Expected Behavior
The old refs are kept up to date as the nodes get merged together

## AI Summary
This pull request introduces a new mechanism to handle project name substitutions in the Nx project graph, ensuring that references to project names in `inputs` and `dependsOn` blocks remain accurate even if a plugin changes a project's name during graph construction. The main addition is the `ProjectNameInNodePropsManager`, which tracks and updates references when project names change. Several related refactorings and improvements were made to integrate this manager into the project configuration merging process.

**Project name substitution and consistency:**

* Added a new `ProjectNameInNodePropsManager` class to manage and apply project name substitutions when project names change, ensuring that all references in `inputs` and `dependsOn` blocks remain consistent.
* Integrated the `ProjectNameInNodePropsManager` into the `mergeCreateNodesResults` function, registering substitutors for node results, marking roots as dirty when names change, and applying substitutions after merging. [[1]](diffhunk://#diff-774ce1a4fd8ec0c898c989fb75e2d8c87a0055549bca680945bce50f717db117R518) [[2]](diffhunk://#diff-774ce1a4fd8ec0c898c989fb75e2d8c87a0055549bca680945bce50f717db117L521-R551) [[3]](diffhunk://#diff-774ce1a4fd8ec0c898c989fb75e2d8c87a0055549bca680945bce50f717db117R563-R571)

**API and function changes:**

* Modified `mergeProjectConfigurationIntoRootMap` to return an object indicating whether a project name was changed, instead of just returning void. [[1]](diffhunk://#diff-774ce1a4fd8ec0c898c989fb75e2d8c87a0055549bca680945bce50f717db117L59-R62) [[2]](diffhunk://#diff-774ce1a4fd8ec0c898c989fb75e2d8c87a0055549bca680945bce50f717db117R238-R244)

**Code organization and import cleanup:**

* Refactored imports in `project-configuration-utils.ts` for better organization and to accommodate the new manager. [[1]](diffhunk://#diff-774ce1a4fd8ec0c898c989fb75e2d8c87a0055549bca680945bce50f717db117L9-R25) [[2]](diffhunk://#diff-774ce1a4fd8ec0c898c989fb75e2d8c87a0055549bca680945bce50f717db117R43-L43)
