### PR TITLE
feat(core): automatically set up ai agents in cnw/init when run from within an ai agent

### DIFF
--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -18,6 +18,7 @@ import {
   agentDisplayMap,
   supportedAgents,
 } from '../create-workspace-options';
+import { detectAiAgentName } from '../utils/ai/ai-output';
 import { CnwError } from '../utils/error-utils';
 
 export async function determineNxCloud(
@@ -150,7 +151,14 @@ export async function determineTemplate(
 export async function determineAiAgents(
   parsedArgs: yargs.Arguments<{ aiAgents?: Agent[]; interactive?: boolean }>
 ): Promise<Agent[]> {
-  return parsedArgs.aiAgents ?? [];
+  if (parsedArgs.aiAgents) {
+    return parsedArgs.aiAgents;
+  }
+  const detected = detectAiAgentName();
+  if (detected) {
+    return [detected as Agent];
+  }
+  return [];
 }
 
 async function aiAgentsPrompt(): Promise<Agent[]> {

--- a/packages/create-nx-workspace/src/utils/ai/ai-output.ts
+++ b/packages/create-nx-workspace/src/utils/ai/ai-output.ts
@@ -14,7 +14,12 @@ import { CnwErrorCode } from '../error-utils';
 let _isAiAgent: boolean | null = null;
 export function isAiAgent(): boolean {
   if (_isAiAgent === null) {
-    _isAiAgent = isClaudeCode() || isOpenCode() || isReplitAi() || isCursorAi();
+    _isAiAgent =
+      isClaudeCode() ||
+      isOpenCode() ||
+      isReplitAi() ||
+      isCursorAi() ||
+      isGeminiCli();
   }
   return _isAiAgent;
 }
@@ -36,6 +41,18 @@ export function isCursorAi(): boolean {
   const hasCursorTraceId = !!process.env.CURSOR_TRACE_ID;
   const hasComposerNoInteraction = !!process.env.COMPOSER_NO_INTERACTION;
   return pagerMatches && hasCursorTraceId && hasComposerNoInteraction;
+}
+
+export function isGeminiCli(): boolean {
+  return !!process.env.GEMINI_CLI;
+}
+
+export function detectAiAgentName(): string | null {
+  if (isClaudeCode()) return 'claude';
+  if (isCursorAi()) return 'cursor';
+  if (isOpenCode()) return 'opencode';
+  if (isGeminiCli()) return 'gemini';
+  return null;
 }
 
 // Progress stages for NDJSON streaming

--- a/packages/nx/src/ai/detect-ai-agent.ts
+++ b/packages/nx/src/ai/detect-ai-agent.ts
@@ -1,0 +1,10 @@
+import { detectAiAgent as nativeDetectAiAgent } from '../native';
+import { Agent, supportedAgents } from './utils';
+
+export function detectAiAgent(): Agent | null {
+  const detected = nativeDetectAiAgent();
+  if (detected && supportedAgents.includes(detected as Agent)) {
+    return detected as Agent;
+  }
+  return null;
+}

--- a/packages/nx/src/command-line/init/ai-agent-prompts.ts
+++ b/packages/nx/src/command-line/init/ai-agent-prompts.ts
@@ -1,6 +1,7 @@
 import { prompt } from 'enquirer';
 import { isCI } from '../../utils/is-ci';
 import { Agent, agentDisplayMap, supportedAgents } from '../../ai/utils';
+import { detectAiAgent } from '../../ai/detect-ai-agent';
 import * as pc from 'picocolors';
 
 export async function determineAiAgents(
@@ -8,7 +9,11 @@ export async function determineAiAgents(
   interactive?: boolean
 ): Promise<Agent[]> {
   if (interactive === false || isCI()) {
-    return aiAgents ?? [];
+    if (aiAgents) {
+      return aiAgents;
+    }
+    const detected = detectAiAgent();
+    return detected ? [detected] : [];
   }
 
   if (aiAgents) {

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -227,6 +227,13 @@ export interface DepsOutputsInput {
   transitive?: boolean
 }
 
+/**
+ * Detects which AI agent is running and returns its name.
+ * Returns None if no agent is detected.
+ * Filtering against supported agents should be done on the TypeScript side.
+ */
+export declare export declare function detectAiAgent(): string | null
+
 export interface EnvironmentInput {
   env: string
 }

--- a/packages/nx/src/native/native-bindings.js
+++ b/packages/nx/src/native/native-bindings.js
@@ -384,6 +384,7 @@ module.exports.canInstallNxConsoleForEditor = nativeBinding.canInstallNxConsoleF
 module.exports.closeDbConnection = nativeBinding.closeDbConnection
 module.exports.connectToNxDb = nativeBinding.connectToNxDb
 module.exports.copy = nativeBinding.copy
+module.exports.detectAiAgent = nativeBinding.detectAiAgent
 module.exports.EventType = nativeBinding.EventType
 module.exports.expandOutputs = nativeBinding.expandOutputs
 module.exports.findImports = nativeBinding.findImports

--- a/packages/nx/src/native/utils/ai.rs
+++ b/packages/nx/src/native/utils/ai.rs
@@ -8,7 +8,13 @@ fn is_claude_ai() -> bool {
             debug!("Claude AI detected via CLAUDECODE environment variable");
             true
         }
-        Err(_) => false,
+        Err(_) => match env::var("CLAUDE_CODE") {
+            Ok(_) => {
+                debug!("Claude AI detected via CLAUDE_CODE environment variable");
+                true
+            }
+            Err(_) => false,
+        },
     }
 }
 
@@ -53,10 +59,42 @@ fn is_opencode_ai() -> bool {
     }
 }
 
+/// Detects if the current process is being run by Gemini CLI
+fn is_gemini_ai() -> bool {
+    match env::var("GEMINI_CLI") {
+        Ok(_) => {
+            debug!("Gemini CLI detected via GEMINI_CLI environment variable");
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// Detects which AI agent is running and returns its name.
+/// Returns None if no agent is detected.
+/// Filtering against supported agents should be done on the TypeScript side.
+#[napi]
+pub fn detect_ai_agent() -> Option<String> {
+    if is_claude_ai() {
+        Some("claude".to_string())
+    } else if is_cursor_ai() {
+        Some("cursor".to_string())
+    } else if is_opencode_ai() {
+        Some("opencode".to_string())
+    } else if is_gemini_ai() {
+        Some("gemini".to_string())
+    } else if is_replit_ai() {
+        Some("replit".to_string())
+    } else {
+        None
+    }
+}
+
 /// Detects if the current process is being run by an AI agent
 #[napi]
 pub fn is_ai_agent() -> bool {
-    let is_ai = is_claude_ai() || is_replit_ai() || is_cursor_ai() || is_opencode_ai();
+    let is_ai =
+        is_claude_ai() || is_replit_ai() || is_cursor_ai() || is_opencode_ai() || is_gemini_ai();
 
     if is_ai {
         debug!("AI agent detected");
@@ -72,11 +110,13 @@ mod tests {
     fn clear_ai_env_vars() {
         let ai_vars = [
             "CLAUDECODE",
+            "CLAUDE_CODE",
             "REPL_ID",
             "PAGER",
             "CURSOR_TRACE_ID",
             "COMPOSER_NO_INTERACTION",
             "OPENCODE",
+            "GEMINI_CLI",
         ];
         for var in &ai_vars {
             unsafe {
@@ -89,11 +129,13 @@ mod tests {
     fn test_ai_agent_detection() {
         // Save original environment state
         let original_claudecode = env::var("CLAUDECODE").ok();
+        let original_claude_code = env::var("CLAUDE_CODE").ok();
         let original_repl_id = env::var("REPL_ID").ok();
         let original_pager = env::var("PAGER").ok();
         let original_cursor_trace_id = env::var("CURSOR_TRACE_ID").ok();
         let original_composer_no_interaction = env::var("COMPOSER_NO_INTERACTION").ok();
         let original_opencode = env::var("OPENCODE").ok();
+        let original_gemini_cli = env::var("GEMINI_CLI").ok();
 
         // Start with clean environment
         clear_ai_env_vars();
@@ -115,16 +157,43 @@ mod tests {
             !is_opencode_ai(),
             "Should not detect OpenCode AI without OPENCODE"
         );
+        assert!(
+            !is_gemini_ai(),
+            "Should not detect Gemini CLI without GEMINI_CLI"
+        );
         assert!(!is_ai_agent(), "Should not detect any AI agent");
 
-        // Test Claude AI detection
+        // Test Claude AI detection via CLAUDECODE
         unsafe {
             env::set_var("CLAUDECODE", "1");
         }
         assert!(is_claude_ai(), "Should detect Claude AI with CLAUDECODE");
         assert!(is_ai_agent(), "Main function should detect Claude AI");
+        assert_eq!(
+            detect_ai_agent(),
+            Some("claude".to_string()),
+            "detect_ai_agent should return claude"
+        );
         unsafe {
             env::remove_var("CLAUDECODE");
+        }
+
+        // Test Claude AI detection via CLAUDE_CODE (underscore variant)
+        unsafe {
+            env::set_var("CLAUDE_CODE", "1");
+        }
+        assert!(is_claude_ai(), "Should detect Claude AI with CLAUDE_CODE");
+        assert!(
+            is_ai_agent(),
+            "Main function should detect Claude AI via CLAUDE_CODE"
+        );
+        assert_eq!(
+            detect_ai_agent(),
+            Some("claude".to_string()),
+            "detect_ai_agent should return claude for CLAUDE_CODE"
+        );
+        unsafe {
+            env::remove_var("CLAUDE_CODE");
         }
 
         // Test Repl.it AI detection
@@ -133,6 +202,11 @@ mod tests {
         }
         assert!(is_replit_ai(), "Should detect Repl.it AI with REPL_ID");
         assert!(is_ai_agent(), "Main function should detect Repl.it AI");
+        assert_eq!(
+            detect_ai_agent(),
+            Some("replit".to_string()),
+            "detect_ai_agent should return replit"
+        );
         unsafe {
             env::remove_var("REPL_ID");
         }
@@ -143,6 +217,11 @@ mod tests {
         }
         assert!(is_opencode_ai(), "Should detect OpenCode AI with OPENCODE");
         assert!(is_ai_agent(), "Main function should detect OpenCode AI");
+        assert_eq!(
+            detect_ai_agent(),
+            Some("opencode".to_string()),
+            "detect_ai_agent should return opencode"
+        );
         unsafe {
             env::remove_var("OPENCODE");
         }
@@ -167,7 +246,27 @@ mod tests {
             "Should detect Cursor AI with correct PAGER and all variables"
         );
         assert!(is_ai_agent(), "Main function should detect Cursor AI");
+        assert_eq!(
+            detect_ai_agent(),
+            Some("cursor".to_string()),
+            "detect_ai_agent should return cursor"
+        );
         clear_ai_env_vars();
+
+        // Test Gemini CLI detection
+        unsafe {
+            env::set_var("GEMINI_CLI", "1");
+        }
+        assert!(is_gemini_ai(), "Should detect Gemini CLI with GEMINI_CLI");
+        assert!(is_ai_agent(), "Main function should detect Gemini CLI");
+        assert_eq!(
+            detect_ai_agent(),
+            Some("gemini".to_string()),
+            "detect_ai_agent should return gemini"
+        );
+        unsafe {
+            env::remove_var("GEMINI_CLI");
+        }
 
         // Test multiple AI agents
         unsafe {
@@ -179,11 +278,24 @@ mod tests {
             "Should detect AI when multiple agents are present"
         );
 
+        // Test detect_ai_agent with no agents
+        clear_ai_env_vars();
+        assert_eq!(
+            detect_ai_agent(),
+            None,
+            "detect_ai_agent should return None when no agent is detected"
+        );
+
         // Restore original environment
         clear_ai_env_vars();
         if let Some(val) = original_claudecode {
             unsafe {
                 env::set_var("CLAUDECODE", val);
+            }
+        }
+        if let Some(val) = original_claude_code {
+            unsafe {
+                env::set_var("CLAUDE_CODE", val);
             }
         }
         if let Some(val) = original_repl_id {
@@ -209,6 +321,11 @@ mod tests {
         if let Some(val) = original_opencode {
             unsafe {
                 env::set_var("OPENCODE", val);
+            }
+        }
+        if let Some(val) = original_gemini_cli {
+            unsafe {
+                env::set_var("GEMINI_CLI", val);
             }
         }
     }


### PR DESCRIPTION

We want to minimize prompts for people and agents. But we also want to help them by setting up nx config for them so their agents can work optimally.
If they're executing `nx init` or `create-nx-workspace` from within an agent, it's a reasonable assumption that they'll want the best AI config for that specific agent - so we set it up for them.