### PR TITLE
fix(repo): use sudo for global npm install in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -539,7 +539,7 @@ jobs:
           corepack prepare --activate
 
       - name: Use npm 11.5.2
-        run: npm install -g npm@11.5.2
+        run: sudo npm install -g npm@11.5.2
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Current Behavior

The `npm install -g npm@11.5.2` step in the publish workflow fails with `EACCES: permission denied, mkdir '/usr/local/share/man/man5'` on newer GitHub Actions runner images.

## Expected Behavior

The global npm install step completes successfully regardless of runner image permissions on `/usr/local/share/man/`.

## Related Issue(s)

This is a known issue with GitHub Actions runners: https://github.com/actions/runner-images/issues/9644