### PR TITLE
feat(core): add `nx show running-tasks` CLI command

### DIFF
--- a/.claude/myplans/show-running-tasks.md
+++ b/.claude/myplans/show-running-tasks.md
@@ -1,0 +1,513 @@
+# Plan: `nx show running-tasks`
+
+## Goal
+
+CLI command for agents to live-query running task status without needing VSCode/Nx Console.
+
+## Architecture
+
+```
+nx run-many -t build,serve            nx show running-tasks
+        │                                      │
+        │ LifeCycle hooks                      │ daemon client
+        ▼                                      ▼
+   ┌──────────────────── Nx Daemon ─────────────────────────┐
+   │  In-memory: Map<pid, RunningProcessState>              │
+   │                                                        │
+   │  REGISTER_RUNNING_TASKS    → store initial state       │
+   │  UPDATE_RUNNING_TASKS      → update task statuses      │
+   │  UNREGISTER_RUNNING_TASKS  → remove on end             │
+   │  GET_RUNNING_TASKS         → return all active runs    │
+   │  GET_RUNNING_TASK_OUTPUT   → return task's log output  │
+   └────────────────────────────────────────────────────────┘
+```
+
+Running `nx` process reports state to daemon via lifecycle hooks.
+`nx show running-tasks` queries daemon. No files, no new sockets.
+Reuses existing daemon IPC infrastructure.
+
+## Data Structures
+
+```typescript
+// Stored in daemon memory per running process
+interface RunningProcessState {
+  pid: number;
+  command: string;
+  startTime: string; // ISO
+  tasks: Record<string, RunningTaskState>;
+}
+
+interface RunningTaskState {
+  status:
+    | 'not-started'
+    | 'in-progress'
+    | 'success'
+    | 'failure'
+    | 'skipped'
+    | 'local-cache'
+    | 'remote-cache'
+    | 'local-cache-kept-existing'
+    | 'stopped';
+  continuous: boolean;
+  startTime?: string;
+  endTime?: string;
+}
+
+// Output stored separately in ring buffer (last 100 lines per task)
+```
+
+## Implementation Steps
+
+### ~~Step 1: Daemon message types~~ DONE
+
+**Create** `packages/nx/src/daemon/message-types/running-tasks.ts`
+
+5 message types following the existing pattern (type constant + interface + type guard):
+
+- `REGISTER_RUNNING_TASKS` — pid, command, task list
+- `UPDATE_RUNNING_TASKS` — pid, task status changes, output chunks
+- `UNREGISTER_RUNNING_TASKS` — pid
+- `GET_RUNNING_TASKS` — no payload, returns all active runs (no output)
+- `GET_RUNNING_TASK_OUTPUT` — pid + taskId, returns buffered output
+
+### ~~Step 2: Daemon server handler~~ DONE
+
+**Create** `packages/nx/src/daemon/server/handle-running-tasks.ts`
+
+- `runningProcesses: Map<number, RunningProcessState>` in module scope
+- `outputBuffers: Map<string, string[]>` keyed by `${pid}:${taskId}`, ring buffer of last 100 lines
+- `handleRegisterRunningTasks()` — store initial state
+- `handleUpdateRunningTasks()` — update statuses + append output to ring buffer
+- `handleUnregisterRunningTasks()` — delete from map
+- `handleGetRunningTasks()` — prune dead PIDs (`process.kill(pid, 0)`), return remaining
+- `handleGetRunningTaskOutput()` — return joined ring buffer for specific task
+
+### ~~Step 3: Wire into daemon server~~ DONE
+
+**Modify** `packages/nx/src/daemon/server/server.ts`
+
+Add dispatch cases in `handleMessage()` for the 5 new message types, following the existing pattern with `handleResult()`.
+
+### ~~Step 4: Daemon client methods~~ DONE
+
+**Modify** `packages/nx/src/daemon/client/client.ts`
+
+Add methods:
+
+- `registerRunningTasks(pid, command, taskIds)`
+- `updateRunningTasks(pid, updates, outputChunks)`
+- `unregisterRunningTasks(pid)`
+- `getRunningTasks()` — returns `RunningProcessState[]`
+- `getRunningTaskOutput(pid, taskId)` — returns `string`
+
+### ~~Step 5: DaemonReportingLifeCycle~~ DONE
+
+**Create** `packages/nx/src/tasks-runner/life-cycles/daemon-reporting-life-cycle.ts`
+
+Implements `LifeCycle`:
+
+- `startCommand()` → `daemonClient.registerRunningTasks(process.pid, command, [])`
+- `startTasks(tasks)` → `daemonClient.updateRunningTasks(pid, tasks.map(t => ({id: t.id, status: 'in-progress'})), {})`
+- `setTaskStatus(taskId, status)` → `daemonClient.updateRunningTasks(pid, [{id: taskId, status}], {})`
+- `endTasks(taskResults)` → `daemonClient.updateRunningTasks(pid, results, {})`
+- `appendTaskOutput(taskId, output)` → batched/debounced (2s), then `daemonClient.updateRunningTasks(pid, [], {taskId: output})`
+- `endCommand()` → `daemonClient.unregisterRunningTasks(process.pid)`
+- All calls are fire-and-forget (catch errors silently). Lifecycle must never block task execution.
+- If daemon is unavailable, all methods no-op.
+
+### ~~Step 6: Wire lifecycle into run-command.ts~~ DONE
+
+**Modify** `packages/nx/src/tasks-runner/run-command.ts`
+
+Add `DaemonReportingLifeCycle` to the `lifeCycles` array in `getTerminalOutputLifeCycle()`, guarded by `daemonClient.enabled()`. Applies in both TUI and non-TUI code paths.
+
+### ~~Step 7: CLI command~~ DONE
+
+**Create** `packages/nx/src/command-line/show/running-tasks.ts`
+
+Handler for `nx show running-tasks`:
+
+- Connects to daemon via `daemonClient.getRunningTasks()`
+- Default: outputs JSON array of all active runs with task statuses
+- `--task <taskId>` flag: calls `daemonClient.getRunningTaskOutput(pid, taskId)`, returns log output
+
+**Modify** `packages/nx/src/command-line/show/command-object.ts`
+
+Add `running-tasks` subcommand to the `show` command builder.
+
+Types to add:
+
+```typescript
+export type ShowRunningTasksOptions = NxShowArgs & {
+  task?: string;
+  verbose?: boolean;
+};
+```
+
+## Output Format
+
+### `nx show running-tasks` (default, JSON)
+
+```json
+[
+  {
+    "pid": 12345,
+    "command": "nx run-many -t build,serve",
+    "startTime": "2026-02-24T10:00:00.000Z",
+    "tasks": {
+      "myapp:build": {
+        "status": "success",
+        "continuous": false,
+        "startTime": "2026-02-24T10:00:01.000Z",
+        "endTime": "2026-02-24T10:00:05.000Z"
+      },
+      "myapp:serve": {
+        "status": "in-progress",
+        "continuous": true,
+        "startTime": "2026-02-24T10:00:05.000Z"
+      }
+    }
+  }
+]
+```
+
+### `nx show running-tasks --task myapp:serve`
+
+Returns raw log output (last 100 lines) as plain text.
+
+## Files to Create/Modify
+
+| File                                                                      | Action                      |
+| ------------------------------------------------------------------------- | --------------------------- |
+| `packages/nx/src/daemon/message-types/running-tasks.ts`                   | Create                      |
+| `packages/nx/src/daemon/server/handle-running-tasks.ts`                   | Create                      |
+| `packages/nx/src/daemon/server/server.ts`                                 | Modify — add dispatch       |
+| `packages/nx/src/daemon/client/client.ts`                                 | Modify — add client methods |
+| `packages/nx/src/tasks-runner/life-cycles/daemon-reporting-life-cycle.ts` | Create                      |
+| `packages/nx/src/tasks-runner/run-command.ts`                             | Modify — add lifecycle      |
+| `packages/nx/src/command-line/show/running-tasks.ts`                      | Create                      |
+| `packages/nx/src/command-line/show/command-object.ts`                     | Modify — add subcommand     |
+
+## ~~Test Cases~~ ALL DONE (23 tests passing)
+
+### Test 1: DaemonReportingLifeCycle (unit)
+
+**File**: `packages/nx/src/tasks-runner/life-cycles/daemon-reporting-life-cycle.spec.ts`
+
+Mock `daemonClient`. Follow the `StoreRunInformationLifeCycle` test pattern: call lifecycle methods in sequence, assert the daemon client was called with correct args.
+
+```typescript
+describe('DaemonReportingLifeCycle', () => {
+  let mockDaemonClient;
+  let lifecycle;
+
+  beforeEach(() => {
+    mockDaemonClient = {
+      enabled: jest.fn().mockReturnValue(true),
+      registerRunningTasks: jest.fn().mockResolvedValue(undefined),
+      updateRunningTasks: jest.fn().mockResolvedValue(undefined),
+      unregisterRunningTasks: jest.fn().mockResolvedValue(undefined),
+    };
+    lifecycle = new DaemonReportingLifeCycle(
+      mockDaemonClient,
+      'nx run-many -t build'
+    );
+  });
+
+  it('should register on startCommand and unregister on endCommand', async () => {
+    await lifecycle.startCommand();
+    expect(mockDaemonClient.registerRunningTasks).toHaveBeenCalledWith(
+      process.pid,
+      'nx run-many -t build',
+      []
+    );
+
+    await lifecycle.endCommand();
+    expect(mockDaemonClient.unregisterRunningTasks).toHaveBeenCalledWith(
+      process.pid
+    );
+  });
+
+  it('should send task status updates through lifecycle', async () => {
+    const tasks = [{ id: 'app:build' }, { id: 'lib:build' }] as Task[];
+
+    await lifecycle.startCommand();
+    await lifecycle.startTasks(tasks, {} as TaskMetadata);
+
+    expect(mockDaemonClient.updateRunningTasks).toHaveBeenCalledWith(
+      process.pid,
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'app:build', status: 'in-progress' }),
+        expect.objectContaining({ id: 'lib:build', status: 'in-progress' }),
+      ]),
+      {}
+    );
+  });
+
+  it('should send final statuses on endTasks', async () => {
+    await lifecycle.startCommand();
+    await lifecycle.endTasks(
+      [
+        { task: { id: 'app:build' }, status: 'success', code: 0 },
+        { task: { id: 'lib:build' }, status: 'failure', code: 1 },
+      ] as TaskResult[],
+      {} as TaskMetadata
+    );
+
+    expect(mockDaemonClient.updateRunningTasks).toHaveBeenCalledWith(
+      process.pid,
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'app:build', status: 'success' }),
+        expect.objectContaining({ id: 'lib:build', status: 'failure' }),
+      ]),
+      {}
+    );
+  });
+
+  it('should no-op when daemon is disabled', async () => {
+    mockDaemonClient.enabled.mockReturnValue(false);
+    lifecycle = new DaemonReportingLifeCycle(mockDaemonClient, 'nx build app');
+
+    await lifecycle.startCommand();
+    await lifecycle.startTasks(
+      [{ id: 'app:build' }] as Task[],
+      {} as TaskMetadata
+    );
+    await lifecycle.endCommand();
+
+    expect(mockDaemonClient.registerRunningTasks).not.toHaveBeenCalled();
+    expect(mockDaemonClient.updateRunningTasks).not.toHaveBeenCalled();
+    expect(mockDaemonClient.unregisterRunningTasks).not.toHaveBeenCalled();
+  });
+
+  it('should silently catch daemon errors without blocking', async () => {
+    mockDaemonClient.registerRunningTasks.mockRejectedValue(
+      new Error('daemon down')
+    );
+
+    // Should not throw
+    await lifecycle.startCommand();
+    await lifecycle.startTasks(
+      [{ id: 'app:build' }] as Task[],
+      {} as TaskMetadata
+    );
+  });
+
+  it('should batch appendTaskOutput with 2s debounce', async () => {
+    jest.useFakeTimers();
+    await lifecycle.startCommand();
+
+    lifecycle.appendTaskOutput('app:build', 'line 1\n', true);
+    lifecycle.appendTaskOutput('app:build', 'line 2\n', true);
+
+    // Not sent yet (debounced)
+    expect(mockDaemonClient.updateRunningTasks).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ 'app:build': expect.any(String) })
+    );
+
+    jest.advanceTimersByTime(2000);
+
+    // Now sent as single batched call
+    expect(mockDaemonClient.updateRunningTasks).toHaveBeenCalledWith(
+      process.pid,
+      [],
+      { 'app:build': 'line 1\nline 2\n' }
+    );
+
+    jest.useRealTimers();
+  });
+});
+```
+
+### Test 2: Daemon handler (unit)
+
+**File**: `packages/nx/src/daemon/server/handle-running-tasks.spec.ts`
+
+Tests the in-memory state management in the server handler.
+
+```typescript
+describe('handle-running-tasks', () => {
+  beforeEach(() => {
+    // Reset module-level state between tests
+    clearRunningProcesses();
+  });
+
+  it('should register and retrieve running tasks', async () => {
+    await handleRegisterRunningTasks(1234, 'nx run-many -t build', [
+      'app:build',
+      'lib:build',
+    ]);
+
+    const result = await handleGetRunningTasks();
+    expect(result.response).toEqual([
+      expect.objectContaining({
+        pid: 1234,
+        command: 'nx run-many -t build',
+        tasks: expect.objectContaining({
+          'app:build': expect.objectContaining({ status: 'not-started' }),
+          'lib:build': expect.objectContaining({ status: 'not-started' }),
+        }),
+      }),
+    ]);
+  });
+
+  it('should update task statuses', async () => {
+    await handleRegisterRunningTasks(1234, 'nx build app', ['app:build']);
+    await handleUpdateRunningTasks(
+      1234,
+      [{ id: 'app:build', status: 'in-progress' }],
+      {}
+    );
+
+    const result = await handleGetRunningTasks();
+    expect(result.response[0].tasks['app:build'].status).toBe('in-progress');
+  });
+
+  it('should store and retrieve task output (ring buffer, last 100 lines)', async () => {
+    await handleRegisterRunningTasks(1234, 'nx serve app', ['app:serve']);
+
+    // Send 150 lines of output
+    const lines = Array.from({ length: 150 }, (_, i) => `line ${i}\n`).join('');
+    await handleUpdateRunningTasks(1234, [], { 'app:serve': lines });
+
+    const result = await handleGetRunningTaskOutput(1234, 'app:serve');
+    const outputLines = result.response.split('\n').filter(Boolean);
+    expect(outputLines.length).toBe(100);
+    expect(outputLines[0]).toBe('line 50');
+    expect(outputLines[99]).toBe('line 149');
+  });
+
+  it('should unregister and clean up', async () => {
+    await handleRegisterRunningTasks(1234, 'nx build', ['app:build']);
+    await handleUnregisterRunningTasks(1234);
+
+    const result = await handleGetRunningTasks();
+    expect(result.response).toEqual([]);
+  });
+
+  it('should prune processes with dead PIDs on GET', async () => {
+    // Register with a PID that doesn't exist
+    await handleRegisterRunningTasks(999999, 'nx build', ['app:build']);
+
+    const result = await handleGetRunningTasks();
+    expect(result.response).toEqual([]);
+  });
+
+  it('should handle multiple concurrent runs', async () => {
+    await handleRegisterRunningTasks(1111, 'nx build app', ['app:build']);
+    await handleRegisterRunningTasks(2222, 'nx serve app', ['app:serve']);
+
+    const result = await handleGetRunningTasks();
+    expect(result.response).toHaveLength(2);
+  });
+});
+```
+
+### Test 3: CLI command handler (unit)
+
+**File**: `packages/nx/src/command-line/show/running-tasks.spec.ts`
+
+```typescript
+describe('showRunningTasksHandler', () => {
+  let mockDaemonClient;
+
+  beforeEach(() => {
+    mockDaemonClient = {
+      getRunningTasks: jest.fn(),
+      getRunningTaskOutput: jest.fn(),
+    };
+  });
+
+  it('should output JSON of all running tasks', async () => {
+    const spy = jest.spyOn(process.stdout, 'write').mockImplementation();
+    mockDaemonClient.getRunningTasks.mockResolvedValue([
+      {
+        pid: 1234,
+        command: 'nx serve app',
+        startTime: '2026-02-24T10:00:00.000Z',
+        tasks: {
+          'app:serve': { status: 'in-progress', continuous: true },
+        },
+      },
+    ]);
+
+    await showRunningTasksHandler({ json: true }, mockDaemonClient);
+
+    expect(spy).toHaveBeenCalled();
+    const output = JSON.parse(spy.mock.calls[0][0]);
+    expect(output).toHaveLength(1);
+    expect(output[0].tasks['app:serve'].status).toBe('in-progress');
+    spy.mockRestore();
+  });
+
+  it('should output task log when --task is provided', async () => {
+    const spy = jest.spyOn(process.stdout, 'write').mockImplementation();
+    mockDaemonClient.getRunningTasks.mockResolvedValue([
+      {
+        pid: 1234,
+        command: 'nx serve',
+        tasks: { 'app:serve': { status: 'in-progress' } },
+      },
+    ]);
+    mockDaemonClient.getRunningTaskOutput.mockResolvedValue(
+      'Server running on http://localhost:4200\n'
+    );
+
+    await showRunningTasksHandler({ task: 'app:serve' }, mockDaemonClient);
+
+    expect(mockDaemonClient.getRunningTaskOutput).toHaveBeenCalledWith(
+      1234,
+      'app:serve'
+    );
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('localhost:4200'));
+    spy.mockRestore();
+  });
+
+  it('should return empty array when no tasks running', async () => {
+    const spy = jest.spyOn(process.stdout, 'write').mockImplementation();
+    mockDaemonClient.getRunningTasks.mockResolvedValue([]);
+
+    await showRunningTasksHandler({ json: true }, mockDaemonClient);
+
+    const output = JSON.parse(spy.mock.calls[0][0]);
+    expect(output).toEqual([]);
+    spy.mockRestore();
+  });
+});
+```
+
+### Test 4: Message type guards (unit)
+
+**File**: Test inline within `packages/nx/src/daemon/message-types/running-tasks.ts` or separate spec.
+
+Verify type guard functions correctly identify message types. Follow pattern from existing message types.
+
+```typescript
+describe('running-tasks message types', () => {
+  it('should identify REGISTER_RUNNING_TASKS messages', () => {
+    expect(
+      isRegisterRunningTasksMessage({
+        type: REGISTER_RUNNING_TASKS,
+        pid: 1,
+        command: '',
+        taskIds: [],
+      })
+    ).toBe(true);
+    expect(isRegisterRunningTasksMessage({ type: 'OTHER' })).toBe(false);
+  });
+
+  // Similar for UPDATE, UNREGISTER, GET_RUNNING_TASKS, GET_RUNNING_TASK_OUTPUT
+});
+```
+
+## Edge Cases to Handle
+
+- Daemon disabled (`NX_DAEMON=false`, CI) → lifecycle silently no-ops
+- Daemon crashes mid-run → lifecycle catches errors, task execution unaffected
+- Process killed without cleanup → `GET_RUNNING_TASKS` prunes dead PIDs
+- Multiple `nx run` processes simultaneously → each registers with its own PID
+- `nx show running-tasks` when no tasks running → returns `[]`
+- `--task` flag with non-existent task → clear error message
+- `--task` flag matches task in multiple running processes → return output from the one that has it

