### PR TITLE
feat(core): add explicit cloud opt-out to CNW

### DIFF
--- a/packages/create-nx-workspace/src/create-workspace-options.ts
+++ b/packages/create-nx-workspace/src/create-workspace-options.ts
@@ -42,10 +42,15 @@ export interface CreateWorkspaceOptions {
   cliName?: string; // Name of the CLI, used when displaying outputs. e.g. nx, Nx
   aiAgents?: Agent[]; // List of AI agents to configure
   /**
-   * @description Skip cloud connection (variant 1 experiment - NXC-3628)
+   * @description Skip cloud connection (deferred - show banner but don't write nxCloudId)
    * @default false
    */
   skipCloudConnect?: boolean;
+  /**
+   * @description Set neverConnectToCloud in nx.json (full opt-out)
+   * @default false
+   */
+  neverConnectToCloud?: boolean;
   /**
    * @description Whether GitHub CLI (gh) is available on the system (for telemetry)
    */

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -35,10 +35,12 @@ export async function determineNxCloud(
 
 export async function determineNxCloudV2(
   parsedArgs: yargs.Arguments<{ nxCloud?: string; interactive?: boolean }>
-): Promise<'github' | 'skip'> {
+): Promise<'yes' | 'skip' | 'never'> {
   // Provided via flag
   if (parsedArgs.nxCloud) {
-    return parsedArgs.nxCloud === 'skip' ? 'skip' : 'github';
+    if (parsedArgs.nxCloud === 'skip') return 'skip';
+    if (parsedArgs.nxCloud === 'never') return 'never';
+    return 'yes';
   }
 
   // Non-interactive mode
@@ -46,9 +48,10 @@ export async function determineNxCloudV2(
     return 'skip';
   }
 
-  // Auto-select GitHub flow for deferred connection (variant 2 locked in - CLOUD-4255)
-  // Note: skipCloudConnect=true prevents actual connection, but we still get the banner
-  return 'github';
+  const result = await nxCloudPrompt('setupNxCloudV2');
+  if (result === 'never') return 'never';
+  if (result === 'skip') return 'skip';
+  return 'yes';
 }
 
 export async function determineIfGitHubWillBeUsed(

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -163,6 +163,7 @@ export const NxCloudChoices = [
   'bitbucket-pipelines',
   'circleci',
   'skip',
+  'never',
   'yes', // Deprecated but still handled
 ];
 
@@ -212,52 +213,14 @@ const messageOptions: Record<string, MessageData[]> = {
    * Simplified Cloud prompt for template flow
    */
   setupNxCloudV2: [
-    //{
-    //  code: 'cloud-v2-remote-cache-visit',
-    //  message: 'Enable remote caching with Nx Cloud?',
-    //  initial: 0,
-    //  choices: [
-    //    { value: 'yes', name: 'Yes' },
-    //    { value: 'skip', name: 'Skip' },
-    //  ],
-    //  footer:
-    //    '\nRemote caching makes your builds faster for development and in CI: https://nx.dev/ci/features/remote-cache',
-    //  fallback: undefined,
-    //  completionMessage: 'cache-setup',
-    //},
-    //{
-    //  code: 'cloud-v2-fast-ci-visit',
-    //  message: 'Speed up CI and reduce compute costs with Nx Cloud?',
-    //  initial: 0,
-    //  choices: [
-    //    { value: 'yes', name: 'Yes' },
-    //    { value: 'skip', name: 'Skip' },
-    //  ],
-    //  footer:
-    //    '\n70% faster CI, 60% less compute, Automatically fix broken PRs: https://nx.dev/nx-cloud',
-    //  fallback: undefined,
-    //  completionMessage: 'ci-setup',
-    //},
-    //{
-    //  code: 'cloud-v2-green-prs-visit',
-    //  message: 'Get to green PRs faster with Nx Cloud?',
-    //  initial: 0,
-    //  choices: [
-    //    { value: 'yes', name: 'Yes' },
-    //    { value: 'skip', name: 'Skip' },
-    //  ],
-    //  footer:
-    //    '\nAutomatically fix broken PRs, 70% faster CI: https://nx.dev/nx-cloud',
-    //  fallback: undefined,
-    //  completionMessage: 'ci-setup',
-    //},
     {
-      code: 'cloud-v2-full-platform-visit',
-      message: 'Try the full Nx platform?',
+      code: 'connect-to-cloud',
+      message: 'Connect to Nx Cloud?',
       initial: 0,
       choices: [
         { value: 'yes', name: 'Yes' },
-        { value: 'skip', name: 'Skip' },
+        { value: 'skip', name: 'Skip for now' },
+        { value: 'never', name: "No, don't ask again" },
       ],
       footer:
         '\nAutomatically fix broken PRs, 70% faster CI: https://nx.dev/nx-cloud',

--- a/packages/create-nx-workspace/src/utils/nx/messages.ts
+++ b/packages/create-nx-workspace/src/utils/nx/messages.ts
@@ -11,7 +11,7 @@ export type BannerVariant = '0' | '2';
  * Generates a simple box banner with the setup URL.
  */
 function generateSimpleBanner(url: string): string[] {
-  const content = `Finish your set up here: ${url}`;
+  const content = `Finish setup: ${url}`;
   // Add padding around content (3 spaces on each side)
   const innerWidth = content.length + 6;
   const horizontalBorder = '+' + '-'.repeat(innerWidth) + '+';

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -16,7 +16,8 @@ export type NxCloud =
   | 'azure'
   | 'bitbucket-pipelines'
   | 'circleci'
-  | 'skip';
+  | 'skip'
+  | 'never';
 
 export async function connectToNxCloudForTemplate(
   directory: string,
@@ -145,4 +146,13 @@ export function getSkippedNxCloudInfo() {
   const out = new CLIOutput(false);
   out.success(getSkippedCloudMessage());
   return out.getOutput();
+}
+
+export function setNeverConnectToCloud(directory: string): void {
+  const { readFileSync, writeFileSync } = require('fs');
+  const { join } = require('path');
+  const nxJsonPath = join(directory, 'nx.json');
+  const nxJson = JSON.parse(readFileSync(nxJsonPath, 'utf-8'));
+  nxJson.neverConnectToCloud = true;
+  writeFileSync(nxJsonPath, JSON.stringify(nxJson, null, 2) + '\n');
 }


### PR DESCRIPTION
## Current Behavior

The CNW cloud prompt is locked to auto-select deferred connection (CLOUD-4255), always generating a short URL but never writing nxCloudId to nx.json. Users have no explicit choice.


## Expected Behavior

The cloud prompt now offers three explicit choices:
- Yes: connect now, generate nxCloudId in nx.json, show strong completion message
- Skip for now: deferred connection (no nxCloudId), still show short URL and update README
- No: full opt-out, set neverConnectToCloud: true in nx.json, no URL, no README update, no cloud messaging

**CLI args:** `--nxCloud=skip`, `--nxCloud=never` (new), `--nxCloud=yes`. Non-interactive defaults to skip.

Closes CLOUD-4242
