### PR TITLE
fix(core): fix TUI help text layout

### DIFF
--- a/packages/nx/src/native/tui/components/help_popup.rs
+++ b/packages/nx/src/native/tui/components/help_popup.rs
@@ -188,28 +188,22 @@ impl HelpPopup {
                 ),
             ]),
             Line::from(""),
-            Line::from(vec![
-                Span::styled(
-                    "If you would prefer to not use the TUI, you can disable it by: ",
-                    Style::default().fg(THEME.primary_fg),
-                ),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "- Adding the `--no-tui` flag to your command.",
-                    Style::default()
-                        .fg(THEME.info)
-                        .add_modifier(Modifier::ITALIC),
-                ),
-            ]),
-            Line::from(vec![
-                Span::styled(
-                    "- Setting `NX_TUI=false` in your environment.",
-                    Style::default()
-                        .fg(THEME.info)
-                        .add_modifier(Modifier::ITALIC),
-                ),
-            ]),
+            Line::from(vec![Span::styled(
+                "If you would prefer to not use the TUI, you can disable it by: ",
+                Style::default().fg(THEME.primary_fg),
+            )]),
+            Line::from(vec![Span::styled(
+                "- Adding the `--no-tui` flag to your command.",
+                Style::default()
+                    .fg(THEME.info)
+                    .add_modifier(Modifier::ITALIC),
+            )]),
+            Line::from(vec![Span::styled(
+                "- Setting `NX_TUI=false` in your environment.",
+                Style::default()
+                    .fg(THEME.info)
+                    .add_modifier(Modifier::ITALIC),
+            )]),
             Line::from(""),
             Line::from(vec![
                 Span::styled(

--- a/packages/nx/src/native/tui/components/help_popup.rs
+++ b/packages/nx/src/native/tui/components/help_popup.rs
@@ -186,23 +186,31 @@ impl HelpPopup {
                     "https://nx.dev/terminal-ui",
                     Style::default().fg(THEME.info),
                 ),
+            ]),
+            Line::from(""),
+            Line::from(vec![
                 Span::styled(
                     "If you would prefer to not use the TUI, you can disable it by: ",
-                    Style::default().fg(THEME.info),
+                    Style::default().fg(THEME.primary_fg),
                 ),
+            ]),
+            Line::from(vec![
                 Span::styled(
                     "- Adding the `--no-tui` flag to your command.",
                     Style::default()
                         .fg(THEME.info)
                         .add_modifier(Modifier::ITALIC),
                 ),
+            ]),
+            Line::from(vec![
                 Span::styled(
-                    "- Setting NX_TUI=false in your environment.",
+                    "- Setting `NX_TUI=false` in your environment.",
                     Style::default()
                         .fg(THEME.info)
                         .add_modifier(Modifier::ITALIC),
                 ),
             ]),
+            Line::from(""),
             Line::from(vec![
                 Span::styled(
                     "If you are finding Nx useful, please consider giving it a star on GitHub, it means a lot: ",


### PR DESCRIPTION
## Current Behavior

The TUI help text format is currently malformed.

<img width="1181" height="191" alt="Screenshot 2026-03-07 at 11 13 40" src="https://github.com/user-attachments/assets/e66316eb-600d-4456-920e-c9538c10e7e7" />

- The links overlap the plaintext
- Some of the plaintext has the link color
- The bullet points are on the same line

## Expected Behavior

Separation of links and plaintext with bullet points on separate lines.

### Changes

The text output of the TUI help section looks like this:

```txt
│                                                                                                                                                                                                                              │
│  Thanks for using Nx! To get the most out of this terminal UI, please check out the docs: https://nx.dev/terminal-uiIf you would prefer to not use the TUI, you can disable it by: - Adding the `--no-tui` flag to your      │
│  command.- Setting NX_TUI=false in your environment.                                                                                                                                                                         │
│  If you are finding Nx useful, please consider giving it a star on GitHub, it means a lot: https://github.com/nrwl/nx                                                                                                        │
│                                                                                                                                                                                                                              │
```

This PR corrects the layout to be more readable:

```txt
│                                                                                                                                                                                                                              │
│  Thanks for using Nx! To get the most out of this terminal UI, please check out the docs: https://nx.dev/terminal-ui                                                                                                         │
│                                                                                                                                                                                                                              │
│  If you would prefer to not use the TUI, you can disable it by:                                                                                                                                                              │
│  - Adding the `--no-tui` flag to your command.                                                                                                                                                                               │
│  - Setting `NX_TUI=false` in your environment.                                                                                                                                                                               │
│                                                                                                                                                                                                                              │
│  If you are finding Nx useful, please consider giving it a star on GitHub, it means a lot: https://github.com/nrwl/nx                                                                                                        │
│                                                                                                                                                                                                                              │
```

### Notes

The help link `https://nx.dev/terminal-ui` doesn't exist at the moment.