### PR TITLE
fix(testing): handle undefined options in playwright preset

### DIFF
--- a/packages/playwright/src/utils/preset.ts
+++ b/packages/playwright/src/utils/preset.ts
@@ -69,7 +69,7 @@ export function nxE2EPreset(
       outputFolder: isTsSolutionSetup
         ? 'test-output/playwright/report'
         : join(offset, 'dist', '.playwright', projectPath, 'playwright-report'),
-      open: options.openHtmlReport,
+      open: options?.openHtmlReport ?? 'on-failure',
     },
   ]);
   const shouldGenerateBlobReports =


### PR DESCRIPTION
## Current Behavior

When calling `nxE2EPreset(__filename)` without passing the optional `options` parameter, the function throws a runtime error because `options.openHtmlReport` accesses a property on `undefined`. Other property accesses in the function already use optional chaining (`options?.testDir`, `options?.generateBlobReports`), but this one was missed.

Additionally, the `openHtmlReport` property documents a default value of `'on-failure'` via JSDoc, but that default was never actually applied in the code.

## Expected Behavior

Calling `nxE2EPreset(__filename)` without the `options` argument works without errors. The `openHtmlReport` option correctly falls back to `'on-failure'` when not specified, matching the documented `@default` in the interface.

## Related Issue(s)

N/A - Discovered when upgrading NX and we didn't pass options