### PR TITLE
fix(angular-rspack): use relative path for postcss-cli-resources output

### DIFF
--- a/packages/angular-rspack/src/lib/config/config-utils/style-config-utils.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/style-config-utils.ts
@@ -110,7 +110,10 @@ export async function getStylesConfig(
         PostcssCliResources({
           baseHref: buildOptions.baseHref,
           deployUrl: buildOptions.deployUrl,
-          resourcesOutputPath: buildOptions.outputPath.media,
+          resourcesOutputPath: relative(
+            buildOptions.outputPath.browser,
+            buildOptions.outputPath.media
+          ),
           loader,
           filename: assetNameTemplate,
           emitFile: platform !== 'server',


### PR DESCRIPTION
## Current Behavior

When using `@nx/angular-rspack` with SCSS imports that reference external assets (e.g., `flag-icon-css`), the `postcss-cli-resources` plugin generates absolute filesystem paths in CSS `url()` values:

```css
.flag-icon-us{background-image:url(/some/project/path/dist/bug-demo/browser/media/us.2d0a1dd6.svg)}
```

This happens because `normalizeOutputPath()` makes `outputPath.media` absolute, and this absolute path is passed directly as `resourcesOutputPath` to `postcss-cli-resources`.

## Expected Behavior

CSS `url()` values contain relative paths:

```css
.flag-icon-us{background-image:url(media/us.2d0a1dd6.svg)}
```

## Related Issue(s)

Fixes #34092