### PR TITLE
fix(nextjs): use out/ as default output dir when output is export

### DIFF
--- a/packages/next/src/plugins/plugin.spec.ts
+++ b/packages/next/src/plugins/plugin.spec.ts
@@ -48,6 +48,7 @@ describe('@nx/next/plugin', () => {
       expect(nodes).toMatchSnapshot();
     });
   });
+
   describe('integrated projects', () => {
     const tempFs = new TempFs('test');
     beforeEach(() => {
@@ -87,6 +88,148 @@ describe('@nx/next/plugin', () => {
       );
 
       expect(nodes).toMatchSnapshot();
+    });
+  });
+  describe('output directory resolution', () => {
+    let tempFs: TempFs;
+
+    beforeEach(() => {
+      tempFs = new TempFs('test-output-dir');
+      context = {
+        nxJsonConfiguration: {
+          namedInputs: {
+            default: ['{projectRoot}/**/*'],
+            production: ['!{projectRoot}/**/*.spec.ts'],
+          },
+        },
+        workspaceRoot: tempFs.tempDir,
+      };
+      tempFs.createFileSync(
+        'my-app/project.json',
+        JSON.stringify({ name: 'my-app' })
+      );
+      tempFs.createFileSync('package-lock.json', '{}');
+    });
+
+    afterEach(() => {
+      jest.resetModules();
+      tempFs.cleanup();
+    });
+
+    async function buildOutputsFor(nextConfigSource: string) {
+      tempFs.createFileSync('my-app/next.config.js', nextConfigSource);
+
+      const nodes = await createNodesFunction(
+        ['my-app/next.config.js'],
+        {
+          buildTargetName: 'my-build',
+          devTargetName: 'my-serve',
+          startTargetName: 'my-start',
+          serveStaticTargetName: 'my-serve-static',
+        },
+        context
+      );
+
+      return nodes[0][1].projects['my-app'].targets['my-build'].outputs;
+    }
+
+    function outputsFor(dir: string) {
+      return [
+        `{workspaceRoot}/my-app/${dir}/!(cache)/**/*`,
+        `{workspaceRoot}/my-app/${dir}/!(cache)`,
+      ];
+    }
+
+    it('should use out/ when output is export', async () => {
+      expect(
+        await buildOutputsFor(`module.exports = { output: 'export' };`)
+      ).toEqual(outputsFor('out'));
+    });
+
+    it('should prefer distDir over output export', async () => {
+      expect(
+        await buildOutputsFor(
+          `module.exports = { output: 'export', distDir: 'custom-dist' };`
+        )
+      ).toEqual(outputsFor('custom-dist'));
+    });
+
+    // `withNx` injects `distDir: '.next'` while `global.NX_GRAPH_CREATION` is
+    // set, which is when this plugin runs, so an explicit `.next` must not be
+    // read as a custom export directory.
+    it('should use out/ when output is export and distDir is explicitly .next', async () => {
+      expect(
+        await buildOutputsFor(
+          `module.exports = { output: 'export', distDir: '.next' };`
+        )
+      ).toEqual(outputsFor('out'));
+    });
+
+    it('should use distDir when output is not export', async () => {
+      expect(
+        await buildOutputsFor(`module.exports = { distDir: 'build' };`)
+      ).toEqual(outputsFor('build'));
+    });
+
+    it('should use out/ when a config function returns output export', async () => {
+      expect(
+        await buildOutputsFor(`module.exports = () => ({ output: 'export' });`)
+      ).toEqual(outputsFor('out'));
+    });
+
+    it('should use out/ when an async config function returns output export', async () => {
+      expect(
+        await buildOutputsFor(
+          `module.exports = async () => ({ output: 'export' });`
+        )
+      ).toEqual(outputsFor('out'));
+    });
+  });
+
+  describe('root projects with output export', () => {
+    let tempFs: TempFs;
+
+    beforeEach(() => {
+      tempFs = new TempFs('test-root-output-export');
+      context = {
+        nxJsonConfiguration: {
+          namedInputs: {
+            default: ['{projectRoot}/**/*'],
+            production: ['!{projectRoot}/**/*.spec.ts'],
+          },
+        },
+        workspaceRoot: tempFs.tempDir,
+      };
+      tempFs.createFileSync('package.json', JSON.stringify({ name: 'root' }));
+      tempFs.createFileSync('package-lock.json', '{}');
+    });
+
+    afterEach(() => {
+      jest.resetModules();
+      tempFs.cleanup();
+    });
+
+    it('should use out/ as output dir when output is export', async () => {
+      tempFs.createFileSync(
+        'next.config.js',
+        `module.exports = { output: 'export' };`
+      );
+
+      const nodes = await createNodesFunction(
+        ['next.config.js'],
+        {
+          buildTargetName: 'build',
+          devTargetName: 'dev',
+          startTargetName: 'start',
+          serveStaticTargetName: 'serve-static',
+        },
+        context
+      );
+
+      expect(nodes[0][1].projects['.'].targets['build'].outputs).toEqual([
+        '{projectRoot}/out/!(cache)/**/*',
+        '{projectRoot}/out/!(cache)',
+      ]);
     });
   });
 });

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -23,6 +23,7 @@ import {
   addBuildAndWatchDepsTargets,
   isUsingTsSolutionSetup,
 } from '@nx/js/internal';
