### PR TITLE
fix(core): resolve non-deterministic plugin worker startup failures

### DIFF
--- a/packages/nx/src/daemon/socket-utils.spec.ts
+++ b/packages/nx/src/daemon/socket-utils.spec.ts
@@ -1,0 +1,53 @@
+import { existsSync, unlinkSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { cleanupStaleSocketFile, isWindows } from './socket-utils';
+
+describe('cleanupStaleSocketFile', () => {
+  let tempSocketPath: string;
+
+  beforeEach(() => {
+    tempSocketPath = join(
+      tmpdir(),
+      `nx-test-socket-${process.pid}-${Date.now()}.sock`
+    );
+  });
+
+  afterEach(() => {
+    try {
+      unlinkSync(tempSocketPath);
+    } catch {}
+  });
+
+  it('should remove an existing socket file', () => {
+    if (isWindows) {
+      return; // Named pipes are managed by the OS on Windows
+    }
+    writeFileSync(tempSocketPath, '');
+    expect(existsSync(tempSocketPath)).toBe(true);
+
+    cleanupStaleSocketFile(tempSocketPath);
+
+    expect(existsSync(tempSocketPath)).toBe(false);
+  });
+
+  it('should not throw if the socket file does not exist', () => {
+    expect(() => {
+      cleanupStaleSocketFile(tempSocketPath);
+    }).not.toThrow();
+  });
+
+  it('should not throw for an empty path', () => {
+    expect(() => {
+      cleanupStaleSocketFile('');
+    }).not.toThrow();
+  });
+
+  it('should not throw if the path is a directory', () => {
+    // Attempting to unlink a directory will throw EISDIR/EPERM,
+    // but cleanupStaleSocketFile should swallow the error.
+    expect(() => {
+      cleanupStaleSocketFile(tmpdir());
+    }).not.toThrow();
+  });
+});

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-worker-lifecycle.spec.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-worker-lifecycle.spec.ts
@@ -1,0 +1,270 @@
+import { ChildProcess, spawn } from 'child_process';
+import { connect, createServer, Server, Socket } from 'net';
+import { existsSync, unlinkSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { cleanupStaleSocketFile } from '../../../daemon/socket-utils';
+
+/**
+ * Helper: waits for a server to become connectable on the given socket path.
+ * Polls every `intervalMs` for up to `timeoutMs`. Resolves with the connected
+ * socket on success, or rejects on timeout.
+ */
+function waitForServer(
+  socketPath: string,
+  timeoutMs = 10_000,
+  intervalMs = 50
+): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const attempt = () => {
+      if (Date.now() > deadline) {
+        reject(
+          new Error(
+            `Server not available on ${socketPath} within ${timeoutMs}ms`
+          )
+        );
+        return;
+      }
+      try {
+        const socket = connect(socketPath, () => {
+          resolve(socket);
+        });
+        socket.once('error', () => {
+          socket.destroy();
+          setTimeout(attempt, intervalMs);
+        });
+      } catch {
+        setTimeout(attempt, intervalMs);
+      }
+    };
+    attempt();
+  });
+}
+
+describe('plugin worker lifecycle', () => {
+  describe('stale socket cleanup before listen', () => {
+    let socketPath: string;
+    let server: Server;
+
+    beforeEach(() => {
+      socketPath = join(
+        tmpdir(),
+        `nx-lifecycle-test-${process.pid}-${Date.now()}.sock`
+      );
+    });
+
+    afterEach((done) => {
+      if (server) {
+        server.close(() => {
+          try {
+            unlinkSync(socketPath);
+          } catch {}
+          done();
+        });
+      } else {
+        try {
+          unlinkSync(socketPath);
+        } catch {}
+        done();
+      }
+    });
+
+    it('should allow a new server to listen after cleaning up a stale socket file', (done) => {
+      // Simulate a stale socket file left behind by a crashed worker
+      writeFileSync(socketPath, '');
+      expect(existsSync(socketPath)).toBe(true);
+
+      // Clean it up (as the fixed plugin-worker.ts now does)
+      cleanupStaleSocketFile(socketPath);
+      expect(existsSync(socketPath)).toBe(false);
+
+      // A new server should be able to listen successfully
+      server = createServer(() => {});
+      server.listen(socketPath, () => {
+        expect(server.listening).toBe(true);
+        done();
+      });
+      server.on('error', (err) => {
+        done.fail(
+          `Server failed to listen after stale socket cleanup: ${err.message}`
+        );
+      });
+    });
+
+    it('should fail with EADDRINUSE if a stale socket file is NOT cleaned up', (done) => {
+      // First server listens normally
+      server = createServer(() => {});
+      server.listen(socketPath, () => {
+        // Second server tries to listen on the same path without cleanup
+        const server2 = createServer(() => {});
+        server2.on('error', (err: NodeJS.ErrnoException) => {
+          expect(err.code).toBe('EADDRINUSE');
+          server2.close();
+          done();
+        });
+        server2.listen(socketPath);
+      });
+    });
+  });
+
+  describe('server listen callback timing', () => {
+    let socketPath: string;
+    let server: Server;
+
+    beforeEach(() => {
+      socketPath = join(
+        tmpdir(),
+        `nx-timing-test-${process.pid}-${Date.now()}.sock`
+      );
+    });
+
+    afterEach((done) => {
+      if (server) {
+        server.close(() => {
+          try {
+            unlinkSync(socketPath);
+          } catch {}
+          done();
+        });
+      } else {
+        try {
+          unlinkSync(socketPath);
+        } catch {}
+        done();
+      }
+    });
+
+    it('should only be connectable AFTER the listen callback fires', async () => {
+      let listenCallbackFired = false;
+
+      server = createServer(() => {});
+
+      // Start listening — the callback fires when the server is ready
+      server.listen(socketPath, () => {
+        listenCallbackFired = true;
+      });
+
+      // Wait for the server to become connectable
+      const socket = await waitForServer(socketPath, 5_000);
+
+      // The listen callback must have fired before we could connect
+      expect(listenCallbackFired).toBe(true);
+
+      socket.destroy();
+    });
+  });
+
+  describe('host-side early exit detection', () => {
+    it('should detect when a worker process exits before accepting connections', async () => {
+      const socketPath = join(
+        tmpdir(),
+        `nx-earlyexit-test-${process.pid}-${Date.now()}.sock`
+      );
+
+      // Spawn a worker that immediately exits (simulating a crash)
+      const worker = spawn(process.execPath, ['-e', 'process.exit(1)'], {
+        stdio: 'ignore',
+      });
+
+      // Simulate the host-side polling logic with exit detection
+      // (mirrors the fix in plugin-pool.ts)
+      let workerExited = false;
+      let workerExitCode: number | null = null;
+      const earlyExitHandler = (code: number | null) => {
+        workerExited = true;
+        workerExitCode = code;
+      };
+      worker.once('exit', earlyExitHandler);
+
+      const result = await new Promise<{
+        detected: boolean;
+        exitCode: number | null;
+      }>((resolve) => {
+        // Safety timeout so the test doesn't hang
+        const safetyTimeout = setTimeout(() => {
+          clearInterval(id);
+          worker.off('exit', earlyExitHandler);
+          resolve({ detected: false, exitCode: null });
+        }, 5_000);
+        safetyTimeout.unref();
+
+        const id = setInterval(() => {
+          if (workerExited) {
+            clearInterval(id);
+            clearTimeout(safetyTimeout);
+            worker.off('exit', earlyExitHandler);
+            resolve({ detected: true, exitCode: workerExitCode });
+            return;
+          }
+        }, 10);
+      });
+
+      expect(result.detected).toBe(true);
+      expect(result.exitCode).toBe(1);
+
+      // Clean up
+      try {
+        unlinkSync(socketPath);
+      } catch {}
+    });
+
+    it('should connect successfully when the worker starts a server normally', async () => {
+      const socketPath = join(
+        tmpdir(),
+        `nx-goodworker-test-${process.pid}-${Date.now()}.sock`
+      );
+
+      // Spawn a worker that creates a server and listens
+      const workerScript = `
+        const { createServer } = require('net');
+        const server = createServer((socket) => {
+          socket.on('data', () => {});
+          socket.on('end', () => {
+            socket.destroy();
+            server.close(() => process.exit(0));
+          });
+        });
+        server.listen(${JSON.stringify(socketPath)}, () => {
+          // Signal readiness via stdout
+          process.stdout.write('READY');
+        });
+      `;
+
+      const worker = spawn(process.execPath, ['-e', workerScript], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      let workerExited = false;
+      const earlyExitHandler = () => {
+        workerExited = true;
+      };
+      worker.once('exit', earlyExitHandler);
+
+      try {
+        // Poll for connection (mirrors plugin-pool.ts logic)
+        const socket = await waitForServer(socketPath, 10_000);
+
+        expect(workerExited).toBe(false);
+        expect(socket).toBeTruthy();
+
+        // Clean up: close the socket which triggers the worker to shut down
+        socket.end();
+        worker.off('exit', earlyExitHandler);
+
+        await new Promise<void>((resolve) => {
+          worker.once('exit', () => resolve());
+          // Safety timeout
+          setTimeout(() => {
+            worker.kill();
+            resolve();
+          }, 5_000);
+        });
+      } finally {
+        try {
+          unlinkSync(socketPath);
+        } catch {}
+      }
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2764,7 +2764,7 @@ importers:
         version: 2.3.0
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 21.1.0(f980f72dbbe44fac982acd2259e3661a)
+        version: 21.1.0(ccee4f196e8198b3110621a4745916e5)
       '@angular/localize':
         specifier: catalog:angular-supported-versions
         version: 21.1.0(@angular/compiler-cli@21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2))(@angular/compiler@21.1.0)
@@ -2870,7 +2870,7 @@ importers:
     dependencies:
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 21.1.0(9613cd481432c3d065f8f0fc994cc2d8)
+        version: 21.1.0(6b1a0cf84e61f1c844c41da18f524ece)
       '@angular/compiler-cli':
         specifier: catalog:angular-supported-versions
         version: 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
@@ -4479,7 +4479,7 @@ importers:
         version: 3.0.0
       webpack-subresource-integrity:
         specifier: ^5.1.0
-        version: 5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
+        version: 5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
     devDependencies:
       nx:
         specifier: workspace:*
@@ -27101,10 +27101,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.1.0(9613cd481432c3d065f8f0fc994cc2d8)':
+  '@angular/build@21.1.0(6b1a0cf84e61f1c844c41da18f524ece)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2101.0(chokidar@5.0.0)
+      '@angular-devkit/architect': 0.2101.0(chokidar@3.6.0)
       '@angular/compiler': 21.1.0
       '@angular/compiler-cli': 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
       '@babel/core': 7.28.5
@@ -27159,10 +27159,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.1.0(f980f72dbbe44fac982acd2259e3661a)':
+  '@angular/build@21.1.0(ccee4f196e8198b3110621a4745916e5)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2101.0(chokidar@5.0.0)
+      '@angular-devkit/architect': 0.2101.0(chokidar@3.6.0)
       '@angular/compiler': 21.1.0
       '@angular/compiler-cli': 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
       '@babel/core': 7.28.5
@@ -30558,7 +30558,7 @@ snapshots:
       execa: 5.1.1
       fs-extra: 11.3.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3)
+      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
       leven: 3.1.0
       lodash: 4.17.21
       open: 8.4.2
@@ -44975,7 +44975,7 @@ snapshots:
       tapable: 2.2.2
       webpack: 5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
-  html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3):
+  html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -56114,12 +56114,12 @@ snapshots:
     optionalDependencies:
       html-webpack-plugin: 5.5.0(webpack@5.101.3)
 
-  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)):
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     optionalDependencies:
-      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3)
+      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
 
   webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3))))(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3))):
     dependencies:


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

Plugin workers intermittently fail to start with "not connected within 5 seconds" errors. The 5-second timeout starts at script load time, but server.listen() only happens after all imports complete (2-4+ seconds later), leaving minimal time for the host to connect. Additionally, if a worker crashes during startup (e.g. EADDRINUSE from a stale socket file), the host continues polling for up to 100 seconds before timing out.

## Expected Behavior

- Connection timeout starts only after the server is confirmed listening, giving the full timeout window for the host to connect
- Stale socket files from crashed workers are cleaned up before listen, preventing EADDRINUSE failures
- Worker crashes during the connection phase are detected immediately, providing fast, actionable errors instead of long timeouts
- Timeouts increased from 5s/10s to 30s/30s to accommodate slow environments

## Related Issue(s)

Fixes #34442 
