### PR TITLE
fix(misc): exclude .netlify paths from Framer proxy edge function

### DIFF
--- a/netlify/edge-functions/rewrite-framer-urls.ts
+++ b/netlify/edge-functions/rewrite-framer-urls.ts
@@ -81,6 +81,7 @@ export const config = {
     '/blog/*',
     '/courses/*',
     '/_next/*',
+    '/.netlify/*',
     '/favicon.ico',
     '/webinar',
     '/sitemap.xml',


### PR DESCRIPTION
## Current Behavior
Requests to `/.netlify/images?url=...` are intercepted by the Framer proxy edge function and forwarded to Framer, returning broken images on docs pages (e.g. sandboxing page).

## Expected Behavior
`/.netlify/*` requests pass through to Next.js, which rewrites them to the astro-docs site where the actual images are hosted.

## Related Issue(s)
Fixes DOC-436

