### PR TITLE
fix(core): update minimatch to 10.2.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ catalogs:
       specifier: ~2.3.6
       version: 2.3.6
     minimatch:
-      specifier: 10.2.1
-      version: 10.2.1
+      specifier: 10.2.4
+      version: 10.2.4
     picocolors:
       specifier: ^1.1.0
       version: 1.1.1
@@ -1135,7 +1135,7 @@ importers:
         version: 2.4.7(webpack@5.101.3)
       minimatch:
         specifier: 'catalog:'
-        version: 10.2.1
+        version: 10.2.4
       next-sitemap:
         specifier: ^3.1.10
         version: 3.1.55(@next/env@14.2.35)(next@14.2.35(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.55.0))
@@ -3008,7 +3008,7 @@ importers:
         version: 2.3.6
       minimatch:
         specifier: 'catalog:'
-        version: 10.2.1
+        version: 10.2.4
       semver:
         specifier: 'catalog:'
         version: 7.7.4
@@ -3287,7 +3287,7 @@ importers:
         version: 30.0.2
       minimatch:
         specifier: 'catalog:'
-        version: 10.2.1
+        version: 10.2.4
       picocolors:
         specifier: 'catalog:'
         version: 1.1.1
@@ -3690,7 +3690,7 @@ importers:
         version: 2.0.3
       minimatch:
         specifier: 'catalog:'
-        version: 10.2.1
+        version: 10.2.4
       node-machine-id:
         specifier: 1.1.12
         version: 1.1.12
@@ -3807,7 +3807,7 @@ importers:
         version: 1.54.0
       minimatch:
         specifier: 'catalog:'
-        version: 10.2.1
+        version: 10.2.4
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
@@ -3872,7 +3872,7 @@ importers:
         version: 3.0.5
       minimatch:
         specifier: 'catalog:'
-        version: 10.2.1
+        version: 10.2.4
       picocolors:
         specifier: 'catalog:'
         version: 1.1.1
@@ -4070,7 +4070,7 @@ importers:
         version: 1.1.8
       minimatch:
         specifier: 'catalog:'
-        version: 10.2.1
+        version: 10.2.4
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
@@ -20010,6 +20010,10 @@ packages:
   minimatch@10.2.1:
     resolution: {integrity: sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==}
     engines: {node: 20 || >=22}
+
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.0.8:
     resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
@@ -44895,7 +44899,7 @@ snapshots:
 
   glob@13.0.0:
     dependencies:
-      minimatch: 10.2.1
+      minimatch: 10.2.4
       minipass: 7.1.2
       path-scurry: 2.0.1
 
@@ -45739,7 +45743,7 @@ snapshots:
 
   ignore-walk@8.0.0:
     dependencies:
-      minimatch: 10.2.1
+      minimatch: 10.2.4
 
   ignore@5.3.2: {}
 
@@ -48861,6 +48865,10 @@ snapshots:
   minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.1:
+    dependencies:
+      brace-expansion: 5.0.2
+
+  minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalog:
   '@zkochan/js-yaml': '0.0.7'
   chalk: '^4.1.0'
   enquirer: '~2.3.6'
-  minimatch: '10.2.1'
+  minimatch: '10.2.4'
   picomatch: '4.0.2'
   picocolors: '^1.1.0'
   semver: '^7.6.3'


### PR DESCRIPTION
As always with these things, there is **no practical vulnerability here for Nx whatsoever**, but patching to reduce noise for consumers.

- minimatch has ReDoS: matchOne() combinatorial backtracking via multiple non-adjacent GLOBSTAR segments - https://github.com/advisories/GHSA-7r86-cg39-jmmj
- minimatch ReDoS: nested *() extglobs generate catastrophically backtracking regular expressions - https://github.com/advisories/GHSA-23c5-xmqv-rm74