### PR TITLE
feat(angular): support security.allowedHosts option in application executor

### DIFF
--- a/packages/angular/src/executors/application/schema.json
+++ b/packages/angular/src/executors/application/schema.json
@@ -54,6 +54,14 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "allowedHosts": {
+          "description": "A list of hostnames that are allowed to access the server-side application. For more information, see https://angular.dev/best-practices/security#preventing-server-side-request-forgery-ssrf. _Note: this is only supported in Angular versions >= 21.2.0_.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "autoCsp": {
           "description": "Enables automatic generation of a hash-based Strict Content Security Policy (https://web.dev/articles/strict-csp#choose-hash) based on scripts in index.html. Will default to true once we are out of experimental/preview phases.",
           "default": false,

--- a/packages/angular/src/executors/application/utils/validate-options.ts
+++ b/packages/angular/src/executors/application/utils/validate-options.ts
@@ -23,6 +23,14 @@ export function validateOptions(options: ApplicationExecutorOptions): void {
     }
   }
 
+  if (lt(angularVersion, '21.2.0')) {
+    if (options.security?.allowedHosts?.length) {
+      throw new Error(
+        `The "security.allowedHosts" option requires Angular version 21.2.0 or greater. You are currently using version ${angularVersion}.`
+      );
+    }
+  }
+
   if (lt(angularVersion, '20.1.0')) {
     if (options.loader) {
       const invalidLoaders = Array.from(


### PR DESCRIPTION
Add security.allowedHosts to application executor schema for SSRF protection (Angular >= 21.2.0) with version validation.