+import type { NextConfig } from 'next';
 import { readdirSync } from 'fs';
 import { dirname, join } from 'path';
 
@@ -253,20 +254,29 @@ function getStartTargetConfig(options: NextPluginOptions, projectRoot: string) {
 }
 
 async function getOutputs(projectRoot, nextConfig) {
-  let dir = '.next';
   const { PHASE_PRODUCTION_BUILD } = require('next/constants');
+  let resolvedConfig: Pick<NextConfig, 'distDir' | 'output'> | undefined;
 
   if (typeof nextConfig === 'function') {
     // Works for both async and sync functions.
-    const configResult = await Promise.resolve(
+    resolvedConfig = await Promise.resolve(
       nextConfig(PHASE_PRODUCTION_BUILD, { defaultConfig: {} })
     );
-    if (configResult?.distDir) {
-      dir = configResult?.distDir;
-    }
-  } else if (typeof nextConfig === 'object' && nextConfig?.distDir) {
-    // If nextConfig is an object, directly use its 'distDir' property.
-    dir = nextConfig.distDir;
+  } else if (typeof nextConfig === 'object') {
+    resolvedConfig = nextConfig;
+  }
+
+  // Mirrors Next.js' own `hasCustomExportOutput` check. With `output: 'export'`,
+  // `next build` treats a custom `distDir` as the export directory and falls back
+  // to `out` otherwise, reusing `.next` internally for intermediate artifacts.
+  let dir: string;
+  if (resolvedConfig?.output === 'export') {
+    dir =
+      resolvedConfig.distDir && resolvedConfig.distDir !== '.next'
+        ? resolvedConfig.distDir
+        : 'out';
+  } else {
+    dir = resolvedConfig?.distDir || '.next';
   }
 
   if (projectRoot === '.') {


### PR DESCRIPTION
## Current Behavior

The `getOutputs()` function in the `@nx/next` plugin only reads `distDir` from the resolved Next.js config to determine the build output directory. When a project uses `output: 'export'` (for [static site generation](https://nextjs.org/docs/app/building-your-application/deploying/static-exports)), Next.js generates output in `out/` by default, but the plugin ignores this and always defaults to `.next/`.

This causes Nx to cache/restore `.next/` instead of `out/`, which breaks deployment pipelines that depend on the `out/` directory for static export builds.

## Expected Behavior

The plugin should resolve the output directory the way `next build` does. Next.js decides it in `hasCustomExportOutput`:

```js
return config.output === 'export' && config.distDir !== '.next';
```

When that holds, `distDir` is the export directory and `.next` is reused internally for intermediate artifacts. Otherwise the export lands in `out`.

Using that same condition, rather than just checking whether `distDir` is set, covers one case worth spelling out. `withNx` returns `{ distDir: '.next', ...userConfig }` while `global.NX_GRAPH_CREATION` is set, which is exactly when this plugin creates its nodes. So a `withNx` project always arrives with a `distDir` even when the user never wrote one, and treating any present `distDir` as custom would leave those projects pointing at `.next/`.

### Edge cases

| Config | Expected output dir | Before this PR | After this PR |
|--------|-------------------|----------------|---------------|
| `{}` (default) | `.next` | `.next` | `.next` |
| `{ distDir: 'build' }` | `build` | `build` | `build` |
| `{ output: 'export' }` | `out` | `.next` | `out` |
| `{ output: 'export', distDir: 'custom' }` | `custom` | `custom` | `custom` |
| `{ output: 'export', distDir: '.next' }` | `out` | `.next` | `out` |
| `withNx({ output: 'export' })` | `out` | `.next` | `out` |
| `{ output: 'standalone' }` | `.next` | `.next` | `.next` |

## Changes

- `getOutputs()` in `packages/next/src/plugins/plugin.ts` now extracts a unified `resolvedConfig` and branches on `output: 'export'` first, applying the same `distDir !== '.next'` condition Next.js uses.
- Added 7 test cases in `packages/next/src/plugins/plugin.spec.ts` covering the resolution: `output: 'export'` on its own, with a custom `distDir`, and with `distDir: '.next'` (the shape `withNx` produces); `distDir` without `output: 'export'`; sync and async config functions; and a root project. They assert on the resolved `outputs` array directly rather than snapshotting the whole node, so a failure points at the output dir instead of at unrelated target config.

## Related Issue(s)

N/A - discovered via broken deployment pipeline when using `output: 'export'` in Next.js projects within an Nx monorepo.
