### PR TITLE
fix(maven): skip directories when recording main artifact

### DIFF
--- a/packages/maven/shared/src/main/kotlin/dev/nx/maven/shared/BuildStateRecorder.kt
+++ b/packages/maven/shared/src/main/kotlin/dev/nx/maven/shared/BuildStateRecorder.kt
@@ -152,7 +152,7 @@ object BuildStateRecorder {
 
     private fun captureMainArtifact(project: MavenProject, basedir: File): ArtifactInfo? {
         val artifactFile = project.artifact?.file
-        if (artifactFile != null && artifactFile.exists()) {
+        if (artifactFile != null && artifactFile.isFile) {
             return ArtifactInfo(
                 file = toRelativePathCached(artifactFile.absolutePath, basedir),
                 type = project.artifact.type,
@@ -162,7 +162,7 @@ object BuildStateRecorder {
                 version = project.artifact.version
             )
         } else if (artifactFile != null) {
-            log.debug("Main artifact file does not exist: ${artifactFile.absolutePath}")
+            log.debug("Main artifact file does not exist or is a directory: ${artifactFile.absolutePath}")
         }
         return null
     }

--- a/packages/maven/shared/src/main/kotlin/dev/nx/maven/shared/BuildStateRecorder.kt
+++ b/packages/maven/shared/src/main/kotlin/dev/nx/maven/shared/BuildStateRecorder.kt
@@ -152,6 +152,7 @@ object BuildStateRecorder {
 
     private fun captureMainArtifact(project: MavenProject, basedir: File): ArtifactInfo? {
         val artifactFile = project.artifact?.file
+        log.debug("    Main artifact file for ${project.artifactId}: ${artifactFile?.absolutePath} (exists=${artifactFile?.exists()}, isFile=${artifactFile?.isFile})")
         if (artifactFile != null && artifactFile.isFile) {
             return ArtifactInfo(
                 file = toRelativePathCached(artifactFile.absolutePath, basedir),


### PR DESCRIPTION
## Current Behavior

`BuildStateRecorder.captureMainArtifact` uses `exists()` to check `project.artifact.file`. Maven sets this to `target/classes` (a directory) by default before `jar:jar` runs. Since `exists()` returns true for directories, the recorder captures `target/classes` as the main artifact with type "jar".

When this stale build state is later applied by `BuildStateApplier`, it sets `project.artifact.file` to a directory, which causes `jar:jar` and `install` goals to fail with errors like:
- "The packaging plugin did not assign a main file to the project"
- "You have to use a classifier to attach supplemental artifacts"

## Expected Behavior

Only actual artifact files (jars, wars, etc.) are recorded as `mainArtifact`. Directories like `target/classes` are skipped since they represent intermediate compilation output, not finished artifacts.

## Related Issue(s)

N/A — discovered during integration of `@nx/maven` plugin for self-building.