### PR TITLE
fix(core): prevent race condition between cache cleanup and remote ca…

### DIFF
--- a/packages/nx/src/tasks-runner/cache-db.spec.ts
+++ b/packages/nx/src/tasks-runner/cache-db.spec.ts
@@ -1,0 +1,327 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Create a stable temp dir that can be used by module-level mocks
+const stableTmpDir = realpathSync(
+  mkdtempSync(join(tmpdir(), 'nx-cache-test-'))
+);
+
+// --- Mock setup (must come before imports of code under test) ---
+
+const mockNxCacheInstance = {
+  cacheDirectory: stableTmpDir,
+  get: jest.fn(),
+  put: jest.fn(),
+  applyRemoteCacheResults: jest.fn(),
+  getTaskOutputsPath: jest.fn(),
+  getCacheSize: jest.fn().mockReturnValue(0),
+  copyFilesFromCache: jest.fn().mockReturnValue(0),
+  removeOldCacheRecords: jest.fn(),
+  checkCacheFsInSync: jest.fn().mockReturnValue(true),
+};
+
+jest.mock('../native', () => ({
+  NxCache: jest.fn().mockImplementation(() => mockNxCacheInstance),
+  IS_WASM: false,
+  getDefaultMaxCacheSize: jest.fn().mockReturnValue(100 * 1024 * 1024),
+  HttpRemoteCache: jest.fn(),
+}));
+
+jest.mock('../config/nx-json', () => ({
+  readNxJson: jest.fn().mockReturnValue({}),
+  NxJsonConfiguration: {},
+}));
+
+jest.mock('../utils/db-connection', () => ({
+  getDbConnection: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../utils/cache-directory', () => ({
+  cacheDir: stableTmpDir,
+  workspaceDataDirectory: stableTmpDir,
+  workspaceDataDirectoryForWorkspace: () => stableTmpDir,
+}));
+
+jest.mock('../utils/workspace-root', () => ({
+  workspaceRoot: stableTmpDir,
+}));
+
+jest.mock('../utils/nx-cloud-utils', () => ({
+  isNxCloudUsed: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('../utils/is-ci', () => ({
+  isCI: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('../utils/output', () => ({
+  output: {
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock('../utils/logger', () => ({
+  logger: {
+    warn: jest.fn(),
+    verbose: jest.fn(),
+  },
+}));
+
+import { DbCache } from './cache';
+import { logger } from '../utils/logger';
+import { RemoteCacheV2 } from './default-tasks-runner';
+
+function createTask(
+  id: string,
+  hash: string,
+  outputs: string[] = ['dist/packages/my-lib']
+) {
+  return {
+    id,
+    hash,
+    target: {
+      project: id.split(':')[0],
+      target: id.split(':')[1] || 'build',
+    },
+    overrides: {},
+    outputs,
+  } as any;
+}
+
+describe('DbCache race condition fixes', () => {
+  let dbCache: DbCache;
+  let mockRemoteCache: jest.Mocked<RemoteCacheV2>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockNxCacheInstance.cacheDirectory = stableTmpDir;
+
+    mockRemoteCache = {
+      retrieve: jest.fn(),
+      store: jest.fn().mockResolvedValue(true),
+    } as any;
+
+    dbCache = new DbCache({
+      nxCloudRemoteCache: null,
+      skipRemoteCache: false,
+    });
+    // Inject the mock remote cache (bypass the async getRemoteCache flow)
+    (dbCache as any).remoteCache = mockRemoteCache;
+  });
+
+  afterAll(() => {
+    try {
+      rmSync(stableTmpDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  describe('put() - local cache eviction guard', () => {
+    it('should skip remote store if local cache entry was evicted by cleanup', async () => {
+      const task = createTask('my-lib:build', 'evicted-hash-1');
+
+      // Mock cache.put() to NOT create the local directory
+      // (simulating maxCacheSize cleanup evicting the entry immediately)
+      mockNxCacheInstance.put.mockImplementation(() => {
+        // Don't create the cache dir — simulating eviction
+      });
+
+      await dbCache.put(task, 'build output', ['dist/packages/my-lib'], 0);
+
+      // remote store should NOT have been called because local entry was evicted
+      expect(mockRemoteCache.store).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('evicted by maxCacheSize')
+      );
+    });
+
+    it('should proceed with remote store if local cache entry exists', async () => {
+      const task = createTask('my-lib:build', 'valid-hash-1');
+
+      // Mock cache.put() to create the local directory
+      mockNxCacheInstance.put.mockImplementation(() => {
+        mkdirSync(join(stableTmpDir, 'valid-hash-1'), { recursive: true });
+      });
+
+      await dbCache.put(task, 'build output', ['dist/packages/my-lib'], 0);
+
+      // remote store should have been called
+      expect(mockRemoteCache.store).toHaveBeenCalledWith(
+        'valid-hash-1',
+        stableTmpDir,
+        'build output',
+        0
+      );
+      expect(logger.warn).not.toHaveBeenCalled();
+
+      // Cleanup
+      rmSync(join(stableTmpDir, 'valid-hash-1'), {
+        recursive: true,
+        force: true,
+      });
+    });
+
+    it('should not warn or skip when there is no remote cache', async () => {
+      const task = createTask('my-lib:build', 'no-remote-hash');
+      (dbCache as any).remoteCache = null;
+
+      mockNxCacheInstance.put.mockImplementation(() => {
+        // Don't create the cache dir
+      });
+
+      await dbCache.put(task, 'build output', ['dist/packages/my-lib'], 0);
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('get() - stale remote cache detection', () => {
+    it('should return null if remote cache outputs path does not exist', async () => {
+      const task = createTask('my-lib:build', 'stale-hash-1');
+
+      // Local cache miss
+      mockNxCacheInstance.get.mockReturnValue(null);
+
+      // Remote cache "hit" but outputs path points to nonexistent dir
+      mockRemoteCache.retrieve.mockResolvedValue({
+        code: 0,
+        terminalOutput: 'cached output',
+        outputsPath: join(stableTmpDir, 'stale-hash-1', 'does-not-exist'),
+      });
+
+      const result = await dbCache.get(task);
+
+      expect(result).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('cached output files are missing')
+      );
+      // applyRemoteCacheResults should NOT have been called
+      expect(
+        mockNxCacheInstance.applyRemoteCacheResults
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should return null if remote cache outputs path is empty', async () => {
+      const task = createTask('my-lib:build', 'empty-hash-1');
+
+      // Local cache miss
+      mockNxCacheInstance.get.mockReturnValue(null);
+
+      // Create an empty outputs directory
+      const outputsPath = join(stableTmpDir, 'empty-hash-1', 'outputs');
+      mkdirSync(outputsPath, { recursive: true });
+
+      mockRemoteCache.retrieve.mockResolvedValue({
+        code: 0,
+        terminalOutput: 'cached output',
+        outputsPath,
+      });
+
+      const result = await dbCache.get(task);
+
+      expect(result).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('cached output files are missing')
+      );
+
+      // Cleanup
+      rmSync(join(stableTmpDir, 'empty-hash-1'), {
+        recursive: true,
+        force: true,
+      });
+    });
+
+    it('should return cache result if remote cache outputs path has content', async () => {
+      const task = createTask('my-lib:build', 'good-hash-1');
+
+      // Local cache miss
+      mockNxCacheInstance.get.mockReturnValue(null);
+
+      // Create outputs directory with content
+      const outputsPath = join(stableTmpDir, 'good-hash-1', 'outputs');
+      mkdirSync(outputsPath, { recursive: true });
+      writeFileSync(join(outputsPath, 'index.js'), 'console.log("hello")');
+
+      mockRemoteCache.retrieve.mockResolvedValue({
+        code: 0,
+        terminalOutput: 'cached output',
+        outputsPath,
+      });
+
+      const result = await dbCache.get(task);
+
+      expect(result).not.toBeNull();
+      expect(result.remote).toBe(true);
+      expect(result.terminalOutput).toBe('cached output');
+      expect(mockNxCacheInstance.applyRemoteCacheResults).toHaveBeenCalled();
+
+      // Cleanup
+      rmSync(join(stableTmpDir, 'good-hash-1'), {
+        recursive: true,
+        force: true,
+      });
+    });
+
+    it('should skip validation for tasks with no expected outputs', async () => {
+      const task = createTask('my-lib:build', 'no-outputs-hash', []);
+
+      mockNxCacheInstance.get.mockReturnValue(null);
+
+      // Remote cache hit with nonexistent path, but task has no outputs
+      mockRemoteCache.retrieve.mockResolvedValue({
+        code: 0,
+        terminalOutput: 'cached output',
+        outputsPath: join(stableTmpDir, 'nonexistent'),
+      });
+
+      const result = await dbCache.get(task);
+
+      // Should still return the result since no file outputs were expected
+      expect(result).not.toBeNull();
+      expect(result.remote).toBe(true);
+    });
+
+    it('should skip validation for failed tasks (code !== 0)', async () => {
+      const task = createTask('my-lib:build', 'failed-hash-1');
+
+      mockNxCacheInstance.get.mockReturnValue(null);
+
+      // Remote cache hit for a failed task (no outputs expected)
+      mockRemoteCache.retrieve.mockResolvedValue({
+        code: 1,
+        terminalOutput: 'build failed',
+        outputsPath: join(stableTmpDir, 'nonexistent'),
+      });
+
+      const result = await dbCache.get(task);
+
+      // Should return result even though path doesn't exist (failed tasks have no outputs)
+      expect(result).not.toBeNull();
+      expect(result.code).toBe(1);
+    });
+
+    it('should return local cache results without remote validation', async () => {
+      const task = createTask('my-lib:build', 'local-hash-1');
+
+      // Local cache hit
+      mockNxCacheInstance.get.mockReturnValue({
+        code: 0,
+        terminalOutput: 'local cached output',
+        outputsPath: join(stableTmpDir, 'local-hash-1'),
+      });
+
+      const result = await dbCache.get(task);
+
+      expect(result).not.toBeNull();
+      expect(result.remote).toBe(false);
+      // Should not hit remote cache at all
+      expect(mockRemoteCache.retrieve).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2764,7 +2764,7 @@ importers:
         version: 2.3.0
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 21.1.0(f980f72dbbe44fac982acd2259e3661a)
+        version: 21.1.0(ccee4f196e8198b3110621a4745916e5)
       '@angular/localize':
         specifier: catalog:angular-supported-versions
         version: 21.1.0(@angular/compiler-cli@21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2))(@angular/compiler@21.1.0)
@@ -2870,7 +2870,7 @@ importers:
     dependencies:
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 21.1.0(9613cd481432c3d065f8f0fc994cc2d8)
+        version: 21.1.0(6b1a0cf84e61f1c844c41da18f524ece)
       '@angular/compiler-cli':
         specifier: catalog:angular-supported-versions
         version: 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
@@ -4479,7 +4479,7 @@ importers:
         version: 3.0.0
       webpack-subresource-integrity:
         specifier: ^5.1.0
-        version: 5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
+        version: 5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
     devDependencies:
       nx:
         specifier: workspace:*
@@ -27101,10 +27101,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.1.0(9613cd481432c3d065f8f0fc994cc2d8)':
+  '@angular/build@21.1.0(6b1a0cf84e61f1c844c41da18f524ece)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2101.0(chokidar@5.0.0)
+      '@angular-devkit/architect': 0.2101.0(chokidar@3.6.0)
       '@angular/compiler': 21.1.0
       '@angular/compiler-cli': 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
       '@babel/core': 7.28.5
@@ -27159,10 +27159,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.1.0(f980f72dbbe44fac982acd2259e3661a)':
+  '@angular/build@21.1.0(ccee4f196e8198b3110621a4745916e5)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2101.0(chokidar@5.0.0)
+      '@angular-devkit/architect': 0.2101.0(chokidar@3.6.0)
       '@angular/compiler': 21.1.0
       '@angular/compiler-cli': 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
       '@babel/core': 7.28.5
@@ -30558,7 +30558,7 @@ snapshots:
       execa: 5.1.1
       fs-extra: 11.3.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3)
+      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
       leven: 3.1.0
       lodash: 4.17.21
       open: 8.4.2
@@ -44975,7 +44975,7 @@ snapshots:
       tapable: 2.2.2
       webpack: 5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
-  html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3):
+  html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -56114,12 +56114,12 @@ snapshots:
     optionalDependencies:
       html-webpack-plugin: 5.5.0(webpack@5.101.3)
 
-  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)):
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     optionalDependencies:
-      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3)
+      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
 
   webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3))))(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3))):
     dependencies:


### PR DESCRIPTION
## Current Behavior

When using `@nx/shared-fs-cache` (or any remote cache) with a `maxCacheSize` setting, cache entries evicted by the local cleanup are not reflected in the remote cache's database. This leads to:

1. **Stale remote cache entries**: The remote DB reports cache hits for entries whose files no longer exist
2. **Silent failure on retrieval**: Nx reports a successful cache hit but no output files are restored (the workspace outputs are actually **deleted** during the failed restore)
3. **Lost build outputs**: Users must manually rebuild affected packages with no clear error message

## Expected Behavior

- When local cache cleanup evicts entries before they can be stored remotely, the remote store is skipped with a warning (preventing stale DB entries)
- When retrieving from remote cache, the outputs path is validated before applying results — missing or empty paths are treated as cache misses with an explicit warning
- The task orchestrator provides defense-in-depth validation for remote cache results with expected file outputs
- The `RemoteCacheV2` abstract class now includes an optional `remove()` method so remote cache implementations can stay in sync with local evictions

## Related Issue(s)

Fixes #34032
