### PR TITLE
feat(nx-dev): add YouTube channel callout to courses page

### DIFF
--- a/nx-dev/ui-video-courses/src/lib/course-hero.tsx
+++ b/nx-dev/ui-video-courses/src/lib/course-hero.tsx
@@ -1,5 +1,5 @@
 import { SectionHeading } from '@nx/nx-dev-ui-common';
-import { YoutubeIcon } from '@nx/nx-dev/ui-icons';
+import { YoutubeIcon } from '@nx/nx-dev-ui-icons';
 import { JSX } from 'react';
 
 export function CourseHero(): JSX.Element {

--- a/nx-dev/ui-video-courses/src/lib/course-hero.tsx
+++ b/nx-dev/ui-video-courses/src/lib/course-hero.tsx
@@ -1,4 +1,5 @@
 import { SectionHeading } from '@nx/nx-dev-ui-common';
+import { YoutubeIcon } from '@nx/nx-dev/ui-icons';
 import { JSX } from 'react';
 
 export function CourseHero(): JSX.Element {
@@ -18,14 +19,7 @@ export function CourseHero(): JSX.Element {
           rel="noopener noreferrer"
           className="mt-6 inline-flex items-center gap-2 rounded-md bg-slate-100 px-4 py-2 text-sm text-slate-700 transition-colors hover:bg-slate-200 dark:bg-white/10 dark:text-slate-300 dark:hover:bg-white/15"
         >
-          <svg
-            role="img"
-            viewBox="0 0 24 24"
-            className="h-5 w-5 fill-[#FF0000]"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
-          </svg>
+          <YoutubeIcon className="h-5 w-5" fill="#FF0000" />
           Check out our YouTube channel for one-off educational videos
         </a>
       </div>

--- a/nx-dev/ui-video-courses/src/lib/course-hero.tsx
+++ b/nx-dev/ui-video-courses/src/lib/course-hero.tsx
@@ -12,6 +12,22 @@ export function CourseHero(): JSX.Element {
           Master Nx with expert-led video courses from the core team. Boost your
           skills and productivity.
         </SectionHeading>
+        <a
+          href="https://www.youtube.com/@naborx"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-6 inline-flex items-center gap-2 rounded-md bg-slate-100 px-4 py-2 text-sm text-slate-700 transition-colors hover:bg-slate-200 dark:bg-white/10 dark:text-slate-300 dark:hover:bg-white/15"
+        >
+          <svg
+            role="img"
+            viewBox="0 0 24 24"
+            className="h-5 w-5 fill-[#FF0000]"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+          </svg>
+          Check out our YouTube channel for one-off educational videos
+        </a>
       </div>
     </section>
   );

--- a/nx-dev/ui-video-courses/tsconfig.lib.json
+++ b/nx-dev/ui-video-courses/tsconfig.lib.json
@@ -24,6 +24,9 @@
   "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"],
   "references": [
     {
+      "path": "../ui-icons/tsconfig.lib.json"
+    },
+    {
       "path": "../ui-common/tsconfig.lib.json"
     },
     {


### PR DESCRIPTION
## Current Behavior

[The courses page](https://deploy-preview-34669--nx-dev.netlify.app/courses) has a hero section with title and subtitle but no mention of the YouTube channel for one-off educational videos.

## Expected Behavior

A subtle callout link with a YouTube icon appears below the hero subtitle, directing users to the Nx YouTube channel for one-off educational videos.

## Related Issue(s)

N/A