### PR TITLE
fix(misc): use pathToFileURL for cross-platform path handling in postcss-cli-resources

### DIFF
--- a/packages/angular-rspack/src/lib/utils/postcss-cli-resources.ts
+++ b/packages/angular-rspack/src/lib/utils/postcss-cli-resources.ts
@@ -8,6 +8,7 @@
 
 import { interpolateName } from 'loader-utils';
 import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { Declaration, Plugin } from 'postcss';
 import { assertIsError } from './misc-helpers';
 
@@ -105,9 +106,15 @@ export default function (options?: PostcssCliResourcesOptions): Plugin {
       inputUrl = inputUrl.slice(1);
     }
 
-    const normalizedUrl = path.resolve(context, inputUrl.replace(/\\/g, '/'));
-    const parsedUrl = new URL(normalizedUrl, 'file:///');
-    const { pathname, hash, search } = parsedUrl;
+    // Separate URL query/hash from the file path before resolving
+    const [, filePath, urlSuffix] = inputUrl.match(/^([^?#]*)(.*)$/)!;
+    const resolvedPath = path.resolve(context, filePath.replace(/\\/g, '/'));
+    const { pathname } = pathToFileURL(resolvedPath);
+    let hash = '';
+    let search = '';
+    if (urlSuffix) {
+      ({ hash, search } = new URL(`file:///dummy${urlSuffix}`));
+    }
     const resolver = (file: string, base: string) =>
       new Promise<string>((resolve, reject) => {
         loader.resolve(base, decodeURI(file), (err, result) => {

--- a/packages/rspack/src/plugins/utils/plugins/postcss-cli-resources.ts
+++ b/packages/rspack/src/plugins/utils/plugins/postcss-cli-resources.ts
@@ -1,5 +1,6 @@
 import { interpolateName } from 'loader-utils';
 import * as path from 'path';
+import { pathToFileURL } from 'url';
 import type { Declaration } from 'postcss';
 import type { LoaderContext } from '@rspack/core';
 
@@ -103,9 +104,15 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
       resourceCache.set(cacheKey, outputUrl);
       return outputUrl;
     }
-    const normalizedUrl = path.resolve(context, inputUrl.replace(/\\/g, '/'));
-    const parsedUrl = new URL(normalizedUrl, 'file:///');
-    const { pathname, hash, search } = parsedUrl;
+    // Separate URL query/hash from the file path before resolving
+    const [, filePath, urlSuffix] = inputUrl.match(/^([^?#]*)(.*)$/)!;
+    const resolvedPath = path.resolve(context, filePath.replace(/\\/g, '/'));
+    const { pathname } = pathToFileURL(resolvedPath);
+    let hash = '';
+    let search = '';
+    if (urlSuffix) {
+      ({ hash, search } = new URL(`file:///dummy${urlSuffix}`));
+    }
     const resolver = (file: string, base: string) =>
       new Promise<boolean | string>((resolve, reject) => {
         loader.resolve(base, decodeURI(file), (err, result) => {

--- a/packages/webpack/src/utils/webpack/plugins/postcss-cli-resources.ts
+++ b/packages/webpack/src/utils/webpack/plugins/postcss-cli-resources.ts
@@ -1,5 +1,6 @@
 import { interpolateName } from 'loader-utils';
 import * as path from 'path';
+import { pathToFileURL } from 'url';
 import type { Declaration } from 'postcss';
 import { LoaderContext } from 'webpack';
 
@@ -103,9 +104,15 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
       resourceCache.set(cacheKey, outputUrl);
       return outputUrl;
     }
-    const normalizedUrl = path.resolve(context, inputUrl.replace(/\\/g, '/'));
-    const parsedUrl = new URL(normalizedUrl, 'file:///');
-    const { pathname, hash, search } = parsedUrl;
+    // Separate URL query/hash from the file path before resolving
+    const [, filePath, urlSuffix] = inputUrl.match(/^([^?#]*)(.*)$/)!;
+    const resolvedPath = path.resolve(context, filePath.replace(/\\/g, '/'));
+    const { pathname } = pathToFileURL(resolvedPath);
+    let hash = '';
+    let search = '';
+    if (urlSuffix) {
+      ({ hash, search } = new URL(`file:///dummy${urlSuffix}`));
+    }
     const resolver = (file: string, base: string) =>
       new Promise<boolean | string>((resolve, reject) => {
         loader.resolve(base, decodeURI(file), (err, result) => {


### PR DESCRIPTION
## Current Behavior

CSS `url()` references to fonts and assets fail to resolve on Windows with webpack, rspack, and angular-rspack builds. The `postcss-cli-resources` plugin passes Windows absolute paths (e.g. `E:\dev\project\font.woff2`) to `new URL(path, 'file:///')`, which misinterprets the drive letter (`E:`) as a URL protocol, stripping it from `pathname` and producing unresolvable paths like `\dev\project\font.woff2`.

## Expected Behavior

CSS `url()` references to fonts, images, and other assets resolve correctly on all platforms.

## Related Issue(s)

Fixes #33052