### PR TITLE
docs(misc): update nx download stats

### DIFF
--- a/astro-docs/src/content/docs/guides/Adopting Nx/from-turborepo.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/from-turborepo.mdoc
@@ -107,7 +107,7 @@ This plugin system helps teams scale organizationally by:
 
 Nx has been battle-tested since 2016:
 
-- ~5 million downloads per week
+- ~9 million downloads per week
 - Nearly 2 million unique [Nx Console](https://marketplace.visualstudio.com/items?itemName=nrwl.angular-console) installations
 - Rich ecosystem of [third-party plugins](/docs/plugin-registry), many with millions of downloads in their own right
 - Used by over half of Fortune 500 companies in production


### PR DESCRIPTION
## Current Behavior
The "7. Thriving Community" section on `nx.dev/docs/guides/adopting-nx/from-turborepo` displayed an outdated Nx download statistic (~5 million downloads per week).

## Expected Behavior
The "7. Thriving Community" section on `nx.dev/docs/guides/adopting-nx/from-turborepo` now reflects the latest Nx download statistic (~9 million downloads per week).

