### PR TITLE
fix(js): resolve ENOWORKSPACES test error in setupVerdaccio for @nx/js:library generator

### DIFF
--- a/packages/js/src/generators/setup-verdaccio/generator.spec.ts
+++ b/packages/js/src/generators/setup-verdaccio/generator.spec.ts
@@ -15,6 +15,12 @@ describe('setup-verdaccio generator', () => {
     tree = createTreeWithEmptyWorkspace();
   });
 
+  it('should create .verdaccio/config.yml with the correct registry', async () => {
+    await generator(tree, options);
+    const config = tree.read('.verdaccio/config.yml', 'utf-8');
+    expect(config).toContain('https://registry.npmjs.org');
+  });
+
   it('should create project.json if it does not exist', async () => {
     await generator(tree, options);
     const config = readJson(tree, 'project.json');

--- a/packages/js/src/generators/setup-verdaccio/generator.ts
+++ b/packages/js/src/generators/setup-verdaccio/generator.ts
@@ -13,7 +13,7 @@ import * as path from 'path';
 import { SetupVerdaccioGeneratorSchema } from './schema';
 import { isUsingTsSolutionSetup } from '../../utils/typescript/ts-solution-setup';
 import { verdaccioVersion } from '../../utils/versions';
-import { execSync } from 'child_process';
+import { getNpmRegistry } from '../../utils/npm-config';
 
 export async function setupVerdaccio(
   tree: Tree,
@@ -22,11 +22,7 @@ export async function setupVerdaccio(
   if (!tree.exists('.verdaccio/config.yml')) {
     generateFiles(tree, path.join(__dirname, 'files'), '.verdaccio', {
       npmUplinkRegistry:
-        execSync('npm config get registry', {
-          windowsHide: true,
-        })
-          ?.toString()
-          ?.trim() ?? 'https://registry.npmjs.org',
+        (await getNpmRegistry(tree.root)) ?? 'https://registry.npmjs.org',
     });
   }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Described in the attached issue.

When running tests for generators that extend the `@nx/js:library` generator, `setupVerdaccio()` errors with `ENOWORKSPACES` in test environments.

After doing some research, this seems to be because while `tree = createTreeWithEmptyWorkspace();` virtualizes the file system for commands that are run on `tree`, however when running commands like `execSync('npm config get registry')`, this runs based on the actual file system, and now since `nx` uses `npm` workspaces by default, this causes an `ENOWORKSPACES` error, because when running commands with `nx`, it runs inside the individual sub-project. In this context, the generated plugin that contains a test for the created generator, this is demonstrated in the attached issue.

The fix in this PR re-uses an existing method `getNpmRegistry(tree.root)` used elsewhere in the `@nx/js` plugin code. The key fix here is that it is attempts to get the registry, but is wrapped in a `try...catch`, so if this errors, it defaults to `undefined`, and the `?? 'https://registry.npmjs.org'` null-coalesce is maintained from the current implementation.

This issue doesn't seem to appear the same inside of the `nx` repo itself, because `nx` uses pnpm workspaces, which doesn't cause the same issue because `workspaces` is not set in the root `package.json`.

An alternative fix could be to instead update the documentation to mention this specific issue that when testing extended generators, you need to mock specific calls to `execSync` that call `npm config` because of the `ENOWORKSPACES` error, as [npm-cli docs](https://docs.npmjs.com/cli/v11/commands/npm-config#synopsis) call this out:
> Note: This command is unaware of workspaces.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
All tests pass regardless of how they are run.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Fixes #30283 
