### PR TITLE
fix(repo): align pnpm version in CI workflows with package.json

### DIFF
--- a/.github/workflows/generate-embeddings.yml
+++ b/.github/workflows/generate-embeddings.yml
@@ -26,7 +26,7 @@ jobs:
         uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
         id: pnpm-install
         with:
-          version: 10.11.1
+          version: 10.28.2
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
         with:
-          version: 10.11.1
+          version: 10.28.2
 
       - name: Use Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
         with:
-          version: 10.11.1 # Aligned with root package.json (pnpm/action-setup will helpfully error if out of sync)
+          version: 10.28.2 # Aligned with root package.json (pnpm/action-setup will helpfully error if out of sync)
 
       - name: Run a security audit
         run: pnpm dlx audit-ci --critical --report-type summary

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ env:
   NX_RUN_GROUP: ${{ github.run_id }}-${{ github.run_attempt }}
   CYPRESS_INSTALL_BINARY: 0
   NODE_VERSION: 22.16.0
-  PNPM_VERSION: 10.11.1 # Aligned with root package.json (pnpm/action-setup will helpfully error if out of sync)
+  PNPM_VERSION: 10.28.2 # Aligned with root package.json (pnpm/action-setup will helpfully error if out of sync)
 
 jobs:
   # We first need to determine the version we are releasing, and if we need a custom repo or ref to use for the git checkout in subsequent steps.
@@ -406,7 +406,7 @@ jobs:
             env
             whoami
             sudo pkg install -y -f node libnghttp2 www/npm git openjdk17
-            sudo npm install --location=global --ignore-scripts pnpm@10.11.1
+            sudo npm install --location=global --ignore-scripts pnpm@10.28.2
             # Set up Java 17
             export JAVA_HOME=/usr/local/openjdk17
             export PATH="$JAVA_HOME/bin:$PATH"


### PR DESCRIPTION
## Current Behavior

Several GitHub Actions workflows hardcode pnpm version `10.11.1`, while `package.json` specifies `pnpm@10.28.2` in the `packageManager` field. This causes CI failures with:

```
Error: Multiple versions of pnpm specified:
  - version 10.11.1 in the GitHub Action config with the key "version"
  - version pnpm@10.28.2 in the package.json with the key "packageManager"
```

## Expected Behavior

All pnpm version references across CI workflows should match the `packageManager` field in `package.json` (`10.28.2`).

## Related Issue(s)

N/A — Fixing CI breakage from version mismatch.

## Changes

Updated pnpm version from `10.11.1` → `10.28.2` in:
- `.github/workflows/npm-audit.yml` — `pnpm/action-setup` version
- `.github/workflows/publish.yml` — `PNPM_VERSION` env var and FreeBSD install
- `.github/workflows/issue-notifier.yml` — `pnpm/action-setup` version
- `.github/workflows/generate-embeddings.yml` — `pnpm/action-setup` version