### PR TITLE
fix(nx-dev): update breadcrumb links to match sidebar

### DIFF
--- a/astro-docs/markdoc.config.mjs
+++ b/astro-docs/markdoc.config.mjs
@@ -244,6 +244,15 @@ export default defineMarkdocConfig({
         },
       },
     },
+    sidebar_group_cards: {
+      render: component('./src/components/markdoc/SidebarGroupCards.astro'),
+      attributes: {
+        group: {
+          type: 'String',
+          required: true,
+        },
+      },
+    },
     metrics: {
       render: component('./src/components/markdoc/Metrics.astro'),
       attributes: {

--- a/astro-docs/src/components/layout/Breadcrumbs.astro
+++ b/astro-docs/src/components/layout/Breadcrumbs.astro
@@ -2,70 +2,119 @@
 import { Icon } from '@astrojs/starlight/components';
 import { getCollection } from 'astro:content';
 
-const { pathname } = Astro.url;
-
-const cleanedPath = pathname.split('?')[0];
-
-const allDocs = await getCollection('docs');
-
-const pathSegments = cleanedPath.split('/').filter(Boolean);
-
 type Crumb = {
-  id: string;
-  name: string;
-  href: string;
+  label: string;
+  href?: string;
   current: boolean;
+};
+
+function slugify(label: string): string {
+  return label
+    .replace(/\.NET/g, 'dotnet')
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
-function findDocByPath (path: string) {
-  path = path.replace(/^docs\//, '');
-  return allDocs.find(d => d.id === `${path}`)
-      ?? allDocs.find(d => d.id === `${path}/index`);
+// --- Primary: Sidebar-based breadcrumbs ---
+const sidebar = Astro.locals.starlightRoute.sidebar;
+
+function findBreadcrumbPath(
+  entries: typeof sidebar,
+  path: Crumb[] = [],
+  slugSegments: string[] = []
+): Crumb[] | null {
+  for (const entry of entries) {
+    if (entry.type === 'link' && entry.isCurrent) {
+      return [...path, { label: entry.label, href: entry.href, current: true }];
+    }
+    if (entry.type === 'group') {
+      const currentSlugs = [...slugSegments, slugify(entry.label)];
+      const groupHref = `/docs/${currentSlugs.join('/')}`;
+      const result = findBreadcrumbPath(
+        entry.entries,
+        [
+          ...path,
+          { label: entry.label, href: groupHref, current: false },
+        ],
+        currentSlugs
+      );
+      if (result) return result;
+    }
+  }
+  return null;
 }
 
-function createNameFromSegment(segment: string): string {
+let crumbs: Crumb[] = findBreadcrumbPath(sidebar) ?? [];
+
+// --- Fallback: URL-path-based breadcrumbs ---
+if (crumbs.length === 0) {
+  const { pathname } = Astro.url;
+  const cleanedPath = pathname.split('?')[0];
+  const allDocs = await getCollection('docs');
+  const pathSegments = cleanedPath.split('/').filter(Boolean);
+
+  function findDocByPath(path: string) {
+    path = path.replace(/^docs\//, '');
+    return (
+      allDocs.find((d) => d.id === `${path}`) ??
+      allDocs.find((d) => d.id === `${path}/index`)
+    );
+  }
+
+  function createNameFromSegment(segment: string): string {
     segment = segment.split('#')[0];
     return segment
-        .split('-')
-        .map(s => s.charAt(0).toUpperCase() + s.slice(1))
-        .join(' ');
+      .split('-')
+      .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+      .join(' ');
+  }
+
+  crumbs = pathSegments
+    .map((segment, index) => {
+      const docPath = pathSegments.slice(0, index + 1).join('/');
+      const doc = findDocByPath(docPath);
+      const label =
+        doc?.data?.sidebar?.label ||
+        doc?.data?.title ||
+        createNameFromSegment(segment);
+      // If `base` is set in config, don't include it in breadcrumbs
+      if (index === 0 && import.meta.env.BASE_URL) return null;
+      return {
+        label,
+        href: `/${docPath}`,
+        current: index === pathSegments.length - 1,
+      };
+    })
+    .filter(Boolean) as Crumb[];
 }
-
-const crumbs: Crumb[] = pathSegments.map((segment, index) => {
-  const docPath = pathSegments.slice(0, index + 1).join('/');
-  const doc = findDocByPath(docPath);
-  const name = doc?.data?.sidebar?.label || doc?.data?.title || createNameFromSegment(segment);
-  // If `base` is set in config, don't include it in breadcrumbs
-  if (index === 0 && import.meta.env.BASE_URL) return null;
-  return {
-    id: segment,
-    name,
-    href: `/${docPath}`,
-    current: index === pathSegments.length - 1,
-  };
-}).filter(Boolean);
 ---
-
 
 <nav class="not-content flex mb-4" aria-label="Breadcrumb">
   <ol role="list" class="flex m-0 p-0 flex-wrap items-center space-x-2 text-sm">
-    {crumbs.map((crumb, index) => (
-      <li class="flex items-center">
-        {index > 0 && (
-          <Icon name="right-caret" class="w-5 h-5 ml-2 mr-2"/>
-        )}
-        <a
-          href={crumb.href}
-          class={`no-underline text-sm${
-            crumb.current 
-              ? ' text-slate-900 dark:text-slate-100 font-semibold'
-          : ' text-slate-500 dark:text-slate-400 font-medium hover:text-slate-700 dark:hover:text-slate-200'
-          } transition-colors`}
-          aria-current={crumb.current ? 'page' : undefined}
-        >
-          {crumb.name}
-        </a>
-      </li>
-    ))}
+    {
+      crumbs.map((crumb, index) => (
+        <li class="flex items-center">
+          {index > 0 && <Icon name="right-caret" class="w-5 h-5 ml-2 mr-2" />}
+          {crumb.href ? (
+            <a
+              href={crumb.href}
+              class={`no-underline text-sm${
+                crumb.current
+                  ? ' text-slate-900 dark:text-slate-100 font-semibold'
+                  : ' text-slate-500 dark:text-slate-400 font-medium hover:text-slate-700 dark:hover:text-slate-200'
+              } transition-colors`}
+              aria-current={crumb.current ? 'page' : undefined}
+            >
+              {crumb.label}
+            </a>
+          ) : (
+            <span class="text-sm text-slate-500 dark:text-slate-400 font-medium">
+              {crumb.label}
+            </span>
+          )}
+        </li>
+      ))
+    }
   </ol>
 </nav>

--- a/astro-docs/src/components/markdoc/SidebarGroupCards.astro
+++ b/astro-docs/src/components/markdoc/SidebarGroupCards.astro
@@ -1,0 +1,108 @@
+---
+import { getCollection } from 'astro:content';
+import Cards from './Cards.astro';
+import LinkCard from './LinkCard.astro';
+
+export interface Props {
+  group: string;
+}
+
+const { group } = Astro.props;
+const groupSegments = group.split('/');
+
+// Use the Starlight resolved sidebar from Astro locals
+const sidebar = Astro.locals.starlightRoute.sidebar;
+type SidebarEntry = (typeof sidebar)[number];
+
+function findGroup(
+  entries: SidebarEntry[],
+  segments: string[],
+  depth: number = 0
+): SidebarEntry | null {
+  for (const entry of entries) {
+    if (entry.type === 'group' && entry.label === segments[depth]) {
+      if (depth === segments.length - 1) {
+        return entry;
+      }
+      return findGroup(entry.entries, segments, depth + 1);
+    }
+  }
+  return null;
+}
+
+interface LinkItem {
+  label: string;
+  href: string;
+}
+
+function slugify(label: string): string {
+  return label
+    .replace(/\.NET/g, 'dotnet')
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+// Build base URL path from the group prop segments
+const baseSlug = groupSegments.map((s) => slugify(s)).join('/');
+
+function collectTopLevelItems(entries: SidebarEntry[]): LinkItem[] {
+  const items: LinkItem[] = [];
+  for (const entry of entries) {
+    if (entry.type === 'link') {
+      items.push({ label: entry.label, href: entry.href });
+    }
+    if (entry.type === 'group') {
+      const groupSlug = slugify(entry.label);
+      items.push({
+        label: entry.label,
+        href: `/docs/${baseSlug}/${groupSlug}`,
+      });
+    }
+  }
+  return items;
+}
+
+const matchedGroup = findGroup(sidebar, groupSegments);
+const linkItems =
+  matchedGroup && matchedGroup.type === 'group'
+    ? collectTopLevelItems(matchedGroup.entries)
+    : [];
+
+// Look up each page in the docs collection for descriptions
+const allDocs = await getCollection('docs');
+
+const processedPages = linkItems.map((item) => {
+  const docPath = item.href.replace(/^\/docs\//, '');
+  const doc = allDocs.find(
+    (d) =>
+      d.id === docPath ||
+      d.id === `${docPath}.mdoc` ||
+      d.id === `${docPath}/index` ||
+      d.id === `${docPath}/index.mdoc`
+  );
+
+  return {
+    title: item.label,
+    description: doc?.data?.description || '',
+    href: item.href,
+  };
+});
+---
+
+{
+  processedPages.length > 0 ? (
+    <Cards>
+      {processedPages.map((page) => (
+        <LinkCard
+          title={page.title}
+          description={page.description}
+          href={page.href}
+          type="documentation"
+        />
+      ))}
+    </Cards>
+  ) : (
+    <p>No pages found in this section.</p>
+  )
+}

--- a/astro-docs/src/content/docs/how-nx-works/index.mdoc
+++ b/astro-docs/src/content/docs/how-nx-works/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: How Nx Works
+description: Core concepts and mental models behind Nx
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="How Nx Works" /%}

--- a/astro-docs/src/content/docs/knowledge-base/angular/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/angular/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Angular
+description: Angular guides and best practices for Nx workspaces
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Angular" /%}

--- a/astro-docs/src/content/docs/knowledge-base/benchmarks/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/benchmarks/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Benchmarks
+description: Performance benchmarks for Nx
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Benchmarks" /%}

--- a/astro-docs/src/content/docs/knowledge-base/continuous-integration/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/continuous-integration/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Continuous Integration
+description: Set up and configure CI pipelines with Nx
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Continuous Integration" /%}

--- a/astro-docs/src/content/docs/knowledge-base/creating-releases/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/creating-releases/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Creating Releases
+description: Guides for creating and publishing releases with Nx
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Creating Releases" /%}

--- a/astro-docs/src/content/docs/knowledge-base/cypress/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/cypress/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Cypress
+description: Cypress guides and best practices for Nx workspaces
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Cypress" /%}

--- a/astro-docs/src/content/docs/knowledge-base/dotnet/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/dotnet/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: .NET
+description: .NET guides and best practices for Nx workspaces
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/.NET" /%}

--- a/astro-docs/src/content/docs/knowledge-base/eslint/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/eslint/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: ESLint
+description: ESLint guides and best practices for Nx workspaces
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/ESLint" /%}

--- a/astro-docs/src/content/docs/knowledge-base/extending-nx/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/extending-nx/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Extending Nx
+description: Guides for extending Nx with custom plugins, generators, and executors
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Extending Nx" /%}

--- a/astro-docs/src/content/docs/knowledge-base/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Knowledge Base
+description: In-depth guides, recipes, and technology-specific documentation for Nx
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base" /%}

--- a/astro-docs/src/content/docs/knowledge-base/installation/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/installation/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Installation
+description: Installation guides for Nx
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Installation" /%}

--- a/astro-docs/src/content/docs/knowledge-base/module-federation/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/module-federation/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Module Federation
+description: Module Federation guides and best practices for Nx workspaces
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Module Federation" /%}

--- a/astro-docs/src/content/docs/knowledge-base/node/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/node/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Node
+description: Node.js guides and best practices for Nx workspaces
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Node" /%}

--- a/astro-docs/src/content/docs/knowledge-base/nx-console/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/nx-console/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Nx Console
+description: Guides for using Nx Console IDE extension
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Nx Console" /%}

--- a/astro-docs/src/content/docs/knowledge-base/organizational-decisions/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/organizational-decisions/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Organizational Decisions
+description: Guidance on monorepo organizational decisions
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Organizational Decisions" /%}

--- a/astro-docs/src/content/docs/knowledge-base/playwright/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/playwright/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Playwright
+description: Playwright guides and best practices for Nx workspaces
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Playwright" /%}

--- a/astro-docs/src/content/docs/knowledge-base/react/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/react/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: React
+description: React guides and best practices for Nx workspaces
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/React" /%}

--- a/astro-docs/src/content/docs/knowledge-base/recipes/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/recipes/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Recipes
+description: Practical recipes and tips for Nx workspaces
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Recipes" /%}

--- a/astro-docs/src/content/docs/knowledge-base/storybook/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/storybook/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Storybook
+description: Storybook guides and best practices for Nx workspaces
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Storybook" /%}

--- a/astro-docs/src/content/docs/knowledge-base/tasks-caching/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/tasks-caching/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Tasks & Caching
+description: Guides for configuring tasks and caching in Nx
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Tasks & Caching" /%}

--- a/astro-docs/src/content/docs/knowledge-base/troubleshooting/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/troubleshooting/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Troubleshooting
+description: Common issues and solutions for Nx workspaces
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Troubleshooting" /%}

--- a/astro-docs/src/content/docs/knowledge-base/typescript/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/typescript/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: TypeScript
+description: TypeScript guides and best practices for Nx workspaces
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/TypeScript" /%}

--- a/astro-docs/src/content/docs/knowledge-base/vite/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/vite/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Vite
+description: Vite guides and best practices for Nx workspaces
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Vite" /%}

--- a/astro-docs/src/content/docs/knowledge-base/vitest/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/vitest/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Vitest
+description: Vitest guides and best practices for Nx workspaces
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Vitest" /%}

--- a/astro-docs/src/content/docs/knowledge-base/vue/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/vue/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Vue
+description: Vue guides and best practices for Nx workspaces
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Vue" /%}

--- a/astro-docs/src/content/docs/knowledge-base/webpack/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/webpack/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Webpack
+description: Webpack guides and best practices for Nx workspaces
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Webpack" /%}

--- a/astro-docs/src/content/docs/platform-features/code-organization/enforce-module-boundaries/index.mdoc
+++ b/astro-docs/src/content/docs/platform-features/code-organization/enforce-module-boundaries/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Enforce Module Boundaries
+description: Enforce constraints on project dependencies in your workspace
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Platform Features/Code Organization/Enforce Module Boundaries" /%}

--- a/astro-docs/src/content/docs/platform-features/code-organization/index.mdoc
+++ b/astro-docs/src/content/docs/platform-features/code-organization/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Code Organization
+description: Tools and features for organizing code in your Nx workspace
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Platform Features/Code Organization" /%}

--- a/astro-docs/src/content/docs/platform-features/enterprise/conformance-reference/index.mdoc
+++ b/astro-docs/src/content/docs/platform-features/enterprise/conformance-reference/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Conformance Reference
+description: Reference documentation for Nx conformance rules
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Platform Features/Enterprise/Conformance Reference" /%}

--- a/astro-docs/src/content/docs/platform-features/enterprise/index.mdoc
+++ b/astro-docs/src/content/docs/platform-features/enterprise/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Enterprise
+description: Enterprise features for Nx Cloud
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Platform Features/Enterprise" /%}

--- a/astro-docs/src/content/docs/platform-features/enterprise/single-tenant/index.mdoc
+++ b/astro-docs/src/content/docs/platform-features/enterprise/single-tenant/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Single Tenant
+description: Single tenant deployment guides for Nx Cloud
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Platform Features/Enterprise/Single Tenant" /%}

--- a/astro-docs/src/content/docs/platform-features/index.mdoc
+++ b/astro-docs/src/content/docs/platform-features/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Platform Features
+description: Explore all the powerful features that Nx provides
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Platform Features" /%}

--- a/astro-docs/src/content/docs/platform-features/maintenance/index.mdoc
+++ b/astro-docs/src/content/docs/platform-features/maintenance/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Maintenance
+description: Guides for maintaining and upgrading your Nx workspace
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Platform Features/Maintenance" /%}

--- a/astro-docs/src/content/docs/platform-features/orchestration-ci/index.mdoc
+++ b/astro-docs/src/content/docs/platform-features/orchestration-ci/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Orchestration & CI
+description: Features for orchestrating tasks and optimizing CI pipelines with Nx
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Platform Features/Orchestration & CI" /%}

--- a/astro-docs/src/content/docs/platform-features/release-publishing/index.mdoc
+++ b/astro-docs/src/content/docs/platform-features/release-publishing/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Release & Publishing
+description: Tools for managing releases and publishing packages with Nx
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Platform Features/Release & Publishing" /%}

--- a/astro-docs/src/content/docs/reference/angular/index.mdoc
+++ b/astro-docs/src/content/docs/reference/angular/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Angular
+description: Angular API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/Angular" /%}

--- a/astro-docs/src/content/docs/reference/cypress/index.mdoc
+++ b/astro-docs/src/content/docs/reference/cypress/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Cypress
+description: Cypress API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/Cypress" /%}

--- a/astro-docs/src/content/docs/reference/detox/index.mdoc
+++ b/astro-docs/src/content/docs/reference/detox/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Detox
+description: Detox API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/Detox" /%}

--- a/astro-docs/src/content/docs/reference/dotnet/index.mdoc
+++ b/astro-docs/src/content/docs/reference/dotnet/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: .NET
+description: .NET API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/.NET" /%}

--- a/astro-docs/src/content/docs/reference/esbuild/index.mdoc
+++ b/astro-docs/src/content/docs/reference/esbuild/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: ESBuild
+description: ESBuild API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/ESBuild" /%}

--- a/astro-docs/src/content/docs/reference/eslint/index.mdoc
+++ b/astro-docs/src/content/docs/reference/eslint/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: ESLint
+description: ESLint API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/ESLint" /%}

--- a/astro-docs/src/content/docs/reference/java/index.mdoc
+++ b/astro-docs/src/content/docs/reference/java/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Java
+description: Java API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/Java" /%}

--- a/astro-docs/src/content/docs/reference/jest/index.mdoc
+++ b/astro-docs/src/content/docs/reference/jest/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Jest
+description: Jest API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/Jest" /%}

--- a/astro-docs/src/content/docs/reference/module-federation/index.mdoc
+++ b/astro-docs/src/content/docs/reference/module-federation/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Module Federation
+description: Module Federation API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/Module Federation" /%}

--- a/astro-docs/src/content/docs/reference/node/index.mdoc
+++ b/astro-docs/src/content/docs/reference/node/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Node
+description: Node.js API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/Node" /%}

--- a/astro-docs/src/content/docs/reference/playwright/index.mdoc
+++ b/astro-docs/src/content/docs/reference/playwright/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Playwright
+description: Playwright API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/Playwright" /%}

--- a/astro-docs/src/content/docs/reference/react/index.mdoc
+++ b/astro-docs/src/content/docs/reference/react/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: React
+description: React API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/React" /%}

--- a/astro-docs/src/content/docs/reference/rollup/index.mdoc
+++ b/astro-docs/src/content/docs/reference/rollup/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Rollup
+description: Rollup API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/Rollup" /%}

--- a/astro-docs/src/content/docs/reference/rsbuild/index.mdoc
+++ b/astro-docs/src/content/docs/reference/rsbuild/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Rsbuild
+description: Rsbuild API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/Rsbuild" /%}

--- a/astro-docs/src/content/docs/reference/rspack/index.mdoc
+++ b/astro-docs/src/content/docs/reference/rspack/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Rspack
+description: Rspack API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/Rspack" /%}

--- a/astro-docs/src/content/docs/reference/storybook/index.mdoc
+++ b/astro-docs/src/content/docs/reference/storybook/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Storybook
+description: Storybook API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/Storybook" /%}

--- a/astro-docs/src/content/docs/reference/typescript/index.mdoc
+++ b/astro-docs/src/content/docs/reference/typescript/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: TypeScript
+description: TypeScript API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/TypeScript" /%}

--- a/astro-docs/src/content/docs/reference/vite/index.mdoc
+++ b/astro-docs/src/content/docs/reference/vite/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Vite
+description: Vite API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/Vite" /%}

--- a/astro-docs/src/content/docs/reference/vitest/index.mdoc
+++ b/astro-docs/src/content/docs/reference/vitest/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Vitest
+description: Vitest API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/Vitest" /%}

--- a/astro-docs/src/content/docs/reference/vue/index.mdoc
+++ b/astro-docs/src/content/docs/reference/vue/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Vue
+description: Vue API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/Vue" /%}

--- a/astro-docs/src/content/docs/reference/webpack/index.mdoc
+++ b/astro-docs/src/content/docs/reference/webpack/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Webpack
+description: Webpack API reference for Nx plugins
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Reference/Webpack" /%}

--- a/astro-docs/src/content/docs/technologies-tools/build-tools/index.mdoc
+++ b/astro-docs/src/content/docs/technologies-tools/build-tools/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Build Tools
+description: Nx support for build tools like Webpack, Vite, Rollup, and more
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Technologies & Tools/Build Tools" /%}

--- a/astro-docs/src/content/docs/technologies-tools/frameworks-libraries/index.mdoc
+++ b/astro-docs/src/content/docs/technologies-tools/frameworks-libraries/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Frameworks & Libraries
+description: Nx support for popular frameworks and libraries
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Technologies & Tools/Frameworks & Libraries" /%}

--- a/astro-docs/src/content/docs/technologies-tools/index.mdoc
+++ b/astro-docs/src/content/docs/technologies-tools/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Technologies & Tools
+description: Nx support for popular frameworks, libraries, and build tools
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Technologies & Tools" /%}

--- a/astro-docs/src/content/docs/technologies-tools/test-tools/index.mdoc
+++ b/astro-docs/src/content/docs/technologies-tools/test-tools/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Test Tools
+description: Nx support for testing tools like Cypress, Jest, Playwright, and more
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Technologies & Tools/Test Tools" /%}


### PR DESCRIPTION
navigation of the breadcrumbs could lead to confusing state since they were based around the folder structure.

Breadcrumbs are now based around the sidebar structure so they match the hierarchy of content. 

Note: I left the existing index file based route pages in place in case there are any links people have booked marked/linked to in other locations. these will get cleaned up when we finally rewrite all the URLs to their new content locations