### PR TITLE
feat(core): add commands for debugging cache inputs / outputs

### DIFF
--- a/e2e/nx/src/__snapshots__/misc.test.ts.snap
+++ b/e2e/nx/src/__snapshots__/misc.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Nx Commands show show target human-readable output should render directory containing inputs 1`] = `
 "~ apps/<APP>/src is a directory containing 7 input file(s) for <APP>:build
@@ -13,7 +13,7 @@ exports[`Nx Commands show show target human-readable output should render direct
 `;
 
 exports[`Nx Commands show show target human-readable output should render matching --check input 1`] = `
-"✓ .gitignore is an input for <APP>:build (files)
+"✓ apps/<APP>/src/main.ts is an input for <APP>:build (files)
 "
 `;
 

--- a/e2e/nx/src/__snapshots__/misc.test.ts.snap
+++ b/e2e/nx/src/__snapshots__/misc.test.ts.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Nx Commands show show target human-readable output should render directory containing inputs 1`] = `
+"~ apps/<APP>/src is a directory containing 7 input file(s) for <APP>:build
+  apps/<APP>/src/app/app.element.css
+  apps/<APP>/src/app/app.element.ts
+  apps/<APP>/src/assets/.gitkeep
+  apps/<APP>/src/favicon.ico
+  apps/<APP>/src/index.html
+  apps/<APP>/src/main.ts
+  apps/<APP>/src/styles.css
+"
+`;
+
+exports[`Nx Commands show show target human-readable output should render matching --check input 1`] = `
+"✓ .gitignore is an input for <APP>:build (files)
+"
+`;
+
+exports[`Nx Commands show show target human-readable output should render matching --check output 1`] = `
+"✓ dist/apps/<APP> is an output of <APP>:build
+"
+`;
+
+exports[`Nx Commands show show target human-readable output should render non-matching --check input 1`] = `
+"✗ definitely/not/an/input.xyz is not an input for <APP>:build
+"
+`;
+
+exports[`Nx Commands show show target human-readable output should render non-matching --check output 1`] = `
+"✗ definitely/not/an/output is not an output of <APP>:build
+"
+`;
+
+exports[`Nx Commands show show target human-readable output should render output paths 1`] = `
+"Output paths for <APP>:build
+
+Configured outputs:
+  dist/apps/<APP>
+"
+`;
+
+exports[`Nx Commands show show target human-readable output should render target info 1`] = `
+"Target: <APP>:build
+Executor: nx:run-commands
+Command: webpack-cli build
+Options:
+  cwd: "apps/<APP>"
+  args: ["--node-env=production"]
+  command: "webpack-cli build"
+Inputs:
+  - production
+  - ^production
+  - {"externalDependencies":["webpack-cli"]}
+Outputs:
+  - {workspaceRoot}/dist/apps/<APP>
+Configurations: production
+Cache: true
+Parallelism: true
+"
+`;

--- a/e2e/nx/src/__snapshots__/misc.test.ts.snap
+++ b/e2e/nx/src/__snapshots__/misc.test.ts.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`Nx Commands show show target human-readable output should render grouped output when checking multiple inputs 1`] = `
+"
+✓ These arguments were inputs for <APP>:build:
+  apps/<APP>/src/main.ts
+  apps/<APP>/src/app/app.element.ts
+
+✗ These arguments were not inputs for <APP>:build:
+  definitely/not/an/input.xyz
+"
+`;
+
+exports[`Nx Commands show show target human-readable output should render grouped output when checking multiple outputs 1`] = `
+"
+✓ These arguments were outputs of <APP>:build:
+  dist/apps/<APP>/main.js
+
+✗ These arguments were not outputs of <APP>:build:
+  definitely/not/an/output
+"
+`;
+
 exports[`Nx Commands show show target human-readable output should render directory containing inputs 1`] = `
 "~ apps/<APP>/src is a directory containing 7 input file(s) for <APP>:build
   apps/<APP>/src/app/app.element.css
@@ -40,22 +61,3 @@ Configured outputs:
 "
 `;
 
-exports[`Nx Commands show show target human-readable output should render target info 1`] = `
-"Target: <APP>:build
-Executor: nx:run-commands
-Command: webpack-cli build
-Options:
-  cwd: "apps/<APP>"
-  args: ["--node-env=production"]
-  command: "webpack-cli build"
-Inputs:
-  - production
-  - ^production
-  - {"externalDependencies":["webpack-cli"]}
-Outputs:
-  - {workspaceRoot}/dist/apps/<APP>
-Configurations: production
-Cache: true
-Parallelism: true
-"
-`;

--- a/e2e/nx/src/__snapshots__/misc.test.ts.snap
+++ b/e2e/nx/src/__snapshots__/misc.test.ts.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`Nx Commands show show target human-readable output should render directory containing inputs 1`] = `
+"~ apps/<APP>/src is a directory containing 7 input file(s) for <APP>:build
+  apps/<APP>/src/app/app.element.css
+  apps/<APP>/src/app/app.element.ts
+  apps/<APP>/src/assets/.gitkeep
+  apps/<APP>/src/favicon.ico
+  apps/<APP>/src/index.html
+  apps/<APP>/src/main.ts
+  apps/<APP>/src/styles.css
+"
+`;
+
 exports[`Nx Commands show show target human-readable output should render grouped output when checking multiple inputs 1`] = `
 "
 ✓ These arguments were inputs for <APP>:build:
@@ -18,18 +30,6 @@ exports[`Nx Commands show show target human-readable output should render groupe
 
 ✗ These arguments were not outputs of <APP>:build:
   definitely/not/an/output
-"
-`;
-
-exports[`Nx Commands show show target human-readable output should render directory containing inputs 1`] = `
-"~ apps/<APP>/src is a directory containing 7 input file(s) for <APP>:build
-  apps/<APP>/src/app/app.element.css
-  apps/<APP>/src/app/app.element.ts
-  apps/<APP>/src/assets/.gitkeep
-  apps/<APP>/src/favicon.ico
-  apps/<APP>/src/index.html
-  apps/<APP>/src/main.ts
-  apps/<APP>/src/styles.css
 "
 `;
 
@@ -58,6 +58,32 @@ exports[`Nx Commands show show target human-readable output should render output
 
 Configured outputs:
   dist/apps/<APP>
+
+Resolved outputs:
+  dist/apps/<APP>
 "
 `;
 
+exports[`Nx Commands show show target human-readable output should render target info 1`] = `
+"Target: <APP>:build
+Executor: nx:run-commands
+Command: webpack-cli build
+Options:
+  cwd: "apps/<APP>"
+  args: ["--node-env=production"]
+  command: "webpack-cli build"
+Inputs:
+  - default
+  - !{projectRoot}/.eslintrc.json
+  - !{projectRoot}/eslint.config.mjs
+  - !{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)
+  - !{projectRoot}/tsconfig.spec.json
+  - ^production
+  - {"externalDependencies":["webpack-cli"]}
+Outputs:
+  - {workspaceRoot}/dist/apps/<APP>
+Configurations: production
+Cache: true
+Parallelism: true
+"
+`;

--- a/e2e/nx/src/__snapshots__/misc.test.ts.snap
+++ b/e2e/nx/src/__snapshots__/misc.test.ts.snap
@@ -73,11 +73,12 @@ Options:
   args: ["--node-env=production"]
   command: "webpack-cli build"
 Inputs:
-  - default
+  - !{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)
   - !{projectRoot}/.eslintrc.json
   - !{projectRoot}/eslint.config.mjs
-  - !{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)
+  - !{projectRoot}/src/test-setup.[jt]s
   - !{projectRoot}/tsconfig.spec.json
+  - default
   - ^production
   - {"externalDependencies":["webpack-cli"]}
 Outputs:

--- a/e2e/nx/src/misc.test.ts
+++ b/e2e/nx/src/misc.test.ts
@@ -106,6 +106,231 @@ describe('Nx Commands', () => {
       await killProcessAndPorts(childProcess.pid, port);
     }, 700000);
 
+    describe('show target', () => {
+      let app: string;
+
+      beforeAll(() => {
+        app = uniq('targetapp');
+        runCLI(
+          `generate @nx/web:app apps/${app} --bundler=webpack --unitTestRunner=vitest --linter=eslint`
+        );
+      });
+
+      /**
+       * Replace the random app name with a stable placeholder so
+       * snapshot output is deterministic across runs.
+       */
+      function normalizeOutput(output: string): string {
+        return output.replaceAll(app, '<APP>');
+      }
+
+      it('should show resolved target configuration', () => {
+        const result = JSON.parse(runCLI(`show target ${app}:build --json`));
+        expect(result.project).toBe(app);
+        expect(result.target).toBe('build');
+        expect(result.executor).toBeDefined();
+        expect(result.options).toBeDefined();
+        expect(result.cache).toBeDefined();
+        expect(result.parallelism).toBeDefined();
+      });
+
+      it('should show target configuration with a specific config', () => {
+        const result = JSON.parse(
+          runCLI(`show target ${app}:build -c production --json`)
+        );
+        expect(result.project).toBe(app);
+        expect(result.target).toBe('build');
+        expect(result.configuration).toBe('production');
+      });
+
+      it('should list resolved input files', () => {
+        const result = JSON.parse(
+          runCLI(`show target inputs ${app}:build --json`)
+        );
+        expect(result.project).toBe(app);
+        expect(result.target).toBe('build');
+        expect(result.files).toBeDefined();
+        expect(Array.isArray(result.files)).toBe(true);
+        expect(result.files.length).toBeGreaterThan(0);
+      });
+
+      it('should list resolved output paths', () => {
+        const result = JSON.parse(
+          runCLI(`show target outputs ${app}:build --json`)
+        );
+        expect(result.project).toBe(app);
+        expect(result.target).toBe('build');
+        expect(result.outputPaths).toBeDefined();
+        expect(Array.isArray(result.outputPaths)).toBe(true);
+        expect(result.outputPaths.length).toBeGreaterThan(0);
+      });
+
+      it('should check a matching input file and exit 0', () => {
+        // Get the list of inputs first
+        const inputs = JSON.parse(
+          runCLI(`show target inputs ${app}:build --json`)
+        );
+        const firstFile = inputs.files[0];
+        expect(firstFile).toBeDefined();
+
+        // runCLI throws on non-zero exit, so success here means exit 0
+        const result = JSON.parse(
+          runCLI(`show target inputs ${app}:build --check ${firstFile} --json`)
+        );
+        expect(result.isInput).toBe(true);
+      });
+
+      it('should report non-matching input file and exit 1', () => {
+        expect(() =>
+          runCLI(
+            `show target inputs ${app}:build --check definitely/not/an/input.xyz --json`
+          )
+        ).toThrow();
+
+        // Also verify the JSON structure via silenceError
+        const output = runCLI(
+          `show target inputs ${app}:build --check definitely/not/an/input.xyz --json`,
+          { silenceError: true }
+        );
+        const result = JSON.parse(output);
+        expect(result.isInput).toBe(false);
+      });
+
+      it('should check a matching output path and exit 0', () => {
+        const outputs = JSON.parse(
+          runCLI(`show target outputs ${app}:build --json`)
+        );
+        const firstOutput = outputs.outputPaths[0];
+        expect(firstOutput).toBeDefined();
+
+        // runCLI throws on non-zero exit, so success here means exit 0
+        const result = JSON.parse(
+          runCLI(
+            `show target outputs ${app}:build --check ${firstOutput} --json`
+          )
+        );
+        expect(result.isOutput).toBe(true);
+      });
+
+      it('should report non-matching output path and exit 1', () => {
+        expect(() =>
+          runCLI(
+            `show target outputs ${app}:build --check definitely/not/an/output --json`
+          )
+        ).toThrow();
+
+        const output = runCLI(
+          `show target outputs ${app}:build --check definitely/not/an/output --json`,
+          { silenceError: true }
+        );
+        const result = JSON.parse(output);
+        expect(result.isOutput).toBe(false);
+        expect(result.matchedOutput).toBeNull();
+      });
+
+      it('should check a directory containing input files and exit 0', () => {
+        // Directory containing inputs is a successful check (exit 0)
+        const result = JSON.parse(
+          runCLI(
+            `show target inputs ${app}:build --check apps/${app}/src --json`
+          )
+        );
+        expect(result.isInput).toBe(false);
+        expect(result.isDirectoryContainingInputs).toBe(true);
+        expect(result.containedInputFiles.length).toBeGreaterThan(0);
+      });
+
+      it('should error when target not found', () => {
+        const output = runCLI(`show target ${app}:nonexistent`, {
+          silenceError: true,
+        });
+        expect(output).toContain('nonexistent');
+        expect(output).toContain('not found');
+      });
+
+      it('should support reversed order syntax', () => {
+        // nx show target app:build inputs (instead of nx show target inputs app:build)
+        const result = JSON.parse(
+          runCLI(`show target ${app}:build inputs --json`)
+        );
+        expect(result.project).toBe(app);
+        expect(result.target).toBe('build');
+        expect(result.files).toBeDefined();
+      });
+
+      it('should error when --check is used without a value', () => {
+        const output = runCLI(`show target inputs ${app}:build --check`, {
+          silenceError: true,
+        });
+        expect(output).toContain('Not enough arguments following: check');
+      });
+
+      describe('human-readable output', () => {
+        it('should render target info', () => {
+          const output = normalizeOutput(runCLI(`show target ${app}:build`));
+          expect(output).toMatchSnapshot();
+        });
+
+        it('should render output paths', () => {
+          const output = normalizeOutput(
+            runCLI(`show target outputs ${app}:build`)
+          );
+          expect(output).toMatchSnapshot();
+        });
+
+        it('should render matching --check input', () => {
+          const inputs = JSON.parse(
+            runCLI(`show target inputs ${app}:build --json`)
+          );
+          const firstFile = inputs.files[0];
+
+          const output = normalizeOutput(
+            runCLI(`show target inputs ${app}:build --check ${firstFile}`)
+          );
+          expect(output).toMatchSnapshot();
+        });
+
+        it('should render non-matching --check input', () => {
+          const output = normalizeOutput(
+            runCLI(
+              `show target inputs ${app}:build --check definitely/not/an/input.xyz`,
+              { silenceError: true }
+            )
+          );
+          expect(output).toMatchSnapshot();
+        });
+
+        it('should render matching --check output', () => {
+          const outputs = JSON.parse(
+            runCLI(`show target outputs ${app}:build --json`)
+          );
+          const firstOutput = outputs.outputPaths[0];
+
+          const output = normalizeOutput(
+            runCLI(`show target outputs ${app}:build --check ${firstOutput}`)
+          );
+          expect(output).toMatchSnapshot();
+        });
+
+        it('should render non-matching --check output', () => {
+          const output = normalizeOutput(
+            runCLI(
+              `show target outputs ${app}:build --check definitely/not/an/output`,
+              { silenceError: true }
+            )
+          );
+          expect(output).toMatchSnapshot();
+        });
+
+        it('should render directory containing inputs', () => {
+          const output = normalizeOutput(
+            runCLI(`show target inputs ${app}:build --check apps/${app}/src`)
+          );
+          expect(output).toMatchSnapshot();
+        });
+      });
+    });
+
     it('should find alternative port when default port is occupied', async () => {
       const app = uniq('myapp');
       runCLI(`generate @nx/web:app apps/${app}`);

--- a/e2e/nx/src/misc.test.ts
+++ b/e2e/nx/src/misc.test.ts
@@ -114,6 +114,16 @@ describe('Nx Commands', () => {
         runCLI(
           `generate @nx/web:app apps/${app} --bundler=webpack --unitTestRunner=vitest --linter=eslint`
         );
+        // Add a production configuration so the `-c production` test has something to resolve
+        updateJson(`apps/${app}/project.json`, (json) => {
+          json.targets ??= {};
+          json.targets.build ??= {};
+          json.targets.build.configurations ??= {};
+          json.targets.build.configurations.production = {
+            optimization: true,
+          };
+          return json;
+        });
       });
 
       /**

--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -445,9 +445,11 @@ export function runCLI(
 
     const r = stripVTControlCharacters(logs);
 
+    runCLI.lastExitCode = 0;
     return r;
   } catch (e) {
     if (opts.silenceError) {
+      runCLI.lastExitCode = (e.status ?? 1) as number;
       return stripVTControlCharacters(e.stdout + e.stderr);
     } else {
       logError(`Original command: ${command}`, `${e.stdout}\n\n${e.stderr}`);
@@ -455,6 +457,7 @@ export function runCLI(
     }
   }
 }
+runCLI.lastExitCode = 0 as number;
 
 export function runLernaCLI(
   command: string,

--- a/packages/devkit/tsconfig.json
+++ b/packages/devkit/tsconfig.json
@@ -11,6 +11,6 @@
     }
   ],
   "nx": {
-    // "addTypecheckTarget": false
+    "addTypecheckTarget": false
   }
 }

--- a/packages/devkit/tsconfig.json
+++ b/packages/devkit/tsconfig.json
@@ -11,6 +11,6 @@
     }
   ],
   "nx": {
-    "addTypecheckTarget": false
+    // "addTypecheckTarget": false
   }
 }

--- a/packages/nx/src/command-line/show/command-object.ts
+++ b/packages/nx/src/command-line/show/command-object.ts
@@ -273,7 +273,7 @@ const showTargetInfoCommand: CommandModule<NxShowArgs, ShowTargetBaseOptions> =
         }
         await showTargetInfoHandler(args);
       });
-      process.exit(exitCode);
+      process.exit(process.exitCode || exitCode);
     },
   };
 

--- a/packages/nx/src/command-line/show/command-object.ts
+++ b/packages/nx/src/command-line/show/command-object.ts
@@ -232,7 +232,7 @@ const showTargetInfoCommand: CommandModule<NxShowArgs, ShowTargetBaseOptions> =
           type: 'string',
           choices: ['inputs', 'outputs'],
           description:
-            'Used to allow running `nx show target app:build inputs` in addition to `nx show target inputs app:build`',
+            'Used to allow running `nx show target app:build inputs` in addition to `nx show target inputs app:build`.',
         })
         .option('configuration', {
           type: 'string',

--- a/packages/nx/src/command-line/show/target.spec.ts
+++ b/packages/nx/src/command-line/show/target.spec.ts
@@ -1,0 +1,823 @@
+import type {
+  ProjectGraph,
+  ProjectGraphProjectNode,
+} from '../../config/project-graph';
+import type { ProjectConfiguration } from '../../config/workspace-json-project-json';
+import { showTargetHandler } from './target';
+
+let graph: ProjectGraph = {
+  nodes: {},
+  dependencies: {},
+  externalNodes: {},
+};
+
+let mockCwd = '/workspace';
+let mockNxJson: Record<string, unknown> = {};
+let mockHashPlan: Record<string, string[]> = {};
+let mockExpandedOutputs: string[] | null = null;
+
+jest.mock('../../project-graph/project-graph', () => ({
+  ...(jest.requireActual(
+    '../../project-graph/project-graph'
+  ) as typeof import('../../project-graph/project-graph')),
+  createProjectGraphAsync: jest
+    .fn()
+    .mockImplementation(() => Promise.resolve(graph)),
+}));
+
+jest.mock('../../utils/workspace-root', () => ({
+  workspaceRoot: '/workspace',
+}));
+
+jest.mock('../../utils/output', () => ({
+  output: {
+    error: jest.fn(),
+    drain: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('../../config/configuration', () => ({
+  readNxJson: jest.fn().mockImplementation(() => mockNxJson),
+}));
+
+jest.mock('../../native', () => {
+  const actual = jest.requireActual('../../native');
+  return {
+    ...actual,
+    expandOutputs: jest
+      .fn()
+      .mockImplementation((_root: string, outputs: string[]) => {
+        if (mockExpandedOutputs !== null) return mockExpandedOutputs;
+        return actual.expandOutputs(_root, outputs);
+      }),
+  };
+});
+
+jest.mock('../../hasher/hash-plan-inspector', () => ({
+  HashPlanInspector: jest.fn().mockImplementation(() => ({
+    init: jest.fn().mockResolvedValue(undefined),
+    inspectTask: jest.fn().mockImplementation(() => mockHashPlan),
+  })),
+}));
+
+const originalCwd = process.cwd;
+
+performance.mark = jest.fn();
+performance.measure = jest.fn();
+
+describe('show target', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(process, 'exit').mockImplementation((() => {}) as any);
+    performance.mark('init-local');
+    mockCwd = '/workspace';
+    mockNxJson = {};
+    mockHashPlan = {};
+    mockExpandedOutputs = null;
+    process.cwd = jest.fn().mockReturnValue(mockCwd);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    process.cwd = originalCwd;
+  });
+
+  it('should show target info when project:target is provided', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              options: { outputPath: 'dist/apps/my-app' },
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    await showTargetHandler({
+      target: 'my-app:build',
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed.project).toBe('my-app');
+    expect(parsed.target).toBe('build');
+    expect(parsed.executor).toBe('@nx/web:build');
+    expect(parsed.options).toEqual({ outputPath: 'dist/apps/my-app' });
+  });
+
+  it('should infer project from cwd when only target name given', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: { executor: '@nx/web:build' },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    process.cwd = jest.fn().mockReturnValue('/workspace/apps/my-app');
+
+    await showTargetHandler({
+      target: 'build',
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed.project).toBe('my-app');
+    expect(parsed.target).toBe('build');
+  });
+
+  it('should output valid JSON with expected structure', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              options: { outputPath: 'dist/apps/my-app' },
+              outputs: ['{options.outputPath}'],
+              inputs: ['default', '^default'],
+              cache: true,
+              configurations: {
+                production: { optimization: true },
+              },
+              defaultConfiguration: 'production',
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    await showTargetHandler({
+      target: 'my-app:build',
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed).toMatchObject({
+      project: 'my-app',
+      target: 'build',
+      executor: '@nx/web:build',
+      options: { outputPath: 'dist/apps/my-app' },
+      inputs: ['default', '^default'],
+      outputs: ['{options.outputPath}'],
+      configurations: ['production'],
+      defaultConfiguration: 'production',
+      cache: true,
+      parallelism: true,
+    });
+  });
+
+  it('should merge configuration options correctly', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              options: { outputPath: 'dist/apps/my-app', optimization: false },
+              configurations: {
+                production: { optimization: true, sourceMap: false },
+              },
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    await showTargetHandler({
+      target: 'my-app:build',
+      configuration: 'production',
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed.options).toEqual({
+      outputPath: 'dist/apps/my-app',
+      optimization: true,
+      sourceMap: false,
+    });
+  });
+
+  it('should expand dependsOn ^build to dependency project:target pairs', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              dependsOn: ['^build'],
+            },
+          },
+        },
+        'app'
+      )
+      .addProjectConfiguration(
+        {
+          root: 'libs/lib-a',
+          name: 'lib-a',
+          targets: {
+            build: { executor: '@nx/js:tsc' },
+          },
+        },
+        'lib'
+      )
+      .addProjectConfiguration(
+        {
+          root: 'libs/lib-b',
+          name: 'lib-b',
+          targets: {
+            build: { executor: '@nx/js:tsc' },
+          },
+        },
+        'lib'
+      )
+      .addDependency('my-app', 'lib-a')
+      .addDependency('my-app', 'lib-b')
+      .build();
+
+    await showTargetHandler({
+      target: 'my-app:build',
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed.dependsOn).toBeDefined();
+    expect(parsed.dependsOn.length).toBeGreaterThan(0);
+
+    const buildDep = parsed.dependsOn.find(
+      (d: { target: string }) => d.target === 'build'
+    );
+    expect(buildDep).toBeDefined();
+    expect(buildDep.projects.sort()).toEqual(['lib-a', 'lib-b']);
+  });
+
+  it('should expand self-reference dependsOn to same project', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: { executor: '@nx/web:build' },
+            test: {
+              executor: '@nx/jest:jest',
+              dependsOn: ['build'],
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    await showTargetHandler({
+      target: 'my-app:test',
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed.dependsOn).toBeDefined();
+    const selfBuild = parsed.dependsOn.find(
+      (d: { target: string }) => d.target === 'build'
+    );
+    expect(selfBuild).toBeDefined();
+    expect(selfBuild.projects).toContain('my-app');
+  });
+
+  it('should error when target not found and list available targets', async () => {
+    const { output } = require('../../utils/output');
+    jest.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit: ${code}`);
+    });
+
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: { executor: '@nx/web:build' },
+            test: { executor: '@nx/jest:jest' },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    await expect(
+      showTargetHandler({
+        target: 'my-app:serve',
+        json: true,
+      })
+    ).rejects.toThrow('process.exit: 1');
+
+    expect(output.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringContaining('serve'),
+        bodyLines: expect.arrayContaining([expect.stringContaining('build')]),
+      })
+    );
+  });
+
+  it('should error when project not found', async () => {
+    const { output } = require('../../utils/output');
+    jest.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit: ${code}`);
+    });
+
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: { build: { executor: '@nx/web:build' } },
+        },
+        'app'
+      )
+      .build();
+
+    await expect(
+      showTargetHandler({
+        target: 'nonexistent:build',
+        json: true,
+      })
+    ).rejects.toThrow('process.exit: 1');
+
+    expect(output.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringContaining('nonexistent'),
+      })
+    );
+  });
+
+  it('should error when configuration not found and list available configs', async () => {
+    const { output } = require('../../utils/output');
+    jest.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`process.exit: ${code}`);
+    });
+
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              configurations: {
+                production: {},
+                staging: {},
+              },
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    await expect(
+      showTargetHandler({
+        target: 'my-app:build',
+        configuration: 'nonexistent',
+        json: true,
+      })
+    ).rejects.toThrow('process.exit: 1');
+
+    expect(output.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringContaining('nonexistent'),
+        bodyLines: expect.arrayContaining([
+          expect.stringContaining('production'),
+        ]),
+      })
+    );
+  });
+
+  it('should resolve output interpolation with {projectRoot}', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              options: { outputPath: 'dist/apps/my-app' },
+              outputs: ['{projectRoot}/dist', '{options.outputPath}'],
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    await showTargetHandler({
+      target: 'my-app:build',
+      outputs: true,
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed.outputPaths).toContain('apps/my-app/dist');
+    expect(parsed.outputPaths).toContain('dist/apps/my-app');
+  });
+
+  it('should list resolved input files with --inputs via HashPlanInspector', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              inputs: ['{projectRoot}/**/*.ts'],
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    mockHashPlan = {
+      'my-app:build': [
+        'file:apps/my-app/src/main.ts',
+        'file:apps/my-app/src/app.ts',
+        'env:NX_CLOUD_ENCRYPTION_KEY',
+        'my-app:ProjectConfiguration',
+        'my-app:TsConfig',
+      ],
+    };
+
+    await showTargetHandler({
+      target: 'my-app:build',
+      inputs: true,
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed.files).toContain('apps/my-app/src/main.ts');
+    expect(parsed.files).toContain('apps/my-app/src/app.ts');
+    expect(parsed.environmentVariables).toContain('NX_CLOUD_ENCRYPTION_KEY');
+    // ProjectConfiguration and TsConfig are implicit — not in output
+    expect(parsed.projectConfigurations).toBeUndefined();
+  });
+
+  it('should identify matching file with --check-input', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              inputs: ['{projectRoot}/**/*.ts'],
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    mockHashPlan = {
+      'my-app:build': ['file:apps/my-app/src/main.ts'],
+    };
+
+    await showTargetHandler({
+      target: 'my-app:build',
+      checkInput: 'apps/my-app/src/main.ts',
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed.isInput).toBe(true);
+  });
+
+  it('should report non-match correctly with --check-input', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              inputs: ['{projectRoot}/**/*.ts'],
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    mockHashPlan = {
+      'my-app:build': ['file:apps/my-app/src/main.ts'],
+    };
+
+    await showTargetHandler({
+      target: 'my-app:build',
+      checkInput: 'apps/my-app/README.md',
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed.isInput).toBe(false);
+  });
+
+  it('should normalize leading ./ in --check-input paths', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              inputs: ['{projectRoot}/**/*.ts'],
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    mockHashPlan = {
+      'my-app:build': ['file:apps/my-app/src/main.ts'],
+    };
+
+    await showTargetHandler({
+      target: 'my-app:build',
+      checkInput: './apps/my-app/src/main.ts',
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed.isInput).toBe(true);
+  });
+
+  it('should report directory containing input files with --check-input', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              inputs: ['{projectRoot}/**/*.ts'],
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    mockHashPlan = {
+      'my-app:build': [
+        'file:apps/my-app/src/main.ts',
+        'file:apps/my-app/src/app.ts',
+      ],
+    };
+
+    await showTargetHandler({
+      target: 'my-app:build',
+      checkInput: './apps/my-app/src',
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed.isInput).toBe(false);
+    expect(parsed.isDirectoryContainingInputs).toBe(true);
+    expect(parsed.containedInputFiles).toContain('apps/my-app/src/main.ts');
+    expect(parsed.containedInputFiles).toContain('apps/my-app/src/app.ts');
+  });
+
+  it('should list resolved output paths with --outputs', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              options: { outputPath: 'dist/apps/my-app' },
+              outputs: ['{options.outputPath}'],
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    await showTargetHandler({
+      target: 'my-app:build',
+      outputs: true,
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed.outputPaths).toContain('dist/apps/my-app');
+  });
+
+  it('should identify matching file with --check-output', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              outputs: ['{projectRoot}/dist'],
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    await showTargetHandler({
+      target: 'my-app:build',
+      checkOutput: 'apps/my-app/dist/main.js',
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed.isOutput).toBe(true);
+    expect(parsed.matchedOutput).toBe('apps/my-app/dist');
+  });
+
+  it('should detect directory containing output paths with --check-output', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              outputs: ['{projectRoot}/dist', '{projectRoot}/coverage'],
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    await showTargetHandler({
+      target: 'my-app:build',
+      checkOutput: 'apps/my-app',
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed.isOutput).toBe(false);
+    expect(parsed.isDirectoryContainingOutputs).toBe(true);
+    expect(parsed.containedOutputPaths).toEqual(
+      expect.arrayContaining(['apps/my-app/dist', 'apps/my-app/coverage'])
+    );
+  });
+
+  it('should match file via expanded outputs when configured paths use globs', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              outputs: ['{projectRoot}/dist/*.js'],
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    // Simulate native expandOutputs resolving glob to actual files
+    mockExpandedOutputs = [
+      'apps/my-app/dist/main.js',
+      'apps/my-app/dist/vendor.js',
+    ];
+
+    await showTargetHandler({
+      target: 'my-app:build',
+      checkOutput: 'apps/my-app/dist/main.js',
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed.isOutput).toBe(true);
+    expect(parsed.matchedOutput).toBe('apps/my-app/dist/main.js');
+  });
+
+  it('should report no match for directory without outputs via --check-output', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              outputs: ['{projectRoot}/dist'],
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    await showTargetHandler({
+      target: 'my-app:build',
+      checkOutput: 'libs/other',
+      json: true,
+    });
+
+    const logged = (console.log as jest.Mock).mock.calls[0][0];
+    const parsed = JSON.parse(logged);
+    expect(parsed.isOutput).toBe(false);
+    expect(parsed.matchedOutput).toBeNull();
+    expect(parsed.isDirectoryContainingOutputs).toBeUndefined();
+  });
+});
+
+class GraphBuilder {
+  nodes: Record<string, ProjectGraphProjectNode> = {};
+  dependencies: Record<
+    string,
+    { type: string; source: string; target: string }[]
+  > = {};
+
+  addProjectConfiguration(
+    project: ProjectConfiguration & { name: string },
+    type: ProjectGraph['nodes'][string]['type']
+  ) {
+    this.nodes[project.name] = {
+      name: project.name,
+      type,
+      data: { ...project },
+    };
+    if (!this.dependencies[project.name]) {
+      this.dependencies[project.name] = [];
+    }
+    return this;
+  }
+
+  addDependency(source: string, target: string) {
+    if (!this.dependencies[source]) {
+      this.dependencies[source] = [];
+    }
+    this.dependencies[source].push({
+      type: 'static',
+      source,
+      target,
+    });
+    return this;
+  }
+
+  build(): ProjectGraph {
+    return {
+      nodes: this.nodes,
+      dependencies: this.dependencies,
+      externalNodes: {},
+    };
+  }
+}

--- a/packages/nx/src/command-line/show/target.spec.ts
+++ b/packages/nx/src/command-line/show/target.spec.ts
@@ -510,14 +510,12 @@ describe('show target', () => {
 
     await showTargetInputsHandler({
       target: 'my-app:build',
-      check: 'apps/my-app/src/main.ts',
-      json: true,
+      check: ['apps/my-app/src/main.ts'],
     });
 
     const logged = (console.log as jest.Mock).mock.calls[0][0];
-    const parsed = JSON.parse(logged);
-    expect(parsed.isInput).toBe(true);
-    expect(parsed.matchedCategory).toBe('files');
+    expect(logged).toContain('apps/my-app/src/main.ts');
+    expect(logged).toContain('is an input');
     expect(process.exitCode).toBe(0);
   });
 
@@ -550,14 +548,13 @@ describe('show target', () => {
 
     await showTargetInputsHandler({
       target: 'my-app:build',
-      check: 'CI',
-      json: true,
+      check: ['CI'],
     });
 
     const logged = (console.log as jest.Mock).mock.calls[0][0];
-    const parsed = JSON.parse(logged);
-    expect(parsed.isInput).toBe(true);
-    expect(parsed.matchedCategory).toBe('environment');
+    expect(logged).toContain('CI');
+    expect(logged).toContain('is an input');
+    expect(logged).toContain('environment');
     expect(process.exitCode).toBe(0);
   });
 
@@ -590,13 +587,12 @@ describe('show target', () => {
 
     await showTargetInputsHandler({
       target: 'my-app:build',
-      check: 'apps/my-app/README.md',
-      json: true,
+      check: ['apps/my-app/README.md'],
     });
 
     const logged = (console.log as jest.Mock).mock.calls[0][0];
-    const parsed = JSON.parse(logged);
-    expect(parsed.isInput).toBe(false);
+    expect(logged).toContain('apps/my-app/README.md');
+    expect(logged).toContain('not');
     expect(process.exitCode).toBe(1);
   });
 
@@ -629,13 +625,11 @@ describe('show target', () => {
 
     await showTargetInputsHandler({
       target: 'my-app:build',
-      check: './apps/my-app/src/main.ts',
-      json: true,
+      check: ['./apps/my-app/src/main.ts'],
     });
 
     const logged = (console.log as jest.Mock).mock.calls[0][0];
-    const parsed = JSON.parse(logged);
-    expect(parsed.isInput).toBe(true);
+    expect(logged).toContain('is an input');
     expect(process.exitCode).toBe(0);
   });
 
@@ -668,16 +662,15 @@ describe('show target', () => {
 
     await showTargetInputsHandler({
       target: 'my-app:build',
-      check: './apps/my-app/src',
-      json: true,
+      check: ['./apps/my-app/src'],
     });
 
-    const logged = (console.log as jest.Mock).mock.calls[0][0];
-    const parsed = JSON.parse(logged);
-    expect(parsed.isInput).toBe(false);
-    expect(parsed.isDirectoryContainingInputs).toBe(true);
-    expect(parsed.containedInputFiles).toContain('apps/my-app/src/main.ts');
-    expect(parsed.containedInputFiles).toContain('apps/my-app/src/app.ts');
+    const calls = (console.log as jest.Mock).mock.calls.map((c) => c[0]);
+    const allLogged = calls.join('\n');
+    expect(allLogged).toContain('directory containing');
+    expect(allLogged).toContain('2');
+    expect(allLogged).toContain('apps/my-app/src/main.ts');
+    expect(allLogged).toContain('apps/my-app/src/app.ts');
     expect(process.exitCode).toBe(0);
   });
 
@@ -728,14 +721,12 @@ describe('show target', () => {
 
     await showTargetOutputsHandler({
       target: 'my-app:build',
-      check: 'apps/my-app/dist/main.js',
-      json: true,
+      check: ['apps/my-app/dist/main.js'],
     });
 
     const logged = (console.log as jest.Mock).mock.calls[0][0];
-    const parsed = JSON.parse(logged);
-    expect(parsed.isOutput).toBe(true);
-    expect(parsed.matchedOutput).toBe('apps/my-app/dist');
+    expect(logged).toContain('apps/my-app/dist/main.js');
+    expect(logged).toContain('is an output');
     expect(process.exitCode).toBe(0);
   });
 
@@ -758,17 +749,13 @@ describe('show target', () => {
 
     await showTargetOutputsHandler({
       target: 'my-app:build',
-      check: 'apps/my-app',
-      json: true,
+      check: ['apps/my-app'],
     });
 
-    const logged = (console.log as jest.Mock).mock.calls[0][0];
-    const parsed = JSON.parse(logged);
-    expect(parsed.isOutput).toBe(false);
-    expect(parsed.isDirectoryContainingOutputs).toBe(true);
-    expect(parsed.containedOutputPaths).toEqual(
-      expect.arrayContaining(['apps/my-app/dist', 'apps/my-app/coverage'])
-    );
+    const calls = (console.log as jest.Mock).mock.calls.map((c) => c[0]);
+    const allLogged = calls.join('\n');
+    expect(allLogged).toContain('directory containing');
+    expect(allLogged).toContain('2');
     expect(process.exitCode).toBe(0);
   });
 
@@ -797,14 +784,12 @@ describe('show target', () => {
 
     await showTargetOutputsHandler({
       target: 'my-app:build',
-      check: 'apps/my-app/dist/main.js',
-      json: true,
+      check: ['apps/my-app/dist/main.js'],
     });
 
     const logged = (console.log as jest.Mock).mock.calls[0][0];
-    const parsed = JSON.parse(logged);
-    expect(parsed.isOutput).toBe(true);
-    expect(parsed.matchedOutput).toBe('apps/my-app/dist/main.js');
+    expect(logged).toContain('apps/my-app/dist/main.js');
+    expect(logged).toContain('is an output');
     expect(process.exitCode).toBe(0);
   });
 
@@ -917,16 +902,133 @@ describe('show target', () => {
 
     await showTargetOutputsHandler({
       target: 'my-app:build',
-      check: 'libs/other',
-      json: true,
+      check: ['libs/other'],
     });
 
     const logged = (console.log as jest.Mock).mock.calls[0][0];
-    const parsed = JSON.parse(logged);
-    expect(parsed.isOutput).toBe(false);
-    expect(parsed.matchedOutput).toBeNull();
-    expect(parsed.isDirectoryContainingOutputs).toBeUndefined();
+    expect(logged).toContain('libs/other');
+    expect(logged).toContain('not');
     expect(process.exitCode).toBe(1);
+  });
+
+  it('should check multiple input paths in a single invocation', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              inputs: ['{projectRoot}/**/*.ts'],
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    mockHashInputs = {
+      'my-app:build': {
+        files: ['apps/my-app/src/main.ts', 'apps/my-app/src/app.ts'],
+        runtime: [],
+        environment: ['CI'],
+        depOutputs: [],
+        external: [],
+      },
+    };
+
+    await showTargetInputsHandler({
+      target: 'my-app:build',
+      check: ['apps/my-app/src/main.ts', 'CI', 'apps/my-app/README.md'],
+    });
+
+    const calls = (console.log as jest.Mock).mock.calls.map((c) => c[0]);
+    expect(calls).toHaveLength(3);
+    // First: matching file
+    expect(calls[0]).toContain('apps/my-app/src/main.ts');
+    expect(calls[0]).toContain('is an input');
+    // Second: matching env var
+    expect(calls[1]).toContain('CI');
+    expect(calls[1]).toContain('is an input');
+    // Third: non-match
+    expect(calls[2]).toContain('apps/my-app/README.md');
+    expect(calls[2]).toContain('not');
+    // exitCode should be 1 because at least one path didn't match
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('should check multiple output paths in a single invocation', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              outputs: ['{projectRoot}/dist'],
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    await showTargetOutputsHandler({
+      target: 'my-app:build',
+      check: ['apps/my-app/dist/main.js', 'libs/other/file.js'],
+    });
+
+    const calls = (console.log as jest.Mock).mock.calls.map((c) => c[0]);
+    expect(calls).toHaveLength(2);
+    // First: matching output
+    expect(calls[0]).toContain('apps/my-app/dist/main.js');
+    expect(calls[0]).toContain('is an output');
+    // Second: non-match
+    expect(calls[1]).toContain('libs/other/file.js');
+    expect(calls[1]).toContain('not');
+    // exitCode should be 1 because at least one path didn't match
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('should set exitCode 0 when all multiple check values match', async () => {
+    graph = new GraphBuilder()
+      .addProjectConfiguration(
+        {
+          root: 'apps/my-app',
+          name: 'my-app',
+          targets: {
+            build: {
+              executor: '@nx/web:build',
+              inputs: ['{projectRoot}/**/*.ts'],
+            },
+          },
+        },
+        'app'
+      )
+      .build();
+
+    mockHashInputs = {
+      'my-app:build': {
+        files: ['apps/my-app/src/main.ts', 'apps/my-app/src/app.ts'],
+        runtime: [],
+        environment: [],
+        depOutputs: [],
+        external: [],
+      },
+    };
+
+    await showTargetInputsHandler({
+      target: 'my-app:build',
+      check: ['apps/my-app/src/main.ts', 'apps/my-app/src/app.ts'],
+    });
+
+    const calls = (console.log as jest.Mock).mock.calls.map((c) => c[0]);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toContain('is an input');
+    expect(calls[1]).toContain('is an input');
+    expect(process.exitCode).toBe(0);
   });
 });
 

--- a/packages/nx/src/command-line/show/target.spec.ts
+++ b/packages/nx/src/command-line/show/target.spec.ts
@@ -79,6 +79,7 @@ describe('show target', () => {
     mockNxJson = {};
     mockHashInputs = {};
     mockExpandedOutputs = null;
+    process.exitCode = undefined;
     process.cwd = jest.fn().mockReturnValue(mockCwd);
   });
 
@@ -517,6 +518,7 @@ describe('show target', () => {
     const parsed = JSON.parse(logged);
     expect(parsed.isInput).toBe(true);
     expect(parsed.matchedCategory).toBe('files');
+    expect(process.exitCode).toBe(0);
   });
 
   it('should identify matching environment variable with --check', async () => {
@@ -556,6 +558,7 @@ describe('show target', () => {
     const parsed = JSON.parse(logged);
     expect(parsed.isInput).toBe(true);
     expect(parsed.matchedCategory).toBe('environment');
+    expect(process.exitCode).toBe(0);
   });
 
   it('should report non-match correctly with --check for inputs', async () => {
@@ -594,6 +597,7 @@ describe('show target', () => {
     const logged = (console.log as jest.Mock).mock.calls[0][0];
     const parsed = JSON.parse(logged);
     expect(parsed.isInput).toBe(false);
+    expect(process.exitCode).toBe(1);
   });
 
   it('should normalize leading ./ in --check paths', async () => {
@@ -632,6 +636,7 @@ describe('show target', () => {
     const logged = (console.log as jest.Mock).mock.calls[0][0];
     const parsed = JSON.parse(logged);
     expect(parsed.isInput).toBe(true);
+    expect(process.exitCode).toBe(0);
   });
 
   it('should report directory containing input files with --check', async () => {
@@ -673,6 +678,7 @@ describe('show target', () => {
     expect(parsed.isDirectoryContainingInputs).toBe(true);
     expect(parsed.containedInputFiles).toContain('apps/my-app/src/main.ts');
     expect(parsed.containedInputFiles).toContain('apps/my-app/src/app.ts');
+    expect(process.exitCode).toBe(0);
   });
 
   it('should list resolved output paths', async () => {
@@ -730,6 +736,7 @@ describe('show target', () => {
     const parsed = JSON.parse(logged);
     expect(parsed.isOutput).toBe(true);
     expect(parsed.matchedOutput).toBe('apps/my-app/dist');
+    expect(process.exitCode).toBe(0);
   });
 
   it('should detect directory containing output paths with --check for outputs', async () => {
@@ -762,6 +769,7 @@ describe('show target', () => {
     expect(parsed.containedOutputPaths).toEqual(
       expect.arrayContaining(['apps/my-app/dist', 'apps/my-app/coverage'])
     );
+    expect(process.exitCode).toBe(0);
   });
 
   it('should match file via expanded outputs when configured paths use globs', async () => {
@@ -797,6 +805,7 @@ describe('show target', () => {
     const parsed = JSON.parse(logged);
     expect(parsed.isOutput).toBe(true);
     expect(parsed.matchedOutput).toBe('apps/my-app/dist/main.js');
+    expect(process.exitCode).toBe(0);
   });
 
   it('should not flag {options.*} outputs as unresolved when option is set', async () => {
@@ -917,6 +926,7 @@ describe('show target', () => {
     expect(parsed.isOutput).toBe(false);
     expect(parsed.matchedOutput).toBeNull();
     expect(parsed.isDirectoryContainingOutputs).toBeUndefined();
+    expect(process.exitCode).toBe(1);
   });
 });
 

--- a/packages/nx/src/command-line/show/target.ts
+++ b/packages/nx/src/command-line/show/target.ts
@@ -621,7 +621,7 @@ function renderTargetInfo(
         if (aIsDep && !bIsDep) return 1;
         if (!aIsDep && bIsDep) return -1;
 
-        return a.localeCompare(b);
+        return a < b ? -1 : a > b ? 1 : 0;
       }
 
       return 0;

--- a/packages/nx/src/command-line/show/target.ts
+++ b/packages/nx/src/command-line/show/target.ts
@@ -672,10 +672,13 @@ function renderInputs(
     );
   }
 
-  printList('External dependencies', data.external);
-  printList('Runtime inputs', data.runtime);
-  printList('Environment variables', data.environment);
-  printList(`Files (${data.files.length})`, data.files.concat(data.depOutputs));
+  printList('External dependencies', [...data.external].sort());
+  printList('Runtime inputs', [...data.runtime].sort());
+  printList('Environment variables', [...data.environment].sort());
+  printList(
+    `Files (${data.files.length})`,
+    [...data.files, ...data.depOutputs].sort()
+  );
 }
 
 function renderCheckInput(data: ReturnType<typeof resolveCheckFromInputs>) {
@@ -695,7 +698,7 @@ function renderCheckInput(data: ReturnType<typeof resolveCheckFromInputs>) {
         String(data.containedInputFiles.length)
       )} input file(s) for ${c.cyan(data.project)}:${c.green(data.target)}`
     );
-    for (const f of data.containedInputFiles) console.log(`  ${f}`);
+    for (const f of [...data.containedInputFiles].sort()) console.log(`  ${f}`);
   } else {
     console.log(
       `${c.red('✗')} ${c.bold(data.value)} is ${c.red(

--- a/packages/nx/src/command-line/show/target.ts
+++ b/packages/nx/src/command-line/show/target.ts
@@ -1,0 +1,740 @@
+import { relative, resolve } from 'path';
+import { calculateDefaultProjectName } from '../../config/calculate-default-project-name';
+import { readNxJson } from '../../config/configuration';
+import type { NxJsonConfiguration } from '../../config/nx-json';
+import type { ProjectGraph } from '../../config/project-graph';
+import {
+  createProjectGraphAsync,
+  readProjectsConfigurationFromProjectGraph,
+} from '../../project-graph/project-graph';
+import {
+  getDependencyConfigs,
+  getOutputsForTargetAndConfiguration,
+} from '../../tasks-runner/utils';
+import { findMatchingProjects } from '../../utils/find-matching-projects';
+import { output } from '../../utils/output';
+import { splitTarget } from '../../utils/split-target';
+import { workspaceRoot } from '../../utils/workspace-root';
+import { ShowTargetOptions } from './command-object';
+
+// ── Shared utilities ─────────────────────────────────────────────────
+
+let _pc: typeof import('picocolors');
+function pc() {
+  return (_pc ??= require('picocolors'));
+}
+
+async function flushOutput() {
+  await new Promise((res) => setImmediate(res));
+  await output.drain();
+}
+
+function printList(header: string, items: unknown[], prefix = '\n') {
+  if (items.length === 0) return;
+  console.log(`${prefix}${pc().bold(header)}:`);
+  for (const item of items) console.log(`  ${item}`);
+}
+
+function outputJson(data: Record<string, unknown>) {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+/** Strips entries whose values are empty arrays from an object. */
+function omitEmptyArrays<T extends Record<string, unknown>>(obj: T): T {
+  const result = {} as T;
+  for (const [k, v] of Object.entries(obj)) {
+    if (Array.isArray(v) && v.length === 0) continue;
+    (result as Record<string, unknown>)[k] = v;
+  }
+  return result;
+}
+
+/**
+ * Categorizes flat hash plan entries (e.g. "file:src/main.ts", "env:CI")
+ * returned by the HashPlanInspector into typed buckets.
+ */
+function categorizeHashPlan(entries: string[]) {
+  const files: string[] = [];
+  const environmentVariables: string[] = [];
+  const runtimeInputs: string[] = [];
+  const externalDependencies: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.startsWith('file:')) files.push(entry.slice(5));
+    else if (entry.startsWith('env:'))
+      environmentVariables.push(entry.slice(4));
+    else if (entry.startsWith('runtime:')) runtimeInputs.push(entry.slice(8));
+    else if (
+      entry.endsWith(':ProjectConfiguration') ||
+      entry.endsWith(':TsConfig') ||
+      entry.startsWith('cwd:')
+    ) {
+      // Implicit inputs — already shown in base display
+    } else {
+      externalDependencies.push(entry);
+    }
+  }
+
+  return { files, environmentVariables, runtimeInputs, externalDependencies };
+}
+
+// ── Entry point ──────────────────────────────────────────────────────
+
+export async function showTargetHandler(
+  args: ShowTargetOptions
+): Promise<void> {
+  performance.mark('code-loading:end');
+  performance.measure('code-loading', 'init-local', 'code-loading:end');
+
+  const graph = await createProjectGraphAsync();
+  const nxJson = readNxJson();
+
+  const { projectName, targetName, configurationName } =
+    resolveTargetIdentifier(args, graph, nxJson);
+
+  const node = resolveProjectNode(projectName, graph);
+  const targetConfig = node.data.targets?.[targetName];
+
+  if (!targetConfig) {
+    const availableTargets = Object.keys(node.data.targets ?? {});
+    output.error({
+      title: `Target "${targetName}" not found for project "${projectName}".`,
+      bodyLines: availableTargets.length
+        ? [`Available targets:`, ...availableTargets.map((t) => `  - ${t}`)]
+        : [`This project has no targets configured.`],
+    });
+    process.exit(1);
+  }
+
+  const configuration = configurationName ?? args.configuration;
+  if (configuration) {
+    const availableConfigs = Object.keys(targetConfig.configurations ?? {});
+    if (!availableConfigs.includes(configuration)) {
+      output.error({
+        title: `Configuration "${configuration}" not found for target "${projectName}:${targetName}".`,
+        bodyLines: availableConfigs.length
+          ? [
+              `Available configurations:`,
+              ...availableConfigs.map((c) => `  - ${c}`),
+            ]
+          : [`This target has no configurations.`],
+      });
+      process.exit(1);
+    }
+  }
+
+  // --inputs and --check-input both use the HashPlanInspector
+  if (args.inputs || args.checkInput !== undefined) {
+    const inputFiles = await resolveInputFiles(
+      projectName,
+      targetName,
+      configuration,
+      graph,
+      nxJson
+    );
+
+    if (args.inputs) {
+      renderInputs(
+        { project: projectName, target: targetName, ...inputFiles },
+        args
+      );
+      await flushOutput();
+      return;
+    }
+
+    // --check-input
+    const data = resolveCheckFromFiles(
+      args.checkInput,
+      projectName,
+      targetName,
+      inputFiles.files
+    );
+    renderCheckInput(data, args);
+    await flushOutput();
+    process.exitCode ||=
+      data.isInput || data.containedInputFiles.length ? 0 : 1;
+    return;
+  }
+
+  if (args.outputs) {
+    const data = resolveOutputsData(
+      projectName,
+      targetName,
+      configuration,
+      node
+    );
+    renderOutputs(data, args);
+    return;
+  }
+
+  if (args.checkOutput !== undefined) {
+    const data = resolveCheckOutputData(
+      args.checkOutput,
+      projectName,
+      targetName,
+      configuration,
+      node
+    );
+    renderCheckOutput(data, args);
+    process.exitCode ||=
+      data.matchedOutput ||
+      data.containedOutputPaths.length ||
+      data.containedExpandedOutputs.length
+        ? 0
+        : 1;
+    return;
+  }
+
+  const data = resolveTargetInfoData(
+    projectName,
+    targetName,
+    configuration,
+    node,
+    graph,
+    nxJson
+  );
+  renderTargetInfo(data, args);
+  await flushOutput();
+}
+
+// ── Target identifier & project resolution ───────────────────────────
+
+function resolveTargetIdentifier(
+  args: ShowTargetOptions,
+  graph: ProjectGraph,
+  nxJson: NxJsonConfiguration
+): { projectName: string; targetName: string; configurationName?: string } {
+  if (!args.target) {
+    output.error({
+      title: 'No target specified.',
+      bodyLines: [
+        `Please specify a target using:`,
+        `  nx show target <project:target>`,
+        `  nx show target <target>  (infers project from cwd)`,
+      ],
+    });
+    process.exit(1);
+  }
+
+  const [project, target, config] = splitTarget(args.target, graph);
+
+  if (project && target) {
+    return {
+      projectName: project,
+      targetName: target,
+      configurationName: config,
+    };
+  }
+
+  const targetName = project; // splitTarget returns the string as the first element
+  const projectName = calculateDefaultProjectName(
+    process.cwd(),
+    workspaceRoot,
+    readProjectsConfigurationFromProjectGraph(graph),
+    nxJson
+  );
+
+  if (!projectName) {
+    output.error({
+      title: `Could not infer project from the current working directory.`,
+      bodyLines: [
+        `Please specify the project explicitly:`,
+        `  nx show target ${projectName ?? '<project>'}:${targetName}`,
+        ``,
+        `Or run this command from within a project directory.`,
+      ],
+    });
+    process.exit(1);
+  }
+
+  return { projectName, targetName };
+}
+
+function resolveProjectNode(projectName: string, graph: ProjectGraph) {
+  let node = graph.nodes[projectName];
+  if (!node) {
+    const projects = findMatchingProjects([projectName], graph.nodes);
+    if (projects.length === 1) {
+      node = graph.nodes[projects[0]];
+    } else if (projects.length > 1) {
+      output.error({
+        title: `Multiple projects matched "${projectName}":`,
+        bodyLines:
+          projects.length > 100 ? [...projects.slice(0, 100), '...'] : projects,
+      });
+      process.exit(1);
+    } else {
+      output.error({
+        title: `Could not find project "${projectName}".`,
+      });
+      process.exit(1);
+    }
+  }
+  return node;
+}
+
+// ── Data resolvers ───────────────────────────────────────────────────
+
+function resolveTargetInfoData(
+  projectName: string,
+  targetName: string,
+  configuration: string | undefined,
+  node: ProjectGraph['nodes'][string],
+  graph: ProjectGraph,
+  nxJson: NxJsonConfiguration
+) {
+  const targetConfig = node.data.targets[targetName];
+
+  const baseOptions = targetConfig.options ?? {};
+  const configOptions = configuration
+    ? (targetConfig.configurations?.[configuration] ?? {})
+    : {};
+
+  const allTargetNames = new Set<string>();
+  for (const n of Object.values(graph.nodes)) {
+    for (const t of Object.keys(n.data.targets ?? {})) {
+      allTargetNames.add(t);
+    }
+  }
+
+  const extraTargetDeps = Object.fromEntries(
+    Object.entries(nxJson.targetDefaults ?? {})
+      .filter(([, config]) => config.dependsOn)
+      .map(([name, config]) => [name, config.dependsOn])
+  );
+
+  const depConfigs = getDependencyConfigs(
+    { project: projectName, target: targetName },
+    extraTargetDeps,
+    graph,
+    [...allTargetNames]
+  );
+
+  const configurations = Object.keys(targetConfig.configurations ?? {});
+
+  const command =
+    targetConfig.metadata?.scriptContent ??
+    targetConfig.options?.command ??
+    (targetConfig.options?.commands?.length === 1
+      ? targetConfig.options.commands[0]
+      : undefined);
+
+  const dependsOn =
+    depConfigs && depConfigs.length > 0
+      ? depConfigs.map((dep) => ({
+          target: dep.target,
+          projects: resolveDependencyProjects(dep, projectName, graph),
+          ...(dep.params ? { params: dep.params } : {}),
+        }))
+      : undefined;
+
+  return {
+    project: projectName,
+    target: targetName,
+    ...(configuration ? { configuration } : {}),
+    executor: targetConfig.executor,
+    ...(command ? { command } : {}),
+    options: { ...baseOptions, ...configOptions } as Record<string, unknown>,
+    ...(targetConfig.inputs ? { inputs: targetConfig.inputs } : {}),
+    ...(targetConfig.outputs
+      ? { outputs: targetConfig.outputs as string[] }
+      : {}),
+    ...(dependsOn ? { dependsOn } : {}),
+    ...(configurations.length > 0 ? { configurations } : {}),
+    ...(targetConfig.defaultConfiguration
+      ? { defaultConfiguration: targetConfig.defaultConfiguration }
+      : {}),
+    cache: targetConfig.cache ?? false,
+    parallelism: targetConfig.parallelism ?? true,
+  };
+}
+
+/**
+ * Uses the HashPlanInspector (native hash planner) to resolve the complete
+ * set of inputs that affect a task's cache hash.  Returns categorized inputs:
+ * files, environment variables, runtime inputs, and external dependencies.
+ */
+async function resolveInputFiles(
+  projectName: string,
+  targetName: string,
+  configuration: string | undefined,
+  graph: ProjectGraph,
+  nxJson: NxJsonConfiguration
+) {
+  const { HashPlanInspector } = (await import(
+    '../../hasher/hash-plan-inspector'
+  )) as typeof import('../../hasher/hash-plan-inspector');
+  const inspector = new HashPlanInspector(graph, workspaceRoot, nxJson);
+  await inspector.init();
+
+  const plan = inspector.inspectTask({
+    project: projectName,
+    target: targetName,
+    configuration,
+  });
+
+  const taskId = `${projectName}:${targetName}`;
+  const entries = plan[taskId] ?? [];
+
+  return categorizeHashPlan(entries);
+}
+
+function resolveCheckFromFiles(
+  rawFileToCheck: string,
+  projectName: string,
+  targetName: string,
+  inputFiles: string[]
+) {
+  const fileToCheck = normalizePath(rawFileToCheck);
+  const isInput = inputFiles.includes(fileToCheck);
+
+  let containedInputFiles: string[] = [];
+  if (!isInput) {
+    const dirPrefix = fileToCheck.endsWith('/')
+      ? fileToCheck
+      : fileToCheck + '/';
+    containedInputFiles = inputFiles.filter((f) => f.startsWith(dirPrefix));
+  }
+
+  return {
+    file: fileToCheck,
+    project: projectName,
+    target: targetName,
+    isInput,
+    containedInputFiles,
+  };
+}
+
+function resolveOutputsData(
+  projectName: string,
+  targetName: string,
+  configuration: string | undefined,
+  node: ProjectGraph['nodes'][string]
+) {
+  const resolvedOutputs = getOutputsForTargetAndConfiguration(
+    { project: projectName, target: targetName, configuration },
+    {},
+    node
+  );
+
+  let expandedOutputs: string[];
+  try {
+    const { expandOutputs } = require('../../native');
+    expandedOutputs = expandOutputs(workspaceRoot, resolvedOutputs);
+  } catch {
+    expandedOutputs = resolvedOutputs;
+  }
+
+  return {
+    project: projectName,
+    target: targetName,
+    outputPaths: resolvedOutputs,
+    expandedOutputs,
+  };
+}
+
+function resolveCheckOutputData(
+  rawFileToCheck: string,
+  projectName: string,
+  targetName: string,
+  configuration: string | undefined,
+  node: ProjectGraph['nodes'][string]
+) {
+  const fileToCheck = normalizePath(rawFileToCheck);
+  const resolvedOutputs = getOutputsForTargetAndConfiguration(
+    { project: projectName, target: targetName, configuration },
+    {},
+    node
+  );
+
+  const normalizedFile = fileToCheck.replace(/\\/g, '/');
+
+  // Expand globs to actual files on disk
+  let expandedOutputs: string[];
+  try {
+    const { expandOutputs } = require('../../native');
+    expandedOutputs = expandOutputs(workspaceRoot, resolvedOutputs);
+  } catch {
+    expandedOutputs = resolvedOutputs;
+  }
+
+  // Check if the file is an output — try configured paths first (prefix match
+  // covers directory outputs), then fall back to expanded outputs (handles globs).
+  let matchedOutput: string | null = null;
+  for (const outputPath of resolvedOutputs) {
+    const normalizedOutput = outputPath.replace(/\\/g, '/');
+    if (
+      normalizedFile === normalizedOutput ||
+      normalizedFile.startsWith(normalizedOutput + '/')
+    ) {
+      matchedOutput = outputPath;
+      break;
+    }
+  }
+  if (!matchedOutput && expandedOutputs.includes(normalizedFile)) {
+    matchedOutput = normalizedFile;
+  }
+
+  // If the path isn't directly an output, check if it's a directory containing outputs
+  let containedOutputPaths: string[] = [];
+  let containedExpandedOutputs: string[] = [];
+  if (!matchedOutput) {
+    const dirPrefix = normalizedFile.endsWith('/')
+      ? normalizedFile
+      : normalizedFile + '/';
+
+    containedOutputPaths = resolvedOutputs.filter((o) =>
+      o.replace(/\\/g, '/').startsWith(dirPrefix)
+    );
+    containedExpandedOutputs = expandedOutputs.filter((o) =>
+      o.replace(/\\/g, '/').startsWith(dirPrefix)
+    );
+  }
+
+  return {
+    file: fileToCheck,
+    project: projectName,
+    target: targetName,
+    matchedOutput,
+    containedOutputPaths,
+    containedExpandedOutputs,
+  };
+}
+
+// ── Renderers ────────────────────────────────────────────────────────
+
+function renderTargetInfo(
+  data: ReturnType<typeof resolveTargetInfoData>,
+  args: ShowTargetOptions
+) {
+  if (args.json) {
+    outputJson(data as Record<string, unknown>);
+    return;
+  }
+
+  const c = pc();
+  console.log(
+    `${c.bold('Target')}: ${c.cyan(data.project)}:${c.green(data.target)}`
+  );
+  if (data.executor) console.log(`${c.bold('Executor')}: ${data.executor}`);
+  if (data.command) console.log(`${c.bold('Command')}: ${data.command}`);
+  if (data.configuration)
+    console.log(`${c.bold('Configuration')}: ${data.configuration}`);
+
+  if (Object.keys(data.options).length > 0) {
+    console.log(`${c.bold('Options')}:`);
+    for (const [key, value] of Object.entries(data.options)) {
+      console.log(`  ${key}: ${JSON.stringify(value)}`);
+    }
+  }
+
+  if (data.inputs && data.inputs.length > 0) {
+    console.log(`${c.bold('Inputs')}:`);
+    for (const input of data.inputs) {
+      console.log(
+        `  - ${typeof input === 'string' ? input : JSON.stringify(input)}`
+      );
+    }
+  }
+
+  if (data.outputs && data.outputs.length > 0) {
+    console.log(`${c.bold('Outputs')}:`);
+    for (const o of data.outputs) console.log(`  - ${o}`);
+  }
+
+  if (data.dependsOn && data.dependsOn.length > 0) {
+    console.log(`${c.bold('Depends On')}:`);
+    for (const dep of data.dependsOn) {
+      console.log(`  ${dep.target} → ${dep.projects.join(', ')}`);
+    }
+  }
+
+  if (data.configurations && data.configurations.length > 0) {
+    console.log(
+      `${c.bold('Configurations')}: ${data.configurations.join(', ')}${
+        data.defaultConfiguration
+          ? ` (default: ${data.defaultConfiguration})`
+          : ''
+      }`
+    );
+  }
+
+  console.log(`${c.bold('Cache')}: ${data.cache}`);
+  console.log(`${c.bold('Parallelism')}: ${data.parallelism}`);
+}
+
+function renderInputs(
+  data: ReturnType<typeof categorizeHashPlan> & {
+    project: string;
+    target: string;
+  },
+  args: ShowTargetOptions
+) {
+  if (args.json) {
+    outputJson(omitEmptyArrays(data as Record<string, unknown>));
+    return;
+  }
+
+  const c = pc();
+  console.log(
+    `${c.bold('Inputs for')} ${c.cyan(data.project)}:${c.green(data.target)}`
+  );
+  printList(`Files (${data.files.length})`, data.files);
+  printList('Environment variables', data.environmentVariables);
+  printList('Runtime inputs', data.runtimeInputs);
+  printList('External dependencies', data.externalDependencies);
+}
+
+function renderCheckInput(
+  data: ReturnType<typeof resolveCheckFromFiles>,
+  args: ShowTargetOptions
+) {
+  if (args.json) {
+    const result: Record<string, unknown> = {
+      file: data.file,
+      project: data.project,
+      target: data.target,
+      isInput: data.isInput,
+    };
+    if (data.containedInputFiles.length > 0) {
+      result.isDirectoryContainingInputs = true;
+      result.containedInputFiles = data.containedInputFiles;
+    }
+    outputJson(result);
+    return;
+  }
+
+  const c = pc();
+  if (data.isInput) {
+    console.log(
+      `${c.green('✓')} ${c.bold(data.file)} is an input for ${c.cyan(
+        data.project
+      )}:${c.green(data.target)}`
+    );
+  } else if (data.containedInputFiles.length > 0) {
+    console.log(
+      `${c.yellow('~')} ${c.bold(data.file)} is a directory containing ${c.bold(
+        String(data.containedInputFiles.length)
+      )} input file(s) for ${c.cyan(data.project)}:${c.green(data.target)}`
+    );
+    for (const f of data.containedInputFiles) console.log(`  ${f}`);
+  } else {
+    console.log(
+      `${c.red('✗')} ${c.bold(data.file)} is ${c.red(
+        'not'
+      )} an input for ${c.cyan(data.project)}:${c.green(data.target)}`
+    );
+  }
+}
+
+function renderOutputs(
+  data: ReturnType<typeof resolveOutputsData>,
+  args: ShowTargetOptions
+) {
+  if (args.json) {
+    outputJson(data as Record<string, unknown>);
+    return;
+  }
+
+  const c = pc();
+  console.log(
+    `${c.bold('Output paths for')} ${c.cyan(data.project)}:${c.green(
+      data.target
+    )}`
+  );
+
+  if (data.outputPaths.length > 0) {
+    printList('Configured outputs', data.outputPaths);
+  }
+  if (
+    data.expandedOutputs.length > 0 &&
+    data.expandedOutputs !== data.outputPaths
+  ) {
+    printList('Expanded files', data.expandedOutputs);
+  }
+  if (data.outputPaths.length === 0) {
+    console.log(`\n  No outputs configured for this target.`);
+  }
+}
+
+function renderCheckOutput(
+  data: ReturnType<typeof resolveCheckOutputData>,
+  args: ShowTargetOptions
+) {
+  const isDirectoryContainingOutputs =
+    data.containedOutputPaths.length > 0 ||
+    data.containedExpandedOutputs.length > 0;
+
+  if (args.json) {
+    const result: Record<string, unknown> = {
+      file: data.file,
+      isOutput: data.matchedOutput !== null,
+      matchedOutput: data.matchedOutput,
+      project: data.project,
+      target: data.target,
+    };
+    if (isDirectoryContainingOutputs) {
+      result.isDirectoryContainingOutputs = true;
+      if (data.containedOutputPaths.length > 0)
+        result.containedOutputPaths = data.containedOutputPaths;
+      if (data.containedExpandedOutputs.length > 0)
+        result.containedExpandedOutputs = data.containedExpandedOutputs;
+    }
+    outputJson(result);
+    return;
+  }
+
+  const c = pc();
+  if (data.matchedOutput) {
+    console.log(
+      `${c.green('✓')} ${c.bold(data.file)} is an output of ${c.cyan(
+        data.project
+      )}:${c.green(data.target)}`
+    );
+  } else if (isDirectoryContainingOutputs) {
+    const totalCount =
+      data.containedOutputPaths.length + data.containedExpandedOutputs.length;
+    console.log(
+      `${c.yellow('~')} ${c.bold(data.file)} is a directory containing ${c.bold(
+        String(totalCount)
+      )} output path(s) for ${c.cyan(data.project)}:${c.green(data.target)}`
+    );
+    printList('Configured outputs', data.containedOutputPaths, '\n');
+    printList('Expanded output files', data.containedExpandedOutputs);
+  } else {
+    console.log(
+      `${c.red('✗')} ${c.bold(data.file)} is ${c.red(
+        'not'
+      )} an output of ${c.cyan(data.project)}:${c.green(data.target)}`
+    );
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function resolveDependencyProjects(
+  dep: { target: string; dependencies?: boolean; projects?: string[] },
+  projectName: string,
+  graph: ProjectGraph
+): string[] {
+  if (dep.projects && dep.projects.length > 0) return dep.projects;
+  if (dep.dependencies) {
+    const depEdges = graph.dependencies[projectName] ?? [];
+    return depEdges
+      .filter((edge) => {
+        const depNode = graph.nodes[edge.target];
+        return depNode && depNode.data.targets?.[dep.target];
+      })
+      .map((edge) => edge.target);
+  }
+  return [projectName];
+}
+
+/**
+ * Converts a user-provided path into a workspace-relative path for comparison
+ * against project file maps.
+ */
+function normalizePath(p: string): string {
+  const absolute = resolve(workspaceRoot, p);
+  return relative(workspaceRoot, absolute).replace(/\\/g, '/');
+}

--- a/packages/nx/src/command-line/show/target.ts
+++ b/packages/nx/src/command-line/show/target.ts
@@ -604,7 +604,29 @@ function renderTargetInfo(
 
   if (data.inputs && data.inputs.length > 0) {
     console.log(`${c.bold('Inputs')}:`);
-    for (const input of data.inputs) {
+    const sortedInputs = [...data.inputs].sort((a, b) => {
+      const aIsString = typeof a === 'string';
+      const bIsString = typeof b === 'string';
+
+      // Objects come after strings
+      if (!aIsString && bIsString) return 1;
+      if (aIsString && !bIsString) return -1;
+
+      // Both are strings
+      if (aIsString && bIsString) {
+        const aIsDep = a.startsWith('^');
+        const bIsDep = b.startsWith('^');
+
+        // Dependency inputs (^) come after regular inputs
+        if (aIsDep && !bIsDep) return 1;
+        if (!aIsDep && bIsDep) return -1;
+
+        return a.localeCompare(b);
+      }
+
+      return 0;
+    });
+    for (const input of sortedInputs) {
       console.log(
         `  - ${typeof input === 'string' ? input : JSON.stringify(input)}`
       );

--- a/packages/nx/src/hasher/hash-plan-inspector.ts
+++ b/packages/nx/src/hasher/hash-plan-inspector.ts
@@ -1,22 +1,25 @@
+import type { Target } from '../command-line/run/run';
 import {
-  HashPlanInspector as NativeHashPlanInspector,
-  HashPlanner,
-  transferProjectGraph,
-  ExternalObject,
-  ProjectGraph as NativeProjectGraph,
-  HashInputs,
-} from '../native';
-import { readNxJson, NxJsonConfiguration } from '../config/nx-json';
-import { transformProjectGraphForRust } from '../native/transform-objects';
+  NxJsonConfiguration,
+  readNxJson,
+  TargetDependencies,
+} from '../config/nx-json';
 import { ProjectGraph } from '../config/project-graph';
-import { workspaceRoot } from '../utils/workspace-root';
+import { TargetDependencyConfig } from '../config/workspace-json-project-json';
+import {
+  ExternalObject,
+  HashInputs,
+  HashPlanner,
+  HashPlanInspector as NativeHashPlanInspector,
+  ProjectGraph as NativeProjectGraph,
+  transferProjectGraph,
+} from '../native';
+import { transformProjectGraphForRust } from '../native/transform-objects';
 import { createProjectRootMappings } from '../project-graph/utils/find-project-for-path';
 import { createTaskGraph } from '../tasks-runner/create-task-graph';
-import type { Target } from '../command-line/run/run';
-import { TargetDependencies } from '../config/nx-json';
-import { TargetDependencyConfig } from '../config/workspace-json-project-json';
 import { splitArgsIntoNxArgsAndOverrides } from '../utils/command-line-utils';
 import { getNxWorkspaceFilesFromContext } from '../utils/workspace-context';
+import { workspaceRoot } from '../utils/workspace-root';
 
 export class HashPlanInspector {
   private readonly projectGraphRef: ExternalObject<NativeProjectGraph>;
@@ -47,7 +50,8 @@ export class HashPlanInspector {
     this.inspector = new NativeHashPlanInspector(
       externalReferences.allWorkspaceFiles,
       this.projectGraphRef,
-      externalReferences.projectFiles
+      externalReferences.projectFiles,
+      this.workspaceRootPath
     );
   }
 
@@ -81,6 +85,7 @@ export class HashPlanInspector {
 
   /**
    * This inspects tasks involved in the execution of a task, including its dependencies by default.
+   * @deprecated Prefer inspectTaskInputs
    */
   inspectTask(
     { project, target, configuration }: Target,

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -47,13 +47,14 @@ export declare class FileLock {
 }
 
 export declare class HashPlanInspector {
-  constructor(allWorkspaceFiles: ExternalObject<Array<FileData>>, projectGraph: ExternalObject<ProjectGraph>, projectFileMap: ExternalObject<Record<string, Array<FileData>>>)
+  constructor(allWorkspaceFiles: ExternalObject<Array<FileData>>, projectGraph: ExternalObject<ProjectGraph>, projectFileMap: ExternalObject<Record<string, Array<FileData>>>, workspaceRoot: string)
+  /** @deprecated Use `inspectInputs()` instead for structured output. */
   inspect(hashPlans: ExternalObject<Record<string, Array<HashInstruction>>>): Record<string, string[]>
   /**
    * Like `inspect()` but returns structured `HashInputs` objects instead of flat strings.
    * Each `HashInstruction` is categorized into the appropriate bucket (files, runtime,
-   * environment, depOutputs, external). TsConfiguration and ProjectConfiguration are
-   * resolved to their respective file paths. Cwd is skipped as it's ambient.
+   * environment, depOutputs, external). TsConfiguration is resolved to the root tsconfig
+   * file path. ProjectConfiguration is skipped for now. Cwd is skipped as it's ambient.
    */
   inspectInputs(hashPlans: ExternalObject<Record<string, Array<HashInstruction>>>): Record<string, HashInputs>
 }

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -49,6 +49,13 @@ export declare class FileLock {
 export declare class HashPlanInspector {
   constructor(allWorkspaceFiles: ExternalObject<Array<FileData>>, projectGraph: ExternalObject<ProjectGraph>, projectFileMap: ExternalObject<Record<string, Array<FileData>>>)
   inspect(hashPlans: ExternalObject<Record<string, Array<HashInstruction>>>): Record<string, string[]>
+  /**
+   * Like `inspect()` but returns structured `HashInputs` objects instead of flat strings.
+   * Each `HashInstruction` is categorized into the appropriate bucket (files, runtime,
+   * environment, depOutputs, external). TsConfiguration and ProjectConfiguration are
+   * resolved to their respective file paths. Cwd is skipped as it's ambient.
+   */
+  inspectInputs(hashPlans: ExternalObject<Record<string, Array<HashInstruction>>>): Record<string, HashInputs>
 }
 
 export declare class HashPlanner {

--- a/packages/nx/src/native/tasks/hash_plan_inspector.rs
+++ b/packages/nx/src/native/tasks/hash_plan_inspector.rs
@@ -1,8 +1,10 @@
 use crate::native::project_graph::types::ProjectGraph;
 use crate::native::tasks::hashers::{collect_project_files, get_workspace_files};
+use crate::native::tasks::task_hasher::{HashInputs, HashInputsBuilder};
 use crate::native::tasks::types::HashInstruction;
 use crate::native::types::FileData;
 use anyhow::anyhow;
+use hashbrown::HashSet;
 use napi::bindgen_prelude::*;
 use rayon::prelude::*;
 use std::collections::HashMap;
@@ -77,5 +79,136 @@ impl HashPlanInspector {
                 acc.entry(task_id.clone()).or_default().extend(files);
                 acc
             }))
+    }
+
+    /// Like `inspect()` but returns structured `HashInputs` objects instead of flat strings.
+    /// Each `HashInstruction` is categorized into the appropriate bucket (files, runtime,
+    /// environment, depOutputs, external). TsConfiguration and ProjectConfiguration are
+    /// resolved to their respective file paths. Cwd is skipped as it's ambient.
+    #[napi(ts_return_type = "Record<string, HashInputs>")]
+    pub fn inspect_inputs(
+        &self,
+        hash_plans: External<HashMap<String, Vec<HashInstruction>>>,
+    ) -> anyhow::Result<HashMap<String, HashInputs>> {
+        let results: Vec<(&String, HashInputsBuilder)> = hash_plans
+            .iter()
+            .flat_map(|(task_id, instructions)| {
+                instructions
+                    .iter()
+                    .map(move |instruction| (task_id, instruction))
+            })
+            .par_bridge()
+            .map(|(task_id, instruction)| {
+                let builder = match instruction {
+                    HashInstruction::WorkspaceFileSet(workspace_file_set) => {
+                        let files: HashSet<String> =
+                            get_workspace_files(workspace_file_set, &self.all_workspace_files)?
+                                .map(|x| x.file.clone())
+                                .collect();
+                        HashInputsBuilder {
+                            files,
+                            ..Default::default()
+                        }
+                    }
+                    HashInstruction::ProjectFileSet(project_name, file_sets) => {
+                        let project = self
+                            .project_graph
+                            .nodes
+                            .get(project_name)
+                            .ok_or_else(|| anyhow!("project {} not found", project_name))?;
+                        let files: HashSet<String> = collect_project_files(
+                            project_name,
+                            &project.root,
+                            file_sets,
+                            &self.project_file_map,
+                        )?
+                        .iter()
+                        .map(|x| x.file.clone())
+                        .collect();
+                        HashInputsBuilder {
+                            files,
+                            ..Default::default()
+                        }
+                    }
+                    HashInstruction::Runtime(runtime) => HashInputsBuilder {
+                        runtime: HashSet::from([runtime.clone()]),
+                        ..Default::default()
+                    },
+                    HashInstruction::Environment(env) => HashInputsBuilder {
+                        environment: HashSet::from([env.clone()]),
+                        ..Default::default()
+                    },
+                    HashInstruction::TaskOutput(_glob, dep_outputs) => HashInputsBuilder {
+                        dep_outputs: dep_outputs.iter().cloned().collect(),
+                        ..Default::default()
+                    },
+                    HashInstruction::External(external) => HashInputsBuilder {
+                        external: HashSet::from([external.clone()]),
+                        ..Default::default()
+                    },
+                    HashInstruction::AllExternalDependencies => HashInputsBuilder {
+                        external: HashSet::from(["AllExternalDependencies".to_string()]),
+                        ..Default::default()
+                    },
+                    HashInstruction::TsConfiguration(_project_name) => {
+                        // Find root-level tsconfig files that affect the hash
+                        let files: HashSet<String> = self
+                            .all_workspace_files
+                            .iter()
+                            .filter(|f| {
+                                !f.file.contains('/')
+                                    && f.file.starts_with("tsconfig")
+                                    && f.file.ends_with(".json")
+                            })
+                            .map(|f| f.file.clone())
+                            .collect();
+                        HashInputsBuilder {
+                            files,
+                            ..Default::default()
+                        }
+                    }
+                    HashInstruction::ProjectConfiguration(project_name) => {
+                        // Resolve the project's configuration file
+                        let mut files = HashSet::new();
+                        if let Some(project) = self.project_graph.nodes.get(project_name) {
+                            let project_json = format!("{}/project.json", project.root);
+                            let package_json = format!("{}/package.json", project.root);
+                            if self
+                                .all_workspace_files
+                                .iter()
+                                .any(|f| f.file == project_json)
+                            {
+                                files.insert(project_json);
+                            } else if self
+                                .all_workspace_files
+                                .iter()
+                                .any(|f| f.file == package_json)
+                            {
+                                files.insert(package_json);
+                            }
+                        }
+                        HashInputsBuilder {
+                            files,
+                            ..Default::default()
+                        }
+                    }
+                    // Cwd is ambient — skip
+                    HashInstruction::Cwd(_) => HashInputsBuilder::default(),
+                };
+                Ok::<_, anyhow::Error>((task_id, builder))
+            })
+            .collect::<anyhow::Result<_>>()?;
+
+        Ok(results
+            .into_iter()
+            .fold(HashMap::new(), |mut acc, (task_id, builder)| {
+                acc.entry(task_id.clone())
+                    .or_insert_with(HashInputsBuilder::default)
+                    .extend(builder);
+                acc
+            })
+            .into_iter()
+            .map(|(k, v)| (k, v.into()))
+            .collect())
     }
 }

--- a/packages/nx/src/native/tasks/hashers/hash_task_output.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_task_output.rs
@@ -20,6 +20,21 @@ pub struct CachedTaskOutput {
     pub files: Vec<String>,
 }
 
+/// Resolves task output files by expanding output paths and filtering by glob pattern.
+/// This is the file-resolution portion without any hashing, for use by the inspector.
+pub fn resolve_task_output_files(
+    workspace_root: &str,
+    glob: &str,
+    outputs: &[String],
+) -> Result<Vec<String>> {
+    let output_files = get_files_for_outputs(workspace_root.to_string(), outputs.to_vec())?;
+    let glob_set = build_glob_set(&[glob])?;
+    Ok(output_files
+        .into_iter()
+        .filter(|f| glob_set.is_match(f))
+        .collect())
+}
+
 pub fn hash_task_output(
     workspace_root: &str,
     glob: &str,

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -48,17 +48,17 @@ pub struct HashInputs {
 /// Internal builder that uses HashSet for O(1) deduplication during accumulation.
 /// Convert to HashInputs via `into()` when ready to return via NAPI.
 #[derive(Debug, Default, Clone)]
-struct HashInputsBuilder {
-    files: HashSet<String>,
-    runtime: HashSet<String>,
-    environment: HashSet<String>,
-    dep_outputs: HashSet<String>,
-    external: HashSet<String>,
+pub(crate) struct HashInputsBuilder {
+    pub(crate) files: HashSet<String>,
+    pub(crate) runtime: HashSet<String>,
+    pub(crate) environment: HashSet<String>,
+    pub(crate) dep_outputs: HashSet<String>,
+    pub(crate) external: HashSet<String>,
 }
 
 impl HashInputsBuilder {
     /// Extends this builder with all values from another builder
-    fn extend(&mut self, other: HashInputsBuilder) {
+    pub(crate) fn extend(&mut self, other: HashInputsBuilder) {
         self.files.extend(other.files);
         self.runtime.extend(other.runtime);
         self.environment.extend(other.environment);

--- a/scripts/copy-built-package/index.ts
+++ b/scripts/copy-built-package/index.ts
@@ -59,14 +59,11 @@ async function promptPackages(): Promise<typeof packages> {
   const { prompt } = require('enquirer');
   // Reserve lines for the prompt header, input, footer hint, and breathing room
   const visibleChoices = Math.max(5, termSize().rows - 4);
-  const result: { packages: typeof packages } = await prompt({
+  const result: { packages: string[] } = await prompt({
     type: 'autocomplete',
     name: 'packages',
     message: 'Select packages to copy',
-    choices: packages.map((p) => ({
-      name: p.npmName,
-      value: p,
-    })),
+    choices: packages.map((p) => p.nxName),
     multiple: true,
     limit: visibleChoices,
     suggest(input: string, choices: { name: string; message: string }[]) {
@@ -82,7 +79,9 @@ async function promptPackages(): Promise<typeof packages> {
     console.error('No packages selected.');
     process.exit(1);
   }
-  return result.packages;
+  return result.packages.map(
+    (nxName) => packages.find((p) => p.nxName === nxName)!
+  );
 }
 
 yargs(hideBin(process.argv))


### PR DESCRIPTION
## Current Behavior
There's not a great way to troubleshoot or test inputs and outputs configurations on tasks.

## Expected Behavior
Adds `nx show target` to enable  users to debug inputs and outputs.  It has flags `--inputs`, `--check-input`, `--outputs`, and `--check-output` to list or test specific file patterns.

<img width="1077" height="198" alt="image" src="https://github.com/user-attachments/assets/7ffd4502-1542-40e6-867c-37f70440a421" />

<img width="1077" height="105" alt="image" src="https://github.com/user-attachments/assets/eb5b09e1-23fb-4710-9fb0-84f0c8e80c14" />

<img width="1077" height="538" alt="image" src="https://github.com/user-attachments/assets/74c60668-285c-4195-ba77-6693a66e4897" />

<img width="1077" height="318" alt="image" src="https://github.com/user-attachments/assets/ee228c43-98c2-441d-8b9d-277b38213e4d" />

<img width="1077" height="92" alt="image" src="https://github.com/user-attachments/assets/8cca6553-4362-4662-b948-723abcc75671" />

<img width="1077" height="74" alt="image" src="https://github.com/user-attachments/assets/6dc2188e-5dc5-4b5f-afd4-2a492a896e1d" />

---

<img width="492" height="430" alt="image" src="https://github.com/user-attachments/assets/ae22bb2e-92c2-4c75-ad6f-b9cccda3def4" />


