### PR TITLE
chore(repo): re-enable e2e tests disabled by api-extractor issue

### DIFF
--- a/e2e/js/src/js-ts-solution.test.ts
+++ b/e2e/js/src/js-ts-solution.test.ts
@@ -11,9 +11,7 @@ import {
   updateJson,
 } from '@nx/e2e-utils';
 
-// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
-// See: https://github.com/qmhc/unplugin-dts/issues/461
-xdescribe('JS - TS solution setup', () => {
+describe('JS - TS solution setup', () => {
   beforeAll(() => {
     newProject({
       packages: ['@nx/js'],

--- a/e2e/next/src/next-ts-solutions.test.ts
+++ b/e2e/next/src/next-ts-solutions.test.ts
@@ -9,9 +9,7 @@ import {
   updateFile,
   updateJson,
 } from '@nx/e2e-utils';
-// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
-// See: https://github.com/qmhc/unplugin-dts/issues/461
-xdescribe('Next TS Solutions', () => {
+describe('Next TS Solutions', () => {
   let proj: string;
 
   beforeAll(() => {

--- a/e2e/react/src/react-ts-solution.test.ts
+++ b/e2e/react/src/react-ts-solution.test.ts
@@ -12,9 +12,7 @@ import {
   updateJson,
 } from '@nx/e2e-utils';
 
-// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
-// See: https://github.com/qmhc/unplugin-dts/issues/461
-xdescribe('React (TS solution)', () => {
+describe('React (TS solution)', () => {
   let workspaceName: string;
 
   beforeAll(() => {

--- a/e2e/react/src/react-vite.test.ts
+++ b/e2e/react/src/react-vite.test.ts
@@ -11,9 +11,7 @@ import {
   uniq,
 } from '@nx/e2e-utils';
 
-// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
-// See: https://github.com/qmhc/unplugin-dts/issues/461
-xdescribe('Build React applications and libraries with Vite', () => {
+describe('Build React applications and libraries with Vite', () => {
   beforeAll(() => {
     newProject({
       packages: ['@nx/react'],

--- a/e2e/release/src/release-publishable-libraries-ts-solution.test.ts
+++ b/e2e/release/src/release-publishable-libraries-ts-solution.test.ts
@@ -47,9 +47,7 @@ expect.addSnapshotSerializer({
   },
 });
 
-// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
-// See: https://github.com/qmhc/unplugin-dts/issues/461
-xdescribe('release publishable libraries in workspace with ts solution setup', () => {
+describe('release publishable libraries in workspace with ts solution setup', () => {
   let e2eRegistryUrl: string;
 
   beforeAll(async () => {

--- a/e2e/release/src/release-publishable-libraries.test.ts
+++ b/e2e/release/src/release-publishable-libraries.test.ts
@@ -49,9 +49,7 @@ expect.addSnapshotSerializer({
   },
 });
 
-// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
-// See: https://github.com/qmhc/unplugin-dts/issues/461
-xdescribe('release publishable libraries', () => {
+describe('release publishable libraries', () => {
   let e2eRegistryUrl: string;
 
   beforeAll(async () => {

--- a/e2e/storybook/src/storybook-nested.test.ts
+++ b/e2e/storybook/src/storybook-nested.test.ts
@@ -13,9 +13,7 @@ import {
 import { writeFileSync } from 'fs';
 import { createFileSync } from 'fs-extra';
 
-// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
-// See: https://github.com/qmhc/unplugin-dts/issues/461
-xdescribe('Storybook generators and executors for standalone workspaces - using React + Vite', () => {
+describe('Storybook generators and executors for standalone workspaces - using React + Vite', () => {
   const appName = uniq('react');
 
   beforeAll(() => {

--- a/e2e/vite/src/vite-legacy.test.ts
+++ b/e2e/vite/src/vite-legacy.test.ts
@@ -26,9 +26,7 @@ import {
 import { join } from 'path';
 import { ChildProcess } from 'child_process';
 
-// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
-// See: https://github.com/qmhc/unplugin-dts/issues/461
-xdescribe('Vite Plugin', () => {
+describe('Vite Plugin', () => {
   let proj: string;
   let originalEnv: string;
   beforeAll(() => {

--- a/e2e/vite/src/vite-ts-solution.test.ts
+++ b/e2e/vite/src/vite-ts-solution.test.ts
@@ -11,9 +11,7 @@ import {
   updateJson,
 } from '@nx/e2e-utils';
 
-// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
-// See: https://github.com/qmhc/unplugin-dts/issues/461
-xdescribe('Vite - TS solution setup', () => {
+describe('Vite - TS solution setup', () => {
   beforeAll(() => {
     newProject({
       packages: ['@nx/react', '@nx/js'],

--- a/e2e/vite/src/vite.test.ts
+++ b/e2e/vite/src/vite.test.ts
@@ -15,9 +15,7 @@ import { names } from '@nx/devkit';
 const myApp = uniq('my-app');
 const myVueApp = uniq('my-vue-app');
 
-// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
-// See: https://github.com/qmhc/unplugin-dts/issues/461
-xdescribe('@nx/vite/plugin', () => {
+describe('@nx/vite/plugin', () => {
   let proj: string;
   let originalEnv: string;
   beforeAll(() => {

--- a/e2e/vue/src/vue-legacy.test.ts
+++ b/e2e/vue/src/vue-legacy.test.ts
@@ -1,8 +1,6 @@
 import { cleanupProject, newProject, runCLI, uniq } from '@nx/e2e-utils';
 
-// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
-// See: https://github.com/qmhc/unplugin-dts/issues/461
-xdescribe('Vue Plugin (legacy)', () => {
+describe('Vue Plugin (legacy)', () => {
   let proj: string;
 
   beforeAll(() => {

--- a/e2e/vue/src/vue-ts-solution.test.ts
+++ b/e2e/vue/src/vue-ts-solution.test.ts
@@ -7,9 +7,7 @@ import {
   updateFile,
 } from '@nx/e2e-utils';
 
-// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
-// See: https://github.com/qmhc/unplugin-dts/issues/461
-xdescribe('Vue (TS solution)', () => {
+describe('Vue (TS solution)', () => {
   let proj: string;
 
   beforeAll(() => {

--- a/e2e/vue/src/vue.test.ts
+++ b/e2e/vue/src/vue.test.ts
@@ -8,9 +8,7 @@ import {
   updateFile,
 } from '@nx/e2e-utils';
 
-// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
-// See: https://github.com/qmhc/unplugin-dts/issues/461
-xdescribe('Vue Plugin', () => {
+describe('Vue Plugin', () => {
   let proj: string;
 
   beforeAll(() => {

--- a/e2e/web/src/web-vite.test.ts
+++ b/e2e/web/src/web-vite.test.ts
@@ -12,9 +12,7 @@ import {
   uniq,
 } from '@nx/e2e-utils';
 
-// TODO: Re-enable once @microsoft/api-extractor ESM import issue is resolved
-// See: https://github.com/qmhc/unplugin-dts/issues/461
-xdescribe('Web Components Applications with bundler set as vite', () => {
+describe('Web Components Applications with bundler set as vite', () => {
   beforeEach(() => newProject({ packages: ['@nx/web', '@nx/react'] }));
   afterEach(() => cleanupProject());
 


### PR DESCRIPTION
## Current Behavior

14 e2e test suites were disabled (`xdescribe`) due to an ESM import issue in `@microsoft/api-extractor@7.57.0` (see https://github.com/qmhc/unplugin-dts/issues/461).

## Expected Behavior

With the upstream issue resolved, all 14 e2e test suites are re-enabled (`describe`) and should pass normally.

## Related Issue(s)

Reverts #34516