### PR TITLE
fix(misc): boost CLI command reference search ranking

### DIFF
--- a/astro-docs/astro.config.mjs
+++ b/astro-docs/astro.config.mjs
@@ -130,7 +130,7 @@ export default defineConfig({
           // Once a term has appeared on a page many times,
           // further appearances have a reduced impact on the page rank.
           // default: 1.4
-          // termSaturation: 1.4,
+          termSaturation: 1.2,
           // termSimilarity changes the ranking based on
           // similarity of terms to the search query.
           // Currently this only takes the length of the term into account.

--- a/astro-docs/src/plugins/utils/nx-cli-generation.ts
+++ b/astro-docs/src/plugins/utils/nx-cli-generation.ts
@@ -88,6 +88,7 @@ export async function loadNxCliPackage(
       docType: 'cli',
       description: 'Complete reference for Nx CLI commands',
       filter: 'type:References',
+      weight: 4,
     },
     rendered: await renderMarkdown(markdown),
     collection: 'nx-reference-packages',
@@ -187,13 +188,14 @@ function generateOptionsTable(
 }
 
 function generateExamplesSection(
-  examples: ParsedCliCommand['examples']
+  examples: ParsedCliCommand['examples'],
+  commandName: string
 ): string {
   if (!examples || examples.length === 0) {
     return '';
   }
 
-  let section = `\n#### Examples\n\n`;
+  let section = `\n#### \`nx ${commandName}\` Examples\n\n`;
 
   for (const example of examples) {
     section += `${example.description}:\n\n`;
@@ -251,7 +253,7 @@ nx ${usageCmd}
 `;
 
     // Add examples section if available
-    section += generateExamplesSection(cmd.examples);
+    section += generateExamplesSection(cmd.examples, fullName);
 
     // If this is a parent command with subcommands, label options as "Shared Options"
     const hasSubcommands = cmd.subcommands && cmd.subcommands.length > 0;


### PR DESCRIPTION
## Current Behavior

Searching for CLI commands like `nx watch` on the docs site does not surface the [Nx Commands reference page](https://nx.dev/docs/reference/nx-commands) on the first page of results, even when filtering by "References."

Root causes:
- **Term saturation**: "nx" appears 150+ times on the CLI reference page (in every heading, usage block, and example), causing it to saturate and contribute almost nothing to ranking differentiation.
- **Page length penalty**: The current `pageLength: 0.5` setting actively penalizes long pages—the CLI reference is one of the longest on the site.
- **No weight boost**: The CLI page had no `weight` set, while generators/executors pages already get `weight: 2.0`.

## Expected Behavior

Searching for `nx watch`, `nx run-many`, or other CLI commands should surface the Nx Commands reference page prominently in results.

This PR applies two quick-win tuning changes:
1. **`weight: 4`** on the CLI commands page entry — gives body text ~16× impact (quadratic scaling), making it competitive with shorter pages that mention commands incidentally. include the command name in the sub headers for more improvement in relevancy search without impacting other pages
2. **`termSaturation: 1.2`** (down from default 1.4) — makes highly repeated terms like "nx" saturate faster so that the differentiating term (e.g. "watch") carries more relative weight.

## Related Issue(s)

Addresses [DOC-401](https://linear.app/nxdev/issue/DOC-401/investigate-boosting-cli-command-reference-pages-in-search)
