### PR TITLE
fix(core): respect --parallel limit for discrete task concurrency

### DIFF
--- a/packages/nx/src/tasks-runner/default-tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/default-tasks-runner.ts
@@ -1,5 +1,5 @@
 import { TasksRunner, TaskStatus } from './tasks-runner';
-import { getThreadCount, TaskOrchestrator } from './task-orchestrator';
+import { getThreadPoolSize, TaskOrchestrator } from './task-orchestrator';
 import { TaskHasher } from '../hasher/task-hasher';
 import { LifeCycle } from './life-cycle';
 import { ProjectGraph } from '../config/project-graph';
@@ -122,7 +122,7 @@ export const defaultTasksRunner: TasksRunner<
     daemon: DaemonClient;
   }
 ): Promise<{ [id: string]: TaskStatus }> => {
-  const threadCount = getThreadCount(options, context.taskGraph);
+  const { total: threadCount } = getThreadPoolSize(options, context.taskGraph);
   await options.lifeCycle.startCommand(threadCount);
   try {
     return await runAllTasks(options, context);

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -90,6 +90,7 @@ export class TaskOrchestrator {
   private waitingForTasks: Function[] = [];
 
   private groups = [];
+  private continuousTasksStarted = 0;
 
   private bailed = false;
   private resolveStopPromise: (() => void) | null = null;
@@ -154,17 +155,23 @@ export class TaskOrchestrator {
 
     performance.mark('task-execution:start');
 
-    const threadCount = getThreadCount(this.options, this.taskGraph);
+    const { discrete, continuous, total } = getThreadPoolSize(
+      this.options,
+      this.taskGraph
+    );
 
     const threads = [];
 
-    process.stdout.setMaxListeners(threadCount + defaultMaxListeners);
-    process.stderr.setMaxListeners(threadCount + defaultMaxListeners);
-    process.setMaxListeners(threadCount + defaultMaxListeners);
+    process.stdout.setMaxListeners(total + defaultMaxListeners);
+    process.stderr.setMaxListeners(total + defaultMaxListeners);
+    process.setMaxListeners(total + defaultMaxListeners);
 
     // initial seeding of the queue
-    for (let i = 0; i < threadCount; ++i) {
-      threads.push(this.executeNextBatchOfTasksUsingTaskSchedule());
+    for (let i = 0; i < discrete; ++i) {
+      threads.push(this.executeDiscreteTaskLoop());
+    }
+    for (let i = 0; i < continuous; ++i) {
+      threads.push(this.executeContinuousTaskLoop(continuous));
     }
 
     await Promise.race([
@@ -204,33 +211,54 @@ export class TaskOrchestrator {
     return this.tasksSchedule.nextBatch();
   }
 
-  private async executeNextBatchOfTasksUsingTaskSchedule() {
-    // completed all the tasks
-    if (!this.tasksSchedule.hasTasks() || this.bailed || this.stopRequested) {
-      return null;
-    }
-
+  private async executeDiscreteTaskLoop() {
     const doNotSkipCache =
       this.options.skipNxCache === false ||
       this.options.skipNxCache === undefined;
 
-    this.processAllScheduledTasks();
-    const batch = this.nextBatch();
-    if (batch) {
-      const groupId = this.closeGroup();
+    while (true) {
+      // completed all the tasks
+      if (!this.tasksSchedule.hasTasks() || this.bailed || this.stopRequested) {
+        return null;
+      }
 
-      await this.applyFromCacheOrRunBatch(doNotSkipCache, batch, groupId);
+      this.processAllScheduledTasks();
 
-      this.openGroup(groupId);
+      const batch = this.nextBatch();
+      if (batch) {
+        const groupId = this.closeGroup();
+        await this.applyFromCacheOrRunBatch(doNotSkipCache, batch, groupId);
+        this.openGroup(groupId);
+        continue;
+      }
 
-      return this.executeNextBatchOfTasksUsingTaskSchedule();
+      const task = this.tasksSchedule.nextTask((t) => !t.continuous);
+      if (task) {
+        const groupId = this.closeGroup();
+        await this.applyFromCacheOrRunTask(doNotSkipCache, task, groupId);
+        this.openGroup(groupId);
+        continue;
+      }
+
+      // block until some other task completes, then try again
+      await new Promise((res) => this.waitingForTasks.push(res));
     }
+  }
 
-    const task = this.tasksSchedule.nextTask();
-    if (task) {
-      const groupId = this.closeGroup();
+  private async executeContinuousTaskLoop(continuousTaskCount: number) {
+    while (true) {
+      // completed all the tasks
+      if (!this.tasksSchedule.hasTasks() || this.bailed || this.stopRequested) {
+        return null;
+      }
 
-      if (task.continuous) {
+      this.processAllScheduledTasks();
+
+      const task = this.tasksSchedule.nextTask((t) => t.continuous);
+      if (task) {
+        // Use a separate groupId space (parallel..parallel+N) so continuous tasks
+        // don't consume discrete group slots
+        const groupId = this.options.parallel + this.continuousTasksStarted++;
         const runningTask = await this.startContinuousTask(task, groupId);
 
         if (this.initializingTaskIds.has(task.id)) {
@@ -245,19 +273,22 @@ export class TaskOrchestrator {
             });
           });
         }
-      } else {
-        await this.applyFromCacheOrRunTask(doNotSkipCache, task, groupId);
+
+        // all continuous tasks have been started, thread can exit
+        if (this.continuousTasksStarted >= continuousTaskCount) {
+          return null;
+        }
+        continue;
       }
 
-      this.openGroup(groupId);
+      // all continuous tasks have been started, thread can exit
+      if (this.continuousTasksStarted >= continuousTaskCount) {
+        return null;
+      }
 
-      return this.executeNextBatchOfTasksUsingTaskSchedule();
+      // block until some other task completes, then try again
+      await new Promise((res) => this.waitingForTasks.push(res));
     }
-
-    // block until some other task completes, then try again
-    return new Promise((res) => this.waitingForTasks.push(res)).then(() =>
-      this.executeNextBatchOfTasksUsingTaskSchedule()
-    );
   }
 
   private processTasks(taskIds: string[]) {
@@ -1161,7 +1192,7 @@ export class TaskOrchestrator {
     );
   }
 
-  private closeGroup() {
+  private closeGroup(): number {
     for (let i = 0; i < this.options.parallel; i++) {
       if (!this.groups[i]) {
         this.groups[i] = true;
@@ -1378,10 +1409,10 @@ export class TaskOrchestrator {
   }
 }
 
-export function getThreadCount(
+export function getThreadPoolSize(
   options: NxArgs & DefaultTasksRunnerOptions,
   taskGraph: TaskGraph
-) {
+): { discrete: number; continuous: number; total: number } {
   if (
     (options as any)['parallel'] === 'false' ||
     (options as any)['parallel'] === false
@@ -1396,9 +1427,13 @@ export function getThreadCount(
     (options as any)['parallel'] = Number((options as any)['maxParallel'] || 3);
   }
 
-  const maxParallel =
-    options['parallel'] +
-    Object.values(taskGraph.tasks).filter((t) => t.continuous).length;
-  const totalTasks = Object.keys(taskGraph.tasks).length;
-  return Math.min(maxParallel, totalTasks);
+  const continuousCount = Object.values(taskGraph.tasks).filter(
+    (t) => t.continuous
+  ).length;
+
+  const discrete = options['parallel'];
+  const continuous = continuousCount;
+  const total = discrete + continuous;
+
+  return { discrete, continuous, total };
 }

--- a/packages/nx/src/tasks-runner/tasks-schedule.spec.ts
+++ b/packages/nx/src/tasks-runner/tasks-schedule.spec.ts
@@ -7,7 +7,11 @@ import * as executorUtils from '../command-line/run/executor-utils';
 import * as taskHistoryUtils from '../utils/task-history';
 import type { LifeCycle } from './life-cycle';
 
-function createMockTask(id: string, parallelism: boolean = true): Task {
+function createMockTask(
+  id: string,
+  parallelism: boolean = true,
+  continuous: boolean = false
+): Task {
   const [project, target] = id.split(':');
   return {
     id,
@@ -18,7 +22,7 @@ function createMockTask(id: string, parallelism: boolean = true): Task {
     outputs: [],
     overrides: {},
     parallelism,
-    continuous: false,
+    continuous,
   };
 }
 
@@ -1108,6 +1112,122 @@ describe('TasksSchedule', () => {
 
       expect(taskSchedule.nextBatch()).toBeNull();
       expect(taskSchedule.nextTask()).not.toBeNull();
+    });
+  });
+
+  describe('nextTask with filter', () => {
+    let taskSchedule: TasksSchedule;
+    let discreteTask: Task;
+    let continuousTask1: Task;
+    let continuousTask2: Task;
+
+    beforeEach(async () => {
+      discreteTask = createMockTask('app1:build', true, false);
+      continuousTask1 = createMockTask('app2:serve', true, true);
+      continuousTask2 = createMockTask('app3:serve', true, true);
+
+      const taskGraph: TaskGraph = {
+        tasks: {
+          'app1:build': discreteTask,
+          'app2:serve': continuousTask1,
+          'app3:serve': continuousTask2,
+        },
+        dependencies: {
+          'app1:build': [],
+          'app2:serve': [],
+          'app3:serve': [],
+        },
+        continuousDependencies: {
+          'app1:build': [],
+          'app2:serve': [],
+          'app3:serve': [],
+        },
+        roots: ['app1:build', 'app2:serve', 'app3:serve'],
+      };
+
+      jest.spyOn(nxJsonUtils, 'readNxJson').mockReturnValue({});
+      jest.spyOn(executorUtils, 'getExecutorInformation').mockReturnValue({
+        schema: { version: 2, properties: {} },
+        implementationFactory: jest.fn(),
+        batchImplementationFactory: jest.fn(),
+        isNgCompat: true,
+        isNxExecutor: true,
+      });
+
+      const projectGraph: ProjectGraph = {
+        nodes: {
+          app1: {
+            data: {
+              root: 'app1',
+              targets: {
+                build: { executor: 'awesome-executors:build' },
+              },
+            },
+            name: 'app1',
+            type: 'app',
+          },
+          app2: {
+            data: {
+              root: 'app2',
+              targets: {
+                serve: { executor: 'awesome-executors:serve' },
+              },
+            },
+            name: 'app2',
+            type: 'app',
+          },
+          app3: {
+            data: {
+              root: 'app3',
+              targets: {
+                serve: { executor: 'awesome-executors:serve' },
+              },
+            },
+            name: 'app3',
+            type: 'app',
+          },
+        } as any,
+        dependencies: {},
+        externalNodes: {},
+        version: '5',
+      };
+
+      taskHistory.getEstimatedTaskTimings.mockReturnValue({});
+      taskSchedule = new TasksSchedule(projectGraph, taskGraph, {
+        lifeCycle,
+      });
+      await taskSchedule.init();
+
+      process.env['NX_BATCH_MODE'] = 'false';
+      await taskSchedule.scheduleNextTasks();
+    });
+
+    afterEach(() => {
+      delete process.env['NX_BATCH_MODE'];
+    });
+
+    it('should return first matching task when filter is provided', () => {
+      const task = taskSchedule.nextTask((t) => t.continuous);
+      expect(task).toBeDefined();
+      expect(task.continuous).toBe(true);
+    });
+
+    it('should skip non-matching tasks', () => {
+      const task = taskSchedule.nextTask((t) => !t.continuous);
+      expect(task).toEqual(discreteTask);
+    });
+
+    it('should return null when no tasks match filter', () => {
+      // Consume the discrete task
+      taskSchedule.nextTask((t) => !t.continuous);
+      // No more discrete tasks
+      const task = taskSchedule.nextTask((t) => !t.continuous);
+      expect(task).toBeNull();
+    });
+
+    it('should return first task when no filter is provided', () => {
+      const task = taskSchedule.nextTask();
+      expect(task).toBeDefined();
     });
   });
 });

--- a/packages/nx/src/tasks-runner/tasks-schedule.ts
+++ b/packages/nx/src/tasks-runner/tasks-schedule.ts
@@ -89,12 +89,21 @@ export class TasksSchedule {
     };
   }
 
-  public nextTask() {
-    if (this.scheduledTasks.length > 0) {
-      return this.taskGraph.tasks[this.scheduledTasks.shift()];
-    } else {
+  public nextTask(filter?: (task: Task) => boolean) {
+    if (this.scheduledTasks.length === 0) {
       return null;
     }
+    if (!filter) {
+      return this.taskGraph.tasks[this.scheduledTasks.shift()];
+    }
+    const idx = this.scheduledTasks.findIndex((id) =>
+      filter(this.taskGraph.tasks[id])
+    );
+    if (idx === -1) {
+      return null;
+    }
+    const [taskId] = this.scheduledTasks.splice(idx, 1);
+    return this.taskGraph.tasks[taskId];
   }
 
   public nextBatch(): Batch {


### PR DESCRIPTION
## Current Behavior

`--parallel=N` doesn't cap discrete task concurrency when continuous tasks exist. `getThreadCount` inflates the thread count to `N + continuousCount`, and all threads are fungible — any thread picks up any task. With `--parallel=1` and 2 continuous tasks, 3 threads run, allowing up to 3 discrete tasks concurrently.

## Expected Behavior

`--parallel=N` caps discrete task concurrency to N. Continuous tasks get dedicated threads that don't inflate the discrete limit.

### Changes

- **Two-pool thread model**: Split the unified thread pool into discrete and continuous pools. Each pool runs its own loop and only picks up matching tasks.
- **`getThreadPoolSize`** (renamed from `getThreadCount`): Returns `{ discrete, continuous, total }`. Discrete pool = `options.parallel`, continuous pool = number of continuous tasks.
- **`executeDiscreteTaskLoop`**: Handles batches + discrete tasks only. Uses slot-based groupIds via `closeGroup`/`openGroup`.
- **`executeContinuousTaskLoop`**: Handles continuous tasks only. Uses counter-based groupIds (`parallel + n++`). Exits once all continuous tasks have been started.
- **`nextTask(filter?)`** on `TasksSchedule`: Optional filter param to dequeue only matching tasks. Scheduler stays unaware of pools/limits.

## Related Issue(s)

Fixes #34117
Fixes #31494 