### PR TITLE
cleanup(core): use picocolors in eslint-plugin

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -97,10 +97,10 @@
     "@phenomnomnominal/tsquery": "catalog:typescript",
     "@typescript-eslint/type-utils": "catalog:eslint",
     "@typescript-eslint/utils": "catalog:eslint",
-    "chalk": "catalog:",
     "confusing-browser-globals": "^1.0.9",
     "globals": "^17.0.0",
     "jsonc-eslint-parser": "^2.1.0",
+    "picocolors": "catalog:",
     "semver": "catalog:",
     "tslib": "catalog:typescript"
   },

--- a/packages/eslint-plugin/src/utils/project-graph-utils.ts
+++ b/packages/eslint-plugin/src/utils/project-graph-utils.ts
@@ -13,10 +13,6 @@ import { readNxJson } from 'nx/src/config/configuration';
 import { TargetProjectLocator } from '@nx/js/internal';
 import { readFileMapCache } from 'nx/src/project-graph/nx-deps-cache';
 
-// TODO (43081j): if `styleText` or `picocolors` ever supports RGB, use
-// that instead.
-const orangeText = (text: string) => `\x1B[38;2;255;165;0m${text}\x1B[39m`;
-
 export function ensureGlobalProjectGraph(ruleName: string) {
   /**
    * Only reuse graph when running from terminal
@@ -47,7 +43,7 @@ export function ensureGlobalProjectGraph(ruleName: string) {
         projectGraph.externalNodes
       );
     } catch {
-      const WARNING_PREFIX = `${pc.reset(orangeText('warning'))}`;
+      const WARNING_PREFIX = `${pc.reset(pc.yellow('warning'))}`;
       const RULE_NAME_SUFFIX = `${pc.reset(pc.dim(`@nx/${ruleName}`))}`;
       process.stdout
         .write(`${WARNING_PREFIX} No cached ProjectGraph is available. The rule will be skipped.

--- a/packages/eslint-plugin/src/utils/project-graph-utils.ts
+++ b/packages/eslint-plugin/src/utils/project-graph-utils.ts
@@ -4,7 +4,7 @@ import {
   readCachedProjectGraph,
 } from '@nx/devkit';
 import { isTerminalRun } from './runtime-lint-utils';
-import chalk = require('chalk');
+import pc from 'picocolors';
 import {
   createProjectRootMappings,
   ProjectRootMappings,
@@ -12,6 +12,10 @@ import {
 import { readNxJson } from 'nx/src/config/configuration';
 import { TargetProjectLocator } from '@nx/js/internal';
 import { readFileMapCache } from 'nx/src/project-graph/nx-deps-cache';
+
+// TODO (43081j): if `styleText` or `picocolors` ever supports RGB, use
+// that instead.
+const orangeText = (text: string) => `\x1B[38;2;255;165;0m${text}\x1B[39m`;
 
 export function ensureGlobalProjectGraph(ruleName: string) {
   /**
@@ -43,8 +47,8 @@ export function ensureGlobalProjectGraph(ruleName: string) {
         projectGraph.externalNodes
       );
     } catch {
-      const WARNING_PREFIX = `${chalk.reset.keyword('orange')('warning')}`;
-      const RULE_NAME_SUFFIX = `${chalk.reset.dim(`@nx/${ruleName}`)}`;
+      const WARNING_PREFIX = `${pc.reset(orangeText('warning'))}`;
+      const RULE_NAME_SUFFIX = `${pc.reset(pc.dim(`@nx/${ruleName}`))}`;
       process.stdout
         .write(`${WARNING_PREFIX} No cached ProjectGraph is available. The rule will be skipped.
           If you encounter this error as part of running standard \`nx\` commands then please open an issue on https://github.com/nrwl/nx

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2638,9 +2638,6 @@ importers:
       '@typescript-eslint/utils':
         specifier: catalog:eslint
         version: 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
-      chalk:
-        specifier: 'catalog:'
-        version: 4.1.2
       confusing-browser-globals:
         specifier: ^1.0.9
         version: 1.0.11
@@ -2653,6 +2650,9 @@ importers:
       jsonc-eslint-parser:
         specifier: ^2.1.0
         version: 2.4.0
+      picocolors:
+        specifier: 'catalog:'
+        version: 1.1.1
       semver:
         specifier: 'catalog:'
         version: 7.8.4


### PR DESCRIPTION
Switches to picocolors in the ESLint plugin.

Doesn't use native `styleText` yet as we'd need to bump the minimum Node
version I think. Also unfortunately needs its own `orange`
implementation for now.

@JamesHenry we could use `ansis` here if we want a third party `orange` but it seems simple enough i'd just keep our own implementation here. one day this could all switch to native `styleText` too.

## Related Issue(s)

N/A
