### PR TITLE
feat(maven): report external Maven dependencies in project graph

### DIFF
--- a/packages/maven/maven-plugin/pom.xml
+++ b/packages/maven/maven-plugin/pom.xml
@@ -256,6 +256,12 @@
             <artifactId>surefire-junit4</artifactId>
             <version>3.2.5</version>
           </dependency>
+          <!-- Support for JUnit 5 tests -->
+          <dependency>
+            <groupId>org.apache.maven.surefire</groupId>
+            <artifactId>surefire-junit-platform</artifactId>
+            <version>3.2.5</version>
+          </dependency>
         </dependencies>
       </plugin>
 

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt
@@ -105,6 +105,20 @@ class NxProjectAnalyzer(
       }
     }
 
+    // Collect external dependencies (not in coordinatesMap)
+    val externalDependencies = project.dependencies
+      .filter { dependency ->
+        !coordinatesMap.containsKey("${dependency.groupId}:${dependency.artifactId}")
+      }
+      .map { dependency ->
+        ExternalMavenDependency(
+          groupId = dependency.groupId,
+          artifactId = dependency.artifactId,
+          version = dependency.version,
+          scope = dependency.scope
+        )
+      }
+
     val dependenciesJson = dependencies.map { nxDependency ->
       val dependency = JsonObject()
 
@@ -115,7 +129,7 @@ class NxProjectAnalyzer(
       dependency
     }
 
-    return ProjectAnalysis(project.file, root, nxProject, dependenciesJson)
+    return ProjectAnalysis(project.file, root, nxProject, dependenciesJson, externalDependencies)
   }
 
   private fun determineProjectType(packaging: String): String {
@@ -128,7 +142,20 @@ class NxProjectAnalyzer(
   }
 }
 
-data class ProjectAnalysis(val pomFile: File, val root: String, val project: JsonElement, val dependencies: List<JsonElement>)
+data class ProjectAnalysis(
+  val pomFile: File,
+  val root: String,
+  val project: JsonElement,
+  val dependencies: List<JsonElement>,
+  val externalDependencies: List<ExternalMavenDependency>
+)
+
+data class ExternalMavenDependency(
+  val groupId: String,
+  val artifactId: String,
+  val version: String?,
+  val scope: String?
+)
 
 data class NxDependency(val type: NxDependencyType, val source: String, val target: String, val sourceFile: File)
 

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt
@@ -106,16 +106,17 @@ class NxProjectAnalyzer(
     }
 
     // Collect external dependencies (not in coordinatesMap)
