### PR TITLE
docs(node): add pruning guide for Docker deployments

### DIFF
--- a/astro-docs/src/content/docs/guides/ci-deployment.mdoc
+++ b/astro-docs/src/content/docs/guides/ci-deployment.mdoc
@@ -4,6 +4,10 @@ description: 'Learn how to generate package.json and pruned lock files for your 
 filter: 'type:Guides'
 ---
 
+{% aside type="note" title="Using TS Solution Setup?" %}
+If your workspace uses TS project references (the default in Nx 20+), use the [prune workflow](/docs/technologies/node/guides/deploying-node-projects) instead. The `generatePackageJson` approach below applies to workspaces without TS Solution Setup.
+{% /aside %}
+
 A common approach to deploying applications is via docker containers. Some applications can be built into bundles that are environment agnostic, while others depend on OS-specific packages being installed. For these situations, having just bundled code is not enough, we also need to have `package.json`.
 
 Nx supports the generation of the project's `package.json` by identifying all the project's dependencies. The generated `package.json` is created next to the built artifacts (usually at `dist/apps/name-of-the-app`).

--- a/astro-docs/src/content/docs/technologies/node/Guides/bundling-node-projects.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/Guides/bundling-node-projects.mdoc
@@ -1,31 +1,37 @@
 ---
-title: Bundling Node.js Applications and Libraries
-description: Learn how to configure bundling for Node.js applications and libraries in an Nx monorepo using Webpack, esbuild, and Vite.
+title: Bundling Projects for Deployment
+description: Bundle your Node.js application into a single file with no node_modules needed. Deploy without a package.json install step.
 sidebar:
-  label: Understand Bundling with Node
+  label: Bundling for Deployment
 filter: 'type:Guides'
 ---
 
-When building Node.js projects, you have two main approaches to distribute your projects final artifact from the monorepo, **bundled** or **not bundled**. Depending on your deployment strategy and tooling preferences, one approach may be more suitable than the other.
+Bundling compiles your code and all its dependencies into a single file (e.g. `main.js`).
+The output is self-contained, so you don't need `node_modules` or an install step at deploy time.
 
-## Bundled vs Non-Bundled Builds
+If your app has native dependencies or you want Docker layer caching for `node_modules`,
+see [pruning projects for deployment](/docs/technologies/node/guides/deploying-node-projects) instead.
 
-**Bundled builds** compile your code and all its dependencies into a single file, e.g. `main.js` This approach:
+## When to bundle instead of prune
+
+| Approach | Best for                                | Trade-off                                     |
+| -------- | --------------------------------------- | --------------------------------------------- |
+| Bundling | Serverless functions, simple APIs       | Single file output, no `node_modules` needed  |
+| [Pruning](/docs/technologies/node/guides/deploying-node-projects)  | Docker deployments, native dependencies | Keeps `node_modules` but only production deps |
+
+Use bundling when:
+
+- Your app has no native dependencies that require OS-level installation
+- You want a single deployable artifact with no install step
+- You're targeting serverless platforms or lightweight containers
+
 {% aside type="note" title="Lazy loaded chunks" %}
-If you're using lazy loaded chunks in your node application, bundling will produce more than a single file. Instead, you'll have a file per chunks entrypoint file. You'll want to make sure all the files are handled correctly for your deployment needs.
+If you use lazy loaded chunks, bundling produces more than a single file.
+You'll have one file per chunk entrypoint.
+Make sure all files are handled correctly for your deployment needs.
 {% /aside %}
 
-- Produces a self-contained artifact that doesn't require `node_modules`
-- Simplifies deployment since you only need to copy a single file
-- Works well for serverless functions and containerized applications
-
-**Non-bundled builds** preserve your module structure and require `node_modules` at runtime. This approach:
-
-- Requires installing dependencies before running
-- Maintains separate files for each module
-- Can improve container rebuilds speeds when paired with Docker Layer Caching
-
-## Bundling Node.js Applications
+## Bundling Node.js applications
 
 {% tabs syncKey="bundler" %}
 
