### PR TITLE
fix(bundling): add docs link to generatePackageJson error message

### DIFF
--- a/packages/esbuild/src/executors/esbuild/lib/normalize.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/normalize.ts
@@ -17,7 +17,7 @@ export function normalizeOptions(
   const isTsSolutionSetup = isUsingTsSolutionSetup();
   if (isTsSolutionSetup && options.generatePackageJson) {
     throw new Error(
-      `Setting 'generatePackageJson: true' is not supported with the current TypeScript setup. Update the 'package.json' file at the project root as needed and unset the 'generatePackageJson' option.`
+      `Setting 'generatePackageJson: true' is not supported with the current TypeScript setup. Update the 'package.json' file at the project root as needed and unset the 'generatePackageJson' option. See https://nx.dev/docs/technologies/node/guides/deploying-node-projects for the recommended pruned package.json workflow.`
     );
   }
 

--- a/packages/rollup/src/plugins/with-nx/with-nx.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx.ts
@@ -220,7 +220,7 @@ export function withNx(
     if (isTsSolutionSetup) {
       if (options.generatePackageJson) {
         throw new Error(
-          `Setting 'generatePackageJson: true' is not supported with the current TypeScript setup. Update the 'package.json' file at the project root as needed and unset the 'generatePackageJson' option.`
+          `Setting 'generatePackageJson: true' is not supported with the current TypeScript setup. Update the 'package.json' file at the project root as needed and unset the 'generatePackageJson' option. See https://nx.dev/docs/technologies/node/guides/deploying-node-projects for the recommended pruned package.json workflow.`
         );
       }
       if (options.generateExportsField) {


### PR DESCRIPTION
## Current Behavior

When users hit the `generatePackageJson: true` error with TS Solution Setup, the error tells them to "unset the option" but gives no guidance on the replacement workflow.

## Expected Behavior

The error message now includes a link to the pruning guide at https://nx.dev/docs/technologies/node/guides/deploying-node-projects so users can immediately find the migration steps.

## Related Issue(s)

Related #30146