### PR TITLE
fix(gradle): destroy streams on exit to prevent daemon pipe hang

### DIFF
--- a/packages/gradle/src/utils/exec-gradle.ts
+++ b/packages/gradle/src/utils/exec-gradle.ts
@@ -63,6 +63,17 @@ export function execGradleAsync(
 
     cp.on('exit', (code, signal) => {
       if (code === null) code = signalToCode(signal);
+      // Forcibly destroy streams to prevent Gradle daemon pipe hang.
+      // When shell: true is used, the Gradle daemon inherits the shell's
+      // stdout/stderr pipes and holds them open after the task completes.
+      // This prevents the shell wrapper from exiting, which in turn
+      // prevents the 'exit' event from firing on the ChildProcess.
+      // By this point all output has already been buffered, so destroying
+      // the streams is safe and releases the pipe FDs from Node's
+      // perspective.
+      // See: nodejs/node#5637, gradle/gradle#3987
+      cp.stdout?.destroy();
+      cp.stderr?.destroy();
       if (code === 0) {
         res(stdout);
       } else {


### PR DESCRIPTION
## Current Behavior

`execGradleAsync()` in `exec-gradle.ts` can hang indefinitely during project graph creation. This manifests as Nx freezing on "Creating project graph nodes" — particularly in CI environments, but also reproducible locally.

## Expected Behavior

`execGradleAsync()` should resolve/reject promptly after the Gradle task completes, regardless of whether the Gradle daemon continues running in the background.

## Root Cause

`execGradleAsync()` uses `execFile()` with `shell: true`, which spawns a shell wrapper process. The Gradle daemon, started by `gradlew`, inherits the shell's stdout/stderr pipe file descriptors. After the `nxProjectGraph` task completes:

1. The `gradlew` wrapper script exits
2. The Gradle daemon continues running, holding the inherited pipe FDs open
3. The shell wrapper process cannot exit because its child (the daemon) still holds its pipes
4. Node.js never fires the `exit` event on the child process
5. The Promise in `execGradleAsync()` never resolves

This is a well-documented interaction between:
- [nodejs/node#5637](https://github.com/nodejs/node/issues/5637) — `execFile` hangs when child exits but disowned children hold pipes
- [gradle/gradle#3987](https://github.com/gradle/gradle/issues/3987) — Gradle daemon inherits parent file descriptors

## Fix

Destroy stdout/stderr streams immediately after the `exit` event fires. By this point, all output data has already been buffered into the `stdout` variable via the `data` event handlers, so no output is lost. Destroying the streams releases the pipe FDs from Node's perspective, allowing the shell wrapper to exit and the Promise to resolve — regardless of daemon state.

```typescript
cp.on('exit', (code, signal) => {
    if (code === null) code = signalToCode(signal);
    // Forcibly destroy streams to prevent Gradle daemon pipe hang.
    cp.stdout?.destroy();
    cp.stderr?.destroy();
    if (code === 0) {
        res(stdout);
    } else {
        rej(stdout);
    }
});
```

## Workarounds Users Currently Need

Without this fix, users must resort to:
- `org.gradle.daemon.idletimeout=5000` in `gradle.properties` (adds 5s latency per invocation)
- CI retry loops with `timeout` + `pkill -f GradleDaemon` (unreliable, wastes CI minutes)
- `--no-daemon` flag (doesn't work reliably with Gradle 8.1+/9.x — a "single-use daemon" is still forked when `org.gradle.jvmargs` is set)

## Related Issues

- #29618 — NX project graph calculation hanging indefinitely
- #32788 — CI hanging at "Creating project graph nodes"
- #31835 — @nx/gradle extremely slow compared to running Gradle directly
- #27494 — Nx operations hang indefinitely