### PR TITLE
fix(testing): infer task inputs from jest config file references

### DIFF
--- a/astro-docs/src/content/docs/technologies/test-tools/jest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/jest/introduction.mdoc
@@ -165,12 +165,13 @@ Configure the plugin in `nx.json`:
 }
 ```
 
-| Option               | Type    | Default | Description                                                                                                                    |
-| -------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `targetName`         | string  | `test`  | Name of the inferred Jest target.                                                                                              |
-| `ciTargetName`       | string  | none    | Creates a CI-only target for atomized test tasks.                                                                              |
-| `ciGroupName`        | string  | none    | Custom group name for atomized tasks in Nx Cloud/UI.                                                                           |
-| `disableJestRuntime` | boolean | `true`  | When `true`, Nx skips creating the Jest runtime and computes inputs/outputs itself. Set to `false` to enable the Jest runtime. |
+| Option               | Type    | Default                        | Description                                                                                                                                                                                                      |
+| -------------------- | ------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `targetName`         | string  | `test`                         | Name of the inferred Jest target.                                                                                                                                                                                |
+| `ciTargetName`       | string  | none                           | Creates a CI-only target for atomized test tasks.                                                                                                                                                                |
+| `ciGroupName`        | string  | none                           | Custom group name for atomized tasks in Nx Cloud/UI.                                                                                                                                                             |
+| `disableJestRuntime` | boolean | `true`                         | When `true`, Nx skips creating the Jest runtime and computes inputs/outputs itself. Set to `false` to enable the Jest runtime.                                                                                   |
+| `useJestResolver`    | boolean | `true` when runtime is enabled | Whether to use Jest's resolver for resolving config file references as task inputs. Follows symlinks and honors custom `moduleDirectories`/`modulePaths`. Faster path-based classification is used when `false`. |
 
 `disableJestRuntime` defaults to `true` because the plugin treats it as enabled only when `options.disableJestRuntime !== false`. This reduces computation time for inferred tasks; set it to `false` if you need Jest runtime inference.
 

--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -1128,14 +1128,13 @@ describe('@nx/jest/plugin config file inputs', () => {
 
   it('should resolve moduleNameMapper <rootDir> to correct scoped package name', async () => {
     await tempFs.createFiles({
-      'node_modules/@schematics/angular/package.json':
-        '{ "name": "@schematics/angular", "version": "1.0.0" }',
-      'node_modules/@schematics/angular/collection.json': '{}',
+      'node_modules/@acme/utils/package.json':
+        '{ "name": "@acme/utils", "version": "1.0.0" }',
+      'node_modules/@acme/utils/index.js': '{}',
     });
     mockConfig({
       moduleNameMapper: {
-        '^@schematics/angular$':
-          '<rootDir>/../node_modules/@schematics/angular/collection.json',
+        '^@acme/utils$': '<rootDir>/../node_modules/@acme/utils/index.js',
       },
     });
     const results = await createNodesFunction(
@@ -1145,7 +1144,7 @@ describe('@nx/jest/plugin config file inputs', () => {
     );
     expect(getTestInputs(results)).toContainEqual(
       expect.objectContaining({
-        externalDependencies: expect.arrayContaining(['@schematics/angular']),
+        externalDependencies: expect.arrayContaining(['@acme/utils']),
       })
     );
   });

--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -889,6 +889,545 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
   });
 });
 
+describe('@nx/jest/plugin config file inputs', () => {
+  let createNodesFunction = createNodesV2[1];
+  let context: CreateNodesContextV2;
+  let tempFs: TempFs;
+  let cwd: string;
+
+  beforeEach(async () => {
+    tempFs = new TempFs('test');
+    cwd = process.cwd();
+    process.chdir(tempFs.tempDir);
+    context = {
+      nxJsonConfiguration: {
+        namedInputs: {
+          default: ['{projectRoot}/**/*'],
+          production: ['!{projectRoot}/**/*.spec.ts'],
+        },
+      },
+      workspaceRoot: tempFs.tempDir,
+    };
+
+    await tempFs.createFiles({
+      'proj/jest.config.js': `module.exports = {}`,
+      'proj/src/unit.spec.ts': '',
+      'proj/project.json': '{}',
+    });
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    tempFs.cleanup();
+    process.chdir(cwd);
+  });
+
+  function mockConfig(config: any) {
+    jest.mock(
+      join(context.workspaceRoot, 'proj/jest.config.js'),
+      () => config,
+      { virtual: true }
+    );
+  }
+
+  function getTestInputs(results: any) {
+    return results[0][1].projects['proj'].targets['test'].inputs;
+  }
+
+  it('should resolve resolver from config as file input', async () => {
+    await tempFs.createFiles({ 'custom-resolver.js': '' });
+    mockConfig({ resolver: '../custom-resolver.js' });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    expect(getTestInputs(results)).toContainEqual(
+      '{workspaceRoot}/custom-resolver.js'
+    );
+  });
+
+  it('should resolve resolver as npm package to external dependency', async () => {
+    mockConfig({ resolver: 'jest-resolver-enhanced' });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    expect(getTestInputs(results)).toContainEqual(
+      expect.objectContaining({
+        externalDependencies: expect.arrayContaining([
+          'jest-resolver-enhanced',
+        ]),
+      })
+    );
+  });
+
+  it('should resolve resolver from preset when not in config', async () => {
+    await tempFs.createFiles({
+      'jest.preset.js': `module.exports = { resolver: '../scripts/custom-resolver.js' };`,
+      'scripts/custom-resolver.js': '',
+    });
+    mockConfig({ preset: '../jest.preset.js' });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    expect(getTestInputs(results)).toContainEqual(
+      '{workspaceRoot}/scripts/custom-resolver.js'
+    );
+  });
+
+  it('should resolve setupFiles concatenated from preset and config', async () => {
+    await tempFs.createFiles({
+      'jest.preset.js': `module.exports = { setupFiles: ['../scripts/preset-setup.js'] };`,
+      'scripts/preset-setup.js': '',
+      'proj/local-setup.js': '',
+    });
+    mockConfig({
+      preset: '../jest.preset.js',
+      setupFiles: ['./local-setup.js'],
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).toContainEqual('{workspaceRoot}/scripts/preset-setup.js');
+    expect(inputs).toContainEqual('{projectRoot}/local-setup.js');
+  });
+
+  it('should resolve setupFilesAfterEnv with <rootDir> prefix', async () => {
+    await tempFs.createFiles({ 'scripts/test-setup.js': '' });
+    mockConfig({
+      setupFilesAfterEnv: ['<rootDir>/../scripts/test-setup.js'],
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    expect(getTestInputs(results)).toContainEqual(
+      '{workspaceRoot}/scripts/test-setup.js'
+    );
+  });
+
+  it('should resolve globalSetup and globalTeardown as file inputs', async () => {
+    await tempFs.createFiles({
+      'scripts/global-setup.js': '',
+      'scripts/global-teardown.js': '',
+    });
+    mockConfig({
+      globalSetup: '../scripts/global-setup.js',
+      globalTeardown: '../scripts/global-teardown.js',
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).toContainEqual('{workspaceRoot}/scripts/global-setup.js');
+    expect(inputs).toContainEqual('{workspaceRoot}/scripts/global-teardown.js');
+  });
+
+  it('should resolve moduleNameMapper file values and skip backreferences', async () => {
+    await tempFs.createFiles({ 'scripts/mock-file.js': '' });
+    mockConfig({
+      moduleNameMapper: {
+        '^module$': '../scripts/mock-file.js',
+        '^@app/(.*)$': '<rootDir>/src/$1',
+      },
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).toContainEqual('{workspaceRoot}/scripts/mock-file.js');
+    const fileInputStrings = inputs.filter((i: any) => typeof i === 'string');
+    expect(fileInputStrings).not.toContainEqual(expect.stringContaining('$1'));
+  });
+
+  it('should resolve moduleNameMapper array values', async () => {
+    await tempFs.createFiles({
+      'scripts/mock-a.js': '',
+      'scripts/mock-b.js': '',
+    });
+    mockConfig({
+      moduleNameMapper: {
+        '^module$': ['../scripts/mock-a.js', '../scripts/mock-b.js'],
+      },
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).toContainEqual('{workspaceRoot}/scripts/mock-a.js');
+    expect(inputs).toContainEqual('{workspaceRoot}/scripts/mock-b.js');
+  });
+
+  it('should resolve transform npm package as external dependency', async () => {
+    mockConfig({ transform: { '^.+\\.ts$': 'ts-jest' } });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    expect(getTestInputs(results)).toContainEqual(
+      expect.objectContaining({
+        externalDependencies: expect.arrayContaining(['ts-jest']),
+      })
+    );
+  });
+
+  it('should resolve transform tuple value', async () => {
+    mockConfig({
+      transform: {
+        '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.json' }],
+      },
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    expect(getTestInputs(results)).toContainEqual(
+      expect.objectContaining({
+        externalDependencies: expect.arrayContaining(['ts-jest']),
+      })
+    );
+  });
+
+  it('should deduplicate inputs from multiple properties', async () => {
+    mockConfig({
+      resolver: 'jest-resolver-enhanced',
+      transform: { '^.+\\.ts$': 'jest-resolver-enhanced' },
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    const extDepsInputs = inputs.filter(
+      (i: any) => typeof i === 'object' && 'externalDependencies' in i
+    );
+    expect(extDepsInputs).toHaveLength(1);
+    const allExtDeps = extDepsInputs[0].externalDependencies;
+    const enhancedCount = allExtDeps.filter(
+      (d: string) => d === 'jest-resolver-enhanced'
+    ).length;
+    expect(enhancedCount).toBe(1);
+  });
+
+  it('should resolve moduleNameMapper <rootDir> to correct scoped package name', async () => {
+    await tempFs.createFiles({
+      'node_modules/@schematics/angular/package.json':
+        '{ "name": "@schematics/angular", "version": "1.0.0" }',
+      'node_modules/@schematics/angular/collection.json': '{}',
+    });
+    mockConfig({
+      moduleNameMapper: {
+        '^@schematics/angular$':
+          '<rootDir>/../node_modules/@schematics/angular/collection.json',
+      },
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    expect(getTestInputs(results)).toContainEqual(
+      expect.objectContaining({
+        externalDependencies: expect.arrayContaining(['@schematics/angular']),
+      })
+    );
+  });
+
+  it('should resolve snapshotResolver as local file', async () => {
+    await tempFs.createFiles({ 'proj/snapshot-resolver.js': '' });
+    mockConfig({ snapshotResolver: './snapshot-resolver.js' });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    expect(getTestInputs(results)).toContainEqual(
+      '{projectRoot}/snapshot-resolver.js'
+    );
+  });
+
+  it('should resolve runner as npm package', async () => {
+    mockConfig({ runner: 'jest-runner-eslint' });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    expect(getTestInputs(results)).toContainEqual(
+      expect.objectContaining({
+        externalDependencies: expect.arrayContaining(['jest-runner-eslint']),
+      })
+    );
+  });
+
+  it('should resolve runner shorthand with jest-runner- prefix', async () => {
+    mockConfig({ runner: 'eslint' });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    expect(getTestInputs(results)).toContainEqual(
+      expect.objectContaining({
+        externalDependencies: expect.arrayContaining(['jest-runner-eslint']),
+      })
+    );
+  });
+
+  it('should resolve watchPlugins shorthand with jest-watch- prefix', async () => {
+    mockConfig({
+      watchPlugins: ['typeahead', 'master'],
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).toContainEqual(
+      expect.objectContaining({
+        externalDependencies: expect.arrayContaining(['jest-watch-typeahead']),
+      })
+    );
+    expect(inputs).toContainEqual(
+      expect.objectContaining({
+        externalDependencies: expect.arrayContaining(['jest-watch-master']),
+      })
+    );
+  });
+
+  it('should resolve testResultsProcessor as npm package', async () => {
+    mockConfig({ testResultsProcessor: 'jest-sonar-reporter' });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    expect(getTestInputs(results)).toContainEqual(
+      expect.objectContaining({
+        externalDependencies: expect.arrayContaining(['jest-sonar-reporter']),
+      })
+    );
+  });
+
+  it('should resolve reporters with tuple format and skip built-ins', async () => {
+    mockConfig({
+      reporters: [
+        'default',
+        'summary',
+        ['jest-junit', { outputDirectory: 'reports' }],
+      ],
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).toContainEqual(
+      expect.objectContaining({
+        externalDependencies: expect.arrayContaining(['jest-junit']),
+      })
+    );
+    const allExtDeps = inputs
+      .filter((i: any) => typeof i === 'object' && 'externalDependencies' in i)
+      .flatMap((i: any) => i.externalDependencies);
+    expect(allExtDeps).not.toContain('default');
+    expect(allExtDeps).not.toContain('summary');
+  });
+
+  it('should resolve watchPlugins with tuple format', async () => {
+    mockConfig({
+      watchPlugins: [
+        ['jest-watch-typeahead/filename', { key: 'p' }],
+        'jest-watch-master',
+      ],
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).toContainEqual(
+      expect.objectContaining({
+        externalDependencies: expect.arrayContaining(['jest-watch-typeahead']),
+      })
+    );
+    expect(inputs).toContainEqual(
+      expect.objectContaining({
+        externalDependencies: expect.arrayContaining(['jest-watch-master']),
+      })
+    );
+  });
+
+  it('should resolve snapshotSerializers as replaced array', async () => {
+    mockConfig({
+      snapshotSerializers: ['jest-serializer-html'],
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    expect(getTestInputs(results)).toContainEqual(
+      expect.objectContaining({
+        externalDependencies: expect.arrayContaining(['jest-serializer-html']),
+      })
+    );
+  });
+
+  it('should load preset from npm package', async () => {
+    await tempFs.createFiles({
+      'node_modules/my-jest-preset/jest-preset.js':
+        'module.exports = { setupFiles: [] };',
+      'node_modules/my-jest-preset/package.json':
+        '{ "name": "my-jest-preset", "version": "1.0.0" }',
+    });
+    mockConfig({ preset: 'my-jest-preset' });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    expect(getTestInputs(results)).toContainEqual(
+      expect.objectContaining({
+        externalDependencies: expect.arrayContaining(['my-jest-preset']),
+      })
+    );
+  });
+
+  it('should resolve paths relative to custom rootDir', async () => {
+    await tempFs.createFiles({
+      'shared/setup.js': '',
+    });
+    mockConfig({
+      rootDir: '../shared',
+      setupFiles: ['./setup.js'],
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    expect(getTestInputs(results)).toContainEqual(
+      '{workspaceRoot}/shared/setup.js'
+    );
+  });
+
+  it('should resolve preset with <rootDir> prefix', async () => {
+    await tempFs.createFiles({
+      'shared/jest.preset.js':
+        'module.exports = { globalSetup: "./global-setup.js" };',
+      'shared/global-setup.js': '',
+      'proj/global-setup.js': '',
+    });
+    mockConfig({
+      preset: '<rootDir>/../shared/jest.preset.js',
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    // Preset is resolved via <rootDir>, so it should appear as an input
+    expect(getTestInputs(results)).toContainEqual(
+      '{workspaceRoot}/shared/jest.preset.js'
+    );
+    // globalSetup from preset resolves relative to rootDir (proj/),
+    // matching Jest's behavior
+    expect(getTestInputs(results)).toContainEqual(
+      '{projectRoot}/global-setup.js'
+    );
+  });
+
+  it('should use jest-resolve when useJestResolver is true', async () => {
+    await tempFs.createFiles({
+      'node_modules/my-jest-preset/jest-preset.js':
+        'module.exports = { setupFiles: [] };',
+      'node_modules/my-jest-preset/package.json':
+        '{ "name": "my-jest-preset", "version": "1.0.0" }',
+    });
+    mockConfig({ preset: 'my-jest-preset' });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true, useJestResolver: true },
+      context
+    );
+    expect(getTestInputs(results)).toContainEqual(
+      expect.objectContaining({
+        externalDependencies: expect.arrayContaining(['my-jest-preset']),
+      })
+    );
+  });
+
+  it('should classify workspace-linked preset as file input when using jest resolver', async () => {
+    await tempFs.createFiles({
+      'libs/my-preset/jest-preset.js': 'module.exports = {};',
+      'libs/my-preset/package.json':
+        '{ "name": "@my-org/jest-preset", "version": "0.0.0" }',
+      'node_modules/@my-org/jest-preset': '',
+    });
+    // Simulate a workspace-linked package via symlink
+    const fs = await import('fs');
+    fs.rmSync(join(tempFs.tempDir, 'node_modules/@my-org/jest-preset'));
+    fs.mkdirSync(join(tempFs.tempDir, 'node_modules/@my-org'), {
+      recursive: true,
+    });
+    fs.symlinkSync(
+      join(tempFs.tempDir, 'libs/my-preset'),
+      join(tempFs.tempDir, 'node_modules/@my-org/jest-preset')
+    );
+    mockConfig({ preset: '@my-org/jest-preset' });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true, useJestResolver: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    // useJestResolver follows symlinks into the workspace
+    expect(inputs).toContainEqual(
+      expect.stringContaining('libs/my-preset/jest-preset.js')
+    );
+    const extDeps = inputs
+      .filter((i: any) => typeof i === 'object' && 'externalDependencies' in i)
+      .flatMap((i: any) => i.externalDependencies);
+    expect(extDeps).not.toContain('@my-org/jest-preset');
+  });
+
+  it('should not crash when preset fails to load', async () => {
+    mockConfig({
+      preset: '../nonexistent-preset.js',
+      setupFiles: ['./local-setup.js'],
+    });
+    await tempFs.createFiles({ 'proj/local-setup.js': '' });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).toContainEqual('{projectRoot}/local-setup.js');
+  });
+});
+
 function mockJestConfig(config: any, context: CreateNodesContextV2) {
   jest.mock(join(context.workspaceRoot, 'proj/jest.config.js'), () => config, {
     virtual: true,

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -727,7 +727,7 @@ function classifyResolvedPath(
   workspaceRoot: string
 ): FilePathInput {
   const relToWorkspace = normalizePath(relative(workspaceRoot, absolutePath));
-  if (relToWorkspace.includes('node_modules')) {
+  if (relToWorkspace.includes('node_modules/')) {
     const nmIndex = relToWorkspace.lastIndexOf('node_modules/');
     const afterNm = relToWorkspace.slice(nmIndex + 'node_modules/'.length);
     return { externalDependencies: [extractPackageName(afterNm)] };

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -37,6 +37,7 @@ import { globWithWorkspaceContext } from 'nx/src/utils/workspace-context';
 import { getInstalledJestMajorVersion } from '../utils/versions';
 
 const pmc = getPackageManagerCommand();
+const REPORTER_BUILTINS = new Set(['default', 'github-actions', 'summary']);
 
 export interface JestPluginOptions {
   targetName?: string;
@@ -52,6 +53,16 @@ export interface JestPluginOptions {
    *  and test matcher instead of Jest's.
    */
   disableJestRuntime?: boolean;
+  /**
+   * Whether to use Jest's resolver (jest-resolve) for resolving config file
+   * references (presets, transforms, setup files, module name mappers, etc.)
+   * as task inputs. When false, uses path-based classification which is fast
+   * but cannot follow symlinks or honor custom moduleDirectories/modulePaths.
+   * Enable this if your config references workspace-linked packages or relies
+   * on Jest-specific resolution behavior.
+   * @default true when disableJestRuntime is false, false otherwise
+   */
+  useJestResolver?: boolean;
 }
 
 type JestTargets = Awaited<ReturnType<typeof buildJestTargets>>;
@@ -267,14 +278,22 @@ async function buildJestTargets(
 
   // Not normalizing it here since also affects options for convert-to-inferred.
   const disableJestRuntime = options.disableJestRuntime !== false;
+  const useJestResolver = options.useJestResolver ?? !disableJestRuntime;
+
+  // Jest defaults rootDir to the config file's directory, but allows overrides
+  const rootDir = rawConfig.rootDir
+    ? resolve(dirname(absConfigFilePath), rawConfig.rootDir)
+    : resolve(context.workspaceRoot, projectRoot);
 
   const cache = (target.cache = true);
-  const inputs = (target.inputs = getInputs(
+  const inputs = (target.inputs = await getInputs(
     namedInputs,
-    rawConfig.preset,
+    rawConfig,
+    rootDir,
     projectRoot,
     context.workspaceRoot,
-    disableJestRuntime
+    presetCache,
+    useJestResolver
   ));
 
   let metadata: ProjectConfiguration['metadata'];
@@ -296,7 +315,7 @@ async function buildJestTargets(
       const { specs, testMatch } = await getTestPaths(
         projectRoot,
         rawConfig,
-        absConfigFilePath,
+        rootDir,
         context,
         presetCache
       );
@@ -539,13 +558,15 @@ async function buildJestTargets(
   return { targets, metadata };
 }
 
-function getInputs(
+async function getInputs(
   namedInputs: NxJsonConfiguration['namedInputs'],
-  preset: string,
+  rawConfig: any,
+  rootDir: string,
   projectRoot: string,
   workspaceRoot: string,
-  disableJestRuntime?: boolean
-): TargetConfiguration['inputs'] {
+  presetCache: Record<string, unknown>,
+  useJestResolver?: boolean
+): Promise<TargetConfiguration['inputs']> {
   const inputs: TargetConfiguration['inputs'] = [
     ...('production' in namedInputs
       ? ['default', '^production']
@@ -553,9 +574,37 @@ function getInputs(
   ];
 
   const externalDependencies = ['jest'];
-  const presetInput = disableJestRuntime
-    ? resolvePresetInputWithoutJestResolver(preset, projectRoot, workspaceRoot)
-    : resolvePresetInputWithJestResolver(preset, projectRoot, workspaceRoot);
+  const resolvedModulePaths = rawConfig.modulePaths?.map((p: string) =>
+    replaceRootDirInPath(rootDir, p)
+  );
+
+  const jestResolve = useJestResolver
+    ? requireJestUtil<typeof import('jest-resolve')>(
+        'jest-resolve',
+        projectRoot,
+        workspaceRoot
+      ).default
+    : null;
+
+  const presetInput = jestResolve
+    ? resolvePresetInputWithJestResolver(
+        rawConfig.preset,
+        rootDir,
+        projectRoot,
+        workspaceRoot,
+        jestResolve,
+        rawConfig.moduleDirectories,
+        resolvedModulePaths
+      )
+    : resolvePresetInputWithoutJestResolver(
+        rawConfig.preset,
+        rootDir,
+        projectRoot,
+        workspaceRoot
+      );
+
+  // Track preset file path to avoid duplicating it with config-derived inputs
+  let presetInputPath: string | null = null;
   if (presetInput) {
     if (
       typeof presetInput !== 'string' &&
@@ -563,7 +612,38 @@ function getInputs(
     ) {
       externalDependencies.push(...presetInput.externalDependencies);
     } else {
+      presetInputPath = presetInput as string;
       inputs.push(presetInput);
+    }
+  }
+
+  const resolveFilePath = jestResolve
+    ? createJestResolveFilePathResolver(
+        rootDir,
+        projectRoot,
+        workspaceRoot,
+        jestResolve,
+        rawConfig.moduleDirectories,
+        resolvedModulePaths
+      )
+    : createFilePathResolverWithoutJest(rootDir, projectRoot, workspaceRoot);
+
+  const configInputs = await getConfigFileInputs(
+    rawConfig,
+    rootDir,
+    presetCache,
+    resolveFilePath
+  );
+
+  for (const fileInput of configInputs.fileInputs) {
+    if (fileInput !== presetInputPath) {
+      inputs.push(fileInput);
+    }
+  }
+
+  for (const dep of configInputs.externalDeps) {
+    if (!externalDependencies.includes(dep)) {
+      externalDependencies.push(dep);
     }
   }
 
@@ -574,62 +654,60 @@ function getInputs(
 
 function resolvePresetInputWithoutJestResolver(
   presetValue: string | undefined,
+  rootDir: string,
   projectRoot: string,
   workspaceRoot: string
 ): TargetConfiguration['inputs'][number] | null {
   if (!presetValue) return null;
 
-  const presetPath = replaceRootDirInPath(projectRoot, presetValue);
-  const isNpmPackage = !presetValue.startsWith('.') && !isAbsolute(presetPath);
+  const presetPath = replaceRootDirInPath(rootDir, presetValue);
+  const isNpmLike = !presetValue.startsWith('.') && !isAbsolute(presetPath);
 
-  if (isNpmPackage) {
-    return { externalDependencies: [presetValue] };
+  if (isNpmLike) {
+    return { externalDependencies: [extractPackageName(presetValue)] };
   }
 
-  if (presetPath.startsWith('..')) {
-    const relativePath = relative(workspaceRoot, join(projectRoot, presetPath));
-    return join('{workspaceRoot}', relativePath);
-  } else {
-    const relativePath = relative(projectRoot, presetPath);
-    return join('{projectRoot}', relativePath);
-  }
+  const absoluteProjectRoot = resolve(workspaceRoot, projectRoot);
+  return classifyResolvedPath(
+    resolve(rootDir, presetPath),
+    absoluteProjectRoot,
+    workspaceRoot
+  );
 }
 
 // preset resolution adapted from:
 // https://github.com/jestjs/jest/blob/c54bccd657fb4cf060898717c09f633b4da3eec4/packages/jest-config/src/normalize.ts#L122
 function resolvePresetInputWithJestResolver(
   presetValue: string | undefined,
+  rootDir: string,
   projectRoot: string,
-  workspaceRoot: string
+  workspaceRoot: string,
+  jestResolve: typeof import('jest-resolve').default,
+  moduleDirectories?: string[],
+  modulePaths?: string[]
 ): TargetConfiguration['inputs'][number] | null {
   if (!presetValue) return null;
 
-  let presetPath = replaceRootDirInPath(projectRoot, presetValue);
-  const isNpmPackage = !presetValue.startsWith('.') && !isAbsolute(presetPath);
+  let presetPath = replaceRootDirInPath(rootDir, presetValue);
   presetPath = presetPath.startsWith('.')
     ? presetPath
     : join(presetPath, 'jest-preset');
-  const { default: jestResolve } = requireJestUtil<
-    typeof import('jest-resolve')
-  >('jest-resolve', projectRoot, workspaceRoot);
-  const absoluteProjectRoot = join(workspaceRoot, projectRoot);
   const presetModule = jestResolve.findNodeModule(presetPath, {
-    basedir: absoluteProjectRoot,
+    basedir: rootDir,
     extensions: ['.json', '.js', '.cjs', '.mjs'],
+    moduleDirectory: moduleDirectories,
+    paths: modulePaths,
   });
 
   if (!presetModule) {
     return null;
   }
 
-  if (isNpmPackage) {
-    return { externalDependencies: [presetValue] };
-  }
-
-  const relativePath = relative(absoluteProjectRoot, presetModule);
-  return relativePath.startsWith('..')
-    ? join('{workspaceRoot}', join(projectRoot, relativePath))
-    : join('{projectRoot}', relativePath);
+  return classifyResolvedPath(
+    presetModule,
+    resolve(workspaceRoot, projectRoot),
+    workspaceRoot
+  );
 }
 
 // Adapted from here https://github.com/jestjs/jest/blob/c13bca3/packages/jest-config/src/utils.ts#L57-L69
@@ -638,6 +716,122 @@ function replaceRootDirInPath(rootDir: string, filePath: string): string {
     return filePath;
   }
   return resolve(rootDir, normalize(`./${filePath.slice('<rootDir>'.length)}`));
+}
+
+type FilePathInput = string | { externalDependencies: string[] } | null;
+type FilePathResolver = (filePath: string) => FilePathInput;
+
+function classifyResolvedPath(
+  absolutePath: string,
+  absoluteProjectRoot: string,
+  workspaceRoot: string
+): FilePathInput {
+  const relToWorkspace = normalizePath(relative(workspaceRoot, absolutePath));
+  if (relToWorkspace.includes('node_modules')) {
+    const nmIndex = relToWorkspace.lastIndexOf('node_modules/');
+    const afterNm = relToWorkspace.slice(nmIndex + 'node_modules/'.length);
+    return { externalDependencies: [extractPackageName(afterNm)] };
+  }
+  const relToProject = normalizePath(
+    relative(absoluteProjectRoot, absolutePath)
+  );
+  if (relToProject.startsWith('..')) {
+    return joinPathFragments('{workspaceRoot}', relToWorkspace);
+  }
+  return joinPathFragments('{projectRoot}', relToProject);
+}
+
+function extractPackageName(value: string): string {
+  const parts = value.split('/');
+  return value.startsWith('@') ? `${parts[0]}/${parts[1]}` : parts[0];
+}
+
+function createFilePathResolverWithoutJest(
+  rootDir: string,
+  projectRoot: string,
+  workspaceRoot: string
+): FilePathResolver {
+  const absoluteProjectRoot = resolve(workspaceRoot, projectRoot);
+  return (filePath: string): FilePathInput => {
+    const resolvedPath = replaceRootDirInPath(rootDir, filePath);
+
+    if (looksLikePackageName(filePath, resolvedPath)) {
+      return { externalDependencies: [extractPackageName(filePath)] };
+    }
+
+    return classifyResolvedPath(
+      resolve(rootDir, resolvedPath),
+      absoluteProjectRoot,
+      workspaceRoot
+    );
+  };
+}
+
+function resolveWithPrefixFallback(
+  filePath: string,
+  prefix: string,
+  resolver: FilePathResolver
+): FilePathInput {
+  if (
+    !filePath.startsWith('.') &&
+    !filePath.startsWith('<rootDir>') &&
+    !isAbsolute(filePath) &&
+    !filePath.startsWith(prefix)
+  ) {
+    const prefixed = resolver(`${prefix}${filePath}`);
+    if (prefixed) return prefixed;
+  }
+  return resolver(filePath);
+}
+
+function looksLikePackageName(filePath: string, resolvedPath: string): boolean {
+  return (
+    !filePath.startsWith('.') &&
+    !filePath.startsWith('<rootDir>') &&
+    !isAbsolute(resolvedPath)
+  );
+}
+
+function createJestResolveFilePathResolver(
+  rootDir: string,
+  projectRoot: string,
+  workspaceRoot: string,
+  jestResolve: typeof import('jest-resolve').default,
+  moduleDirectories?: string[],
+  modulePaths?: string[]
+): FilePathResolver {
+  const absoluteProjectRoot = resolve(workspaceRoot, projectRoot);
+  const cache = new Map<string, FilePathInput>();
+  return (filePath: string): FilePathInput => {
+    if (cache.has(filePath)) {
+      return cache.get(filePath);
+    }
+
+    const resolvedPath = replaceRootDirInPath(rootDir, filePath);
+    let result: FilePathInput;
+    const absolutePath = jestResolve.findNodeModule(resolvedPath, {
+      basedir: rootDir,
+      extensions: ['.js', '.json', '.cjs', '.mjs', '.mts', '.cts', '.node'],
+      moduleDirectory: moduleDirectories,
+      paths: modulePaths,
+    });
+    if (!absolutePath) {
+      if (looksLikePackageName(filePath, resolvedPath)) {
+        result = { externalDependencies: [extractPackageName(filePath)] };
+      } else {
+        result = null;
+      }
+    } else {
+      result = classifyResolvedPath(
+        absolutePath,
+        absoluteProjectRoot,
+        workspaceRoot
+      );
+    }
+
+    cache.set(filePath, result);
+    return result;
+  };
 }
 
 function getOutputs(
@@ -720,13 +914,13 @@ function requireJestUtil<T>(
 async function getTestPaths(
   projectRoot: string,
   rawConfig: any,
-  absConfigFilePath: string,
+  rootDir: string,
   context: CreateNodesContextV2,
   presetCache: Record<string, unknown>
 ): Promise<{ specs: string[]; testMatch: string[] }> {
   const testMatch = await getJestOption<string[]>(
     rawConfig,
-    absConfigFilePath,
+    rootDir,
     'testMatch',
     presetCache
   );
@@ -745,7 +939,7 @@ async function getTestPaths(
 
   const testRegex = await getJestOption<string[]>(
     rawConfig,
-    absConfigFilePath,
+    rootDir,
     'testRegex',
     presetCache
   );
@@ -761,31 +955,170 @@ async function getTestPaths(
   return { specs: paths, testMatch };
 }
 
+async function loadPresetConfig(
+  rawConfig: any,
+  rootDir: string,
+  presetCache: Record<string, unknown>
+): Promise<Record<string, any> | null> {
+  if (!rawConfig.preset) return null;
+
+  const presetValue = replaceRootDirInPath(rootDir, rawConfig.preset);
+  let presetPath: string;
+  if (presetValue.startsWith('.') || isAbsolute(presetValue)) {
+    presetPath = resolve(rootDir, presetValue);
+  } else {
+    try {
+      presetPath = require.resolve(join(presetValue, 'jest-preset'), {
+        paths: [rootDir],
+      });
+    } catch {
+      return null;
+    }
+  }
+  try {
+    if (!presetCache[presetPath]) {
+      presetCache[presetPath] = loadConfigFile(presetPath);
+    }
+    return (await presetCache[presetPath]) as Record<string, any>;
+  } catch {
+    // If preset fails to load, ignore the error and continue.
+    // This is safe and less jarring for users. They will need to fix the
+    // preset for Jest to run, and at that point we can read in the correct
+    // value.
+    return null;
+  }
+}
+
+async function getConfigFileInputs(
+  rawConfig: any,
+  rootDir: string,
+  presetCache: Record<string, unknown>,
+  resolveFilePath: FilePathResolver
+): Promise<{ fileInputs: string[]; externalDeps: string[] }> {
+  const fileInputs = new Set<string>();
+  const externalDeps = new Set<string>();
+  const preset = await loadPresetConfig(rawConfig, rootDir, presetCache);
+
+  function addInput(input: FilePathInput) {
+    if (!input) return;
+    if (typeof input === 'string') {
+      fileInputs.add(input);
+    } else {
+      input.externalDependencies.forEach((d) => externalDeps.add(d));
+    }
+  }
+
+  // Replaced properties: rawConfig[prop] wins over preset[prop]
+  for (const prop of [
+    'resolver',
+    'globalSetup',
+    'globalTeardown',
+    'snapshotResolver',
+    'testResultsProcessor',
+  ] as const) {
+    const value = rawConfig[prop] ?? preset?.[prop];
+    if (typeof value === 'string') {
+      addInput(resolveFilePath(value));
+    }
+  }
+
+  // runner uses jest-runner- prefix resolution
+  const runner = rawConfig.runner ?? preset?.runner;
+  if (typeof runner === 'string') {
+    addInput(
+      resolveWithPrefixFallback(runner, 'jest-runner-', resolveFilePath)
+    );
+  }
+
+  // Concatenated properties: preset values + config values
+  for (const prop of ['setupFiles', 'setupFilesAfterEnv'] as const) {
+    const values = [
+      ...((preset?.[prop] as string[]) ?? []),
+      ...((rawConfig[prop] as string[]) ?? []),
+    ];
+    for (const value of values) {
+      if (typeof value === 'string') {
+        addInput(resolveFilePath(value));
+      }
+    }
+  }
+
+  // Merged: moduleNameMapper — config keys win (skip values with backreferences like $1)
+  const moduleNameMapper: Record<string, string | string[]> = {
+    ...(preset?.moduleNameMapper ?? {}),
+    ...(rawConfig.moduleNameMapper ?? {}),
+  };
+  for (const value of Object.values(moduleNameMapper)) {
+    const values = Array.isArray(value) ? value : [value];
+    for (const v of values) {
+      if (typeof v !== 'string') continue;
+      if (/\$\d/.test(v)) continue;
+      addInput(resolveFilePath(v));
+    }
+  }
+
+  // Merged: transform — config keys win
+  const transform: Record<string, string | [string, unknown]> = {
+    ...(preset?.transform ?? {}),
+    ...(rawConfig.transform ?? {}),
+  };
+  for (const value of Object.values(transform)) {
+    let transformPath: string;
+    if (Array.isArray(value)) {
+      transformPath = value[0];
+    } else if (typeof value === 'string') {
+      transformPath = value;
+    } else {
+      continue;
+    }
+    addInput(resolveFilePath(transformPath));
+  }
+
+  // Replaced: snapshotSerializers, reporters, watchPlugins
+  const snapshotSerializers: string[] =
+    (rawConfig.snapshotSerializers as string[]) ??
+    (preset?.snapshotSerializers as string[]) ??
+    [];
+  for (const value of snapshotSerializers) {
+    if (typeof value === 'string') {
+      addInput(resolveFilePath(value));
+    }
+  }
+
+  const reporters: (string | [string, unknown])[] =
+    rawConfig.reporters ?? preset?.reporters ?? [];
+  for (const entry of reporters) {
+    const name = Array.isArray(entry) ? entry[0] : entry;
+    if (typeof name !== 'string') continue;
+    if (REPORTER_BUILTINS.has(name)) continue;
+    addInput(resolveFilePath(name));
+  }
+
+  // watchPlugins uses jest-watch- prefix resolution
+  const watchPlugins: (string | [string, unknown])[] =
+    rawConfig.watchPlugins ?? preset?.watchPlugins ?? [];
+  for (const entry of watchPlugins) {
+    const name = Array.isArray(entry) ? entry[0] : entry;
+    if (typeof name !== 'string') continue;
+    addInput(resolveWithPrefixFallback(name, 'jest-watch-', resolveFilePath));
+  }
+
+  return {
+    fileInputs: [...fileInputs],
+    externalDeps: [...externalDeps],
+  };
+}
+
 async function getJestOption<T = any>(
   rawConfig: any,
-  absConfigFilePath: string,
+  rootDir: string,
   optionName: string,
   presetCache: Record<string, unknown>
 ): Promise<T> {
   if (rawConfig[optionName]) return rawConfig[optionName];
 
-  if (rawConfig.preset) {
-    const dir = dirname(absConfigFilePath);
-    const presetPath = resolve(dir, rawConfig.preset);
-    try {
-      let preset = presetCache[presetPath];
-      if (!preset) {
-        preset = await loadConfigFile(presetPath);
-        presetCache[presetPath] = preset;
-      }
-      if (preset[optionName]) return preset[optionName];
-    } catch {
-      // If preset fails to load, ignore the error and continue.
-      // This is safe and less jarring for users. They will need to fix the
-      // preset for Jest to run, and at that point we can read in the correct
-      // value.
-    }
-  }
+  const preset = await loadPresetConfig(rawConfig, rootDir, presetCache);
+  if (preset?.[optionName]) return preset[optionName];
 
   return undefined;
 }


### PR DESCRIPTION
## Current Behavior

The Jest plugin infers `test` target inputs from the preset file path but ignores other config properties that reference files — transforms, setup files, module name mappers, reporters, watch plugins, etc. Changes to those files don't invalidate the test cache.

## Expected Behavior

All Jest config properties that reference files are resolved and included as task inputs, matching Jest's merge semantics:

- **Replaced** (config wins over preset): `resolver`, `globalSetup`, `globalTeardown`, `snapshotResolver`, `snapshotSerializers`, `testResultsProcessor`, `runner`, `reporters`, `watchPlugins`
- **Concatenated** (preset + config): `setupFiles`, `setupFilesAfterEnv`
- **Deep merged** (config keys win): `moduleNameMapper`, `transform`

Also handles `jest-runner-`/`jest-watch-` prefix resolution, `<rootDir>` in preset values, and Windows path normalization.

Adds a `useJestResolver` option to control whether jest-resolve is used for input resolution, decoupled from `disableJestRuntime`. By default, inputs are resolved using path-based classification (fast, no filesystem calls beyond what's already done). When `useJestResolver` is enabled, jest-resolve is used instead, which follows symlinks and honors custom `moduleDirectories`/`modulePaths` — more accurate for workspace-linked packages but slower due to filesystem probing per resolved path.