### PR TITLE
fix(gradle): use object format for dependsOn instead of shorthand strings

### DIFF
--- a/e2e/gradle/src/gradle-import.test.ts
+++ b/e2e/gradle/src/gradle-import.test.ts
@@ -19,7 +19,7 @@ import { createFileSync } from 'fs-extra';
 
 describe('Nx Import Gradle', () => {
   const tempImportE2ERoot = join(e2eCwd, 'nx-import');
-  beforeAll(() => {
+  beforeEach(() => {
     newProject({
       packages: ['@nx/js'],
     });
@@ -49,7 +49,7 @@ describe('Nx Import Gradle', () => {
     runCommand(`git commit -am "update"`);
   });
 
-  afterAll(() => cleanupProject());
+  afterEach(() => cleanupProject());
 
   it('should be able to import a kotlin gradle app', () => {
     const tempGradleProjectName = 'created-gradle-app-kotlin';

--- a/e2e/gradle/src/gradle.test.ts
+++ b/e2e/gradle/src/gradle.test.ts
@@ -44,8 +44,9 @@ describe('Gradle', () => {
         expect(buildOutput).toContain(':list:classes');
         expect(buildOutput).toContain(':utilities:classes');
 
-        const bootJarOutput = runCLI('bootJar app --no-batch', {
+        const bootJarOutput = runCLI('bootJar app', {
           verbose: true,
+          redirectStderr: true,
         });
         expect(bootJarOutput).toContain(':app:bootJar');
       });

--- a/e2e/gradle/src/gradle.test.ts
+++ b/e2e/gradle/src/gradle.test.ts
@@ -44,7 +44,9 @@ describe('Gradle', () => {
         expect(buildOutput).toContain(':list:classes');
         expect(buildOutput).toContain(':utilities:classes');
 
-        const bootJarOutput = runCLI('bootJar app', { verbose: true });
+        const bootJarOutput = runCLI('bootJar app --no-batch', {
+          verbose: true,
+        });
         expect(bootJarOutput).toContain(':app:bootJar');
       });
 

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/data/DependsOnEntry.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/data/DependsOnEntry.kt
@@ -1,0 +1,14 @@
+package dev.nx.gradle.data
+
+import com.google.gson.annotations.SerializedName
+
+enum class DependsOnParams {
+  @SerializedName("forward") FORWARD,
+  @SerializedName("ignore") IGNORE
+}
+
+data class DependsOnEntry(
+    val target: String,
+    val projects: List<String>? = null,
+    val params: DependsOnParams? = null
+)

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
@@ -78,8 +78,7 @@ private fun processTestFiles(
                   gitIgnoreClassifier)
           targetGroups[testCiTargetGroup]?.add(targetName)
 
-          ciDependsOn.add(
-              mapOf("target" to targetName, "projects" to listOf("self"), "params" to "forward"))
+          ciDependsOn.add(mapOf("target" to targetName, "params" to "forward"))
         }
       }
 }

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
@@ -23,7 +23,7 @@ fun addTestCiTargets(
 ) {
   ensureTargetGroupExists(targetGroups, testCiTargetGroup)
 
-  val ciDependsOn = mutableListOf<Map<String, String>>()
+  val ciDependsOn = mutableListOf<Map<String, Any>>()
 
   processTestFiles(
       testFiles,
@@ -58,7 +58,7 @@ private fun processTestFiles(
     projectRoot: String,
     workspaceRoot: String,
     ciTestTargetName: String,
-    ciDependsOn: MutableList<Map<String, String>>,
+    ciDependsOn: MutableList<Map<String, Any>>,
     gitIgnoreClassifier: GitIgnoreClassifier
 ) {
   testFiles
@@ -79,7 +79,7 @@ private fun processTestFiles(
           targetGroups[testCiTargetGroup]?.add(targetName)
 
           ciDependsOn.add(
-              mapOf("target" to targetName, "projects" to "self", "params" to "forward"))
+              mapOf("target" to targetName, "projects" to listOf("self"), "params" to "forward"))
         }
       }
 }
@@ -143,7 +143,7 @@ private fun ensureParentCiTarget(
     testTask: Task,
     projectRoot: String,
     workspaceRoot: String,
-    ciDependsOn: List<Map<String, String>>,
+    ciDependsOn: List<Map<String, Any>>,
     gitIgnoreClassifier: GitIgnoreClassifier
 ) {
   if (ciDependsOn.isNotEmpty()) {

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
@@ -1,5 +1,7 @@
 package dev.nx.gradle.utils
 
+import dev.nx.gradle.data.DependsOnEntry
+import dev.nx.gradle.data.DependsOnParams
 import dev.nx.gradle.data.NxTargets
 import dev.nx.gradle.data.TargetGroups
 import dev.nx.gradle.utils.parsing.containsEssentialTestAnnotations
@@ -23,7 +25,7 @@ fun addTestCiTargets(
 ) {
   ensureTargetGroupExists(targetGroups, testCiTargetGroup)
 
-  val ciDependsOn = mutableListOf<Map<String, Any>>()
+  val ciDependsOn = mutableListOf<DependsOnEntry>()
 
   processTestFiles(
       testFiles,
@@ -58,7 +60,7 @@ private fun processTestFiles(
     projectRoot: String,
     workspaceRoot: String,
     ciTestTargetName: String,
-    ciDependsOn: MutableList<Map<String, Any>>,
+    ciDependsOn: MutableList<DependsOnEntry>,
     gitIgnoreClassifier: GitIgnoreClassifier
 ) {
   testFiles
@@ -78,7 +80,7 @@ private fun processTestFiles(
                   gitIgnoreClassifier)
           targetGroups[testCiTargetGroup]?.add(targetName)
 
-          ciDependsOn.add(mapOf("target" to targetName, "params" to "forward"))
+          ciDependsOn.add(DependsOnEntry(target = targetName, params = DependsOnParams.FORWARD))
         }
       }
 }
@@ -142,7 +144,7 @@ private fun ensureParentCiTarget(
     testTask: Task,
     projectRoot: String,
     workspaceRoot: String,
-    ciDependsOn: List<Map<String, Any>>,
+    ciDependsOn: List<DependsOnEntry>,
     gitIgnoreClassifier: GitIgnoreClassifier
 ) {
   if (ciDependsOn.isNotEmpty()) {

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
@@ -123,6 +123,8 @@ fun processTargetsForProject(
   // with Kotlin Multiplatform which adds tasks dynamically
   val testTasks = project.tasks.withType(Test::class.java).toList()
   val hasCiTestTarget = ciTestTargetBaseName != null && testTasks.isNotEmpty() && atomized
+  // Pre-index test tasks by prefixed name for O(1) lookup during dependency replacement
+  val testTasksByPrefixedName = testTasks.associateBy { applyPrefix(it.name) }
 
   logger.info(
       "${project.name}: hasCiTestTarget = $hasCiTestTarget (ciTestTargetName=$ciTestTargetBaseName, testTasks.size=${testTasks.size}, atomized=$atomized)")
@@ -205,25 +207,30 @@ fun processTargetsForProject(
         val ciCheckTargetName =
             applyPrefix(targetNameOverrides.getOrDefault("ciCheckTargetName", "check-ci"))
         if (task.name == "check") {
+          @Suppress("UNCHECKED_CAST")
           val replacedDependencies =
-              (target["dependsOn"] as? List<*>)?.map { dependency ->
-                val dependsOn = dependency.toString()
+              (target["dependsOn"] as? List<Map<String, Any>>)?.map { dependency ->
+                val depTarget = dependency["target"] as? String ?: return@map dependency
 
-                when {
-                  hasCiTestTarget && dependsOn == "$nxProjectName:$testTargetName" -> {
-                    "$nxProjectName:$ciTestTargetBaseName"
-                  }
-                  hasCiTestTarget && dependsOn.startsWith("$nxProjectName:") -> {
-                    val taskName = dependsOn.removePrefix("$nxProjectName:")
-                    // Check if it's a test task that's not the default test target
-                    if (testTasks.any { it.name == taskName } &&
-                        applyPrefix(taskName) != testTargetName) {
-                      "$nxProjectName:$ciTestTargetBaseName-$taskName"
-                    } else {
-                      dependency
+                val newTargetName =
+                    when {
+                      hasCiTestTarget && depTarget == testTargetName -> ciTestTargetBaseName
+                      hasCiTestTarget -> {
+                        // depTarget is already prefixed, so use pre-indexed lookup
+                        val matchingTask = testTasksByPrefixedName[depTarget]
+                        if (matchingTask != null && depTarget != testTargetName) {
+                          "$ciTestTargetBaseName-${matchingTask.name}"
+                        } else {
+                          null
+                        }
+                      }
+                      else -> null
                     }
-                  }
-                  else -> dependency
+
+                if (newTargetName != null) {
+                  dependency.toMutableMap().apply { this["target"] = newTargetName }
+                } else {
+                  dependency
                 }
               } ?: emptyList()
 
@@ -242,11 +249,12 @@ fun processTargetsForProject(
         if (task.name == "build") {
           val ciBuildTargetName =
               applyPrefix(targetNameOverrides.getOrDefault("ciBuildTargetName", "build-ci"))
+          @Suppress("UNCHECKED_CAST")
           val replacedDependencies =
-              (target["dependsOn"] as? List<*>)?.map { dep ->
-                val dependsOn = dep.toString()
-                if (dependsOn == "$nxProjectName:${applyPrefix("check")}") {
-                  "$nxProjectName:$ciCheckTargetName"
+              (target["dependsOn"] as? List<Map<String, Any>>)?.map { dep ->
+                val depTarget = dep["target"] as? String ?: return@map dep
+                if (depTarget == applyPrefix("check")) {
+                  dep.toMutableMap().apply { this["target"] = ciCheckTargetName }
                 } else {
                   dep
                 }

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
@@ -5,6 +5,7 @@ import dev.nx.gradle.data.*
 import java.io.File
 import java.util.*
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.tasks.testing.Test
 
 /**
@@ -136,14 +137,7 @@ fun processTargetsForProject(
       val now = Date()
       logger.info("$now ${project.name}: Processing task ${task.path}")
 
-      // Apply target name override if applicable, then apply prefix
-      val targetName =
-          applyPrefix(
-              if (task.name == "test" && targetNameOverrides.containsKey("testTargetName")) {
-                targetNameOverrides["testTargetName"]!!
-              } else {
-                task.name
-              })
+      val targetName = resolveTargetName(task, targetNameOverrides, targetNamePrefix)
 
       // Group task under its group if available, using the overridden name
       task.group
@@ -207,60 +201,29 @@ fun processTargetsForProject(
         val ciCheckTargetName =
             applyPrefix(targetNameOverrides.getOrDefault("ciCheckTargetName", "check-ci"))
         if (task.name == "check") {
-          // Get all dependencies (same-project + cross-project) directly from
-          // Gradle's task graph for CI target construction.
-          // The target's dependsOn only has cross-project deps (same-project
-          // deps are handled by Gradle internally), but CI targets need to
-          // reference same-project targets like test -> test-ci.
-          val allCheckDeps = getDependsOnTask(task)
-          val ciCheckDependsOn = mutableListOf<Map<String, Any>>()
-
-          allCheckDeps.forEach { depTask ->
-            val depProject = depTask.project
-            if (depProject.buildFile.path != null && depProject.buildFile.exists()) {
-              val depTargetName =
-                  applyPrefix(
-                      if (depTask.name == "test" &&
-                          targetNameOverrides.containsKey("testTargetName")) {
-                        targetNameOverrides["testTargetName"]!!
-                      } else {
-                        depTask.name
-                      })
-
-              if (depProject == project) {
-                // Same-project dep: replace test targets with CI test targets
-                val newTargetName =
-                    when {
-                      hasCiTestTarget && depTargetName == testTargetName -> ciTestTargetBaseName
-                      hasCiTestTarget -> {
-                        val matchingTask = testTasksByPrefixedName[depTargetName]
-                        if (matchingTask != null && depTargetName != testTargetName) {
-                          "$ciTestTargetBaseName-${matchingTask.name}"
-                        } else {
-                          null
-                        }
-                      }
-                      else -> null
+          val ciCheckDependsOn =
+              buildCiDependsOn(task, project, targetNameOverrides, targetNamePrefix) { depTargetName
+                ->
+                when {
+                  hasCiTestTarget && depTargetName == testTargetName -> ciTestTargetBaseName
+                  hasCiTestTarget -> {
+                    val matchingTask = testTasksByPrefixedName[depTargetName]
+                    if (matchingTask != null && depTargetName != testTargetName) {
+                      "$ciTestTargetBaseName-${matchingTask.name}"
+                    } else {
+                      null
                     }
-                ciCheckDependsOn.add(mapOf("target" to (newTargetName ?: depTargetName)))
-              } else {
-                // Cross-project dep: keep as-is
-                ciCheckDependsOn.add(
-                    mapOf(
-                        "target" to depTargetName,
-                        "projects" to listOf(getNxProjectName(depProject))))
+                  }
+                  else -> null
+                }
               }
-            }
-          }
 
-          val newTarget: MutableMap<String, Any?> =
+          targets[ciCheckTargetName] =
               mutableMapOf(
                   "dependsOn" to ciCheckDependsOn,
                   "executor" to "nx:noop",
                   "cache" to true,
                   "metadata" to getMetadata("Runs Gradle Check in CI", projectBuildPath, "check"))
-
-          targets[ciCheckTargetName] = newTarget
           ensureTargetGroupExists(targetGroups, testCiTargetGroup)
           targetGroups[testCiTargetGroup]?.add(ciCheckTargetName)
         }
@@ -268,45 +231,18 @@ fun processTargetsForProject(
         if (task.name == "build") {
           val ciBuildTargetName =
               applyPrefix(targetNameOverrides.getOrDefault("ciBuildTargetName", "build-ci"))
-          // Get all dependencies directly from Gradle's task graph
-          val allBuildDeps = getDependsOnTask(task)
-          val ciBuildDependsOn = mutableListOf<Map<String, Any>>()
-
-          allBuildDeps.forEach { depTask ->
-            val depProject = depTask.project
-            if (depProject.buildFile.path != null && depProject.buildFile.exists()) {
-              val depTargetName =
-                  applyPrefix(
-                      if (depTask.name == "test" &&
-                          targetNameOverrides.containsKey("testTargetName")) {
-                        targetNameOverrides["testTargetName"]!!
-                      } else {
-                        depTask.name
-                      })
-
-              if (depProject == project) {
-                // Same-project dep: replace check with check-ci
-                val finalTargetName =
-                    if (depTargetName == applyPrefix("check")) ciCheckTargetName else depTargetName
-                ciBuildDependsOn.add(mapOf("target" to finalTargetName))
-              } else {
-                // Cross-project dep: keep as-is
-                ciBuildDependsOn.add(
-                    mapOf(
-                        "target" to depTargetName,
-                        "projects" to listOf(getNxProjectName(depProject))))
+          val ciBuildDependsOn =
+              buildCiDependsOn(task, project, targetNameOverrides, targetNamePrefix) { depTargetName
+                ->
+                if (depTargetName == applyPrefix("check")) ciCheckTargetName else null
               }
-            }
-          }
 
-          val newTarget: MutableMap<String, Any?> =
+          targets[ciBuildTargetName] =
               mutableMapOf(
                   "dependsOn" to ciBuildDependsOn,
                   "executor" to "nx:noop",
                   "cache" to true,
                   "metadata" to getMetadata("Runs Gradle Build in CI", projectBuildPath, "build"))
-
-          targets[ciBuildTargetName] = newTarget
           ensureTargetGroupExists(targetGroups, "build")
           targetGroups["build"]?.add(ciBuildTargetName)
         }
@@ -320,4 +256,61 @@ fun processTargetsForProject(
 
   logger.info("Final targets in processTargetsForProject: $targets")
   return GradleTargets(targets, targetGroups, externalNodes)
+}
+
+/**
+ * Build CI dependsOn list from a task's Gradle dependencies. Splits into same-project and
+ * cross-project entries, groups cross-project deps by target, and applies an optional same-project
+ * replacement function (e.g., test -> ci-test, check -> ci-check).
+ *
+ * @param replaceSameProject returns a replacement target name for same-project deps, or null to
+ *   keep as-is
+ */
+fun buildCiDependsOn(
+    task: Task,
+    project: Project,
+    targetNameOverrides: Map<String, String>,
+    targetNamePrefix: String,
+    replaceSameProject: (String) -> String?
+): List<Map<String, Any>> {
+  val allDeps = getDependsOnTask(task)
+  val result = mutableListOf<Map<String, Any>>()
+  val crossProjectByTarget = mutableMapOf<String, MutableList<String>>()
+
+  allDeps.forEach { depTask ->
+    val depProject = depTask.project
+    if (depProject.buildFile.path != null && depProject.buildFile.exists()) {
+      val depTargetName = resolveTargetName(depTask, targetNameOverrides, targetNamePrefix)
+
+      if (depProject == project) {
+        val replaced = replaceSameProject(depTargetName)
+        result.add(mapOf("target" to (replaced ?: depTargetName)))
+      } else {
+        crossProjectByTarget
+            .getOrPut(depTargetName) { mutableListOf() }
+            .add(getNxProjectName(depProject))
+      }
+    }
+  }
+
+  crossProjectByTarget.forEach { (targetName, projects) ->
+    result.add(mapOf("target" to targetName, "projects" to projects.distinct()))
+  }
+
+  return result
+}
+
+/** Resolve a dependency task's target name, applying overrides and prefix. */
+fun resolveTargetName(
+    depTask: Task,
+    targetNameOverrides: Map<String, String>,
+    targetNamePrefix: String
+): String {
+  val baseName =
+      if (depTask.name == "test" && targetNameOverrides.containsKey("testTargetName")) {
+        targetNameOverrides["testTargetName"]!!
+      } else {
+        depTask.name
+      }
+  return if (targetNamePrefix.isNotEmpty()) "$targetNamePrefix$baseName" else baseName
 }

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
@@ -200,22 +200,18 @@ fun processTargetsForProject(
       if (ciTestTargetBaseName != null) {
         val ciCheckTargetName =
             applyPrefix(targetNameOverrides.getOrDefault("ciCheckTargetName", "check-ci"))
+
+        // Maps a same-project dep target to its CI equivalent (e.g., test -> ci-test)
+        fun ciTestReplacementFor(depTargetName: String): String? {
+          if (!hasCiTestTarget) return null
+          if (depTargetName == testTargetName) return ciTestTargetBaseName
+          return testTasksByPrefixedName[depTargetName]?.let { "$ciTestTargetBaseName-${it.name}" }
+        }
+
         if (task.name == "check") {
           val ciCheckDependsOn =
-              buildCiDependsOn(task, project, targetNameOverrides, targetNamePrefix) { depTargetName
-                ->
-                when {
-                  hasCiTestTarget && depTargetName == testTargetName -> ciTestTargetBaseName
-                  hasCiTestTarget -> {
-                    val matchingTask = testTasksByPrefixedName[depTargetName]
-                    if (matchingTask != null && depTargetName != testTargetName) {
-                      "$ciTestTargetBaseName-${matchingTask.name}"
-                    } else {
-                      null
-                    }
-                  }
-                  else -> null
-                }
+              buildCiDependsOn(task, project, targetNameOverrides, targetNamePrefix) {
+                ciTestReplacementFor(it)
               }
 
           targets[ciCheckTargetName] =
@@ -232,9 +228,8 @@ fun processTargetsForProject(
           val ciBuildTargetName =
               applyPrefix(targetNameOverrides.getOrDefault("ciBuildTargetName", "build-ci"))
           val ciBuildDependsOn =
-              buildCiDependsOn(task, project, targetNameOverrides, targetNamePrefix) { depTargetName
-                ->
-                if (depTargetName == applyPrefix("check")) ciCheckTargetName else null
+              buildCiDependsOn(task, project, targetNameOverrides, targetNamePrefix) {
+                if (it == applyPrefix("check")) ciCheckTargetName else null
               }
 
           targets[ciBuildTargetName] =

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
@@ -207,18 +207,34 @@ fun processTargetsForProject(
         val ciCheckTargetName =
             applyPrefix(targetNameOverrides.getOrDefault("ciCheckTargetName", "check-ci"))
         if (task.name == "check") {
-          @Suppress("UNCHECKED_CAST")
-          val replacedDependencies =
-              (target["dependsOn"] as? List<Map<String, Any>>)?.map { dependency ->
-                val depTarget = dependency["target"] as? String ?: return@map dependency
+          // Get all dependencies (same-project + cross-project) directly from
+          // Gradle's task graph for CI target construction.
+          // The target's dependsOn only has cross-project deps (same-project
+          // deps are handled by Gradle internally), but CI targets need to
+          // reference same-project targets like test -> test-ci.
+          val allCheckDeps = getDependsOnTask(task)
+          val ciCheckDependsOn = mutableListOf<Map<String, Any>>()
 
+          allCheckDeps.forEach { depTask ->
+            val depProject = depTask.project
+            if (depProject.buildFile.path != null && depProject.buildFile.exists()) {
+              val depTargetName =
+                  applyPrefix(
+                      if (depTask.name == "test" &&
+                          targetNameOverrides.containsKey("testTargetName")) {
+                        targetNameOverrides["testTargetName"]!!
+                      } else {
+                        depTask.name
+                      })
+
+              if (depProject == project) {
+                // Same-project dep: replace test targets with CI test targets
                 val newTargetName =
                     when {
-                      hasCiTestTarget && depTarget == testTargetName -> ciTestTargetBaseName
+                      hasCiTestTarget && depTargetName == testTargetName -> ciTestTargetBaseName
                       hasCiTestTarget -> {
-                        // depTarget is already prefixed, so use pre-indexed lookup
-                        val matchingTask = testTasksByPrefixedName[depTarget]
-                        if (matchingTask != null && depTarget != testTargetName) {
+                        val matchingTask = testTasksByPrefixedName[depTargetName]
+                        if (matchingTask != null && depTargetName != testTargetName) {
                           "$ciTestTargetBaseName-${matchingTask.name}"
                         } else {
                           null
@@ -226,17 +242,20 @@ fun processTargetsForProject(
                       }
                       else -> null
                     }
-
-                if (newTargetName != null) {
-                  dependency.toMutableMap().apply { this["target"] = newTargetName }
-                } else {
-                  dependency
-                }
-              } ?: emptyList()
+                ciCheckDependsOn.add(mapOf("target" to (newTargetName ?: depTargetName)))
+              } else {
+                // Cross-project dep: keep as-is
+                ciCheckDependsOn.add(
+                    mapOf(
+                        "target" to depTargetName,
+                        "projects" to listOf(getNxProjectName(depProject))))
+              }
+            }
+          }
 
           val newTarget: MutableMap<String, Any?> =
               mutableMapOf(
-                  "dependsOn" to replacedDependencies,
+                  "dependsOn" to ciCheckDependsOn,
                   "executor" to "nx:noop",
                   "cache" to true,
                   "metadata" to getMetadata("Runs Gradle Check in CI", projectBuildPath, "check"))
@@ -249,20 +268,40 @@ fun processTargetsForProject(
         if (task.name == "build") {
           val ciBuildTargetName =
               applyPrefix(targetNameOverrides.getOrDefault("ciBuildTargetName", "build-ci"))
-          @Suppress("UNCHECKED_CAST")
-          val replacedDependencies =
-              (target["dependsOn"] as? List<Map<String, Any>>)?.map { dep ->
-                val depTarget = dep["target"] as? String ?: return@map dep
-                if (depTarget == applyPrefix("check")) {
-                  dep.toMutableMap().apply { this["target"] = ciCheckTargetName }
-                } else {
-                  dep
-                }
-              } ?: emptyList()
+          // Get all dependencies directly from Gradle's task graph
+          val allBuildDeps = getDependsOnTask(task)
+          val ciBuildDependsOn = mutableListOf<Map<String, Any>>()
+
+          allBuildDeps.forEach { depTask ->
+            val depProject = depTask.project
+            if (depProject.buildFile.path != null && depProject.buildFile.exists()) {
+              val depTargetName =
+                  applyPrefix(
+                      if (depTask.name == "test" &&
+                          targetNameOverrides.containsKey("testTargetName")) {
+                        targetNameOverrides["testTargetName"]!!
+                      } else {
+                        depTask.name
+                      })
+
+              if (depProject == project) {
+                // Same-project dep: replace check with check-ci
+                val finalTargetName =
+                    if (depTargetName == applyPrefix("check")) ciCheckTargetName else depTargetName
+                ciBuildDependsOn.add(mapOf("target" to finalTargetName))
+              } else {
+                // Cross-project dep: keep as-is
+                ciBuildDependsOn.add(
+                    mapOf(
+                        "target" to depTargetName,
+                        "projects" to listOf(getNxProjectName(depProject))))
+              }
+            }
+          }
 
           val newTarget: MutableMap<String, Any?> =
               mutableMapOf(
-                  "dependsOn" to replacedDependencies,
+                  "dependsOn" to ciBuildDependsOn,
                   "executor" to "nx:noop",
                   "cache" to true,
                   "metadata" to getMetadata("Runs Gradle Build in CI", projectBuildPath, "build"))

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
@@ -215,7 +215,8 @@ fun processTargetsForProject(
 
         if (task.name == "check") {
           val ciCheckDependsOn =
-              buildCiDependsOn(task, project, targetNameOverrides, targetNamePrefix, ciTestReplacements)
+              buildCiDependsOn(
+                  task, project, targetNameOverrides, targetNamePrefix, ciTestReplacements)
 
           targets[ciCheckTargetName] =
               mutableMapOf(
@@ -232,7 +233,10 @@ fun processTargetsForProject(
               applyPrefix(targetNameOverrides.getOrDefault("ciBuildTargetName", "build-ci"))
           val ciBuildDependsOn =
               buildCiDependsOn(
-                  task, project, targetNameOverrides, targetNamePrefix,
+                  task,
+                  project,
+                  targetNameOverrides,
+                  targetNamePrefix,
                   mapOf(applyPrefix("check") to ciCheckTargetName))
 
           targets[ciBuildTargetName] =

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
@@ -201,18 +201,21 @@ fun processTargetsForProject(
         val ciCheckTargetName =
             applyPrefix(targetNameOverrides.getOrDefault("ciCheckTargetName", "check-ci"))
 
-        // Maps a same-project dep target to its CI equivalent (e.g., test -> ci-test)
-        fun ciTestReplacementFor(depTargetName: String): String? {
-          if (!hasCiTestTarget) return null
-          if (depTargetName == testTargetName) return ciTestTargetBaseName
-          return testTasksByPrefixedName[depTargetName]?.let { "$ciTestTargetBaseName-${it.name}" }
+        // Build CI test replacements: maps original target names to their CI equivalents
+        // e.g., "test" -> "ci-test", "testDebug" -> "ci-test-testDebug"
+        val ciTestReplacements = mutableMapOf<String, String>()
+        if (hasCiTestTarget) {
+          testTasksByPrefixedName.forEach { (prefixedName, testTask) ->
+            ciTestReplacements[prefixedName] = "$ciTestTargetBaseName-${testTask.name}"
+          }
+          // The default test target gets the base CI name (e.g., "test" -> "ci-test")
+          // Set after the loop so it takes priority over the generic pattern
+          ciTestReplacements[testTargetName] = ciTestTargetBaseName!!
         }
 
         if (task.name == "check") {
           val ciCheckDependsOn =
-              buildCiDependsOn(task, project, targetNameOverrides, targetNamePrefix) {
-                ciTestReplacementFor(it)
-              }
+              buildCiDependsOn(task, project, targetNameOverrides, targetNamePrefix, ciTestReplacements)
 
           targets[ciCheckTargetName] =
               mutableMapOf(
@@ -228,9 +231,9 @@ fun processTargetsForProject(
           val ciBuildTargetName =
               applyPrefix(targetNameOverrides.getOrDefault("ciBuildTargetName", "build-ci"))
           val ciBuildDependsOn =
-              buildCiDependsOn(task, project, targetNameOverrides, targetNamePrefix) {
-                if (it == applyPrefix("check")) ciCheckTargetName else null
-              }
+              buildCiDependsOn(
+                  task, project, targetNameOverrides, targetNamePrefix,
+                  mapOf(applyPrefix("check") to ciCheckTargetName))
 
           targets[ciBuildTargetName] =
               mutableMapOf(
@@ -255,21 +258,18 @@ fun processTargetsForProject(
 
 /**
  * Build CI dependsOn list from a task's Gradle dependencies. Splits into same-project and
- * cross-project entries, groups cross-project deps by target, and applies an optional same-project
- * replacement function (e.g., test -> ci-test, check -> ci-check).
- *
- * @param replaceSameProject returns a replacement target name for same-project deps, or null to
- *   keep as-is
+ * cross-project entries, groups cross-project deps by target, and optionally replaces same-project
+ * target names using the provided map (e.g., test -> ci-test, check -> ci-check).
  */
 fun buildCiDependsOn(
     task: Task,
     project: Project,
     targetNameOverrides: Map<String, String>,
     targetNamePrefix: String,
-    replaceSameProject: (String) -> String?
-): List<Map<String, Any>> {
+    sameProjectReplacements: Map<String, String> = emptyMap()
+): List<DependsOnEntry> {
   val allDeps = getDependsOnTask(task)
-  val result = mutableListOf<Map<String, Any>>()
+  val result = mutableListOf<DependsOnEntry>()
   val crossProjectByTarget = mutableMapOf<String, MutableList<String>>()
 
   allDeps.forEach { depTask ->
@@ -278,8 +278,8 @@ fun buildCiDependsOn(
       val depTargetName = resolveTargetName(depTask, targetNameOverrides, targetNamePrefix)
 
       if (depProject == project) {
-        val replaced = replaceSameProject(depTargetName)
-        result.add(mapOf("target" to (replaced ?: depTargetName)))
+        val finalName = sameProjectReplacements[depTargetName] ?: depTargetName
+        result.add(DependsOnEntry(target = finalName))
       } else {
         crossProjectByTarget
             .getOrPut(depTargetName) { mutableListOf() }
@@ -289,7 +289,7 @@ fun buildCiDependsOn(
   }
 
   crossProjectByTarget.forEach { (targetName, projects) ->
-    result.add(mapOf("target" to targetName, "projects" to projects.distinct()))
+    result.add(DependsOnEntry(target = targetName, projects = projects.distinct()))
   }
 
   return result

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -291,10 +291,6 @@ fun getDependsOnForTask(
     targetNamePrefix: String = ""
 ): List<Map<String, Any>>? {
 
-  // Helper function to apply prefix to target names
-  fun applyPrefix(name: String): String =
-      if (targetNamePrefix.isNotEmpty()) "$targetNamePrefix$name" else name
-
   // Check cache to prevent infinite recursion, but only if dependsOnTasks is null
   // When dependsOnTasks is provided, we should not use cache since dependencies might be different
   val cache = taskDependencyCache.get()
@@ -323,14 +319,7 @@ fun getDependsOnForTask(
           }
 
           if (depProject.buildFile.path != null && depProject.buildFile.exists()) {
-            val targetName =
-                applyPrefix(
-                    if (depTask.name == "test" &&
-                        targetNameOverrides.containsKey("testTargetName")) {
-                      targetNameOverrides["testTargetName"]!!
-                    } else {
-                      depTask.name
-                    })
+            val targetName = resolveTargetName(depTask, targetNameOverrides, targetNamePrefix)
             DepEntry(getNxProjectName(depProject), targetName, depProject == taskProject)
           } else {
             null

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -340,10 +340,8 @@ fun getDependsOnForTask(
     val result = mutableListOf<Map<String, Any>>()
     val grouped = depEntries.groupBy { it.isSameProject }
 
-    // Same-project dependencies are NOT included in dependsOn.
-    // Gradle handles same-project task ordering internally when running a task.
-    // Including them would cause Nx to schedule them as separate tasks, which
-    // can fail when tasks exist during project graph generation but not execution.
+    // Same-project dependencies: just target name, no projects field
+    grouped[true]?.forEach { entry -> result.add(mapOf("target" to entry.targetName)) }
 
     // Cross-project dependencies: group by target, collect projects into array
     grouped[false]

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -274,12 +274,6 @@ fun getDependsOnTask(task: Task): Set<Task> {
  * @param targetNamePrefix optional prefix to apply to all target names
  * @return list of dependsOn task names (possibly replaced), or null if none found or error occurred
  */
-private data class ResolvedTaskDep(
-    val projectName: String,
-    val targetName: String,
-    val isSameProject: Boolean
-)
-
 // Add a thread-local cache to prevent infinite recursion in dependency resolution
 internal val taskDependencyCache =
     ThreadLocal.withInitial { mutableMapOf<String, List<DependsOnEntry>?>() }
@@ -303,47 +297,41 @@ fun getDependsOnForTask(
 
   fun mapTasksToObjects(tasks: Collection<Task>): List<DependsOnEntry> {
     val taskProject = task.project
+    val sameProjectDependsOn = mutableListOf<DependsOnEntry>()
+    val crossProjectByTarget = mutableMapOf<String, MutableList<String>>()
 
-    val depEntries =
-        tasks.mapNotNull { depTask ->
-          val depProject = depTask.project
+    tasks.forEach { depTask ->
+      val depProject = depTask.project
 
-          if (task.name != "buildDependents" &&
-              depProject != taskProject &&
-              dependencies != null &&
-              taskProject.buildFile.exists()) {
-            dependencies.add(
-                Dependency(
-                    taskProject.projectDir.path,
-                    depProject.projectDir.path,
-                    taskProject.buildFile.path))
-          }
+      if (task.name != "buildDependents" &&
+          depProject != taskProject &&
+          dependencies != null &&
+          taskProject.buildFile.exists()) {
+        dependencies.add(
+            Dependency(
+                taskProject.projectDir.path,
+                depProject.projectDir.path,
+                taskProject.buildFile.path))
+      }
 
-          if (depProject.buildFile.path != null && depProject.buildFile.exists()) {
-            val targetName = resolveTargetName(depTask, targetNameOverrides, targetNamePrefix)
-            ResolvedTaskDep(getNxProjectName(depProject), targetName, depProject == taskProject)
-          } else {
-            null
-          }
+      if (depProject.buildFile.path != null && depProject.buildFile.exists()) {
+        val targetName = resolveTargetName(depTask, targetNameOverrides, targetNamePrefix)
+        if (depProject == taskProject) {
+          sameProjectDependsOn.add(DependsOnEntry(target = targetName))
+        } else {
+          crossProjectByTarget
+              .getOrPut(targetName) { mutableListOf() }
+              .add(getNxProjectName(depProject))
+        }
+      }
+    }
+
+    val crossProjectDependsOn =
+        crossProjectByTarget.map { (targetName, projects) ->
+          DependsOnEntry(target = targetName, projects = projects.distinct())
         }
 
-    val result = mutableListOf<DependsOnEntry>()
-    val grouped = depEntries.groupBy { it.isSameProject }
-
-    // Same-project dependencies: just target name, no projects field
-    grouped[true]?.forEach { entry -> result.add(DependsOnEntry(target = entry.targetName)) }
-
-    // Cross-project dependencies: group by target, collect projects into array
-    grouped[false]
-        ?.groupBy { it.targetName }
-        ?.forEach { (targetName, entries) ->
-          result.add(
-              DependsOnEntry(
-                  target = targetName,
-                  projects = entries.map { it.projectName }.distinct()))
-        }
-
-    return result
+    return sameProjectDependsOn + crossProjectDependsOn
   }
 
   // Add a placeholder to prevent infinite recursion only when not using pre-computed dependencies

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -1,8 +1,8 @@
 package dev.nx.gradle.utils
 
 import dev.nx.gradle.NxTaskExtension
-import dev.nx.gradle.data.DependsOnEntry
 import dev.nx.gradle.data.Dependency
+import dev.nx.gradle.data.DependsOnEntry
 import dev.nx.gradle.data.ExternalDepData
 import dev.nx.gradle.data.ExternalNode
 import java.io.File

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -1,6 +1,7 @@
 package dev.nx.gradle.utils
 
 import dev.nx.gradle.NxTaskExtension
+import dev.nx.gradle.data.DependsOnEntry
 import dev.nx.gradle.data.Dependency
 import dev.nx.gradle.data.ExternalDepData
 import dev.nx.gradle.data.ExternalNode
@@ -273,7 +274,7 @@ fun getDependsOnTask(task: Task): Set<Task> {
  * @param targetNamePrefix optional prefix to apply to all target names
  * @return list of dependsOn task names (possibly replaced), or null if none found or error occurred
  */
-private data class DepEntry(
+private data class ResolvedTaskDep(
     val projectName: String,
     val targetName: String,
     val isSameProject: Boolean
@@ -281,7 +282,7 @@ private data class DepEntry(
 
 // Add a thread-local cache to prevent infinite recursion in dependency resolution
 internal val taskDependencyCache =
-    ThreadLocal.withInitial { mutableMapOf<String, List<Map<String, Any>>?>() }
+    ThreadLocal.withInitial { mutableMapOf<String, List<DependsOnEntry>?>() }
 
 fun getDependsOnForTask(
     dependsOnTasks: Set<Task>?,
@@ -289,7 +290,7 @@ fun getDependsOnForTask(
     dependencies: MutableSet<Dependency>? = null,
     targetNameOverrides: Map<String, String> = emptyMap(),
     targetNamePrefix: String = ""
-): List<Map<String, Any>>? {
+): List<DependsOnEntry>? {
 
   // Check cache to prevent infinite recursion, but only if dependsOnTasks is null
   // When dependsOnTasks is provided, we should not use cache since dependencies might be different
@@ -300,7 +301,7 @@ fun getDependsOnForTask(
     return cache[taskKey]
   }
 
-  fun mapTasksToObjects(tasks: Collection<Task>): List<Map<String, Any>> {
+  fun mapTasksToObjects(tasks: Collection<Task>): List<DependsOnEntry> {
     val taskProject = task.project
 
     val depEntries =
@@ -320,25 +321,26 @@ fun getDependsOnForTask(
 
           if (depProject.buildFile.path != null && depProject.buildFile.exists()) {
             val targetName = resolveTargetName(depTask, targetNameOverrides, targetNamePrefix)
-            DepEntry(getNxProjectName(depProject), targetName, depProject == taskProject)
+            ResolvedTaskDep(getNxProjectName(depProject), targetName, depProject == taskProject)
           } else {
             null
           }
         }
 
-    val result = mutableListOf<Map<String, Any>>()
+    val result = mutableListOf<DependsOnEntry>()
     val grouped = depEntries.groupBy { it.isSameProject }
 
     // Same-project dependencies: just target name, no projects field
-    grouped[true]?.forEach { entry -> result.add(mapOf("target" to entry.targetName)) }
+    grouped[true]?.forEach { entry -> result.add(DependsOnEntry(target = entry.targetName)) }
 
     // Cross-project dependencies: group by target, collect projects into array
     grouped[false]
         ?.groupBy { it.targetName }
         ?.forEach { (targetName, entries) ->
           result.add(
-              mapOf(
-                  "target" to targetName, "projects" to entries.map { it.projectName }.distinct()))
+              DependsOnEntry(
+                  target = targetName,
+                  projects = entries.map { it.projectName }.distinct()))
         }
 
     return result

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -340,11 +340,10 @@ fun getDependsOnForTask(
     val result = mutableListOf<Map<String, Any>>()
     val grouped = depEntries.groupBy { it.isSameProject }
 
-    // Same-project dependencies: one entry per target
-    grouped[true]
-        ?.map { it.targetName }
-        ?.distinct()
-        ?.forEach { targetName -> result.add(mapOf("target" to targetName)) }
+    // Same-project dependencies are NOT included in dependsOn.
+    // Gradle handles same-project task ordering internally when running a task.
+    // Including them would cause Nx to schedule them as separate tasks, which
+    // can fail when tasks exist during project graph generation but not execution.
 
     // Cross-project dependencies: group by target, collect projects into array
     grouped[false]
@@ -366,7 +365,7 @@ fun getDependsOnForTask(
       val combinedDependsOn = getDependsOnTask(task)
       val result =
           if (combinedDependsOn.isNotEmpty()) {
-            mapTasksToObjects(combinedDependsOn)
+            mapTasksToObjects(combinedDependsOn).ifEmpty { null }
           } else {
             null
           }
@@ -388,7 +387,7 @@ fun getDependsOnForTask(
     return try {
       val result =
           if (dependsOnTasks.isNotEmpty()) {
-            mapTasksToObjects(dependsOnTasks)
+            mapTasksToObjects(dependsOnTasks).ifEmpty { null }
           } else {
             null
           }

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -273,8 +273,15 @@ fun getDependsOnTask(task: Task): Set<Task> {
  * @param targetNamePrefix optional prefix to apply to all target names
  * @return list of dependsOn task names (possibly replaced), or null if none found or error occurred
  */
+private data class DepEntry(
+    val projectName: String,
+    val targetName: String,
+    val isSameProject: Boolean
+)
+
 // Add a thread-local cache to prevent infinite recursion in dependency resolution
-internal val taskDependencyCache = ThreadLocal.withInitial { mutableMapOf<String, List<String>?>() }
+internal val taskDependencyCache =
+    ThreadLocal.withInitial { mutableMapOf<String, List<Map<String, Any>>?>() }
 
 fun getDependsOnForTask(
     dependsOnTasks: Set<Task>?,
@@ -282,7 +289,7 @@ fun getDependsOnForTask(
     dependencies: MutableSet<Dependency>? = null,
     targetNameOverrides: Map<String, String> = emptyMap(),
     targetNamePrefix: String = ""
-): List<String>? {
+): List<Map<String, Any>>? {
 
   // Helper function to apply prefix to target names
   fun applyPrefix(name: String): String =
@@ -297,35 +304,58 @@ fun getDependsOnForTask(
     return cache[taskKey]
   }
 
-  fun mapTasksToNames(tasks: Collection<Task>): List<String> {
-    return tasks.mapNotNull { depTask ->
-      val depProject = depTask.project
-      val taskProject = task.project
+  fun mapTasksToObjects(tasks: Collection<Task>): List<Map<String, Any>> {
+    val taskProject = task.project
 
-      if (task.name != "buildDependents" &&
-          depProject != taskProject &&
-          dependencies != null &&
-          taskProject.buildFile.exists()) {
-        dependencies.add(
-            Dependency(
-                taskProject.projectDir.path,
-                depProject.projectDir.path,
-                taskProject.buildFile.path))
-      }
+    val depEntries =
+        tasks.mapNotNull { depTask ->
+          val depProject = depTask.project
 
-      if (depProject.buildFile.path != null && depProject.buildFile.exists()) {
-        val taskName =
-            applyPrefix(
-                if (depTask.name == "test" && targetNameOverrides.containsKey("testTargetName")) {
-                  targetNameOverrides["testTargetName"]!!
-                } else {
-                  depTask.name
-                })
-        "${getNxProjectName(depProject)}:${taskName}"
-      } else {
-        null
-      }
-    }
+          if (task.name != "buildDependents" &&
+              depProject != taskProject &&
+              dependencies != null &&
+              taskProject.buildFile.exists()) {
+            dependencies.add(
+                Dependency(
+                    taskProject.projectDir.path,
+                    depProject.projectDir.path,
+                    taskProject.buildFile.path))
+          }
+
+          if (depProject.buildFile.path != null && depProject.buildFile.exists()) {
+            val targetName =
+                applyPrefix(
+                    if (depTask.name == "test" &&
+                        targetNameOverrides.containsKey("testTargetName")) {
+                      targetNameOverrides["testTargetName"]!!
+                    } else {
+                      depTask.name
+                    })
+            DepEntry(getNxProjectName(depProject), targetName, depProject == taskProject)
+          } else {
+            null
+          }
+        }
+
+    val result = mutableListOf<Map<String, Any>>()
+    val grouped = depEntries.groupBy { it.isSameProject }
+
+    // Same-project dependencies: one entry per target
+    grouped[true]
+        ?.map { it.targetName }
+        ?.distinct()
+        ?.forEach { targetName -> result.add(mapOf("target" to targetName)) }
+
+    // Cross-project dependencies: group by target, collect projects into array
+    grouped[false]
+        ?.groupBy { it.targetName }
+        ?.forEach { (targetName, entries) ->
+          result.add(
+              mapOf(
+                  "target" to targetName, "projects" to entries.map { it.projectName }.distinct()))
+        }
+
+    return result
   }
 
   // Add a placeholder to prevent infinite recursion only when not using pre-computed dependencies
@@ -336,7 +366,7 @@ fun getDependsOnForTask(
       val combinedDependsOn = getDependsOnTask(task)
       val result =
           if (combinedDependsOn.isNotEmpty()) {
-            mapTasksToNames(combinedDependsOn)
+            mapTasksToObjects(combinedDependsOn)
           } else {
             null
           }
@@ -358,7 +388,7 @@ fun getDependsOnForTask(
     return try {
       val result =
           if (dependsOnTasks.isNotEmpty()) {
-            mapTasksToNames(dependsOnTasks)
+            mapTasksToObjects(dependsOnTasks)
           } else {
             null
           }

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/AddTestCiTargetsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/AddTestCiTargetsTest.kt
@@ -3,6 +3,7 @@ package dev.nx.gradle.utils
 import dev.nx.gradle.data.*
 import java.io.File
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -160,10 +161,15 @@ class AddTestCiTargetsTest {
     val ciTarget = targets["ci--DependentTest"]
     assertTrue(ciTarget != null, "CI target should be created")
 
-    // Same-project dependencies are not included in dependsOn;
-    // Gradle handles same-project task ordering internally.
-    val dependsOn = ciTarget?.get("dependsOn")
-    assertTrue(dependsOn == null, "Same-project dependsOn should not be present, got $dependsOn")
+    // Same-project dependencies should be included as object format without projects field
+    val dependsOn = ciTarget?.get("dependsOn") as? List<*>
+    assertNotNull(dependsOn, "Same-project dependsOn should be present")
+    assertTrue(
+        dependsOn!!.any { (it as? Map<*, *>)?.get("target") == "compileTestKotlin" },
+        "Expected dependsOn to contain 'compileTestKotlin', got $dependsOn")
+    assertTrue(
+        dependsOn.all { (it as? Map<*, *>)?.containsKey("projects") != true },
+        "Same-project deps should not have projects field")
   }
 
   @Test

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/AddTestCiTargetsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/AddTestCiTargetsTest.kt
@@ -160,11 +160,12 @@ class AddTestCiTargetsTest {
     val ciTarget = targets["ci--DependentTest"]
     assertTrue(ciTarget != null, "CI target should be created")
 
-    val dependsOn = ciTarget?.get("dependsOn") as? List<*>
+    @Suppress("UNCHECKED_CAST")
+    val dependsOn = ciTarget?.get("dependsOn") as? List<Map<String, Any>>
     assertTrue(dependsOn != null, "dependsOn should be present when test task has dependencies")
     assertTrue(dependsOn!!.isNotEmpty(), "dependsOn should not be empty")
     assertTrue(
-        dependsOn.any { it.toString().contains("compileTestKotlin") },
+        dependsOn.any { it["target"] == "compileTestKotlin" },
         "dependsOn should contain the dependency task name")
   }
 

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/AddTestCiTargetsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/AddTestCiTargetsTest.kt
@@ -126,7 +126,7 @@ class AddTestCiTargetsTest {
   }
 
   @Test
-  fun `should include dependsOn when test task has dependencies`() {
+  fun `should not include same-project dependsOn for CI targets`() {
     File(projectRoot, "build.gradle").apply { writeText("// test build file") }
 
     val testFile =
@@ -160,13 +160,10 @@ class AddTestCiTargetsTest {
     val ciTarget = targets["ci--DependentTest"]
     assertTrue(ciTarget != null, "CI target should be created")
 
-    @Suppress("UNCHECKED_CAST")
-    val dependsOn = ciTarget?.get("dependsOn") as? List<Map<String, Any>>
-    assertTrue(dependsOn != null, "dependsOn should be present when test task has dependencies")
-    assertTrue(dependsOn!!.isNotEmpty(), "dependsOn should not be empty")
-    assertTrue(
-        dependsOn.any { it["target"] == "compileTestKotlin" },
-        "dependsOn should contain the dependency task name")
+    // Same-project dependencies are not included in dependsOn;
+    // Gradle handles same-project task ordering internally.
+    val dependsOn = ciTarget?.get("dependsOn")
+    assertTrue(dependsOn == null, "Same-project dependsOn should not be present, got $dependsOn")
   }
 
   @Test

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/AddTestCiTargetsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/AddTestCiTargetsTest.kt
@@ -165,10 +165,10 @@ class AddTestCiTargetsTest {
     val dependsOn = ciTarget?.get("dependsOn") as? List<*>
     assertNotNull(dependsOn, "Same-project dependsOn should be present")
     assertTrue(
-        dependsOn!!.any { (it as? Map<*, *>)?.get("target") == "compileTestKotlin" },
+        dependsOn!!.any { (it as? DependsOnEntry)?.target == "compileTestKotlin" },
         "Expected dependsOn to contain 'compileTestKotlin', got $dependsOn")
     assertTrue(
-        dependsOn.all { (it as? Map<*, *>)?.containsKey("projects") != true },
+        dependsOn.all { (it as? DependsOnEntry)?.projects == null },
         "Same-project deps should not have projects field")
   }
 

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTargetsForProjectTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTargetsForProjectTest.kt
@@ -87,32 +87,32 @@ class ProcessTargetsForProjectTest {
     val checkDependsOn = checkTarget["dependsOn"] as? List<*>
     assertNotNull(checkDependsOn, "Check dependsOn should not be null in processed targets")
     assertTrue(
-        checkDependsOn.contains("${project.name}:test"),
-        "Expected 'check' to depend on 'test' in processed targets")
+        checkDependsOn.any { (it as? Map<*, *>)?.get("target") == "test" },
+        "Expected 'check' to depend on 'test' in processed targets, got $checkDependsOn")
 
     val checkCiTarget = gradleTargets.targets["ci-check"]
     assertNotNull(checkCiTarget, "Check CI target should exist in processed targets")
     val checkCiDependsOn = checkCiTarget["dependsOn"] as? List<*>
     assertNotNull(checkCiDependsOn, "Check CI dependsOn should not be null in processed targets")
     assertTrue(
-        checkCiDependsOn.contains("${project.name}:ci-test"),
-        "Expected 'ci-check' to depend on 'ci-test' in processed targets")
+        checkCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-test" },
+        "Expected 'ci-check' to depend on 'ci-test' in processed targets, got $checkCiDependsOn")
 
     val buildTarget = gradleTargets.targets["build"]
     assertNotNull(buildTarget, "Build target should exist in processed targets")
     val buildDependsOn = buildTarget["dependsOn"] as? List<*>
     assertNotNull(buildDependsOn, "Build dependsOn should not be null in processed targets")
     assertTrue(
-        buildDependsOn.contains("${project.name}:check"),
-        "Expected 'build' to depend on 'check' in processed targets")
+        buildDependsOn.any { (it as? Map<*, *>)?.get("target") == "check" },
+        "Expected 'build' to depend on 'check' in processed targets, got $buildDependsOn")
 
     val buildCiTarget = gradleTargets.targets["ci-build"]
     assertNotNull(buildCiTarget, "Build CI target should exist in processed targets")
     val buildCiDependsOn = buildCiTarget["dependsOn"] as? List<*>
     assertNotNull(buildCiDependsOn, "Build CI dependsOn should not be null in processed targets")
     assertTrue(
-        buildCiDependsOn.contains("${project.name}:ci-check"),
-        "Expected 'ci-build' to depend on 'ci-check' in processed targets")
+        buildCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-check" },
+        "Expected 'ci-build' to depend on 'ci-check' in processed targets, got $buildCiDependsOn")
   }
 
   @Test
@@ -204,9 +204,10 @@ class ProcessTargetsForProjectTest {
     val checkDependsOn = checkTarget["dependsOn"] as? List<*>
     assertNotNull(checkDependsOn, "Check dependsOn should not be null")
     assertTrue(
-        checkDependsOn.contains("${project.name}:test"), "Expected 'check' to depend on 'test'")
+        checkDependsOn.any { (it as? Map<*, *>)?.get("target") == "test" },
+        "Expected 'check' to depend on 'test', got $checkDependsOn")
     assertFalse(
-        checkDependsOn.contains("${project.name}:ci-test"),
+        checkDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-test" },
         "Expected 'check' NOT to depend on 'ci-test'")
 
     val checkCiTarget = gradleTargets.targets["ci-check"]
@@ -214,20 +215,21 @@ class ProcessTargetsForProjectTest {
     val checkCiDependsOn = checkCiTarget["dependsOn"] as? List<*>
     assertNotNull(checkCiDependsOn, "Check CI dependsOn should not be null in processed targets")
     assertFalse(
-        checkCiDependsOn.contains("${project.name}:ci-test"),
+        checkCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-test" },
         "Expected 'ci-check' to NOT depend on 'ci-test' in processed targets")
     assertTrue(
-        checkCiDependsOn.contains("${project.name}:test"),
-        "Expected 'ci-check' to depend on 'test' in processed targets")
+        checkCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "test" },
+        "Expected 'ci-check' to depend on 'test' in processed targets, got $checkCiDependsOn")
 
     val buildTarget = gradleTargets.targets["build"]
     assertNotNull(buildTarget, "Build target should exist")
     val buildDependsOn = buildTarget["dependsOn"] as? List<*>
     assertNotNull(buildDependsOn, "Build dependsOn should not be null")
     assertTrue(
-        buildDependsOn.contains("${project.name}:check"), "Expected 'build' to depend on 'check'")
+        buildDependsOn.any { (it as? Map<*, *>)?.get("target") == "check" },
+        "Expected 'build' to depend on 'check', got $buildDependsOn")
     assertFalse(
-        buildDependsOn.contains("${project.name}:ci-check"),
+        buildDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-check" },
         "Expected 'build' NOT to depend on 'ci-check'")
 
     val buildCiTarget = gradleTargets.targets["ci-build"]
@@ -235,8 +237,8 @@ class ProcessTargetsForProjectTest {
     val buildCiDependsOn = buildCiTarget["dependsOn"] as? List<*>
     assertNotNull(buildCiDependsOn, "Build CI dependsOn should not be null in processed targets")
     assertTrue(
-        buildCiDependsOn.contains("${project.name}:ci-check"),
-        "Expected 'ci-build' to depend on 'ci-check' in processed targets")
+        buildCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-check" },
+        "Expected 'ci-build' to depend on 'ci-check' in processed targets, got $buildCiDependsOn")
   }
 
   @Test
@@ -347,11 +349,11 @@ class ProcessTargetsForProjectTest {
     assertNotNull(checkCiDependsOn, "Check CI dependsOn should not be null in processed targets")
 
     assertTrue(
-        checkCiDependsOn.contains("${project.name}:ci-test"),
-        "Expected 'ci-check' to depend on 'ci-test' in processed targets")
+        checkCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-test" },
+        "Expected 'ci-check' to depend on 'ci-test' in processed targets, got $checkCiDependsOn")
     assertTrue(
-        checkCiDependsOn.contains("${project.name}:ci-test-integrationTest"),
-        "Expected 'ci-check' to depend on 'ci-test-integrationTest' in processed targets")
+        checkCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-test-integrationTest" },
+        "Expected 'ci-check' to depend on 'ci-test-integrationTest' in processed targets, got $checkCiDependsOn")
 
     // Verify that individual atomized test targets exist
     assertTrue(
@@ -420,12 +422,12 @@ class ProcessTargetsForProjectTest {
 
     val checkDependsOn = gradleTargets.targets["check"]?.get("dependsOn") as? List<*>
     assertTrue(
-        checkDependsOn?.contains(":app:test") == true,
-        "Expected check to depend on ':app:test', got $checkDependsOn")
+        checkDependsOn?.any { (it as? Map<*, *>)?.get("target") == "test" } == true,
+        "Expected check to depend on 'test', got $checkDependsOn")
 
     val ciCheckDependsOn = gradleTargets.targets["ci-check"]?.get("dependsOn") as? List<*>
     assertTrue(
-        ciCheckDependsOn?.contains(":app:ci-test") == true,
-        "Expected ci-check to depend on ':app:ci-test', got $ciCheckDependsOn")
+        ciCheckDependsOn?.any { (it as? Map<*, *>)?.get("target") == "ci-test" } == true,
+        "Expected ci-check to depend on 'ci-test', got $ciCheckDependsOn")
   }
 }

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTargetsForProjectTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTargetsForProjectTest.kt
@@ -81,7 +81,7 @@ class ProcessTargetsForProjectTest {
         gradleTargets.targets["ci-build"],
         "Expected ci-build target to be present in processed targets")
 
-    // Same-project dependsOn are not included in regular targets (Gradle handles internally)
+    // Same-project dependsOn are included as object format without projects field
     val checkTarget = gradleTargets.targets["check"]
     assertNotNull(checkTarget, "Check target should exist in processed targets")
     val buildTarget = gradleTargets.targets["build"]
@@ -188,7 +188,7 @@ class ProcessTargetsForProjectTest {
         gradleTargets.targets.containsKey("ci-build"),
         "Expected ci-build target to be present as a main target")
 
-    // Same-project dependsOn are not included in regular targets (Gradle handles internally)
+    // Same-project dependsOn are included as object format without projects field
     val checkTarget = gradleTargets.targets["check"]
     assertNotNull(checkTarget, "Check target should exist")
     val buildTarget = gradleTargets.targets["build"]
@@ -395,7 +395,7 @@ class ProcessTargetsForProjectTest {
             workspaceRoot = workspaceRoot,
             atomized = true)
 
-    // Same-project dependsOn are not included in regular targets
+    // Same-project dependsOn are included as object format without projects field
     // CI targets compute dependencies directly from Gradle's task graph
     val ciCheckDependsOn = gradleTargets.targets["ci-check"]?.get("dependsOn") as? List<*>
     assertTrue(

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTargetsForProjectTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTargetsForProjectTest.kt
@@ -81,15 +81,13 @@ class ProcessTargetsForProjectTest {
         gradleTargets.targets["ci-build"],
         "Expected ci-build target to be present in processed targets")
 
-    // Verify dependencies are rewritten for 'check' and 'build' tasks in the returned targets
+    // Same-project dependsOn are not included in regular targets (Gradle handles internally)
     val checkTarget = gradleTargets.targets["check"]
     assertNotNull(checkTarget, "Check target should exist in processed targets")
-    val checkDependsOn = checkTarget["dependsOn"] as? List<*>
-    assertNotNull(checkDependsOn, "Check dependsOn should not be null in processed targets")
-    assertTrue(
-        checkDependsOn.any { (it as? Map<*, *>)?.get("target") == "test" },
-        "Expected 'check' to depend on 'test' in processed targets, got $checkDependsOn")
+    val buildTarget = gradleTargets.targets["build"]
+    assertNotNull(buildTarget, "Build target should exist in processed targets")
 
+    // CI targets compute dependencies directly from Gradle's task graph
     val checkCiTarget = gradleTargets.targets["ci-check"]
     assertNotNull(checkCiTarget, "Check CI target should exist in processed targets")
     val checkCiDependsOn = checkCiTarget["dependsOn"] as? List<*>
@@ -97,14 +95,6 @@ class ProcessTargetsForProjectTest {
     assertTrue(
         checkCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-test" },
         "Expected 'ci-check' to depend on 'ci-test' in processed targets, got $checkCiDependsOn")
-
-    val buildTarget = gradleTargets.targets["build"]
-    assertNotNull(buildTarget, "Build target should exist in processed targets")
-    val buildDependsOn = buildTarget["dependsOn"] as? List<*>
-    assertNotNull(buildDependsOn, "Build dependsOn should not be null in processed targets")
-    assertTrue(
-        buildDependsOn.any { (it as? Map<*, *>)?.get("target") == "check" },
-        "Expected 'build' to depend on 'check' in processed targets, got $buildDependsOn")
 
     val buildCiTarget = gradleTargets.targets["ci-build"]
     assertNotNull(buildCiTarget, "Build CI target should exist in processed targets")
@@ -198,39 +188,24 @@ class ProcessTargetsForProjectTest {
         gradleTargets.targets.containsKey("ci-build"),
         "Expected ci-build target to be present as a main target")
 
-    // Verify dependencies are NOT rewritten for 'check' and 'build' tasks
+    // Same-project dependsOn are not included in regular targets (Gradle handles internally)
     val checkTarget = gradleTargets.targets["check"]
     assertNotNull(checkTarget, "Check target should exist")
-    val checkDependsOn = checkTarget["dependsOn"] as? List<*>
-    assertNotNull(checkDependsOn, "Check dependsOn should not be null")
-    assertTrue(
-        checkDependsOn.any { (it as? Map<*, *>)?.get("target") == "test" },
-        "Expected 'check' to depend on 'test', got $checkDependsOn")
-    assertFalse(
-        checkDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-test" },
-        "Expected 'check' NOT to depend on 'ci-test'")
+    val buildTarget = gradleTargets.targets["build"]
+    assertNotNull(buildTarget, "Build target should exist")
 
+    // CI targets compute dependencies directly from Gradle's task graph
     val checkCiTarget = gradleTargets.targets["ci-check"]
     assertNotNull(checkCiTarget, "Check CI target should exist in processed targets")
     val checkCiDependsOn = checkCiTarget["dependsOn"] as? List<*>
     assertNotNull(checkCiDependsOn, "Check CI dependsOn should not be null in processed targets")
+    // When atomized is false, ci-check should depend on 'test' (not 'ci-test')
     assertFalse(
         checkCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-test" },
         "Expected 'ci-check' to NOT depend on 'ci-test' in processed targets")
     assertTrue(
         checkCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "test" },
         "Expected 'ci-check' to depend on 'test' in processed targets, got $checkCiDependsOn")
-
-    val buildTarget = gradleTargets.targets["build"]
-    assertNotNull(buildTarget, "Build target should exist")
-    val buildDependsOn = buildTarget["dependsOn"] as? List<*>
-    assertNotNull(buildDependsOn, "Build dependsOn should not be null")
-    assertTrue(
-        buildDependsOn.any { (it as? Map<*, *>)?.get("target") == "check" },
-        "Expected 'build' to depend on 'check', got $buildDependsOn")
-    assertFalse(
-        buildDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-check" },
-        "Expected 'build' NOT to depend on 'ci-check'")
 
     val buildCiTarget = gradleTargets.targets["ci-build"]
     assertNotNull(buildCiTarget, "Build CI target should exist in processed targets")
@@ -420,11 +395,8 @@ class ProcessTargetsForProjectTest {
             workspaceRoot = workspaceRoot,
             atomized = true)
 
-    val checkDependsOn = gradleTargets.targets["check"]?.get("dependsOn") as? List<*>
-    assertTrue(
-        checkDependsOn?.any { (it as? Map<*, *>)?.get("target") == "test" } == true,
-        "Expected check to depend on 'test', got $checkDependsOn")
-
+    // Same-project dependsOn are not included in regular targets
+    // CI targets compute dependencies directly from Gradle's task graph
     val ciCheckDependsOn = gradleTargets.targets["ci-check"]?.get("dependsOn") as? List<*>
     assertTrue(
         ciCheckDependsOn?.any { (it as? Map<*, *>)?.get("target") == "ci-test" } == true,

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTargetsForProjectTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTargetsForProjectTest.kt
@@ -93,7 +93,7 @@ class ProcessTargetsForProjectTest {
     val checkCiDependsOn = checkCiTarget["dependsOn"] as? List<*>
     assertNotNull(checkCiDependsOn, "Check CI dependsOn should not be null in processed targets")
     assertTrue(
-        checkCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-test" },
+        checkCiDependsOn.any { (it as? DependsOnEntry)?.target == "ci-test" },
         "Expected 'ci-check' to depend on 'ci-test' in processed targets, got $checkCiDependsOn")
 
     val buildCiTarget = gradleTargets.targets["ci-build"]
@@ -101,7 +101,7 @@ class ProcessTargetsForProjectTest {
     val buildCiDependsOn = buildCiTarget["dependsOn"] as? List<*>
     assertNotNull(buildCiDependsOn, "Build CI dependsOn should not be null in processed targets")
     assertTrue(
-        buildCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-check" },
+        buildCiDependsOn.any { (it as? DependsOnEntry)?.target == "ci-check" },
         "Expected 'ci-build' to depend on 'ci-check' in processed targets, got $buildCiDependsOn")
   }
 
@@ -201,10 +201,10 @@ class ProcessTargetsForProjectTest {
     assertNotNull(checkCiDependsOn, "Check CI dependsOn should not be null in processed targets")
     // When atomized is false, ci-check should depend on 'test' (not 'ci-test')
     assertFalse(
-        checkCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-test" },
+        checkCiDependsOn.any { (it as? DependsOnEntry)?.target == "ci-test" },
         "Expected 'ci-check' to NOT depend on 'ci-test' in processed targets")
     assertTrue(
-        checkCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "test" },
+        checkCiDependsOn.any { (it as? DependsOnEntry)?.target == "test" },
         "Expected 'ci-check' to depend on 'test' in processed targets, got $checkCiDependsOn")
 
     val buildCiTarget = gradleTargets.targets["ci-build"]
@@ -212,7 +212,7 @@ class ProcessTargetsForProjectTest {
     val buildCiDependsOn = buildCiTarget["dependsOn"] as? List<*>
     assertNotNull(buildCiDependsOn, "Build CI dependsOn should not be null in processed targets")
     assertTrue(
-        buildCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-check" },
+        buildCiDependsOn.any { (it as? DependsOnEntry)?.target == "ci-check" },
         "Expected 'ci-build' to depend on 'ci-check' in processed targets, got $buildCiDependsOn")
   }
 
@@ -324,10 +324,10 @@ class ProcessTargetsForProjectTest {
     assertNotNull(checkCiDependsOn, "Check CI dependsOn should not be null in processed targets")
 
     assertTrue(
-        checkCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-test" },
+        checkCiDependsOn.any { (it as? DependsOnEntry)?.target == "ci-test" },
         "Expected 'ci-check' to depend on 'ci-test' in processed targets, got $checkCiDependsOn")
     assertTrue(
-        checkCiDependsOn.any { (it as? Map<*, *>)?.get("target") == "ci-test-integrationTest" },
+        checkCiDependsOn.any { (it as? DependsOnEntry)?.target == "ci-test-integrationTest" },
         "Expected 'ci-check' to depend on 'ci-test-integrationTest' in processed targets, got $checkCiDependsOn")
 
     // Verify that individual atomized test targets exist
@@ -399,7 +399,7 @@ class ProcessTargetsForProjectTest {
     // CI targets compute dependencies directly from Gradle's task graph
     val ciCheckDependsOn = gradleTargets.targets["ci-check"]?.get("dependsOn") as? List<*>
     assertTrue(
-        ciCheckDependsOn?.any { (it as? Map<*, *>)?.get("target") == "ci-test" } == true,
+        ciCheckDependsOn?.any { (it as? DependsOnEntry)?.target == "ci-test" } == true,
         "Expected ci-check to depend on 'ci-test', got $ciCheckDependsOn")
   }
 }

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -82,7 +82,9 @@ class ProcessTaskUtilsTest {
     val dependsOn = getDependsOnForTask(null, taskA, dependencies)
 
     assertNotNull(dependsOn)
-    assertTrue(dependsOn!!.contains("myApp:taskB"))
+    assertTrue(
+        dependsOn!!.any { it["target"] == "taskB" },
+        "Expected dependsOn entry with target 'taskB' but got $dependsOn")
   }
 
   @Test
@@ -273,11 +275,19 @@ class ProcessTaskUtilsTest {
       assertEquals(resultWithPreComputed!!.size, resultWithoutPreComputed!!.size)
       assertEquals(2, resultWithPreComputed.size)
 
-      // Should contain both dependencies
-      assertTrue(resultWithPreComputed.contains("test:taskB"))
-      assertTrue(resultWithPreComputed.contains("test:taskC"))
-      assertTrue(resultWithoutPreComputed.contains("test:taskB"))
-      assertTrue(resultWithoutPreComputed.contains("test:taskC"))
+      // Should contain both dependencies as object entries with target names
+      assertTrue(
+          resultWithPreComputed.any { it["target"] == "taskB" },
+          "Expected target 'taskB' in $resultWithPreComputed")
+      assertTrue(
+          resultWithPreComputed.any { it["target"] == "taskC" },
+          "Expected target 'taskC' in $resultWithPreComputed")
+      assertTrue(
+          resultWithoutPreComputed.any { it["target"] == "taskB" },
+          "Expected target 'taskB' in $resultWithoutPreComputed")
+      assertTrue(
+          resultWithoutPreComputed.any { it["target"] == "taskC" },
+          "Expected target 'taskC' in $resultWithoutPreComputed")
     }
 
     @Test
@@ -478,11 +488,11 @@ class ProcessTaskUtilsTest {
     assertNotNull(result["metadata"])
     assertNotNull(result["options"])
 
-    // Verify dependsOn is populated
-    val dependsOn = result["dependsOn"] as? List<*>
+    // Verify dependsOn is populated with object format
+    @Suppress("UNCHECKED_CAST") val dependsOn = result["dependsOn"] as? List<Map<String, Any>>
     assertNotNull(dependsOn)
     assertEquals(1, dependsOn!!.size)
-    assertEquals("testProject:compile", dependsOn[0])
+    assertEquals("compile", dependsOn[0]["target"])
 
     // Verify inputs contain both regular inputs and consolidated dependentTasksOutputFiles
     val inputs = result["inputs"] as? List<*>
@@ -633,9 +643,12 @@ class ProcessTaskUtilsTest {
         val dependsOn = getDependsOnForTask(null, appTask, dependencies)
 
         assertNotNull(dependsOn)
-        assertTrue(
-            dependsOn!!.contains(":lib:compileJava"),
-            "Expected ':lib:compileJava' but got $dependsOn")
+        val libEntry = dependsOn!!.find { it["target"] == "compileJava" }
+        assertNotNull(
+            libEntry, "Expected dependsOn entry with target 'compileJava' but got $dependsOn")
+        @Suppress("UNCHECKED_CAST") val projects = libEntry!!["projects"] as? List<String>
+        assertNotNull(projects, "Expected 'projects' field for cross-project dependency")
+        assertTrue(projects!!.contains(":lib"), "Expected project ':lib' in $projects")
       } finally {
         rootDir.deleteRecursively()
       }

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -1,5 +1,6 @@
 package dev.nx.gradle.utils
 
+import dev.nx.gradle.data.DependsOnEntry
 import dev.nx.gradle.data.Dependency
 import dev.nx.gradle.data.ExternalNode
 import org.gradle.api.Project
@@ -84,9 +85,8 @@ class ProcessTaskUtilsTest {
     // Same-project dependencies use object format without projects field
     assertNotNull(dependsOn, "Same-project dependsOn should be present")
     assertEquals(1, dependsOn!!.size)
-    assertEquals("taskB", dependsOn[0]["target"])
-    assertFalse(
-        dependsOn[0].containsKey("projects"), "Same-project deps should not have projects field")
+    assertEquals("taskB", dependsOn[0].target)
+    assertNull(dependsOn[0].projects, "Same-project deps should not have projects field")
   }
 
   @Test
@@ -278,7 +278,7 @@ class ProcessTaskUtilsTest {
       assertEquals(2, resultWithPreComputed!!.size)
       assertEquals(2, resultWithoutPreComputed!!.size)
       assertTrue(
-          resultWithPreComputed.all { !it.containsKey("projects") },
+          resultWithPreComputed.all { it.projects == null },
           "Same-project deps should not have projects field")
     }
 
@@ -484,7 +484,7 @@ class ProcessTaskUtilsTest {
     val dependsOn = result["dependsOn"] as? List<*>
     assertNotNull(dependsOn, "Same-project dependsOn should be present")
     assertTrue(
-        dependsOn!!.any { (it as? Map<*, *>)?.get("target") == "compile" },
+        dependsOn!!.any { (it as? DependsOnEntry)?.target == "compile" },
         "Expected dependsOn to contain 'compile', got $dependsOn")
 
     // Verify inputs contain both regular inputs and consolidated dependentTasksOutputFiles
@@ -636,12 +636,11 @@ class ProcessTaskUtilsTest {
         val dependsOn = getDependsOnForTask(null, appTask, dependencies)
 
         assertNotNull(dependsOn)
-        val libEntry = dependsOn!!.find { it["target"] == "compileJava" }
+        val libEntry = dependsOn!!.find { it.target == "compileJava" }
         assertNotNull(
             libEntry, "Expected dependsOn entry with target 'compileJava' but got $dependsOn")
-        @Suppress("UNCHECKED_CAST") val projects = libEntry!!["projects"] as? List<String>
-        assertNotNull(projects, "Expected 'projects' field for cross-project dependency")
-        assertTrue(projects!!.contains(":lib"), "Expected project ':lib' in $projects")
+        assertNotNull(libEntry!!.projects, "Expected 'projects' field for cross-project dependency")
+        assertTrue(libEntry.projects!!.contains(":lib"), "Expected project ':lib' in ${libEntry.projects}")
       } finally {
         rootDir.deleteRecursively()
       }
@@ -701,17 +700,17 @@ class ProcessTaskUtilsTest {
         // Should have 2 entries: "classes" (with lib + util) and "jar" (with lib)
         assertEquals(2, dependsOn!!.size, "Expected 2 dependsOn entries, got $dependsOn")
 
-        val classesEntry = dependsOn.find { it["target"] == "classes" }
+        val classesEntry = dependsOn.find { it.target == "classes" }
         assertNotNull(classesEntry, "Expected 'classes' target in $dependsOn")
-        @Suppress("UNCHECKED_CAST") val classesProjects = classesEntry!!["projects"] as List<String>
-        assertTrue(classesProjects.contains(":lib"), "Expected :lib in classes projects")
-        assertTrue(classesProjects.contains(":util"), "Expected :util in classes projects")
+        assertNotNull(classesEntry!!.projects, "Expected projects for classes entry")
+        assertTrue(classesEntry.projects!!.contains(":lib"), "Expected :lib in classes projects")
+        assertTrue(classesEntry.projects!!.contains(":util"), "Expected :util in classes projects")
 
-        val jarEntry = dependsOn.find { it["target"] == "jar" }
+        val jarEntry = dependsOn.find { it.target == "jar" }
         assertNotNull(jarEntry, "Expected 'jar' target in $dependsOn")
-        @Suppress("UNCHECKED_CAST") val jarProjects = jarEntry!!["projects"] as List<String>
-        assertTrue(jarProjects.contains(":lib"), "Expected :lib in jar projects")
-        assertEquals(1, jarProjects.size, "jar should only have 1 project")
+        assertNotNull(jarEntry!!.projects, "Expected projects for jar entry")
+        assertTrue(jarEntry.projects!!.contains(":lib"), "Expected :lib in jar projects")
+        assertEquals(1, jarEntry.projects!!.size, "jar should only have 1 project")
       } finally {
         rootDir.deleteRecursively()
       }

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -1,7 +1,7 @@
 package dev.nx.gradle.utils
 
-import dev.nx.gradle.data.DependsOnEntry
 import dev.nx.gradle.data.Dependency
+import dev.nx.gradle.data.DependsOnEntry
 import dev.nx.gradle.data.ExternalNode
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
@@ -640,7 +640,8 @@ class ProcessTaskUtilsTest {
         assertNotNull(
             libEntry, "Expected dependsOn entry with target 'compileJava' but got $dependsOn")
         assertNotNull(libEntry!!.projects, "Expected 'projects' field for cross-project dependency")
-        assertTrue(libEntry.projects!!.contains(":lib"), "Expected project ':lib' in ${libEntry.projects}")
+        assertTrue(
+            libEntry.projects!!.contains(":lib"), "Expected project ':lib' in ${libEntry.projects}")
       } finally {
         rootDir.deleteRecursively()
       }

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -67,7 +67,7 @@ class ProcessTaskUtilsTest {
   }
 
   @Test
-  fun `test getDependsOnForTask with direct dependsOn`() {
+  fun `test getDependsOnForTask with direct dependsOn same project returns null`() {
     val project = ProjectBuilder.builder().withName("myApp").build()
     // Create a build file so the task dependencies are properly detected
     val buildFile = java.io.File(project.projectDir, "build.gradle")
@@ -81,10 +81,9 @@ class ProcessTaskUtilsTest {
     val dependencies = mutableSetOf<Dependency>()
     val dependsOn = getDependsOnForTask(null, taskA, dependencies)
 
-    assertNotNull(dependsOn)
-    assertTrue(
-        dependsOn!!.any { it["target"] == "taskB" },
-        "Expected dependsOn entry with target 'taskB' but got $dependsOn")
+    // Same-project dependencies are not included in dependsOn;
+    // Gradle handles same-project task ordering internally.
+    assertNull(dependsOn)
   }
 
   @Test
@@ -246,7 +245,7 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
-    fun `test getDependsOnForTask with pre-computed dependsOnTasks`() {
+    fun `test getDependsOnForTask with pre-computed dependsOnTasks same project returns null`() {
       // Create a build file so the task dependencies are properly detected
       val buildFile = java.io.File(project.projectDir, "build.gradle")
       buildFile.writeText("// test build file")
@@ -269,25 +268,10 @@ class ProcessTaskUtilsTest {
       val dependencies2 = mutableSetOf<Dependency>()
       val resultWithoutPreComputed = getDependsOnForTask(null, taskA, dependencies2)
 
-      // Both results should be identical
-      assertNotNull(resultWithPreComputed)
-      assertNotNull(resultWithoutPreComputed)
-      assertEquals(resultWithPreComputed!!.size, resultWithoutPreComputed!!.size)
-      assertEquals(2, resultWithPreComputed.size)
-
-      // Should contain both dependencies as object entries with target names
-      assertTrue(
-          resultWithPreComputed.any { it["target"] == "taskB" },
-          "Expected target 'taskB' in $resultWithPreComputed")
-      assertTrue(
-          resultWithPreComputed.any { it["target"] == "taskC" },
-          "Expected target 'taskC' in $resultWithPreComputed")
-      assertTrue(
-          resultWithoutPreComputed.any { it["target"] == "taskB" },
-          "Expected target 'taskB' in $resultWithoutPreComputed")
-      assertTrue(
-          resultWithoutPreComputed.any { it["target"] == "taskC" },
-          "Expected target 'taskC' in $resultWithoutPreComputed")
+      // Same-project dependencies are not included in dependsOn;
+      // Gradle handles same-project task ordering internally.
+      assertNull(resultWithPreComputed)
+      assertNull(resultWithoutPreComputed)
     }
 
     @Test
@@ -488,11 +472,8 @@ class ProcessTaskUtilsTest {
     assertNotNull(result["metadata"])
     assertNotNull(result["options"])
 
-    // Verify dependsOn is populated with object format
-    @Suppress("UNCHECKED_CAST") val dependsOn = result["dependsOn"] as? List<Map<String, Any>>
-    assertNotNull(dependsOn)
-    assertEquals(1, dependsOn!!.size)
-    assertEquals("compile", dependsOn[0]["target"])
+    // Same-project dependsOn should not be included (Gradle handles internally)
+    assertNull(result["dependsOn"])
 
     // Verify inputs contain both regular inputs and consolidated dependentTasksOutputFiles
     val inputs = result["inputs"] as? List<*>

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -81,9 +81,12 @@ class ProcessTaskUtilsTest {
     val dependencies = mutableSetOf<Dependency>()
     val dependsOn = getDependsOnForTask(null, taskA, dependencies)
 
-    // Same-project dependencies are not included in dependsOn;
-    // Gradle handles same-project task ordering internally.
-    assertNull(dependsOn)
+    // Same-project dependencies use object format without projects field
+    assertNotNull(dependsOn, "Same-project dependsOn should be present")
+    assertEquals(1, dependsOn!!.size)
+    assertEquals("taskB", dependsOn[0]["target"])
+    assertFalse(
+        dependsOn[0].containsKey("projects"), "Same-project deps should not have projects field")
   }
 
   @Test
@@ -268,10 +271,15 @@ class ProcessTaskUtilsTest {
       val dependencies2 = mutableSetOf<Dependency>()
       val resultWithoutPreComputed = getDependsOnForTask(null, taskA, dependencies2)
 
-      // Same-project dependencies are not included in dependsOn;
-      // Gradle handles same-project task ordering internally.
-      assertNull(resultWithPreComputed)
-      assertNull(resultWithoutPreComputed)
+      // Same-project dependencies use object format without projects field
+      assertNotNull(
+          resultWithPreComputed, "Same-project dependsOn should be present (pre-computed)")
+      assertNotNull(resultWithoutPreComputed, "Same-project dependsOn should be present (computed)")
+      assertEquals(2, resultWithPreComputed!!.size)
+      assertEquals(2, resultWithoutPreComputed!!.size)
+      assertTrue(
+          resultWithPreComputed.all { !it.containsKey("projects") },
+          "Same-project deps should not have projects field")
     }
 
     @Test
@@ -472,8 +480,12 @@ class ProcessTaskUtilsTest {
     assertNotNull(result["metadata"])
     assertNotNull(result["options"])
 
-    // Same-project dependsOn should not be included (Gradle handles internally)
-    assertNull(result["dependsOn"])
+    // Same-project dependsOn should be present as object format without projects field
+    val dependsOn = result["dependsOn"] as? List<*>
+    assertNotNull(dependsOn, "Same-project dependsOn should be present")
+    assertTrue(
+        dependsOn!!.any { (it as? Map<*, *>)?.get("target") == "compile" },
+        "Expected dependsOn to contain 'compile', got $dependsOn")
 
     // Verify inputs contain both regular inputs and consolidated dependentTasksOutputFiles
     val inputs = result["inputs"] as? List<*>
@@ -630,6 +642,76 @@ class ProcessTaskUtilsTest {
         @Suppress("UNCHECKED_CAST") val projects = libEntry!!["projects"] as? List<String>
         assertNotNull(projects, "Expected 'projects' field for cross-project dependency")
         assertTrue(projects!!.contains(":lib"), "Expected project ':lib' in $projects")
+      } finally {
+        rootDir.deleteRecursively()
+      }
+    }
+
+    @Test
+    fun `getDependsOnForTask returns multiple entries for different cross-project targets`() {
+      val rootDir =
+          java.io.File.createTempFile("root", "").apply {
+            delete()
+            mkdirs()
+          }
+      val appDir = java.io.File(rootDir, "app").apply { mkdirs() }
+      val libDir = java.io.File(rootDir, "lib").apply { mkdirs() }
+      val utilDir = java.io.File(rootDir, "util").apply { mkdirs() }
+
+      try {
+        val rootProject = ProjectBuilder.builder().withProjectDir(rootDir).withName("root").build()
+        val appProject =
+            ProjectBuilder.builder()
+                .withParent(rootProject)
+                .withProjectDir(appDir)
+                .withName("app")
+                .build()
+        val libProject =
+            ProjectBuilder.builder()
+                .withParent(rootProject)
+                .withProjectDir(libDir)
+                .withName("lib")
+                .build()
+        val utilProject =
+            ProjectBuilder.builder()
+                .withParent(rootProject)
+                .withProjectDir(utilDir)
+                .withName("util")
+                .build()
+
+        java.io.File(appDir, "build.gradle").writeText("// app")
+        java.io.File(libDir, "build.gradle").writeText("// lib")
+        java.io.File(utilDir, "build.gradle").writeText("// util")
+
+        // Different targets on different projects
+        val libClasses = libProject.tasks.register("classes").get()
+        val libJar = libProject.tasks.register("jar").get()
+        val utilClasses = utilProject.tasks.register("classes").get()
+
+        // app:build depends on lib:classes, lib:jar, and util:classes
+        val appTask =
+            appProject.tasks.register("build").get().apply {
+              dependsOn(libClasses, libJar, utilClasses)
+            }
+
+        val dependencies = mutableSetOf<Dependency>()
+        val dependsOn = getDependsOnForTask(null, appTask, dependencies)
+
+        assertNotNull(dependsOn, "dependsOn should not be null")
+        // Should have 2 entries: "classes" (with lib + util) and "jar" (with lib)
+        assertEquals(2, dependsOn!!.size, "Expected 2 dependsOn entries, got $dependsOn")
+
+        val classesEntry = dependsOn.find { it["target"] == "classes" }
+        assertNotNull(classesEntry, "Expected 'classes' target in $dependsOn")
+        @Suppress("UNCHECKED_CAST") val classesProjects = classesEntry!!["projects"] as List<String>
+        assertTrue(classesProjects.contains(":lib"), "Expected :lib in classes projects")
+        assertTrue(classesProjects.contains(":util"), "Expected :util in classes projects")
+
+        val jarEntry = dependsOn.find { it["target"] == "jar" }
+        assertNotNull(jarEntry, "Expected 'jar' target in $dependsOn")
+        @Suppress("UNCHECKED_CAST") val jarProjects = jarEntry!!["projects"] as List<String>
+        assertTrue(jarProjects.contains(":lib"), "Expected :lib in jar projects")
+        assertEquals(1, jarProjects.size, "jar should only have 1 project")
       } finally {
         rootDir.deleteRecursively()
       }

--- a/packages/gradle/src/executors/gradle/get-exclude-task.spec.ts
+++ b/packages/gradle/src/executors/gradle/get-exclude-task.spec.ts
@@ -114,6 +114,42 @@ describe('getExcludeTasks', () => {
     );
     expect(excludes).toEqual(new Set());
   });
+
+  it('should handle object-format dependsOn entries', () => {
+    const objectNodes: any = {
+      app1: {
+        name: 'app1',
+        type: 'app',
+        data: {
+          root: 'app1',
+          targets: {
+            build: {
+              dependsOn: [
+                { target: 'compileJava' },
+                { target: 'build', projects: ['app2'] },
+              ],
+              options: { taskName: ':app1:build' },
+            },
+            compileJava: { options: { taskName: ':app1:compileJava' } },
+          },
+        },
+      },
+      app2: {
+        name: 'app2',
+        type: 'app',
+        data: {
+          root: 'app2',
+          targets: {
+            build: { dependsOn: [], options: { taskName: ':app2:build' } },
+          },
+        },
+      },
+    };
+    const targets = new Set<string>(['app1:build']);
+    const runningTaskIds = new Set<string>(['app1:build']);
+    const excludes = getExcludeTasks(targets, objectNodes, runningTaskIds);
+    expect(excludes).toEqual(new Set([':app1:compileJava', ':app2:build']));
+  });
 });
 
 describe('getAllDependsOn', () => {
@@ -176,5 +212,33 @@ describe('getAllDependsOn', () => {
   it('should not include the starting task in the result', () => {
     const dependencies = getAllDependsOn(nodes, 'a', 'build');
     expect(dependencies).not.toContain('a:build');
+  });
+
+  it('should handle object-format dependsOn entries', () => {
+    const objectNodes: any = {
+      app: {
+        name: 'app',
+        type: 'app',
+        data: {
+          root: 'app',
+          targets: {
+            build: {
+              dependsOn: [
+                { target: 'compileJava' },
+                { target: 'jar', projects: ['lib'] },
+              ],
+            },
+            compileJava: {},
+          },
+        },
+      },
+      lib: {
+        name: 'lib',
+        type: 'lib',
+        data: { root: 'lib', targets: { jar: {} } },
+      },
+    };
+    const dependencies = getAllDependsOn(objectNodes, 'app', 'build');
+    expect(dependencies).toEqual(new Set(['app:compileJava', 'lib:jar']));
   });
 });

--- a/packages/gradle/src/executors/gradle/get-exclude-task.ts
+++ b/packages/gradle/src/executors/gradle/get-exclude-task.ts
@@ -4,6 +4,36 @@ import {
 } from 'nx/src/config/project-graph';
 
 /**
+ * Resolves a dependsOn entry to an Nx task ID (project:target format).
+ * Handles both string format ("project:target") and object format
+ * ({ target: "name", projects?: ["proj1"] }).
+ * For same-project object deps (no projects field), uses the owning project name.
+ */
+function resolveDepToTaskId(
+  dep: string | { target?: string; projects?: string | string[] },
+  owningProject: string
+): string | null {
+  if (typeof dep === 'string') {
+    return dep;
+  }
+  const target = dep?.target;
+  if (!target) {
+    return null;
+  }
+  if (dep.projects) {
+    const projectList = Array.isArray(dep.projects)
+      ? dep.projects
+      : [dep.projects];
+    // For cross-project deps, use the first project
+    return projectList[0] !== 'self'
+      ? `${projectList[0]}:${target}`
+      : `${owningProject}:${target}`;
+  }
+  // Same-project dep (no projects field)
+  return `${owningProject}:${target}`;
+}
+
+/**
  * Returns Gradle CLI arguments to exclude dependent tasks
  * that are not part of the current execution set.
  *
@@ -29,9 +59,9 @@ export function getExcludeTasks(
     const taskDeps = nodes[project]?.data?.targets?.[target]?.dependsOn ?? [];
 
     for (const dep of taskDeps) {
-      const taskId = typeof dep === 'string' ? dep : dep?.target;
-      if (taskId && !runningTaskIds.has(taskId)) {
-        const gradleTaskName = getGradleTaskNameWithNxTaskId(taskId, nodes);
+      const depTaskId = resolveDepToTaskId(dep, project);
+      if (depTaskId && !runningTaskIds.has(depTaskId)) {
+        const gradleTaskName = getGradleTaskNameWithNxTaskId(depTaskId, nodes);
         if (gradleTaskName && !includeDependsOnTasks.has(gradleTaskName)) {
           excludes.add(gradleTaskName);
         }
@@ -71,7 +101,7 @@ export function getAllDependsOn(
           ?.dependsOn ?? [];
 
       for (const dep of directDependencies) {
-        const depTaskId = typeof dep === 'string' ? dep : dep?.target;
+        const depTaskId = resolveDepToTaskId(dep, currentProjectName);
         if (depTaskId && !allDependsOn.has(depTaskId)) {
           stack.push(depTaskId);
         }


### PR DESCRIPTION
## Current Behavior

The Gradle plugin generates `dependsOn` entries using the shorthand string format (e.g., `"projectName:taskName"`). This doesn't leverage the full object syntax that Nx supports.

## Expected Behavior

`dependsOn` entries now use the object format:
- Same-project dependencies: `{ "target": "taskName" }`
- Cross-project dependencies: `{ "target": "taskName", "projects": ["proj1", "proj2"] }` with projects grouped by target name

This is more explicit, consistent with the CI targets code (which already used object format), and enables the `projects` array for grouping multiple project dependencies under a single target.

## Related Issue(s)

N/A - internal improvement