### PR TITLE
feat(core): enable output prefixing for direct nx:run-commands path

### DIFF
--- a/packages/nx/src/executors/run-commands/running-tasks.ts
+++ b/packages/nx/src/executors/run-commands/running-tasks.ts
@@ -651,6 +651,9 @@ function processEnv(
   if (color) {
     res.FORCE_COLOR = `${color}`;
   }
+  // Don't leak NX_PREFIX_OUTPUT to child processes — the parent
+  // task-orchestrator handles prefixing, not the spawned commands.
+  delete res.NX_PREFIX_OUTPUT;
   return res;
 }
 

--- a/packages/nx/src/tasks-runner/running-tasks/node-child-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/node-child-process.ts
@@ -1,10 +1,10 @@
 import * as pc from 'picocolors';
 import type { ChildProcess, Serializable } from 'child_process';
 import { readFileSync } from 'fs';
-import { EOL } from 'os';
 import { Transform } from 'stream';
 import * as treeKill from 'tree-kill';
 import { signalToCode } from '../../utils/exit-codes';
+import { addPrefixTransformer, getColor } from './output-prefix';
 import type { RunningTask } from './running-task';
 
 export class NodeChildProcessWithNonDirectOutput implements RunningTask {
@@ -115,55 +115,6 @@ export class NodeChildProcessWithNonDirectOutput implements RunningTask {
       });
     }
   }
