### PR TITLE
chore(repo): add sandbox exclusions for writes and reads

### DIFF
--- a/.nx/workflows/sandboxing-config.yaml
+++ b/.nx/workflows/sandboxing-config.yaml
@@ -3,3 +3,6 @@ exclude-reads:
   - .nx/**/*
   - .git/**/*
   - '**/package.json'
+  - pnpm-workspace.yaml
+exclude-writes:
+  - nx/**/*


### PR DESCRIPTION
## Current Behavior

The sandboxing config only excludes reads for `node_modules`, `.nx`, `.git`, and `package.json` paths. No write exclusions are configured, and `pnpm-workspace.yaml` is not excluded from reads.

## Expected Behavior

- The `nx/**/*` directory is excluded from write sandboxing, allowing write operations to the nx directory during CI workflows.
- `pnpm-workspace.yaml` is excluded from read sandboxing, similar to other workspace config files.

## Related Issue(s)

N/A