### PR TITLE
fix(core): handle Ctrl+C gracefully in configure-ai-agents

### DIFF
--- a/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
+++ b/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
@@ -60,6 +60,19 @@ export async function configureAiAgentsHandler(
 export async function configureAiAgentsHandlerImpl(
   options: ConfigureAiAgentsOptions
 ): Promise<void> {
+  // Node 24 has stricter readline behavior, and enquirer is not checking for closed state
+  // when invoking operations, thus you get an ERR_USE_AFTER_CLOSE error.
+  process.on('uncaughtException', (error) => {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error['code'] === 'ERR_USE_AFTER_CLOSE'
+    )
+      return;
+    throw error;
+  });
+
   const normalizedOptions = normalizeOptions(options);
 
   const {


### PR DESCRIPTION
## Current Behavior

Pressing Ctrl+C during the `nx configure-ai-agents` multiselect prompt throws an ugly `ERR_USE_AFTER_CLOSE` stack trace. Node 24 has stricter readline behavior and enquirer doesn't check for closed state.

<img width="1231" height="453" alt="Screenshot 2026-02-13 at 09 41 09" src="https://github.com/user-attachments/assets/f6814568-d96b-4007-859d-2b590e6cc2eb" />


## Expected Behavior

Pressing Ctrl+C exits silently without a stack trace, matching the behavior already implemented in `nx init` and `create-nx-workspace`.

## Related Issue(s)

N/A — discovered during Node 24 compatibility testing.