### PR TITLE
feat(testing): add cacheDir option to playwright executor

### DIFF
--- a/docs/generated/packages/playwright/executors/playwright.json
+++ b/docs/generated/packages/playwright/executors/playwright.json
@@ -154,6 +154,10 @@
         "type": "boolean",
         "description": "Skip running playwright install before running playwright tests. This is to ensure that playwright browsers are installed before running tests.",
         "default": false
+      },
+      "cacheDir": {
+        "type": "string",
+        "description": "Directory for Playwright internal cache (browser binaries, etc.). Sets the PWTEST_CACHE_DIR environment variable."
       }
     },
     "required": [],

--- a/packages/playwright/src/executors/playwright/schema.json
+++ b/packages/playwright/src/executors/playwright/schema.json
@@ -155,6 +155,10 @@
       "type": "boolean",
       "description": "Skip running playwright install before running playwright tests. This is to ensure that playwright browsers are installed before running tests.",
       "default": false
+    },
+    "cacheDir": {
+      "type": "string",
+      "description": "Directory for Playwright internal cache (browser binaries, etc.). Sets the PWTEST_CACHE_DIR environment variable."
     }
   },
   "required": []


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The Playwright executor does not support configuring a custom cache directory for Playwright's internal cache (browser binaries, etc.). Users who need to control where Playwright stores its cache, for example in CI environments with specific disk constraints like not being able to DTE tasks or shared caching setups, have no way to set this through the executor configuration.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

A new `cacheDir` option is available on the Playwright executor. When provided, it sets the `PWTEST_CACHE_DIR` environment variable on the forked Playwright process, allowing users to control where Playwright stores its internal cache.
  ```json
  {
    "targets": {
      "e2e": {
        "executor": "@nx/playwright:playwright",
        "options": {
          "cacheDir": "/tmp/playwright-cache"
        }
      }
    }
  }

