### PR TITLE
feat(core): add yarn berry catalog support

### DIFF
--- a/packages/devkit/src/utils/catalog/manager-factory.ts
+++ b/packages/devkit/src/utils/catalog/manager-factory.ts
@@ -1,6 +1,7 @@
 import { detectPackageManager } from 'nx/src/devkit-exports';
 import type { CatalogManager } from './manager';
 import { PnpmCatalogManager } from './pnpm-manager';
+import { YarnCatalogManager } from './yarn-manager';
 
 /**
  * Factory function to get the appropriate catalog manager based on the package manager
@@ -13,6 +14,8 @@ export function getCatalogManager(
   switch (packageManager) {
     case 'pnpm':
       return new PnpmCatalogManager();
+    case 'yarn':
+      return new YarnCatalogManager();
     default:
       return null;
   }

--- a/packages/devkit/src/utils/catalog/manager.ts
+++ b/packages/devkit/src/utils/catalog/manager.ts
@@ -1,6 +1,21 @@
 import type { Tree } from 'nx/src/devkit-exports';
-import type { PnpmWorkspaceYaml } from 'nx/src/utils/pnpm-workspace';
-import type { CatalogReference } from './types';
+import type { CatalogDefinitions, CatalogReference } from './types';
+
+export function formatCatalogError(
+  error: string,
+  suggestions: string[]
+): string {
+  let message = error;
+
+  if (suggestions.length > 0) {
+    message += '\n\nSuggestions:';
+    suggestions.forEach((suggestion) => {
+      message += `\n  • ${suggestion}`;
+    });
+  }
+
+  return message;
+}
 
 /**
  * Interface for catalog managers that handle package manager-specific catalog implementations.
@@ -12,11 +27,13 @@ export interface CatalogManager {
 
   parseCatalogReference(version: string): CatalogReference | null;
 
+  getCatalogDefinitionFilePaths(): string[];
+
   /**
    * Get catalog definitions from the workspace.
    */
