### PR TITLE
fix(webpack): ensure safe `process.env` fallback replacement

### DIFF
--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -58,7 +58,7 @@ function getClientEnvironment(mode) {
     },
     // Provide a fallback for process.env itself to handle cases where code
     // accesses process.env directly (e.g., in Cypress component testing)
-    { 'process.env': '{}' } as Record<string, string>
+    { 'process.env': '({})' } as Record<string, string>
   );
 
   return { stringified };

--- a/packages/rspack/src/plugins/utils/apply-web-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-web-config.ts
@@ -428,7 +428,7 @@ function getClientEnvironment(mode?: string) {
     },
     // Provide a fallback for process.env itself to handle cases where code
     // accesses process.env directly (e.g., in Cypress component testing)
-    { 'process.env': '{}' } as Record<string, string>
+    { 'process.env': '({})' } as Record<string, string>
   );
 
   return { stringified };

--- a/packages/rspack/src/utils/with-web.ts
+++ b/packages/rspack/src/utils/with-web.ts
@@ -85,7 +85,7 @@ function getClientEnvironment(mode?: string) {
     },
     // Provide a fallback for process.env itself to handle cases where code
     // accesses process.env directly (e.g., in Cypress component testing)
-    { 'process.env': '{}' } as Record<string, string>
+    { 'process.env': '({})' } as Record<string, string>
   );
 
   return { stringified };

--- a/packages/webpack/src/utils/get-client-environment.ts
+++ b/packages/webpack/src/utils/get-client-environment.ts
@@ -26,7 +26,7 @@ export function getClientEnvironment(mode?: string) {
     },
     // Provide a fallback for process.env itself to handle cases where code
     // accesses process.env directly (e.g., in Cypress component testing)
-    { 'process.env': '{}' } as Record<string, string>
+    { 'process.env': '({})' } as Record<string, string>
   );
 
   return { stringified };


### PR DESCRIPTION
PR #30826 introduced a fallback definition for `process.env`:

```ts
{ 'process.env': '{}' }
```

Since `DefinePlugin` performs raw textual replacement, this can generate invalid JavaScript when user code accesses environment variables via dot notation:

```ts
process.env.SOME_KEY
```

becomes:

```js
{}.SOME_KEY
```

`{}` is parsed as a block statement (not an object literal), resulting in:


> Unexpected token: punc (.)

This PR updates the fallback to a parenthesized object literal:

```ts
{ 'process.env': '({})' }
```

which produces valid output:

```js
({}).SOME_KEY
```

This preserves the intended bundle-size optimization while ensuring syntactically correct output for standard `process.env.X` access patterns.


## Related Issue(s)
Refs #30826
Fixes #34460 

//CC @Coly010 @coolassassin 
