### PR TITLE
fix(vitest): handle zoneless Angular apps in vitest configuration generator

### DIFF
--- a/packages/angular/src/generators/utils/add-vitest.ts
+++ b/packages/angular/src/generators/utils/add-vitest.ts
@@ -123,9 +123,8 @@ export async function addVitestAnalog(
     addPlugin: options.addPlugin ?? false,
     skipFormat: options.skipFormat,
     skipPackageJson: options.skipPackageJson,
+    zoneless: options.zoneless,
   });
-
-  createAnalogSetupFile(tree, options, angularMajorVersion);
 }
 
 function validateVitestVersion(tree: Tree): void {
@@ -225,53 +224,4 @@ function addVitestScreenshotsToGitIgnore(tree: Tree): void {
   } else {
     logger.warn(`Couldn't find .gitignore file to update`);
   }
-}
-
-function createAnalogSetupFile(
-  tree: Tree,
-  options: AddVitestAnalogOptions,
-  angularMajorVersion: number
-): void {
-  let setupFile: string;
-
-  if (angularMajorVersion >= 21) {
-    setupFile = `import '@angular/compiler';
-import '@analogjs/vitest-angular/setup-snapshots';
-import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
-
-setupTestBed(${options.zoneless ? '' : '{ zoneless: false }'});
-`;
-  } else if (angularMajorVersion === 20) {
-    setupFile = `import '@angular/compiler';
-import '@analogjs/vitest-angular/setup-zone';
-import {
-  BrowserTestingModule,
-  platformBrowserTesting,
-} from '@angular/platform-browser/testing';
-import { getTestBed } from '@angular/core/testing';
-
-getTestBed().initTestEnvironment(
-  BrowserTestingModule,
-  platformBrowserTesting(),
-);
-`;
-  } else {
-    setupFile = `import '@analogjs/vitest-angular/setup-zone';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing';
-import { getTestBed } from '@angular/core/testing';
-
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting(),
-);
-`;
-  }
-
-  tree.write(
-    joinPathFragments(options.projectRoot, 'src/test-setup.ts'),
-    setupFile
-  );
 }

--- a/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
+++ b/packages/vite/src/generators/vitest/__snapshots__/vitest.spec.ts.snap
@@ -2,18 +2,10 @@
 
 exports[`vitest generator angular should generate src/test-setup.ts 1`] = `
 "import '@angular/compiler';
-import '@analogjs/vitest-angular/setup-zone';
+import '@analogjs/vitest-angular/setup-snapshots';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
-import {
-  BrowserTestingModule,
-  platformBrowserTesting,
-} from '@angular/platform-browser/testing';
-import { getTestBed } from '@angular/core/testing';
-
-getTestBed().initTestEnvironment(
-  BrowserTestingModule,
-  platformBrowserTesting(),
-);
+setupTestBed({ zoneless: false });
 "
 `;
 

