### PR TITLE
fix(core): set windowsHide: true on all child process spawns

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -76,7 +76,8 @@
             ]
           }
         ],
-        "@nx/workspace/valid-command-object": "error"
+        "@nx/workspace/valid-command-object": "error",
+        "@nx/workspace/require-windows-hide": "error"
       }
     },
     {

--- a/astro-docs/src/plugins/utils/cnw-generation.ts
+++ b/astro-docs/src/plugins/utils/cnw-generation.ts
@@ -40,6 +40,7 @@ export async function loadCnwPackage(
     const child = fork(subprocessPath, [], {
       cwd: workspaceRoot,
       silent: true,
+      windowsHide: true,
     });
 
     let stdout = '';

--- a/astro-docs/src/plugins/utils/nx-cli-generation.ts
+++ b/astro-docs/src/plugins/utils/nx-cli-generation.ts
@@ -42,6 +42,7 @@ export async function loadNxCliPackage(
       cwd: workspaceRoot,
       silent: true,
       stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+      windowsHide: true,
     });
 
     child.on('message', (message: any) => {

--- a/packages/create-nx-workspace/src/utils/child-process-utils.ts
+++ b/packages/create-nx-workspace/src/utils/child-process-utils.ts
@@ -25,7 +25,7 @@ export function spawnAndWait(command: string, args: string[], cwd: string) {
         ESLINT_USE_FLAT_CONFIG: process.env.ESLINT_USE_FLAT_CONFIG ?? 'true',
       },
       shell: true,
-      windowsHide: false,
+      windowsHide: true,
     });
 
     childProcess.on('exit', (code, signal) => {
@@ -47,7 +47,7 @@ export function execAndWait(
   return new Promise<{ code: number; stdout: string }>((res, rej) => {
     exec(
       command,
-      { cwd, env: { ...process.env, NX_DAEMON: 'false' }, windowsHide: false },
+      { cwd, env: { ...process.env, NX_DAEMON: 'false' }, windowsHide: true },
       (error, stdout, stderr) => {
         if (error) {
           if (silenceErrors) {

--- a/packages/create-nx-workspace/src/utils/git/default-base.ts
+++ b/packages/create-nx-workspace/src/utils/git/default-base.ts
@@ -8,7 +8,7 @@ export function deduceDefaultBase(): string {
   const nxDefaultBase = 'main';
   try {
     return (
-      execSync('git config --get init.defaultBranch', { windowsHide: false })
+      execSync('git config --get init.defaultBranch', { windowsHide: true })
         .toString()
         .trim() || nxDefaultBase
     );

--- a/packages/create-nx-workspace/src/utils/git/git.ts
+++ b/packages/create-nx-workspace/src/utils/git/git.ts
@@ -36,7 +36,7 @@ export async function checkGitVersion(): Promise<string | null | undefined> {
  */
 export function isGitAvailable(): boolean {
   try {
-    execSync('git --version', { stdio: 'ignore' });
+    execSync('git --version', { stdio: 'ignore', windowsHide: true });
     return true;
   } catch {
     return false;
@@ -49,7 +49,7 @@ export function isGitAvailable(): boolean {
  */
 export function isGhCliAvailable(): boolean {
   try {
-    execSync('gh --version', { stdio: 'ignore' });
+    execSync('gh --version', { stdio: 'ignore', windowsHide: true });
     return true;
   } catch {
     return false;

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -407,7 +407,7 @@ function shouldRecordStats(): boolean {
     // Use npm to check registry - this works regardless of which package manager invoked us
     const stdout = execSync('npm config get registry', {
       encoding: 'utf-8',
-      windowsHide: false,
+      windowsHide: true,
     });
     const url = new URL(stdout.trim());
 

--- a/packages/create-nx-workspace/src/utils/package-manager.ts
+++ b/packages/create-nx-workspace/src/utils/package-manager.ts
@@ -261,7 +261,7 @@ export function getPackageManagerVersion(
   const version = execSync(`${packageManager} --version`, {
     cwd,
     encoding: 'utf-8',
-    windowsHide: false,
+    windowsHide: true,
   }).trim();
   pmVersionCache.set(packageManager, version);
   return version;

--- a/packages/cypress/plugins/cypress-preset.ts
+++ b/packages/cypress/plugins/cypress-preset.ts
@@ -77,14 +77,14 @@ function startWebServer(webServerCommand: string) {
     // Windows is fine so we leave it attached to this process
     detached: process.platform !== 'win32',
     stdio: 'inherit',
-    windowsHide: false,
+    windowsHide: true,
   });
 
   return async () => {
     if (process.platform === 'win32') {
       try {
         execSync('taskkill /pid ' + serverProcess.pid + ' /T /F', {
-          windowsHide: false,
+          windowsHide: true,
         });
       } catch (e) {
         if (process.env.NX_VERBOSE_LOGGING === 'true') {

--- a/packages/detox/src/executors/build/build.impl.ts
+++ b/packages/detox/src/executors/build/build.impl.ts
@@ -41,6 +41,7 @@ export function runCliBuild(
       {
         cwd: pathResolve(workspaceRoot, projectRoot),
         env: process.env,
+        windowsHide: true,
       }
     );
 

--- a/packages/detox/src/executors/test/test.impl.ts
+++ b/packages/detox/src/executors/test/test.impl.ts
@@ -62,6 +62,7 @@ function runCliTest(
       {
         cwd: pathResolve(workspaceRoot, projectRoot),
         env: process.env,
+        windowsHide: true,
       }
     );
 

--- a/packages/devkit/src/tasks/install-packages-task.ts
+++ b/packages/devkit/src/tasks/install-packages-task.ts
@@ -43,7 +43,7 @@ export function installPackagesTask(
     const execSyncOptions: ExecSyncOptions = {
       cwd: join(tree.root, cwd),
       stdio: process.env.NX_GENERATE_QUIET === 'true' ? 'ignore' : 'inherit',
-      windowsHide: false,
+      windowsHide: true,
     };
     // ensure local registry from process is not interfering with the install
     // when we start the process from temp folder the local registry would override the custom registry

--- a/packages/docker/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/docker/src/executors/release-publish/release-publish.impl.ts
@@ -88,7 +88,7 @@ async function checkDockerImageExistsLocally(imageRef: string) {
         : imageRef;
       const childProcess = exec(
         `docker images --filter "reference=${normalizedImageRef}" --quiet`,
-        { encoding: 'utf8' }
+        { encoding: 'utf8', windowsHide: true }
       );
       let result = '';
       childProcess.stdout?.on('data', (data) => {
@@ -118,6 +118,7 @@ async function dockerPush(imageReference: string, quiet: boolean) {
         {
           encoding: 'utf8',
           maxBuffer: LARGE_BUFFER,
+          windowsHide: true,
         }
       );
       let result = '';

--- a/packages/expo/src/executors/build-list/build-list.impl.ts
+++ b/packages/expo/src/executors/build-list/build-list.impl.ts
@@ -48,6 +48,7 @@ export function runCliBuildList(
         cwd: pathResolve(workspaceRoot, projectRoot),
         env: process.env,
         stdio: ['inherit', 'pipe', 'inherit', 'ipc'], // only stream stdout on child process
+        windowsHide: true,
       }
     );
 

--- a/packages/expo/src/executors/build/build.impl.ts
+++ b/packages/expo/src/executors/build/build.impl.ts
@@ -65,6 +65,7 @@ function runCliBuild(
           ...(options.local ? { YARN_ENABLE_IMMUTABLE_INSTALLS: 'false' } : {}),
           ...process.env,
         },
+        windowsHide: true,
       }
     );
 

--- a/packages/expo/src/executors/export/export.impl.ts
+++ b/packages/expo/src/executors/export/export.impl.ts
@@ -44,7 +44,11 @@ function exportAsync(
     childProcess = fork(
       require.resolve('@expo/cli/build/bin/cli'),
       [`export`, ...createExportOptions(options, projectRoot)],
-      { cwd: pathResolve(workspaceRoot, projectRoot), env: process.env }
+      {
+        cwd: pathResolve(workspaceRoot, projectRoot),
+        env: process.env,
+        windowsHide: true,
+      }
     );
 
     // Ensure the child process is killed when the parent exits

--- a/packages/expo/src/executors/prebuild/prebuild.impl.ts
+++ b/packages/expo/src/executors/prebuild/prebuild.impl.ts
@@ -51,7 +51,11 @@ export function prebuildAsync(
     childProcess = fork(
       require.resolve('@expo/cli/build/bin/cli'),
       ['prebuild', ...createPrebuildOptions(options), '--no-install'],
-      { cwd: join(workspaceRoot, projectRoot), env: process.env }
+      {
+        cwd: join(workspaceRoot, projectRoot),
+        env: process.env,
+        windowsHide: true,
+      }
     );
 
     // Ensure the child process is killed when the parent exits

--- a/packages/expo/src/executors/run/run.impl.ts
+++ b/packages/expo/src/executors/run/run.impl.ts
@@ -66,6 +66,7 @@ function runCliRun(
       {
         cwd: pathResolve(workspaceRoot, projectRoot),
         env: process.env,
+        windowsHide: true,
       }
     );
 

--- a/packages/expo/src/executors/serve/serve.impl.ts
+++ b/packages/expo/src/executors/serve/serve.impl.ts
@@ -80,6 +80,7 @@ function serveAsync(
         cwd: pathResolve(workspaceRoot, projectRoot),
         env: process.env,
         stdio: ['inherit', 'pipe', 'pipe', 'ipc'],
+        windowsHide: true,
       }
     );
 

--- a/packages/expo/src/executors/start/start.impl.ts
+++ b/packages/expo/src/executors/start/start.impl.ts
@@ -52,6 +52,7 @@ function startAsync(
           RCT_METRO_PORT: options.port.toString(),
           ...process.env,
         },
+        windowsHide: true,
       }
     );
 

--- a/packages/expo/src/executors/submit/submit.impl.ts
+++ b/packages/expo/src/executors/submit/submit.impl.ts
@@ -43,6 +43,7 @@ function runCliSubmit(
       {
         cwd: pathResolve(workspaceRoot, projectRoot),
         env: process.env,
+        windowsHide: true,
       }
     );
 

--- a/packages/expo/src/executors/update/update.impl.ts
+++ b/packages/expo/src/executors/update/update.impl.ts
@@ -43,7 +43,11 @@ function runCliUpdate(
     childProcess = fork(
       resolveEas(workspaceRoot),
       ['update', ...createUpdateOptions(options)],
-      { cwd: pathResolve(workspaceRoot, projectRoot), env: process.env }
+      {
+        cwd: pathResolve(workspaceRoot, projectRoot),
+        env: process.env,
+        windowsHide: true,
+      }
     );
 
     // Ensure the child process is killed when the parent exits

--- a/packages/expo/src/utils/pod-install-task.ts
+++ b/packages/expo/src/utils/pod-install-task.ts
@@ -69,7 +69,7 @@ export function podInstall(
       execSync('touch .xcode.env', {
         cwd: iosDirectory,
         stdio: 'inherit',
-        windowsHide: false,
+        windowsHide: true,
       });
     }
     execSync(
@@ -79,7 +79,7 @@ export function podInstall(
       {
         cwd: iosDirectory,
         stdio: 'inherit',
-        windowsHide: false,
+        windowsHide: true,
       }
     );
   } catch (e) {

--- a/packages/expo/src/utils/resolve-eas.ts
+++ b/packages/expo/src/utils/resolve-eas.ts
@@ -11,13 +11,13 @@ export function resolveEas(workspaceRoot: string): string {
 
   let npmGlobalPath: string, yarnGlobalPath: string;
   try {
-    npmGlobalPath = execSync('npm root -g', { windowsHide: false })
+    npmGlobalPath = execSync('npm root -g', { windowsHide: true })
       ?.toString()
       ?.trim()
       ?.replace('\u001b[2K\u001b[1G', ''); // strip out ansi codes
   } catch {}
   try {
-    yarnGlobalPath = execSync('yarn global dir', { windowsHide: false })
+    yarnGlobalPath = execSync('yarn global dir', { windowsHide: true })
       ?.toString()
       ?.trim()
       ?.replace('\u001b[2K\u001b[1G', ''); // strip out ansi codes

--- a/packages/js/src/executors/node/lib/kill-tree.ts
+++ b/packages/js/src/executors/node/lib/kill-tree.ts
@@ -21,7 +21,7 @@ export async function killTree(pid: number, signal: NodeJS.Signals) {
         exec(
           'taskkill /pid ' + pid + ' /T /F',
           {
-            windowsHide: false,
+            windowsHide: true,
           },
           (error) => {
             // Ignore Fatal errors (128) because it might be due to the process already being killed.
@@ -37,7 +37,7 @@ export async function killTree(pid: number, signal: NodeJS.Signals) {
           pidsToProcess,
           function (parentPid) {
             return spawn('pgrep', ['-P', parentPid], {
-              windowsHide: false,
+              windowsHide: true,
             });
           },
           function () {
@@ -55,7 +55,7 @@ export async function killTree(pid: number, signal: NodeJS.Signals) {
               'ps',
               ['-o', 'pid', '--no-headers', '--ppid', parentPid],
               {
-                windowsHide: false,
+                windowsHide: true,
               }
             );
           },

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -190,6 +190,7 @@ export async function* nodeExecutor(
                   NX_FILE_TO_RUN: fileToRunCorrectPath(fileToRun),
                   NX_MAPPINGS: JSON.stringify(mappings),
                 },
+                windowsHide: true,
               }
             );
 
@@ -306,6 +307,7 @@ export async function* nodeExecutor(
             {
               cwd: context.root,
               stdio: 'inherit',
+              windowsHide: true,
             }
           );
           childProcess.once('exit', (code) => {

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -148,7 +148,7 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
         env: processEnv(true),
         cwd: context.root,
         stdio: ['ignore', 'pipe', 'pipe'],
-        windowsHide: false,
+        windowsHide: true,
       });
 
       const resultJson = JSON.parse(result.toString());
@@ -174,7 +174,7 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
               env: processEnv(true),
               cwd: context.root,
               stdio: 'ignore',
-              windowsHide: false,
+              windowsHide: true,
             });
             console.log(
               `Added the dist-tag ${tag} to v${currentVersion} for registry ${registry}.\n`
@@ -295,7 +295,7 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
       env: processEnv(true),
       cwd: context.root,
       stdio: ['ignore', 'pipe', 'pipe'],
-      windowsHide: false,
+      windowsHide: true,
     });
     // If in dry-run mode, the version on disk will not represent the version that would be published, so we scrub it from the output to avoid confusion.
     const dryRunVersionPlaceholder = 'X.X.X-dry-run';

--- a/packages/js/src/executors/verdaccio/verdaccio.impl.ts
+++ b/packages/js/src/executors/verdaccio/verdaccio.impl.ts
@@ -97,6 +97,7 @@ function startVerdaccio(
             : {}),
         },
         stdio: 'inherit',
+        windowsHide: true,
       }
     );
 
@@ -139,7 +140,7 @@ function createVerdaccioOptions(
 
 function setupNpm(options: VerdaccioExecutorSchema) {
   try {
-    execSync('npm --version', { env, windowsHide: false });
+    execSync('npm --version', { env, windowsHide: true });
   } catch (e) {
     return () => {};
   }
@@ -154,7 +155,7 @@ function setupNpm(options: VerdaccioExecutorSchema) {
         npmRegistryPaths.push(
           execSync(
             `npm config get ${registryName} --location ${options.location}`,
-            { env, windowsHide: false }
+            { env, windowsHide: true }
           )
             ?.toString()
             ?.trim()
@@ -162,12 +163,12 @@ function setupNpm(options: VerdaccioExecutorSchema) {
         );
         execSync(
           `npm config set ${registryName} http://${options.listenAddress}:${options.port}/ --location ${options.location}`,
-          { env, windowsHide: false }
+          { env, windowsHide: true }
         );
 
         execSync(
           `npm config set //${options.listenAddress}:${options.port}/:_authToken="secretVerdaccioToken" --location ${options.location}`,
-          { env, windowsHide: false }
+          { env, windowsHide: true }
         );
 
         logger.info(
@@ -184,7 +185,7 @@ function setupNpm(options: VerdaccioExecutorSchema) {
       try {
         const currentNpmRegistryPath = execSync(
           `npm config get registry --location ${options.location}`,
-          { env, windowsHide: false }
+          { env, windowsHide: true }
         )
           ?.toString()
           ?.trim()
@@ -197,7 +198,7 @@ function setupNpm(options: VerdaccioExecutorSchema) {
           ) {
             execSync(
               `npm config set ${registryName} ${npmRegistryPaths[index]} --location ${options.location}`,
-              { env, windowsHide: false }
+              { env, windowsHide: true }
             );
             logger.info(
               `Reset npm ${registryName} to ${npmRegistryPaths[index]}`
@@ -207,7 +208,7 @@ function setupNpm(options: VerdaccioExecutorSchema) {
               `npm config delete ${registryName} --location ${options.location}`,
               {
                 env,
-                windowsHide: false,
+                windowsHide: true,
               }
             );
             logger.info('Cleared custom npm registry');
@@ -215,7 +216,7 @@ function setupNpm(options: VerdaccioExecutorSchema) {
         });
         execSync(
           `npm config delete //${options.listenAddress}:${options.port}/:_authToken  --location ${options.location}`,
-          { env, windowsHide: false }
+          { env, windowsHide: true }
         );
       } catch (e) {
         throw new Error(`Failed to reset npm registry: ${e.message}`);
@@ -234,7 +235,7 @@ function getYarnUnsafeHttpWhitelist(isYarnV1: boolean) {
         JSON.parse(
           execSync(`yarn config get unsafeHttpWhitelist --json`, {
             env,
-            windowsHide: false,
+            windowsHide: true,
           }).toString()
         )
       )
@@ -250,13 +251,13 @@ function setYarnUnsafeHttpWhitelist(
       `yarn config set unsafeHttpWhitelist --json '${JSON.stringify(
         Array.from(currentWhitelist)
       )}'` + (options.location === 'user' ? ' --home' : ''),
-      { env, windowsHide: false }
+      { env, windowsHide: true }
     );
   } else {
     execSync(
       `yarn config unset unsafeHttpWhitelist` +
         (options.location === 'user' ? ' --home' : ''),
-      { env, windowsHide: false }
+      { env, windowsHide: true }
     );
   }
 }
@@ -269,9 +270,7 @@ function setupYarn(options: VerdaccioExecutorSchema) {
   try {
     isYarnV1 =
       major(
-        execSync('yarn --version', { env, windowsHide: false })
-          .toString()
-          .trim()
+        execSync('yarn --version', { env, windowsHide: true }).toString().trim()
       ) === 1;
   } catch {
     // This would fail if yarn is not installed which is okay
@@ -286,7 +285,7 @@ function setupYarn(options: VerdaccioExecutorSchema) {
       yarnRegistryPaths.push(
         execSync(`yarn config get ${scopeName}${registryConfigName}`, {
           env,
-          windowsHide: false,
+          windowsHide: true,
         })
           ?.toString()
           ?.trim()
@@ -296,7 +295,7 @@ function setupYarn(options: VerdaccioExecutorSchema) {
       execSync(
         `yarn config set ${scopeName}${registryConfigName} http://${options.listenAddress}:${options.port}/` +
           (options.location === 'user' ? ' --home' : ''),
-        { env, windowsHide: false }
+        { env, windowsHide: true }
       );
 
       logger.info(
@@ -323,7 +322,7 @@ function setupYarn(options: VerdaccioExecutorSchema) {
       try {
         const currentYarnRegistryPath = execSync(
           `yarn config get ${registryConfigName}`,
-          { env, windowsHide: false }
+          { env, windowsHide: true }
         )
           ?.toString()
           ?.trim()
@@ -344,7 +343,7 @@ function setupYarn(options: VerdaccioExecutorSchema) {
               {
                 env,
 
-                windowsHide: false,
+                windowsHide: true,
               }
             );
             logger.info(
@@ -354,7 +353,7 @@ function setupYarn(options: VerdaccioExecutorSchema) {
             execSync(
               `yarn config ${isYarnV1 ? 'delete' : 'unset'} ${registryName}` +
                 (options.location === 'user' ? ' --home' : ''),
-              { env, windowsHide: false }
+              { env, windowsHide: true }
             );
             logger.info(`Cleared custom yarn ${registryConfigName}`);
           }

--- a/packages/js/src/generators/setup-verdaccio/generator.ts
+++ b/packages/js/src/generators/setup-verdaccio/generator.ts
@@ -23,7 +23,7 @@ export async function setupVerdaccio(
     generateFiles(tree, path.join(__dirname, 'files'), '.verdaccio', {
       npmUplinkRegistry:
         execSync('npm config get registry', {
-          windowsHide: false,
+          windowsHide: true,
         })
           ?.toString()
           ?.trim() ?? 'https://registry.npmjs.org',

--- a/packages/js/src/plugins/jest/start-local-registry.ts
+++ b/packages/js/src/plugins/jest/start-local-registry.ts
@@ -35,7 +35,7 @@ export function startLocalRegistry({
         }`.split(' '),
         ...(storage ? [`--storage`, storage] : []),
       ],
-      { stdio: 'pipe' }
+      { stdio: 'pipe', windowsHide: true }
     );
 
     const listener = (data) => {
@@ -58,7 +58,7 @@ export function startLocalRegistry({
         execSync(
           `npm config set //${listenAddress}:${port}/:_authToken "${authToken}" --ws=false`,
           {
-            windowsHide: false,
+            windowsHide: true,
           }
         );
 
@@ -78,7 +78,7 @@ export function startLocalRegistry({
           execSync(
             `npm config delete //${listenAddress}:${port}/:_authToken --ws=false`,
             {
-              windowsHide: false,
+              windowsHide: true,
             }
           );
         });

--- a/packages/js/src/release/utils/update-lock-file.ts
+++ b/packages/js/src/release/utils/update-lock-file.ts
@@ -133,7 +133,7 @@ function execLockFileUpdate(command: string, cwd: string, env: object): void {
         ...process.env,
         ...env,
       },
-      windowsHide: false,
+      windowsHide: true,
     });
   } catch (e) {
     output.error({

--- a/packages/js/src/release/version-actions.ts
+++ b/packages/js/src/release/version-actions.ts
@@ -106,7 +106,7 @@ export default class JsVersionActions extends VersionActions {
         exec(
           `npm view ${packageName} version --"${registryConfigKey}=${registry}" --tag=${tag}`,
           {
-            windowsHide: false,
+            windowsHide: true,
           },
           (error, stdout, stderr) => {
             if (error) {

--- a/packages/js/src/utils/npm-config.ts
+++ b/packages/js/src/utils/npm-config.ts
@@ -108,7 +108,7 @@ async function getNpmConfigValue(key: string, cwd: string): Promise<string> {
 async function execAsync(command: string, cwd: string): Promise<string> {
   // Must be non-blocking async to allow spinner to render
   return new Promise<string>((resolve, reject) => {
-    exec(command, { cwd, windowsHide: false }, (error, stdout, stderr) => {
+    exec(command, { cwd, windowsHide: true }, (error, stdout, stderr) => {
       if (error) {
         return reject((stderr ? `${stderr}\n` : '') + error);
       }

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -84,7 +84,7 @@ export async function compileSwc(
     const swcCmdLog = execSync(getSwcCmd(normalizedOptions), {
       encoding: 'utf8',
       cwd: normalizedOptions.swcCliOptions.swcCwd,
-      windowsHide: false,
+      windowsHide: true,
       stdio: 'pipe',
     });
     logger.log(swcCmdLog.replace(/\n/, ''));
@@ -148,7 +148,7 @@ export async function* compileSwcWatch(
 
       const swcWatcher = exec(getSwcCmd(normalizedOptions, true), {
         cwd: normalizedOptions.swcCliOptions.swcCwd,
-        windowsHide: false,
+        windowsHide: true,
       });
 
       processOnExit = () => {

--- a/packages/maven/src/utils/detect-maven-executable.ts
+++ b/packages/maven/src/utils/detect-maven-executable.ts
@@ -49,7 +49,7 @@ export function isMaven4(workspaceRoot: string): boolean {
 export function detectMavenExecutable(workspaceRoot: string): string {
   // First priority: Check for Maven Daemon
   try {
-    execSync('mvnd --version', { stdio: 'pipe' });
+    execSync('mvnd --version', { stdio: 'pipe', windowsHide: true });
     logger.verbose(`[Maven] Found Maven Daemon, using: mvnd`);
     return 'mvnd';
   } catch {

--- a/packages/module-federation/src/executors/utils/build-static-remotes.ts
+++ b/packages/module-federation/src/executors/utils/build-static-remotes.ts
@@ -49,6 +49,7 @@ export async function buildStaticRemotes(
           // Ensure that webpack serve env var is not passed to static remotes
           WEBPACK_SERVE: 'false',
         },
+        windowsHide: true,
       }
     );
 

--- a/packages/module-federation/src/plugins/utils/build-static-remotes.ts
+++ b/packages/module-federation/src/plugins/utils/build-static-remotes.ts
@@ -39,6 +39,7 @@ export async function buildStaticRemotes(
           ...process.env,
           WEBPACK_SERVE: 'false',
         },
+        windowsHide: true,
       }
     );
     // File to debug build failures e.g. 2024-01-01T00_00_0_0Z-build.log'

--- a/packages/module-federation/src/plugins/utils/start-static-remotes-file-server.ts
+++ b/packages/module-federation/src/plugins/utils/start-static-remotes-file-server.ts
@@ -56,6 +56,7 @@ export function startStaticRemotesFileServer(
         FORCE_COLOR: 'true',
         ...process.env,
       },
+      windowsHide: true,
     }
   );
   process.on('SIGTERM', () => httpServerProcess.kill('SIGTERM'));

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -195,6 +195,7 @@ function runCliBuild(
         cwd: pathResolve(workspaceRoot, projectRoot),
         stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
         env: process.env,
+        windowsHide: true,
       }
     );
 

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -107,6 +107,7 @@ export default async function* serveExecutor(
         {
           cwd: options.dev ? projectRoot : nextDir,
           stdio: 'inherit',
+          windowsHide: true,
         }
       );
 

--- a/packages/nuxt/src/generators/application/application.ts
+++ b/packages/nuxt/src/generators/application/application.ts
@@ -242,7 +242,7 @@ export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
       execSync(`npx -y nuxi prepare`, {
         cwd: options.appProjectRoot,
 
-        windowsHide: false,
+        windowsHide: true,
       });
     } catch (e) {
       console.error(

--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -276,14 +276,14 @@ function getLocalNxVersion(workspace: WorkspaceTypeAndRoot): string | null {
 function _getLatestVersionOfNx(): string {
   try {
     return execSync('npm view nx@latest version', {
-      windowsHide: false,
+      windowsHide: true,
     })
       .toString()
       .trim();
   } catch {
     try {
       return execSync('pnpm view nx@latest version', {
-        windowsHide: false,
+        windowsHide: true,
       })
         .toString()
         .trim();

--- a/packages/nx/src/ai/clone-ai-config-repo.ts
+++ b/packages/nx/src/ai/clone-ai-config-repo.ts
@@ -16,6 +16,7 @@ function getLatestCommitHash(): string {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 30000, // 30 second timeout
+      windowsHide: true,
     });
     const hash = output.split('\t')[0];
     if (!hash || hash.length < 10) {
@@ -50,6 +51,7 @@ function cloneRepo(targetPath: string): void {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 120000, // 2 minute timeout for clone
+      windowsHide: true,
     });
 
     // Remove .git directory after clone

--- a/packages/nx/src/command-line/add/add.ts
+++ b/packages/nx/src/command-line/add/add.ts
@@ -59,7 +59,7 @@ async function installPackage(
       exec(
         command,
         {
-          windowsHide: false,
+          windowsHide: true,
         },
         (error, stdout, stderr) => {
           if (error) {

--- a/packages/nx/src/command-line/exec/exec.ts
+++ b/packages/nx/src/command-line/exec/exec.ts
@@ -54,7 +54,7 @@ export async function nxExecCommand(
         NX_PROJECT_ROOT_PATH:
           projectGraph.nodes?.[process.env.NX_TASK_TARGET_PROJECT]?.data?.root,
       },
-      windowsHide: false,
+      windowsHide: true,
     });
   } else {
     // nx exec is being ran inside of Nx's context
@@ -105,7 +105,7 @@ async function runScriptAsNxTarget(
             projectGraph.nodes?.[projectName]?.data?.root
           )
         : workspaceRoot,
-      windowsHide: false,
+      windowsHide: true,
     });
   });
 }
@@ -132,7 +132,7 @@ function runTargetOnProject(
   execSync(command, {
     stdio: 'inherit',
 
-    windowsHide: false,
+    windowsHide: true,
   });
 }
 

--- a/packages/nx/src/command-line/format/format.ts
+++ b/packages/nx/src/command-line/format/format.ts
@@ -216,7 +216,7 @@ function write(prettier: typeof import('prettier'), patterns: string[]) {
       )}`,
       {
         stdio: [0, 1, 2],
-        windowsHide: false,
+        windowsHide: true,
       }
     );
 
@@ -227,7 +227,7 @@ function write(prettier: typeof import('prettier'), patterns: string[]) {
         )} --parser json`,
         {
           stdio: [0, 1, 2],
-          windowsHide: false,
+          windowsHide: true,
         }
       );
     }
@@ -244,7 +244,7 @@ async function check(patterns: string[]): Promise<string[]> {
   return new Promise((resolve, reject) => {
     exec(
       `node "${prettierPath}" --list-different ${patterns.join(' ')}`,
-      { encoding: 'utf-8', windowsHide: false },
+      { encoding: 'utf-8', windowsHide: true },
       (error, stdout) => {
         if (error) {
           // The command failed because Prettier threw an error.

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -1521,6 +1521,6 @@ function getHelpTextFromTarget(
 
   return execSync(command, {
     cwd: target.options?.cwd ?? workspaceRoot,
-    windowsHide: false,
+    windowsHide: true,
   }).toString();
 }

--- a/packages/nx/src/command-line/init/configure-plugins.ts
+++ b/packages/nx/src/command-line/init/configure-plugins.ts
@@ -90,7 +90,7 @@ export async function runPluginInitGenerator(
   runNxSync(command, {
     stdio: [0, 1, 2],
     cwd: repoRoot,
-    windowsHide: false,
+    windowsHide: true,
     packageManagerCommand: pmc,
   });
 }

--- a/packages/nx/src/command-line/init/implementation/angular/integrated-workspace.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/integrated-workspace.ts
@@ -6,6 +6,6 @@ export function setupIntegratedWorkspace(): void {
   execSync(`${pmc.exec} nx g @nx/angular:ng-add`, {
     stdio: [0, 1, 2],
 
-    windowsHide: false,
+    windowsHide: true,
   });
 }

--- a/packages/nx/src/command-line/init/implementation/angular/legacy-angular-versions.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/legacy-angular-versions.ts
@@ -129,7 +129,7 @@ export async function getLegacyMigrationFunctionIfApplicable(
     output.log({ title: '📝 Setting up workspace' });
     execSync(`${pmc.exec} ${legacyMigrationCommand}`, {
       stdio: [0, 1, 2],
-      windowsHide: false,
+      windowsHide: true,
     });
 
     if (useNxCloud) {
@@ -170,7 +170,7 @@ async function installDependencies(
   }
   writeJsonFile(`package.json`, json);
 
-  execSync(pmc.install, { stdio: [0, 1, 2], windowsHide: false });
+  execSync(pmc.install, { stdio: [0, 1, 2], windowsHide: true });
 }
 
 async function resolvePackageVersion(

--- a/packages/nx/src/command-line/init/implementation/deduce-default-base.ts
+++ b/packages/nx/src/command-line/init/implementation/deduce-default-base.ts
@@ -5,35 +5,35 @@ export function deduceDefaultBase() {
   try {
     execSync(`git rev-parse --verify main`, {
       stdio: ['ignore', 'ignore', 'ignore'],
-      windowsHide: false,
+      windowsHide: true,
     });
     return 'main';
   } catch {
     try {
       execSync(`git rev-parse --verify dev`, {
         stdio: ['ignore', 'ignore', 'ignore'],
-        windowsHide: false,
+        windowsHide: true,
       });
       return 'dev';
     } catch {
       try {
         execSync(`git rev-parse --verify develop`, {
           stdio: ['ignore', 'ignore', 'ignore'],
-          windowsHide: false,
+          windowsHide: true,
         });
         return 'develop';
       } catch {
         try {
           execSync(`git rev-parse --verify next`, {
             stdio: ['ignore', 'ignore', 'ignore'],
-            windowsHide: false,
+            windowsHide: true,
           });
           return 'next';
         } catch {
           try {
             execSync(`git rev-parse --verify master`, {
               stdio: ['ignore', 'ignore', 'ignore'],
-              windowsHide: false,
+              windowsHide: true,
             });
             return 'master';
           } catch {

--- a/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
@@ -65,13 +65,13 @@ export function generateDotNxSetup(version?: string) {
   flushChanges(host.root, changes);
   // Ensure that the dot-nx installation is available.
   // This is needed when using a global nx with dot-nx, otherwise running any nx command using global command will fail due to missing modules.
-  execSync('./nx --version', { stdio: 'ignore' });
+  execSync('./nx --version', { stdio: 'ignore', windowsHide: true });
 }
 
 export function normalizeVersionForNxJson(pkg: string, version: string) {
   if (!valid(version)) {
     version = execSync(`npm view ${pkg}@${version} version`, {
-      windowsHide: false,
+      windowsHide: true,
     }).toString();
   }
   return version.trimEnd();

--- a/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
@@ -92,7 +92,7 @@ function performInstallation(
     cp.execSync('npm i', {
       cwd: path.dirname(installationPath),
       stdio: 'inherit',
-      windowsHide: false,
+      windowsHide: true,
     });
   } catch (e) {
     // revert possible changes to the current installation

--- a/packages/nx/src/command-line/init/implementation/react/check-for-uncommitted-changes.ts
+++ b/packages/nx/src/command-line/init/implementation/react/check-for-uncommitted-changes.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process';
 
 export function checkForUncommittedChanges() {
   const gitResult = execSync('git status --porcelain', {
-    windowsHide: false,
+    windowsHide: true,
   }).toString();
 
   const filteredResults = gitResult

--- a/packages/nx/src/command-line/init/implementation/react/index.ts
+++ b/packages/nx/src/command-line/init/implementation/react/index.ts
@@ -72,7 +72,7 @@ function installDependencies(options: NormalizedOptions) {
 
   execSync(`${options.pmc.addDev} ${dependencies.join(' ')}`, {
     stdio: [0, 1, 2],
-    windowsHide: false,
+    windowsHide: true,
   });
 }
 

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -233,7 +233,7 @@ export function runInstall(
   execSync(pmc.install, {
     stdio: [0, 1, 2],
     cwd: repoRoot,
-    windowsHide: false,
+    windowsHide: true,
   });
 }
 

--- a/packages/nx/src/command-line/init/init-v1.ts
+++ b/packages/nx/src/command-line/init/init-v1.ts
@@ -95,7 +95,7 @@ export async function initHandler(options: InitArgs) {
     } else {
       execSync(`npx --yes create-nx-workspace@${version} ${args}`, {
         stdio: [0, 1, 2],
-        windowsHide: false,
+        windowsHide: true,
       });
     }
   }

--- a/packages/nx/src/command-line/mcp/mcp.ts
+++ b/packages/nx/src/command-line/mcp/mcp.ts
@@ -32,6 +32,7 @@ export async function mcpHandler(args: any) {
   spawnSync(executable, execArgs, {
     stdio: 'inherit',
     cwd: workspaceRoot,
+    windowsHide: true,
   });
 }
 
@@ -57,6 +58,7 @@ export async function showHelp() {
   const helpOutput = spawnSync(executable, execArgs, {
     cwd: workspaceRoot,
     encoding: 'utf-8',
+    windowsHide: true,
   });
 
   console.log(helpOutput.stdout?.toString().replaceAll('nx-mcp', 'nx mcp'));

--- a/packages/nx/src/command-line/migrate/migrate-ui-api.ts
+++ b/packages/nx/src/command-line/migrate/migrate-ui-api.ts
@@ -62,11 +62,13 @@ export function recordInitialMigrationMetadata(
   const gitRef = execSync('git rev-parse HEAD', {
     cwd: workspacePath,
     encoding: 'utf-8',
+    windowsHide: true,
   }).trim();
 
   const gitSubject = execSync('git log -1 --pretty=%s', {
     cwd: workspacePath,
     encoding: 'utf-8',
+    windowsHide: true,
   }).trim();
 
   parsedMigrationsJson['nx-console'] = {
@@ -102,22 +104,26 @@ export function finishMigrationProcess(
   execSync('git add .', {
     cwd: workspacePath,
     encoding: 'utf-8',
+    windowsHide: true,
   });
 
   execSync(`git commit -m "${commitMessage}" --no-verify`, {
     cwd: workspacePath,
     encoding: 'utf-8',
+    windowsHide: true,
   });
 
   if (squashCommits && initialGitRef) {
     execSync(`git reset --soft ${initialGitRef.ref}`, {
       cwd: workspacePath,
       encoding: 'utf-8',
+      windowsHide: true,
     });
 
     execSync(`git commit -m "${commitMessage}" --no-verify`, {
       cwd: workspacePath,
       encoding: 'utf-8',
+      windowsHide: true,
     });
   }
 }
@@ -143,6 +149,7 @@ export async function runSingleMigration(
     const gitRefBefore = execSync('git rev-parse HEAD', {
       cwd: workspacePath,
       encoding: 'utf-8',
+      windowsHide: true,
     }).trim();
 
     // Run migration in a separate process so it can be cancelled
@@ -165,6 +172,7 @@ export async function runSingleMigration(
       {
         cwd: workspacePath,
         stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
       }
     );
 
@@ -228,6 +236,7 @@ export async function runSingleMigration(
         execSync('git add migrations.json', {
           cwd: workspacePath,
           encoding: 'utf-8',
+          windowsHide: true,
         });
       } catch (e) {
         // do nothing, this will fail if it's gitignored
@@ -235,11 +244,13 @@ export async function runSingleMigration(
       execSync('git commit --amend --no-verify --no-edit', {
         cwd: workspacePath,
         encoding: 'utf-8',
+        windowsHide: true,
       });
       // The revision changes after the amend, so we need to update it
       const amendedGitRef = execSync('git rev-parse HEAD', {
         cwd: workspacePath,
         encoding: 'utf-8',
+        windowsHide: true,
       }).trim();
 
       modifyMigrationsJsonMetadata(
@@ -274,6 +285,7 @@ export async function runSingleMigration(
       execSync('git add migrations.json', {
         cwd: workspacePath,
         encoding: 'utf-8',
+        windowsHide: true,
       });
     } catch (e) {
       // do nothing, this will fail if it's gitignored
@@ -442,6 +454,7 @@ export function undoMigration(workspacePath: string, id: string) {
     execSync(`git reset --hard ${existing.ref}^`, {
       cwd: workspacePath,
       encoding: 'utf-8',
+      windowsHide: true,
     });
     migrationsJsonMetadata.completedMigrations[id] = {
       type: 'skipped',

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -1558,7 +1558,7 @@ function runInstall(nxWorkspaceRoot?: string) {
   });
   execSync(installCommand, {
     stdio: [0, 1, 2],
-    windowsHide: false,
+    windowsHide: true,
     cwd: nxWorkspaceRoot ?? process.cwd(),
   });
 }
@@ -1907,7 +1907,7 @@ export async function runMigration() {
       }
       execSync(`${p} _migrate ${process.argv.slice(3).join(' ')}`, {
         stdio: ['inherit', 'inherit', 'inherit'],
-        windowsHide: false,
+        windowsHide: true,
       });
     }
   } else {
@@ -1995,14 +1995,14 @@ export async function nxCliPath(nxWorkspaceRoot?: string) {
       execSync(pmc.preInstall, {
         cwd: tmpDir,
         stdio,
-        windowsHide: false,
+        windowsHide: true,
       });
       // if it's berry ensure we set the node_linker to node-modules
       if (packageManager === 'yarn' && pmc.ciInstall.includes('immutable')) {
         execSync('yarn config set nodeLinker node-modules', {
           cwd: tmpDir,
           stdio,
-          windowsHide: false,
+          windowsHide: true,
         });
       }
     }
@@ -2010,7 +2010,7 @@ export async function nxCliPath(nxWorkspaceRoot?: string) {
     execSync(`${pmc.install} ${pmc.ignoreScriptsFlag ?? ''}`, {
       cwd: tmpDir,
       stdio,
-      windowsHide: false,
+      windowsHide: true,
     });
 
     // Set NODE_PATH so that these modules can be used for module resolution

--- a/packages/nx/src/command-line/migrate/run-migration-process.js
+++ b/packages/nx/src/command-line/migrate/run-migration-process.js
@@ -30,6 +30,7 @@ async function runMigrationProcess() {
     const gitRefBefore = execSync('git rev-parse HEAD', {
       cwd: workspacePath,
       encoding: 'utf-8',
+      windowsHide: true,
     }).trim();
 
     const { changes: fileChanges, nextSteps } = await runNxOrAngularMigration(
@@ -45,6 +46,7 @@ async function runMigrationProcess() {
     const gitRefAfter = execSync('git rev-parse HEAD', {
       cwd: workspacePath,
       encoding: 'utf-8',
+      windowsHide: true,
     }).trim();
 
     // Report success

--- a/packages/nx/src/command-line/nx-cloud/connect/view-logs.ts
+++ b/packages/nx/src/command-line/nx-cloud/connect/view-logs.ts
@@ -48,7 +48,7 @@ export async function viewLogs(): Promise<number> {
   const pmc = getPackageManagerCommand();
   execSync(`${pmc.exec} nx-cloud upload-and-show-run-details`, {
     stdio: [0, 1, 2],
-    windowsHide: false,
+    windowsHide: true,
   });
 
   if (!cloudUsed) {

--- a/packages/nx/src/command-line/release/config/version-plans.ts
+++ b/packages/nx/src/command-line/release/config/version-plans.ts
@@ -360,7 +360,7 @@ async function getCommitForVersionPlanFile(
     exec(
       `git log --diff-filter=A --pretty=format:"%s|%h|%an|%ae|%b" -n 1 -- ${rawVersionPlan.absolutePath}`,
       {
-        windowsHide: false,
+        windowsHide: true,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/packages/nx/src/command-line/release/utils/exec-command.ts
+++ b/packages/nx/src/command-line/release/utils/exec-command.ts
@@ -10,7 +10,7 @@ export async function execCommand(
       ...options,
       stdio: ['pipe', 'pipe', 'pipe'], // stdin, stdout, stderr
       encoding: 'utf-8',
-      windowsHide: false,
+      windowsHide: true,
     });
 
     let stdout = '';

--- a/packages/nx/src/command-line/release/utils/launch-editor.ts
+++ b/packages/nx/src/command-line/release/utils/launch-editor.ts
@@ -14,7 +14,7 @@ export async function launchEditor(filePath: string) {
   return new Promise((resolve, reject) => {
     const editorProcess = spawn(cmd, [...args, filePath], {
       stdio: 'inherit', // This will ensure the editor uses the current terminal
-      windowsHide: false,
+      windowsHide: true,
     });
 
     editorProcess.on('exit', (code) => {
@@ -30,7 +30,7 @@ export async function launchEditor(filePath: string) {
 function getGitConfig(key): string | null {
   try {
     return execSync(`git config --get ${key}`, {
-      windowsHide: false,
+      windowsHide: true,
     })
       .toString()
       .trim();

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/github.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/github.ts
@@ -57,6 +57,7 @@ export class GithubRemoteReleaseClient extends RemoteReleaseClient<GithubRemoteR
       const remoteUrl = execSync(`git remote get-url ${remoteName}`, {
         encoding: 'utf8',
         stdio: 'pipe',
+        windowsHide: true,
       }).trim();
 
       // Use the default provider if custom one is not specified or releases are disabled
@@ -128,7 +129,7 @@ export class GithubRemoteReleaseClient extends RemoteReleaseClient<GithubRemoteR
           const token = execSync(`gh auth token`, {
             encoding: 'utf8',
             stdio: 'pipe',
-            windowsHide: false,
+            windowsHide: true,
           }).trim();
           return { token, headerName: 'Authorization' };
         }

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.ts
@@ -59,6 +59,7 @@ export class GitLabRemoteReleaseClient extends RemoteReleaseClient<GitLabRelease
       const remoteUrl = execSync(`git remote get-url ${remoteName}`, {
         encoding: 'utf8',
         stdio: 'pipe',
+        windowsHide: true,
       }).trim();
 
       // Use the default provider if custom one is not specified or releases are disabled

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -519,7 +519,7 @@ function runPreVersionCommand(
       maxBuffer: LARGE_BUFFER,
       stdio,
       env,
-      windowsHide: false,
+      windowsHide: true,
     });
   } catch (e) {
     const title = verbose

--- a/packages/nx/src/command-line/run/run.ts
+++ b/packages/nx/src/command-line/run/run.ts
@@ -134,7 +134,7 @@ async function printTargetRunHelpInternal(
     } else {
       const cp = exec(helpCommand, {
         env,
-        windowsHide: false,
+        windowsHide: true,
       });
       cp.on('exit', (code) => {
         process.exit(code);

--- a/packages/nx/src/command-line/watch/watch.ts
+++ b/packages/nx/src/command-line/watch/watch.ts
@@ -134,7 +134,7 @@ class BatchCommandRunner extends BatchFunctionRunner {
               [this.projectNameEnv]: env[this.projectNameEnv],
               [this.fileChangesEnv]: env[this.fileChangesEnv],
             },
-            windowsHide: false,
+            windowsHide: true,
           });
           commandExec.on('close', () => {
             resolve();

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -1290,7 +1290,7 @@ export class DaemonClient {
         cwd: workspaceRoot,
         stdio: ['ignore', this._out.fd, this._err.fd],
         detached: true,
-        windowsHide: false,
+        windowsHide: true,
         shell: false,
         env: {
           ...DAEMON_ENV_OVERRIDABLE_SETTINGS,

--- a/packages/nx/src/daemon/client/generate-help-output.ts
+++ b/packages/nx/src/daemon/client/generate-help-output.ts
@@ -9,7 +9,7 @@ export function generateDaemonHelpOutput(): string {
    */
   const res = spawnSync(process.execPath, ['./exec-is-server-available.js'], {
     cwd: __dirname,
-    windowsHide: false,
+    windowsHide: true,
   });
 
   const isServerAvailable = res?.stdout?.toString().trim().indexOf('true') > -1;

--- a/packages/nx/src/daemon/server/shutdown-utils.ts
+++ b/packages/nx/src/daemon/server/shutdown-utils.ts
@@ -55,7 +55,7 @@ async function startNewDaemonInBackground() {
     cwd: workspaceRoot,
     stdio: ['ignore', out.fd, err.fd],
     detached: true,
-    windowsHide: false,
+    windowsHide: true,
     shell: false,
     env: process.env,
   });

--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -605,7 +605,7 @@ describe('Run Commands', () => {
           ...process.env,
           ...env(),
         },
-        windowsHide: false,
+        windowsHide: true,
       });
       expect(exec).toHaveBeenNthCalledWith(2, `echo 'Hello Universe'`, {
         maxBuffer: LARGE_BUFFER,
@@ -613,7 +613,7 @@ describe('Run Commands', () => {
           ...process.env,
           ...env(),
         },
-        windowsHide: false,
+        windowsHide: true,
       });
     });
 
@@ -636,7 +636,7 @@ describe('Run Commands', () => {
           ...process.env,
           ...env(),
         },
-        windowsHide: false,
+        windowsHide: true,
       });
       expect(exec).toHaveBeenNthCalledWith(2, `echo 'Hello Universe'`, {
         maxBuffer: LARGE_BUFFER,
@@ -644,7 +644,7 @@ describe('Run Commands', () => {
           ...process.env,
           ...env(),
         },
-        windowsHide: false,
+        windowsHide: true,
       });
     });
 
@@ -664,12 +664,12 @@ describe('Run Commands', () => {
       expect(exec).toHaveBeenNthCalledWith(1, `echo 'Hello World'`, {
         maxBuffer: LARGE_BUFFER,
         env: { ...process.env, FORCE_COLOR: `true`, ...env() },
-        windowsHide: false,
+        windowsHide: true,
       });
       expect(exec).toHaveBeenNthCalledWith(2, `echo 'Hello Universe'`, {
         maxBuffer: LARGE_BUFFER,
         env: { ...process.env, FORCE_COLOR: `true`, ...env() },
-        windowsHide: false,
+        windowsHide: true,
       });
     });
   });

--- a/packages/nx/src/executors/run-commands/running-tasks.ts
+++ b/packages/nx/src/executors/run-commands/running-tasks.ts
@@ -401,7 +401,7 @@ class RunningNodeProcess implements RunningTask {
       maxBuffer: LARGE_BUFFER,
       env,
       cwd,
-      windowsHide: false,
+      windowsHide: true,
     });
 
     // Register process for metrics collection

--- a/packages/nx/src/executors/run-script/run-script.impl.ts
+++ b/packages/nx/src/executors/run-script/run-script.impl.ts
@@ -56,7 +56,7 @@ function nodeProcess(
   return new Promise<void>((res, rej) => {
     let cp = exec(
       command,
-      { cwd, env, maxBuffer: LARGE_BUFFER, windowsHide: false },
+      { cwd, env, maxBuffer: LARGE_BUFFER, windowsHide: true },
       (error) => {
         if (error) {
           rej(error);

--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
@@ -36,7 +36,7 @@ function getNxInitDate(): string | null {
   try {
     const nxInitIso = execSync(
       'git log --diff-filter=A --follow --format=%aI -- nx.json | tail -1',
-      { stdio: 'pipe', windowsHide: false }
+      { stdio: 'pipe', windowsHide: true }
     )
       .toString()
       .trim();

--- a/packages/nx/src/plugins/js/lock-file/bun-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/bun-parser.ts
@@ -175,7 +175,7 @@ export function readBunLockFile(lockFilePath: string): string {
   return execSync(`bun ${lockFilePath}`, {
     encoding: 'utf-8',
     maxBuffer: 1024 * 1024 * 10,
-    windowsHide: false,
+    windowsHide: true,
   });
 }
 

--- a/packages/nx/src/project-graph/file-utils.ts
+++ b/packages/nx/src/project-graph/file-utils.ts
@@ -108,7 +108,7 @@ function defaultReadFileAtRevision(
       : execSync(`git show ${revision}:${filePathInGitRepository}`, {
           maxBuffer: TEN_MEGABYTES,
           stdio: ['pipe', 'pipe', 'ignore'],
-          windowsHide: false,
+          windowsHide: true,
         })
           .toString()
           .trim();

--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -358,7 +358,7 @@ export class Cache {
           stdio: 'ignore',
           detached: true,
           shell: false,
-          windowsHide: false,
+          windowsHide: true,
         });
         p.unref();
       } catch (e) {

--- a/packages/nx/src/tasks-runner/fork.ts
+++ b/packages/nx/src/tasks-runner/fork.ts
@@ -18,6 +18,7 @@ const childProcess = fork(script, {
   stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
   env: process.env,
   execArgv,
+  windowsHide: true,
 });
 
 const pseudoIPC = new PseudoIPCClient(pseudoIPCPath);

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -73,6 +73,7 @@ export class ForkedProcessTaskRunner {
         ...env,
         NX_FORKED_TASK_EXECUTOR: 'true',
       },
+      windowsHide: true,
     });
 
     // Register batch worker process with all tasks
@@ -219,6 +220,7 @@ export class ForkedProcessTaskRunner {
     const childId = task.id;
     const pseudoTerminal = await this.createPseudoTerminal();
     this.pseudoTerminals.add(pseudoTerminal);
+    // eslint-disable-next-line @nx/workspace/require-windows-hide -- this is the Rust pseudo-terminal fork, not child_process.fork
     const p = await pseudoTerminal.fork(childId, forkScript, {
       cwd: process.cwd(),
       execArgv: process.execArgv,
@@ -294,6 +296,7 @@ export class ForkedProcessTaskRunner {
           ...env,
           NX_FORKED_TASK_EXECUTOR: 'true',
         },
+        windowsHide: true,
       });
 
       // Register forked process for metrics collection
@@ -360,6 +363,7 @@ export class ForkedProcessTaskRunner {
           ...env,
           NX_FORKED_TASK_EXECUTOR: 'true',
         },
+        windowsHide: true,
       });
 
       // Register forked process for metrics collection

--- a/packages/nx/src/utils/ab-testing.ts
+++ b/packages/nx/src/utils/ab-testing.ts
@@ -108,7 +108,7 @@ function shouldRecordStats(): boolean {
   try {
     const stdout = execSync(pmc.getRegistryUrl, {
       encoding: 'utf-8',
-      windowsHide: false,
+      windowsHide: true,
     });
     const url = new URL(stdout.trim());
 

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -290,7 +290,7 @@ function getMergeBase(base: string, head: string = 'HEAD') {
       maxBuffer: TEN_MEGABYTES,
       cwd: workspaceRoot,
       stdio: 'pipe',
-      windowsHide: false,
+      windowsHide: true,
     })
       .toString()
       .trim();
@@ -300,7 +300,7 @@ function getMergeBase(base: string, head: string = 'HEAD') {
         maxBuffer: TEN_MEGABYTES,
         cwd: workspaceRoot,
         stdio: 'pipe',
-        windowsHide: false,
+        windowsHide: true,
       })
         .toString()
         .trim();
@@ -321,7 +321,7 @@ function parseGitOutput(command: string): string[] {
     maxBuffer: TEN_MEGABYTES,
     cwd: workspaceRoot,
     stdio: 'pipe',
-    windowsHide: false,
+    windowsHide: true,
   })
     .toString('utf-8')
     .split('\n')

--- a/packages/nx/src/utils/default-base.ts
+++ b/packages/nx/src/utils/default-base.ts
@@ -5,7 +5,7 @@ export function deduceDefaultBase(): string {
   try {
     return (
       execSync('git config --get init.defaultBranch', {
-        windowsHide: false,
+        windowsHide: true,
       })
         .toString()
         .trim() || nxDefaultBase

--- a/packages/nx/src/utils/git-utils.index-filter.ts
+++ b/packages/nx/src/utils/git-utils.index-filter.ts
@@ -9,10 +9,10 @@ try {
   const { execSync } = require('child_process');
   // NOTE: Using env vars because Windows PowerShell has its own handling of quotes (") messes up quotes in args, even if escaped.
   const src = process.env.NX_IMPORT_SOURCE;
-  execSync('git read-tree --empty', { stdio: 'inherit', windowsHide: false });
+  execSync('git read-tree --empty', { stdio: 'inherit', windowsHide: true });
   execSync(`git reset ${process.env.GIT_COMMIT} -- "${src}"`, {
     stdio: 'inherit',
-    windowsHide: false,
+    windowsHide: true,
   });
 } catch (error) {
   console.error(`Error executing Git commands: ${error}`);

--- a/packages/nx/src/utils/git-utils.tree-filter.ts
+++ b/packages/nx/src/utils/git-utils.tree-filter.ts
@@ -15,7 +15,7 @@ try {
   const src = process.env.NX_IMPORT_SOURCE;
   const dest = process.env.NX_IMPORT_DESTINATION;
   const files = execSync(`git ls-files -z ${src}`, {
-    windowsHide: false,
+    windowsHide: true,
   })
     .toString()
     .trim()

--- a/packages/nx/src/utils/git-utils.ts
+++ b/packages/nx/src/utils/git-utils.ts
@@ -4,12 +4,16 @@ import { logger } from './logger';
 
 function execAsync(command: string, execOptions: ExecOptions) {
   return new Promise<string>((res, rej) => {
-    exec(command, execOptions, (err, stdout, stderr) => {
-      if (err) {
-        return rej(err);
+    exec(
+      command,
+      { ...execOptions, windowsHide: true },
+      (err, stdout, stderr) => {
+        if (err) {
+          return rej(err);
+        }
+        res(stdout.toString());
       }
-      res(stdout.toString());
-    });
+    );
   });
 }
 
@@ -40,7 +44,7 @@ export class GitRepository {
   getGitRootPath(cwd: string) {
     return execSync('git rev-parse --show-toplevel', {
       cwd,
-      windowsHide: false,
+      windowsHide: true,
     })
       .toString()
       .trim();
@@ -293,7 +297,7 @@ export function getVcsRemoteInfo(directory?: string): VcsRemoteInfo | null {
   try {
     const gitRemote = execSync('git remote -v', {
       stdio: 'pipe',
-      windowsHide: false,
+      windowsHide: true,
       cwd: directory,
     })
       .toString()
@@ -347,13 +351,14 @@ export function commitChanges(
       encoding: 'utf8',
       stdio: 'pipe',
       cwd: directory,
+      windowsHide: true,
     });
     execSync('git commit --no-verify -F -', {
       encoding: 'utf8',
       stdio: 'pipe',
       input: commitMessage,
       cwd: directory,
-      windowsHide: false,
+      windowsHide: true,
     });
   } catch (err) {
     if (directory) {
@@ -375,7 +380,7 @@ export function getLatestCommitSha(directory?: string): string | null {
     return execSync('git rev-parse HEAD', {
       encoding: 'utf8',
       stdio: 'pipe',
-      windowsHide: false,
+      windowsHide: true,
       cwd: directory,
     }).trim();
   } catch {

--- a/packages/nx/src/utils/require-nx-key.ts
+++ b/packages/nx/src/utils/require-nx-key.ts
@@ -7,7 +7,7 @@ export async function requireNxKey(): Promise<typeof import('@nx/key')> {
     if ('code' in e && e.code === 'MODULE_NOT_FOUND') {
       try {
         execSync(`${getPackageManagerCommand().addDev} @nx/key@latest`, {
-          windowsHide: false,
+          windowsHide: true,
         });
 
         // @ts-ignore

--- a/packages/playwright/src/executors/merge-reports/merge-reports.impl.ts
+++ b/packages/playwright/src/executors/merge-reports/merge-reports.impl.ts
@@ -84,7 +84,7 @@ export async function mergeReportsExecutor(
       cwd: projectRoot,
       stdio: 'inherit',
       shell: true,
-      windowsHide: false,
+      windowsHide: true,
     }
   );
 

--- a/packages/playwright/src/executors/playwright/playwright.impl.ts
+++ b/packages/playwright/src/executors/playwright/playwright.impl.ts
@@ -82,7 +82,7 @@ export async function playwrightExecutor(
     execSync(`${pmc.exec} playwright install`, {
       cwd: workspaceRoot,
       stdio: 'inherit',
-      windowsHide: false,
+      windowsHide: true,
     });
   }
 
@@ -146,6 +146,7 @@ function runPlaywright(args: string[], cwd: string, env?: NodeJS.ProcessEnv) {
       stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
       cwd,
       ...(env ? { env } : {}),
+      windowsHide: true,
     });
   } catch (e) {
     console.error(e);

--- a/packages/playwright/src/generators/configuration/configuration.ts
+++ b/packages/playwright/src/generators/configuration/configuration.ts
@@ -326,7 +326,7 @@ function getBrowsersInstallTask() {
     const pmc = getPackageManagerCommand();
     execSync(`${pmc.exec} playwright install`, {
       cwd: workspaceRoot,
-      windowsHide: false,
+      windowsHide: true,
     });
   };
 }

--- a/packages/plugin/src/utils/testing-utils/async-commands.ts
+++ b/packages/plugin/src/utils/testing-utils/async-commands.ts
@@ -21,7 +21,7 @@ export function runCommandAsync(
       {
         cwd: opts.cwd ?? tmpProjPath(),
         env: { ...process.env, ...opts.env },
-        windowsHide: false,
+        windowsHide: true,
       },
       (err, stdout, stderr) => {
         if (!opts.silenceError && err) {

--- a/packages/plugin/src/utils/testing-utils/commands.ts
+++ b/packages/plugin/src/utils/testing-utils/commands.ts
@@ -21,7 +21,7 @@ export function runNxCommand(
     const execSyncOptions: ExecSyncOptions = {
       cwd,
       env: { ...process.env, ...opts.env },
-      windowsHide: false,
+      windowsHide: true,
     };
     if (fileExists(tmpProjPath('package.json'))) {
       const pmc = getPackageManagerCommand(detectPackageManager(cwd));
@@ -59,6 +59,7 @@ export function runCommand(
       cwd: opts.cwd ?? tmpProjPath(),
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, ...opts?.env },
+      windowsHide: true,
     }).toString();
   } catch (e) {
     return e.stdout.toString() + e.stderr.toString();

--- a/packages/plugin/src/utils/testing-utils/nx-project.ts
+++ b/packages/plugin/src/utils/testing-utils/nx-project.ts
@@ -21,7 +21,7 @@ function runNxNewCommand(args?: string, silent?: boolean) {
     {
       cwd: localTmpDir,
       ...(silent && false ? { stdio: ['ignore', 'ignore', 'ignore'] } : {}),
-      windowsHide: false,
+      windowsHide: true,
     }
   );
 }
@@ -56,7 +56,7 @@ export function runPackageManagerInstall(silent: boolean = true) {
   const install = execSync(pmc.install, {
     cwd,
     ...(silent ? { stdio: ['ignore', 'ignore', 'ignore'] } : {}),
-    windowsHide: false,
+    windowsHide: true,
   });
   return install ? install.toString() : '';
 }

--- a/packages/react-native/src/executors/build-android/build-android.impl.ts
+++ b/packages/react-native/src/executors/build-android/build-android.impl.ts
@@ -35,6 +35,7 @@ function runCliBuild(
         stdio: 'inherit',
         cwd: pathResolve(workspaceRoot, projectRoot),
         env: { ...process.env, RCT_METRO_PORT: options.port.toString() },
+        windowsHide: true,
       }
     );
 

--- a/packages/react-native/src/executors/build-ios/build-ios.impl.ts
+++ b/packages/react-native/src/executors/build-ios/build-ios.impl.ts
@@ -41,6 +41,7 @@ function runCliBuildIOS(
       {
         cwd: pathResolve(workspaceRoot, projectRoot),
         env: { ...process.env, RCT_METRO_PORT: options.port.toString() },
+        windowsHide: true,
       }
     );
 

--- a/packages/react-native/src/executors/bundle/bundle.impl.ts
+++ b/packages/react-native/src/executors/bundle/bundle.impl.ts
@@ -39,6 +39,7 @@ function runCliBuild(
         stdio: 'inherit',
         cwd: pathResolve(workspaceRoot, projectRoot),
         env: process.env,
+        windowsHide: true,
       }
     );
 

--- a/packages/react-native/src/executors/run-android/run-android.impl.ts
+++ b/packages/react-native/src/executors/run-android/run-android.impl.ts
@@ -56,6 +56,7 @@ function runCliRunAndroid(
         stdio: 'inherit',
         cwd: pathResolve(workspaceRoot, projectRoot),
         env: { ...process.env, RCT_METRO_PORT: options.port.toString() },
+        windowsHide: true,
       }
     );
 

--- a/packages/react-native/src/executors/run-ios/run-ios.impl.ts
+++ b/packages/react-native/src/executors/run-ios/run-ios.impl.ts
@@ -56,6 +56,7 @@ function runCliRunIOS(
         stdio: 'inherit',
         cwd: pathResolve(workspaceRoot, projectRoot),
         env: { ...process.env, RCT_METRO_PORT: options.port.toString() },
+        windowsHide: true,
       }
     );
 

--- a/packages/react-native/src/executors/start/start.impl.ts
+++ b/packages/react-native/src/executors/start/start.impl.ts
@@ -69,6 +69,7 @@ function startAsync(
         cwd: pathResolve(workspaceRoot, projectRoot),
         env: process.env,
         stdio: 'inherit',
+        windowsHide: true,
       }
     );
 

--- a/packages/react-native/src/executors/upgrade/upgrade.impl.ts
+++ b/packages/react-native/src/executors/upgrade/upgrade.impl.ts
@@ -36,6 +36,7 @@ export function runCliUpgrade(
         stdio: 'inherit',
         cwd: pathResolve(workspaceRoot, projectRoot),
         env: process.env,
+        windowsHide: true,
       }
     );
 

--- a/packages/react-native/src/migrations/update-21-4-0/upgrade-react-native-projects.ts
+++ b/packages/react-native/src/migrations/update-21-4-0/upgrade-react-native-projects.ts
@@ -27,6 +27,7 @@ export default async function update(tree: Tree) {
       execSync(command, {
         stdio: 'inherit',
         cwd: process.cwd(),
+        windowsHide: true,
       });
     } catch (error) {
       logger.warn(

--- a/packages/react-native/src/utils/pod-install-task.ts
+++ b/packages/react-native/src/utils/pod-install-task.ts
@@ -72,7 +72,7 @@ export function podInstall(
       execSync('touch .xcode.env', {
         cwd: iosDirectory,
         stdio: 'inherit',
-        windowsHide: false,
+        windowsHide: true,
       });
     }
     const podCommand = [
@@ -83,7 +83,7 @@ export function podInstall(
     execSync(podCommand, {
       cwd: iosDirectory,
       stdio: 'inherit',
-      windowsHide: false,
+      windowsHide: true,
     });
   } catch (e) {
     logger.error(podInstallErrorMessage);

--- a/packages/react/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
+++ b/packages/react/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
@@ -98,6 +98,7 @@ async function buildHost(
       {
         cwd: context.root,
         stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+        windowsHide: true,
       }
     );
     staticProcess.stdout.on('data', (data) => {

--- a/packages/remix/src/executors/build/build.impl.ts
+++ b/packages/remix/src/executors/build/build.impl.ts
@@ -34,6 +34,7 @@ async function runBuild(
     const p = fork(remixBin, args, {
       cwd: join(context.root, projectRoot),
       stdio: 'inherit',
+      windowsHide: true,
     });
     p.on('exit', (code) => {
       if (code === 0) resolve();

--- a/packages/remix/src/executors/serve/serve.impl.ts
+++ b/packages/remix/src/executors/serve/serve.impl.ts
@@ -65,6 +65,7 @@ export default async function* serveExecutor(
       const server = fork(remixBin, ['dev', ...args], {
         cwd: join(workspaceRoot, projectRoot),
         stdio: 'inherit',
+        windowsHide: true,
       });
 
       server.once('exit', (code) => {

--- a/packages/rspack/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
+++ b/packages/rspack/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
@@ -97,6 +97,7 @@ async function buildHost(
       {
         cwd: context.root,
         stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+        windowsHide: true,
       }
     );
     staticProcess.stdout.on('data', (data) => {

--- a/packages/rspack/src/plugins/utils/plugins/rspack-nx-build-coordination-plugin.ts
+++ b/packages/rspack/src/plugins/utils/plugins/rspack-nx-build-coordination-plugin.ts
@@ -56,7 +56,7 @@ export class RspackNxBuildCoordinationPlugin {
     try {
       return await new Promise<void>((res) => {
         this.buildCmdProcess = exec(this.buildCmd, {
-          windowsHide: false,
+          windowsHide: true,
         });
 
         this.buildCmdProcess.stdout.pipe(process.stdout);

--- a/packages/storybook/src/generators/migrate-10/calling-storybook-cli.ts
+++ b/packages/storybook/src/generators/migrate-10/calling-storybook-cli.ts
@@ -25,7 +25,7 @@ export function callUpgrade(schema: Schema): 1 | Buffer {
       } upgrade ${schema.autoAcceptAllPrompts ? '--yes' : ''}`,
       {
         stdio: [0, 1, 2],
-        windowsHide: false,
+        windowsHide: true,
       }
     );
 

--- a/packages/storybook/src/generators/migrate-8/calling-storybook-cli.ts
+++ b/packages/storybook/src/generators/migrate-8/calling-storybook-cli.ts
@@ -25,7 +25,7 @@ export function callUpgrade(schema: Schema): 1 | Buffer {
       } upgrade ${schema.autoAcceptAllPrompts ? '--yes' : ''}`,
       {
         stdio: [0, 1, 2],
-        windowsHide: false,
+        windowsHide: true,
       }
     );
 
@@ -94,7 +94,7 @@ export function callAutomigrate(
           `${commandToRun}  ${schema.autoAcceptAllPrompts ? '--yes' : ''}`,
           {
             stdio: 'inherit',
-            windowsHide: false,
+            windowsHide: true,
           }
         );
 

--- a/packages/storybook/src/generators/migrate-9/calling-storybook-cli.ts
+++ b/packages/storybook/src/generators/migrate-9/calling-storybook-cli.ts
@@ -25,7 +25,7 @@ export function callUpgrade(schema: Schema): 1 | Buffer {
       } upgrade ${schema.autoAcceptAllPrompts ? '--yes' : ''}`,
       {
         stdio: [0, 1, 2],
-        windowsHide: false,
+        windowsHide: true,
       }
     );
 
@@ -90,7 +90,7 @@ export function callAutomigrate(
           `${commandToRun}  ${schema.autoAcceptAllPrompts ? '--yes' : ''}`,
           {
             stdio: 'inherit',
-            windowsHide: false,
+            windowsHide: true,
             env: process.env,
           }
         );

--- a/packages/vite/plugins/nx-vite-build-coordination.plugin.ts
+++ b/packages/vite/plugins/nx-vite-build-coordination.plugin.ts
@@ -19,7 +19,7 @@ export function nxViteBuildCoordinationPlugin(
   async function buildChangedProjects() {
     await new Promise<void>((res) => {
       activeBuildProcess = exec(options.buildCommand, {
-        windowsHide: false,
+        windowsHide: true,
       });
       activeBuildProcess.stdout.pipe(process.stdout);
       activeBuildProcess.stderr.pipe(process.stderr);

--- a/packages/vite/src/utils/executor-utils.ts
+++ b/packages/vite/src/utils/executor-utils.ts
@@ -34,7 +34,7 @@ export async function validateTypes(opts: {
       {
         cwd: opts.workspaceRoot,
         stdio: 'inherit',
-        windowsHide: false,
+        windowsHide: true,
       }
     );
   }

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -181,7 +181,7 @@ export default async function* fileServerExecutor(
           execFileSync(pmCmd, args, {
             stdio: [0, 1, 2],
             shell: true,
-            windowsHide: false,
+            windowsHide: true,
           });
         } catch {
           throw new Error(
@@ -246,6 +246,7 @@ export default async function* fileServerExecutor(
       FORCE_COLOR: 'true',
       ...process.env,
     },
+    windowsHide: true,
   });
 
   const processExitListener = () => {

--- a/packages/webpack/src/plugins/webpack-nx-build-coordination-plugin.ts
+++ b/packages/webpack/src/plugins/webpack-nx-build-coordination-plugin.ts
@@ -74,7 +74,7 @@ export class WebpackNxBuildCoordinationPlugin {
     try {
       return await new Promise<void>((res) => {
         this.buildCmdProcess = exec(this.buildCmd, {
-          windowsHide: false,
+          windowsHide: true,
         });
 
         this.buildCmdProcess.stdout.pipe(process.stdout);

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -81,7 +81,7 @@ export async function newGenerator(tree: Tree, opts: Schema) {
           cwd: joinPathFragments(tree.root, options.directory),
           stdio:
             process.env.NX_GENERATE_QUIET === 'true' ? 'ignore' : 'inherit',
-          windowsHide: false,
+          windowsHide: true,
         });
       }
       installPackagesTask(

--- a/packages/workspace/src/generators/utils/get-npm-package-version.ts
+++ b/packages/workspace/src/generators/utils/get-npm-package-version.ts
@@ -24,7 +24,7 @@ export function getNpmPackageVersion(
       ['view', packageSpec, 'version', '--json'],
       {
         stdio: ['pipe', 'pipe', 'ignore'],
-        windowsHide: false,
+        windowsHide: true,
       }
     );
 

--- a/packages/workspace/src/utilities/default-base.ts
+++ b/packages/workspace/src/utilities/default-base.ts
@@ -5,7 +5,7 @@ export function deduceDefaultBase(): string {
   try {
     return (
       execSync('git config --get init.defaultBranch', {
-        windowsHide: false,
+        windowsHide: true,
       })
         .toString()
         .trim() || nxDefaultBase

--- a/tools/eslint-rules/index.ts
+++ b/tools/eslint-rules/index.ts
@@ -7,6 +7,10 @@ import {
   rule as validCommandObject,
 } from './rules/valid-command-object';
 import {
+  RULE_NAME as requireWindowsHideName,
+  rule as requireWindowsHide,
+} from './rules/require-windows-hide';
+import {
   RULE_NAME as validSchemaDescriptionName,
   rule as validSchemaDescription,
 } from './rules/valid-schema-description';
@@ -39,5 +43,6 @@ module.exports = {
     [validSchemaDescriptionName]: validSchemaDescription,
     [validCommandObjectName]: validCommandObject,
     [ensurePnpmLockVersionName]: ensurePnpmLockVersion,
+    [requireWindowsHideName]: requireWindowsHide,
   },
 };

--- a/tools/eslint-rules/rules/require-windows-hide.spec.ts
+++ b/tools/eslint-rules/rules/require-windows-hide.spec.ts
@@ -1,0 +1,63 @@
+import { TSESLint } from '@typescript-eslint/utils';
+import { rule, RULE_NAME } from './require-windows-hide';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+});
+
+ruleTester.run(RULE_NAME, rule, {
+  valid: [
+    // spawn with windowsHide: true
+    `import { spawn } from 'child_process';
+     spawn('echo', ['hello'], { stdio: 'inherit', windowsHide: true });`,
+    // fork with windowsHide: true
+    `import { fork } from 'child_process';
+     fork('script.js', { stdio: 'inherit', windowsHide: true });`,
+    // execSync with windowsHide: true
+    `import { execSync } from 'child_process';
+     execSync('echo hello', { windowsHide: true });`,
+    // spawnSync with windowsHide: true
+    `import { spawnSync } from 'child_process';
+     spawnSync('echo', ['hello'], { windowsHide: true });`,
+    // Not a spawn function, should not report
+    `someOtherFunction({ stdio: 'inherit' });`,
+    // Test file should be ignored
+    {
+      code: `import { spawn } from 'child_process';
+             spawn('echo', ['hello'], { stdio: 'inherit' });`,
+      filename: 'some-file.spec.ts',
+    },
+  ],
+  invalid: [
+    // spawn missing windowsHide
+    {
+      code: `import { spawn } from 'child_process';
+             spawn('echo', ['hello'], { stdio: 'inherit' });`,
+      errors: [{ messageId: 'missingWindowsHide' }],
+    },
+    // spawn with windowsHide: false
+    {
+      code: `import { spawn } from 'child_process';
+             spawn('echo', ['hello'], { stdio: 'inherit', windowsHide: false });`,
+      errors: [{ messageId: 'windowsHideMustBeTrue' }],
+    },
+    // fork missing windowsHide
+    {
+      code: `import { fork } from 'child_process';
+             fork('script.js', { stdio: ['inherit', 'pipe', 'pipe', 'ipc'] });`,
+      errors: [{ messageId: 'missingWindowsHide' }],
+    },
+    // execSync missing windowsHide
+    {
+      code: `import { execSync } from 'child_process';
+             execSync('echo hello', { encoding: 'utf-8' });`,
+      errors: [{ messageId: 'missingWindowsHide' }],
+    },
+    // Member expression: child_process.spawn
+    {
+      code: `import * as cp from 'child_process';
+             cp.spawn('echo', ['hello'], { stdio: 'inherit' });`,
+      errors: [{ messageId: 'missingWindowsHide' }],
+    },
+  ],
+});

--- a/tools/eslint-rules/rules/require-windows-hide.ts
+++ b/tools/eslint-rules/rules/require-windows-hide.ts
@@ -1,0 +1,116 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+
+// NOTE: The rule will be available in ESLint configs as "@nx/workspace-require-windows-hide"
+export const RULE_NAME = 'require-windows-hide';
+
+const SPAWN_FUNCTIONS = new Set([
+  'spawn',
+  'spawnSync',
+  'fork',
+  'exec',
+  'execSync',
+  'execFile',
+  'execFileSync',
+]);
+
+export const rule = ESLintUtils.RuleCreator(() => __filename)({
+  name: RULE_NAME,
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Ensures that child_process spawn/exec/fork calls include windowsHide: true to prevent console windows from flashing on Windows.',
+    },
+    schema: [],
+    messages: {
+      missingWindowsHide:
+        'windowsHide must be set to true to prevent console windows from flashing on Windows.',
+      windowsHideMustBeTrue:
+        'windowsHide must be set to true to prevent console windows from flashing on Windows.',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    // Skip spec/test files
+    if (
+      context.physicalFilename.endsWith('.spec.ts') ||
+      context.physicalFilename.endsWith('.test.ts')
+    ) {
+      return {};
+    }
+
+    return {
+      CallExpression(node: TSESTree.CallExpression) {
+        const calleeName = getCalleeName(node);
+        if (!calleeName || !SPAWN_FUNCTIONS.has(calleeName)) {
+          return;
+        }
+
+        // Find the options argument (object expression) in the call arguments
+        const optionsArg = node.arguments.find(
+          (arg): arg is TSESTree.ObjectExpression =>
+            arg.type === 'ObjectExpression'
+        );
+
+        if (!optionsArg) {
+          // If there's a spread or variable reference we can't statically analyze, skip
+          const hasNonLiteralObject = node.arguments.some(
+            (arg) =>
+              arg.type === 'Identifier' ||
+              arg.type === 'SpreadElement' ||
+              (arg.type === 'ObjectExpression' &&
+                arg.properties.some((p) => p.type === 'SpreadElement'))
+          );
+          // Only report if all args are literals and none is an options object
+          if (!hasNonLiteralObject) {
+            return;
+          }
+          return;
+        }
+
+        // Look for windowsHide property
+        const windowsHideProp = optionsArg.properties.find(
+          (prop): prop is TSESTree.Property =>
+            prop.type === 'Property' &&
+            prop.key.type === 'Identifier' &&
+            prop.key.name === 'windowsHide'
+        );
+
+        if (!windowsHideProp) {
+          // windowsHide is missing from the options object
+          context.report({
+            messageId: 'missingWindowsHide',
+            node: optionsArg,
+          });
+          return;
+        }
+
+        // windowsHide exists but check it's set to true
+        if (
+          windowsHideProp.value.type === 'Literal' &&
+          windowsHideProp.value.value !== true
+        ) {
+          context.report({
+            messageId: 'windowsHideMustBeTrue',
+            node: windowsHideProp,
+          });
+        }
+      },
+    };
+  },
+});
+
+function getCalleeName(node: TSESTree.CallExpression): string | null {
+  // Direct call: spawn(...)
+  if (node.callee.type === 'Identifier') {
+    return node.callee.name;
+  }
+  // Member expression: child_process.spawn(...)
+  if (
+    node.callee.type === 'MemberExpression' &&
+    node.callee.property.type === 'Identifier'
+  ) {
+    return node.callee.property.name;
+  }
+  return null;
+}

--- a/tools/workspace-plugin/src/conformance-rules/no-ignored-tracked-files/index.ts
+++ b/tools/workspace-plugin/src/conformance-rules/no-ignored-tracked-files/index.ts
@@ -17,6 +17,7 @@ export default createConformanceRule({
       const result = execSync('git ls-files -i --exclude-standard -c', {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
       }).trim();
 
       if (result) {


### PR DESCRIPTION
## Current Behavior

On Windows, `child_process.spawn`/`fork`/`exec` calls default to `windowsHide: false`, which creates a visible console window for each subprocess. This causes command prompt windows to flash on screen during project graph creation (daemon spawn), task execution, cache cleanup, and many other operations.

## Expected Behavior

No console windows should flash on Windows. All child process spawns use `windowsHide: true` to suppress the console window, and a custom ESLint rule enforces this going forward.

## Changes

- Set `windowsHide: true` on all `spawn`/`fork`/`exec`/`execSync`/`spawnSync` calls across the entire codebase (~123 files)
- Added custom ESLint rule `@nx/workspace/require-windows-hide` that:
  - Errors when any `spawn`/`fork`/`exec` call has an options object **missing** `windowsHide: true`
  - Errors when `windowsHide` is explicitly set to `false`
  - Skips test/spec files
- Updated test expectations in `run-commands.impl.spec.ts` to match

## Related Issue(s)

<!-- No specific issue filed, reported via development workflow -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)