### PR TITLE
fix(core): hitting [1] or [2] should remove pinned panes if they match the current task

### DIFF
--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -990,12 +990,12 @@ impl App {
                                                                 );
                                                             }
                                                             '1' => {
-                                                                self.assign_current_task_to_pane(0);
+                                                                self.toggle_current_task_in_pane(0);
                                                                 let _ = self.handle_pty_resize();
                                                                 // No need to debounce
                                                             }
                                                             '2' => {
-                                                                self.assign_current_task_to_pane(1);
+                                                                self.toggle_current_task_in_pane(1);
                                                                 let _ = self.handle_pty_resize();
                                                                 // No need to debounce
                                                             }
@@ -1670,83 +1670,112 @@ impl App {
         let _ = self.handle_pty_resize();
     }
 
-    fn assign_current_task_to_pane(&mut self, pane_idx: usize) -> Option<()> {
-        // Extract selected item (task or batch) to end the immutable borrow
+    /// Toggle pin state: if the selected task is already in this pane, unpin it;
+    /// otherwise pin it (moving from the other pane if needed). Used by [1]/[2] keys.
+    fn toggle_current_task_in_pane(&mut self, pane_idx: usize) -> Option<()> {
         let selection = self.selection_manager.lock().get_selection().cloned()?;
 
-        // If we're in spacebar mode, clear the spacebar placeholder before pinning
-        // In spacebar mode, pane_tasks[0] is a placeholder that may hold a stale task
         if self.spacebar_mode {
-            // Clear the spacebar placeholder in pane 0
-            self.pane_tasks[0] = None;
-            self.clear_pane_pty_reference(0);
-            self.dependency_view_states[0] = None;
+            self.exit_spacebar_and_pin(selection, pane_idx);
+        } else if self.pane_tasks[pane_idx].as_ref() == Some(&selection) {
+            // Already pinned to this pane — unpin it
+            self.pane_tasks[pane_idx] = None;
+            self.clear_pane_pty_reference(pane_idx);
+            self.dependency_view_states[pane_idx] = None;
 
-            // Exit spacebar mode first
-            self.set_spacebar_mode(false, Some(SelectionMode::TrackByName));
-
-            // Dispatch action before moving selection
-            self.dispatch_action(Action::PinSelection(selection.clone(), pane_idx));
-            self.pane_tasks[pane_idx] = Some(selection);
-            self.layout_manager
-                .set_pane_arrangement(PaneArrangement::Single);
-        } else {
-            // Check if the item is already pinned to the OTHER pane
-            let other_pane_idx = 1 - pane_idx;
-            if self.pane_tasks[other_pane_idx].as_ref() == Some(&selection) {
-                // Clear the other pane - item is "moving" to the new pane
-                self.pane_tasks[other_pane_idx] = None;
-                self.clear_pane_pty_reference(other_pane_idx);
-                self.dependency_view_states[other_pane_idx] = None;
-                self.dispatch_action(Action::UnpinSelection(other_pane_idx));
-
-                // Adjust layout since we now only have one pane
-                self.layout_manager
-                    .set_pane_arrangement(PaneArrangement::Single);
-
-                // Dispatch action before moving selection, then assign
-                self.dispatch_action(Action::PinSelection(selection.clone(), pane_idx));
-                self.pane_tasks[pane_idx] = Some(selection);
-            } else if self.pane_tasks[pane_idx].as_ref() == Some(&selection) {
-                // Task is already pinned to this pane - just focus it
-                self.update_focus(Focus::MultipleOutput(pane_idx));
-                return None; // Early return - no need to update layout or resize
-            } else {
-                // Pin the item to the specified pane
-                // Cleanup old completed batch before replacing
-                self.cleanup_pane_completed_batch(pane_idx);
-
-                // Dispatch action before moving selection
-                self.dispatch_action(Action::PinSelection(selection.clone(), pane_idx));
-                self.pane_tasks[pane_idx] = Some(selection);
-                self.update_focus(Focus::TaskList);
-
-                // Exit spacebar mode when pinning
-                // When pinning an item, use name-based selection
-                self.set_spacebar_mode(false, Some(SelectionMode::TrackByName));
-
-                // Set pane arrangement based on count of pinned tasks
-                let pinned_count = self.pane_tasks.iter().filter(|t| t.is_some()).count();
-                match pinned_count {
-                    0 => self
-                        .layout_manager
-                        .set_pane_arrangement(PaneArrangement::None),
-                    1 => self
-                        .layout_manager
-                        .set_pane_arrangement(PaneArrangement::Single),
-                    _ => self
-                        .layout_manager
-                        .set_pane_arrangement(PaneArrangement::Double),
+            let pinned_count = self.pane_tasks.iter().filter(|t| t.is_some()).count();
+            match pinned_count {
+                0 => {
+                    self.update_focus(Focus::TaskList);
+                    self.set_spacebar_mode(false, Some(SelectionMode::TrackByPosition));
+                    self.layout_manager
+                        .set_pane_arrangement(PaneArrangement::None);
                 }
-
-                // Already assigned above, so just continue to layout update
-                self.finalize_pane_assignment();
-                return Some(());
+                1 => self
+                    .layout_manager
+                    .set_pane_arrangement(PaneArrangement::Single),
+                _ => self
+                    .layout_manager
+                    .set_pane_arrangement(PaneArrangement::Double),
             }
+
+            self.dispatch_action(Action::UnpinSelection(pane_idx));
+        } else {
+            self.move_or_pin_selection(selection, pane_idx);
         }
 
         self.finalize_pane_assignment();
         Some(())
+    }
+
+    /// Pin the selected task to a pane. If the task is already pinned to the other
+    /// pane, it moves it. Never unpins, never focuses. Used by init and as a
+    /// building block for display_and_focus.
+    fn assign_current_task_to_pane(&mut self, pane_idx: usize) -> Option<()> {
+        let selection = self.selection_manager.lock().get_selection().cloned()?;
+
+        if self.spacebar_mode {
+            self.exit_spacebar_and_pin(selection, pane_idx);
+        } else {
+            self.move_or_pin_selection(selection, pane_idx);
+        }
+
+        self.finalize_pane_assignment();
+        Some(())
+    }
+
+    /// Shared helper: exit spacebar mode and pin the selection to the target pane.
+    fn exit_spacebar_and_pin(&mut self, selection: SelectionEntry, pane_idx: usize) {
+        self.pane_tasks[0] = None;
+        self.clear_pane_pty_reference(0);
+        self.dependency_view_states[0] = None;
+
+        self.set_spacebar_mode(false, Some(SelectionMode::TrackByName));
+
+        self.dispatch_action(Action::PinSelection(selection.clone(), pane_idx));
+        self.pane_tasks[pane_idx] = Some(selection);
+        self.layout_manager
+            .set_pane_arrangement(PaneArrangement::Single);
+    }
+
+    /// Shared helper: move a selection from the other pane or pin a fresh selection.
+    fn move_or_pin_selection(&mut self, selection: SelectionEntry, pane_idx: usize) {
+        let other_pane_idx = 1 - pane_idx;
+        if self.pane_tasks[other_pane_idx].as_ref() == Some(&selection) {
+            // Moving from the other pane
+            self.pane_tasks[other_pane_idx] = None;
+            self.clear_pane_pty_reference(other_pane_idx);
+            self.dependency_view_states[other_pane_idx] = None;
+            self.dispatch_action(Action::UnpinSelection(other_pane_idx));
+
+            self.layout_manager
+                .set_pane_arrangement(PaneArrangement::Single);
+
+            self.dispatch_action(Action::PinSelection(selection.clone(), pane_idx));
+            self.pane_tasks[pane_idx] = Some(selection);
+        } else {
+            // Fresh pin
+            self.cleanup_pane_completed_batch(pane_idx);
+
+            self.dispatch_action(Action::PinSelection(selection.clone(), pane_idx));
+            self.pane_tasks[pane_idx] = Some(selection);
+            self.update_focus(Focus::TaskList);
+
+            self.set_spacebar_mode(false, Some(SelectionMode::TrackByName));
+
+            let pinned_count = self.pane_tasks.iter().filter(|t| t.is_some()).count();
+            match pinned_count {
+                0 => self
+                    .layout_manager
+                    .set_pane_arrangement(PaneArrangement::None),
+                1 => self
+                    .layout_manager
+                    .set_pane_arrangement(PaneArrangement::Single),
+                _ => self
+                    .layout_manager
+                    .set_pane_arrangement(PaneArrangement::Double),
+            }
+        }
     }
 
     fn finalize_pane_assignment(&mut self) {
@@ -1911,9 +1940,18 @@ impl App {
         if force_spacebar_mode {
             self.toggle_output_visibility();
         } else {
+            // If already pinned to a pane, just focus it rather than reassigning
+            let selection = self.selection_manager.lock().get_selection().cloned();
+            if let Some(ref sel) = selection {
+                if let Some(pane_idx) = self.pane_tasks.iter().position(|t| t.as_ref() == Some(sel))
+                {
+                    self.update_focus(Focus::MultipleOutput(pane_idx));
+                    return;
+                }
+            }
             self.assign_current_task_to_pane(0);
         }
-        // Unlike in standard spacebar mode, also set focus to the pane, if applicable (if the user pressed enter a second time, there will be no visible panes)
+        // Focus the pane if one is now visible
         if self.has_visible_panes() {
             self.update_focus(Focus::MultipleOutput(0));
         }


### PR DESCRIPTION
## Current Behavior

Pressing `[1]` or `[2]` on a task that's already pinned to that slot **focuses** the pane instead of unpinning it. This means there's no way to unpin a single pane via keyboard — you can only nuke everything with `[0]`.

This regression was introduced in #34175, which fixed a real problem: pressing Enter on an already-pinned task would unpin it, leaving focus on an invisible pane (a ghost pane — you're staring at nothing but the TUI thinks you're looking at output). The fix was to make the "already pinned to this pane" branch focus instead of unpin. The problem is that `[1]`, `[2]`, and Enter all flowed through the same function (`assign_current_task_to_pane`), so changing behavior for Enter changed it for everyone. One lock got swapped out, and every door started behaving the same way.

## Expected Behavior

`[1]` and `[2]` are **toggles**: press once to pin, press again to unpin. Enter is a **display** action: show me this task's output and put my cursor there — if it's already visible somewhere, just take me to it.

After this change:

- **`[1]` / `[2]`** on an already-pinned task → unpins it (pane disappears, layout adjusts, focus returns to task list if no panes remain)
- **Enter** on an already-pinned task → focuses whichever pane it's in (even if it's in pane 2 and you'd normally expect pane 1)
- **Init** (startup restore of pinned tasks) → pure assignment, no toggling, no focusing

## Approach

The old code had one function trying to serve three masters. Rather than adding a flag parameter (`should_toggle: bool`) — which would just be a boolean that lies about its intentions at every call site — the function was split along the actual semantic boundaries:

| Function | Used by | "Already pinned here" behavior |
|---|---|---|
| `toggle_current_task_in_pane` | `[1]` / `[2]` keys | **Unpin** (toggle off) |
| `assign_current_task_to_pane` | `init()` | No-op (task is where it should be) |
| `display_and_focus_current_task_in_terminal_pane` | Enter key | **Focus** the existing pane |

The shared logic — exiting spacebar mode, moving a task between panes, fresh-pinning — lives in two small helpers (`exit_spacebar_and_pin`, `move_or_pin_selection`) that both `toggle` and `assign` delegate to. The only code that differs is the "what do we do when it's already here?" branch, which is exactly the part that *should* differ.

**Why not keep one function with a mode parameter?** Because the three behaviors aren't variations of the same action — they're genuinely different user intents. A toggle is "I changed my mind." A focus is "Take me there." An assignment is "Put this here." Encoding that as an enum parameter just moves the branching somewhere less obvious and makes the call sites harder to read. The function names now document the intent at the point of use, and there's no shared state to accidentally couple.

**Why does Enter check all panes, not just pane 0?** Because if you pinned a task to pane 2 via `[2]` and then press Enter on it, the least surprising thing is to jump to where it already lives — not to silently duplicate it into pane 1 or ignore you. The task is already on screen; Enter means "show me."

## Related Issue(s)

Fixes the regression introduced by #34175.
