### PR TITLE
fix(core): remove unused getTerminalOutput from BatchProcess

### DIFF
--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -14,8 +14,6 @@ export class BatchProcess {
     (task: string, result: TaskResult) => void
   > = [];
   private outputCallbacks: Array<(output: string) => void> = [];
-  private terminalOutputChunks: string[] = [];
-  private joinedTerminalOutput: string | undefined;
 
   constructor(
     private childProcess: ChildProcess,
@@ -59,7 +57,6 @@ export class BatchProcess {
     if (this.childProcess.stdout) {
       this.childProcess.stdout.on('data', (chunk) => {
         const output = chunk.toString();
-        this.terminalOutputChunks.push(output);
 
         // Maintain current terminal output behavior
         process.stdout.write(chunk);
@@ -75,7 +72,6 @@ export class BatchProcess {
     if (this.childProcess.stderr) {
       this.childProcess.stderr.on('data', (chunk) => {
         const output = chunk.toString();
-        this.terminalOutputChunks.push(output);
 
         // Maintain current terminal output behavior
         process.stderr.write(chunk);
@@ -133,10 +129,5 @@ export class BatchProcess {
     if (this.childProcess.connected) {
       this.childProcess.kill(signal);
     }
-  }
-
-  getTerminalOutput(): string {
-    this.joinedTerminalOutput ??= this.terminalOutputChunks.join('');
-    return this.joinedTerminalOutput;
   }
 }


### PR DESCRIPTION
## Current Behavior

`BatchProcess` accumulates all stdout/stderr output in `terminalOutputChunks` and exposes it via `getTerminalOutput()`, but nothing ever calls `getTerminalOutput()`. The accumulated strings are unique allocations (created via `chunk.toString()`), not shared with the output callbacks or `process.stdout.write`.

For verbose batched tasks (e.g., Maven/Gradle with hundreds of tasks), this can hold tens to hundreds of MB for the entire batch duration.

## Expected Behavior

Remove the dead accumulation code. stdout/stderr chunks are still forwarded to `process.stdout`/`process.stderr` and output callbacks as before — only the unused storage is removed.