### PR TITLE
fix(gradle): tee batch runner output to stderr for terminal display

### DIFF
--- a/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/GradleRunner.kt
+++ b/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/GradleRunner.kt
@@ -105,8 +105,8 @@ fun runBuildLauncher(
         .apply {
           forTasks(*taskNames)
           addArguments(*(args + excludeArgs).toTypedArray())
-          setStandardOutput(outputStream)
-          setStandardError(errorStream)
+          setStandardOutput(TeeOutputStream(outputStream, System.err))
+          setStandardError(TeeOutputStream(errorStream, System.err))
           withDetailedFailure()
           addProgressListener(buildListener(tasks, taskStartTimes, taskResults), OperationType.TASK)
         }
@@ -175,8 +175,8 @@ fun runTestLauncher(
           // arguments here
           addArguments(
               *(args + excludeArgs).toTypedArray()) // Combine your existing args with JUnit args
-          setStandardOutput(outputStream)
-          setStandardError(errorStream)
+          setStandardOutput(TeeOutputStream(outputStream, System.err))
+          setStandardError(TeeOutputStream(errorStream, System.err))
           addProgressListener(
               testListener(tasks, testTaskStatus, testStartTimes, testEndTimes), eventTypes)
           withDetailedFailure()

--- a/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/TeeOutputStream.kt
+++ b/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/TeeOutputStream.kt
@@ -1,0 +1,39 @@
+package dev.nx.gradle.runner
+
+import java.io.OutputStream
+
+/**
+ * An OutputStream that writes to two destinations simultaneously.
+ * Used to capture Gradle output for JSON results while also
+ * forwarding it to stderr for real-time terminal display.
+ */
+class TeeOutputStream(
+    private val primary: OutputStream,
+    private val secondary: OutputStream
+) : OutputStream() {
+
+  override fun write(b: Int) {
+    primary.write(b)
+    secondary.write(b)
+  }
+
+  override fun write(b: ByteArray) {
+    primary.write(b)
+    secondary.write(b)
+  }
+
+  override fun write(b: ByteArray, off: Int, len: Int) {
+    primary.write(b, off, len)
+    secondary.write(b, off, len)
+  }
+
+  override fun flush() {
+    primary.flush()
+    secondary.flush()
+  }
+
+  override fun close() {
+    primary.close()
+    // Don't close secondary (e.g. System.err) — we don't own it
+  }
+}


### PR DESCRIPTION
## Current Behavior

When running Gradle batch tasks (e.g. `nx build my-gradle-project --no-tui`), the terminal shows no task output. The Gradle build output is captured into `ByteArrayOutputStream` for JSON results but never forwarded to the terminal. Users can only see the output in Nx Cloud task results.

## Expected Behavior

Gradle batch task output (build logs, test results, etc.) should be visible in the terminal in real-time as the batch executes.

## Changes

- **`TeeOutputStream.kt`** (new): An `OutputStream` that writes to two destinations simultaneously — captures output for JSON results while also forwarding to `System.err` for terminal display.
- **`GradleRunner.kt`**: Wrap `setStandardOutput` and `setStandardError` with `TeeOutputStream` to tee into `System.err` in both `runBuildLauncher` and `runTestLauncher`.
- **`gradle-batch.impl.ts`**: Replace `PseudoTerminal` (which swallowed all output with `quiet: true`) with `execSync` using `stdio: ['pipe', 'pipe', 'inherit']` so stderr flows directly to the terminal.