### PR TITLE
fix(release): use docker version in commit messages for docker-only releases

### DIFF
--- a/packages/nx/src/command-line/release/utils/shared.spec.ts
+++ b/packages/nx/src/command-line/release/utils/shared.spec.ts
@@ -78,19 +78,16 @@ describe('shared', () => {
             currentVersion: '1.0.0',
             dependentProjects: [],
             newVersion: '1.0.1',
-            dockerVersion: null,
           },
           bar: {
             currentVersion: '1.0.0',
             dependentProjects: [],
             newVersion: '1.0.1',
-            dockerVersion: null,
           },
           baz: {
             currentVersion: '1.0.0',
             dependentProjects: [],
             newVersion: '1.0.1',
-            dockerVersion: null,
           },
         };
         const userCommitMessage =
@@ -323,6 +320,303 @@ describe('shared', () => {
           ]
         `);
       });
+
+      it('should interpolate docker version for a single fixed group when newVersion is null (docker-only release)', () => {
+        const releaseGroups: ReleaseGroupWithName[] = [
+          {
+            name: 'my-group',
+            projectsRelationship: 'fixed',
+            projects: ['app-a', 'app-b'],
+            version: {
+              ...createVersionConfig(),
+              conventionalCommits: false,
+            },
+            changelog: false,
+            releaseTag: {
+              pattern: 'v{version}',
+              checkAllBranchesWhen: undefined,
+              requireSemver: true,
+              preferDockerVersion: undefined,
+              strictPreid: false,
+            },
+            versionPlans: false,
+            resolvedVersionPlans: false,
+          },
+        ];
+        const releaseGroupToFilteredProjects = new Map().set(
+          releaseGroups[0],
+          new Set(['app-a', 'app-b'])
+        );
+        const versionData = {
+          'app-a': {
+            currentVersion: '1.0.0',
+            dependentProjects: [],
+            newVersion: null,
+            dockerVersion: '2024.01.abc123',
+          },
+          'app-b': {
+            currentVersion: '1.0.0',
+            dependentProjects: [],
+            newVersion: null,
+            dockerVersion: '2024.01.abc123',
+          },
+        };
+        const result = createCommitMessageValues(
+          releaseGroups,
+          releaseGroupToFilteredProjects,
+          versionData,
+          'chore(release): publish v{version}'
+        );
+        expect(result).toMatchInlineSnapshot(`
+          [
+            "chore(release): publish v2024.01.abc123",
+          ]
+        `);
+      });
+
+      it('should interpolate docker version for a single independent project with {projectName} when newVersion is null', () => {
+        const releaseGroups: ReleaseGroupWithName[] = [
+          {
+            name: '__default__',
+            projectsRelationship: 'independent',
+            projects: ['my-app'],
+            version: {
+              ...createVersionConfig(),
+              conventionalCommits: false,
+            },
+            changelog: false,
+            releaseTag: {
+              pattern: '{projectName}-{version}',
+              checkAllBranchesWhen: undefined,
+              requireSemver: true,
+              preferDockerVersion: undefined,
+              strictPreid: false,
+            },
+            versionPlans: false,
+            resolvedVersionPlans: false,
+          },
+        ];
+        const releaseGroupToFilteredProjects = new Map().set(
+          releaseGroups[0],
+          new Set(['my-app'])
+        );
+        const versionData = {
+          'my-app': {
+            currentVersion: '1.0.0',
+            dependentProjects: [],
+            newVersion: null,
+            dockerVersion: '2024.02.def456',
+          },
+        };
+        const result = createCommitMessageValues(
+          releaseGroups,
+          releaseGroupToFilteredProjects,
+          versionData,
+          'chore(release): publish {projectName} v{version}'
+        );
+        expect(result).toMatchInlineSnapshot(`
+          [
+            "chore(release): publish my-app v2024.02.def456",
+          ]
+        `);
+      });
+
+      it('should include docker-only independent projects as bullet points in multi-group commits', () => {
+        const releaseGroups: ReleaseGroupWithName[] = [
+          {
+            name: 'one',
+            projectsRelationship: 'independent',
+            projects: ['foo'],
+            version: {
+              ...createVersionConfig(),
+              conventionalCommits: false,
+            },
+            changelog: false,
+            releaseTag: {
+              pattern: '{projectName}-{version}',
+              checkAllBranchesWhen: undefined,
+              requireSemver: true,
+              preferDockerVersion: undefined,
+              strictPreid: false,
+            },
+            versionPlans: false,
+            resolvedVersionPlans: false,
+          },
+          {
+            name: 'two',
+            projectsRelationship: 'fixed',
+            projects: ['bar'],
+            version: {
+              ...createVersionConfig(),
+              conventionalCommits: false,
+            },
+            changelog: false,
+            releaseTag: {
+              pattern: 'v{version}',
+              checkAllBranchesWhen: undefined,
+              requireSemver: true,
+              preferDockerVersion: undefined,
+              strictPreid: false,
+            },
+            versionPlans: false,
+            resolvedVersionPlans: false,
+          },
+        ];
+        const releaseGroupToFilteredProjects = new Map()
+          .set(releaseGroups[0], new Set(['foo']))
+          .set(releaseGroups[1], new Set(['bar']));
+        const versionData = {
+          foo: {
+            currentVersion: '1.0.0',
+            dependentProjects: [],
+            newVersion: null,
+            dockerVersion: '2024.03.ghi789',
+          },
+          bar: {
+            currentVersion: '1.0.0',
+            dependentProjects: [],
+            newVersion: '1.0.1',
+          },
+        };
+        const result = createCommitMessageValues(
+          releaseGroups,
+          releaseGroupToFilteredProjects,
+          versionData,
+          'chore(release): publish v{version}'
+        );
+        expect(result).toMatchInlineSnapshot(`
+          [
+            "chore(release): publish",
+            "- project: foo 2024.03.ghi789",
+            "- release-group: two 1.0.1",
+          ]
+        `);
+      });
+
+      it('should include docker-only fixed groups as bullet points in multi-group commits', () => {
+        const releaseGroups: ReleaseGroupWithName[] = [
+          {
+            name: 'one',
+            projectsRelationship: 'independent',
+            projects: ['foo'],
+            version: {
+              ...createVersionConfig(),
+              conventionalCommits: false,
+            },
+            changelog: false,
+            releaseTag: {
+              pattern: '{projectName}-{version}',
+              checkAllBranchesWhen: undefined,
+              requireSemver: true,
+              preferDockerVersion: undefined,
+              strictPreid: false,
+            },
+            versionPlans: false,
+            resolvedVersionPlans: false,
+          },
+          {
+            name: 'two',
+            projectsRelationship: 'fixed',
+            projects: ['bar', 'baz'],
+            version: {
+              ...createVersionConfig(),
+              conventionalCommits: false,
+            },
+            changelog: false,
+            releaseTag: {
+              pattern: 'v{version}',
+              checkAllBranchesWhen: undefined,
+              requireSemver: true,
+              preferDockerVersion: undefined,
+              strictPreid: false,
+            },
+            versionPlans: false,
+            resolvedVersionPlans: false,
+          },
+        ];
+        const releaseGroupToFilteredProjects = new Map()
+          .set(releaseGroups[0], new Set(['foo']))
+          .set(releaseGroups[1], new Set(['bar', 'baz']));
+        const versionData = {
+          foo: {
+            currentVersion: '1.0.0',
+            dependentProjects: [],
+            newVersion: '1.0.1',
+          },
+          bar: {
+            currentVersion: '2.0.0',
+            dependentProjects: [],
+            newVersion: null,
+            dockerVersion: '2024.04.jkl012',
+          },
+          baz: {
+            currentVersion: '2.0.0',
+            dependentProjects: [],
+            newVersion: null,
+            dockerVersion: '2024.04.jkl012',
+          },
+        };
+        const result = createCommitMessageValues(
+          releaseGroups,
+          releaseGroupToFilteredProjects,
+          versionData,
+          'chore(release): publish v{version}'
+        );
+        expect(result).toMatchInlineSnapshot(`
+          [
+            "chore(release): publish",
+            "- project: foo 1.0.1",
+            "- release-group: two 2024.04.jkl012",
+          ]
+        `);
+      });
+
+      it('should prefer newVersion over dockerVersion when both are present', () => {
+        const releaseGroups: ReleaseGroupWithName[] = [
+          {
+            name: 'my-group',
+            projectsRelationship: 'fixed',
+            projects: ['app-a'],
+            version: {
+              ...createVersionConfig(),
+              conventionalCommits: false,
+            },
+            changelog: false,
+            releaseTag: {
+              pattern: 'v{version}',
+              checkAllBranchesWhen: undefined,
+              requireSemver: true,
+              preferDockerVersion: undefined,
+              strictPreid: false,
+            },
+            versionPlans: false,
+            resolvedVersionPlans: false,
+          },
+        ];
+        const releaseGroupToFilteredProjects = new Map().set(
+          releaseGroups[0],
+          new Set(['app-a'])
+        );
+        const versionData = {
+          'app-a': {
+            currentVersion: '1.0.0',
+            dependentProjects: [],
+            newVersion: '1.1.0',
+            dockerVersion: '2024.01.abc123',
+          },
+        };
+        const result = createCommitMessageValues(
+          releaseGroups,
+          releaseGroupToFilteredProjects,
+          versionData,
+          'chore(release): publish v{version}'
+        );
+        expect(result).toMatchInlineSnapshot(`
+          [
+            "chore(release): publish v1.1.0",
+          ]
+        `);
+      });
     });
   });
 
@@ -363,13 +657,11 @@ describe('shared', () => {
             currentVersion: '1.0.0',
             dependentProjects: [],
             newVersion: null,
-            dockerVersion: null,
           },
           b: {
             currentVersion: '1.0.0',
             dependentProjects: [],
             newVersion: null,
-            dockerVersion: null,
           },
         }
       );

--- a/packages/nx/src/command-line/release/utils/shared.ts
+++ b/packages/nx/src/command-line/release/utils/shared.ts
@@ -147,7 +147,8 @@ export function createCommitMessageValues(
     );
     const projectVersionData = versionData[releaseGroupProjectNames[0]]; // all at the same version, so we can just pick the first one
     const releaseVersion = new ReleaseVersion({
-      version: projectVersionData.newVersion,
+      version:
+        projectVersionData.newVersion ?? projectVersionData.dockerVersion,
       releaseTagPattern: releaseGroup.releaseTag.pattern,
       releaseGroupName: releaseGroup.name,
     });
@@ -174,7 +175,8 @@ export function createCommitMessageValues(
     if (releaseGroupProjectNames.length === 1) {
       const projectVersionData = versionData[releaseGroupProjectNames[0]];
       const releaseVersion = new ReleaseVersion({
-        version: projectVersionData.newVersion,
+        version:
+          projectVersionData.newVersion ?? projectVersionData.dockerVersion,
         releaseTagPattern: releaseGroup.releaseTag.pattern,
         projectName: releaseGroupProjectNames[0],
         releaseGroupName: releaseGroup.name,
@@ -211,9 +213,13 @@ export function createCommitMessageValues(
       );
       for (const project of versionedProjects) {
         const projectVersionData = versionData[project];
-        if (projectVersionData.newVersion !== null) {
+        if (
+          projectVersionData.newVersion !== null ||
+          projectVersionData.dockerVersion != null
+        ) {
           const releaseVersion = new ReleaseVersion({
-            version: projectVersionData.newVersion,
+            version:
+              projectVersionData.newVersion ?? projectVersionData.dockerVersion,
             releaseTagPattern: releaseGroup.releaseTag.pattern,
             projectName: project,
             releaseGroupName: releaseGroup.name,
@@ -231,9 +237,13 @@ export function createCommitMessageValues(
       releaseGroupToFilteredProjects.get(releaseGroup)
     );
     const projectVersionData = versionData[releaseGroupProjectNames[0]]; // all at the same version, so we can just pick the first one
-    if (projectVersionData.newVersion !== null) {
+    if (
+      projectVersionData.newVersion !== null ||
+      projectVersionData.dockerVersion != null
+    ) {
       const releaseVersion = new ReleaseVersion({
-        version: projectVersionData.newVersion,
+        version:
+          projectVersionData.newVersion ?? projectVersionData.dockerVersion,
         releaseTagPattern: releaseGroup.releaseTag.pattern,
         releaseGroupName: releaseGroup.name,
       });
@@ -299,7 +309,7 @@ export function createGitTagValues(
         const projectVersionData = versionData[project];
         if (
           projectVersionData.newVersion !== null ||
-          projectVersionData.dockerVersion !== null
+          projectVersionData.dockerVersion != null
         ) {
           const preferDockerVersion =
             shouldPreferDockerVersionForReleaseGroup(releaseGroup);
@@ -352,7 +362,7 @@ export function createGitTagValues(
     const projectVersionData = versionData[releaseGroupProjectNames[0]]; // all at the same version, so we can just pick the first one
     if (
       projectVersionData.newVersion !== null ||
-      projectVersionData.dockerVersion !== null
+      projectVersionData.dockerVersion != null
     ) {
       const preferDockerVersion =
         shouldPreferDockerVersionForReleaseGroup(releaseGroup);


### PR DESCRIPTION


<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

## Current Behavior
When performing a docker-only release (`newVersion` is null, `dockerVersion` is set), `createCommitMessageValues()` failed to include the version in commit messages. Three code paths passed null as the version or skipped docker-only projects entirely:

- **Single fixed group:** passed null to ReleaseVersion constructor
- **Multi-group independent projects:** skipped docker-only projects from bullet points
- **Multi-group fixed groups:** skipped docker-only groups from bullet points

## Expected Behavior
Apply fallback pattern (`newVersion ?? dockerVersion`) where the code is just checking `newVersion` currently.

Also fix `createGitTagValues()` dockerVersion guards to use loose inequality (!= null) instead of strict (!== null), since dockerVersion is typed as `string | undefined`, not `string | null`.

## Testing

Added test cases to `packages/nx/src/command-line/release/utils/shared.spec.ts`

- [x] `npx nx format`
- [x] `npx nx run nx:test`
- [x] `pnpm check-commit`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

I [searched](https://github.com/nrwl/nx/issues?q=is%3Aissue%20state%3Aopen%20docker%20version%20git) but could not find any issues filed for this. Please let me know if it is necessary to file one.
