### PR TITLE
docs(misc): clean up outdated version references

### DIFF
--- a/astro-docs/src/content/docs/guides/Tasks & Caching/configure-inputs.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/configure-inputs.mdoc
@@ -5,7 +5,7 @@ filter: 'type:Guides'
 ---
 
 When Nx [computes the hash for a given operation](/docs/concepts/how-caching-works), it takes into account the `inputs` of the target.
-The `inputs` are a list of **file sets**, **runtime** inputs and **environment variables** that affect the output of the target.
+The `inputs` are a list of file sets, runtime inputs, and environment variables that affect the output of the target.
 If any of the `inputs` change, the cache is invalidated and the target is re-run.
 
 Nx errs on the side of caution when using inputs. Ideally, the "perfect" configuration of inputs will allow Nx to never re-run something when it does not need to. In practice though, it is better to play it safe and include more than strictly necessary in the inputs of a task. Forgetting to consider something during computation hash calculation may lead to negative consequences for end users. Start safe and fine-tune your inputs when there are clear opportunities to improve the cache hit rate.
@@ -324,7 +324,7 @@ Be sure to [view the existing inputs](#viewing-the-inputs-of-a-task) and start f
 
 Inputs of a task are configured in the `inputs` array on the target. This can be done in several different places:
 
-- As of Nx 18, Nx Plugins often [infer inputs for tasks](/docs/concepts/inferred-tasks) which run other tools.
+- Nx Plugins often [infer inputs for tasks](/docs/concepts/inferred-tasks) which run other tools.
   - In doing so, they will also define some reasonable defaults for the `inputs` of those tasks.
 - The `inputs` array in the `targetDefaults` for a set of targets in `nx.json`.
 - The `inputs` array for a specific target in the project configuration file.

--- a/astro-docs/src/content/docs/guides/Tasks & Caching/configure-outputs.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/configure-outputs.mdoc
@@ -55,7 +55,7 @@ View the project's configuration to see a list of the outputs which are defined 
 The tasks you run in your workspace will likely already have `outputs` defined.
 Be sure to [view the existing outputs](#viewing-outputs-of-a-task) and start from there.
 
-As of Nx 18, Nx Plugins often [infer outputs for tasks](/docs/concepts/inferred-tasks) which run other tools.
+Nx Plugins often [infer outputs for tasks](/docs/concepts/inferred-tasks) which run other tools.
 Nx Plugins will look at the configuration files and/or command-line-arguments of the tools in your workspace to understand the outputs of running those tools.
 In most cases, this inference will be inline with the outputs of the tool.
 Nx will reflect changes to the configuration or command-line arguments of your tools without any additional changes.

--- a/astro-docs/src/content/docs/reference/environment-variables.mdoc
+++ b/astro-docs/src/content/docs/reference/environment-variables.mdoc
@@ -1,6 +1,6 @@
 ---
 title: Environment Variables
-description: A comprehensive reference of all environment variables that can be used to configure and control Nx behavior in different environments.
+description: Reference for all environment variables that configure and control Nx behavior in different environments.
 sidebar:
   order: 6
 filter: 'type:References'
@@ -12,7 +12,7 @@ The following environment variables are ones that you can set to change the beha
 
 | Property                           | Type           | Description                                                                                                                                                                                                                         |
 | ---------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NX_ADD_PLUGINS`                   | boolean        | If set to `false`, Nx will not add plugins to infer tasks. This is `true` by default. Workspaces created before Nx 18 will have this disabled via a migration for backwards compatibility                                           |
+| `NX_ADD_PLUGINS`                   | boolean        | If set to `false`, Nx will not add plugins to infer tasks. This is `true` by default.                                                                                                                                               |
 | `NX_BASE`                          | string         | The default base branch to use when calculating the affected projects. Can be overridden on the command line with `--base`.                                                                                                         |
 | `NX_CACHE_DIRECTORY`               | string         | The cache for task outputs is stored in `.nx/cache` by default. Set this variable to use a different directory.                                                                                                                     |
 | `NX_CACHE_PROJECT_GRAPH`           | boolean        | If set to `false`, disables the project graph cache. Most useful when developing a plugin that modifies the project graph.                                                                                                          |
@@ -81,7 +81,7 @@ Nx will set the following environment variables so they can be accessible within
 The following environment variables are specific to Nx Cloud and can be used to configure cloud-specific behavior:
 
 {% aside type="tip" title="Verbose Logging" %}
-Similar to the Nx CLI, Nx Cloud also used the `NX_VERBOSE_LOGGING` environment variable to output debug information
+Similar to the Nx CLI, Nx Cloud also uses the `NX_VERBOSE_LOGGING` environment variable to output debug information
 {% /aside %}
 
 | Property                              | Type    | Description                                                                                                                                                                                                            |

--- a/astro-docs/src/content/docs/technologies/build-tools/webpack/Guides/webpack-config-setup.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/webpack/Guides/webpack-config-setup.mdoc
@@ -54,10 +54,10 @@ The basic configuration works with Webpack CLI, whereas the Nx-enhanced configur
 ### Basic configuration for Nx
 
 {% aside type="tip" title="Module federation support" %}
-Currently, Nx module federation requires an enhanced Webpack configuration file an the use of the `withModuleFederation` plugin. See the next section for more details.
+Currently, Nx module federation requires an enhanced Webpack configuration file and the use of the `withModuleFederation` plugin. See the next section for more details.
 {% /aside %}
 
-A basic Webpack configuration was introduced in Nx 18, and it looks like this:
+A basic Webpack configuration looks like this:
 
 ```js
 // apps/demo/webpack.config.js
@@ -84,14 +84,14 @@ module.exports = {
 };
 ```
 
-The [`NxAppWebpackPlugin`](/docs/technologies/build-tools/webpack/guides/webpack-plugins#nxappwebpackplugin) plugin takes a `main` entry file and produces a bundle in the output directory as defined in `output.path`. You can also pass the `index` option if it is a webapp, which will handle outputting scripts and stylesheets in the output file. Note that `NxWebpackPlugin` is optional, and you can bring your own Webpack configuration without using it or any plugins from `@nx/webpack`.
+The [`NxAppWebpackPlugin`](/docs/technologies/build-tools/webpack/guides/webpack-plugins#nxappwebpackplugin) plugin takes a `main` entry file and produces a bundle in the output directory as defined in `output.path`. You can also pass the `index` option if it is a webapp, which will handle outputting scripts and stylesheets in the output file. `NxWebpackPlugin` is optional, and you can bring your own Webpack configuration without using it or any plugins from `@nx/webpack`.
 
 For more information, see the [Webpack plugins guide](/docs/technologies/build-tools/webpack/guides/webpack-plugins).
 
 ### Nx-enhanced configuration with composable plugins
 
 {% aside type="tip" title="Non-standard webpack config" %}
-Nx-enhanced configuration, via `composePlugins` and [`withNx`](/docs/technologies/build-tools/webpack/guides/webpack-plugins#withnx) functions, requires the usage of `@nx/webpack:webpack` executor in your `project.json` file. This flavor of configuration do not work with the Webpack CLI.
+Nx-enhanced configuration, via `composePlugins` and [`withNx`](/docs/technologies/build-tools/webpack/guides/webpack-plugins#withnx) functions, requires the usage of `@nx/webpack:webpack` executor in your `project.json` file. This flavor of configuration does not work with the Webpack CLI.
 {% /aside %}
 
 Nx supports a function to be returned from the Webpack configuration file. This function is a composable plugin that is understood by the `@nx/webpack:webpack` executor. The enhanced configuration looks something like this:
@@ -127,7 +127,7 @@ In addition to the `withNx` composable plugin, Nx provides other composable plug
 
 ## Customize your Webpack configuration
 
-For most apps, the default configuration of Webpack is sufficient, but sometimes you need to tweak a setting in your Webpack config. This guide explains how to make a small change without taking on the maintenance burden of the entire webpack config.
+For most apps, the default configuration of Webpack is sufficient, but sometimes you need to tweak a setting in your Webpack config. The following sections show how to make a small change without taking on the maintenance burden of the entire webpack config.
 
 ### Configure Webpack for React projects
 

--- a/astro-docs/src/content/docs/technologies/build-tools/webpack/Guides/webpack-plugins.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/webpack/Guides/webpack-plugins.mdoc
@@ -13,12 +13,11 @@ Nx provides two types of Webpack plugins:
 2. [_Nx-enhanced_](#nxenhanced-plugins) plugins that work with
    the [`@nx/webpack:webpack`](/docs/technologies/build-tools/webpack/executors#webpack) executor.
 
-The basic plugins are used in Nx 18 to provide seamless integration with the Webpack CLI. Prior to Nx 18, apps are
-generated with Nx-enhanced plugins and require `@nx/webpack:webpack` executor to be used.
+The basic plugins integrate directly with the Webpack CLI.
 
-This guide contains information on the plugins provided by Nx. For more information on webpack configuration and the
-difference between basic and Nx-enhanced configuration, refer to
-the [Nx Webpack configuration guide](/docs/technologies/build-tools/webpack/guides/webpack-config-setup).
+For more information on webpack configuration and the
+difference between basic and Nx-enhanced configuration, see
+the [Webpack configuration guide](/docs/technologies/build-tools/webpack/guides/webpack-config-setup).
 
 ## Basic plugins
 
@@ -385,7 +384,7 @@ module.exports = {
 ## Nx-enhanced plugins
 
 The Nx-enhanced plugins work with `@nx/webpack:webpack` executor and receive the target options and context from the
-executor. These are used prior to Nx 18, and are still used when using [Module Federation](/docs/technologies/module-federation/concepts/module-federation-and-nx).
+executor. These are used when using [Module Federation](/docs/technologies/module-federation/concepts/module-federation-and-nx).
 
 The plugins are used in conjunction with `composePlugins` utility to generate a final Webpack configuration object, once all of the plugins have applied their changes.
 

--- a/astro-docs/src/content/docs/technologies/module-federation/concepts/faster-builds-with-module-federation.mdoc
+++ b/astro-docs/src/content/docs/technologies/module-federation/concepts/faster-builds-with-module-federation.mdoc
@@ -19,8 +19,7 @@ Federation:
   to unexpected errors.
 
 Nx provides the best experience for teams that want faster builds, but want to also minimize the downsides that come
-with Module Federation. Starting in Nx 14,
-we provide specialized generators, executors, and utilities that make Module Federation easy to set up and work with.
+with Module Federation. Nx provides specialized generators, executors, and utilities that make Module Federation easy to set up and work with.
 
 ## When should I use Module Federation?
 
@@ -63,8 +62,7 @@ three remotes under these routes:
 1. `/cart`
 1. `/about`
 
-But before we begin, we've put together a couple of example repos (React and Angular) for you to inspect if you want to
-skip ahead.
+Before you begin, check out the example repos (React and Angular) if you want to skip ahead.
 
 {% github_repository url="https://github.com/nrwl/ng-module-federation" /%}
 
@@ -302,9 +300,8 @@ The required `name` property is the magic to link the host and remotes together.
 three remotes by their names.
 
 {% aside type="note" title="More details" %}
-It is important that the values in `remotes` property matches the `name` property of the remote applications. Otherwise,
-webpack will throw an error. Nx handles this automatically for you so there shouldn't be an issue unless it was modified
-manually.
+The values in the `remotes` property must match the `name` property of the remote applications. Otherwise,
+webpack will throw an error. Nx handles this automatically, so this is only a concern if you modify it manually.
 {% /aside %}
 
 ## What does `withModuleFederation` do?
@@ -353,8 +350,7 @@ bundles before optimizing the shared behavior.
 To analyze the size of your bundles, run build with `--statsJson` and use a tool
 like [`webpack-bundle-analyzer`](https://www.npmjs.com/package/webpack-bundle-analyzer).
 
-If you have any feedback regarding this feature, we'd love to hear from you--check
-our [community page](https://nx.dev/community) for links to our Discord and Twitter.
+If you have any feedback regarding this feature, let us know on [our community page](https://nx.dev/community).
 {% /aside %}
 
 ## Remote computation caching with Nx Cloud
@@ -492,7 +488,7 @@ production/
 └── (snip)
 ```
 
-The above command is just an example. You'll need to use what make sense for your team and workspace.
+The above command is just an example. You'll need to use what makes sense for your team and workspace.
 
 For examples of how CI/CD pipelines can be configured using Nx Cloud and GitHub, see
 our [React](https://github.com/nrwl/react-module-federation)
@@ -507,7 +503,7 @@ and [Angular](https://github.com/nrwl/ng-module-federation) examples.
 By using Module Federation you essentially split your application build process vertically. You can also split it
 horizontally by making some libraries buildable.
 
-We don't recommend making all libraries in your workspace buildable--it will make some things faster but many other
+Making all libraries in your workspace buildable is not recommended. It will make some things faster but many other
 things slower. But in some scenarios making a few large libraries at the bottom of your graph buildable can speed up
 your CI.
 

--- a/astro-docs/src/content/docs/technologies/react/Guides/deploy-nextjs-to-vercel.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/Guides/deploy-nextjs-to-vercel.mdoc
@@ -6,7 +6,7 @@ sidebar:
 filter: 'type:Guides'
 ---
 
-Starting from Nx 11, your Next.js application should already be ready for deployment to Vercel.
+Your Next.js application should already be ready for deployment to Vercel.
 
 ## Configure your Vercel project's settings appropriately
 
@@ -50,4 +50,4 @@ The `nx-ignore` command uses Nx to detect whether the current commit affects the
 
 ## Next steps
 
-Naturally, you can continue on and set any additional Environment Variables etc that may be appropriate for your projects, but we have now covered the key points needed to deploy Next.js projects from Nx workspaces on Vercel!
+You can continue to set any additional environment variables that may be appropriate for your projects.

--- a/astro-docs/src/content/docs/technologies/react/Guides/use-environment-variables-in-react.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/Guides/use-environment-variables-in-react.mdoc
@@ -13,7 +13,7 @@ In React applications using Vite (e.g. those using `@nx/vite:*` executors), Nx i
 - `NODE_ENV`
 - Variables prefixed with `VITE_`, such as `VITE_CUSTOM_VAR`
 
-You can read more about how to define environment variables in Vite [here](https://vite.dev/guide/env-and-mode.html).
+For more details, see the [Vite environment variables documentation](https://vite.dev/guide/env-and-mode.html).
 
 You can then use these variables in your application code like so: `import.meta.env.VITE_CUSTOM_VAR`.
 
@@ -31,9 +31,9 @@ The root cause of this issue is that Nx has already loaded variables from `.env.
 
 #### Solution
 
-We recommend that developers adapt to the Nx way of handling environment variables and refer to our [documentation on defining environment variables](/docs/guides/tips-n-tricks/define-environment-variables). This will help ensure consistent behavior and prevent conflicts when using Nx with Vite.
+Adapt to the Nx way of handling environment variables by following the [guide on defining environment variables](/docs/guides/tips-n-tricks/define-environment-variables). This ensures consistent behavior and prevents conflicts when using Nx with Vite.
 
-However, if you still want to use Vite's `mode`, you still can. To ensure seamless integration between Nx and Vite environment variables, you can establish a clear distinction between `configuration` and `mode` names. By assigning distinct names to both `configuration` and `mode`, you can eliminate any potential conflicts that may arise during environment variable loading. Additionally, consider defining custom configurations in your Nx workspace, each with a corresponding `mode` option. For example, you can create configurations like `development`, `production`, and `staging`, each with its respective `mode` set, like this:
+However, if you still want to use Vite's `mode`, you can. To avoid conflicts between Nx and Vite environment variables, establish a clear distinction between `configuration` and `mode` names. By assigning distinct names to both `configuration` and `mode`, you can eliminate any potential conflicts that may arise during environment variable loading. Additionally, consider defining custom configurations in your Nx workspace, each with a corresponding `mode` option. For example, you can create configurations like `development`, `production`, and `staging`, each with its respective `mode` set, like this:
 
 ```json frame="none"
 "configurations": {
@@ -66,16 +66,15 @@ includes the following variables in the build process:
 - `NODE_ENV`
 - Variables prefixed with `NX_PUBLIC`, such as `NX_PUBLIC_CUSTOM_VAR` (when using the [NxAppWebpackPlugin](/docs/technologies/build-tools/webpack/guides/webpack-plugins#nxappwebpackplugin) or the [withNx](/docs/technologies/build-tools/webpack/guides/webpack-plugins#withnx) plugins)
 
-Defining environment variables can vary between OSes. It's also important to know that this is temporary for the life of
-the shell session.
+Defining environment variables can vary between OSes. This is temporary for the life of the shell session.
 
 ### Using environment variables in `index.html`
 
 Nx supports interpolating environment variables into your `index.html` file for React and Web applications built with Webpack.
 This feature is available when using the [NxAppWebpackPlugin](/docs/technologies/build-tools/webpack/guides/webpack-plugins#nxappwebpackplugin) or the [withNx](/docs/technologies/build-tools/webpack/guides/webpack-plugins#withnx) plugins.
 
-{% aside type="note" title="Predefined Nx variable" %}
-Note that with the release of Nx 19, you won't be able to use predefined Nx variable on this [link](/docs/reference/environment-variables).
+{% aside type="note" title="Predefined Nx variables" %}
+You can't use [predefined Nx environment variables](/docs/reference/environment-variables) in `index.html` interpolation.
 {% /aside %}
 
 To interpolate an environment variable named `NX_PUBLIC_DOMAIN_NAME` into your `index.html`, surround it with `%` symbols like so:

--- a/astro-docs/src/content/docs/technologies/react/next/Guides/next-config-setup.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/next/Guides/next-config-setup.mdoc
@@ -6,7 +6,7 @@ sidebar:
 filter: 'type:References'
 ---
 
-Next.js plugins are configured in the project's `next.config.js` file. Nx adds a its own plugin (`withNx`) to help the Next.js application
+Next.js plugins are configured in the project's `next.config.js` file. Nx adds its own plugin (`withNx`) to help the Next.js application
 understand workspace libraries, and other Nx-specific features. See below for an example of the `withNx` plugin that Nx adds by default.
 
 ```js frame="none"
@@ -23,7 +23,7 @@ module.exports = withNx({
 });
 ```
 
-This guide contains information on how to configure and compose the Nx plugin with other plugins, such as `@next/mdx`. Note that Nx prior to version 16 is missing the compose utility from the `@nx/next` package, and a workaround will be provided for Nx 15 and prior.
+You can configure and compose the Nx plugin with other plugins, such as `@next/mdx`.
 
 {% aside type="caution" title="Avoid next-compose-plugins" %}
 There is a popular package called `next-compose-plugins` that has not been maintained for over two years. This package does not correctly combine plugins in all situations. If you do use it, replace the package with Nx 16's `composePlugins` utility (see below).
@@ -49,11 +49,9 @@ Type: `boolean`
 
 For a monorepo, set to `true` to incorporate `.babelrc` files from individual libraries into the build. Note, however, that doing so will prevent the application's `.babelrc` settings from being applied to its libraries. It is generally recommended not to enable this option, as it can lead to a lack of consistency throughout the workspace. Instead, the application's `.babelrc` file should include the presets and plugins needed by its libraries directly. For more information on babel root-mode, see here: https://babeljs.io/docs/en/options#rootmode
 
-Set this to `true` if you want `.babelrc` from libraries to be used in a monorepo. Note that setting this to `true` means the application's `.babelrc` will not apply to libraries, and it is recommended not to use this option as it may lead to inconsistency in the workspace. Instead, add babel presets/plugins required by libraries directly to the application's `.babelrc` file. See: https://babeljs.io/docs/en/options#rootmode
+## Composing plugins using `composePlugins` utility
 
-## Composing plugins using `composePlugins` utility (Nx 16 and later)
-
-Since Nx 16, we provide a `composePlugins` utility function that helps users combine multiple Next.js plugins together.
+The `composePlugins` utility function helps you combine multiple Next.js plugins together.
 
 ```js frame="none"
 // next.config.js
@@ -89,7 +87,7 @@ const plugins = [
 module.exports = composePlugins(...plugins)(nextConfig);
 ```
 
-This the exported configuration will correctly call each plugin in order and apply their configuration changes to the final object. Note that `composePlugins` function will return an async function, so if you need to debug the configuration you can add a debug plugin as follows.
+The exported configuration will correctly call each plugin in order and apply their configuration changes to the final object. Note that `composePlugins` function will return an async function, so if you need to debug the configuration you can add a debug plugin as follows.
 
 ```js frame="none"
 module.exports = composePlugins(...plugins, function debug(config) {
@@ -97,39 +95,4 @@ module.exports = composePlugins(...plugins, function debug(config) {
   console.log({ config });
   return config;
 })(nextConfig);
-```
-
-## Manually composing plugins (Nx 15 and prior)
-
-If you are not on Nx 16 and later versions, the `composePlugins` utility is not available. However, you can use the workaround below to use multiple plugins.
-
-```js frame="none"
-// next.config.js
-
-// ...
-
-/**
- * @type {import('@nx/next/plugins/with-nx').WithNxOptions}
- **/
-const nextConfig = {
-  // ...
-};
-
-const plugins = [
-  // Your plugins exlcuding withNx
-];
-
-module.exports = async (phase, context) => {
-  let updatedConfig = plugins.reduce((acc, fn) => fn(acc), nextConfig);
-
-  // Apply the async function that `withNx` returns.
-  updatedConfig = await withNx(updatedConfig)(phase, context);
-
-  // If you have plugins that has to be added after Nx you can do that here.
-  // For example, Sentry needs to be added last.
-  const { withSentryConfig } = require('@sentry/nextjs');
-  updatedConfig = withSentryConfig(updatedConfig);
-
-  return updatedConfig;
-};
 ```

--- a/astro-docs/src/content/docs/technologies/react/react-native/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/react-native/introduction.mdoc
@@ -51,31 +51,16 @@ Make sure to install the `@nx/react-native` version that matches the version of 
 
 In any Nx workspace, you can install `@nx/react-native` by running the following command:
 
-{% tabs syncKey="nx-version" %}
-{% tabitem label="Nx 18+" %}
-
 ```shell
 nx add @nx/react-native
 ```
 
 This will install the correct version of `@nx/react-native`.
 
-{% /tabitem %}
-{% tabitem label="Nx < 18" %}
-
-Install the `@nx/react-native` package with your package manager.
-
-```shell
-npm add -D @nx/react-native
-```
-
-{% /tabitem %}
-{% /tabs %}
-
 ### How @nx/react-native Infers Tasks
 
 {% aside type="note" title="Inferred Tasks" %}
-Since Nx 18, Nx plugins can infer tasks for your projects based on the configuration of different tools. You can read more about it at the [Inferred Tasks concept page](/docs/concepts/inferred-tasks).
+Nx plugins can infer tasks for your projects based on the configuration of different tools. You can read more about it at the [Inferred Tasks concept page](/docs/concepts/inferred-tasks).
 {% /aside %}
 
 The `@nx/react-native` plugin will create a task for any project that has an app configuration file present. Any of the following files will be recognized as an app configuration file:

--- a/astro-docs/src/content/docs/technologies/test-tools/cypress/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/cypress/introduction.mdoc
@@ -27,7 +27,7 @@ The `@nx/cypress` plugin supports the following package versions.
 
 ## Setting Up @nx/cypress
 
-> Info about [Cypress Component Testing can be found here](/docs/technologies/test-tools/cypress/guides/cypress-component-testing)
+> For Cypress Component Testing, see [the component testing guide](/docs/technologies/test-tools/cypress/guides/cypress-component-testing).
 
 ### Installation
 
@@ -37,31 +37,16 @@ Make sure to install the `@nx/cypress` version that matches the version of `nx` 
 
 In any Nx workspace, you can install `@nx/cypress` by running the following command:
 
-{% tabs %}
-{% tabitem label="Nx 18+" %}
-
 ```shell
 nx add @nx/cypress
 ```
 
 This will install the correct version of `@nx/cypress`.
 
-{% /tabitem %}
-{% tabitem label="Nx < 18" %}
-
-Install the `@nx/cypress` package with your package manager.
-
-```shell
-npm add -D @nx/cypress
-```
-
-{% /tabitem %}
-{% /tabs %}
-
 ### How @nx/cypress Infers Tasks
 
 {% aside type="note" title="Inferred Tasks" %}
-Since Nx 18, Nx plugins can infer tasks for your projects based on the configuration of different tools. You can read more about it at the [Inferred Tasks concept page](/docs/concepts/inferred-tasks).
+Nx plugins can infer tasks for your projects based on the configuration of different tools. You can read more about it at the [Inferred Tasks concept page](/docs/concepts/inferred-tasks).
 {% /aside %}
 
 The `@nx/cypress` plugin will create a task for any project that has a Cypress configuration file present. Any of the following files will be recognized as a Cypress configuration file:
@@ -284,7 +269,7 @@ For adding more dynamic configurations to your Cypress configuration, you can lo
 
 If you need to pass a variable to Cypress that you don't want to commit to your repository (i.e. API keys, dynamic values based on configurations, API URLs), you can use [Cypress environment variables](https://docs.cypress.io/guides/guides/environment-variables).
 
-There are a handful of ways to pass environment variables to Cypress, but the most common is going to be via the [`cypress.env.json` file](https://docs.cypress.io/guides/guides/environment-variables#Option-1-configuration-file), the `-e` Cypress arg or the `env` option from the `@nx/cypress:cypress` executor in the [project configuration](/docs/reference/project-configuration#task-definitions-targets) or the command line.
+There are a handful of ways to pass environment variables to Cypress, but the most common is via the [`cypress.env.json` file](https://docs.cypress.io/guides/guides/environment-variables#Option-1-configuration-file), the `-e` Cypress arg or the `env` option from the `@nx/cypress:cypress` executor in the [project configuration](/docs/reference/project-configuration#task-definitions-targets) or the command line.
 
 Create a `cypress.env.json` file in the projects root (i.e. `apps/my-cool-app-e2e/cypress.env.json`). Cypress will automatically pick up this file. This method is helpful for configurations that you don't want to commit. Make sure to add the file to the `.gitignore` and add documentation so people in your repo know what values to populate in their local copy of the `cypress.env.json` file.
 


### PR DESCRIPTION
## Current Behavior

Documentation contains version-conditional content and version qualifiers referencing Nx versions older than 20 (e.g. "Nx 18+" / "Nx < 18" tabs, "Starting from Nx 11", "Since Nx 16", "Prior to Nx 18"). These are no longer useful since the current version is 22.

## Expected Behavior

Remove conditional content gated on versions < 20. Keep only the modern code path as the default. Also apply style guide fixes to all touched pages (fix typos, remove self-referential language, replace non-descriptive link text, remove AI-style phrases).

### Changes across 11 files:

**Version-conditional tabs removed:**
- [`react-native/introduction`](https://deploy-preview-34707--nx-docs.netlify.app/docs/technologies/react/react-native/introduction) — Removed "Nx < 18" tab, kept `nx add` as default
- [`cypress/introduction`](https://deploy-preview-34707--nx-docs.netlify.app/docs/technologies/test-tools/cypress/introduction) — Same

**Outdated version qualifiers removed:**
- [`next-config-setup`](https://deploy-preview-34707--nx-docs.netlify.app/docs/technologies/react/next/guides/next-config-setup) — Removed "Nx 15 and prior" section, dropped "Nx 16" qualifier
- [`deploy-nextjs-to-vercel`](https://deploy-preview-34707--nx-docs.netlify.app/docs/technologies/react/guides/deploy-nextjs-to-vercel) — Removed "Starting from Nx 11"
- [`faster-builds-with-module-federation`](https://deploy-preview-34707--nx-docs.netlify.app/docs/technologies/module-federation/concepts/faster-builds-with-module-federation) — Removed "Starting in Nx 14"
- [`webpack-plugins`](https://deploy-preview-34707--nx-docs.netlify.app/docs/technologies/build-tools/webpack/guides/webpack-plugins) — Removed "Prior to Nx 18" references
- [`webpack-config-setup`](https://deploy-preview-34707--nx-docs.netlify.app/docs/technologies/build-tools/webpack/guides/webpack-config-setup) — Removed "introduced in Nx 18"
- [`use-environment-variables-in-react`](https://deploy-preview-34707--nx-docs.netlify.app/docs/technologies/react/guides/use-environment-variables-in-react) — Removed "with the release of Nx 19"
- [`environment-variables`](https://deploy-preview-34707--nx-docs.netlify.app/docs/reference/environment-variables) — Removed "Workspaces created before Nx 18"
- [`configure-inputs`](https://deploy-preview-34707--nx-docs.netlify.app/docs/guides/tasks--caching/configure-inputs) — Removed "As of Nx 18"
- [`configure-outputs`](https://deploy-preview-34707--nx-docs.netlify.app/docs/guides/tasks--caching/configure-outputs) — Removed "As of Nx 18"

**Style guide fixes:** Fixed typos, removed self-referential language, replaced non-descriptive link text ("here", "this page"), removed AI-style phrases ("seamless", "comprehensive", "It's important to note"), added missing Oxford comma.

## Related Issue(s)

Fixes DOC-437