### PR TITLE
chore(misc): add .netlify to gitignore instead of nxignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,7 +114,8 @@ node_modules/
 # Upstream docs local configuration (machine-specific)
 .upstreamdocs.local.json
 
-astro-docs/.netlify
+# Netlify build artifacts
+.netlify
 
 coverage
 


### PR DESCRIPTION
This addresses feedback on PR #34726 - .netlify directories are build artifacts and should be in .gitignore rather than .nxignore. This also generalizes the pattern from `astro-docs/.netlify` to `.netlify` to cover the root-level `.netlify/static/documentation` directory that was causing duplicate project detection.