-    val externalDependencies = project.dependencies
-      .filter { dependency ->
-        !coordinatesMap.containsKey("${dependency.groupId}:${dependency.artifactId}")
+    // Use project.artifacts (includes transitive deps) instead of project.dependencies (direct only)
+    val externalDependencies = project.artifacts
+      .filter { artifact ->
+        !coordinatesMap.containsKey("${artifact.groupId}:${artifact.artifactId}")
       }
-      .map { dependency ->
+      .map { artifact ->
         ExternalMavenDependency(
-          groupId = dependency.groupId,
-          artifactId = dependency.artifactId,
-          version = dependency.version,
-          scope = dependency.scope
+          groupId = artifact.groupId,
+          artifactId = artifact.artifactId,
+          version = artifact.version,
+          scope = artifact.scope
         )
       }
 

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt
@@ -66,19 +66,10 @@ class NxProjectAnalyzer(
 
     // Project metadata including target groups
     val metadataStart = System.currentTimeMillis()
-    val projectMetadata = JsonObject()
-    projectMetadata.addProperty("mavenProject", projectName)
-    projectMetadata.add("targetGroups", targetGroups)
-    val technologies = JsonArray()
-    technologies.add("maven")
-    projectMetadata.add("technologies", technologies)
-    nxProject.add("metadata", projectMetadata)
-
-    // Tags
-    val tags = JsonArray()
-    tags.add("maven:${project.groupId}")
-    tags.add("maven:${project.packaging}")
-    nxProject.add("tags", tags)
+    nxProject.add("metadata", buildProjectMetadata(
+      projectName, project.groupId, project.artifactId, targetGroups
+    ))
+    nxProject.add("tags", buildProjectTags(project.groupId, project.packaging))
     val metadataTime = System.currentTimeMillis() - metadataStart
     log.info("Metadata and tags creation took ${metadataTime}ms for project: ${project.artifactId}")
 
@@ -170,4 +161,25 @@ data class NxDependency(val type: NxDependencyType, val source: String, val targ
 
 enum class NxDependencyType {
   Implicit, Static, Dynamic
+}
+
+internal fun buildProjectMetadata(
+  projectName: String, groupId: String, artifactId: String, targetGroups: JsonElement
+): JsonObject {
+  val metadata = JsonObject()
+  metadata.addProperty("mavenProject", projectName)
+  metadata.addProperty("groupId", groupId)
+  metadata.addProperty("artifactId", artifactId)
+  metadata.add("targetGroups", targetGroups)
+  val technologies = JsonArray()
+  technologies.add("maven")
+  metadata.add("technologies", technologies)
+  return metadata
+}
+
+internal fun buildProjectTags(groupId: String, packaging: String): JsonArray {
+  val tags = JsonArray()
+  tags.add("maven:$groupId")
+  tags.add("maven:$packaging")
+  return tags
 }

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzer.kt
@@ -51,8 +51,14 @@ class NxProjectAnalyzer(
     val configCreationTime = System.currentTimeMillis() - configCreationStart
     log.info("Basic config creation took ${configCreationTime}ms for project: ${project.artifactId}")
 
+    // Build list of external dep node names for target inputs
+    val externalDepNames = project.artifacts
+      .filter { !coordinatesMap.containsKey("${it.groupId}:${it.artifactId}") }
+      .map { "maven:${it.groupId}:${it.artifactId}" }
+      .distinct()
+
     val targetAnalysisStart = System.currentTimeMillis()
-    val (nxTargets, targetGroups) = nxTargetFactory.createNxTargets(project)
+    val (nxTargets, targetGroups) = nxTargetFactory.createNxTargets(project, externalDepNames)
     val targetAnalysisTime = System.currentTimeMillis() - targetAnalysisStart
     log.info("Target analysis took ${targetAnalysisTime}ms for project: ${project.artifactId}")
 
@@ -116,7 +122,8 @@ class NxProjectAnalyzer(
           groupId = artifact.groupId,
           artifactId = artifact.artifactId,
           version = artifact.version,
-          scope = artifact.scope
+          scope = artifact.scope,
+          artifactFile = artifact.file
         )
       }
 
@@ -155,7 +162,8 @@ data class ExternalMavenDependency(
   val groupId: String,
   val artifactId: String,
   val version: String?,
-  val scope: String?
+  val scope: String?,
+  val artifactFile: File?
 )
 
 data class NxDependency(val type: NxDependencyType, val source: String, val target: String, val sourceFile: File)

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt
@@ -286,6 +286,17 @@ class NxProjectAnalyzerMojo : AbstractMojo() {
       data.addProperty("groupId", extDep.groupId)
       data.addProperty("artifactId", extDep.artifactId)
       data.addProperty("version", extDep.version ?: "managed")
+
+      // Read the .sha1 sidecar file that Maven already computed next to the artifact
+      extDep.artifactFile?.let { jarFile ->
+        val sha1File = File("${jarFile.absolutePath}.sha1")
+        if (sha1File.exists()) {
+          data.addProperty("hash", sha1File.readText().trim())
+        } else {
+          log.warn("No .sha1 hash file found for ${coordinates} at ${sha1File.absolutePath}")
+        }
+      }
+
       node.add("data", data)
 
       externalNodes.add(nodeName, node)

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt
@@ -19,6 +19,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.io.FileReader
+import java.security.MessageDigest
 
 /**
  * Maven plugin to analyze project structure and generate JSON for Nx integration
@@ -259,94 +260,12 @@ class NxProjectAnalyzerMojo : AbstractMojo() {
   }
 
   private fun generateExternalNodes(projectAnalyses: List<ProjectAnalysis>): JsonObject {
-    val externalNodes = JsonObject()
-
-    // Deduplicate external deps across all projects by groupId:artifactId
-    val seen = mutableMapOf<String, ExternalMavenDependency>()
-    projectAnalyses.forEach { analysis ->
-      analysis.externalDependencies.forEach { extDep ->
-        val key = "${extDep.groupId}:${extDep.artifactId}"
-        // Keep the first occurrence (or one with a version if the existing one has none)
-        val existing = seen[key]
-        if (existing == null || (existing.version == null && extDep.version != null)) {
-          seen[key] = extDep
-        }
-      }
-    }
-
-    // Create external node JSON for each unique dependency
-    seen.forEach { (coordinates, extDep) ->
-      val nodeName = "maven:${coordinates}"
-      val node = JsonObject()
-      node.addProperty("type", "maven")
-      node.addProperty("name", nodeName)
-
-      val data = JsonObject()
-      data.addProperty("packageName", coordinates)
-      data.addProperty("groupId", extDep.groupId)
-      data.addProperty("artifactId", extDep.artifactId)
-      data.addProperty("version", extDep.version ?: "managed")
-
-      // Read the .sha1 sidecar file that Maven already computed next to the artifact
-      extDep.artifactFile?.let { jarFile ->
-        val sha1File = File("${jarFile.absolutePath}.sha1")
-        if (sha1File.exists()) {
-          data.addProperty("hash", sha1File.readText().trim())
-        } else {
-          log.warn("No .sha1 hash file found for ${coordinates} at ${sha1File.absolutePath}")
-        }
-      }
-
-      node.add("data", data)
-
-      externalNodes.add(nodeName, node)
-    }
-
-    return externalNodes
+    return buildExternalNodes(projectAnalyses)
   }
 
   private fun generateExternalEdges(allExternalDeps: List<ExternalMavenDependency>): List<JsonObject> {
-    val edges = mutableListOf<JsonObject>()
     val localRepo = session.repositorySession.localRepository.basedir
-    val reader = MavenXpp3Reader()
-
-    // Build set of known external node keys for quick lookup
-    val externalNodeKeys = allExternalDeps
-      .map { "${it.groupId}:${it.artifactId}" }
-      .toSet()
-
-    // Deduplicate: only process each groupId:artifactId once
-    val seen = mutableSetOf<String>()
-    val uniqueDeps = allExternalDeps.filter { seen.add("${it.groupId}:${it.artifactId}") }
-
-    for (dep in uniqueDeps) {
-      val version = dep.version ?: continue
-      val pomPath = File(
-        localRepo,
-        "${dep.groupId.replace('.', '/')}/${dep.artifactId}/${version}/${dep.artifactId}-${version}.pom"
-      )
-
-      if (!pomPath.exists()) continue
-
-      try {
-        val model = FileReader(pomPath).use { reader.read(it) }
-        model.dependencies?.forEach { pomDep ->
-          val targetKey = "${pomDep.groupId}:${pomDep.artifactId}"
-          if (externalNodeKeys.contains(targetKey)) {
-            val edge = JsonObject()
-            edge.addProperty("type", "static")
-            edge.addProperty("source", "maven:${dep.groupId}:${dep.artifactId}")
-            edge.addProperty("target", "maven:${targetKey}")
-            edges.add(edge)
-          }
-        }
-      } catch (e: Exception) {
-        log.debug("Could not parse POM for ${dep.groupId}:${dep.artifactId}:${version}: ${e.message}")
-      }
-    }
-
-    log.info("Generated ${edges.size} external-to-external dependency edges")
-    return edges
+    return buildExternalEdges(allExternalDeps, localRepo)
   }
 
   private fun generateCoordinatesMap(
@@ -356,4 +275,118 @@ class NxProjectAnalyzerMojo : AbstractMojo() {
     projects.associate { project ->
       "${project.groupId}:${project.artifactId}" to pathFormatter.normalizeRelativePath(project.basedir.canonicalFile.relativeTo(workspaceRoot).path)
     }
+}
+
+/**
+ * Builds a deduplicated map of external nodes from project analyses.
+ * Extracted as a top-level function for testability.
+ */
+internal fun buildExternalNodes(projectAnalyses: List<ProjectAnalysis>): JsonObject {
+  val log: Logger = LoggerFactory.getLogger("dev.nx.maven.ExternalNodes")
+  val externalNodes = JsonObject()
+
+  // Deduplicate external deps across all projects by groupId:artifactId
+  val seen = mutableMapOf<String, ExternalMavenDependency>()
+  projectAnalyses.forEach { analysis ->
+    analysis.externalDependencies.forEach { extDep ->
+      val key = "${extDep.groupId}:${extDep.artifactId}"
+      // Keep the first occurrence (or one with a version if the existing one has none)
+      val existing = seen[key]
+      if (existing == null || (existing.version == null && extDep.version != null)) {
+        seen[key] = extDep
+      }
+    }
+  }
+
+  // Create external node JSON for each unique dependency
+  seen.forEach { (coordinates, extDep) ->
+    val nodeName = "maven:${coordinates}"
+    val node = JsonObject()
+    node.addProperty("type", "maven")
+    node.addProperty("name", nodeName)
+
+    val data = JsonObject()
+    data.addProperty("packageName", coordinates)
+    data.addProperty("groupId", extDep.groupId)
+    data.addProperty("artifactId", extDep.artifactId)
+    data.addProperty("version", extDep.version ?: "managed")
+
+    // Read the .sha1 sidecar file that Maven already computed next to the artifact
+    var hash: String? = null
+    extDep.artifactFile?.let { jarFile ->
+      val sha1File = File("${jarFile.absolutePath}.sha1")
+      if (sha1File.exists()) {
+        hash = sha1File.readText().trim()
+      }
+    }
+    // Fallback: hash the coordinates so cache invalidation still works on version bumps
+    if (hash == null) {
+      val version = extDep.version ?: "managed"
+      hash = sha1("${extDep.groupId}:${extDep.artifactId}:${version}")
+    }
+    data.addProperty("hash", hash)
+
+    node.add("data", data)
+
+    externalNodes.add(nodeName, node)
+  }
+
+  return externalNodes
+}
+
+/**
+ * Builds external-to-external dependency edges by reading POM files
+ * from the local Maven repository.
+ * Extracted as a top-level function for testability.
+ */
+internal fun buildExternalEdges(
+  allExternalDeps: List<ExternalMavenDependency>,
+  localRepo: File
+): List<JsonObject> {
+  val log: Logger = LoggerFactory.getLogger("dev.nx.maven.ExternalEdges")
+  val edges = mutableListOf<JsonObject>()
+  val reader = MavenXpp3Reader()
+
+  // Build set of known external node keys for quick lookup
+  val externalNodeKeys = allExternalDeps
+    .map { "${it.groupId}:${it.artifactId}" }
+    .toSet()
+
+  // Deduplicate: only process each groupId:artifactId once
+  val seen = mutableSetOf<String>()
+  val uniqueDeps = allExternalDeps.filter { seen.add("${it.groupId}:${it.artifactId}") }
+
+  for (dep in uniqueDeps) {
+    val version = dep.version ?: continue
+    val pomPath = File(
+      localRepo,
+      "${dep.groupId.replace('.', '/')}/${dep.artifactId}/${version}/${dep.artifactId}-${version}.pom"
+    )
+
+    if (!pomPath.exists()) continue
+
+    try {
+      val model = FileReader(pomPath).use { reader.read(it) }
+      model.dependencies?.forEach { pomDep ->
+        val targetKey = "${pomDep.groupId}:${pomDep.artifactId}"
+        if (externalNodeKeys.contains(targetKey)) {
+          val edge = JsonObject()
+          edge.addProperty("type", "static")
+          edge.addProperty("source", "maven:${dep.groupId}:${dep.artifactId}")
+          edge.addProperty("target", "maven:${targetKey}")
+          edges.add(edge)
+        }
+      }
+    } catch (e: Exception) {
+      log.debug("Could not parse POM for ${dep.groupId}:${dep.artifactId}:${version}: ${e.message}")
+    }
+  }
+
+  log.info("Generated ${edges.size} external-to-external dependency edges")
+  return edges
+}
+
+private fun sha1(input: String): String {
+  val digest = MessageDigest.getInstance("SHA-1")
+  return digest.digest(input.toByteArray()).joinToString("") { "%02x".format(it) }
 }

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/NxProjectAnalyzerMojo.kt
@@ -231,7 +231,7 @@ class NxProjectAnalyzerMojo : AbstractMojo() {
     val createNodesResults = JsonArray()
 
     // Build a deduplicated map of all external nodes across all projects
-    val allExternalNodes = generateExternalNodes(inMemoryAnalyses)
+    val allExternalNodes = buildExternalNodes(inMemoryAnalyses)
 
     inMemoryAnalyses.forEach { analysis ->
       val resultTuple = JsonArray()
@@ -257,10 +257,6 @@ class NxProjectAnalyzerMojo : AbstractMojo() {
     }
 
     return createNodesResults
-  }
-
-  private fun generateExternalNodes(projectAnalyses: List<ProjectAnalysis>): JsonObject {
-    return buildExternalNodes(projectAnalyses)
   }
 
   private fun generateExternalEdges(allExternalDeps: List<ExternalMavenDependency>): List<JsonObject> {

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/NxTargetFactory.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/NxTargetFactory.kt
@@ -43,7 +43,8 @@ class NxTargetFactory(
 
 
   fun createNxTargets(
-    project: MavenProject
+    project: MavenProject,
+    externalDependencies: List<String> = emptyList()
   ): Pair<JsonObject, JsonObject> {
     val nxTargets = JsonObject()
     val targetGroups = mutableMapOf<String, List<String>>()
@@ -65,11 +66,12 @@ class NxTargetFactory(
       project,
       phaseTargets,
       ciPhaseTargets,
-      ciPhasesWithGoals
+      ciPhasesWithGoals,
+      externalDependencies
     )
 
     // Create individual goal targets for granular execution
-    createIndividualGoalTargets(plugins, project, nxTargets)
+    createIndividualGoalTargets(plugins, project, nxTargets, externalDependencies)
 
     val mavenPhasesGroup = mutableListOf<String>()
     phaseTargets.forEach { (phase, target) ->
@@ -90,7 +92,8 @@ class NxTargetFactory(
         project,
         nxTargets,
         ciPhaseTargets["${applyPrefix("test-ci")}"]!!,
-        phaseGoals["test"]!!
+        phaseGoals["test"]!!,
+        externalDependencies
       )
 
       atomizedTestTargets.forEach { (goal, target) ->
@@ -120,7 +123,8 @@ class NxTargetFactory(
    * This is similar to createPhaseTarget but delegates to the Maven batch runner.
    */
   private fun createPhaseBatchTarget(
-    project: MavenProject, phase: String, goals: List<GoalDescriptor>
+    project: MavenProject, phase: String, goals: List<GoalDescriptor>,
+    externalDependencies: List<String> = emptyList()
   ): NxTarget {
     // Sort goals by priority (lower numbers execute first)
     val sortedGoals = goals.sortedWith(compareBy<GoalDescriptor> { it.executionPriority }.thenBy { it.executionId })
@@ -206,6 +210,7 @@ class NxTargetFactory(
       outputs.forEach { output -> outputsArray.add(output) }
       target.outputs = outputsArray
       addBuildStateJsonInputsAndOutputs(project, target)
+      addExternalDependenciesInput(target, externalDependencies)
     }
 
     return target
@@ -217,7 +222,8 @@ class NxTargetFactory(
     project: MavenProject,
     phaseTargets: MutableMap<String, NxTarget>,
     ciPhaseTargets: MutableMap<String, NxTarget>,
-    ciPhasesWithGoals: MutableSet<String>
+    ciPhasesWithGoals: MutableSet<String>,
+    externalDependencies: List<String>
   ) {
     lifecycles.forEach { lifecycle ->
       log.info(
@@ -233,7 +239,7 @@ class NxTargetFactory(
       lifecycle.phases.forEachIndexed { index, phase ->
         createRegularPhaseTarget(
           lifecycle.phases, index, phase, phaseGoals, project,
-          phaseTargets, hasInstall
+          phaseTargets, hasInstall, externalDependencies
         )
       }
 
@@ -242,7 +248,7 @@ class NxTargetFactory(
         if (testIndex > -1) {
           createCiPhaseTarget(
             lifecycle.phases, index, phase, phaseGoals, project,
-            ciPhaseTargets, ciPhasesWithGoals, hasInstall
+            ciPhaseTargets, ciPhasesWithGoals, hasInstall, externalDependencies
           )
         }
       }
@@ -256,13 +262,14 @@ class NxTargetFactory(
     phaseGoals: Map<String, MutableList<GoalDescriptor>>,
     project: MavenProject,
     phaseTargets: MutableMap<String, NxTarget>,
-    hasInstall: Boolean
+    hasInstall: Boolean,
+    externalDependencies: List<String>
   ) {
     val goalsForPhase = phaseGoals[phase]
     val hasGoals = goalsForPhase?.isNotEmpty() == true
 
     // Create target for all phases - either with goals or as noop
-    val target = createPhaseBatchTarget(project, phase, goalsForPhase ?: emptyList())
+    val target = createPhaseBatchTarget(project, phase, goalsForPhase ?: emptyList(), externalDependencies)
 
 
     target.dependsOn = target.dependsOn ?: JsonArray()
@@ -301,7 +308,8 @@ class NxTargetFactory(
     project: MavenProject,
     ciPhaseTargets: MutableMap<String, NxTarget>,
     ciPhasesWithGoals: MutableSet<String>,
-    hasInstall: Boolean
+    hasInstall: Boolean,
+    externalDependencies: List<String>
   ) {
     val goalsForPhase = phaseGoals[phase]
     val hasGoals = goalsForPhase?.isNotEmpty() == true
@@ -315,10 +323,10 @@ class NxTargetFactory(
 
     // Create CI targets for phases with goals, or noop for test/structural phases
     val ciTarget = if (hasGoals && phase != "test") {
-      createPhaseBatchTarget(project, phase, goalsForPhase!!)
+      createPhaseBatchTarget(project, phase, goalsForPhase!!, externalDependencies)
     } else {
       // Noop for test phase (will be orchestrated by atomized tests) or structural phases
-      createPhaseBatchTarget(project, phase, emptyList())
+      createPhaseBatchTarget(project, phase, emptyList(), externalDependencies)
     }
     // Initialize dependsOn for all CI targets (for atomized tests or phase dependencies)
     ciTarget.dependsOn = ciTarget.dependsOn ?: JsonArray()
@@ -395,7 +403,8 @@ class NxTargetFactory(
   private fun createIndividualGoalTargets(
     plugins: List<Plugin>,
     project: MavenProject,
-    nxTargets: JsonObject
+    nxTargets: JsonObject,
+    externalDependencies: List<String>
   ) {
     plugins.forEach { plugin: Plugin ->
       val pluginDescriptor = runCatching { getPluginDescriptor(plugin, project) }
@@ -420,7 +429,8 @@ class NxTargetFactory(
             pluginDescriptor,
             goalPrefix,
             goal,
-            execution
+            execution,
+            externalDependencies
           ) ?: return@forEach
           nxTargets.add(goalTargetName, goalTarget.toJSON())
 
@@ -438,7 +448,8 @@ class NxTargetFactory(
             pluginDescriptor,
             goalPrefix,
             goal,
-            null
+            null,
+            externalDependencies
           ) ?: return@forEach
           nxTargets.add(goalTargetName, goalTarget.toJSON())
 
@@ -488,7 +499,8 @@ class NxTargetFactory(
     pluginDescriptor: PluginDescriptor,
     goalPrefix: String,
     goalName: String,
-    execution: PluginExecution?
+    execution: PluginExecution?,
+    externalDependencies: List<String>
   ): NxTarget? {
     val options = JsonObject()
     val goalSpec = if (execution != null) "$goalPrefix:$goalName@${execution.id}" else "$goalPrefix:$goalName"
@@ -531,6 +543,7 @@ class NxTargetFactory(
       val outputsArray = JsonArray()
       analysis.outputs.forEach { output -> outputsArray.add(output) }
       target.outputs = outputsArray
+      addExternalDependenciesInput(target, externalDependencies)
     }
 
     addBuildStateJsonInputsAndOutputs(project, target)
@@ -545,7 +558,8 @@ class NxTargetFactory(
     project: MavenProject,
     nxTargets: JsonObject,
     testCiTarget: NxTarget,
-    testGoals: MutableList<GoalDescriptor>
+    testGoals: MutableList<GoalDescriptor>,
+    externalDependencies: List<String>
   ): Map<String, NxTarget> {
     val goalDescriptor = testGoals.first()
     val targets = mutableMapOf<String, NxTarget>()
@@ -594,6 +608,7 @@ class NxTargetFactory(
         if (input.transitive) obj.addProperty("transitive", true)
         target.inputs?.add(obj)
       }
+      addExternalDependenciesInput(target, externalDependencies)
 
       targets[targetName] = target
       testCiTargetGroup.add(targetName)
@@ -627,6 +642,16 @@ class NxTargetFactory(
     target.outputs?.add(pathFormatter.formatOutputPath(buildJsonFile, project.basedir))
   }
 
+
+  private fun addExternalDependenciesInput(target: NxTarget, externalDependencies: List<String>) {
+    if (externalDependencies.isNotEmpty() && target.inputs != null) {
+      val extDepsObj = JsonObject()
+      val extDepsArray = JsonArray()
+      externalDependencies.forEach { extDepsArray.add(it) }
+      extDepsObj.add("externalDependencies", extDepsArray)
+      target.inputs!!.add(extDepsObj)
+    }
+  }
 
   private fun getPluginDescriptor(
     plugin: Plugin,

--- a/packages/maven/maven-plugin/src/test/kotlin/dev/nx/maven/ExternalDependenciesTest.kt
+++ b/packages/maven/maven-plugin/src/test/kotlin/dev/nx/maven/ExternalDependenciesTest.kt
@@ -1,0 +1,277 @@
+package dev.nx.maven
+
+import com.google.gson.JsonObject
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ExternalDependenciesTest {
+
+  @Nested
+  inner class BuildExternalNodes {
+
+    @Test
+    fun `reads hash from sha1 sidecar file next to artifact`(@TempDir tempDir: File) {
+      val jarFile = File(tempDir, "guava-31.1.jar").apply { createNewFile() }
+      File(tempDir, "guava-31.1.jar.sha1").writeText("abc123def456")
+
+      val result = buildExternalNodes(listOf(
+        analysisWithDeps(tempDir, listOf(
+          dep("com.google.guava", "guava", "31.1", jarFile)
+        ))
+      ))
+
+      val data = result.nodeData("com.google.guava:guava")
+      assertEquals("abc123def456", data.get("hash").asString)
+      assertEquals("31.1", data.get("version").asString)
+    }
+
+    @Test
+    fun `falls back to coordinates hash when no sha1 file exists`(@TempDir tempDir: File) {
+      val jarFile = File(tempDir, "guava-31.1.jar").apply { createNewFile() }
+
+      val result = buildExternalNodes(listOf(
+        analysisWithDeps(tempDir, listOf(
+          dep("com.google.guava", "guava", "31.1", jarFile)
+        ))
+      ))
+
+      val hash = result.nodeData("com.google.guava:guava").get("hash").asString
+      // Should be a SHA-1 hex string (40 chars), not null
+      assertEquals(40, hash.length)
+      assertTrue(hash.matches(Regex("[0-9a-f]+")))
+    }
+
+    @Test
+    fun `deduplicates same dep across projects and prefers versioned over null`() {
+      val analyses = listOf(
+        analysisWithDeps(deps = listOf(
+          dep("com.example", "lib", null)
+        )),
+        analysisWithDeps(deps = listOf(
+          dep("com.example", "lib", "2.0.0")
+        ))
+      )
+
+      val result = buildExternalNodes(analyses)
+
+      assertEquals(1, result.size())
+      assertEquals("2.0.0", result.nodeData("com.example:lib").get("version").asString)
+    }
+
+    @Test
+    fun `uses managed as version when version is null`() {
+      val result = buildExternalNodes(listOf(
+        analysisWithDeps(deps = listOf(dep("org.slf4j", "slf4j-api", null)))
+      ))
+
+      assertEquals("managed", result.nodeData("org.slf4j:slf4j-api").get("version").asString)
+    }
+
+    @Test
+    fun `fallback hash changes when version changes`() {
+      val v1 = buildExternalNodes(listOf(
+        analysisWithDeps(deps = listOf(dep("com.example", "lib", "1.0.0")))
+      ))
+      val v2 = buildExternalNodes(listOf(
+        analysisWithDeps(deps = listOf(dep("com.example", "lib", "2.0.0")))
+      ))
+
+      val hash1 = v1.nodeData("com.example:lib").get("hash").asString
+      val hash2 = v2.nodeData("com.example:lib").get("hash").asString
+      assertTrue(hash1 != hash2, "Different versions should produce different hashes")
+    }
+
+    @Test
+    fun `sets correct node structure`() {
+      val result = buildExternalNodes(listOf(
+        analysisWithDeps(deps = listOf(dep("com.google.guava", "guava", "31.1")))
+      ))
+
+      val node = result.getAsJsonObject("maven:com.google.guava:guava")
+      assertEquals("maven", node.get("type").asString)
+      assertEquals("maven:com.google.guava:guava", node.get("name").asString)
+
+      val data = node.getAsJsonObject("data")
+      assertEquals("com.google.guava:guava", data.get("packageName").asString)
+      assertEquals("com.google.guava", data.get("groupId").asString)
+      assertEquals("guava", data.get("artifactId").asString)
+    }
+  }
+
+  @Nested
+  inner class BuildExternalEdges {
+
+    @Test
+    fun `creates edge when dep POM depends on another known external dep`(@TempDir localRepo: File) {
+      // guava depends on jsr305 — set up a fake local repo POM
+      writePom(localRepo, "com.google.guava", "guava", "31.1", listOf(
+        PomDep("com.google.code.findbugs", "jsr305")
+      ))
+
+      val deps = listOf(
+        dep("com.google.guava", "guava", "31.1"),
+        dep("com.google.code.findbugs", "jsr305", "3.0.2")
+      )
+
+      val edges = buildExternalEdges(deps, localRepo)
+
+      assertEquals(1, edges.size)
+      assertEquals("maven:com.google.guava:guava", edges[0].get("source").asString)
+      assertEquals("maven:com.google.code.findbugs:jsr305", edges[0].get("target").asString)
+      assertEquals("static", edges[0].get("type").asString)
+    }
+
+    @Test
+    fun `ignores deps in POM that are not in our external node set`(@TempDir localRepo: File) {
+      // guava depends on checker-qual, but checker-qual is NOT in our external deps
+      writePom(localRepo, "com.google.guava", "guava", "31.1", listOf(
+        PomDep("org.checkerframework", "checker-qual")
+      ))
+
+      val deps = listOf(
+        dep("com.google.guava", "guava", "31.1")
+      )
+
+      val edges = buildExternalEdges(deps, localRepo)
+
+      assertTrue(edges.isEmpty())
+    }
+
+    @Test
+    fun `skips deps with null version`(@TempDir localRepo: File) {
+      val deps = listOf(
+        dep("com.google.guava", "guava", null)
+      )
+
+      val edges = buildExternalEdges(deps, localRepo)
+
+      assertTrue(edges.isEmpty())
+    }
+
+    @Test
+    fun `skips deps when POM file does not exist`(@TempDir localRepo: File) {
+      // No POM written to localRepo
+      val deps = listOf(
+        dep("com.google.guava", "guava", "31.1"),
+        dep("com.google.code.findbugs", "jsr305", "3.0.2")
+      )
+
+      val edges = buildExternalEdges(deps, localRepo)
+
+      assertTrue(edges.isEmpty())
+    }
+
+    @Test
+    fun `handles malformed POM gracefully`(@TempDir localRepo: File) {
+      // Write an invalid POM
+      val pomDir = File(localRepo, "com/google/guava/guava/31.1")
+      pomDir.mkdirs()
+      File(pomDir, "guava-31.1.pom").writeText("this is not valid xml")
+
+      val deps = listOf(
+        dep("com.google.guava", "guava", "31.1"),
+        dep("com.google.code.findbugs", "jsr305", "3.0.2")
+      )
+
+      val edges = buildExternalEdges(deps, localRepo)
+
+      // Should not throw, just return no edges
+      assertTrue(edges.isEmpty())
+    }
+
+    @Test
+    fun `deduplicates same dep appearing from multiple projects`(@TempDir localRepo: File) {
+      writePom(localRepo, "com.google.guava", "guava", "31.1", listOf(
+        PomDep("com.google.code.findbugs", "jsr305")
+      ))
+
+      // Same dep listed twice (as if from two different projects)
+      val deps = listOf(
+        dep("com.google.guava", "guava", "31.1"),
+        dep("com.google.guava", "guava", "31.1"),
+        dep("com.google.code.findbugs", "jsr305", "3.0.2")
+      )
+
+      val edges = buildExternalEdges(deps, localRepo)
+
+      // Should only produce one edge, not two
+      assertEquals(1, edges.size)
+    }
+
+    @Test
+    fun `creates multiple edges for dep with multiple known transitive deps`(@TempDir localRepo: File) {
+      writePom(localRepo, "org.springframework", "spring-core", "6.0.0", listOf(
+        PomDep("org.springframework", "spring-jcl"),
+        PomDep("io.micrometer", "micrometer-core"),
+        PomDep("some.unknown", "not-in-our-set")  // should be ignored
+      ))
+
+      val deps = listOf(
+        dep("org.springframework", "spring-core", "6.0.0"),
+        dep("org.springframework", "spring-jcl", "6.0.0"),
+        dep("io.micrometer", "micrometer-core", "1.10.0")
+      )
+
+      val edges = buildExternalEdges(deps, localRepo)
+
+      assertEquals(2, edges.size)
+      val targets = edges.map { it.get("target").asString }.toSet()
+      assertTrue(targets.contains("maven:org.springframework:spring-jcl"))
+      assertTrue(targets.contains("maven:io.micrometer:micrometer-core"))
+    }
+  }
+
+  // --- Helpers ---
+
+  private data class PomDep(val groupId: String, val artifactId: String)
+
+  private fun dep(
+    groupId: String, artifactId: String, version: String?,
+    artifactFile: File? = null
+  ) = ExternalMavenDependency(groupId, artifactId, version, "compile", artifactFile)
+
+  private fun analysisWithDeps(
+    pomDir: File = File("/tmp"),
+    deps: List<ExternalMavenDependency>
+  ) = ProjectAnalysis(
+    pomFile = File(pomDir, "pom.xml").apply { if (!exists()) createNewFile() },
+    root = "project",
+    project = JsonObject(),
+    dependencies = emptyList(),
+    externalDependencies = deps
+  )
+
+  /** Shorthand to get a node's data object by coordinates */
+  private fun JsonObject.nodeData(coordinates: String): JsonObject =
+    getAsJsonObject("maven:$coordinates").getAsJsonObject("data")
+
+  /** Write a minimal POM to the local repo directory structure */
+  private fun writePom(
+    localRepo: File, groupId: String, artifactId: String,
+    version: String, deps: List<PomDep>
+  ) {
+    val pomDir = File(localRepo, "${groupId.replace('.', '/')}/$artifactId/$version")
+    pomDir.mkdirs()
+
+    val depsXml = deps.joinToString("\n") { d ->
+      "<dependency><groupId>${d.groupId}</groupId><artifactId>${d.artifactId}</artifactId></dependency>"
+    }
+
+    val xml = buildString {
+      appendLine("""<?xml version="1.0" encoding="UTF-8"?>""")
+      appendLine("<project>")
+      appendLine("  <modelVersion>4.0.0</modelVersion>")
+      appendLine("  <groupId>$groupId</groupId>")
+      appendLine("  <artifactId>$artifactId</artifactId>")
+      appendLine("  <version>$version</version>")
+      appendLine("  <dependencies>$depsXml</dependencies>")
+      appendLine("</project>")
+    }
+
+    File(pomDir, "$artifactId-$version.pom").writeText(xml)
+  }
+}

--- a/packages/maven/maven-plugin/src/test/kotlin/dev/nx/maven/NxProjectAnalyzerTest.kt
+++ b/packages/maven/maven-plugin/src/test/kotlin/dev/nx/maven/NxProjectAnalyzerTest.kt
@@ -1,0 +1,59 @@
+package dev.nx.maven
+
+import com.google.gson.JsonObject
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class NxProjectAnalyzerTest {
+
+  @Test
+  fun `metadata includes groupId, artifactId, and mavenProject`() {
+    val metadata = buildProjectMetadata(
+      projectName = "com.example:my-lib",
+      groupId = "com.example",
+      artifactId = "my-lib",
+      targetGroups = JsonObject()
+    )
+
+    assertEquals("com.example", metadata.get("groupId").asString)
+    assertEquals("my-lib", metadata.get("artifactId").asString)
+    assertEquals("com.example:my-lib", metadata.get("mavenProject").asString)
+  }
+
+  @Test
+  fun `metadata includes technologies and target groups`() {
+    val targetGroups = JsonObject()
+    targetGroups.add("Maven Phases", com.google.gson.JsonArray().apply { add("build") })
+
+    val metadata = buildProjectMetadata(
+      projectName = "com.example:my-lib",
+      groupId = "com.example",
+      artifactId = "my-lib",
+      targetGroups = targetGroups
+    )
+
+    val technologies = metadata.getAsJsonArray("technologies")
+    assertEquals(1, technologies.size())
+    assertEquals("maven", technologies[0].asString)
+    assertTrue(metadata.getAsJsonObject("targetGroups").has("Maven Phases"))
+  }
+
+  @Test
+  fun `tags include groupId and packaging`() {
+    val tags = buildProjectTags(groupId = "org.acme", packaging = "jar")
+
+    val tagValues = (0 until tags.size()).map { tags[it].asString }
+    assertTrue(tagValues.contains("maven:org.acme"))
+    assertTrue(tagValues.contains("maven:jar"))
+  }
+
+  @Test
+  fun `tags use war packaging`() {
+    val tags = buildProjectTags(groupId = "com.example", packaging = "war")
+
+    val tagValues = (0 until tags.size()).map { tags[it].asString }
+    assertTrue(tagValues.contains("maven:com.example"))
+    assertTrue(tagValues.contains("maven:war"))
+  }
+}

--- a/packages/maven/src/plugins/dependencies.ts
+++ b/packages/maven/src/plugins/dependencies.ts
@@ -36,7 +36,10 @@ export const createDependencies: CreateDependencies = async (
     (dep) => ({
       ...dep,
       source: rootToProjectMap.get(dep.source),
-      target: rootToProjectMap.get(dep.target),
+      // External deps use maven: prefix — pass through as-is
+      target: dep.target.startsWith('maven:')
+        ? dep.target
+        : rootToProjectMap.get(dep.target),
     })
   );
 

--- a/packages/maven/src/plugins/dependencies.ts
+++ b/packages/maven/src/plugins/dependencies.ts
@@ -35,7 +35,9 @@ export const createDependencies: CreateDependencies = async (
   const transformedDependencies = mavenData.createDependenciesResults.map(
     (dep) => ({
       ...dep,
-      source: rootToProjectMap.get(dep.source),
+      source: dep.source.startsWith('maven:')
+        ? dep.source
+        : rootToProjectMap.get(dep.source),
       // External deps use maven: prefix — pass through as-is
       target: dep.target.startsWith('maven:')
         ? dep.target

--- a/packages/maven/src/plugins/types.ts
+++ b/packages/maven/src/plugins/types.ts
@@ -1,4 +1,4 @@
-import type { CreateNodesResultV2 } from '@nx/devkit';
+import type { CreateNodesResultV2, ProjectGraphExternalNode } from '@nx/devkit';
 import type { RawProjectGraphDependency } from 'nx/src/project-graph/project-graph-builder';
 
 export interface MavenPluginOptions {
@@ -14,6 +14,7 @@ export const DEFAULT_OPTIONS: MavenPluginOptions = {};
 export interface MavenAnalysisData {
   createNodesResults: CreateNodesResultV2;
   createDependenciesResults: RawProjectGraphDependency[];
+  externalNodes?: Record<string, ProjectGraphExternalNode>;
   generatedAt?: number;
   workspaceRoot?: string;
   totalProjects?: number;

--- a/packages/maven/src/plugins/types.ts
+++ b/packages/maven/src/plugins/types.ts
@@ -1,4 +1,4 @@
-import type { CreateNodesResultV2, ProjectGraphExternalNode } from '@nx/devkit';
+import type { CreateNodesResultV2 } from '@nx/devkit';
 import type { RawProjectGraphDependency } from 'nx/src/project-graph/project-graph-builder';
 
 export interface MavenPluginOptions {
@@ -14,7 +14,6 @@ export const DEFAULT_OPTIONS: MavenPluginOptions = {};
 export interface MavenAnalysisData {
   createNodesResults: CreateNodesResultV2;
   createDependenciesResults: RawProjectGraphDependency[];
-  externalNodes?: Record<string, ProjectGraphExternalNode>;
   generatedAt?: number;
   workspaceRoot?: string;
   totalProjects?: number;


### PR DESCRIPTION
## Current Behavior

The Maven plugin only reports dependencies between workspace projects. External dependencies (Spring, JUnit, etc.) from Maven Central are invisible — `nx graph` doesn't show the full dependency picture, and Nx can't invalidate cache when an external dependency changes.

## Expected Behavior

External Maven dependencies now appear as full-fidelity external nodes in the Nx project graph, with dependency edges between them, hashes for cache correctness, and `externalDependencies` inputs on targets.

### External Nodes

External nodes use the naming convention `maven:groupId:artifactId` (e.g., `maven:org.springframework:spring-core`) with:
- Type `"maven"`
- `groupId` and `artifactId` as separate fields
- Declared version (or `"managed"` if inherited from a parent POM)
- SHA-1 hash read from Maven's `.sha1` sidecar files in `~/.m2/repository`

### External-to-External Edges

Edges between external nodes are derived by parsing POMs from the local Maven repository. For example, `spring-boot-starter-web` → `spring-web` → `spring-core`. This gives `nx graph` a complete picture of the transitive dependency tree.

### Cache Invalidation via externalDependencies Inputs

Every cacheable target now includes `{"externalDependencies": ["maven:groupId:artifactId", ...]}` in its inputs. This means Nx invalidates cache when a resolved artifact changes — important for SNAPSHOTs and version ranges where the dependency can change without `pom.xml` changing.

### Changes

**Kotlin (maven-plugin)**
- `NxProjectAnalyzerMojo.kt`: Changed ResolutionScope to COMPILE for full transitive resolution. Added `generateExternalNodes()` with deduplication and SHA-1 hash reading. Added `generateExternalEdges()` via POM parsing from ~/.m2. Embedded external nodes in createNodesResult tuples, added project-to-external and external-to-external dependency edges.
- `NxProjectAnalyzer.kt`: Uses `project.artifacts` (transitive) instead of `project.dependencies` (direct only) for external deps. Added `artifactFile` field for hash lookup. Collects external dep names and passes them to target factory.
- `NxTargetFactory.kt`: Accepts externalDependencies list, threads it through all target creation methods, and adds `{"externalDependencies": [...]}` to every cacheable target's inputs.

**TypeScript**
- `dependencies.ts`: External sources/targets with `maven:` prefix pass through as-is instead of rootToProjectMap lookup.
- `types.ts`: Added `externalNodes` field to `MavenAnalysisData`.

## Related Issue(s)

<!-- Feature parity with Gradle plugin for external dependency support -->