### PR TITLE
feat(core): improve AX of configure-ai-agents with auto-detection

### DIFF
--- a/e2e/nx/src/configure-ai-agents.test.ts
+++ b/e2e/nx/src/configure-ai-agents.test.ts
@@ -9,8 +9,14 @@ import {
 } from '@nx/e2e-utils';
 
 describe('configure-ai-agents', () => {
-  beforeAll(() => newProject({ packages: ['@nx/web', '@nx/js', '@nx/react'] }));
-  afterAll(() => cleanupProject());
+  beforeAll(() => {
+    process.env.NX_USE_LOCAL = 'true';
+    newProject({ packages: ['@nx/web', '@nx/js', '@nx/react'] });
+  });
+  afterAll(() => {
+    delete process.env.NX_USE_LOCAL;
+    cleanupProject();
+  });
 
   it('should generate local configuration', () => {
     runCLI(`configure-ai-agents --agents claude --no-interactive`);
@@ -184,4 +190,178 @@ describe('configure-ai-agents', () => {
       expect(skillsContents.length).toBeGreaterThan(0);
     });
   });
+
+  describe('when running from a detected AI agent', () => {
+    // Simulate Claude Code detection via CLAUDECODE env var.
+    // No --no-interactive flag, no --agents flag: the command auto-detects
+    // which agent is calling it and configures accordingly.
+    const claudeEnv = { CLAUDECODE: '1' };
+
+    beforeAll(() => {
+      // Start clean: remove all agent configs
+      removeFile('CLAUDE.md');
+      removeFile('.claude');
+      removeFile('GEMINI.md');
+      removeFile('.gemini');
+    });
+
+    it('should configure the detected agent without prompting on a clean workspace', () => {
+      // No --agents flag — the command detects claude via CLAUDECODE env var
+      const output = runCLI('configure-ai-agents', {
+        env: claudeEnv,
+      });
+
+      // Should have configured claude (the detected agent)
+      expect(readFile('CLAUDE.md')).toContain('# General Guidelines');
+      expect(readFile('.claude/settings.json')).toContain('nx-claude-plugins');
+
+      // Should mention other unconfigured agents with a command to configure them
+      expect(output).toContain('not yet configured');
+      expect(output).toContain('configure-ai-agents --agents');
+    });
+
+    it('should report up-to-date when the detected agent is fully configured', () => {
+      // Claude is already fully configured from previous test
+      const output = runCLI('configure-ai-agents', {
+        env: claudeEnv,
+      });
+
+      expect(output).toContain('up to date');
+    });
+
+    it('should update the detected agent when its rules are outdated', () => {
+      // Make claude outdated
+      updateFile('CLAUDE.md', (content: string) =>
+        content.replace('nx_docs', 'nx_docs_outdated')
+      );
+
+      const output = runCLI('configure-ai-agents', {
+        env: claudeEnv,
+      });
+
+      // Should have updated claude's rules
+      expect(readFile('CLAUDE.md')).not.toContain('nx_docs_outdated');
+      expect(output).toContain('configured successfully');
+    });
+
+    it('should update other outdated agents alongside the detected agent', () => {
+      // Configure gemini fully first
+      runCLI('configure-ai-agents --agents gemini --no-interactive');
+      expect(readFile('GEMINI.md')).toBeTruthy();
+
+      // Make gemini outdated
+      updateFile('GEMINI.md', (content: string) =>
+        content.replace('nx_docs', 'nx_docs_outdated')
+      );
+
+      // Run from detected claude agent — should also update outdated gemini
+      const output = runCLI('configure-ai-agents', {
+        env: claudeEnv,
+      });
+
+      // Gemini should have been updated because it was outdated
+      expect(readFile('GEMINI.md')).not.toContain('nx_docs_outdated');
+      expect(output).toContain('configured successfully');
+    });
+
+    it('should list non-configured agents with a suggested command', () => {
+      // Remove gemini config to make it non-configured
+      removeFile('GEMINI.md');
+      removeFile('.gemini');
+
+      const output = runCLI('configure-ai-agents', {
+        env: claudeEnv,
+      });
+
+      // Claude is up-to-date, gemini is non-configured
+      // Should suggest running configure-ai-agents for gemini
+      expect(output).toContain('not yet configured');
+      expect(output).toContain('gemini');
+      expect(output).toContain('configure-ai-agents --agents');
+    });
+
+    it('should ignore the detected agent when --agents is explicitly passed', () => {
+      // Clean up both agents
+      removeFile('CLAUDE.md');
+      removeFile('.claude');
+      removeFile('GEMINI.md');
+      removeFile('.gemini');
+
+      // Explicitly pass --agents gemini — should ONLY configure gemini,
+      // ignoring the detected claude agent entirely
+      runCLI('configure-ai-agents --agents gemini --no-interactive', {
+        env: claudeEnv,
+      });
+
+      // Gemini should be configured because it was explicitly requested
+      expect(readFile('GEMINI.md')).toContain('# General Guidelines');
+
+      // Claude should NOT be configured — --agents overrides detection
+      expect(() => readFile('CLAUDE.md')).toThrow();
+    });
+
+    it('should throw with --check when the detected agent is outdated', () => {
+      // Restore claude config (previous test removed it)
+      runCLI('configure-ai-agents --agents claude --no-interactive');
+
+      // Make claude outdated
+      updateFile('CLAUDE.md', (content: string) =>
+        content.replace('nx_docs', 'nx_docs_outdated')
+      );
+
+      let didThrow = false;
+      try {
+        runCLI('configure-ai-agents --check', {
+          env: claudeEnv,
+        });
+      } catch {
+        didThrow = true;
+      }
+      expect(didThrow).toBe(true);
+
+      // Restore
+      runCLI('configure-ai-agents --agents claude --no-interactive');
+    });
+
+    it('should throw with --check when a non-detected agent is outdated', () => {
+      // Configure gemini fully
+      runCLI('configure-ai-agents --agents gemini --no-interactive');
+
+      // Make gemini outdated while claude stays up-to-date
+      updateFile('GEMINI.md', (content: string) =>
+        content.replace('nx_docs', 'nx_docs_outdated')
+      );
+
+      let didThrow = false;
+      try {
+        runCLI('configure-ai-agents --check', {
+          env: claudeEnv,
+        });
+      } catch {
+        didThrow = true;
+      }
+      expect(didThrow).toBe(true);
+
+      // Restore
+      runCLI('configure-ai-agents --agents gemini --no-interactive');
+    });
+
+    it('should not throw with --check when --agents scopes to up-to-date agents only', () => {
+      // Make claude outdated
+      updateFile('CLAUDE.md', (content: string) =>
+        content.replace('nx_docs', 'nx_docs_outdated')
+      );
+
+      // --agents gemini --check should only check gemini, ignoring
+      // the detected (and outdated) claude entirely
+      const output = runCLI('configure-ai-agents --agents gemini --check', {
+        env: claudeEnv,
+      });
+      expect(output).toContain('up to date');
+
+      // Restore
+      runCLI('configure-ai-agents --agents claude --no-interactive');
+    });
+  });
+
 });