@@ -130,17 +136,21 @@ nx build my-app
 # Deploy dist/my-app/main.js - no node_modules needed
 ```
 
-## When NOT to Bundle
+## When not to bundle
 
-If you're publishing a library package to npm, avoid bundling dependencies. Instead, declare them in `package.json` so package managers can handle versioning and deduplication.
+If you're publishing a library package to npm, avoid bundling dependencies.
+Declare them in `package.json` so package managers can handle versioning and deduplication.
 
-For Docker based deployments, non-bundled builds can improve build times through layer caching. When dependencies don't change, Docker reuses the cached `node_modules` layer, only rebuilding your application code.
+For Docker-based deployments, non-bundled builds can improve build times through layer caching.
+When dependencies don't change, Docker reuses the cached `node_modules` layer and only rebuilds your application code.
 
-Instead of running `build`, use the `prune` target which prepares your application for deployment with its dependencies:
+Instead of running `build`, use the `prune` target to prepare your application for deployment with its dependencies:
 
 ```shell
 nx prune my-app
 ```
+
+For the full setup, see [pruning projects for deployment](/docs/technologies/node/guides/deploying-node-projects).
 
 This creates a deployment-ready structure:
 
@@ -159,11 +169,12 @@ WORKDIR /app
 CMD ["node", "main.js"]
 ```
 
-## Bundling Libraries
+## Bundling libraries
 
-Nx recommends publishing workspace dependencies as separate packages rather than bundling them into a single library. This approach provides better versioning control and allows consumers to manage their own dependency trees.
+Publish workspace dependencies as separate packages rather than bundling them into a single library.
+This gives better versioning control and lets consumers manage their own dependency trees.
 
-However, bundling workspace libraries could make sense when:
+Bundling workspace libraries makes sense when:
 
 - The library contains only types that should be inlined
 - You want to distribute an internal library as part of your package
