### PR TITLE
fix(nx-dev): use shared preview url for netlify deploy

### DIFF
--- a/astro-docs/astro.config.mjs
+++ b/astro-docs/astro.config.mjs
@@ -7,6 +7,11 @@ import markdoc from '@astrojs/markdoc';
 import tailwindcss from '@tailwindcss/vite';
 import { sidebar } from './sidebar.mts';
 import rehypeTableOptionLinks from './src/plugins/utils/rehype-table-option-links.ts';
+import { resolveNxDevUrl } from './src/utils/resolve-nx-dev-url.ts';
+
+// Always resolve NX_DEV_URL so downstream consumers (Footer, Header) pick it up.
+// For deploy previews this overrides any site-level env var to point to the matching preview.
+process.env.NX_DEV_URL = resolveNxDevUrl();
 
 const BASE = '/docs';
 

--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -3,6 +3,7 @@ import {
   getTechnologyKBItems,
   getTechnologyAPIItems,
 } from './src/plugins/utils/plugin-mappings';
+import { resolveNxDevUrl } from './src/utils/resolve-nx-dev-url';
 
 type SidebarItems = NonNullable<StarlightUserConfig['sidebar']>;
 
@@ -1159,7 +1160,7 @@ const referenceGroups: SidebarItems = [
       },
       {
         label: 'Changelog',
-        link: `${process.env.NX_DEV_URL ?? 'https://nx.dev'}/changelog`,
+        link: `${resolveNxDevUrl()}/changelog`,
       },
       {
         label: 'Deprecations',

--- a/astro-docs/src/components/layout/PageFrame.astro
+++ b/astro-docs/src/components/layout/PageFrame.astro
@@ -38,7 +38,7 @@ const bannerId = bannerConfig ? `${bannerConfig.title}-${bannerConfig.activeUnti
                 <GitHubStarWidget starsCount={githubStarsCount} client:load />
                 <div class="flex flex-col mx-2 gap-2">
                   <a
-                    href="https://nx.dev/contact"
+                    href={`${import.meta.env.SITE || 'https://nx.dev'}/contact`}
                     class="w-full inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-md transition no-underline border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 shadow-sm"
                     title="Contact Us"
                   >

--- a/astro-docs/src/utils/resolve-nx-dev-url.ts
+++ b/astro-docs/src/utils/resolve-nx-dev-url.ts
@@ -1,0 +1,14 @@
+export function resolveNxDevUrl(): string {
+  // Deploy previews always point to the matching nx-dev preview,
+  // overriding any site-level env var that would otherwise point to production.
+  if (
+    process.env.NETLIFY &&
+    process.env.CONTEXT === 'deploy-preview' &&
+    process.env.REVIEW_ID
+  ) {
+    const url = `https://deploy-preview-${process.env.REVIEW_ID}--nx-dev.netlify.app`;
+    console.log(`[deploy-preview] NX_DEV_URL overridden to: ${url}`);
+    return url;
+  }
+  return process.env.NX_DEV_URL ?? 'https://nx.dev';
+}

--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -2,8 +2,19 @@
 const { withNx } = require('@nx/next/plugins/with-nx');
 const redirectRules = require('./redirect-rules');
 
-if (!process.env.NEXT_PUBLIC_ASTRO_URL && !global.NX_GRAPH_CREATION) {
-  // If we're building for production throw error as each env must set this value.
+// For deploy previews, always point to the matching astro-docs preview
+// (overrides any site-level env var that would otherwise point to production).
+if (
+  !global.NX_GRAPH_CREATION &&
+  process.env.NETLIFY &&
+  process.env.CONTEXT === 'deploy-preview' &&
+  process.env.REVIEW_ID
+) {
+  process.env.NEXT_PUBLIC_ASTRO_URL = `https://deploy-preview-${process.env.REVIEW_ID}--nx-docs.netlify.app`;
+  console.log(
+    `[deploy-preview] NEXT_PUBLIC_ASTRO_URL overridden to: ${process.env.NEXT_PUBLIC_ASTRO_URL}`
+  );
+} else if (!process.env.NEXT_PUBLIC_ASTRO_URL && !global.NX_GRAPH_CREATION) {
   if (
     process.env.NODE_ENV === 'production' &&
     (process.env.VERCEL || process.env.NETLIFY)
@@ -11,9 +22,8 @@ if (!process.env.NEXT_PUBLIC_ASTRO_URL && !global.NX_GRAPH_CREATION) {
     throw new Error(
       `The NEXT_PUBLIC_ASTRO_URL environment variable is not set. Please set it to the URL of the Astro site.`
     );
-  }
-  // For dev, default to the canary docs.
-  else {
+  } else {
+    // For dev, default to the canary docs.
     process.env.NEXT_PUBLIC_ASTRO_URL = 'https://master--nx-docs.netlify.app';
   }
 }


### PR DESCRIPTION
nextjs and astro should route to same preview deployments now

![wm_2026-02-16T19-40-04](https://github.com/user-attachments/assets/593c011a-ff78-4412-9bf0-ad186157f5d4)


