### PR TITLE
fix(linter): add catalog: references when fixing missing dependencies

### DIFF
--- a/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
@@ -2239,6 +2239,429 @@ describe('Dependency checks (eslint)', () => {
 
       expect(result).toContain('"external1": "catalog:"');
     });
+
+    it('should use catalog: for missing dep when package is in default catalog but not in root package.json', () => {
+      const packageJson = {
+        name: '@mycompany/liba',
+        dependencies: {
+          external1: '^16.0.0',
+        },
+      };
+
+      const fileSys = {
+        './libs/liba/package.json': JSON.stringify(packageJson, null, 2),
+        './libs/liba/src/index.ts': '',
+        './package.json': JSON.stringify(rootPackageJson, null, 2),
+        './pnpm-workspace.yaml': `catalog:\n  random-external: '^1.0.0'\n`,
+      };
+      vol.fromJSON(fileSys, '/root');
+
+      const failures = runRule(
+        {},
+        `/root/libs/liba/package.json`,
+        JSON.stringify(packageJson, null, 2),
+        {
+          nodes: {
+            liba: {
+              name: 'liba',
+              type: 'lib',
+              data: {
+                root: 'libs/liba',
+                targets: {
+                  build: {},
+                },
+              },
+            },
+          },
+          externalNodes,
+          dependencies: {
+            liba: [
+              { source: 'liba', target: 'npm:external1', type: 'static' },
+              {
+                source: 'liba',
+                target: 'npm:random-external',
+                type: 'static',
+              },
+            ],
+          },
+        },
+        {
+          liba: [
+            createFile(`libs/liba/src/main.ts`, [
+              'npm:external1',
+              'npm:random-external',
+            ]),
+            createFile(`libs/liba/package.json`, ['npm:external1']),
+          ],
+        }
+      );
+
+      expect(failures.length).toEqual(1);
+      expect(failures[0].message).toContain('random-external');
+
+      const content = JSON.stringify(packageJson, null, 2);
+      const result =
+        content.slice(0, failures[0].fix!.range[0]) +
+        failures[0].fix!.text +
+        content.slice(failures[0].fix!.range[1]);
+
+      expect(result).toContain('"random-external": "catalog:"');
+    });
+
+    it('should use catalog: for missing dep when package is in catalogs.default', () => {
+      const packageJson = {
+        name: '@mycompany/liba',
+        dependencies: {
+          external1: '^16.0.0',
+        },
+      };
+
+      const fileSys = {
+        './libs/liba/package.json': JSON.stringify(packageJson, null, 2),
+        './libs/liba/src/index.ts': '',
+        './package.json': JSON.stringify(rootPackageJson, null, 2),
+        './pnpm-workspace.yaml': `catalogs:\n  default:\n    random-external: '^1.0.0'\n`,
+      };
+      vol.fromJSON(fileSys, '/root');
+
+      const failures = runRule(
+        {},
+        `/root/libs/liba/package.json`,
+        JSON.stringify(packageJson, null, 2),
+        {
+          nodes: {
+            liba: {
+              name: 'liba',
+              type: 'lib',
+              data: {
+                root: 'libs/liba',
+                targets: {
+                  build: {},
+                },
+              },
+            },
+          },
+          externalNodes,
+          dependencies: {
+            liba: [
+              { source: 'liba', target: 'npm:external1', type: 'static' },
+              {
+                source: 'liba',
+                target: 'npm:random-external',
+                type: 'static',
+              },
+            ],
+          },
+        },
+        {
+          liba: [
+            createFile(`libs/liba/src/main.ts`, [
+              'npm:external1',
+              'npm:random-external',
+            ]),
+            createFile(`libs/liba/package.json`, ['npm:external1']),
+          ],
+        }
+      );
+
+      expect(failures.length).toEqual(1);
+      expect(failures[0].message).toContain('random-external');
+
+      const content = JSON.stringify(packageJson, null, 2);
+      const result =
+        content.slice(0, failures[0].fix!.range[0]) +
+        failures[0].fix!.text +
+        content.slice(failures[0].fix!.range[1]);
+
+      expect(result).toContain('"random-external": "catalog:"');
+    });
+
+    it('should use catalog:name for missing dep when package is in a named catalog but not in root package.json', () => {
+      const packageJson = {
+        name: '@mycompany/liba',
+        dependencies: {
+          external1: '^16.0.0',
+        },
+      };
+
+      const fileSys = {
+        './libs/liba/package.json': JSON.stringify(packageJson, null, 2),
+        './libs/liba/src/index.ts': '',
+        './package.json': JSON.stringify(rootPackageJson, null, 2),
+        './pnpm-workspace.yaml': `catalogs:\n  react:\n    random-external: '^1.0.0'\n`,
+      };
+      vol.fromJSON(fileSys, '/root');
+
+      const failures = runRule(
+        {},
+        `/root/libs/liba/package.json`,
+        JSON.stringify(packageJson, null, 2),
+        {
+          nodes: {
+            liba: {
+              name: 'liba',
+              type: 'lib',
+              data: {
+                root: 'libs/liba',
+                targets: {
+                  build: {},
+                },
+              },
+            },
+          },
+          externalNodes,
+          dependencies: {
+            liba: [
+              { source: 'liba', target: 'npm:external1', type: 'static' },
+              {
+                source: 'liba',
+                target: 'npm:random-external',
+                type: 'static',
+              },
+            ],
+          },
+        },
+        {
+          liba: [
+            createFile(`libs/liba/src/main.ts`, [
+              'npm:external1',
+              'npm:random-external',
+            ]),
+            createFile(`libs/liba/package.json`, ['npm:external1']),
+          ],
+        }
+      );
+
+      expect(failures.length).toEqual(1);
+      expect(failures[0].message).toContain('random-external');
+
+      const content = JSON.stringify(packageJson, null, 2);
+      const result =
+        content.slice(0, failures[0].fix!.range[0]) +
+        failures[0].fix!.text +
+        content.slice(failures[0].fix!.range[1]);
+
+      expect(result).toContain('"random-external": "catalog:react"');
+    });
+
+    it('should fall back to installed version when package is in multiple catalogs', () => {
+      const packageJson = {
+        name: '@mycompany/liba',
+        dependencies: {
+          external1: '^16.0.0',
+        },
+      };
+
+      const fileSys = {
+        './libs/liba/package.json': JSON.stringify(packageJson, null, 2),
+        './libs/liba/src/index.ts': '',
+        './package.json': JSON.stringify(rootPackageJson, null, 2),
+        './pnpm-workspace.yaml': `catalog:\n  random-external: '^1.0.0'\ncatalogs:\n  react:\n    random-external: '^1.2.0'\n`,
+      };
+      vol.fromJSON(fileSys, '/root');
+
+      const failures = runRule(
+        {},
+        `/root/libs/liba/package.json`,
+        JSON.stringify(packageJson, null, 2),
+        {
+          nodes: {
+            liba: {
+              name: 'liba',
+              type: 'lib',
+              data: {
+                root: 'libs/liba',
+                targets: {
+                  build: {},
+                },
+              },
+            },
+          },
+          externalNodes,
+          dependencies: {
+            liba: [
+              { source: 'liba', target: 'npm:external1', type: 'static' },
+              {
+                source: 'liba',
+                target: 'npm:random-external',
+                type: 'static',
+              },
+            ],
+          },
+        },
+        {
+          liba: [
+            createFile(`libs/liba/src/main.ts`, [
+              'npm:external1',
+              'npm:random-external',
+            ]),
+            createFile(`libs/liba/package.json`, ['npm:external1']),
+          ],
+        }
+      );
+
+      expect(failures.length).toEqual(1);
+      expect(failures[0].message).toContain('random-external');
+
+      const content = JSON.stringify(packageJson, null, 2);
+      const result =
+        content.slice(0, failures[0].fix!.range[0]) +
+        failures[0].fix!.text +
+        content.slice(failures[0].fix!.range[1]);
+
+      // Should use installed version, not catalog reference
+      expect(result).toContain('"random-external": "1.2.3"');
+      expect(result).not.toContain('catalog:');
+    });
+
+    it('should use the catalog whose version satisfies when package is in multiple catalogs', () => {
+      const packageJson = {
+        name: '@mycompany/liba',
+        dependencies: {
+          external1: '^16.0.0',
+        },
+      };
+
+      const fileSys = {
+        './libs/liba/package.json': JSON.stringify(packageJson, null, 2),
+        './libs/liba/src/index.ts': '',
+        './package.json': JSON.stringify(rootPackageJson, null, 2),
+        './pnpm-workspace.yaml': `catalogs:\n  react:\n    random-external: '^1.0.0'\n  angular:\n    random-external: '^2.0.0'\n`,
+      };
+      vol.fromJSON(fileSys, '/root');
+
+      const failures = runRule(
+        {},
+        `/root/libs/liba/package.json`,
+        JSON.stringify(packageJson, null, 2),
+        {
+          nodes: {
+            liba: {
+              name: 'liba',
+              type: 'lib',
+              data: {
+                root: 'libs/liba',
+                targets: {
+                  build: {},
+                },
+              },
+            },
+          },
+          externalNodes,
+          dependencies: {
+            liba: [
+              { source: 'liba', target: 'npm:external1', type: 'static' },
+              {
+                source: 'liba',
+                target: 'npm:random-external',
+                type: 'static',
+              },
+            ],
+          },
+        },
+        {
+          liba: [
+            createFile(`libs/liba/src/main.ts`, [
+              'npm:external1',
+              'npm:random-external',
+            ]),
+            createFile(`libs/liba/package.json`, ['npm:external1']),
+          ],
+        }
+      );
+
+      expect(failures.length).toEqual(1);
+      expect(failures[0].message).toContain('random-external');
+
+      const content = JSON.stringify(packageJson, null, 2);
+      const result =
+        content.slice(0, failures[0].fix!.range[0]) +
+        failures[0].fix!.text +
+        content.slice(failures[0].fix!.range[1]);
+
+      // installed 1.2.3 satisfies ^1.0.0 (react) but not ^2.0.0 (angular)
+      expect(result).toContain('"random-external": "catalog:react"');
+    });
+
+    it('should match file: protocol catalog entry by exact comparison', () => {
+      const packageJson = {
+        name: '@mycompany/liba',
+        dependencies: {
+          external1: '^16.0.0',
+        },
+      };
+
+      const fileExternalNodes: Record<string, ProjectGraphExternalNode> = {
+        ...externalNodes,
+        'npm:random-external': {
+          name: 'npm:random-external',
+          type: 'npm',
+          data: {
+            packageName: 'random-external',
+            version: 'file:../random-external',
+          },
+        },
+      };
+
+      const fileSys = {
+        './libs/liba/package.json': JSON.stringify(packageJson, null, 2),
+        './libs/liba/src/index.ts': '',
+        './package.json': JSON.stringify(rootPackageJson, null, 2),
+        './pnpm-workspace.yaml': `catalog:\n  random-external: 'file:../random-external'\n`,
+      };
+      vol.fromJSON(fileSys, '/root');
+
+      const failures = runRule(
+        {},
+        `/root/libs/liba/package.json`,
+        JSON.stringify(packageJson, null, 2),
+        {
+          nodes: {
+            liba: {
+              name: 'liba',
+              type: 'lib',
+              data: {
+                root: 'libs/liba',
+                targets: {
+                  build: {},
+                },
+              },
+            },
+          },
+          externalNodes: fileExternalNodes,
+          dependencies: {
+            liba: [
+              { source: 'liba', target: 'npm:external1', type: 'static' },
+              {
+                source: 'liba',
+                target: 'npm:random-external',
+                type: 'static',
+              },
+            ],
+          },
+        },
+        {
+          liba: [
+            createFile(`libs/liba/src/main.ts`, [
+              'npm:external1',
+              'npm:random-external',
+            ]),
+            createFile(`libs/liba/package.json`, ['npm:external1']),
+          ],
+        }
+      );
+
+      expect(failures.length).toEqual(1);
+      expect(failures[0].message).toContain('random-external');
+
+      const content = JSON.stringify(packageJson, null, 2);
+      const result =
+        content.slice(0, failures[0].fix!.range[0]) +
+        failures[0].fix!.text +
+        content.slice(failures[0].fix!.range[1]);
+
+      expect(result).toContain('"random-external": "catalog:"');
+    });
   });
 
   it('should require swc if @nx/js:swc executor', () => {

--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -175,6 +175,86 @@ export default ESLintUtils.RuleCreator(
 
     const rootPackageJsonDeps = getAllDependencies(rootPackageJson);
 
+    const catalogManager = getCatalogManager(workspaceRoot);
+    const catalogDefs = catalogManager?.getCatalogDefinitions(workspaceRoot);
+
+    function catalogEntryMatchesInstalled(
+      catalogVersionSpec: string,
+      installedVersion: string
+    ): boolean {
+      if (installedVersion === '*') {
+        return true;
+      }
+      // For non-semver values (file:, link:, etc.), use exact comparison
+      if (installedVersion.includes(':') || catalogVersionSpec.includes(':')) {
+        return installedVersion === catalogVersionSpec;
+      }
+      return satisfies(installedVersion, catalogVersionSpec, {
+        includePrerelease: true,
+      });
+    }
+
+    function getCatalogVersionForPackage(packageName: string): string | null {
+      if (!catalogDefs) {
+        return null;
+      }
+
+      const matches: { catalogRef: string; versionSpec: string }[] = [];
+
+      // Check default catalog — `catalog` takes precedence over `catalogs.default`.
+      // Both existing simultaneously is a pnpm error caught by validateCatalogReference.
+      const defaultEntry =
+        catalogDefs.catalog?.[packageName] ??
+        catalogDefs.catalogs?.default?.[packageName];
+      if (defaultEntry) {
+        matches.push({ catalogRef: 'catalog:', versionSpec: defaultEntry });
+      }
+
+      // Check named catalogs (skip "default" — handled above)
+      if (catalogDefs.catalogs) {
+        for (const [name, entries] of Object.entries(catalogDefs.catalogs)) {
+          if (name === 'default' || !entries?.[packageName]) {
+            continue;
+          }
+          matches.push({
+            catalogRef: `catalog:${name}`,
+            versionSpec: entries[packageName],
+          });
+        }
+      }
+
+      if (!matches.length) {
+        return null;
+      }
+
+      // Filter by installed version compatibility when available
+      const installedVersion = npmDependencies[packageName];
+      const valid = installedVersion
+        ? matches.filter((m) =>
+            catalogEntryMatchesInstalled(m.versionSpec, installedVersion)
+          )
+        : matches;
+
+      if (valid.length !== 1) {
+        return null;
+      }
+
+      return valid[0].catalogRef;
+    }
+
+    function getVersionForMissingDependency(packageName: string): string {
+      if (rootPackageJsonDeps[packageName]) {
+        return rootPackageJsonDeps[packageName];
+      }
+
+      const catalogVersion = getCatalogVersionForPackage(packageName);
+      if (catalogVersion) {
+        return catalogVersion;
+      }
+
+      return npmDependencies[packageName];
+    }
+
     function getDependencySection(node: AST.JSONProperty): string | undefined {
       // Check if this node is a dependency section itself
       const directSection = (node.key as JSONLiteral)?.value as string;
@@ -220,8 +300,7 @@ export default ESLintUtils.RuleCreator(
               ) {
                 projPackageJsonDeps[d] = WORKSPACE_VERSION_WILDCARD;
               } else {
-                projPackageJsonDeps[d] =
-                  rootPackageJsonDeps[d] || npmDependencies[d];
+                projPackageJsonDeps[d] = getVersionForMissingDependency(d);
               }
             });
 
@@ -251,17 +330,16 @@ export default ESLintUtils.RuleCreator(
       packageName: string,
       packageRange: string
     ) {
-      const manager = getCatalogManager(workspaceRoot);
-      if (!manager) {
+      if (!catalogManager) {
         return;
       }
 
-      if (!manager.isCatalogReference(packageRange)) {
+      if (!catalogManager.isCatalogReference(packageRange)) {
         return;
       }
 
       try {
-        manager.validateCatalogReference(
+        catalogManager.validateCatalogReference(
           workspaceRoot,
           packageName,
           packageRange
@@ -307,10 +385,9 @@ export default ESLintUtils.RuleCreator(
 
       // Resolve catalog references before validation
       let resolvedPackageRange = packageRange;
-      const manager = getCatalogManager(workspaceRoot);
 
-      if (manager?.isCatalogReference(packageRange)) {
-        const resolved = manager.resolveCatalogReference(
+      if (catalogManager?.isCatalogReference(packageRange)) {
+        const resolved = catalogManager.resolveCatalogReference(
           workspaceRoot,
           packageName,
           packageRange
@@ -426,7 +503,7 @@ export default ESLintUtils.RuleCreator(
           },
           fix: (fixer) => {
             expectedDependencyNames.sort().reduce((acc, d) => {
-              acc[d] = rootPackageJsonDeps[d] || npmDependencies[d];
+              acc[d] = getVersionForMissingDependency(d);
               return acc;
             }, projPackageJsonDeps);
 


### PR DESCRIPTION
## Current Behavior

When the `dependency-checks` ESLint rule auto-fixes missing dependencies in a project's `package.json`, it resolves the version from the root `package.json` or falls back to the installed version from the project graph. This inserts explicit version strings even when the workspace uses catalogs, breaking same-version policy.

## Expected Behavior

The fixer now checks catalogs before falling back to installed versions. When exactly one catalog entry for a missing dependency satisfies the installed version, the fixer inserts `catalog:` (default catalog) or `catalog:<name>` (named catalog) instead of an explicit version.

Fallback chain: root `package.json` → catalog lookup → installed version.

Edge cases handled:
- Package in multiple catalogs but only one satisfies → uses that one
- Package in multiple catalogs and multiple satisfy → falls back to installed version
- `file:` and other protocol-based versions → exact string comparison instead of semver
- No catalog manager or no catalog definitions → falls back to installed version

Also caches the catalog manager instance and catalog definitions per lint run instead of re-creating them per function call.