### PR TITLE
fix(js): include tsbuildinfo in dependentTasksOutputFiles for tsc tasks

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -1683,7 +1683,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                       "{projectRoot}/cypress.config.ts",
                       "{projectRoot}/**/*.cy.ts",
                       {
-                        "dependentTasksOutputFiles": "**/*.d.ts",
+                        "dependentTasksOutputFiles": "**/*.{d.ts,tsbuildinfo}",
                       },
                     ],
                     "metadata": {
@@ -2449,7 +2449,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                       "{projectRoot}/cypress/tsconfig.json",
                       "{projectRoot}/src/**/*.spec.ts",
                       {
-                        "dependentTasksOutputFiles": "**/*.d.ts",
+                        "dependentTasksOutputFiles": "**/*.{d.ts,tsbuildinfo}",
                       },
                     ],
                     "metadata": {
@@ -4254,7 +4254,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                       "{projectRoot}/other/**/*.ts",
                       "{projectRoot}/src/**/foo.ts",
                       {
-                        "dependentTasksOutputFiles": "**/*.d.ts",
+                        "dependentTasksOutputFiles": "**/*.{d.ts,tsbuildinfo}",
                       },
                     ],
                     "metadata": {

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -875,9 +875,11 @@ function getInputs(
       cache
     )
   ) {
-    // Importing modules from a referenced project will load its output declaration files (d.ts)
+    // tsc --build reads .d.ts and .tsbuildinfo files from referenced projects
     // https://www.typescriptlang.org/docs/handbook/project-references.html#what-is-a-project-reference
-    inputs.push({ dependentTasksOutputFiles: '**/*.d.ts' });
+    inputs.push({
+      dependentTasksOutputFiles: '**/*.{d.ts,tsbuildinfo}',
+    });
   } else {
     inputs.push('production' in namedInputs ? '^production' : '^default');
   }


### PR DESCRIPTION
## Current Behavior

The `@nx/js/typescript` plugin sets `dependentTasksOutputFiles: '**/*.d.ts'` for tsc tasks with external project references. This misses `.tsbuildinfo` files that `tsc --build` reads from referenced projects for incremental compilation, which can lead to incorrect cache hits.

## Expected Behavior

`dependentTasksOutputFiles` uses the glob `**/*.{d.ts,tsbuildinfo}`, ensuring all files read by `tsc --build` from dependencies are tracked as inputs for correct cache invalidation.