### PR TITLE
fix(maven): correctly map between maven locators and nx project names

### DIFF
--- a/e2e/maven/src/maven-name-overrides.test.ts
+++ b/e2e/maven/src/maven-name-overrides.test.ts
@@ -1,0 +1,54 @@
+import {
+  cleanupProject,
+  newProject,
+  runCLI,
+  uniq,
+  readJson,
+} from '@nx/e2e-utils';
+
+import { createMavenProject } from './utils/create-maven-project';
+
+describe('Maven with project name overrides', () => {
+  let mavenProjectName = uniq('my-maven-project');
+
+  beforeAll(async () => {
+    newProject({
+      preset: 'apps',
+      packages: ['@nx/maven'],
+    });
+    // Create Maven project with custom Nx project name prefix
+    // This creates project.json files with names like "custom-app", "custom-lib", "custom-utils"
+    // while Maven artifactIds remain "app", "lib", "utils"
+    await createMavenProject(mavenProjectName, undefined, 'custom-');
+    runCLI(`add @nx/maven`);
+  });
+
+  afterAll(() => cleanupProject());
+
+  it('should detect Maven projects with overridden names', () => {
+    const projects = runCLI(`show projects`);
+    expect(projects).toContain('custom-app');
+    expect(projects).toContain('custom-lib');
+    expect(projects).toContain('custom-utils');
+  });
+
+  it('should use Maven coordinates for -pl flag despite custom Nx name', () => {
+    const projectJson = readJson('app/project.json');
+    // The project.json has a custom name that doesn't match Maven coordinates
+    expect(projectJson.name).toBe('custom-app');
+
+    // The inferred target should have the correct Maven coordinates in options.project
+    const output = runCLI('show project custom-app --json');
+    const project = JSON.parse(output);
+    const installTarget = project.targets['install'];
+    expect(installTarget.options.project).toBe('com.example:app');
+  });
+
+  it('should build Maven project with overridden names', () => {
+    // Build custom-app which depends on custom-lib -> custom-utils
+    // This tests that the executor uses options.project (Maven coordinates)
+    // instead of the Nx project name for the -pl flag
+    const buildOutput = runCLI('run custom-app:install', { verbose: true });
+    expect(buildOutput).toContain('BUILD SUCCESS');
+  });
+});

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt
@@ -61,6 +61,7 @@ class NxProjectAnalyzer(
     // Project metadata including target groups
     val metadataStart = System.currentTimeMillis()
     val projectMetadata = JsonObject()
+    projectMetadata.addProperty("mavenProject", projectName)
     projectMetadata.add("targetGroups", targetGroups)
     nxProject.add("metadata", projectMetadata)
 

--- a/packages/maven/src/executors/maven/maven.impl.ts
+++ b/packages/maven/src/executors/maven/maven.impl.ts
@@ -10,6 +10,19 @@ const nxMavenApplyGoal = 'dev.nx.maven:nx-maven-plugin:apply';
 const nxMavenRecordGoal = 'dev.nx.maven:nx-maven-plugin:record';
 
 /**
+ * Get the Maven project coordinates (groupId:artifactId) from project metadata.
+ * Falls back to the Nx project name if metadata is not available.
+ */
+function getMavenProjectName(context: ExecutorContext): string {
+  const projectConfig =
+    context.projectGraph?.nodes?.[context.projectName]?.data;
+  return (
+    (projectConfig?.metadata as Record<string, string>)?.mavenProject ||
+    context.projectName
+  );
+}
+
+/**
  * Build Maven command arguments
  */
 function buildMavenArgs(
@@ -65,9 +78,9 @@ export default async function mavenExecutor(
   context: ExecutorContext
 ): Promise<{ success: boolean }> {
   const mavenExecutable = detectMavenExecutable(workspaceRoot);
-  const projectName = context.projectName;
+  const mavenProject = getMavenProjectName(context);
   const useMaven4 = isMaven4(workspaceRoot);
-  const args = buildMavenArgs(options, projectName, useMaven4);
+  const args = buildMavenArgs(options, mavenProject, useMaven4);
 
   return runCommandsImpl(
     {


### PR DESCRIPTION

## Current Behavior
nx passes along nx project names to the maven batch executor which might not be the same as the maven project locators.

## Expected Behavior
nx should use the maven locators so it's guaranteed to work for maven

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
