### PR TITLE
fix(core): update extras e2e snapshot for CI workflow in default inputs

### DIFF
--- a/e2e/nx/src/__snapshots__/extras.test.ts.snap
+++ b/e2e/nx/src/__snapshots__/extras.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`Extra Nx Misc Tests task graph inputs should correctly expand default task inputs 1`] = `
 {
   "general": [
+    ".github/workflows/ci.yml",
     ".gitignore",
     "nx.json",
   ],


### PR DESCRIPTION
## Current Behavior

The `extras.test.ts` e2e snapshot test fails because `.github/workflows/ci.yml` now appears in expanded default task inputs after #34580 changed non-interactive CNW to generate CI workflow files.

## Expected Behavior

Snapshot reflects the current behavior where `.github/workflows/ci.yml` is included in the general inputs.

## Related Issue(s)

Alternative fix to #34616 — this updates the snapshot to match the new behavior rather than reverting the behavior change.