### PR TITLE
feat(core): improve codex support for configure-ai-agents

### DIFF
--- a/packages/nx/src/ai/constants.ts
+++ b/packages/nx/src/ai/constants.ts
@@ -1,4 +1,3 @@
-import { homedir } from 'os';
 import { join } from 'path';
 import { major } from 'semver';
 import { readJsonFile } from '../utils/fileutils';
@@ -42,7 +41,9 @@ export function opencodeMcpPath(root: string): string {
   return join(root, 'opencode.json');
 }
 
-export const codexConfigTomlPath = join(homedir(), '.codex', 'config.toml');
+export function codexConfigTomlPath(root: string): string {
+  return join(root, '.codex', 'config.toml');
+}
 
 export const nxRulesMarkerCommentStart = `<!-- nx configuration start-->`;
 export const nxRulesMarkerCommentDescription = `<!-- Leave the start & end comments to automatically receive updates. -->`;

--- a/packages/nx/src/ai/utils.ts
+++ b/packages/nx/src/ai/utils.ts
@@ -198,9 +198,10 @@ async function getAgentConfiguration(
     case 'codex': {
       const rulesPath = agentsMdPath(workspaceRoot);
       const agentsMdExists = existsSync(rulesPath);
+      const mcpPath = codexConfigTomlPath(workspaceRoot);
       let mcpConfigured: boolean;
-      if (existsSync(codexConfigTomlPath)) {
-        const tomlContents = readFileSync(codexConfigTomlPath, 'utf-8');
+      if (existsSync(mcpPath)) {
+        const tomlContents = readFileSync(mcpPath, 'utf-8');
         mcpConfigured = tomlContents.includes(nxMcpTomlHeader);
       } else {
         mcpConfigured = false;
@@ -210,7 +211,7 @@ async function getAgentConfiguration(
         mcp: mcpConfigured,
         rules: agentsMdExists,
         rulesPath,
-        mcpPath: codexConfigTomlPath,
+        mcpPath,
       };
       break;
     }

--- a/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
+++ b/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
@@ -335,7 +335,7 @@ function getAgentFooterDescription(agent: AgentConfiguration): string {
     case 'opencode':
       return `Configures MCP server. Adds skills and agents. Updates ${rulesFile}.`;
     case 'codex':
-      return `Configures MCP server. Updates ${rulesFile}.`;
+      return `Configures MCP server. Adds skills. Updates ${rulesFile}.`;
     default:
       return '';
   }
@@ -359,7 +359,7 @@ function getAgentConfiguredDescription(agent: AgentConfiguration): string {
     case 'opencode':
       return `MCP + skills + ${rulesFile}`;
     case 'codex':
-      return `MCP + ${rulesFile}`;
+      return `MCP + skills + ${rulesFile}`;
     default:
       return '';
   }


### PR DESCRIPTION
Codex has only basic MCP/AGENTS.md support right now. Also, because it used to have only global-level config files, we had some extra logic around configuring that.

We want Codex to get the latest skills too (they don't support custom subagents yet, though) and use project-level config files that they now support.
