### PR TITLE
fix(core): fall back to invoking PM in detection

### DIFF
--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -151,9 +151,73 @@ describe('package-manager', () => {
             return jest.requireActual('fs').existsSync(p);
         }
       });
-      const packageManager = detectPackageManager();
-      expect(packageManager).toEqual('npm');
-      expect(fs.existsSync).toHaveBeenCalledTimes(4);
+      const originalUserAgent = process.env.npm_config_user_agent;
+      delete process.env.npm_config_user_agent;
+      try {
+        const packageManager = detectPackageManager();
+        expect(packageManager).toEqual('npm');
+        expect(fs.existsSync).toHaveBeenCalledTimes(4);
+      } finally {
+        process.env.npm_config_user_agent = originalUserAgent;
+      }
+    });
+
+    it('should detect pnpm from npm_config_user_agent when no lock file exists', () => {
+      jest.spyOn(configModule, 'readNxJson').mockReturnValueOnce({});
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+      const originalUserAgent = process.env.npm_config_user_agent;
+      process.env.npm_config_user_agent =
+        'pnpm/8.15.4 npm/? node/v20.11.1 darwin arm64';
+      try {
+        expect(detectPackageManager()).toEqual('pnpm');
+      } finally {
+        process.env.npm_config_user_agent = originalUserAgent;
+      }
+    });
+
+    it('should detect yarn from npm_config_user_agent when no lock file exists', () => {
+      jest.spyOn(configModule, 'readNxJson').mockReturnValueOnce({});
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+      const originalUserAgent = process.env.npm_config_user_agent;
+      process.env.npm_config_user_agent =
+        'yarn/1.22.21 npm/? node/v20.11.1 darwin arm64';
+      try {
+        expect(detectPackageManager()).toEqual('yarn');
+      } finally {
+        process.env.npm_config_user_agent = originalUserAgent;
+      }
+    });
+
+    it('should detect bun from npm_config_user_agent when no lock file exists', () => {
+      jest.spyOn(configModule, 'readNxJson').mockReturnValueOnce({});
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+      const originalUserAgent = process.env.npm_config_user_agent;
+      process.env.npm_config_user_agent = 'bun/1.0.25';
+      try {
+        expect(detectPackageManager()).toEqual('bun');
+      } finally {
+        process.env.npm_config_user_agent = originalUserAgent;
+      }
+    });
+
+    it('should prefer lock file detection over npm_config_user_agent', () => {
+      jest.spyOn(configModule, 'readNxJson').mockReturnValueOnce({});
+      jest.spyOn(fs, 'existsSync').mockImplementation((p) => {
+        switch (p) {
+          case 'yarn.lock':
+            return true;
+          default:
+            return false;
+        }
+      });
+      const originalUserAgent = process.env.npm_config_user_agent;
+      process.env.npm_config_user_agent =
+        'pnpm/8.15.4 npm/? node/v20.11.1 darwin arm64';
+      try {
+        expect(detectPackageManager()).toEqual('yarn');
+      } finally {
+        process.env.npm_config_user_agent = originalUserAgent;
+      }
     });
   });
 

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -69,8 +69,30 @@ export function detectPackageManager(dir: string = ''): PackageManager {
         ? 'yarn'
         : existsSync(join(dir, 'pnpm-lock.yaml'))
           ? 'pnpm'
-          : 'npm')
+          : detectInvokedPackageManager())
   );
+}
+
+/**
+ * Detects which package manager was used to invoke the current command
+ * based on the npm_config_user_agent environment variable.
+ *
+ * Falls back to 'npm' if detection fails.
+ */
+function detectInvokedPackageManager(): PackageManager {
+  const userAgent = process.env.npm_config_user_agent;
+  if (userAgent) {
+    if (userAgent.startsWith('pnpm/')) {
+      return 'pnpm';
+    }
+    if (userAgent.startsWith('yarn/')) {
+      return 'yarn';
+    }
+    if (userAgent.startsWith('bun/')) {
+      return 'bun';
+    }
+  }
+  return 'npm';
 }
 
 /**


### PR DESCRIPTION
## Current Behavior
when you run things like `pnpm nx@latest init`, there might not be a pnpm lockfile yet. So nx commands will detect the PM as `npm` by default... even though the fact that the user is invoking the command via `pnpm` is a strong signal that that's the PM they want to use.

## Expected Behavior
We fall back to detecting the invoking PM via env var if no lockfile exists.
