### PR TITLE
fix(core): preserve nxCloud=skip in non-interactive CNW mode

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -641,8 +641,7 @@ async function normalizeArgsMiddleware(
           nxCloud = 'yes';
           skipCloudConnect = false;
         } else if (cloudChoice === 'skip') {
-          nxCloud = 'yes';
-          skipCloudConnect = true;
+          nxCloud = 'skip';
         } else {
           nxCloud = 'never';
           neverConnectToCloud = true;
@@ -732,8 +731,7 @@ async function normalizeArgsMiddleware(
           nxCloud = 'yes';
           skipCloudConnect = false;
         } else if (cloudChoice === 'skip') {
-          nxCloud = 'yes';
-          skipCloudConnect = true;
+          nxCloud = 'skip';
         } else {
           nxCloud = 'never';
           neverConnectToCloud = true;


### PR DESCRIPTION
## Current Behavior

After #34580, `determineNxCloudV2()` returns `'skip'` in non-interactive mode, but the caller remaps it to `nxCloud = 'yes'` with `skipCloudConnect = true`. This causes `setupCI()` to run and generate `.github/workflows/ci.yml` in new workspaces — which didn't happen before.

This breaks the `extras.test.ts` e2e snapshot test because `.github/workflows/ci.yml` now appears in the expanded default task inputs.

## Expected Behavior

Keep `nxCloud = 'skip'` when the cloud choice is `'skip'`, which prevents CI file generation in non-interactive mode. This restores the behavior prior to #34580.

## Related Issue(s)

Fixes the `extras.test.ts` e2e snapshot failure introduced by #34580.