### PR TITLE
fix(linter): support eslint v10

### DIFF
--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -32,7 +32,7 @@
   "executors": "./executors.json",
   "peerDependencies": {
     "@zkochan/js-yaml": "0.0.7",
-    "eslint": "^8.0.0 || ^9.0.0"
+    "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
   },
   "dependencies": {
     "@nx/devkit": "workspace:*",

--- a/packages/eslint/src/executors/lint/utility/eslint-utils.ts
+++ b/packages/eslint/src/executors/lint/utility/eslint-utils.ts
@@ -11,7 +11,6 @@ export async function resolveAndInstantiateESLint(
 ) {
   if (useFlatConfig && eslintConfigPath && !isFlatConfig(eslintConfigPath)) {
     throw new Error(
-      // todo: add support for eslint.config.mjs,
       'When using the new Flat Config with ESLint, all configs must be named eslint.config.js or eslint.config.cjs and .eslintrc files may not be used. See https://eslint.org/docs/latest/use/configure/configuration-files'
     );
   }

--- a/packages/eslint/src/utils/resolve-eslint-class.ts
+++ b/packages/eslint/src/utils/resolve-eslint-class.ts
@@ -5,17 +5,28 @@ export async function resolveESLintClass(opts?: {
   useFlatConfigOverrideVal: boolean;
 }): Promise<typeof ESLint> {
   try {
+    const shouldESLintUseFlatConfig =
+      typeof opts?.useFlatConfigOverrideVal === 'boolean'
+        ? opts.useFlatConfigOverrideVal
+        : useFlatConfig();
+
+    // In eslint 8.57.0 (the final v8 version), a dedicated API was added for resolving the correct ESLint class.
+    const eslintModule = (await import('eslint')) as typeof import('eslint') & {
+      loadESLint?: (opts: { useFlatConfig: boolean }) => Promise<typeof ESLint>;
+    };
+
+    if (typeof eslintModule.loadESLint === 'function') {
+      return await eslintModule.loadESLint({
+        useFlatConfig: shouldESLintUseFlatConfig,
+      });
+    }
+
     // Explicitly use the FlatESLint and LegacyESLint classes here because the ESLint class points at a different one based on ESLint v8 vs ESLint v9
     // But the decision on which one to use is not just based on the major version of ESLint.
     // @ts-expect-error The may be wrong based on our installed eslint version
     const { LegacyESLint, FlatESLint } = await import(
       'eslint/use-at-your-own-risk'
     );
-
-    const shouldESLintUseFlatConfig =
-      typeof opts?.useFlatConfigOverrideVal === 'boolean'
-        ? opts.useFlatConfigOverrideVal
-        : useFlatConfig();
 
     return shouldESLintUseFlatConfig ? FlatESLint : LegacyESLint;
   } catch {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3116,7 +3116,7 @@ importers:
         specifier: 0.0.7
         version: 0.0.7
       eslint:
-        specifier: ^8.0.0 || ^9.0.0
+        specifier: ^8.0.0 || ^9.0.0 || ^10.0.0
         version: 8.57.0
       semver:
         specifier: 'catalog:'


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

`@nx/eslint` relies on ESLint internals that changed in ESLint v10 (`use-at-your-own-risk`), which causes failures.

It looks like https://github.com/nrwl/nx/pull/24632 originally attempted to use `loadESLint()` which would've been forward compatible with v10, but it was later removed in https://github.com/nrwl/nx/pull/27404 in favor of the `use-at-your-own-risk` import.

## Expected Behavior

`@nx/eslint` supports ESLint v10.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #34415