### PR TITLE
fix(gradle): exclude non-JS gradle sub-projects from eslint plugin

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -245,7 +245,11 @@
     },
     {
       "plugin": "@nx/eslint/plugin",
-      "exclude": ["packages/**/__fixtures__/**/*"],
+      "exclude": [
+        "packages/**/__fixtures__/**/*",
+        "packages/gradle/project-graph/**/*",
+        "packages/gradle/batch-runner/**/*"
+      ],
       "options": {
         "targetName": "lint"
       }

--- a/nx.json
+++ b/nx.json
@@ -245,11 +245,7 @@
     },
     {
       "plugin": "@nx/eslint/plugin",
-      "exclude": [
-        "packages/**/__fixtures__/**/*",
-        "packages/gradle/project-graph/**/*",
-        "packages/gradle/batch-runner/**/*"
-      ],
+      "exclude": ["packages/**/__fixtures__/**/*"],
       "options": {
         "targetName": "lint"
       }

--- a/packages/gradle/.eslintrc.json
+++ b/packages/gradle/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*", "project-graph", "batch-runner"],
+  "ignorePatterns": ["!**/*", "node_modules", "project-graph", "batch-runner"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],

--- a/packages/gradle/.eslintrc.json
+++ b/packages/gradle/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*", "node_modules"],
+  "ignorePatterns": ["!**/*", "project-graph", "batch-runner"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],


### PR DESCRIPTION
## Current Behavior

The `@nx/eslint/plugin` infers a `lint` target for `gradle-project-graph` because it contains a single `.ts` file (`publish-maven.ts`), even though it's a Kotlin/Gradle project. Similarly, the parent `gradle` project's `eslint .` scans into non-JS sub-project directories unnecessarily.

## Expected Behavior

Non-JS Gradle sub-projects (`project-graph`, `batch-runner`) should not have lint targets inferred by the ESLint plugin, and the parent `gradle` project's lint should not scan into those directories.

## Changes

- Add `project-graph` and `batch-runner` to ESLint `ignorePatterns` in `packages/gradle/.eslintrc.json`