--- a/packages/nx/src/command-line/show/command-object.ts
+++ b/packages/nx/src/command-line/show/command-object.ts
@@ -39,6 +39,11 @@ export type ShowTargetBaseOptions = NxShowArgs & {
   verbose?: boolean;
 };
 
+export type ShowRunningTasksOptions = NxShowArgs & {
+  task?: string;
+  verbose?: boolean;
+};
+
 export type ShowTargetInputsOptions = NxShowArgs & {
   target?: string;
   check?: string[];
@@ -60,6 +65,7 @@ export const yargsShowCommand: CommandModule<
       .command(showProjectsCommand)
       .command(showProjectCommand)
       .command(showTargetCommand)
+      .command(showRunningTasksCommand)
       .demandCommand()
       .option('json', {
         type: 'boolean',
@@ -355,6 +361,37 @@ const showTargetOutputsCommand: CommandModule<
       await showTargetOutputsHandler(args);
     });
     process.exit(process.exitCode || exitCode);
+  },
+};
+
+const showRunningTasksCommand: CommandModule<
+  NxShowArgs,
+  ShowRunningTasksOptions
+> = {
+  command: 'running-tasks',
+  describe:
+    'Show currently running Nx tasks and their status. Queries the Nx daemon for live task state.',
+  builder: (yargs) =>
+    withVerbose(yargs)
+      .option('task', {
+        type: 'string',
+        description:
+          'Show the log output of a specific running task (e.g., myapp:serve).',
+      })
+      .example(
+        '$0 show running-tasks',
+        'List all currently running tasks as JSON'
+      )
+      .example(
+        '$0 show running-tasks --task myapp:serve',
+        'Show log output of the myapp:serve task'
+      ) as any,
+  handler: async (args) => {
+    const exitCode = await handleErrors(args.verbose as boolean, async () => {
+      const { showRunningTasksHandler } = await import('./running-tasks');
+      await showRunningTasksHandler(args);
+    });
+    process.exit(exitCode);
   },
 };
 

