### PR TITLE
chore(repo): upgrade fast-xml-parser to 5.3.7 to fix CVE-2026-25896

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "eslint-plugin-react-hooks": "5.0.0",
     "eslint-plugin-storybook": "^0.8.0",
     "express": "^4.21.2",
-    "fast-xml-parser": "^4.2.7",
+    "fast-xml-parser": "^5.3.7",
     "figures": "3.2.0",
     "file-type": "^16.2.0",
     "flat": "^5.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -984,8 +984,8 @@ importers:
         specifier: ^4.21.2
         version: 4.21.2
       fast-xml-parser:
-        specifier: ^4.2.7
-        version: 4.5.3
+        specifier: ^5.3.7
+        version: 5.3.7
       figures:
         specifier: 3.2.0
         version: 3.2.0
@@ -16678,8 +16678,8 @@ packages:
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
 
-  fast-xml-parser@4.5.3:
-    resolution: {integrity: sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==}
+  fast-xml-parser@5.3.7:
+    resolution: {integrity: sha512-JzVLro9NQv92pOM/jTCR6mHlJh2FGwtomH8ZQjhFj/R29P2Fnj38OgPJVtcvYw6SuKClhgYuwUZf5b3rd8u2mA==}
     hasBin: true
 
   fastest-levenshtein@1.0.16:
@@ -23917,8 +23917,8 @@ packages:
   strip-literal@3.0.0:
     resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
 
-  strnum@1.1.2:
-    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
+  strnum@2.1.2:
+    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
 
   strtok3@6.3.0:
     resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
@@ -43813,9 +43813,9 @@ snapshots:
 
   fast-uri@3.0.6: {}
 
-  fast-xml-parser@4.5.3:
+  fast-xml-parser@5.3.7:
     dependencies:
-      strnum: 1.1.2
+      strnum: 2.1.2
 
   fastest-levenshtein@1.0.16: {}
 
@@ -53586,7 +53586,7 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  strnum@1.1.2: {}
+  strnum@2.1.2: {}
 
   strtok3@6.3.0:
     dependencies:


### PR DESCRIPTION
## Current Behavior

The NPM audit CI job is failing due to a critical XSS vulnerability (CVE-2026-25896) in `fast-xml-parser` version 4.5.3.

## Expected Behavior

The NPM audit should pass with no critical vulnerabilities.

## Related Issue(s)

Fixes the failing NPM audit CI run: https://github.com/nrwl/nx/actions/runs/22288455713

---

This PR upgrades `fast-xml-parser` from `^4.2.7` to `^5.3.7` to address GHSA-m7jm-9gc2-mpf2, a critical XSS vulnerability that allows entity encoding bypass via regex injection in DOCTYPE entity names.

The package is only used in `scripts/documentation/internal-link-checker.ts` for parsing XML sitemaps, so the risk of this upgrade is low.