### PR TITLE
feat(core): add --stdin to affected options

### DIFF
--- a/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
@@ -1,3 +1,4 @@
+import * as stream from 'node:stream';
 import * as yargs from 'yargs';
 
 import {
@@ -6,6 +7,7 @@ import {
   withOutputStyleOption,
   withRunManyOptions,
   withTuiOptions,
+  parseCSV,
 } from './shared-options';
 import { withEnvironmentVariables } from '../../internal-testing-utils/with-environment';
 
@@ -15,8 +17,8 @@ describe('shared-options', () => {
   describe('withAffectedOptions', () => {
     const command = withAffectedOptions(argv);
 
-    it('should parse files to array', () => {
-      const result = command.parseSync([
+    it('should parse files to array', async () => {
+      const result = await command.parseAsync([
         'affected',
         '--files',
         'file1',
@@ -39,8 +41,80 @@ describe('shared-options', () => {
       );
     });
 
-    it('should parse head and base', () => {
-      const result = command.parseSync([
+    it('should parse files from stdin', async () => {
+      const stdinMock = new stream.PassThrough();
+      jest.spyOn(process, 'stdin', 'get').mockReturnValue(stdinMock as any);
+
+      stdinMock.push('file1,file');
+      stdinMock.push('2,file3');
+      stdinMock.push(null);
+
+      const result = await command.parseAsync(['affected', '--stdin']);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          _: ['affected'],
+          files: ['file1', 'file2', 'file3'],
+        })
+      );
+
+      stdinMock.end();
+    });
+
+    it('should parse files from stdin and a single --files option', async () => {
+      const stdinMock = new stream.PassThrough();
+      jest.spyOn(process, 'stdin', 'get').mockReturnValue(stdinMock as any);
+
+      stdinMock.push('file1,file');
+      stdinMock.push('2,file3');
+      stdinMock.push(null);
+
+      const result = await command.parseAsync([
+        'affected',
+        '--stdin',
+        '--files',
+        'file4',
+      ]);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          _: ['affected'],
+          files: ['file1', 'file2', 'file3', 'file4'],
+        })
+      );
+
+      stdinMock.end();
+    });
+
+    it('should parse files from stdin and multiple --files options', async () => {
+      const stdinMock = new stream.PassThrough();
+      jest.spyOn(process, 'stdin', 'get').mockReturnValue(stdinMock as any);
+
+      stdinMock.push('file1,file');
+      stdinMock.push('2');
+      stdinMock.push(null);
+
+      const result = await command.parseAsync([
+        'affected',
+        '--stdin',
+        '--files',
+        'file3',
+        '--files',
+        'file4',
+      ]);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          _: ['affected'],
+          files: ['file1', 'file2', 'file3', 'file4'],
+        })
+      );
+
+      stdinMock.end();
+    });
+
+    it('should parse head and base', async () => {
+      const result = await command.parseAsync([
         'affected',
         '--head',
         'head',
@@ -60,8 +134,8 @@ describe('shared-options', () => {
   describe('withRunManyOptions', () => {
     const command = withRunManyOptions(argv);
 
-    it('should parse projects to array', () => {
-      const result = command.parseSync([
+    it('should parse projects to array', async () => {
+      const result = await command.parseAsync([
         'run-many',
         '--projects',
         'project1',

--- a/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
@@ -188,21 +188,21 @@ describe('shared-options', () => {
   });
 
   describe('withOutputStyle', () => {
-    it('should coerce outputStyle based on NX_TUI', () =>
+    it('should coerce outputStyle based on NX_TUI', async () =>
       withEnvironmentVariables(
         {
           NX_TUI: 'true',
           CI: 'false',
           NX_TUI_SKIP_CAPABILITY_CHECK: 'true',
         },
-        () => {
+        async () => {
           const command = withOutputStyleOption(argv);
-          const result = command.parseSync([]);
+          const result = await command.parseAsync([]);
           expect(result['output-style']).toEqual('tui');
         }
       ));
 
-    it('should use NX_DEFAULT_OUTPUT_STYLE if not set', () =>
+    it('should use NX_DEFAULT_OUTPUT_STYLE if not set', async () =>
       withEnvironmentVariables(
         {
           NX_TUI: false,
@@ -210,89 +210,92 @@ describe('shared-options', () => {
           NX_TUI_SKIP_CAPABILITY_CHECK: 'true',
           NX_DEFAULT_OUTPUT_STYLE: 'stream-without-prefixes',
         },
-        () => {
+        async () => {
           const command = withOutputStyleOption(argv);
-          const result = command.parseSync([]);
+          const result = await command.parseAsync([]);
           expect(result.outputStyle).toEqual('stream-without-prefixes');
         }
       ));
 
-    it('should set NX_TUI if using not set', () =>
+    it('should set NX_TUI if using not set', async () =>
       withEnvironmentVariables(
         {
           NX_TUI: false,
           CI: 'false',
           NX_TUI_SKIP_CAPABILITY_CHECK: 'true',
         },
-        () => {
+        async () => {
           const command = withOutputStyleOption(argv);
-          const result = command.parseSync([]);
+          const result = await command.parseAsync([]);
           expect(process.env.NX_TUI).toEqual('true');
         }
       ));
 
     it.each(['dynamic', 'tui'])(
       'should set NX_TUI if using output-style=%s',
-      () =>
+      async () =>
         withEnvironmentVariables(
           {
             NX_TUI: false,
             CI: 'false',
             NX_TUI_SKIP_CAPABILITY_CHECK: 'true',
           },
-          () => {
+          async () => {
             const command = withOutputStyleOption(argv);
-            const result = command.parseSync(['--output-style', 'dynamic']);
+            const result = await command.parseAsync([
+              '--output-style',
+              'dynamic',
+            ]);
             expect(process.env.NX_TUI).toEqual('true');
           }
         )
     );
 
-    it('should enable the tui when flag set', () =>
+    it('should enable the tui when flag set', async () =>
       withEnvironmentVariables(
         {
           NX_TUI: 'false',
           CI: 'false',
           NX_TUI_SKIP_CAPABILITY_CHECK: 'true',
         },
-        () => {
+        async () => {
           const command = withOutputStyleOption(withTuiOptions(argv));
-          command.parseSync(['--tui']);
+          await command.parseAsync(['--tui']);
           expect(process.env.NX_TUI).toEqual('true');
         }
       ));
 
-    it('should disable the tui when flag set to false', () =>
+    it('should disable the tui when flag set to false', async () =>
       withEnvironmentVariables(
         {
           NX_TUI: 'true',
           CI: 'false',
           NX_TUI_SKIP_CAPABILITY_CHECK: 'true',
         },
-        () => {
+        async () => {
           const command = withOutputStyleOption(withTuiOptions(argv));
-          command.parseSync(['--tui=false']);
+          await command.parseAsync(['--tui=false']);
           expect(process.env.NX_TUI).toEqual('false');
         }
       ));
   });
 
   describe('withTuiOptions', () => {
-    it('should parse tui flag', () => {
+    it('should parse tui flag', async () => {
       const command = withTuiOptions(argv);
-      const result = command.parseSync(['--tui']);
+      const result = await command.parseAsync(['--tui']);
       expect(result.tui).toEqual(true);
     });
 
-    it('should parse tui flag set to false', () => {
+    it('should parse tui flag set to false', async () => {
       const command = withTuiOptions(argv);
-      const result = command.parseSync(['--tui=false']);
+      const result = await command.parseAsync(['--tui=false']);
       expect(result.tui).toEqual(false);
     });
 
-    it('should parse tuiAutoExit flag', () => {
+    it('should parse tuiAutoExit flag', async () => {
       const command = withTuiOptions(argv);
-      const result = command.parseSync(['--tuiAutoExit=5']);
+      const result = await command.parseAsync(['--tuiAutoExit=5']);
       expect(result.tuiAutoExit).toEqual(5);
     });
   });

--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -217,6 +217,11 @@ export function withAffectedOptions(yargs: Argv) {
       requiresArg: true,
       coerce: parseCSV,
     })
+    .option('stdin', {
+      describe:
+        'Change the way Nx is calculating the affected command by providing directly changed files from stdin, list of files delimited by commas.',
+      type: 'boolean',
+    })
     .option('uncommitted', {
       describe: 'Uncommitted changes.',
       type: 'boolean',
@@ -247,9 +252,22 @@ export function withAffectedOptions(yargs: Argv) {
     .implies('head', 'base')
     .conflicts({
       files: ['uncommitted', 'untracked', 'base', 'head'],
+      stdin: ['uncommitted', 'untracked', 'base', 'head'],
       untracked: ['uncommitted', 'files', 'base', 'head'],
       uncommitted: ['files', 'untracked', 'base', 'head'],
-    });
+    })
+    .middleware(async (args) => {
+      if (args.stdin) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of process.stdin) {
+          chunks.push(chunk);
+        }
+        const files = parseCSV(Buffer.concat(chunks).toString());
+        if (Array.isArray(args.files)) files.push(...args.files);
+        else if (typeof args.files === 'string') files.push(args.files);
+        args.files = files as any; // Yargs types don't reflect the coerce option
+      }
+    }, true);
 }
 
 export interface RunManyOptions extends RunOptions {


### PR DESCRIPTION
- **feat(core): add `--stdin` to affected options**
- **fix(core): use newline-delimited stdin and add TTY guard for --stdin option**

Supercedes #28770

Co-authored-by: @aaronccasanova