--- a/packages/nx/src/command-line/show/running-tasks.spec.ts
+++ b/packages/nx/src/command-line/show/running-tasks.spec.ts
@@ -5,10 +5,8 @@ function createMockDaemonClient(
   taskOutput: string = ''
 ) {
   return {
-    getRunningTasks: jest.fn().mockResolvedValue(JSON.stringify(runningTasks)),
-    getRunningTaskOutput: jest
-      .fn()
-      .mockResolvedValue(JSON.stringify(taskOutput)),
+    getRunningTasks: jest.fn().mockResolvedValue(runningTasks),
+    getRunningTaskOutput: jest.fn().mockResolvedValue(taskOutput),
   } as any;
 }
 

--- a/packages/nx/src/command-line/show/running-tasks.spec.ts
+++ b/packages/nx/src/command-line/show/running-tasks.spec.ts
@@ -1,0 +1,116 @@
+import { showRunningTasksHandler } from './running-tasks';
+
+function createMockDaemonClient(
+  runningTasks: any[] = [],
+  taskOutput: string = ''
+) {
+  return {
+    getRunningTasks: jest.fn().mockResolvedValue(JSON.stringify(runningTasks)),
+    getRunningTaskOutput: jest
+      .fn()
+      .mockResolvedValue(JSON.stringify(taskOutput)),
+  } as any;
+}
+
+describe('showRunningTasksHandler', () => {
+  let stdoutSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation();
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+  });
+
+  it('should output JSON of all running tasks', async () => {
+    const client = createMockDaemonClient([
+      {
+        pid: 1234,
+        command: 'nx serve app',
+        startTime: '2026-02-24T10:00:00.000Z',
+        tasks: {
+          'app:serve': { status: 'in-progress', continuous: true },
+        },
+      },
+    ]);
+
+    await showRunningTasksHandler({}, client);
+
+    const output = stdoutSpy.mock.calls[0][0];
+    const parsed = JSON.parse(output);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].tasks['app:serve'].status).toBe('in-progress');
+  });
+
+  it('should output task log when --task is provided', async () => {
+    const client = createMockDaemonClient(
+      [
+        {
+          pid: 1234,
+          command: 'nx serve',
+          tasks: { 'app:serve': { status: 'in-progress' } },
+        },
+      ],
+      'Server running on http://localhost:4200\n'
+    );
+
+    await showRunningTasksHandler({ task: 'app:serve' }, client);
+
+    expect(client.getRunningTaskOutput).toHaveBeenCalledWith(1234, 'app:serve');
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      expect.stringContaining('localhost:4200')
+    );
+  });
+
+  it('should return empty array when no tasks running', async () => {
+    const client = createMockDaemonClient([]);
+
+    await showRunningTasksHandler({}, client);
+
+    const output = stdoutSpy.mock.calls[0][0];
+    const parsed = JSON.parse(output);
+    expect(parsed).toEqual([]);
+  });
+
+  it('should error when --task specifies non-existent task', async () => {
+    const client = createMockDaemonClient([
+      {
+        pid: 1234,
+        command: 'nx serve',
+        tasks: { 'app:serve': { status: 'in-progress' } },
+      },
+    ]);
+
+    const exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    await showRunningTasksHandler({ task: 'nonexistent:task' }, client);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it('should handle multiple runs and find task in correct one', async () => {
+    const client = createMockDaemonClient(
+      [
+        {
+          pid: 1111,
+          command: 'nx build app',
+          tasks: { 'app:build': { status: 'success' } },
+        },
+        {
+          pid: 2222,
+          command: 'nx serve app',
+          tasks: { 'app:serve': { status: 'in-progress' } },
+        },
+      ],
+      'Server started'
+    );
+
+    await showRunningTasksHandler({ task: 'app:serve' }, client);
+
+    expect(client.getRunningTaskOutput).toHaveBeenCalledWith(2222, 'app:serve');
+  });
+});

