### PR TITLE
fix(core): remove redundant `allWorkspaceFiles` from the project graph pipeline

### DIFF
--- a/packages/nx/src/daemon/server/handle-hash-tasks.ts
+++ b/packages/nx/src/daemon/server/handle-hash-tasks.ts
@@ -18,7 +18,7 @@ export async function handleHashTasks(payload: {
   cwd: string;
   collectInputs?: boolean;
 }) {
-  const { error, projectGraph, allWorkspaceFiles, fileMap, rustReferences } =
+  const { error, projectGraph, rustReferences } =
     await getCachedSerializedProjectGraphPromise();
 
   if (error) {

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -56,7 +56,6 @@ let cachedSerializedProjectGraphPromise: Promise<SerializedProjectGraph>;
 export let fileMapWithFiles:
   | {
       fileMap: FileMap;
-      allWorkspaceFiles: FileData[];
       rustReferences: NxWorkspaceFilesExternals;
     }
   | undefined;
@@ -453,14 +452,12 @@ async function createAndSerializeProjectGraph({
   try {
     performance.mark('create-project-graph-start');
     const fileMap = copyFileMap(fileMapWithFiles.fileMap);
-    const allWorkspaceFiles = copyFileData(fileMapWithFiles.allWorkspaceFiles);
     const rustReferences = fileMapWithFiles.rustReferences;
     const { projectGraph, projectFileMapCache } =
       await buildProjectGraphUsingFileMap(
         projects,
         knownExternalNodes,
         fileMap,
-        allWorkspaceFiles,
         rustReferences,
         currentProjectFileMapCache || readFileMapCache(),
         await getPlugins(),

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -46,8 +46,6 @@ interface SerializedProjectGraph {
   error: Error | null;
   projectGraph: ProjectGraph | null;
   projectFileMapCache: FileMapCache | null;
-  fileMap: FileMap | null;
-  allWorkspaceFiles: FileData[] | null;
   serializedProjectGraph: string | null;
   serializedSourceMaps: string | null;
   sourceMaps: ConfigurationSourceMaps | null;
@@ -168,8 +166,6 @@ export async function getCachedSerializedProjectGraphPromise(): Promise<Serializ
       sourceMaps: null,
       projectGraph: null,
       projectFileMapCache: null,
-      fileMap: null,
-      allWorkspaceFiles: null,
       rustReferences: null,
     };
   }
@@ -398,9 +394,7 @@ async function processFilesAndCreateAndSerializeProjectGraph(
           error: g.error,
           projectGraph: null,
           projectFileMapCache: null,
-          fileMap: null,
           rustReferences: null,
-          allWorkspaceFiles: null,
           serializedProjectGraph: null,
           serializedSourceMaps: null,
           sourceMaps: null,
@@ -416,9 +410,7 @@ async function processFilesAndCreateAndSerializeProjectGraph(
         ),
         projectGraph: null,
         projectFileMapCache: null,
-        fileMap: null,
         rustReferences: null,
-        allWorkspaceFiles: null,
         serializedProjectGraph: null,
         serializedSourceMaps: null,
         sourceMaps: null,
@@ -431,9 +423,7 @@ async function processFilesAndCreateAndSerializeProjectGraph(
       error: err,
       projectGraph: null,
       projectFileMapCache: null,
-      fileMap: null,
       rustReferences: null,
-      allWorkspaceFiles: null,
       serializedProjectGraph: null,
       serializedSourceMaps: null,
       sourceMaps: null,
@@ -502,8 +492,6 @@ async function createAndSerializeProjectGraph({
       error: null,
       projectGraph,
       projectFileMapCache,
-      fileMap,
-      allWorkspaceFiles,
       serializedProjectGraph,
       serializedSourceMaps,
       sourceMaps,
@@ -517,8 +505,6 @@ async function createAndSerializeProjectGraph({
       error: e,
       projectGraph: null,
       projectFileMapCache: null,
-      fileMap: null,
-      allWorkspaceFiles: null,
       serializedProjectGraph: null,
       serializedSourceMaps: null,
       sourceMaps: null,

--- a/packages/nx/src/hasher/create-task-hasher.ts
+++ b/packages/nx/src/hasher/create-task-hasher.ts
@@ -16,7 +16,7 @@ export function createTaskHasher(
   if (daemonClient.enabled()) {
     return new DaemonBasedTaskHasher(daemonClient, runnerOptions);
   } else {
-    const { fileMap, allWorkspaceFiles, rustReferences } = getFileMap();
+    const { rustReferences } = getFileMap();
     return new InProcessTaskHasher(
       projectGraph,
       nxJson,

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -46,18 +46,15 @@ import { DelayedSpinner } from '../utils/delayed-spinner';
 import { hashObject } from '../hasher/file-hasher';
 
 let storedFileMap: FileMap | null = null;
-let storedAllWorkspaceFiles: FileData[] | null = null;
 let storedRustReferences: NxWorkspaceFilesExternals | null = null;
 
 export function getFileMap(): {
   fileMap: FileMap;
-  allWorkspaceFiles: FileData[];
   rustReferences: NxWorkspaceFilesExternals | null;
 } {
   if (!!storedFileMap) {
     return {
       fileMap: storedFileMap,
-      allWorkspaceFiles: storedAllWorkspaceFiles,
       rustReferences: storedRustReferences,
     };
   } else {
@@ -66,7 +63,6 @@ export function getFileMap(): {
         nonProjectFiles: [],
         projectFileMap: {},
       },
-      allWorkspaceFiles: [],
       rustReferences: null,
     };
   }
@@ -74,11 +70,9 @@ export function getFileMap(): {
 
 export function hydrateFileMap(
   fileMap: FileMap,
-  allWorkspaceFiles: FileData[],
   rustReferences: NxWorkspaceFilesExternals
 ) {
   storedFileMap = fileMap;
-  storedAllWorkspaceFiles = allWorkspaceFiles;
   storedRustReferences = rustReferences;
 }
 
@@ -86,7 +80,6 @@ export async function buildProjectGraphUsingProjectFileMap(
   projectRootMap: Record<string, ProjectConfiguration>,
   externalNodes: Record<string, ProjectGraphExternalNode>,
   fileMap: FileMap,
-  allWorkspaceFiles: FileData[],
   rustReferences: NxWorkspaceFilesExternals,
   fileMapCache: FileMapCache | null,
   plugins: LoadedNxPlugin[],
@@ -96,7 +89,6 @@ export async function buildProjectGraphUsingProjectFileMap(
   projectFileMapCache: FileMapCache;
 }> {
   storedFileMap = fileMap;
-  storedAllWorkspaceFiles = allWorkspaceFiles;
   storedRustReferences = rustReferences;
 
   const projects: Record<string, ProjectConfiguration> = {};

--- a/packages/nx/src/project-graph/file-map-utils.spec.ts
+++ b/packages/nx/src/project-graph/file-map-utils.spec.ts
@@ -47,12 +47,6 @@ describe('fileMapUtils', () => {
           },
           nonProjectFiles: [{ file: 'tools/myfile.txt', hash: 'some-hash' }],
         },
-        allWorkspaceFiles: [
-          { file: 'apps/demo/src/main.ts', hash: 'some-hash' },
-          { file: 'apps/demo-e2e/src/main.ts', hash: 'some-hash' },
-          { file: 'libs/ui/src/index.ts', hash: 'some-hash' },
-          { file: 'tools/myfile.txt', hash: 'some-hash' },
-        ],
       });
     });
   });

--- a/packages/nx/src/project-graph/file-map-utils.ts
+++ b/packages/nx/src/project-graph/file-map-utils.ts
@@ -1,14 +1,13 @@
-import {
+import type {
   FileData,
   FileMap,
   ProjectFileMap,
   ProjectGraph,
 } from '../config/project-graph';
-import {
+import type {
   ProjectConfiguration,
   ProjectsConfigurations,
 } from '../config/workspace-json-project-json';
-import { daemonClient } from '../daemon/client/client';
 import { NxWorkspaceFilesExternals } from '../native';
 import {
   getAllFileDataInContext,
@@ -16,14 +15,12 @@ import {
 } from '../utils/workspace-context';
 import { workspaceRoot } from '../utils/workspace-root';
 import { readProjectsConfigurationFromProjectGraph } from './project-graph';
-import { buildAllWorkspaceFiles } from './utils/build-all-workspace-files';
 import {
   createProjectRootMappingsFromProjectConfigurations,
   findProjectForPath,
 } from './utils/find-project-for-path';
 
 export interface WorkspaceFileMap {
-  allWorkspaceFiles: FileData[];
   fileMap: FileMap;
 }
 
@@ -70,7 +67,6 @@ export function createFileMap(
     }
   }
   return {
-    allWorkspaceFiles,
     fileMap: {
       projectFileMap,
       nonProjectFiles,
@@ -94,10 +90,6 @@ export function updateFileMap(
   );
   return {
     fileMap: updates.fileMap,
-    allWorkspaceFiles: buildAllWorkspaceFiles(
-      updates.fileMap.projectFileMap,
-      updates.fileMap.nonProjectFiles
-    ),
     rustReferences: updates.externalReferences,
   };
 }

--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -136,8 +136,10 @@ export async function buildProjectGraphAndSourceMapsWithoutDaemon() {
   performance.mark('retrieve-project-configurations:end');
 
   performance.mark('retrieve-workspace-files:start');
-  const { allWorkspaceFiles, fileMap, rustReferences } =
-    await retrieveWorkspaceFiles(workspaceRoot, projectRootMap);
+  const { fileMap, rustReferences } = await retrieveWorkspaceFiles(
+    workspaceRoot,
+    projectRootMap
+  );
   performance.mark('retrieve-workspace-files:end');
 
   const cacheEnabled = process.env.NX_CACHE_PROJECT_GRAPH !== 'false';
@@ -151,7 +153,6 @@ export async function buildProjectGraphAndSourceMapsWithoutDaemon() {
       projects,
       externalNodes,
       fileMap,
-      allWorkspaceFiles,
       rustReferences,
       cacheEnabled ? readFileMapCache() : null,
       plugins,
@@ -230,9 +231,11 @@ async function readCachedGraphAndHydrateFileMap(minimumComputedAt?: number) {
       project,
     ])
   );
-  const { allWorkspaceFiles, fileMap, rustReferences } =
-    await retrieveWorkspaceFiles(workspaceRoot, projectRootMap);
-  hydrateFileMap(fileMap, allWorkspaceFiles, rustReferences);
+  const { fileMap, rustReferences } = await retrieveWorkspaceFiles(
+    workspaceRoot,
+    projectRootMap
+  );
+  hydrateFileMap(fileMap, rustReferences);
   return graph;
 }
 

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -12,15 +12,13 @@ import {
 import type { LoadedNxPlugin } from '../plugins/loaded-nx-plugin';
 import {
   getNxWorkspaceFilesFromContext,
-  globWithWorkspaceContext,
   multiGlobWithWorkspaceContext,
 } from '../../utils/workspace-context';
-import { buildAllWorkspaceFiles } from './build-all-workspace-files';
 import { join } from 'path';
 import { getOnlyDefaultPlugins, getPlugins } from '../plugins/get-plugins';
 
 /**
- * Walks the workspace directory to create the `projectFileMap`, `ProjectConfigurations` and `allWorkspaceFiles`
+ * Walks the workspace directory to create the `projectFileMap` and `ProjectConfigurations`
  * @throws
  * @param workspaceRoot
  * @param nxJson
@@ -49,7 +47,6 @@ export async function retrieveWorkspaceFiles(
   );
 
   return {
-    allWorkspaceFiles: buildAllWorkspaceFiles(projectFileMap, globalFiles),
     fileMap: {
       projectFileMap,
       nonProjectFiles: globalFiles,


### PR DESCRIPTION
## Current Behavior

`allWorkspaceFiles` (a flat `FileData[]` of every file in the workspace) is built, stored, copied, and passed through the project graph pipeline — even though no consumer uses it. The data is fully redundant with `fileMap.projectFileMap` + `fileMap.nonProjectFiles`. In the daemon, it's deep-copied on every graph serialization via `copyFileData()` and rebuilt on every incremental update via `buildAllWorkspaceFiles()`.

## Expected Behavior

`allWorkspaceFiles` is removed from:

- `retrieveWorkspaceFiles` return value
- `buildProjectGraphUsingProjectFileMap` parameters
- `hydrateFileMap` / `getFileMap` / `storedAllWorkspaceFiles`
- `fileMapWithFiles` daemon state and `SerializedProjectGraph` interface
- `WorkspaceFileMap` interface and `updateFileMap` return value

This eliminates redundant allocations, copies, and retained references.

Native/Rust code is unaffected — it uses `rustReferences.allWorkspaceFiles` (`ExternalObject`), which is a separate code path.