### PR TITLE
fix(core): prevent silent ts-node fallback breaking ESM plugins on No…

### DIFF
--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -75,8 +75,8 @@
     "yargs-parser": "catalog:"
   },
   "peerDependencies": {
-    "@swc-node/register": "catalog:swc",
-    "@swc/core": "catalog:swc"
+    "@swc-node/register": "^1.8.0",
+    "@swc/core": "^1.3.85"
   },
   "peerDependenciesMeta": {
     "@swc-node/register": {

--- a/packages/nx/src/plugins/js/utils/register.spec.ts
+++ b/packages/nx/src/plugins/js/utils/register.spec.ts
@@ -34,3 +34,67 @@ describe('getTsNodeCompilerOptions', () => {
     ).toEqual(['es2022']);
   });
 });
+
+describe('getTranspiler - native TypeScript support', () => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    process,
+    'features'
+  );
+
+  function setProcessFeatures(value: any) {
+    Object.defineProperty(process, 'features', {
+      value,
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  afterEach(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(process, 'features', originalDescriptor);
+    } else {
+      delete (process as any).features;
+    }
+  });
+
+  it('should still use SWC when available even with native TS support', () => {
+    // Even when Node natively supports TS, SWC should be preferred when available
+    // because it's a faster, more complete transpiler
+    setProcessFeatures({ typescript: 'strip' });
+
+    const { getTranspiler } = require('./register');
+
+    // With SWC installed (as in this dev environment), getTranspiler should
+    // return a transpiler factory function regardless of native TS support
+    const result = getTranspiler({ module: 1 });
+    expect(result).toBeDefined();
+  });
+
+  it('should work correctly without native TS support', () => {
+    // Verify baseline behavior: getTranspiler should not throw
+    // when process.features.typescript is not available
+    setProcessFeatures(undefined);
+
+    const { getTranspiler } = require('./register');
+    expect(() => getTranspiler({ module: 1 })).not.toThrow();
+  });
+
+  it('should check process.features.typescript at call time not import time', () => {
+    // The native TS check uses process.features?.typescript which is
+    // evaluated at call time. This ensures the check is dynamic and
+    // doesn't use a cached module-level value.
+    const { getTranspiler } = require('./register');
+
+    // First call without native TS
+    setProcessFeatures(undefined);
+    const result1 = getTranspiler({ module: 1 });
+
+    // Second call with native TS - should still work (SWC takes priority)
+    setProcessFeatures({ typescript: 'strip' });
+    const result2 = getTranspiler({ module: 1 });
+
+    // Both should return defined values since SWC is installed
+    expect(result1).toBeDefined();
+    expect(result2).toBeDefined();
+  });
+});

