### PR TITLE
feat(testing): add cacheDir option to playwright executor

### DIFF
--- a/packages/playwright/src/executors/playwright/schema.json
+++ b/packages/playwright/src/executors/playwright/schema.json
@@ -155,6 +155,10 @@
       "type": "boolean",
       "description": "Skip running playwright install before running playwright tests. This is to ensure that playwright browsers are installed before running tests.",
       "default": false
+    },
+    "cacheDir": {
+      "type": "string",
+      "description": "Directory for Playwright internal cache (browser binaries, etc.). Sets the PWTEST_CACHE_DIR environment variable."
     }
   },
   "required": []


### PR DESCRIPTION
## Current Behavior

The Playwright executor does not support configuring a custom cache directory for Playwright's internal cache (browser binaries, etc.). Users who need to control where Playwright stores its cache, for example in CI environments with specific disk constraints like not being able to DTE tasks or shared caching setups, have no way to set this through the executor configuration.

## Expected Behavior

A new `cacheDir` option is available on the Playwright executor. When provided, it sets the `PWTEST_CACHE_DIR` environment variable on the forked Playwright process, allowing users to control where Playwright stores its internal cache.
  ```json
  {
    "targets": {
      "e2e": {
        "executor": "@nx/playwright:playwright",
        "options": {
          "cacheDir": "/tmp/playwright-cache"
        }
      }
    }
  }
  ```

## Related Issue(s)

Replaces #34397