### PR TITLE
fix(nx-dev): exclude large native deps from build bundle

### DIFF
--- a/nx-dev/nx-dev/netlify.toml
+++ b/nx-dev/nx-dev/netlify.toml
@@ -1,2 +1,18 @@
 [[plugins]]
   package = "@netlify/plugin-nextjs"
+[functions]
+# Exclude large native binaries from function bundles to stay under the 250MB limit.
+# should also look at outputFileTracingExcludes in next.config.js.
+included_files = [
+  "!node_modules/@swc/core-*/**",
+  "!node_modules/@esbuild/**",
+  "!node_modules/esbuild/**",
+  "!node_modules/@nx/nx-darwin-arm64/**",
+  "!node_modules/@nx/nx-darwin-x64/**",
+  "!node_modules/@nx/nx-freebsd-x64/**",
+  "!node_modules/@nx/nx-linux-*/**",
+  "!node_modules/@nx/nx-win32-*/**",
+  "!node_modules/typescript/**",
+  "!node_modules/webpack/**",
+  "!node_modules/sass/**",
+]

--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -26,6 +26,39 @@ module.exports = withNx({
   // Limit static generation workers to reduce memory usage on CI (Netlify 8GB limit)
   experimental: {
     cpus: 1,
+    // Exclude large, unnecessary packages from the server function trace.
+    // We have to say under 250MB for Neltify
+    outputFileTracingExcludes: {
+      '*': [
+        // Native binaries - not needed at runtime for the website
+        'node_modules/@swc/core-linux-x64-musl/**',
+        'node_modules/@swc/core-linux-x64-gnu/**',
+        'node_modules/@swc/core-linux-arm64-musl/**',
+        'node_modules/@swc/core-linux-arm64-gnu/**',
+        'node_modules/@swc/core-linux-arm-gnueabihf/**',
+        'node_modules/@swc/core-win32-x64-msvc/**',
+        'node_modules/@swc/core-win32-arm64-msvc/**',
+        'node_modules/@swc/core-win32-ia32-msvc/**',
+        'node_modules/@swc/core-darwin-x64/**',
+        'node_modules/@swc/core-darwin-arm64/**',
+        'node_modules/@esbuild/**',
+        'node_modules/esbuild/**',
+        'node_modules/@nx/nx-darwin-arm64/**',
+        'node_modules/@nx/nx-darwin-x64/**',
+        'node_modules/@nx/nx-freebsd-x64/**',
+        'node_modules/@nx/nx-linux-arm-gnueabihf/**',
+        'node_modules/@nx/nx-linux-arm64-gnu/**',
+        'node_modules/@nx/nx-linux-arm64-musl/**',
+        'node_modules/@nx/nx-linux-x64-gnu/**',
+        'node_modules/@nx/nx-linux-x64-musl/**',
+        'node_modules/@nx/nx-win32-arm64-msvc/**',
+        'node_modules/@nx/nx-win32-x64-msvc/**',
+        // Build tools not needed at runtime
+        'node_modules/typescript/**',
+        'node_modules/webpack/**',
+        'node_modules/sass/**',
+      ],
+    },
   },
   async rewrites() {
     // Only configure rewrites if NEXT_PUBLIC_ASTRO_URL is set


### PR DESCRIPTION
we were including native binaries in the final netlify function build for nextjs which was fine until we reach the limit of 250mb causing a failure to upload the function (AWS imposed lambda limit)

Now we strip out any deps we know we don't need for the app which are dev deps and not runtime required.