### PR TITLE
docs(core): add synthetic monorepos page

### DIFF
--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -93,10 +93,6 @@ const learnGroups: SidebarItems = [
         link: 'concepts/ci-concepts/parallelization-distribution',
       },
       { label: 'Nx Daemon', link: 'concepts/nx-daemon' },
-      {
-        label: 'Synthetic Monorepos',
-        link: 'concepts/synthetic-monorepos',
-      },
     ],
   },
   {
@@ -105,6 +101,10 @@ const learnGroups: SidebarItems = [
     items: [
       { label: 'Run Tasks', link: 'features/run-tasks' },
       { label: 'Enhance Your LLM', link: 'features/enhance-ai' },
+      {
+        label: 'Synthetic Monorepos',
+        link: 'concepts/synthetic-monorepos',
+      },
       {
         label: 'Code Organization',
         collapsed: true,

--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -93,6 +93,10 @@ const learnGroups: SidebarItems = [
         link: 'concepts/ci-concepts/parallelization-distribution',
       },
       { label: 'Nx Daemon', link: 'concepts/nx-daemon' },
+      {
+        label: 'Synthetic Monorepos',
+        link: 'concepts/synthetic-monorepos',
+      },
     ],
   },
   {

--- a/astro-docs/src/assets/concepts/synthetic-monorepo.svg
+++ b/astro-docs/src/assets/concepts/synthetic-monorepo.svg
@@ -1,0 +1,122 @@
+<svg width="980" height="720" viewBox="0 0 980 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Defs: arrow markers -->
+  <defs>
+    <marker id="arrowBlue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto" markerUnits="strokeWidth">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#476088"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto" markerUnits="strokeWidth">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#70AF40"/>
+    </marker>
+  </defs>
+
+  <!-- Outer dotted border: Synthetic Monorepo boundary -->
+  <rect x="40" y="40" width="900" height="590" rx="24" ry="24"
+        stroke="#94A3B8" stroke-width="3" stroke-dasharray="12 6" fill="none"/>
+
+  <!-- "Synthetic Monorepo" label at bottom inside box -->
+  <text x="490" y="665" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="26" font-weight="700" fill="#94A3B8">Synthetic Monorepo</text>
+
+  <!-- ============================================ -->
+  <!-- Monorepo A (top-left): a rounded rect with 3 internal projects -->
+  <!-- ============================================ -->
+  <rect x="80" y="70" width="260" height="200" rx="16" ry="16"
+        stroke="#9CA3AF" stroke-width="2" fill="none"/>
+  <text x="210" y="100" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#9CA3AF">Monorepo A</text>
+
+  <!-- App 1 (blue) -->
+  <circle cx="140" cy="165" r="38" fill="#476088"/>
+  <text x="140" y="161" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="white">App 1</text>
+  <text x="140" y="178" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#CBD5E1">frontend</text>
+
+  <!-- Lib A (green) -->
+  <circle cx="270" cy="145" r="32" fill="#70AF40"/>
+  <text x="270" y="141" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="white">Lib A</text>
+  <text x="270" y="157" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E8F5E9">utils</text>
+
+  <!-- Lib B (green) -->
+  <circle cx="248" cy="222" r="28" fill="#70AF40"/>
+  <text x="248" y="218" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600" fill="white">Lib B</text>
+  <text x="248" y="233" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" fill="#E8F5E9">ui</text>
+
+  <!-- Internal arrows within Monorepo A -->
+  <line x1="175" y1="155" x2="238" y2="143" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arrowBlue)" opacity="0.4"/>
+  <line x1="165" y1="190" x2="225" y2="212" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arrowBlue)" opacity="0.4"/>
+
+  <!-- ============================================ -->
+  <!-- Monorepo B (right): a rounded rect with 2 internal projects -->
+  <!-- ============================================ -->
+  <rect x="640" y="70" width="260" height="200" rx="16" ry="16"
+        stroke="#9CA3AF" stroke-width="2" fill="none"/>
+  <text x="770" y="100" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" fill="#9CA3AF">Monorepo B</text>
+
+  <!-- App 2 (blue) -->
+  <circle cx="710" cy="170" r="38" fill="#476088"/>
+  <text x="710" y="166" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="white">App 2</text>
+  <text x="710" y="183" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#CBD5E1">backend</text>
+
+  <!-- Lib C (green) -->
+  <circle cx="840" cy="185" r="32" fill="#70AF40"/>
+  <text x="840" y="181" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="white">Lib C</text>
+  <text x="840" y="197" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E8F5E9">auth</text>
+
+  <!-- Internal arrow within Monorepo B -->
+  <line x1="745" y1="175" x2="808" y2="182" stroke="#9CA3AF" stroke-width="1.5" marker-end="url(#arrowBlue)" opacity="0.4"/>
+
+  <!-- ============================================ -->
+  <!-- Standalone repos -->
+  <!-- ============================================ -->
+
+  <!-- Lib D (green, standalone, CENTER - pushed down to middle row) -->
+  <circle cx="490" cy="340" r="38" fill="#70AF40"/>
+  <text x="490" y="336" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="white">Lib D</text>
+  <text x="490" y="352" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E8F5E9">shared</text>
+  <text x="490" y="390" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="500" fill="#9CA3AF">standalone repo</text>
+
+  <!-- App 3 (blue, standalone, bottom-left) -->
+  <circle cx="200" cy="500" r="42" fill="#476088"/>
+  <text x="200" y="496" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="white">App 3</text>
+  <text x="200" y="513" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#CBD5E1">mobile</text>
+  <text x="200" y="554" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="500" fill="#9CA3AF">standalone repo</text>
+
+  <!-- Lib E (green, standalone, bottom-center) -->
+  <circle cx="490" cy="520" r="32" fill="#70AF40"/>
+  <text x="490" y="516" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="white">Lib E</text>
+  <text x="490" y="532" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#E8F5E9">design</text>
+  <text x="490" y="564" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="500" fill="#9CA3AF">standalone repo</text>
+
+  <!-- App 4 (blue, standalone, bottom-right) -->
+  <circle cx="770" cy="500" r="42" fill="#476088"/>
+  <text x="770" y="496" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" fill="white">App 4</text>
+  <text x="770" y="513" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" fill="#CBD5E1">API</text>
+  <text x="770" y="554" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="500" fill="#9CA3AF">standalone repo</text>
+
+  <!-- ============================================ -->
+  <!-- Cross-repo dependency arrows -->
+  <!-- ============================================ -->
+
+  <!-- App 2 → Lib D (shared): curve down-left -->
+  <path d="M 675 185 C 620 240, 560 280, 525 325" stroke="#476088" stroke-width="2.5" fill="none" marker-end="url(#arrowBlue)"/>
+
+  <!-- Lib A → Lib D: gentle arc down -->
+  <path d="M 300 155 C 370 200, 420 260, 458 322" stroke="#70AF40" stroke-width="2" fill="none" marker-end="url(#arrowGreen)"/>
+
+  <!-- App 3 → Lib B (in Monorepo A): straight up -->
+  <path d="M 210 458 C 220 380, 230 320, 242 252" stroke="#476088" stroke-width="2.5" fill="none" marker-end="url(#arrowBlue)"/>
+
+  <!-- App 3 → Lib E (design): horizontal -->
+  <path d="M 242 500 C 320 490, 400 500, 458 515" stroke="#476088" stroke-width="2.5" fill="none" marker-end="url(#arrowBlue)"/>
+
+  <!-- App 4 → Lib C (in Monorepo B): straight up -->
+  <path d="M 790 458 C 805 380, 820 310, 835 217" stroke="#476088" stroke-width="2.5" fill="none" marker-end="url(#arrowBlue)"/>
+
+  <!-- App 4 → Lib D (shared): arc up-left -->
+  <path d="M 730 490 C 650 460, 570 410, 525 358" stroke="#476088" stroke-width="2.5" fill="none" marker-end="url(#arrowBlue)"/>
+
+  <!-- App 4 → Lib E (design): horizontal left -->
+  <path d="M 728 505 C 660 510, 580 515, 522 518" stroke="#476088" stroke-width="2" fill="none" marker-end="url(#arrowBlue)"/>
+
+  <!-- Lib D → Lib C (cross-repo lib dependency): arc up-right -->
+  <path d="M 525 330 C 620 300, 740 260, 812 200" stroke="#70AF40" stroke-width="2" fill="none" marker-end="url(#arrowGreen)"/>
+
+
+</svg>

--- a/astro-docs/src/content/docs/concepts/synthetic-monorepos.mdoc
+++ b/astro-docs/src/content/docs/concepts/synthetic-monorepos.mdoc
@@ -15,42 +15,19 @@ A synthetic monorepo connects separate repositories into a unified dependency gr
 
 Unlike a traditional monorepo where all code lives in one repository, a synthetic monorepo leaves each repository where it is. Instead, it builds a cross-repo graph that tooling can reason about, just as if the code were in one place.
 
-Nx implements synthetic monorepos through [Nx Polygraph](/docs/enterprise/polygraph). Polygraph connects existing repositories into a unified, intelligent graph. It works with any repo, even those that don't use Nx, through metadata-only workspaces that require zero changes to target repos.
+## What synthetic monorepos enable
 
-## Why they matter
+A synthetic monorepo addresses several downsides of a polyrepo setup:
 
-Repository boundaries create problems at multiple levels:
+**Visibility** — An automatic cross-repo dependency graph shows which repo depends on which and what a change affects downstream. Always up to date, discovered from actual code — not a manually maintained spreadsheet or catalog. Nx implements this through the [Workspace Graph](/docs/enterprise/polygraph).
 
-|                     | Polyrepo problem                                                                                                         | What a synthetic monorepo solves                                                                                      |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
-| **Visibility**      | No way to see how projects across repos relate. Platform engineers manually catalog and cross-reference dozens of repos. | Automatic cross-repo dependency graph shows which repo depends on which and what a change affects downstream.         |
-| **Coordination**    | Cross-repo changes require coordinating PRs, ensuring compatibility, and managing release order manually.                | Tooling on top of the graph enables coordinated changes, impact analysis, and conformance checking across boundaries. |
-| **Standards**       | Enforcing common conventions across repos requires manual effort and often drifts.                                       | Conformance rules and architecture constraints apply across the entire graph.                                         |
-| **CI intelligence** | Each repo has its own CI in isolation. No affected detection, caching, or distribution across repo boundaries.           | CI can work across the full graph: affected detection, remote caching, and distributed task execution span repos.     |
-| **AI agents**       | Agents operate within a single repo, missing downstream impacts, shared types, and cross-project relationships.          | Agents read the cross-repo graph and perform coordinated changes across repo boundaries.                              |
+**Coordination** — Cross-repo changes no longer require manually sequencing PRs, managing compatibility, and coordinating release order. Tooling on top of the graph enables impact analysis, coordinated changes, and conformance checking across repo boundaries.
 
-## What synthetic monorepos provide
+**Governance** — Organizational standards apply across every connected repo through [conformance rules](/docs/enterprise/polygraph/conformance). Scheduled [custom workflows](/docs/enterprise/polygraph/custom-workflows) check repos continuously — even ones nobody has touched in months. Detection and enforcement happen automatically, not through tickets and follow-ups.
 
-### Cross-repo dependency graph
+**CI intelligence** — [Affected detection](/docs/concepts/mental-model#affected-commands), [remote caching](/docs/concepts/how-caching-works), and [distributed task execution](/docs/concepts/ci-concepts/parallelization-distribution) work across the full graph, not just within a single repo.
 
-Nx Polygraph automatically creates a dependency graph across repositories through the [Workspace Graph](/docs/enterprise/polygraph). This gives you the same visibility you'd get in a monorepo: which project depends on which, what a change affects downstream, and how teams' work relates.
-
-### Tooling on top of the graph
-
-The graph becomes actionable, not just a visualization. Conformance checking, impact analysis, and coordinated changes all become possible across repo boundaries. Nx Cloud CI features like [affected detection](/docs/concepts/mental-model#affected-commands), [remote caching](/docs/concepts/how-caching-works), and [distribution](/docs/concepts/ci-concepts/parallelization-distribution) work across the full graph.
-
-### AI agent workflows across repos
-
-Nx Polygraph exposes metadata that AI agents can read and use to operate across polyrepo boundaries. Through Nx's [MCP integration](/docs/features/enhance-ai) and agent skills, this enables multi-repo agentic workflows:
-
-1. You give a prompt like _"Change the ratings API to also include the review author"_
-2. A **coordinator agent** reads the Polygraph graph, identifies affected repos (e.g., backend and frontend)
-3. **Per-repo agents** are spawned in parallel: the backend agent adjusts the API, the frontend agent updates the UI
-4. The coordinator **funnels context between agents** (e.g., the DTO structure from the backend agent is passed to the frontend agent so types stay in sync)
-5. Each agent **submits a PR** in its repo, [self-healing CI](/docs/features/ci-features/self-healing-ci) kicks in if CI fails
-6. Result: coordinated PRs across repos, tracked in a single Nx Cloud dashboard
-
-This is the same workflow you'd get with a real monorepo, but without requiring code to live in one repository.
+**AI agents** — AI coding agents are [dramatically less effective in polyrepos](https://youtu.be/alIto5fqrfk) — they can only see one repo at a time, so cross-repo features require you to manually shuttle context between sessions. A synthetic monorepo gives agents cross-repo visibility, enabling coordinated changes, parallel execution, and automatic PR creation across boundaries. [Self-healing CI](/docs/features/ci-features/self-healing-ci) catches failures automatically.
 
 ## When to use a synthetic monorepo vs. a real monorepo
 
@@ -58,8 +35,14 @@ A real monorepo is the best option when you can consolidate. It gives you atomic
 
 A synthetic monorepo is the better starting point when:
 
-- **Consolidation isn't feasible yet** — team autonomy concerns, divergent CI setups, or hundreds of repos make migration impractical.
-- **You need cross-repo visibility now** — you can't wait months for a migration to see how projects relate across teams.
-- **Teams need to stay autonomous** — each team keeps their repo, workflow, and release cadence while still participating in a unified graph.
+- **Consolidation isn't feasible yet:** team autonomy concerns, divergent CI setups, or hundreds of repos make migration impractical.
+- **You need cross-repo visibility now:** you can't wait months for a migration to see how projects relate across teams.
+- **Teams need to stay autonomous:** each team keeps their repo, workflow, and release cadence while still participating in a unified graph.
 
 The two aren't mutually exclusive. Start synthetic for org-wide visibility, then consolidate tightly coupled teams into real monorepos where it makes sense.
+
+## Synthetic monorepos with Nx Polygraph
+
+Nx implements synthetic monorepos through [Nx Polygraph](/docs/enterprise/polygraph). Polygraph connects existing repositories into a unified, intelligent graph that powers the visibility, coordination, and CI features described above. It works with any repo, even those that don't use Nx, and requires zero changes to target repos.
+
+Learn more about [getting started with Nx Polygraph](/docs/enterprise/polygraph).

--- a/astro-docs/src/content/docs/concepts/synthetic-monorepos.mdoc
+++ b/astro-docs/src/content/docs/concepts/synthetic-monorepos.mdoc
@@ -54,15 +54,12 @@ This is the same workflow you'd get with a real monorepo, but without requiring 
 
 ## When to use a synthetic monorepo vs. a real monorepo
 
-A real monorepo gives you the deepest integration: atomic commits, a single toolchain, and the simplest mental model. If you can consolidate, it's the best option.
+A real monorepo is the best option when you can consolidate. It gives you atomic commits, a single toolchain, and the simplest mental model.
 
-But consolidation isn't always feasible. Teams have autonomy concerns, repos have different CI setups, and migrating hundreds of repos is a multi-month effort. A synthetic monorepo gives you monorepo intelligence without requiring that migration.
+A synthetic monorepo is the better starting point when:
 
-**Start synthetic, consolidate where it makes sense.** The two approaches aren't mutually exclusive. A common progression:
+- **Consolidation isn't feasible yet** — team autonomy concerns, divergent CI setups, or hundreds of repos make migration impractical.
+- **You need cross-repo visibility now** — you can't wait months for a migration to see how projects relate across teams.
+- **Teams need to stay autonomous** — each team keeps their repo, workflow, and release cadence while still participating in a unified graph.
 
-1. **Connect** existing repos into a unified graph with Nx Polygraph. No code changes, no CI changes required.
-2. **Observe** how projects relate. Use the graph for visibility, impact analysis, and conformance checking.
-3. **Automate** coordinated changes, cross-repo CI, and AI agent workflows across the graph.
-4. **Consolidate gradually** where it makes sense. Teams that work closely together can merge repos into a real monorepo, guided by the relationships the graph reveals.
-
-You might end up with a mix: a few real monorepos for tightly coupled teams, connected through a synthetic monorepo for org-wide visibility. Nx supports both, and moving between them is incremental.
+The two aren't mutually exclusive. Start synthetic for org-wide visibility, then consolidate tightly coupled teams into real monorepos where it makes sense.

--- a/astro-docs/src/content/docs/concepts/synthetic-monorepos.mdoc
+++ b/astro-docs/src/content/docs/concepts/synthetic-monorepos.mdoc
@@ -23,7 +23,7 @@ A synthetic monorepo addresses several downsides of a polyrepo setup:
 
 **Coordination** — Cross-repo changes no longer require manually sequencing PRs, managing compatibility, and coordinating release order. Tooling on top of the graph enables impact analysis, coordinated changes, and conformance checking across repo boundaries.
 
-**Governance** — Organizational standards apply across every connected repo through [conformance rules](/docs/enterprise/polygraph/conformance). Scheduled [custom workflows](/docs/enterprise/polygraph/custom-workflows) check repos continuously — even ones nobody has touched in months. Detection and enforcement happen automatically, not through tickets and follow-ups.
+**Governance** — Organizational standards apply across every connected repo through [conformance rules](/docs/enterprise/conformance). Scheduled [custom workflows](/docs/enterprise/custom-workflows) check repos continuously — even ones nobody has touched in months. Detection and enforcement happen automatically, not through tickets and follow-ups.
 
 **CI intelligence** — [Affected detection](/docs/concepts/mental-model#affected-commands), [remote caching](/docs/concepts/how-caching-works), and [distributed task execution](/docs/concepts/ci-concepts/parallelization-distribution) work across the full graph, not just within a single repo.
 

--- a/astro-docs/src/content/docs/concepts/synthetic-monorepos.mdoc
+++ b/astro-docs/src/content/docs/concepts/synthetic-monorepos.mdoc
@@ -1,0 +1,70 @@
+---
+title: Synthetic Monorepos
+description: Learn how synthetic monorepos connect separate repositories into a unified dependency graph, giving you monorepo intelligence without moving code.
+---
+
+Most organizations don't have a single giant monorepo. They have a handful of monorepos per team or domain, plus dozens of standalone repos. Consolidating everything into one repository is not just a technical challenge: the organizational side — bringing teams along, changing workflows, ensuring adoption — is often harder than the code migration itself.
+
+Synthetic monorepos let you get monorepo benefits without that consolidation.
+
+## What is a synthetic monorepo?
+
+A synthetic monorepo connects separate repositories into a unified dependency graph without moving any code. Which repo depends on which, what a change affects downstream, how projects relate across teams: all of that becomes visible automatically.
+
+> A synthetic monorepo doesn't tear down the walls between repos. It creates tunnels through them, giving humans and AI agents the visibility to effectively work across boundaries.
+
+Unlike a traditional monorepo where all code lives in one repository, a synthetic monorepo leaves each repository where it is. Instead, it builds a cross-repo graph that tooling can reason about, just as if the code were in one place.
+
+## Why they matter
+
+Repository boundaries create problems at multiple levels.
+
+### For humans
+
+Collaboration, visibility, and enforcing common standards across an organization becomes hard when code is spread across many repos. A platform engineer or software architect who needs to ensure multiple systems work together cohesively has to manually catalog, inspect, and cross-reference dozens or hundreds of repos to make sure things align.
+
+Cross-repo changes are especially painful: coordinating PRs, ensuring compatibility, managing release order — all of this becomes a manual, error-prone process.
+
+### For AI agents
+
+Repository boundaries are walls AI agents cannot see across. Agents operate at a local maximum based on the information available in a single repo, missing downstream impacts, shared types, and cross-project relationships.
+
+Consider an AI agent implementing a feature that spans a backend API and a frontend app in separate repos. Without cross-repo visibility, the agent must work against specs or documentation rather than actual implementation. Information gets lost in handoffs, shared types must be manually provided, and coordination falls on the human.
+
+With a synthetic monorepo, the agent can read the cross-repo graph and understand how projects relate, enabling coordinated changes across repo boundaries.
+
+## What synthetic monorepos provide
+
+### Cross-repo dependency graph
+
+Automatically creates a dependency graph across repositories, representing how they connect. This gives you the same visibility you'd get in a monorepo: which project depends on which, what a change affects downstream, and how teams' work relates.
+
+### Tooling on top of the graph
+
+The graph becomes actionable, not just a visualization. Conformance checking, impact analysis, and coordinated changes all become possible across repo boundaries. CI intelligence like affected detection, caching, and distribution can work across the full graph.
+
+### AI agent enablement
+
+Tooling built on synthetic monorepos exposes metadata that AI agents can read and use to see beyond polyrepo boundaries. This enables patterns like:
+
+- A **coordinator agent** reads the cross-repo graph and identifies affected repos
+- **Per-repo agents** are spawned for each repo that needs changes (backend, frontend, etc.)
+- The coordinator **funnels context between agents** (e.g., passing DTO structures from the backend agent to the frontend agent)
+- Agents **manage the PR lifecycle** across repos, with a consolidated view as if submitting to one repo
+
+## An entry point, not an endpoint
+
+A synthetic monorepo is an entry point, not an endpoint. Organizations can start with cross-repo visibility and gradually deepen integration where it makes sense, one team or repo at a time.
+
+The progression looks like this:
+
+1. **Connect** — Link existing repos into a unified graph. No code changes, no CI changes required.
+2. **Observe** — Use the graph for visibility, impact analysis, and conformance checking.
+3. **Automate** — Enable coordinated changes, cross-repo CI, and AI agent workflows.
+4. **Migrate gradually** — Where it makes sense, consolidate repos into actual monorepos, guided by the relationships the graph reveals.
+
+You don't have to reorganize your repos to start getting monorepo benefits. Start synthetic, migrate gradually, move at your own pace.
+
+{% aside type="note" title="Nx and synthetic monorepos" %}
+Nx supports synthetic monorepos through [Nx Polygraph](/docs/enterprise/polygraph), which connects existing repositories into a unified, intelligent graph. Polygraph works with any repo — even those that don't use Nx — through metadata-only workspaces that require zero changes to target repos.
+{% /aside %}

--- a/astro-docs/src/content/docs/concepts/synthetic-monorepos.mdoc
+++ b/astro-docs/src/content/docs/concepts/synthetic-monorepos.mdoc
@@ -47,7 +47,7 @@ Nx Polygraph exposes metadata that AI agents can read and use to operate across 
 2. A **coordinator agent** reads the Polygraph graph, identifies affected repos (e.g., backend and frontend)
 3. **Per-repo agents** are spawned in parallel: the backend agent adjusts the API, the frontend agent updates the UI
 4. The coordinator **funnels context between agents** (e.g., the DTO structure from the backend agent is passed to the frontend agent so types stay in sync)
-5. Each agent **submits a PR** in its repo, [self-healing CI](/docs/platform-features/ci/self-healing-ci) kicks in if CI fails
+5. Each agent **submits a PR** in its repo, [self-healing CI](/docs/features/ci-features/self-healing-ci) kicks in if CI fails
 6. Result: coordinated PRs across repos, tracked in a single Nx Cloud dashboard
 
 This is the same workflow you'd get with a real monorepo, but without requiring code to live in one repository.

--- a/astro-docs/src/content/docs/concepts/synthetic-monorepos.mdoc
+++ b/astro-docs/src/content/docs/concepts/synthetic-monorepos.mdoc
@@ -3,7 +3,7 @@ title: Synthetic Monorepos
 description: Learn how synthetic monorepos connect separate repositories into a unified dependency graph, giving you monorepo intelligence without moving code.
 ---
 
-Most organizations don't have a single giant monorepo. They have a handful of monorepos per team or domain, plus dozens of standalone repos. Consolidating everything into one repository is not just a technical challenge: the organizational side — bringing teams along, changing workflows, ensuring adoption — is often harder than the code migration itself.
+Most organizations don't have a single giant monorepo. They have a handful of monorepos per team or domain, plus dozens of standalone repos. Consolidating everything into one repository is not just a technical challenge. The organizational side (bringing teams along, changing workflows, ensuring adoption) is often harder than the code migration itself.
 
 Synthetic monorepos let you get monorepo benefits without that consolidation.
 
@@ -11,60 +11,58 @@ Synthetic monorepos let you get monorepo benefits without that consolidation.
 
 A synthetic monorepo connects separate repositories into a unified dependency graph without moving any code. Which repo depends on which, what a change affects downstream, how projects relate across teams: all of that becomes visible automatically.
 
-> A synthetic monorepo doesn't tear down the walls between repos. It creates tunnels through them, giving humans and AI agents the visibility to effectively work across boundaries.
+![A synthetic monorepo connecting multiple monorepos and standalone repos into a unified dependency graph](../../../assets/concepts/synthetic-monorepo.svg)
 
 Unlike a traditional monorepo where all code lives in one repository, a synthetic monorepo leaves each repository where it is. Instead, it builds a cross-repo graph that tooling can reason about, just as if the code were in one place.
 
+Nx implements synthetic monorepos through [Nx Polygraph](/docs/enterprise/polygraph). Polygraph connects existing repositories into a unified, intelligent graph. It works with any repo, even those that don't use Nx, through metadata-only workspaces that require zero changes to target repos.
+
 ## Why they matter
 
-Repository boundaries create problems at multiple levels.
+Repository boundaries create problems at multiple levels:
 
-### For humans
-
-Collaboration, visibility, and enforcing common standards across an organization becomes hard when code is spread across many repos. A platform engineer or software architect who needs to ensure multiple systems work together cohesively has to manually catalog, inspect, and cross-reference dozens or hundreds of repos to make sure things align.
-
-Cross-repo changes are especially painful: coordinating PRs, ensuring compatibility, managing release order — all of this becomes a manual, error-prone process.
-
-### For AI agents
-
-Repository boundaries are walls AI agents cannot see across. Agents operate at a local maximum based on the information available in a single repo, missing downstream impacts, shared types, and cross-project relationships.
-
-Consider an AI agent implementing a feature that spans a backend API and a frontend app in separate repos. Without cross-repo visibility, the agent must work against specs or documentation rather than actual implementation. Information gets lost in handoffs, shared types must be manually provided, and coordination falls on the human.
-
-With a synthetic monorepo, the agent can read the cross-repo graph and understand how projects relate, enabling coordinated changes across repo boundaries.
+|                     | Polyrepo problem                                                                                                         | What a synthetic monorepo solves                                                                                      |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| **Visibility**      | No way to see how projects across repos relate. Platform engineers manually catalog and cross-reference dozens of repos. | Automatic cross-repo dependency graph shows which repo depends on which and what a change affects downstream.         |
+| **Coordination**    | Cross-repo changes require coordinating PRs, ensuring compatibility, and managing release order manually.                | Tooling on top of the graph enables coordinated changes, impact analysis, and conformance checking across boundaries. |
+| **Standards**       | Enforcing common conventions across repos requires manual effort and often drifts.                                       | Conformance rules and architecture constraints apply across the entire graph.                                         |
+| **CI intelligence** | Each repo has its own CI in isolation. No affected detection, caching, or distribution across repo boundaries.           | CI can work across the full graph: affected detection, remote caching, and distributed task execution span repos.     |
+| **AI agents**       | Agents operate within a single repo, missing downstream impacts, shared types, and cross-project relationships.          | Agents read the cross-repo graph and perform coordinated changes across repo boundaries.                              |
 
 ## What synthetic monorepos provide
 
 ### Cross-repo dependency graph
 
-Automatically creates a dependency graph across repositories, representing how they connect. This gives you the same visibility you'd get in a monorepo: which project depends on which, what a change affects downstream, and how teams' work relates.
+Nx Polygraph automatically creates a dependency graph across repositories through the [Workspace Graph](/docs/enterprise/polygraph). This gives you the same visibility you'd get in a monorepo: which project depends on which, what a change affects downstream, and how teams' work relates.
 
 ### Tooling on top of the graph
 
-The graph becomes actionable, not just a visualization. Conformance checking, impact analysis, and coordinated changes all become possible across repo boundaries. CI intelligence like affected detection, caching, and distribution can work across the full graph.
+The graph becomes actionable, not just a visualization. Conformance checking, impact analysis, and coordinated changes all become possible across repo boundaries. Nx Cloud CI features like [affected detection](/docs/concepts/mental-model#affected-commands), [remote caching](/docs/concepts/how-caching-works), and [distribution](/docs/concepts/ci-concepts/parallelization-distribution) work across the full graph.
 
-### AI agent enablement
+### AI agent workflows across repos
 
-Tooling built on synthetic monorepos exposes metadata that AI agents can read and use to see beyond polyrepo boundaries. This enables patterns like:
+Nx Polygraph exposes metadata that AI agents can read and use to operate across polyrepo boundaries. Through Nx's [MCP integration](/docs/features/enhance-ai) and agent skills, this enables multi-repo agentic workflows:
 
-- A **coordinator agent** reads the cross-repo graph and identifies affected repos
-- **Per-repo agents** are spawned for each repo that needs changes (backend, frontend, etc.)
-- The coordinator **funnels context between agents** (e.g., passing DTO structures from the backend agent to the frontend agent)
-- Agents **manage the PR lifecycle** across repos, with a consolidated view as if submitting to one repo
+1. You give a prompt like _"Change the ratings API to also include the review author"_
+2. A **coordinator agent** reads the Polygraph graph, identifies affected repos (e.g., backend and frontend)
+3. **Per-repo agents** are spawned in parallel: the backend agent adjusts the API, the frontend agent updates the UI
+4. The coordinator **funnels context between agents** (e.g., the DTO structure from the backend agent is passed to the frontend agent so types stay in sync)
+5. Each agent **submits a PR** in its repo, [self-healing CI](/docs/platform-features/ci/self-healing-ci) kicks in if CI fails
+6. Result: coordinated PRs across repos, tracked in a single Nx Cloud dashboard
 
-## An entry point, not an endpoint
+This is the same workflow you'd get with a real monorepo, but without requiring code to live in one repository.
 
-A synthetic monorepo is an entry point, not an endpoint. Organizations can start with cross-repo visibility and gradually deepen integration where it makes sense, one team or repo at a time.
+## When to use a synthetic monorepo vs. a real monorepo
 
-The progression looks like this:
+A real monorepo gives you the deepest integration: atomic commits, a single toolchain, and the simplest mental model. If you can consolidate, it's the best option.
 
-1. **Connect** — Link existing repos into a unified graph. No code changes, no CI changes required.
-2. **Observe** — Use the graph for visibility, impact analysis, and conformance checking.
-3. **Automate** — Enable coordinated changes, cross-repo CI, and AI agent workflows.
-4. **Migrate gradually** — Where it makes sense, consolidate repos into actual monorepos, guided by the relationships the graph reveals.
+But consolidation isn't always feasible. Teams have autonomy concerns, repos have different CI setups, and migrating hundreds of repos is a multi-month effort. A synthetic monorepo gives you monorepo intelligence without requiring that migration.
 
-You don't have to reorganize your repos to start getting monorepo benefits. Start synthetic, migrate gradually, move at your own pace.
+**Start synthetic, consolidate where it makes sense.** The two approaches aren't mutually exclusive. A common progression:
 
-{% aside type="note" title="Nx and synthetic monorepos" %}
-Nx supports synthetic monorepos through [Nx Polygraph](/docs/enterprise/polygraph), which connects existing repositories into a unified, intelligent graph. Polygraph works with any repo — even those that don't use Nx — through metadata-only workspaces that require zero changes to target repos.
-{% /aside %}
+1. **Connect** existing repos into a unified graph with Nx Polygraph. No code changes, no CI changes required.
+2. **Observe** how projects relate. Use the graph for visibility, impact analysis, and conformance checking.
+3. **Automate** coordinated changes, cross-repo CI, and AI agent workflows across the graph.
+4. **Consolidate gradually** where it makes sense. Teams that work closely together can merge repos into a real monorepo, guided by the relationships the graph reveals.
+
+You might end up with a mix: a few real monorepos for tightly coupled teams, connected through a synthetic monorepo for org-wide visibility. Nx supports both, and moving between them is incremental.


### PR DESCRIPTION
## Current Behavior

No documentation exists explaining the concept of synthetic monorepos — how they bridge polyrepo and monorepo setups by connecting separate repositories into a unified dependency graph.

https://deploy-preview-34565--nx-docs.netlify.app/docs/concepts/synthetic-monorepos

## Expected Behavior

New concept page under "How Nx Works" that explains:
- What synthetic monorepos are (unified graph across separate repos without moving code)
- Why they matter for humans (visibility, cross-repo coordination) and AI agents (seeing beyond repo boundaries)
- What they provide (cross-repo graph, actionable tooling, AI agent enablement)
- How they serve as a gradual entry point toward deeper monorepo adoption

## Related Issue(s)

N/A — new documentation page based on existing content from webinars and internal knowledge.