-}
-
-/**
- * Splits a chunk into lines, optionally prepends a prefix, and writes each
- * non-empty line to the given writable (defaults to `process.stdout`).
- */
-export function writePrefixedLines(
-  chunk: string | Buffer,
-  prefix?: string,
-  writable: NodeJS.WritableStream = process.stdout
-) {
-  const lines = chunk.toString().split(/\r\n|[\n\v\f\r\x85\u2028\u2029]/g);
-  for (const line of lines) {
-    if (line) {
-      writable.write(prefix ? prefix + ' ' + line + EOL : line + EOL);
-    }
-  }
-}
-
-function addPrefixTransformer(prefix?: string) {
-  return new Transform({
-    transform(chunk, _encoding, callback) {
-      writePrefixedLines(chunk, prefix, this);
-      callback();
-    },
-  });
-}
-
-const colors = [
-  pc.green,
-  pc.greenBright,
-  pc.blue,
-  pc.blueBright,
-  pc.cyan,
-  pc.cyanBright,
-  pc.yellow,
-  pc.yellowBright,
-  pc.magenta,
-  pc.magentaBright,
-];
-
-export function getColor(projectName: string) {
-  let code = 0;
-  for (let i = 0; i < projectName.length; ++i) {
-    code += projectName.charCodeAt(i);
-  }
-  const colorIndex = code % colors.length;
-
-  return colors[colorIndex];
 }
 
 /**

--- a/packages/nx/src/tasks-runner/running-tasks/node-child-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/node-child-process.ts
@@ -146,7 +146,7 @@ const colors = [
   pc.magentaBright,
 ];
 
-function getColor(projectName: string) {
+export function getColor(projectName: string) {
   let code = 0;
   for (let i = 0; i < projectName.length; ++i) {
     code += projectName.charCodeAt(i);

--- a/packages/nx/src/tasks-runner/running-tasks/node-child-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/node-child-process.ts
@@ -1,6 +1,7 @@
 import * as pc from 'picocolors';
 import type { ChildProcess, Serializable } from 'child_process';
 import { readFileSync } from 'fs';
+import { EOL } from 'os';
 import { Transform } from 'stream';
 import * as treeKill from 'tree-kill';
 import { signalToCode } from '../../utils/exit-codes';
@@ -116,18 +117,27 @@ export class NodeChildProcessWithNonDirectOutput implements RunningTask {
   }
 }
 
+/**
+ * Splits a chunk into lines, optionally prepends a prefix, and writes each
+ * non-empty line to the given writable (defaults to `process.stdout`).
+ */
+export function writePrefixedLines(
+  chunk: string | Buffer,
+  prefix?: string,
+  writable: NodeJS.WritableStream = process.stdout
+) {
+  const lines = chunk.toString().split(/\r\n|[\n\v\f\r\x85\u2028\u2029]/g);
+  for (const line of lines) {
+    if (line) {
+      writable.write(prefix ? prefix + ' ' + line + EOL : line + EOL);
+    }
+  }
+}
+
 function addPrefixTransformer(prefix?: string) {
-  const newLineSeparator = process.platform.startsWith('win') ? '\r\n' : '\n';
   return new Transform({
     transform(chunk, _encoding, callback) {
-      const list = chunk.toString().split(/\r\n|[\n\v\f\r\x85\u2028\u2029]/g);
-      list
-        .filter(Boolean)
-        .forEach((m) =>
-          this.push(
-            prefix ? prefix + ' ' + m + newLineSeparator : m + newLineSeparator
-          )
-        );
+      writePrefixedLines(chunk, prefix, this);
       callback();
     },
   });

--- a/packages/nx/src/tasks-runner/running-tasks/output-prefix.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/output-prefix.ts
@@ -26,6 +26,24 @@ export function getColor(projectName: string) {
 }
 
 /**
+ * Formats a chunk by splitting it into lines and optionally prepending a prefix.
+ * Returns an array of formatted line strings (including EOL).
+ */
+export function formatPrefixedLines(
+  chunk: string | Buffer,
+  prefix?: string
+): string[] {
+  const lines = chunk.toString().split(/\r\n|[\n\v\f\r\x85\u2028\u2029]/g);
+  const result: string[] = [];
+  for (const line of lines) {
+    if (line) {
+      result.push(prefix ? prefix + ' ' + line + EOL : line + EOL);
+    }
+  }
+  return result;
+}
+
+/**
  * Splits a chunk into lines, optionally prepends a prefix, and writes each
  * non-empty line to the given writable (defaults to `process.stdout`).
  */
@@ -34,18 +52,17 @@ export function writePrefixedLines(
   prefix?: string,
   writable: NodeJS.WritableStream = process.stdout
 ) {
-  const lines = chunk.toString().split(/\r\n|[\n\v\f\r\x85\u2028\u2029]/g);
-  for (const line of lines) {
-    if (line) {
-      writable.write(prefix ? prefix + ' ' + line + EOL : line + EOL);
-    }
+  for (const line of formatPrefixedLines(chunk, prefix)) {
+    writable.write(line);
   }
 }
 
 export function addPrefixTransformer(prefix?: string) {
   return new Transform({
     transform(chunk, _encoding, callback) {
-      writePrefixedLines(chunk, prefix, this);
+      for (const line of formatPrefixedLines(chunk, prefix)) {
+        this.push(line);
+      }
       callback();
     },
   });

--- a/packages/nx/src/tasks-runner/running-tasks/output-prefix.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/output-prefix.ts
@@ -1,0 +1,52 @@
+import * as pc from 'picocolors';
+import { EOL } from 'os';
+import { Transform } from 'stream';
+
+const colors = [
+  pc.green,
+  pc.greenBright,
+  pc.blue,
+  pc.blueBright,
+  pc.cyan,
+  pc.cyanBright,
+  pc.yellow,
+  pc.yellowBright,
+  pc.magenta,
+  pc.magentaBright,
+];
+
+export function getColor(projectName: string) {
+  let code = 0;
+  for (let i = 0; i < projectName.length; ++i) {
+    code += projectName.charCodeAt(i);
+  }
+  const colorIndex = code % colors.length;
+
+  return colors[colorIndex];
+}
+
+/**
+ * Splits a chunk into lines, optionally prepends a prefix, and writes each
+ * non-empty line to the given writable (defaults to `process.stdout`).
+ */
+export function writePrefixedLines(
+  chunk: string | Buffer,
+  prefix?: string,
+  writable: NodeJS.WritableStream = process.stdout
+) {
+  const lines = chunk.toString().split(/\r\n|[\n\v\f\r\x85\u2028\u2029]/g);
+  for (const line of lines) {
+    if (line) {
+      writable.write(prefix ? prefix + ' ' + line + EOL : line + EOL);
+    }
+  }
+}
+
+export function addPrefixTransformer(prefix?: string) {
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      writePrefixedLines(chunk, prefix, this);
+      callback();
+    },
+  });
+}

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -691,7 +691,7 @@ export class TaskOrchestrator {
         }
         const runCommandsOptions = {
           ...combinedOptions,
-          env,
+          env: shouldPrefix ? { ...env, NX_PREFIX_OUTPUT: 'false' } : env,
           usePty:
             this.tuiEnabled ||
             (!this.tasksSchedule.hasTasks() &&

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -33,10 +33,7 @@ import { ForkedProcessTaskRunner } from './forked-process-task-runner';
 import { isTuiEnabled } from './is-tui-enabled';
 import { TaskMetadata, TaskResult } from './life-cycle';
 import { PseudoTtyProcess } from './pseudo-terminal';
-import {
-  getColor,
-  writePrefixedLines,
-} from './running-tasks/node-child-process';
+import { getColor, writePrefixedLines } from './running-tasks/output-prefix';
 import { NoopChildProcess } from './running-tasks/noop-child-process';
 import { RunningTask } from './running-tasks/running-task';
 import {

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -33,7 +33,10 @@ import { ForkedProcessTaskRunner } from './forked-process-task-runner';
 import { isTuiEnabled } from './is-tui-enabled';
 import { TaskMetadata, TaskResult } from './life-cycle';
 import { PseudoTtyProcess } from './pseudo-terminal';
-import { getColor } from './running-tasks/node-child-process';
+import {
+  getColor,
+  writePrefixedLines,
+} from './running-tasks/node-child-process';
 import { NoopChildProcess } from './running-tasks/noop-child-process';
 import { RunningTask } from './running-tasks/running-task';
 import {
@@ -689,8 +692,6 @@ export class TaskOrchestrator {
           const args = getPrintableCommandArgsForTask(task);
           output.logCommand(args.join(' '));
         }
-        // When prefixing, suppress direct output from the PTY/process
-        // so we can intercept it via onOutput and add prefixes ourselves.
         const runCommandsOptions = {
           ...combinedOptions,
           env,
@@ -698,7 +699,7 @@ export class TaskOrchestrator {
             this.tuiEnabled ||
             (!this.tasksSchedule.hasTasks() &&
               this.runningContinuousTasks.size === 0),
-          streamOutput: shouldPrefix ? false : streamOutput,
+          streamOutput: streamOutput && !shouldPrefix,
         };
 
         const runningTask = await runCommands(
@@ -716,21 +717,9 @@ export class TaskOrchestrator {
 
         if (shouldPrefix) {
           const color = getColor(task.target.project);
-          const prefixText = `${task.target.project}:`;
-          const newLineSeparator = process.platform.startsWith('win')
-            ? '\r\n'
-            : '\n';
+          const formattedPrefix = pc.bold(color(`${task.target.project}:`));
           runningTask.onOutput((chunk) => {
-            const lines = chunk
-              .toString()
-              .split(/\r\n|[\n\v\f\r\x85\u2028\u2029]/g);
-            for (const line of lines) {
-              if (line.trim().length > 0) {
-                process.stdout.write(
-                  pc.bold(color(prefixText)) + ' ' + line + newLineSeparator
-                );
-              }
-            }
+            writePrefixedLines(chunk, formattedPrefix);
           });
         } else if (this.tuiEnabled) {
           if (runningTask instanceof PseudoTtyProcess) {
@@ -750,7 +739,7 @@ export class TaskOrchestrator {
           }
         }
 
-        if (!streamOutput && !shouldPrefix) {
+        if (!streamOutput) {
           // TODO: shouldn't this be checking if the task is continuous before writing anything to disk or calling printTaskTerminalOutput?
           runningTask.onExit((code, terminalOutput) => {
             this.options.lifeCycle.printTaskTerminalOutput(

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -736,7 +736,7 @@ export class TaskOrchestrator {
           }
         }
 
-        if (!streamOutput) {
+        if (!streamOutput && !shouldPrefix) {
           // TODO: shouldn't this be checking if the task is continuous before writing anything to disk or calling printTaskTerminalOutput?
           runningTask.onExit((code, terminalOutput) => {
             this.options.lifeCycle.printTaskTerminalOutput(

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -1,5 +1,6 @@
 import { defaultMaxListeners } from 'events';
 import { writeFileSync } from 'fs';
+import * as pc from 'picocolors';
 import { relative } from 'path';
 import { performance } from 'perf_hooks';
 import { NxJsonConfiguration } from '../config/nx-json';
@@ -32,6 +33,7 @@ import { ForkedProcessTaskRunner } from './forked-process-task-runner';
 import { isTuiEnabled } from './is-tui-enabled';
 import { TaskMetadata, TaskResult } from './life-cycle';
 import { PseudoTtyProcess } from './pseudo-terminal';
+import { getColor } from './running-tasks/node-child-process';
 import { NoopChildProcess } from './running-tasks/noop-child-process';
 import { RunningTask } from './running-tasks/running-task';
 import {
@@ -655,15 +657,16 @@ export class TaskOrchestrator {
     pipeOutput: boolean
   ): Promise<RunningTask> {
     const shouldPrefix =
-      streamOutput && process.env.NX_PREFIX_OUTPUT === 'true';
+      streamOutput &&
+      process.env.NX_PREFIX_OUTPUT === 'true' &&
+      !this.tuiEnabled;
     const targetConfiguration = getTargetConfigurationForTask(
       task,
       this.projectGraph
     );
     if (
       process.env.NX_RUN_COMMANDS_DIRECTLY !== 'false' &&
-      targetConfiguration.executor === 'nx:run-commands' &&
-      !shouldPrefix
+      targetConfiguration.executor === 'nx:run-commands'
     ) {
       try {
         const { schema } = getExecutorForTask(task, this.projectGraph);
@@ -686,6 +689,8 @@ export class TaskOrchestrator {
           const args = getPrintableCommandArgsForTask(task);
           output.logCommand(args.join(' '));
         }
+        // When prefixing, suppress direct output from the PTY/process
+        // so we can intercept it via onOutput and add prefixes ourselves.
         const runCommandsOptions = {
           ...combinedOptions,
           env,
@@ -693,7 +698,7 @@ export class TaskOrchestrator {
             this.tuiEnabled ||
             (!this.tasksSchedule.hasTasks() &&
               this.runningContinuousTasks.size === 0),
-          streamOutput,
+          streamOutput: shouldPrefix ? false : streamOutput,
         };
 
         const runningTask = await runCommands(
@@ -709,7 +714,25 @@ export class TaskOrchestrator {
           this.runningRunCommandsTasks.delete(task.id);
         });
 
-        if (this.tuiEnabled) {
+        if (shouldPrefix) {
+          const color = getColor(task.target.project);
+          const prefixText = `${task.target.project}:`;
+          const newLineSeparator = process.platform.startsWith('win')
+            ? '\r\n'
+            : '\n';
+          runningTask.onOutput((chunk) => {
+            const lines = chunk
+              .toString()
+              .split(/\r\n|[\n\v\f\r\x85\u2028\u2029]/g);
+            for (const line of lines) {
+              if (line.trim().length > 0) {
+                process.stdout.write(
+                  pc.bold(color(prefixText)) + ' ' + line + newLineSeparator
+                );
+              }
+            }
+          });
+        } else if (this.tuiEnabled) {
           if (runningTask instanceof PseudoTtyProcess) {
             // This is an external of a the pseudo terminal where a task is running and can be passed to the TUI
             this.options.lifeCycle.registerRunningTask(
@@ -727,7 +750,7 @@ export class TaskOrchestrator {
           }
         }
 
-        if (!streamOutput) {
+        if (!streamOutput && !shouldPrefix) {
           // TODO: shouldn't this be checking if the task is continuous before writing anything to disk or calling printTaskTerminalOutput?
           runningTask.onExit((code, terminalOutput) => {
             this.options.lifeCycle.printTaskTerminalOutput(

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -691,7 +691,7 @@ export class TaskOrchestrator {
         }
         const runCommandsOptions = {
           ...combinedOptions,
-          env: shouldPrefix ? { ...env, NX_PREFIX_OUTPUT: 'false' } : env,
+          env,
           usePty:
             this.tuiEnabled ||
             (!this.tasksSchedule.hasTasks() &&


### PR DESCRIPTION
## Current Behavior

When `NX_PREFIX_OUTPUT=true` (e.g. `--output-style=stream`), `nx:run-commands` tasks are forced out of the fast direct execution path and into a slower forked process, because the direct path had no mechanism to prefix output with project names.

## Expected Behavior

`nx:run-commands` tasks stay on the direct execution path even when output prefixing is needed. The PTY's `quiet` mode suppresses direct stdout writes, and the orchestrator intercepts output via `onOutput` callbacks to prefix each line with the colored project name before writing to stdout.

### Changes

- Allow `nx:run-commands` to use the direct execution path regardless of prefix output setting
- When prefixing is enabled, suppress direct stream output and intercept it via `onOutput` to add colored project-name prefixes
- Extract a shared `writePrefixedLines` utility used by both the direct path and the existing `addPrefixTransformer` stream — eliminates duplicated split/filter/prefix logic
- Use `os.EOL` instead of manual platform newline detection
- Hoist formatted prefix string outside the per-line callback for efficiency
- Simplify boolean expressions (`streamOutput && !shouldPrefix` instead of ternary, remove redundant guard)

## Related Issue(s)

N/A — performance improvement for streaming output mode.