### PR TITLE
fix(release): add null-safe fallback for version in createGitTagValues

### DIFF
--- a/packages/nx/src/command-line/release/config/config.ts
+++ b/packages/nx/src/command-line/release/config/config.ts
@@ -920,7 +920,7 @@ export async function createNxReleaseConfig(
       // If any project in the group has docker configuration, disable semver requirement
       releaseGroup.releaseTag.requireSemver = false;
 
-      // Set preferDockerVersion to true by default when docker projects exist,
+      // Set preferDockerVersion by default when docker projects exist,
       // unless user has explicitly configured it
       if (
         releaseGroup.releaseTag.preferDockerVersion === false &&
@@ -931,7 +931,19 @@ export async function createNxReleaseConfig(
         userConfig.releaseTag?.preferDockerVersion === undefined &&
         userConfig.releaseTagPatternPreferDockerVersion === undefined
       ) {
-        releaseGroup.releaseTag.preferDockerVersion = true;
+        // Check if ALL projects have docker config, or just some
+        const allProjectsHaveDocker = releaseGroup.projects.every(
+          (projectName) => {
+            const projectNode = projectGraph.nodes[projectName];
+            const projectDockerConfig = projectNode?.data.release?.docker;
+            return projectDockerConfig !== undefined || !!releaseGroup.docker;
+          }
+        );
+
+        // Use 'both' for mixed groups so non-docker projects fall back correctly
+        releaseGroup.releaseTag.preferDockerVersion = allProjectsHaveDocker
+          ? true
+          : 'both';
       }
     }
   }

--- a/packages/nx/src/command-line/release/utils/shared.ts
+++ b/packages/nx/src/command-line/release/utils/shared.ts
@@ -313,16 +313,21 @@ export function createGitTagValues(
               );
             }
           } else {
-            // Use either docker version or semver version based on preference
-            tags.push(
-              interpolate(releaseGroup.releaseTag.pattern, {
-                version: preferDockerVersion
-                  ? projectVersionData.dockerVersion
-                  : projectVersionData.newVersion,
-                projectName: sanitizeProjectNameForGitTag(project),
-                releaseGroupName: releaseGroup.name,
-              })
-            );
+            // Use either docker version or semver version based on preference, with null fallback
+            const version = preferDockerVersion
+              ? (projectVersionData.dockerVersion ??
+                projectVersionData.newVersion)
+              : (projectVersionData.newVersion ??
+                projectVersionData.dockerVersion);
+            if (version) {
+              tags.push(
+                interpolate(releaseGroup.releaseTag.pattern, {
+                  version,
+                  projectName: sanitizeProjectNameForGitTag(project),
+                  releaseGroupName: releaseGroup.name,
+                })
+              );
+            }
           }
         }
       }
@@ -356,15 +361,18 @@ export function createGitTagValues(
           );
         }
       } else {
-        // Use either docker version or semver version based on preference
-        tags.push(
-          interpolate(releaseGroup.releaseTag.pattern, {
-            version: preferDockerVersion
-              ? projectVersionData.dockerVersion
-              : projectVersionData.newVersion,
-            releaseGroupName: releaseGroup.name,
-          })
-        );
+        // Use either docker version or semver version based on preference, with null fallback
+        const version = preferDockerVersion
+          ? (projectVersionData.dockerVersion ?? projectVersionData.newVersion)
+          : (projectVersionData.newVersion ?? projectVersionData.dockerVersion);
+        if (version) {
+          tags.push(
+            interpolate(releaseGroup.releaseTag.pattern, {
+              version,
+              releaseGroupName: releaseGroup.name,
+            })
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
 ## Current Behavior

  When nx release runs with docker-configured projects (either via explicit config or
  @nx/docker plugin inference), git tags are created with the literal string {version}
  instead of the actual version number (e.g., v{version} instead of v1.0.6, or
  app-3@{version} instead of app-3@1.0.0).

  This happens because:

  1. If ANY project in a release group has docker config, preferDockerVersion is auto-set to
  true for the ENTIRE group
  2. createGitTagValues() then blindly selects projectVersionData.dockerVersion, which is
  null for non-docker projects (or projects with no changes)
  3. The interpolate() function receives null for {version} and returns the literal
  placeholder unchanged

  Commit messages are unaffected because createCommitMessageValues() only uses newVersion and
   already guards against null. The changelog code (changelog.ts:1117-1121) also already has
  the correct null-safe pattern.

 ## Expected Behavior

  When preferDockerVersion is true but dockerVersion is null, git tags should fall back to
  using newVersion instead of producing literal {version} placeholders. When both versions
  are null, no tag should be created.

  For mixed release groups (some projects have docker config, some don't), the auto-enable
  logic should use 'both' mode instead of true, which already has proper null-safe checks for
   each version type.

 ## Changes

  - shared.ts: Added null-safe fallback (??) in createGitTagValues() for both independent and
   fixed group code paths, plus a guard to skip tag creation when both versions are null
  - config.ts: Refined auto-enable logic to check whether ALL or only SOME projects have
  docker config — mixed groups now get 'both' mode instead of true
  - shared.spec.ts: Added 5 test cases covering null version fallback scenarios for fixed
  groups, independent groups, both-null, reverse fallback, and mixed groups

 ## Related Issue(s)

  Fixes #34382
  Fixes #33890
  Fixes #34391