### PR TITLE
chore(gradle): bump version to 0.1.13

### DIFF
--- a/packages/gradle/migrations.json
+++ b/packages/gradle/migrations.json
@@ -83,6 +83,12 @@
       "cli": "nx",
       "description": "Change dev.nx.gradle.project-graph to version 0.1.12 in build file",
       "factory": "./src/migrations/22-5-0/change-plugin-version-0-1-12"
+    },
+    "change-plugin-version-0-1-13": {
+      "version": "22.5.3-beta.0",
+      "cli": "nx",
+      "description": "Change dev.nx.gradle.project-graph to version 0.1.13 in build file",
+      "factory": "./src/migrations/22-5-3/change-plugin-version-0-1-13"
     }
   },
   "packageJsonUpdates": {}

--- a/packages/gradle/project-graph/build.gradle.kts
+++ b/packages/gradle/project-graph/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 group = "dev.nx.gradle"
 
-version = "0.1.12"
+version = "0.1.13"
 
 repositories { mavenCentral() }
 

--- a/packages/gradle/src/migrations/22-5-3/change-plugin-version-0-1-13.md
+++ b/packages/gradle/src/migrations/22-5-3/change-plugin-version-0-1-13.md
@@ -1,0 +1,21 @@
+#### Change dev.nx.gradle.project-graph to version 0.1.13
+
+Change dev.nx.gradle.project-graph to version 0.1.13 in build file
+
+#### Sample Code Changes
+
+##### Before
+
+```text title="build.gradle"
+plugins {
+	id "dev.nx.gradle.project-graph" version "0.1.12"
+}
+```
+
+##### After
+
+```text title="build.gradle"
+plugins {
+    id "dev.nx.gradle.project-graph" version "0.1.13"
+}
+```