--- a/packages/vite/src/generators/vitest/vitest.spec.ts
+++ b/packages/vite/src/generators/vitest/vitest.spec.ts
@@ -235,7 +235,6 @@ describe('vitest generator', () => {
       expect(tree.read('apps/my-test-angular-app/src/test-setup.ts', 'utf-8'))
         .toMatchInlineSnapshot(`
         "import '@analogjs/vitest-angular/setup-zone';
-
         import {
           BrowserDynamicTestingModule,
           platformBrowserDynamicTesting,

--- a/packages/vitest/src/generators/configuration/configuration.ts
+++ b/packages/vitest/src/generators/configuration/configuration.ts
@@ -126,12 +126,25 @@ export async function configurationGeneratorInternal(
 
       const setupFile = joinPathFragments(root, relativeTestSetupPath);
       if (!tree.exists(setupFile)) {
-        if (isAngularV20(tree)) {
+        const angularMajorVersion = getAngularMajorVersion(tree);
+        const zoneless =
+          schema.zoneless ?? isZonelessProject(tree, schema.project);
+
+        if (angularMajorVersion >= 21) {
           tree.write(
             setupFile,
             `import '@angular/compiler';
-import '@analogjs/vitest-angular/setup-zone';
+import '@analogjs/vitest-angular/setup-snapshots';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
+setupTestBed(${zoneless ? '' : '{ zoneless: false }'});
+`
+          );
+        } else if (angularMajorVersion === 20) {
+          tree.write(
+            setupFile,
+            `import '@angular/compiler';
+import '@analogjs/vitest-angular/${zoneless ? 'setup-snapshots' : 'setup-zone'}';
 import {
   BrowserTestingModule,
   platformBrowserTesting,
@@ -140,15 +153,14 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserTestingModule,
-  platformBrowserTesting()
+  platformBrowserTesting(),
 );
 `
           );
         } else {
           tree.write(
             setupFile,
-            `import '@analogjs/vitest-angular/setup-zone';
-
+            `import '@analogjs/vitest-angular/${zoneless ? 'setup-snapshots' : 'setup-zone'}';
 import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting,
@@ -157,7 +169,7 @@ import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
+  platformBrowserDynamicTesting(),
 );
 `
           );
@@ -450,26 +462,65 @@ function tryFindSetupFile(tree: Tree, projectRoot: string) {
   }
 }
 
-function isAngularV20(tree: Tree) {
+function getAngularMajorVersion(tree: Tree): number {
   const angularVersion = getDependencyVersionFromPackageJson(
     tree,
     '@angular/core'
   );
 
   if (!angularVersion) {
-    // assume the latest version will be installed, which will be 20 or later
-    return true;
+    // assume the latest version will be installed
+    return 21;
   }
 
   const cleanedAngularVersion =
-    clean(angularVersion) ?? coerce(angularVersion).version;
+    clean(angularVersion) ?? coerce(angularVersion)?.version;
 
   if (typeof cleanedAngularVersion !== 'string') {
-    // assume the latest version will be installed,
-    return true;
+    // assume the latest version will be installed
+    return 21;
   }
 
-  return major(cleanedAngularVersion) >= 20;
+  return major(cleanedAngularVersion);
+}
+
+function isZonelessProject(tree: Tree, projectName: string): boolean {
+  const project = readProjectConfiguration(tree, projectName);
+
+  if (project.projectType === 'application') {
+    const buildTarget = findBuildTarget(project);
+    if (!buildTarget?.options?.polyfills) {
+      return true;
+    }
+    const polyfills = buildTarget.options.polyfills as string[] | string;
+    const polyfillsList = Array.isArray(polyfills) ? polyfills : [polyfills];
+    return !polyfillsList.includes('zone.js');
+  }
+
+  // For libraries, check if zone.js is installed in the workspace
+  return getDependencyVersionFromPackageJson(tree, 'zone.js') === null;
+}
+
+function findBuildTarget(project: {
+  targets?: Record<string, { executor?: string; options?: any }>;
+}): { executor?: string; options?: any } | null {
+  for (const target of Object.values(project.targets ?? {})) {
+    if (
+      [
+        '@angular-devkit/build-angular:browser',
+        '@angular-devkit/build-angular:browser-esbuild',
+        '@angular-devkit/build-angular:application',
+        '@angular/build:application',
+        '@nx/angular:application',
+        '@nx/angular:browser-esbuild',
+        '@nx/angular:webpack-browser',
+      ].includes(target.executor)
+    ) {
+      return target;
+    }
+  }
+
+  return project.targets?.build ?? null;
 }
 
 export default configurationGenerator;

--- a/packages/vitest/src/generators/configuration/schema.d.ts
+++ b/packages/vitest/src/generators/configuration/schema.d.ts
@@ -14,4 +14,5 @@ export interface VitestGeneratorSchema {
   // internal options
   projectType?: 'application' | 'library';
   viteVersion?: 5 | 6 | 7;
+  zoneless?: boolean;
 }

--- a/packages/vitest/src/generators/configuration/schema.json
+++ b/packages/vitest/src/generators/configuration/schema.json
@@ -65,6 +65,11 @@
       "default": false,
       "description": "Do not add dependencies to `package.json`.",
       "x-priority": "internal"
+    },
+    "zoneless": {
+      "type": "boolean",
+      "description": "Whether the Angular project is zoneless. When not provided, it is auto-detected from the project configuration.",
+      "x-priority": "internal"
     }
   },
   "required": ["project"]


### PR DESCRIPTION
## Current Behavior

When running `@nx/vitest:configuration` on an Angular project, the generator always generates `import '@analogjs/vitest-angular/setup-zone'` regardless of whether the app is zoneless. Additionally, the setup file generation logic for Angular 21+ (which uses `setupTestBed()`) only exists in `packages/angular/src/generators/utils/add-vitest.ts` (`createAnalogSetupFile`), making the vitest generator not self-contained.

## Expected Behavior

The vitest configuration generator should:
- Auto-detect whether an Angular project is zoneless (by checking polyfills for apps, or zone.js dependency for libraries)
- Generate `setup-snapshots` instead of `setup-zone` for zoneless projects
- Handle Angular 21+ `setupTestBed()` setup directly, without requiring a separate function in the angular package
- Accept an explicit `zoneless` option to override auto-detection

## Related Issue(s)

Fixes #33983