### PR TITLE
feat(core): add safe plugin cache write utilities with LRU eviction

### DIFF
--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -17,7 +17,7 @@ import { getLockFileName } from '@nx/js';
 import { readdirSync } from 'fs';
 import { hashObject } from 'nx/src/devkit-internals';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
-import { PluginCache, readPluginCache } from 'nx/src/utils/plugin-cache-utils';
+import { PluginCache } from 'nx/src/utils/plugin-cache-utils';
 import { globWithWorkspaceContext } from 'nx/src/utils/workspace-context';
 import { dirname, join, relative } from 'path';
 import { NX_PLUGIN_OPTIONS } from '../utils/constants';
@@ -52,7 +52,7 @@ export const createNodes: CreateNodesV2<CypressPluginOptions> = [
       workspaceDataDirectory,
       `cypress-${optionsHash}.hash`
     );
-    const pluginCache = readPluginCache<CypressTargets>(cachePath);
+    const pluginCache = new PluginCache<CypressTargets>(cachePath);
     try {
       return await createNodesFromFiles(
         (configFile, options, context) =>

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -1,4 +1,7 @@
 export {
   signalToCode,
   createProjectRootMappingsFromProjectConfigurations,
+  PluginCache,
+  readPluginCache,
+  safeWriteFileCache,
 } from 'nx/src/devkit-internals';

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -2,6 +2,5 @@ export {
   signalToCode,
   createProjectRootMappingsFromProjectConfigurations,
   PluginCache,
-  readPluginCache,
   safeWriteFileCache,
 } from 'nx/src/devkit-internals';

--- a/packages/dotnet/src/analyzer/analyzer-client.ts
+++ b/packages/dotnet/src/analyzer/analyzer-client.ts
@@ -1,16 +1,12 @@
 import { execFileSync, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, readFileSync, readdirSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import {
-  logger,
-  workspaceRoot,
-  ProjectConfiguration,
-  writeJsonFile,
-} from '@nx/devkit';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { logger, workspaceRoot, ProjectConfiguration } from '@nx/devkit';
 import { hashWithWorkspaceContext } from 'nx/src/utils/workspace-context';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { hashObject } from 'nx/src/hasher/file-hasher';
+import { PluginCache, readPluginCache } from 'nx/src/utils/plugin-cache-utils';
 
 export interface AnalysisSuccessResult {
   // Maps project file path -> node configuration
@@ -26,7 +22,7 @@ export interface AnalysisErrorResult {
 }
 export type AnalysisResult = AnalysisSuccessResult | AnalysisErrorResult;
 
-const analyzerCaches = new Map<string, Record<string, AnalysisSuccessResult>>();
+const analyzerCaches = new Map<string, PluginCache<AnalysisSuccessResult>>();
 
 function getCachePathForOptionsHash(optionsHash: string): string {
   return join(workspaceDataDirectory, `dotnet-${optionsHash}.hash`);
@@ -34,37 +30,21 @@ function getCachePathForOptionsHash(optionsHash: string): string {
 
 function readAnalyzerCache(
   optionsHash: string
-): Record<string, AnalysisSuccessResult> {
+): PluginCache<AnalysisSuccessResult> {
   if (analyzerCaches.has(optionsHash)) {
     return analyzerCaches.get(optionsHash)!;
   }
   const cacheFilePath = getCachePathForOptionsHash(optionsHash);
-  try {
-    return JSON.parse(readFileSync(cacheFilePath, 'utf-8'));
-  } catch {
-    return {};
-  }
+  return readPluginCache<AnalysisSuccessResult>(cacheFilePath);
 }
 
 function writeAnalyzerCache(
   optionsHash: string,
-  cache: Record<string, AnalysisSuccessResult>
+  cache: PluginCache<AnalysisSuccessResult>
 ): void {
   analyzerCaches.set(optionsHash, cache);
   const cacheFilePath = getCachePathForOptionsHash(optionsHash);
-  const cacheDir = dirname(cacheFilePath);
-  if (!existsSync(cacheDir)) {
-    mkdirSync(cacheDir, { recursive: true });
-  }
-  try {
-    writeJsonFile(cacheFilePath, cache);
-  } catch (error) {
-    logger.warn(
-      `Failed to write .NET analyzer cache to ${cacheFilePath}: ${
-        (error as Error).message
-      }`
-    );
-  }
+  cache.writeToDisk(cacheFilePath);
 }
 
 /**
@@ -247,7 +227,7 @@ export async function analyzeProjects(
 
   const optionsHash = hashObject(options);
   const analyzerCache = readAnalyzerCache(optionsHash);
-  const cachedResult = analyzerCache[filesHash];
+  const cachedResult = analyzerCache.get(filesHash);
   if (cachedResult) {
     // Update cache
     cache = {
@@ -267,10 +247,8 @@ export async function analyzeProjects(
       result,
     };
     // Update persistent cache
-    writeAnalyzerCache(optionsHash, {
-      ...analyzerCache,
-      [filesHash]: result,
-    });
+    analyzerCache.set(filesHash, result);
+    writeAnalyzerCache(optionsHash, analyzerCache);
 
     return result;
   } catch (error) {

--- a/packages/dotnet/src/analyzer/analyzer-client.ts
+++ b/packages/dotnet/src/analyzer/analyzer-client.ts
@@ -6,7 +6,7 @@ import { logger, workspaceRoot, ProjectConfiguration } from '@nx/devkit';
 import { hashWithWorkspaceContext } from 'nx/src/utils/workspace-context';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { hashObject } from 'nx/src/hasher/file-hasher';
-import { PluginCache, readPluginCache } from 'nx/src/utils/plugin-cache-utils';
+import { PluginCache } from 'nx/src/utils/plugin-cache-utils';
 
 export interface AnalysisSuccessResult {
   // Maps project file path -> node configuration
@@ -35,7 +35,7 @@ function readAnalyzerCache(
     return analyzerCaches.get(optionsHash)!;
   }
   const cacheFilePath = getCachePathForOptionsHash(optionsHash);
-  return readPluginCache<AnalysisSuccessResult>(cacheFilePath);
+  return new PluginCache<AnalysisSuccessResult>(cacheFilePath);
 }
 
 function writeAnalyzerCache(

--- a/packages/gradle/src/plugin-v1/nodes.ts
+++ b/packages/gradle/src/plugin-v1/nodes.ts
@@ -8,7 +8,7 @@ import {
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { basename, dirname, join } from 'node:path';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
-import { PluginCache, readPluginCache } from 'nx/src/utils/plugin-cache-utils';
+import { PluginCache } from 'nx/src/utils/plugin-cache-utils';
 import { findProjectForPath } from 'nx/src/devkit-internals';
 
 import {
@@ -66,8 +66,9 @@ export const createNodesV2: CreateNodesV2<GradlePluginOptions> = [
       workspaceDataDirectory,
       `gradle-${optionsHash}.hash`
     );
-    const pluginCache =
-      readPluginCache<Partial<ProjectConfiguration>>(cachePath);
+    const pluginCache = new PluginCache<Partial<ProjectConfiguration>>(
+      cachePath
+    );
 
     await populateGradleReport(
       context.workspaceRoot,

--- a/packages/gradle/src/plugin-v1/utils/get-gradle-report.ts
+++ b/packages/gradle/src/plugin-v1/utils/get-gradle-report.ts
@@ -3,6 +3,7 @@ import { join, relative } from 'node:path';
 
 import {
   AggregateCreateNodesError,
+  logger,
   normalizePath,
   readJsonFile,
   workspaceRoot,
@@ -130,7 +131,15 @@ export function writeGradleReportToCache(
     ),
   };
 
-  writeJsonFile(cachePath, gradleReportJson);
+  try {
+    writeJsonFile(cachePath, gradleReportJson);
+  } catch (e) {
+    logger.warn(
+      `Failed to write Gradle report cache to ${cachePath}: ${
+        e instanceof Error ? e.message : 'unknown error'
+      }`
+    );
+  }
 }
 
 let gradleReportCache: GradleReport;

--- a/packages/gradle/src/plugin/nodes.ts
+++ b/packages/gradle/src/plugin/nodes.ts
@@ -9,7 +9,7 @@ import {
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { dirname, join } from 'node:path';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
-import { PluginCache, readPluginCache } from 'nx/src/utils/plugin-cache-utils';
+import { PluginCache } from 'nx/src/utils/plugin-cache-utils';
 
 import { hashObject } from 'nx/src/hasher/file-hasher';
 import {
@@ -115,8 +115,9 @@ export const createNodesV2: CreateNodesV2<GradlePluginOptions> = [
       workspaceDataDirectory,
       `gradle-${optionsHash}.hash`
     );
-    const pluginCache =
-      readPluginCache<Partial<ProjectConfiguration>>(cachePath);
+    const pluginCache = new PluginCache<Partial<ProjectConfiguration>>(
+      cachePath
+    );
 
     await populateProjectGraph(
       context.workspaceRoot,

--- a/packages/gradle/src/plugin/utils/get-project-graph-from-gradle-plugin.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-from-gradle-plugin.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import {
   AggregateCreateNodesError,
   hashArray,
+  logger,
   ProjectConfiguration,
   ProjectGraphExternalNode,
   readJsonFile,
@@ -56,7 +57,15 @@ export function writeProjectGraphReportToCache(
     ...results,
   };
 
-  writeJsonFile(cachePath, projectGraphReportJson);
+  try {
+    writeJsonFile(cachePath, projectGraphReportJson);
+  } catch (e) {
+    logger.warn(
+      `Failed to write Gradle project graph report cache to ${cachePath}: ${
+        e instanceof Error ? e.message : 'unknown error'
+      }`
+    );
+  }
 }
 
 let projectGraphReportCache: ProjectGraphReport;

--- a/packages/maven/src/plugins/maven-data-cache.ts
+++ b/packages/maven/src/plugins/maven-data-cache.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { readJsonFile, writeJsonFile } from '@nx/devkit';
+import { PluginCache, readPluginCache } from 'nx/src/utils/plugin-cache-utils';
 import { MavenAnalysisData } from './types';
 
 /**
@@ -7,14 +7,8 @@ import { MavenAnalysisData } from './types';
  */
 export function readMavenCache(
   cachePath: string
-): Record<string, MavenAnalysisData> {
-  try {
-    return process.env.NX_CACHE_PROJECT_GRAPH !== 'false'
-      ? readJsonFile(cachePath)
-      : {};
-  } catch {
-    return {};
-  }
+): PluginCache<MavenAnalysisData> {
+  return readPluginCache<MavenAnalysisData>(cachePath);
 }
 
 /**
@@ -22,9 +16,9 @@ export function readMavenCache(
  */
 export function writeMavenCache(
   cachePath: string,
-  cache: Record<string, MavenAnalysisData>
+  cache: PluginCache<MavenAnalysisData>
 ): void {
-  writeJsonFile(cachePath, cache);
+  cache.writeToDisk(cachePath);
 }
 
 /**

--- a/packages/maven/src/plugins/maven-data-cache.ts
+++ b/packages/maven/src/plugins/maven-data-cache.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { PluginCache, readPluginCache } from 'nx/src/utils/plugin-cache-utils';
+import { PluginCache } from 'nx/src/utils/plugin-cache-utils';
 import { MavenAnalysisData } from './types';
 
 /**
@@ -8,7 +8,7 @@ import { MavenAnalysisData } from './types';
 export function readMavenCache(
   cachePath: string
 ): PluginCache<MavenAnalysisData> {
-  return readPluginCache<MavenAnalysisData>(cachePath);
+  return new PluginCache<MavenAnalysisData>(cachePath);
 }
 
 /**

--- a/packages/maven/src/plugins/nodes.ts
+++ b/packages/maven/src/plugins/nodes.ts
@@ -54,7 +54,7 @@ export const createNodes: CreateNodesV2<MavenPluginOptions> = [
 
     try {
       // Try to get cached data first (skip cache if in verbose mode)
-      let mavenData = isVerbose ? null : mavenCache[hash];
+      let mavenData = isVerbose ? null : mavenCache.get(hash);
 
       // If no cached data or cache is stale, run fresh Maven analysis
       if (!mavenData) {
@@ -63,7 +63,7 @@ export const createNodes: CreateNodesV2<MavenPluginOptions> = [
           verbose: isVerbose,
         });
         // Cache the results with the hash
-        mavenCache[hash] = mavenData;
+        mavenCache.set(hash, mavenData);
       }
 
       // Store in module-level variable for createDependencies to use

--- a/packages/nx/plugins/package-json.ts
+++ b/packages/nx/plugins/package-json.ts
@@ -8,24 +8,24 @@ import {
 import { workspaceDataDirectory } from '../src/utils/cache-directory';
 import { join } from 'path';
 import { ProjectConfiguration } from '../src/config/workspace-json-project-json';
-import { readJsonFile, writeJsonFile } from '../src/utils/fileutils';
+import { readJsonFile } from '../src/utils/fileutils';
+import { PluginCache, readPluginCache } from '../src/utils/plugin-cache-utils';
 
-export type PackageJsonConfigurationCache = {
-  [hash: string]: ProjectConfiguration;
-};
+export type PackageJsonConfigurationCache = PluginCache<ProjectConfiguration>;
 
 const cachePath = join(workspaceDataDirectory, 'package-json.hash');
 
-export function readPackageJsonConfigurationCache() {
-  try {
-    return readJsonFile<PackageJsonConfigurationCache>(cachePath);
-  } catch (e) {
-    return {};
-  }
+let packageJsonPluginCache: PluginCache<ProjectConfiguration> | null = null;
+
+export function readPackageJsonConfigurationCache(): PackageJsonConfigurationCache {
+  packageJsonPluginCache = readPluginCache<ProjectConfiguration>(cachePath);
+  return packageJsonPluginCache;
 }
 
-function writeCache(cache: PackageJsonConfigurationCache) {
-  writeJsonFile(cachePath, cache);
+function writeCache() {
+  if (packageJsonPluginCache) {
+    packageJsonPluginCache.writeToDisk(cachePath);
+  }
 }
 
 const plugin: NxPluginV2 = {
@@ -54,7 +54,7 @@ const plugin: NxPluginV2 = {
         context
       );
 
-      writeCache(cache);
+      writeCache();
 
       return result;
     },

--- a/packages/nx/plugins/package-json.ts
+++ b/packages/nx/plugins/package-json.ts
@@ -9,7 +9,7 @@ import { workspaceDataDirectory } from '../src/utils/cache-directory';
 import { join } from 'path';
 import { ProjectConfiguration } from '../src/config/workspace-json-project-json';
 import { readJsonFile } from '../src/utils/fileutils';
-import { PluginCache, readPluginCache } from '../src/utils/plugin-cache-utils';
+import { PluginCache } from '../src/utils/plugin-cache-utils';
 
 export type PackageJsonConfigurationCache = PluginCache<ProjectConfiguration>;
 
@@ -18,7 +18,7 @@ const cachePath = join(workspaceDataDirectory, 'package-json.hash');
 let packageJsonPluginCache: PluginCache<ProjectConfiguration> | null = null;
 
 export function readPackageJsonConfigurationCache(): PackageJsonConfigurationCache {
-  packageJsonPluginCache = readPluginCache<ProjectConfiguration>(cachePath);
+  packageJsonPluginCache = new PluginCache<ProjectConfiguration>(cachePath);
   return packageJsonPluginCache;
 }
 

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -47,3 +47,8 @@ export { isUsingPrettierInTree } from './utils/is-using-prettier';
 export { readYamlFile } from './utils/fileutils';
 export { globalSpinner } from './utils/spinner';
 export { signalToCode } from './utils/exit-codes';
+export {
+  PluginCache,
+  readPluginCache,
+  safeWriteFileCache,
+} from './utils/plugin-cache-utils';

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -47,8 +47,4 @@ export { isUsingPrettierInTree } from './utils/is-using-prettier';
 export { readYamlFile } from './utils/fileutils';
 export { globalSpinner } from './utils/spinner';
 export { signalToCode } from './utils/exit-codes';
-export {
-  PluginCache,
-  readPluginCache,
-  safeWriteFileCache,
-} from './utils/plugin-cache-utils';
+export { PluginCache, safeWriteFileCache } from './utils/plugin-cache-utils';

--- a/packages/nx/src/plugins/package-json/create-nodes.spec.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.spec.ts
@@ -2,6 +2,7 @@ import '../../internal-testing-utils/mock-fs';
 
 import { vol } from 'memfs';
 import { createNodeFromPackageJson, createNodesV2 } from './create-nodes';
+import { PluginCache } from '../../utils/plugin-cache-utils';
 
 describe('nx package.json workspaces plugin', () => {
   const context = {
@@ -47,8 +48,14 @@ describe('nx package.json workspaces plugin', () => {
       '/root'
     );
 
-    expect(createNodeFromPackageJson('package.json', '/root', {}, false))
-      .toMatchInlineSnapshot(`
+    expect(
+      createNodeFromPackageJson(
+        'package.json',
+        '/root',
+        new PluginCache(),
+        false
+      )
+    ).toMatchInlineSnapshot(`
       {
         "projects": {
           ".": {
@@ -99,7 +106,7 @@ describe('nx package.json workspaces plugin', () => {
       createNodeFromPackageJson(
         'packages/lib-a/package.json',
         '/root',
-        {},
+        new PluginCache(),
         false
       )
     ).toMatchInlineSnapshot(`
@@ -153,7 +160,7 @@ describe('nx package.json workspaces plugin', () => {
       createNodeFromPackageJson(
         'packages/lib-b/package.json',
         '/root',
-        {},
+        new PluginCache(),
         false
       )
     ).toMatchInlineSnapshot(`
@@ -794,15 +801,19 @@ describe('nx package.json workspaces plugin', () => {
     );
 
     expect(
-      createNodeFromPackageJson('apps/myapp/package.json', '/root', {}, false)
-        .projects['apps/myapp'].projectType
+      createNodeFromPackageJson(
+        'apps/myapp/package.json',
+        '/root',
+        new PluginCache(),
+        false
+      ).projects['apps/myapp'].projectType
     ).toEqual('application');
 
     expect(
       createNodeFromPackageJson(
         'packages/mylib/package.json',
         '/root',
-        {},
+        new PluginCache(),
         false
       ).projects['packages/mylib'].projectType
     ).toEqual('library');
@@ -826,9 +837,12 @@ describe('nx package.json workspaces plugin', () => {
     );
 
     expect(
-      createNodeFromPackageJson('package.json', '/root', {}, false).projects[
-        '.'
-      ].projectType
+      createNodeFromPackageJson(
+        'package.json',
+        '/root',
+        new PluginCache(),
+        false
+      ).projects['.'].projectType
     ).toEqual('library');
   });
 
@@ -856,13 +870,17 @@ describe('nx package.json workspaces plugin', () => {
       createNodeFromPackageJson(
         'packages/mylib/package.json',
         '/root',
-        {},
+        new PluginCache(),
         false
       ).projects['packages/mylib'].projectType
     ).toEqual('library');
     expect(
-      createNodeFromPackageJson('example/package.json', '/root', {}, false)
-        .projects['example'].projectType
+      createNodeFromPackageJson(
+        'example/package.json',
+        '/root',
+        new PluginCache(),
+        false
+      ).projects['example'].projectType
     ).toBeUndefined();
   });
 

--- a/packages/nx/src/plugins/package-json/create-nodes.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.ts
@@ -186,7 +186,7 @@ export function createNodeFromPackageJson(
     nxVersion,
   });
 
-  const cached = cache[hash];
+  const cached = cache.get(hash);
   if (cached) {
     return {
       projects: {
@@ -203,7 +203,7 @@ export function createNodeFromPackageJson(
     isInPackageManagerWorkspaces
   );
 
-  cache[hash] = project;
+  cache.set(hash, project);
   return {
     projects: {
       [project.root]: project,

--- a/packages/nx/src/project-graph/nx-deps-cache.ts
+++ b/packages/nx/src/project-graph/nx-deps-cache.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, renameSync, statSync } from 'node:fs';
+import { existsSync, mkdirSync, renameSync, rmSync, statSync } from 'node:fs';
 import { join } from 'path';
 import { performance } from 'perf_hooks';
 import { NxJsonConfiguration } from '../config/nx-json';
@@ -9,6 +9,8 @@ import type {
   ProjectGraph,
 } from '../config/project-graph';
 import { ProjectConfiguration } from '../config/workspace-json-project-json';
+import { isOnDaemon } from '../daemon/is-on-daemon';
+import { serverLogger } from '../daemon/logger';
 import { workspaceDataDirectory } from '../utils/cache-directory';
 import {
   directoryExists,
@@ -16,15 +18,14 @@ import {
   readJsonFile,
   writeJsonFile,
 } from '../utils/fileutils';
+import { logger } from '../utils/logger';
 import { nxVersion } from '../utils/versions';
-import { ConfigurationSourceMaps } from './utils/project-configuration-utils';
 import {
   ProjectGraphError,
   ProjectGraphErrorTypes,
   StaleProjectGraphCacheError,
 } from './error-types';
-import { isOnDaemon } from '../daemon/is-on-daemon';
-import { serverLogger } from '../daemon/logger';
+import { ConfigurationSourceMaps } from './utils/project-configuration-utils';
 
 export interface FileMapCache {
   version: string;
@@ -274,9 +275,12 @@ export function writeCache(
     }
   } while (!done && retry < 5);
   if (!done) {
-    throw new Error(
-      `Failed to write project graph cache to ${nxProjectGraph} and ${nxFileMap} after 5 attempts.`
+    logger.warn(
+      `Failed to write project graph cache to ${nxProjectGraph} and ${nxFileMap} after 5 attempts. Continuing without cache.`
     );
+    tryRemoveFile(nxProjectGraph);
+    tryRemoveFile(nxFileMap);
+    tryRemoveFile(nxSourceMaps);
   }
   performance.mark('write cache:end');
   performance.measure('write cache', 'write cache:start', 'write cache:end');
@@ -479,6 +483,16 @@ type PluginData = {
   version: string;
   options?: unknown;
 };
+
+function tryRemoveFile(path: string): void {
+  try {
+    if (existsSync(path)) {
+      rmSync(path);
+    }
+  } catch {
+    // Best effort
+  }
+}
 
 function getNxJsonPluginsData(
   nxJson: NxJsonConfiguration,

--- a/packages/nx/src/utils/plugin-cache-utils.spec.ts
+++ b/packages/nx/src/utils/plugin-cache-utils.spec.ts
@@ -1,0 +1,316 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  PluginCache,
+  readPluginCache,
+  safeWriteFileCache,
+} from './plugin-cache-utils';
+
+describe('plugin-cache-utils', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'nx-cache-utils-test-'));
+  });
+
+  describe('PluginCache', () => {
+    it('should track access in session log on get', () => {
+      const cache = new PluginCache<string>({ a: '1', b: '2', c: '3' }, [
+        'a',
+        'b',
+        'c',
+      ]);
+
+      cache.get('a'); // access 'a', moves to end
+
+      const serialized = cache.toSerializable();
+      expect(serialized.accessOrder).toEqual(['b', 'c', 'a']);
+    });
+
+    it('should track access in session log on set', () => {
+      const cache = new PluginCache<string>({}, []);
+      cache.set('x', 'hello');
+      cache.set('y', 'world');
+
+      const serialized = cache.toSerializable();
+      expect(serialized.entries['x']).toBe('hello');
+      expect(serialized.entries['y']).toBe('world');
+      expect(serialized.accessOrder).toEqual(['x', 'y']);
+    });
+
+    it('should move existing key to end on set', () => {
+      const cache = new PluginCache<string>({ a: '1', b: '2' }, ['a', 'b']);
+      cache.set('a', 'updated'); // re-set 'a', moves to end
+
+      const serialized = cache.toSerializable();
+      expect(serialized.accessOrder).toEqual(['b', 'a']);
+    });
+
+    it('should NOT track access on has()', () => {
+      const cache = new PluginCache<string>({ a: '1', b: '2' }, ['a', 'b']);
+      expect(cache.has('a')).toBe(true);
+      expect(cache.has('c')).toBe(false);
+
+      // No access tracked, so order should be unchanged
+      const serialized = cache.toSerializable();
+      expect(serialized.accessOrder).toEqual(['a', 'b']);
+    });
+
+    it('should return undefined for missing keys on get', () => {
+      const cache = new PluginCache<string>({ a: '1' }, ['a']);
+      expect(cache.get('missing')).toBeUndefined();
+
+      // Missing key should not appear in session log
+      const serialized = cache.toSerializable();
+      expect(serialized.accessOrder).toEqual(['a']);
+    });
+
+    it('should dedup session log at serialization: access a→b→a expects [b, a]', () => {
+      const cache = new PluginCache<string>({ a: '1', b: '2', c: '3' }, [
+        'a',
+        'b',
+        'c',
+      ]);
+
+      cache.get('a');
+      cache.get('b');
+      cache.get('a'); // duplicate access
+
+      const serialized = cache.toSerializable();
+      // c was unaccessed → stays at front
+      // b then a based on last access
+      expect(serialized.accessOrder).toEqual(['c', 'b', 'a']);
+    });
+
+    it('should place new keys (from set) after unaccessed but before accessed', () => {
+      const cache = new PluginCache<string>({ a: '1' }, ['a']);
+
+      cache.set('new1', 'v1');
+      cache.get('a');
+
+      const serialized = cache.toSerializable();
+      // 'new1' is a new key not in original accessOrder → placed after unaccessed
+      // 'a' was accessed → placed at end
+      expect(serialized.accessOrder).toEqual(['new1', 'a']);
+    });
+  });
+
+  describe('readPluginCache', () => {
+    it('should read current format with entries and accessOrder', () => {
+      const cachePath = join(tempDir, 'cache.json');
+      writeFileSync(
+        cachePath,
+        JSON.stringify({
+          entries: { a: '1', b: '2' },
+          accessOrder: ['b', 'a'],
+        })
+      );
+
+      const cache = readPluginCache<string>(cachePath);
+      expect(cache.get('a')).toBe('1');
+      expect(cache.toSerializable().accessOrder).toContain('a');
+      expect(cache.toSerializable().accessOrder).toContain('b');
+    });
+
+    it('should migrate previous timestamp format', () => {
+      const cachePath = join(tempDir, 'old-ts-cache.json');
+      writeFileSync(
+        cachePath,
+        JSON.stringify({
+          entries: { stale: '1', fresh: '2' },
+          accessedAt: { stale: 100, fresh: 999 },
+        })
+      );
+
+      const cache = readPluginCache<string>(cachePath);
+      const serialized = cache.toSerializable();
+
+      // Should be sorted by accessedAt: stale (100) before fresh (999)
+      expect(serialized.accessOrder).toEqual(['stale', 'fresh']);
+      expect(serialized.entries).toEqual({ stale: '1', fresh: '2' });
+    });
+
+    it('should migrate legacy plain Record format', () => {
+      const cachePath = join(tempDir, 'legacy-cache.json');
+      writeFileSync(cachePath, JSON.stringify({ a: '1', b: '2' }));
+
+      const cache = readPluginCache<string>(cachePath);
+      const serialized = cache.toSerializable();
+
+      expect(serialized.entries).toEqual({ a: '1', b: '2' });
+      expect(serialized.accessOrder).toEqual(['a', 'b']);
+    });
+
+    it('should return empty cache if file does not exist', () => {
+      const cache = readPluginCache<string>(join(tempDir, 'nope.json'));
+      expect(cache.has('anything')).toBe(false);
+    });
+
+    it('should return empty cache if file is corrupted', () => {
+      const cachePath = join(tempDir, 'bad.json');
+      writeFileSync(cachePath, 'not json!!!');
+
+      const cache = readPluginCache<string>(cachePath);
+      expect(cache.has('anything')).toBe(false);
+    });
+  });
+
+  describe('writeToDisk', () => {
+    it('should write cache with entries and accessOrder', () => {
+      const cachePath = join(tempDir, 'plugin-cache.json');
+      const cache = new PluginCache<string>({ a: '1' }, ['a']);
+
+      cache.writeToDisk(cachePath);
+
+      const written = JSON.parse(readFileSync(cachePath, 'utf-8'));
+      expect(written.entries).toEqual({ a: '1' });
+      expect(written.accessOrder).toEqual(['a']);
+    });
+
+    it('should evict oldest 50% when RangeError and retry', () => {
+      const cachePath = join(tempDir, 'plugin-cache.json');
+
+      const entries: Record<string, any> = {};
+      const accessOrder: string[] = [];
+      for (let i = 0; i < 10; i++) {
+        entries[`key${i}`] = `value${i}`;
+        accessOrder.push(`key${i}`);
+      }
+      // Value whose toJSON throws RangeError to simulate "string too large"
+      entries['key0'] = {
+        toJSON() {
+          throw new RangeError('Invalid string length');
+        },
+      };
+
+      const cache = new PluginCache(entries, accessOrder);
+      cache.writeToDisk(cachePath);
+
+      // key0-key4 evicted (front of queue), key5-key9 remain
+      const written = JSON.parse(readFileSync(cachePath, 'utf-8'));
+      expect(Object.keys(written.entries).length).toBe(5);
+      expect(written.entries['key5']).toBe('value5');
+      expect(written.entries['key9']).toBe('value9');
+      expect(written.entries['key0']).toBeUndefined();
+      expect(written.accessOrder).toEqual([
+        'key5',
+        'key6',
+        'key7',
+        'key8',
+        'key9',
+      ]);
+    });
+
+    it('should write empty cache when circular ref (TypeError) is encountered', () => {
+      const cachePath = join(tempDir, 'plugin-cache.json');
+      const circular: any = { self: null };
+      circular.self = circular;
+
+      const cache = new PluginCache({ a: circular }, ['a']);
+      cache.writeToDisk(cachePath);
+
+      // Circular refs are a hard error — skips eviction, writes empty cache
+      expect(existsSync(cachePath)).toBe(true);
+      const written = JSON.parse(readFileSync(cachePath, 'utf-8'));
+      expect(written.entries).toEqual({});
+      expect(written.accessOrder).toEqual([]);
+    });
+
+    it('should write empty cache when RangeError persists after eviction', () => {
+      const cachePath = join(tempDir, 'plugin-cache.json');
+      const entries: Record<string, any> = {};
+      const accessOrder: string[] = [];
+      for (let i = 0; i < 4; i++) {
+        entries[`key${i}`] = {
+          toJSON() {
+            throw new RangeError('Invalid string length');
+          },
+        };
+        accessOrder.push(`key${i}`);
+      }
+
+      const cache = new PluginCache(entries, accessOrder);
+      cache.writeToDisk(cachePath);
+
+      // Should write an empty cache (not delete the file)
+      expect(existsSync(cachePath)).toBe(true);
+      const written = JSON.parse(readFileSync(cachePath, 'utf-8'));
+      expect(written.entries).toEqual({});
+      expect(written.accessOrder).toEqual([]);
+    });
+
+    it('should evict based on LRU order when accessed keys exist', () => {
+      const cachePath = join(tempDir, 'plugin-cache.json');
+
+      const entries: Record<string, any> = {};
+      const accessOrder: string[] = [];
+      for (let i = 0; i < 10; i++) {
+        entries[`key${i}`] = `value${i}`;
+        accessOrder.push(`key${i}`);
+      }
+      // Put a RangeError-throwing value in key5 (survives eviction position)
+      // to verify eviction is based on access order
+      entries['key5'] = {
+        toJSON() {
+          throw new RangeError('Invalid string length');
+        },
+      };
+
+      const cache = new PluginCache(entries, accessOrder);
+
+      // Access key0 to move it to the end (most recently used)
+      cache.get('key0');
+
+      cache.writeToDisk(cachePath);
+
+      // After access, order is: [key1..key9, key0]
+      // Evict first 5: [key1, key2, key3, key4, key5]
+      // Remaining: [key6, key7, key8, key9, key0]
+      // key5 (with RangeError) was evicted, so serialization succeeds
+      const written = JSON.parse(readFileSync(cachePath, 'utf-8'));
+      expect(written.entries['key0']).toBe('value0');
+      expect(written.entries['key5']).toBeUndefined();
+      expect(written.accessOrder).toEqual([
+        'key6',
+        'key7',
+        'key8',
+        'key9',
+        'key0',
+      ]);
+    });
+  });
+
+  describe('safeWriteFileCache', () => {
+    it('should write data successfully', () => {
+      const cachePath = join(tempDir, 'cache.json');
+      const content = JSON.stringify({ foo: 'bar' });
+
+      safeWriteFileCache(cachePath, content);
+
+      expect(readFileSync(cachePath, 'utf-8')).toBe(content);
+    });
+
+    it('should create parent directories if they do not exist', () => {
+      const cachePath = join(tempDir, 'nested', 'dir', 'cache.json');
+      const content = JSON.stringify({ foo: 'bar' });
+
+      safeWriteFileCache(cachePath, content);
+
+      expect(readFileSync(cachePath, 'utf-8')).toBe(content);
+    });
+
+    it('should not throw on write failure and attempt to remove existing file', () => {
+      const dirAsFile = join(tempDir, 'im-a-dir');
+      mkdirSync(dirAsFile);
+
+      expect(() => safeWriteFileCache(dirAsFile, 'data')).not.toThrow();
+    });
+  });
+});

--- a/packages/nx/src/utils/plugin-cache-utils.spec.ts
+++ b/packages/nx/src/utils/plugin-cache-utils.spec.ts
@@ -7,11 +7,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import {
-  PluginCache,
-  readPluginCache,
-  safeWriteFileCache,
-} from './plugin-cache-utils';
+import { PluginCache, safeWriteFileCache } from './plugin-cache-utils';
 
 describe('plugin-cache-utils', () => {
   let tempDir: string;
@@ -102,7 +98,7 @@ describe('plugin-cache-utils', () => {
     });
   });
 
-  describe('readPluginCache', () => {
+  describe('PluginCache constructor from cachePath', () => {
     it('should read current format with entries and accessOrder', () => {
       const cachePath = join(tempDir, 'cache.json');
       writeFileSync(
@@ -113,43 +109,22 @@ describe('plugin-cache-utils', () => {
         })
       );
 
-      const cache = readPluginCache<string>(cachePath);
+      const cache = new PluginCache<string>(cachePath);
       expect(cache.get('a')).toBe('1');
       expect(cache.toSerializable().accessOrder).toContain('a');
       expect(cache.toSerializable().accessOrder).toContain('b');
     });
 
-    it('should migrate previous timestamp format', () => {
-      const cachePath = join(tempDir, 'old-ts-cache.json');
-      writeFileSync(
-        cachePath,
-        JSON.stringify({
-          entries: { stale: '1', fresh: '2' },
-          accessedAt: { stale: 100, fresh: 999 },
-        })
-      );
-
-      const cache = readPluginCache<string>(cachePath);
-      const serialized = cache.toSerializable();
-
-      // Should be sorted by accessedAt: stale (100) before fresh (999)
-      expect(serialized.accessOrder).toEqual(['stale', 'fresh']);
-      expect(serialized.entries).toEqual({ stale: '1', fresh: '2' });
-    });
-
-    it('should migrate legacy plain Record format', () => {
+    it('should return empty cache for unrecognized format', () => {
       const cachePath = join(tempDir, 'legacy-cache.json');
       writeFileSync(cachePath, JSON.stringify({ a: '1', b: '2' }));
 
-      const cache = readPluginCache<string>(cachePath);
-      const serialized = cache.toSerializable();
-
-      expect(serialized.entries).toEqual({ a: '1', b: '2' });
-      expect(serialized.accessOrder).toEqual(['a', 'b']);
+      const cache = new PluginCache<string>(cachePath);
+      expect(cache.has('a')).toBe(false);
     });
 
     it('should return empty cache if file does not exist', () => {
-      const cache = readPluginCache<string>(join(tempDir, 'nope.json'));
+      const cache = new PluginCache<string>(join(tempDir, 'nope.json'));
       expect(cache.has('anything')).toBe(false);
     });
 
@@ -157,7 +132,7 @@ describe('plugin-cache-utils', () => {
       const cachePath = join(tempDir, 'bad.json');
       writeFileSync(cachePath, 'not json!!!');
 
-      const cache = readPluginCache<string>(cachePath);
+      const cache = new PluginCache<string>(cachePath);
       expect(cache.has('anything')).toBe(false);
     });
   });

--- a/packages/nx/src/utils/plugin-cache-utils.ts
+++ b/packages/nx/src/utils/plugin-cache-utils.ts
@@ -1,0 +1,251 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+import { logger } from './logger';
+
+/**
+ * On-disk format for plugin caches with LRU metadata.
+ */
+interface PluginCacheData<T> {
+  entries: Record<string, T>;
+  accessOrder: string[];
+}
+
+/**
+ * A plugin cache that tracks access order for LRU eviction.
+ *
+ * Uses explicit `get()` / `set()` / `has()` methods instead of a Proxy
+ * for easier debugging and predictable behavior.
+ *
+ * Access order is tracked via an append-only session log. Deduplication
+ * happens once at serialization time (`toSerializable()`), keeping per-access
+ * cost at O(1).
+ *
+ * Eviction splices the first half of the deduped access-order queue — the
+ * least recently used keys.
+ */
+export class PluginCache<T> {
+  private entries: Record<string, T>;
+  private accessOrder: Set<string>;
+
+  constructor(
+    entries: Record<string, T> = {},
+    accessOrder: string[] | Set<string> = new Set()
+  ) {
+    this.entries = entries;
+    this.accessOrder =
+      accessOrder instanceof Set ? accessOrder : new Set(accessOrder);
+  }
+
+  private touch(key: string): void {
+    // Sets are guaranteed to maintain insertion order, so we can delete and re-add to move it to the end.
+    this.accessOrder.delete(key); // remove from current position in access order
+    this.accessOrder.add(key); // add to end of access order (most recently accessed)
+  }
+
+  /**
+   * Returns the value for `key`, or `undefined` if not present.
+   * Tracks the access in the session log for LRU ordering.
+   */
+  get(key: string): T | undefined {
+    if (key in this.entries) {
+      this.touch(key);
+      return this.entries[key];
+    }
+    return undefined;
+  }
+
+  /**
+   * Sets `key` to `value` and tracks the access in the session log.
+   */
+  set(key: string, value: T): void {
+    this.entries[key] = value;
+    this.touch(key);
+  }
+
+  /**
+   * Returns `true` if `key` exists in the cache.
+   * Does NOT track access — use this for existence checks that
+   * should not affect eviction order.
+   */
+  has(key: string): boolean {
+    return key in this.entries;
+  }
+
+  /**
+   * Returns the serializable cache data (entries + accessOrder).
+   */
+  toSerializable(): PluginCacheData<T> {
+    return {
+      entries: this.entries,
+      accessOrder: [...this.accessOrder],
+    };
+  }
+
+  /**
+   * Safely writes this cache to disk.
+   *
+   * Strategy:
+   * 1. Serialize to JSON
+   *    - RangeError (string too large): evict oldest 50% and retry
+   *    - Other errors (e.g. circular refs): skip straight to empty cache
+   * 2. Write the serialized string to disk — if this fails (fs error),
+   *    wipe the cache file so a corrupted file doesn't persist
+   * 3. On total serialization failure (even after eviction),
+   *    write an empty cache so the file is valid
+   */
+  writeToDisk(cachePath: string): void {
+    mkdirSync(dirname(cachePath), { recursive: true });
+
+    let content: string | undefined;
+
+    try {
+      content = JSON.stringify({
+        entries: this.entries,
+        accessOrder: [...this.accessOrder],
+      });
+    } catch (e) {
+      // RangeError → string too large, recoverable via eviction
+      if (e instanceof RangeError) {
+        const reduced = this.evictOldestHalf();
+        try {
+          content = JSON.stringify(reduced);
+          logger.warn(
+            `Plugin cache at ${cachePath} exceeded capacity. Evicted 50% of entries.`
+          );
+        } catch {
+          // Still fails after eviction — fall through to empty cache
+        }
+      }
+      // Other errors (TypeError for circular refs, etc.) fall through to empty cache
+    }
+
+    // If serialization still fails, fall back to an empty cache
+    if (content === undefined) {
+      content = JSON.stringify({ entries: {}, accessOrder: [] });
+      logger.warn(
+        `Failed to serialize plugin cache at ${cachePath}. Writing empty cache.`
+      );
+    }
+
+    // Attempt to write the serialized content to disk
+    try {
+      writeFileSync(cachePath, content);
+    } catch {
+      // Filesystem error — wipe cache so a corrupted file doesn't persist
+      tryRemoveFile(cachePath);
+      logger.warn(
+        `Failed to write plugin cache at ${cachePath}. Cache has been cleared.`
+      );
+    }
+  }
+
+  /**
+   * Evicts the oldest 50% of entries (front of the access-order queue)
+   * and returns the remaining entries + accessOrder as a plain object.
+   */
+  private evictOldestHalf(): PluginCacheData<T> {
+    const accessOrderArr = [...this.accessOrder];
+    if (accessOrderArr.length === 0) return { entries: {}, accessOrder: [] };
+
+    const cutoff = Math.ceil(accessOrderArr.length / 2);
+    const remaining = accessOrderArr.slice(cutoff);
+
+    const entries: Record<string, T> = {};
+    for (const key of remaining) {
+      if (key in this.entries) {
+        entries[key] = this.entries[key];
+      }
+    }
+
+    return { entries, accessOrder: remaining };
+  }
+}
+
+/**
+ * Reads a plugin cache from disk, returning a PluginCache instance.
+ *
+ * Backward compatible:
+ * - Old format (plain Record<string, T>): all keys go into accessOrder as-is
+ * - Previous timestamp format ({ entries, accessedAt }): keys sorted by timestamp
+ */
+export function readPluginCache<T>(cachePath: string): PluginCache<T> {
+  try {
+    if (
+      process.env.NX_CACHE_PROJECT_GRAPH === 'false' ||
+      !existsSync(cachePath)
+    ) {
+      return new PluginCache<T>();
+    }
+    const raw = JSON.parse(readFileSync(cachePath, 'utf-8'));
+
+    // Current format: { entries, accessOrder }
+    if (
+      raw &&
+      typeof raw === 'object' &&
+      'entries' in raw &&
+      'accessOrder' in raw &&
+      Array.isArray(raw.accessOrder)
+    ) {
+      return new PluginCache<T>(raw.entries, raw.accessOrder);
+    }
+
+    // Previous timestamp format: { entries, accessedAt }
+    if (
+      raw &&
+      typeof raw === 'object' &&
+      'entries' in raw &&
+      'accessedAt' in raw
+    ) {
+      const accessOrder = Object.keys(raw.entries).sort(
+        (a, b) => (raw.accessedAt[a] ?? 0) - (raw.accessedAt[b] ?? 0)
+      );
+      return new PluginCache<T>(raw.entries, accessOrder);
+    }
+
+    // Legacy format: plain Record<string, T>
+    if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+      return new PluginCache<T>(raw, Object.keys(raw));
+    }
+
+    return new PluginCache<T>();
+  } catch {
+    return new PluginCache<T>();
+  }
+}
+
+/**
+ * Safely writes already-stringified content to a cache file on disk.
+ *
+ * Strategy:
+ * 1. Attempt mkdirSync + writeFileSync
+ * 2. On failure: remove existing cache file, log warning, return without throwing
+ */
+export function safeWriteFileCache(cachePath: string, content: string): void {
+  try {
+    mkdirSync(dirname(cachePath), { recursive: true });
+    writeFileSync(cachePath, content);
+  } catch (e) {
+    logger.warn(
+      `Failed to write cache at ${cachePath}: ${
+        e instanceof Error ? e.message : 'unknown error'
+      }. Removing existing cache file.`
+    );
+    tryRemoveFile(cachePath);
+  }
+}
+
+// --- Internal helpers ---
+
+function tryRemoveFile(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch {
+    // Intentionally ignored — best effort
+  }
+}

--- a/packages/nx/src/utils/plugin-cache-utils.ts
+++ b/packages/nx/src/utils/plugin-cache-utils.ts
@@ -105,6 +105,7 @@ export class PluginCache<T> {
    * 3. On total serialization failure (even after eviction),
    *    write an empty cache so the file is valid
    */
+
   writeToDisk(cachePath: string): void {
     mkdirSync(dirname(cachePath), { recursive: true });
 
@@ -119,6 +120,9 @@ export class PluginCache<T> {
       // RangeError → string too large, recoverable via eviction
       if (e instanceof RangeError) {
         const reduced = this.evictOldestHalf();
+        // Update in-memory state
+        this.entries = reduced.entries;
+        this.accessOrder = new Set(reduced.accessOrder);
         try {
           content = JSON.stringify(reduced);
         } catch {
@@ -141,6 +145,7 @@ export class PluginCache<T> {
       tryRemoveFile(cachePath);
     }
   }
+
 
   /**
    * Evicts the oldest 50% of entries (front of the access-order queue)

--- a/packages/nx/src/utils/plugin-cache-utils.ts
+++ b/packages/nx/src/utils/plugin-cache-utils.ts
@@ -146,7 +146,6 @@ export class PluginCache<T> {
     }
   }
 
-
   /**
    * Evicts the oldest 50% of entries (front of the access-order queue)
    * and returns the remaining entries + accessOrder as a plain object.

--- a/packages/nx/src/utils/plugin-cache-utils.ts
+++ b/packages/nx/src/utils/plugin-cache-utils.ts
@@ -1,11 +1,6 @@
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  unlinkSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { readJsonFile } from './fileutils';
 import { logger } from './logger';
 
 /**
@@ -33,13 +28,24 @@ export class PluginCache<T> {
   private entries: Record<string, T>;
   private accessOrder: Set<string>;
 
+  constructor(cachePath: string);
   constructor(
-    entries: Record<string, T> = {},
-    accessOrder: string[] | Set<string> = new Set()
+    entries?: Record<string, T>,
+    accessOrder?: string[] | Set<string>
+  );
+  constructor(
+    cachePathOrEntries?: string | Record<string, T>,
+    accessOrder?: string[] | Set<string>
   ) {
-    this.entries = entries;
-    this.accessOrder =
-      accessOrder instanceof Set ? accessOrder : new Set(accessOrder);
+    if (typeof cachePathOrEntries === 'string') {
+      const loaded = loadFromDisk<T>(cachePathOrEntries);
+      this.entries = loaded.entries;
+      this.accessOrder = loaded.accessOrder;
+    } else {
+      this.entries = cachePathOrEntries ?? {};
+      this.accessOrder =
+        accessOrder instanceof Set ? accessOrder : new Set(accessOrder ?? []);
+    }
   }
 
   private touch(key: string): void {
@@ -115,9 +121,6 @@ export class PluginCache<T> {
         const reduced = this.evictOldestHalf();
         try {
           content = JSON.stringify(reduced);
-          logger.warn(
-            `Plugin cache at ${cachePath} exceeded capacity. Evicted 50% of entries.`
-          );
         } catch {
           // Still fails after eviction — fall through to empty cache
         }
@@ -128,9 +131,6 @@ export class PluginCache<T> {
     // If serialization still fails, fall back to an empty cache
     if (content === undefined) {
       content = JSON.stringify({ entries: {}, accessOrder: [] });
-      logger.warn(
-        `Failed to serialize plugin cache at ${cachePath}. Writing empty cache.`
-      );
     }
 
     // Attempt to write the serialized content to disk
@@ -139,9 +139,6 @@ export class PluginCache<T> {
     } catch {
       // Filesystem error — wipe cache so a corrupted file doesn't persist
       tryRemoveFile(cachePath);
-      logger.warn(
-        `Failed to write plugin cache at ${cachePath}. Cache has been cleared.`
-      );
     }
   }
 
@@ -168,21 +165,28 @@ export class PluginCache<T> {
 }
 
 /**
- * Reads a plugin cache from disk, returning a PluginCache instance.
+ * Loads plugin cache data from disk.
  *
- * Backward compatible:
- * - Old format (plain Record<string, T>): all keys go into accessOrder as-is
- * - Previous timestamp format ({ entries, accessedAt }): keys sorted by timestamp
+ * Returns the current format `{ entries, accessOrder }` if it matches,
+ * otherwise returns an empty cache (no backward compat — stale caches
+ * are simply discarded).
  */
-export function readPluginCache<T>(cachePath: string): PluginCache<T> {
+function loadFromDisk<T>(cachePath: string): {
+  entries: Record<string, T>;
+  accessOrder: Set<string>;
+} {
+  const empty = {
+    entries: {} as Record<string, T>,
+    accessOrder: new Set<string>(),
+  };
   try {
     if (
       process.env.NX_CACHE_PROJECT_GRAPH === 'false' ||
       !existsSync(cachePath)
     ) {
-      return new PluginCache<T>();
+      return empty;
     }
-    const raw = JSON.parse(readFileSync(cachePath, 'utf-8'));
+    const raw = readJsonFile<PluginCacheData<T>>(cachePath);
 
     // Current format: { entries, accessOrder }
     if (
@@ -192,30 +196,12 @@ export function readPluginCache<T>(cachePath: string): PluginCache<T> {
       'accessOrder' in raw &&
       Array.isArray(raw.accessOrder)
     ) {
-      return new PluginCache<T>(raw.entries, raw.accessOrder);
+      return { entries: raw.entries, accessOrder: new Set(raw.accessOrder) };
     }
 
-    // Previous timestamp format: { entries, accessedAt }
-    if (
-      raw &&
-      typeof raw === 'object' &&
-      'entries' in raw &&
-      'accessedAt' in raw
-    ) {
-      const accessOrder = Object.keys(raw.entries).sort(
-        (a, b) => (raw.accessedAt[a] ?? 0) - (raw.accessedAt[b] ?? 0)
-      );
-      return new PluginCache<T>(raw.entries, accessOrder);
-    }
-
-    // Legacy format: plain Record<string, T>
-    if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
-      return new PluginCache<T>(raw, Object.keys(raw));
-    }
-
-    return new PluginCache<T>();
+    return empty;
   } catch {
-    return new PluginCache<T>();
+    return empty;
   }
 }
 

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -7,10 +7,8 @@ import {
   joinPathFragments,
   normalizePath,
   type ProjectConfiguration,
-  readJsonFile,
   type TargetConfiguration,
   type TargetDependencyConfig,
-  writeJsonFile,
 } from '@nx/devkit';
 import { calculateHashForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { loadConfigFile } from '@nx/devkit/src/utils/config-utils';
@@ -22,6 +20,7 @@ import { readdirSync } from 'node:fs';
 import { dirname, join, parse, posix, relative, resolve } from 'node:path';
 import { hashObject } from 'nx/src/hasher/file-hasher';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
+import { PluginCache, readPluginCache } from 'nx/src/utils/plugin-cache-utils';
 import { getFilesInDirectoryUsingContext } from 'nx/src/utils/workspace-context';
 import { getReporterOutputs, type ReporterOutput } from '../utils/reporters';
 
@@ -40,25 +39,6 @@ interface NormalizedOptions {
 
 type PlaywrightTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
 
-function readTargetsCache(
-  cachePath: string
-): Record<string, PlaywrightTargets> {
-  try {
-    return process.env.NX_CACHE_PROJECT_GRAPH !== 'false'
-      ? readJsonFile(cachePath)
-      : {};
-  } catch {
-    return {};
-  }
-}
-
-function writeTargetsToCache(
-  cachePath: string,
-  results: Record<string, PlaywrightTargets>
-) {
-  writeJsonFile(cachePath, results);
-}
-
 const playwrightConfigGlob = '**/playwright.config.{js,ts,cjs,cts,mjs,mts}';
 export const createNodes: CreateNodesV2<PlaywrightPluginOptions> = [
   playwrightConfigGlob,
@@ -68,17 +48,17 @@ export const createNodes: CreateNodesV2<PlaywrightPluginOptions> = [
       workspaceDataDirectory,
       `playwright-${optionsHash}.hash`
     );
-    const targetsCache = readTargetsCache(cachePath);
+    const pluginCache = readPluginCache<PlaywrightTargets>(cachePath);
     try {
       return await createNodesFromFiles(
         (configFile, options, context) =>
-          createNodesInternal(configFile, options, context, targetsCache),
+          createNodesInternal(configFile, options, context, pluginCache),
         configFilePaths,
         options,
         context
       );
     } finally {
-      writeTargetsToCache(cachePath, targetsCache);
+      pluginCache.writeToDisk(cachePath);
     }
   },
 ];
@@ -89,7 +69,7 @@ async function createNodesInternal(
   configFilePath: string,
   options: PlaywrightPluginOptions,
   context: CreateNodesContextV2,
-  targetsCache: Record<string, PlaywrightTargets>
+  pluginCache: PluginCache<PlaywrightTargets>
 ) {
   const projectRoot = dirname(configFilePath);
 
@@ -114,13 +94,18 @@ async function createNodesInternal(
     [getLockFileName(detectPackageManager(context.workspaceRoot))]
   );
 
-  targetsCache[hash] ??= await buildPlaywrightTargets(
-    configFilePath,
-    projectRoot,
-    normalizedOptions,
-    context
-  );
-  const { targets, metadata } = targetsCache[hash];
+  if (!pluginCache.has(hash)) {
+    pluginCache.set(
+      hash,
+      await buildPlaywrightTargets(
+        configFilePath,
+        projectRoot,
+        normalizedOptions,
+        context
+      )
+    );
+  }
+  const { targets, metadata } = pluginCache.get(hash);
 
   return {
     projects: {

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -20,7 +20,7 @@ import { readdirSync } from 'node:fs';
 import { dirname, join, parse, posix, relative, resolve } from 'node:path';
 import { hashObject } from 'nx/src/hasher/file-hasher';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
-import { PluginCache, readPluginCache } from 'nx/src/utils/plugin-cache-utils';
+import { PluginCache } from 'nx/src/utils/plugin-cache-utils';
 import { getFilesInDirectoryUsingContext } from 'nx/src/utils/workspace-context';
 import { getReporterOutputs, type ReporterOutput } from '../utils/reporters';
 
@@ -48,7 +48,7 @@ export const createNodes: CreateNodesV2<PlaywrightPluginOptions> = [
       workspaceDataDirectory,
       `playwright-${optionsHash}.hash`
     );
-    const pluginCache = readPluginCache<PlaywrightTargets>(cachePath);
+    const pluginCache = new PluginCache<PlaywrightTargets>(cachePath);
     try {
       return await createNodesFromFiles(
         (configFile, options, context) =>


### PR DESCRIPTION
## Current Behavior

 Plugin cache writes (`writeJsonFile`, `writeFileSync`) across the codebase have inconsistent error handling:
- Some throw on failure, aborting project graph calculation entirely
- Some silently swallow errors, leaving corrupted cache files on disk
- No mechanism exists to recover from oversized or corrupted caches
- `nx-deps-cache.ts` retries 5 times then throws, crashing the graph

## Expected Behavior

- Plugin cache write failures **never** abort graph calculation — they warn and continue
- A centralized `safeWritePluginCache` utility handles all hash-map plugin caches with a 3-step strategy:
1. Attempt full write
2. On failure: evict oldest 50% of entries (LRU) and retry
3. On second failure: wipe cache file, log warning, return without throwing
- `PluginCache<T>` class wraps cache data with a Proxy that transparently tracks access order, enabling true LRU
eviction (not just insertion order)
- Access order is stored as a simple `string[]` array — front is oldest, back is most recent
- Backward-compatible with 3 on-disk formats: legacy plain `Record`, timestamp-based `{ entries, accessedAt }`, and
current `{ entries, accessOrder }`
- All plugin cache consumers migrated: package-json, js/lockfile, dotnet, cypress, playwright, gradle, maven
- `nx-deps-cache.ts` changed from throw-after-retries to warn + cleanup
- New utilities exported via `@nx/devkit` internals for plugin authors

## Related Issue(s)

Fixes NXC-3833"