### PR TITLE
fix(core): properly quote shell metacharacters in CLI args passed to tasks

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -657,6 +657,30 @@ describe('Run Commands', () => {
         )
       ).toEqual('echo --define="FOO=bar|baz"');
     });
+
+    it('should not re-quote word-split fragments of a single-quoted JSON value', () => {
+      // Simulates what happens when the shell word-splits:
+      //   --config \'{"env":{"cliArg":"i am from the cli args"}}\'
+      // The shell produces these separate argv entries because \" makes "
+      // literal but doesn't prevent word splitting:
+      expect(
+        interpolateArgsIntoCommand(
+          'echo',
+          {
+            __unparsed__: [
+              '--config',
+              '\'{"env":{"cliArg":"i',
+              'am',
+              'from',
+              'the',
+              'cli',
+              'args"}}\'',
+            ],
+          } as any,
+          true
+        )
+      ).toEqual(`echo --config '{"env":{"cliArg":"i am from the cli args"}}'`);
+    });
   });
 
   describe('--color', () => {

--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -584,6 +584,79 @@ describe('Run Commands', () => {
         )
       ).toEqual(`echo --hello="test 123" "hello world" "random config" 456`); // should wrap aroound __unparsed__ args with key value
     });
+
+    it.each([
+      ['pipe (|)', '--grep=@tag1|@tag2', 'echo --grep="@tag1|@tag2"'],
+      ['ampersand (&)', '--flag=a&b', 'echo --flag="a&b"'],
+      ['dollar sign ($)', '--path=$HOME/dir', 'echo --path="$HOME/dir"'],
+      ['semicolon (;)', '--cmd=echo;ls', 'echo --cmd="echo;ls"'],
+      ['parentheses', '--expr=(a+b)', 'echo --expr="(a+b)"'],
+      ['asterisk (*)', '--pattern=*.txt', 'echo --pattern="*.txt"'],
+      ['backtick (`)', '--cmd=`pwd`', 'echo --cmd="`pwd`"'],
+      ['angle brackets (>)', '--compare=a>b', 'echo --compare="a>b"'],
+      [
+        'question mark (?)',
+        '--pattern=file?.txt',
+        'echo --pattern="file?.txt"',
+      ],
+      [
+        'square brackets ([])',
+        '--pattern=[abc].txt',
+        'echo --pattern="[abc].txt"',
+      ],
+      ['hash (#)', '--tag=#important', 'echo --tag="#important"'],
+      ['tilde (~)', '--path=~/documents', 'echo --path="~/documents"'],
+      ['newline', '--msg=hello\nworld', 'echo --msg="hello\nworld"'],
+      ['tab', '--msg=hello\tworld', 'echo --msg="hello\tworld"'],
+    ])('should wrap shell metacharacter %s in quotes', (_, input, expected) => {
+      expect(
+        interpolateArgsIntoCommand(
+          'echo',
+          { __unparsed__: [input] } as any,
+          true
+        )
+      ).toEqual(expected);
+    });
+
+    it('should handle positional args with shell metacharacters', () => {
+      expect(
+        interpolateArgsIntoCommand(
+          'echo',
+          { __unparsed__: ['tag1|tag2', 'a&b', '$HOME'] } as any,
+          true
+        )
+      ).toEqual('echo "tag1|tag2" "a&b" "$HOME"');
+    });
+
+    it('should not double-wrap already quoted values with shell metacharacters', () => {
+      expect(
+        interpolateArgsIntoCommand(
+          'echo',
+          { __unparsed__: ['"@tag1|@tag2"', "'a&b'"] } as any,
+          true
+        )
+      ).toEqual('echo "@tag1|@tag2" \'a&b\'');
+    });
+
+    it('should escape existing double quotes when wrapping', () => {
+      expect(
+        interpolateArgsIntoCommand(
+          'echo',
+          { __unparsed__: ['--msg=hello "world"'] } as any,
+          true
+        )
+      ).toEqual('echo --msg="hello \\"world\\""');
+    });
+
+    it('should handle values containing equals signs', () => {
+      expect(
+        interpolateArgsIntoCommand(
+          'echo',
+          { __unparsed__: ['--define=FOO=bar|baz'] } as any,
+          true
+        )
+      ).toEqual('echo --define="FOO=bar|baz"');
+    });
   });
 
   describe('--color', () => {

--- a/packages/nx/src/utils/serialize-overrides-into-command-line.spec.ts
+++ b/packages/nx/src/utils/serialize-overrides-into-command-line.spec.ts
@@ -62,6 +62,22 @@ describe('serializeOverridesIntoCommandLine', () => {
       ]);
     });
 
