### PR TITLE
chore(maven): bump maven plugin version to 0.0.14

### DIFF
--- a/packages/maven/batch-runner-adapters/maven3/pom.xml
+++ b/packages/maven/batch-runner-adapters/maven3/pom.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0          http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>batch-runner-adapters</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14</version>
     </parent>
 
     <artifactId>maven3-adapter</artifactId>

--- a/packages/maven/batch-runner-adapters/maven4/pom.xml
+++ b/packages/maven/batch-runner-adapters/maven4/pom.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0          http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>batch-runner-adapters</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/batch-runner-adapters/pom.xml
+++ b/packages/maven/batch-runner-adapters/pom.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0          http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>nx-maven-parent</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/batch-runner/pom.xml
+++ b/packages/maven/batch-runner/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>nx-maven-parent</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/maven-plugin/pom.xml
+++ b/packages/maven/maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.nx.maven</groupId>
     <artifactId>nx-maven-parent</artifactId>
-    <version>0.0.13</version>
+    <version>0.0.14</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/maven-plugin/project.json
+++ b/packages/maven/maven-plugin/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "install": {
-      "command": "for i in {1..5}; do ./mvnw install && break || sleep 10; done"
+      "command": "for i in {1..5}; do ./mvnw install -pl dev.nx.maven:nx-maven-plugin -am && break || sleep 10; done"
     },
     "_install": {
       "command": "node scripts/run-native-target.js install nx-maven-plugin"

--- a/packages/maven/migrations.json
+++ b/packages/maven/migrations.json
@@ -36,6 +36,12 @@
       "version": "22.5.0-beta.4",
       "description": "Update Maven plugin version from 0.0.12 to 0.0.13 in pom.xml files",
       "factory": "./dist/migrations/0-0-13/update-pom-xml-version"
+    },
+    "update-0-0-14": {
+      "cli": "nx",
+      "version": "22.6.0-beta.1",
+      "description": "Update Maven plugin version from 0.0.13 to 0.0.14 in pom.xml files",
+      "factory": "./dist/migrations/0-0-14/update-pom-xml-version"
     }
   }
 }

--- a/packages/maven/pom.xml
+++ b/packages/maven/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.nx.maven</groupId>
     <artifactId>nx-parent</artifactId>
-    <version>0.0.13</version>
+    <version>0.0.14</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/shared/pom.xml
+++ b/packages/maven/shared/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>nx-maven-parent</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/src/migrations/0-0-14/update-pom-xml-version.ts
+++ b/packages/maven/src/migrations/0-0-14/update-pom-xml-version.ts
@@ -1,0 +1,11 @@
+import { Tree } from '@nx/devkit';
+import { updateNxMavenPluginVersion } from '../../utils/pom-xml-updater';
+
+/**
+ * Migration for @nx/maven v0.0.14
+ * Updates the Maven plugin version to 0.0.14 in pom.xml files
+ */
+export default async function update(tree: Tree) {
+  // Update user pom.xml files
+  updateNxMavenPluginVersion(tree, '0.0.14');
+}

--- a/packages/maven/src/utils/versions.ts
+++ b/packages/maven/src/utils/versions.ts
@@ -1,2 +1,2 @@
 export const nxVersion = require('../../package.json').version;
-export const mavenPluginVersion = '0.0.13';
+export const mavenPluginVersion = '0.0.14';

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>dev.nx.maven</groupId>
   <artifactId>nx-parent</artifactId>
-  <version>0.0.13</version>
+  <version>0.0.14</version>
   <packaging>pom</packaging>
 
   <name>Nx Parent</name>


### PR DESCRIPTION
## Current Behavior

The Maven plugin is on version `0.0.13`.

## Expected Behavior

The Maven plugin is bumped to version `0.0.14`, with a migration generated for Nx `22.6.0-beta.1`.