### PR TITLE
fix(misc): bump minimatch to 10.2.1 to address CVE-2026-26996

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,8 +237,8 @@ catalogs:
       specifier: ^20.19.10
       version: 20.19.19
     ts-morph:
-      specifier: ^24.0.0
-      version: 24.0.0
+      specifier: ^27.0.2
+      version: 27.0.2
     ts-node:
       specifier: 10.9.1
       version: 10.9.1
@@ -2864,7 +2864,7 @@ importers:
         version: 7.7.3
       ts-morph:
         specifier: catalog:typescript
-        version: 24.0.0
+        version: 27.0.2
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
@@ -12400,8 +12400,8 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
 
-  '@ts-morph/common@0.25.0':
-    resolution: {integrity: sha512-kMnZz+vGGHi4GoHnLmMhGNjm44kGtKUXGnOvrKmMwAuvNjM/PgKVGfUnL7IDvK7Jb2QQ82jq3Zmp04Gy+r3Dkg==}
+  '@ts-morph/common@0.28.1':
+    resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
 
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
@@ -24505,8 +24505,8 @@ packages:
       typescript: '*'
       webpack: ^5.0.0
 
-  ts-morph@24.0.0:
-    resolution: {integrity: sha512-2OAOg/Ob5yx9Et7ZX4CvTCc0UFoZHwLEJ+dpDPSUi5TgwwlTlX47w+iFRrEwzUZwYACjq83cgjS/Da50Ga37uw==}
+  ts-morph@27.0.2:
+    resolution: {integrity: sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==}
 
   ts-node@10.9.1:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
@@ -37877,9 +37877,9 @@ snapshots:
 
   '@trysound/sax@0.2.0': {}
 
-  '@ts-morph/common@0.25.0':
+  '@ts-morph/common@0.28.1':
     dependencies:
-      minimatch: 9.0.5
+      minimatch: 10.2.1
       path-browserify: 1.0.1
       tinyglobby: 0.2.15
 
