### PR TITLE
cleanup(core): reduce misc allocations

### DIFF
--- a/packages/nx/src/native/cache/validate_outputs.rs
+++ b/packages/nx/src/native/cache/validate_outputs.rs
@@ -1,14 +1,16 @@
 use itertools::Itertools;
 use regex::Regex;
+use std::sync::LazyLock;
 
 use crate::native::glob::{contains_glob_pattern, glob_transform::partition_glob};
 
 const ALLOWED_WORKSPACE_ROOT_OUTPUT_PREFIXES: [&str; 2] = ["!{workspaceRoot}", "{workspaceRoot}"];
 
-fn is_missing_prefix(output: &str) -> bool {
-    let re = Regex::new(r"^!?\{[\s\S]+\}").expect("Output pattern regex should compile");
+static OUTPUT_PREFIX_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^!?\{[\s\S]+\}").expect("Output pattern regex should compile"));
 
-    !re.is_match(output)
+fn is_missing_prefix(output: &str) -> bool {
+    !OUTPUT_PREFIX_RE.is_match(output)
 }
 
 #[napi]

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -73,7 +73,7 @@ impl HashPlanner {
                     &inputs,
                     &task_graph,
                     &external_deps_mapped,
-                    &mut Box::new(hashbrown::HashSet::from([task.target.project.to_string()])),
+                    &mut Box::new(hashbrown::HashSet::from([task.target.project.as_str()])),
                 )?;
 
                 let mut inputs: Vec<HashInstruction> = target
@@ -246,14 +246,14 @@ impl HashPlanner {
         }
     }
 
