### PR TITLE
fix(vitest): respect reporters from target options in vitest executor

### DIFF
--- a/packages/vitest/src/executors/test/lib/utils.ts
+++ b/packages/vitest/src/executors/test/lib/utils.ts
@@ -77,6 +77,8 @@ export async function getOptions(
     runMode: _runMode,
     reportsDirectory,
     coverage,
+    reporter,
+    reporters,
     // parseCLI artifacts
     '--': _dashdash,
     color: _color,
@@ -95,14 +97,23 @@ export async function getOptions(
     // but leaving it here in case someone did not migrate correctly
     root: resolved?.config?.root ?? root,
     config: viteConfigPath,
-    // Pass reporters from config so NxReporter can be merged without losing config reporters
-    // Safe: CLI options override (not merge with) config reporters, so no duplication
-    reporters: resolved?.config?.['test']?.reporters,
+    // Vitest's resolveConfig processes reporters in two steps:
+    // 1. options.reporters (plural) sets resolved.reporters
+    // 2. resolved.reporter (singular, from config) overwrites resolved.reporters
+    // Setting reporter to [] prevents config's reporter from overriding NxReporter
+    // (which is pushed onto reporters in vitest.impl.ts).
+    reporter: [],
+    reporters:
+      reporter ??
+      reporters ??
+      // reporter (singular) has higher priority in vitest but is not declared in InlineConfig
+      (resolved?.config?.['test'] as Record<string, any>)?.reporter ??
+      resolved?.config?.['test']?.reporters,
     coverage: {
       ...(coverage ?? {}),
       ...(reportsDirectory && { reportsDirectory }),
     },
-  };
+  } as Record<string, any>;
 }
 
 export function getOptionsAsArgv(obj: Record<string, any>): string[] {


### PR DESCRIPTION
## Current Behavior

The vitest executor ignores `reporter`/`reporters` set in target options (project.json). Both forms leak through as passthrough CLI args, causing vitest's `resolveConfig` to override the `reporters` array (which includes NxReporter), making the executor hang indefinitely.

Additionally, when the vite config uses `reporter` (singular), the config value always overrides the `reporters` array passed as inline options — again removing NxReporter.

## Expected Behavior

Target-level `reporter`/`reporters` options take priority over config-file values. NxReporter is always preserved in the final reporters array regardless of configuration source.

Priority chain: target `reporter` (singular) > target `reporters` (plural) > config `reporter` (singular) > config `reporters` (plural).

## Related Issue(s)

Fixes #34495