### PR TITLE
fix(misc): prevent nxCloudId from being generated for new workspaces

### DIFF
--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -297,7 +297,7 @@ export function runCreateWorkspace(
   // Needed for bun workarounds, see below
   const registry = execSync('npm config get registry').toString().trim();
 
-  let command = `${pm.createWorkspace} ${name} --nxCloud=skip --no-interactive`;
+  let command = `${pm.createWorkspace} ${name} --no-interactive`;
 
   if (preset) {
     command += ` --preset=${preset}`;

--- a/e2e/workspace-create/src/create-nx-workspace-angular.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace-angular.test.ts
@@ -4,6 +4,7 @@ import {
   cleanupProject,
   expectCodeIsFormatted,
   getSelectedPackageManager,
+  readJson,
   runCreateWorkspace,
   uniq,
 } from '@nx/e2e-utils';
@@ -34,6 +35,9 @@ describe('create-nx-workspace --preset=angular', () => {
     checkFilesExist('src/app/app-module.ts');
     checkFilesDoNotExist('src/app/app.routes.ts');
     expectCodeIsFormatted();
+
+    const nxJson = readJson(`nx.json`);
+    expect(nxJson.nxCloudId).toBeUndefined();
   });
 
   it('should create a workspace with a single angular app at the root using standalone APIs', () => {

--- a/e2e/workspace-create/src/create-nx-workspace-base-templates.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace-base-templates.test.ts
@@ -1,5 +1,6 @@
 import {
   cleanupProject,
+  readJson,
   runCLI,
   runCreateWorkspace,
   uniq,
@@ -25,6 +26,9 @@ describe('create-nx-workspace --template', () => {
         });
 
         expect(() => runCLI('run-many -t lint,test,build')).not.toThrow();
+
+        const nxJson = readJson(`nx.json`);
+        expect(nxJson.nxCloudId).toBeUndefined();
       },
       600_000
     );

--- a/e2e/workspace-create/src/create-nx-workspace-frameworks-next.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace-frameworks-next.test.ts
@@ -4,6 +4,7 @@ import {
   expectCodeIsFormatted,
   expectNoAngularDevkit,
   getSelectedPackageManager,
+  readJson,
   runCreateWorkspace,
   uniq,
 } from '@nx/e2e-utils';
@@ -30,6 +31,9 @@ describe('create-nx-workspace --preset=next', () => {
 
     expectNoAngularDevkit();
     expectCodeIsFormatted();
+
+    const nxJson = readJson(`nx.json`);
+    expect(nxJson.nxCloudId).toBeUndefined();
   });
 
   it('should be able to create a nextjs standalone workspace using app router', () => {

--- a/e2e/workspace-create/src/create-nx-workspace-frameworks-nuxt.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace-frameworks-nuxt.test.ts
@@ -3,6 +3,7 @@ import {
   cleanupProject,
   expectCodeIsFormatted,
   getSelectedPackageManager,
+  readJson,
   runCreateWorkspace,
   uniq,
 } from '@nx/e2e-utils';
@@ -29,6 +30,9 @@ describe('create-nx-workspace --preset=nuxt', () => {
     checkFilesExist('app/app.vue');
     checkFilesExist('app/pages/index.vue');
     expectCodeIsFormatted();
+
+    const nxJson = readJson(`nx.json`);
+    expect(nxJson.nxCloudId).toBeUndefined();
   });
 
   it('should be able to create a nuxt monorepo', () => {

--- a/e2e/workspace-create/src/create-nx-workspace-frameworks-vue.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace-frameworks-vue.test.ts
@@ -3,6 +3,7 @@ import {
   cleanupProject,
   expectCodeIsFormatted,
   getSelectedPackageManager,
+  readJson,
   runCreateWorkspace,
   uniq,
 } from '@nx/e2e-utils';
@@ -29,6 +30,9 @@ describe('create-nx-workspace --preset=vue', () => {
     checkFilesExist('src/main.ts');
     checkFilesExist('src/app/App.vue');
     expectCodeIsFormatted();
+
+    const nxJson = readJson(`nx.json`);
+    expect(nxJson.nxCloudId).toBeUndefined();
   });
 
   it('should be able to create a vue monorepo', () => {

--- a/e2e/workspace-create/src/create-nx-workspace-npm.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace-npm.test.ts
@@ -46,6 +46,9 @@ describe('create-nx-workspace --preset=npm', () => {
     } else {
       expect(packageJson.workspaces).toEqual(['packages/*']);
     }
+
+    const nxJson = readJson(`nx.json`);
+    expect(nxJson.nxCloudId).toBeUndefined();
   });
 
   it('should add angular application', () => {

--- a/e2e/workspace-create/src/create-nx-workspace-react-template.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace-react-template.test.ts
@@ -1,6 +1,7 @@
 import {
   cleanupProject,
   runCLI,
+  readJson,
   runCreateWorkspace,
   uniq,
 } from '@nx/e2e-utils';
@@ -22,6 +23,9 @@ describe('create-nx-workspace --template', () => {
         });
 
         expect(() => runCLI('run-many -t lint,test,build')).not.toThrow();
+
+        const nxJson = readJson(`nx.json`);
+        expect(nxJson.nxCloudId).toBeUndefined();
       },
       600_000
     );

--- a/e2e/workspace-create/src/create-nx-workspace-react.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace-react.test.ts
@@ -33,6 +33,9 @@ describe('create-nx-workspace --preset=react', () => {
     checkFilesExist('vite.config.mts');
     checkFilesDoNotExist('tsconfig.base.json');
     expectCodeIsFormatted();
+
+    const nxJson = readJson(`nx.json`);
+    expect(nxJson.nxCloudId).toBeUndefined();
   });
 
   it('should create a workspace with a single react app with webpack and playwright at the root', () => {

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -158,6 +158,9 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
       ...options,
       preset,
       workspaceGlobs,
+      // We want new workspaces to have a short URL to finish Cloud onboarding, but not have nxCloudId set up since it will be handled as part of the onboarding flow.
+      // This is skipping nxCloudId for the "custom" flow.
+      nxCloud: 'skip',
     });
 
     // Mark workspace as ready for SIGINT handler


### PR DESCRIPTION
## Current Behavior

When creating a new workspace using `create-nx-workspace` with the "custom" preset flow, an `nxCloudId` is generated and added to `nx.json`. This happens even though the onboarding flow is supposed to handle Cloud setup separately via a short URL.

## Expected Behavior

New workspaces created via `create-nx-workspace` should not have `nxCloudId` set in `nx.json`. Instead, a short URL is provided for users to finish Cloud onboarding on their own. The `nxCloud: 'skip'` option is now passed for the custom flow to prevent the ID from being generated.

E2E tests are updated to verify that `nxCloudId` is undefined in the generated `nx.json` across all workspace presets.

## Related Issue(s)

N/A - internal fix for workspace creation behavior.