### PR TITLE
docs(misc): improve AX for getting started pages

### DIFF
--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -24,8 +24,6 @@ const learnGroups: SidebarItems = [
     items: [
       { label: 'Intro to Nx', link: 'getting-started/intro' },
       { label: 'Installation', link: 'getting-started/installation' },
-      { label: 'Editor Setup', link: 'getting-started/editor-setup' },
-      { label: 'AI Integrations', link: 'getting-started/ai-setup' },
       {
         label: 'Start a New Project',
         link: 'getting-started/start-new-project',
@@ -34,6 +32,8 @@ const learnGroups: SidebarItems = [
         label: 'Add to Existing Project',
         link: 'getting-started/start-with-existing-project',
       },
+      { label: 'Editor Setup', link: 'getting-started/editor-setup' },
+      { label: 'AI Integrations', link: 'getting-started/ai-setup' },
       {
         label: 'Nx Cloud',
         link: 'getting-started/nx-cloud',

--- a/astro-docs/src/content/docs/getting-started/ai-setup.mdoc
+++ b/astro-docs/src/content/docs/getting-started/ai-setup.mdoc
@@ -7,7 +7,9 @@ sidebar:
 filter: 'type:Features'
 ---
 
-This guide shows how to configure your Nx workspace for AI coding assistants. The setup gives your agent workspace context and CI integration, making it smarter when working in an Nx monorepo and more autonomous when iterating on CI failures.
+AI coding assistants often hallucinate outdated Nx commands and lack context about your workspace structure. Without workspace awareness, they suggest commands that don't exist or miss project relationships entirely.
+
+Nx's AI integration gives assistants accurate, real-time information about your workspace, projects, and available commands—making them smarter when working in an Nx monorepo and more autonomous when iterating on CI failures.
 
 ## Configure Nx AI Integration
 
@@ -24,7 +26,7 @@ To automatically configure your Nx monorepo to work best with AI agents and assi
 npx nx configure-ai-agents
 ```
 
-This will prompt you for which AI agents/assistants to configure and set up the [Nx MCP server](/docs/features/enhance-ai), AI agent configuration files (`AGENTS.md`, `CLAUDE.md`, etc.), and agent skills. For Claude Code, skills are installed via a plugin; for other agents, they're copied into your workspace.
+This will prompt you for which AI agents/assistants to configure and set up the [Nx MCP server](/docs/features/enhance-ai) (Model Context Protocol—a standard for giving AI assistants tool access), AI agent configuration files (`AGENTS.md`, `CLAUDE.md`, etc.), and agent skills. For Claude Code, skills are installed via a plugin; for other agents, they're copied into your workspace.
 
 Alternatively, you can install just the skills via:
 
@@ -43,7 +45,7 @@ The Nx AI integration provides your coding assistant with powerful capabilities:
 - **Workspace Understanding** - Graph-aware exploration of project dependencies and relationships. AI gets structured data instead of grepping through files.
 - **[Real-time Terminal Integration](https://nx.dev/blog/nx-terminal-integration-ai)** - AI can read your terminal output, running processes, and error messages without copy-pasting.
 - **Reliable Code Generation** - AI invokes Nx generators for predictable scaffolding, then adapts the result to your workspace. Faster, standardized, fewer hallucinations.
-- **Autonomous CI Workflows** - The CI monitor skill bridges your local agent with Nx Cloud. Push, monitor, get failures, fix, repeat until CI is green. Enables "Ralph Wiggum loop" patterns where you review the final PR, not every CI hiccup.
+- **Autonomous CI Workflows** - The CI monitor skill bridges your local agent with Nx Cloud. Push, monitor, get failures, fix, repeat until CI is green. Enables autonomous CI workflows ("Ralph Wiggum loop")—you review the final PR, not every intermediate fix.
 - **Cross-project Impact Analysis** - Understanding the implications of changes across your entire monorepo.
 
 ## Configure CI to Leverage AI Capabilities

--- a/astro-docs/src/content/docs/getting-started/editor-setup.mdoc
+++ b/astro-docs/src/content/docs/getting-started/editor-setup.mdoc
@@ -6,7 +6,9 @@ sidebar:
 filter: 'type:Features'
 ---
 
-Nx Console editor extensions make your developer experience richer. The extensions:
+Running CLI commands manually and discovering available tasks is tedious. You lose context switching between terminal and editor, and it's easy to forget which generators or tasks are available for each project.
+
+Nx Console brings Nx directly into your editor. The extensions:
 
 - [enhance AI integrations](/docs/features/enhance-ai) by providing workspace-level context and up-to-date docs
 - show [inferred tasks](/docs/concepts/inferred-tasks) and help you invoke them via the Project Details View
@@ -30,11 +32,11 @@ If you are using [VSCode](https://code.visualstudio.com/) or a [JetBrains IDE](h
 
 ![Nx Console screenshot](../../../assets/nx-console/nx-console-screenshot.webp)
 
-### Neovim
+### Neovim (Community)
 
 If you are using [Neovim](https://neovim.io/), you can install [Equilibris/nx.nvim](https://github.com/Equilibris/nx.nvim) with your favorite package manager.
 
-This plugin is **NOT** built or maintained by the Nx team. They are maintained by independent community contributors.
+**Community Plugin**: This plugin is maintained by independent community contributors, not the Nx team.
 
 ## Troubleshooting
 

--- a/astro-docs/src/content/docs/getting-started/installation.mdoc
+++ b/astro-docs/src/content/docs/getting-started/installation.mdoc
@@ -55,6 +55,44 @@ nx --version
 
 You should see a version number like `22.5.0`.
 
+### Update Global Installation
+
+{% tabs syncKey="install-method" %}
+{% tabitem label="npm" %}
+
+```shell
+npm update --global nx
+```
+
+**Note:** You can also use `yarn global upgrade nx`, `pnpm update --global nx`, or `bun update --global nx`
+{% /tabitem %}
+
+{% tabitem label="Homebrew (macOS, Linux)" %}
+
+```shell
+brew upgrade nx
+```
+
+{% /tabitem %}
+
+{% tabitem label="Chocolatey (Windows)" %}
+
+```shell
+choco upgrade nx
+```
+
+{% /tabitem %}
+
+{% tabitem label="apt (Ubuntu)" %}
+
+```shell
+sudo apt update
+sudo apt upgrade nx
+```
+
+{% /tabitem %}
+{% /tabs %}
+
 ## Install in a Repository
 
 To add Nx to an existing repository, run:
@@ -69,9 +107,9 @@ This installs the `nx` package as a dev dependency and creates an `nx.json` conf
 You can also manually install the [`nx` NPM package](https://www.npmjs.com/package/nx) and create an [nx.json](/docs/reference/nx-json) configuration file.
 {% /aside %}
 
-## Update Nx
+### Update Nx in Your Repository
 
-When you update Nx, it will also [automatically update your dependencies](/docs/features/automate-updating-dependencies) if you have an [Nx plugin](/docs/concepts/nx-plugins) installed for that dependency. To update Nx, run:
+When you update Nx in your repository, it will also [automatically update your dependencies](/docs/features/automate-updating-dependencies) if you have an [Nx plugin](/docs/concepts/nx-plugins) installed for that dependency. To update Nx, run:
 
 ```shell
 nx migrate latest
@@ -83,6 +121,6 @@ This creates a `migrations.json` file with any update scripts that need to be ru
 nx migrate --run-migrations
 ```
 
-{% aside type="tip" title="Update One Major Version at a Time" %}
+{% aside type="note" title="Update One Major Version at a Time" %}
 To avoid potential issues, it is [recommended to update one major version of Nx at a time](/docs/guides/tips-n-tricks/advanced-update#one-major-version-at-a-time-small-steps).
 {% /aside %}

--- a/astro-docs/src/content/docs/getting-started/installation.mdoc
+++ b/astro-docs/src/content/docs/getting-started/installation.mdoc
@@ -1,12 +1,15 @@
 ---
 title: Installation
-description: Install Nx globally via npm, Homebrew, Chocolatey, or apt. Add Nx to existing repos with nx init and keep dependencies updated automatically.
+description: Install Nx globally via npm, Homebrew, Chocolatey, or apt. Add Nx to existing repos with nx init.
 sidebar:
   order: 2
 filter: 'type:Guides'
 ---
 
-To install Nx on your machine, choose one of the following methods based on your operating system and package manager. You can also use `npx` to run Nx without installing it globally.
+## Global Installation
+
+Install Nx globally to run commands from anywhere. Choose a method based on your operating system and package manager.
+
 {% tabs syncKey="install-method" %}
 {% tabitem label="npm" %}
 
@@ -14,7 +17,7 @@ To install Nx on your machine, choose one of the following methods based on your
 npm add --global nx
 ```
 
-**Note:** You can also use `yarn`, `pnpm`, or `bun`
+**Note:** You can also use `yarn global add nx`, `pnpm add --global nx`, or `bun add --global nx`
 {% /tabitem %}
 
 {% tabitem label="Homebrew (macOS, Linux)" %}
@@ -44,34 +47,37 @@ sudo apt install nx
 {% /tabitem %}
 {% /tabs %}
 
-## Adding Nx to Your Repository
+### Verify Installation
+
+```shell
+nx --version
+```
+
+You should see a version number like `22.5.0`.
+
+## Install in a Repository
 
 To add Nx to an existing repository, run:
 
 ```shell
-nx init
+npx nx@latest init
 ```
 
-**Note:** You can also manually install the [`nx` NPM package](https://www.npmjs.com/package/nx) and create a [nx.json](/docs/reference/nx-json) to configure it.
-Learn more about [adopting Nx in an existing project](/docs/guides/adopting-nx)
+This installs the `nx` package as a dev dependency and creates an `nx.json` configuration file. If you have Nx installed globally, it will defer to the local version in your repository.
 
-### Starter Repository
-
-To create a starter repository, you can use the `create-nx-workspace` command. This will create a new Nx workspace with a default configuration and example applications.
-
-```shell
-npx create-nx-workspace@latest
-```
+{% aside type="note" title="Manual Installation" %}
+You can also manually install the [`nx` NPM package](https://www.npmjs.com/package/nx) and create an [nx.json](/docs/reference/nx-json) configuration file.
+{% /aside %}
 
 ## Update Nx
 
-When you update Nx, Nx will also [automatically update your dependencies](/docs/features/automate-updating-dependencies) if you have an [Nx plugin](/docs/concepts/nx-plugins) installed for that dependency. To update Nx, run:
+When you update Nx, it will also [automatically update your dependencies](/docs/features/automate-updating-dependencies) if you have an [Nx plugin](/docs/concepts/nx-plugins) installed for that dependency. To update Nx, run:
 
 ```shell
 nx migrate latest
 ```
 
-This will create a `migrations.json` file with any update scripts that need to be run. Run them with:
+This creates a `migrations.json` file with any update scripts that need to be run. Run them with:
 
 ```shell
 nx migrate --run-migrations
@@ -80,18 +86,3 @@ nx migrate --run-migrations
 {% aside type="tip" title="Update One Major Version at a Time" %}
 To avoid potential issues, it is [recommended to update one major version of Nx at a time](/docs/guides/tips-n-tricks/advanced-update#one-major-version-at-a-time-small-steps).
 {% /aside %}
-
-## Tutorials
-
-Try one of these tutorials for a full walkthrough of what to do after you install Nx:
-
-- [TypeScript Monorepo Tutorial](/docs/getting-started/tutorials/typescript-packages-tutorial)
-- [React Monorepo Tutorial](/docs/getting-started/tutorials/react-monorepo-tutorial)
-- [Angular Monorepo Tutorial](/docs/getting-started/tutorials/angular-monorepo-tutorial)
-
-## More Documentation
-
-- [Add Nx to an Existing Repository](/docs/guides/adopting-nx)
-- [Update Nx](/docs/features/automate-updating-dependencies)
-- [Update Your Global Nx Installation](/docs/guides/installation/update-global-installation)
-- [Install Nx in a Non-Javascript Repo](/docs/guides/installation/install-non-javascript)

--- a/astro-docs/src/content/docs/getting-started/intro.mdoc
+++ b/astro-docs/src/content/docs/getting-started/intro.mdoc
@@ -1,43 +1,32 @@
 ---
 title: What is Nx?
-description: 'Nx is an AI-first monorepo platform that connects everything from your editor to CI. Helping you deliver fast, without breaking things.'
+description: 'Nx is a build system with smart caching and task orchestration for monorepos. Ship faster without breaking things.'
 sidebar:
   order: 1
   label: Introduction
 filter: 'type:Features'
 ---
 
-Nx is a powerful, open-source monorepo platform that helps you **efficiently get from starting a feature in your editor to a green PR**.
+Nx is a build system for monorepos. It helps you **develop faster** and **keep CI fast** as your codebase scales.
 
 {% youtube src="https://youtu.be/pbAQErStl9o" title="What is Nx?" width="100%" /%}
 
-## The Monorepo Challenge
+## Challenges of Monorepos
 
-A **monorepo** is a single repository containing multiple projects that can share code and be developed together. Monorepos are especially powerful for AI-assisted development—all your code in one place means more context for AI to work with, and caching means faster verification loops when agents run build, test, and lint.
+Monorepos have many advantages and are especially powerful for AI-assisted development. But as teams and codebases grow, monorepos are hard to scale:
 
-But as codebases grow, development gets harder:
-
-- **Slow builds and tests** - Running build, test, and lint across projects takes longer and longer
-- **Flaky CI** - Tests pass locally but fail in CI, or fail randomly
-- **Code sharing complexity** - Extracting shared code into libraries creates dependency management headaches
-- **Lost context** - Developers (and AI agents) struggle to understand how changes impact other parts of the codebase
-
-These problems compound as teams scale. What worked for 5 developers breaks down at 50.
-
-**Nx reduces friction across your entire development cycle** with intelligent caching, task orchestration, and deep understanding of your codebase structure.
-
-{% callout type="deepdive" title="Can I add Nx to a single-project repo?" %}
-Yes, Nx provides value even for single-project repositories. You get fast task caching, intelligent task orchestration, and access to Nx plugins for your specific technology stack. As your project grows into a monorepo, the foundation is already in place.
-
-Nx can also connect multiple repositories into a synthetic monorepo, letting you orchestrate large changes across all connected repos.
-{% /callout %}
+- **Slow builds and tests** - Hundreds or thousands of tasks compete for CI resources.
+- **Complex task pipelines** - Projects depend on each other, so tasks need to run in the right order — and that's hard to manage by hand.
+- **Flaky CI** - Longer pipelines lead to random failures and inconsistent results between local and CI environments.
 
 ## What Nx Does
 
-Nx is a build system and monorepo platform. At its core:
+**Nx reduces friction across your entire development cycle** with intelligent caching, task orchestration, and deep understanding of your codebase structure.
+
+At its core, Nx:
 
 1. **Runs tasks fast** - [Caches results](/docs/features/cache-task-results) so you never rebuild the same code twice
-2. **Understands your codebase** - Builds a [project graph](/docs/features/explore-graph) showing how everything connects
+2. **Understands your codebase** - Builds [project and task graphs](/docs/features/explore-graph) showing how everything connects
 3. **Orchestrates intelligently** - Runs tasks in the [right order](/docs/concepts/task-pipeline-configuration), parallelizing when possible
 
 ```shell
@@ -96,6 +85,12 @@ Nx is modular. Start with just the CLI and add capabilities as your needs grow.
 | [**Nx Plugins**](/docs/technologies)                 | Technology-specific automation (generators, executors, dependency detection)                                                                                                           |
 | [**Nx Console**](/docs/getting-started/editor-setup) | Editor extension for VSCode/JetBrains with visual UI and [AI assistance](/docs/features/enhance-ai)                                                                                    |
 | [**Nx Cloud**](/docs/features/ci-features)           | [Remote caching](/docs/features/ci-features/remote-cache), [affected commands](/docs/features/ci-features/affected), and [self-healing CI](/docs/features/ci-features/self-healing-ci) |
+
+{% callout type="deepdive" title="Can I add Nx to a single-project repo?" %}
+Yes, Nx provides value even for single-project repositories. You get fast task caching, intelligent task orchestration, and access to Nx plugins for your specific technology stack. As your project grows into a monorepo, the foundation is already in place.
+
+Nx can also connect multiple repositories into a synthetic monorepo, letting you orchestrate large changes across all connected repos.
+{% /callout %}
 
 ## Where to Go from Here
 

--- a/astro-docs/src/content/docs/getting-started/intro.mdoc
+++ b/astro-docs/src/content/docs/getting-started/intro.mdoc
@@ -7,15 +7,24 @@ sidebar:
 filter: 'type:Features'
 ---
 
-Nx is a powerful, open-source, technology-agnostic **monorepo platform** designed to efficiently manage codebases of any scale. From small workspaces to large enterprise monorepos, Nx provides the tools to **efficiently get from starting a feature in your editor to a green PR**.
-
-As teams and codebases grow, productivity bottlenecks multiply: build times increase, CI becomes flaky, and code sharing becomes complex. **Nx reduces friction across your entire development cycle.**
+Nx is a powerful, open-source monorepo platform that helps you **efficiently get from starting a feature in your editor to a green PR**.
 
 {% youtube src="https://youtu.be/pbAQErStl9o" title="What is Nx?" width="100%" /%}
 
-## Start small, extend as you grow
+## The Monorepo Challenge
 
-Nx is built in a modular fashion, allowing you to adopt as little or as much as you'd like at any moment in your development lifecycle. You can **start with just the core and add additional capabilities incrementally** as your needs grow and complexity increases.
+A **monorepo** is a single repository containing multiple projects that can share code and be developed together. Monorepos are especially powerful for AI-assisted development—all your code in one place means more context for AI to work with, and caching means faster verification loops when agents run build, test, and lint.
+
+But as codebases grow, development gets harder:
+
+- **Slow builds and tests** - Running build, test, and lint across projects takes longer and longer
+- **Flaky CI** - Tests pass locally but fail in CI, or fail randomly
+- **Code sharing complexity** - Extracting shared code into libraries creates dependency management headaches
+- **Lost context** - Developers (and AI agents) struggle to understand how changes impact other parts of the codebase
+
+These problems compound as teams scale. What worked for 5 developers breaks down at 50.
+
+**Nx reduces friction across your entire development cycle** with intelligent caching, task orchestration, and deep understanding of your codebase structure.
 
 {% callout type="deepdive" title="Can I add Nx to a single-project repo?" %}
 Yes, Nx provides value even for single-project repositories. You get fast task caching, intelligent task orchestration, and access to Nx plugins for your specific technology stack. As your project grows into a monorepo, the foundation is already in place.
@@ -23,9 +32,21 @@ Yes, Nx provides value even for single-project repositories. You get fast task c
 Nx can also connect multiple repositories into a synthetic monorepo, letting you orchestrate large changes across all connected repos.
 {% /callout %}
 
-At the **foundation is Nx Core**, a Rust-based, technology-agnostic task runner. Nx Core creates a knowledge graph of your workspace, understanding project relationships and dependencies. This enables highly optimized and fast task execution regardless of technology stack. It runs `package.json` scripts in [TypeScript monorepos](/docs/technologies/typescript/introduction) or Gradle tasks in [Java projects](/docs/technologies/java/introduction) or [can be extended](/docs/extending-nx/intro) to meet your project's specific needs.
+## What Nx Does
 
-{% callout type="deepdive" title="What do you mean by \"running NPM scripts\"?" %}
+Nx is a build system and monorepo platform. At its core:
+
+1. **Runs tasks fast** - [Caches results](/docs/features/cache-task-results) so you never rebuild the same code twice
+2. **Understands your codebase** - Builds a [project graph](/docs/features/explore-your-workspace) showing how everything connects
+3. **Orchestrates intelligently** - Runs tasks in the [right order](/docs/concepts/task-pipeline-configuration), parallelizing when possible
+
+```shell
+nx build myapp            # Run a task
+nx build myapp            # Run again - instant cache hit
+nx run-many -t build test # Run across all projects
+```
+
+{% callout type="deepdive" title="How does Nx run tasks?" %}
 
 At the very core, Nx is a super fast, intelligent task runner. Let's take the example of an NPM workspace. This could be a project's `package.json`:
 
@@ -65,27 +86,38 @@ From there, you can gradually enhance your setup by adding features like [task c
 
 {% /callout %}
 
-Nx Core provides everything you need to get started and works perfectly on its own.
-**When you're ready for more, the Nx monorepo platform offers additional capabilities you can adopt incrementally**.
-Extend your setup with [**Nx Cloud**](/docs/getting-started/nx-cloud) for remote caching, distributed task execution, and [**AI-powered self-healing CI**](/docs/features/ci-features/self-healing-ci) that automatically detects, analyzes, and fixes CI failures.
-Integrate [**Nx Console**](/docs/getting-started/editor-setup) with your editor for powerful autocomplete, project graph visualization, CI notifications, and an MCP to [make your AI coding assistant smarter](/docs/features/enhance-ai).
-Add [**Nx Plugins**](/docs/technologies) for technology-specific automation and DX improvements, or build custom platform capabilities using [Nx Devkit](/docs/extending-nx/intro).
+## Start Small, Grow as Needed
 
-## Where to go from here?
+Nx is modular. Start with just the CLI and add capabilities as your needs grow.
+
+| Component                                            | What It Does                                                                                                                                                                           |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Nx Core**                                          | Task runner with [local caching](/docs/features/cache-task-results). Works with any tech stack.                                                                                        |
+| [**Nx Plugins**](/docs/technologies)                 | Technology-specific automation (generators, executors, dependency detection)                                                                                                           |
+| [**Nx Console**](/docs/getting-started/editor-setup) | Editor extension for VSCode/JetBrains with visual UI and [AI assistance](/docs/features/enhance-ai)                                                                                    |
+| [**Nx Cloud**](/docs/features/ci-features)           | [Remote caching](/docs/features/ci-features/remote-cache), [affected commands](/docs/features/ci-features/affected), and [self-healing CI](/docs/features/ci-features/self-healing-ci) |
+
+## Where to Go from Here
+
+{% callout type="note" title="Choose Your Path" %}
+**Starting fresh?** → [Create a new workspace](/docs/getting-started/start-new-project)
+
+**Have an existing project?** → [Add Nx to your project](/docs/getting-started/start-with-existing-project)
+
+**Want hands-on learning?** → [Follow a tutorial](/docs/getting-started/tutorials)
+
+**Prefer video?** → [Learn with our video courses](https://nx.dev/courses)
+{% /callout %}
 
 {% cardgrid %}
 
-{% linkcard title="Nx quickstart" description="Dive right in with our quickstart steps to create your first project or add Nx to your existing one."  href="/docs/quickstart"  /%}
+{% linkcard title="Quickstart" description="Get your first Nx project running in minutes." href="/docs/quickstart" /%}
 
-{% linkcard title="Explore Technologies" description="Explore Nx's technology integrations and how it can support your specific stack."  href="/docs/technologies" /%}
+{% linkcard title="Technologies" description="Find plugins for React, Angular, Node, Gradle, Maven, .NET, and more." href="/docs/technologies" /%}
 
-{% linkcard title="Step by step with our tutorials" description="Learn more about Nx through hands-on tutorials for different technology stacks."  href="/docs/getting-started/tutorials" /%}
+{% linkcard title="Concepts" description="Improve your understanding of how Nx works under the hood." href="/docs/concepts" /%}
 
-{% linkcard title="Learn with our video courses" description="Dive deeper with comprehensive video courses that walk you through Nx concepts."  href="https://nx.dev/courses" /%}
-
-{% linkcard title="Dive deep into Nx features" description="Discover all the powerful features that Nx provides to streamline your workflow."  href="/docs/features" /%}
-
-{% linkcard title="Understand underlying concepts" description="Improve your understanding of the core concepts of how Nx works under the hood."  href="/docs/concepts" /%}
+{% linkcard title="Features" description="Discover all the powerful features that Nx provides to streamline your workflow." href="/docs/features" /%}
 
 {% /cardgrid %}
 

--- a/astro-docs/src/content/docs/getting-started/intro.mdoc
+++ b/astro-docs/src/content/docs/getting-started/intro.mdoc
@@ -37,7 +37,7 @@ Nx can also connect multiple repositories into a synthetic monorepo, letting you
 Nx is a build system and monorepo platform. At its core:
 
 1. **Runs tasks fast** - [Caches results](/docs/features/cache-task-results) so you never rebuild the same code twice
-2. **Understands your codebase** - Builds a [project graph](/docs/features/explore-your-workspace) showing how everything connects
+2. **Understands your codebase** - Builds a [project graph](/docs/features/explore-graph) showing how everything connects
 3. **Orchestrates intelligently** - Runs tasks in the [right order](/docs/concepts/task-pipeline-configuration), parallelizing when possible
 
 ```shell

--- a/astro-docs/src/content/docs/getting-started/intro.mdoc
+++ b/astro-docs/src/content/docs/getting-started/intro.mdoc
@@ -18,6 +18,7 @@ Monorepos have many advantages and are especially powerful for AI-assisted devel
 - **Slow builds and tests** - Hundreds or thousands of tasks compete for CI resources.
 - **Complex task pipelines** - Projects depend on each other, so tasks need to run in the right order — and that's hard to manage by hand.
 - **Flaky CI** - Longer pipelines lead to random failures and inconsistent results between local and CI environments.
+- **Architectural erosion** - Without clear boundaries, unwanted dependencies creep in and projects become tightly coupled.
 
 ## What Nx Does
 
@@ -28,6 +29,8 @@ At its core, Nx:
 1. **Runs tasks fast** - [Caches results](/docs/features/cache-task-results) so you never rebuild the same code twice
 2. **Understands your codebase** - Builds [project and task graphs](/docs/features/explore-graph) showing how everything connects
 3. **Orchestrates intelligently** - Runs tasks in the [right order](/docs/concepts/task-pipeline-configuration), parallelizing when possible
+4. **Enforces boundaries** - [Module boundary rules](/docs/features/enforce-module-boundaries) prevent unwanted dependencies between projects
+5. **Handles flakiness** - [Automatically re-runs flaky tasks](/docs/features/ci-features/flaky-tasks) and [self-heals CI failures](/docs/features/ci-features/self-healing-ci)
 
 ```shell
 nx build myapp            # Run a task

--- a/astro-docs/src/content/docs/getting-started/intro.mdoc
+++ b/astro-docs/src/content/docs/getting-started/intro.mdoc
@@ -74,7 +74,7 @@ This will execute the `build` script from `my-project`'s `package.json`, equival
 
 Similarly you [can run tasks across all projects](/docs/features/run-tasks), just specific ones or just those from projects you touched.
 
-From there, you can gradually enhance your setup by adding features like [task caching](/docs/features/cache-task-results), adding [plugins](/docs/technologies), optimizing your CI via [task distribution](/docs/features/ci-features/distribute-task-execution), and many more powerful capabilities as your needs grow.
+From there, you can gradually enhance your setup by adding features like [task caching](/docs/features/cache-task-results), adding [plugins](/docs/plugin-registry), optimizing your CI via [task distribution](/docs/features/ci-features/distribute-task-execution), and many more powerful capabilities as your needs grow.
 
 {% /callout %}
 
@@ -85,7 +85,7 @@ Nx is modular. Start with just the CLI and add capabilities as your needs grow.
 | Component                                            | What It Does                                                                                                                                                                           |
 | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Nx Core**                                          | Task runner with [local caching](/docs/features/cache-task-results). Works with any tech stack.                                                                                        |
-| [**Nx Plugins**](/docs/technologies)                 | Technology-specific automation (generators, executors, dependency detection)                                                                                                           |
+| [**Nx Plugins**](/docs/plugin-registry)              | Technology-specific automation (generators, executors, dependency detection)                                                                                                           |
 | [**Nx Console**](/docs/getting-started/editor-setup) | Editor extension for VSCode/JetBrains with visual UI and [AI assistance](/docs/features/enhance-ai)                                                                                    |
 | [**Nx Cloud**](/docs/features/ci-features)           | [Remote caching](/docs/features/ci-features/remote-cache), [affected commands](/docs/features/ci-features/affected), and [self-healing CI](/docs/features/ci-features/self-healing-ci) |
 
@@ -111,7 +111,7 @@ Nx can also connect multiple repositories into a synthetic monorepo, letting you
 
 {% linkcard title="Quickstart" description="Get your first Nx project running in minutes." href="/docs/quickstart" /%}
 
-{% linkcard title="Technologies" description="Find plugins for React, Angular, Node, Gradle, Maven, .NET, and more." href="/docs/technologies" /%}
+{% linkcard title="Plugins" description="Find plugins for React, Angular, Node, Gradle, Maven, .NET, and more." href="/docs/plugin-registry" /%}
 
 {% linkcard title="Concepts" description="Improve your understanding of how Nx works under the hood." href="/docs/concepts" /%}
 

--- a/astro-docs/src/content/docs/getting-started/start-new-project.mdoc
+++ b/astro-docs/src/content/docs/getting-started/start-new-project.mdoc
@@ -1,77 +1,48 @@
 ---
-title: Start a new project with Nx
-description: Create a new Nx workspace manually with your favorite CLI or use the guided setup with presets for various technology stacks and configurations.
+title: Start a New Project
+description: Create a new Nx workspace with starter templates or via Nx Cloud in the browser.
 sidebar:
-  label: Start a new project
+  label: Start a New Project
   order: 3
 filter: 'type:Guides'
 ---
 
-When you start a new project with Nx, you have two options: manual or guided.
+Create a new Nx workspace using one of these options:
 
-## Option 1: Manual setup
+- **[Option 1: Create locally with templates](#option-1-create-locally-with-templates)** - Run a command to scaffold a new monorepo on your machine
+- **[Option 2: Create via Nx Cloud](#option-2-create-via-nx-cloud)** - Use the browser-based setup with CI/CD pre-configured
 
-In a nutshell, this means using your favorite CLI to create your initial project setup and then adding Nx to it.
-
-Let's take the example of an NPM workspace. Create a new root-level `package.json` like:
-
-```json
-// package.json
-{
-  "name": "my-workspace",
-  "version": "1.0.0",
-  "private": true,
-  "workspaces": ["packages/*", "apps/*"]
-}
-```
-
-Then you can add Nx to it by using:
-
-```shell
-nx@latest init
-```
-
-{% aside type="note" title="Global Installs" %}
-Make sure you have [Nx installed globally](/docs/getting-started/installation) or use `npx` if you're in a JavaScript environment
+{% aside type="note" title="Adding Nx to an existing project?" %}
+If you already have a project and want to add Nx to it, see [Add to an Existing Project](/docs/getting-started/start-with-existing-project) instead.
 {% /aside %}
 
-Nx will detect the underlying workspace configuration, ask you a couple of questions and install itself into the workspace. You can now [run tasks with Nx](/docs/features/run-tasks) and incrementally add functionality, like:
+## Option 1: Create Locally with Templates
 
-- [Configure caching](/docs/features/cache-task-results)
-- [Adding Nx plugins to help refine your workflows](/docs/plugin-registry)
-- [Optimizing your CI](/docs/guides/nx-cloud/setup-ci)
-
-## Option 2: Create a new workspace with presets
-
-Alternatively, you can choose a more guided approach by leveraging some of the presets Nx comes with.
-
-Run the following command to get started:
+Run the following command to create a new Nx workspace:
 
 ```shell
 npx create-nx-workspace@latest
 ```
 
-This interactive command will guide you through the setup process, allowing you to:
+This interactive command guides you through the setup:
 
-- **Choose your workspace name** - This will be the name of your root directory
-- **Select your preferred package manager** - npm, yarn, or pnpm
-- **Pick a preset** - Choose from [various technology stacks and configurations](/docs/reference/create-nx-workspace#presets)
-- **Configure additional options** - Such as styling solutions, testing frameworks, and more
+- **Workspace name** - The name of your root directory
+- **Template** - Choose from [various technology stacks](/docs/reference/create-nx-workspace#presets) (React, Angular, Node, etc.)
+- **Package manager** - npm, yarn, pnpm, or bun
+- **Additional options** - Styling, testing frameworks, and more depending on your template
 
-Choose a preset that matches your technology stack. This gives you a fully configured workspace.
+For a minimal setup, choose the **empty workspace** template (`--preset=ts`). This gives you a bare TypeScript monorepo that you can extend incrementally.
 
-You can also choose **an empty workspace preset** (`--preset=ts`) which sets up the bare minimum configuration for TypeScript and Nx. This allows you to add technologies and features incrementally over time as you need them.
-
-## Option 3: Get the complete Nx monorepo platform experience
+## Option 2: Create via Nx Cloud
 
 [![Nx Cloud onboarding](../../../assets/getting-started/nx-cloud-starting-screen.avif)](https://cloud.nx.app/get-started?utm_source=nx-docs&utm_medium=nx-cloud-onboarding&utm_campaign=start-new-project)
 
-For the complete experience, you can also get [started directly from the Nx Cloud application](https://cloud.nx.app/get-started?utm_source=nx-docs&utm_medium=nx-cloud-onboarding&utm_campaign=start-new-project).
+[Create your workspace directly from Nx Cloud](https://cloud.nx.app/get-started?utm_source=nx-docs&utm_medium=nx-cloud-onboarding&utm_campaign=start-new-project) for a browser-based setup experience.
 
-This approach gives you a fully end-to-end development workflow right from the start, making it easy to get up and running when your project is in its initial phase.
-You'll get a fully working CI configuration that includes Nx Cloud's AI-powered features like **AI-powered self-healing CI** that automatically fixes common CI failures.
-This means you benefit from intelligent automation right from day one, without having to configure complex CI pipelines manually.
+This option gives you:
 
-As your project grows and scales, you'll have access to additional features like **remote caching** to speed up builds across your team, **distributed task execution with Nx Agents** to parallelize work across multiple machines, and **automatic test splitting** to optimize your CI pipeline performance.
+- A working CI configuration out of the box
+- [Remote caching](/docs/features/ci-features/remote-cache) enabled from the start
+- [Self-healing CI](/docs/features/ci-features/self-healing-ci) that automatically fixes common failures
 
-[Get started with the complete Nx monorepo platform experience →](https://cloud.nx.app/get-started?utm_source=nx-docs&utm_medium=nx-cloud-onboarding&utm_campaign=start-new-project)
+[Get started with Nx Cloud →](https://cloud.nx.app/get-started?utm_source=nx-docs&utm_medium=nx-cloud-onboarding&utm_campaign=start-new-project)

--- a/astro-docs/src/content/docs/getting-started/start-with-existing-project.mdoc
+++ b/astro-docs/src/content/docs/getting-started/start-with-existing-project.mdoc
@@ -1,102 +1,49 @@
 ---
-title: Start with an existing project
-description: Add Nx to any existing project with a single command. Start with Nx Core and gradually adopt plugins, CI integrations, and other capabilities.
+title: Add to an Existing Project
+description: Add Nx to any existing project with a single command. Start with task running and caching, then gradually adopt more capabilities.
 sidebar:
   order: 4
-  label: Add to existing project
+  label: Add to Existing Project
 filter: 'type:Guides'
 ---
 
 {% course_video src="https://youtu.be/3hW53b1IJ84" courseTitle="From PNPM Workspaces to Distributed CI" courseUrl="https://nx.dev/courses/pnpm-nx-next/lessons-01-nx-init" /%}
 
-In many situations, you have an existing codebase and want to improve it with Nx using an **incremental adoption approach**.
+Nx is designed for incremental adoption. Start with just task running and [caching](/docs/features/cache-task-results), then add [plugins](/docs/technologies), [CI integrations](/docs/guides/nx-cloud/setup-ci), or other capabilities as your needs grow.
 
-Thanks to [Nx's modular architecture](/docs/getting-started/intro), you can start with just **Nx Core** and then gradually add [technology-specific plugins](/docs/technologies), [CI integrations](/docs/getting-started/nx-cloud), or other capabilities as your requirements evolve.
-
-Getting started is remarkably simple. You can add Nx to any existing project with a single command:
+Add Nx to any existing project with a single command:
 
 ```shell
-nx@latest init
+npx nx@latest init
 ```
 
-{% aside type="note" title="Global Installs" %}
-Make sure you have [Nx installed globally](/docs/getting-started/installation) or use `npx` if you're in a JavaScript environment
-{% /aside %}
-
-Whether a monorepo, single project or something in between, `nx init` walks you through adding and configuring Nx. You can pick a minimal approach or detailed guided setup. At the end you'll have an Nx workspace ready for anything!
+Whether a monorepo, single project, or something in between, `nx init` walks you through adding and configuring Nx. At the end you'll have an Nx workspace ready for anything.
 
 ## Next Steps
 
-After initializing Nx, you can [run tasks](/docs/features/run-tasks) with `nx <task> <project-name>` (e.g. `nx build myproject`) or run one or many tasks across all projects with `nx run-many -t <task1> <task2>`.
+After initializing Nx, try these commands:
 
-You can also explore your codebase using:
-
-- `nx graph` to view an interactive graph
-- `nx show projects` to see a list of all projects
-- `nx show project <project-name>` to view an interactive project detailed view
-
-### Update CI Configurations
-
-Now that Nx is installed, you'll want to update CI configurations to leverage Nx. You can do this by changing previous commands to use `nx` instead.
-
-For example, switching from `pnpm` commands to use `nx`
-
-```diff
-// .github/workflows/ci.yaml
--     - run: pnpm run -r build
--     - run: pnpm run -r test
-+     - run: npx nx run-many -t test build
+```shell
+nx build <project-name>      # Run a task
+nx build <project-name>      # Run again - instant cache hit
+nx run-many -t build test    # Run tasks across all projects
+nx graph                     # Visualize project dependencies
 ```
 
-You can directly invoke `package.json` scripts with `nx` as well
+From here you can:
 
-```diff
-// .github/workflows/ci.yaml
--     - run: npm run build
--     - run: npm run test
-+     - run: npx nx build
-+     - run: npx nx test
-```
+- [Configure task caching](/docs/features/cache-task-results) to speed up repeated builds
+- [Add Nx plugins](/docs/technologies) for your tech stack (React, Angular, Node, etc.)
+- [Set up CI](/docs/guides/nx-cloud/setup-ci) with remote caching and affected commands
+- Enable [remote caching](/docs/features/ci-features/remote-cache) with `nx connect`
 
-[View CI provider specific setups](/docs/guides/nx-cloud/setup-ci) to learn more.
-
-### Nx Cloud
-
-{% aside type="note" title="How do I know if I enabled Nx Cloud?" %}
-Validate Nx Cloud is enabled by checking the `nx.json` file for `nxCloudId` property.
-You can add Nx Cloud at any point by running the `nx connect` command.
-{%/aside%}
-
-After initializing Nx, you'll need to commit and push the changes to your repository.
-
-Once your changes are pushed, you can finish setting up your workspace by clicking on the list printed to your terminal, or by visiting [Nx Cloud directly](https://cloud.nx.app/get-started?utm_source=nx.dev&utm_campaign=nx_init) and clicking _"Connect an existing Nx repository"_
-
-To leverage Self Healing CI, you'll need to add the following to your CI configuration:
-
-```diff
-// .github/workflows/ci.yaml
-      - run: npx nx run-many -t lint test build
-+       # Enable Self Healing CI w/ Nx Cloud
-+     - run: npx nx fix-ci
-+       if: always()
-```
-
-### Empower Your Editor
-
-Enhance your developer experience by using the Nx Console editor extension.
-
-{% install_nx_console /%}
-
-## In-depth Guides
-
-Here are some guides that give you more details based on the technology stack you're using:
+## In-Depth Guides
 
 {% cardgrid %}
 
-{% linkcard title="Add to Existing Monorepo"
-href="/docs/guides/adopting-nx/adding-to-monorepo" %}
-{% /linkcard %}
-{% linkcard title="Add to Any Project"  href="/docs/guides/adopting-nx/adding-to-existing-project" /%}
+{% linkcard title="Add to Existing Monorepo" href="/docs/guides/adopting-nx/adding-to-monorepo" /%}
+
+{% linkcard title="Add to Any Project" href="/docs/guides/adopting-nx/adding-to-existing-project" /%}
 
 {% linkcard title="Migrate from Angular CLI" href="/docs/technologies/angular/migration/angular" /%}
 


### PR DESCRIPTION
## Current Behavior

Getting started pages had overlapping content and unclear focus:
- `installation.mdoc` mentioned CNW and tutorials (belongs elsewhere)
- `start-new-project.mdoc` had manual setup option (belongs on add-to-existing)
- `start-with-existing-project.mdoc` duplicated CI examples, editor buttons, Nx Cloud walkthrough
- `intro.mdoc` mixed messaging - some "challenges" were polyrepo problems

## Expected Behavior

Each page is now focused with no duplication:

### intro.mdoc
- Clear problem/solution structure following Turborepo's approach
- Problem: concise (builds get slow as codebase scales)
- Solution: caching, task orchestration, affected commands
- **Removed**: Polyrepo problems from challenge list (code sharing, lost context)
- **Removed**: Lengthy deepdive callouts
- Net reduction: 67 deletions, 14 insertions

### installation.mdoc
- Global install (npm/brew/choco/apt) + verification step
- Local install (`nx init`) for existing repos
- Update instructions
- **Removed**: CNW mention, tutorials section, "More Documentation"

### start-new-project.mdoc
- Option 1: Create locally with templates (`create-nx-workspace`)
- Option 2: Create via Nx Cloud (browser-based)
- **Removed**: Manual setup option (that's for existing projects)
- Updated terminology: "presets" → "templates"

### start-with-existing-project.mdoc
- Focused: `nx init` → run tasks → see caching → explore graph
- Links to other pages instead of duplicating content
- **Removed**: CI config examples, Nx Cloud walkthrough, editor buttons

### editor-setup.mdoc
- Added problem hook explaining why editor integration matters
- Clarified Neovim is community-maintained

### ai-setup.mdoc
- Added problem hook about AI hallucination without workspace context
- Explained MCP acronym (Model Context Protocol)
- Clarified "Ralph Wiggum loop" terminology

### sidebar.mts
- Reordered to match natural flow: Installation → Start New/Add Existing → Editor/AI

## Related Issue(s)

Closes DOC-405