### PR TITLE
feat(core): extract sandbox detection into reusable utility

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -21,23 +21,8 @@ import { performance } from 'perf_hooks';
 import { setupWorkspaceContext } from '../src/utils/workspace-context';
 import { daemonClient } from '../src/daemon/client/client';
 import { removeDbConnections } from '../src/utils/db-connection';
-import { isAiAgent } from '../src/native';
-
-function handleAgenticSandbox() {
-  const sandboxEnvVars = [
-    'SANDBOX_RUNTIME',
-    'CODEX_SANDBOX',
-    'GEMINI_SANDBOX',
-    'CURSOR_SANDBOX',
-  ];
-  if (isAiAgent() && sandboxEnvVars.some((e) => process.env[e] !== undefined)) {
-    process.env['NX_DAEMON'] = 'false';
-    process.env['NX_ISOLATE_PLUGINS'] = 'false';
-  }
-}
 
 async function main() {
-  handleAgenticSandbox();
   if (
     process.argv[2] !== 'report' &&
     process.argv[2] !== '--version' &&

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -30,6 +30,7 @@ import { ConfigurationSourceMaps } from '../../project-graph/utils/project-confi
 import { isJsonMessage } from '../../utils/consume-messages-from-socket';
 import { DelayedSpinner } from '../../utils/delayed-spinner';
 import { isCI } from '../../utils/is-ci';
+import { isSandbox } from '../../utils/is-sandbox';
 import { output } from '../../utils/output';
 import { PromisedBasedQueue } from '../../utils/promised-based-queue';
 import type {
@@ -230,7 +231,7 @@ export class DaemonClient {
       // version mismatch => no daemon because the installed nx version differs from the running one
       if (
         isNxVersionMismatch() ||
-        ((isCI() || isDocker()) && env !== 'true') ||
+        ((isCI() || isDocker() || isSandbox()) && env !== 'true') ||
         isDaemonDisabled() ||
         nxJsonIsNotPresent() ||
         (useDaemonProcessOption === undefined && env === 'false') ||

--- a/packages/nx/src/project-graph/plugins/isolation/enabled.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/enabled.ts
@@ -1,4 +1,5 @@
 import { IS_WASM } from '../../../native';
+import { isSandbox } from '../../../utils/is-sandbox';
 
 export function isIsolationEnabled() {
   // Explicitly enabled, regardless of further conditions
@@ -9,7 +10,9 @@ export function isIsolationEnabled() {
     // Explicitly disabled
     process.env.NX_ISOLATE_PLUGINS === 'false' ||
     // Isolation is disabled on WASM builds currently.
-    IS_WASM
+    IS_WASM ||
+    // Isolation is disabled in sandbox environments (AI agents, etc.)
+    isSandbox()
   ) {
     return false;
   }

--- a/packages/nx/src/utils/is-sandbox.spec.ts
+++ b/packages/nx/src/utils/is-sandbox.spec.ts
@@ -1,0 +1,38 @@
+import { isSandbox } from './is-sandbox';
+
+describe('isSandbox', () => {
+  const envVars = [
+    'SANDBOX_RUNTIME',
+    'GEMINI_SANDBOX',
+    'CODEX_SANDBOX',
+    'CURSOR_SANDBOX',
+  ];
+
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of envVars) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of envVars) {
+      if (originalEnv[key] !== undefined) {
+        process.env[key] = originalEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  it('should return false when no sandbox env vars are set', () => {
+    expect(isSandbox()).toBe(false);
+  });
+
+  it.each(envVars)('should return true when %s is set', (envVar: string) => {
+    process.env[envVar] = 'true';
+    expect(isSandbox()).toBe(true);
+  });
+});

--- a/packages/nx/src/utils/is-sandbox.ts
+++ b/packages/nx/src/utils/is-sandbox.ts
@@ -1,0 +1,8 @@
+export function isSandbox(): boolean {
+  return (
+    !!process.env.SANDBOX_RUNTIME ||
+    !!process.env.GEMINI_SANDBOX ||
+    !!process.env.CODEX_SANDBOX ||
+    !!process.env.CURSOR_SANDBOX
+  );
+}


### PR DESCRIPTION
Add isSandbox() utility that checks for sandbox environment variables
(SANDBOX_RUNTIME, GEMINI_SANDBOX, CODEX_SANDBOX, CURSOR_SANDBOX) and
use it to disable the daemon and plugin isolation in sandbox environments.