--- a/packages/gradle/src/migrations/22-5-3/change-plugin-version-0-1-13.spec.ts
+++ b/packages/gradle/src/migrations/22-5-3/change-plugin-version-0-1-13.spec.ts
@@ -1,0 +1,261 @@
+import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
+import { Tree } from '@nx/devkit';
+import { FsTree } from 'nx/src/generators/tree';
+import update from './change-plugin-version-0-1-13';
+import { gradleProjectGraphPluginName } from '../../utils/versions';
+
+describe('change-plugin-version-0-1-13 migration', () => {
+  let tempFs: TempFs;
+  let cwd: string;
+  let tree: Tree;
+
+  beforeEach(async () => {
+    tempFs = new TempFs('test');
+    cwd = process.cwd();
+    process.chdir(tempFs.tempDir);
+    tree = new FsTree(tempFs.tempDir, false);
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    process.chdir(cwd);
+  });
+
+  it('should update plugin version to 0.1.13 in Groovy DSL', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({
+        plugins: ['@nx/gradle'],
+      }),
+      'proj/settings.gradle': '',
+      'proj/build.gradle': `plugins {
+    id 'java'
+    id "${gradleProjectGraphPluginName}" version "0.0.1"
+}`,
+    });
+
+    await update(tree);
+
+    const content = tree.read('proj/build.gradle', 'utf-8');
+    expect(content).toContain(
+      `id "${gradleProjectGraphPluginName}" version "0.1.13"`
+    );
+    expect(content).not.toContain('version "0.0.1"');
+  });
+
+  it('should update plugin version to 0.1.13 in Kotlin DSL', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({
+        plugins: ['@nx/gradle'],
+      }),
+      'proj/settings.gradle.kts': '',
+      'proj/build.gradle.kts': `plugins {
+    id("java")
+    id("${gradleProjectGraphPluginName}") version("0.0.1")
+}`,
+    });
+
+    await update(tree);
+
+    const content = tree.read('proj/build.gradle.kts', 'utf-8');
+    expect(content).toContain(
+      `id("${gradleProjectGraphPluginName}") version("0.1.13")`
+    );
+    expect(content).not.toContain('version("0.0.1")');
+  });
+
+  it('should not update if nx.json is missing', async () => {
+    await tempFs.createFiles({
+      'proj/settings.gradle': '',
+      'proj/build.gradle': `plugins {
+    id 'java'
+    id "${gradleProjectGraphPluginName}" version "0.0.1"
+}`,
+    });
+
+    await update(tree);
+
+    const content = tree.read('proj/build.gradle', 'utf-8');
+    expect(content).toContain('version "0.0.1"');
+    expect(content).not.toContain('version "0.1.13"');
+  });
+
+  it('should not update if Gradle plugin is not present', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({}),
+      'proj/settings.gradle': '',
+      'proj/build.gradle': `plugins {
+    id 'java'
+}`,
+    });
+
+    await update(tree);
+
+    const content = tree.read('proj/build.gradle', 'utf-8');
+    expect(content).not.toContain(gradleProjectGraphPluginName);
+  });
+
+  it('should handle multiple build.gradle files', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({
+        plugins: ['@nx/gradle'],
+      }),
+      'proj1/settings.gradle': '',
+      'proj1/build.gradle': `plugins {
+    id 'java'
+    id "${gradleProjectGraphPluginName}" version "0.0.1"
+}`,
+      'proj2/settings.gradle': '',
+      'proj2/build.gradle': `plugins {
+    id 'java'
+    id "${gradleProjectGraphPluginName}" version "0.0.1"
+}`,
+    });
+
+    await update(tree);
+
+    const proj1Content = tree.read('proj1/build.gradle', 'utf-8');
+    const proj2Content = tree.read('proj2/build.gradle', 'utf-8');
+
+    expect(proj1Content).toContain(
+      `id "${gradleProjectGraphPluginName}" version "0.1.13"`
+    );
+    expect(proj2Content).toContain(
+      `id "${gradleProjectGraphPluginName}" version "0.1.13"`
+    );
+    expect(proj1Content).not.toContain('version "0.0.1"');
+    expect(proj2Content).not.toContain('version "0.0.1"');
+  });
+
+  it('should update plugin version in libs.versions.toml with version.ref', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({
+        plugins: ['@nx/gradle'],
+      }),
+      'proj/settings.gradle': '',
+      'proj/build.gradle': `plugins {
+    id 'java'
+}`,
+      'proj/gradle/libs.versions.toml': `[versions]
+nx-project-graph = "0.0.1"
+
+[plugins]
+nx-graph = { id = "${gradleProjectGraphPluginName}", version.ref = "nx-project-graph" }
+`,
+    });
+
+    await update(tree);
+
+    const catalogContent = tree.read('proj/gradle/libs.versions.toml', 'utf-8');
+    expect(catalogContent).toContain('nx-project-graph = "0.1.13"');
+    expect(catalogContent).not.toContain('nx-project-graph = "0.0.1"');
+  });
+
+  it('should update plugin version in libs.versions.toml with direct version', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({
+        plugins: ['@nx/gradle'],
+      }),
+      'proj/settings.gradle': '',
+      'proj/build.gradle': `plugins {
+    id 'java'
+}`,
+      'proj/gradle/libs.versions.toml': `[plugins]
+nx-graph = { id = "${gradleProjectGraphPluginName}", version = "0.0.1" }
+`,
+    });
+
+    await update(tree);
+
+    const catalogContent = tree.read('proj/gradle/libs.versions.toml', 'utf-8');
+    expect(catalogContent).toContain('version = "0.1.13"');
+    expect(catalogContent).not.toContain('version = "0.0.1"');
+  });
+
+  it('should update plugin version in libs.versions.toml with simple format', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({
+        plugins: ['@nx/gradle'],
+      }),
+      'proj/settings.gradle': '',
+      'proj/build.gradle': `plugins {
+    id 'java'
+}`,
+      'proj/gradle/libs.versions.toml': `[plugins]
+nx-graph = "${gradleProjectGraphPluginName}:0.0.1"
+`,
+    });
+
+    await update(tree);
+
+    const catalogContent = tree.read('proj/gradle/libs.versions.toml', 'utf-8');
+    expect(catalogContent).toContain(
+      `"${gradleProjectGraphPluginName}:0.1.13"`
+    );
+    expect(catalogContent).not.toContain(':0.0.1');
+  });
+
+  it('should handle both version catalog and build.gradle updates', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({
+        plugins: ['@nx/gradle'],
+      }),
+      'proj/settings.gradle': '',
+      'proj/build.gradle': `plugins {
+    id 'java'
+    id "${gradleProjectGraphPluginName}" version "0.0.1"
+}`,
+      'proj/gradle/libs.versions.toml': `[versions]
+nx-project-graph = "0.0.2"
+
+[plugins]
+nx-graph = { id = "${gradleProjectGraphPluginName}", version.ref = "nx-project-graph" }
+`,
+    });
+
+    await update(tree);
+
+    const buildContent = tree.read('proj/build.gradle', 'utf-8');
+    const catalogContent = tree.read('proj/gradle/libs.versions.toml', 'utf-8');
+
+    expect(buildContent).toContain(
+      `id "${gradleProjectGraphPluginName}" version "0.1.13"`
+    );
+    expect(catalogContent).toContain('nx-project-graph = "0.1.13"');
+    expect(buildContent).not.toContain('version "0.0.1"');
+    expect(catalogContent).not.toContain('nx-project-graph = "0.0.2"');
+  });
+
+  it('should update nx-gradle-project-graph version in comprehensive libs.versions.toml', async () => {
+    await tempFs.createFiles({
+      'nx.json': JSON.stringify({
+        plugins: ['@nx/gradle'],
+      }),
+      'proj/settings.gradle': '',
+      'proj/build.gradle': `plugins {
+    id 'java'
+}`,
+      'proj/gradle/libs.versions.toml': `[versions]
+nx-gradle-project-graph = "0.1.3"
+
+[libraries]
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+
+[plugins]
+nx-gradle-project-graph = { id = "${gradleProjectGraphPluginName}", version.ref = "nx-gradle-project-graph" }
+
+[bundles]
+kotlin-base = ["kotlin-stdlib", "kotlin-reflect"]
+junit-base = ["junit"]
+`,
+    });
+
+    await update(tree);
+
+    const catalogContent = tree.read('proj/gradle/libs.versions.toml', 'utf-8');
+
+    expect(catalogContent).toContain('nx-gradle-project-graph = "0.1.13"');
+    expect(catalogContent).not.toContain('nx-gradle-project-graph = "0.1.3"');
+  });
+});

