### PR TITLE
feat(js): support configurable typecheck config name

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -50,6 +50,7 @@ export interface TscPluginOptions {
     | boolean
     | {
         targetName?: string;
+        configName?: string;
       };
   build?:
     | boolean
@@ -69,6 +70,7 @@ interface NormalizedPluginOptions {
     | false
     | {
         targetName: string;
+        configName: string;
       };
   build:
     | false
@@ -369,7 +371,9 @@ async function resolveValidConfigFilesAndHashes(
     );
 
     // Skip configs that can't produce any targets based on plugin options
-    const isTypecheckConfig = configContext.basename === 'tsconfig.json';
+    const isTypecheckConfig =
+      configContext.basename ===
+      (options.typecheck ? options.typecheck.configName : 'tsconfig.json');
     const isBuildConfig =
       options.build && configContext.basename === options.build.configName;
     if (!isTypecheckConfig && !isBuildConfig) {
@@ -522,8 +526,8 @@ function buildTscTargets(
 
   let internalProjectReferences: Record<string, ParsedTsconfigData>;
   if (
-    config.basename === 'tsconfig.json' &&
     options.typecheck &&
+    config.basename === options.typecheck.configName &&
     tsConfig.raw?.['nx']?.addTypecheckTarget !== false
   ) {
     internalProjectReferences = resolveInternalProjectReferences(
@@ -1463,7 +1467,9 @@ function normalizePluginOptions(
   const compiler = pluginOptions.compiler ?? defaultCompiler;
 
   const defaultTypecheckTargetName = 'typecheck';
+  const defaultTypecheckConfigName = 'tsconfig.json';
   let typecheck: NormalizedPluginOptions['typecheck'] = {
+    configName: defaultTypecheckConfigName,
     targetName: defaultTypecheckTargetName,
   };
   if (pluginOptions.typecheck === false) {
@@ -1473,6 +1479,8 @@ function normalizePluginOptions(
     typeof pluginOptions.typecheck !== 'boolean'
   ) {
     typecheck = {
+      configName:
+        pluginOptions.typecheck.configName ?? defaultTypecheckConfigName,
       targetName:
         pluginOptions.typecheck.targetName ?? defaultTypecheckTargetName,
     };


### PR DESCRIPTION
## Current Behavior

The TypeScript plugin's typecheck target inference was tied to `tsconfig.json`, so users could not configure a different tsconfig file name for typecheck inference.

## Expected Behavior

The plugin supports configuring `typecheck.configName`, which defaults to `tsconfig.json`.
