### PR TITLE
fix(core): avoid dropping unrelated continuous deps in `makeAcyclic`

### DIFF
--- a/packages/nx/src/tasks-runner/task-graph-utils.spec.ts
+++ b/packages/nx/src/tasks-runner/task-graph-utils.spec.ts
@@ -184,6 +184,43 @@ describe('task graph utils', () => {
       });
       expect(graph.roots).toEqual(['d', 'e']);
     });
+
+    it('should not drop unrelated dependencies when only one dep type has the cycle', () => {
+      const graph = {
+        roots: ['d'],
+        dependencies: {
+          a: ['b', 'c'],
+          b: ['d'],
+          c: ['e'],
+          d: [],
+          e: ['a'],
+        },
+        continuousDependencies: {
+          a: ['b'],
+          b: [],
+          c: [],
+          d: [],
+          e: ['b'],
+        },
+      };
+
+      makeAcyclic(graph);
+
+      expect(graph.dependencies).toEqual({
+        a: ['b', 'c'],
+        b: ['d'],
+        c: ['e'],
+        d: [],
+        e: [],
+      });
+      expect(graph.continuousDependencies).toEqual({
+        a: ['b'],
+        b: [],
+        c: [],
+        d: [],
+        e: ['b'],
+      });
+    });
   });
 
   describe('validateNoAtomizedTasks', () => {

--- a/packages/nx/src/tasks-runner/task-graph-utils.ts
+++ b/packages/nx/src/tasks-runner/task-graph-utils.ts
@@ -86,8 +86,14 @@ function _makeAcyclic(
   const continuousDeps = graph.continuousDependencies?.[id] ?? [];
   for (const d of [...deps, ...continuousDeps]) {
     if (path.includes(d)) {
-      deps.splice(deps.indexOf(d), 1);
-      continuousDeps.splice(continuousDeps.indexOf(d), 1);
+      const depsIdx = deps.indexOf(d);
+      if (depsIdx >= 0) {
+        deps.splice(depsIdx, 1);
+      }
+      const continuousIdx = continuousDeps.indexOf(d);
+      if (continuousIdx >= 0) {
+        continuousDeps.splice(continuousIdx, 1);
+      }
     } else {
       _makeAcyclic(graph, d, visited, [...path, d]);
     }


### PR DESCRIPTION
## Current Behavior

Cycles in the task graph could remove unrelated `continuousDependencies` when the cycle exists only in `dependencies`, leading to missing continuous task edges.

## Expected Behavior

Cycle removal only removes the specific cyclic edge from the list where it appears, preserving unrelated continuous dependencies.