### PR TITLE
fix(core): ensure postTasksExecution fires on SIGINT for continuous tasks

### DIFF
--- a/packages/nx/src/executors/run-commands/running-tasks.ts
+++ b/packages/nx/src/executors/run-commands/running-tasks.ts
@@ -525,8 +525,6 @@ class RunningNodeProcess implements RunningTask {
     });
     process.on('SIGINT', () => {
       this.kill('SIGTERM');
-      // we exit here because we don't need to write anything to cache.
-      process.exit(signalToCode('SIGINT'));
     });
     process.on('SIGTERM', () => {
       this.kill('SIGTERM');
@@ -710,8 +708,6 @@ function registerProcessListener(
   });
   process.on('SIGINT', () => {
     runningTask.kill('SIGTERM');
-    // we exit here because we don't need to write anything to cache.
-    process.exit(signalToCode('SIGINT'));
   });
   process.on('SIGTERM', () => {
     runningTask.kill('SIGTERM');

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -110,7 +110,7 @@ export class TaskOrchestrator {
     { runningTask: RunningTask; stopping: boolean }
   >();
   private discreteTaskExitHandled = new Map<string, Promise<void>>();
-  private cleanupDone = false;
+  private cleanupPromise: Promise<void> | null = null;
 
   private batchTaskResultsStreamed = new Set<string>();
 
@@ -234,13 +234,23 @@ export class TaskOrchestrator {
         const runningTask = await this.startContinuousTask(task, groupId);
 
         if (this.initializingTaskIds.has(task.id)) {
+          // Initiating tasks must block this thread until the task exits.
+          // This is the only onExit callback so we can await it before
+          // calling res(). The one in startContinuousTask is skipped for
+          // initiating tasks — exitCallbacks.forEach doesn't await async
+          // callbacks, so a second callback would create a floating promise
+          // that may not resolve before run() returns.
+          const ownsRunningTasksService =
+            this.runningContinuousTasks.get(task.id)?.ownsRunningTasksService ??
+            true;
           await new Promise<void>((res) => {
-            runningTask.onExit((code) => {
-              if (!this.tuiEnabled) {
-                if (code > 128) {
-                  process.exit(code);
-                }
-              }
+            runningTask.onExit(async (code) => {
+              await this.handleContinuousTaskExit(
+                code,
+                task,
+                groupId,
+                ownsRunningTasksService
+              );
               res();
             });
           });
@@ -955,7 +965,12 @@ export class TaskOrchestrator {
         groupId,
         ownsRunningTasksService: false,
       });
-      this.registerContinuousTaskExitHandler(runningTask, task, groupId, false);
+      // Initiating tasks complete inline in executeNextBatchOfTasksUsingTaskSchedule
+      if (!this.initializingTaskIds.has(task.id)) {
+        runningTask.onExit(async (code) => {
+          await this.handleContinuousTaskExit(code, task, groupId, false);
+        });
+      }
 
       // task is already running by another process, we schedule the next tasks
       // and release the threads
@@ -1008,7 +1023,12 @@ export class TaskOrchestrator {
       groupId,
       ownsRunningTasksService: true,
     });
-    this.registerContinuousTaskExitHandler(childProcess, task, groupId, true);
+    // Initiating tasks complete inline in executeNextBatchOfTasksUsingTaskSchedule
+    if (!this.initializingTaskIds.has(task.id)) {
+      childProcess.onExit(async (code) => {
+        await this.handleContinuousTaskExit(code, task, groupId, true);
+      });
+    }
     await this.scheduleNextTasksAndReleaseThreads();
 
     return childProcess;
@@ -1275,42 +1295,40 @@ export class TaskOrchestrator {
 
   // endregion utils
 
-  private registerContinuousTaskExitHandler(
-    runningTask: RunningTask,
+  private async handleContinuousTaskExit(
+    code: number,
     task: Task,
     groupId: number,
     ownsRunningTasksService: boolean
   ) {
-    runningTask.onExit(async (code) => {
-      // If cleanup already completed this task, nothing left to do
-      if (this.completedTasks[task.id] !== undefined) {
-        return;
-      }
+    // If cleanup already completed this task, nothing left to do
+    if (this.completedTasks[task.id] !== undefined) {
+      return;
+    }
 
-      const stoppingReason = this.runningContinuousTasks.get(
-        task.id
-      )?.stoppingReason;
-      if (stoppingReason || EXPECTED_TERMINATION_SIGNALS.has(code)) {
-        const reason =
-          stoppingReason === 'fulfilled' ? 'fulfilled' : 'interrupted';
-        await this.completeContinuousTask(
-          task,
-          groupId,
-          ownsRunningTasksService,
-          reason
-        );
-      } else {
-        console.error(
-          `Task "${task.id}" is continuous but exited with code ${code}`
-        );
-        await this.completeContinuousTask(
-          task,
-          groupId,
-          ownsRunningTasksService,
-          'crashed'
-        );
-      }
-    });
+    const stoppingReason = this.runningContinuousTasks.get(
+      task.id
+    )?.stoppingReason;
+    if (stoppingReason || EXPECTED_TERMINATION_SIGNALS.has(code)) {
+      const reason =
+        stoppingReason === 'fulfilled' ? 'fulfilled' : 'interrupted';
+      await this.completeContinuousTask(
+        task,
+        groupId,
+        ownsRunningTasksService,
+        reason
+      );
+    } else {
+      console.error(
+        `Task "${task.id}" is continuous but exited with code ${code}`
+      );
+      await this.completeContinuousTask(
+        task,
+        groupId,
+        ownsRunningTasksService,
+        'crashed'
+      );
+    }
   }
 
   private async completeContinuousTask(
@@ -1346,11 +1364,14 @@ export class TaskOrchestrator {
   }
 
   private async cleanup() {
-    if (this.cleanupDone) {
-      return;
+    if (this.cleanupPromise) {
+      return this.cleanupPromise;
     }
-    this.cleanupDone = true;
+    this.cleanupPromise = this.performCleanup();
+    return this.cleanupPromise;
+  }
 
+  private async performCleanup() {
     // Mark all running tasks for intentional stop
     const reason = this.stopRequested ? 'interrupted' : 'fulfilled';
     for (const entry of this.runningContinuousTasks.values()) {
@@ -1421,6 +1442,7 @@ export class TaskOrchestrator {
       });
     });
     process.once('SIGTERM', () => {
+      this.stopRequested = true;
       this.cleanup().finally(() => {
         if (this.resolveStopPromise) {
           this.resolveStopPromise();
@@ -1428,6 +1450,7 @@ export class TaskOrchestrator {
       });
     });
     process.once('SIGHUP', () => {
+      this.stopRequested = true;
       this.cleanup().finally(() => {
         if (this.resolveStopPromise) {
           this.resolveStopPromise();

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -1433,6 +1433,17 @@ export class TaskOrchestrator {
   private setupSignalHandlers() {
     process.once('SIGINT', () => {
       this.stopRequested = true;
+      if (!this.tuiEnabled) {
+        // Silence output immediately — pnpm (and similar wrappers) may
+        // exit before nx finishes cleanup, returning the shell prompt.
+        // Any output after that point would appear after the prompt.
+        const noop = (_chunk, _encoding, callback) => {
+          if (callback) callback();
+          return true;
+        };
+        process.stdout.write = noop as any;
+        process.stderr.write = noop as any;
+      }
       this.cleanup().finally(() => {
         if (this.resolveStopPromise) {
           this.resolveStopPromise();


### PR DESCRIPTION
## Current Behavior

When pressing Ctrl+C on continuous tasks (e.g., `nx run app:serve`), `postTasksExecution` never fires or fires with incomplete task results. This affects any plugin or custom lifecycle hook relying on `postTasksExecution` to perform cleanup, reporting, or post-run logic.

The issue manifests in non-TUI mode (`NX_TUI=false`) and in setups where nx runs as a child of a package manager (pnpm/npm), which sends SIGTERM shortly after SIGINT.

## Expected Behavior

`postTasksExecution` fires reliably on Ctrl+C with complete task results, regardless of whether TUI is enabled or how the nx process is invoked.

## Technical Details

Three independent issues caused the broken behavior:

**1. Initiating continuous task exits before orchestrator cleanup**

When the initiating task is continuous and exits with a signal code (e.g., 130 from SIGINT), the `onExit` handler called `process.exit(code)` synchronously — before the orchestrator's SIGINT handler could run. Cleanup and `postTasksExecution` never executed.

Fixed by replacing `process.exit()` with proper task completion via `handleContinuousTaskExit`, and ensuring initiating tasks are the sole `onExit` callback (to avoid floating promises from `exitCallbacks.forEach` not awaiting async callbacks).

**2. run-commands SIGINT handlers call `process.exit(130)`**

Every `nx:run-commands` task running in the main process registered a SIGINT handler that called `process.exit(signalToCode('SIGINT'))`, killing the process before the orchestrator's async cleanup could run.

Fixed by removing `process.exit()` from both SIGINT handlers in `running-tasks.ts`. The `this.kill('SIGTERM')` call is kept for prompt child termination. Cache-write safety is already guaranteed by `postRunSteps` guards (`stopRequested`, `status !== 'stopped'`).

**3. `cleanup()` resolves prematurely on concurrent signals**

When pnpm/npm sends SIGTERM ~30ms after SIGINT, the SIGTERM handler saw `cleanupDone = true` (set at the start of cleanup, before async work), returned immediately, and its `.finally()` called `resolveStopPromise()` before SIGINT's cleanup finished. `run()` returned with incomplete task results.

Fixed by replacing the `cleanupDone` boolean with a stored promise. Concurrent callers now await the same in-progress cleanup.

**Additional fixes:**

- SIGTERM/SIGHUP handlers now set `stopRequested = true` so externally terminated tasks are correctly classified as `'interrupted'` rather than `'fulfilled'`.
- Extracted shared exit-handling logic into `handleContinuousTaskExit` to consolidate reason-determination between initiating and non-initiating continuous tasks.