### PR TITLE
fix(vite): skip root-relative paths in nxViteTsPaths resolveId

### DIFF
--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -174,6 +174,12 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
       // Let other resolvers handle this path.
       if (!foundTsConfigPath) return null;
 
+      // Skip absolute and root-relative paths — these are filesystem paths,
+      // not TypeScript import specifiers. In Vite, `/foo` is a project-root-
+      // relative URL and must be resolved by Vite's built-in resolver, not
+      // by tsconfig path mapping (which would incorrectly use baseUrl).
+      if (importPath.startsWith('/')) return null;
+
       let resolvedFile: string;
       try {
         resolvedFile = matchTsPathEsm(importPath);


### PR DESCRIPTION
## Current Behavior

The `resolveId` hook in `nxViteTsPaths` processes all import paths, including Vite root-relative paths (e.g. `/src/test-setup.ts`). In Vite, `/foo` means "relative to project root," but `nxViteTsPaths` resolves it via tsconfig's `baseUrl` (workspace root), producing wrong paths.

In an Angular standalone workspace with Vitest + Analog, generating a library and running `nx test test-lib` fails with `Error: Need to call TestBed.initTestEnvironment() first` because the library's `src/test-setup.ts` resolves to the root app's file instead. The Analog Angular compiler never compiled that file, so the transform returns empty content and `setupTestBed()` never runs.

## Expected Behavior

`nxViteTsPaths` should skip `/`-prefixed paths and let Vite's built-in resolver handle them. These are filesystem paths (absolute or root-relative), not TypeScript import specifiers. Library tests should work correctly with their own `test-setup.ts`.

## Related Issue(s)

Fixes #34300