### PR TITLE
docs(core): clarify run-commands args option accepts both string and …

### DIFF
--- a/astro-docs/src/content/docs/guides/Tasks & Caching/pass-args-to-commands.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/pass-args-to-commands.mdoc
@@ -191,7 +191,7 @@ Support for providing command args as options was added in **Nx v18.1.1**.
 
 {% /tabitem %}
 
-{% tabitem label="Setting the \"args\" option" %}
+{% tabitem label="Setting the \"args\" option as an array" %}
 
 ```json {% meta="{6-12}" %}
 // apps/my-app/project.json
@@ -202,8 +202,25 @@ Support for providing command args as options was added in **Nx v18.1.1**.
     "build": {
       "options": {
         "args": ["--assetsInlineLimit=2048", "--assetsDir=static/assets"]
-        // it also accepts a single string:
-        // "args": "--assetsInlineLimit=2048 --assetsDir=static/assets"
+      }
+    }
+  }
+}
+```
+
+{% /tabitem %}
+
+{% tabitem label="Setting the \"args\" option as a string" %}
+
+```json {% meta="{6-12}" %}
+// apps/my-app/project.json
+{
+  "sourceRoot": "apps/my-app/src",
+  "projectType": "application",
+  "targets": {
+    "build": {
+      "options": {
+        "args": "--assetsInlineLimit=2048 --assetsDir=static/assets"
       }
     }
   }
@@ -240,7 +257,7 @@ To provide the same args for all projects in the workspace, you need to update t
 
 {% /tabitem %}
 
-{% tabitem label="Setting the \"args\" option" %}
+{% tabitem label="Setting the \"args\" option as an array" %}
 
 ```json
 // nx.json
@@ -249,6 +266,23 @@ To provide the same args for all projects in the workspace, you need to update t
     "build": {
       "options": {
         "args": ["--assetsInlineLimit=2048", "--assetsDir=static/assets"]
+      }
+    }
+  }
+}
+```
+
+{% /tabitem %}
+
+{% tabitem label="Setting the \"args\" option as a string" %}
+
+```json
+// nx.json
+{
+  "targetDefaults": {
+    "build": {
+      "options": {
+        "args": "--assetsInlineLimit=2048 --assetsDir=static/assets"
       }
     }
   }

--- a/packages/nx/src/executors/run-commands/schema.json
+++ b/packages/nx/src/executors/run-commands/schema.json
@@ -141,7 +141,7 @@
           "type": "string"
         }
       ],
-      "description": "Extra arguments. You can pass them as follows: nx run project:target --args='--wait=100'. You can then use {args.wait} syntax to interpolate them in the workspace config file. See example [above](#chaining-commands-interpolating-args-and-setting-the-cwd)"
+      "description": "Extra arguments. Accepts an array of strings or a single string. You can pass them as follows: nx run project:target --args='--wait=100'. You can then use {args.wait} syntax to interpolate them in the workspace config file. See example [above](#chaining-commands-interpolating-args-and-setting-the-cwd)"
     },
     "envFile": {
       "type": "string",


### PR DESCRIPTION
…array

The `args` option for the `nx:run-commands` executor accepts both a string and an array of strings, but the docs only showed the array form with a comment mentioning the string form. Updated the schema description to explicitly state both types are accepted and split the docs into separate tabs showing each format clearly.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
