### PR TITLE
fix(repo): replace addnab/docker-run-action with direct docker run

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -354,12 +354,24 @@ jobs:
           architecture: x86
 
       - name: Build in docker
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
         if: ${{ matrix.settings.docker }}
-        with:
-          image: ${{ matrix.settings.docker }}
-          options: --user 0:0 -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index -v ${{ github.workspace }}:/build -w /build
-          run: ${{ matrix.settings.build }}
+        shell: bash
+        env:
+          BUILD_SCRIPT: ${{ matrix.settings.build }}
+        run: |
+          SCRIPT_FILE=$(mktemp)
+          echo "$BUILD_SCRIPT" > "$SCRIPT_FILE"
+          docker run --rm \
+            --user 0:0 \
+            -e PNPM_VERSION \
+            -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db \
+            -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache \
+            -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index \
+            -v ${{ github.workspace }}:/build \
+            -v "$SCRIPT_FILE:/build-script.sh" \
+            -w /build \
+            ${{ matrix.settings.docker }} \
+            bash /build-script.sh
 
       - name: Build
         run: ${{ matrix.settings.build }}


### PR DESCRIPTION
## Current Behavior

The publish workflow uses `addnab/docker-run-action@v3` which is based on `docker:20.10` (Docker API 1.41). GitHub's `ubuntu-24.04` runners now ship Docker Engine 28.x which requires minimum API version 1.44, causing all 4 Linux Docker builds to fail:

```
docker: Error response from daemon: client version 1.41 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.
```

Failed run: https://github.com/nrwl/nx/actions/runs/21961139962

## Expected Behavior

Linux Docker builds (x86_64-gnu, x86_64-musl, aarch64-gnu, aarch64-musl) complete successfully using the host's modern Docker CLI.

https://github.com/nrwl/nx/actions/runs/21996143819

## Related Issue(s)

The `addnab/docker-run-action` repo is abandoned (last release March 2021, last commit May 2021) with open issues about this exact problem.