### PR TITLE
chore(misc): add .netlify to nxignore

### DIFF
--- a/.nxignore
+++ b/.nxignore
@@ -10,3 +10,6 @@ packages/nx/src/native/native-bindings.js
 
 # Workaround for ignore-files crate bug with prefix matching
 **/target/
+
+# Netlify build artifacts
+.netlify


### PR DESCRIPTION
The .netlify/static/documentation directory was being detected as a project with name "docs", conflicting with the actual docs project. This caused the project graph to fail during Netlify deploys.