### PR TITLE
fix(js): remove redundant vite.config.ts generation for vitest projects

### DIFF
--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1773,7 +1773,7 @@ describe('lib', () => {
   });
 
   describe('--testEnvironment', () => {
-    it('should generate a vite config with testEnvironment set to node', async () => {
+    it('should generate a vitest config with testEnvironment set to node', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
         directory: 'my-node-lib',
@@ -1781,12 +1781,13 @@ describe('lib', () => {
         testEnvironment: 'node',
       });
 
-      const content = tree.read('my-node-lib/vite.config.ts', 'utf-8');
+      expect(tree.exists('my-node-lib/vite.config.ts')).toBe(false);
+      const content = tree.read('my-node-lib/vitest.config.mts', 'utf-8');
 
       expect(content).toContain(`environment: 'node'`);
     });
 
-    it('should generate a vite config with testEnvironment set to jsdom by default', async () => {
+    it('should generate a vitest config with testEnvironment set to jsdom by default', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
         directory: 'my-jsdom-lib',
@@ -1794,7 +1795,8 @@ describe('lib', () => {
         testEnvironment: undefined,
       });
 
-      const content = tree.read('my-jsdom-lib/vite.config.ts', 'utf-8');
+      expect(tree.exists('my-jsdom-lib/vite.config.ts')).toBe(false);
+      const content = tree.read('my-jsdom-lib/vitest.config.mts', 'utf-8');
 
       expect(content).toContain(`environment: 'jsdom'`);
     });

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -173,7 +173,6 @@ export async function libraryGeneratorInternal(
     options.unitTestRunner === 'vitest' &&
     options.bundler !== 'vite' // Test would have been set up already
   ) {
-    const { createOrEditViteConfig } = ensurePackage('@nx/vite', nxVersion);
     ensurePackage('@nx/vitest', nxVersion);
     // nx-ignore-next-line
     const { configurationGenerator } = require('@nx/vitest/generators');
@@ -188,16 +187,6 @@ export async function libraryGeneratorInternal(
       addPlugin: options.addPlugin,
     });
     tasks.push(vitestTask);
-    createOrEditViteConfig(
-      tree,
-      {
-        project: options.name,
-        includeLib: false,
-        includeVitest: true,
-        testEnvironment: options.testEnvironment,
-      },
-      true
-    );
   }
 
   if (!schema.skipTsConfig && !options.isUsingTsSolutionConfig) {

--- a/packages/plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/plugin/src/generators/plugin/plugin.spec.ts
@@ -236,7 +236,7 @@ describe('NxPlugin Plugin Generator', () => {
     });
 
     describe('vitest', () => {
-      it('should generate test files with vite.config.ts', async () => {
+      it('should generate test files with vitest.config.mts', async () => {
         await pluginGenerator(
           tree,
           getSchema({
@@ -245,7 +245,8 @@ describe('NxPlugin Plugin Generator', () => {
           })
         );
 
-        ['my-plugin/vite.config.ts'].forEach((path) =>
+        expect(tree.exists('my-plugin/vite.config.ts')).toBeFalsy();
+        ['my-plugin/vitest.config.mts'].forEach((path) =>
           expect(tree.exists(path)).toBeTruthy()
         );
 


### PR DESCRIPTION
## Current Behavior

When generating a library with vitest as the test runner and a non-vite bundler (e.g. `tsc`), the js library generator creates two config files:
- `vitest.config.mts` (from the vitest `configurationGenerator`) with `root: __dirname`
- `vite.config.ts` (from a second `createOrEditViteConfig` call) with `root: import.meta.dirname`

The redundant `vite.config.ts` uses ESM-only `import.meta.dirname` syntax, which causes TS1470 when the project targets CommonJS output:

```
vite.config.ts:5:9 - error TS1470: The 'import.meta' meta-property is not allowed in files which will build into CommonJS output.

5   root: import.meta.dirname,
          ~~~~~~~~~~~
```

## Expected Behavior

Only `vitest.config.mts` should be generated. The vitest `configurationGenerator` already handles creating the correct config file with `root: __dirname`. The second `createOrEditViteConfig` call from `@nx/vite` was redundant and produced the conflicting file.

## Related Issue(s)

Fixes #34399