@@ -245,9 +256,9 @@ See `rollupOptions` from [vite documentation for more information](https://vite.
 
 {% /tabs %}
 
-## Managing Workspace Dependencies
+## Managing workspace dependencies
 
-When building libraries that consume other workspace libraries, always define the dependency relationship in `package.json`:
+When building libraries that consume other workspace libraries, define the dependency relationship in `package.json`:
 
 ```json
 // libs/my-lib/package.json
@@ -266,7 +277,7 @@ The `workspace:*` syntax:
 
 This ensures your library correctly declares its dependencies regardless of whether they're bundled.
 
-## Quick Reference
+## Quick reference
 
 | Scenario                                | Tool    | Key Settings                                                 |
 | --------------------------------------- | ------- | ------------------------------------------------------------ |

--- a/astro-docs/src/content/docs/technologies/node/Guides/bundling-node-projects.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/Guides/bundling-node-projects.mdoc
@@ -14,10 +14,10 @@ see [pruning projects for deployment](/docs/technologies/node/guides/deploying-n
 
 ## When to bundle instead of prune
 
-| Approach | Best for                                | Trade-off                                     |
-| -------- | --------------------------------------- | --------------------------------------------- |
-| Bundling | Serverless functions, simple APIs       | Single file output, no `node_modules` needed  |
-| [Pruning](/docs/technologies/node/guides/deploying-node-projects)  | Docker deployments, native dependencies | Keeps `node_modules` but only production deps |
+| Approach                                                          | Best for                                | Trade-off                                     |
+| ----------------------------------------------------------------- | --------------------------------------- | --------------------------------------------- |
+| Bundling                                                          | Serverless functions, simple APIs       | Single file output, no `node_modules` needed  |
+| [Pruning](/docs/technologies/node/guides/deploying-node-projects) | Docker deployments, native dependencies | Keeps `node_modules` but only production deps |
 
 Use bundling when:
 

--- a/astro-docs/src/content/docs/technologies/node/Guides/deploying-node-projects.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/Guides/deploying-node-projects.mdoc
@@ -1,0 +1,314 @@
+---
+title: Pruning Projects for Deployment
+description: Generate a pruned package.json and lockfile so Docker installs only production dependencies. Replaces the deprecated generatePackageJson option in Nx 20+.
+sidebar:
+  label: Pruning for Deployment
+filter: 'type:Guides'
+---
+
+When deploying Node.js applications to containers, you typically need only production dependencies, not your entire workspace `node_modules`.
+Pruning generates a standalone `package.json`, a pruned lockfile, and copies any workspace libraries your app depends on.
+The result is everything you need to run `npm ci` inside a Docker image with only the packages your application uses.
+
+To bundle your app into a single file instead (no `node_modules` needed),
+see [Bundling projects for deployment](/docs/technologies/node/guides/bundling-node-projects).
+
+## When to prune instead of bundle
+
+| Approach | Best for                                | Trade-off                                     |
+| -------- | --------------------------------------- | --------------------------------------------- |
+| [Bundling](/docs/technologies/node/guides/bundling-node-projects) | Serverless functions, simple APIs       | Single file output, no `node_modules` needed  |
+| Pruning  | Docker deployments, native dependencies | Keeps `node_modules` but only production deps |
+
+Use pruning when:
+
+- Your app has native dependencies (e.g. `bcrypt`, `sharp`) that can't be bundled
+- You want Docker layer caching, where dependency layers rebuild only when `package.json` changes
+- You consume workspace libraries as packages rather than bundling them
+
+{% aside type="tip" %}
+New Node applications include prune targets by default.
+Pass `--docker` to also generate an example Dockerfile: `nx g @nx/node:app --docker`.
+{% /aside %}
+
+## How pruning works
+
+Pruning uses four Nx targets that run in sequence:
+
+1. `build` compiles your application (esbuild, webpack, tsc, etc.).
+1. `prune-lockfile` (`@nx/js:prune-lockfile`) reads your project `package.json`, generates a minimal `package.json`, and creates a pruned lockfile containing only production dependencies.
+1. `copy-workspace-modules` (`@nx/js:copy-workspace-modules`) copies workspace libraries referenced via `workspace:*` into a `workspace_modules/` directory and rewrites their dependency references to `file:` paths.
+1. `prune` (`nx:noop`) depends on both `prune-lockfile` and `copy-workspace-modules`, giving you a single command to run.
+
+After running `nx prune my-app`, the build output directory contains:
+
+```text
+apps/my-app/dist/
+├── main.js                          # Compiled application
+├── package.json                     # Pruned production dependencies
+├── package-lock.json                # Pruned lockfile (or yarn.lock / pnpm-lock.yaml)
+└── workspace_modules/               # Only present if you have workspace deps
+    └── @my-org/
+        └── my-lib/
+            ├── package.json
+            └── ...
+```
+
+## Set up prune targets
+
+Add the following targets to your project's `package.json` or `project.json`:
+
+{% tabs syncKey="config" %}
+
+{% tabitem label="package.json" %}
+
+```json
+// apps/my-app/package.json
+{
+  "name": "@my-org/my-app",
+  "nx": {
+    "targets": {
+      "prune-lockfile": {
+        "dependsOn": [
+          "build"
+        ],
+        "cache": true,
+        "executor": "@nx/js:prune-lockfile",
+        "outputs": [
+          "{workspaceRoot}/apps/my-app/dist/package.json",
+          "{workspaceRoot}/apps/my-app/dist/package-lock.json"
+        ],
+        "options": {
+          "buildTarget": "build"
+        }
+      },
+      "copy-workspace-modules": {
+        "dependsOn": [
+          "build"
+        ],
+        "cache": true,
+        "outputs": [
+          "{workspaceRoot}/apps/my-app/dist/workspace_modules"
+        ],
+        "executor": "@nx/js:copy-workspace-modules",
+        "options": {
+          "buildTarget": "build"
+        }
+      },
+      "prune": {
+        "dependsOn": [
+          "prune-lockfile",
+          "copy-workspace-modules"
+        ],
+        "executor": "nx:noop"
+      }
+    }
+  }
+}
+```
+
+{% /tabitem %}
+
+{% tabitem label="project.json" %}
+
+```json
+// apps/my-app/project.json
+{
+  "name": "@my-org/my-app",
+  "targets": {
+    "prune-lockfile": {
+      "dependsOn": [
+        "build"
+      ],
+      "cache": true,
+      "executor": "@nx/js:prune-lockfile",
+      "outputs": [
+        "{workspaceRoot}/apps/my-app/dist/package.json",
+        "{workspaceRoot}/apps/my-app/dist/package-lock.json"
+      ],
+      "options": {
+        "buildTarget": "build"
+      }
+    },
+    "copy-workspace-modules": {
+      "dependsOn": [
+        "build"
+      ],
+      "cache": true,
+      "outputs": [
+        "{workspaceRoot}/apps/my-app/dist/workspace_modules"
+      ],
+      "executor": "@nx/js:copy-workspace-modules",
+      "options": {
+        "buildTarget": "build"
+      }
+    },
+    "prune": {
+      "dependsOn": [
+        "prune-lockfile",
+        "copy-workspace-modules"
+      ],
+      "executor": "nx:noop"
+    }
+  }
+}
+```
+
+{% /tabitem %}
+
+{% /tabs %}
+
+Replace `package-lock.json` in the `outputs` array with `yarn.lock` or `pnpm-lock.yaml` if needed.
+
+Then run:
+
+```shell
+nx prune my-app
+```
+
+Both `prune-lockfile` and `copy-workspace-modules` set `cache: true`,
+so subsequent runs are instant when nothing changes.
+
+## Use pruned output in Docker
+
+The generated Dockerfile copies the build output and runs `npm install`:
+
+```dockerfile
+# apps/my-app/Dockerfile
+FROM docker.io/node:lts-alpine
+
+ENV HOST=0.0.0.0
+ENV PORT=3000
+
+WORKDIR /app
+
+COPY dist .
+
+# You can remove this install step if you build with `--bundle` option.
+# The bundled output will include external dependencies.
+RUN npm --omit=dev -f install
+
+CMD ["node", "main.js"]
+```
+
+The `COPY dist .` line works because the Dockerfile lives inside the project directory (`apps/my-app/`),
+and the build output goes to `apps/my-app/dist/`.
+The pruned `package.json`, lockfile, and `workspace_modules/` are all inside `dist/`.
+
+Build and run:
+
+```shell
+# Build the app and prune dependencies
+nx prune my-app
+
+# Build the Docker image
+npx nx docker:build my-app
+
+# Run the container
+nx docker:run my-app -p 3000:3000
+```
+
+## Migrate from `generatePackageJson`
+
+If you're upgrading to Nx 20+ with TS Solution Setup (the default for new workspaces),
+the `generatePackageJson` option is no longer supported.
+You'll see this error:
+
+{% aside type="caution" title="Error: generatePackageJson not supported" %}
+`Setting 'generatePackageJson: true' is not supported with the current TypeScript setup. Update the 'package.json' file at the project root as needed and unset the 'generatePackageJson' option.`
+{% /aside %}
+
+Follow these steps to migrate to the prune workflow:
+
+### Step 1: Move dependencies to your project package.json
+
+With TS Solution Setup, each project has its own `package.json`.
+List all runtime dependencies there:
+
+```json
+// apps/my-app/package.json
+{
+  "name": "@my-org/my-app",
+  "dependencies": {
+    "express": "^4.18.0",
+    "@my-org/shared-utils": "workspace:*"
+  }
+}
+```
+
+Use the `workspace:*` protocol for workspace libraries.
+
+### Step 2: Remove `generatePackageJson` from your build configuration
+
+{% tabs syncKey="bundler" %}
+
+{% tabitem label="esbuild" %}
+
+Remove `generatePackageJson` from your esbuild target options:
+
+```json
+// apps/my-app/package.json
+{
+  "nx": {
+    "targets": {
+      "build": {
+        "executor": "@nx/esbuild:esbuild",
+        "options": {
+          "platform": "node",
+          "outputPath": "dist/apps/my-app",
+          "format": ["cjs"],
+          "main": "apps/my-app/src/main.ts",
+          "tsConfig": "apps/my-app/tsconfig.app.json"
+        }
+      }
+    }
+  }
+}
+```
+
+{% /tabitem %}
+
+{% tabitem label="Webpack" %}
+
+Remove `generatePackageJson` from your webpack config:
+
+```js
+// apps/my-app/webpack.config.js
+const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
+const { join } = require('path');
+
+module.exports = {
+  output: {
+    path: join(__dirname, '../../dist/apps/my-app'),
+  },
+  plugins: [
+    new NxAppWebpackPlugin({
+      target: 'node',
+      compiler: 'tsc',
+      main: './src/main.ts',
+      tsConfig: './tsconfig.app.json',
+    }),
+  ],
+};
+```
+
+{% /tabitem %}
+
+{% tabitem label="Rollup / Vite" %}
+
+Remove `generatePackageJson` from your rollup or vite build options.
+With TS Solution Setup, the project `package.json` is used directly.
+
+{% /tabitem %}
+
+{% /tabs %}
+
+### Step 3: Add prune targets
+
+Add the `prune-lockfile`, `copy-workspace-modules`, and `prune` targets
+to your project `package.json` as shown in the [set up prune targets](#set-up-prune-targets) section.
+
+### Step 4: Update your Dockerfile
+
+Replace references to the old generated `package.json` with the pruned output.
+See the [use pruned output in Docker](#use-pruned-output-in-docker) section for a recommended Dockerfile structure.

--- a/astro-docs/src/content/docs/technologies/node/Guides/deploying-node-projects.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/Guides/deploying-node-projects.mdoc
@@ -15,10 +15,10 @@ see [Bundling projects for deployment](/docs/technologies/node/guides/bundling-n
 
 ## When to prune instead of bundle
 
-| Approach | Best for                                | Trade-off                                     |
-| -------- | --------------------------------------- | --------------------------------------------- |
+| Approach                                                          | Best for                                | Trade-off                                     |
+| ----------------------------------------------------------------- | --------------------------------------- | --------------------------------------------- |
 | [Bundling](/docs/technologies/node/guides/bundling-node-projects) | Serverless functions, simple APIs       | Single file output, no `node_modules` needed  |
-| Pruning  | Docker deployments, native dependencies | Keeps `node_modules` but only production deps |
+| Pruning                                                           | Docker deployments, native dependencies | Keeps `node_modules` but only production deps |
 
 Use pruning when:
 
@@ -69,9 +69,7 @@ Add the following targets to your project's `package.json` or `project.json`:
   "nx": {
     "targets": {
       "prune-lockfile": {
-        "dependsOn": [
-          "build"
-        ],
+        "dependsOn": ["build"],
         "cache": true,
         "executor": "@nx/js:prune-lockfile",
         "outputs": [
@@ -83,23 +81,16 @@ Add the following targets to your project's `package.json` or `project.json`:
         }
       },
       "copy-workspace-modules": {
-        "dependsOn": [
-          "build"
-        ],
+        "dependsOn": ["build"],
         "cache": true,
-        "outputs": [
-          "{workspaceRoot}/apps/my-app/dist/workspace_modules"
-        ],
+        "outputs": ["{workspaceRoot}/apps/my-app/dist/workspace_modules"],
         "executor": "@nx/js:copy-workspace-modules",
         "options": {
           "buildTarget": "build"
         }
       },
       "prune": {
-        "dependsOn": [
-          "prune-lockfile",
-          "copy-workspace-modules"
-        ],
+        "dependsOn": ["prune-lockfile", "copy-workspace-modules"],
         "executor": "nx:noop"
       }
     }
@@ -117,9 +108,7 @@ Add the following targets to your project's `package.json` or `project.json`:
   "name": "@my-org/my-app",
   "targets": {
     "prune-lockfile": {
-      "dependsOn": [
-        "build"
-      ],
+      "dependsOn": ["build"],
       "cache": true,
       "executor": "@nx/js:prune-lockfile",
       "outputs": [
@@ -131,23 +120,16 @@ Add the following targets to your project's `package.json` or `project.json`:
       }
     },
     "copy-workspace-modules": {
-      "dependsOn": [
-        "build"
-      ],
+      "dependsOn": ["build"],
       "cache": true,
-      "outputs": [
-        "{workspaceRoot}/apps/my-app/dist/workspace_modules"
-      ],
+      "outputs": ["{workspaceRoot}/apps/my-app/dist/workspace_modules"],
       "executor": "@nx/js:copy-workspace-modules",
       "options": {
         "buildTarget": "build"
       }
     },
     "prune": {
-      "dependsOn": [
-        "prune-lockfile",
-        "copy-workspace-modules"
-      ],
+      "dependsOn": ["prune-lockfile", "copy-workspace-modules"],
       "executor": "nx:noop"
     }
   }


### PR DESCRIPTION
## Current Behavior

Users migrating to Nx 20's TS Solution Setup lose `generatePackageJson` support and have no documentation on the replacement prune workflow (`prune-lockfile`, `copy-workspace-modules`). The error message tells them to "unset the option" but doesn't explain what to do instead.

## Expected Behavior

A dedicated guide at `/docs/technologies/node/guides/deploying-node-projects` covers the full prune workflow: when to use pruning vs bundling, target configuration, Dockerfile setup, and step-by-step migration from `generatePackageJson`.

Also updated the existing bundling guide to match the same structure (intro table, cross-links, style guide compliance). The two articles are sister guides covering the two ways to deploy Node.js apps: bundle everything into a single file, or prune dependencies for a `node_modules`-based install.

Cross-links added from the bundling guide and ci-deployment guide.

## Related Issue(s)

Closes #30146