### PR TITLE
fix(nx-dev): include nx cli examples on refs page

### DIFF
--- a/astro-docs/src/plugins/utils/cli-subprocess.cjs
+++ b/astro-docs/src/plugins/utils/cli-subprocess.cjs
@@ -18,6 +18,10 @@ require('ts-node').register({
 
 // TypeScript paths are now handled by pnpm workspaces, no need for tsconfig-paths
 
+const { examples: cliExamples } = importFresh(
+  join(workspaceRoot, 'packages/nx/src/command-line/examples')
+);
+
 // Inline command parser functions
 const YargsTypes = ['array', 'count', 'string', 'boolean', 'number'];
 
@@ -42,6 +46,7 @@ async function parseCommand(name, command) {
         command.description || command.describe || command.desc || '',
       aliases: [],
       options: [],
+      examples: cliExamples[name] || [],
     };
   }
 
@@ -111,6 +116,7 @@ async function parseCommand(name, command) {
     aliases: command.aliases || [],
     options,
     subcommands: subcommands.length > 0 ? subcommands : undefined,
+    examples: cliExamples[name] || [],
   };
 }
 

--- a/astro-docs/src/plugins/utils/nx-cli-generation.ts
+++ b/astro-docs/src/plugins/utils/nx-cli-generation.ts
@@ -18,6 +18,10 @@ export interface ParsedCliCommand {
     choices?: string[];
   }>;
   subcommands?: ParsedCliCommand[];
+  examples?: Array<{
+    command: string;
+    description: string;
+  }>;
 }
 
 export async function loadNxCliPackage(
@@ -85,7 +89,6 @@ export async function loadNxCliPackage(
       description: 'Complete reference for Nx CLI commands',
       filter: 'type:References',
     },
-    // @ts-expect-error - astro types are mismatched bc of auto generated location loading, etc
     rendered: await renderMarkdown(markdown),
     collection: 'nx-reference-packages',
   };
@@ -183,6 +186,23 @@ function generateOptionsTable(
   return section;
 }
 
+function generateExamplesSection(
+  examples: ParsedCliCommand['examples']
+): string {
+  if (!examples || examples.length === 0) {
+    return '';
+  }
+
+  let section = `\n#### Examples\n\n`;
+
+  for (const example of examples) {
+    section += `${example.description}:\n\n`;
+    section += `\`\`\`bash\nnx ${example.command}\n\`\`\`\n\n`;
+  }
+
+  return section;
+}
+
 function generateCLIMarkdown(
   commands: Record<string, ParsedCliCommand>
 ): string {
@@ -217,6 +237,9 @@ ${flattenedCommands
 nx ${usageCmd}
 \`\`\`
 `;
+
+    // Add examples section if available
+    section += generateExamplesSection(cmd.examples);
 
     // If this is a parent command with subcommands, label options as "Shared Options"
     const hasSubcommands = cmd.subcommands && cmd.subcommands.length > 0;


### PR DESCRIPTION
![wm_2026-02-06T11-26-54@2x](https://github.com/user-attachments/assets/c2814268-e921-420b-a9e2-2b90c8a89526)
https://deploy-preview-34367--nx-docs.netlify.app/docs/reference/nx-commands#nx-add

cli examples are included in the generated page now

fixes: DOC-402