### PR TITLE
cleanup(core): reduce terminal output duplication and allocations in task runner

### DIFF
--- a/packages/nx/src/executors/run-commands/running-tasks.ts
+++ b/packages/nx/src/executors/run-commands/running-tasks.ts
@@ -223,7 +223,7 @@ export class ParallelRunningTasks implements RunningTask {
 }
 
 export class SeriallyRunningTasks implements RunningTask {
-  private terminalOutput = '';
+  private terminalOutputChunks: string[] = [];
   private currentProcess: RunningTask | PseudoTtyProcess | null = null;
   private exitCallbacks: Array<(code: number, terminalOutput: string) => void> =
     [];
@@ -242,19 +242,21 @@ export class SeriallyRunningTasks implements RunningTask {
         this.error = e;
       })
       .finally(() => {
+        const terminalOutput = this.terminalOutputChunks.join('');
+        this.terminalOutputChunks = [];
         for (const cb of this.exitCallbacks) {
-          cb(this.code, this.terminalOutput);
+          cb(this.code, terminalOutput);
         }
       });
   }
 
   getResults(): Promise<{ code: number; terminalOutput: string }> {
     return new Promise((res, rej) => {
-      this.onExit((code) => {
+      this.onExit((code, terminalOutput) => {
         if (this.error) {
           rej(this.error);
         } else {
-          res({ code, terminalOutput: this.terminalOutput });
+          res({ code, terminalOutput });
         }
       });
     });
@@ -301,15 +303,14 @@ export class SeriallyRunningTasks implements RunningTask {
       });
 
       let { code, terminalOutput } = await childProcess.getResults();
-      this.terminalOutput += terminalOutput;
+      this.terminalOutputChunks.push(terminalOutput);
       this.code = code;
       if (code !== 0) {
         const output = `Warning: command "${c.command}" exited with non-zero status code`;
-        terminalOutput += output;
         if (options.streamOutput) {
           process.stderr.write(output);
         }
-        this.terminalOutput += terminalOutput;
+        this.terminalOutputChunks.push(output);
 
         // Stop running commands
         break;
@@ -374,7 +375,7 @@ export class SeriallyRunningTasks implements RunningTask {
 }
 
 class RunningNodeProcess implements RunningTask {
-  private terminalOutput = '';
+  private terminalOutputChunks: string[] = [];
   private childProcess: ChildProcess;
   private exitCallbacks: Array<(code: number, terminalOutput: string) => void> =
     [];
@@ -393,9 +394,10 @@ class RunningNodeProcess implements RunningTask {
   ) {
     env = processEnv(color, cwd, env, envFile);
     this.command = commandConfig.command;
-    this.terminalOutput = pc.dim('> ') + commandConfig.command + '\r\n\r\n';
+    const header = pc.dim('> ') + commandConfig.command + '\r\n\r\n';
+    this.terminalOutputChunks.push(header);
     if (streamOutput) {
-      process.stdout.write(this.terminalOutput);
+      process.stdout.write(header);
     }
     this.childProcess = exec(commandConfig.command, {
       maxBuffer: LARGE_BUFFER,
@@ -460,7 +462,7 @@ class RunningNodeProcess implements RunningTask {
     this.childProcess.stdout.on('data', (data) => {
       const output = addColorAndPrefix(data, commandConfig);
 
-      this.terminalOutput += output;
+      this.terminalOutputChunks.push(output);
       this.triggerOutputListeners(output);
 
       if (streamOutput) {
@@ -471,14 +473,14 @@ class RunningNodeProcess implements RunningTask {
         isReady(this.readyWhenStatus, data.toString())
       ) {
         for (const cb of this.exitCallbacks) {
-          cb(0, this.terminalOutput);
+          cb(0, this.terminalOutputChunks.join(''));
         }
       }
     });
     this.childProcess.stderr.on('data', (err) => {
       const output = addColorAndPrefix(err, commandConfig);
 
-      this.terminalOutput += output;
+      this.terminalOutputChunks.push(output);
       this.triggerOutputListeners(output);
 
       if (streamOutput) {
@@ -489,24 +491,28 @@ class RunningNodeProcess implements RunningTask {
         isReady(this.readyWhenStatus, err.toString())
       ) {
         for (const cb of this.exitCallbacks) {
-          cb(1, this.terminalOutput);
+          cb(1, this.terminalOutputChunks.join(''));
         }
       }
     });
     this.childProcess.on('error', (err) => {
       const output = addColorAndPrefix(err.toString(), commandConfig);
-      this.terminalOutput += output;
+      this.terminalOutputChunks.push(output);
       if (streamOutput) {
         process.stderr.write(output);
       }
+      const terminalOutput = this.terminalOutputChunks.join('');
+      this.terminalOutputChunks = [];
       for (const cb of this.exitCallbacks) {
-        cb(1, this.terminalOutput);
+        cb(1, terminalOutput);
       }
     });
     this.childProcess.on('exit', (code) => {
       if (!this.readyWhenStatus.length || isReady(this.readyWhenStatus)) {
+        const terminalOutput = this.terminalOutputChunks.join('');
+        this.terminalOutputChunks = [];
         for (const cb of this.exitCallbacks) {
-          cb(code, this.terminalOutput);
+          cb(code, terminalOutput);
         }
       }
     });

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -244,12 +244,7 @@ export class ForkedProcessTaskRunner {
     });
     this.processes.add(p);
 
-    let terminalOutput = '';
-    p.onOutput((msg) => {
-      terminalOutput += msg;
-    });
-
-    p.onExit((code) => {
+    p.onExit((code, terminalOutput) => {
       if (!this.tuiEnabled && code > 128) {
         process.exit(code);
       }

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -14,7 +14,8 @@ export class BatchProcess {
     (task: string, result: TaskResult) => void
   > = [];
   private outputCallbacks: Array<(output: string) => void> = [];
-  private terminalOutput: string = '';
+  private terminalOutputChunks: string[] = [];
+  private joinedTerminalOutput: string | undefined;
 
   constructor(
     private childProcess: ChildProcess,
@@ -58,7 +59,7 @@ export class BatchProcess {
     if (this.childProcess.stdout) {
       this.childProcess.stdout.on('data', (chunk) => {
         const output = chunk.toString();
-        this.terminalOutput += output;
+        this.terminalOutputChunks.push(output);
 
         // Maintain current terminal output behavior
         process.stdout.write(chunk);
@@ -74,7 +75,7 @@ export class BatchProcess {
     if (this.childProcess.stderr) {
       this.childProcess.stderr.on('data', (chunk) => {
         const output = chunk.toString();
-        this.terminalOutput += output;
+        this.terminalOutputChunks.push(output);
 
         // Maintain current terminal output behavior
         process.stderr.write(chunk);
@@ -135,6 +136,7 @@ export class BatchProcess {
   }
 
   getTerminalOutput(): string {
-    return this.terminalOutput;
+    this.joinedTerminalOutput ??= this.terminalOutputChunks.join('');
+    return this.joinedTerminalOutput;
   }
 }

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -674,30 +674,15 @@ export class TaskOrchestrator {
         }
 
         if (!streamOutput) {
-          if (runningTask instanceof PseudoTtyProcess) {
-            // TODO: shouldn't this be checking if the task is continuous before writing anything to disk or calling printTaskTerminalOutput?
-            let terminalOutput = '';
-            runningTask.onOutput((data) => {
-              terminalOutput += data;
-            });
-            runningTask.onExit((code) => {
-              this.options.lifeCycle.printTaskTerminalOutput(
-                task,
-                code === 0 ? 'success' : 'failure',
-                terminalOutput
-              );
-              writeFileSync(temporaryOutputPath, terminalOutput);
-            });
-          } else {
-            runningTask.onExit((code, terminalOutput) => {
-              this.options.lifeCycle.printTaskTerminalOutput(
-                task,
-                code === 0 ? 'success' : 'failure',
-                terminalOutput
-              );
-              writeFileSync(temporaryOutputPath, terminalOutput);
-            });
-          }
+          // TODO: shouldn't this be checking if the task is continuous before writing anything to disk or calling printTaskTerminalOutput?
+          runningTask.onExit((code, terminalOutput) => {
+            this.options.lifeCycle.printTaskTerminalOutput(
+              task,
+              code === 0 ? 'success' : 'failure',
+              terminalOutput
+            );
+            writeFileSync(temporaryOutputPath, terminalOutput);
+          });
         }
 
         return runningTask;


### PR DESCRIPTION
## Current Behavior

Terminal output in the task runner is accumulated via repeated string concatenation (`terminalOutput += chunk`). Each `+=` on a growing string causes V8 to allocate a new, larger string and copy the old contents, resulting in O(n²) allocation behavior for tasks with large output. Additionally, `PseudoTtyProcess.onExit` didn't pass `terminalOutput` to its callbacks, forcing callers like `TaskOrchestrator` to duplicate output accumulation logic with a separate `onOutput` listener.

## Expected Behavior

- Terminal output is collected in `string[]` arrays and joined once at the end, reducing intermediate allocations from O(n²) to O(n)
- `PseudoTtyProcess.onExit` now passes `terminalOutput` as a second argument, matching the signature of other `RunningTask` implementations
- `TaskOrchestrator` no longer needs a special code path for `PseudoTtyProcess` — unified `onExit` handling for all task types
- `tui-summary-life-cycle` accumulates output in chunks during execution and stores the finalized string on task completion, allowing chunk arrays to be GC'd
- `SeriallyRunningTasks` and `RunningNodeProcess` similarly switched to chunk-based accumulation
- `BatchProcess` and `NodeChildProcessWithNonDirectOutput` lazily join and cache their terminal output