-  getCatalogDefinitions(workspaceRoot: string): PnpmWorkspaceYaml | null;
-  getCatalogDefinitions(tree: Tree): PnpmWorkspaceYaml | null;
+  getCatalogDefinitions(workspaceRoot: string): CatalogDefinitions | null;
+  getCatalogDefinitions(tree: Tree): CatalogDefinitions | null;
 
   /**
    * Resolve a catalog reference to an actual version.

--- a/packages/devkit/src/utils/catalog/pnpm-manager.ts
+++ b/packages/devkit/src/utils/catalog/pnpm-manager.ts
@@ -3,12 +3,12 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { output, type Tree } from 'nx/src/devkit-exports';
 import { readYamlFile } from 'nx/src/devkit-internals';
-import type {
-  PnpmCatalogEntry,
-  PnpmWorkspaceYaml,
-} from 'nx/src/utils/pnpm-workspace';
 import { formatCatalogError, type CatalogManager } from './manager';
-import type { CatalogReference } from './types';
+import type {
+  CatalogDefinitions,
+  CatalogEntry,
+  CatalogReference,
+} from './types';
 
 const PNPM_WORKSPACE_FILENAME = 'pnpm-workspace.yaml';
 
@@ -42,7 +42,7 @@ export class PnpmCatalogManager implements CatalogManager {
     return [PNPM_WORKSPACE_FILENAME];
   }
 
-  getCatalogDefinitions(treeOrRoot: Tree | string): PnpmWorkspaceYaml | null {
+  getCatalogDefinitions(treeOrRoot: Tree | string): CatalogDefinitions | null {
     if (typeof treeOrRoot === 'string') {
       const configPath = join(treeOrRoot, PNPM_WORKSPACE_FILENAME);
       if (!existsSync(configPath)) {
@@ -72,7 +72,7 @@ export class PnpmCatalogManager implements CatalogManager {
       return null;
     }
 
-    let catalogToUse: PnpmCatalogEntry | undefined;
+    let catalogToUse: CatalogEntry | undefined;
     if (catalogRef.isDefaultCatalog) {
       // Check both locations for default catalog
       catalogToUse = catalogDefs.catalog ?? catalogDefs.catalogs?.default;
@@ -105,7 +105,7 @@ export class PnpmCatalogManager implements CatalogManager {
       );
     }
 
-    let catalogToUse: PnpmCatalogEntry | undefined;
+    let catalogToUse: CatalogEntry | undefined;
 
     if (catalogRef.isDefaultCatalog) {
       const hasCatalog = !!catalogDefs.catalog;
@@ -253,7 +253,7 @@ export class PnpmCatalogManager implements CatalogManager {
         const normalizedCatalogName =
           catalogName === 'default' ? undefined : catalogName;
 
-        let targetCatalog: PnpmCatalogEntry;
+        let targetCatalog: CatalogEntry;
         if (!normalizedCatalogName) {
           // Default catalog - update whichever exists, prefer catalog over catalogs.default
           if (configData.catalog) {
@@ -297,9 +297,9 @@ export class PnpmCatalogManager implements CatalogManager {
   }
 }
 
-function readConfigFromFs(path: string): PnpmWorkspaceYaml | null {
+function readConfigFromFs(path: string): CatalogDefinitions | null {
   try {
-    return readYamlFile<PnpmWorkspaceYaml>(path);
+    return readYamlFile<CatalogDefinitions>(path);
   } catch (error) {
     output.warn({
       title: `Unable to parse ${PNPM_WORKSPACE_FILENAME}`,
@@ -312,11 +312,11 @@ function readConfigFromFs(path: string): PnpmWorkspaceYaml | null {
 function readConfigFromTree(
   tree: Tree,
   path: string
-): PnpmWorkspaceYaml | null {
+): CatalogDefinitions | null {
   const content = tree.read(path, 'utf-8');
 
   try {
-    return load(content, { filename: path }) as PnpmWorkspaceYaml;
+    return load(content, { filename: path }) as CatalogDefinitions;
   } catch (error) {
     output.warn({
       title: `Unable to parse ${PNPM_WORKSPACE_FILENAME}`,

--- a/packages/devkit/src/utils/catalog/types.ts
+++ b/packages/devkit/src/utils/catalog/types.ts
@@ -2,3 +2,8 @@ export interface CatalogReference {
   catalogName?: string;
   isDefaultCatalog: boolean;
 }
+
+export interface CatalogDefinitions {
+  catalog?: Record<string, string>;
+  catalogs?: Record<string, Record<string, string>>;
+}

--- a/packages/devkit/src/utils/catalog/types.ts
+++ b/packages/devkit/src/utils/catalog/types.ts
@@ -3,7 +3,11 @@ export interface CatalogReference {
   isDefaultCatalog: boolean;
 }
 
+export interface CatalogEntry {
+  [packageName: string]: string;
+}
+
 export interface CatalogDefinitions {
-  catalog?: Record<string, string>;
-  catalogs?: Record<string, Record<string, string>>;
+  catalog?: CatalogEntry;
+  catalogs?: Record<string, CatalogEntry>;
 }

--- a/packages/devkit/src/utils/catalog/yarn-manager.ts
+++ b/packages/devkit/src/utils/catalog/yarn-manager.ts
@@ -3,12 +3,12 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { output, type Tree } from 'nx/src/devkit-exports';
 import { readYamlFile } from 'nx/src/devkit-internals';
-import type {
-  YarnCatalogEntry,
-  YarnWorkspaceYaml,
-} from 'nx/src/utils/yarn-workspace';
 import { formatCatalogError, type CatalogManager } from './manager';
-import type { CatalogReference } from './types';
+import type {
+  CatalogDefinitions,
+  CatalogEntry,
+  CatalogReference,
+} from './types';
 
 const YARNRC_FILENAME = '.yarnrc.yml';
 
@@ -42,7 +42,7 @@ export class YarnCatalogManager implements CatalogManager {
     return [YARNRC_FILENAME];
   }
 
-  getCatalogDefinitions(treeOrRoot: Tree | string): YarnWorkspaceYaml | null {
+  getCatalogDefinitions(treeOrRoot: Tree | string): CatalogDefinitions | null {
     if (typeof treeOrRoot === 'string') {
       const configPath = join(treeOrRoot, YARNRC_FILENAME);
       if (!existsSync(configPath)) {
@@ -72,7 +72,7 @@ export class YarnCatalogManager implements CatalogManager {
       return null;
     }
 
-    let catalogToUse: YarnCatalogEntry | undefined;
+    let catalogToUse: CatalogEntry | undefined;
     if (catalogRef.isDefaultCatalog) {
       // Check both locations for default catalog
       catalogToUse = catalogDefs.catalog ?? catalogDefs.catalogs?.default;
@@ -105,7 +105,7 @@ export class YarnCatalogManager implements CatalogManager {
       );
     }
 
-    let catalogToUse: YarnCatalogEntry | undefined;
+    let catalogToUse: CatalogEntry | undefined;
 
     if (catalogRef.isDefaultCatalog) {
       const hasCatalog = !!catalogDefs.catalog;
@@ -252,7 +252,7 @@ export class YarnCatalogManager implements CatalogManager {
         const normalizedCatalogName =
           catalogName === 'default' ? undefined : catalogName;
 
-        let targetCatalog: YarnCatalogEntry;
+        let targetCatalog: CatalogEntry;
         if (!normalizedCatalogName) {
           // Default catalog - update whichever exists, prefer catalog over catalogs.default
           if (configData.catalog) {
@@ -296,9 +296,9 @@ export class YarnCatalogManager implements CatalogManager {
   }
 }
 
-function readConfigFromFs(path: string): YarnWorkspaceYaml | null {
+function readConfigFromFs(path: string): CatalogDefinitions | null {
   try {
-    return readYamlFile<YarnWorkspaceYaml>(path);
+    return readYamlFile<CatalogDefinitions>(path);
   } catch (error) {
     output.warn({
       title: `Unable to parse ${YARNRC_FILENAME}`,
@@ -311,12 +311,11 @@ function readConfigFromFs(path: string): YarnWorkspaceYaml | null {
 function readConfigFromTree(
   tree: Tree,
   path: string
-): YarnWorkspaceYaml | null {
+): CatalogDefinitions | null {
   const content = tree.read(path, 'utf-8');
-  const { load } = require('@zkochan/js-yaml');
 
   try {
-    return load(content, { filename: path }) as YarnWorkspaceYaml;
+    return load(content, { filename: path }) as CatalogDefinitions;
   } catch (error) {
     output.warn({
       title: `Unable to parse ${YARNRC_FILENAME}`,

--- a/packages/devkit/src/utils/catalog/yarn-manager.ts
+++ b/packages/devkit/src/utils/catalog/yarn-manager.ts
@@ -4,19 +4,19 @@ import { join } from 'node:path';
 import { output, type Tree } from 'nx/src/devkit-exports';
 import { readYamlFile } from 'nx/src/devkit-internals';
 import type {
-  PnpmCatalogEntry,
-  PnpmWorkspaceYaml,
-} from 'nx/src/utils/pnpm-workspace';
+  YarnCatalogEntry,
+  YarnWorkspaceYaml,
+} from 'nx/src/utils/yarn-workspace';
 import { formatCatalogError, type CatalogManager } from './manager';
 import type { CatalogReference } from './types';
 
-const PNPM_WORKSPACE_FILENAME = 'pnpm-workspace.yaml';
+const YARNRC_FILENAME = '.yarnrc.yml';
 
 /**
- * PNPM-specific catalog manager implementation
+ * Yarn Berry (v4+) catalog manager implementation
  */
