### PR TITLE
chore(maven): upgrade maven-shade-plugin to 3.6.0

### DIFF
--- a/packages/maven/batch-runner-adapters/maven3/pom.xml
+++ b/packages/maven/batch-runner-adapters/maven3/pom.xml
@@ -87,7 +87,6 @@
     </dependencies>
 
     <build>
-        <finalName>maven3-adapter</finalName>
         <sourceDirectory>src/main/kotlin</sourceDirectory>
         <plugins>
             <plugin>
@@ -109,7 +108,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -117,6 +116,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <outputFile>${project.build.directory}/maven3-adapter.jar</outputFile>
                             <artifactSet>
                                 <includes>
                                     <include>dev.nx.maven:nx-maven-shared</include>

--- a/packages/maven/batch-runner-adapters/maven4/pom.xml
+++ b/packages/maven/batch-runner-adapters/maven4/pom.xml
@@ -104,7 +104,6 @@
     </dependencies>
 
     <build>
-        <finalName>maven4-adapter</finalName>
         <sourceDirectory>src/main/kotlin</sourceDirectory>
 
         <plugins>
@@ -139,7 +138,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -147,6 +146,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <outputFile>${project.build.directory}/maven4-adapter.jar</outputFile>
                             <artifactSet>
                                 <includes>
                                     <include>dev.nx.maven:nx-maven-shared</include>

--- a/packages/maven/batch-runner/pom.xml
+++ b/packages/maven/batch-runner/pom.xml
@@ -139,7 +139,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/packages/maven/pom.xml
+++ b/packages/maven/pom.xml
@@ -107,7 +107,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.0</version>
         </plugin>
 
         <!-- Maven Flatten Plugin for publishing -->


### PR DESCRIPTION
## Current Behavior

The `maven-shade-plugin` at version 3.5.0 intermittently fails on CI with:

```
Could not replace original artifact with shaded artifact!
```

This is a file-locking race condition where the plugin fails to atomically replace the original JAR with the shaded JAR.

## Expected Behavior

Upgrading to 3.6.0 resolves the intermittent CI failures by using improved file-handling logic with better retry behavior during the artifact replacement step.

## Related Issue(s)

N/A - fixes intermittent CI flakiness in `maven-batch-runner` builds.