### PR TITLE
fix(js): strip catalogs from pruned pnpm lockfile

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -1047,6 +1047,29 @@ describe('pnpm LockFile utility', () => {
           ).default
         );
       });
+
+      it('should strip catalogs from pruned lockfile', () => {
+        const typescriptPackageJson = require(
+          joinPathFragments(
+            __dirname,
+            '__fixtures__/pruning/typescript/package.json'
+          )
+        );
+        const lockFileWithCatalogs = lockFile.replace(
+          'lockfileVersion:',
+          'catalogs:\n  default:\n    typescript: 4.9.5\n\nlockfileVersion:'
+        );
+
+        const prunedGraph = pruneProjectGraph(graph, typescriptPackageJson);
+        const result = stringifyPnpmLockfile(
+          prunedGraph,
+          lockFileWithCatalogs,
+          typescriptPackageJson,
+          '/virtual'
+        );
+
+        expect(result).not.toContain('catalogs');
+      });
     });
   });
 

--- a/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
+++ b/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
@@ -829,6 +829,7 @@ function normalizeLockfile(
   if (!lockfileToSave.pnpmfileChecksum) {
     delete lockfileToSave.pnpmfileChecksum;
   }
+  delete lockfileToSave['catalogs'];
   return lockfileToSave;
 }
 


### PR DESCRIPTION
## Current Behavior

When using `generatePackageJson: true`, Nx generates a pruned `pnpm-lock.yaml` that includes the `catalogs:` section from the root lockfile. Since the dist folder doesn't include `pnpm-workspace.yaml`, pnpm 10.24.0+ throws `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` during `pnpm install --frozen-lockfile`.

## Expected Behavior

The pruned lockfile strips the `catalogs` section since the dist folder has no `pnpm-workspace.yaml` to define them.

## Related Issue(s)

Fixes #34337