### PR TITLE
fix(core): commands shouldn't hang when passing --help

### DIFF
--- a/packages/nx/bin/init-local.ts
+++ b/packages/nx/bin/init-local.ts
@@ -47,6 +47,7 @@ export async function initLocal(workspace: WorkspaceTypeAndRoot) {
       const split = newArgs.indexOf('--');
       if (help > -1 && (split === -1 || split > help)) {
         commandsObject.showHelp();
+        process.exit(0);
       } else {
         commandsObject.parse(newArgs);
       }

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -1059,9 +1059,12 @@ export class DaemonClient {
   private setUpConnection() {
     const socketPath = this.getSocketPath();
 
-    this.socketMessenger = new DaemonSocketMessenger(
-      connect(socketPath)
-    ).listen(
+    const socket = connect(socketPath);
+    // Unref the socket so it doesn't keep the process alive. The
+    // sendMessageToDaemon method uses a keep-alive setTimeout to
+    // explicitly hold the event loop open while awaiting a response.
+    socket.unref();
+    this.socketMessenger = new DaemonSocketMessenger(socket).listen(
       (message) => this.handleMessage(message),
       () => {
         // it's ok for the daemon to terminate if the client doesn't wait on


### PR DESCRIPTION
## Current Behavior
`--help` on commands that hit yargs help are hanging

## Expected Behavior
It doesn't hang. This contains a quick fix in adding the process.exit call, but also adds the unref needed to maintain previous working behavior. We'll need to investigate long term if additional areas keep commands alive, but adding this unref theoretically allows removing the process.exit calls from `nx show`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