@@ -54262,9 +54262,9 @@ snapshots:
       typescript: 5.9.2
       webpack: 5.101.3(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
-  ts-morph@24.0.0:
+  ts-morph@27.0.2:
     dependencies:
-      '@ts-morph/common': 0.25.0
+      '@ts-morph/common': 0.28.1
       code-block-writer: 13.0.3
 
   ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(typescript@5.9.2):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ catalogs:
       specifier: ~2.3.6
       version: 2.3.6
     minimatch:
-      specifier: 10.1.1
-      version: 10.1.1
+      specifier: 10.2.1
+      version: 10.2.1
     picocolors:
       specifier: ^1.1.0
       version: 1.1.1
@@ -1132,7 +1132,7 @@ importers:
         version: 2.4.7(webpack@5.101.3)
       minimatch:
         specifier: 'catalog:'
-        version: 10.1.1
+        version: 10.2.1
       next-sitemap:
         specifier: ^3.1.10
         version: 3.1.55(@next/env@14.2.35)(next@14.2.35(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.55.0))
@@ -3005,7 +3005,7 @@ importers:
         version: 2.3.6
       minimatch:
         specifier: 'catalog:'
-        version: 10.1.1
+        version: 10.2.1
       semver:
         specifier: 'catalog:'
         version: 7.7.3
@@ -3284,7 +3284,7 @@ importers:
         version: 30.0.2
       minimatch:
         specifier: 'catalog:'
-        version: 10.1.1
+        version: 10.2.1
       picocolors:
         specifier: 'catalog:'
         version: 1.1.1
@@ -3687,7 +3687,7 @@ importers:
         version: 2.0.3
       minimatch:
         specifier: 'catalog:'
-        version: 10.1.1
+        version: 10.2.1
       node-machine-id:
         specifier: 1.1.12
         version: 1.1.12
@@ -3804,7 +3804,7 @@ importers:
         version: 1.54.0
       minimatch:
         specifier: 'catalog:'
-        version: 10.1.1
+        version: 10.2.1
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
@@ -3869,7 +3869,7 @@ importers:
         version: 3.0.5
       minimatch:
         specifier: 'catalog:'
-        version: 10.1.1
+        version: 10.2.1
       picocolors:
         specifier: 'catalog:'
         version: 1.1.1
@@ -4067,7 +4067,7 @@ importers:
         version: 1.1.8
       minimatch:
         specifier: 'catalog:'
-        version: 10.1.1
+        version: 10.2.1
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
@@ -8306,8 +8306,8 @@ packages:
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
 
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+  '@isaacs/brace-expansion@5.0.1':
+    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
@@ -14116,6 +14116,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.3:
+    resolution: {integrity: sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==}
+    engines: {node: 20 || >=22}
+
   bare-events@2.6.0:
     resolution: {integrity: sha512-EKZ5BTXYExaNqi3I3f9RtEsaI/xBSGjE0XZCZilPzFAV/goswFHuPd9jEZlPIZ/iNZJwDSao9qRiScySz7MbQg==}
 
@@ -14253,6 +14257,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.2:
+    resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -19769,6 +19777,10 @@ packages:
 
   minimatch@10.1.1:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
+    engines: {node: 20 || >=22}
+
+  minimatch@10.2.1:
+    resolution: {integrity: sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==}
     engines: {node: 20 || >=22}
 
   minimatch@3.0.8:
@@ -32427,7 +32439,7 @@ snapshots:
 
   '@isaacs/balanced-match@4.0.1': {}
 
-  '@isaacs/brace-expansion@5.0.0':
+  '@isaacs/brace-expansion@5.0.1':
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
@@ -40473,6 +40485,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.3: {}
+
   bare-events@2.6.0:
     optional: true
 
@@ -40686,6 +40700,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.2:
+    dependencies:
+      balanced-match: 4.0.3
 
   braces@3.0.3:
     dependencies:
@@ -44373,7 +44391,7 @@ snapshots:
 
   glob@13.0.0:
     dependencies:
-      minimatch: 10.1.1
+      minimatch: 10.2.1
       minipass: 7.1.2
       path-scurry: 2.0.1
 
@@ -45197,7 +45215,7 @@ snapshots:
 
   ignore-walk@8.0.0:
     dependencies:
-      minimatch: 10.1.1
+      minimatch: 10.2.1
 
   ignore@5.3.2: {}
 
@@ -48310,7 +48328,11 @@ snapshots:
 
   minimatch@10.1.1:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      '@isaacs/brace-expansion': 5.0.1
+
+  minimatch@10.2.1:
+    dependencies:
+      brace-expansion: 5.0.2
 
   minimatch@3.0.8:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalog:
   '@zkochan/js-yaml': '0.0.7'
   chalk: '^4.1.0'
   enquirer: '~2.3.6'
-  minimatch: '10.1.1'
+  minimatch: '10.2.1'
   picomatch: '4.0.2'
   picocolors: '^1.1.0'
   semver: '^7.6.3'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -96,7 +96,7 @@ catalogs:
   typescript:
     '@phenomnomnominal/tsquery': '~6.1.4'
     '@types/node': '^20.19.10'
-    ts-morph: '^24.0.0'
+    ts-morph: '^27.0.2'
     ts-node: '10.9.1'
     tsconfig-paths: '^4.1.2'
     tslib: '^2.3.0'


### PR DESCRIPTION
## Current Behavior

Several Nx packages directly depend on a minimatch version with a high-severity vulnerability (https://github.com/advisories/GHSA-3ppc-4f35-3m26).

## Expected Behavior

Several Nx packages should depend directly on a minimatch version that does not include the reported high-severity vulnerability.

Note: unsafe `minimatch` versions can still be pulled in transitively. Upstream deps need to be updated, and then we need to update the Nx packages to newer versions.

## Related Issue(s)

Fixes #34507 
Fixes #32440 
