### PR TITLE
fix(bundling): fix regression on process.env usage for webpack

### DIFF
--- a/packages/webpack/src/utils/get-client-environment.ts
+++ b/packages/webpack/src/utils/get-client-environment.ts
@@ -26,7 +26,12 @@ export function getClientEnvironment(mode?: string) {
     },
     // Provide a fallback for process.env itself to handle cases where code
     // accesses process.env directly (e.g., in Cypress component testing)
-    { 'process.env': '({})' } as Record<string, string>
+    {
+      'process.env': Object.keys(raw).reduce((env, key) => {
+        env[key] = JSON.stringify(raw[key]);
+        return env;
+      }, {}),
+    }
   );
 
   return { stringified };


### PR DESCRIPTION
When we optimized the `process.env` values to not embed the full object
unnecessarily, we also regressed in cases where users do use
`process.env` instead of `process.env["NX_PUBLIC_FOO"]`.

## Current behavior

Users cannot use `process.env` and must access each key individuall.
Although the serializing the full object can bloat bundle sizes, we also
don't want to break existing apps unnecessarily.

## Expected behavior

Existing apps should continue to work as usual.

## Related issues

Fixes #34279
