### PR TITLE
fix(core): add missing @nx/angular-rspack packages to nx packageGroup

### DIFF
--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -107,6 +107,8 @@
       "@nx/eslint",
       "@nx/workspace",
       "@nx/angular",
+      "@nx/angular-rspack",
+      "@nx/angular-rspack-compiler",
       "@nx/jest",
       "@nx/cypress",
       "@nx/detox",


### PR DESCRIPTION
## Current Behavior

Running `nx migrate latest` updates all `@nx/*` packages except `@nx/angular-rspack` and `@nx/angular-rspack-compiler`.

## Expected Behavior

`nx migrate latest` updates `@nx/angular-rspack` and `@nx/angular-rspack-compiler` along with all other `@nx/*` packages.

## Related Issue(s)

Fixes #32772