### PR TITLE
fix(repo): fix e2e CI failures from Node 22.12 incompatibility

### DIFF
--- a/.github/workflows/nightly/process-matrix.ts
+++ b/.github/workflows/nightly/process-matrix.ts
@@ -75,7 +75,7 @@ const matrixData: MatrixData = {
       os_name: 'Linux',
       os_timeout: 60,
       package_managers: ['npm', 'pnpm', 'yarn'],
-      node_versions: ['20.19.0', '22.12.0', '24.0.0'],
+      node_versions: ['20.19.0', '22.13.0', '24.0.0'],
       excluded: ['e2e-detox', 'e2e-react-native', 'e2e-expo']
     },
     // Docker is not supported on ARM-based macOS runners (no nested virtualization)


### PR DESCRIPTION
## Current Behavior

Two categories of e2e CI failures were observed in run https://github.com/nrwl/nx/actions/runs/22127884259:

1. **`e2e-nx-init` and `e2e-js` fail on Node 22.12.0** with:
   ```
   error eslint-visitor-keys@5.0.0: The engine "node" is incompatible with this module.
   Expected version "^20.19.0 || ^22.13.0 || >=24". Got "22.12.0"
   ```
   Node 22.12.0 is one minor version short of the `^22.13.0` range required by `eslint-visitor-keys@5.0.0`.

2. **`e2e-nx` tests fail because `[isolated-plugin]` / `[plugin-worker]` verbose messages leak into captured stdout**, causing:
   - `JSON.parse(runCLI('show project --json'))` to throw `SyntaxError: Unexpected token 'i', "[isolated-p"...`
   - `expect(runCLI('show projects')).toEqual('')` to fail with worker spawn noise
   - The `@nx/workspace:infer-targets` test to unexpectedly find `@nx/remix` in output (from a worker spawn message)

   Root cause: in `isolated-plugin.ts`, the plugin worker's stdout was piped directly to `process.stdout`, so `[plugin-worker]` verbose messages written by the worker ended up in the stdout captured by `runCLI` in e2e tests.

## Expected Behavior

1. The CI matrix uses a Node 22.x version that satisfies `^22.13.0`.

2. Plugin worker verbose/diagnostic messages go to `process.stderr` (not `process.stdout`), so they don't contaminate output captured by `runCLI` in e2e tests. Both worker stdout and stderr now pipe to `process.stderr`, and the max listener bump is consolidated to `+2` on stderr.

## Related Issue(s)

N/A — identified from CI run https://github.com/nrwl/nx/actions/runs/22127884259