### PR TITLE
fix(core): prevent changelog from resolving git tags for dependent pr…

### DIFF
--- a/packages/nx/src/command-line/release/changelog/version-plan-filtering.ts
+++ b/packages/nx/src/command-line/release/changelog/version-plan-filtering.ts
@@ -133,6 +133,8 @@ export async function resolveChangelogFromSHA({
   strictPreid,
   useAutomaticFromRef,
   resolveRepositoryTags,
+  projectName,
+  verbose,
 }: {
   fromRef?: string;
   tagPattern: string;
@@ -143,7 +145,13 @@ export async function resolveChangelogFromSHA({
   strictPreid: boolean;
   useAutomaticFromRef: boolean;
   resolveRepositoryTags: RepoGitTags['resolveTags'];
+  /** Optional project name for contextual logging when resolving per-project tags */
+  projectName?: string;
+  /** Whether to output verbose/debug logging */
+  verbose?: boolean;
 }): Promise<string | null> {
+  const logContext = projectName ? ` for project "${projectName}"` : '';
+
   // If user provided a from ref, resolve it to a SHA
   if (fromRef) {
     return await getCommitHash(fromRef);
@@ -161,8 +169,20 @@ export async function resolveChangelogFromSHA({
     }
   );
   if (latestTag?.tag) {
+    if (verbose) {
+      console.log(
+        `Resolved changelog from SHA${logContext} via tag: ${latestTag.tag}`
+      );
+    }
     return await getCommitHash(latestTag.tag);
   }
+
+  if (verbose) {
+    console.log(
+      `No matching git tag found${logContext} for pattern "${tagPattern}"`
+    );
+  }
+
   // Finally, if automatic from ref is enabled, use the first commit as a fallback
   if (useAutomaticFromRef) {
     return await getFirstGitCommit();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2764,7 +2764,7 @@ importers:
         version: 2.3.0
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 21.1.0(f980f72dbbe44fac982acd2259e3661a)
+        version: 21.1.0(ccee4f196e8198b3110621a4745916e5)
       '@angular/localize':
         specifier: catalog:angular-supported-versions
         version: 21.1.0(@angular/compiler-cli@21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2))(@angular/compiler@21.1.0)
@@ -2870,7 +2870,7 @@ importers:
     dependencies:
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 21.1.0(9613cd481432c3d065f8f0fc994cc2d8)
+        version: 21.1.0(6b1a0cf84e61f1c844c41da18f524ece)
       '@angular/compiler-cli':
         specifier: catalog:angular-supported-versions
         version: 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
@@ -4479,7 +4479,7 @@ importers:
         version: 3.0.0
       webpack-subresource-integrity:
         specifier: ^5.1.0
-        version: 5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
+        version: 5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
     devDependencies:
       nx:
         specifier: workspace:*
@@ -27101,10 +27101,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.1.0(9613cd481432c3d065f8f0fc994cc2d8)':
+  '@angular/build@21.1.0(6b1a0cf84e61f1c844c41da18f524ece)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2101.0(chokidar@5.0.0)
+      '@angular-devkit/architect': 0.2101.0(chokidar@3.6.0)
       '@angular/compiler': 21.1.0
       '@angular/compiler-cli': 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
       '@babel/core': 7.28.5
@@ -27159,10 +27159,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.1.0(f980f72dbbe44fac982acd2259e3661a)':
+  '@angular/build@21.1.0(ccee4f196e8198b3110621a4745916e5)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2101.0(chokidar@5.0.0)
+      '@angular-devkit/architect': 0.2101.0(chokidar@3.6.0)
       '@angular/compiler': 21.1.0
       '@angular/compiler-cli': 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
       '@babel/core': 7.28.5
@@ -30558,7 +30558,7 @@ snapshots:
       execa: 5.1.1
       fs-extra: 11.3.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3)
+      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
       leven: 3.1.0
       lodash: 4.17.21
       open: 8.4.2
@@ -44975,7 +44975,7 @@ snapshots:
       tapable: 2.2.2
       webpack: 5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
-  html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3):
+  html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -56114,12 +56114,12 @@ snapshots:
     optionalDependencies:
       html-webpack-plugin: 5.5.0(webpack@5.101.3)
 
-  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)):
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     optionalDependencies:
-      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3)
+      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
 
   webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3))))(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3))):
     dependencies:


### PR DESCRIPTION
…ojects in independent releases

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

When running `nx release changelog` (or `releaseChangelog()`) for a project in an independent release group, Nx incorrectly includes dependent projects in the changelog processing list. It attempts to resolve git tags and fetch git history for these dependents — even though they will never have changelog entries generated. If a dependent has never been released (no git tag), Nx throws a fatal error: "Unable to determine the previous git tag."

## Expected Behavior

For independent release groups, only the explicitly targeted projects should have git tags resolved and changelog entries generated. Dependent projects should be excluded from changelog processing entirely, since they are versioned independently and may never have been released.

## Related Issue(s)

Fixes #34438 

