### PR TITLE
fix(core): use a consistent batch id between scheduler and task runner

### DIFF
--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -44,7 +44,7 @@ export class ForkedProcessTaskRunner {
 
   // TODO: vsavkin delegate terminal output printing
   public async forkProcessForBatch(
-    { executorName, taskGraph: batchTaskGraph }: Batch,
+    { id: batchId, executorName, taskGraph: batchTaskGraph }: Batch,
     projectGraph: ProjectGraph,
     fullTaskGraph: TaskGraph,
     env: NodeJS.ProcessEnv
@@ -73,7 +73,6 @@ export class ForkedProcessTaskRunner {
 
     // Register batch worker process with all tasks
     if (p.pid) {
-      const batchId = `${executorName}-${p.pid}`;
       const taskIds = Object.keys(batchTaskGraph.tasks);
       getProcessMetricsService().registerBatch(batchId, taskIds, p.pid);
     }


### PR DESCRIPTION
## Current Behavior

Batch IDs are generated in two places: the task scheduler uses an incremental counter (`executorName N`) while the forked process task runner generates its own using the process PID (`executorName-pid`). This means the batch ID registered in metrics doesn't match the one used everywhere else.

## Expected Behavior

Batch IDs are only created by the task scheduler. The forked process task runner uses the scheduler-assigned ID to ensure consistency across the system.