### PR TITLE
fix(core) not finding workspace project from deep imports on enforce module boundaries

### DIFF
--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
@@ -1515,15 +1515,13 @@ Violation detected in:
     expect(failures.length).toEqual(1);
   });
 
-  it('should error on importing an app', () => {
+  it('should error on importing an app (in tsconig paths)', () => {
     const failures = runRule(
       {},
       `${process.cwd()}/proj/libs/mylib/src/main.ts`,
       `
         import '@mycompany/myapp';
         import('@mycompany/myapp');
-        import('myapp');
-        import('myapp/subpath');
       `,
       {
         nodes: {
@@ -1545,6 +1543,60 @@ Violation detected in:
               tags: [],
               implicitDependencies: [],
               targets: {},
+            },
+          },
+        },
+        dependencies: {},
+      },
+      {
+        mylibName: [createFile(`libs/mylib/src/main.ts`)],
+        myappName: [createFile(`apps/myapp/src/index.ts`)],
+      }
+    );
+
+    const message = 'Imports of apps are forbidden';
+    expect(failures.length).toEqual(2);
+    expect(failures[0].message).toEqual(message);
+    expect(failures[1].message).toEqual(message);
+  });
+
+  it('should error on importing an app (not in tsconig paths)', () => {
+    const failures = runRule(
+      {},
+      `${process.cwd()}/proj/libs/mylib/src/main.ts`,
+      `
+        import 'myapp';
+        import('myapp');
+        import('myapp/subpath');
+        import 'myapp/subpath';
+      `,
+      {
+        nodes: {
+          mylibName: {
+            name: 'mylibName',
+            type: 'lib',
+            data: {
+              root: 'libs/mylib',
+              tags: [],
+              implicitDependencies: [],
+              targets: {},
+            },
+          },
+          myappName: {
+            name: 'myappName',
+            type: 'app',
+            data: {
+              root: 'apps/myapp',
+              tags: [],
+              implicitDependencies: [],
+              targets: {},
+              metadata: {
+                js: {
+                  packageName: "myapp",
+                  isInPackageManagerWorkspaces: true,
+                  packageMain: "dist/main.js"
+                }
+              }
             },
           },
         },

--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
@@ -1515,7 +1515,7 @@ Violation detected in:
     expect(failures.length).toEqual(1);
   });
 
-  it('should error on importing an app (in tsconig paths)', () => {
+  it('should error on importing an app (in tsconfig paths)', () => {
     const failures = runRule(
       {},
       `${process.cwd()}/proj/libs/mylib/src/main.ts`,
@@ -1560,7 +1560,7 @@ Violation detected in:
     expect(failures[1].message).toEqual(message);
   });
 
-  it('should error on importing an app (not in tsconig paths)', () => {
+  it('should error on importing an app (not in tsconfig paths)', () => {
     const failures = runRule(
       {},
       `${process.cwd()}/proj/libs/mylib/src/main.ts`,

--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
@@ -1592,11 +1592,11 @@ Violation detected in:
               targets: {},
               metadata: {
                 js: {
-                  packageName: "myapp",
+                  packageName: 'myapp',
                   isInPackageManagerWorkspaces: true,
-                  packageMain: "dist/main.js"
-                }
-              }
+                  packageMain: 'dist/main.js',
+                },
+              },
             },
           },
         },

--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
@@ -1522,6 +1522,8 @@ Violation detected in:
       `
         import '@mycompany/myapp';
         import('@mycompany/myapp');
+        import('myapp');
+        import('myapp/subpath');
       `,
       {
         nodes: {
@@ -1555,9 +1557,11 @@ Violation detected in:
     );
 
     const message = 'Imports of apps are forbidden';
-    expect(failures.length).toEqual(2);
+    expect(failures.length).toEqual(4);
     expect(failures[0].message).toEqual(message);
     expect(failures[1].message).toEqual(message);
+    expect(failures[2].message).toEqual(message);
+    expect(failures[3].message).toEqual(message);
   });
 
   it('should error on importing an e2e project', () => {

--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
@@ -373,7 +373,6 @@ export default ESLintUtils.RuleCreator(
           sourceFilePath,
           imp
         );
-
       if (!targetProject) {
         // non-project imports cannot use relative or absolute paths
         if (isRelativePath(imp) || imp.startsWith('/')) {

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -1277,9 +1277,9 @@ describe('TargetProjectLocator', () => {
     );
 
     it.each`
-      exports                                                      | importPath
-      ${'dist/index.js'}                                           | ${'app1'}
-      ${{ '.': 'dist/index.js' }}                                  | ${'app1/subpath'}
+      exports                     | importPath
+      ${'dist/index.js'}          | ${'app1'}
+      ${{ '.': 'dist/index.js' }} | ${'app1/subpath'}
     `(
       'should find app "$importPath" as "app1" project when exports="$exports"',
       ({ exports, importPath }) => {

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -1245,7 +1245,7 @@ describe('TargetProjectLocator', () => {
       ${{ './features/*.js': './dist/features/*.js' }}             | ${'@org/pkg1/features/some-file.js'}
       ${{ import: './dist/index.js', default: './dist/index.js' }} | ${'@org/pkg1'}
     `(
-      'should find "$importPath" as "pkg1" project when exports="$exports"',
+      'should find lib "$importPath" as "pkg1" project when exports="$exports"',
       ({ exports, importPath }) => {
         let projects: Record<string, ProjectGraphProjectNode> = {
           pkg1: {
@@ -1273,6 +1273,42 @@ describe('TargetProjectLocator', () => {
           targetProjectLocator.findImportInWorkspaceProjects(importPath);
 
         expect(result).toEqual('pkg1');
+      }
+    );
+
+    it.each`
+      exports                                                      | importPath
+      ${'dist/index.js'}                                           | ${'app1'}
+      ${{ '.': 'dist/index.js' }}                                  | ${'app1/subpath'}
+    `(
+      'should find app "$importPath" as "app1" project when exports="$exports"',
+      ({ exports, importPath }) => {
+        let projects: Record<string, ProjectGraphProjectNode> = {
+          app1: {
+            name: 'app1',
+            type: 'app' as const,
+            data: {
+              root: 'app1',
+              metadata: {
+                js: {
+                  packageName: 'app1',
+                  packageExports: exports,
+                  isInPackageManagerWorkspaces: true,
+                },
+              },
+            },
+          },
+        };
+
+        const targetProjectLocator = new TargetProjectLocator(
+          projects,
+          {},
+          new Map()
+        );
+        const result =
+          targetProjectLocator.findImportInWorkspaceProjects(importPath);
+
+        expect(result).toEqual('app1');
       }
     );
 

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -317,8 +317,11 @@ export class TargetProjectLocator {
   findImportInWorkspaceProjects(importPath: string): string | null {
     this.packagesMetadata ??= getWorkspacePackagesMetadata(this.nodes);
 
-    if (this.packagesMetadata.entryPointsToProjectMap[importPath]) {
-      return this.packagesMetadata.entryPointsToProjectMap[importPath].name;
+    const slashIndex = importPath.indexOf("/");
+    const impPath = importPath[0] !== "@" && slashIndex > 0 ? importPath.slice(0, slashIndex) : importPath;
+    // const impPath = importPath;
+    if (this.packagesMetadata.entryPointsToProjectMap[impPath]) {
+      return this.packagesMetadata.entryPointsToProjectMap[impPath].name;
     }
 
     const project = matchImportToWildcardEntryPointsToProjectMap(

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -316,8 +316,11 @@ export class TargetProjectLocator {
 
   findImportInWorkspaceProjects(importPath: string): string | null {
     this.packagesMetadata ??= getWorkspacePackagesMetadata(this.nodes);
-    const slashIndex = importPath.indexOf("/");
-    const impPath = importPath[0] !== "@" && slashIndex > 0 ? importPath.slice(0, slashIndex) : importPath;
+    const slashIndex = importPath.indexOf('/');
+    const impPath =
+      importPath[0] !== '@' && slashIndex > 0
+        ? importPath.slice(0, slashIndex)
+        : importPath;
     if (this.packagesMetadata.entryPointsToProjectMap[impPath]) {
       return this.packagesMetadata.entryPointsToProjectMap[impPath].name;
     }

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -316,10 +316,8 @@ export class TargetProjectLocator {
 
   findImportInWorkspaceProjects(importPath: string): string | null {
     this.packagesMetadata ??= getWorkspacePackagesMetadata(this.nodes);
-
     const slashIndex = importPath.indexOf("/");
     const impPath = importPath[0] !== "@" && slashIndex > 0 ? importPath.slice(0, slashIndex) : importPath;
-    // const impPath = importPath;
     if (this.packagesMetadata.entryPointsToProjectMap[impPath]) {
       return this.packagesMetadata.entryPointsToProjectMap[impPath].name;
     }


### PR DESCRIPTION
## Current Behavior
`@nx/enforce-module-boundaries` was not identifying the importing of an app if it was installed as a dependency in the `package.json` and was not listed in the `paths` of the tsconfig.

Also `targetProjectLocator.findImportInWorkspaceProjects` wasn't finding projects in the workspace if they weren't namespaced and were using subpaths.

## Expected Behavior
`targetProjectLocator.findImportInWorkspaceProjects` should find projects even if they aren't namespaced and are using subpaths.
`@nx/enforce-module-boundaries` should error on importing apps even if they are not namespaced, installed as project dependencies, and don't exist in the `paths` of the relevant tsconfig.

## Related Issue(s)
none (as far as I can tell)

Fixes #