--- a/packages/gradle/src/migrations/22-5-3/change-plugin-version-0-1-13.ts
+++ b/packages/gradle/src/migrations/22-5-3/change-plugin-version-0-1-13.ts
@@ -1,0 +1,24 @@
+import { Tree, readNxJson } from '@nx/devkit';
+import { hasGradlePlugin } from '../../utils/has-gradle-plugin';
+import { addNxProjectGraphPlugin } from '../../generators/init/gradle-project-graph-plugin-utils';
+import { updateNxPluginVersionInCatalogsAst } from '../../utils/version-catalog-ast-utils';
+
+/* Change the plugin version to 0.1.13
+ */
+export default async function update(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  if (!nxJson) {
+    return;
+  }
+  if (!hasGradlePlugin(tree)) {
+    return;
+  }
+
+  const gradlePluginVersionToUpdate = '0.1.13';
+
+  // Update version in version catalogs using AST-based approach to preserve formatting
+  await updateNxPluginVersionInCatalogsAst(tree, gradlePluginVersionToUpdate);
+
+  // Then update in build.gradle(.kts) files
+  await addNxProjectGraphPlugin(tree, gradlePluginVersionToUpdate);
+}

--- a/packages/gradle/src/utils/versions.ts
+++ b/packages/gradle/src/utils/versions.ts
@@ -1,4 +1,4 @@
 export const nxVersion = require('../../package.json').version;
 
 export const gradleProjectGraphPluginName = 'dev.nx.gradle.project-graph';
-export const gradleProjectGraphVersion = '0.1.12';
+export const gradleProjectGraphVersion = '0.1.13';


### PR DESCRIPTION
## Current Behavior

The Gradle project graph plugin (`dev.nx.gradle.project-graph`) is at version 0.1.12.

## Expected Behavior

Bump the Gradle project graph plugin to version 0.1.13, including a migration to automatically update users' build files.

## Related Issue(s)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)