### PR TITLE
chore(core): force nx-dev:prebuild-banner onto linux-extra-large

### DIFF
--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -94,6 +94,15 @@ assignment-rules:
       - agent: linux-extra-large
         parallelism: 6
 
+  # TODO(altan): remove when scheduling issue resolved
+  - projects:
+      - nx-dev
+    targets:
+      - prebuild-banner
+    run-on:
+      - agent: linux-extra-large
+        parallelism: 6
+
   - targets:
       - "*"
     run-on:

--- a/nx.json
+++ b/nx.json
@@ -344,7 +344,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 1000000000,
+  "bust": 1,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true

--- a/nx.json
+++ b/nx.json
@@ -344,7 +344,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 10,
+  "bust": 1000000000,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true


### PR DESCRIPTION
Temp fix while scheduling is fixed for real
