### PR TITLE
fix(core): use --lockfile-only for Bun updateLockFile

### DIFF
--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -231,7 +231,7 @@ export function getPackageManagerCommand(
       return {
         install: 'bun install',
         ciInstall: 'bun install --no-cache',
-        updateLockFile: 'bun install --frozen-lockfile',
+        updateLockFile: 'bun install --lockfile-only',
         add: 'bun install',
         addDev: 'bun install -D',
         rm: 'bun rm',


### PR DESCRIPTION
## Current Behavior

The Bun package manager config uses `--frozen-lockfile` for `updateLockFile`:

```typescript
updateLockFile: 'bun install --frozen-lockfile',
```

However, `--frozen-lockfile` **prevents** changes to the lockfile, causing `nx release` to fail when trying to update the lockfile after version bumps.

## Expected Behavior

Use `--lockfile-only` which generates/updates the lockfile without installing dependencies:

```typescript
updateLockFile: 'bun install --lockfile-only',
```

This is consistent with other package managers:
- npm: `npm install --package-lock-only`
- pnpm: `pnpm install --lockfile-only`
- yarn berry: `yarn install --mode update-lockfile`

## Background

When Bun support was added in PR #22602 (April 2024), `--lockfile-only` didn't exist in Bun. Bun has since added this flag.

Closes #34344