### PR TITLE
feat(core): add passthrough for nx-cloud apply-locally command

### DIFF
--- a/packages/nx/src/command-line/nx-cloud/apply-locally/apply-locally.ts
+++ b/packages/nx/src/command-line/nx-cloud/apply-locally/apply-locally.ts
@@ -1,0 +1,15 @@
+import { readNxJson } from '../../../config/nx-json';
+import { isNxCloudUsed } from '../../../utils/nx-cloud-utils';
+import { executeNxCloudCommand, warnNotConnectedToCloud } from '../utils';
+
+export interface ApplyLocallyArgs {
+  verbose?: boolean;
+}
+
+export function applyLocallyHandler(args: ApplyLocallyArgs): Promise<number> {
+  if (!isNxCloudUsed(readNxJson())) {
+    warnNotConnectedToCloud();
+    return Promise.resolve(0);
+  }
+  return executeNxCloudCommand('apply-locally', args.verbose);
+}

--- a/packages/nx/src/command-line/nx-cloud/apply-locally/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/apply-locally/command-object.ts
@@ -1,0 +1,18 @@
+import { CommandModule } from 'yargs';
+import { withVerbose } from '../../yargs-utils/shared-options';
+
+export const yargsApplyLocallyCommand: CommandModule = {
+  command: 'apply-locally [options]',
+  describe:
+    'Applies a self-healing CI fix locally. This command is an alias for `nx-cloud apply-locally`.',
+  builder: (yargs) =>
+    withVerbose(yargs)
+      .help(false)
+      .showHelpOnFail(false)
+      .option('help', { describe: 'Show help.', type: 'boolean' }),
+  handler: async (args: any) => {
+    process.exit(
+      await (await import('./apply-locally')).applyLocallyHandler(args)
+    );
+  },
+};

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -46,6 +46,7 @@ import { yargsStartCiRunCommand } from './nx-cloud/start-ci-run/command-object';
 import { yargsStartAgentCommand } from './nx-cloud/start-agent/command-object';
 import { yargsStopAllAgentsCommand } from './nx-cloud/complete-run/command-object';
 import { yargsFixCiCommand } from './nx-cloud/fix-ci/command-object';
+import { yargsApplyLocallyCommand } from './nx-cloud/apply-locally/command-object';
 import { yargsDownloadCloudClientCommand } from './nx-cloud/download-cloud-client/command-object';
 import {
   yargsPrintAffectedCommand,
@@ -115,6 +116,7 @@ export const commandsObject = yargs
   .command(yargsStartAgentCommand)
   .command(yargsStopAllAgentsCommand)
   .command(yargsFixCiCommand)
+  .command(yargsApplyLocallyCommand)
   .command(yargsDownloadCloudClientCommand)
   .command(yargsMcpCommand)
   .command(resolveConformanceCommandObject())


### PR DESCRIPTION

## Current Behavior
folks had to type in `nx-cloud apply-locally`

## Expected Behavior
now `nx apply-locally` works
