### PR TITLE
fix(core): allow nx cloud commands to run outside of a workspace

### DIFF
--- a/packages/js/src/executors/verdaccio/verdaccio.impl.ts
+++ b/packages/js/src/executors/verdaccio/verdaccio.impl.ts
@@ -272,7 +272,7 @@ function setupYarn(options: VerdaccioExecutorSchema) {
         execSync('yarn --version', { env, windowsHide: false })
           .toString()
           .trim()
-      ) < 2;
+      ) === 1;
   } catch {
     // This would fail if yarn is not installed which is okay
     return () => {};

--- a/packages/js/src/executors/verdaccio/verdaccio.impl.ts
+++ b/packages/js/src/executors/verdaccio/verdaccio.impl.ts
@@ -272,7 +272,7 @@ function setupYarn(options: VerdaccioExecutorSchema) {
         execSync('yarn --version', { env, windowsHide: false })
           .toString()
           .trim()
-      ) === 1;
+      ) < 2;
   } catch {
     // This would fail if yarn is not installed which is okay
     return () => {};

--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -94,7 +94,7 @@ async function main() {
       handleNxVersionCommand(LOCAL_NX_VERSION, GLOBAL_NX_VERSION);
     }
 
-    if (!workspace) {
+    if (!workspace && !isNxCloudCommand(process.argv[2])) {
       handleNoWorkspace(GLOBAL_NX_VERSION);
     }
 
@@ -198,6 +198,7 @@ function isNxCloudCommand(command: string): boolean {
     'view-logs',
     'fix-ci',
     'record',
+    'polygraph',
   ];
   return nxCloudCommands.includes(command);
 }

--- a/packages/nx/src/command-line/nx-cloud/login/login.ts
+++ b/packages/nx/src/command-line/nx-cloud/login/login.ts
@@ -1,6 +1,4 @@
-import { readNxJson } from '../../../config/nx-json';
-import { isNxCloudUsed } from '../../../utils/nx-cloud-utils';
-import { executeNxCloudCommand, warnNotConnectedToCloud } from '../utils';
+import { executeNxCloudCommand } from '../utils';
 
 export interface LoginArgs {
   nxCloudUrl?: string;
@@ -8,15 +6,6 @@ export interface LoginArgs {
 }
 
 export function loginHandler(args: LoginArgs): Promise<number> {
-  try {
-    if (!isNxCloudUsed(readNxJson())) {
-      warnNotConnectedToCloud();
-      return Promise.resolve(0);
-    }
-  } catch {
-    // Not in an Nx workspace — proceed with login anyway
-  }
-
   if (args.nxCloudUrl) {
     process.env.NX_CLOUD_API = args.nxCloudUrl;
   }

--- a/packages/nx/src/command-line/nx-cloud/logout/logout.ts
+++ b/packages/nx/src/command-line/nx-cloud/logout/logout.ts
@@ -1,15 +1,9 @@
-import { readNxJson } from '../../../config/nx-json';
-import { isNxCloudUsed } from '../../../utils/nx-cloud-utils';
-import { executeNxCloudCommand, warnNotConnectedToCloud } from '../utils';
+import { executeNxCloudCommand } from '../utils';
 
 export interface LogoutArgs {
   verbose?: boolean;
 }
 
 export function logoutHandler(args: LogoutArgs): Promise<number> {
-  if (!isNxCloudUsed(readNxJson())) {
-    warnNotConnectedToCloud();
-    return Promise.resolve(0);
-  }
   return executeNxCloudCommand('logout', args.verbose);
 }


### PR DESCRIPTION
## Current Behavior

Running Nx Cloud commands (login, logout, polygraph, etc.) from outside an Nx workspace fails with 'The current directory is not part of an Nx workspace' because handleNoWorkspace exits before reaching the cloud command handler. Additionally, polygraph was not in the isNxCloudCommand list.

## Expected Behavior

Nx Cloud commands work regardless of whether you are inside an Nx workspace, since they only delegate to the cloud client.

## Related Issue(s)

N/A