### PR TITLE
fix(nextjs): reset daemon client after project graph creation in withNx

### DIFF
--- a/packages/next/plugins/with-nx.ts
+++ b/packages/next/plugins/with-nx.ts
@@ -141,7 +141,10 @@ function withNx(
 
       let graph: ProjectGraph;
       try {
-        graph = await createProjectGraphAsync();
+        graph = await createProjectGraphAsync({
+          exitOnError: false,
+          resetDaemonClient: true,
+        });
       } catch (e) {
         throw new Error(
           'Could not create project graph. Please ensure that your workspace is valid.',


### PR DESCRIPTION
## Current Behavior

Running `nx test` for Next.js projects causes Jest to hang with:
```
Jest did not exit one second after the test run has completed.
```

This happens because `next/jest` loads `next.config.js`, which calls `withNx` → `createProjectGraphAsync()`. The daemon client socket connection is left open, keeping the Node.js event loop alive and preventing Jest from exiting. Non-Next.js projects are unaffected since they don't trigger this code path.

## Expected Behavior

Jest exits cleanly after tests complete for Next.js projects, without needing `forceExit: true`.

## Fix

Pass `resetDaemonClient: true` to `createProjectGraphAsync()` in `packages/next/plugins/with-nx.ts`. This tells the project graph function to call `daemonClient.reset()` after fetching the graph, which closes the socket and allows Jest to exit.

### Verification

| Scenario | Before | After |
|----------|--------|-------|
| `nx test next-app` | Hangs | Exits cleanly |
| `NX_DAEMON=false nx test next-app` | Exits cleanly | Exits cleanly |
| Direct `npx jest` | Exits cleanly | Exits cleanly |
| Non-Next.js `nx test react-lib` | Exits cleanly | Exits cleanly |

## Related Issue(s)

Fixes #32880