+    it('should not re-quote single-quoted values', () => {
+      expect(
+        serializeOverridesIntoCommandLine({
+          config: '\'{"env":{"cliArg":"i am from the cli args"}}\'',
+        })
+      ).toEqual(['--config=\'{"env":{"cliArg":"i am from the cli args"}}\'']);
+    });
+
+    it('should not re-quote double-quoted values', () => {
+      expect(
+        serializeOverridesIntoCommandLine({
+          config: '"some value with spaces"',
+        })
+      ).toEqual(['--config="some value with spaces"']);
+    });
+
     it('should not wrap values without special characters', () => {
       expect(serializeOverridesIntoCommandLine({ key: 'simplevalue' })).toEqual(
         ['--key=simplevalue']

--- a/packages/nx/src/utils/serialize-overrides-into-command-line.spec.ts
+++ b/packages/nx/src/utils/serialize-overrides-into-command-line.spec.ts
@@ -1,0 +1,71 @@
+import { serializeOverridesIntoCommandLine } from './serialize-overrides-into-command-line';
+
+describe('serializeOverridesIntoCommandLine', () => {
+  it('should serialize simple key-value pairs', () => {
+    expect(serializeOverridesIntoCommandLine({ key: 'value' })).toEqual([
+      '--key=value',
+    ]);
+  });
+
+  it('should serialize boolean true as flag', () => {
+    expect(serializeOverridesIntoCommandLine({ verbose: true })).toEqual([
+      '--verbose',
+    ]);
+  });
+
+  it('should serialize boolean false as --no-flag', () => {
+    expect(serializeOverridesIntoCommandLine({ verbose: false })).toEqual([
+      '--no-verbose',
+    ]);
+  });
+
+  it('should serialize arrays as multiple flags', () => {
+    expect(
+      serializeOverridesIntoCommandLine({ include: ['a', 'b', 'c'] })
+    ).toEqual(['--include=a', '--include=b', '--include=c']);
+  });
+
+  it('should flatten nested objects', () => {
+    expect(
+      serializeOverridesIntoCommandLine({ env: { foo: 'bar', baz: 'qux' } })
+    ).toEqual(['--env.foo=bar', '--env.baz=qux']);
+  });
+
+  it('should preserve positional arguments from _', () => {
+    expect(serializeOverridesIntoCommandLine({ _: ['pos1', 'pos2'] })).toEqual([
+      'pos1',
+      'pos2',
+    ]);
+  });
+
+  describe('shell metacharacter quoting', () => {
+    it.each([
+      ['spaces', 'hello world', '--key="hello world"'],
+      ['pipe (|)', '@tag1|@tag2', '--key="@tag1|@tag2"'],
+      ['ampersand (&)', 'a&b', '--key="a&b"'],
+      ['dollar sign ($)', '$HOME/dir', '--key="$HOME/dir"'],
+      ['semicolon (;)', 'echo;ls', '--key="echo;ls"'],
+      ['parentheses', '(a+b)', '--key="(a+b)"'],
+      ['asterisk (*)', '*.txt', '--key="*.txt"'],
+      ['backtick (`)', '`pwd`', '--key="`pwd`"'],
+      ['angle brackets (>)', 'a>b', '--key="a>b"'],
+      ['question mark (?)', 'file?.txt', '--key="file?.txt"'],
+      ['square brackets ([])', '[abc].txt', '--key="[abc].txt"'],
+      ['hash (#)', '#important', '--key="#important"'],
+      ['tilde (~)', '~/documents', '--key="~/documents"'],
+      ['embedded double quotes', 'hello "world"', '--key="hello \\"world\\""'],
+      ['newline', 'hello\nworld', '--key="hello\nworld"'],
+      ['tab', 'hello\tworld', '--key="hello\tworld"'],
+    ])('should wrap values with %s in quotes', (_, value, expected) => {
+      expect(serializeOverridesIntoCommandLine({ key: value })).toEqual([
+        expected,
+      ]);
+    });
+
+    it('should not wrap values without special characters', () => {
+      expect(serializeOverridesIntoCommandLine({ key: 'simplevalue' })).toEqual(
+        ['--key=simplevalue']
+      );
+    });
+  });
+});

--- a/packages/nx/src/utils/serialize-overrides-into-command-line.ts
+++ b/packages/nx/src/utils/serialize-overrides-into-command-line.ts
@@ -1,4 +1,5 @@
 import { flatten } from 'flat';
+import { needsShellQuoting } from './shell-quoting';
 
 export function serializeOverridesIntoCommandLine(options: {
   [k: string]: any;
@@ -30,17 +31,10 @@ function serializeOption(key: string, value: any, unparsed: string[]) {
         unparsed
       );
     }
-  } else if (
-    typeof value === 'string' &&
-    stringShouldBeWrappedIntoQuotes(value)
-  ) {
+  } else if (typeof value === 'string' && needsShellQuoting(value)) {
     const sanitized = value.replace(/"/g, String.raw`\"`);
     unparsed.push(`--${key}="${sanitized}"`);
   } else if (value != null) {
     unparsed.push(`--${key}=${value}`);
   }
-}
-
-function stringShouldBeWrappedIntoQuotes(str: string) {
-  return str.includes(' ') || str.includes('{') || str.includes('"');
 }

--- a/packages/nx/src/utils/serialize-overrides-into-command-line.ts
+++ b/packages/nx/src/utils/serialize-overrides-into-command-line.ts
@@ -1,5 +1,5 @@
 import { flatten } from 'flat';
-import { needsShellQuoting } from './shell-quoting';
+import { isAlreadyQuoted, needsShellQuoting } from './shell-quoting';
 
 export function serializeOverridesIntoCommandLine(options: {
   [k: string]: any;
@@ -31,7 +31,11 @@ function serializeOption(key: string, value: any, unparsed: string[]) {
         unparsed
       );
     }
-  } else if (typeof value === 'string' && needsShellQuoting(value)) {
+  } else if (
+    typeof value === 'string' &&
+    needsShellQuoting(value) &&
+    !isAlreadyQuoted(value)
+  ) {
     const sanitized = value.replace(/"/g, String.raw`\"`);
     unparsed.push(`--${key}="${sanitized}"`);
   } else if (value != null) {

--- a/packages/nx/src/utils/shell-quoting.spec.ts
+++ b/packages/nx/src/utils/shell-quoting.spec.ts
@@ -1,0 +1,43 @@
+import { needsShellQuoting } from './shell-quoting';
+
+describe('needsShellQuoting', () => {
+  it.each([
+    ['pipe', 'a|b'],
+    ['ampersand', 'a&b'],
+    ['semicolon', 'a;b'],
+    ['less than', 'a<b'],
+    ['greater than', 'a>b'],
+    ['parentheses', '(a)'],
+    ['dollar sign', '$var'],
+    ['backtick', '`cmd`'],
+    ['backslash', 'a\\b'],
+    ['double quote', 'say "hi"'],
+    ['single quote', "it's"],
+    ['asterisk', '*.txt'],
+    ['question mark', 'file?.txt'],
+    ['square brackets', '[abc]'],
+    ['curly braces', '{a,b}'],
+    ['tilde', '~/path'],
+    ['hash', '#comment'],
+    ['exclamation', '!history'],
+    ['space', 'hello world'],
+    ['tab', 'hello\tworld'],
+    ['newline', 'hello\nworld'],
+  ])('returns true for %s: %j', (_, value) => {
+    expect(needsShellQuoting(value)).toBe(true);
+  });
+
+  it.each([
+    ['alphanumeric', 'hello123'],
+    ['hyphens', 'my-value'],
+    ['underscores', 'my_value'],
+    ['dots', 'file.txt'],
+    ['colons', 'key:value'],
+    ['slashes', 'path/to/file'],
+    ['at signs', 'user@host'],
+    ['equals', 'a=b'],
+    ['empty string', ''],
+  ])('returns false for %s: %j', (_, value) => {
+    expect(needsShellQuoting(value)).toBe(false);
+  });
+});

--- a/packages/nx/src/utils/shell-quoting.ts
+++ b/packages/nx/src/utils/shell-quoting.ts
@@ -1,0 +1,30 @@
+/**
+ * Shell metacharacters that have special meaning and require quoting.
+ *
+ * Characters included:
+ * - | - pipe
+ * - & - background/AND
+ * - ; - command separator
+ * - < > - redirections
+ * - ( ) - subshell
+ * - $ - variable expansion
+ * - ` - command substitution
+ * - \ - escape
+ * - " ' - quotes
+ * - * ? [ ] - globbing
+ * - { } - brace expansion
+ * - ~ - home directory
+ * - # - comment
+ * - ! - history expansion
+ * - \s - whitespace (spaces, tabs, newlines)
+ */
+const SHELL_META_CHARS = /[|&;<>()$`\\!"'*?[\]{}~#\s]/;
+
+/**
+ * Check if a string contains shell metacharacters that require quoting.
+ * These characters have special meaning in shell and would be interpreted
+ * incorrectly if not quoted (e.g., | for pipe, & for background, etc.)
+ */
+export function needsShellQuoting(str: string): boolean {
+  return SHELL_META_CHARS.test(str);
+}

--- a/packages/nx/src/utils/shell-quoting.ts
+++ b/packages/nx/src/utils/shell-quoting.ts
@@ -28,3 +28,14 @@ const SHELL_META_CHARS = /[|&;<>()$`\\!"'*?[\]{}~#\s]/;
 export function needsShellQuoting(str: string): boolean {
   return SHELL_META_CHARS.test(str);
 }
+
+/**
+ * Check if a string is already wrapped in matching quotes (single or double).
+ */
+export function isAlreadyQuoted(str: string): boolean {
+  return (
+    str.length >= 2 &&
+    ((str[0] === "'" && str[str.length - 1] === "'") ||
+      (str[0] === '"' && str[str.length - 1] === '"'))
+  );
+}


### PR DESCRIPTION
## Current Behavior

When CLI arguments containing shell metacharacters (like `|`, `&`, `$`, `;`, `*`, etc.) are passed through Nx to underlying tasks, they are not properly quoted, causing shell interpretation errors.

For example, running:
```bash
nx test app --grep="@tag1|@tag2"
```

Would fail with `/bin/sh: @smoke: command not found` because the pipe character `|` was interpreted by the shell as a pipe operator instead of being passed as a literal string to the underlying command.

Users had to use awkward double-quoting workarounds like `--grep='"@tag1|@tag2"'` to get the expected behavior.

## Expected Behavior

CLI arguments containing shell metacharacters should be automatically quoted before being passed to underlying commands, so that:
```bash
nx test app --grep="@tag1|@tag2"
```

Works correctly and passes `--grep="@tag1|@tag2"` to the underlying test runner without shell interpretation.

## Related Issue(s)

Fixes #32305
Fixes #26682

## Implementation Details

- Created a shared `needsShellQuoting()` utility in `packages/nx/src/utils/shell-quoting.ts` that detects shell metacharacters
- Updated `wrapArgIntoQuotesIfNeeded()` in `run-commands.impl.ts` to use the shared utility
- Updated `stringShouldBeWrappedIntoQuotes()` in `serialize-overrides-into-command-line.ts` to use the shared utility
- Fixed a bug where `arg.split('=')` would incorrectly split values containing `=` (e.g., `--define=FOO=bar|baz`)
- Added proper escaping of embedded double quotes when wrapping values
- Added comprehensive test coverage

### Shell metacharacters now handled:
`|` `&` `;` `<` `>` `(` `)` `$` `` ` `` `\` `"` `'` `*` `?` `[` `]` `{` `}` `~` `#` `!` and whitespace