### PR TITLE
fix(core): add socket timeouts and cleanup to prevent Nx hanging in CI

### DIFF
--- a/packages/nx/src/daemon/client/client.spec.ts
+++ b/packages/nx/src/daemon/client/client.spec.ts
@@ -1,0 +1,129 @@
+import { EventEmitter } from 'events';
+
+// Mock socket implementation for testing timeout behavior
+class MockSocket extends EventEmitter {
+  destroyed = false;
+  _timeout = 0;
+
+  setTimeout(ms: number) {
+    this._timeout = ms;
+  }
+
+  destroy(err?: Error) {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    if (err) {
+      this.emit('error', err);
+    }
+    this.emit('close');
+  }
+
+  write(_data: any) {}
+}
+
+let mockSocket: MockSocket;
+let connectCallback: (() => void) | undefined;
+
+jest.mock('net', () => ({
+  connect: jest.fn((_path: string, cb?: () => void) => {
+    mockSocket = new MockSocket();
+    connectCallback = cb;
+    return mockSocket;
+  }),
+}));
+
+jest.mock('../../config/configuration', () => ({
+  readNxJson: jest.fn(() => null),
+}));
+
+jest.mock('../tmp-dir', () => ({
+  DAEMON_DIR_FOR_CURRENT_WORKSPACE: '/tmp/test-daemon',
+  DAEMON_OUTPUT_LOG_FILE: '/tmp/test-daemon/log',
+  isDaemonDisabled: jest.fn(() => false),
+  removeSocketDir: jest.fn(),
+  socketDir: '/tmp/test-socket',
+}));
+
+jest.mock('../cache', () => ({
+  readDaemonProcessJsonCache: jest.fn(() => ({
+    socketPath: '/tmp/test-daemon.sock',
+  })),
+  getDaemonProcessIdSync: jest.fn(() => 1234),
+}));
+
+jest.mock('../../utils/output', () => ({
+  output: {
+    warn: jest.fn(),
+    error: jest.fn(),
+    log: jest.fn(),
+  },
+}));
+
+jest.mock('../../native', () => ({
+  IS_WASM: false,
+}));
+
+describe('DaemonClient', () => {
+  let DaemonClient: any;
+
+  beforeEach(() => {
+    connectCallback = undefined;
+    const clientModule = require('./client');
+    DaemonClient = clientModule.DaemonClient;
+  });
+
+  describe('isServerAvailable', () => {
+    it('should return false when socket times out', async () => {
+      const client = new DaemonClient();
+
+      const availablePromise = client.isServerAvailable();
+
+      // Don't invoke connectCallback — simulate an unresponsive daemon.
+      // Instead, fire the timeout event.
+      mockSocket.emit('timeout');
+
+      const result = await availablePromise;
+
+      expect(result).toBe(false);
+      expect(mockSocket.destroyed).toBe(true);
+    });
+
+    it('should set a socket timeout when checking availability', async () => {
+      const client = new DaemonClient();
+
+      const availablePromise = client.isServerAvailable();
+
+      // The socket should have a timeout set (30 seconds)
+      expect(mockSocket._timeout).toBe(30_000);
+
+      // Clean up — simulate error to resolve the promise
+      mockSocket.emit('error', new Error('test cleanup'));
+
+      await availablePromise;
+    });
+
+    it('should return true when socket connects successfully', async () => {
+      const client = new DaemonClient();
+
+      const availablePromise = client.isServerAvailable();
+
+      // Simulate successful connection by invoking the connect callback
+      connectCallback?.();
+
+      const result = await availablePromise;
+      expect(result).toBe(true);
+    });
+
+    it('should return false when socket emits error', async () => {
+      const client = new DaemonClient();
+
+      const availablePromise = client.isServerAvailable();
+
+      // Don't invoke connectCallback — simulate a connection error.
+      mockSocket.emit('error', new Error('ECONNREFUSED'));
+
+      const result = await availablePromise;
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/nx/src/daemon/client/daemon-socket-messenger.spec.ts
+++ b/packages/nx/src/daemon/client/daemon-socket-messenger.spec.ts
@@ -1,0 +1,116 @@
+import { DaemonSocketMessenger } from './daemon-socket-messenger';
+import { EventEmitter } from 'events';
+
+class MockSocket extends EventEmitter {
+  destroyed = false;
+  _timeout = 0;
+
+  setTimeout(ms: number) {
+    this._timeout = ms;
+  }
+
+  destroy(err?: Error) {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    if (err) {
+      this.emit('error', err);
+    }
+    this.emit('close');
+  }
+
+  write(_data: any) {}
+}
+
+describe('DaemonSocketMessenger', () => {
+  describe('listen()', () => {
+    it('should destroy the socket on timeout event', () => {
+      const socket = new MockSocket() as any;
+      const messenger = new DaemonSocketMessenger(socket);
+
+      const onError = jest.fn();
+      const onClose = jest.fn();
+
+      messenger.listen(() => {}, onClose, onError);
+
+      // Simulate timeout event
+      socket.emit('timeout');
+
+      expect(socket.destroyed).toBe(true);
+      expect(onError).toHaveBeenCalled();
+      expect(onError.mock.calls[0][0].message).toContain(
+        'Socket timed out communicating with Nx Daemon'
+      );
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('should transition to message exchange timeout after connect', () => {
+      const socket = new MockSocket() as any;
+      const messenger = new DaemonSocketMessenger(socket);
+
+      // Simulate initial connect-phase timeout set by setUpConnection
+      socket.setTimeout(30_000);
+      expect(socket._timeout).toBe(30_000);
+
+      messenger.listen(() => {});
+
+      // Simulate successful connection
+      socket.emit('connect');
+
+      // Should transition to 5-minute message exchange timeout
+      expect(socket._timeout).toBe(5 * 60 * 1000);
+    });
+
+    it('should propagate socket errors to onError callback', () => {
+      const socket = new MockSocket() as any;
+      const messenger = new DaemonSocketMessenger(socket);
+
+      const onError = jest.fn();
+      messenger.listen(
+        () => {},
+        () => {},
+        onError
+      );
+
+      const error = new Error('connection refused');
+      socket.emit('error', error);
+
+      expect(onError).toHaveBeenCalledWith(error);
+    });
+
+    it('should call onClose when socket closes', () => {
+      const socket = new MockSocket() as any;
+      const messenger = new DaemonSocketMessenger(socket);
+
+      const onClose = jest.fn();
+      messenger.listen(() => {}, onClose);
+
+      socket.emit('close');
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('should keep aggressive connect timeout until connection is established', () => {
+      const socket = new MockSocket() as any;
+      const messenger = new DaemonSocketMessenger(socket);
+
+      // Simulate initial connect-phase timeout
+      socket.setTimeout(30_000);
+
+      messenger.listen(() => {});
+
+      // Before connect event, timeout should remain at connect-phase value
+      expect(socket._timeout).toBe(30_000);
+    });
+  });
+
+  describe('close()', () => {
+    it('should destroy the socket', () => {
+      const socket = new MockSocket() as any;
+      const messenger = new DaemonSocketMessenger(socket);
+
+      messenger.close();
+
+      expect(socket.destroyed).toBe(true);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2764,7 +2764,7 @@ importers:
         version: 2.3.0
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 21.1.0(f980f72dbbe44fac982acd2259e3661a)
+        version: 21.1.0(ccee4f196e8198b3110621a4745916e5)
       '@angular/localize':
         specifier: catalog:angular-supported-versions
         version: 21.1.0(@angular/compiler-cli@21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2))(@angular/compiler@21.1.0)
@@ -2870,7 +2870,7 @@ importers:
     dependencies:
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 21.1.0(9613cd481432c3d065f8f0fc994cc2d8)
+        version: 21.1.0(6b1a0cf84e61f1c844c41da18f524ece)
       '@angular/compiler-cli':
         specifier: catalog:angular-supported-versions
         version: 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
@@ -4479,7 +4479,7 @@ importers:
         version: 3.0.0
       webpack-subresource-integrity:
         specifier: ^5.1.0
-        version: 5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
+        version: 5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
     devDependencies:
       nx:
         specifier: workspace:*
@@ -27101,10 +27101,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.1.0(9613cd481432c3d065f8f0fc994cc2d8)':
+  '@angular/build@21.1.0(6b1a0cf84e61f1c844c41da18f524ece)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2101.0(chokidar@5.0.0)
+      '@angular-devkit/architect': 0.2101.0(chokidar@3.6.0)
       '@angular/compiler': 21.1.0
       '@angular/compiler-cli': 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
       '@babel/core': 7.28.5
@@ -27159,10 +27159,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@21.1.0(f980f72dbbe44fac982acd2259e3661a)':
+  '@angular/build@21.1.0(ccee4f196e8198b3110621a4745916e5)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2101.0(chokidar@5.0.0)
+      '@angular-devkit/architect': 0.2101.0(chokidar@3.6.0)
       '@angular/compiler': 21.1.0
       '@angular/compiler-cli': 21.1.0(@angular/compiler@21.1.0)(typescript@5.9.2)
       '@babel/core': 7.28.5
@@ -30558,7 +30558,7 @@ snapshots:
       execa: 5.1.1
       fs-extra: 11.3.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3)
+      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
       leven: 3.1.0
       lodash: 4.17.21
       open: 8.4.2
@@ -44975,7 +44975,7 @@ snapshots:
       tapable: 2.2.2
       webpack: 5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
-  html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3):
+  html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -56114,12 +56114,12 @@ snapshots:
     optionalDependencies:
       html-webpack-plugin: 5.5.0(webpack@5.101.3)
 
-  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)):
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     optionalDependencies:
-      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3)
+      html-webpack-plugin: 5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
 
   webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3))))(webpack@5.104.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3))):
     dependencies:


### PR DESCRIPTION
## Current Behavior

Nx commands hang indefinitely in GitHub Actions CI environments. The process stops responding during daemon initialization with no error output and no crash. Setting `NX_DAEMON=false` and `NX_IS_OFFLINE=true` does not reliably fix the issue.

The root cause is that multiple `net.connect()` calls in the daemon client have no timeout handlers. In CI environments with containerization or resource constraints, the daemon socket path may exist but the daemon process isn't responsive — causing `connect()` to hang forever.

## Expected Behavior

Nx should detect unresponsive daemon connections within 30 seconds and fail gracefully instead of hanging indefinitely. Socket connections should time out, file handles should be cleaned up promptly, and HTTP downloads should have reasonable timeouts.

## Related Issue(s)

Fixes #33998
