### PR TITLE
docs(misc): add /docs redirect

### DIFF
--- a/netlify/edge-functions/rewrite-framer-urls.ts
+++ b/netlify/edge-functions/rewrite-framer-urls.ts
@@ -75,6 +75,7 @@ export const config = {
   // Only process HTML requests to save on compute
   accept: ['text/html'],
   excludedPath: [
+    '/docs',
     '/docs/*',
     '/api/*',
     '/blog/*',

--- a/nx-dev/nx-dev/_redirects
+++ b/nx-dev/nx-dev/_redirects
@@ -4,6 +4,9 @@
 # Netlify processes these top-to-bottom, first match wins.
 # Specific rules MUST come before wildcard rules.
 
+# --- docs ---
+/docs /docs/getting-started/intro 301
+
 # --- cliUrls ---
 /cli/connect-to-nx-cloud /docs/features/ci-features 301
 /cli/affected-dep-graph /docs/reference/deprecated/affected-graph 301


### PR DESCRIPTION
The clean-up PR inverted the reverse proxy logic such that only the defined paths are passed to Next.js. The default is to return Framer pages. Since we also remove the Nextjs redirect, we lose the `/docs` one that was missing from `_redirects` file.

https://github.com/nrwl/nx/pull/34672

This PR adds the redirect to fix it again.