### PR TITLE
docs(core): move synthetic monorepos to How Nx Works section

### DIFF
--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -93,6 +93,10 @@ const learnGroups: SidebarItems = [
         link: 'concepts/ci-concepts/parallelization-distribution',
       },
       { label: 'Nx Daemon', link: 'concepts/nx-daemon' },
+      {
+        label: 'Synthetic Monorepos',
+        link: 'concepts/synthetic-monorepos',
+      },
     ],
   },
   {
@@ -101,10 +105,6 @@ const learnGroups: SidebarItems = [
     items: [
       { label: 'Run Tasks', link: 'features/run-tasks' },
       { label: 'Enhance Your LLM', link: 'features/enhance-ai' },
-      {
-        label: 'Synthetic Monorepos',
-        link: 'concepts/synthetic-monorepos',
-      },
       {
         label: 'Code Organization',
         collapsed: true,


### PR DESCRIPTION
## Current Behavior

The "Synthetic Monorepos" page appears under the "Platform Features" sidebar section.

## Expected Behavior

The "Synthetic Monorepos" page appears under the "How Nx Works" sidebar section (after "Nx Daemon"), which is a better conceptual fit.

## Related Issue(s)

N/A - sidebar reorganization