### PR TITLE
fix(maven): include test sources in testCompile task hash

### DIFF
--- a/e2e/maven/src/maven-test-compile-cache.test.ts
+++ b/e2e/maven/src/maven-test-compile-cache.test.ts
@@ -1,0 +1,72 @@
+import {
+  checkFilesExist,
+  cleanupProject,
+  newProject,
+  runCLI,
+  uniq,
+  updateFile,
+} from '@nx/e2e-utils';
+import { createMavenProject } from './utils/create-maven-project';
+
+describe('Maven testCompile cache invalidation', () => {
+  const projectName = uniq('test-compile-cache');
+
+  beforeAll(async () => {
+    newProject({
+      preset: 'apps',
+      packages: ['@nx/maven'],
+    });
+    await createMavenProject(projectName);
+    runCLI(`add @nx/maven`);
+  });
+
+  afterAll(() => cleanupProject());
+
+  it('should invalidate testCompile cache when test sources change', () => {
+    // Step 1: Run verify to populate the cache (all tests pass)
+    const firstRun = runCLI('run-many -t verify', { verbose: true });
+    expect(firstRun).toContain('BUILD SUCCESS');
+    checkFilesExist(
+      'app/target/app-1.0.0-SNAPSHOT.jar',
+      'lib/target/lib-1.0.0-SNAPSHOT.jar',
+      'utils/target/utils-1.0.0-SNAPSHOT.jar'
+    );
+
+    // Step 2: Modify a test source file — add a failing test.
+    // This should invalidate the testCompile cache for app because
+    // src/test/java/**/*.java is an input to the testCompile task hash.
+    updateFile(
+      'app/src/test/java/com/example/app/AppApplicationTests.java',
+      `package com.example.app;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@SpringBootTest
+class AppApplicationTests {
+    @Test
+    void contextLoads() {
+    }
+
+    @Test
+    void thisTestShouldFail() {
+        fail("This test is intentionally failing");
+    }
+}`
+    );
+
+    // Step 3: Run verify again WITHOUT nx reset.
+    // If testCompile correctly includes test sources in its hash,
+    // the modified test file causes a cache miss, Maven recompiles,
+    // and the failing test is detected.
+    let error: any;
+    try {
+      runCLI('run-many -t verify');
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeDefined();
+    expect(error.stdout || error.stderr).toContain('thisTestShouldFail');
+  });
+});

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/cache/CacheConfig.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/cache/CacheConfig.kt
@@ -81,7 +81,7 @@ data class CacheConfig(
                 ),
                 "maven-compiler-plugin:testCompile" to MojoConfig(
                     inputParameters = setOf(
-                        Parameter("testCompileSourceRoots", "**/*.java"),
+                        Parameter("compileSourceRoots", "**/*.java"),
                     ),
                     outputParameters = setOf(
                         Parameter("outputDirectory", null),

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/utils/MavenExpressionResolver.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/utils/MavenExpressionResolver.kt
@@ -15,16 +15,6 @@ class MavenExpressionResolver(
     private val log: Logger = LoggerFactory.getLogger(MavenExpressionResolver::class.java)
 
     fun resolveParameter(parameter: Parameter, project: MavenProject): List<String> {
-        // For compileSourceRoots and testCompileSourceRoots, always use collection handling
-        // to include ALL source roots (including generated sources)
-        if (parameter.name in setOf("compileSourceRoots", "testCompileSourceRoots")) {
-            return when (parameter.name) {
-                "compileSourceRoots" -> project.compileSourceRoots ?: emptyList()
-                "testCompileSourceRoots" -> project.testCompileSourceRoots ?: emptyList()
-                else -> emptyList()
-            }
-        }
-
         return when (parameter.type) {
             "java.io.File" -> listOfNotNull(
                 resolveStringParameterValue(


### PR DESCRIPTION
## Current Behavior

The `maven-compiler-plugin:testCompile` Nx target hash never includes test source files (`src/test/java/**/*.java`). Modifying test sources does not invalidate the `testCompile` cache, so stale compiled test classes can be served from cache.

This is caused by two compounding bugs:

1. **CacheConfig** uses parameter name `testCompileSourceRoots`, but the Maven compiler plugin descriptor names the field `compileSourceRoots` for both `compile` and `testCompile` mojos (they differ only in `default-value`). `MojoAnalyzer` looks it up in the mojo descriptor, gets `null`, and silently skips it via `?: return@forEach`.

2. **MavenExpressionResolver** has a special-case block that resolves source roots by parameter name rather than by the parameter's `default-value` expression. Since both mojos share the field name `compileSourceRoots`, `testCompile` always resolves to `project.compileSourceRoots` (main sources) instead of `project.testCompileSourceRoots` (test sources).

## Expected Behavior

Changes to test source files correctly invalidate the `testCompile` cache entry, causing Maven to recompile test classes on the next run.

## Changes

- **CacheConfig.kt**: Fix parameter name from `testCompileSourceRoots` to `compileSourceRoots` (the actual name in the Maven mojo descriptor)
- **MavenExpressionResolver.kt**: Remove the special-case block that short-circuited resolution by parameter name. The existing `resolveCollectionParameter` → `resolveCollectionExpression` path already correctly resolves based on the `default-value` expression (`${project.testCompileSourceRoots}` for testCompile vs `${project.compileSourceRoots}` for compile)
- **E2e test**: Added `maven-test-compile-cache.test.ts` that validates test source changes invalidate the testCompile cache without any `nx reset` workaround

## Related Issue(s)

<!-- N/A — discovered during batch runner development -->