### PR TITLE
fix(maven): synchronize batch runner invoke() to prevent concurrent access

### DIFF
--- a/packages/maven/batch-runner-adapters/maven3/src/main/kotlin/dev/nx/maven/adapter/maven3/CachingMaven3Invoker.kt
+++ b/packages/maven/batch-runner-adapters/maven3/src/main/kotlin/dev/nx/maven/adapter/maven3/CachingMaven3Invoker.kt
@@ -71,6 +71,7 @@ class CachingMaven3Invoker(
         log.debug("CachingMaven3Invoker initialized")
     }
 
+    @Synchronized
     override fun invoke(
         args: List<String>,
         workingDir: File,

--- a/packages/maven/batch-runner-adapters/maven4/src/main/kotlin/dev/nx/maven/adapter/maven4/Maven4AdapterInvoker.kt
+++ b/packages/maven/batch-runner-adapters/maven4/src/main/kotlin/dev/nx/maven/adapter/maven4/Maven4AdapterInvoker.kt
@@ -46,6 +46,7 @@ class Maven4AdapterInvoker(
         log.debug("Maven4AdapterInvoker ready")
     }
 
+    @Synchronized
     override fun invoke(
         args: List<String>,
         workingDir: File,


### PR DESCRIPTION
## Current Behavior

The Maven batch runner uses a parallel thread pool to execute tasks. When multiple tasks are independent roots in the task graph, they get picked up by separate threads simultaneously. Both threads call `invoke()` on the same shared `CachingResidentMavenInvoker` (Maven 4) or `CachingMaven3Invoker` (Maven 3) instance concurrently.

Maven 4's `LookupInvoker.invoke()` is not thread-safe — it snapshots/restores `System.getProperties()` and the thread context classloader in a `finally` block, and all concurrent invocations share the same resident `MavenContext`. This can cause deadlocks in Maven's internal session machinery.

## Expected Behavior

Maven executions through the shared invoker are serialized via `@Synchronized`, preventing concurrent access to non-thread-safe Maven internals. The parallel thread pool still handles task graph management, build state recording, and result emission concurrently.
