### PR TITLE
fix(nx-cloud): allow download-cloud-client to work outside nx workspaces

### DIFF
--- a/packages/nx/src/command-line/nx-cloud/download-cloud-client/download-cloud-client.ts
+++ b/packages/nx/src/command-line/nx-cloud/download-cloud-client/download-cloud-client.ts
@@ -4,7 +4,6 @@ import { getCloudOptions } from '../../../nx-cloud/utilities/get-cloud-options';
 import { isNxCloudUsed } from '../../../utils/nx-cloud-utils';
 import { handleErrors } from '../../../utils/handle-errors';
 import { output } from '../../../utils/output';
-import { warnNotConnectedToCloud } from '../utils';
 
 export interface DownloadCloudClientArgs {
   verbose?: boolean;
@@ -13,13 +12,19 @@ export interface DownloadCloudClientArgs {
 export function downloadCloudClientHandler(
   args: DownloadCloudClientArgs
 ): Promise<number> {
-  if (!isNxCloudUsed(readNxJson())) {
-    warnNotConnectedToCloud();
-    return Promise.resolve(1);
-  }
-
   return handleErrors(args.verbose, async () => {
-    const options = getCloudOptions();
+    // Try to get cloud options from nx.json if available, otherwise
+    // fall back to defaults (env vars / https://cloud.nx.app).
+    let options: { url?: string; customProxyConfigPath?: string } = {};
+    try {
+      const nxJson = readNxJson();
+      if (isNxCloudUsed(nxJson)) {
+        options = getCloudOptions();
+      }
+    } catch {
+      // Not in an Nx workspace — use defaults
+    }
+
     const result = await verifyOrUpdateNxCloudClient(options);
 
     if (result) {


### PR DESCRIPTION
Remove the isNxCloudUsed guard that prevented the command from running without an nx.json. Now gracefully falls back to default cloud URL when not in an Nx workspace.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
