### PR TITLE
docs(misc): clarify security email usage in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,3 +13,15 @@ Instead, please report them to the Security Team at security@nrwl.io.
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
 
 Nx follows the principle of Coordinated Vulnerability Disclosure.
+
+## What Should Be Reported
+
+The security email is for **demonstrable, verified vulnerabilities within the Nx codebase itself**.
+
+**Please do not use the security email for:**
+
+- Reports about outdated dependencies (e.g., "package X has a newer version available")
+- Reports about dependencies with known CVEs that do not directly affect Nx functionality
+- General vulnerability scanner output
+
+If you have a concern about an outdated dependency that you believe impacts Nx users, please open a [GitHub issue](https://github.com/nrwl/nx/issues/new/choose) instead.


### PR DESCRIPTION
## Current Behavior

The SECURITY.md file does not clarify what types of reports should be sent to the security email, leading to reports about outdated dependencies and vulnerability scanner output.

## Expected Behavior

The file now clarifies that the security email is for demonstrable, verified vulnerabilities in the Nx codebase itself, not for:
- Outdated dependency reports
- Dependencies with CVEs that don't directly affect Nx
- General vulnerability scanner output

## Related Issue(s)

Fixes NXC-3898