### PR TITLE
chore(nx-dev): condense redirect rules

### DIFF
--- a/nx-dev/nx-dev/redirect-rules-docs-to-astro.js
+++ b/nx-dev/nx-dev/redirect-rules-docs-to-astro.js
@@ -2,9 +2,50 @@
 // Wildcards reduce individual redirects by using pattern matching
 // Original: 1073 entries, Consolidated: 710 entries
 const docsToAstroRedirects = {
+  // ========== EXCEPTIONS (must be before wildcards) ==========
+  // convert-to-inferred routes all go to the same destination
+  '/technologies/test-tools/cypress/api/generators/convert-to-inferred':
+    '/docs/guides/tasks--caching/convert-to-inferred',
+  '/technologies/test-tools/detox/api/generators/convert-to-inferred':
+    '/docs/guides/tasks--caching/convert-to-inferred',
+  '/technologies/eslint/api/generators/convert-to-inferred':
+    '/docs/guides/tasks--caching/convert-to-inferred',
+  '/technologies/react/expo/api/generators/convert-to-inferred':
+    '/docs/guides/tasks--caching/convert-to-inferred',
+  '/technologies/test-tools/jest/api/generators/convert-to-inferred':
+    '/docs/guides/tasks--caching/convert-to-inferred',
+  '/technologies/react/next/api/generators/convert-to-inferred':
+    '/docs/guides/tasks--caching/convert-to-inferred',
+  '/technologies/test-tools/playwright/api/generators/convert-to-inferred':
+    '/docs/guides/tasks--caching/convert-to-inferred',
+  '/technologies/react/react-native/api/generators/convert-to-inferred':
+    '/docs/guides/tasks--caching/convert-to-inferred',
+  '/technologies/react/remix/api/generators/convert-to-inferred':
+    '/docs/guides/tasks--caching/convert-to-inferred',
+  '/technologies/build-tools/rollup/api/generators/convert-to-inferred':
+    '/docs/guides/tasks--caching/convert-to-inferred',
+  '/technologies/build-tools/rspack/api/generators/convert-to-inferred':
+    '/docs/guides/tasks--caching/convert-to-inferred',
+  '/technologies/test-tools/storybook/api/generators/convert-to-inferred':
+    '/docs/guides/tasks--caching/convert-to-inferred',
+  '/technologies/build-tools/vite/api/generators/convert-to-inferred':
+    '/docs/guides/tasks--caching/convert-to-inferred',
+  '/technologies/build-tools/webpack/api/generators/convert-to-inferred':
+    '/docs/guides/tasks--caching/convert-to-inferred',
+
   // ========== WILDCARD PATTERNS ==========
   // These wildcards replace many individual redirect rules
 
+  // devkit/documents exceptions (must be before wildcard)
+  '/reference/core-api/devkit/documents/README': '/docs/reference/devkit',
+  '/reference/core-api/devkit/documents/ngcli_adapter/README':
+    '/docs/reference/devkit/ngcli_adapter',
+  '/reference/core-api/devkit/documents/runTasksInSerial':
+    '/docs/reference/benchmarks/caching',
+  '/reference/core-api/devkit/documents/serializeJson':
+    '/docs/reference/benchmarks/caching',
+  '/reference/core-api/devkit/documents/stripIndents':
+    '/docs/reference/benchmarks/caching',
   '/reference/core-api/devkit/documents/:slug*':
     '/docs/reference/devkit/:slug*',
   '/reference/core-api/nx/documents/:slug*': '/docs/reference/nx-commands',
@@ -119,7 +160,6 @@ const docsToAstroRedirects = {
   '/ci/concepts/cache-security': '/docs/concepts/ci-concepts/cache-security',
   '/ci/concepts/heartbeat':
     '/docs/concepts/ci-concepts/heartbeat-and-manual-shutdown-handling',
-  '/ci/concepts/nx-cloud-ai': '/docs/concepts/ci-concepts/ai-features',
   '/ci/recipes/security/google-auth': '/docs/guides/nx-cloud/google-auth',
   '/ci/recipes/security/access-tokens': '/docs/guides/nx-cloud/access-tokens',
   '/ci/recipes/security/personal-access-tokens':
@@ -127,29 +167,13 @@ const docsToAstroRedirects = {
   '/ci/recipes/security/encryption': '/docs/guides/nx-cloud/encryption',
   '/ci/recipes/source-control-integration':
     '/docs/guides/nx-cloud/source-control-integration',
-  '/ci/recipes/source-control-integration/github':
-    '/docs/guides/nx-cloud/setup-ci',
-  '/ci/recipes/source-control-integration/bitbucket':
-    '/docs/guides/nx-cloud/setup-ci',
-  '/ci/recipes/source-control-integration/gitlab':
-    '/docs/guides/nx-cloud/setup-ci',
-  '/ci/recipes/source-control-integration/azure-devops':
+  '/ci/recipes/source-control-integration/:path*':
     '/docs/guides/nx-cloud/setup-ci',
   '/ci/recipes/enterprise': '/docs/enterprise',
-  '/ci/recipes/enterprise/single-tenant/overview':
-    '/docs/enterprise/single-tenant/overview',
-  '/ci/recipes/enterprise/single-tenant/auth-github':
-    '/docs/enterprise/single-tenant/auth-github',
-  '/ci/recipes/enterprise/single-tenant/auth-gitlab':
-    '/docs/enterprise/single-tenant/auth-gitlab',
-  '/ci/recipes/enterprise/single-tenant/auth-bitbucket':
-    '/docs/enterprise/single-tenant/auth-bitbucket',
-  '/ci/recipes/enterprise/single-tenant/auth-bitbucket-data-center':
-    '/docs/enterprise/single-tenant/auth-bitbucket-data-center',
   '/ci/recipes/enterprise/single-tenant/auth-saml':
     '/docs/enterprise/single-tenant',
-  '/ci/recipes/enterprise/single-tenant/custom-github-app':
-    '/docs/enterprise/single-tenant/custom-github-app',
+  '/ci/recipes/enterprise/single-tenant/:path*':
+    '/docs/enterprise/single-tenant/:path*',
   '/ci/recipes/enterprise/conformance': '/docs/enterprise/conformance',
   '/ci/recipes/enterprise/conformance/configure-conformance-rules-in-nx-cloud':
     '/docs/enterprise/configure-conformance-rules-in-nx-cloud',
@@ -180,36 +204,8 @@ const docsToAstroRedirects = {
   '/ci/reference/credits-pricing': '/docs/reference/nx-cloud/credits-pricing',
   '/ci/reference/release-notes': '/docs/reference/nx-cloud/release-notes',
   '/concepts': '/docs/concepts',
-  '/concepts/mental-model': '/docs/concepts/mental-model',
-  '/concepts/how-caching-works': '/docs/concepts/how-caching-works',
-  '/concepts/task-pipeline-configuration':
-    '/docs/concepts/task-pipeline-configuration',
-  '/concepts/nx-plugins': '/docs/concepts/nx-plugins',
-  '/concepts/inferred-tasks': '/docs/concepts/inferred-tasks',
-  '/concepts/types-of-configuration': '/docs/concepts/types-of-configuration',
-  '/concepts/executors-and-configurations':
-    '/docs/concepts/executors-and-configurations',
-  '/concepts/common-tasks': '/docs/concepts/common-tasks',
-  '/concepts/sync-generators': '/docs/concepts/sync-generators',
-  '/concepts/typescript-project-linking':
-    '/docs/concepts/typescript-project-linking',
-  '/concepts/buildable-and-publishable-libraries':
-    '/docs/concepts/buildable-and-publishable-libraries',
-  '/concepts/decisions': '/docs/concepts/decisions',
-  '/concepts/decisions/overview': '/docs/concepts/decisions/overview',
-  '/concepts/decisions/why-monorepos': '/docs/concepts/decisions/why-monorepos',
-  '/concepts/decisions/dependency-management':
-    '/docs/concepts/decisions/dependency-management',
-  '/concepts/decisions/code-ownership':
-    '/docs/concepts/decisions/code-ownership',
-  '/concepts/decisions/project-size': '/docs/concepts/decisions/project-size',
-  '/concepts/decisions/project-dependency-rules':
-    '/docs/concepts/decisions/project-dependency-rules',
-  '/concepts/decisions/folder-structure':
-    '/docs/concepts/decisions/folder-structure',
-  '/concepts/nx-daemon': '/docs/concepts/nx-daemon',
-  '/extending-nx': '/docs/extending-nx',
-  '/extending-nx/intro': '/docs/extending-nx/intro',
+  '/concepts/:path*': '/docs/concepts/:path*',
+  // /extending-nx exceptions (don't follow simple prepend pattern)
   '/extending-nx/intro/getting-started': '/docs/extending-nx/intro',
   '/extending-nx/api/nx-devkit/overview': '/docs/extending-nx',
   '/extending-nx/api/plugin/overview': '/docs/extending-nx',
@@ -218,46 +214,21 @@ const docsToAstroRedirects = {
     '/docs/extending-nx/organization-specific-plugin',
   '/extending-nx/tutorials/tooling-plugin': '/docs/extending-nx/tooling-plugin',
   '/extending-nx/recipes': '/docs/extending-nx',
-  '/extending-nx/recipes/local-generators':
-    '/docs/extending-nx/local-generators',
-  '/extending-nx/recipes/composing-generators':
-    '/docs/extending-nx/composing-generators',
   '/extending-nx/recipes/generator-options': '/docs/extending-nx',
-  '/extending-nx/recipes/creating-files': '/docs/extending-nx/creating-files',
-  '/extending-nx/recipes/modifying-files': '/docs/extending-nx/modifying-files',
-  '/extending-nx/recipes/create-sync-generator':
-    '/docs/extending-nx/create-sync-generator',
-  '/extending-nx/recipes/migration-generators':
-    '/docs/extending-nx/migration-generators',
-  '/extending-nx/recipes/local-executors': '/docs/extending-nx/local-executors',
-  '/extending-nx/recipes/compose-executors':
-    '/docs/extending-nx/compose-executors',
-  '/extending-nx/recipes/create-preset': '/docs/extending-nx/create-preset',
-  '/extending-nx/recipes/create-install-package':
-    '/docs/extending-nx/create-install-package',
-  '/extending-nx/recipes/project-graph-plugins':
-    '/docs/extending-nx/project-graph-plugins',
-  '/extending-nx/recipes/publish-plugin': '/docs/extending-nx/publish-plugin',
-  '/extending-nx/recipes/task-running-lifecycle':
-    '/docs/extending-nx/task-running-lifecycle',
   '/extending-nx/api': '/docs/extending-nx',
   '/extending-nx/api/nx-devkit': '/docs/extending-nx',
   '/extending-nx/api/nx-devkit/ngcli-adapter': '/docs/extending-nx',
   '/extending-nx/api/plugin': '/docs/extending-nx',
-  '/features': '/docs/features',
-  '/features/run-tasks': '/docs/features/run-tasks',
-  '/features/cache-task-results': '/docs/features/cache-task-results',
+  // /extending-nx wildcard (covers simple /docs prepend cases)
+  '/extending-nx': '/docs/extending-nx',
+  '/extending-nx/:path*': '/docs/extending-nx/:path*',
+  // /features exceptions (non-standard mappings)
   '/features/enhance-AI': '/docs/features/enhance-ai',
-  '/features/explore-graph': '/docs/features/explore-graph',
-  '/features/generate-code': '/docs/features/generate-code',
-  '/features/automate-updating-dependencies':
-    '/docs/features/automate-updating-dependencies',
-  '/features/enforce-module-boundaries':
-    '/docs/features/enforce-module-boundaries',
-  '/features/manage-releases': '/docs/features/manage-releases',
-  '/features/ci-features': '/docs/features/ci-features',
   '/features/maintain-ts-monorepos':
     '/docs/features/maintain-typescript-monorepos',
+  // /features wildcard
+  '/features': '/docs/features',
+  '/features/:path*': '/docs/features/:path*',
   '/getting-started': '/docs/getting-started/intro',
   '/getting-started/intro': '/docs/getting-started/intro',
   '/getting-started/installation': '/docs/getting-started/installation',
@@ -322,92 +293,14 @@ const docsToAstroRedirects = {
     '/docs/guides/tasks--caching/convert-to-inferred',
   '/recipes/running-tasks/self-hosted-caching':
     '/docs/guides/tasks--caching/self-hosted-caching',
-  '/recipes/adopting-nx/adding-to-monorepo':
-    '/docs/guides/adopting-nx/adding-to-monorepo',
-  '/recipes/adopting-nx/from-turborepo':
-    '/docs/guides/adopting-nx/from-turborepo',
-  '/recipes/adopting-nx/adding-to-existing-project':
-    '/docs/guides/adopting-nx/adding-to-existing-project',
-  '/recipes/adopting-nx/import-project':
-    '/docs/guides/adopting-nx/import-project',
-  '/recipes/adopting-nx/preserving-git-histories':
-    '/docs/guides/adopting-nx/preserving-git-histories',
-  '/recipes/adopting-nx/manual': '/docs/guides/adopting-nx/manual',
-  '/recipes/nx-release/release-npm-packages':
-    '/docs/guides/nx-release/release-npm-packages',
-  '/recipes/nx-release/release-docker-images':
-    '/docs/guides/nx-release/release-docker-images',
-  '/recipes/nx-release/publish-rust-crates':
-    '/docs/guides/nx-release/publish-rust-crates',
-  '/recipes/nx-release/release-projects-independently':
-    '/docs/guides/nx-release/release-projects-independently',
-  '/recipes/nx-release/updating-version-references':
-    '/docs/guides/nx-release/updating-version-references',
-  '/recipes/nx-release/automatically-version-with-conventional-commits':
-    '/docs/guides/nx-release/automatically-version-with-conventional-commits',
-  '/recipes/nx-release/customize-conventional-commit-types':
-    '/docs/guides/nx-release/customize-conventional-commit-types',
-  '/recipes/nx-release/file-based-versioning-version-plans':
-    '/docs/guides/nx-release/file-based-versioning-version-plans',
-  '/recipes/nx-release/configure-custom-registries':
-    '/docs/guides/nx-release/configure-custom-registries',
-  '/recipes/nx-release/publish-in-ci-cd':
-    '/docs/guides/nx-release/publish-in-ci-cd',
-  '/recipes/nx-release/automate-github-releases':
-    '/docs/guides/nx-release/automate-github-releases',
-  '/recipes/nx-release/automate-gitlab-releases':
-    '/docs/guides/nx-release/automate-gitlab-releases',
-  '/recipes/nx-release/update-local-registry-setup':
-    '/docs/guides/nx-release/update-local-registry-setup',
-  '/recipes/nx-release/configure-changelog-format':
-    '/docs/guides/nx-release/configure-changelog-format',
-  '/recipes/nx-release/build-before-versioning':
-    '/docs/guides/nx-release/build-before-versioning',
-  '/recipes/nx-release/configuration-version-prefix':
-    '/docs/guides/nx-release/configuration-version-prefix',
-  '/recipes/nx-console/console-telemetry':
-    '/docs/guides/nx-console/console-telemetry',
-  '/recipes/nx-console/console-project-details':
-    '/docs/guides/nx-console/console-project-details',
-  '/recipes/nx-console/console-generate-command':
-    '/docs/guides/nx-console/console-generate-command',
-  '/recipes/nx-console/console-run-command':
-    '/docs/guides/nx-console/console-run-command',
-  '/recipes/nx-console/console-nx-cloud':
-    '/docs/guides/nx-console/console-nx-cloud',
-  '/recipes/nx-console/console-migrate-ui':
-    '/docs/guides/nx-console/console-migrate-ui',
-  '/recipes/nx-console/console-troubleshooting':
-    '/docs/guides/nx-console/console-troubleshooting',
+  '/recipes/adopting-nx/:path*': '/docs/guides/adopting-nx/:path*',
+  '/recipes/nx-release/:path*': '/docs/guides/nx-release/:path*',
+  '/recipes/nx-console/:path*': '/docs/guides/nx-console/:path*',
   '/recipes/enforce-module-boundaries':
     '/docs/features/enforce-module-boundaries',
-  '/recipes/enforce-module-boundaries/ban-dependencies-with-tags':
-    '/docs/guides/enforce-module-boundaries/ban-dependencies-with-tags',
-  '/recipes/enforce-module-boundaries/tag-multiple-dimensions':
-    '/docs/guides/enforce-module-boundaries/tag-multiple-dimensions',
-  '/recipes/enforce-module-boundaries/ban-external-imports':
-    '/docs/guides/enforce-module-boundaries/ban-external-imports',
-  '/recipes/enforce-module-boundaries/tags-allow-list':
-    '/docs/guides/enforce-module-boundaries/tags-allow-list',
-  '/recipes/tips-n-tricks/standalone-to-monorepo':
-    '/docs/guides/tips-n-tricks/standalone-to-monorepo',
-  '/recipes/tips-n-tricks/keep-nx-versions-in-sync':
-    '/docs/guides/tips-n-tricks/keep-nx-versions-in-sync',
-  '/recipes/tips-n-tricks/define-environment-variables':
-    '/docs/guides/tips-n-tricks/define-environment-variables',
-  '/recipes/tips-n-tricks/browser-support':
-    '/docs/guides/tips-n-tricks/browser-support',
-  '/recipes/tips-n-tricks/include-assets-in-build':
-    '/docs/guides/tips-n-tricks/include-assets-in-build',
-  '/recipes/tips-n-tricks/include-all-packagejson':
-    '/docs/guides/tips-n-tricks/include-all-packagejson',
-  '/recipes/tips-n-tricks/identify-dependencies-between-folders':
-    '/docs/guides/tips-n-tricks/identify-dependencies-between-folders',
-  '/recipes/tips-n-tricks/analyze-source-files':
-    '/docs/guides/tips-n-tricks/analyze-source-files',
-  '/recipes/tips-n-tricks/advanced-update':
-    '/docs/guides/tips-n-tricks/advanced-update',
-  '/recipes/tips-n-tricks/yarn-pnp': '/docs/guides/tips-n-tricks/yarn-pnp',
+  '/recipes/enforce-module-boundaries/:path*':
+    '/docs/guides/enforce-module-boundaries/:path*',
+  '/recipes/tips-n-tricks/:path*': '/docs/guides/tips-n-tricks/:path*',
   '/recipes/adopting-nx': '/docs/guides/adopting-nx',
   '/recipes/nx-release': '/docs/guides/nx-release',
   '/recipes/nx-console': '/docs/guides/nx-console',
@@ -454,95 +347,54 @@ const docsToAstroRedirects = {
   '/reference/core-api/conformance/executors':
     '/docs/reference/conformance/executors',
   '/reference/core-api/owners/generators': '/docs/reference/owners/generators',
+  '/reference/core-api/owners/generators/:path*':
+    '/docs/reference/owners/generators',
   '/reference/core-api/shared-fs-cache/generators':
     '/docs/reference/remote-cache-plugins/shared-fs-cache/generators',
   '/reference/core-api': '/docs/reference',
-  '/reference/core-api/nx': '/reference/nx',
-  '/reference/core-api/workspace': '/reference/workspace',
-  '/reference/core-api/plugin': '/reference/plugin',
-  '/reference/core-api/web': '/reference/web',
+  '/reference/core-api/nx': '/docs/reference/nx',
+  '/reference/core-api/workspace': '/docs/reference/workspace',
+  '/reference/core-api/plugin': '/docs/reference/plugin',
+  '/reference/core-api/web': '/docs/reference/web',
   '/reference/core-api/create-nx-workspace':
     '/docs/reference/create-nx-workspace',
   '/reference/core-api/devkit/documents': '/docs/reference/devkit',
   '/reference/core-api/devkit': '/docs/reference/devkit',
-  '/reference/core-api/devkit/documents/README': '/docs/reference/devkit',
-  '/reference/core-api/devkit/documents/ngcli_adapter/README':
-    '/docs/reference/devkit/ngcli_adapter',
-  '/reference/core-api/devkit/documents/runTasksInSerial':
-    '/docs/reference/benchmarks/caching',
-  '/reference/core-api/devkit/documents/serializeJson':
-    '/docs/reference/benchmarks/caching',
-  '/reference/core-api/devkit/documents/stripIndents':
-    '/docs/reference/benchmarks/caching',
   '/reference/core-api/devkit/executors': '/docs/reference/devkit',
   '/reference/core-api/devkit/generators': '/docs/reference/devkit',
   '/reference/core-api/devkit/migrations': '/docs/reference/devkit',
   '/reference/core-api/nx/documents': '/docs/reference/nx-commands',
   '/reference/core-api/nx/documents/create-nx-workspace':
     'https://canary.nx.dev/docs/reference/create-nx-workspace',
-  '/reference/core-api/nx/executors': '/reference/nx/executors',
-  '/reference/core-api/nx/executors/noop': '/reference/nx/executors',
-  '/reference/core-api/nx/executors/run-commands': '/reference/nx/executors',
-  '/reference/core-api/nx/executors/run-script': '/reference/nx/executors',
-  '/reference/core-api/nx/generators': '/reference/nx/generators',
+  '/reference/core-api/nx/executors': '/docs/reference/nx/executors',
+  '/reference/core-api/nx/executors/:path*': '/docs/reference/nx/executors',
+  '/reference/core-api/nx/generators': '/docs/reference/nx/generators',
   '/reference/core-api/nx/generators/connect-to-nx-cloud':
-    '/reference/nx/generators',
-  '/reference/core-api/nx/migrations': '/reference/nx/migrations',
+    '/docs/reference/nx/generators',
+  '/reference/core-api/nx/migrations': '/docs/reference/nx/migrations',
   '/reference/core-api/plugin/executors': '/reference/plugin/executors',
-  '/reference/core-api/plugin/generators': '/reference/plugin/generators',
-  '/reference/core-api/plugin/generators/plugin':
-    '/reference/plugin/generators',
-  '/reference/core-api/plugin/generators/create-package':
-    '/reference/plugin/generators',
-  '/reference/core-api/plugin/generators/e2e-project':
-    '/reference/plugin/generators',
-  '/reference/core-api/plugin/generators/migration':
-    '/reference/plugin/generators',
-  '/reference/core-api/plugin/generators/generator':
-    '/reference/plugin/generators',
-  '/reference/core-api/plugin/generators/executor':
-    '/reference/plugin/generators',
-  '/reference/core-api/plugin/generators/plugin-lint-checks':
-    '/reference/plugin/generators',
-  '/reference/core-api/plugin/generators/preset':
-    '/reference/plugin/generators',
+  '/reference/core-api/plugin/generators': '/docs/reference/plugin/generators',
+  '/reference/core-api/plugin/generators/:path*':
+    '/docs/reference/plugin/generators',
   '/reference/core-api/plugin/migrations': '/reference/plugin/migrations',
-  '/reference/core-api/web/executors': '/reference/web/executors',
-  '/reference/core-api/web/executors/file-server': '/reference/web/executors',
-  '/reference/core-api/web/generators': '/reference/web/generators',
-  '/reference/core-api/web/generators/init': '/reference/web/generators',
-  '/reference/core-api/web/generators/application': '/reference/web/generators',
-  '/reference/core-api/web/generators/static-config':
-    '/reference/web/generators',
+  '/reference/core-api/web/executors': '/docs/reference/web/executors',
+  '/reference/core-api/web/executors/file-server':
+    '/docs/reference/web/executors',
+  '/reference/core-api/web/generators': '/docs/reference/web/generators',
+  '/reference/core-api/web/generators/:path*': '/docs/reference/web/generators',
   '/reference/core-api/web/migrations': '/reference/web/migrations',
-  '/reference/core-api/workspace/documents': '/reference/workspace',
+  '/reference/core-api/workspace/documents': '/docs/reference/workspace',
   '/reference/core-api/workspace/documents/nx-nodejs-typescript-version-matrix':
     '/docs/reference/nodejs-typescript-compatibility',
   '/reference/core-api/workspace/executors': '/reference/workspace/executors',
   '/reference/core-api/workspace/executors/counter':
     '/reference/workspace/executors',
-  '/reference/core-api/workspace/generators': '/reference/workspace/generators',
-  '/reference/core-api/workspace/generators/preset':
-    '/reference/workspace/generators',
-  '/reference/core-api/workspace/generators/move':
-    '/reference/workspace/generators',
-  '/reference/core-api/workspace/generators/remove':
-    '/reference/workspace/generators',
-  '/reference/core-api/workspace/generators/convert-to-monorepo':
-    '/reference/workspace/generators',
-  '/reference/core-api/workspace/generators/new':
-    '/reference/workspace/generators',
-  '/reference/core-api/workspace/generators/run-commands':
-    '/reference/workspace/generators',
-  '/reference/core-api/workspace/generators/fix-configuration':
-    '/reference/workspace/generators',
-  '/reference/core-api/workspace/generators/npm-package':
-    '/reference/workspace/generators',
-  '/reference/core-api/workspace/generators/ci-workflow':
-    '/reference/workspace/generators',
-  '/reference/core-api/workspace/generators/infer-targets':
-    '/reference/workspace/generators',
-  '/reference/core-api/workspace/migrations': '/reference/workspace/migrations',
+  '/reference/core-api/workspace/generators':
+    '/docs/reference/workspace/generators',
+  '/reference/core-api/workspace/generators/:path*':
+    '/docs/reference/workspace/generators',
+  '/reference/core-api/workspace/migrations':
+    '/docs/reference/workspace/migrations',
   '/reference/core-api/azure-cache/executors':
     '/docs/reference/remote-cache-plugins/azure-cache/overview',
   '/reference/core-api/azure-cache/generators':
@@ -553,17 +405,11 @@ const docsToAstroRedirects = {
     '/docs/reference/conformance/overview',
   '/reference/core-api/conformance/generators':
     '/docs/reference/conformance/generators',
-  '/reference/core-api/conformance/generators/create-rule':
-    '/docs/reference/conformance/generators',
-  '/reference/core-api/conformance/generators/preset':
+  '/reference/core-api/conformance/generators/:path*':
     '/docs/reference/conformance/generators',
   '/reference/core-api/conformance/migrations':
     '/docs/reference/conformance/overview',
   '/reference/core-api/owners/executors': '/docs/reference/owners/overview',
-  '/reference/core-api/owners/generators/init':
-    '/docs/reference/owners/generators',
-  '/reference/core-api/owners/generators/sync-codeowners-file':
-    '/docs/reference/owners/generators',
   '/reference/core-api/owners/migrations': '/docs/reference/owners/overview',
   '/reference/core-api/gcs-cache/executors':
     '/docs/reference/remote-cache-plugins/gcs-cache',
@@ -583,6 +429,7 @@ const docsToAstroRedirects = {
     '/docs/reference/remote-cache-plugins/shared-fs-cache/generators',
   '/reference/core-api/shared-fs-cache/migrations':
     '/docs/reference/remote-cache-plugins/shared-fs-cache/overview',
+  // /showcase exceptions (benchmarks go to /docs/reference/benchmarks)
   '/showcase/benchmarks/tsc-batch-mode':
     '/docs/reference/benchmarks/tsc-batch-mode',
   '/showcase/benchmarks/caching': '/docs/reference/benchmarks/caching',
@@ -693,42 +540,14 @@ const docsToAstroRedirects = {
   '/technologies/test-tools/detox': '/docs/technologies/test-tools/detox',
   '/technologies/test-tools/detox/introduction':
     '/docs/technologies/test-tools/detox/introduction',
-  '/technologies/typescript/recipes/switch-to-workspaces-project-references':
-    '/docs/technologies/typescript/guides/switch-to-workspaces-project-references',
-  '/technologies/typescript/recipes/enable-tsc-batch-mode':
-    '/docs/technologies/typescript/guides/enable-tsc-batch-mode',
-  '/technologies/typescript/recipes/define-secondary-entrypoints':
-    '/docs/technologies/typescript/guides/define-secondary-entrypoints',
-  '/technologies/typescript/recipes/compile-multiple-formats':
-    '/docs/technologies/typescript/guides/compile-multiple-formats',
-  '/technologies/typescript/recipes/js-and-ts':
-    '/docs/technologies/typescript/guides/js-and-ts',
-  '/technologies/angular/recipes/use-environment-variables-in-angular':
-    '/docs/technologies/angular/guides/use-environment-variables-in-angular',
-  '/technologies/angular/recipes/using-tailwind-css-with-angular-projects':
-    '/docs/technologies/angular/guides/using-tailwind-css-with-angular-projects',
-  '/technologies/angular/recipes/module-federation-with-ssr':
-    '/docs/technologies/angular/guides/module-federation-with-ssr',
-  '/technologies/angular/recipes/dynamic-module-federation-with-angular':
-    '/docs/technologies/angular/guides/dynamic-module-federation-with-angular',
-  '/technologies/angular/recipes/setup-incremental-builds-angular':
-    '/docs/technologies/angular/guides/setup-incremental-builds-angular',
-  '/technologies/angular/recipes/nx-and-angular':
-    '/docs/technologies/angular/guides/nx-and-angular',
-  '/technologies/angular/recipes/nx-devkit-angular-devkit':
-    '/docs/technologies/angular/guides/nx-devkit-angular-devkit',
-  '/technologies/angular/recipes/angular-nx-version-matrix':
-    '/docs/technologies/angular/guides/angular-nx-version-matrix',
+  '/technologies/typescript/recipes/:path*':
+    '/docs/technologies/typescript/guides/:path*',
+  '/technologies/angular/recipes/:path*':
+    '/docs/technologies/angular/guides/:path*',
   '/technologies/angular/angular-rspack/recipes':
     '/docs/technologies/angular/angular-rspack/guides/getting-started',
-  '/technologies/angular/angular-rspack/recipes/getting-started':
-    '/docs/technologies/angular/angular-rspack/guides/getting-started',
-  '/technologies/angular/angular-rspack/recipes/migrate-from-webpack':
-    '/docs/technologies/angular/angular-rspack/guides/migrate-from-webpack',
-  '/technologies/angular/angular-rspack/recipes/handling-configurations':
-    '/docs/technologies/angular/angular-rspack/guides/handling-configurations',
-  '/technologies/angular/angular-rspack/recipes/internationalization':
-    '/docs/technologies/angular/angular-rspack/guides/internationalization',
+  '/technologies/angular/angular-rspack/recipes/:path*':
+    '/docs/technologies/angular/angular-rspack/guides/:path*',
   '/technologies/angular/angular-rspack/api':
     '/docs/technologies/angular/angular-rspack/guides/getting-started',
   '/technologies/angular/angular-rspack/api/create-config':
@@ -741,23 +560,8 @@ const docsToAstroRedirects = {
     '/docs/technologies/angular/angular-rsbuild/create-config',
   '/technologies/angular/angular-rsbuild/api/create-server':
     '/docs/technologies/angular/angular-rsbuild/create-server',
-  '/technologies/react/recipes/react-native':
-    '/docs/technologies/react/guides/react-native',
-  '/technologies/react/recipes/remix': '/docs/technologies/react/guides/remix',
-  '/technologies/react/recipes/react-router':
-    '/docs/technologies/react/guides/react-router',
-  '/technologies/react/recipes/use-environment-variables-in-react':
-    '/docs/technologies/react/guides/use-environment-variables-in-react',
-  '/technologies/react/recipes/using-tailwind-css-in-react':
-    '/docs/technologies/react/guides/using-tailwind-css-in-react',
-  '/technologies/react/recipes/adding-assets-react':
-    '/docs/technologies/react/guides/adding-assets-react',
-  '/technologies/react/recipes/module-federation-with-ssr':
-    '/docs/technologies/react/guides/module-federation-with-ssr',
-  '/technologies/react/recipes/deploy-nextjs-to-vercel':
-    '/docs/technologies/react/guides/deploy-nextjs-to-vercel',
-  '/technologies/react/recipes/react-compiler':
-    '/docs/technologies/react/guides/react-compiler',
+  '/technologies/react/recipes/:path*':
+    '/docs/technologies/react/guides/:path*',
   '/technologies/react/next/recipes': '/docs/technologies/react/next/guides',
   '/technologies/react/next/recipes/next-config-setup':
     '/docs/technologies/react/next/guides/next-config-setup',
@@ -774,49 +578,29 @@ const docsToAstroRedirects = {
   '/technologies/vue/nuxt/recipes/deploy-nuxt-to-vercel':
     '/docs/technologies/vue/nuxt/guides/deploy-nuxt-to-vercel',
   '/technologies/vue/nuxt/api': '/docs/technologies/vue/nuxt',
-  '/technologies/node/recipes/node-server-fly-io':
-    '/docs/technologies/node/guides/node-server-fly-io',
-  '/technologies/node/recipes/node-serverless-functions-netlify':
-    '/docs/technologies/node/guides/node-serverless-functions-netlify',
-  '/technologies/node/recipes/node-aws-lambda':
-    '/docs/technologies/node/guides/node-aws-lambda',
-  '/technologies/node/recipes/application-proxies':
-    '/docs/technologies/node/guides/application-proxies',
-  '/technologies/node/recipes/wait-for-tasks':
-    '/docs/technologies/node/guides/wait-for-tasks',
+  '/technologies/node/recipes/:path*': '/docs/technologies/node/guides/:path*',
   '/technologies/node/express/api': '/docs/technologies/node/express',
   '/technologies/node/nest/api': '/docs/technologies/node/nest',
   '/technologies/java/introduction': '/docs/technologies/java/introduction',
-  '/technologies/module-federation/recipes/create-a-host':
-    '/docs/technologies/module-federation/guides/create-a-host',
-  '/technologies/module-federation/recipes/create-a-remote':
-    '/docs/technologies/module-federation/guides/create-a-remote',
-  '/technologies/module-federation/recipes/federate-a-module':
-    '/docs/technologies/module-federation/guides/federate-a-module',
+  // exception: nx-module-federation-plugin renamed to create-a-host
   '/technologies/module-federation/recipes/nx-module-federation-plugin':
     '/docs/technologies/module-federation/guides/create-a-host',
-  '/technologies/module-federation/recipes/nx-module-federation-dev-server-plugin':
-    '/docs/technologies/module-federation/guides/nx-module-federation-dev-server-plugin',
-  '/technologies/eslint/recipes/eslint':
-    '/docs/technologies/eslint/guides/eslint',
-  '/technologies/eslint/recipes/flat-config':
-    '/docs/technologies/eslint/guides/flat-config',
+  '/technologies/module-federation/recipes/:path*':
+    '/docs/technologies/module-federation/guides/:path*',
+  '/technologies/eslint/recipes/:path*':
+    '/docs/technologies/eslint/guides/:path*',
   '/technologies/eslint/eslint-plugin/recipes':
     '/docs/technologies/eslint/eslint-plugin/guides',
-  '/technologies/eslint/eslint-plugin/recipes/enforce-module-boundaries':
-    '/docs/technologies/eslint/eslint-plugin/guides/enforce-module-boundaries',
-  '/technologies/eslint/eslint-plugin/recipes/dependency-checks':
-    '/docs/technologies/eslint/eslint-plugin/guides/dependency-checks',
+  '/technologies/eslint/eslint-plugin/recipes/:path*':
+    '/docs/technologies/eslint/eslint-plugin/guides/:path*',
   '/technologies/eslint/eslint-plugin/api':
     '/docs/technologies/eslint/eslint-plugin',
   '/technologies/build-tools/docker':
     '/docs/technologies/build-tools/docker/introduction',
   '/technologies/build-tools/webpack/recipes':
     '/docs/technologies/build-tools/webpack/guides',
-  '/technologies/build-tools/webpack/recipes/webpack-config-setup':
-    '/docs/technologies/build-tools/webpack/guides/webpack-config-setup',
-  '/technologies/build-tools/webpack/recipes/webpack-plugins':
-    '/docs/technologies/build-tools/webpack/guides/webpack-plugins',
+  '/technologies/build-tools/webpack/recipes/:path*':
+    '/docs/technologies/build-tools/webpack/guides/:path*',
   '/technologies/build-tools/webpack/api':
     '/docs/technologies/build-tools/webpack',
   '/technologies/build-tools/vite/recipes':
@@ -843,12 +627,8 @@ const docsToAstroRedirects = {
     '/docs/technologies/build-tools/rsbuild/introduction',
   '/technologies/test-tools/cypress/recipes':
     '/docs/technologies/test-tools/cypress/guides/cypress-component-testing',
-  '/technologies/test-tools/cypress/recipes/cypress-component-testing':
-    '/docs/technologies/test-tools/cypress/guides/cypress-component-testing',
-  '/technologies/test-tools/cypress/recipes/cypress-setup-node-events':
-    '/docs/technologies/test-tools/cypress/guides/cypress-setup-node-events',
-  '/technologies/test-tools/cypress/recipes/cypress-v11-migration':
-    '/docs/technologies/test-tools/cypress/guides/cypress-v11-migration',
+  '/technologies/test-tools/cypress/recipes/:path*':
+    '/docs/technologies/test-tools/cypress/guides/:path*',
   '/technologies/test-tools/cypress/api':
     '/docs/technologies/test-tools/cypress',
   '/technologies/test-tools/jest/recipes':
@@ -860,36 +640,11 @@ const docsToAstroRedirects = {
     '/docs/technologies/test-tools/playwright',
   '/technologies/test-tools/storybook/recipes':
     '/docs/technologies/test-tools/storybook/guides',
-  '/technologies/test-tools/storybook/recipes/best-practices':
-    '/docs/technologies/test-tools/storybook/guides/best-practices',
+  // exception: storybook-9-setup renamed to upgrading-storybook
   '/technologies/test-tools/storybook/recipes/storybook-9-setup':
     '/docs/technologies/test-tools/storybook/guides/upgrading-storybook',
-  '/technologies/test-tools/storybook/recipes/overview-react':
-    '/docs/technologies/test-tools/storybook/guides/overview-react',
-  '/technologies/test-tools/storybook/recipes/overview-angular':
-    '/docs/technologies/test-tools/storybook/guides/overview-angular',
-  '/technologies/test-tools/storybook/recipes/overview-vue':
-    '/docs/technologies/test-tools/storybook/guides/overview-vue',
-  '/technologies/test-tools/storybook/recipes/configuring-storybook':
-    '/docs/technologies/test-tools/storybook/guides/configuring-storybook',
-  '/technologies/test-tools/storybook/recipes/one-storybook-for-all':
-    '/docs/technologies/test-tools/storybook/guides/one-storybook-for-all',
-  '/technologies/test-tools/storybook/recipes/one-storybook-per-scope':
-    '/docs/technologies/test-tools/storybook/guides/one-storybook-per-scope',
-  '/technologies/test-tools/storybook/recipes/one-storybook-with-composition':
-    '/docs/technologies/test-tools/storybook/guides/one-storybook-with-composition',
-  '/technologies/test-tools/storybook/recipes/custom-builder-configs':
-    '/docs/technologies/test-tools/storybook/guides/custom-builder-configs',
-  '/technologies/test-tools/storybook/recipes/storybook-interaction-tests':
-    '/docs/technologies/test-tools/storybook/guides/storybook-interaction-tests',
-  '/technologies/test-tools/storybook/recipes/upgrading-storybook':
-    '/docs/technologies/test-tools/storybook/guides/upgrading-storybook',
-  '/technologies/test-tools/storybook/recipes/storybook-composition-setup':
-    '/docs/technologies/test-tools/storybook/guides/storybook-composition-setup',
-  '/technologies/test-tools/storybook/recipes/angular-storybook-compodoc':
-    '/docs/technologies/test-tools/storybook/guides/angular-storybook-compodoc',
-  '/technologies/test-tools/storybook/recipes/angular-configuring-styles':
-    '/docs/technologies/test-tools/storybook/guides/angular-configuring-styles',
+  '/technologies/test-tools/storybook/recipes/:path*':
+    '/docs/technologies/test-tools/storybook/guides/:path*',
   '/technologies/test-tools/storybook/api':
     '/docs/technologies/test-tools/storybook/guides/angular-configuring-styles',
   '/technologies/test-tools/detox/recipes':
@@ -899,16 +654,12 @@ const docsToAstroRedirects = {
     '/docs/technologies/test-tools/cypress/executors',
   '/technologies/test-tools/cypress/api/generators':
     '/docs/technologies/test-tools/cypress/generators',
-  '/technologies/test-tools/cypress/api/generators/convert-to-inferred':
-    '/docs/guides/tasks--caching/convert-to-inferred',
   '/technologies/test-tools/cypress/api/migrations':
     '/docs/technologies/test-tools/cypress/migrations',
   '/technologies/test-tools/detox/api/executors':
     '/docs/technologies/test-tools/detox/executors',
   '/technologies/test-tools/detox/api/generators':
     '/docs/technologies/test-tools/detox/generators',
-  '/technologies/test-tools/detox/api/generators/convert-to-inferred':
-    '/docs/guides/tasks--caching/convert-to-inferred',
   '/technologies/test-tools/detox/api/migrations':
     '/docs/technologies/test-tools/detox/migrations',
   '/technologies/build-tools/esbuild/api/executors':
@@ -919,8 +670,6 @@ const docsToAstroRedirects = {
     '/docs/technologies/build-tools/esbuild/generators',
   '/technologies/build-tools/esbuild/api/migrations':
     '/docs/technologies/build-tools/esbuild',
-  '/technologies/eslint/api/generators/convert-to-inferred':
-    '/docs/guides/tasks--caching/convert-to-inferred',
   '/technologies/eslint/eslint-plugin/api/executors':
     '/docs/technologies/eslint/eslint-plugin',
   '/technologies/eslint/eslint-plugin/api/generators':
@@ -931,8 +680,6 @@ const docsToAstroRedirects = {
     '/docs/technologies/react/expo/executors',
   '/technologies/react/expo/api/generators':
     '/docs/technologies/react/expo/generators',
-  '/technologies/react/expo/api/generators/convert-to-inferred':
-    '/docs/guides/tasks--caching/convert-to-inferred',
   '/technologies/react/expo/api/migrations':
     '/docs/technologies/react/expo/migrations',
   '/technologies/node/express/api/executors': '/docs/technologies/node/express',
@@ -946,8 +693,6 @@ const docsToAstroRedirects = {
     '/docs/technologies/test-tools/jest/executors',
   '/technologies/test-tools/jest/api/generators':
     '/docs/technologies/test-tools/jest/generators',
-  '/technologies/test-tools/jest/api/generators/convert-to-inferred':
-    '/docs/guides/tasks--caching/convert-to-inferred',
   '/technologies/test-tools/jest/api/migrations':
     '/docs/technologies/test-tools/jest/migrations',
   '/technologies/node/nest/api/executors': '/docs/technologies/node/nest',
@@ -959,8 +704,6 @@ const docsToAstroRedirects = {
     '/docs/technologies/react/next/executors',
   '/technologies/react/next/api/generators':
     '/docs/technologies/react/next/generators',
-  '/technologies/react/next/api/generators/convert-to-inferred':
-    '/docs/guides/tasks--caching/convert-to-inferred',
   '/technologies/react/next/api/migrations':
     '/docs/technologies/react/next/migrations',
   '/technologies/vue/nuxt/api/executors': '/docs/technologies/vue/nuxt',
@@ -972,32 +715,24 @@ const docsToAstroRedirects = {
     '/docs/technologies/test-tools/playwright/executors',
   '/technologies/test-tools/playwright/api/generators':
     '/docs/technologies/test-tools/playwright/generators',
-  '/technologies/test-tools/playwright/api/generators/convert-to-inferred':
-    '/docs/guides/tasks--caching/convert-to-inferred',
   '/technologies/test-tools/playwright/api/migrations':
     '/docs/technologies/test-tools/playwright/migrations',
   '/technologies/react/react-native/api/executors':
     '/docs/technologies/react/react-native/executors',
   '/technologies/react/react-native/api/generators':
     '/docs/technologies/react/react-native/generators',
-  '/technologies/react/react-native/api/generators/convert-to-inferred':
-    '/docs/guides/tasks--caching/convert-to-inferred',
   '/technologies/react/react-native/api/migrations':
     '/docs/technologies/react/react-native/migrations',
   '/technologies/react/remix/api/executors':
     '/docs/technologies/react/remix/executors',
   '/technologies/react/remix/api/generators':
     '/docs/technologies/react/remix/generators',
-  '/technologies/react/remix/api/generators/convert-to-inferred':
-    '/docs/guides/tasks--caching/convert-to-inferred',
   '/technologies/react/remix/api/migrations':
     '/docs/technologies/react/remix/migrations',
   '/technologies/build-tools/rollup/api/executors':
     '/docs/technologies/build-tools/rollup/executors',
   '/technologies/build-tools/rollup/api/generators':
     '/docs/technologies/build-tools/rollup/generators',
-  '/technologies/build-tools/rollup/api/generators/convert-to-inferred':
-    '/docs/guides/tasks--caching/convert-to-inferred',
   '/technologies/build-tools/rollup/api/migrations':
     '/docs/technologies/build-tools/rollup/migrations',
   '/technologies/build-tools/rsbuild/api/executors':
@@ -1010,32 +745,24 @@ const docsToAstroRedirects = {
     '/docs/technologies/build-tools/rspack/executors',
   '/technologies/build-tools/rspack/api/generators':
     '/docs/technologies/build-tools/rspack/generators',
-  '/technologies/build-tools/rspack/api/generators/convert-to-inferred':
-    '/docs/guides/tasks--caching/convert-to-inferred',
   '/technologies/build-tools/rspack/api/migrations':
     '/docs/technologies/build-tools/rspack/migrations',
   '/technologies/test-tools/storybook/api/executors':
     '/docs/technologies/test-tools/storybook/executors',
   '/technologies/test-tools/storybook/api/generators':
     '/docs/technologies/test-tools/storybook/generators',
-  '/technologies/test-tools/storybook/api/generators/convert-to-inferred':
-    '/docs/guides/tasks--caching/convert-to-inferred',
   '/technologies/test-tools/storybook/api/migrations':
     '/docs/technologies/test-tools/storybook/migrations',
   '/technologies/build-tools/vite/api/executors':
     '/docs/technologies/build-tools/vite/executors',
   '/technologies/build-tools/vite/api/generators':
     '/docs/technologies/build-tools/vite/generators',
-  '/technologies/build-tools/vite/api/generators/convert-to-inferred':
-    '/docs/guides/tasks--caching/convert-to-inferred',
   '/technologies/build-tools/vite/api/migrations':
     '/docs/technologies/build-tools/vite/migrations',
   '/technologies/build-tools/webpack/api/executors':
     '/docs/technologies/build-tools/webpack/executors',
   '/technologies/build-tools/webpack/api/generators':
     '/docs/technologies/build-tools/webpack/generators',
-  '/technologies/build-tools/webpack/api/generators/convert-to-inferred':
-    '/docs/guides/tasks--caching/convert-to-inferred',
   '/technologies/build-tools/webpack/api/migrations':
     '/docs/technologies/build-tools/webpack/migrations',
   '/technologies/typescript/recipes':
@@ -1097,59 +824,26 @@ const docsToAstroRedirects = {
   '/technologies/vue/api/executors': '/docs/technologies/vue',
   '/technologies/vue/api/generators': '/docs/technologies/vue/generators',
   '/technologies/vue/api/migrations': '/docs/technologies/vue/migrations',
-  '/troubleshooting': '/docs/troubleshooting',
-  '/troubleshooting/resolve-circular-dependencies':
-    '/docs/troubleshooting/resolve-circular-dependencies',
-  '/troubleshooting/troubleshoot-nx-install-issues':
-    '/docs/troubleshooting/troubleshoot-nx-install-issues',
-  '/troubleshooting/troubleshoot-cache-misses':
-    '/docs/troubleshooting/troubleshoot-cache-misses',
-  '/troubleshooting/unknown-local-cache':
-    '/docs/troubleshooting/unknown-local-cache',
-  '/troubleshooting/performance-profiling':
-    '/docs/troubleshooting/performance-profiling',
+  // /troubleshooting exception (name changed)
   '/troubleshooting/convert-to-inferred':
     '/docs/troubleshooting/troubleshoot-convert-to-inferred',
+  // /troubleshooting wildcard
+  '/troubleshooting': '/docs/troubleshooting',
+  '/troubleshooting/:path*': '/docs/troubleshooting/:path*',
   '/ci': '/docs/getting-started/nx-cloud',
   '/ci/recipes': '/docs/guides/nx-cloud',
   '/ci/recipes/improving-ttg': '/docs/guides/nx-cloud/optimize-your-ttg',
   '/ci/recipes/set-up': '/docs/guides/nx-cloud/setup-ci',
-  '/ci/recipes/set-up/monorepo-ci-azure': '/docs/guides/nx-cloud/setup-ci',
-  '/ci/recipes/set-up/monorepo-ci-circle-ci': '/docs/guides/nx-cloud/setup-ci',
-  '/ci/recipes/set-up/monorepo-ci-jenkins': '/docs/guides/nx-cloud/setup-ci',
-  '/ci/recipes/set-up/monorepo-ci-gitlab': '/docs/guides/nx-cloud/setup-ci',
-  '/ci/recipes/set-up/monorepo-ci-bitbucket-pipelines':
-    '/docs/guides/nx-cloud/setup-ci',
+  '/ci/recipes/set-up/:path*': '/docs/guides/nx-cloud/setup-ci',
   '/ci/recipes/security': '/docs/guides/nx-cloud',
   '/ci/recipes/dte': '/docs/guides/nx-cloud/manual-dte',
-  '/ci/recipes/dte/github-dte': '/docs/guides/nx-cloud/manual-dte',
-  '/ci/recipes/dte/circle-ci-dte': '/docs/guides/nx-cloud/manual-dte',
-  '/ci/recipes/dte/azure-dte': '/docs/guides/nx-cloud/manual-dte',
-  '/ci/recipes/dte/bitbucket-dte': '/docs/guides/nx-cloud/manual-dte',
-  '/ci/recipes/dte/gitlab-dte': '/docs/guides/nx-cloud/manual-dte',
-  '/ci/recipes/dte/jenkins-dte': '/docs/guides/nx-cloud/manual-dte',
+  '/ci/recipes/dte/:path*': '/docs/guides/nx-cloud/manual-dte',
   '/ci/recipes/other': '/docs/guides/nx-cloud/setup-ci',
   '/see-also': '/docs/getting-started/intro',
   '/see-also/sitemap': '/docs/getting-started/intro',
+  // /showcase wildcard (all example-repos go to intro)
   '/showcase': '/docs/getting-started/intro',
-  '/showcase/example-repos': '/docs/getting-started/intro',
-  '/showcase/example-repos/add-express': '/docs/getting-started/intro',
-  '/showcase/example-repos/add-lit': '/docs/getting-started/intro',
-  '/showcase/example-repos/add-solid': '/docs/getting-started/intro',
-  '/showcase/example-repos/add-qwik': '/docs/getting-started/intro',
-  '/showcase/example-repos/add-rust': '/docs/getting-started/intro',
-  '/showcase/example-repos/add-dotnet': '/docs/getting-started/intro',
-  '/showcase/example-repos/add-astro': '/docs/getting-started/intro',
-  '/showcase/example-repos/add-svelte': '/docs/getting-started/intro',
-  '/showcase/example-repos/add-fastify': '/docs/getting-started/intro',
-  '/showcase/example-repos/apollo-react': '/docs/getting-started/intro',
-  '/showcase/example-repos/nestjs-prisma': '/docs/getting-started/intro',
-  '/showcase/example-repos/mongo-fastify': '/docs/getting-started/intro',
-  '/showcase/example-repos/redis-fastify': '/docs/getting-started/intro',
-  '/showcase/example-repos/postgres-fastify': '/docs/getting-started/intro',
-  '/showcase/example-repos/serverless-fastify-planetscale':
-    '/docs/getting-started/intro',
-  '/showcase/example-repos/mfe': '/docs/getting-started/intro',
+  '/showcase/example-repos/:path*': '/docs/getting-started/intro',
   '/reference/workspace': '/docs/reference/workspace',
   '/reference/workspace/generators': '/docs/reference/workspace/generators',
   '/reference/workspace/migrations': '/docs/reference/workspace/migrations',

--- a/nx-dev/nx-dev/redirect-rules.js
+++ b/nx-dev/nx-dev/redirect-rules.js
@@ -1067,15 +1067,10 @@ const commandRedirects = {
 
 const canonicalSiteRedirects = {
   '/blog/': '/blog',
-  '/blog': '/blog',
-  '/nx-cloud': '/nx-cloud',
-  '/community': '/community',
   '/technologies/java/gradle/introduction':
     '/docs/technologies/java/gradle/introduction',
   '/technologies/java/maven/introduction':
     '/docs/technologies/java/maven/introduction',
-  '/docs/technologies/test-tools/playwright/guides/merge-atomized-outputs':
-    '/docs/technologies/test-tools/playwright/guides/merge-atomized-outputs',
 };
 
 // We got rid of `/recipes` URLs, so we need to redirect them to new /technologies or /reference URLs.

--- a/nx-dev/nx-dev/redirect-rules.js
+++ b/nx-dev/nx-dev/redirect-rules.js
@@ -49,7 +49,7 @@ const diataxis = {
   '/features/integrate-with-editors': '/docs/getting-started/editor-setup',
   '/using-nx/mental-model': '/docs/concepts/mental-model',
   '/using-nx/caching': '/docs/concepts/how-caching-works',
-  '/using-nx/dte': '/features/distribute-task-execution',
+  '/using-nx/dte': '/docs/features/ci-features/distribute-task-execution',
   '/using-nx/affected': '/docs/features/ci-features/affected',
   '/using-nx/ci-overview': '/docs/guides/nx-cloud/setup-ci',
   '/using-nx/updating-nx': '/docs/features/automate-updating-dependencies',
@@ -74,9 +74,9 @@ const diataxis = {
   '/executors/run-commands-builder':
     '/docs/guides/tasks--caching/run-commands-executor',
   '/executors/creating-custom-builders': '/docs/extending-nx/local-executors',
-  '/generators/using-generators': '/features/use-code-generators',
+  '/generators/using-generators': '/docs/features/generate-code',
   '/generators/workspace-generators':
-    '/recipes/generators/workspace-generators',
+    '/docs/reference/deprecated/workspace-generators',
   '/generators/composing-generators': '/docs/extending-nx/composing-generators',
   '/generators/generator-options': '/docs/extending-nx',
   '/generators/creating-files': '/docs/extending-nx/creating-files',
@@ -96,13 +96,13 @@ const diataxis = {
   '/structure/project-graph-plugins':
     '/docs/extending-nx/project-graph-plugins',
   '/ci/monorepo-ci-azure': '/docs/guides/nx-cloud/setup-ci',
-  '/ci/monorepo-ci-circle-ci': '/nx-cloud/recipes/set-up/monorepo-ci-circle-ci',
-  '/ci/monorepo-ci-github-actions': '/recipes/ci/monorepo-ci-github-actions',
-  '/ci/monorepo-ci-jenkins': '/nx-cloud/recipes/set-up/monorepo-ci-jenkins',
-  '/ci/monorepo-ci-gitlab': '/nx-cloud/recipes/set-up/monorepo-ci-gitlab',
-  '/ci/monorepo-ci-bitbucket-pipelines':
-    '/nx-cloud/recipes/set-up/monorepo-ci-bitbucket-pipelines',
-  '/ci/distributed-builds': '/nx-cloud/concepts/parallelization-distribution', // 👀
+  '/ci/monorepo-ci-circle-ci': '/docs/guides/nx-cloud/setup-ci',
+  '/ci/monorepo-ci-github-actions': '/docs/guides/nx-cloud/setup-ci',
+  '/ci/monorepo-ci-jenkins': '/docs/guides/nx-cloud/setup-ci',
+  '/ci/monorepo-ci-gitlab': '/docs/guides/nx-cloud/setup-ci',
+  '/ci/monorepo-ci-bitbucket-pipelines': '/docs/guides/nx-cloud/setup-ci',
+  '/ci/distributed-builds':
+    '/docs/concepts/ci-concepts/parallelization-distribution', // 👀
   '/ci/setup-incremental-builds-angular':
     '/recipes/angular/setup-incremental-builds-angular',
   '/guides/turbo-and-nx': '/docs/guides/adopting-nx/from-turborepo',
@@ -156,12 +156,12 @@ const overviewUrls = {};
 const cliUrls = {
   // Exceptions: these don't follow the /cli/X -> /packages/nx/documents/X pattern
   '/cli/connect-to-nx-cloud': '/docs/features/ci-features',
-  '/cli/affected-dep-graph': '/deprecated/affected-graph',
-  '/cli/affected-apps': '/deprecated/print-affected',
-  '/cli/affected-libs': '/deprecated/print-affected',
-  '/cli/print-affected': '/deprecated/print-affected',
+  '/cli/affected-dep-graph': '/docs/reference/deprecated/affected-graph',
+  '/cli/affected-apps': '/docs/reference/deprecated/print-affected',
+  '/cli/affected-libs': '/docs/reference/deprecated/print-affected',
+  '/cli/print-affected': '/docs/reference/deprecated/print-affected',
   // Wildcard: all other /cli/* routes
-  '/cli/:path*': '/packages/nx/documents/:path*',
+  '/cli/:path*': '/docs/reference/nx-commands',
 };
 /**
  * Recipes

--- a/nx-dev/nx-dev/redirect-rules.js
+++ b/nx-dev/nx-dev/redirect-rules.js
@@ -5,189 +5,30 @@ const docsToAstroRedirects = require('./redirect-rules-docs-to-astro.js');
 
 /**
  * Executors & Generators old url schemes to package schema viewer url schemes (added 2022-03-16)
+ * REMOVED: 130 routes from 2022 that chain 3+ hops deep. Original sources like
+ * /workspace/library, /angular/application, /nest/class etc. pointed to /packages/X/...
+ * which chains through /packages/:path* -> /nx-api/:path* -> /reference/core-api/... -> /docs/...
  */
-const schemaUrls = {
-  '/workspace/library': '/packages/workspace/generators/library',
-  '/workspace/npm-package': '/packages/workspace/generators/npm-package',
-  '/workspace/move': '/packages/workspace/generators/move',
-  '/workspace/remove': '/packages/workspace/generators/remove',
-  '/workspace/run-commands-generator':
-    '/packages/workspace/generators/run-commands',
-  '/workspace/convert-to-nx-project-generator':
-    '/packages/workspace/generators/convert-to-nx-project',
-
-  '/workspace/run-commands-executor': '/packages/nx/executors/run-commands',
-  '/workspace/run-script': '/packages/nx/executors/run-script',
-  '/packages/workspace/executors/run-commands':
-    '/packages/nx/executors/run-commands',
-  '/packages/workspace/executors/run-script':
-    '/packages/nx/executors/run-script',
-
-  '/js/library': '/packages/js/generators/library',
-  '/js/convert-to-swc': '/packages/js/generators/convert-to-swc',
-  '/js/tsc': '/packages/js/executors/tsc',
-  '/js/swc': '/packages/js/executors/swc',
-  '/web/application': '/packages/web/generators/application',
-  '/web/build': '/packages/web/executors/webpack',
-  '/web/dev-server': '/packages/web/executors/dev-server',
-  '/web/file-server': '/packages/web/executors/file-server',
-  '/web/package': '/packages/web/executors/rollup',
-  '/angular/application': '/packages/angular/generators/application',
-  '/angular/downgrade-module': '/packages/angular/generators/downgrade-module',
-  '/angular/karma': '/packages/angular/generators/karma',
-  '/angular/karma-project': '/packages/angular/generators/karma-project',
-  '/angular/library': '/packages/angular/generators/library',
-  '/angular/library-secondary-entry-point':
-    '/packages/angular/generators/library-secondary-entry-point',
-  '/angular/mfe-host': '/packages/angular/generators/mf-host',
-  '/angular/mfe-remote': '/packages/angular/generators/mf-remote',
-  '/packages/angular/generators/mfe-host':
-    '/packages/angular/generators/mf-host',
-  '/packages/angular/generators/mfe-remote':
-    '/packages/angular/generators/mf-remote',
-  '/angular/move': '/packages/angular/generators/move',
-  '/angular/ngrx': '/packages/angular/generators/ngrx',
-  '/angular/scam': '/packages/angular/generators/scam',
-  '/angular/scam-directive': '/packages/angular/generators/scam-directive',
-  '/angular/scam-pipe': '/packages/angular/generators/scam-pipe',
-  '/angular/setup-mfe': '/packages/angular/generators/setup-mf',
-  '/packages/angular/generators/setup-mfe':
-    '/packages/angular/generators/setup-mf',
-  '/angular/setup-tailwind': '/packages/angular/generators/setup-tailwind',
-  '/angular/stories': '/packages/angular/generators/stories',
-  '/angular/storybook-configuration':
-    '/packages/angular/generators/storybook-configuration',
-  '/angular/upgrade-module': '/packages/angular/generators/upgrade-module',
-  '/angular/web-worker': '/packages/angular/generators/web-worker',
-  '/angular/delegate-build': '/packages/angular/executors/delegate-build',
-  '/angular/ng-packagr-lite': '/packages/angular/executors/ng-packagr-lite',
-  '/angular/package': '/packages/angular/executors/package',
-  '/angular/webpack-browser': '/packages/angular/executors/webpack-browser',
-  '/angular/webpack-server': '/packages/angular/executors/dev-server',
-  '/packages/angular/executors/webpack-server':
-    '/packages/angular/executors/dev-server',
-  '/angular/webpack-dev-server': '/packages/angular/executors/dev-server',
-  '/packages/angular/executors/webpack-dev-server':
-    '/packages/angular/executors/dev-server',
-  '/react/application': '/packages/react/generators/application',
-  '/react/component': '/packages/react/generators/component',
-  '/react/component-story': '/packages/react/generators/component-story',
-  '/react/library': '/packages/react/generators/library',
-  '/react/redux': '/packages/react/generators/redux',
-  '/react/stories': '/packages/react/generators/stories',
-  '/react/storybook-configuration':
-    '/packages/react/generators/storybook-configuration',
-  '/react/hook': '/packages/react/generators/hook',
-  '/jest/jest': '/packages/jest/executors/jest',
-  '/cypress/cypress': '/packages/cypress/executors/cypress',
-  '/cypress/cypress-project': '/packages/cypress/generators/cypress-project',
-  '/storybook/configuration': '/packages/storybook/generators/configuration',
-  '/storybook/cypress-project':
-    '/packages/storybook/generators/cypress-project',
-  '/storybook/migrate-defaults-5-to-6':
-    '/packages/storybook/generators/migrate-defaults-5-to-6',
-  '/storybook/migrate-stories-to-6-2':
-    '/packages/storybook/generators/migrate-stories-to-6-2',
-  '/storybook/executors-build': '/packages/storybook/executors/build',
-  '/storybook/executors-storybook': '/packages/storybook/executors/storybook',
-  '/storybook/extra-topics-for-angular-projects':
-    '/storybook/overview-angular#more-documentation',
-  '/linter/eslint': '/packages/eslint/executors/lint',
-  '/linter/workspace-rule': '/packages/eslint/generators/workspace-rule',
-  '/node/application': '/packages/node/generators/application',
-  '/node/library': '/packages/node/generators/library',
-  '/node/webpack': '/packages/node/executors/webpack',
-  '/node/node': '/packages/node/executors/node',
-  '/express/application': '/packages/express/generators/application',
-  '/nest/application': '/packages/nest/generators/application',
-  '/nest/class': '/packages/nest/generators/class',
-  '/nest/controller': '/packages/nest/generators/controller',
-  '/nest/decorator': '/packages/nest/generators/decorator',
-  '/nest/filter': '/packages/nest/generators/filter',
-  '/nest/gateway': '/packages/nest/generators/gateway',
-  '/nest/guard': '/packages/nest/generators/guard',
-  '/nest/interceptor': '/packages/nest/generators/interceptor',
-  '/nest/interface': '/packages/nest/generators/interface',
-  '/nest/library': '/packages/nest/generators/library',
-  '/nest/middleware': '/packages/nest/generators/middleware',
-  '/nest/module': '/packages/nest/generators/module',
-  '/nest/pipe': '/packages/nest/generators/pipe',
-  '/nest/provider': '/packages/nest/generators/provider',
-  '/nest/resolver': '/packages/nest/generators/resolver',
-  '/nest/resource': '/packages/nest/generators/resource',
-  '/nest/service': '/packages/nest/generators/service',
-  '/next/application': '/packages/next/generators/application',
-  '/next/component': '/packages/next/generators/component',
-  '/next/page': '/packages/next/generators/page',
-  '/next/build': '/packages/next/executors/build',
-  '/next/server': '/packages/next/executors/server',
-  '/next/export': '/packages/next/executors/export',
-  '/detox/application': '/packages/detox/generators/application',
-  '/detox/build': '/packages/detox/executors/build',
-  '/detox/test': '/packages/detox/executors/test',
-  '/react-native/application': '/packages/react-native/generators/application',
-  '/react-native/component': '/packages/react-native/generators/component',
-  '/react-native/library': '/packages/react-native/generators/library',
-  '/react-native/component-story':
-    '/packages/react-native/generators/component-story',
-  '/react-native/stories': '/packages/react-native/generators/stories',
-  '/react-native/storybook-configuration':
-    '/packages/react-native/generators/storybook-configuration',
-  '/react-native/build-android':
-    '/packages/react-native/executors/build-android',
-  '/react-native/bundle': '/packages/react-native/executors/bundle',
-  '/react-native/ensure-symlink':
-    '/packages/react-native/executors/ensure-symlink',
-  '/react-native/run-android': '/packages/react-native/executors/run-android',
-  '/react-native/run-ios': '/packages/react-native/executors/run-ios',
-  '/react-native/start': '/packages/react-native/executors/start',
-  '/react-native/storybook': '/packages/react-native/executors/storybook',
-  '/react-native/sync-deps': '/packages/react-native/executors/sync-deps',
-  '/packages/cypress/generators/cypress-e2e-configuration':
-    '/packages/cypress/generators/configuration',
-  '/packages/cypress/generators/cypress-component-configuration':
-    '/packages/cypress/generators/component-configuration',
-  '/packages/esbuild/generators/esbuild-project':
-    '/packages/esbuild/generators/configuration',
-  '/packages/jest/generators/jest-project':
-    '/packages/jest/generators/configuration',
-  '/packages/nx-plugin/generators/executor':
-    '/packages/plugin/generators/executor',
-  '/packages/nx-plugin/generators/migration':
-    '/packages/plugin/generators/migration',
-  '/packages/nx-plugin/generators/plugin': '/packages/plugin/generators/plugin',
-  '/packages/nx-plugin/generators/schematic':
-    '/packages/plugin/generators/generator',
-  '/packages/nx-plugin/generators/e2e': '/packages/plugin/executors/e2e',
-  '/packages/rollup/generators/rollup-project':
-    '/packages/rollup/generators/configuration',
-  '/packages/webpack/generators/webpack-project':
-    '/packages/webpack/generators/configuration',
-  '/nx-plugin/executor': '/packages/plugin/generators/executor',
-  '/nx-plugin/migration': '/packages/plugin/generators/migration',
-  '/nx-plugin/plugin': '/packages/plugin/generators/plugin',
-  '/nx-plugin/schematic': '/packages/plugin/generators/generator',
-  '/nx-plugin/e2e': '/packages/plugin/executors/e2e',
-};
+const schemaUrls = {};
 
 /**
  * Guide specific rules (added 2022-01-04)
  */
 const guideUrls = {
-  '/core-concepts/configuration': '/reference/project-configuration',
-  '/core-concepts/mental-model': '/using-nx/mental-model',
-  '/core-concepts/updating-nx': '/using-nx/updating-nx',
-  '/core-concepts/ci-overview': '/using-nx/ci-overview',
-  '/getting-started/nx-cli': '/using-nx/nx-cli',
-  '/getting-started/console': '/using-nx/console',
-  '/core-extended/affected': '/using-nx/affected',
-  '/core-extended/computation-caching': '/using-nx/caching',
-  '/guides/nextjs': '/next/overview',
-  '/using-nx/nx-devkit': '/extending-nx/nx-devkit',
-  '/structure/project-graph-plugins': '/extending-nx/project-graph-plugins',
+  '/core-concepts/configuration': '/docs/reference/project-configuration',
+  '/core-concepts/mental-model': '/docs/concepts/mental-model',
+  '/core-concepts/updating-nx': '/docs/features/automate-updating-dependencies',
+  '/core-concepts/ci-overview': '/docs/guides/nx-cloud/setup-ci',
+  '/getting-started/nx-cli': '/docs/getting-started/intro',
+  '/getting-started/console': '/docs/getting-started/editor-setup',
+  '/core-extended/affected': '/docs/features/ci-features/affected',
+  '/core-extended/computation-caching': '/docs/concepts/how-caching-works',
+  '/guides/nextjs': '/packages/next',
+  '/using-nx/nx-devkit': '/docs/extending-nx/intro',
   '/guides/lerna-and-nx': 'https://lerna.js.org',
   '/migration/lerna-and-nx': 'https://lerna.js.org',
-  '/cypress/v10-migration-guide': '/cypress/v11-migration-guide',
+  '/cypress/v10-migration-guide':
+    '/packages/cypress/documents/v11-migration-guide',
   '/cypress/generators/migrate-to-cypress-10':
     '/packages/cypress/generators/migrate-to-cypress-11',
 };
@@ -196,178 +37,161 @@ const guideUrls = {
  * Diataxis restructure specific rules (added 2022-09-02)
  */
 const diataxis = {
-  '/getting-started/nx-setup': '/getting-started/intro',
+  '/getting-started/nx-setup': '/docs/getting-started/intro',
   '/getting-started/nx-core': '/getting-started/core-tutorial',
-  '/getting-started/nx-and-typescript': '/getting-started/intro',
-  '/getting-started/nx-and-react': '/getting-started/intro',
-  '/getting-started/nx-and-angular': '/getting-started/intro',
-  '/configuration/packagejson': '/reference/project-configuration',
-  '/configuration/projectjson': '/reference/project-configuration',
-  '/using-nx/nx-cli': '/getting-started/intro',
-  '/using-nx/console': '/getting-started/editor-setup',
-  '/features/integrate-with-editors': '/getting-started/editor-setup',
-  '/using-nx/mental-model': '/concepts/mental-model',
-  '/using-nx/caching': '/concepts/how-caching-works',
+  '/getting-started/nx-and-typescript': '/docs/getting-started/intro',
+  '/getting-started/nx-and-react': '/docs/getting-started/intro',
+  '/getting-started/nx-and-angular': '/docs/getting-started/intro',
+  '/configuration/packagejson': '/docs/reference/project-configuration',
+  '/configuration/projectjson': '/docs/reference/project-configuration',
+  '/using-nx/nx-cli': '/docs/getting-started/intro',
+  '/using-nx/console': '/docs/getting-started/editor-setup',
+  '/features/integrate-with-editors': '/docs/getting-started/editor-setup',
+  '/using-nx/mental-model': '/docs/concepts/mental-model',
+  '/using-nx/caching': '/docs/concepts/how-caching-works',
   '/using-nx/dte': '/features/distribute-task-execution',
-  '/using-nx/affected': '/concepts/affected',
-  '/using-nx/ci-overview': '/recipes/ci/ci-setup',
-  '/using-nx/updating-nx': '/features/automate-updating-dependencies',
+  '/using-nx/affected': '/docs/features/ci-features/affected',
+  '/using-nx/ci-overview': '/docs/guides/nx-cloud/setup-ci',
+  '/using-nx/updating-nx': '/docs/features/automate-updating-dependencies',
   '/using-nx/nx-nodejs-typescript-version-matrix':
-    '/workspace/nx-nodejs-typescript-version-matrix',
-  '/extending-nx/nx-devkit': '/extending-nx/intro/getting-started',
+    '/packages/workspace/documents/nx-nodejs-typescript-version-matrix',
+  '/extending-nx/nx-devkit': '/docs/extending-nx/intro',
   '/extending-nx/project-inference-plugins':
-    '/recipes/advanced-plugins/project-inference-plugins',
+    '/docs/extending-nx/project-graph-plugins',
   '/extending-nx/project-graph-plugins':
-    '/recipes/advanced-plugins/project-graph-plugins',
-  '/migration/lerna-and-nx': '/recipes/adopting-nx/lerna-and-nx',
-  '/migration/adding-to-monorepo': '/recipes/adopting-nx/adding-to-monorepo',
-  '/migration/migration-cra': '/recipes/adopting-nx/adding-to-existing-project',
-  '/migration/migration-angular': '/recipes/adopting-nx/migration-angular',
-  '/migration/migration-angularjs': '/recipes/adopting-nx/migration-angular',
-  '/recipes/angular/migration/angularjs':
-    '/recipes/adopting-nx/migration-angular',
+    '/docs/extending-nx/project-graph-plugins',
+  '/migration/adding-to-monorepo':
+    '/docs/guides/adopting-nx/adding-to-monorepo',
+  '/migration/migration-cra':
+    '/docs/guides/adopting-nx/adding-to-existing-project',
+  '/migration/migration-angular': '/docs/technologies/angular',
+  '/migration/migration-angularjs': '/docs/technologies/angular',
+  '/recipes/angular/migration/angularjs': '/docs/technologies/angular',
   '/migration/preserving-git-histories':
-    '/recipes/adopting-nx/preserving-git-histories',
-  '/migration/manual': '/recipes/adopting-nx/manual',
-  '/executors/using-builders': '/concepts/executors-and-configurations',
-  '/executors/run-commands-builder': '/recipes/executors/run-commands-executor',
-  '/executors/creating-custom-builders':
-    '/recipes/executors/creating-custom-executors',
+    '/docs/guides/adopting-nx/preserving-git-histories',
+  '/migration/manual': '/docs/guides/adopting-nx/manual',
+  '/executors/using-builders': '/docs/concepts/executors-and-configurations',
+  '/executors/run-commands-builder':
+    '/docs/guides/tasks--caching/run-commands-executor',
+  '/executors/creating-custom-builders': '/docs/extending-nx/local-executors',
   '/generators/using-generators': '/features/use-code-generators',
   '/generators/workspace-generators':
     '/recipes/generators/workspace-generators',
-  '/generators/composing-generators':
-    '/recipes/generators/composing-generators',
-  '/generators/generator-options': '/recipes/generators/generator-options',
-  '/generators/creating-files': '/recipes/generators/creating-files',
-  '/generators/modifying-files': '/recipes/generators/modifying-files',
+  '/generators/composing-generators': '/docs/extending-nx/composing-generators',
+  '/generators/generator-options': '/docs/extending-nx',
+  '/generators/creating-files': '/docs/extending-nx/creating-files',
+  '/generators/modifying-files': '/docs/extending-nx/modifying-files',
   '/structure/applications-and-libraries':
     'more-concepts/applications-and-libraries',
-  '/structure/creating-libraries': '/concepts/more-concepts/creating-libraries',
-  '/structure/library-types': '/concepts/more-concepts/library-types',
-  '/structure/grouping-libraries': '/concepts/more-concepts/grouping-libraries',
+  '/structure/creating-libraries': '/docs/concepts/decisions/project-size',
+  '/structure/library-types':
+    '/docs/concepts/decisions/project-dependency-rules',
+  '/structure/grouping-libraries': '/docs/concepts/decisions/folder-structure',
   '/structure/buildable-and-publishable-libraries':
-    '/concepts/more-concepts/buildable-and-publishable-libraries',
-  '/structure/monorepo-tags': '/features/enforce-module-boundaries',
+    '/docs/concepts/buildable-and-publishable-libraries',
+  '/structure/monorepo-tags': '/docs/features/enforce-module-boundaries',
   '/core-features/enforce-project-boundaries':
-    '/features/enforce-module-boundaries',
-  '/structure/dependency-graph': '/features/explore-graph',
+    '/docs/features/enforce-module-boundaries',
+  '/structure/dependency-graph': '/docs/features/explore-graph',
   '/structure/project-graph-plugins':
-    '/recipes/advanced-plugins/project-graph-plugins',
-  '/ci/monorepo-ci-azure': '/recipes/ci/monorepo-ci-azure',
-  '/ci/monorepo-ci-circle-ci': '/recipes/ci/monorepo-ci-circle-ci',
+    '/docs/extending-nx/project-graph-plugins',
+  '/ci/monorepo-ci-azure': '/docs/guides/nx-cloud/setup-ci',
+  '/ci/monorepo-ci-circle-ci': '/nx-cloud/recipes/set-up/monorepo-ci-circle-ci',
   '/ci/monorepo-ci-github-actions': '/recipes/ci/monorepo-ci-github-actions',
-  '/ci/monorepo-ci-jenkins': '/recipes/ci/monorepo-ci-jenkins',
-  '/ci/monorepo-ci-gitlab': '/recipes/ci/monorepo-ci-gitlab',
+  '/ci/monorepo-ci-jenkins': '/nx-cloud/recipes/set-up/monorepo-ci-jenkins',
+  '/ci/monorepo-ci-gitlab': '/nx-cloud/recipes/set-up/monorepo-ci-gitlab',
   '/ci/monorepo-ci-bitbucket-pipelines':
-    '/recipes/ci/monorepo-ci-bitbucket-pipelines',
+    '/nx-cloud/recipes/set-up/monorepo-ci-bitbucket-pipelines',
   '/ci/distributed-builds': '/nx-cloud/concepts/parallelization-distribution', // 👀
   '/ci/setup-incremental-builds-angular':
-    '/recipes/other/setup-incremental-builds-angular',
-  '/guides/turbo-and-nx': '/recipes/adopting-nx/from-turborepo',
-  '/guides/why-monorepos': '/concepts/more-concepts/why-monorepos',
-  '/guides/adding-assets-react': '/recipes/other/adding-assets-react',
-  '/guides/environment-variables': '/reference/environment-variables',
-  '/guides/performance-profiling': '/recipes/other/performance-profiling',
-  '/guides/eslint': '/recipes/other/eslint',
+    '/recipes/angular/setup-incremental-builds-angular',
+  '/guides/turbo-and-nx': '/docs/guides/adopting-nx/from-turborepo',
+  '/guides/why-monorepos': '/docs/concepts/decisions/why-monorepos',
+  '/guides/adding-assets-react': '/recipes/react/adding-assets',
+  '/guides/environment-variables': '/docs/reference/environment-variables',
+  '/guides/performance-profiling':
+    '/docs/troubleshooting/performance-profiling',
+  '/guides/eslint': '/docs/technologies/eslint',
   '/guides/customize-webpack': '/recipes/webpack/webpack-config-setup',
-  '/guides/nx-daemon': '/concepts/more-concepts/nx-daemon',
-  '/guides/js-and-ts': '/recipes/other/js-and-ts',
-  '/guides/browser-support': '/recipes/other/browser-support',
-  '/guides/react-native': '/recipes/other/react-native',
-  '/guides/deploy-nextjs-to-vercel': '/recipes/other/deploy-nextjs-to-vercel',
+  '/guides/nx-daemon': '/docs/concepts/nx-daemon',
+  '/guides/js-and-ts': '/docs/technologies/typescript/guides/js-and-ts',
+  '/guides/browser-support': '/docs/guides/tips-n-tricks/browser-support',
+  '/guides/react-native': '/recipes/react/react-native',
+  '/guides/deploy-nextjs-to-vercel': '/recipes/react/deploy-nextjs-to-vercel',
   '/guides/using-tailwind-css-in-react':
-    '/recipes/other/using-tailwind-css-in-react',
-  '/guides/react-18': '/recipes/other/react-18',
+    '/recipes/react/using-tailwind-css-in-react',
+  '/guides/react-18': '/nx-api/react',
   '/guides/using-tailwind-css-with-angular-projects':
-    '/recipes/other/using-tailwind-css-with-angular-projects',
-  '/guides/misc-ngrx': '/recipes/other/misc-ngrx',
-  '/guides/misc-data-persistence': '/recipes/other/misc-data-persistence',
+    '/recipes/angular/using-tailwind-css-with-angular-projects',
+  '/guides/misc-ngrx': '/packages/angular/generators/ngrx',
+  '/guides/misc-data-persistence': '/packages/angular/generators/ngrx',
   '/guides/nx-devkit-angular-devkit':
-    '/concepts/more-concepts/nx-devkit-angular-devkit',
+    '/nx-api/angular/documents/nx-devkit-angular-devkit',
   '/module-federation/faster-builds':
-    '/recipes/module-federation/faster-builds',
+    '/concepts/module-federation/faster-builds-with-module-federation',
   '/module-federation/micro-frontend-architecture':
-    '/concepts/more-concepts/micro-frontend-architecture',
+    '/concepts/module-federation/micro-frontend-architecture',
   '/module-federation/dynamic-module-federation-with-angular':
-    '/recipes/module-federation/dynamic-module-federation-with-angular',
+    '/recipes/angular/dynamic-module-federation-with-angular',
   '/examples/nx-examples': '/recipes/other/nx-examples',
-  '/examples/react-nx': '/recipes/other/react-nx',
-  '/examples/apollo-react': '/recipes/other/apollo-react',
-  '/examples/caching': '/recipes/other/caching',
-  '/examples/dte': '/recipes/other/dte',
-  '/recipe/workspace-generators': '/recipes/generators/local-generators',
+  '/examples/react-nx':
+    '/docs/getting-started/tutorials/react-monorepo-tutorial',
+  '/examples/apollo-react': '/docs/getting-started/intro',
+  '/examples/caching': '/showcase/example-repos/caching',
+  '/examples/dte': '/showcase/example-repos/dte',
+  '/recipe/workspace-generators': '/docs/extending-nx/local-generators',
   '/recipes/other/customize-webpack': '/recipes/webpack/webpack-config-setup',
 };
 
 /**
  * API overview packages
  */
-const overviewUrls = {
-  '/workspace/nrwl-workspace-overview': '/packages/workspace',
-  '/js/overview': '/packages/js',
-  '/web/overview': '/packages/web',
-  '/angular/overview': '/packages/angular',
-  '/react/overview': '/packages/react',
-  '/jest/overview': '/packages/jest',
-  '/cypress/overview': '/packages/cypress',
-  '/linter/overview': '/packages/eslint',
-  '/node/overview': '/packages/node',
-  '/express/overview': '/packages/express',
-  '/nest/overview': '/packages/nest',
-  '/next/overview': '/packages/next',
-  '/detox/overview': '/packages/detox',
-  '/react-native/overview': '/packages/react-native',
-  '/nx-plugin/overview': '/packages/plugin',
-};
+// REMOVED: overviewUrls (15 routes from 2022) - destinations all chain through
+// /packages/:path* -> /nx-api/:path* -> /technologies/... -> /docs/technologies/...
+const overviewUrls = {};
 
 /**
  * API removing CLI and putting the content into Nx
  */
 const cliUrls = {
-  '/cli/create-nx-workspace': '/nx/create-nx-workspace',
-  '/cli/generate': '/nx/generate',
-  '/cli/run': '/nx/run',
-  '/cli/daemon': '/nx/daemon',
-  '/cli/dep-graph': '/nx/dep-graph',
-  '/cli/run-many': '/nx/run-many',
-  '/cli/affected': '/nx/affected',
-  '/cli/format-check': '/nx/format-check',
-  '/cli/format-write': '/nx/format-write',
-  '/cli/migrate': '/nx/migrate',
-  '/cli/report': '/nx/report',
-  '/cli/list': '/nx/list',
-  '/cli/connect-to-nx-cloud': '/ci/features',
-  '/cli/reset': '/nx/reset',
+  // Exceptions: these don't follow the /cli/X -> /packages/nx/documents/X pattern
+  '/cli/connect-to-nx-cloud': '/docs/features/ci-features',
+  '/cli/affected-dep-graph': '/deprecated/affected-graph',
+  '/cli/affected-apps': '/deprecated/print-affected',
+  '/cli/affected-libs': '/deprecated/print-affected',
+  '/cli/print-affected': '/deprecated/print-affected',
+  // Wildcard: all other /cli/* routes
+  '/cli/:path*': '/packages/nx/documents/:path*',
 };
 /**
  * Recipes
  */
 const recipesUrls = {
-  '/recipe/adding-to-monorepo': '/recipes/adopting-nx/adding-to-monorepo',
+  '/recipe/adding-to-monorepo': '/docs/guides/adopting-nx/adding-to-monorepo',
   '/recipes/other/ban-dependencies-with-tags':
-    '/recipes/enforce-module-boundaries/ban-dependencies-with-tags',
+    '/docs/guides/enforce-module-boundaries/ban-dependencies-with-tags',
   '/recipes/other/tag-multiple-dimensions':
-    '/recipes/enforce-module-boundaries/tag-multiple-dimensions',
+    '/docs/guides/enforce-module-boundaries/tag-multiple-dimensions',
   '/recipes/other/ban-external-imports':
-    '/recipes/enforce-module-boundaries/ban-external-imports',
+    '/docs/guides/enforce-module-boundaries/ban-external-imports',
   '/recipes/other/tags-allow-list':
-    '/recipes/enforce-module-boundaries/tags-allow-list',
-  '/recipes/other/react-nx': '/showcase/example-repos/react-nx',
-  '/recipes/other/apollo-react': '/showcase/example-repos/apollo-react',
+    '/docs/guides/enforce-module-boundaries/tags-allow-list',
+  '/recipes/other/react-nx':
+    '/docs/getting-started/tutorials/react-monorepo-tutorial',
+  '/recipes/other/apollo-react': '/docs/getting-started/intro',
   '/recipes/other/caching': '/showcase/example-repos/caching',
   '/recipes/other/dte': '/showcase/example-repos/dte',
   '/recipes/other/deploy-nextjs-to-vercel':
-    '/recipes/deployment/deploy-nextjs-to-vercel',
+    '/recipes/react/deploy-nextjs-to-vercel',
   '/recipes/other/root-level-scripts':
-    '/recipes/managing-repository/root-level-scripts',
+    '/docs/guides/tasks--caching/root-level-scripts',
   '/recipes/other/analyze-source-files':
-    '/recipes/managing-repository/analyze-source-files',
+    '/docs/guides/tips-n-tricks/analyze-source-files',
   '/recipes/other/workspace-watching':
-    '/recipes/managing-repository/workspace-watching',
+    '/docs/guides/tasks--caching/workspace-watching',
   '/recipes/other/advanced-update':
-    '/recipes/managing-repository/advanced-update',
-  '/recipes/other/js-and-ts': '/recipes/managing-repository/js-and-ts',
+    '/docs/guides/tips-n-tricks/advanced-update',
+  '/recipes/other/js-and-ts': '/docs/technologies/typescript/guides/js-and-ts',
   '/packages/cypress/documents/cypress-component-testing':
     '/recipes/cypress/cypress-component-testing',
   '/packages/cypress/documents/cypress-v11-migration':
@@ -375,7 +199,7 @@ const recipesUrls = {
   '/packages/next/documents/next-config-setup':
     '/recipes/next/next-config-setup',
   '/packages/vite/documents/set-up-vite-manually':
-    '/recipes/vite/set-up-vite-manually',
+    '/recipes/vite/configure-vite',
   '/recipes/vite/set-up-vite-manually': '/recipes/vite/configure-vite',
   '/packages/webpack/documents/webpack-plugins':
     '/recipes/webpack/webpack-plugins',
@@ -384,10 +208,11 @@ const recipesUrls = {
   '/showcase/example-repos/add-nuxt': '/nx-api/nuxt',
   '/showcase/example-repos/add-vue': '/nx-api/vue',
   '/recipes/react/react-18': '/nx-api/react',
-  '/recipes/nx-console/console-shortcuts': '/getting-started/editor-setup',
-  '/recipes/nx-console/console-project-pane': '/getting-started/editor-setup',
+  '/recipes/nx-console/console-shortcuts': '/docs/getting-started/editor-setup',
+  '/recipes/nx-console/console-project-pane':
+    '/docs/getting-started/editor-setup',
   '/recipes/nx-console/console-add-dependency-command':
-    '/getting-started/editor-setup',
+    '/docs/getting-started/editor-setup',
   // This one was folded into a more holistic recipe around managing version reference updates
   '/recipes/nx-release/publish-custom-dist-directory':
     '/recipes/nx-release/updating-version-references#scenario-2-i-want-to-publish-from-a-custom-dist-directory-and-not-update-references-in-my-source-packagejson-files',
@@ -397,16 +222,17 @@ const recipesUrls = {
  * Nx Cloud
  */
 const nxCloudUrls = {
-  '/nx-cloud/set-up/add-nx-cloud': '/ci/features/remote-cache',
-  '/nx-cloud/set-up/set-up-caching': '/ci/features/remote-cache',
-  '/nx-cloud/set-up/set-up-dte': '/ci/features/distribute-task-execution',
+  '/nx-cloud/set-up/add-nx-cloud': '/docs/features/ci-features/remote-cache',
+  '/nx-cloud/set-up/set-up-caching': '/docs/features/ci-features/remote-cache',
+  '/nx-cloud/set-up/set-up-dte':
+    '/docs/features/ci-features/distribute-task-execution',
   '/nx-cloud/private-cloud/standalone': '/ci/private-cloud/ami-setup',
   '/nx-cloud/private-cloud/kubernetes-setup':
-    '/nx-cloud/private-cloud/get-started',
-  '/recipes/ci': '/ci/recipes',
-  '/recipes/ci/ci-setup': '/ci/recipes/set-up',
-  '/nx-cloud/recipes/set-up/ci-setup': '/ci/recipes/set-up',
-  '/recipes/ci/monorepo-ci-azure': '/ci/recipes/set-up/monorepo-ci-azure',
+    '/docs/enterprise/single-tenant/overview',
+  '/recipes/ci': '/docs/guides/nx-cloud',
+  '/recipes/ci/ci-setup': '/docs/guides/nx-cloud/setup-ci',
+  '/nx-cloud/recipes/set-up/ci-setup': '/docs/guides/nx-cloud/setup-ci',
+  '/recipes/ci/monorepo-ci-azure': '/docs/guides/nx-cloud/setup-ci',
   '/recipes/ci/monorepo-ci-circle-ci':
     '/nx-cloud/recipes/set-up/monorepo-ci-circle-ci',
   '/recipes/ci/monorepo-ci-github-action':
@@ -417,358 +243,107 @@ const nxCloudUrls = {
     '/nx-cloud/recipes/set-up/monorepo-ci-gitlab',
   '/recipes/ci/monorepo-ci-bitbucket-pipelines':
     '/nx-cloud/recipes/set-up/monorepo-ci-bitbucket-pipelines',
-  '/recipes/ci/ci-deployment': '/ci/recipes/other/ci-deployment',
-  '/nx-cloud/intro/what-is-nx-cloud': '/ci/getting-started/intro',
-  '/nx-cloud/set-up': '/ci/recipes/set-up',
-  '/nx-cloud/set-up/record-commands': '/ci/recipes/other/record-commands',
-  '/nx-cloud/set-up/github': '/ci/recipes/source-control-integration/github',
+  '/recipes/ci/ci-deployment': '/docs/guides/ci-deployment',
+  '/nx-cloud/intro/what-is-nx-cloud': '/docs/getting-started/nx-cloud',
+  '/nx-cloud/set-up': '/docs/guides/nx-cloud/setup-ci',
+  '/nx-cloud/set-up/record-commands': '/docs/guides/nx-cloud/record-commands',
+  '/nx-cloud/set-up/github': '/docs/guides/nx-cloud/setup-ci',
   '/nx-cloud/recipes/source-control-integration/github':
-    '/ci/recipes/source-control-integration/github',
-  '/nx-cloud/set-up/bitbucket-cloud':
-    '/ci/recipes/source-control-integration/bitbucket',
+    '/docs/guides/nx-cloud/setup-ci',
+  '/nx-cloud/set-up/bitbucket-cloud': '/docs/guides/nx-cloud/setup-ci',
   '/nx-cloud/recipes/source-control-integration/bitbucket-cloud':
-    '/ci/recipes/source-control-integration/bitbucket',
+    '/docs/guides/nx-cloud/setup-ci',
   '/ci/recipes/source-control-integration/bitbucket-cloud':
-    '/ci/recipes/source-control-integration/bitbucket',
-  '/nx-cloud/set-up/gitlab': '/ci/recipes/source-control-integration/gitlab',
-  '/core-features/remote-cache': '/ci/features/remote-cache',
+    '/docs/guides/nx-cloud/setup-ci',
+  '/nx-cloud/set-up/gitlab': '/docs/guides/nx-cloud/setup-ci',
+  '/core-features/remote-cache': '/docs/features/ci-features/remote-cache',
   '/core-features/distribute-task-execution':
-    '/ci/features/distribute-task-execution',
-  '/concepts/affected': '/ci/features/affected',
-  '/nx-cloud/private-cloud': '/ci/recipes/enterprise/single-tenant',
+    '/docs/features/ci-features/distribute-task-execution',
+  '/concepts/affected': '/docs/features/ci-features/affected',
+  '/nx-cloud/private-cloud': '/docs/enterprise/single-tenant/overview',
   '/nx-cloud/private-cloud/get-started':
-    '/ci/recipes/enterprise/single-tenant/overview',
-  '/ci/recipes/enterprise/on-premise/on-premise':
-    'https://github.com/nrwl/nx-cloud-helm',
+    '/docs/enterprise/single-tenant/overview',
+  // On-premise / private cloud -> GitHub helm repo (wildcards)
   '/ci/features/on-premise': 'https://github.com/nrwl/nx-cloud-helm',
-  '/nx-cloud/private-cloud/auth-single-admin':
+  '/nx-cloud/private-cloud/:path*': 'https://github.com/nrwl/nx-cloud-helm',
+  '/ci/recipes/on-premise/:path*': 'https://github.com/nrwl/nx-cloud-helm',
+  '/ci/recipes/enterprise/on-premise/:path*':
     'https://github.com/nrwl/nx-cloud-helm',
-  '/nx-cloud/private-cloud/auth-github':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/nx-cloud/private-cloud/ami-setup': 'https://github.com/nrwl/nx-cloud-helm',
-  '/nx-cloud/private-cloud/auth-gitlab':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/nx-cloud/private-cloud/auth-bitbucket':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/nx-cloud/private-cloud/auth-saml': 'https://github.com/nrwl/nx-cloud-helm',
-  '/nx-cloud/private-cloud/auth-saml-managed':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/nx-cloud/private-cloud/advanced-config':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/on-premise': 'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/enterprise/on-premise': 'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/enterprise/on-premise/ami-setup':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/enterprise/on-premise/advanced-config':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/on-premise/auth-github': 'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/enterprise/on-premise/auth-github':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/on-premise/ami-setup': 'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/on-premise/auth-gitlab': 'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/enterprise/on-premise/auth-gitlab':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/on-premise/auth-bitbucket':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/enterprise/on-premise/auth-bitbucket':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/enterprise/on-premise/auth-bitbucket-data-center':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/on-premise/auth-saml': 'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/enterprise/on-premise/auth-saml':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/enterprise/on-premise/custom-github-app':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/on-premise/auth-saml-managed':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/enterprise/on-premise/auth-saml-managed':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/ci/recipes/on-premise/advanced-config':
-    'https://github.com/nrwl/nx-cloud-helm',
-  '/concepts/dte': '/ci/concepts/parallelization-distribution',
-  '/nx-cloud/concepts/dte': '/ci/concepts/parallelization-distribution',
+  '/concepts/dte': '/docs/concepts/ci-concepts/parallelization-distribution',
+  '/nx-cloud/concepts/dte':
+    '/docs/concepts/ci-concepts/parallelization-distribution',
   '/nx-cloud/intro/nx-cloud-workflows': '/ci/features/nx-cloud-workflows',
-  '/nx-cloud/account': '/ci/recipes/security',
-  '/nx-cloud/account/google-auth': '/ci/recipes/security/google-auth',
-  '/nx-cloud/account/access-tokens': '/ci/recipes/security/access-tokens',
-  '/nx-cloud/account/scenarios': '/ci/concepts/cache-security',
-  '/nx-cloud/concepts/scenarios': '/ci/concepts/cache-security',
-  '/nx-cloud/account/encryption': '/ci/recipes/security/encryption',
-  '/nx-cloud/concepts/encryption': '/ci/recipes/security/encryption',
+  '/nx-cloud/account': '/docs/guides/nx-cloud',
+  '/nx-cloud/account/google-auth': '/docs/guides/nx-cloud/google-auth',
+  '/nx-cloud/account/access-tokens': '/docs/guides/nx-cloud/access-tokens',
+  '/nx-cloud/account/scenarios': '/docs/concepts/ci-concepts/cache-security',
+  '/nx-cloud/concepts/scenarios': '/docs/concepts/ci-concepts/cache-security',
+  '/nx-cloud/account/encryption': '/docs/guides/nx-cloud/encryption',
+  '/nx-cloud/concepts/encryption': '/docs/guides/nx-cloud/encryption',
   '/nx-cloud/features/nx-cloud-workflows':
-    '/ci/features/distribute-task-execution',
-  '/ci/features/nx-agents': '/ci/features/distribute-task-execution',
-  '/ci': '/ci/getting-started/intro',
+    '/docs/features/ci-features/distribute-task-execution',
+  '/ci/features/nx-agents':
+    '/docs/features/ci-features/distribute-task-execution',
   '/concepts/more-concepts/illustrated-dte':
-    '/ci/concepts/parallelization-distribution',
+    '/docs/concepts/ci-concepts/parallelization-distribution',
   '/core-features/:path*': '/features/:path*',
-  '/ci/recipes/set-up/connect-to-cloud': '/ci/recipes/set-up',
-  '/ci/intro/connect-to-cloud': '/ci/recipes/set-up',
+  '/ci/recipes/set-up/connect-to-cloud': '/docs/guides/nx-cloud/setup-ci',
+  '/ci/intro/connect-to-cloud': '/docs/guides/nx-cloud/setup-ci',
   '/pricing/special-offer': 'https://forms.gle/FBzvsspz1o63fDAz6',
   '/powerpack/special-offer': 'https://forms.gle/mWjQo6Vrv5Kt6WYh9',
-  '/ci/intro/why-nx-cloud': '/ci/getting-started/intro',
-  '/ci/intro/ci-with-nx': '/ci/recipes/set-up',
-  '/ci/intro/connect-to-nx-cloud': '/ci/recipes/set-up',
+  '/ci/intro/why-nx-cloud': '/docs/getting-started/nx-cloud',
+  '/ci/intro/ci-with-nx': '/docs/guides/nx-cloud/setup-ci',
+  '/ci/intro/connect-to-nx-cloud': '/docs/guides/nx-cloud/setup-ci',
 };
 
 /**
- * Tutorial Updates (updated 2023-01-13)
+ * Tutorial Updates — consolidated with wildcards
  */
-const tutorialBaseUrls = {
+const tutorialRedirects = {
   '/(l|latest)/(a|angular)/tutorial/1-code-generation':
-    '/angular-tutorial/1-code-generation',
+    '/docs/getting-started/tutorials/angular-monorepo-tutorial',
   '/(l|latest)/(a|node)/tutorial/1-code-generation':
-    '/getting-started/tutorials',
-  '/tutorial': '/getting-started/tutorials',
-  '/tutorial/:path*': '/getting-started/tutorials',
+    '/docs/getting-started/tutorials',
   '/(l|latest)/(r|react)/tutorial/1-code-generation':
-    '/react-tutorial/1-code-generation',
-};
-const oldReactTutorialPaths = [
-  '/react-tutorial/01-create-application',
-  '/react-tutorial/02-add-e2e-test',
-  '/react-tutorial/03-display-todos',
-  '/react-tutorial/04-connect-to-api',
-  '/react-tutorial/05-add-node-app',
-  '/react-tutorial/06-proxy',
-  '/react-tutorial/07-share-code',
-  '/react-tutorial/08-create-libs',
-  '/react-tutorial/09-dep-graph',
-  '/react-tutorial/10-computation-caching',
-  '/react-tutorial/11-test-affected-projects',
-  '/react-tutorial/12-summary',
-];
-const reactRedirectDestination = '/react-tutorial/1-code-generation';
-const reactTutorialRedirects = oldReactTutorialPaths.reduce((acc, path) => {
-  acc[path] = reactRedirectDestination;
-  return acc;
-}, {});
-const oldNodeTutorialPaths = [
-  '/node-tutorial/01-create-application',
-  '/node-tutorial/02-display-todos',
-  '/node-tutorial/03-share-code',
-  '/node-tutorial/04-create-libs',
-  '/node-tutorial/05-dep-graph',
-  '/node-tutorial/06-computation-caching',
-  '/node-tutorial/07-test-affected-projects',
-  '/node-tutorial/4-workspace-optimization',
-  '/node-tutorial/08-summary',
-];
-
-const extraNodeRedirects = {
-  '/getting-started/node-tutorial': '/getting-started/tutorials',
-  '/node-tutorial/1-code-generation': '/getting-started/tutorials',
-  '/node-tutorial/2-project-graph': '/getting-started/tutorials',
-  '/node-tutorial/3-task-running': '/getting-started/tutorials',
-  '/node-tutorial/4-task-pipelines': '/getting-started/tutorials',
-  '/node-tutorial/5-docker-target': '/getting-started/tutorials',
-  '/node-tutorial/6-summary': '/getting-started/tutorials',
+    '/docs/getting-started/tutorials/react-monorepo-tutorial',
+  '/tutorial': '/docs/getting-started/tutorials',
+  '/tutorial/:path*': '/docs/getting-started/tutorials',
+  '/getting-started/node-tutorial': '/docs/getting-started/tutorials',
   '/getting-started/tutorials/node-server-tutorial':
-    '/getting-started/tutorials',
+    '/docs/getting-started/tutorials',
+  // Wildcard patterns (all sub-paths go to the same destination)
+  '/react-tutorial/:path*':
+    '/docs/getting-started/tutorials/react-monorepo-tutorial',
+  '/angular-tutorial/:path*':
+    '/docs/getting-started/tutorials/angular-monorepo-tutorial',
+  '/node-tutorial/:path*': '/docs/getting-started/tutorials',
+  '/react-standalone-tutorial/:path*':
+    '/docs/getting-started/tutorials/react-monorepo-tutorial',
+  '/angular-standalone-tutorial/:path*':
+    '/docs/getting-started/tutorials/angular-monorepo-tutorial',
 };
-const nodeRedirectDestination = '/getting-started/tutorials';
-const nodeTutorialRedirects = oldNodeTutorialPaths.reduce((acc, path) => {
-  acc[path] = nodeRedirectDestination;
-  return acc;
-}, {});
-
-const tutorialRedirects = Object.assign(
-  tutorialBaseUrls,
-  reactTutorialRedirects,
-  nodeTutorialRedirects,
-  extraNodeRedirects
-);
-
-const oldAngularTutorialPaths = [
-  '/angular-tutorial/01-create-application',
-  '/angular-tutorial/02-add-e2e-test',
-  '/angular-tutorial/03-display-todos',
-  '/angular-tutorial/04-connect-to-api',
-  '/angular-tutorial/05-add-node-app',
-  '/angular-tutorial/06-proxy',
-  '/angular-tutorial/07-share-code',
-  '/angular-tutorial/08-create-libs',
-  '/angular-tutorial/09-dep-graph',
-  '/angular-tutorial/10-computation-caching',
-  '/angular-tutorial/11-test-affected-projects',
-  '/angular-tutorial/12-summary',
-];
-
-const angularRedirectDestination = '/angular-tutorial/1-code-generation';
-for (const path of oldAngularTutorialPaths) {
-  tutorialRedirects[path] = angularRedirectDestination;
-}
 
 /**
- * New single-page standalone tutorials
+ * Standalone tutorial redirects (individual routes that don't fit wildcards)
  */
 const standaloneTutorialRedirects = {
   '/showcase/example-repos/react-nx':
-    '/getting-started/tutorials/react-monorepo-tutorial',
-  '/react-tutorial': '/getting-started/tutorials/react-monorepo-tutorial',
-  '/react-tutorial/1-code-generation':
-    '/getting-started/tutorials/react-monorepo-tutorial',
-  '/react-tutorial/2-project-graph':
-    '/getting-started/tutorials/react-monorepo-tutorial',
-  '/react-tutorial/3-task-running':
-    '/getting-started/tutorials/react-monorepo-tutorial',
-  '/react-tutorial/4-task-pipelines':
-    '/getting-started/tutorials/react-monorepo-tutorial',
-  '/react-tutorial/5-summary':
-    '/getting-started/tutorials/react-monorepo-tutorial',
+    '/docs/getting-started/tutorials/react-monorepo-tutorial',
+  // Bare paths (matched before wildcards above)
+  '/react-tutorial': '/docs/getting-started/tutorials/react-monorepo-tutorial',
   '/react-standalone-tutorial':
-    '/getting-started/tutorials/react-monorepo-tutorial',
-  '/react-standalone-tutorial/1-code-generation':
-    '/getting-started/tutorials/react-monorepo-tutorial',
-  '/react-standalone-tutorial/2-project-graph':
-    '/getting-started/tutorials/react-monorepo-tutorial',
-  '/react-standalone-tutorial/3-task-running':
-    '/getting-started/tutorials/react-monorepo-tutorial',
-  '/react-standalone-tutorial/4-task-pipelines':
-    '/getting-started/tutorials/react-monorepo-tutorial',
-  '/react-standalone-tutorial/5-summary':
-    '/getting-started/tutorials/react-monorepo-tutorial',
+    '/docs/getting-started/tutorials/react-monorepo-tutorial',
   '/angular-standalone-tutorial':
-    '/getting-started/tutorials/angular-monorepo-tutorial',
-  '/angular-standalone-tutorial/1-code-generation':
-    '/getting-started/tutorials/angular-monorepo-tutorial',
-  '/angular-standalone-tutorial/2-project-graph':
-    '/getting-started/tutorials/angular-monorepo-tutorial',
-  '/angular-standalone-tutorial/3-task-running':
-    '/getting-started/tutorials/angular-monorepo-tutorial',
-  '/angular-standalone-tutorial/4-task-pipelines':
-    '/getting-started/tutorials/angular-monorepo-tutorial',
-  '/angular-standalone-tutorial/5-summary':
-    '/getting-started/tutorials/angular-monorepo-tutorial',
+    '/docs/getting-started/tutorials/angular-monorepo-tutorial',
 };
 
-const packagesIndexes = {
-  '/nx': '/packages/nx',
-  '/workspace': '/packages/workspace',
-  '/devkit': '/packages/devkit',
-  '/nx-plugin': '/packages/plugin',
-  '/angular': '/packages/angular',
-  '/cypress': '/packages/cypress',
-  '/detox': '/packages/detox',
-  '/esbuild': '/packages/esbuild',
-  '/eslint-plugin-nx': '/packages/eslint-plugin-nx',
-  '/expo': '/packages/expo',
-  '/express': '/packages/express',
-  '/jest': '/packages/jest',
-  '/js': '/packages/js',
-  '/linter': '/packages/eslint',
-  '/nest': '/packages/nest',
-  '/next': '/packages/next',
-  '/node': '/packages/node',
-  '/react-native': '/packages/react',
-  '/rollup': '/packages/rollup',
-  '/storybook': '/packages/storybook',
-  '/vite': '/packages/vite',
-  '/web': '/packages/web',
-  '/webpack': '/packages/webpack',
-};
+// REMOVED: packagesIndexes (23 routes) - destinations chain through
+// /packages/:path* -> /nx-api/:path* -> /technologies/... -> /docs/technologies/...
+const packagesIndexes = {};
 
-const packagesDocuments = {
-  '/nx/create-nx-workspace': '/packages/nx/documents/create-nx-workspace',
-  '/nx/init': '/packages/nx/documents/init',
-  '/nx/generate': '/packages/nx/documents/generate',
-  '/nx/run': '/packages/nx/documents/run',
-  '/nx/daemon': '/packages/nx/documents/daemon',
-  '/nx/dep-graph': '/packages/nx/documents/dep-graph',
-  '/nx/run-many': '/packages/nx/documents/run-many',
-  '/nx/affected': '/packages/nx/documents/affected',
-  '/nx/format-check': '/packages/nx/documents/format-check',
-  '/nx/format-write': '/packages/nx/documents/format-write',
-  '/nx/migrate': '/packages/nx/documents/migrate',
-  '/nx/report': '/packages/nx/documents/report',
-  '/nx/list': '/packages/nx/documents/list',
-  '/nx/workspace-generator': '/packages/nx/documents/workspace-generator',
-  '/nx/connect-to-nx-cloud': '/packages/nx/documents/connect-to-nx-cloud',
-  '/nx/reset': '/packages/nx/documents/reset',
-  '/nx/repair': '/packages/nx/documents/repair',
-  '/nx/exec': '/packages/nx/documents/exec',
-  '/nx/watch': '/packages/nx/documents/watch',
-  '/workspace/nx-nodejs-typescript-version-matrix':
-    '/packages/workspace/documents/nx-nodejs-typescript-version-matrix',
-  '/devkit/index': '/packages/devkit/documents/nx_devkit',
-  '/packages/devkit/documents/nrwl_devkit':
-    '/packages/devkit/documents/nx_devkit',
-  '/devkit/ngcli_adapter': '/packages/devkit/documents/ngcli_adapter',
-  '/angular-nx-version-matrix':
-    '/packages/angular/documents/angular-nx-version-matrix',
-  '/cypress/cypress-component-testing':
-    '/packages/cypress/documents/cypress-component-testing',
-  '/cypress/v11-migration-guide':
-    '/packages/cypress/documents/v11-migration-guide',
-  '/storybook/overview-react': '/packages/storybook/documents/overview-react',
-  '/packages/storybook/documents/overview-react':
-    '/recipes/storybook/overview-react',
-  '/storybook/overview-angular':
-    '/packages/storybook/documents/overview-angular',
-  '/packages/storybook/documents/overview-angular':
-    '/recipes/storybook/overview-angular',
-  '/packages/storybook/documents/configuring-storybook':
-    '/recipes/storybook/configuring-storybook',
-  '/packages/storybook/documents/custom-builder-configs':
-    '/recipes/storybook/custom-builder-configs',
-  '/packages/storybook/documents/storybook-interaction-tests':
-    '/recipes/storybook/storybook-interaction-tests',
-  '/storybook/best-practices': '/packages/storybook/documents/best-practices',
-  '/storybook/storybook-composition-setup':
-    '/packages/storybook/documents/storybook-composition-setup',
-  '/packages/storybook/documents/storybook-composition-setup':
-    '/recipes/storybook/storybook-composition-setup',
-  '/storybook/angular-storybook-compodoc':
-    '/packages/storybook/documents/angular-storybook-compodoc',
-  '/packages/storybook/documents/angular-storybook-compodoc':
-    '/recipes/storybook/angular-storybook-compodoc',
-  '/storybook/angular-storybook-targets':
-    '/deprecated/storybook/angular-storybook-targets',
-  '/packages/storybook/documents/angular-storybook-targets':
-    '/deprecated/storybook/angular-storybook-targets',
-  '/storybook/angular-configuring-styles':
-    '/packages/storybook/documents/angular-configuring-styles',
-  '/packages/storybook/documents/angular-configuring-styles':
-    '/recipes/storybook/angular-configuring-styles',
-  '/storybook/angular-browser-target':
-    '/deprecated/storybook/angular-project-build-config',
-  '/deprecated/storybook/angular-browser-target':
-    '/deprecated/storybook/angular-project-build-config',
-  '/storybook/migrate-webpack-final-angular':
-    '/deprecated/storybook/migrate-webpack-final-angular',
-  '/storybook/upgrade-storybook-v6-angular':
-    '/deprecated/storybook/upgrade-storybook-v6-angular',
-  '/storybook/migrate-webpack-final-react':
-    '/deprecated/storybook/migrate-webpack-final-react',
-  '/storybook/upgrade-storybook-v6-react':
-    '/deprecated/storybook/upgrade-storybook-v6-react',
-  '/packages/storybook/documents/angular-browser-target':
-    '/deprecated/storybook/angular-project-build-config',
-  '/packages/storybook/documents/migrate-webpack-final-angular':
-    '/deprecated/storybook/migrate-webpack-final-angular',
-  '/packages/storybook/documents/upgrade-storybook-v6-angular':
-    '/deprecated/storybook/upgrade-storybook-v6-angular',
-  '/packages/storybook/documents/migrate-webpack-final-react':
-    '/deprecated/storybook/migrate-webpack-final-react',
-  '/packages/storybook/documents/upgrade-storybook-v6-react':
-    '/deprecated/storybook/upgrade-storybook-v6-react',
-  '/packages/storybook/documents/migrate-storybook-7':
-    '/packages/storybook/generators/migrate-7',
-  '/linter/eslint-plugin-nx': '/packages/eslint/documents/eslint-plugin-nx',
-  '/packages/add-nx-to-monorepo': '/packages/nx/documents/init',
-  '/packages/cra-to-nx': '/packages/nx/documents/init',
-  '/packages/make-angular-cli-faster': '/packages/nx/documents/init',
-  '/packages/eslint-plugin-nx': '/packages/eslint-plugin',
-  '/packages/eslint-plugin-nx/documents/enforce-module-boundaries':
-    '/packages/eslint-plugin/documents/enforce-module-boundaries',
-  '/packages/eslint-plugin-nx/documents/overview':
-    '/packages/eslint-plugin/documents/overview',
-  '/packages/node/executors/webpack': '/packages/webpack/executors/webpack',
-  '/packages/web/executors/webpack': '/packages/webpack/executors/webpack',
-  '/packages/web/executors/dev-server':
-    '/packages/webpack/executors/dev-server',
-  '/packages/web/executors/rollup': '/packages/rollup/executors/rollup',
-};
+// REMOVED: packagesDocuments (65 routes) - destinations chain through
+// /packages/:path* -> /nx-api/:path* and /recipes/* -> /technologies/*/recipes/*
+const packagesDocuments = {};
 
 /**
  * Concept documents Updates (updated 2023-10-18)
@@ -777,17 +352,17 @@ const conceptUrls = {
   '/concepts/more-concepts/global-nx':
     '/getting-started/installation#installing-nx-globally',
   '/getting-started/package-based-repo-tutorial':
-    '/getting-started/tutorials/typescript-packages-tutorial',
+    '/docs/getting-started/tutorials/typescript-packages-tutorial',
   '/getting-started/tutorials/package-based-repo-tutorial':
-    '/getting-started/tutorials/typescript-packages-tutorial',
+    '/docs/getting-started/tutorials/typescript-packages-tutorial',
   '/getting-started/integrated-repo-tutorial':
-    '/getting-started/tutorials/react-monorepo-tutorial',
+    '/docs/getting-started/tutorials/react-monorepo-tutorial',
   '/getting-started/tutorials/integrated-repo-tutorial':
-    '/getting-started/tutorials/react-monorepo-tutorial',
+    '/docs/getting-started/tutorials/react-monorepo-tutorial',
   '/getting-started/react-standalone-tutorial':
-    '/getting-started/tutorials/react-monorepo-tutorial',
+    '/docs/getting-started/tutorials/react-monorepo-tutorial',
   '/getting-started/angular-standalone-tutorial':
-    '/getting-started/tutorials/angular-monorepo-tutorial',
+    '/docs/getting-started/tutorials/angular-monorepo-tutorial',
   '/concepts/more-concepts/micro-frontend-architecture':
     '/concepts/module-federation/micro-frontend-architecture',
   '/concepts/more-concepts/faster-builds-with-module-federation':
@@ -797,79 +372,66 @@ const conceptUrls = {
   '/concepts/more-concepts/nx-devkit-angular-devkit':
     '/nx-api/angular/documents/nx-devkit-angular-devkit',
   '/concepts/more-concepts/incremental-builds':
-    '/concepts/more-concepts/buildable-and-publishable-libraries',
-  '/concepts/turbo-and-nx': '/recipes/adopting-nx/from-turborepo',
+    '/docs/concepts/buildable-and-publishable-libraries',
+  '/concepts/turbo-and-nx': '/docs/guides/adopting-nx/from-turborepo',
 };
 
 const nested5minuteTutorialUrls = {
   '/tutorials/package-based-repo-tutorial':
-    '/getting-started/tutorials/typescript-packages-tutorial',
+    '/docs/getting-started/tutorials/typescript-packages-tutorial',
   '/getting-started/tutorials/npm-workspaces-tutorial':
-    '/getting-started/tutorials/typescript-packages-tutorial',
+    '/docs/getting-started/tutorials/typescript-packages-tutorial',
   '/tutorials/integrated-repo-tutorial':
-    '/getting-started/tutorials/integrated-repo-tutorial',
+    '/docs/getting-started/tutorials/react-monorepo-tutorial',
   '/tutorials/react-standalone-tutorial':
-    '/getting-started/tutorials/react-monorepo-tutorial',
+    '/docs/getting-started/tutorials/react-monorepo-tutorial',
   '/getting-started/tutorials/react-standalone-tutorial':
-    '/getting-started/tutorials/react-monorepo-tutorial',
+    '/docs/getting-started/tutorials/react-monorepo-tutorial',
   '/tutorials/angular-standalone-tutorial':
-    '/getting-started/tutorials/angular-monorepo-tutorial',
+    '/docs/getting-started/tutorials/angular-monorepo-tutorial',
   '/getting-started/tutorials/angular-standalone-tutorial':
-    '/getting-started/tutorials/angular-monorepo-tutorial',
+    '/docs/getting-started/tutorials/angular-monorepo-tutorial',
   '/getting-started/tutorials/vue-standalone-tutorial':
-    '/getting-started/tutorials',
-  '/tutorials/node-server-tutorial': '/getting-started/tutorials',
-  '/angular-tutorial': '/getting-started/tutorials/angular-monorepo-tutorial',
-  '/angular-tutorial/1-code-generation':
-    '/getting-started/tutorials/angular-monorepo-tutorial',
+    '/docs/getting-started/tutorials',
+  '/tutorials/node-server-tutorial': '/docs/getting-started/tutorials',
+  // Bare /angular-tutorial is needed since wildcard only matches sub-paths
+  '/angular-tutorial':
+    '/docs/getting-started/tutorials/angular-monorepo-tutorial',
   '/getting-started/angular-monorepo-tutorial':
-    '/getting-started/tutorials/angular-monorepo-tutorial',
-  '/angular-tutorial/2-project-graph':
-    '/getting-started/tutorials/angular-monorepo-tutorial',
-  '/angular-tutorial/3-task-running':
-    '/getting-started/tutorials/angular-monorepo-tutorial',
-  '/angular-tutorial/4-workspace-optimization':
-    '/getting-started/tutorials/angular-monorepo-tutorial',
-  '/angular-tutorial/5-summary':
-    '/getting-started/tutorials/angular-monorepo-tutorial',
+    '/docs/getting-started/tutorials/angular-monorepo-tutorial',
 };
 
 const pluginUrls = {
   '/plugin-features/create-your-own-plugin':
-    '/extending-nx/tutorials/organization-specific-plugin',
+    '/docs/extending-nx/organization-specific-plugin',
   '/extending-nx/tutorials/create-plugin':
-    '/extending-nx/tutorials/organization-specific-plugin',
-  '/extending-nx/tutorials/publish-plugin':
-    '/extending-nx/tutorials/tooling-plugin',
-  '/recipes/advanced-plugins': '/extending-nx/recipes',
-  '/recipes/advanced-plugins/create-preset':
-    '/extending-nx/recipes/create-preset',
+    '/docs/extending-nx/organization-specific-plugin',
+  '/extending-nx/tutorials/publish-plugin': '/docs/extending-nx/tooling-plugin',
+  '/recipes/advanced-plugins': '/docs/extending-nx',
+  '/recipes/advanced-plugins/create-preset': '/docs/extending-nx/create-preset',
   '/recipes/advanced-plugins/migration-generators':
-    '/extending-nx/recipes/migration-generators',
+    '/docs/extending-nx/migration-generators',
   '/recipes/advanced-plugins/project-graph-plugins':
-    '/extending-nx/recipes/project-graph-plugins',
+    '/docs/extending-nx/project-graph-plugins',
   // Removed inference doc when updating for v2 API
   '/extending-nx/recipes/project-inference-plugins':
-    '/extending-nx/recipes/project-graph-plugins',
+    '/docs/extending-nx/project-graph-plugins',
   '/recipes/advanced-plugins/project-inference-plugins':
-    '/extending-nx/recipes/project-graph-plugins',
+    '/docs/extending-nx/project-graph-plugins',
   '/recipes/advanced-plugins/share-your-plugin':
     '/extending-nx/tutorials/maintain-published-plugin',
   '/recipes/executors/compose-executors':
-    '/extending-nx/recipes/compose-executors',
+    '/docs/extending-nx/compose-executors',
   '/recipes/executors/creating-custom-executors':
-    '/extending-nx/recipes/local-executors',
-  '/recipes/generators': '/extending-nx/recipes',
+    '/docs/extending-nx/local-executors',
+  '/recipes/generators': '/docs/extending-nx',
   '/recipes/generators/composing-generators':
-    '/extending-nx/recipes/composing-generators',
-  '/recipes/generators/creating-files': '/extending-nx/recipes/creating-files',
-  '/recipes/generators/generator-options':
-    '/extending-nx/recipes/generator-options',
-  '/recipes/generators/local-generators':
-    '/extending-nx/recipes/local-generators',
-  '/recipes/generators/modifying-files':
-    '/extending-nx/recipes/modifying-files',
-  '/extending-nx/registry': '/plugin-registry',
+    '/docs/extending-nx/composing-generators',
+  '/recipes/generators/creating-files': '/docs/extending-nx/creating-files',
+  '/recipes/generators/generator-options': '/docs/extending-nx',
+  '/recipes/generators/local-generators': '/docs/extending-nx/local-generators',
+  '/recipes/generators/modifying-files': '/docs/extending-nx/modifying-files',
+  '/extending-nx/registry': '/docs/plugin-registry',
 };
 
 const referenceUrls = {
@@ -882,12 +444,14 @@ const missingAndCatchAllRedirects = {
   '/(l|latest|p|previous)/:path*': '/:path*',
   '/(a|angular|n|node)/:path*': '/:path*',
   // Storybook
-  '/(l|latest)/(r|react)/storybook/overview': '/storybook/overview-react',
-  '/(l|latest)/(a|angular)/storybook/overview': '/storybook/overview-angular',
+  '/(l|latest)/(r|react)/storybook/overview':
+    '/docs/technologies/test-tools/storybook/guides/overview-react',
+  '/(l|latest)/(a|angular)/storybook/overview':
+    '/docs/technologies/test-tools/storybook/guides/overview-angular',
   '/(l|latest)/(a|angular|r|react)/storybook/executors':
-    '/storybook/executors-storybook',
+    '/packages/storybook/executors/storybook',
   // Nx Console
-  '/nx-console': '/using-nx/console',
+  '/nx-console': '/docs/getting-started/editor-setup',
   '/packages/:path*': '/nx-api/:path*',
 };
 
@@ -899,11 +463,12 @@ const marketing = {
 
 const movePluginFeaturesToCore = {
   '/plugin-features/use-task-executors':
-    '/concepts/executors-and-configurations',
+    '/docs/concepts/executors-and-configurations',
   '/features/plugin-features/use-task-executors':
-    '/concepts/executors-and-configurations',
-  '/plugin-features/use-code-generators': '/features/generate-code',
-  '/features/plugin-features/use-code-generators': '/features/generate-code',
+    '/docs/concepts/executors-and-configurations',
+  '/plugin-features/use-code-generators': '/docs/features/generate-code',
+  '/features/plugin-features/use-code-generators':
+    '/docs/features/generate-code',
 };
 
 const makeMoreConceptsSubmenu = {
@@ -912,7 +477,7 @@ const makeMoreConceptsSubmenu = {
 };
 
 const pluginsToExtendNx = {
-  '/plugins': '/extending-nx/intro/getting-started',
+  '/plugins': '/docs/extending-nx/intro',
   '/plugins/:path*': '/extending-nx/:path*',
 };
 
@@ -920,29 +485,25 @@ const pluginsToExtendNx = {
 const latestRecipesRefactoring = {
   // removed
   '/recipes/getting-started/set-up-a-new-workspace':
-    '/getting-started/installation',
+    '/docs/getting-started/installation',
   '/recipes/other/misc-ngrx': '/packages/angular/generators/ngrx', // 486 views
   '/recipes/other/misc-data-persistence': '/packages/angular/generators/ngrx', // 200 views
   '/recipes/other/standalone-ngrx-apis': '/packages/angular/generators/ngrx', //47 views -> can be freely removed
   '/recipes/other/export-project-graph': '/recipes/features/explore-graph', // 20 views -> contents moved to explore-graph
   '/recipes/executors/use-executor-configurations':
-    '/concepts/executors-and-configurations',
+    '/docs/concepts/executors-and-configurations',
   // ci
   '/recipes/other/azure-last-successful-commit':
-    '/recipes/ci/azure-last-successful-commit',
+    '/docs/guides/nx-cloud/setup-ci',
   // angular
-  '/recipes/adopting-nx/migration-angular':
-    '/recipes/angular/migration/angular',
+  '/recipes/adopting-nx/migration-angular': '/docs/technologies/angular',
   '/recipes/adopting-nx-angular/angular-integrated':
-    '/recipes/angular/migration/angular',
-  '/recipes/adopting-nx-angular/angular-manual':
-    '/recipes/angular/migration/angular',
-  '/recipes/angular/migration/angular-manual':
-    '/recipes/angular/migration/angular',
+    '/docs/technologies/angular',
+  '/recipes/adopting-nx-angular/angular-manual': '/docs/technologies/angular',
+  '/recipes/angular/migration/angular-manual': '/docs/technologies/angular',
   '/recipes/adopting-nx-angular/angular-multiple':
-    '/recipes/angular/migration/angular-multiple',
-  '/recipes/adopting-nx/migration-angularjs':
-    '/recipes/angular/migration/angularjs',
+    '/docs/technologies/angular/migration/angular-multiple',
+  '/recipes/adopting-nx/migration-angularjs': '/docs/technologies/angular',
   '/recipes/environment-variables/use-environment-variables-in-angular':
     '/recipes/angular/use-environment-variables-in-angular',
   '/recipes/other/using-tailwind-css-with-angular-projects':
@@ -953,10 +514,10 @@ const latestRecipesRefactoring = {
     '/recipes/angular/setup-incremental-builds-angular',
   // react
   '/recipes/adopting-nx/migration-cra':
-    '/recipes/adopting-nx/adding-to-existing-project',
+    '/docs/guides/adopting-nx/adding-to-existing-project',
   '/recipes/react/migration-cra':
-    '/recipes/adopting-nx/adding-to-existing-project',
-  '/recipes/other/react-18': '/recipes/react/react-18',
+    '/docs/guides/adopting-nx/adding-to-existing-project',
+  '/recipes/other/react-18': '/nx-api/react',
   '/recipes/other/react-native': '/recipes/react/react-native',
   '/recipes/other/remix': '/recipes/react/remix',
   '/recipes/environment-variables/use-environment-variables-in-react':
@@ -974,74 +535,73 @@ const latestRecipesRefactoring = {
     '/recipes/node/node-serverless-functions-netlify',
   '/recipes/deployment/node-aws-lambda': '/recipes/node/node-aws-lambda',
   // examples
-  '/recipes/module-federation/nx-examples': '/showcase/example-repos/mfe',
-  '/recipes/database/nestjs-prisma': '/showcase/example-repos/nestjs-prisma',
-  '/recipes/database/mongo-fastify': '/showcase/example-repos/mongo-fastify',
-  '/recipes/database/redis-fastify': '/showcase/example-repos/redis-fastify',
-  '/recipes/database/postgres-fastify':
-    '/showcase/example-repos/postgres-fastify',
+  '/recipes/module-federation/nx-examples': '/docs/getting-started/intro',
+  '/recipes/database/nestjs-prisma': '/docs/getting-started/intro',
+  '/recipes/database/mongo-fastify': '/docs/getting-started/intro',
+  '/recipes/database/redis-fastify': '/docs/getting-started/intro',
+  '/recipes/database/postgres-fastify': '/docs/getting-started/intro',
   '/recipes/database/serverless-fastify-planetscale':
-    '/showcase/example-repos/serverless-fastify-planetscale',
+    '/docs/getting-started/intro',
   '/recipes/example-repos/:path*': '/showcase/example-repos/:path*',
   // tips and tricks
   '/recipes/environment-variables/define-environment-variables':
-    '/recipes/tips-n-tricks/define-environment-variables',
-  '/recipes/other/eslint': '/recipes/tips-n-tricks/eslint',
-  '/recipes/other/browser-support': '/recipes/tips-n-tricks/browser-support',
+    '/docs/guides/tips-n-tricks/define-environment-variables',
+  '/recipes/other/eslint': '/docs/technologies/eslint',
+  '/recipes/other/browser-support':
+    '/docs/guides/tips-n-tricks/browser-support',
   '/recipes/other/include-assets-in-build':
-    '/recipes/tips-n-tricks/include-assets-in-build',
+    '/docs/guides/tips-n-tricks/include-assets-in-build',
   '/recipes/other/include-all-packagejson':
-    '/recipes/tips-n-tricks/include-all-packagejson',
+    '/docs/guides/tips-n-tricks/include-all-packagejson',
   '/recipes/other/identify-dependencies-between-folders':
-    '/recipes/tips-n-tricks/identify-dependencies-between-folders',
+    '/docs/guides/tips-n-tricks/identify-dependencies-between-folders',
   '/recipes/managing-repository/root-level-scripts':
-    '/recipes/tips-n-tricks/root-level-scripts',
+    '/docs/guides/tasks--caching/root-level-scripts',
   '/recipes/managing-repository/analyze-source-files':
-    '/recipes/tips-n-tricks/analyze-source-files',
+    '/docs/guides/tips-n-tricks/analyze-source-files',
   '/recipes/managing-repository/workspace-watching':
-    '/recipes/tips-n-tricks/workspace-watching',
+    '/docs/guides/tasks--caching/workspace-watching',
   '/recipes/managing-repository/standalone-to-integrated':
-    '/recipes/tips-n-tricks/standalone-to-integrated',
-  '/recipes/managing-repository/js-and-ts': '/recipes/tips-n-tricks/js-and-ts',
+    '/docs/guides/tips-n-tricks/standalone-to-monorepo',
+  '/recipes/managing-repository/js-and-ts':
+    '/docs/technologies/typescript/guides/js-and-ts',
   '/recipes/managing-repository/advanced-update':
-    '/recipes/tips-n-tricks/advanced-update',
+    '/docs/guides/tips-n-tricks/advanced-update',
   '/recipes/executors/run-commands-executor':
-    '/recipes/tips-n-tricks/run-commands-executor',
+    '/docs/guides/tasks--caching/run-commands-executor',
   // ci
-  '/recipes/ci/azure-last-successful-commit': '/recipes/ci/monorepo-ci-azure',
+  '/recipes/ci/azure-last-successful-commit': '/docs/guides/nx-cloud/setup-ci',
   // nx concepts
   '/recipes/module-federation/faster-builds':
-    '/concepts/more-concepts/faster-builds-with-module-federation',
+    '/concepts/module-federation/faster-builds-with-module-federation',
   '/nx-api/js/documents/typescript-project-references':
-    '/concepts/typescript-project-linking',
-  '/reference/commands': '/reference/nx-commands',
+    '/docs/concepts/typescript-project-linking',
+  '/reference/commands': '/docs/reference/nx-commands',
 };
 
 const coreFeatureAndConceptsRefactoring = {
-  '/features/share-your-cache': '/ci/features/remote-cache',
+  '/features/share-your-cache': '/docs/features/ci-features/remote-cache',
   '/concepts/more-concepts/customizing-inputs':
-    '/recipes/running-tasks/configure-inputs',
+    '/docs/guides/tasks--caching/configure-inputs',
   '/recipes/tips-n-tricks/root-level-scripts':
-    '/recipes/running-tasks/root-level-scripts',
+    '/docs/guides/tasks--caching/root-level-scripts',
   '/recipes/tips-n-tricks/run-commands-executor':
-    '/recipes/running-tasks/run-commands-executor',
+    '/docs/guides/tasks--caching/run-commands-executor',
   '/recipes/tips-n-tricks/workspace-watching':
-    '/recipes/running-tasks/workspace-watching',
+    '/docs/guides/tasks--caching/workspace-watching',
   '/recipes/tips-n-tricks/reduce-repetitive-configuration':
-    '/recipes/running-tasks/reduce-repetitive-configuration',
-  '/concepts/more-concepts/global-nx':
-    '/getting-started/installation#installing-nx-globally',
+    '/docs/guides/tasks--caching/reduce-repetitive-configuration',
   '/concepts/more-concepts/nx-and-the-wrapper':
     '/getting-started/installation#selfmanaged-nx-installation',
   '/recipes/running-tasks/customizing-inputs':
-    '/recipes/running-tasks/configure-inputs',
+    '/docs/guides/tasks--caching/configure-inputs',
 };
 
 // rename nx/linter to eslint
 const eslintRename = {
   '/nx-api/linter': '/nx-api/eslint',
   '/nx-api/linter/documents': '/nx-api/eslint/documents',
-  '/nx-api/linter/documents/overview': '/nx-api/eslint/documents/overview',
+  '/nx-api/linter/documents/overview': '/docs/technologies/eslint/introduction',
   '/nx-api/linter/executors': '/nx-api/eslint/executors',
   '/nx-api/linter/executors/eslint': '/nx-api/eslint/executors/lint',
   '/nx-api/linter/generators': '/nx-api/eslint/generators',
@@ -1056,18 +616,19 @@ const eslintRename = {
 
 // move troubleshooting out of recipes
 const troubleshootingOutOfRecipes = {
-  '/recipes/troubleshooting': '/troubleshooting',
+  '/recipes/troubleshooting': '/docs/troubleshooting',
   '/recipes/troubleshooting/:path*': '/troubleshooting/:path*',
   '/ci/recipes/troubleshooting/:path*': '/ci/troubleshooting/:path*',
   '/recipes/other/resolve-circular-dependencies':
-    '/troubleshooting/resolve-circular-dependencies',
+    '/docs/troubleshooting/resolve-circular-dependencies',
   '/recipes/ci/troubleshoot-nx-install-issues':
-    '/troubleshooting/troubleshoot-nx-install-issues',
+    '/docs/troubleshooting/troubleshoot-nx-install-issues',
   '/recipes/other/troubleshoot-cache-misses':
-    '/troubleshooting/troubleshoot-cache-misses',
-  '/recipes/other/unknown-local-cache': '/troubleshooting/unknown-local-cache',
+    '/docs/troubleshooting/troubleshoot-cache-misses',
+  '/recipes/other/unknown-local-cache':
+    '/docs/troubleshooting/unknown-local-cache',
   '/recipes/other/performance-profiling':
-    '/troubleshooting/performance-profiling',
+    '/docs/troubleshooting/performance-profiling',
 };
 
 /**
@@ -1081,22 +642,18 @@ const removedDeprecatedUrls = {
   '/recipes/tips-n-tricks/integrated-in-package-based':
     '/deprecated/integrated-vs-package-based',
   '/recipes/tips-n-tricks/standalone-to-integrated':
-    '/recipes/tips-n-tricks/standalone-to-monorepo',
+    '/docs/guides/tips-n-tricks/standalone-to-monorepo',
   '/recipes/other/rescope': '/deprecated/rescope', // Removed in Nx 20
   '/nx-api/nx/documents/affected-dep-graph': '/deprecated/affected-graph', // nx affected:graph was removed in Nx 19
-  '/cli/affected-dep-graph': '/deprecated/affected-graph',
   '/nx/affected-dep-graph': '/deprecated/affected-graph',
   '/nx-api/nx/documents/print-affected': '/deprecated/print-affected', // nx affected:graph was removed in Nx 19
-  '/cli/affected-apps': '/deprecated/print-affected',
-  '/cli/affected-libs': '/deprecated/print-affected',
-  '/cli/print-affected': '/deprecated/print-affected',
   '/packages/nx/documents/print-affected': '/deprecated/print-affected',
   '/nx/affected-apps': '/deprecated/print-affected',
   '/nx/affected-libs': '/deprecated/print-affected',
   '/nx/print-affected': '/deprecated/print-affected',
   '/packages/nx/documents/affected-apps': '/deprecated/print-affected',
   '/packages/nx/documents/affected-libs': '/deprecated/print-affected',
-  '/deprecated/default-collection': '/features/generate-code', // 46 views: has not worked since Nx 17 and has very little views
+  '/deprecated/default-collection': '/docs/features/generate-code', // 46 views: has not worked since Nx 17 and has very little views
   '/deprecated/workspace-lint': '/nx-api/nx/documents/report', // 168 views: workspace-lint hasn't worked since Nx 15 and users should use `nx report` to check versions and other info
   '/deprecated/storybook/angular-storybook-targets':
     '/recipes/storybook/overview-angular', // 49 views
@@ -1114,26 +671,29 @@ const removedDeprecatedUrls = {
 };
 
 const decisionsSection = {
-  '/concepts/more-concepts/why-monorepos': '/concepts/decisions/why-monorepos',
+  '/concepts/more-concepts/why-monorepos':
+    '/docs/concepts/decisions/why-monorepos',
   '/concepts/more-concepts/dependency-management':
-    '/concepts/decisions/dependency-management',
-  '/concepts/more-concepts/code-sharing': '/concepts/decisions/code-ownership',
+    '/docs/concepts/decisions/dependency-management',
+  '/concepts/more-concepts/code-sharing':
+    '/docs/concepts/decisions/code-ownership',
   '/concepts/more-concepts/applications-and-libraries':
-    '/concepts/decisions/project-size',
+    '/docs/concepts/decisions/project-size',
   '/concepts/more-concepts/creating-libraries':
-    '/concepts/decisions/project-size',
+    '/docs/concepts/decisions/project-size',
   '/concepts/more-concepts/library-types':
-    '/concepts/decisions/project-dependency-rules',
+    '/docs/concepts/decisions/project-dependency-rules',
   '/concepts/more-concepts/grouping-libraries':
-    '/concepts/decisions/folder-structure',
-  '/concepts/more-concepts/turbo-and-nx': '/recipes/adopting-nx/from-turborepo',
-  '/concepts/more-concepts/nx-daemon': '/concepts/nx-daemon',
+    '/docs/concepts/decisions/folder-structure',
+  '/concepts/more-concepts/turbo-and-nx':
+    '/docs/guides/adopting-nx/from-turborepo',
+  '/concepts/more-concepts/nx-daemon': '/docs/concepts/nx-daemon',
   '/concepts/more-concepts/buildable-and-publishable-libraries':
-    '/concepts/buildable-and-publishable-libraries',
+    '/docs/concepts/buildable-and-publishable-libraries',
 };
 // Blog post redirects
 const blogPosts = {
-  '/blog/2024-05-07-nx-19-release': '/blog/2024-05-08-nx-19-release',
+  '/blog/2024-05-07-nx-19-release': '/blog/nx-19-release',
   '/blog/2024-05-08-nx-19-release': '/blog/nx-19-release',
   '/blog/2024-04-19-manage-your-gradle':
     '/blog/manage-your-gradle-project-using-nx',
@@ -1165,7 +725,8 @@ const blogPosts = {
 };
 
 const featurePagesUpdate = {
-  '/ci/troubleshooting/explain-with-ai': '/ci/features/self-healing-ci',
+  '/ci/troubleshooting/explain-with-ai':
+    '/docs/features/ci-features/self-healing-ci',
   '/ci/concepts/ai-features': '/docs/features/ci-features/self-healing-ci',
   '/ci/concepts/nx-cloud-ai': '/docs/features/ci-features/self-healing-ci',
   '/concepts/ci-concepts/ai-features':
@@ -1173,40 +734,38 @@ const featurePagesUpdate = {
 };
 
 const enterpriseNxSection = {
-  '/features/powerpack': '/nx-enterprise',
-  '/features/powerpack/conformance': '/nx-enterprise/conformance',
-  '/features/powerpack/owners': '/nx-enterprise/owners',
+  '/features/powerpack': '/docs/enterprise',
+  '/features/powerpack/conformance': '/docs/enterprise/conformance',
+  '/features/powerpack/owners': '/docs/enterprise/owners',
   '/features/powerpack/custom-caching':
-    '/recipes/running-tasks/self-hosted-caching',
-  '/recipes/installation/activate-powerpack': '/nx-enterprise/activate-license',
-  '/nx-enterprise/activate-powerpack': '/nx-enterprise/activate-license',
-  '/nx-enterprise/powerpack': '/nx-enterprise',
-  '/nx-enterprise/powerpack/conformance': '/nx-enterprise/conformance',
-  '/nx-enterprise/powerpack/owners': '/nx-enterprise/owners',
-  '/nx-enterprise/powerpack/licenses-and-trials': '/nx-enterprise',
+    '/docs/guides/tasks--caching/self-hosted-caching',
+  '/recipes/installation/activate-powerpack':
+    '/docs/enterprise/activate-license',
 };
 
 const manualDTEUpdate = {
-  '/ci/recipes/enterprise/dte': '/ci/recipes/dte',
-  '/ci/recipes/enterprise/dte/github-dte': '/ci/recipes/dte/github-dte',
-  '/ci/recipes/enterprise/dte/circle-ci-dte': '/ci/recipes/dte/circle-ci-dte',
-  '/ci/recipes/enterprise/dte/azure-dte': '/ci/recipes/dte/azure-dte',
-  '/ci/recipes/enterprise/dte/bitbucket-dte': '/ci/recipes/dte/bitbucket-dte',
-  '/ci/recipes/enterprise/dte/gitlab-dte': '/ci/recipes/dte/gitlab-dte',
-  '/ci/recipes/enterprise/dte/jenkins-dte': '/ci/recipes/dte/jenkins-dte',
-  '/showcase/benchmarks/dte': '/showcase/benchmarks/nx-agents',
+  '/ci/recipes/enterprise/dte': '/docs/guides/nx-cloud/manual-dte',
+  '/ci/recipes/enterprise/dte/github-dte': '/docs/guides/nx-cloud/manual-dte',
+  '/ci/recipes/enterprise/dte/circle-ci-dte':
+    '/docs/guides/nx-cloud/manual-dte',
+  '/ci/recipes/enterprise/dte/azure-dte': '/docs/guides/nx-cloud/manual-dte',
+  '/ci/recipes/enterprise/dte/bitbucket-dte':
+    '/docs/guides/nx-cloud/manual-dte',
+  '/ci/recipes/enterprise/dte/gitlab-dte': '/docs/guides/nx-cloud/manual-dte',
+  '/ci/recipes/enterprise/dte/jenkins-dte': '/docs/guides/nx-cloud/manual-dte',
+  '/showcase/benchmarks/dte': '/docs/reference/benchmarks/nx-agents',
 };
 
 const powerpackRedirects = {
   '/powerpack/:path*': '/enterprise',
   '/nx-enterprise/powerpack/custom-caching':
-    '/recipes/running-tasks/self-hosted-caching',
-  '/nx-enterprise/powerpack/free-licenses-and-trials': '/nx-enterprise',
+    '/docs/guides/tasks--caching/self-hosted-caching',
+  '/nx-enterprise/powerpack/free-licenses-and-trials': '/docs/enterprise',
 
   // Redirects for renamed powerpack packages
   '/nx-api/powerpack-owners': '/nx-api/owners',
   '/nx-api/powerpack-owners/documents/overview':
-    '/nx-api/owners/documents/overview',
+    '/docs/reference/owners/overview',
 
   '/nx-api/powerpack-conformance': '/nx-api/conformance',
   '/nx-api/powerpack-conformance/documents/overview':
@@ -1216,19 +775,19 @@ const powerpackRedirects = {
 
   '/nx-api/powerpack-azure-cache': '/nx-api/azure-cache',
   '/nx-api/powerpack-azure-cache/documents/overview':
-    '/nx-api/azure-cache/documents/overview',
+    '/docs/reference/remote-cache-plugins/azure-cache/overview',
 
   '/nx-api/powerpack-gcs-cache': '/nx-api/gcs-cache',
   '/nx-api/powerpack-gcs-cache/documents/overview':
-    '/nx-api/gcs-cache/documents/overview',
+    '/docs/reference/remote-cache-plugins/gcs-cache/overview',
 
   '/nx-api/powerpack-s3-cache': '/nx-api/s3-cache',
   '/nx-api/powerpack-s3-cache/documents/overview':
-    '/nx-api/s3-cache/documents/overview',
+    '/docs/reference/remote-cache-plugins/s3-cache/overview',
 
   '/nx-api/powerpack-shared-fs-cache': '/nx-api/shared-fs-cache',
   '/nx-api/powerpack-shared-fs-cache/documents/overview':
-    '/nx-api/shared-fs-cache/documents/overview',
+    '/docs/reference/remote-cache-plugins/shared-fs-cache/overview',
 
   // Reference redirects from powerpack to new structure
   '/docs/reference/powerpack/conformance': '/docs/reference/conformance',
@@ -1260,22 +819,22 @@ const powerpackRedirects = {
 
 const tmpTerminalUiRedirects = {
   // This will be a dedicated landing page in a follow up, redirect to the recipe for now
-  '/terminal-ui': '/recipes/running-tasks/terminal-ui',
+  '/terminal-ui': '/docs/guides/tasks--caching/terminal-ui',
 };
 
 const nxApiRedirects = {
   // Old index page lists official plugins, so redirect to plugin registry
-  '/nx-api': '/plugin-registry',
+  '/nx-api': '/docs/plugin-registry',
   // Reference
   '/nx-api/azure-cache/documents/overview':
-    '/reference/core-api/azure-cache/overview',
-  '/nx-api/owners/documents/overview': '/reference/core-api/owners/overview',
+    '/docs/reference/remote-cache-plugins/azure-cache/overview',
+  '/nx-api/owners/documents/overview': '/docs/reference/owners/overview',
   '/nx-api/gcs-cache/documents/overview':
-    '/reference/core-api/gcs-cache/overview',
+    '/docs/reference/remote-cache-plugins/gcs-cache/overview',
   '/nx-api/s3-cache/documents/overview':
-    '/reference/core-api/s3-cache/overview',
+    '/docs/reference/remote-cache-plugins/s3-cache/overview',
   '/nx-api/shared-fs-cache/documents/overview':
-    '/reference/core-api/shared-fs-cache/overview',
+    '/docs/reference/remote-cache-plugins/shared-fs-cache/overview',
   '/nx-api/devkit/:slug*': '/reference/core-api/devkit/:slug*',
   '/nx-api/nx/:slug*': '/reference/core-api/nx/:slug*',
   '/nx-api/workspace/:slug*': '/reference/core-api/workspace/:slug*',
@@ -1283,6 +842,7 @@ const nxApiRedirects = {
   '/nx-api/plugin/:slug*': '/reference/core-api/plugin/:slug*',
   '/nx-api/web/documents/:slug*': '/reference/core-api/web',
   '/nx-api/web/:slug*': '/reference/core-api/web/:slug*',
+  '/nx-api/web': '/docs/technologies/build-tools/web/introduction',
   '/nx-api/azure-cache/:slug*': '/reference/core-api/azure-cache/:slug*',
   '/nx-api/conformance/:slug*': '/reference/core-api/conformance/:slug*',
   '/nx-api/owners/:slug*': '/reference/core-api/owners/:slug*',
@@ -1295,85 +855,118 @@ const nxApiRedirects = {
   '/nx-api/create-nx-workspace/migrations/:slug*': '/reference/core-api',
   '/nx-api/create-nx-workspace/generators/:slug*': '/reference/core-api',
   '/nx-api/create-nx-workspace/executors/:slug*': '/reference/core-api',
-  '/nx-api/create-nx-workspace/documents': '/reference/core-api',
+  '/nx-api/create-nx-workspace/documents': '/docs/reference',
   '/nx-api/create-nx-workspace/:slug*':
     '/reference/core-api/create-nx-workspace/:slug*',
   // Angular Rspack and Rsbuild -- these never had executors, generators, or migrations
   // We'll just redirect them to the API index, and make sure create-server and create-config exist
   '/nx-api/angular-rspack/documents/create-config':
-    '/technologies/angular/angular-rspack/api/create-config',
+    '/docs/technologies/angular/angular-rspack/create-config',
   '/nx-api/angular-rspack/documents/create-server':
-    '/technologies/angular/angular-rspack/api/create-server',
+    '/docs/technologies/angular/angular-rspack/create-server',
   '/nx-api/angular-rsbuild/documents/create-config':
-    '/technologies/angular/angular-rsbuild/api/create-config',
+    '/docs/technologies/angular/angular-rsbuild/create-config',
   '/nx-api/angular-rsbuild/documents/create-server':
-    '/technologies/angular/angular-rsbuild/api/create-server',
+    '/docs/technologies/angular/angular-rsbuild/create-server',
   '/nx-api/angular-rspack/documents':
-    '/technologies/angular/angular-rspack/introduction',
+    '/docs/technologies/angular/angular-rspack/introduction',
   '/nx-api/angular-rsbuild/documents':
-    '/technologies/angular/angular-rsbuild/api',
+    '/docs/technologies/angular/angular-rsbuild/create-config',
   '/nx-api/angular-rspack/executors':
-    '/technologies/angular/angular-rspack/api',
+    '/docs/technologies/angular/angular-rspack/guides/getting-started',
   '/nx-api/angular-rsbuild/executors':
-    '/technologies/angular/angular-rsbuild/api',
-  '/nx-api/angular-rspack': '/technologies/angular/angular-rspack/introduction',
-  '/nx-api/angular-rsbuild': '/technologies/angular/angular-rsbuild/api',
+    '/docs/technologies/angular/angular-rsbuild/create-config',
+  '/nx-api/angular-rspack':
+    '/docs/technologies/angular/angular-rspack/introduction',
+  '/nx-api/angular-rsbuild':
+    '/docs/technologies/angular/angular-rsbuild/create-config',
   '/nx-api/angular-rspack/migrations':
-    '/technologies/angular/angular-rspack/api',
+    '/docs/technologies/angular/angular-rspack/guides/getting-started',
   '/nx-api/angular-rsbuild/migrations':
-    '/technologies/angular/angular-rsbuild/api',
+    '/docs/technologies/angular/angular-rsbuild/create-config',
   '/nx-api/angular-rspack/generators':
-    '/technologies/angular/angular-rspack/api',
+    '/docs/technologies/angular/angular-rspack/guides/getting-started',
   '/nx-api/angular-rsbuild/generators':
-    '/technologies/angular/angular-rsbuild/api',
+    '/docs/technologies/angular/angular-rsbuild/create-config',
   // Technologies
-  '/nx-api/angular/documents/overview': '/technologies/angular/introduction',
-  '/nx-api/react/documents/overview': '/technologies/react/introduction',
+  '/nx-api/angular/documents/overview':
+    '/docs/technologies/angular/introduction',
+  '/nx-api/angular': '/docs/technologies/angular/introduction',
+  '/nx-api/react/documents/overview': '/docs/technologies/react/introduction',
+  '/nx-api/react': '/docs/technologies/react/introduction',
   '/nx-api/react-native/documents/overview':
-    '/technologies/react/react-native/introduction',
-  '/nx-api/vue/documents': '/technologies/vue/introduction',
-  '/nx-api/vue/documents/overview': '/technologies/vue/introduction',
-  '/nx-api/next/documents/overview': '/technologies/react/next/introduction',
-  '/nx-api/remix/documents/overview': '/technologies/react/remix/introduction',
-  '/nx-api/nuxt/documents/overview': '/technologies/vue/nuxt/introduction',
-  '/nx-api/expo/documents/overview': '/technologies/react/expo/introduction',
-  '/nx-api/nest/documents': '/technologies/node/nest/introduction',
-  '/nx-api/nest/documents/overview': '/technologies/node/nest/introduction',
-  '/nx-api/express/documents': '/technologies/node/express/introduction',
+    '/docs/technologies/react/react-native/introduction',
+  '/nx-api/react-native': '/docs/technologies/react/react-native/introduction',
+  '/nx-api/vue/documents': '/docs/technologies/vue/introduction',
+  '/nx-api/vue/documents/overview': '/docs/technologies/vue/introduction',
+  '/nx-api/vue': '/docs/technologies/vue/introduction',
+  '/nx-api/next/documents/overview':
+    '/docs/technologies/react/next/introduction',
+  '/nx-api/next': '/docs/technologies/react/next/introduction',
+  '/nx-api/remix/documents/overview':
+    '/docs/technologies/react/remix/introduction',
+  '/nx-api/remix': '/docs/technologies/react/remix/introduction',
+  '/nx-api/nuxt/documents/overview': '/docs/technologies/vue/nuxt/introduction',
+  '/nx-api/nuxt': '/docs/technologies/vue/nuxt/introduction',
+  '/nx-api/expo/documents/overview':
+    '/docs/technologies/react/expo/introduction',
+  '/nx-api/expo': '/docs/technologies/react/expo/introduction',
+  '/nx-api/nest/documents': '/docs/technologies/node/nest/introduction',
+  '/nx-api/nest/documents/overview':
+    '/docs/technologies/node/nest/introduction',
+  '/nx-api/nest': '/docs/technologies/node/nest/introduction',
+  '/nx-api/express/documents': '/docs/technologies/node/express/introduction',
   '/nx-api/express/documents/overview':
-    '/technologies/node/express/introduction',
-  '/nx-api/node/documents/overview': '/technologies/node/introduction',
+    '/docs/technologies/node/express/introduction',
+  '/nx-api/express': '/docs/technologies/node/express/introduction',
+  '/nx-api/node/documents/overview': '/docs/technologies/node/introduction',
+  '/nx-api/node': '/docs/technologies/node/introduction',
   '/nx-api/webpack/documents/overview':
-    '/technologies/build-tools/webpack/introduction',
+    '/docs/technologies/build-tools/webpack/introduction',
+  '/nx-api/webpack': '/docs/technologies/build-tools/webpack/introduction',
   '/nx-api/vite/documents/overview':
-    '/technologies/build-tools/vite/introduction',
+    '/docs/technologies/build-tools/vite/introduction',
+  '/nx-api/vite': '/docs/technologies/build-tools/vite/introduction',
   '/nx-api/rollup/documents/overview':
-    '/technologies/build-tools/rollup/introduction',
+    '/docs/technologies/build-tools/rollup/introduction',
+  '/nx-api/rollup': '/docs/technologies/build-tools/rollup/introduction',
   '/nx-api/esbuild/documents/overview':
-    '/technologies/build-tools/esbuild/introduction',
+    '/docs/technologies/build-tools/esbuild/introduction',
+  '/nx-api/esbuild': '/docs/technologies/build-tools/esbuild/introduction',
   '/nx-api/rspack/documents/overview':
-    '/technologies/build-tools/rspack/introduction',
+    '/docs/technologies/build-tools/rspack/introduction',
+  '/nx-api/rspack': '/docs/technologies/build-tools/rspack/introduction',
   '/nx-api/rsbuild/documents/overview':
-    '/technologies/build-tools/rsbuild/introduction',
+    '/docs/technologies/build-tools/rsbuild/introduction',
+  '/nx-api/rsbuild': '/docs/technologies/build-tools/rsbuild/introduction',
   '/nx-api/cypress/documents/overview':
-    '/technologies/test-tools/cypress/introduction',
+    '/docs/technologies/test-tools/cypress/introduction',
   '/nx-api/jest/documents/overview':
-    '/technologies/test-tools/jest/introduction',
+    '/docs/technologies/test-tools/jest/introduction',
   '/nx-api/playwright/documents/overview':
-    '/technologies/test-tools/playwright/introduction',
+    '/docs/technologies/test-tools/playwright/introduction',
   '/nx-api/storybook/documents/overview':
-    '/technologies/test-tools/storybook/introduction',
+    '/docs/technologies/test-tools/storybook/introduction',
+  '/nx-api/storybook': '/docs/technologies/test-tools/storybook/introduction',
   '/nx-api/detox/documents/overview':
-    '/technologies/test-tools/detox/introduction',
-  '/nx-api/js/documents/overview': '/technologies/typescript/introduction',
+    '/docs/technologies/test-tools/detox/introduction',
+  '/nx-api/detox': '/docs/technologies/test-tools/detox/introduction',
+  '/nx-api/js/documents/overview': '/docs/technologies/typescript/introduction',
+  '/nx-api/js': '/docs/technologies/typescript/introduction',
   '/nx-api/gradle/documents': '/docs/technologies/java/gradle/introduction',
   '/nx-api/gradle/documents/overview':
     '/docs/technologies/java/gradle/introduction',
-  '/nx-api/eslint/documents/overview': '/technologies/eslint/introduction',
+  '/nx-api/gradle': '/docs/technologies/java/gradle/introduction',
+  '/nx-api/eslint/documents/overview': '/docs/technologies/eslint/introduction',
   '/nx-api/eslint-plugin/documents/overview':
-    '/technologies/eslint/eslint-plugin/api',
+    '/docs/technologies/eslint/eslint-plugin',
   '/nx-api/module-federation/documents/overview':
-    '/technologies/module-federation/introduction',
+    '/docs/technologies/module-federation/introduction',
+  '/nx-api/module-federation':
+    '/docs/technologies/module-federation/introduction',
+  '/nx-api/vitest': '/docs/technologies/test-tools/vitest/introduction',
+  '/nx-api/vitest/generators/configuration':
+    '/docs/technologies/test-tools/vitest/guides',
   // Wildcard rules (must come after specific rules)
   '/nx-api/angular/documents/:slug*': '/technologies/angular/recipes/:slug*',
   '/nx-api/angular/:slug*': '/technologies/angular/api/:slug*',
@@ -1448,19 +1041,59 @@ const nxApiRedirects = {
     '/technologies/module-federation/api/:slug*',
 };
 
+const legacyPluginOverviewRedirects = {
+  '/cypress/overview': '/docs/technologies/test-tools/cypress/introduction',
+  '/detox/overview': '/docs/technologies/test-tools/detox/introduction',
+  '/jest/overview': '/docs/technologies/test-tools/jest/introduction',
+  '/expo/overview': '/docs/technologies/react/expo/introduction',
+  '/express/overview': '/docs/technologies/node/express/introduction',
+  '/nest/overview': '/docs/technologies/node/nest/introduction',
+  '/next/overview': '/docs/technologies/react/next/introduction',
+  '/js/overview': '/docs/technologies/typescript/introduction',
+};
+
+const deprecatedReferenceRedirects = {
+  '/deprecated/global-implicit-dependencies':
+    '/docs/reference/deprecated/global-implicit-dependencies',
+  '/deprecated/affected-config': '/docs/reference/deprecated/affected-config',
+  '/deprecated/custom-tasks-runner':
+    '/docs/reference/deprecated/custom-tasks-runner',
+  '/deprecated/legacy-cache': '/docs/reference/deprecated/legacy-cache',
+};
+
+const commandRedirects = {
+  '/nx/affected': '/docs/reference/nx-commands#nx-affected',
+};
+
+const canonicalSiteRedirects = {
+  '/blog/': '/blog',
+  '/blog': '/blog',
+  '/nx-cloud': '/nx-cloud',
+  '/community': '/community',
+  '/technologies/java/gradle/introduction':
+    '/docs/technologies/java/gradle/introduction',
+  '/technologies/java/maven/introduction':
+    '/docs/technologies/java/maven/introduction',
+  '/docs/technologies/test-tools/playwright/guides/merge-atomized-outputs':
+    '/docs/technologies/test-tools/playwright/guides/merge-atomized-outputs',
+};
+
 // We got rid of `/recipes` URLs, so we need to redirect them to new /technologies or /reference URLs.
 const nxRecipesRedirects = {
   // Recipes index pages
-  '/recipes/module-federation': '/technologies/module-federation/recipes',
-  '/recipes/react': '/technologies/react/recipes',
-  '/recipes/angular': '/technologies/angular/recipes',
-  '/recipes/node': '/technologies/node/recipes',
-  '/recipes/storybook': '/technologies/test-tools/storybook/recipes',
-  '/recipes/cypress': '/technologies/test-tools/cypress/recipes',
-  '/recipes/next': '/technologies/react/next/recipes',
-  '/recipes/nuxt': '/technologies/vue/nuxt/recipes',
-  '/recipes/vite': '/technologies/build-tools/vite/recipes',
-  '/recipes/webpack': '/technologies/build-tools/webpack/recipes',
+  '/recipes/module-federation':
+    '/docs/technologies/module-federation/guides/create-a-host',
+  '/recipes/react': '/docs/technologies/react/guides/adding-assets-react',
+  '/recipes/angular':
+    '/docs/technologies/angular/guides/angular-nx-version-matrix',
+  '/recipes/node': '/docs/technologies/node/guides/application-proxies',
+  '/recipes/storybook': '/docs/technologies/test-tools/storybook/guides',
+  '/recipes/cypress':
+    '/docs/technologies/test-tools/cypress/guides/cypress-component-testing',
+  '/recipes/next': '/docs/technologies/react/next/guides',
+  '/recipes/nuxt': '/docs/technologies/vue/nuxt/guides',
+  '/recipes/vite': '/docs/technologies/build-tools/vite/guides',
+  '/recipes/webpack': '/docs/technologies/build-tools/webpack/guides',
   // Recipes sub-pages
   '/recipes/module-federation/:slug*':
     '/technologies/module-federation/recipes/:slug*',
@@ -1474,44 +1107,41 @@ const nxRecipesRedirects = {
   '/recipes/vite/:slug*': '/technologies/build-tools/vite/recipes/:slug*',
   '/recipes/webpack/:slug*': '/technologies/build-tools/webpack/recipes/:slug*',
   // Angular - has some special cases for angular-rspack
-  '/recipes/angular/rspack': '/technologies/angular/angular-rspack/recipes',
+  '/recipes/angular/rspack':
+    '/docs/technologies/angular/angular-rspack/guides/getting-started',
   '/recipes/angular/rspack/introduction':
-    '/technologies/angular/angular-rspack/introduction',
+    '/docs/technologies/angular/angular-rspack/introduction',
   '/recipes/angular/rspack/:slug*':
     '/technologies/angular/angular-rspack/recipes/:slug*',
-  '/recipes/angular/migration': '/technologies/angular/migration',
-  '/recipes/angular/migration/angular': '/technologies/angular',
+  '/recipes/angular/migration': '/docs/technologies/angular/migration',
+  '/recipes/angular/migration/angular': '/docs/technologies/angular',
   '/recipes/angular/migration/angular-multiple':
-    '/technologies/angular/migration/angular-multiple',
+    '/docs/technologies/angular/migration/angular-multiple',
   '/recipes/angular/:slug*': '/technologies/angular/recipes/:slug*',
   // Tips-n-tricks - keeping individual because destinations vary greatly
-  '/recipes/tips-n-tricks/eslint': '/technologies/eslint',
+  '/recipes/tips-n-tricks/eslint': '/docs/technologies/eslint',
   '/recipes/tips-n-tricks/flat-config':
-    '/technologies/eslint/recipes/flat-config',
+    '/docs/technologies/eslint/guides/flat-config',
   '/recipes/tips-n-tricks/switch-to-workspaces-project-references':
-    '/technologies/typescript/recipes/switch-to-workspaces-project-references',
+    '/docs/technologies/typescript/guides/switch-to-workspaces-project-references',
   '/recipes/tips-n-tricks/enable-tsc-batch-mode':
-    '/technologies/typescript/recipes/enable-tsc-batch-mode',
+    '/docs/technologies/typescript/guides/enable-tsc-batch-mode',
   '/recipes/tips-n-tricks/define-secondary-entrypoints':
-    '/technologies/typescript/recipes/define-secondary-entrypoints',
+    '/docs/technologies/typescript/guides/define-secondary-entrypoints',
   '/recipes/tips-n-tricks/compile-multiple-formats':
-    '/technologies/typescript/recipes/compile-multiple-formats',
+    '/docs/technologies/typescript/guides/compile-multiple-formats',
   '/recipes/tips-n-tricks/js-and-ts':
-    '/technologies/typescript/recipes/js-and-ts',
+    '/docs/technologies/typescript/guides/js-and-ts',
 };
 
 const nxModuleFederationConceptsRedirects = {
   '/concepts/module-federation/:slug*':
     '/technologies/module-federation/concepts/:slug*',
 };
-const contentDedupeRedirects = {
-  '/technologies/react/recipes/react-native':
-    '/technologies/react/react-native/introduction',
-  '/technologies/react/recipes/remix': '/technologies/react/remix/introduction',
-};
+const contentDedupeRedirects = {};
 
 const gettingStartedRedirects = {
-  '/getting-started/why-nx': '/getting-started/intro',
+  '/getting-started/why-nx': '/docs/getting-started/intro',
 };
 
 // Pricing page: 07/08/25
@@ -1521,14 +1151,14 @@ const pricingRedirects = {
 
 // Removed CI tutorials: 07/21/25
 const ciTutorialRedirects = {
-  '/ci/intro/tutorials/circle': '/ci/recipes/set-up/monorepo-ci-circle-ci',
+  '/ci/intro/tutorials/circle': '/docs/guides/nx-cloud/setup-ci',
   '/ci/intro/tutorials/github-actions':
     '/ci/recipes/set-up/monorepo-ci-github-actions',
 };
 
 const dockerReleaseRedirect = {
   '/recipes/nx-release/get-started-with-nx-release':
-    '/recipes/nx-release/release-npm-packages',
+    '/docs/guides/nx-release/release-npm-packages',
 };
 
 const removeEvolvingNx = {
@@ -1577,6 +1207,10 @@ module.exports = {
   manualDTEUpdate,
   powerpackRedirects,
   tmpTerminalUiRedirects,
+  legacyPluginOverviewRedirects,
+  deprecatedReferenceRedirects,
+  commandRedirects,
+  canonicalSiteRedirects,
   nxApiRedirects,
   nxRecipesRedirects,
   nxModuleFederationConceptsRedirects,

--- a/nx-dev/nx-dev/redirect-rules.spec.js
+++ b/nx-dev/nx-dev/redirect-rules.spec.js
@@ -3,76 +3,62 @@ import redirectRules from './redirect-rules';
 describe('Redirect rules configuration', () => {
   describe('Safety checks', () => {
     it('should not redirect to itself', () => {
-      const rules = {
-        ...redirectRules.cliUrls,
-        ...redirectRules.diataxis,
-        ...redirectRules.guideUrls,
-        ...redirectRules.overviewUrls,
-        ...redirectRules.schemaUrls,
-        ...redirectRules.tutorialRedirects,
-      };
+      const allRules = {};
+      for (const section of Object.keys(redirectRules)) {
+        Object.assign(allRules, redirectRules[section]);
+      }
 
-      for (let k of Object.keys(rules)) {
-        expect(k).not.toEqual(rules[k]);
+      for (const k of Object.keys(allRules)) {
+        expect(k).not.toEqual(allRules[k]);
+      }
+    });
+
+    it('should not have empty destinations', () => {
+      for (const section of Object.keys(redirectRules)) {
+        for (const [source, dest] of Object.entries(redirectRules[section])) {
+          expect(dest).toBeTruthy();
+        }
       }
     });
   });
 
   describe('Tutorial redirects', () => {
-    test('old tutorial links', () => {
-      const oldReactUrls = [
-        '/react-tutorial/01-create-application',
-        '/react-tutorial/02-add-e2e-test',
-        '/react-tutorial/03-display-todos',
-        '/react-tutorial/04-connect-to-api',
-        '/react-tutorial/05-add-node-app',
-        '/react-tutorial/06-proxy',
-        '/react-tutorial/07-share-code',
-        '/react-tutorial/08-create-libs',
-        '/react-tutorial/09-dep-graph',
-        '/react-tutorial/10-computation-caching',
-        '/react-tutorial/11-test-affected-projects',
-        '/react-tutorial/12-summary',
-      ];
-
-      for (const url of oldReactUrls) {
-        expect(redirectRules.tutorialRedirects[url]).toEqual(
-          '/react-tutorial/1-code-generation'
-        );
-      }
+    test('react tutorial wildcard covers old step URLs', () => {
+      // Individual react tutorial step URLs are now handled by
+      // '/react-tutorial/:path*' -> '/docs/getting-started/tutorials/react-monorepo-tutorial'
+      expect(redirectRules.tutorialRedirects['/react-tutorial/:path*']).toEqual(
+        '/docs/getting-started/tutorials/react-monorepo-tutorial'
+      );
     });
 
-    test('old angular tutorial links', () => {
-      const oldAngularUrls = [
-        '/angular-tutorial/01-create-application',
-        '/angular-tutorial/02-add-e2e-test',
-        '/angular-tutorial/03-display-todos',
-        '/angular-tutorial/04-connect-to-api',
-        '/angular-tutorial/05-add-node-app',
-        '/angular-tutorial/06-proxy',
-        '/angular-tutorial/07-share-code',
-        '/angular-tutorial/08-create-libs',
-        '/angular-tutorial/09-dep-graph',
-        '/angular-tutorial/10-computation-caching',
-        '/angular-tutorial/11-test-affected-projects',
-        '/angular-tutorial/12-summary',
-      ];
-
-      for (const url of oldAngularUrls) {
-        expect(redirectRules.tutorialRedirects[url]).toEqual(
-          '/angular-tutorial/1-code-generation'
-        );
-      }
+    test('angular tutorial wildcard covers old step URLs', () => {
+      // Individual angular tutorial step URLs are now handled by
+      // '/angular-tutorial/:path*' -> '/docs/getting-started/tutorials/angular-monorepo-tutorial'
+      expect(
+        redirectRules.tutorialRedirects['/angular-tutorial/:path*']
+      ).toEqual('/docs/getting-started/tutorials/angular-monorepo-tutorial');
     });
 
-    test('old tutorial links', () => {
-      const oldTutorialUrls = ['/tutorials/integrated-repo-tutorial'];
+    test('old integrated-repo tutorial link', () => {
+      expect(
+        redirectRules.nested5minuteTutorialUrls[
+          '/tutorials/integrated-repo-tutorial'
+        ]
+      ).toEqual('/docs/getting-started/tutorials/react-monorepo-tutorial');
+    });
+  });
 
-      for (const url of oldTutorialUrls) {
-        expect(redirectRules.nested5minuteTutorialUrls[url]).toEqual(
-          '/getting-started' + url
-        );
-      }
+  describe('Wildcard consolidation', () => {
+    test('cli wildcard exists', () => {
+      expect(redirectRules.cliUrls['/cli/:path*']).toEqual(
+        '/packages/nx/documents/:path*'
+      );
+    });
+
+    test('concept wildcard exists in docsToAstroRedirects', () => {
+      expect(redirectRules.docsToAstroRedirects['/concepts/:path*']).toEqual(
+        '/docs/concepts/:path*'
+      );
     });
   });
 });

--- a/nx-dev/nx-dev/redirect-rules.spec.js
+++ b/nx-dev/nx-dev/redirect-rules.spec.js
@@ -51,7 +51,7 @@ describe('Redirect rules configuration', () => {
   describe('Wildcard consolidation', () => {
     test('cli wildcard exists', () => {
       expect(redirectRules.cliUrls['/cli/:path*']).toEqual(
-        '/packages/nx/documents/:path*'
+        '/docs/reference/nx-commands'
       );
     });
 


### PR DESCRIPTION
## Current Behavior

We have ~1,657 redirect rules across `redirect-rules.js` and `redirect-rules-docs-to-astro.js`, getting close to Netlify's limit and we need room for more as the Astro migration continues.

## Expected Behavior

Reduced to **1,139 rules** (~31% reduction) by:

- Resolving duplicate/conflicting source paths across sections
- Flattening multi-hop redirect chains to point directly to final destinations
- Consolidating groups of individual rules into wildcard patterns (tutorials, CLI, helm, concepts, recipes, etc.)
- Removing old 2022-era sections (`schemaUrls`, `overviewUrls`, `packagesIndexes`, `packagesDocuments`) whose destinations chain 3-5 hops deep and are long superseded by newer redirects
- made sure old links in nx code base still have redirects (will update in future PR)

Build, tests, and internal link check all pass with no issues.

## Related Issue(s)

Fixes DOC-403