### PR TITLE
fix(testing): remove stale ci.yml from extras.test snapshot

### DIFF
--- a/e2e/nx/src/__snapshots__/extras.test.ts.snap
+++ b/e2e/nx/src/__snapshots__/extras.test.ts.snap
@@ -3,7 +3,6 @@
 exports[`Extra Nx Misc Tests task graph inputs should correctly expand default task inputs 1`] = `
 {
   "general": [
-    ".github/workflows/ci.yml",
     ".gitignore",
     "nx.json",
   ],


### PR DESCRIPTION
## Current Behavior

The `extras.test.ts` e2e test is flaking on master because the snapshot file expects `.github/workflows/ci.yml` in the "general" task inputs, but `create-nx-workspace --no-interactive` no longer generates it.

PR #34332 accidentally updated the snapshot to include this file — the author likely ran tests against a cached workspace from before PR #34616 fixed the CI workflow generation bug.

## Expected Behavior

The snapshot should not include `.github/workflows/ci.yml` since `create-nx-workspace` correctly skips CI workflow generation in non-interactive mode (fixed in PR #34616).

## Related Issue(s)

Fixes the `e2e-nx:e2e-ci--src/extras.test.ts` CI flakiness on master.