### PR TITLE
fix(nx-dev): fix og images wrong URL for embeds

### DIFF
--- a/nx-dev/nx-dev/app/layout.tsx
+++ b/nx-dev/nx-dev/app/layout.tsx
@@ -10,6 +10,15 @@ import { FrontendObservability } from '../lib/components/frontend-observability'
 
 // Metadata for the entire site
 export const metadata: Metadata = {
+  // Resolve relative URLs in metadata (e.g., OG images) to the correct deployment URL
+  // - VERCEL_URL: Vercel preview deployments (hostname only, needs https://)
+  // - DEPLOY_URL: Netlify branch deploys and PR previews (full URL)
+  // - URL: Netlify production (full URL)
+  metadataBase: new URL(
+    process.env.VERCEL_URL
+      ? `https://${process.env.VERCEL_URL}`
+      : process.env.DEPLOY_URL || process.env.URL || 'https://nx.dev'
+  ),
   appleWebApp: { title: 'Nx' },
   applicationName: 'Nx',
   icons: [


### PR DESCRIPTION
fixes: DOC-399

next used the VERCEL_URL by default for metadataBase. this is not present in netlify. so resolve to netlify URLs if VERCEL_URL is not present so metadata links are correct. 

working on PR:
<img width="704" height="875" alt="image" src="https://github.com/user-attachments/assets/4edd194e-27d6-46ce-bdd2-7da4ab70d482" />
<img width="976" height="204" alt="image" src="https://github.com/user-attachments/assets/63ea32f5-20cf-4df2-96a1-a1bc2ff59411" />


https://6984ce9d1bad30000873247d--nx-dev.netlify.app/blog/nx-2026-roadmap
