### PR TITLE
fix(core): prevent TUI panic when Nx Console is connected

### DIFF
--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -401,7 +401,7 @@ impl AppLifeCycle {
         Ok(())
     }
 
-    #[napi]
+    #[napi(async_runtime)]
     pub fn end_command(&self) -> napi::Result<()> {
         self.with_app(|app| app.end_command());
         Ok(())


### PR DESCRIPTION
## Current Behavior

After the napi v2→v3 migration, running tasks with TUI enabled while Nx Console is connected causes a panic: `there is no reactor running, must be called from the context of a Tokio 1.x runtime`. This happens because `end_command` is a sync NAPI callback that calls `end_running_tasks()` which uses `tokio::spawn`, but napi v3 no longer wraps sync callbacks with Tokio runtime context by default.

## Expected Behavior

Tasks complete without panic when Nx Console is connected and TUI is enabled.