--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -304,6 +304,16 @@ export function getTranspiler(
   let tsNodeOptions: TsConfigOptions | undefined;
   if (swcNodeInstalled && !preferTsNode) {
     _getTranspiler = getSwcTranspiler;
+  } else if (
+    !swcNodeInstalled &&
+    !!(process as any).features?.typescript &&
+    !preferTsNode
+  ) {
+    // When SWC is not available but Node natively supports TypeScript
+    // (Node 22.6+), skip registering any transpiler rather than falling
+    // back to ts-node. The ts-node fallback registers CommonJS require
+    // hooks which break ESM plugins with ERR_REQUIRE_ESM on Node 24.
+    _getTranspiler = undefined;
   } else if (tsNodeInstalled) {
     // We can fall back on ts-node if it's available
     _getTranspiler = getTsNodeTranspiler;

--- a/packages/nx/src/project-graph/plugins/transpiler.spec.ts
+++ b/packages/nx/src/project-graph/plugins/transpiler.spec.ts
@@ -1,0 +1,152 @@
+import { nodeNativelySupportsTypeScript } from './transpiler';
+
+describe('nodeNativelySupportsTypeScript', () => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    process,
+    'features'
+  );
+
+  function setProcessFeatures(value: any) {
+    Object.defineProperty(process, 'features', {
+      value,
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  afterEach(() => {
+    // Restore original process.features after each test
+    if (originalDescriptor) {
+      Object.defineProperty(process, 'features', originalDescriptor);
+    } else {
+      delete (process as any).features;
+    }
+  });
+
+  it('should return true when process.features.typescript is "strip"', () => {
+    setProcessFeatures({ typescript: 'strip' });
+    expect(nodeNativelySupportsTypeScript()).toBe(true);
+  });
+
+  it('should return true when process.features.typescript is "transform"', () => {
+    setProcessFeatures({ typescript: 'transform' });
+    expect(nodeNativelySupportsTypeScript()).toBe(true);
+  });
+
+  it('should return true when process.features.typescript is true', () => {
+    setProcessFeatures({ typescript: true });
+    expect(nodeNativelySupportsTypeScript()).toBe(true);
+  });
+
+  it('should return false when process.features.typescript is false', () => {
+    setProcessFeatures({ typescript: false });
+    expect(nodeNativelySupportsTypeScript()).toBe(false);
+  });
+
+  it('should return false when process.features is undefined', () => {
+    setProcessFeatures(undefined);
+    expect(nodeNativelySupportsTypeScript()).toBe(false);
+  });
+
+  it('should return false when process.features exists but typescript is not set', () => {
+    setProcessFeatures({});
+    expect(nodeNativelySupportsTypeScript()).toBe(false);
+  });
+});
+
+describe('registerPluginTSTranspiler', () => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    process,
+    'features'
+  );
+
+  function setProcessFeatures(value: any) {
+    Object.defineProperty(process, 'features', {
+      value,
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(process, 'features', originalDescriptor);
+    } else {
+      delete (process as any).features;
+    }
+  });
+
+  it('should skip transpiler registration and only register tsconfig paths when Node supports TS natively', () => {
+    // Simulate Node 22.6+ with native TypeScript support
+    setProcessFeatures({ typescript: 'strip' });
+
+    const mockRegisterTsConfigPaths = jest.fn(() => jest.fn());
+    const mockRegisterTranspiler = jest.fn(() => jest.fn());
+
+    jest.doMock('../../plugins/js/utils/register', () => ({
+      registerTsConfigPaths: mockRegisterTsConfigPaths,
+      registerTranspiler: mockRegisterTranspiler,
+    }));
+
+    jest.doMock('../../plugins/js/utils/typescript', () => ({
+      readTsConfigWithoutFiles: jest.fn(() => ({
+        options: {},
+        raw: {},
+      })),
+    }));
+
+    jest.doMock('node:fs', () => ({
+      existsSync: jest.fn(() => true),
+    }));
+
+    const {
+      registerPluginTSTranspiler,
+      pluginTranspilerIsRegistered,
+    } = require('./transpiler');
+
+    registerPluginTSTranspiler();
+
+    // tsconfig paths should still be registered for path mapping
+    expect(mockRegisterTsConfigPaths).toHaveBeenCalled();
+    // But the transpiler (swc/ts-node) should NOT be registered
+    expect(mockRegisterTranspiler).not.toHaveBeenCalled();
+    // The transpiler should still be considered "registered" for cleanup
+    expect(pluginTranspilerIsRegistered()).toBe(true);
+  });
+
+  it('should register transpiler when Node does not support TS natively', () => {
+    // Simulate older Node without native TypeScript support
+    setProcessFeatures(undefined);
+
+    const mockRegisterTsConfigPaths = jest.fn(() => jest.fn());
+    const mockRegisterTranspiler = jest.fn(() => jest.fn());
+
+    jest.doMock('../../plugins/js/utils/register', () => ({
+      registerTsConfigPaths: mockRegisterTsConfigPaths,
+      registerTranspiler: mockRegisterTranspiler,
+    }));
+
+    jest.doMock('../../plugins/js/utils/typescript', () => ({
+      readTsConfigWithoutFiles: jest.fn(() => ({
+        options: {},
+        raw: {},
+      })),
+    }));
+
+    jest.doMock('node:fs', () => ({
+      existsSync: jest.fn(() => true),
+    }));
+
+    const { registerPluginTSTranspiler } = require('./transpiler');
+
+    registerPluginTSTranspiler();
+
+    // Both tsconfig paths and transpiler should be registered
+    expect(mockRegisterTsConfigPaths).toHaveBeenCalled();
+    expect(mockRegisterTranspiler).toHaveBeenCalled();
+  });
+});

--- a/packages/nx/src/project-graph/plugins/transpiler.ts
+++ b/packages/nx/src/project-graph/plugins/transpiler.ts
@@ -11,8 +11,26 @@ import { workspaceRoot } from '../../utils/workspace-root';
 export let unregisterPluginTSTranspiler: (() => void) | null = null;
 
 /**
+ * When Node.js natively supports TypeScript (process.features.typescript is
+ * truthy, available in Node 22.6+), we can skip registering swc-node or
+ * ts-node transpilers since Node.js will handle TypeScript natively.
+ *
+ * This prevents the problematic fallback path where a missing SWC causes
+ * ts-node to be used, which then fails on ESM plugins with ERR_REQUIRE_ESM
+ * on Node 24.
+ */
+export function nodeNativelySupportsTypeScript(): boolean {
+  return !!(process as any).features?.typescript;
+}
+
+/**
  * Register swc-node or ts-node if they are not currently registered
  * with some default settings which work well for Nx plugins.
+ *
+ * If Node.js natively supports TypeScript (Node 22.6+), the transpiler
+ * registration is skipped and only tsconfig path mappings are registered.
+ * This avoids issues with ts-node's CommonJS require hooks breaking ESM
+ * plugin loading on modern Node versions.
  */
 export function registerPluginTSTranspiler() {
   // Get the first tsconfig that matches the allowed set
@@ -22,6 +40,17 @@ export function registerPluginTSTranspiler() {
   ].find((x) => existsSync(x));
 
   if (!tsConfigName) {
+    return;
+  }
+
+  // When Node.js natively supports TypeScript, skip transpiler registration
+  // but still register tsconfig-paths for path mapping support. This prevents
+  // the ts-node fallback that breaks ESM plugins with ERR_REQUIRE_ESM.
+  if (nodeNativelySupportsTypeScript()) {
+    const cleanupFn = registerTsConfigPaths(tsConfigName);
+    unregisterPluginTSTranspiler = () => {
+      cleanupFn?.();
+    };
     return;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2764,7 +2764,7 @@ importers:
         version: 2.3.0
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 21.1.0(f980f72dbbe44fac982acd2259e3661a)
+        version: 21.1.0(ccee4f196e8198b3110621a4745916e5)
       '@angular/localize':
         specifier: catalog:angular-supported-versions
         version: 21.1.0(@angular/compiler-cli@21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2))(@angular/compiler@21.1.0)
@@ -2870,7 +2870,7 @@ importers:
     dependencies:
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 21.1.0(9613cd481432c3d065f8f0fc994cc2d8)
+        version: 21.1.0(6b1a0cf84e61f1c844c41da18f524ece)
       '@angular/compiler-cli':
         specifier: catalog:angular-supported-versions
         version: 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
@@ -3647,11 +3647,11 @@ importers:
         specifier: 0.2.4
         version: 0.2.4
       '@swc-node/register':
-        specifier: catalog:swc
-        version: 1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2)
+        specifier: ^1.8.0
+        version: 1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2)
       '@swc/core':
