### PR TITLE
feat(core): add --otp to top-level nx release command and detect EOTP errors

### DIFF
--- a/packages/nx/src/command-line/release/command-object.ts
+++ b/packages/nx/src/command-line/release/command-object.ts
@@ -107,6 +107,7 @@ export type ReleaseOptions = NxReleaseArgs &
     yes?: boolean;
     preid?: VersionOptions['preid'];
     skipPublish?: boolean;
+    otp?: number;
   };
 
 export type VersionPlanArgs = {
@@ -224,6 +225,11 @@ const releaseCommand: CommandModule<NxReleaseArgs, ReleaseOptions> = {
             type: 'boolean',
             description:
               'Skip publishing by automatically answering no to the confirmation prompt for publishing.',
+          })
+          .option('otp', {
+            type: 'number',
+            description:
+              'A one-time password for publishing to a registry that requires 2FA.',
           })
           .check((argv) => {
             if (argv.yes !== undefined && argv.skipPublish !== undefined) {


### PR DESCRIPTION
## Current Behavior
When publish fails due to missing OTP code, its not clear as a user who is using the top level command what to do next.

## Expected Behavior
Add the --otp flag to the top-level `nx release` command so users can provide a one-time password for 2FA-enabled registries when running the full release orchestration (version + changelog + publish).

When publish fails due to an expired or missing OTP (EOTP error), display a helpful warning listing affected projects and the exact command to re-run the publish step in isolation with a new OTP.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
