### PR TITLE
feat(gradle): use glob patterns for task inputs

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
@@ -108,7 +108,8 @@ private fun buildTestCiTarget(
     gitIgnoreClassifier: GitIgnoreClassifier
 ): MutableMap<String, Any?> {
   val taskInputs =
-      getInputsForTask(null, testTask, projectRoot, workspaceRoot, null, gitIgnoreClassifier)
+      getInputsForTask(
+          null, testTask, projectRoot, workspaceRoot, null, gitIgnoreClassifier, testTask.project)
 
   val target =
       mutableMapOf<String, Any?>(
@@ -146,7 +147,8 @@ private fun ensureParentCiTarget(
 ) {
   if (ciDependsOn.isNotEmpty()) {
     val taskInputs =
-        getInputsForTask(null, testTask, projectRoot, workspaceRoot, null, gitIgnoreClassifier)
+        getInputsForTask(
+            null, testTask, projectRoot, workspaceRoot, null, gitIgnoreClassifier, testTask.project)
 
     targets[ciTestTargetName] =
         mutableMapOf<String, Any?>(


### PR DESCRIPTION
## Current Behavior
We currently enumerate over all inputs, which can blow up the size of the gradle node report. 

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Refactor task input processing to use glob patterns instead of individual file paths. This improves cache efficiency by grouping source files by their source roots and using {projectRoot}/**/* and {workspaceRoot}/**/* patterns.

Also improves NxProjectReportTask to use buffered file comparison instead of loading entire JSON into memory for comparison.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #Q-247
