### PR TITLE
fix(core): prevent staggered and duplicate lines in dynamic output

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/dynamic-run-many-terminal-output-life-cycle.ts
@@ -93,6 +93,7 @@ export async function createRunManyDynamicOutputRenderer({
   let renderIntervalId: NodeJS.Timeout | undefined;
 
   const moveCursorToStartOfPinnedFooter = () => {
+    readline.cursorTo(process.stdout, 0);
     readline.moveCursor(process.stdout, 0, -pinnedFooterNumLines);
   };
 

--- a/packages/nx/src/tasks-runner/life-cycles/dynamic-run-one-terminal-output-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/dynamic-run-one-terminal-output-life-cycle.ts
@@ -101,6 +101,7 @@ export async function createRunOneDynamicOutputRenderer({
   let renderDependentTargetsIntervalId: NodeJS.Timeout | undefined;
 
   const moveCursorToStartOfDependentTargetLines = () => {
+    readline.cursorTo(process.stdout, 0);
     readline.moveCursor(process.stdout, 0, -dependentTargetsNumLines);
   };
 

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -913,7 +913,14 @@ export function setEnvVarsBasedOnArgs(
     process.env.NX_STREAM_OUTPUT = 'true';
     process.env.NX_PREFIX_OUTPUT = 'false';
   }
-  if (nxArgs.outputStyle === 'dynamic' || nxArgs.outputStyle === 'tui') {
+  // Dynamic output styles only require forced streaming when the full TUI is
+  // active. If the TUI is disabled (e.g. single-task run-many fallback), the
+  // dynamic-legacy renderer should own the terminal output without interleaved
+  // task streaming.
+  if (
+    (nxArgs.outputStyle === 'dynamic' || nxArgs.outputStyle === 'tui') &&
+    isTuiEnabled()
+  ) {
     process.env.NX_STREAM_OUTPUT = 'true';
   }
   if (loadDotEnvFiles) {

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -913,14 +913,9 @@ export function setEnvVarsBasedOnArgs(
     process.env.NX_STREAM_OUTPUT = 'true';
     process.env.NX_PREFIX_OUTPUT = 'false';
   }
-  // Dynamic output styles only require forced streaming when the full TUI is
-  // active. If the TUI is disabled (e.g. single-task run-many fallback), the
-  // dynamic-legacy renderer should own the terminal output without interleaved
-  // task streaming.
-  if (
-    (nxArgs.outputStyle === 'dynamic' || nxArgs.outputStyle === 'tui') &&
-    isTuiEnabled()
-  ) {
+  // Force streaming only when the TUI is active, so it can capture and
+  // render task output. Other output styles manage their own streaming.
+  if (isTuiEnabled()) {
     process.env.NX_STREAM_OUTPUT = 'true';
   }
   if (loadDotEnvFiles) {

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -90,12 +90,17 @@ class CLIOutput {
   }
 
   overwriteLine(lineText: string = '') {
+    // Ensure we always start writing from column 0.
+    readline.cursorTo(process.stdout, 0);
     // this replaces the existing text up to the new line length
     process.stdout.write(lineText);
     // clear whatever text might be left to the right of the cursor (happens
     // when existing text was longer than new one)
     readline.clearLine(process.stdout, 1);
-    process.stdout.write(EOL);
+    // Move to the next line and re-anchor to column 0 without relying on
+    // terminal newline translation behavior.
+    process.stdout.write('\n');
+    readline.cursorTo(process.stdout, 0);
   }
 
   private writeOutputTitle({


### PR DESCRIPTION
## Current Behavior

- In some `nx run-many` executions, terminal output can appear staggered or visually misaligned instead of updating cleanly in place.
- For `run-many` cases that end up running a single task (especially when TUI is not active), the spinner/status line can be rendered twice.

## Expected Behavior

- Dynamic terminal output updates should remain stable and aligned, with clean in-place refreshes.
- Single-task `run-many` should display a single spinner/status line with no duplicate rendering.