### PR TITLE
feat(core): add agentic mode to nx init

### DIFF
--- a/packages/nx/src/command-line/init/command-object.ts
+++ b/packages/nx/src/command-line/init/command-object.ts
@@ -1,11 +1,28 @@
 import { Argv, CommandModule } from 'yargs';
 import { parseCSV } from '../yargs-utils/shared-options';
+import { isAiAgent } from '../../native';
+import {
+  writeAiOutput,
+  buildErrorResult,
+  writeErrorLog,
+  determineErrorCode,
+} from './utils/ai-output';
 
 export const yargsInitCommand: CommandModule = {
   command: 'init',
   describe:
     'Adds Nx to any type of workspace. It installs nx, creates an nx.json configuration file and optionally sets up remote caching. For more info, check https://nx.dev/recipes/adopting-nx.',
-  builder: (yargs) => withInitOptions(yargs),
+  builder: async (yargs: Argv) => {
+    // Check for --help flag directly since async builder doesn't receive helpOrVersionSet reliably
+    const wantsHelp =
+      process.argv.includes('--help') || process.argv.includes('-h');
+    if (wantsHelp) {
+      const y = await withInitOptions(yargs);
+      y.showHelp();
+      process.exit(0);
+    }
+    return withInitOptions(yargs);
+  },
   handler: async (args: any) => {
     // Node 24 has stricter readline behavior, and enquirer is not checking for closed state
     // when invoking operations, thus you get an ERR_USE_AFTER_CLOSE error.
@@ -28,9 +45,19 @@ export const yargsInitCommand: CommandModule = {
         await require('./init-v1').initHandler(args);
       }
       process.exit(0);
-    } catch {
-      // Ensure the cursor is always restored just in case the user has bailed during interactive prompts
-      process.stdout.write('\x1b[?25h');
+    } catch (error) {
+      // Output structured error for AI agents
+      if (isAiAgent()) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        const errorCode = determineErrorCode(error);
+        const errorLogPath = writeErrorLog(error);
+        writeAiOutput(buildErrorResult(errorMessage, errorCode, errorLogPath));
+      } else {
+        // Ensure the cursor is always restored just in case the user has bailed during interactive prompts
+        // Skip for AI agents to avoid corrupting NDJSON output
+        process.stdout.write('\x1b[?25h');
+      }
       process.exit(1);
     }
   },
