### PR TITLE
feat(core): add .nx/polygraph to gitignore in migration and caia

### DIFF
--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -136,6 +136,12 @@
       "version": "22.1.0-beta.5",
       "description": "Updates the nx wrapper.",
       "implementation": "./src/migrations/update-22-1-0/update-nx-wrapper"
+    },
+    "22-7-0-add-polygraph-to-git-ignore": {
+      "cli": "nx",
+      "version": "22.7.0-beta.0",
+      "description": "Adds .nx/polygraph to .gitignore",
+      "implementation": "./src/migrations/update-22-7-0/add-polygraph-to-git-ignore"
     }
   }
 }

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
@@ -632,6 +632,64 @@ describe('setup-ai-agents generator', () => {
       });
     });
 
+    describe('gitignore', () => {
+      it('should add .nx/polygraph to .gitignore when it does not exist', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+          agents: ['claude'],
+        };
+
+        await setupAiAgentsGenerator(tree, options);
+
+        const gitignore = tree.read('.gitignore')?.toString();
+        expect(gitignore).toContain('.nx/polygraph');
+      });
+
+      it('should add .nx/polygraph to existing .gitignore', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+          agents: ['claude'],
+        };
+
+        tree.write('.gitignore', 'node_modules\ndist\n');
+
+        await setupAiAgentsGenerator(tree, options);
+
+        const gitignore = tree.read('.gitignore')?.toString();
+        expect(gitignore).toContain('node_modules');
+        expect(gitignore).toContain('.nx/polygraph');
+      });
+
+      it('should not duplicate if .nx/polygraph is already present', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+          agents: ['claude'],
+        };
+
+        tree.write('.gitignore', 'node_modules\n.nx/polygraph\n');
+
+        await setupAiAgentsGenerator(tree, options);
+
+        const gitignore = tree.read('.gitignore')?.toString();
+        const matches = gitignore.match(/\.nx\/polygraph/g);
+        expect(matches).toHaveLength(1);
+      });
+
+      it('should not add if a broader pattern already covers it', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+          agents: ['claude'],
+        };
+
+        tree.write('.gitignore', '.nx/\n');
+
+        await setupAiAgentsGenerator(tree, options);
+
+        const gitignore = tree.read('.gitignore')?.toString();
+        expect(gitignore).not.toContain('.nx/polygraph');
+      });
+    });
+
     describe('empty agents array', () => {
       it('should NOT generate any files when agents array is empty', async () => {
         const options: SetupAiAgentsGeneratorSchema = {

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -19,6 +19,7 @@ import {
   installPackageToTmp,
   readModulePackageJson,
 } from '../../utils/package-json';
+import { addEntryToGitIgnore } from '../../utils/ignore';
 import { ensurePackageHasProvenance } from '../../utils/provenance';
 import { workspaceRoot } from '../../utils/workspace-root';
 import {
@@ -291,6 +292,12 @@ export async function setupAiAgentsGeneratorImpl(
       }
     }
   }
+
+  addEntryToGitIgnore(
+    tree,
+    join(options.directory, '.gitignore'),
+    '.nx/polygraph'
+  );
 
   await formatChangedFilesWithPrettierIfAvailable(tree);
 

--- a/packages/nx/src/migrations/update-22-7-0/add-polygraph-to-git-ignore.spec.ts
+++ b/packages/nx/src/migrations/update-22-7-0/add-polygraph-to-git-ignore.spec.ts
@@ -45,4 +45,26 @@ describe('add-polygraph-to-git-ignore migration', () => {
     const gitignore = tree.read('.gitignore')?.toString();
     expect(gitignore).not.toContain('.nx/polygraph');
   });
+
+  it('should skip for lerna workspaces without nx.json', () => {
+    tree.write('.gitignore', 'node_modules\n');
+    tree.write('lerna.json', '{}');
+    tree.delete('nx.json');
+
+    addPolygraphToGitIgnore(tree);
+
+    const gitignore = tree.read('.gitignore')?.toString();
+    expect(gitignore).not.toContain('.nx/polygraph');
+  });
+
+  it('should not skip for lerna workspaces that also have nx.json', () => {
+    tree.write('.gitignore', 'node_modules\n');
+    tree.write('lerna.json', '{}');
+    // nx.json already exists from createTreeWithEmptyWorkspace
+
+    addPolygraphToGitIgnore(tree);
+
+    const gitignore = tree.read('.gitignore')?.toString();
+    expect(gitignore).toContain('.nx/polygraph');
+  });
 });

--- a/packages/nx/src/migrations/update-22-7-0/add-polygraph-to-git-ignore.spec.ts
+++ b/packages/nx/src/migrations/update-22-7-0/add-polygraph-to-git-ignore.spec.ts
@@ -1,0 +1,48 @@
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import { Tree } from '../../generators/tree';
+import addPolygraphToGitIgnore from './add-polygraph-to-git-ignore';
+
+describe('add-polygraph-to-git-ignore migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should not create .gitignore if it does not exist', () => {
+    tree.delete('.gitignore');
+
+    addPolygraphToGitIgnore(tree);
+
+    expect(tree.exists('.gitignore')).toBe(false);
+  });
+
+  it('should add .nx/polygraph to existing .gitignore', () => {
+    tree.write('.gitignore', 'node_modules\ndist\n');
+
+    addPolygraphToGitIgnore(tree);
+
+    const gitignore = tree.read('.gitignore')?.toString();
+    expect(gitignore).toContain('node_modules');
+    expect(gitignore).toContain('.nx/polygraph');
+  });
+
+  it('should not duplicate if .nx/polygraph is already present', () => {
+    tree.write('.gitignore', 'node_modules\n.nx/polygraph\n');
+
+    addPolygraphToGitIgnore(tree);
+
+    const gitignore = tree.read('.gitignore')?.toString();
+    const matches = gitignore.match(/\.nx\/polygraph/g);
+    expect(matches).toHaveLength(1);
+  });
+
+  it('should not add if a broader pattern already covers it', () => {
+    tree.write('.gitignore', '.nx/\n');
+
+    addPolygraphToGitIgnore(tree);
+
+    const gitignore = tree.read('.gitignore')?.toString();
+    expect(gitignore).not.toContain('.nx/polygraph');
+  });
+});

