### PR TITLE
feat(core): implement configure-ai-agents outdated message after tasks

### DIFF
--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -320,11 +320,11 @@ export async function setupAiAgentsGeneratorImpl(
     if (hasAgent('copilot')) {
       try {
         if (
-          isEditorInstalled(SupportedEditor.VSCode) &&
-          canInstallNxConsoleForEditor(SupportedEditor.VSCode)
+          (await isEditorInstalled(SupportedEditor.VSCode)) &&
+          (await canInstallNxConsoleForEditor(SupportedEditor.VSCode))
         ) {
           if (!check) {
-            installNxConsoleForEditor(SupportedEditor.VSCode);
+            await installNxConsoleForEditor(SupportedEditor.VSCode);
           }
           messages.push({
             title: `Installed Nx Console for VSCode`,
@@ -338,11 +338,11 @@ export async function setupAiAgentsGeneratorImpl(
       }
       try {
         if (
-          isEditorInstalled(SupportedEditor.VSCodeInsiders) &&
-          canInstallNxConsoleForEditor(SupportedEditor.VSCodeInsiders)
+          (await isEditorInstalled(SupportedEditor.VSCodeInsiders)) &&
+          (await canInstallNxConsoleForEditor(SupportedEditor.VSCodeInsiders))
         ) {
           if (!check) {
-            installNxConsoleForEditor(SupportedEditor.VSCodeInsiders);
+            await installNxConsoleForEditor(SupportedEditor.VSCodeInsiders);
           }
           messages.push({
             title: `Installed Nx Console for VSCode Insiders`,
@@ -358,11 +358,11 @@ export async function setupAiAgentsGeneratorImpl(
     if (hasAgent('cursor')) {
       try {
         if (
-          isEditorInstalled(SupportedEditor.Cursor) &&
-          canInstallNxConsoleForEditor(SupportedEditor.Cursor)
+          (await isEditorInstalled(SupportedEditor.Cursor)) &&
+          (await canInstallNxConsoleForEditor(SupportedEditor.Cursor))
         ) {
           if (!check) {
-            installNxConsoleForEditor(SupportedEditor.Cursor);
+            await installNxConsoleForEditor(SupportedEditor.Cursor);
           }
           messages.push({
             title: `Installed Nx Console for Cursor`,

--- a/packages/nx/src/ai/utils.ts
+++ b/packages/nx/src/ai/utils.ts
@@ -154,16 +154,18 @@ async function getAgentConfiguration(
     }
     case 'copilot': {
       const rulesPath = agentsMdPath(workspaceRoot);
-      const hasInstalledVSCode = isEditorInstalled(SupportedEditor.VSCode);
-      const hasInstalledVSCodeInsiders = isEditorInstalled(
+      const hasInstalledVSCode = await isEditorInstalled(
+        SupportedEditor.VSCode
+      );
+      const hasInstalledVSCodeInsiders = await isEditorInstalled(
         SupportedEditor.VSCodeInsiders
       );
       const hasInstalledNxConsoleForVSCode =
         hasInstalledVSCode &&
-        !canInstallNxConsoleForEditor(SupportedEditor.VSCode);
+        !(await canInstallNxConsoleForEditor(SupportedEditor.VSCode));
       const hasInstalledNxConsoleForVSCodeInsiders =
         hasInstalledVSCodeInsiders &&
-        !canInstallNxConsoleForEditor(SupportedEditor.VSCodeInsiders);
+        !(await canInstallNxConsoleForEditor(SupportedEditor.VSCodeInsiders));
 
       const agentsMdExists = existsSync(rulesPath);
 
@@ -180,10 +182,12 @@ async function getAgentConfiguration(
     }
     case 'cursor': {
       const rulesPath = agentsMdPath(workspaceRoot);
-      const hasInstalledCursor = isEditorInstalled(SupportedEditor.Cursor);
-      const hasInstalledNxConsole = !canInstallNxConsoleForEditor(
+      const hasInstalledCursor = await isEditorInstalled(
         SupportedEditor.Cursor
       );
+      const hasInstalledNxConsole = !(await canInstallNxConsoleForEditor(
+        SupportedEditor.Cursor
+      ));
       const agentsMdExists = existsSync(rulesPath);
 
       agentConfiguration = {

--- a/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
+++ b/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
@@ -22,13 +22,19 @@ export async function configureAiAgentsHandler(
   args: ConfigureAiAgentsOptions,
   inner = false
 ): Promise<void> {
+  // When called as inner from the tmp install, just run the impl directly
+  if (inner) {
+    return await configureAiAgentsHandlerImpl(args);
+  }
+
   // Use environment variable to force local execution
   if (
     process.env.NX_USE_LOCAL === 'true' ||
-    process.env.NX_AI_FILES_USE_LOCAL === 'true' ||
-    inner
+    process.env.NX_AI_FILES_USE_LOCAL === 'true'
   ) {
-    return await configureAiAgentsHandlerImpl(args);
+    await configureAiAgentsHandlerImpl(args);
+    await resetDaemonAgentStatus();
+    return;
   }
 
   let cleanup: () => void | undefined;
@@ -43,19 +49,19 @@ export async function configureAiAgentsHandler(
     );
 
     const module = await import(modulePath);
-    const configureAiAgentsResult = await module.configureAiAgentsHandler(
-      args,
-      true
-    );
+    await module.configureAiAgentsHandler(args, true);
     cleanup();
-    return configureAiAgentsResult;
   } catch (error) {
     if (cleanup) {
       cleanup();
     }
     // Fall back to local implementation
-    return configureAiAgentsHandlerImpl(args);
+    await configureAiAgentsHandlerImpl(args);
   }
+
+  // Reset daemon cache using the local daemon client (the inner handler's
+  // client belongs to the tmp install and isn't connected to our daemon)
+  await resetDaemonAgentStatus();
 }
 
 export async function configureAiAgentsHandlerImpl(
@@ -276,15 +282,6 @@ export async function configureAiAgentsHandlerImpl(
 
     configSpinner.stop();
 
-    // Tell the daemon to stop showing outdated agent messages
-    try {
-      if (await daemonClient.isServerAvailable()) {
-        await daemonClient.resetConfigureAiAgentsStatus();
-      }
-    } catch {
-      // Daemon may not be running, that's fine
-    }
-
     output.success({
       title: 'AI agents configured successfully',
       bodyLines: configuredOrUpdatedAgents.map(
@@ -407,4 +404,21 @@ function normalizeOptions(
     agents,
     check,
   };
+}
+
+async function resetDaemonAgentStatus(): Promise<void> {
+  try {
+    // Don't check daemonClient.enabled() — the CLI sets NX_DAEMON=false for
+    // configure-ai-agents (it doesn't need the daemon to do its work), but a
+    // daemon started by a previous command may still be running and serving
+    // cached status. We just need to reach it to reset its cache.
+    if (await daemonClient.isServerAvailable()) {
+      await daemonClient.resetConfigureAiAgentsStatus();
+    }
+  } catch {
+    // Daemon may not be running, that's fine
+  } finally {
+    // Close the daemon socket so the process can exit cleanly.
+    daemonClient.reset();
+  }
 }

--- a/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
+++ b/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
@@ -10,6 +10,7 @@ import {
   getAgentConfigurations,
   supportedAgents,
 } from '../../ai/utils';
+import { daemonClient } from '../../daemon/client/client';
 import { installPackageToTmp } from '../../devkit-internals';
 import { output } from '../../utils/output';
 import { ensurePackageHasProvenance } from '../../utils/provenance';
@@ -274,6 +275,15 @@ export async function configureAiAgentsHandlerImpl(
     );
 
     configSpinner.stop();
+
+    // Tell the daemon to stop showing outdated agent messages
+    try {
+      if (await daemonClient.isServerAvailable()) {
+        await daemonClient.resetConfigureAiAgentsStatus();
+      }
+    } catch {
+      // Daemon may not be running, that's fine
+    }
 
     output.success({
       title: 'AI agents configured successfully',

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -83,6 +83,13 @@ import {
   SET_NX_CONSOLE_PREFERENCE_AND_INSTALL,
   type SetNxConsolePreferenceAndInstallResponse,
 } from '../message-types/nx-console';
+import {
+  GET_CONFIGURE_AI_AGENTS_STATUS,
+  RESET_CONFIGURE_AI_AGENTS_STATUS,
+  type ConfigureAiAgentsStatusResponse,
+  type HandleGetConfigureAiAgentsStatusMessage,
+  type HandleResetConfigureAiAgentsStatusMessage,
+} from '../message-types/configure-ai-agents';
 import { REGISTER_PROJECT_GRAPH_LISTENER } from '../message-types/register-project-graph-listener';
 import {
   HandlePostTasksExecutionMessage,
@@ -960,6 +967,20 @@ export class DaemonClient {
     const message: HandleSetNxConsolePreferenceAndInstallMessage = {
       type: SET_NX_CONSOLE_PREFERENCE_AND_INSTALL,
       preference,
+    };
+    return this.sendToDaemonViaQueue(message);
+  }
+
+  getConfigureAiAgentsStatus(): Promise<ConfigureAiAgentsStatusResponse> {
+    const message: HandleGetConfigureAiAgentsStatusMessage = {
+      type: GET_CONFIGURE_AI_AGENTS_STATUS,
+    };
+    return this.sendToDaemonViaQueue(message);
+  }
+
+  resetConfigureAiAgentsStatus(): Promise<{ success: boolean }> {
+    const message: HandleResetConfigureAiAgentsStatusMessage = {
+      type: RESET_CONFIGURE_AI_AGENTS_STATUS,
     };
     return this.sendToDaemonViaQueue(message);
   }

--- a/packages/nx/src/daemon/message-types/configure-ai-agents.ts
+++ b/packages/nx/src/daemon/message-types/configure-ai-agents.ts
@@ -1,0 +1,47 @@
+export const GET_CONFIGURE_AI_AGENTS_STATUS =
+  'GET_CONFIGURE_AI_AGENTS_STATUS' as const;
+
+export type HandleGetConfigureAiAgentsStatusMessage = {
+  type: typeof GET_CONFIGURE_AI_AGENTS_STATUS;
+};
+
+export type AgentStatusInfo = {
+  name: string;
+  displayName: string;
+};
+
+export type ConfigureAiAgentsStatusResponse = {
+  fullyConfiguredAgents: AgentStatusInfo[];
+  outdatedAgents: AgentStatusInfo[];
+  partiallyConfiguredAgents: AgentStatusInfo[];
+  nonConfiguredAgents: AgentStatusInfo[];
+};
+
+export function isHandleGetConfigureAiAgentsStatusMessage(
+  message: unknown
+): message is HandleGetConfigureAiAgentsStatusMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message['type'] === GET_CONFIGURE_AI_AGENTS_STATUS
+  );
+}
+
+export const RESET_CONFIGURE_AI_AGENTS_STATUS =
+  'RESET_CONFIGURE_AI_AGENTS_STATUS' as const;
+
+export type HandleResetConfigureAiAgentsStatusMessage = {
+  type: typeof RESET_CONFIGURE_AI_AGENTS_STATUS;
+};
+
+export function isHandleResetConfigureAiAgentsStatusMessage(
+  message: unknown
+): message is HandleResetConfigureAiAgentsStatusMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message['type'] === RESET_CONFIGURE_AI_AGENTS_STATUS
+  );
+}

--- a/packages/nx/src/daemon/server/handle-configure-ai-agents.ts
+++ b/packages/nx/src/daemon/server/handle-configure-ai-agents.ts
@@ -1,0 +1,111 @@
+import type { ConfigureAiAgentsStatusResponse } from '../message-types/configure-ai-agents';
+import type { HandlerResult } from './server';
+import { serverLogger } from '../logger';
+import { workspaceRoot } from '../../utils/workspace-root';
+import { getLatestNxTmpPath } from './latest-nx';
+
+const emptyStatus: ConfigureAiAgentsStatusResponse = {
+  fullyConfiguredAgents: [],
+  outdatedAgents: [],
+  partiallyConfiguredAgents: [],
+  nonConfiguredAgents: [],
+};
+
+let cachedStatus: ConfigureAiAgentsStatusResponse | null = null;
+let isComputing = false;
+
+const log = (...messageParts: unknown[]) => {
+  serverLogger.log('[AI-AGENTS]:', ...messageParts);
+};
+
+export async function handleGetConfigureAiAgentsStatus(): Promise<HandlerResult> {
+  if (cachedStatus !== null) {
+    log('Returning cached agent configuration status');
+    return {
+      response: cachedStatus,
+      description: 'handleGetConfigureAiAgentsStatus',
+    };
+  }
+
+  if (!isComputing) {
+    isComputing = true;
+    log('Starting agent configuration status computation');
+    computeAgentStatuses()
+      .then((result) => {
+        cachedStatus = result;
+        isComputing = false;
+        log(
+          'Agent configuration status computation completed:',
+          `${result.fullyConfiguredAgents.length} fully configured,`,
+          `${result.outdatedAgents.length} outdated,`,
+          `${result.partiallyConfiguredAgents.length} partially configured,`,
+          `${result.nonConfiguredAgents.length} non-configured`
+        );
+      })
+      .catch((e) => {
+        log(`Error computing agent configuration status: ${e.message}`);
+        cachedStatus = { ...emptyStatus };
+        isComputing = false;
+      });
+  }
+
+  return {
+    response: { ...emptyStatus },
+    description: 'handleGetConfigureAiAgentsStatus',
+  };
+}
+
+export async function handleResetConfigureAiAgentsStatus(): Promise<HandlerResult> {
+  log(
+    'Resetting cached agent configuration status.',
+    `Previous state: cachedStatus=${cachedStatus === null ? 'null' : 'set'},`,
+    `isComputing=${isComputing}.`,
+    'Next GET will recompute.'
+  );
+  cachedStatus = null;
+  isComputing = false;
+  return {
+    response: { success: true },
+    description: 'handleResetConfigureAiAgentsStatus',
+  };
+}
+
+async function computeAgentStatuses(): Promise<ConfigureAiAgentsStatusResponse> {
+  try {
+    const tmpPath = await getLatestNxTmpPath();
+
+    const modulePath = require.resolve('nx/src/ai/utils.js', {
+      paths: [tmpPath],
+    });
+
+    const { getAgentConfigurations, supportedAgents } = await import(
+      modulePath
+    );
+
+    const {
+      fullyConfiguredAgents,
+      partiallyConfiguredAgents,
+      nonConfiguredAgents,
+    } = await getAgentConfigurations([...supportedAgents], workspaceRoot);
+
+    const toStatusInfo = (agent: { name: string; displayName: string }) => ({
+      name: agent.name,
+      displayName: agent.displayName,
+    });
+
+    return {
+      fullyConfiguredAgents: fullyConfiguredAgents.map(toStatusInfo),
+      outdatedAgents: fullyConfiguredAgents
+        .filter((agent: { outdated: boolean }) => agent.outdated)
+        .map(toStatusInfo),
+      partiallyConfiguredAgents: partiallyConfiguredAgents.map(toStatusInfo),
+      nonConfiguredAgents: nonConfiguredAgents.map(toStatusInfo),
+    };
+  } catch (error) {
+    log(
+      'Failed to compute agent configuration status from latest Nx. Error:',
+      error.message
+    );
+    return { ...emptyStatus };
+  }
+}

--- a/packages/nx/src/daemon/server/latest-nx.ts
+++ b/packages/nx/src/daemon/server/latest-nx.ts
@@ -1,0 +1,55 @@
+import { installPackageToTmpAsync } from '../../devkit-internals';
+import { serverLogger } from '../logger';
+
+// Module-level state - persists across invocations within daemon lifecycle
+let latestNxTmpPath: string | null = null;
+let cleanupFn: (() => void) | null = null;
+let installPromise: Promise<string> | null = null;
+
+/**
+ * Returns the path to a temp directory containing `nx@latest`.
+ * The installation is cached for the lifetime of the daemon process.
+ * Guards against concurrent callers by reusing the in-flight promise.
+ */
+export async function getLatestNxTmpPath(): Promise<string> {
+  if (latestNxTmpPath !== null) {
+    serverLogger.log(
+      '[LATEST-NX]: Reusing cached Nx installation from',
+      latestNxTmpPath
+    );
+    return latestNxTmpPath;
+  }
+
+  if (installPromise) {
+    return installPromise;
+  }
+
+  installPromise = (async () => {
+    serverLogger.log('[LATEST-NX]: Pulling latest Nx...');
+    const result = await installPackageToTmpAsync('nx', 'latest');
+    latestNxTmpPath = result.tempDir;
+    cleanupFn = result.cleanup;
+    installPromise = null;
+    serverLogger.log(
+      '[LATEST-NX]: Successfully pulled latest Nx to',
+      latestNxTmpPath
+    );
+    return latestNxTmpPath;
+  })();
+  return installPromise;
+}
+
+/**
+ * Clean up the latest Nx installation on daemon shutdown.
+ */
+export function cleanupLatestNx(): void {
+  if (cleanupFn) {
+    serverLogger.log(
+      '[LATEST-NX]: Cleaning up latest Nx installation from',
+      latestNxTmpPath
+    );
+    cleanupFn();
+  }
+  latestNxTmpPath = null;
+  cleanupFn = null;
+}

--- a/packages/nx/src/daemon/server/latest-nx.ts
+++ b/packages/nx/src/daemon/server/latest-nx.ts
@@ -25,16 +25,19 @@ export async function getLatestNxTmpPath(): Promise<string> {
   }
 
   installPromise = (async () => {
-    serverLogger.log('[LATEST-NX]: Pulling latest Nx...');
-    const result = await installPackageToTmpAsync('nx', 'latest');
-    latestNxTmpPath = result.tempDir;
-    cleanupFn = result.cleanup;
-    installPromise = null;
-    serverLogger.log(
-      '[LATEST-NX]: Successfully pulled latest Nx to',
-      latestNxTmpPath
-    );
-    return latestNxTmpPath;
+    try {
+      serverLogger.log('[LATEST-NX]: Pulling latest Nx...');
+      const result = await installPackageToTmpAsync('nx', 'latest');
+      latestNxTmpPath = result.tempDir;
+      cleanupFn = result.cleanup;
+      serverLogger.log(
+        '[LATEST-NX]: Successfully pulled latest Nx to',
+        latestNxTmpPath
+      );
+      return latestNxTmpPath;
+    } finally {
+      installPromise = null;
+    }
   })();
   return installPromise;
 }

--- a/packages/nx/src/daemon/server/nx-console-operations.ts
+++ b/packages/nx/src/daemon/server/nx-console-operations.ts
@@ -100,7 +100,7 @@ export async function getNxConsoleStatusImpl(): Promise<boolean> {
   const preferences = new NxConsolePreferences(homedir());
   const preference = preferences.getAutoInstallPreference();
 
-  const canInstallConsole = canInstallNxConsole();
+  const canInstallConsole = await canInstallNxConsole();
 
   // If user previously opted in but extension is not installed,
   // they must have manually uninstalled it - respect that choice
@@ -127,7 +127,7 @@ export async function handleNxConsolePreferenceAndInstallImpl(
 
   let installed = false;
   if (preference) {
-    installed = installNxConsole();
+    installed = await installNxConsole();
   }
 
   return { installed };

--- a/packages/nx/src/daemon/server/nx-console-operations.ts
+++ b/packages/nx/src/daemon/server/nx-console-operations.ts
@@ -1,4 +1,3 @@
-import { installPackageToTmpAsync } from '../../devkit-internals';
 import { homedir } from 'os';
 import {
   canInstallNxConsole,
@@ -6,10 +5,7 @@ import {
   NxConsolePreferences,
 } from '../../native';
 import { serverLogger } from '../logger';
-
-// Module-level state - persists across invocations within daemon lifecycle
-let latestNxTmpPath: string | null = null;
-let cleanupFn: (() => void) | null = null;
+import { getLatestNxTmpPath } from './latest-nx';
 
 const log = (...messageParts: unknown[]) => {
   serverLogger.log('[NX-CONSOLE]:', ...messageParts);
@@ -33,24 +29,11 @@ export async function getNxConsoleStatus({
   }
 
   try {
-    // If we don't have a tmp path yet, pull latest Nx
-    if (latestNxTmpPath === null) {
-      log('Pulling latest Nx (latest) to check console status...');
-      const packageInstallResults = await installPackageToTmpAsync(
-        'nx',
-        'latest'
-      );
-      latestNxTmpPath = packageInstallResults.tempDir;
-      cleanupFn = packageInstallResults.cleanup;
-      log('Successfully pulled latest Nx to', latestNxTmpPath);
-    } else {
-      log('Reusing cached Nx installation from', latestNxTmpPath);
-    }
+    const tmpPath = await getLatestNxTmpPath();
 
-    // Try to use the cached tmp path
     const modulePath = require.resolve(
       'nx/src/daemon/server/nx-console-operations.js',
-      { paths: [latestNxTmpPath] }
+      { paths: [tmpPath] }
     );
 
     const module = await import(modulePath);
@@ -58,11 +41,7 @@ export async function getNxConsoleStatus({
     log('Console status check completed, shouldPrompt:', result);
     return result;
   } catch (error) {
-    // If tmp path failed (e.g., directory was deleted), fall back to local immediately
-    log(
-      'Failed to use latest Nx, falling back to local implementation. Error:',
-      error.message
-    );
+    log('Failed to use latest Nx for console status. Error:', error.message);
     return await getNxConsoleStatusImpl();
   }
 }
@@ -90,24 +69,11 @@ export async function handleNxConsolePreferenceAndInstall({
   }
 
   try {
-    // If we don't have a tmp path yet, pull latest Nx
-    if (latestNxTmpPath === null) {
-      log('Pulling latest Nx (latest) to handle preference and install...');
-      const packageInstallResults = await installPackageToTmpAsync(
-        'nx',
-        'latest'
-      );
-      latestNxTmpPath = packageInstallResults.tempDir;
-      cleanupFn = packageInstallResults.cleanup;
-      log('Successfully pulled latest Nx to', latestNxTmpPath);
-    } else {
-      log('Reusing cached Nx installation from', latestNxTmpPath);
-    }
+    const tmpPath = await getLatestNxTmpPath();
 
-    // Try to use the cached tmp path
     const modulePath = require.resolve(
       'nx/src/daemon/server/nx-console-operations.js',
-      { paths: [latestNxTmpPath] }
+      { paths: [tmpPath] }
     );
 
     const module = await import(modulePath);
@@ -121,25 +87,12 @@ export async function handleNxConsolePreferenceAndInstall({
     );
     return result;
   } catch (error) {
-    // If tmp path failed (e.g., directory was deleted), fall back to local immediately
     log(
-      'Failed to use latest Nx, falling back to local implementation. Error:',
+      'Failed to use latest Nx for preference install. Error:',
       error.message
     );
     return await handleNxConsolePreferenceAndInstallImpl(preference);
   }
-}
-
-/**
- * Clean up the latest Nx installation on daemon shutdown.
- */
-export function cleanupLatestNxInstallation(): void {
-  if (cleanupFn) {
-    log('Cleaning up latest Nx installation from', latestNxTmpPath);
-    cleanupFn();
-  }
-  latestNxTmpPath = null;
-  cleanupFn = null;
 }
 
 export async function getNxConsoleStatusImpl(): Promise<boolean> {

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -159,6 +159,16 @@ import {
   handleGetNxConsoleStatus,
   handleSetNxConsolePreferenceAndInstall,
 } from './handle-nx-console';
+import {
+  GET_CONFIGURE_AI_AGENTS_STATUS,
+  RESET_CONFIGURE_AI_AGENTS_STATUS,
+  isHandleGetConfigureAiAgentsStatusMessage,
+  isHandleResetConfigureAiAgentsStatusMessage,
+} from '../message-types/configure-ai-agents';
+import {
+  handleGetConfigureAiAgentsStatus,
+  handleResetConfigureAiAgentsStatus,
+} from './handle-configure-ai-agents';
 import { deserialize, serialize } from 'v8';
 
 let performanceObserver: PerformanceObserver | undefined;
@@ -442,6 +452,20 @@ async function handleMessage(socket: Socket, data: string) {
       socket,
       SET_NX_CONSOLE_PREFERENCE_AND_INSTALL,
       () => handleSetNxConsolePreferenceAndInstall(payload.preference),
+      mode
+    );
+  } else if (isHandleGetConfigureAiAgentsStatusMessage(payload)) {
+    await handleResult(
+      socket,
+      GET_CONFIGURE_AI_AGENTS_STATUS,
+      () => handleGetConfigureAiAgentsStatus(),
+      mode
+    );
+  } else if (isHandleResetConfigureAiAgentsStatusMessage(payload)) {
+    await handleResult(
+      socket,
+      RESET_CONFIGURE_AI_AGENTS_STATUS,
+      () => handleResetConfigureAiAgentsStatus(),
       mode
     );
   } else {
@@ -756,6 +780,11 @@ export async function startServer(): Promise<Server> {
 
           // Kick off Nx Console check in background to prime the cache
           handleGetNxConsoleStatus().catch(() => {
+            // Ignore errors, this is a background operation
+          });
+
+          // Kick off AI agents outdated check in background to prime the cache
+          handleGetConfigureAiAgentsStatus().catch(() => {
             // Ignore errors, this is a background operation
           });
 

--- a/packages/nx/src/daemon/server/shutdown-utils.ts
+++ b/packages/nx/src/daemon/server/shutdown-utils.ts
@@ -11,7 +11,7 @@ import {
 import { removeDbConnections } from '../../utils/db-connection';
 import { cleanupPlugins } from '../../project-graph/plugins/get-plugins';
 import { MESSAGE_END_SEQ } from '../../utils/consume-messages-from-socket';
-import { cleanupLatestNxInstallation } from './nx-console-operations';
+import { cleanupLatestNx } from './latest-nx';
 import { spawn } from 'child_process';
 import { join } from 'path';
 import { mkdirSync, existsSync, writeFileSync } from 'node:fs';
@@ -145,8 +145,8 @@ async function performShutdown(
 
     removeDbConnections();
 
-    // Clean up Nx Console latest installation
-    cleanupLatestNxInstallation();
+    // Clean up shared latest Nx installation
+    cleanupLatestNx();
 
     serverLogger.log(`Server stopped because: "${reason}"`);
   } finally {

--- a/packages/nx/src/native/ide/install.rs
+++ b/packages/nx/src/native/ide/install.rs
@@ -126,17 +126,17 @@ fn install_extension(command: &str) -> Result<bool, Error> {
 }
 
 #[napi]
-pub fn can_install_nx_console() -> bool {
+pub async fn can_install_nx_console() -> bool {
     enable_logger();
 
     let current_editor = get_current_editor();
     debug!("Detected editor: {:?}", current_editor);
 
-    can_install_nx_console_for_editor(*current_editor)
+    can_install_nx_console_for_editor(*current_editor).await
 }
 
 #[napi]
-pub fn can_install_nx_console_for_editor(editor: SupportedEditor) -> bool {
+pub async fn can_install_nx_console_for_editor(editor: SupportedEditor) -> bool {
     enable_logger();
 
     if let Some(command) = get_command_for_editor(&editor) {
@@ -151,17 +151,17 @@ pub fn can_install_nx_console_for_editor(editor: SupportedEditor) -> bool {
 }
 
 #[napi]
-pub fn install_nx_console() -> bool {
+pub async fn install_nx_console() -> bool {
     enable_logger();
 
     let current_editor = get_current_editor();
     debug!("Detected editor: {:?}", current_editor);
 
-    return install_nx_console_for_editor(*current_editor);
+    return install_nx_console_for_editor(*current_editor).await;
 }
 
 #[napi]
-pub fn install_nx_console_for_editor(editor: SupportedEditor) -> bool {
+pub async fn install_nx_console_for_editor(editor: SupportedEditor) -> bool {
     enable_logger();
 
     if let Some(command) = get_command_for_editor(&editor) {
@@ -256,7 +256,7 @@ fn get_command_for_editor(editor: &SupportedEditor) -> Option<&'static str> {
 }
 
 #[napi]
-pub fn is_editor_installed(editor: SupportedEditor) -> bool {
+pub async fn is_editor_installed(editor: SupportedEditor) -> bool {
     enable_logger();
 
     if let Some(command) = get_command_for_editor(&editor) {

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -212,9 +212,9 @@ export interface CachedResult {
   size?: number
 }
 
-export declare export declare function canInstallNxConsole(): boolean
+export declare export declare function canInstallNxConsole(): Promise<boolean>
 
-export declare export declare function canInstallNxConsoleForEditor(editor: SupportedEditor): boolean
+export declare export declare function canInstallNxConsoleForEditor(editor: SupportedEditor): Promise<boolean>
 
 export declare export declare function closeDbConnection(connection: ExternalObject<NxDbConnection>): void
 
@@ -344,16 +344,16 @@ export interface InputsInput {
   projects?: string | Array<string>
 }
 
-export declare export declare function installNxConsole(): boolean
+export declare export declare function installNxConsole(): Promise<boolean>
 
-export declare export declare function installNxConsoleForEditor(editor: SupportedEditor): boolean
+export declare export declare function installNxConsoleForEditor(editor: SupportedEditor): Promise<boolean>
 
 export const IS_WASM: boolean
 
 /** Detects if the current process is being run by an AI agent */
 export declare export declare function isAiAgent(): boolean
 
-export declare export declare function isEditorInstalled(editor: SupportedEditor): boolean
+export declare export declare function isEditorInstalled(editor: SupportedEditor): Promise<boolean>
 
 export declare export declare function logDebug(message: string): void
 

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -552,6 +552,8 @@ export async function runCommandForTasks(
       printSummary();
     }
 
+    await printConfigureAiAgentsDisclaimer();
+
     await printNxKey();
 
     return {
@@ -561,6 +563,24 @@ export async function runCommandForTasks(
   } catch (e) {
     restoreTerminal?.();
     throw e;
+  }
+}
+
+async function printConfigureAiAgentsDisclaimer(): Promise<void> {
+  try {
+    if (!daemonClient.enabled() || !(await daemonClient.isServerAvailable())) {
+      return;
+    }
+    const { outdatedAgents } = await daemonClient.getConfigureAiAgentsStatus();
+    if (outdatedAgents.length > 0) {
+      output.logRawLine(
+        output.dim(
+          'Your AI agent configuration is outdated. Run "nx configure-ai-agents" to update.'
+        )
+      );
+    }
+  } catch {
+    // Silently ignore errors
   }
 }
 

--- a/packages/nx/src/utils/nx-console-prompt.ts
+++ b/packages/nx/src/utils/nx-console-prompt.ts
@@ -12,7 +12,7 @@ export async function ensureNxConsoleInstalled() {
   const preferences = new NxConsolePreferences(homedir());
   let setting = preferences.getAutoInstallPreference();
 
-  const canInstallConsole = canInstallNxConsole();
+  const canInstallConsole = await canInstallNxConsole();
 
   // If user previously opted in but extension is not installed,
   // they must have manually uninstalled it - respect that choice
@@ -37,7 +37,7 @@ export async function ensureNxConsoleInstalled() {
   }
 
   if (setting) {
-    const installed = installNxConsole();
+    const installed = await installNxConsole();
     if (installed) {
       output.log({ title: 'Successfully installed Nx Console!' });
     }

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -232,6 +232,11 @@ class CLIOutput {
     this.addNewline();
   }
 
+  logRawLine(message: string) {
+    this.writeToStdOut(`${message}${EOL}`);
+    this.addNewline();
+  }
+
   logCommand(message: string, taskStatus?: TaskStatus) {
     this.addNewline();
     this.writeToStdOut(this.getCommandWithStatus(message, taskStatus));


### PR DESCRIPTION
 After running nx build (or any task), the daemon now shows a hint if your AI agent configuration is outdated: "Your AI agent configuration is outdated. Run nx configure-ai-agents to update."

  The daemon computes and caches the full agent configuration status (fully configured, outdated, partially configured, non-configured) using latest Nx from npm, so the check is always against the newest available configuration. Running nx configure-ai-agents resets the daemon's cache so the message disappears on the next build.

  Key changes

  - Daemon agent status endpoint: New GET_CONFIGURE_AI_AGENTS_STATUS / RESET_CONFIGURE_AI_AGENTS_STATUS message types. The handler fires off
  computation in the background and returns immediately (never blocks the request). Results are cached for the daemon's lifetime.
  - Shared latest-nx module: Extracted the "install nx@latest to tmp" logic from nx-console-operations into daemon/server/latest-nx.ts so both Nx Console and AI agents handlers share a single cached installation. Includes a race-condition guard (in-flight promise deduplication).
  - Post-task outdated hint: run-command.ts queries the daemon after task execution and prints a single dim line if agents are outdated.
  - Daemon reset from configure-ai-agents: The CLI sets NX_DAEMON=false for configure-ai-agents, so we bypass daemonClient.enabled() and use
  isServerAvailable() directly to reach an already-running daemon. The socket is closed in a finally block so the process exits cleanly.
  - Async editor detection (Rust): Made isEditorInstalled, canInstallNxConsoleForEditor, installNxConsole, and related napi functions async so they run on the libuv thread pool instead of blocking Node's event loop. This prevents the daemon from stalling for ~3.5s when checking editor extensions.
  - output.logRawLine: New helper that prints a single line without the NX prefix.