-        specifier: catalog:swc
-        version: 1.15.8(@swc/helpers@0.5.18)
+        specifier: ^1.3.85
+        version: 1.15.10(@swc/helpers@0.5.18)
       '@yarnpkg/lockfile':
         specifier: ^1.1.0
         version: 1.1.0
@@ -27101,10 +27101,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.1.0(9613cd481432c3d065f8f0fc994cc2d8)':
+  '@angular/build@21.1.0(6b1a0cf84e61f1c844c41da18f524ece)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2101.0(chokidar@5.0.0)
+      '@angular-devkit/architect': 0.2101.0(chokidar@3.6.0)
       '@angular/compiler': 21.1.0
       '@angular/compiler-cli': 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
       '@babel/core': 7.28.5
@@ -27159,10 +27159,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.1.0(f980f72dbbe44fac982acd2259e3661a)':
+  '@angular/build@21.1.0(ccee4f196e8198b3110621a4745916e5)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2101.0(chokidar@5.0.0)
+      '@angular-devkit/architect': 0.2101.0(chokidar@3.6.0)
       '@angular/compiler': 21.1.0
       '@angular/compiler-cli': 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
       '@babel/core': 7.28.5
@@ -29964,7 +29964,7 @@ snapshots:
       '@babel/parser': 7.28.3
       '@babel/template': 7.27.2
       '@babel/types': 7.28.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -33457,7 +33457,7 @@ snapshots:
     dependencies:
       '@napi-rs/lzma': 1.4.3
       '@napi-rs/tar': 0.1.5
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -37557,10 +37557,30 @@ snapshots:
       - supports-color
       - typescript
 
