### PR TITLE
chore(core): exclude .nx, .git, and package.json from sandbox reads

### DIFF
--- a/.nx/workflows/sandboxing-config.yaml
+++ b/.nx/workflows/sandboxing-config.yaml
@@ -1,2 +1,5 @@
 exclude-reads:
   - '**/node_modules/**'
+  - .nx/**
+  - .git
+  - '**/package.json'


### PR DESCRIPTION
## Current Behavior

The sandboxing config only excludes `**/node_modules/**` from reads, meaning `.nx`, `.git`, and `package.json` files are still being read during sandboxed operations.

## Expected Behavior

Exclude `.nx/**`, `.git`, and `**/package.json` from sandbox reads to reduce unnecessary file access during sandboxed workflows.

## Related Issue(s)

N/A