### PR TITLE
fix(core): replace buggy ignore-files trie with correct path-component gitignore matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,22 +261,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
- "regex-automata",
  "serde",
 ]
 
@@ -313,12 +303,6 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "byteorder-lite"
@@ -514,15 +498,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,16 +590,6 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
 
 [[package]]
 name = "ctor"
@@ -722,16 +687,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
-
-[[package]]
 name = "dispatch2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,12 +759,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "endian-type"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
-
-[[package]]
 name = "env_filter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,16 +822,6 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
-name = "faster-hex"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
-dependencies = [
- "heapless",
- "serde",
-]
 
 [[package]]
 name = "fastrand"
@@ -1132,16 +1071,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,244 +1112,6 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
-name = "gix-actor"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f79dc4dca964c163419ad50a63552171b3597b804f9de6a96779b207b4d710"
-dependencies = [
- "bstr",
- "gix-date",
- "gix-utils",
- "itoa",
- "thiserror 2.0.18",
- "winnow",
-]
-
-[[package]]
-name = "gix-config"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58e2ff8eef96b71f2c5e260f02ca0475caff374027c5cc5a29bda69fac67404"
-dependencies = [
- "bstr",
- "gix-config-value",
- "gix-features",
- "gix-glob",
- "gix-path",
- "gix-ref",
- "gix-sec",
- "memchr",
- "smallvec",
- "thiserror 2.0.18",
- "unicode-bom",
- "winnow",
-]
-
-[[package]]
-name = "gix-config-value"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2409cffa4fe8b303847d5b6ba8df9da9ba65d302fc5ee474ea0cac5afde79840"
-dependencies = [
- "bitflags 2.10.0",
- "bstr",
- "gix-path",
- "libc",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-date"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1dcfa6042b334f049c2e717ae816806272a7801b13ff2eadad3f069d7b4a85"
-dependencies = [
- "bstr",
- "itoa",
- "jiff",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-features"
-version = "0.45.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56aad357ae016449434705033df644ac6253dfcf1281aad3af3af9e907560d1"
-dependencies = [
- "gix-path",
- "gix-trace",
- "gix-utils",
- "libc",
- "prodash",
- "walkdir",
-]
-
-[[package]]
-name = "gix-fs"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785b9c499e46bc78d7b81c148c21b3fca18655379ee729a856ed19ce50d359ec"
-dependencies = [
- "bstr",
- "fastrand",
- "gix-features",
- "gix-path",
- "gix-utils",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-glob"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8546300aee4c65c5862c22a3e321124a69b654a61a8b60de546a9284812b7e2"
-dependencies = [
- "bitflags 2.10.0",
- "bstr",
- "gix-features",
- "gix-path",
-]
-
-[[package]]
-name = "gix-hash"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e153930f42ccdab8a3306b1027cd524879f6a8996cd0c474d18b0e56cae7714d"
-dependencies = [
- "faster-hex",
- "gix-features",
- "sha1-checked",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-hashtable"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222f7428636020bef272a87ed833ea48bf5fb3193f99852ae16fbb5a602bd2f0"
-dependencies = [
- "gix-hash",
- "hashbrown 0.16.1",
- "parking_lot",
-]
-
-[[package]]
-name = "gix-lock"
-version = "20.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115268ae5e3b3b7bc7fc77260eecee05acca458e45318ca45d35467fa81a3ac5"
-dependencies = [
- "gix-tempfile",
- "gix-utils",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-object"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283df1e0c2b00f099683f2dd4bb3e2552ce87a46fcdd1ca2ac35e387a2d67136"
-dependencies = [
- "bstr",
- "gix-actor",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-path",
- "gix-utils",
- "gix-validate",
- "itoa",
- "smallvec",
- "thiserror 2.0.18",
- "winnow",
-]
-
-[[package]]
-name = "gix-path"
-version = "0.10.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
-dependencies = [
- "bstr",
- "gix-trace",
- "gix-validate",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-ref"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb33aa97006e37e9e83fde233569a66b02ed16fd4b0406cdf35834b06cf8a63"
-dependencies = [
- "gix-actor",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-path",
- "gix-tempfile",
- "gix-utils",
- "gix-validate",
- "memmap2",
- "thiserror 2.0.18",
- "winnow",
-]
-
-[[package]]
-name = "gix-sec"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9962ed6d9114f7f100efe038752f41283c225bb507a2888903ac593dffa6be"
-dependencies = [
- "bitflags 2.10.0",
- "gix-path",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "gix-tempfile"
-version = "20.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad89218e74850f42d364ed3877c7291f0474c8533502df91bb877ecc5cb0dd40"
-dependencies = [
- "gix-fs",
- "libc",
- "parking_lot",
- "tempfile",
-]
-
-[[package]]
-name = "gix-trace"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e42a4c2583357721ba2d887916e78df504980f22f1182df06997ce197b89504"
-
-[[package]]
-name = "gix-utils"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
-dependencies = [
- "fastrand",
- "unicode-normalization",
-]
-
-[[package]]
-name = "gix-validate"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
-dependencies = [
- "bstr",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "globset"
@@ -1477,15 +1168,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,16 +1212,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -1799,25 +1471,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ignore-files"
-version = "3.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b0030836e50229b1c47a6604ea95268b164492d6104d79989179a02255254f"
-dependencies = [
- "dunce",
- "futures",
- "gix-config",
- "ignore",
- "miette",
- "normalize-path",
- "project-origins",
- "radix_trie",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "image"
 version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,47 +1629,6 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
-
-[[package]]
-name = "jiff"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
-dependencies = [
- "jiff-static",
- "jiff-tzdb-platform",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "jiff-tzdb"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68971ebff725b9e2ca27a601c5eb38a4c5d64422c4cbab0c535f248087eda5c2"
-
-[[package]]
-name = "jiff-tzdb-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
-dependencies = [
- "jiff-tzdb",
-]
 
 [[package]]
 name = "jni"
@@ -2281,15 +1893,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "memmap2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2423,15 +2026,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "nix"
@@ -2585,7 +2179,6 @@ dependencies = [
  "globset",
  "hashbrown 0.14.5",
  "ignore",
- "ignore-files",
  "insta",
  "interprocess",
  "itertools 0.10.5",
@@ -2632,7 +2225,6 @@ dependencies = [
  "walkdir",
  "watchexec",
  "watchexec-events",
- "watchexec-filterer-ignore",
  "watchexec-signals",
  "winapi",
  "winres",
@@ -2883,21 +2475,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "portable-pty"
 version = "0.8.1"
 source = "git+https://github.com/cammisuli/wezterm?rev=b538ee29e1e89eeb4832fb35ae095564dce34c29#b538ee29e1e89eeb4832fb35ae095564dce34c29"
@@ -3004,26 +2581,6 @@ dependencies = [
  "tokio",
  "tracing",
  "windows 0.62.2",
-]
-
-[[package]]
-name = "prodash"
-version = "30.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6efc566849d3d9d737c5cb06cc50e48950ebe3d3f9d70631490fff3a07b139"
-dependencies = [
- "parking_lot",
-]
-
-[[package]]
-name = "project-origins"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42382141d102db809df94324b513c388b047ebc47926eec5417623b88781527"
-dependencies = [
- "futures",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -3155,16 +2712,6 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "radix_trie"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
 
 [[package]]
 name = "rand"
@@ -3697,27 +3244,6 @@ checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
 dependencies = [
  "libc",
  "serial-core",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "sha1-checked"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
-dependencies = [
- "digest",
- "sha1",
 ]
 
 [[package]]
@@ -4653,18 +4179,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "unicode-bom"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
-
-[[package]]
 name = "unicode-id"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4675,15 +4189,6 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -4937,21 +4442,6 @@ checksum = "9c4a8973a20c7d30198a12272519163168a9ba8b687693ec9d1f027b75b860d1"
 dependencies = [
  "notify-types",
  "watchexec-signals",
-]
-
-[[package]]
-name = "watchexec-filterer-ignore"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923b0345fd40893ec39caf41ef2f4ce999b1bf25338001d211719f48ee7d7da4"
-dependencies = [
- "dunce",
- "ignore",
- "ignore-files",
- "normalize-path",
- "tracing",
- "watchexec",
- "watchexec-events",
 ]
 
 [[package]]

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -84,7 +84,6 @@ nix = { version = "0.30.0", features = ["process", "signal"] }
 arboard = { version = "3.4.1", features = ["wayland-data-control"] }
 crossterm = { version = "0.29.0", features = ["event-stream", "use-dev-tty"] }
 portable-pty = { git = "https://github.com/cammisuli/wezterm", rev = "b538ee29e1e89eeb4832fb35ae095564dce34c29" }
-ignore-files = "3.0.5"
 fs4 = "0.12.0"
 ratatui = { version = "0.29" }
 reqwest = { version = "0.12.22", default-features = false, features = [
@@ -93,7 +92,6 @@ reqwest = { version = "0.12.22", default-features = false, features = [
 rusqlite = { version = "0.32.1", features = ["bundled", "array", "vtab"] }
 watchexec = "8.0.1"
 watchexec-events = "6.0.0"
-watchexec-filterer-ignore = "7.0.0"
 watchexec-signals = "5.0.1"
 machine-uid = "0.5.2"
 interprocess = { version = "=2.2.3", features = ["tokio"] }

--- a/packages/nx/src/native/watch/git_utils.rs
+++ b/packages/nx/src/native/watch/git_utils.rs
@@ -1,11 +1,10 @@
-use ignore_files::IgnoreFile;
 use std::path::{Path, PathBuf};
 use tracing::trace;
 
 use crate::native::utils::git::parent_gitignore_files;
 
 /// Collect .gitignore files using a simple approach that reuses walker logic
-fn collect_workspace_gitignores<P: AsRef<Path>>(root: P) -> Vec<IgnoreFile> {
+fn collect_workspace_gitignores<P: AsRef<Path>>(root: P) -> Vec<PathBuf> {
     use crate::native::walker::nx_walker_sync;
 
     // Use our own walker to find .gitignore files, filtering out node_modules
@@ -17,16 +16,7 @@ fn collect_workspace_gitignores<P: AsRef<Path>>(root: P) -> Vec<IgnoreFile> {
         .filter_map(|relative_path| {
             // Only process .gitignore files
             if relative_path.file_name()?.to_str()? == ".gitignore" {
-                let absolute_path = root_path.join(&relative_path);
-                let parent = absolute_path
-                    .parent()
-                    .unwrap_or(&absolute_path)
-                    .to_path_buf();
-                Some(IgnoreFile {
-                    path: absolute_path,
-                    applies_in: Some(parent),
-                    applies_to: None,
-                })
+                Some(root_path.join(&relative_path))
             } else {
                 None
             }
@@ -34,7 +24,7 @@ fn collect_workspace_gitignores<P: AsRef<Path>>(root: P) -> Vec<IgnoreFile> {
         .collect()
 }
 
-pub(in crate::native) fn get_gitignore_files<T: AsRef<str>>(root: T) -> Vec<IgnoreFile> {
+pub(in crate::native) fn get_gitignore_files<T: AsRef<str>>(root: T) -> Vec<PathBuf> {
     let root_path = PathBuf::from(root.as_ref());
 
     // Start with workspace .gitignore files
@@ -42,17 +32,7 @@ pub(in crate::native) fn get_gitignore_files<T: AsRef<str>>(root: T) -> Vec<Igno
 
     // Add parent .gitignore files using shared logic
     if let Some(gitignore_paths) = parent_gitignore_files(&root_path) {
-        ignore_files.extend(gitignore_paths.into_iter().map(|gitignore_path| {
-            let applies_in = gitignore_path
-                .parent()
-                .expect(".gitignore file should have a parent directory")
-                .to_path_buf();
-            IgnoreFile {
-                path: gitignore_path,
-                applies_in: Some(applies_in),
-                applies_to: None,
-            }
-        }));
+        ignore_files.extend(gitignore_paths);
     }
 
     trace!(?ignore_files, "Final ignore files list");

--- a/packages/nx/src/native/watch/utils.rs
+++ b/packages/nx/src/native/watch/utils.rs
@@ -1,17 +1,12 @@
-use ignore_files::IgnoreFile;
 use std::path::Path;
 use std::{fs, path::PathBuf};
 use tracing::trace;
 use watchexec_events::{Event, Tag};
 
-pub(super) fn get_nx_ignore<P: AsRef<Path>>(origin: P) -> Option<IgnoreFile> {
+pub(super) fn get_nx_ignore<P: AsRef<Path>>(origin: P) -> Option<PathBuf> {
     let nx_ignore_path = PathBuf::from(origin.as_ref()).join(".nxignore");
     if nx_ignore_path.exists() {
-        Some(IgnoreFile {
-            path: nx_ignore_path,
-            applies_in: Some(origin.as_ref().into()),
-            applies_to: None,
-        })
+        Some(nx_ignore_path)
     } else {
         None
     }

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -1,4 +1,6 @@
 use ignore::Match;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use std::path::PathBuf;
 use tracing::trace;
 use watchexec::error::RuntimeError;
 use watchexec::filter::Filterer;
@@ -6,24 +8,29 @@ use watchexec_events::filekind::{CreateKind, FileEventKind, ModifyKind, RemoveKi
 
 use crate::native::watch::git_utils::get_gitignore_files;
 use crate::native::watch::utils::{get_nx_ignore, transform_event};
-use ignore_files::IgnoreFilter;
 use watchexec_events::{Event, FileType, Priority, Source, Tag};
-use watchexec_filterer_ignore::IgnoreFilterer;
 
 #[derive(Debug)]
 pub struct WatchFilterer {
-    pub nx_ignore: Option<IgnoreFilter>,
-    pub git_ignore: IgnoreFilterer,
+    origin: PathBuf,
+    nx_ignore: Option<Gitignore>,
+    /// Per-directory gitignore instances, sorted deepest-first (most path components first).
+    /// Each entry is (directory the .gitignore applies in, compiled Gitignore).
+    git_ignores: Vec<(PathBuf, Gitignore)>,
 }
 
 impl WatchFilterer {
-    fn filter_event(&self, event: &Event, priority: Priority) -> bool {
+    fn filter_event(&self, event: &Event) -> bool {
         let mut pass = true;
         for (path, file_type) in event.paths() {
             let path = dunce::simplified(path);
-            let is_dir = file_type.map_or(false, |t| matches!(t, FileType::Dir));
+            let is_dir = file_type.is_some_and(|t| matches!(t, FileType::Dir));
             let nx_ignore_match_type = if let Some(nx_ignore) = &self.nx_ignore {
-                nx_ignore.match_path(path, is_dir)
+                if path.starts_with(&self.origin) {
+                    nx_ignore.matched_path_or_any_parents(path, is_dir)
+                } else {
+                    Match::None
+                }
             } else {
                 Match::None
             };
@@ -39,10 +46,32 @@ impl WatchFilterer {
                 trace!(?path, "nxignore ignore match, ignoring gitignore");
                 pass &= false;
             } else {
-                pass &= self
-                    .git_ignore
-                    .check_event(event, priority)
-                    .expect("git ignore check never errors")
+                // Check gitignores deepest-first; first match wins
+                let git_match = self
+                    .git_ignores
+                    .iter()
+                    .filter(|(dir, _)| path.starts_with(dir))
+                    .find_map(|(_, gitignore)| {
+                        match gitignore.matched_path_or_any_parents(path, is_dir) {
+                            Match::None => None,
+                            m => Some(m),
+                        }
+                    });
+
+                match git_match {
+                    Some(Match::Ignore(_)) => {
+                        trace!(?path, "gitignore match - blocked");
+                        pass &= false;
+                    }
+                    Some(Match::Whitelist(_)) => {
+                        trace!(?path, "gitignore whitelist match - allowed");
+                        pass &= true;
+                    }
+                    _ => {
+                        // No gitignore matched — allow through
+                        pass &= true;
+                    }
+                }
             }
         }
 
@@ -57,7 +86,7 @@ impl Filterer for WatchFilterer {
         let event = transformed.as_ref().unwrap_or(watch_event);
 
         trace!(?event, "checking if event is valid");
-        if !self.filter_event(event, priority) {
+        if !self.filter_event(event) {
             return Ok(false);
         }
 
@@ -123,13 +152,13 @@ impl Filterer for WatchFilterer {
     }
 }
 
-pub(super) async fn create_filter(
+pub(super) fn create_filter(
     origin: &str,
     additional_globs: &[String],
     use_ignore: bool,
 ) -> anyhow::Result<WatchFilterer> {
     let ignore_files = use_ignore.then(|| get_gitignore_files(origin));
-    let nx_ignore_file = get_nx_ignore(origin);
+    let nx_ignore_path = get_nx_ignore(origin);
 
     trace!(
         ?use_ignore,
@@ -137,36 +166,63 @@ pub(super) async fn create_filter(
         ?ignore_files,
         "Using these ignore files for the watcher"
     );
-    let mut git_ignore = if let Some(ignore_files) = ignore_files {
-        IgnoreFilter::new(origin, &ignore_files)
-            .await
-            .map_err(anyhow::Error::from)?
-    } else {
-        IgnoreFilter::empty(origin)
-    };
 
-    git_ignore
-        .add_globs(
-            &additional_globs
-                .iter()
-                .map(String::as_ref)
-                .collect::<Vec<_>>(),
-            Some(&origin.into()),
-        )
-        .map_err(anyhow::Error::from)?;
+    let mut git_ignores: Vec<(PathBuf, Gitignore)> = Vec::new();
 
-    let nx_ignore = if let Some(nx_ignore_file) = nx_ignore_file {
-        Some(
-            IgnoreFilter::new(origin, &[nx_ignore_file])
-                .await
-                .map_err(anyhow::Error::from)?,
-        )
+    // Build per-directory Gitignore instances from .gitignore files
+    if let Some(paths) = ignore_files {
+        for gitignore_path in paths {
+            let (gitignore, err) = Gitignore::new(&gitignore_path);
+            if let Some(err) = err {
+                trace!(
+                    ?err,
+                    ?gitignore_path,
+                    "error parsing gitignore, using partial result"
+                );
+            }
+            let dir = gitignore_path
+                .parent()
+                .unwrap_or(&gitignore_path)
+                .to_path_buf();
+            git_ignores.push((dir, gitignore));
+        }
+    }
+
+    // Build additional globs as a synthetic gitignore rooted at origin
+    if !additional_globs.is_empty() {
+        let mut builder = GitignoreBuilder::new(origin);
+        for glob in additional_globs {
+            builder.add_line(None, glob)?;
+        }
+        let gitignore = builder.build()?;
+        git_ignores.push((PathBuf::from(origin), gitignore));
+    }
+
+    // Sort deepest-first (most path components first) so deeper gitignores take priority
+    git_ignores.sort_by(|(a, _), (b, _)| {
+        let a_depth = a.components().count();
+        let b_depth = b.components().count();
+        b_depth.cmp(&a_depth)
+    });
+
+    // Build .nxignore
+    let nx_ignore = if let Some(nxignore_path) = nx_ignore_path {
+        let (gitignore, err) = Gitignore::new(&nxignore_path);
+        if let Some(err) = err {
+            trace!(
+                ?err,
+                ?nxignore_path,
+                "error parsing nxignore, using partial result"
+            );
+        }
+        Some(gitignore)
     } else {
         None
     };
 
     Ok(WatchFilterer {
-        git_ignore: IgnoreFilterer(git_ignore),
+        origin: PathBuf::from(origin),
+        git_ignores,
         nx_ignore,
     })
 }

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -295,9 +295,11 @@ impl Watcher {
                 .pathset(path_set.iter().map(|p| WatchedPath::non_recursive(p)));
             *watched_path_set.lock() = path_set;
 
-            watch_exec.config.filterer(
-                watch_filterer::create_filter(&origin, &additional_globs, use_ignore).await?,
-            );
+            watch_exec.config.filterer(watch_filterer::create_filter(
+                &origin,
+                &additional_globs,
+                use_ignore,
+            )?);
             trace!("starting watch exec");
             watch_exec.main().await.map_err(anyhow::Error::from)?.ok();
             Ok(())


### PR DESCRIPTION
## Current Behavior

The `nx watch` file watcher uses the `ignore-files` and `watchexec-filterer-ignore` crates to handle `.gitignore` matching. These crates use a trie-based approach that has a bug with path-component matching — certain gitignore patterns (e.g., prefix patterns) don't match correctly, causing files that should be ignored to trigger unnecessary watch events.

## Expected Behavior

Gitignore patterns are matched correctly using per-directory `Gitignore` instances from the `ignore` crate — the same crate already used by the file walker. Each `.gitignore` file is scoped to its directory, and matching is done deepest-first so that nested gitignores take priority — matching standard git behavior.

### What changed

- Replaced `ignore-files` + `watchexec-filterer-ignore` with direct use of `ignore::gitignore::{Gitignore, GitignoreBuilder}`, aligning the watcher with the approach already used by the file walker
- Each `.gitignore` is now compiled as a standalone instance tied to its parent directory
- Gitignore evaluation walks deepest-first; first match wins
- `.nxignore` matching now uses `matched_path_or_any_parents` for correct ancestor checking
- `create_filter` is now synchronous (no longer `async`) since the new approach doesn't need async I/O
- Removed 2 crate dependencies (`ignore-files`, `watchexec-filterer-ignore`)