### PR TITLE
fix(core): send minimal task graph over IPC to forked processes

### DIFF
--- a/packages/nx/src/tasks-runner/batch/batch-messages.ts
+++ b/packages/nx/src/tasks-runner/batch/batch-messages.ts
@@ -24,7 +24,6 @@ export interface RunTasksMessage {
   executorName: string;
   projectGraph: ProjectGraph;
   batchTaskGraph: TaskGraph;
-  fullTaskGraph: TaskGraph;
 }
 
 export interface CompleteTaskMessage {

--- a/packages/nx/src/tasks-runner/batch/run-batch.ts
+++ b/packages/nx/src/tasks-runner/batch/run-batch.ts
@@ -35,8 +35,7 @@ function getBatchExecutor(
 async function runTasks(
   executorName: string,
   projectGraph: ProjectGraph,
-  batchTaskGraph: TaskGraph,
-  fullTaskGraph: TaskGraph
+  batchTaskGraph: TaskGraph
 ) {
   const input: Record<string, any> = {};
   const projectsConfigurations =
@@ -54,7 +53,7 @@ async function runTasks(
     nxJsonConfiguration,
     isVerbose: false,
     projectGraph,
-    taskGraph: fullTaskGraph,
+    taskGraph: batchTaskGraph,
   };
   for (const task of tasks) {
     const projectConfiguration =
@@ -118,8 +117,7 @@ process.on('message', async (message: BatchMessage) => {
       const results = await runTasks(
         message.executorName,
         message.projectGraph,
-        message.batchTaskGraph,
-        message.fullTaskGraph
+        message.batchTaskGraph
       );
       process.send({
         type: BatchMessageType.CompleteBatchExecution,

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -45,7 +45,6 @@ export class ForkedProcessTaskRunner {
   public async forkProcessForBatch(
     { executorName, taskGraph: batchTaskGraph }: Batch,
     projectGraph: ProjectGraph,
-    fullTaskGraph: TaskGraph,
     env: NodeJS.ProcessEnv
   ): Promise<BatchProcess> {
     const count = Object.keys(batchTaskGraph.tasks).length;
@@ -90,7 +89,6 @@ export class ForkedProcessTaskRunner {
       executorName,
       projectGraph,
       batchTaskGraph,
-      fullTaskGraph,
     });
 
     return cp;

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -46,6 +46,7 @@ import {
   removeTasksFromTaskGraph,
   shouldStreamOutput,
 } from './utils';
+import { createMinimalTaskGraph } from './task-graph-utils';
 import { SharedRunningTask } from './running-tasks/shared-running-task';
 
 export class TaskOrchestrator {
@@ -440,7 +441,6 @@ export class TaskOrchestrator {
         await this.forkedProcessTaskRunner.forkProcessForBatch(
           batch,
           this.projectGraph,
-          this.taskGraph,
           env
         );
 
@@ -777,7 +777,7 @@ export class TaskOrchestrator {
             temporaryOutputPath,
             streamOutput,
             pipeOutput,
-            taskGraph: this.taskGraph,
+            taskGraph: createMinimalTaskGraph(this.taskGraph, task.id),
             env,
             disablePseudoTerminal,
           })
@@ -785,7 +785,7 @@ export class TaskOrchestrator {
             temporaryOutputPath,
             streamOutput,
             pipeOutput,
-            taskGraph: this.taskGraph,
+            taskGraph: createMinimalTaskGraph(this.taskGraph, task.id),
             env,
           });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2764,7 +2764,7 @@ importers:
         version: 2.3.0
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 21.1.0(f980f72dbbe44fac982acd2259e3661a)
+        version: 21.1.0(ccee4f196e8198b3110621a4745916e5)
       '@angular/localize':
         specifier: catalog:angular-supported-versions
         version: 21.1.0(@angular/compiler-cli@21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2))(@angular/compiler@21.1.0)
@@ -2870,7 +2870,7 @@ importers:
     dependencies:
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 21.1.0(9613cd481432c3d065f8f0fc994cc2d8)
+        version: 21.1.0(6b1a0cf84e61f1c844c41da18f524ece)
       '@angular/compiler-cli':
         specifier: catalog:angular-supported-versions
         version: 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
@@ -4479,7 +4479,7 @@ importers:
         version: 3.0.0
       webpack-subresource-integrity:
         specifier: ^5.1.0
-        version: 5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
+        version: 5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
     devDependencies:
       nx:
         specifier: workspace:*
@@ -27101,10 +27101,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.1.0(9613cd481432c3d065f8f0fc994cc2d8)':
+  '@angular/build@21.1.0(6b1a0cf84e61f1c844c41da18f524ece)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2101.0(chokidar@5.0.0)
+      '@angular-devkit/architect': 0.2101.0(chokidar@3.6.0)
       '@angular/compiler': 21.1.0
       '@angular/compiler-cli': 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
       '@babel/core': 7.28.5
@@ -27159,10 +27159,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.1.0(f980f72dbbe44fac982acd2259e3661a)':
+  '@angular/build@21.1.0(ccee4f196e8198b3110621a4745916e5)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2101.0(chokidar@5.0.0)
+      '@angular-devkit/architect': 0.2101.0(chokidar@3.6.0)
       '@angular/compiler': 21.1.0
       '@angular/compiler-cli': 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
       '@babel/core': 7.28.5
@@ -30558,7 +30558,7 @@ snapshots:
       execa: 5.1.1
       fs-extra: 11.3.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3)
+      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
       leven: 3.1.0
       lodash: 4.17.21
       open: 8.4.2
@@ -44975,7 +44975,7 @@ snapshots:
       tapable: 2.2.2
       webpack: 5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
-  html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3):
+  html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -56114,12 +56114,12 @@ snapshots:
     optionalDependencies:
       html-webpack-plugin: 5.5.0(webpack@5.101.3)
 
-  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)):
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     optionalDependencies:
-      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3)
+      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
 
   webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3))))(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3))):
     dependencies:


### PR DESCRIPTION
## Current Behavior

The `TaskOrchestrator` sends the entire `TaskGraph` (140MB+ in large monorepos with 2000+ projects) via IPC to every forked child process. This causes 20+ second delays before tasks can start due to JSON serialization overhead, and this cost is paid per-worker (21+ parallel workers).

For batch executors, both `batchTaskGraph` (the relevant subset) and `fullTaskGraph` (the entire graph) are sent redundantly.

## Expected Behavior

For non-batch tasks, only a minimal task graph containing the executing task and its direct dependencies is sent over IPC. For batch tasks, the `batchTaskGraph` (already scoped to the batch) is used for the executor context, and the redundant `fullTaskGraph` is no longer transmitted.

This reduces IPC payload size from 140MB+ to a few KB per task, eliminating the serialization bottleneck.

## Related Issue(s)

Fixes #33995 
