### PR TITLE
fix(core): preserve existing source properties in claude plugin config

### DIFF
--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
@@ -393,6 +393,45 @@ describe('setup-ai-agents generator', () => {
         expect(config.enabledPlugins['nx@nx-claude-plugins']).toBe(true);
       });
 
+      it('should preserve existing ref in nx-claude-plugins source', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+          agents: ['claude'],
+        };
+
+        // Create existing config with a custom ref
+        tree.write(
+          '.claude/settings.json',
+          JSON.stringify({
+            extraKnownMarketplaces: {
+              'nx-claude-plugins': {
+                source: {
+                  source: 'github',
+                  repo: 'nrwl/nx-ai-agents-config',
+                  ref: 'experimental',
+                },
+              },
+            },
+            enabledPlugins: {
+              'nx@nx-claude-plugins': true,
+            },
+          })
+        );
+
+        await setupAiAgentsGenerator(tree, options);
+
+        const config = JSON.parse(
+          tree.read('.claude/settings.json')?.toString() ?? '{}'
+        );
+        expect(config.extraKnownMarketplaces['nx-claude-plugins']).toEqual({
+          source: {
+            source: 'github',
+            repo: 'nrwl/nx-ai-agents-config',
+            ref: 'experimental',
+          },
+        });
+      });
+
       it('should NOT write to .mcp.json for claude (MCP is provided by plugin)', async () => {
         const options: SetupAiAgentsGeneratorSchema = {
           directory: '.',

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -171,6 +171,7 @@ export async function setupAiAgentsGeneratorImpl(
         ...json.extraKnownMarketplaces,
         'nx-claude-plugins': {
           source: {
+            ...json.extraKnownMarketplaces?.['nx-claude-plugins']?.source,
             source: 'github',
             repo: 'nrwl/nx-ai-agents-config',
           },


### PR DESCRIPTION
## Current Behavior

Running `configure-ai-agents` overwrites the entire `source` object in `extraKnownMarketplaces['nx-claude-plugins']`, removing any user-added properties like `ref`.

## Expected Behavior

User-added source properties (e.g. `ref`) are preserved, while `source` and `repo` are always set to the correct values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)