--- a/e2e/nx/src/configure-ai-agents.test.ts
+++ b/e2e/nx/src/configure-ai-agents.test.ts
@@ -363,5 +363,4 @@ describe('configure-ai-agents', () => {
       runCLI('configure-ai-agents --agents claude --no-interactive');
     });
   });
-
 });

--- a/e2e/nx/src/configure-ai-agents.test.ts
+++ b/e2e/nx/src/configure-ai-agents.test.ts
@@ -201,7 +201,6 @@ describe('configure-ai-agents', () => {
       // Start clean: remove all agent configs
       removeFile('CLAUDE.md');
       removeFile('.claude');
-      removeFile('GEMINI.md');
       removeFile('.gemini');
     });
 
@@ -247,10 +246,10 @@ describe('configure-ai-agents', () => {
     it('should update other outdated agents alongside the detected agent', () => {
       // Configure gemini fully first
       runCLI('configure-ai-agents --agents gemini --no-interactive');
-      expect(readFile('GEMINI.md')).toBeTruthy();
+      expect(readFile('AGENTS.md')).toBeTruthy();
 
       // Make gemini outdated
-      updateFile('GEMINI.md', (content: string) =>
+      updateFile('AGENTS.md', (content: string) =>
         content.replace('nx_docs', 'nx_docs_outdated')
       );
 
@@ -260,13 +259,13 @@ describe('configure-ai-agents', () => {
       });
 
       // Gemini should have been updated because it was outdated
-      expect(readFile('GEMINI.md')).not.toContain('nx_docs_outdated');
+      expect(readFile('AGENTS.md')).not.toContain('nx_docs_outdated');
       expect(output).toContain('configured successfully');
     });
 
     it('should list non-configured agents with a suggested command', () => {
       // Remove gemini config to make it non-configured
-      removeFile('GEMINI.md');
+      // Note: .gemini removal is sufficient — without settings.json, gemini is non-configured
       removeFile('.gemini');
 
       const output = runCLI('configure-ai-agents', {
@@ -284,7 +283,6 @@ describe('configure-ai-agents', () => {
       // Clean up both agents
       removeFile('CLAUDE.md');
       removeFile('.claude');
-      removeFile('GEMINI.md');
       removeFile('.gemini');
 
       // Explicitly pass --agents gemini — should ONLY configure gemini,
@@ -294,7 +292,7 @@ describe('configure-ai-agents', () => {
       });
 
       // Gemini should be configured because it was explicitly requested
-      expect(readFile('GEMINI.md')).toContain('# General Guidelines');
+      expect(readFile('AGENTS.md')).toContain('# General Guidelines');
 
       // Claude should NOT be configured — --agents overrides detection
       expect(() => readFile('CLAUDE.md')).toThrow();
@@ -328,7 +326,7 @@ describe('configure-ai-agents', () => {
       runCLI('configure-ai-agents --agents gemini --no-interactive');
 
       // Make gemini outdated while claude stays up-to-date
-      updateFile('GEMINI.md', (content: string) =>
+      updateFile('AGENTS.md', (content: string) =>
         content.replace('nx_docs', 'nx_docs_outdated')
       );
 

--- a/e2e/utils/get-env-info.ts
+++ b/e2e/utils/get-env-info.ts
@@ -152,6 +152,7 @@ export function getStrippedEnvironmentVariables() {
         'NX_ISOLATE_PLUGINS',
         'NX_VERBOSE_LOGGING',
         'NX_NATIVE_LOGGING',
+        'NX_USE_LOCAL',
       ];
 
       if (key.startsWith('NX_') && !allowedKeys.includes(key)) {

--- a/e2e/utils/get-env-info.ts
+++ b/e2e/utils/get-env-info.ts
@@ -170,6 +170,22 @@ export function getStrippedEnvironmentVariables() {
         return false;
       }
 
+      // Remove AI agent detection env vars to prevent the test runner's
+      // environment (e.g., running inside Claude Code) from leaking into
+      // e2e test subprocesses. Tests that need these pass them explicitly.
+      const aiAgentEnvVars = [
+        'CLAUDECODE',
+        'CLAUDE_CODE',
+        'OPENCODE',
+        'GEMINI_CLI',
+        'CURSOR_TRACE_ID',
+        'COMPOSER_NO_INTERACTION',
+        'REPL_ID',
+      ];
+      if (aiAgentEnvVars.includes(key)) {
+        return false;
+      }
+
       return true;
     })
   );

--- a/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
+++ b/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
@@ -218,10 +218,6 @@ export async function configureAiAgentsHandlerImpl(
   const detectedAgent = detectAiAgent();
   const agentsExplicitlyPassed = options.agents !== undefined;
 
-  // DEBUG
-  console.error(`[DEBUG] detectedAgent=${detectedAgent}, agentsExplicitlyPassed=${agentsExplicitlyPassed}, interactive=${options.interactive}, options.agents=${JSON.stringify(options.agents)}`);
-  console.error(`[DEBUG] nonConfigured=${nonConfiguredAgents.map(a=>a.name)}, partial=${partiallyConfiguredAgents.map(a=>a.name)}, fully=${fullyConfiguredAgents.map(a=>a.name)}, disabled=${disabledAgents.map(a=>a.name)}`);
-
   if (
     detectedAgent &&
     !agentsExplicitlyPassed &&


### PR DESCRIPTION
## Current Behavior

When `configure-ai-agents` is invoked from within an AI agent (e.g. Claude Code), it either shows an interactive multi-select prompt (which the agent can't interact with) or requires `--agents` and `--no-interactive` flags to work correctly. This makes the experience awkward when AI agents call the command as part of workspace setup.

## Expected Behavior

When an AI agent is detected (via environment variables like `CLAUDECODE`), the command now:

1. **Auto-configures the detected agent** if it's not yet configured, partially configured, or outdated — no prompts needed
2. **Auto-updates any other outdated agents** alongside the detected one
3. **Reports non-configured agents** with a suggested `nx configure-ai-agents --agents ...` command
4. **Reports up-to-date status** if the detected agent is already fully configured

When `--agents` is explicitly passed, detection is ignored entirely (existing behavior preserved). `--check` mode also works with detection — it checks the detected agent plus all other configured agents.

Additionally:
- Strips AI agent detection env vars (`CLAUDECODE`, `CLAUDE_CODE`, `OPENCODE`, `GEMINI_CLI`, etc.) from e2e subprocess environments to prevent the test runner's environment from leaking into tests
- Fixes e2e tests to use `AGENTS.md` (not `GEMINI.md`) for gemini assertions, matching what the gemini generator actually creates for fresh installations
