### PR TITLE
feat(core): use jemalloc with tuned decay timers for native module

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
+[env]
+JEMALLOC_SYS_WITH_MALLOC_CONF = "dirty_decay_ms:1000,muzzy_decay_ms:0"
+
 [build]
 target-dir = 'dist/target'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -174,7 +174,7 @@ jobs:
               bash -c "
                 set -e
                 echo 'https://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories
-                apk add --no-cache curl xz openjdk21
+                apk add --no-cache curl xz openjdk21 build-base lld
 
                 # Set up Java 21
                 export JAVA_HOME=/usr/lib/jvm/java-21-openjdk
@@ -193,6 +193,10 @@ jobs:
                 # Install PNPM
                 npm i -g pnpm@${PNPM_VERSION} --force
                 pnpm --version
+
+                # Help clang find GCC runtime (crtbeginS.o, libgcc) and use lld for jemalloc build
+                GCC_DIR=\$(dirname \$(find /usr/lib/gcc -name crtbeginS.o | head -1))
+                export CFLAGS=\"\${CFLAGS} -fuse-ld=lld --gcc-install-dir=\${GCC_DIR}\"
 
                 # Install deps and run native build
                 pnpm install --frozen-lockfile
@@ -230,6 +234,9 @@ jobs:
               node --version
               npm --version
 
+              # Help clang find GCC runtime (crtbeginS.o, libgcc) and use lld for jemalloc build
+              export CFLAGS="${CFLAGS} -fuse-ld=lld --gcc-toolchain=/usr/aarch64-unknown-linux-gnu"
+
               npm i -g pnpm@${PNPM_VERSION} --force
               pnpm --version
 
@@ -260,7 +267,7 @@ jobs:
               bash -c "
                 set -e
                 echo 'https://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories
-                apk add --no-cache curl xz openjdk21
+                apk add --no-cache curl xz openjdk21 build-base lld
 
                 # Set up Java 21
                 export JAVA_HOME=/usr/lib/jvm/java-21-openjdk
@@ -279,6 +286,10 @@ jobs:
                 # Install PNPM
                 npm i -g pnpm@${PNPM_VERSION} --force
                 pnpm --version
+
+                # Help clang find GCC runtime (crtbeginS.o, libgcc) and use lld for jemalloc build
+                GCC_DIR=\$(dirname \$(find /aarch64-linux-musl-cross/lib/gcc -name crtbeginS.o | head -1))
+                export CFLAGS=\"\${CFLAGS} -fuse-ld=lld --gcc-install-dir=\${GCC_DIR}\"
 
                 # Install deps and run native build
                 pnpm install --frozen-lockfile

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,6 +2214,7 @@ dependencies = [
  "tempfile",
  "terminal-colorsaurus",
  "thiserror 1.0.69",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3830,6 +3831,26 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -76,6 +76,11 @@ winapi = { version = "0.3", features = ["fileapi", "psapi"] }
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
 
+# Windows excluded: tikv-jemalloc-sys fails to build with MSVC (spaces in cl.exe path break configure).
+# Track https://github.com/tikv/jemallocator/pull/99 for upstream fix.
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+tikv-jemallocator = { version = "0.6", features = ["disable_initial_exec_tls"] }
+
 [target.'cfg(all(not(windows), not(target_family = "wasm")))'.dependencies]
 mio = "1.0"
 nix = { version = "0.30.0", features = ["process", "signal"] }

--- a/packages/nx/src/lib.rs
+++ b/packages/nx/src/lib.rs
@@ -4,4 +4,10 @@
 #[macro_use]
 extern crate napi_derive;
 
+// Windows excluded: tikv-jemalloc-sys fails to build with MSVC.
+// Track https://github.com/tikv/jemallocator/pull/99
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 pub mod native;


### PR DESCRIPTION
## Current Behavior

The Nx native module (Rust cdylib loaded by Node.js) uses the system allocator. The daemon process retains a large RSS footprint after the initial project graph build, even though most of that memory is no longer in use. On macOS and Linux, the system allocator doesn't aggressively return freed pages to the OS.

## Expected Behavior

The daemon's steady-state RSS drops significantly after graph build by using jemalloc with tuned page purge timers. Peak RSS and wall time are unaffected.

## Changes

Adds [tikv-jemallocator](https://github.com/tikv/jemallocator) as the global allocator on Linux and macOS, with two compile-time settings:

- **`dirty_decay_ms:1000`** — returns freed pages to the OS after 1s instead of the default 10s. Tuned to Nx's phase-separated workload (graph build → idle → task execution), where transitions happen every ~30-60s. Benchmarked against 5s and 10s — both too slow to purge between phases.
- **`muzzy_decay_ms:0`** — skips the lazy purge phase (`MADV_FREE`) and goes straight to `MADV_DONTNEED`. Required on macOS and Linux ≥ 4.5 where `MADV_FREE` doesn't actually reduce RSS.

Windows and WASI continue using the system allocator. Windows is excluded because `tikv-jemalloc-sys` fails to build with MSVC (spaces in `cl.exe` path break the autoconf configure script). Tracked upstream in [tikv/jemallocator#99](https://github.com/tikv/jemallocator/pull/99).

### Other Settings Considered

Tested narenas reduction, tcache_max, extent fit tuning, background threads, and decay timer values. Only the decay timer configuration improved steady-state RSS without wall time regression.