### PR TITLE
fix(repo): revert sudo for global npm install in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -551,7 +551,7 @@ jobs:
           corepack prepare --activate
 
       - name: Use npm 11.5.2
-        run: sudo npm install -g npm@11.5.2
+        run: npm install -g npm@11.5.2
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Current Behavior

The publish workflow uses `sudo npm install -g npm@11.5.2` which was added in #34409. This causes issues with OIDC token permissions in the release pipeline since `sudo` runs as a different user context.

## Expected Behavior

The publish workflow should use `npm install -g npm@11.5.2` without `sudo`, matching the standard approach used elsewhere and avoiding permission context issues during release.

## Related Issue(s)

Reverts #34409