--- a/packages/nx/src/migrations/update-22-7-0/add-polygraph-to-git-ignore.ts
+++ b/packages/nx/src/migrations/update-22-7-0/add-polygraph-to-git-ignore.ts
@@ -5,5 +5,9 @@ export default function addPolygraphToGitIgnore(tree: Tree) {
   if (!tree.exists('.gitignore')) {
     return;
   }
+  // Lerna users that don't use nx.json may not expect .nx directory changes
+  if (tree.exists('lerna.json') && !tree.exists('nx.json')) {
+    return;
+  }
   addEntryToGitIgnore(tree, '.gitignore', '.nx/polygraph');
 }

--- a/packages/nx/src/migrations/update-22-7-0/add-polygraph-to-git-ignore.ts
+++ b/packages/nx/src/migrations/update-22-7-0/add-polygraph-to-git-ignore.ts
@@ -1,0 +1,9 @@
+import { Tree } from '../../generators/tree';
+import { addEntryToGitIgnore } from '../../utils/ignore';
+
+export default function addPolygraphToGitIgnore(tree: Tree) {
+  if (!tree.exists('.gitignore')) {
+    return;
+  }
+  addEntryToGitIgnore(tree, '.gitignore', '.nx/polygraph');
+}

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -26,3 +26,23 @@ export function getIgnoreObjectForTree(tree: Tree) {
 
   return ig;
 }
+
+/**
+ * Adds an entry to a .gitignore file if it's not already covered by existing patterns.
+ * Creates the file if it doesn't exist.
+ */
+export function addEntryToGitIgnore(
+  tree: Tree,
+  gitignorePath: string,
+  entry: string
+) {
+  const gitignore = tree.exists(gitignorePath)
+    ? tree.read(gitignorePath, 'utf-8')
+    : '';
+  const ig = ignore();
+  ig.add(gitignore);
+  if (!ig.ignores(entry)) {
+    const updatedLines = gitignore.length ? [gitignore, entry] : [entry];
+    tree.write(gitignorePath, updatedLines.join('\n'));
+  }
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive changes that only update `.gitignore` using an ignore-pattern check to avoid duplicates or already-covered entries; no runtime behavior beyond file generation/migrations.
> 
> **Overview**
> Ensures `.nx/polygraph` is automatically ignored by Git.
> 
> Adds a `22-7-0-add-polygraph-to-git-ignore` migration (registered in `migrations.json`) that appends `.nx/polygraph` to an existing `.gitignore`, while skipping Lerna-only workspaces (with `lerna.json` but no `nx.json`).
> 
> Updates the `setup-ai-agents` generator to also add `.nx/polygraph` to the target directory’s `.gitignore`, and introduces a shared `addEntryToGitIgnore` helper that avoids adding the entry when it’s already present or covered by broader ignore rules; tests were added for both the migration and generator behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de6f23238a2258d99b3780a2fbe0c6a8b0b97840. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->