### PR TITLE
fix(core): add missing FileType import for Windows watcher build

### DIFF
--- a/packages/nx/src/native/watch/types.rs
+++ b/packages/nx/src/native/watch/types.rs
@@ -124,6 +124,7 @@ pub fn transform_event_to_watch_events(
 
         #[cfg(target_os = "windows")]
         {
+            use watchexec_events::FileType;
             // Skip directory events - they're handled by register_new_directory_watches
             if path.1.map_or(false, |ft| matches!(ft, FileType::Dir)) {
                 return Ok(vec![]);


### PR DESCRIPTION
## Current Behavior

The Windows build (`aarch64-pc-windows-msvc`) fails to compile with:

```
error[E0433]: failed to resolve: use of undeclared type `FileType`
  --> packages\nx\src\native\watch\types.rs:128:55
```

The `FileType` type is used inside a `#[cfg(target_os = "windows")]` block but was not imported.

## Expected Behavior

The Windows build compiles successfully. The `FileType` import is scoped inside the `#[cfg(target_os = "windows")]` block (matching the existing pattern in the macOS block) so there are no unused imports on any platform.

## Related Issue(s)

N/A — build breakage discovered during CI publish workflow.