### PR TITLE
feat(angular): support headless option in unit-test executor

### DIFF
--- a/packages/angular/src/executors/unit-test/schema.json
+++ b/packages/angular/src/executors/unit-test/schema.json
@@ -38,6 +38,10 @@
       "type": "string",
       "pattern": "^\\d+x\\d+$"
     },
+    "headless": {
+      "type": "boolean",
+      "description": "Forces all configured browsers to run in headless mode. When using the Vitest runner, this option is ignored if no browsers are configured. The Karma runner does not support this option. _Note: this is only supported in Angular versions >= 21.2.0_."
+    },
     "include": {
       "type": "array",
       "items": {

--- a/packages/angular/src/executors/unit-test/unit-test.impl.ts
+++ b/packages/angular/src/executors/unit-test/unit-test.impl.ts
@@ -8,6 +8,7 @@ import { createBuilderContext } from 'nx/src/adapter/ngcli-adapter';
 import { targetFromTargetString } from '../../utils/targets';
 import type { ApplicationExecutorOptions } from '../application/schema';
 import type { BuildAngularLibraryExecutorOptions } from '../package/schema';
+import { lt } from 'semver';
 import { getInstalledAngularVersionInfo } from '../utilities/angular-version-utils';
 import { assertBuilderPackageIsInstalled } from '../utilities/builder-package';
 import {
@@ -20,7 +21,7 @@ export default async function* unitTestExecutor(
   options: UnitTestExecutorOptions,
   context: ExecutorContext
 ): AsyncIterable<BuilderOutput> {
-  validateOptions();
+  validateOptions(options);
 
   const {
     plugins: pluginPaths,
@@ -62,7 +63,7 @@ export default async function* unitTestExecutor(
   );
 }
 
-function validateOptions(): void {
+function validateOptions(options: UnitTestExecutorOptions): void {
   const { version: angularVersion, major: angularMajorVersion } =
     getInstalledAngularVersionInfo();
 
@@ -70,6 +71,14 @@ function validateOptions(): void {
     throw new Error(
       `The "unit-test" executor is only available for Angular versions >= 21.0.0. You are currently using version ${angularVersion}.`
     );
+  }
+
+  if (lt(angularVersion, '21.2.0')) {
+    if (options.headless !== undefined) {
+      throw new Error(
+        `The "headless" option requires Angular version 21.2.0 or greater. You are currently using version ${angularVersion}.`
+      );
+    }
   }
 }
 


### PR DESCRIPTION
Add headless boolean to unit-test executor schema to force browsers into headless mode (Angular >= 21.2.0) with version validation.