### PR TITLE
fix(module-federation): widen @module-federation/enhanced peer dep range and update to v2

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -2241,6 +2241,23 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "22.5.3": {
+      "version": "22.5.3-beta.0",
+      "packages": {
+        "@module-federation/enhanced": {
+          "version": "^2.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@module-federation/runtime": {
+          "version": "^2.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@module-federation/sdk": {
+          "version": "^2.0.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/angular/src/utils/backward-compatible-versions.ts
+++ b/packages/angular/src/utils/backward-compatible-versions.ts
@@ -31,7 +31,7 @@ export const backwardCompatibleVersions: VersionMap = {
     typesExpressVersion: '^4.17.21',
     browserSyncVersion: '^3.0.0',
     moduleFederationNodeVersion: '^2.7.21',
-    moduleFederationEnhancedVersion: '^0.21.2',
+    moduleFederationEnhancedVersion: '^2.0.0',
     angularEslintVersion: '^20.3.0',
     typescriptEslintVersion: '^7.16.0',
     tailwindVersion: '^3.0.2',

--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -14,7 +14,7 @@ export const expressVersion = '^4.21.2';
 export const typesExpressVersion = '^4.17.21';
 export const browserSyncVersion = '^3.0.0';
 export const moduleFederationNodeVersion = '^2.7.21';
-export const moduleFederationEnhancedVersion = '^0.21.2';
+export const moduleFederationEnhancedVersion = '^2.0.0';
 export const webpackMergeVersion = '^5.8.0';
 
 export const angularEslintVersion = '^21.0.1';

--- a/packages/module-federation/migrations.json
+++ b/packages/module-federation/migrations.json
@@ -121,6 +121,23 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "22.5.3": {
+      "version": "22.5.3-beta.0",
+      "packages": {
+        "@module-federation/enhanced": {
+          "version": "^2.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@module-federation/runtime": {
+          "version": "^2.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@module-federation/sdk": {
+          "version": "^2.0.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/module-federation/package.json
+++ b/packages/module-federation/package.json
@@ -24,9 +24,9 @@
   "main": "index.js",
   "executors": "./executors.json",
   "dependencies": {
-    "@module-federation/enhanced": "^0.21.2",
+    "@module-federation/enhanced": ">=0.21.2 <3.0.0",
     "@module-federation/node": "^2.7.21",
-    "@module-federation/sdk": "^0.21.2",
+    "@module-federation/sdk": ">=0.21.2 <3.0.0",
     "@nx/devkit": "workspace:*",
     "@nx/js": "workspace:*",
     "@nx/web": "workspace:*",

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -181,6 +181,23 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "22.5.3": {
+      "version": "22.5.3-beta.0",
+      "packages": {
+        "@module-federation/enhanced": {
+          "version": "^2.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@module-federation/runtime": {
+          "version": "^2.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@module-federation/sdk": {
+          "version": "^2.0.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -62,7 +62,7 @@ export const isbotVersion = '^3.6.5';
 export const corsVersion = '~2.8.5';
 export const typesCorsVersion = '~2.8.12';
 export const moduleFederationNodeVersion = '^2.7.21';
-export const moduleFederationEnhancedVersion = '^0.21.2';
+export const moduleFederationEnhancedVersion = '^2.0.0';
 
 // style preprocessors
 export const lessVersion = '3.12.2';

--- a/packages/rspack/migrations.json
+++ b/packages/rspack/migrations.json
@@ -114,6 +114,23 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "22.5.3": {
+      "version": "22.5.3-beta.0",
+      "packages": {
+        "@module-federation/enhanced": {
+          "version": "^2.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@module-federation/runtime": {
+          "version": "^2.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@module-federation/sdk": {
+          "version": "^2.0.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   },
   "version": "0.1"

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -61,8 +61,16 @@
     "@nx/nest": "workspace:*"
   },
   "peerDependencies": {
-    "@module-federation/enhanced": "^0.21.2",
+    "@module-federation/enhanced": ">=0.21.2 <3.0.0",
     "@module-federation/node": "^2.7.21"
+  },
+  "peerDependenciesMeta": {
+    "@module-federation/enhanced": {
+      "optional": true
+    },
+    "@module-federation/node": {
+      "optional": true
+    }
   },
   "nx-migrations": {
     "migrations": "./migrations.json"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3433,14 +3433,14 @@ importers:
   packages/module-federation:
     dependencies:
       '@module-federation/enhanced':
-        specifier: ^0.21.2
-        version: 0.21.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.3(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
+        specifier: '>=0.21.2 <3.0.0'
+        version: 0.21.6(@rspack/core@1.6.8(@swc/helpers@0.5.18))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.3(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
       '@module-federation/node':
         specifier: ^2.7.21
         version: 2.7.21(@rspack/core@1.6.8(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.55.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.3(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
       '@module-federation/sdk':
-        specifier: ^0.21.2
-        version: 0.21.2
+        specifier: '>=0.21.2 <3.0.0'
+        version: 0.21.6
       '@nx/devkit':
         specifier: workspace:*
         version: link:../devkit
@@ -4079,8 +4079,8 @@ importers:
   packages/rspack:
     dependencies:
       '@module-federation/enhanced':
-        specifier: ^0.21.2
-        version: 0.21.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.3(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
+        specifier: '>=0.21.2 <3.0.0'
+        version: 0.21.6(@rspack/core@1.6.8(@swc/helpers@0.5.18))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.3(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
       '@module-federation/node':
         specifier: ^2.7.21
         version: 2.7.21(@rspack/core@1.6.8(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.55.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.3(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
@@ -33057,6 +33057,14 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@module-federation/data-prefetch@0.21.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@module-federation/runtime': 0.21.6
+      '@module-federation/sdk': 0.21.6
+      fs-extra: 9.1.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   '@module-federation/dts-plugin@0.21.2(typescript@5.9.2)':
     dependencies:
       '@module-federation/error-codes': 0.21.2
@@ -33168,6 +33176,34 @@ snapshots:
       '@module-federation/bridge-react-webpack-plugin': 0.21.6
       '@module-federation/cli': 0.21.6(typescript@5.9.2)
       '@module-federation/data-prefetch': 0.21.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@module-federation/dts-plugin': 0.21.6(typescript@5.9.2)
+      '@module-federation/error-codes': 0.21.6
+      '@module-federation/inject-external-runtime-core-plugin': 0.21.6(@module-federation/runtime-tools@0.21.6)
+      '@module-federation/managers': 0.21.6
+      '@module-federation/manifest': 0.21.6(typescript@5.9.2)
+      '@module-federation/rspack': 0.21.6(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.2)
+      '@module-federation/runtime-tools': 0.21.6
+      '@module-federation/sdk': 0.21.6
+      btoa: 1.2.1
+      schema-utils: 4.3.2
+      upath: 2.0.1
+    optionalDependencies:
+      typescript: 5.9.2
+      webpack: 5.101.3(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - debug
+      - react
+      - react-dom
+      - supports-color
+      - utf-8-validate
+
+  '@module-federation/enhanced@0.21.6(@rspack/core@1.6.8(@swc/helpers@0.5.18))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.3(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))':
+    dependencies:
+      '@module-federation/bridge-react-webpack-plugin': 0.21.6
+      '@module-federation/cli': 0.21.6(typescript@5.9.2)
+      '@module-federation/data-prefetch': 0.21.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@module-federation/dts-plugin': 0.21.6(typescript@5.9.2)
       '@module-federation/error-codes': 0.21.6
       '@module-federation/inject-external-runtime-core-plugin': 0.21.6(@module-federation/runtime-tools@0.21.6)


### PR DESCRIPTION
The `@module-federation/enhanced` peer dependency in `@nx/rspack` was pinned to
`^0.21.2` which under semver 0.x rules only allows `>=0.21.2 <0.22.0`. Since
the package has released 0.22.x, 0.23.x, and 2.0.x, users installing the latest
version get unmet peer dependency warnings.

- Widen dep ranges from `^0.21.2` to `>=0.21.2 <3.0.0` in @nx/rspack and
  @nx/module-federation to accept all current versions
- Make MF peer deps optional in @nx/rspack since not all rspack users use
  Module Federation
- Update generator version constants to `^2.0.0` so new projects scaffold
  with the latest stable version
- Add 22.5.3 migration entries to update existing projects to ^2.0.0

Fixes #34420
