### PR TITLE
fix(angular): preserve skipLibCheck in tsconfig.json for standalone projects

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -1173,6 +1173,17 @@ describe('app', () => {
       expect(appTree.exists('e2e/playwright.config.ts')).toBeTruthy();
       expect(appTree.exists('e2e/src/example.spec.ts')).toBeTruthy();
     });
+
+    it('should keep skipLibCheck in tsconfig.json when there is no tsconfig.base.json', async () => {
+      appTree.delete('tsconfig.base.json');
+
+      await generateApp(appTree, '.', {
+        name: 'my-app',
+      });
+
+      const tsconfig = readJson(appTree, 'tsconfig.json');
+      expect(tsconfig.compilerOptions.skipLibCheck).toBe(true);
+    });
   });
 
   describe('--minimal', () => {

--- a/packages/angular/src/generators/application/lib/update-tsconfig-files.ts
+++ b/packages/angular/src/generators/application/lib/update-tsconfig-files.ts
@@ -72,11 +72,16 @@ export function updateTsconfigFiles(tree: Tree, options: NormalizedSchema) {
       ...json.compilerOptions,
       ...compilerOptions,
     };
-    json.compilerOptions = getNeededCompilerOptionOverrides(
-      tree,
-      json.compilerOptions,
-      rootTsConfigPath
-    );
+    // For standalone projects, rootTsConfigPath and tsconfigPath are the same
+    // file. Calling getNeededCompilerOptionOverrides would compare the file
+    // against itself and strip options like skipLibCheck that are already set.
+    if (tsconfigPath !== rootTsConfigPath) {
+      json.compilerOptions = getNeededCompilerOptionOverrides(
+        tree,
+        json.compilerOptions,
+        rootTsConfigPath
+      );
+    }
     return json;
   });
 


### PR DESCRIPTION
## Current Behavior

When creating a new Angular standalone project with Vitest (`create-nx-workspace` → Angular → Standalone), running tests fails with:

```
✘ [ERROR] TS2304: Cannot find name 'Disposable'. [plugin angular-compiler]

    node_modules/@vitest/spy/dist/index.d.ts:158:80:
      158 │ ...tends Procedure | Constructable = Procedure> extends Disposable {
```

For standalone (root) projects, `getRootTsConfigFileName` returns `tsconfig.json` — the same file as the project tsconfig. `getNeededCompilerOptionOverrides` compares the file against itself, sees `skipLibCheck: true` already matches, and strips it. The result: `skipLibCheck` disappears from the final `tsconfig.json`.

## Expected Behavior

Standalone Angular projects should have `skipLibCheck: true` in their `tsconfig.json` (matching what Angular CLI generates), preventing type errors from third-party `.d.ts` files like `@vitest/spy`.

## Related Issue(s)

Fixes #34164