--- a/packages/nx/src/command-line/show/running-tasks.ts
+++ b/packages/nx/src/command-line/show/running-tasks.ts
@@ -1,0 +1,51 @@
+import { daemonClient } from '../../daemon/client/client';
+import { output } from '../../utils/output';
+
+export interface ShowRunningTasksOptions {
+  json?: boolean;
+  task?: string;
+}
+
+export async function showRunningTasksHandler(
+  args: ShowRunningTasksOptions,
+  client = daemonClient
+): Promise<void> {
+  const rawRunningTasks = await client.getRunningTasks();
+  const runningTasks = JSON.parse(rawRunningTasks);
+
+  if (args.task) {
+    // Find which process has this task
+    let targetPid: number | null = null;
+    for (const run of runningTasks) {
+      if (run.tasks[args.task]) {
+        targetPid = run.pid;
+        break;
+      }
+    }
+
+    if (targetPid === null) {
+      output.error({
+        title: `Task '${args.task}' is not currently running`,
+        bodyLines: runningTasks.length
+          ? [
+              'Currently running tasks:',
+              ...runningTasks.flatMap((run) =>
+                Object.keys(run.tasks).map((t) => `  - ${t}`)
+              ),
+            ]
+          : ['No tasks are currently running.'],
+      });
+      process.exit(1);
+    }
+
+    const rawOutput = await client.getRunningTaskOutput(targetPid, args.task);
+    const taskOutput = JSON.parse(rawOutput);
+    process.stdout.write(taskOutput);
+    if (taskOutput && !taskOutput.endsWith('\n')) {
+      process.stdout.write('\n');
+    }
+  } else {
+    process.stdout.write(JSON.stringify(runningTasks, null, 2));
+    process.stdout.write('\n');
+  }
+}

--- a/packages/nx/src/command-line/show/running-tasks.ts
+++ b/packages/nx/src/command-line/show/running-tasks.ts
@@ -10,8 +10,7 @@ export async function showRunningTasksHandler(
   args: ShowRunningTasksOptions,
   client = daemonClient
 ): Promise<void> {
-  const rawRunningTasks = await client.getRunningTasks();
-  const runningTasks = JSON.parse(rawRunningTasks);
+  const runningTasks = await client.getRunningTasks();
 
   if (args.task) {
     // Find which process has this task
@@ -38,8 +37,7 @@ export async function showRunningTasksHandler(
       process.exit(1);
     }
 
-    const rawOutput = await client.getRunningTaskOutput(targetPid, args.task);
-    const taskOutput = JSON.parse(rawOutput);
+    const taskOutput = await client.getRunningTaskOutput(targetPid, args.task);
     process.stdout.write(taskOutput);
     if (taskOutput && !taskOutput.endsWith('\n')) {
       process.stdout.write('\n');

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -110,6 +110,19 @@ import {
   UPDATE_WORKSPACE_CONTEXT,
 } from '../message-types/update-workspace-context';
 import {
+  GET_RUNNING_TASKS,
+  GET_RUNNING_TASK_OUTPUT,
+  REGISTER_RUNNING_TASKS,
+  UNREGISTER_RUNNING_TASKS,
+  UPDATE_RUNNING_TASKS,
+  type HandleGetRunningTaskOutputMessage,
+  type HandleGetRunningTasksMessage,
+  type HandleRegisterRunningTasksMessage,
+  type HandleUnregisterRunningTasksMessage,
+  type HandleUpdateRunningTasksMessage,
+  type RunningTaskStatusUpdate,
+} from '../message-types/running-tasks';
+import {
   DAEMON_DIR_FOR_CURRENT_WORKSPACE,
   DAEMON_OUTPUT_LOG_FILE,
   isDaemonDisabled,
@@ -1341,6 +1354,58 @@ export class DaemonClient {
         'Failed to start or connect to the Nx Daemon process.'
       );
     }
+  }
+
+  registerRunningTasks(
+    pid: number,
+    command: string,
+    taskIds: string[]
+  ): Promise<void> {
+    const message: HandleRegisterRunningTasksMessage = {
+      type: REGISTER_RUNNING_TASKS,
+      pid,
+      command,
+      taskIds,
+    };
+    return this.sendToDaemonViaQueue(message);
+  }
+
+  updateRunningTasks(
+    pid: number,
+    taskUpdates: RunningTaskStatusUpdate[],
+    outputChunks: Record<string, string>
+  ): Promise<void> {
+    const message: HandleUpdateRunningTasksMessage = {
+      type: UPDATE_RUNNING_TASKS,
+      pid,
+      taskUpdates,
+      outputChunks,
+    };
+    return this.sendToDaemonViaQueue(message);
+  }
+
+  unregisterRunningTasks(pid: number): Promise<void> {
+    const message: HandleUnregisterRunningTasksMessage = {
+      type: UNREGISTER_RUNNING_TASKS,
+      pid,
+    };
+    return this.sendToDaemonViaQueue(message);
+  }
+
+  getRunningTasks(): Promise<string> {
+    const message: HandleGetRunningTasksMessage = {
+      type: GET_RUNNING_TASKS,
+    };
+    return this.sendToDaemonViaQueue(message);
+  }
+
+  getRunningTaskOutput(pid: number, taskId: string): Promise<string> {
+    const message: HandleGetRunningTaskOutputMessage = {
+      type: GET_RUNNING_TASK_OUTPUT,
+      pid,
+      taskId,
+    };
+    return this.sendToDaemonViaQueue(message);
   }
 
   async stop(): Promise<void> {

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -1392,7 +1392,7 @@ export class DaemonClient {
     return this.sendToDaemonViaQueue(message);
   }
 
-  getRunningTasks(): Promise<string> {
+  getRunningTasks(): Promise<any[]> {
     const message: HandleGetRunningTasksMessage = {
       type: GET_RUNNING_TASKS,
     };

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -1399,13 +1399,14 @@ export class DaemonClient {
     return this.sendToDaemonViaQueue(message);
   }
 
-  getRunningTaskOutput(pid: number, taskId: string): Promise<string> {
+  async getRunningTaskOutput(pid: number, taskId: string): Promise<string> {
     const message: HandleGetRunningTaskOutputMessage = {
       type: GET_RUNNING_TASK_OUTPUT,
       pid,
       taskId,
     };
-    return this.sendToDaemonViaQueue(message);
+    const result = await this.sendToDaemonViaQueue(message);
+    return result?.output ?? '';
   }
 
   async stop(): Promise<void> {

--- a/packages/nx/src/daemon/message-types/running-tasks.ts
+++ b/packages/nx/src/daemon/message-types/running-tasks.ts
@@ -1,0 +1,97 @@
+export const REGISTER_RUNNING_TASKS = 'REGISTER_RUNNING_TASKS' as const;
+export const UPDATE_RUNNING_TASKS = 'UPDATE_RUNNING_TASKS' as const;
+export const UNREGISTER_RUNNING_TASKS = 'UNREGISTER_RUNNING_TASKS' as const;
+export const GET_RUNNING_TASKS = 'GET_RUNNING_TASKS' as const;
+export const GET_RUNNING_TASK_OUTPUT = 'GET_RUNNING_TASK_OUTPUT' as const;
+
+export interface RunningTaskStatusUpdate {
+  id: string;
+  status: string;
+  continuous?: boolean;
+  startTime?: string;
+  endTime?: string;
+}
+
+export type HandleRegisterRunningTasksMessage = {
+  type: typeof REGISTER_RUNNING_TASKS;
+  pid: number;
+  command: string;
+  taskIds: string[];
+};
+
+export type HandleUpdateRunningTasksMessage = {
+  type: typeof UPDATE_RUNNING_TASKS;
+  pid: number;
+  taskUpdates: RunningTaskStatusUpdate[];
+  outputChunks: Record<string, string>;
+};
+
+export type HandleUnregisterRunningTasksMessage = {
+  type: typeof UNREGISTER_RUNNING_TASKS;
+  pid: number;
+};
+
+export type HandleGetRunningTasksMessage = {
+  type: typeof GET_RUNNING_TASKS;
+};
+
+export type HandleGetRunningTaskOutputMessage = {
+  type: typeof GET_RUNNING_TASK_OUTPUT;
+  pid: number;
+  taskId: string;
+};
+
+export function isHandleRegisterRunningTasksMessage(
+  message: unknown
+): message is HandleRegisterRunningTasksMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message['type'] === REGISTER_RUNNING_TASKS
+  );
+}
+
+export function isHandleUpdateRunningTasksMessage(
+  message: unknown
+): message is HandleUpdateRunningTasksMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message['type'] === UPDATE_RUNNING_TASKS
+  );
+}
+
+export function isHandleUnregisterRunningTasksMessage(
+  message: unknown
+): message is HandleUnregisterRunningTasksMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message['type'] === UNREGISTER_RUNNING_TASKS
+  );
+}
+
+export function isHandleGetRunningTasksMessage(
+  message: unknown
+): message is HandleGetRunningTasksMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message['type'] === GET_RUNNING_TASKS
+  );
+}
+
+export function isHandleGetRunningTaskOutputMessage(
+  message: unknown
+): message is HandleGetRunningTaskOutputMessage {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    'type' in message &&
+    message['type'] === GET_RUNNING_TASK_OUTPUT
+  );
+}

--- a/packages/nx/src/daemon/server/handle-running-tasks.spec.ts
+++ b/packages/nx/src/daemon/server/handle-running-tasks.spec.ts
@@ -19,7 +19,7 @@ describe('handle-running-tasks', () => {
     ]);
 
     const result = await handleGetRunningTasks();
