### PR TITLE
fix(repo): remove redundant inputs override for build-base target

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -112,7 +112,6 @@
     },
     "build-base": {
       "dependsOn": ["^build-base", "build-native"],
-      "inputs": ["production", "^production"],
       "cache": true
     },
     "test-native": {

--- a/packages/angular-rspack-compiler/.eslintrc.json
+++ b/packages/angular-rspack-compiler/.eslintrc.json
@@ -45,6 +45,7 @@
             "ignoredDependencies": [
               "@angular/core",
               "jsonc-eslint-parser",
+              "semver",
               "vitest",
               "memfs"
             ]

--- a/packages/angular/.eslintrc.json
+++ b/packages/angular/.eslintrc.json
@@ -52,6 +52,7 @@
             "buildTargets": ["build-base"],
             "ignoredDependencies": [
               "@angular-devkit/architect",
+              "@angular-devkit/core",
               "@angular-devkit/schematics",
               "@nx/cypress",
               "@nx/jest",

--- a/packages/nx/.eslintrc.json
+++ b/packages/nx/.eslintrc.json
@@ -145,7 +145,9 @@
               // Nx Docker plugin conditionally available dynamically at runtime
               "@nx/docker",
               // Only used in test-utils at the time of writing
-              "@ltd/j-toml"
+              "@ltd/j-toml",
+              // Used in WASI browser implementation (nx.wasi-browser.js)
+              "@napi-rs/wasm-runtime"
             ]
           }
         ]


### PR DESCRIPTION
## Current Behavior

The `build-base` target in `nx.json` has a manual `inputs` override of `["production", "^production"]` which shadows the more accurate inputs inferred by the `@nx/js/typescript` plugin.

## Expected Behavior

Let the `@nx/js/typescript` plugin infer the correct inputs for `build-base` tasks, providing more accurate cache invalidation based on the actual tsconfig project references.

## Lint Rule Changes

Removing the broad `inputs` override causes the `@nx/dependency-checks` lint rule to flag a few dependencies as "unused" across three packages. This happens because the rule uses the build target's inputs to determine which files to scan for imports, and the narrower tsc-inferred inputs don't cover certain files:

- **`packages/nx`**: `@napi-rs/wasm-runtime` — used in `nx.wasi-browser.js`, a `.js` file outside tsconfig scope
- **`packages/angular`**: `@angular-devkit/core` — only referenced as a string (for `ensurePackage()`, migrations config) and is a `peerDependency`, not directly imported at runtime
- **`packages/angular-rspack-compiler`**: `semver` — used in `patch/patch-angular-build.js`, a `.js` patch file outside tsconfig scope

These are all legitimate dependencies. Adding the `.js` files to tsconfig would require `allowJs` and pull non-TS scripts into the build pipeline unnecessarily. Adding them to `ignoredDependencies` in each package's `.eslintrc.json` is the correct fix.