### PR TITLE
chore(repo): disable e2e tests broken by @microsoft/api-extractor@7.57.0

### DIFF
--- a/e2e/js/src/js-ts-solution.test.ts
+++ b/e2e/js/src/js-ts-solution.test.ts
@@ -11,7 +11,9 @@ import {
   updateJson,
 } from '@nx/e2e-utils';
 
-describe('JS - TS solution setup', () => {
+// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
+// See: https://github.com/qmhc/unplugin-dts/issues/461
+xdescribe('JS - TS solution setup', () => {
   beforeAll(() => {
     newProject({
       packages: ['@nx/js'],

--- a/e2e/next/src/next-ts-solutions.test.ts
+++ b/e2e/next/src/next-ts-solutions.test.ts
@@ -9,7 +9,9 @@ import {
   updateFile,
   updateJson,
 } from '@nx/e2e-utils';
-describe('Next TS Solutions', () => {
+// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
+// See: https://github.com/qmhc/unplugin-dts/issues/461
+xdescribe('Next TS Solutions', () => {
   let proj: string;
 
   beforeAll(() => {

--- a/e2e/react/src/react-ts-solution.test.ts
+++ b/e2e/react/src/react-ts-solution.test.ts
@@ -12,7 +12,9 @@ import {
   updateJson,
 } from '@nx/e2e-utils';
 
-describe('React (TS solution)', () => {
+// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
+// See: https://github.com/qmhc/unplugin-dts/issues/461
+xdescribe('React (TS solution)', () => {
   let workspaceName: string;
 
   beforeAll(() => {

--- a/e2e/react/src/react-vite.test.ts
+++ b/e2e/react/src/react-vite.test.ts
@@ -11,7 +11,9 @@ import {
   uniq,
 } from '@nx/e2e-utils';
 
-describe('Build React applications and libraries with Vite', () => {
+// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
+// See: https://github.com/qmhc/unplugin-dts/issues/461
+xdescribe('Build React applications and libraries with Vite', () => {
   beforeAll(() => {
     newProject({
       packages: ['@nx/react'],

--- a/e2e/release/src/release-publishable-libraries-ts-solution.test.ts
+++ b/e2e/release/src/release-publishable-libraries-ts-solution.test.ts
@@ -47,7 +47,9 @@ expect.addSnapshotSerializer({
   },
 });
 
-describe('release publishable libraries in workspace with ts solution setup', () => {
+// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
+// See: https://github.com/qmhc/unplugin-dts/issues/461
+xdescribe('release publishable libraries in workspace with ts solution setup', () => {
   let e2eRegistryUrl: string;
 
   beforeAll(async () => {

--- a/e2e/release/src/release-publishable-libraries.test.ts
+++ b/e2e/release/src/release-publishable-libraries.test.ts
@@ -49,7 +49,9 @@ expect.addSnapshotSerializer({
   },
 });
 
-describe('release publishable libraries', () => {
+// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
+// See: https://github.com/qmhc/unplugin-dts/issues/461
+xdescribe('release publishable libraries', () => {
   let e2eRegistryUrl: string;
 
   beforeAll(async () => {

--- a/e2e/storybook/src/storybook-nested.test.ts
+++ b/e2e/storybook/src/storybook-nested.test.ts
@@ -13,7 +13,9 @@ import {
 import { writeFileSync } from 'fs';
 import { createFileSync } from 'fs-extra';
 
-describe('Storybook generators and executors for standalone workspaces - using React + Vite', () => {
+// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
+// See: https://github.com/qmhc/unplugin-dts/issues/461
+xdescribe('Storybook generators and executors for standalone workspaces - using React + Vite', () => {
   const appName = uniq('react');
 
   beforeAll(() => {

--- a/e2e/vite/src/vite-legacy.test.ts
+++ b/e2e/vite/src/vite-legacy.test.ts
@@ -26,7 +26,9 @@ import {
 import { join } from 'path';
 import { ChildProcess } from 'child_process';
 
-describe('Vite Plugin', () => {
+// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
+// See: https://github.com/qmhc/unplugin-dts/issues/461
+xdescribe('Vite Plugin', () => {
   let proj: string;
   let originalEnv: string;
   beforeAll(() => {

--- a/e2e/vite/src/vite-ts-solution.test.ts
+++ b/e2e/vite/src/vite-ts-solution.test.ts
@@ -11,7 +11,9 @@ import {
   updateJson,
 } from '@nx/e2e-utils';
 
-describe('Vite - TS solution setup', () => {
+// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
+// See: https://github.com/qmhc/unplugin-dts/issues/461
+xdescribe('Vite - TS solution setup', () => {
   beforeAll(() => {
     newProject({
       packages: ['@nx/react', '@nx/js'],

--- a/e2e/vite/src/vite.test.ts
+++ b/e2e/vite/src/vite.test.ts
@@ -15,7 +15,9 @@ import { names } from '@nx/devkit';
 const myApp = uniq('my-app');
 const myVueApp = uniq('my-vue-app');
 
-describe('@nx/vite/plugin', () => {
+// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
+// See: https://github.com/qmhc/unplugin-dts/issues/461
+xdescribe('@nx/vite/plugin', () => {
   let proj: string;
   let originalEnv: string;
   beforeAll(() => {

--- a/e2e/vue/src/vue-legacy.test.ts
+++ b/e2e/vue/src/vue-legacy.test.ts
@@ -1,6 +1,8 @@
 import { cleanupProject, newProject, runCLI, uniq } from '@nx/e2e-utils';
 
-describe('Vue Plugin (legacy)', () => {
+// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
+// See: https://github.com/qmhc/unplugin-dts/issues/461
+xdescribe('Vue Plugin (legacy)', () => {
   let proj: string;
 
   beforeAll(() => {

--- a/e2e/vue/src/vue-ts-solution.test.ts
+++ b/e2e/vue/src/vue-ts-solution.test.ts
@@ -7,7 +7,9 @@ import {
   updateFile,
 } from '@nx/e2e-utils';
 
-describe('Vue (TS solution)', () => {
+// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
+// See: https://github.com/qmhc/unplugin-dts/issues/461
+xdescribe('Vue (TS solution)', () => {
   let proj: string;
 
   beforeAll(() => {

--- a/e2e/vue/src/vue.test.ts
+++ b/e2e/vue/src/vue.test.ts
@@ -8,7 +8,9 @@ import {
   updateFile,
 } from '@nx/e2e-utils';
 
-describe('Vue Plugin', () => {
+// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
+// See: https://github.com/qmhc/unplugin-dts/issues/461
+xdescribe('Vue Plugin', () => {
   let proj: string;
 
   beforeAll(() => {

--- a/e2e/web/src/web-vite.test.ts
+++ b/e2e/web/src/web-vite.test.ts
@@ -12,7 +12,9 @@ import {
   uniq,
 } from '@nx/e2e-utils';
 
-describe('Web Components Applications with bundler set as vite', () => {
+// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
+// See: https://github.com/qmhc/unplugin-dts/issues/461
+xdescribe('Web Components Applications with bundler set as vite', () => {
   beforeEach(() => newProject({ packages: ['@nx/web', '@nx/react'] }));
   afterEach(() => cleanupProject());
 


### PR DESCRIPTION
## Current Behavior

14 e2e tests are failing across master with "Failed to process project graph" errors. The root cause is `@microsoft/api-extractor@7.57.0` which has a broken ESM export (`ConsoleMessageId`). When `@nx/vite/plugin` or `@nx/vitest` plugins load `vite.config.mts` files, they transitively import api-extractor which crashes.

## Expected Behavior

Broken e2e tests are disabled via `xdescribe` so they no longer block CI. Tests should be re-enabled once the upstream api-extractor ESM issue is fixed.

## Disabled Tests

| Project | Test File |
|---------|-----------|
| e2e-vite | `vite.test.ts`, `vite-legacy.test.ts`, `vite-ts-solution.test.ts` |
| e2e-vue | `vue.test.ts`, `vue-legacy.test.ts`, `vue-ts-solution.test.ts` |
| e2e-js | `js-ts-solution.test.ts` |
| e2e-web | `web-vite.test.ts` |
| e2e-react | `react-vite.test.ts`, `react-ts-solution.test.ts` |
| e2e-next | `next-ts-solutions.test.ts` |
| e2e-release | `release-publishable-libraries.test.ts`, `release-publishable-libraries-ts-solution.test.ts` |
| e2e-storybook | `storybook-nested.test.ts` |

## Related Issue(s)

Upstream: https://github.com/qmhc/unplugin-dts/issues/461