+  '@swc-node/core@1.14.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)':
+    dependencies:
+      '@swc/core': 1.15.10(@swc/helpers@0.5.18)
+      '@swc/types': 0.1.25
+
   '@swc-node/core@1.14.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)':
     dependencies:
       '@swc/core': 1.15.8(@swc/helpers@0.5.18)
       '@swc/types': 0.1.25
+
+  '@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2)':
+    dependencies:
+      '@swc-node/core': 1.14.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)
+      '@swc-node/sourcemap-support': 0.6.1
+      '@swc/core': 1.15.10(@swc/helpers@0.5.18)
+      colorette: 2.0.20
+      debug: 4.4.3(supports-color@8.1.1)
+      oxc-resolver: 11.16.4
+      pirates: 4.0.7
+      tslib: 2.8.1
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@swc/types'
+      - supports-color
 
   '@swc-node/register@1.11.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2)':
     dependencies:
@@ -37673,7 +37693,6 @@ snapshots:
       '@swc/core-win32-ia32-msvc': 1.15.10
       '@swc/core-win32-x64-msvc': 1.15.10
       '@swc/helpers': 0.5.18
-    optional: true
 
   '@swc/core@1.15.8(@swc/helpers@0.5.18)':
     dependencies:
@@ -47702,7 +47721,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 2.0.0
       connect: 3.7.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
       error-stack-parser: 2.1.4
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
@@ -48191,7 +48210,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.2.0
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -55124,7 +55143,7 @@ snapshots:
   vite-node@3.2.4(@types/node@20.19.19)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.1)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.1.3(@types/node@20.19.19)(jiti@2.4.2)(less@4.1.3)(lightningcss@1.30.1)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.0)
@@ -55145,7 +55164,7 @@ snapshots:
   vite-node@3.2.4(@types/node@24.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.85.1)(sass@1.97.1)(stylus@0.64.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.1.3(@types/node@24.2.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.1)(sass-embedded@1.85.1)(sass@1.97.1)(stylus@0.64.0)(terser@5.44.1)(tsx@4.20.5)(yaml@2.8.0)


### PR DESCRIPTION
…de 24

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
After upgrading Nx from ≤ 22.4.5 to ≥ 22.5.0, ESM workspace plugins written in TypeScript fail to load on Node 24 with `ERR_REQUIRE_ESM`. This is caused by three compounding issues:

1. Commit 2bd8ef3f72 changed the `@swc-node/register` peer dependency from `^1.8.0` to an exact pin (`1.11.1` via `catalog:swc`). Since it's an optional peer, pnpm silently drops it when users have any other compatible version (e.g. `1.9.x`), causing `packageIsInstalled('@swc-node/register')` to return false.

2. When SWC is not detected, Nx falls back to ts-node, which registers CommonJS require hooks. On Node 24, loading `.ts` files from ESM packages via `require()` throws `ERR_REQUIRE_ESM`.

3. `registerPluginTSTranspiler()` does not check for Node's native TypeScript support (`process.features.typescript`), even though `registerTsProject()` already does. This means a transpiler is always registered even when unnecessary.


## Expected Behavior
- ESM workspace plugins load correctly on Node 24
- `@swc-node/register` is resolved with a compatible range (`^1.8.0`), not an exact pin
- When Node natively supports TypeScript (Node 22.6+), the plugin transpiler registration is skipped, avoiding the broken ts-node fallback
- When SWC is missing and Node has native TS support, `getTranspiler()` skips ts-node instead of registering CJS hooks that break ESM
- Existing setups that worked on ≤ 22.4.5 continue to work

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #34472 
