### PR TITLE
feat(core): support q to quit in graph

### DIFF
--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -55,6 +55,7 @@ import { readFileMapCache } from '../../project-graph/nx-deps-cache';
 import { filterUsingGlobPatterns } from '../../hasher/task-hasher';
 import { ConfigurationSourceMaps } from '../../project-graph/utils/project-configuration-utils';
 import { findMatchingProjects } from '../../utils/find-matching-projects';
+import { handleQToQuit } from '../../utils/handle-q-to-quit';
 
 import { createTaskHasher } from '../../hasher/create-task-hasher';
 import { ProjectGraphError } from '../../project-graph/error-types';
@@ -772,7 +773,10 @@ async function startServer(
     }
   });
 
+  const cleanupQToQuit = handleQToQuit(() => handleTermination(0));
+
   const handleTermination = async (exitCode: number) => {
+    cleanupQToQuit();
     if (unregisterFileWatcher) {
       unregisterFileWatcher();
     }

--- a/packages/nx/src/utils/handle-q-to-quit.ts
+++ b/packages/nx/src/utils/handle-q-to-quit.ts
@@ -1,0 +1,40 @@
+import { isCI } from './is-ci';
+
+/**
+ * Sets up a 'q' keypress listener for graceful shutdown in non-TUI interactive mode.
+ * Only activates when stdin is a TTY and not running in CI.
+ *
+ * This should only be called from contexts where the TUI is NOT active.
+ * The dynamic life cycles are only used when TUI is disabled, and commands
+ * like `nx watch` and `nx graph` never use the TUI.
+ *
+ * Returns a cleanup function to remove the listener.
+ */
+export function handleQToQuit(onQuit: () => void): () => void {
+  if (!process.stdin.isTTY || isCI()) {
+    return () => {};
+  }
+
+  const onData = (data: string) => {
+    if (data === 'q') {
+      onQuit();
+    } else if (data === '\x03') {
+      // Ctrl+C is swallowed in raw mode, so we re-emit SIGINT
+      process.kill(process.pid, 'SIGINT');
+    }
+  };
+
+  process.stdin.setRawMode(true);
+  process.stdin.resume();
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', onData);
+  process.stdin.unref();
+
+  return () => {
+    process.stdin.off('data', onData);
+    process.stdin.pause();
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(false);
+    }
+  };
+}


### PR DESCRIPTION
## Current Behavior
TUI is used for 90% of real usage commands, and q exits it. No other command is quittable with q, but I find myself hitting Q to exit them anyways due to the tui muscle memory

## Expected Behavior
Most commands can be quit with q.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
