### PR TITLE
feat(gradle): add build target name override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
   main-linux:
     runs-on: ubuntu-latest
     env:
-      NX_BATCH_MODE: 'true'
       NX_E2E_CI_CACHE_KEY: e2e-github-linux
       NX_DAEMON: 'true'
       NX_PERF_LOGGING: 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
   main-linux:
     runs-on: ubuntu-latest
     env:
+      NX_BATCH_MODE: 'true'
       NX_E2E_CI_CACHE_KEY: e2e-github-linux
       NX_DAEMON: 'true'
       NX_PERF_LOGGING: 'false'

--- a/packages/gradle/project-graph/project.json
+++ b/packages/gradle/project-graph/project.json
@@ -2,13 +2,6 @@
   "name": "gradle-project-graph",
   "$schema": "node_modules/nx/schemas/project-schema.json",
   "targets": {
-    "test": {
-      "command": "./gradlew :project-graph:test",
-      "options": {
-        "args": []
-      },
-      "cache": true
-    },
     "lint": {
       "command": "./gradlew :project-graph:ktfmtCheck",
       "cache": true

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
@@ -118,6 +118,7 @@ fun processTargetsForProject(
 
   val ciTestTargetBaseName = targetNameOverrides["ciTestTargetName"]?.let { applyPrefix(it) }
   val testTargetName = applyPrefix(targetNameOverrides.getOrDefault("testTargetName", "test"))
+  val buildTargetName = applyPrefix(targetNameOverrides.getOrDefault("buildTargetName", "build"))
 
   // Create a snapshot of test tasks to avoid ConcurrentModificationException
   // with Kotlin Multiplatform which adds tasks dynamically
@@ -137,10 +138,12 @@ fun processTargetsForProject(
       // Apply target name override if applicable, then apply prefix
       val targetName =
           applyPrefix(
-              if (task.name == "test" && targetNameOverrides.containsKey("testTargetName")) {
-                targetNameOverrides["testTargetName"]!!
-              } else {
-                task.name
+              when {
+                task.name == "test" && targetNameOverrides.containsKey("testTargetName") ->
+                    targetNameOverrides["testTargetName"]!!
+                task.name == "build" && targetNameOverrides.containsKey("buildTargetName") ->
+                    targetNameOverrides["buildTargetName"]!!
+                else -> task.name
               })
 
       // Group task under its group if available, using the overridden name

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -317,10 +317,12 @@ fun getDependsOnForTask(
       if (depProject.buildFile.path != null && depProject.buildFile.exists()) {
         val taskName =
             applyPrefix(
-                if (depTask.name == "test" && targetNameOverrides.containsKey("testTargetName")) {
-                  targetNameOverrides["testTargetName"]!!
-                } else {
-                  depTask.name
+                when {
+                  depTask.name == "test" && targetNameOverrides.containsKey("testTargetName") ->
+                      targetNameOverrides["testTargetName"]!!
+                  depTask.name == "build" && targetNameOverrides.containsKey("buildTargetName") ->
+                      targetNameOverrides["buildTargetName"]!!
+                  else -> depTask.name
                 })
         "${getNxProjectName(depProject)}:${taskName}"
       } else {

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTargetsForProjectTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTargetsForProjectTest.kt
@@ -421,13 +421,13 @@ class ProcessTargetsForProjectTest {
 
     val checkDependsOn = gradleTargets.targets["check"]?.get("dependsOn") as? List<*>
     assertTrue(
-        checkDependsOn?.contains(":app:test") == true,
-        "Expected check to depend on ':app:test', got $checkDependsOn")
+        checkDependsOn?.contains("app:test") == true,
+        "Expected check to depend on 'app:test', got $checkDependsOn")
 
     val ciCheckDependsOn = gradleTargets.targets["ci-check"]?.get("dependsOn") as? List<*>
     assertTrue(
-        ciCheckDependsOn?.contains(":app:ci-test") == true,
-        "Expected ci-check to depend on ':app:ci-test', got $ciCheckDependsOn")
+        ciCheckDependsOn?.contains("app:ci-test") == true,
+        "Expected ci-check to depend on 'app:ci-test', got $ciCheckDependsOn")
   }
 
   @Nested

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTargetsForProjectTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTargetsForProjectTest.kt
@@ -421,13 +421,13 @@ class ProcessTargetsForProjectTest {
 
     val checkDependsOn = gradleTargets.targets["check"]?.get("dependsOn") as? List<*>
     assertTrue(
-        checkDependsOn?.contains("app:test") == true,
-        "Expected check to depend on 'app:test', got $checkDependsOn")
+        checkDependsOn?.contains(":app:test") == true,
+        "Expected check to depend on ':app:test', got $checkDependsOn")
 
     val ciCheckDependsOn = gradleTargets.targets["ci-check"]?.get("dependsOn") as? List<*>
     assertTrue(
-        ciCheckDependsOn?.contains("app:ci-test") == true,
-        "Expected ci-check to depend on 'app:ci-test', got $ciCheckDependsOn")
+        ciCheckDependsOn?.contains(":app:ci-test") == true,
+        "Expected ci-check to depend on ':app:ci-test', got $ciCheckDependsOn")
   }
 
   @Nested

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTargetsForProjectTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTargetsForProjectTest.kt
@@ -435,7 +435,7 @@ class ProcessTargetsForProjectTest {
 
     @Test
     fun `should override build target name when buildTargetName is specified`(
-      @TempDir workspaceDir: File
+        @TempDir workspaceDir: File
     ) {
       val workspaceRoot = workspaceDir.absolutePath
       val projectDir = File(workspaceRoot, "project-a").apply { mkdirs() }
@@ -444,10 +444,10 @@ class ProcessTargetsForProjectTest {
       File(projectDir, "build.gradle").writeText("// test build file")
 
       val checkTask =
-        project.tasks.register("check").get().apply {
-          group = "verification"
-          description = "Runs all checks"
-        }
+          project.tasks.register("check").get().apply {
+            group = "verification"
+            description = "Runs all checks"
+          }
       project.tasks.register("build").get().apply {
         group = "build"
         description = "Assembles and tests"
@@ -459,19 +459,19 @@ class ProcessTargetsForProjectTest {
       val dependencies = mutableSetOf<Dependency>()
 
       val gradleTargets =
-        processTargetsForProject(
-          project = project,
-          dependencies = dependencies,
-          targetNameOverrides = targetNameOverrides,
-          workspaceRoot = workspaceRoot,
-          atomized = false)
+          processTargetsForProject(
+              project = project,
+              dependencies = dependencies,
+              targetNameOverrides = targetNameOverrides,
+              workspaceRoot = workspaceRoot,
+              atomized = false)
 
       assertNotNull(
-        gradleTargets.targets["build-kt"],
-        "Expected 'build-kt' target to be present (overridden from 'build')")
+          gradleTargets.targets["build-kt"],
+          "Expected 'build-kt' target to be present (overridden from 'build')")
       assertTrue(
-        gradleTargets.targetGroups["build"]?.contains("build-kt") == true,
-        "Expected 'build-kt' to be in the 'build' target group")
+          gradleTargets.targetGroups["build"]?.contains("build-kt") == true,
+          "Expected 'build-kt' to be in the 'build' target group")
     }
   }
 }

--- a/packages/gradle/src/plugin/utils/gradle-plugin-options.ts
+++ b/packages/gradle/src/plugin/utils/gradle-plugin-options.ts
@@ -1,5 +1,6 @@
 export interface GradlePluginOptions {
   testTargetName?: string;
+  buildTargetName?: string;
   ciTestTargetName?: string;
   gradleExecutableDirectory?: string;
   targetNamePrefix?: string;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

The Nx Gradle plugin allows users to override the test target name via testTargetName configuration, but there is no equivalent option to override the build target name. This limits flexibility when teams want to customize their target naming conventions to match their workflow or avoid conflicts with existing targets.

## Expected Behavior

Users can now configure a buildTargetName option in the Gradle plugin configuration to override the default build target name.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