-export class PnpmCatalogManager implements CatalogManager {
-  readonly name = 'pnpm';
+export class YarnCatalogManager implements CatalogManager {
+  readonly name = 'yarn';
   readonly catalogProtocol = 'catalog:';
 
   isCatalogReference(version: string): boolean {
@@ -39,21 +39,21 @@ export class PnpmCatalogManager implements CatalogManager {
   }
 
   getCatalogDefinitionFilePaths(): string[] {
-    return [PNPM_WORKSPACE_FILENAME];
+    return [YARNRC_FILENAME];
   }
 
-  getCatalogDefinitions(treeOrRoot: Tree | string): PnpmWorkspaceYaml | null {
+  getCatalogDefinitions(treeOrRoot: Tree | string): YarnWorkspaceYaml | null {
     if (typeof treeOrRoot === 'string') {
-      const configPath = join(treeOrRoot, PNPM_WORKSPACE_FILENAME);
+      const configPath = join(treeOrRoot, YARNRC_FILENAME);
       if (!existsSync(configPath)) {
         return null;
       }
       return readConfigFromFs(configPath);
     } else {
-      if (!treeOrRoot.exists(PNPM_WORKSPACE_FILENAME)) {
+      if (!treeOrRoot.exists(YARNRC_FILENAME)) {
         return null;
       }
-      return readConfigFromTree(treeOrRoot, PNPM_WORKSPACE_FILENAME);
+      return readConfigFromTree(treeOrRoot, YARNRC_FILENAME);
     }
   }
 
@@ -72,7 +72,7 @@ export class PnpmCatalogManager implements CatalogManager {
       return null;
     }
 
-    let catalogToUse: PnpmCatalogEntry | undefined;
+    let catalogToUse: YarnCatalogEntry | undefined;
     if (catalogRef.isDefaultCatalog) {
       // Check both locations for default catalog
       catalogToUse = catalogDefs.catalog ?? catalogDefs.catalogs?.default;
@@ -99,19 +99,19 @@ export class PnpmCatalogManager implements CatalogManager {
     if (!catalogDefs) {
       throw new Error(
         formatCatalogError(
-          `Cannot get Pnpm catalog definitions. No ${PNPM_WORKSPACE_FILENAME} found in workspace root.`,
-          [`Create a ${PNPM_WORKSPACE_FILENAME} file in your workspace root`]
+          `Cannot get Yarn catalog definitions. No ${YARNRC_FILENAME} found in workspace root.`,
+          [`Create a ${YARNRC_FILENAME} file in your workspace root`]
         )
       );
     }
 
-    let catalogToUse: PnpmCatalogEntry | undefined;
+    let catalogToUse: YarnCatalogEntry | undefined;
 
     if (catalogRef.isDefaultCatalog) {
       const hasCatalog = !!catalogDefs.catalog;
       const hasCatalogsDefault = !!catalogDefs.catalogs?.default;
 
-      // Error if both defined (matches pnpm behavior)
+      // Error if both defined
       if (hasCatalog && hasCatalogsDefault) {
         throw new Error(
           "The 'default' catalog was defined multiple times. Use the 'catalog' field or 'catalogs.default', but not both."
@@ -123,7 +123,7 @@ export class PnpmCatalogManager implements CatalogManager {
         const availableCatalogs = Object.keys(catalogDefs.catalogs || {});
 
         const suggestions = [
-          `Define a default catalog in ${PNPM_WORKSPACE_FILENAME} under the "catalog" key`,
+          `Define a default catalog in ${YARNRC_FILENAME} under the "catalog" key`,
         ];
         if (availableCatalogs.length > 0) {
           suggestions.push(
@@ -135,7 +135,7 @@ export class PnpmCatalogManager implements CatalogManager {
 
         throw new Error(
           formatCatalogError(
-            `No default catalog defined in ${PNPM_WORKSPACE_FILENAME}`,
+            `No default catalog defined in ${YARNRC_FILENAME}`,
             suggestions
           )
         );
@@ -153,7 +153,7 @@ export class PnpmCatalogManager implements CatalogManager {
             : null;
 
         const suggestions = [
-          `Define the catalog in ${PNPM_WORKSPACE_FILENAME} under the "catalogs" key`,
+          `Define the catalog in ${YARNRC_FILENAME} under the "catalogs" key`,
         ];
         if (availableCatalogs.length > 0) {
           suggestions.push(
@@ -168,7 +168,7 @@ export class PnpmCatalogManager implements CatalogManager {
 
         throw new Error(
           formatCatalogError(
-            `Catalog "${catalogRef.catalogName}" not found in ${PNPM_WORKSPACE_FILENAME}`,
+            `Catalog "${catalogRef.catalogName}" not found in ${YARNRC_FILENAME}`,
             suggestions
           )
         );
@@ -189,7 +189,7 @@ export class PnpmCatalogManager implements CatalogManager {
 
       const availablePackages = Object.keys(catalogToUse!);
       const suggestions = [
-        `Add "${packageName}" to ${catalogName} in ${PNPM_WORKSPACE_FILENAME}`,
+        `Add "${packageName}" to ${catalogName} in ${YARNRC_FILENAME}`,
       ];
       if (availablePackages.length > 0) {
         suggestions.push(
@@ -221,23 +221,22 @@ export class PnpmCatalogManager implements CatalogManager {
     let writeYaml: (content: string) => void;
 
     if (typeof treeOrRoot === 'string') {
-      const configPath = join(treeOrRoot, PNPM_WORKSPACE_FILENAME);
+      const configPath = join(treeOrRoot, YARNRC_FILENAME);
       checkExists = () => existsSync(configPath);
       readYaml = () => readFileSync(configPath, 'utf-8');
       writeYaml = (content) => writeFileSync(configPath, content, 'utf-8');
     } else {
-      checkExists = () => treeOrRoot.exists(PNPM_WORKSPACE_FILENAME);
-      readYaml = () => treeOrRoot.read(PNPM_WORKSPACE_FILENAME, 'utf-8');
-      writeYaml = (content) =>
-        treeOrRoot.write(PNPM_WORKSPACE_FILENAME, content);
+      checkExists = () => treeOrRoot.exists(YARNRC_FILENAME);
+      readYaml = () => treeOrRoot.read(YARNRC_FILENAME, 'utf-8');
+      writeYaml = (content) => treeOrRoot.write(YARNRC_FILENAME, content);
     }
 
     if (!checkExists()) {
       output.warn({
-        title: `No ${PNPM_WORKSPACE_FILENAME} found`,
+        title: `No ${YARNRC_FILENAME} found`,
         bodyLines: [
-          `Cannot update catalog versions without a ${PNPM_WORKSPACE_FILENAME} file.`,
-          `Create a ${PNPM_WORKSPACE_FILENAME} file to use catalogs.`,
+          `Cannot update catalog versions without a ${YARNRC_FILENAME} file.`,
+          `Create a ${YARNRC_FILENAME} file to use catalogs.`,
         ],
       });
       return;
@@ -253,7 +252,7 @@ export class PnpmCatalogManager implements CatalogManager {
         const normalizedCatalogName =
           catalogName === 'default' ? undefined : catalogName;
 
-        let targetCatalog: PnpmCatalogEntry;
+        let targetCatalog: YarnCatalogEntry;
         if (!normalizedCatalogName) {
           // Default catalog - update whichever exists, prefer catalog over catalogs.default
           if (configData.catalog) {
@@ -297,12 +296,12 @@ export class PnpmCatalogManager implements CatalogManager {
   }
 }
 
-function readConfigFromFs(path: string): PnpmWorkspaceYaml | null {
+function readConfigFromFs(path: string): YarnWorkspaceYaml | null {
   try {
-    return readYamlFile<PnpmWorkspaceYaml>(path);
+    return readYamlFile<YarnWorkspaceYaml>(path);
   } catch (error) {
     output.warn({
-      title: `Unable to parse ${PNPM_WORKSPACE_FILENAME}`,
+      title: `Unable to parse ${YARNRC_FILENAME}`,
       bodyLines: [error.toString()],
     });
     return null;
@@ -312,14 +311,15 @@ function readConfigFromFs(path: string): PnpmWorkspaceYaml | null {
 function readConfigFromTree(
   tree: Tree,
   path: string
-): PnpmWorkspaceYaml | null {
+): YarnWorkspaceYaml | null {
   const content = tree.read(path, 'utf-8');
+  const { load } = require('@zkochan/js-yaml');
 
   try {
-    return load(content, { filename: path }) as PnpmWorkspaceYaml;
+    return load(content, { filename: path }) as YarnWorkspaceYaml;
   } catch (error) {
     output.warn({
-      title: `Unable to parse ${PNPM_WORKSPACE_FILENAME}`,
+      title: `Unable to parse ${YARNRC_FILENAME}`,
       bodyLines: [error.toString()],
     });
     return null;

--- a/packages/nx/src/utils/catalog/manager-factory.ts
+++ b/packages/nx/src/utils/catalog/manager-factory.ts
@@ -1,6 +1,7 @@
 import { detectPackageManager } from '../package-manager';
 import type { CatalogManager } from './manager';
 import { PnpmCatalogManager } from './pnpm-manager';
+import { YarnCatalogManager } from './yarn-manager';
 
 /**
  * Factory function to get the appropriate catalog manager based on the package manager
@@ -13,6 +14,8 @@ export function getCatalogManager(
   switch (packageManager) {
     case 'pnpm':
       return new PnpmCatalogManager();
+    case 'yarn':
+      return new YarnCatalogManager();
     default:
       return null;
   }

--- a/packages/nx/src/utils/catalog/manager.ts
+++ b/packages/nx/src/utils/catalog/manager.ts
@@ -1,6 +1,21 @@
 import type { Tree } from '../../generators/tree';
-import type { PnpmWorkspaceYaml } from '../pnpm-workspace';
-import type { CatalogReference } from './types';
+import type { CatalogDefinitions, CatalogReference } from './types';
+
+export function formatCatalogError(
+  error: string,
+  suggestions: string[]
+): string {
+  let message = error;
+
+  if (suggestions.length > 0) {
+    message += '\n\nSuggestions:';
+    suggestions.forEach((suggestion) => {
+      message += `\n  • ${suggestion}`;
+    });
+  }
+
+  return message;
+}
 
 /**
  * Interface for catalog managers that handle package manager-specific catalog implementations.
@@ -17,8 +32,8 @@ export interface CatalogManager {
   /**
    * Get catalog definitions from the workspace.
    */
-  getCatalogDefinitions(workspaceRoot: string): PnpmWorkspaceYaml | null;
-  getCatalogDefinitions(tree: Tree): PnpmWorkspaceYaml | null;
+  getCatalogDefinitions(workspaceRoot: string): CatalogDefinitions | null;
+  getCatalogDefinitions(tree: Tree): CatalogDefinitions | null;
 
   /**
    * Resolve a catalog reference to an actual version.

--- a/packages/nx/src/utils/catalog/pnpm-manager.ts
+++ b/packages/nx/src/utils/catalog/pnpm-manager.ts
@@ -4,9 +4,12 @@ import { join } from 'node:path';
 import type { Tree } from '../../generators/tree';
 import { readYamlFile } from '../fileutils';
 import { output } from '../output';
-import type { PnpmCatalogEntry, PnpmWorkspaceYaml } from '../pnpm-workspace';
 import { formatCatalogError, type CatalogManager } from './manager';
-import type { CatalogReference } from './types';
+import type {
+  CatalogDefinitions,
+  CatalogEntry,
+  CatalogReference,
+} from './types';
 
 const PNPM_WORKSPACE_FILENAME = 'pnpm-workspace.yaml';
 
@@ -40,7 +43,7 @@ export class PnpmCatalogManager implements CatalogManager {
     return [PNPM_WORKSPACE_FILENAME];
   }
 
-  getCatalogDefinitions(treeOrRoot: Tree | string): PnpmWorkspaceYaml | null {
+  getCatalogDefinitions(treeOrRoot: Tree | string): CatalogDefinitions | null {
     if (typeof treeOrRoot === 'string') {
       const configPath = join(treeOrRoot, PNPM_WORKSPACE_FILENAME);
       if (!existsSync(configPath)) {
@@ -70,7 +73,7 @@ export class PnpmCatalogManager implements CatalogManager {
       return null;
     }
 
-    let catalogToUse: PnpmCatalogEntry | undefined;
+    let catalogToUse: CatalogEntry | undefined;
     if (catalogRef.isDefaultCatalog) {
       // Check both locations for default catalog
       catalogToUse = catalogDefs.catalog ?? catalogDefs.catalogs?.default;
@@ -103,7 +106,7 @@ export class PnpmCatalogManager implements CatalogManager {
       );
     }
 
-    let catalogToUse: PnpmCatalogEntry | undefined;
+    let catalogToUse: CatalogEntry | undefined;
 
     if (catalogRef.isDefaultCatalog) {
       const hasCatalog = !!catalogDefs.catalog;
@@ -251,7 +254,7 @@ export class PnpmCatalogManager implements CatalogManager {
         const normalizedCatalogName =
           catalogName === 'default' ? undefined : catalogName;
 
-        let targetCatalog: PnpmCatalogEntry;
+        let targetCatalog: CatalogEntry;
         if (!normalizedCatalogName) {
           // Default catalog - update whichever exists, prefer catalog over catalogs.default
           if (configData.catalog) {
@@ -295,9 +298,9 @@ export class PnpmCatalogManager implements CatalogManager {
   }
 }
 
-function readConfigFromFs(path: string): PnpmWorkspaceYaml | null {
+function readConfigFromFs(path: string): CatalogDefinitions | null {
   try {
-    return readYamlFile<PnpmWorkspaceYaml>(path);
+    return readYamlFile<CatalogDefinitions>(path);
   } catch (error) {
     output.warn({
       title: `Unable to parse ${PNPM_WORKSPACE_FILENAME}`,
@@ -310,11 +313,11 @@ function readConfigFromFs(path: string): PnpmWorkspaceYaml | null {
 function readConfigFromTree(
   tree: Tree,
   path: string
-): PnpmWorkspaceYaml | null {
+): CatalogDefinitions | null {
   const content = tree.read(path, 'utf-8');
 
   try {
-    return load(content, { filename: path }) as PnpmWorkspaceYaml;
+    return load(content, { filename: path }) as CatalogDefinitions;
   } catch (error) {
     output.warn({
       title: `Unable to parse ${PNPM_WORKSPACE_FILENAME}`,

--- a/packages/nx/src/utils/catalog/types.ts
+++ b/packages/nx/src/utils/catalog/types.ts
@@ -2,3 +2,8 @@ export interface CatalogReference {
   catalogName?: string;
   isDefaultCatalog: boolean;
 }
+
+export interface CatalogDefinitions {
+  catalog?: Record<string, string>;
+  catalogs?: Record<string, Record<string, string>>;
+}

--- a/packages/nx/src/utils/catalog/types.ts
+++ b/packages/nx/src/utils/catalog/types.ts
@@ -3,7 +3,11 @@ export interface CatalogReference {
   isDefaultCatalog: boolean;
 }
 
+export interface CatalogEntry {
+  [packageName: string]: string;
+}
+
 export interface CatalogDefinitions {
-  catalog?: Record<string, string>;
-  catalogs?: Record<string, Record<string, string>>;
+  catalog?: CatalogEntry;
+  catalogs?: Record<string, CatalogEntry>;
 }

--- a/packages/nx/src/utils/catalog/yarn-manager.spec.ts
+++ b/packages/nx/src/utils/catalog/yarn-manager.spec.ts
@@ -1,0 +1,592 @@
+import { load } from '@zkochan/js-yaml';
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import type { Tree } from '../../generators/tree';
+import { YarnCatalogManager } from './yarn-manager';
+
+describe('YarnCatalogManager', () => {
+  let tree: Tree;
+  let manager: YarnCatalogManager;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    manager = new YarnCatalogManager();
+  });
+
+  describe('isCatalogReference', () => {
+    it('should return true for catalog references', () => {
+      expect(manager.isCatalogReference('catalog:')).toBe(true);
+      expect(manager.isCatalogReference('catalog:react18')).toBe(true);
+    });
+
+    it('should return false for non-catalog references', () => {
+      expect(manager.isCatalogReference('^18.0.0')).toBe(false);
+      expect(manager.isCatalogReference('latest')).toBe(false);
+      expect(manager.isCatalogReference('catalog')).toBe(false);
+    });
+  });
+
+  describe('parseCatalogReference', () => {
+    it('should parse default catalog reference', () => {
+      const result = manager.parseCatalogReference('catalog:');
+
+      expect(result).toStrictEqual({
+        catalogName: undefined,
+        isDefaultCatalog: true,
+      });
+    });
+
+    it('should normalize catalog:default to default catalog reference', () => {
+      const result = manager.parseCatalogReference('catalog:default');
+
+      expect(result).toStrictEqual({
+        catalogName: undefined,
+        isDefaultCatalog: true,
+      });
+    });
+
+    it('should parse named catalog reference', () => {
+      const result = manager.parseCatalogReference('catalog:react18');
+
+      expect(result).toStrictEqual({
+        catalogName: 'react18',
+        isDefaultCatalog: false,
+      });
+    });
+
+    it('should return null for non-catalog reference', () => {
+      const result = manager.parseCatalogReference('^18.0.0');
+
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('getCatalogDefinitions', () => {
+    it('should return null when no .yarnrc.yml exists', () => {
+      const result = manager.getCatalogDefinitions(tree);
+
+      expect(result).toBe(null);
+    });
+
+    it('should parse catalog definitions from .yarnrc.yml', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+nodeLinker: node-modules
+yarnPath: .yarn/releases/yarn-4.0.0.cjs
+catalog:
+  react: ^18.0.0
+  lodash: ^4.17.21
+catalogs:
+  react17:
+    react: ^17.0.0
+    react-dom: ^17.0.0
+  react18:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+`
+      );
+
+      const result = manager.getCatalogDefinitions(tree);
+
+      expect(result.catalog).toStrictEqual({
+        react: '^18.0.0',
+        lodash: '^4.17.21',
+      });
+      expect(result.catalogs).toStrictEqual({
+        react17: {
+          react: '^17.0.0',
+          'react-dom': '^17.0.0',
+        },
+        react18: {
+          react: '^18.0.0',
+          'react-dom': '^18.0.0',
+        },
+      });
+    });
+
+    it('should include catalog fields alongside other config fields', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+nodeLinker: node-modules
+yarnPath: .yarn/releases/yarn-4.0.0.cjs
+catalog:
+  react: ^18.0.0
+`
+      );
+
+      const result = manager.getCatalogDefinitions(tree);
+
+      expect(result.catalog).toStrictEqual({
+        react: '^18.0.0',
+      });
+    });
+
+    it('should handle parsing errors gracefully', () => {
+      tree.write('.yarnrc.yml', 'invalid: yaml: content: [');
+
+      const result = manager.getCatalogDefinitions(tree);
+
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('resolveCatalogReference', () => {
+    it('should resolve default catalog reference from top-level catalog field', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalog:
+  react: ^18.0.0
+`
+      );
+
+      const result = manager.resolveCatalogReference(tree, 'react', 'catalog:');
+
+      expect(result).toBe('^18.0.0');
+    });
+
+    it('should resolve catalog:default from top-level catalog field', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalog:
+  react: ^18.0.0
+`
+      );
+
+      const result = manager.resolveCatalogReference(
+        tree,
+        'react',
+        'catalog:default'
+      );
+
+      expect(result).toBe('^18.0.0');
+    });
+
+    it('should resolve catalog: from catalogs.default field', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalogs:
+  default:
+    react: ^18.0.0
+`
+      );
+
+      const result = manager.resolveCatalogReference(tree, 'react', 'catalog:');
+
+      expect(result).toBe('^18.0.0');
+    });
+
+    it('should resolve catalog:default from catalogs.default field', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalogs:
+  default:
+    react: ^18.0.0
+`
+      );
+
+      const result = manager.resolveCatalogReference(
+        tree,
+        'react',
+        'catalog:default'
+      );
+
+      expect(result).toBe('^18.0.0');
+    });
+
+    it('should resolve named catalog reference', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalogs:
+  react17:
+    react: ^17.0.0
+`
+      );
+
+      const result = manager.resolveCatalogReference(
+        tree,
+        'react',
+        'catalog:react17'
+      );
+
+      expect(result).toBe('^17.0.0');
+    });
+
+    it('should return null for non-catalog references', () => {
+      const result = manager.resolveCatalogReference(tree, 'react', '^18.0.0');
+
+      expect(result).toBe(null);
+    });
+
+    it('should return null for missing catalog', () => {
+      const result = manager.resolveCatalogReference(
+        tree,
+        'react',
+        'catalog:nonexistent'
+      );
+
+      expect(result).toBe(null);
+    });
+
+    it('should return null for missing package in catalog', () => {
+      const result = manager.resolveCatalogReference(
+        tree,
+        'nonexistent',
+        'catalog:'
+      );
+
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('validateCatalogReference', () => {
+    it('should throw for non-catalog syntax', () => {
+      expect(() =>
+        manager.validateCatalogReference(tree, 'react', '^18.0.0')
+      ).toThrow(
+        'Invalid catalog reference syntax: "^18.0.0". Expected format: "catalog:" or "catalog:name"'
+      );
+    });
+
+    it('should throw when .yarnrc.yml not found', () => {
+      expect(() =>
+        manager.validateCatalogReference(tree, 'react', 'catalog:')
+      ).toThrow(
+        'Cannot get Yarn catalog definitions. No .yarnrc.yml found in workspace root.'
+      );
+    });
+
+    it('should throw for catalog: when both definitions exist', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalog:
+  react: ^18.0.0
+catalogs:
+  default:
+    lodash: ^4.17.21
+`
+      );
+
+      expect(() =>
+        manager.validateCatalogReference(tree, 'react', 'catalog:')
+      ).toThrow(
+        "The 'default' catalog was defined multiple times. Use the 'catalog' field or 'catalogs.default', but not both."
+      );
+    });
+
+    it('should throw for catalog:default when both definitions exist', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalog:
+  react: ^18.0.0
+catalogs:
+  default:
+    lodash: ^4.17.21
+`
+      );
+
+      expect(() =>
+        manager.validateCatalogReference(tree, 'react', 'catalog:default')
+      ).toThrow(
+        "The 'default' catalog was defined multiple times. Use the 'catalog' field or 'catalogs.default', but not both."
+      );
+    });
+
+    it('should throw when default catalog not found', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+nodeLinker: node-modules
+`
+      );
+
+      expect(() =>
+        manager.validateCatalogReference(tree, 'react', 'catalog:')
+      ).toThrow('No default catalog defined in .yarnrc.yml');
+    });
+
+    it('should throw when named catalog not found', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+nodeLinker: node-modules
+`
+      );
+
+      expect(() =>
+        manager.validateCatalogReference(tree, 'react', 'catalog:non-existent')
+      ).toThrow('Catalog "non-existent" not found in .yarnrc.yml');
+    });
+
+    it('should throw for a missing package in catalog', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalog:
+  react: ^18.0.0
+`
+      );
+
+      expect(() =>
+        manager.validateCatalogReference(tree, 'lodash', 'catalog:')
+      ).toThrow('Package "lodash" not found in default catalog ("catalog")');
+    });
+
+    it('should not throw for existing catalog entry in top-level catalog', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalog:
+  react: ^18.0.0
+`
+      );
+
+      expect(() =>
+        manager.validateCatalogReference(tree, 'react', 'catalog:')
+      ).not.toThrow();
+    });
+
+    it('should validate catalog:default with top-level catalog field', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalog:
+  react: ^18.0.0
+`
+      );
+
+      expect(() =>
+        manager.validateCatalogReference(tree, 'react', 'catalog:default')
+      ).not.toThrow();
+    });
+
+    it('should validate catalog: with catalogs.default field', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalogs:
+  default:
+    react: ^18.0.0
+`
+      );
+
+      expect(() =>
+        manager.validateCatalogReference(tree, 'react', 'catalog:')
+      ).not.toThrow();
+    });
+
+    it('should validate catalog:default with catalogs.default field', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalogs:
+  default:
+    react: ^18.0.0
+`
+      );
+
+      expect(() =>
+        manager.validateCatalogReference(tree, 'react', 'catalog:default')
+      ).not.toThrow();
+    });
+  });
+
+  describe('updateCatalogVersions', () => {
+    it('should update existing top-level catalog field', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalog:
+  react: ^18.0.0
+  lodash: ^4.17.21
+`
+      );
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.3.0' },
+      ]);
+
+      const content = tree.read('.yarnrc.yml', 'utf-8');
+      const result = load(content);
+      expect(result.catalog.react).toBe('^18.3.0');
+      expect(result.catalog.lodash).toBe('^4.17.21');
+    });
+
+    it('should update existing catalogs.default field', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalogs:
+  default:
+    react: ^18.0.0
+    lodash: ^4.17.21
+`
+      );
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.3.0' },
+      ]);
+
+      const content = tree.read('.yarnrc.yml', 'utf-8');
+      const result = load(content);
+      expect(result.catalogs.default.react).toBe('^18.3.0');
+      expect(result.catalogs.default.lodash).toBe('^4.17.21');
+    });
+
+    it('should update existing top-level catalog field with catalogName: "default"', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalog:
+  react: ^18.0.0
+  lodash: ^4.17.21
+`
+      );
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.3.0', catalogName: 'default' },
+      ]);
+
+      const content = tree.read('.yarnrc.yml', 'utf-8');
+      const result = load(content);
+      expect(result.catalog.react).toBe('^18.3.0');
+      expect(result.catalog.lodash).toBe('^4.17.21');
+    });
+
+    it('should update existing catalogs.default field with catalogName: "default"', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalogs:
+  default:
+    react: ^18.0.0
+    lodash: ^4.17.21
+`
+      );
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.3.0', catalogName: 'default' },
+      ]);
+
+      const content = tree.read('.yarnrc.yml', 'utf-8');
+      const result = load(content);
+      expect(result.catalogs.default.react).toBe('^18.3.0');
+      expect(result.catalogs.default.lodash).toBe('^4.17.21');
+    });
+
+    it('should create catalog field when neither exists', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+nodeLinker: node-modules
+`
+      );
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.0.0' },
+      ]);
+
+      const content = tree.read('.yarnrc.yml', 'utf-8');
+      const result = load(content);
+      expect(result.catalog.react).toBe('^18.0.0');
+      expect(result.catalogs).toBeUndefined();
+    });
+
+    it('should update named catalog', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalogs:
+  react18:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+`
+      );
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.3.0', catalogName: 'react18' },
+      ]);
+
+      const content = tree.read('.yarnrc.yml', 'utf-8');
+      const result = load(content);
+      expect(result.catalogs.react18.react).toBe('^18.3.0');
+      expect(result.catalogs.react18['react-dom']).toBe('^18.0.0');
+    });
+
+    it('should handle multiple updates at once', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalog:
+  react: ^18.0.0
+catalogs:
+  react17:
+    react: ^17.0.0
+`
+      );
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.3.0' },
+        { packageName: 'react', version: '^17.0.2', catalogName: 'react17' },
+      ]);
+
+      const content = tree.read('.yarnrc.yml', 'utf-8');
+      const result = load(content);
+      expect(result.catalog.react).toBe('^18.3.0');
+      expect(result.catalogs.react17.react).toBe('^17.0.2');
+    });
+
+    it('should add new packages to existing catalog', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalog:
+  react: ^18.0.0
+`
+      );
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'lodash', version: '^4.17.21' },
+      ]);
+
+      const content = tree.read('.yarnrc.yml', 'utf-8');
+      const result = load(content);
+      expect(result.catalog.react).toBe('^18.0.0');
+      expect(result.catalog.lodash).toBe('^4.17.21');
+    });
+
+    it('should preserve non-catalog fields in .yarnrc.yml', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+nodeLinker: node-modules
+yarnPath: .yarn/releases/yarn-4.0.0.cjs
+catalog:
+  react: ^18.0.0
+plugins:
+  - path: .yarn/plugins/plugin-typescript.cjs
+`
+      );
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.3.0' },
+      ]);
+
+      const content = tree.read('.yarnrc.yml', 'utf-8');
+      const result = load(content);
+      expect(result.catalog.react).toBe('^18.3.0');
+      expect(result.nodeLinker).toBe('node-modules');
+      expect(result.yarnPath).toBe('.yarn/releases/yarn-4.0.0.cjs');
+      expect(result.plugins).toStrictEqual([
+        { path: '.yarn/plugins/plugin-typescript.cjs' },
+      ]);
+    });
+  });
+});

--- a/packages/nx/src/utils/catalog/yarn-manager.ts
+++ b/packages/nx/src/utils/catalog/yarn-manager.ts
@@ -4,9 +4,12 @@ import { join } from 'node:path';
 import type { Tree } from '../../generators/tree';
 import { readYamlFile } from '../fileutils';
 import { output } from '../output';
-import type { YarnCatalogEntry, YarnWorkspaceYaml } from '../yarn-workspace';
 import { formatCatalogError, type CatalogManager } from './manager';
-import type { CatalogReference } from './types';
+import type {
+  CatalogDefinitions,
+  CatalogEntry,
+  CatalogReference,
+} from './types';
 
 const YARNRC_FILENAME = '.yarnrc.yml';
 
@@ -40,7 +43,7 @@ export class YarnCatalogManager implements CatalogManager {
     return [YARNRC_FILENAME];
   }
 
-  getCatalogDefinitions(treeOrRoot: Tree | string): YarnWorkspaceYaml | null {
+  getCatalogDefinitions(treeOrRoot: Tree | string): CatalogDefinitions | null {
     if (typeof treeOrRoot === 'string') {
       const configPath = join(treeOrRoot, YARNRC_FILENAME);
       if (!existsSync(configPath)) {
@@ -70,7 +73,7 @@ export class YarnCatalogManager implements CatalogManager {
       return null;
     }
 
-    let catalogToUse: YarnCatalogEntry | undefined;
+    let catalogToUse: CatalogEntry | undefined;
     if (catalogRef.isDefaultCatalog) {
       // Check both locations for default catalog
       catalogToUse = catalogDefs.catalog ?? catalogDefs.catalogs?.default;
@@ -103,7 +106,7 @@ export class YarnCatalogManager implements CatalogManager {
       );
     }
 
-    let catalogToUse: YarnCatalogEntry | undefined;
+    let catalogToUse: CatalogEntry | undefined;
 
     if (catalogRef.isDefaultCatalog) {
       const hasCatalog = !!catalogDefs.catalog;
@@ -250,7 +253,7 @@ export class YarnCatalogManager implements CatalogManager {
         const normalizedCatalogName =
           catalogName === 'default' ? undefined : catalogName;
 
-        let targetCatalog: YarnCatalogEntry;
+        let targetCatalog: CatalogEntry;
         if (!normalizedCatalogName) {
           // Default catalog - update whichever exists, prefer catalog over catalogs.default
           if (configData.catalog) {
@@ -294,9 +297,9 @@ export class YarnCatalogManager implements CatalogManager {
   }
 }
 
-function readConfigFromFs(path: string): YarnWorkspaceYaml | null {
+function readConfigFromFs(path: string): CatalogDefinitions | null {
   try {
-    return readYamlFile<YarnWorkspaceYaml>(path);
+    return readYamlFile<CatalogDefinitions>(path);
   } catch (error) {
     output.warn({
       title: `Unable to parse ${YARNRC_FILENAME}`,
@@ -309,12 +312,11 @@ function readConfigFromFs(path: string): YarnWorkspaceYaml | null {
 function readConfigFromTree(
   tree: Tree,
   path: string
-): YarnWorkspaceYaml | null {
+): CatalogDefinitions | null {
   const content = tree.read(path, 'utf-8');
-  const { load } = require('@zkochan/js-yaml');
 
   try {
-    return load(content, { filename: path }) as YarnWorkspaceYaml;
+    return load(content, { filename: path }) as CatalogDefinitions;
   } catch (error) {
     output.warn({
       title: `Unable to parse ${YARNRC_FILENAME}`,

--- a/packages/nx/src/utils/yarn-workspace.ts
+++ b/packages/nx/src/utils/yarn-workspace.ts
@@ -1,8 +1,0 @@
-export interface YarnCatalogEntry {
-  [packageName: string]: string;
-}
-
-export interface YarnWorkspaceYaml {
-  catalog?: YarnCatalogEntry;
-  catalogs?: Record<string, YarnCatalogEntry>;
-}

--- a/packages/nx/src/utils/yarn-workspace.ts
+++ b/packages/nx/src/utils/yarn-workspace.ts
@@ -1,0 +1,8 @@
+export interface YarnCatalogEntry {
+  [packageName: string]: string;
+}
+
+export interface YarnWorkspaceYaml {
+  catalog?: YarnCatalogEntry;
+  catalogs?: Record<string, YarnCatalogEntry>;
+}


### PR DESCRIPTION
## Current Behavior

The Nx catalog system (`catalog:` protocol) only supports pnpm workspaces. Yarn Berry (v4+) introduced [catalog support](https://yarnpkg.com/features/catalogs) in `.yarnrc.yml`, but Nx does not recognize `catalog:` references in Yarn workspaces. This means Yarn Berry users cannot benefit from Nx's catalog-aware dependency resolution, validation, or version updating.

## Expected Behavior

Nx should support Yarn Berry's `catalog:` protocol, just like it does for pnpm. With this PR:

- `catalog:` and `catalog:<name>` references in `package.json` dependencies are correctly resolved against `.yarnrc.yml` definitions for Yarn Berry workspaces
- Validation provides helpful error messages with suggestions (missing catalog, missing package, duplicate default definitions)
- Catalog versions can be updated programmatically via `updateCatalogVersions`
- The `CatalogManager` interface is generalized with `getCatalogDefinitionFilePaths()` and `CatalogDefinitions` to support multiple package managers cleanly

### Changes

- **`YarnCatalogManager`** — New manager that reads `catalog:` / `catalogs:` from `.yarnrc.yml`, mirroring the pnpm implementation with Yarn-specific config paths and error messages
- **`yarn-workspace.ts`** — Type definitions for Yarn's `.yarnrc.yml` catalog structure (`YarnWorkspaceYaml`, `YarnCatalogEntry`)
- **`manager-factory.ts`** — Registers `YarnCatalogManager` for `yarn` package manager
- **`manager.ts`** — Adds `getCatalogDefinitionFilePaths()` to the `CatalogManager` interface; moves `formatCatalogError` here from `types.ts` (runtime function doesn't belong with type-only exports)
- **`types.ts`** — Adds generic `CatalogDefinitions` interface so consumers don't need to depend on package-manager-specific types
- **`pnpm-manager.ts`** — Implements the new `getCatalogDefinitionFilePaths()` method; import cleanup
- **592-line test suite** covering parsing, resolution, validation (named catalogs, default catalog, dual-definition errors, missing catalogs/packages with suggestions), and `updateCatalogVersions`

### Context

I'm currently applying a patch on the compiled `@nx/devkit` package in my Yarn Berry project to get catalog support while waiting for upstream support:

<details>
<summary>Current workaround patch on <code>@nx/devkit</code></summary>

```diff
diff --git a/src/utils/catalog/manager-factory.js b/src/utils/catalog/manager-factory.js
index 6216749..d46e242 100644
--- a/src/utils/catalog/manager-factory.js
+++ b/src/utils/catalog/manager-factory.js
@@ -3,6 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.getCatalogManager = getCatalogManager;
 const devkit_exports_1 = require("nx/src/devkit-exports");
 const pnpm_manager_1 = require("./pnpm-manager");
+const yarn_manager_1 = require("./yarn-manager");
 /**
  * Factory function to get the appropriate catalog manager based on the package manager
  */
@@ -11,6 +12,8 @@ function getCatalogManager(workspaceRoot) {
     switch (packageManager) {
         case 'pnpm':
             return new pnpm_manager_1.PnpmCatalogManager();
+        case 'yarn':
+            return new yarn_manager_1.YarnCatalogManager();
         default:
             return null;
     }
diff --git a/src/utils/catalog/yarn-manager.js b/src/utils/catalog/yarn-manager.js
new file mode 100644
index 0000000..048fdec
--- /dev/null
+++ b/src/utils/catalog/yarn-manager.js
@@ -0,0 +1,102 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.YarnCatalogManager = void 0;
+const node_fs_1 = require("node:fs");
+const node_path_1 = require("node:path");
+const devkit_exports_1 = require("nx/src/devkit-exports");
+const devkit_internals_1 = require("nx/src/devkit-internals");
+class YarnCatalogManager {
+    constructor() {
+        this.name = 'yarn';
+        this.catalogProtocol = 'catalog:';
+    }
+    isCatalogReference(version) {
+        return version.startsWith(this.catalogProtocol);
+    }
+    parseCatalogReference(version) {
+        if (!this.isCatalogReference(version)) { return null; }
+        return { catalogName: undefined, isDefaultCatalog: true };
+    }
+    getCatalogDefinitions(treeOrRoot) {
+        if (typeof treeOrRoot === 'string') {
+            const p = (0, node_path_1.join)(treeOrRoot, '.yarnrc.yml');
+            if (!(0, node_fs_1.existsSync)(p)) { return null; }
+            return readYamlFileFromFs(p);
+        } else {
+            if (!treeOrRoot.exists('.yarnrc.yml')) { return null; }
+            return readYamlFileFromTree(treeOrRoot, '.yarnrc.yml');
+        }
+    }
+    resolveCatalogReference(treeOrRoot, packageName, version) {
+        if (!this.parseCatalogReference(version)) { return null; }
+        const config = this.getCatalogDefinitions(treeOrRoot);
+        if (!config || !config.catalog) { return null; }
+        return config.catalog[packageName] || null;
+    }
+    validateCatalogReference(treeOrRoot, packageName, version) {
+        if (!this.parseCatalogReference(version)) {
+            throw new Error(`Invalid catalog reference: "${version}"`);
+        }
+        const config = this.getCatalogDefinitions(treeOrRoot);
+        if (!config) { throw new Error('No .yarnrc.yml found'); }
+        if (!config.catalog) { throw new Error('No catalog in .yarnrc.yml'); }
+        if (!config.catalog[packageName]) {
+            throw new Error(`"${packageName}" not in .yarnrc.yml catalog`);
+        }
+    }
+    updateCatalogVersions() {}
+}
+exports.YarnCatalogManager = YarnCatalogManager;
+function readYamlFileFromFs(path) {
+    try { return (0, devkit_internals_1.readYamlFile)(path); }
+    catch (e) {
+        devkit_exports_1.output.warn({ title: 'Unable to parse .yarnrc.yml', bodyLines: [e.toString()] });
+        return null;
+    }
+}
+function readYamlFileFromTree(tree, path) {
+    const content = tree.read(path, 'utf-8');
+    const { load } = require('@zkochan/js-yaml');
+    try { return load(content, { filename: path }); }
+    catch (e) {
+        devkit_exports_1.output.warn({ title: 'Unable to parse .yarnrc.yml', bodyLines: [e.toString()] });
+        return null;
+    }
+}
```

</details>

This PR replaces that workaround with a proper TypeScript implementation including full test coverage, named catalog support, helpful error messages, and `updateCatalogVersions` support.

## Related Issue(s)

<!-- No existing issue found for Yarn Berry catalog support — this PR introduces the feature -->