@@ -74,6 +101,17 @@ async function withInitOptions(yargs: Argv) {
         string: true,
         description: 'List of AI agents to set up.',
         choices: ['claude', 'codex', 'copilot', 'cursor', 'gemini', 'opencode'],
+      })
+      .option('plugins', {
+        type: 'string',
+        description:
+          'Plugins to install: "skip" for none, "all" for all detected, or comma-separated list (e.g., @nx/vite,@nx/jest).',
+      })
+      .option('cacheable', {
+        type: 'string',
+        description:
+          'Comma-separated list of cacheable operations (e.g., build,test,lint).',
+        coerce: parseCSV,
       });
   } else {
     return yargs

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'fs';
+import { join } from 'path';
 
 import { prompt } from 'enquirer';
 import { prerelease } from 'semver';
@@ -15,7 +16,6 @@ import { configurePlugins, installPluginPackages } from './configure-plugins';
 import { determineAiAgents } from './ai-agent-prompts';
 import { setupAiAgentsGenerator } from '../../ai/set-up-ai-agents/set-up-ai-agents';
 import { FsTree, flushChanges } from '../../generators/tree';
-import { Agent } from '../../ai/utils';
 import { addNxToMonorepo } from './implementation/add-nx-to-monorepo';
 import { addNxToNpmRepo } from './implementation/add-nx-to-npm-repo';
 import { addNxToTurborepo } from './implementation/add-nx-to-turborepo';
@@ -32,6 +32,18 @@ import {
 import { addNxToCraRepo } from './implementation/react';
 import { ensurePackageHasProvenance } from '../../utils/provenance';
 import { installPackageToTmp } from '../../devkit-internals';
+import { isAiAgent } from '../../native';
+import { supportedAgents, Agent } from '../../ai/utils';
+import {
+  logProgress,
+  writeAiOutput,
+  buildNeedsInputResult,
+  buildSuccessResult,
+  buildErrorResult,
+  writeErrorLog,
+  determineErrorCode,
+  DetectedPlugin,
+} from './utils/ai-output';
 
 export interface InitArgs {
   interactive: boolean;
@@ -41,6 +53,8 @@ export interface InitArgs {
   verbose?: boolean;
   force?: boolean;
   aiAgents?: Agent[];
+  plugins?: string; // 'skip' | 'all' | comma-separated list
+  cacheable?: string[]; // Cacheable operations (e.g., ['build', 'test', 'lint'])
 }
 
 export async function initHandler(
@@ -83,6 +97,38 @@ async function initHandlerImpl(options: InitArgs): Promise<void> {
     output.log({ title: `Using version ${process.env.NX_VERSION}` });
   }
 
+  // AI agent mode: apply defaults for non-interactive operation
+  const aiMode = isAiAgent();
+  if (aiMode) {
+    options.interactive = false; // Force non-interactive
+
+    if (options.nxCloud === undefined) {
+      options.nxCloud = false; // Default to skip Nx Cloud
+    }
+
+    // Auto-detect .nx installation for non-JS projects
+    if (options.useDotNxInstallation === undefined) {
+      const hasPackageJson = existsSync('package.json');
+      options.useDotNxInstallation = !hasPackageJson;
+    }
+
+    // Auto-detect and set the current AI agent for setup
+    if (options.aiAgents === undefined) {
+      const detectedAgent = detectCurrentAiAgent();
+      if (detectedAgent) {
+        options.aiAgents = [detectedAgent];
+      }
+    }
+
+    // Set default cacheable operations for AI mode
+    // These are commonly cacheable scripts that benefit from caching
+    if (options.cacheable === undefined) {
+      options.cacheable = ['build', 'test', 'lint'];
+    }
+
+    logProgress('starting', 'Initializing Nx...');
+  }
+
   // TODO(jack): Remove this Angular logic once `@nx/angular` is compatible with inferred targets.
   if (existsSync('angular.json')) {
     await addNxToAngularCliRepo({
@@ -104,7 +150,8 @@ async function initHandlerImpl(options: InitArgs): Promise<void> {
   const _isMonorepo = _isNonJs ? false : isMonorepo(packageJson);
   const _isCRA = _isNonJs ? false : isCRA(packageJson);
 
-  let guided = true;
+  // AI mode defaults to minimum setup, humans can choose
+  let guided = !aiMode; // Default to minimum (false) for AI, guided (true) for humans
   if (options.interactive && !(_isTurborepo || _isCRA || _isNonJs)) {
     const setupType = await prompt<{ setupPreference: string }>([
       {
@@ -124,6 +171,9 @@ async function initHandlerImpl(options: InitArgs): Promise<void> {
    * inputs and outputs.
    */
   if (_isTurborepo) {
+    if (aiMode) {
+      logProgress('detecting', 'Detected Turborepo project');
+    }
     await addNxToTurborepo({
       interactive: options.interactive,
     });
@@ -136,6 +186,9 @@ async function initHandlerImpl(options: InitArgs): Promise<void> {
   const pmc = getPackageManagerCommand();
 
   if (_isCRA) {
+    if (aiMode) {
+      logProgress('detecting', 'Detected Create React App project');
+    }
     await addNxToCraRepo({
       addE2e: false,
       force: options.force,
@@ -145,21 +198,32 @@ async function initHandlerImpl(options: InitArgs): Promise<void> {
       nxCloud: false,
     });
   } else if (_isMonorepo) {
+    if (aiMode) {
+      logProgress('detecting', 'Detected monorepo project');
+    }
     await addNxToMonorepo(
       {
         interactive: options.interactive,
         nxCloud: false,
+        cacheable: options.cacheable,
       },
       guided
     );
   } else if (_isNonJs) {
+    if (aiMode) {
+      logProgress('detecting', 'Detected non-JavaScript project');
+    }
     generateDotNxSetup(version);
     console.log('');
   } else {
+    if (aiMode) {
+      logProgress('detecting', 'Detected NPM project');
+    }
     await addNxToNpmRepo(
       {
         interactive: options.interactive,
         nxCloud: false,
+        cacheable: options.cacheable,
       },
       guided
     );
@@ -167,37 +231,112 @@ async function initHandlerImpl(options: InitArgs): Promise<void> {
 
   const repoRoot = process.cwd();
 
-  createNxJsonFile(repoRoot, [], [], {});
+  if (aiMode) {
+    logProgress('configuring', 'Creating nx.json...');
+  }
+  createNxJsonFile(repoRoot, [], options.cacheable ?? [], {});
   updateGitIgnore(repoRoot);
 
   const nxJson = readNxJson(repoRoot);
 
-  if (guided) {
+  // Handle plugins based on mode and flags
+  let pluginsToInstall: string[] = [];
+  let updatePackageScripts = false;
+
+  if (aiMode) {
+    // AI mode: handle --plugins flag
+    const parsedPlugins = parsePluginsFlag(options.plugins);
+
+    if (parsedPlugins === 'skip') {
+      // Skip plugins entirely
+      logProgress('detecting', 'Skipping plugin installation');
+      pluginsToInstall = [];
+    } else {
+      // Need to detect plugins for 'all' or to return needs_input
+      logProgress('detecting', 'Checking for recommended plugins...');
+
+      let detectedPluginNames: string[];
+      if (_isCRA) {
+        detectedPluginNames = ['@nx/vite'];
+      } else {
+        const { plugins: detected } = await detectPlugins(
+          nxJson,
+          packageJson,
+          false // non-interactive
+        );
+        detectedPluginNames = detected;
+      }
+
+      if (parsedPlugins === 'all') {
+        // Install all detected plugins
+        pluginsToInstall = detectedPluginNames;
+        updatePackageScripts = true;
+      } else if (Array.isArray(parsedPlugins)) {
+        // Install specific plugins from the comma-separated list
+        pluginsToInstall = parsedPlugins;
+        updatePackageScripts = true;
+      } else if (detectedPluginNames.length > 0) {
+        // No --plugins flag provided and plugins were detected
+        // Return needs_input for AI to ask user
+        const detectedPlugins: DetectedPlugin[] = detectedPluginNames.map(
+          (name) => ({
+            name,
+            reason: getPluginReason(name),
+          })
+        );
+
+        logProgress(
+          'detecting',
+          `Detected ${detectedPluginNames.length} plugin(s): ${detectedPluginNames.join(', ')}`
+        );
+        writeAiOutput(buildNeedsInputResult(detectedPlugins));
+        process.exit(0);
+      }
+      // else: no plugins flag and no plugins detected, proceed with empty array
+    }
+
+    if (pluginsToInstall.length > 0) {
+      logProgress('installing', 'Installing Nx packages...');
+
+      for (const plugin of pluginsToInstall) {
+        logProgress('plugins', `Installing ${plugin}...`);
+      }
+
+      installPluginPackages(repoRoot, pmc, pluginsToInstall);
+      await configurePlugins(
+        pluginsToInstall,
+        updatePackageScripts,
+        pmc,
+        repoRoot,
+        options.verbose
+      );
+    }
+  } else if (guided) {
+    // Non-AI guided mode: existing behavior with interactive prompts
     output.log({ title: '🧐 Checking dependencies' });
 
-    let plugins: string[];
-    let updatePackageScripts: boolean;
-
     if (_isCRA) {
-      plugins = ['@nx/vite'];
+      pluginsToInstall = ['@nx/vite'];
       updatePackageScripts = true;
     } else {
       const { plugins: _plugins, updatePackageScripts: _updatePackageScripts } =
         await detectPlugins(nxJson, packageJson, options.interactive);
-      plugins = _plugins;
+      pluginsToInstall = _plugins;
       updatePackageScripts = _updatePackageScripts;
     }
 
-    output.log({ title: '📦 Installing Nx' });
+    if (pluginsToInstall.length > 0) {
+      output.log({ title: '📦 Installing Nx' });
 
-    installPluginPackages(repoRoot, pmc, plugins);
-    await configurePlugins(
-      plugins,
-      updatePackageScripts,
-      pmc,
-      repoRoot,
-      options.verbose
-    );
+      installPluginPackages(repoRoot, pmc, pluginsToInstall);
+      await configurePlugins(
+        pluginsToInstall,
+        updatePackageScripts,
+        pmc,
+        repoRoot,
+        options.verbose
+      );
+    }
   }
 
   const selectedAgents = await determineAiAgents(
@@ -235,15 +374,83 @@ async function initHandlerImpl(options: InitArgs): Promise<void> {
     await initCloud('nx-init');
   }
 
-  printFinalMessage({
-    learnMoreLink: 'https://nx.dev/getting-started/adding-to-existing',
-    appendLines: _isMonorepo
-      ? [
-          `- Read a detailed guide about adding Nx to NPM/YARN/PNPM workspaces: https://nx.dev/recipes/adopting-nx/adding-to-monorepos`,
-          `- Learn how Nx helps manage your TypeScript monorepo: https://nx.dev/features/maintain-ts-monorepos`,
-        ]
-      : [],
-  });
+  // Output success result for AI agents
+  if (aiMode) {
+    writeAiOutput(
+      buildSuccessResult({
+        nxVersion: version,
+        pluginsInstalled: pluginsToInstall,
+      })
+    );
+  }
+
+  // Skip human-readable output for AI agents
+  if (!aiMode) {
+    printFinalMessage({
+      learnMoreLink: 'https://nx.dev/getting-started/adding-to-existing',
+      appendLines: _isMonorepo
+        ? [
+            `- Read a detailed guide about adding Nx to NPM/YARN/PNPM workspaces: https://nx.dev/recipes/adopting-nx/adding-to-monorepos`,
+            `- Learn how Nx helps manage your TypeScript monorepo: https://nx.dev/features/maintain-ts-monorepos`,
+          ]
+        : [],
+    });
+  }
+}
+
+/**
+ * Generate a reason for why a plugin was detected.
+ * Used for AI `needs_input` output.
+ */
+function getPluginReason(plugin: string): string {
+  const reasonMap: Record<string, string> = {
+    '@nx/eslint': 'eslint detected in dependencies',
+    '@nx/storybook': 'storybook detected in dependencies',
+    '@nx/vite': 'vite detected in dependencies',
+    '@nx/vitest': 'vitest detected in dependencies',
+    '@nx/webpack': 'webpack detected in dependencies',
+    '@nx/rspack': '@rspack/core detected in dependencies',
+    '@nx/rollup': 'rollup detected in dependencies',
+    '@nx/jest': 'jest detected in dependencies',
+    '@nx/cypress': 'cypress detected in dependencies',
+    '@nx/playwright': '@playwright/test detected in dependencies',
+    '@nx/detox': 'detox detected in dependencies',
+    '@nx/expo': 'expo detected in dependencies',
+    '@nx/next': 'next.js detected in dependencies',
+    '@nx/nuxt': 'nuxt detected in dependencies',
+    '@nx/react-native': 'react-native detected in dependencies',
+    '@nx/remix': '@remix-run/dev detected in dependencies',
+    '@nx/rsbuild': '@rsbuild/core detected in dependencies',
+    '@nx/react': '@react-router/dev detected in dependencies',
+    '@nx/gradle': 'gradlew detected in workspace',
+    '@nx/dotnet': '.NET project files detected',
+    '@nx/maven': 'maven project files detected',
+    '@nx/docker': 'Dockerfile detected in workspace',
+  };
+  return reasonMap[plugin] || `${plugin} detected`;
+}
+
+/**
+ * Parse the --plugins flag value.
+ * Returns: 'skip' | 'all' | string[] (specific plugins)
+ */
+function parsePluginsFlag(
+  value: string | undefined
+): 'skip' | 'all' | string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === 'skip') {
+    return 'skip';
+  }
+  if (value === 'all') {
+    return 'all';
+  }
+  // Comma-separated list - filter out empty strings from edge cases like "--plugins=" or "--plugins=,"
+  return value
+    .split(',')
+    .map((p) => p.trim())
+    .filter(Boolean);
 }
 
 const npmPackageToPluginMap: Record<string, `@nx/${string}`> = {
@@ -445,4 +652,42 @@ export async function detectPlugins(
     ]).then((r) => r.updatePackageScripts === 'Yes'));
 
   return { plugins: pluginsToInstall, updatePackageScripts };
+}
+
+/**
+ * Detect the current AI agent from environment variables.
+ * Returns the agent name if detected and supported, null otherwise.
+ *
+ * Maps environment variable detection to supported agent names:
+ * - CLAUDECODE → 'claude'
+ * - OPENCODE → 'opencode'
+ * - CURSOR_TRACE_ID + PAGER + COMPOSER_NO_INTERACTION → 'cursor'
+ *
+ * Note: replit (REPL_ID) is detected by isAiAgent() but not in supportedAgents,
+ * so it returns null.
+ */
+function detectCurrentAiAgent(): Agent | null {
+  // Check Claude Code (CLAUDECODE env var)
+  if (process.env.CLAUDECODE) {
+    return supportedAgents.includes('claude') ? 'claude' : null;
+  }
+
+  // Check OpenCode (OPENCODE env var)
+  if (process.env.OPENCODE) {
+    return supportedAgents.includes('opencode') ? 'opencode' : null;
+  }
+
+  // Check Cursor (requires all three env vars)
+  if (
+    process.env.PAGER === 'head -n 10000 | cat' &&
+    process.env.CURSOR_TRACE_ID &&
+    process.env.COMPOSER_NO_INTERACTION
+  ) {
+    return supportedAgents.includes('cursor') ? 'cursor' : null;
+  }
+
+  // Note: replit (REPL_ID) is detected by isAiAgent() but not in supportedAgents
+  // so we don't return it here
+
+  return null;
 }

--- a/packages/nx/src/command-line/init/utils/ai-output.ts
+++ b/packages/nx/src/command-line/init/utils/ai-output.ts
@@ -1,0 +1,384 @@
+/**
+ * AI Agent NDJSON Output Utilities for nx init
+ *
+ * When an AI agent is detected, nx init switches to AI-optimized output mode:
+ * - NDJSON (Newline-Delimited JSON) output for structured parsing
+ * - Progress stages for tracking initialization steps
+ * - Structured success/error/needs_input results
+ *
+ * NOTE: This is intentionally duplicated from create-nx-workspace.
+ * CNW is self-contained and cannot import from the nx package.
+ */
+
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { writeFileSync } from 'fs';
+import { isAiAgent } from '../../../native';
+
+// Progress stages for NDJSON streaming
+export type ProgressStage =
+  | 'starting'
+  | 'detecting'
+  | 'configuring'
+  | 'installing'
+  | 'plugins'
+  | 'complete'
+  | 'error'
+  | 'needs_input';
+
+// Error codes specific to nx init
+export type NxInitErrorCode =
+  | 'ALREADY_INITIALIZED'
+  | 'PACKAGE_INSTALL_ERROR'
+  | 'UNCOMMITTED_CHANGES'
+  | 'UNSUPPORTED_PROJECT'
+  | 'PLUGIN_INIT_ERROR'
+  | 'NETWORK_ERROR'
+  | 'UNKNOWN';
+
+export interface ProgressMessage {
+  stage: ProgressStage;
+  message: string;
+}
+
+export interface DetectedPlugin {
+  name: string;
+  reason: string;
+}
+
+export interface NeedsInputResult {
+  stage: 'needs_input';
+  success: false;
+  inputType: 'plugins';
+  message: string;
+  detectedPlugins: DetectedPlugin[];
+  options: string[];
+  recommendedOption: string;
+  recommendedReason: string;
+  exampleCommand: string;
+}
+
+export interface NextStep {
+  title: string;
+  command?: string;
+  url?: string;
+  note?: string;
+}
+
+export interface UserNextSteps {
+  description: string;
+  steps: NextStep[];
+}
+
+export interface PluginWarning {
+  plugin: string;
+  error: string;
+  hint: string;
+}
+
+export interface SuccessResult {
+  stage: 'complete';
+  success: true;
+  result: {
+    nxVersion: string;
+    pluginsInstalled: string[];
+  };
+  warnings?: PluginWarning[];
+  userNextSteps: UserNextSteps;
+  docs: {
+    gettingStarted: string;
+    nxCloud: string;
+  };
+}
+
+export interface ErrorResult {
+  stage: 'error';
+  success: false;
+  errorCode: NxInitErrorCode;
+  error: string;
+  hints: string[];
+  errorLogPath?: string;
+}
+
+export type AiOutputMessage =
+  | ProgressMessage
+  | NeedsInputResult
+  | SuccessResult
+  | ErrorResult;
+
+/**
+ * Write NDJSON message to stdout.
+ * Only outputs if running under an AI agent.
+ * Each message is a single line of JSON.
+ */
+export function writeAiOutput(message: AiOutputMessage): void {
+  if (isAiAgent()) {
+    process.stdout.write(JSON.stringify(message) + '\n');
+
+    // For success results, output plain text instructions that the agent can show the user
+    if (
+      message.stage === 'complete' &&
+      'success' in message &&
+      message.success
+    ) {
+      const successMsg = message as SuccessResult;
+      const steps = successMsg.userNextSteps.steps;
+
+      let plainText = '\n---USER_NEXT_STEPS---\n';
+      plainText +=
+        '[DISPLAY] Show the user these next steps to complete setup:\n\n';
+
+      steps.forEach((step, i) => {
+        plainText += `${i + 1}. ${step.title}`;
+        if (step.command) {
+          plainText += `\n   Run: ${step.command}`;
+        }
+        if (step.url) {
+          plainText += `\n   Visit: ${step.url}`;
+        }
+        if (step.note) {
+          plainText += `\n   ${step.note}`;
+        }
+        plainText += '\n';
+      });
+
+      plainText += '---END---\n';
+
+      process.stdout.write(plainText);
+    }
+  }
+}
+
+/**
+ * Log progress stage during initialization.
+ * Only outputs if running under an AI agent.
+ */
+export function logProgress(stage: ProgressStage, message: string): void {
+  writeAiOutput({ stage, message });
+}
+
+/**
+ * Build needs_input result for plugin selection.
+ * This tells the AI which plugins are available and how to proceed.
+ */
+export function buildNeedsInputResult(
+  detectedPlugins: DetectedPlugin[]
+): NeedsInputResult {
+  const pluginList = detectedPlugins.map((p) => p.name).join(',');
+
+  return {
+    stage: 'needs_input',
+    success: false,
+    inputType: 'plugins',
+    message:
+      'Plugin selection required. Ask the user which plugins to install, then run again with --plugins flag.',
+    detectedPlugins,
+    options: ['--plugins=skip', '--plugins=all', `--plugins=${pluginList}`],
+    recommendedOption: '--plugins=skip',
+    recommendedReason: 'Plugins can be added later with nx add.',
+    exampleCommand: `nx init --plugins=${detectedPlugins[0]?.name || '@nx/vite'}`,
+  };
+}
+
+/**
+ * Build success result object with next steps.
+ */
+export function buildSuccessResult(options: {
+  nxVersion: string;
+  pluginsInstalled: string[];
+  warnings?: PluginWarning[];
+}): SuccessResult {
+  const { nxVersion, pluginsInstalled, warnings } = options;
+
+  // Build user-facing next steps
+  const steps: NextStep[] = [
+    {
+      title: 'Explore your workspace',
+      command: 'nx graph',
+      note: 'Visualize project dependencies',
+    },
+    {
+      title: 'List projects and details',
+      command: 'nx show projects',
+      note: 'Or nx show project <project-name> to see targets and configuration',
+    },
+    {
+      title: 'Run a task',
+      command: 'nx run <project>:<script>',
+      note: 'Run any script from a project package.json (e.g., nx run client:build)',
+    },
+    {
+      title: 'Enable Remote Caching',
+      command: 'nx connect',
+      note: 'Speed up CI by 30-70% with Nx Cloud',
+    },
+  ];
+
+  const successResult: SuccessResult = {
+    stage: 'complete',
+    success: true,
+    result: {
+      nxVersion,
+      pluginsInstalled,
+    },
+    userNextSteps: {
+      description: 'Show user these steps to complete setup.',
+      steps,
+    },
+    docs: {
+      gettingStarted: 'https://nx.dev/getting-started/intro',
+      nxCloud: 'https://nx.dev/ci/intro/why-nx-cloud',
+    },
+  };
+
+  if (warnings && warnings.length > 0) {
+    successResult.warnings = warnings;
+  }
+
+  return successResult;
+}
+
+/**
+ * Build error result object with helpful hints.
+ */
+export function buildErrorResult(
+  error: string,
+  errorCode: NxInitErrorCode,
+  errorLogPath?: string
+): ErrorResult {
+  const hints = getErrorHints(errorCode);
+
+  return {
+    stage: 'error',
+    success: false,
+    errorCode,
+    error,
+    hints,
+    errorLogPath,
+  };
+}
+
+/**
+ * Get helpful hints based on error code.
+ */
+export function getErrorHints(errorCode: NxInitErrorCode): string[] {
+  switch (errorCode) {
+    case 'ALREADY_INITIALIZED':
+      return [
+        'Workspace already has nx.json',
+        'Remove nx.json to reinitialize',
+        'Use nx add to add plugins to existing workspace',
+      ];
+    case 'PACKAGE_INSTALL_ERROR':
+      return [
+        'Check your package manager is installed correctly',
+        'Try clearing npm/yarn/pnpm cache',
+        'Check for conflicting global packages',
+      ];
+    case 'UNCOMMITTED_CHANGES':
+      return [
+        'Commit or stash your changes before running nx init',
+        'Use --force to skip this check (not recommended)',
+      ];
+    case 'UNSUPPORTED_PROJECT':
+      return [
+        'Project type could not be detected',
+        'Ensure you are in a valid project directory',
+        'Check https://nx.dev/getting-started for supported project types',
+      ];
+    case 'PLUGIN_INIT_ERROR':
+      return [
+        'One or more plugin init generators failed',
+        'Check the error log for details',
+        "Try running 'nx add <plugin>' manually",
+      ];
+    case 'NETWORK_ERROR':
+      return [
+        'Check your internet connection',
+        'Try again in a few moments',
+        'Check if npm registry is accessible',
+      ];
+    default:
+      return [
+        'An unexpected error occurred',
+        'Check the error log for details',
+        'Report issues at https://github.com/nrwl/nx/issues',
+      ];
+  }
+}
+
+/**
+ * Write detailed error information to a temp file for AI debugging.
+ * Returns the path to the error log file.
+ */
+export function writeErrorLog(error: Error | unknown): string {
+  const timestamp = Date.now();
+  const errorLogPath = join(tmpdir(), `nx-init-error-${timestamp}.log`);
+
+  let errorDetails = `Nx Init Error Log\n`;
+  errorDetails += `==================\n`;
+  errorDetails += `Timestamp: ${new Date(timestamp).toISOString()}\n\n`;
+
+  if (error instanceof Error) {
+    errorDetails += `Error: ${error.message}\n\n`;
+    if (error.stack) {
+      errorDetails += `Stack Trace:\n${error.stack}\n`;
+    }
+  } else {
+    errorDetails += `Error: ${String(error)}\n`;
+  }
+
+  try {
+    writeFileSync(errorLogPath, errorDetails);
+  } catch {
+    // If we can't write the log, return empty path
+    return '';
+  }
+
+  return errorLogPath;
+}
+
+/**
+ * Determine error code from an error object.
+ */
+export function determineErrorCode(error: Error | unknown): NxInitErrorCode {
+  const message = error instanceof Error ? error.message : String(error);
+  const lowerMessage = message.toLowerCase();
+
+  if (
+    lowerMessage.includes('nx.json already exists') ||
+    lowerMessage.includes('already initialized')
+  ) {
+    return 'ALREADY_INITIALIZED';
+  }
+
+  if (
+    lowerMessage.includes('install') ||
+    lowerMessage.includes('npm') ||
+    lowerMessage.includes('yarn') ||
+    lowerMessage.includes('pnpm')
+  ) {
+    return 'PACKAGE_INSTALL_ERROR';
+  }
+
+  if (
+    lowerMessage.includes('uncommitted') ||
+    lowerMessage.includes('git status')
+  ) {
+    return 'UNCOMMITTED_CHANGES';
+  }
+
+  if (
+    lowerMessage.includes('network') ||
+    lowerMessage.includes('enotfound') ||
+    lowerMessage.includes('etimedout')
+  ) {
+    return 'NETWORK_ERROR';
+  }
+
+  if (lowerMessage.includes('plugin') || lowerMessage.includes('generator')) {
+    return 'PLUGIN_INIT_ERROR';
+  }
+
+  return 'UNKNOWN';
+}


### PR DESCRIPTION
## Current Behavior

When AI agents (Claude Code, Cursor, Windsurf, etc.) run `nx init`, the command works but:
- Uses interactive prompts that AI agents can't handle
- Outputs human-readable text that AI agents must parse
- Doesn't provide structured progress or error information

## Expected Behavior

When `nx init` detects an AI agent (via environment variables like `CLAUDE_CODE=1`), it should:
- Skip interactive prompts and use sensible defaults
- Output structured NDJSON for progress updates, success, and errors
- Include detailed context for AI agents to understand and fix issues

## Changes

This PR adds agentic mode to `nx init`:

### `nx init` Changes
- Detect AI agents via `isAiAgent()` native function
- Auto-defaults: `interactive=false`, `nxCloud=false`, auto-detect `.nx` installation
- NDJSON output with `type: progress|success|error`
- Error logs written to `.nx/ai-errors/` with full context
- Cursor restoration escape sequence skipped for AI agents (prevents NDJSON corruption)

### Output Format
```jsonl
{"type":"progress","step":"starting","message":"Initializing Nx..."}
{"type":"success","nxVersion":"22.5.0","projectsDetected":1,"pluginsInstalled":["@nx/vite"]}
```

Or on error:
```jsonl
{"type":"error","message":"Failed to install","code":"INSTALL_ERROR","errorLogPath":".nx/ai-errors/nx-init-error-2025-01-15T10-30-00.log"}
```

## Related Issue(s)

Part of NXA-921 (agentic mode initiative)