### PR TITLE
chore(core): move io tracing dir to .nx/sandbox-metadata

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -8,7 +8,6 @@ common-env-vars: &common-env-vars
   # These are need for build and link validation for next.js and astro apps
   NEXT_PUBLIC_ASTRO_URL: 'https://master--nx-docs.netlify.app'
   NX_DEV_URL: 'https://canary.nx.dev'
-  NX_CLOUD_IO_TRACING_DIRECTORY: '/home/workflows/workspace/sandboxing-task-metadata'
 
 common-init-steps: &common-init-steps
   - name: Checkout

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -137,6 +137,12 @@
       "description": "Updates the nx wrapper.",
       "implementation": "./src/migrations/update-22-1-0/update-nx-wrapper"
     },
+    "22-5-0-add-sandbox-metadata-to-git-ignore": {
+      "cli": "nx",
+      "version": "22.5.0-beta.0",
+      "description": "Adds .nx/sandbox-metadata to .gitignore",
+      "implementation": "./src/migrations/update-22-5-0/add-sandbox-metadata-to-git-ignore"
+    },
     "22-6-1-add-claude-worktrees-to-git-ignore": {
       "cli": "nx",
       "version": "22.6.0-beta.10",

--- a/packages/nx/src/migrations/update-22-5-0/add-sandbox-metadata-to-git-ignore.ts
+++ b/packages/nx/src/migrations/update-22-5-0/add-sandbox-metadata-to-git-ignore.ts
@@ -1,0 +1,12 @@
+import { Tree } from '../../generators/tree';
+import { addEntryToGitIgnore } from '../../utils/ignore';
+
+export default function addSandboxMetadataToGitIgnore(tree: Tree) {
+  if (!tree.exists('.gitignore')) {
+    return;
+  }
+  if (tree.exists('lerna.json') && !tree.exists('nx.json')) {
+    return;
+  }
+  addEntryToGitIgnore(tree, '.gitignore', '.nx/sandbox-metadata');
+}


### PR DESCRIPTION
Adds a migration to gitignore `.nx/sandbox-metadata` and removes the now-redundant `NX_CLOUD_IO_TRACING_DIRECTORY` env var from agents.yaml (the executor sets it).