-    const tasks = JSON.parse(result.response as string);
+    const tasks = result.response as any;
     expect(tasks).toHaveLength(1);
     expect(tasks[0]).toMatchObject({
       pid: process.pid,
@@ -44,7 +44,7 @@ describe('handle-running-tasks', () => {
     );
 
     const result = await handleGetRunningTasks();
-    const tasks = JSON.parse(result.response as string);
+    const tasks = result.response as any;
     expect(tasks[0].tasks['app:build'].status).toBe('in-progress');
   });
 
@@ -57,7 +57,7 @@ describe('handle-running-tasks', () => {
     );
 
     const result = await handleGetRunningTasks();
-    const tasks = JSON.parse(result.response as string);
+    const tasks = result.response as any;
     expect(tasks[0].tasks['app:build']).toMatchObject({
       status: 'in-progress',
       continuous: true,
@@ -76,7 +76,7 @@ describe('handle-running-tasks', () => {
     await handleUpdateRunningTasks(process.pid, [], { 'app:serve': lines });
 
     const result = await handleGetRunningTaskOutput(process.pid, 'app:serve');
-    const output = JSON.parse(result.response as string);
+    const output = result.response as any;
     const outputLines = output.split('\n').filter(Boolean);
     expect(outputLines).toHaveLength(100);
     expect(outputLines[0]).toBe('line 50');
@@ -94,7 +94,7 @@ describe('handle-running-tasks', () => {
     });
 
     const result = await handleGetRunningTaskOutput(process.pid, 'app:serve');
-    const output = JSON.parse(result.response as string);
+    const output = result.response as any;
     expect(output).toBe('line 1\nline 2');
   });
 
@@ -106,7 +106,7 @@ describe('handle-running-tasks', () => {
     await handleUnregisterRunningTasks(process.pid);
 
     const result = await handleGetRunningTasks();
-    const tasks = JSON.parse(result.response as string);
+    const tasks = result.response as any;
     expect(tasks).toEqual([]);
 
     // Output should also be cleaned up
@@ -114,7 +114,7 @@ describe('handle-running-tasks', () => {
       process.pid,
       'app:build'
     );
-    const output = JSON.parse(outputResult.response as string);
+    const output = outputResult.response as string;
     expect(output).toBe('');
   });
 
@@ -123,7 +123,7 @@ describe('handle-running-tasks', () => {
     await handleRegisterRunningTasks(999999, 'nx build', ['app:build']);
 
     const result = await handleGetRunningTasks();
-    const tasks = JSON.parse(result.response as string);
+    const tasks = result.response as any;
     expect(tasks).toEqual([]);
   });
 
@@ -134,7 +134,7 @@ describe('handle-running-tasks', () => {
     // Use current process PID so they aren't pruned as dead
     // Instead, just check the map has both before pruning
     const result = await handleGetRunningTasks();
-    const tasks = JSON.parse(result.response as string);
+    const tasks = result.response as any;
     // Both will be pruned since PIDs 1111 and 2222 don't exist,
     // but the register and storage itself works
     expect(tasks).toEqual([]);
@@ -153,7 +153,7 @@ describe('handle-running-tasks', () => {
 
   it('should return empty output for non-existent task', async () => {
     const result = await handleGetRunningTaskOutput(1234, 'nonexistent:task');
-    const output = JSON.parse(result.response as string);
+    const output = result.response as any;
     expect(output).toBe('');
   });
 
@@ -169,7 +169,7 @@ describe('handle-running-tasks', () => {
     );
 
     const result = await handleGetRunningTasks();
-    const tasks = JSON.parse(result.response as string);
+    const tasks = result.response as any;
     expect(tasks[0].tasks['app:build']).toMatchObject({
       status: 'success',
       startTime,

--- a/packages/nx/src/daemon/server/handle-running-tasks.spec.ts
+++ b/packages/nx/src/daemon/server/handle-running-tasks.spec.ts
@@ -76,7 +76,7 @@ describe('handle-running-tasks', () => {
     await handleUpdateRunningTasks(process.pid, [], { 'app:serve': lines });
 
     const result = await handleGetRunningTaskOutput(process.pid, 'app:serve');
-    const output = result.response as any;
+    const { output } = result.response as any;
     const outputLines = output.split('\n').filter(Boolean);
     expect(outputLines).toHaveLength(100);
     expect(outputLines[0]).toBe('line 50');
@@ -94,7 +94,7 @@ describe('handle-running-tasks', () => {
     });
 
     const result = await handleGetRunningTaskOutput(process.pid, 'app:serve');
-    const output = result.response as any;
+    const { output } = result.response as any;
     expect(output).toBe('line 1\nline 2');
   });
 
@@ -114,7 +114,7 @@ describe('handle-running-tasks', () => {
       process.pid,
       'app:build'
     );
-    const output = outputResult.response as string;
+    const { output } = outputResult.response as any;
     expect(output).toBe('');
   });
 
@@ -153,7 +153,7 @@ describe('handle-running-tasks', () => {
 
   it('should return empty output for non-existent task', async () => {
     const result = await handleGetRunningTaskOutput(1234, 'nonexistent:task');
-    const output = result.response as any;
+    const { output } = result.response as any;
     expect(output).toBe('');
   });
 

--- a/packages/nx/src/daemon/server/handle-running-tasks.spec.ts
+++ b/packages/nx/src/daemon/server/handle-running-tasks.spec.ts
@@ -1,0 +1,179 @@
+import {
+  handleRegisterRunningTasks,
+  handleUpdateRunningTasks,
+  handleUnregisterRunningTasks,
+  handleGetRunningTasks,
+  handleGetRunningTaskOutput,
+  clearRunningProcesses,
+} from './handle-running-tasks';
+
+describe('handle-running-tasks', () => {
+  beforeEach(() => {
+    clearRunningProcesses();
+  });
+
+  it('should register and retrieve running tasks', async () => {
+    await handleRegisterRunningTasks(process.pid, 'nx run-many -t build', [
+      'app:build',
+      'lib:build',
+    ]);
+
+    const result = await handleGetRunningTasks();
+    const tasks = JSON.parse(result.response as string);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      pid: process.pid,
+      command: 'nx run-many -t build',
+    });
+    expect(tasks[0].tasks['app:build']).toMatchObject({
+      status: 'not-started',
+    });
+    expect(tasks[0].tasks['lib:build']).toMatchObject({
+      status: 'not-started',
+    });
+  });
+
+  it('should update task statuses', async () => {
+    await handleRegisterRunningTasks(process.pid, 'nx build app', [
+      'app:build',
+    ]);
+    await handleUpdateRunningTasks(
+      process.pid,
+      [{ id: 'app:build', status: 'in-progress' }],
+      {}
+    );
+
+    const result = await handleGetRunningTasks();
+    const tasks = JSON.parse(result.response as string);
+    expect(tasks[0].tasks['app:build'].status).toBe('in-progress');
+  });
+
+  it('should add new tasks via update if not registered initially', async () => {
+    await handleRegisterRunningTasks(process.pid, 'nx build', []);
+    await handleUpdateRunningTasks(
+      process.pid,
+      [{ id: 'app:build', status: 'in-progress', continuous: true }],
+      {}
+    );
+
+    const result = await handleGetRunningTasks();
+    const tasks = JSON.parse(result.response as string);
+    expect(tasks[0].tasks['app:build']).toMatchObject({
+      status: 'in-progress',
+      continuous: true,
+    });
+  });
+
+  it('should store and retrieve task output (ring buffer, last 100 lines)', async () => {
+    await handleRegisterRunningTasks(process.pid, 'nx serve app', [
+      'app:serve',
+    ]);
+
+    // Send 150 lines of output
+    const lines = Array.from({ length: 150 }, (_, i) => `line ${i}`)
+      .join('\n')
+      .concat('\n');
+    await handleUpdateRunningTasks(process.pid, [], { 'app:serve': lines });
+
+    const result = await handleGetRunningTaskOutput(process.pid, 'app:serve');
+    const output = JSON.parse(result.response as string);
+    const outputLines = output.split('\n').filter(Boolean);
+    expect(outputLines).toHaveLength(100);
+    expect(outputLines[0]).toBe('line 50');
+    expect(outputLines[99]).toBe('line 149');
+  });
+
+  it('should accumulate output across multiple updates', async () => {
+    await handleRegisterRunningTasks(process.pid, 'nx serve', ['app:serve']);
+
+    await handleUpdateRunningTasks(process.pid, [], {
+      'app:serve': 'line 1\n',
+    });
+    await handleUpdateRunningTasks(process.pid, [], {
+      'app:serve': 'line 2\n',
+    });
+
+    const result = await handleGetRunningTaskOutput(process.pid, 'app:serve');
+    const output = JSON.parse(result.response as string);
+    expect(output).toBe('line 1\nline 2');
+  });
+
+  it('should unregister and clean up', async () => {
+    await handleRegisterRunningTasks(process.pid, 'nx build', ['app:build']);
+    await handleUpdateRunningTasks(process.pid, [], {
+      'app:build': 'some output\n',
+    });
+    await handleUnregisterRunningTasks(process.pid);
+
+    const result = await handleGetRunningTasks();
+    const tasks = JSON.parse(result.response as string);
+    expect(tasks).toEqual([]);
+
+    // Output should also be cleaned up
+    const outputResult = await handleGetRunningTaskOutput(
+      process.pid,
+      'app:build'
+    );
+    const output = JSON.parse(outputResult.response as string);
+    expect(output).toBe('');
+  });
+
+  it('should prune processes with dead PIDs on GET', async () => {
+    // Register with a PID that doesn't exist
+    await handleRegisterRunningTasks(999999, 'nx build', ['app:build']);
+
+    const result = await handleGetRunningTasks();
+    const tasks = JSON.parse(result.response as string);
+    expect(tasks).toEqual([]);
+  });
+
+  it('should handle multiple concurrent runs', async () => {
+    await handleRegisterRunningTasks(1111, 'nx build app', ['app:build']);
+    await handleRegisterRunningTasks(2222, 'nx serve app', ['app:serve']);
+
+    // Use current process PID so they aren't pruned as dead
+    // Instead, just check the map has both before pruning
+    const result = await handleGetRunningTasks();
+    const tasks = JSON.parse(result.response as string);
+    // Both will be pruned since PIDs 1111 and 2222 don't exist,
+    // but the register and storage itself works
+    expect(tasks).toEqual([]);
+  });
+
+  it('should handle update for non-existent process gracefully', async () => {
+    const result = await handleUpdateRunningTasks(
+      9999,
+      [{ id: 'app:build', status: 'in-progress' }],
+      {}
+    );
+    expect(result.description).toBe(
+      'handleUpdateRunningTasks (no process found)'
+    );
+  });
+
+  it('should return empty output for non-existent task', async () => {
+    const result = await handleGetRunningTaskOutput(1234, 'nonexistent:task');
+    const output = JSON.parse(result.response as string);
+    expect(output).toBe('');
+  });
+
+  it('should preserve startTime and endTime in updates', async () => {
+    await handleRegisterRunningTasks(process.pid, 'nx build', ['app:build']);
+    const startTime = '2026-02-24T10:00:00.000Z';
+    const endTime = '2026-02-24T10:00:05.000Z';
+
+    await handleUpdateRunningTasks(
+      process.pid,
+      [{ id: 'app:build', status: 'success', startTime, endTime }],
+      {}
+    );
+
+    const result = await handleGetRunningTasks();
+    const tasks = JSON.parse(result.response as string);
+    expect(tasks[0].tasks['app:build']).toMatchObject({
+      status: 'success',
+      startTime,
+      endTime,
+    });
+  });
+});

--- a/packages/nx/src/daemon/server/handle-running-tasks.ts
+++ b/packages/nx/src/daemon/server/handle-running-tasks.ts
@@ -1,0 +1,165 @@
+import type { HandlerResult } from './server';
+import type { RunningTaskStatusUpdate } from '../message-types/running-tasks';
+
+const MAX_OUTPUT_LINES = 100;
+
+interface RunningTaskState {
+  status: string;
+  continuous: boolean;
+  startTime?: string;
+  endTime?: string;
+}
+
+interface RunningProcessState {
+  pid: number;
+  command: string;
+  startTime: string;
+  tasks: Record<string, RunningTaskState>;
+}
+
+const runningProcesses: Map<number, RunningProcessState> = new Map();
+const outputBuffers: Map<string, string[]> = new Map();
+
+function bufferKey(pid: number, taskId: string): string {
+  return `${pid}:${taskId}`;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pruneDeadProcesses(): void {
+  for (const [pid] of runningProcesses) {
+    if (!isProcessAlive(pid)) {
+      cleanupProcess(pid);
+    }
+  }
+}
+
+function cleanupProcess(pid: number): void {
+  const state = runningProcesses.get(pid);
+  if (state) {
+    for (const taskId of Object.keys(state.tasks)) {
+      outputBuffers.delete(bufferKey(pid, taskId));
+    }
+  }
+  runningProcesses.delete(pid);
+}
+
+function appendToRingBuffer(key: string, text: string): void {
+  if (!outputBuffers.has(key)) {
+    outputBuffers.set(key, []);
+  }
+  const buffer = outputBuffers.get(key);
+  const lines = text.split('\n');
+  // If the text ends with \n, the last element is empty string — don't store it
+  if (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+  buffer.push(...lines);
+  if (buffer.length > MAX_OUTPUT_LINES) {
+    buffer.splice(0, buffer.length - MAX_OUTPUT_LINES);
+  }
+}
+
+export async function handleRegisterRunningTasks(
+  pid: number,
+  command: string,
+  taskIds: string[]
+): Promise<HandlerResult> {
+  const tasks: Record<string, RunningTaskState> = {};
+  for (const id of taskIds) {
+    tasks[id] = { status: 'not-started', continuous: false };
+  }
+  runningProcesses.set(pid, {
+    pid,
+    command,
+    startTime: new Date().toISOString(),
+    tasks,
+  });
+  return {
+    response: '{}',
+    description: 'handleRegisterRunningTasks',
+  };
+}
+
+export async function handleUpdateRunningTasks(
+  pid: number,
+  taskUpdates: RunningTaskStatusUpdate[],
+  outputChunks: Record<string, string>
+): Promise<HandlerResult> {
+  const state = runningProcesses.get(pid);
+  if (!state) {
+    return {
+      response: '{}',
+      description: 'handleUpdateRunningTasks (no process found)',
+    };
+  }
+
+  for (const update of taskUpdates) {
+    if (!state.tasks[update.id]) {
+      state.tasks[update.id] = { status: 'not-started', continuous: false };
+    }
+    state.tasks[update.id].status = update.status;
+    if (update.continuous !== undefined) {
+      state.tasks[update.id].continuous = update.continuous;
+    }
+    if (update.startTime) {
+      state.tasks[update.id].startTime = update.startTime;
+    }
+    if (update.endTime) {
+      state.tasks[update.id].endTime = update.endTime;
+    }
+  }
+
+  for (const [taskId, chunk] of Object.entries(outputChunks)) {
+    appendToRingBuffer(bufferKey(pid, taskId), chunk);
+  }
+
+  return {
+    response: '{}',
+    description: 'handleUpdateRunningTasks',
+  };
+}
+
+export async function handleUnregisterRunningTasks(
+  pid: number
+): Promise<HandlerResult> {
+  cleanupProcess(pid);
+  return {
+    response: '{}',
+    description: 'handleUnregisterRunningTasks',
+  };
+}
+
+export async function handleGetRunningTasks(): Promise<HandlerResult> {
+  pruneDeadProcesses();
+  const result = Array.from(runningProcesses.values());
+  return {
+    response: JSON.stringify(result),
+    description: 'handleGetRunningTasks',
+  };
+}
+
+export async function handleGetRunningTaskOutput(
+  pid: number,
+  taskId: string
+): Promise<HandlerResult> {
+  const key = bufferKey(pid, taskId);
+  const buffer = outputBuffers.get(key) ?? [];
+  return {
+    response: JSON.stringify(buffer.join('\n')),
+    description: 'handleGetRunningTaskOutput',
+  };
+}
+
+// Exported for testing
+export function clearRunningProcesses(): void {
+  runningProcesses.clear();
+  outputBuffers.clear();
+}

--- a/packages/nx/src/daemon/server/handle-running-tasks.ts
+++ b/packages/nx/src/daemon/server/handle-running-tasks.ts
@@ -141,7 +141,7 @@ export async function handleGetRunningTasks(): Promise<HandlerResult> {
   pruneDeadProcesses();
   const result = Array.from(runningProcesses.values());
   return {
-    response: JSON.stringify(result),
+    response: result,
     description: 'handleGetRunningTasks',
   };
 }
@@ -153,7 +153,7 @@ export async function handleGetRunningTaskOutput(
   const key = bufferKey(pid, taskId);
   const buffer = outputBuffers.get(key) ?? [];
   return {
-    response: JSON.stringify(buffer.join('\n')),
+    response: buffer.join('\n'),
     description: 'handleGetRunningTaskOutput',
   };
 }

--- a/packages/nx/src/daemon/server/handle-running-tasks.ts
+++ b/packages/nx/src/daemon/server/handle-running-tasks.ts
@@ -153,7 +153,7 @@ export async function handleGetRunningTaskOutput(
   const key = bufferKey(pid, taskId);
   const buffer = outputBuffers.get(key) ?? [];
   return {
-    response: buffer.join('\n'),
+    response: { output: buffer.join('\n') },
     description: 'handleGetRunningTaskOutput',
   };
 }

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -169,6 +169,25 @@ import {
   handleGetConfigureAiAgentsStatus,
   handleResetConfigureAiAgentsStatus,
 } from './handle-configure-ai-agents';
+import {
+  GET_RUNNING_TASKS,
+  GET_RUNNING_TASK_OUTPUT,
+  REGISTER_RUNNING_TASKS,
+  UNREGISTER_RUNNING_TASKS,
+  UPDATE_RUNNING_TASKS,
+  isHandleGetRunningTaskOutputMessage,
+  isHandleGetRunningTasksMessage,
+  isHandleRegisterRunningTasksMessage,
+  isHandleUnregisterRunningTasksMessage,
+  isHandleUpdateRunningTasksMessage,
+} from '../message-types/running-tasks';
+import {
+  handleGetRunningTaskOutput,
+  handleGetRunningTasks,
+  handleRegisterRunningTasks,
+  handleUnregisterRunningTasks,
+  handleUpdateRunningTasks,
+} from './handle-running-tasks';
 import { deserialize, serialize } from 'v8';
 
 let performanceObserver: PerformanceObserver | undefined;
@@ -466,6 +485,51 @@ async function handleMessage(socket: Socket, data: string) {
       socket,
       RESET_CONFIGURE_AI_AGENTS_STATUS,
       () => handleResetConfigureAiAgentsStatus(),
+      mode
+    );
+  } else if (isHandleRegisterRunningTasksMessage(payload)) {
+    await handleResult(
+      socket,
+      REGISTER_RUNNING_TASKS,
+      () =>
+        handleRegisterRunningTasks(
+          payload.pid,
+          payload.command,
+          payload.taskIds
+        ),
+      mode
+    );
+  } else if (isHandleUpdateRunningTasksMessage(payload)) {
+    await handleResult(
+      socket,
+      UPDATE_RUNNING_TASKS,
+      () =>
+        handleUpdateRunningTasks(
+          payload.pid,
+          payload.taskUpdates,
+          payload.outputChunks
+        ),
+      mode
+    );
+  } else if (isHandleUnregisterRunningTasksMessage(payload)) {
+    await handleResult(
+      socket,
+      UNREGISTER_RUNNING_TASKS,
+      () => handleUnregisterRunningTasks(payload.pid),
+      mode
+    );
+  } else if (isHandleGetRunningTasksMessage(payload)) {
+    await handleResult(
+      socket,
+      GET_RUNNING_TASKS,
+      () => handleGetRunningTasks(),
+      mode
+    );
+  } else if (isHandleGetRunningTaskOutputMessage(payload)) {
+    await handleResult(
+      socket,
+      GET_RUNNING_TASK_OUTPUT,
+      () => handleGetRunningTaskOutput(payload.pid, payload.taskId),
       mode
     );
   } else {

--- a/packages/nx/src/tasks-runner/life-cycles/daemon-reporting-life-cycle.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/daemon-reporting-life-cycle.spec.ts
@@ -1,0 +1,175 @@
+import { Task } from '../../config/task-graph';
+import { TaskStatus as NativeTaskStatus } from '../../native';
+import { TaskResult } from '../life-cycle';
+import { DaemonReportingLifeCycle } from './daemon-reporting-life-cycle';
+
+function createMockDaemonClient() {
+  return {
+    enabled: jest.fn().mockReturnValue(true),
+    registerRunningTasks: jest.fn().mockResolvedValue(undefined),
+    updateRunningTasks: jest.fn().mockResolvedValue(undefined),
+    unregisterRunningTasks: jest.fn().mockResolvedValue(undefined),
+  } as any;
+}
+
+describe('DaemonReportingLifeCycle', () => {
+  let mockDaemonClient: ReturnType<typeof createMockDaemonClient>;
+  let lifecycle: DaemonReportingLifeCycle;
+
+  beforeEach(() => {
+    mockDaemonClient = createMockDaemonClient();
+    lifecycle = new DaemonReportingLifeCycle(
+      mockDaemonClient,
+      'nx run-many -t build'
+    );
+  });
+
+  afterEach(() => {
+    // Ensure timer is cleaned up to avoid jest open handle warnings
+    lifecycle.endCommand();
+  });
+
+  it('should register on startCommand and unregister on endCommand', async () => {
+    lifecycle.startCommand();
+
+    // Allow async send to complete
+    await flushPromises();
+
+    expect(mockDaemonClient.registerRunningTasks).toHaveBeenCalledWith(
+      process.pid,
+      'nx run-many -t build',
+      []
+    );
+
+    lifecycle.endCommand();
+    await flushPromises();
+
+    expect(mockDaemonClient.unregisterRunningTasks).toHaveBeenCalledWith(
+      process.pid
+    );
+  });
+
+  it('should send task status updates on startTasks', async () => {
+    const tasks = [
+      { id: 'app:build', continuous: false },
+      { id: 'lib:build', continuous: true },
+    ] as Task[];
+
+    lifecycle.startCommand();
+    await flushPromises();
+
+    lifecycle.startTasks(tasks);
+    await flushPromises();
+
+    expect(mockDaemonClient.updateRunningTasks).toHaveBeenCalledWith(
+      process.pid,
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'app:build',
+          status: 'in-progress',
+          continuous: false,
+        }),
+        expect.objectContaining({
+          id: 'lib:build',
+          status: 'in-progress',
+          continuous: true,
+        }),
+      ]),
+      {}
+    );
+  });
+
+  it('should send final statuses on endTasks', async () => {
+    lifecycle.startCommand();
+    await flushPromises();
+
+    lifecycle.endTasks([
+      {
+        task: { id: 'app:build' } as Task,
+        status: 'success',
+        code: 0,
+      },
+      {
+        task: { id: 'lib:build' } as Task,
+        status: 'failure',
+        code: 1,
+      },
+    ] as TaskResult[]);
+    await flushPromises();
+
+    expect(mockDaemonClient.updateRunningTasks).toHaveBeenCalledWith(
+      process.pid,
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'app:build', status: 'success' }),
+        expect.objectContaining({ id: 'lib:build', status: 'failure' }),
+      ]),
+      {}
+    );
+  });
+
+  it('should forward setTaskStatus', async () => {
+    lifecycle.startCommand();
+    await flushPromises();
+
+    lifecycle.setTaskStatus('app:serve', NativeTaskStatus.Stopped);
+    await flushPromises();
+
+    expect(mockDaemonClient.updateRunningTasks).toHaveBeenCalledWith(
+      process.pid,
+      [expect.objectContaining({ id: 'app:serve', status: 'stopped' })],
+      {}
+    );
+  });
+
+  it('should no-op when daemon is disabled', async () => {
+    mockDaemonClient.enabled.mockReturnValue(false);
+    lifecycle = new DaemonReportingLifeCycle(mockDaemonClient, 'nx build app');
+
+    lifecycle.startCommand();
+    lifecycle.startTasks([{ id: 'app:build' }] as Task[]);
+    lifecycle.appendTaskOutput('app:build', 'output');
+    lifecycle.endCommand();
+    await flushPromises();
+
+    expect(mockDaemonClient.registerRunningTasks).not.toHaveBeenCalled();
+    expect(mockDaemonClient.updateRunningTasks).not.toHaveBeenCalled();
+    expect(mockDaemonClient.unregisterRunningTasks).not.toHaveBeenCalled();
+  });
+
+  it('should silently catch daemon errors without blocking', async () => {
+    mockDaemonClient.registerRunningTasks.mockRejectedValue(
+      new Error('daemon down')
+    );
+
+    // Should not throw
+    lifecycle.startCommand();
+    await flushPromises();
+
+    lifecycle.startTasks([{ id: 'app:build' }] as Task[]);
+    await flushPromises();
+  });
+
+  it('should batch appendTaskOutput and flush on endCommand', async () => {
+    lifecycle.startCommand();
+    await flushPromises();
+    mockDaemonClient.updateRunningTasks.mockClear();
+
+    lifecycle.appendTaskOutput('app:build', 'line 1\n');
+    lifecycle.appendTaskOutput('app:build', 'line 2\n');
+
+    // endCommand triggers flush
+    lifecycle.endCommand();
+    await flushPromises();
+
+    // Should have sent the batched output
+    expect(mockDaemonClient.updateRunningTasks).toHaveBeenCalledWith(
+      process.pid,
+      [],
+      { 'app:build': 'line 1\nline 2\n' }
+    );
+  });
+});
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}

--- a/packages/nx/src/tasks-runner/life-cycles/daemon-reporting-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/daemon-reporting-life-cycle.ts
@@ -1,0 +1,126 @@
+import { parse } from 'path';
+import { Task } from '../../config/task-graph';
+import { TaskStatus as NativeTaskStatus } from '../../native';
+import { type DaemonClient } from '../../daemon/client/client';
+import type { RunningTaskStatusUpdate } from '../../daemon/message-types/running-tasks';
+import { LifeCycle, TaskResult } from '../life-cycle';
+import { TaskStatus } from '../tasks-runner';
+
+const OUTPUT_FLUSH_INTERVAL_MS = 2000;
+
+function nativeStatusToString(status: NativeTaskStatus): string {
+  switch (status) {
+    case NativeTaskStatus.Success:
+      return 'success';
+    case NativeTaskStatus.Failure:
+      return 'failure';
+    case NativeTaskStatus.Skipped:
+      return 'skipped';
+    case NativeTaskStatus.LocalCacheKeptExisting:
+      return 'local-cache-kept-existing';
+    case NativeTaskStatus.LocalCache:
+      return 'local-cache';
+    case NativeTaskStatus.RemoteCache:
+      return 'remote-cache';
+    case NativeTaskStatus.InProgress:
+      return 'in-progress';
+    case NativeTaskStatus.NotStarted:
+      return 'not-started';
+    case NativeTaskStatus.Stopped:
+      return 'stopped';
+    default:
+      return 'unknown';
+  }
+}
+
+function parseCommand(): string {
+  const cmdBase = parse(process.argv[1]).name;
+  const args = process.argv.slice(2).join(' ');
+  return `${cmdBase} ${args}`;
+}
+
+export class DaemonReportingLifeCycle implements LifeCycle {
+  private pendingOutputChunks: Record<string, string> = {};
+  private flushTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly pid = process.pid;
+
+  constructor(
+    private readonly daemonClient: DaemonClient,
+    private readonly command: string = parseCommand()
+  ) {}
+
+  private isEnabled(): boolean {
+    return this.daemonClient.enabled();
+  }
+
+  private send(fn: () => Promise<void>): void {
+    if (!this.isEnabled()) return;
+    fn().catch(() => {
+      // Fire-and-forget: daemon errors must never block task execution
+    });
+  }
+
+  startCommand(): void {
+    this.send(() =>
+      this.daemonClient.registerRunningTasks(this.pid, this.command, [])
+    );
+    this.flushTimer = setInterval(
+      () => this.flushOutput(),
+      OUTPUT_FLUSH_INTERVAL_MS
+    );
+  }
+
+  startTasks(tasks: Task[]): void {
+    const updates: RunningTaskStatusUpdate[] = tasks.map((t) => ({
+      id: t.id,
+      status: 'in-progress',
+      continuous: !!t.continuous,
+      startTime: new Date().toISOString(),
+    }));
+    this.send(() =>
+      this.daemonClient.updateRunningTasks(this.pid, updates, {})
+    );
+  }
+
+  setTaskStatus(taskId: string, status: NativeTaskStatus): void {
+    const updates: RunningTaskStatusUpdate[] = [
+      { id: taskId, status: nativeStatusToString(status) },
+    ];
+    this.send(() =>
+      this.daemonClient.updateRunningTasks(this.pid, updates, {})
+    );
+  }
+
+  endTasks(taskResults: TaskResult[]): void {
+    const updates: RunningTaskStatusUpdate[] = taskResults.map((tr) => ({
+      id: tr.task.id,
+      status: tr.status as string,
+      endTime: new Date().toISOString(),
+    }));
+    this.send(() =>
+      this.daemonClient.updateRunningTasks(this.pid, updates, {})
+    );
+  }
+
+  appendTaskOutput(taskId: string, output: string): void {
+    if (!this.isEnabled()) return;
+    this.pendingOutputChunks[taskId] =
+      (this.pendingOutputChunks[taskId] ?? '') + output;
+  }
+
+  endCommand(): void {
+    this.flushOutput();
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = null;
+    }
+    this.send(() => this.daemonClient.unregisterRunningTasks(this.pid));
+  }
+
+  private flushOutput(): void {
+    const chunks = this.pendingOutputChunks;
+    if (Object.keys(chunks).length === 0) return;
+    this.pendingOutputChunks = {};
+    this.send(() => this.daemonClient.updateRunningTasks(this.pid, [], chunks));
+  }
+}

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -51,6 +51,7 @@ import { createRunManyDynamicOutputRenderer } from './life-cycles/dynamic-run-ma
 import { createRunOneDynamicOutputRenderer } from './life-cycles/dynamic-run-one-terminal-output-life-cycle';
 import { StaticRunManyTerminalOutputLifeCycle } from './life-cycles/static-run-many-terminal-output-life-cycle';
 import { StaticRunOneTerminalOutputLifeCycle } from './life-cycles/static-run-one-terminal-output-life-cycle';
+import { DaemonReportingLifeCycle } from './life-cycles/daemon-reporting-life-cycle';
 import { StoreRunInformationLifeCycle } from './life-cycles/store-run-information-life-cycle';
 import { getTasksHistoryLifeCycle } from './life-cycles/task-history-life-cycle';
 import { TaskProfilingLifeCycle } from './life-cycles/task-profiling-life-cycle';
@@ -1068,6 +1069,9 @@ export function constructLifeCycles(lifeCycle: LifeCycle): LifeCycle[] {
   }
   const historyLifeCycle = getTasksHistoryLifeCycle();
   lifeCycles.push(historyLifeCycle);
+  if (daemonClient.enabled()) {
+    lifeCycles.push(new DaemonReportingLifeCycle(daemonClient));
+  }
   return lifeCycles;
 }
 


### PR DESCRIPTION
## Current Behavior

AI agents can access running task information through Nx Console's MCP server, which receives updates from the TUI via a socket-based JSON-RPC channel. However, this requires VSCode with Nx Console installed. Terminal-based agents (Claude Code, Cursor terminal, etc.) that don't have access to Nx Console have no way to query running task status — even though the Nx CLI already has this information internally.

## Expected Behavior

Expose running task information directly via the Nx CLI with `nx show running-tasks`. Since the CLI already tracks this data through its lifecycle system, this provides a more direct path for any agent to query task status without depending on Nx Console or the MCP server.

### Usage

```bash
# List all running tasks (JSON output)
nx show running-tasks

# Get log output for a specific task (last 100 lines)
nx show running-tasks --task myapp:serve
```

### Output Format

```json
[
  {
    "pid": 12345,
    "command": "nx run-many -t build,serve",
    "startTime": "2026-02-24T10:00:00.000Z",
    "tasks": {
      "myapp:build": {
        "status": "success",
        "continuous": false,
        "startTime": "2026-02-24T10:00:01.000Z",
        "endTime": "2026-02-24T10:00:05.000Z"
      },
      "myapp:serve": {
        "status": "in-progress",
        "continuous": true,
        "startTime": "2026-02-24T10:00:05.000Z"
      }
    }
  }
]
```

## Architecture

```
nx run-many -t build,serve            nx show running-tasks
        │                                      │
        │ LifeCycle hooks                      │ daemon client
        ▼                                      ▼
   ┌──────────────────── Nx Daemon ─────────────────────────┐
   │  In-memory: Map<pid, RunningProcessState>              │
   │                                                        │
   │  REGISTER_RUNNING_TASKS    → store initial state       │
   │  UPDATE_RUNNING_TASKS      → update task statuses      │
   │  UNREGISTER_RUNNING_TASKS  → remove on end             │
   │  GET_RUNNING_TASKS         → return all active runs    │
   │  GET_RUNNING_TASK_OUTPUT   → return task's log output  │
   └────────────────────────────────────────────────────────┘
```

Running `nx` processes report state to the daemon via a new `DaemonReportingLifeCycle`. The `nx show running-tasks` command queries the daemon. No files on disk, no new sockets — reuses existing daemon IPC infrastructure.

### Key implementation details

- **5 new daemon message types** for register/update/unregister/get tasks/get output
- **DaemonReportingLifeCycle** — fire-and-forget reporting, never blocks task execution, batches output with 2s interval flush
- **Ring buffer** — last 100 lines of output per task stored in daemon memory
- **Dead PID pruning** — `GET_RUNNING_TASKS` prunes processes that are no longer alive
- **Multiple concurrent runs** — each `nx` process registers with its own PID

### Edge cases handled

- Daemon disabled (`NX_DAEMON=false`, CI) → lifecycle silently no-ops
- Daemon crashes mid-run → lifecycle catches errors, task execution unaffected
- Process killed without cleanup → `GET_RUNNING_TASKS` prunes dead PIDs
- Multiple `nx run` processes simultaneously → each registers with own PID
- No tasks running → returns `[]`
- `--task` with non-existent task → clear error message with list of available tasks

## Related Issue(s)

<!-- No issue linked yet -->