-    fn self_and_deps_inputs(
-        &self,
+    fn self_and_deps_inputs<'a>(
+        &'a self,
         project_name: &str,
         task: &Task,
         inputs: &SplitInputs,
         task_graph: &TaskGraph,
-        external_deps_mapped: &hashbrown::HashMap<&String, Vec<&String>>,
-        visited: &mut Box<hashbrown::HashSet<String>>,
+        external_deps_mapped: &hashbrown::HashMap<&String, Vec<&'a String>>,
+        visited: &mut Box<hashbrown::HashSet<&'a str>>,
     ) -> anyhow::Result<Vec<HashInstruction>> {
         let project_deps = &self.project_graph.dependencies[project_name]
             .iter()
@@ -305,16 +305,16 @@ impl HashPlanner {
         task_graph: &TaskGraph,
         project_deps: &[&'a String],
         external_deps_mapped: &hashbrown::HashMap<&String, Vec<&'a String>>,
-        visited: &mut Box<hashbrown::HashSet<String>>,
+        visited: &mut Box<hashbrown::HashSet<&'a str>>,
     ) -> anyhow::Result<Vec<HashInstruction>> {
         let mut deps_inputs: Vec<HashInstruction> = vec![];
 
         for input in inputs {
             for dep in project_deps {
-                if visited.contains(*dep) {
+                if visited.contains(dep.as_str()) {
                     continue;
                 }
-                visited.insert(dep.to_string());
+                visited.insert(dep.as_str());
 
                 if self.project_graph.nodes.contains_key(*dep) {
                     let Some(dep_inputs) = get_inputs_for_dependency(

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -255,9 +255,7 @@ impl HashPlanner {
         external_deps_mapped: &hashbrown::HashMap<&String, Vec<&'a String>>,
         visited: &mut Box<hashbrown::HashSet<&'a str>>,
     ) -> anyhow::Result<Vec<HashInstruction>> {
-        let project_deps = &self.project_graph.dependencies[project_name]
-            .iter()
-            .collect::<Vec<_>>();
+        let project_deps = &self.project_graph.dependencies[project_name];
         let self_inputs = self.gather_self_inputs(project_name, &inputs.self_inputs);
         let deps_inputs = self.gather_dependency_inputs(
             task,
@@ -303,11 +301,12 @@ impl HashPlanner {
         task: &Task,
         inputs: &[Input],
         task_graph: &TaskGraph,
-        project_deps: &[&'a String],
+        project_deps: &'a [String],
         external_deps_mapped: &hashbrown::HashMap<&String, Vec<&'a String>>,
         visited: &mut Box<hashbrown::HashSet<&'a str>>,
     ) -> anyhow::Result<Vec<HashInstruction>> {
-        let mut deps_inputs: Vec<HashInstruction> = vec![];
+        let mut deps_inputs: Vec<HashInstruction> =
+            Vec::with_capacity(inputs.len() * project_deps.len());
 
         for input in inputs {
             for dep in project_deps {
@@ -316,9 +315,9 @@ impl HashPlanner {
                 }
                 visited.insert(dep.as_str());
 
-                if self.project_graph.nodes.contains_key(*dep) {
+                if self.project_graph.nodes.contains_key(dep) {
                     let Some(dep_inputs) = get_inputs_for_dependency(
-                        &self.project_graph.nodes[*dep],
+                        &self.project_graph.nodes[dep],
                         &self.nx_json,
                         input,
                     )?

--- a/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
@@ -73,8 +73,8 @@ pub fn hash_workspace_files_with_inputs(
             .filter(|file| glob.is_match(&file.file))
         {
             debug!("Adding {:?} ({:?}) to hash", file.hash, file.file);
-            hasher.update(file.file.clone().as_bytes());
-            hasher.update(file.hash.clone().as_bytes());
+            hasher.update(file.file.as_bytes());
+            hasher.update(file.hash.as_bytes());
             files.push(file.file.clone());
         }
         let hashed_value = hasher.digest().to_string();

--- a/packages/nx/src/native/utils/find_matching_projects.rs
+++ b/packages/nx/src/native/utils/find_matching_projects.rs
@@ -150,8 +150,10 @@ fn add_matching_projects_by_name<'a>(
     pattern: &ProjectPattern,
     matched_projects: &mut HashSet<&'a str>,
 ) -> anyhow::Result<()> {
-    let keys = projects.keys().map(|k| k.as_str()).collect::<Vec<_>>();
-    if let Some(project_name) = keys.iter().find(|k| *k == &pattern.value) {
+    if let Some(project_name) = projects
+        .get_key_value(pattern.value)
+        .map(|(k, _)| k.as_str())
+    {
         if pattern.exclude {
             matched_projects.remove(pattern.value);
         } else {

--- a/packages/nx/src/native/workspace/context.rs
+++ b/packages/nx/src/native/workspace/context.rs
@@ -165,10 +165,8 @@ impl FilesWorker {
             let removal = map.remove(&PathBuf::from(deleted_path));
             if removal.is_none() {
                 // If the path is a directory, this retains only files not in the directory.
-                map.retain(|path, _| {
-                    let owned_deleted_path = deleted_path.to_owned();
-                    !path.starts_with(owned_deleted_path + "/")
-                });
+                let prefix = Path::new(deleted_path);
+                map.retain(|path, _| !path.starts_with(prefix));
             };
         }
 

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -908,7 +908,7 @@ function targetDefaultShouldBeApplied(
 }
 
 function deepClone(obj) {
-  return JSON.parse(JSON.stringify(obj));
+  return structuredClone(obj);
 }
 
 export function mergeTargetDefaultWithTargetDefinition(


### PR DESCRIPTION
## Current Behavior

Several Rust native modules and one TS utility have unnecessary allocations:
- `hash_planner.rs`: visited set uses `HashSet<String>` with `to_string()` per insert; unnecessary `.collect::<Vec<_>>()` creating temp vecs; no pre-allocation for dependency inputs
- `context.rs`: `update_files` allocates a String per map entry inside retain loop
- `hash_workspace_files.rs`: `.clone()` before `.as_bytes()` — 2 needless heap allocs per file
- `find_matching_projects.rs`: collects HashMap keys into Vec + linear search instead of O(1) lookup
- `validate_outputs.rs`: compiles regex on every call
- `project-configuration-utils.ts`: uses `JSON.parse(JSON.stringify())` for deep cloning

## Expected Behavior

All unnecessary allocations removed:
- Borrow `&str` from project graph instead of cloning Strings into visited set
- Use `Path::new()` once outside retain closure (also more correct — component-boundary-aware matching)
- Call `.as_bytes()` directly without clone
- Use `HashMap::get_key_value()` for O(1) lookup
- Cache compiled regex with `LazyLock<Regex>`
- Use `structuredClone` (Node 18+) instead of JSON round-trip

See individual commits for detailed rationale per change.