### PR TITLE
fix(js): normalize paths to posix format in typescript plugin

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -30,7 +30,6 @@ import {
   resolve,
   sep,
 } from 'node:path';
-import * as posix from 'node:path/posix';
 import { hashArray, hashFile, hashObject } from 'nx/src/hasher/file-hasher';
 import picomatch = require('picomatch');
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
@@ -187,7 +186,7 @@ function createConfigContext(
   return {
     originalPath: configFilePath,
     absolutePath,
-    relativePath: posix.relative(workspaceRoot, absolutePath),
+    relativePath: posixRelative(workspaceRoot, absolutePath),
     basename: basename(configFilePath),
     basenameNoExt: basename(configFilePath, '.json'),
     dirname: dirname(absolutePath),
@@ -216,7 +215,7 @@ function getConfigContext(
   if (!cache.projectContexts.has(projectRoot)) {
     cache.projectContexts.set(projectRoot, {
       root: projectRoot,
-      normalized: posix.normalize(projectRoot),
+      normalized: normalizePath(projectRoot),
       absolute: join(workspaceRoot, projectRoot),
     });
   }
@@ -1440,6 +1439,12 @@ function readTsConfig(
     ts = require('typescript');
   }
 
+  // Normalize to forward slashes for TypeScript compatibility on Windows.
+  // TypeScript's parser normalizes paths inconsistently — diagnostics use
+  // normalized paths but the source file retains the original, causing
+  // assertion failures when backslashes are present.
+  tsConfigPath = tsConfigPath.replaceAll('\\', '/');
+
   const tsSys: System = {
     ...ts.sys,
     readFile: (path) => readFile(path, workspaceRoot, cache),
@@ -1683,5 +1688,5 @@ function toRelativePaths(
 }
 
 function posixRelative(workspaceRoot: string, path: string): string {
-  return posix.normalize(relative(workspaceRoot, path));
+  return normalizePath(relative(workspaceRoot, path));
 }


### PR DESCRIPTION
## Current Behavior

On Windows, the `@nx/js` TypeScript plugin fails during project graph creation with a path mismatch assertion error. The plugin uses `path.join()` and `path.relative()` from Node's `path` module, which produce backslash-separated paths on Windows. These are passed to TypeScript's `readConfigFile` API, which has an internal inconsistency: its parser normalizes paths to forward slashes for diagnostics but retains the original (backslash) path on the source file, causing an assertion failure when parse diagnostics are present.

Additionally, `posix.normalize()` was incorrectly relied upon to convert backslashes to forward slashes — it only normalizes paths already in POSIX format.

## Expected Behavior

The TypeScript plugin normalizes paths to POSIX format (forward slashes) for TypeScript API compatibility and cache key consistency, working correctly on both Windows and Unix systems.

## Related Issue(s)

Fixes #31232