### PR TITLE
chore(repo): improve e2e test timeout handling and bump cache bust

### DIFF
--- a/e2e/react/src/module-federation/utils.ts
+++ b/e2e/react/src/module-federation/utils.ts
@@ -1,4 +1,4 @@
-import { readJson, runCLI as _runCLI } from '@nx/e2e-utils';
+import { readJson, RunCmdOpts, runCLI as _runCLI } from '@nx/e2e-utils';
 import { join } from 'path';
 
 export function readPort(appName: string): number {
@@ -18,8 +18,9 @@ export function readPort(appName: string): number {
 }
 
 // Using this function to debug when DB errors occur during MF e2e tests.
-export function runCLI(cmd: string, opts?: { env?: Record<string, string> }) {
+export function runCLI(cmd: string, opts?: RunCmdOpts) {
   return _runCLI(cmd, {
+    ...opts,
     verbose: true,
     env: {
       ...opts?.env,

--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -25,7 +25,7 @@ import {
   getYarnMajorVersion,
   isVerboseE2ERun,
 } from './get-env-info';
-import { logError } from './log-utils';
+import { logError, logInfo } from './log-utils';
 
 export interface RunCmdOpts {
   silenceError?: boolean;
@@ -34,6 +34,7 @@ export interface RunCmdOpts {
   silent?: boolean;
   verbose?: boolean;
   redirectStderr?: boolean;
+  timeout?: number;
 }
 
 /**
@@ -416,11 +417,14 @@ export function runCLI(
     redirectStderr: undefined,
   }
 ): string {
+  const timeoutMs = opts.timeout ?? 5 * 60 * 1000;
   try {
     const pm = getPackageManagerCommand();
     const commandToRun = `${pm.runNxSilent} ${command} ${
       (opts.verbose ?? isVerboseE2ERun()) ? ' --verbose' : ''
     }${opts.redirectStderr ? ' 2>&1' : ''}`;
+    logInfo(`Run Command: ${command}`);
+    const startTime = performance.now();
     const logs = execSync(commandToRun, {
       cwd: opts.cwd || tmpProjPath(),
       env: {
@@ -433,7 +437,10 @@ export function runCLI(
       encoding: 'utf-8',
       stdio: 'pipe',
       maxBuffer: 50 * 1024 * 1024,
+      timeout: timeoutMs,
     });
+    const elapsed = ((performance.now() - startTime) / 1000).toFixed(1);
+    logInfo(`Run Command: ${command} (${elapsed}s)`);
 
     if (opts.verbose ?? isVerboseE2ERun()) {
       output.log({
@@ -448,6 +455,15 @@ export function runCLI(
     runCLI.lastExitCode = 0;
     return r;
   } catch (e) {
+    if (e.killed || e.signal) {
+      const timeoutSec = Math.round(timeoutMs / 1000);
+      const processOutput = stripVTControlCharacters(
+        `${e.stdout ?? ''}\n\n${e.stderr ?? ''}`
+      ).trim();
+      const msg = `Command timed out after ${timeoutSec}s: ${command}\n\nProcess output:\n${processOutput}`;
+      logError(`Command timed out`, msg);
+      throw new Error(msg);
+    }
     if (opts.silenceError) {
       runCLI.lastExitCode = (e.status ?? 1) as number;
       return stripVTControlCharacters(e.stdout + e.stderr);
@@ -466,6 +482,7 @@ export function runLernaCLI(
     env: undefined,
   }
 ): string {
+  const timeoutMs = opts.timeout ?? 2 * 60 * 1000;
   try {
     const pm = getPackageManagerCommand();
     const fullCommand = `${pm.runLerna} ${command}`;
@@ -478,6 +495,7 @@ export function runLernaCLI(
       encoding: 'utf-8',
       stdio: 'pipe',
       maxBuffer: 50 * 1024 * 1024,
+      timeout: timeoutMs,
     });
 
     if (opts.verbose ?? isVerboseE2ERun()) {
@@ -491,6 +509,15 @@ export function runLernaCLI(
 
     return r;
   } catch (e) {
+    if (e.killed || e.signal) {
+      const timeoutSec = Math.round(timeoutMs / 1000);
+      const processOutput = stripVTControlCharacters(
+        `${e.stdout ?? ''}\n\n${e.stderr ?? ''}`
+      ).trim();
+      const msg = `Command timed out after ${timeoutSec}s: ${command}\n\nProcess output:\n${processOutput}`;
+      logError(`Command timed out`, msg);
+      throw new Error(msg);
+    }
     if (opts.silenceError) {
       return stripVTControlCharacters(e.stdout + e.stderr);
     } else {

--- a/nx.json
+++ b/nx.json
@@ -344,7 +344,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 4,
+  "bust": 2,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true


### PR DESCRIPTION
## Current Behavior

E2E tests may timeout without clear error messages, making it difficult to diagnose test failures.

## Expected Behavior

E2E test utilities should provide better timeout handling and logging to help diagnose test failures.

## Changes

- Add timeout handling to e2e test utilities (`runCLI` and `runLernaCLI`)
- Add command logging to track execution time
- Improve timeout error messages with process output
- Bump cache bust value

## Related Issue(s)

CI stability and debugging improvements