### PR TITLE
fix(core): gate tui-logger init behind `NX_TUI` env var

### DIFF
--- a/packages/nx/src/native/logger/mod.rs
+++ b/packages/nx/src/native/logger/mod.rs
@@ -123,10 +123,16 @@ fn initialize_logger() {
                 .unwrap_or_else(|_| EnvFilter::new("nx::native=info")),
         );
 
+    let tui_layer = if env::var("NX_TUI").map(|v| v == "true").unwrap_or(false) {
+        tui_logger::init_logger(tui_logger::LevelFilter::Trace).ok();
+        Some(TuiTracingSubscriberLayer)
+    } else {
+        None
+    };
+
     let registry = tracing_subscriber::registry()
         .with(stdout_layer)
-        .with(TuiTracingSubscriberLayer);
-    tui_logger::init_logger(tui_logger::LevelFilter::Trace).ok();
+        .with(tui_layer);
 
     if env::var("NX_NATIVE_FILE_LOGGING").is_err() {
         // File logging is not enabled


### PR DESCRIPTION
## Current Behavior

`tui_logger::init_logger()` and `TuiTracingSubscriberLayer` are initialized unconditionally in `initialize_logger()`. This spawns a background thread, causing unnecessary allocation churn and increased processing.

## Expected Behavior

`tui_logger` is only initialized when `NX_TUI=true`, avoiding the background thread and allocation overhead for all non-TUI contexts.