### PR TITLE
fix(core): surface clearer error when CNW hits SANDBOX_FAILED

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -569,6 +569,16 @@ async function normalizeArgsMiddleware(
     if (!templateProvided && !presetProvided) {
       const workspaceName = (argv.name as string) || (argv._[0] as string);
       writeAiOutput(buildTemplateRequiredResult(workspaceName));
+      await recordStat({
+        nxVersion,
+        command: 'create-nx-workspace',
+        useCloud: false,
+        meta: {
+          type: 'cancel',
+          flowVariant: getFlowVariant(),
+          aiAgent: true,
+        },
+      });
       process.exit(0); // Exit 0 - JSON output has success: false, AI parses that
     }
 

--- a/packages/create-nx-workspace/src/create-sandbox.ts
+++ b/packages/create-nx-workspace/src/create-sandbox.ts
@@ -47,10 +47,29 @@ export async function createSandbox(packageManager: PackageManager) {
     installSpinner.succeed();
   } catch (e) {
     installSpinner.fail();
+    const logFile = e instanceof CnwError ? e.logFile : undefined;
+    const exitCode = e instanceof CnwError ? e.exitCode : undefined;
     const message = e instanceof Error ? e.message : String(e);
+
+    const lines = [`Failed to install dependencies`];
+    if (message?.trim()) {
+      lines.push(message.trim());
+    }
+    if (exitCode != null) {
+      lines.push(`Exit code: ${exitCode}`);
+    }
+    if (logFile) {
+      lines.push(`Log file: ${logFile}`);
+    }
+    lines.push(
+      `\nPlease verify that "${install}" runs successfully in a temporary directory.`
+    );
+
     throw new CnwError(
       'SANDBOX_FAILED',
-      `Failed to install dependencies: ${message}`
+      lines.join('\n'),
+      logFile,
+      exitCode ?? undefined
     );
   } finally {
     installSpinner.stop();

--- a/packages/create-nx-workspace/src/utils/child-process-utils.ts
+++ b/packages/create-nx-workspace/src/utils/child-process-utils.ts
@@ -1,7 +1,7 @@
 import { spawn, exec } from 'child_process';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
-import { CreateNxWorkspaceError } from './error-utils';
+import { CnwError } from './error-utils';
 
 /**
  * Use spawn only for interactive shells
@@ -47,7 +47,12 @@ export function execAndWait(
   return new Promise<{ code: number; stdout: string }>((res, rej) => {
     exec(
       command,
-      { cwd, env: { ...process.env, NX_DAEMON: 'false' }, windowsHide: false },
+      {
+        cwd,
+        env: { ...process.env, NX_DAEMON: 'false' },
+        windowsHide: false,
+        maxBuffer: 1024 * 1024 * 10, // 10MB — default 1MB can be exceeded by verbose PM output
+      },
       (error, stdout, stderr) => {
         if (error) {
           if (silenceErrors) {
@@ -55,8 +60,15 @@ export function execAndWait(
           } else {
             const logFile = join(cwd, 'error.log');
             writeFileSync(logFile, `${stdout}\n${stderr}`);
-            const message = stderr && stderr.trim().length ? stderr : stdout;
-            rej(new CreateNxWorkspaceError(message, error.code, logFile));
+            const message =
+              stderr && stderr.trim().length
+                ? stderr
+                : stdout && stdout.trim().length
+                  ? stdout
+                  : `Command failed with exit code ${error.code ?? 'unknown'}. See ${logFile} for details.`;
+            rej(
+              new CnwError('UNKNOWN', message, logFile, error.code ?? undefined)
+            );
           }
         } else {
           res({ code: 0, stdout });

--- a/packages/create-nx-workspace/src/utils/package-manager.ts
+++ b/packages/create-nx-workspace/src/utils/package-manager.ts
@@ -49,7 +49,10 @@ export function getPackageManagerCommand(
   switch (packageManager) {
     case 'yarn':
       const useBerry = +pmMajor >= 2;
-      const installCommand = 'yarn install --silent';
+      // Don't use --silent so that error output is captured on failure.
+      // Since install is run via exec() (not spawn), output is captured
+      // in memory and never shown to the terminal.
+      const installCommand = 'yarn install';
       return {
         preInstall: `yarn set version ${pmVersion}`,
         install: useBerry
@@ -69,7 +72,7 @@ export function getPackageManagerCommand(
         useExec = true;
       }
       return {
-        install: 'pnpm install --no-frozen-lockfile --silent --ignore-scripts',
+        install: 'pnpm install --no-frozen-lockfile --ignore-scripts',
         exec: useExec ? 'pnpm exec' : 'pnpx',
         globalAdd: 'pnpm add -g',
         getRegistryUrl: 'pnpm config get registry',
@@ -77,7 +80,7 @@ export function getPackageManagerCommand(
 
     case 'npm':
       return {
-        install: 'npm install --silent --ignore-scripts',
+        install: 'npm install --ignore-scripts',
         exec: 'npx',
         globalAdd: 'npm i -g',
         getRegistryUrl: 'npm config get registry',
@@ -85,7 +88,7 @@ export function getPackageManagerCommand(
     case 'bun':
       // bun doesn't current support programmatically reading config https://github.com/oven-sh/bun/issues/7140
       return {
-        install: 'bun install --silent --ignore-scripts',
+        install: 'bun install --ignore-scripts',
         exec: 'bunx',
         globalAdd: 'bun install -g',
       };


### PR DESCRIPTION
This PR surfaces install errors instead of silently failing without anything useful printed. It also records `needs_input` in the AX flow as `cancelled` so we account for cases where AI agents exit without recording either success, complete, or cancelled.

BEFORE:

<img width="1288" height="381" alt="image" src="https://github.com/user-attachments/assets/44fe9642-764e-452b-90be-f30c4a230be5" />

AFTER:

<img width="1279" height="850" alt="Screenshot 2026-03-05 at 12 30 25 PM" src="https://github.com/user-attachments/assets/24c96584-2790-4dcb-8404-7e221c50876c" />

## Notes

1. **Remove `--silent` from all PM install commands** — since `execAndWait` uses `exec()` (captures output in memory, never shown to terminal), `--silent` just suppressed error info for no benefit
2. **Increase `maxBuffer`** from default 1MB to 10MB to prevent process being killed when PMs emit verbose output
3. **Fallback error message** when both stderr and stdout are empty — includes exit code and log file path
4. **Structured sandbox error** with exit code, log file, and actionable hint
5. **Record telemetry stat** for AI agent `needs_input` flow (was previously missing)
6. **Migrate from deprecated `CreateNxWorkspaceError`** to `CnwError` in `execAndWait`

## Related Issue(s)

Fixes NXC-4035