### PR TITLE
fix(core): use scoped cache key for unresolved npm imports in TargetProjectLocator

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -138,7 +138,6 @@ export class TargetProjectLocator {
     }
 
     if (isBuiltinModuleImport(importExpr)) {
-      this.npmResolutionCache.set(importExpr, null);
       return null;
     }
 
@@ -176,8 +175,14 @@ export class TargetProjectLocator {
       return localProject;
     }
 
-    // nothing found, cache for later
-    this.npmResolutionCache.set(importExpr, null);
+    // nothing found, cache the negative result with the scoped key
+    const packageName = getPackageNameFromImportPath(importExpr);
+    const dirPath = dirname(
+      filePath.startsWith(workspaceRoot)
+        ? filePath.replace(workspaceRoot, '')
+        : filePath
+    );
+    this.npmResolutionCache.set(`${packageName}__${dirPath}`, null);
     return null;
   }
 


### PR DESCRIPTION
## Current Behavior

`TargetProjectLocator.findProjectFromImport` stores `null` for unresolved imports using a bare `importExpr` key, but `findNpmProjectFromImport` looks up cache entries using `${packageName}__${dirPath}`. The key mismatch means repeated lookups for the same import+directory re-run the full resolution waterfall (typescript + require.resolve) instead of returning the cached `null`.

## Expected Behavior

Store `null` for unresolved imports using the same `${packageName}__${dirPath}` key that `findNpmProjectFromImport` uses for lookups. Repeated lookups for already-failed imports skip the expensive resolution steps.

Also removes an unused cache write for builtin module imports as a minor cleanup.