### PR TITLE
fix(core): extract writeFormattedJsonFile and fix analytics formatting

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -37,6 +37,7 @@ import {
   readJsonFile,
   writeJsonFile,
 } from '../../utils/fileutils';
+import { writeFormattedJsonFile } from '../../utils/write-formatted-json-file';
 import { logger } from '../../utils/logger';
 import { commitChanges } from '../../utils/git-utils';
 import {
@@ -1481,26 +1482,6 @@ async function generateMigrationsJsonAndUpdatePackageJson(
       title: `The migrate command failed.`,
     });
     throw e;
-  }
-}
-
-async function writeFormattedJsonFile(
-  filePath: string,
-  content: any,
-  options?: JsonWriteOptions
-): Promise<void> {
-  const formattedContent = await formatFilesWithPrettierIfAvailable(
-    [{ path: filePath, content: JSON.stringify(content) }],
-    workspaceRoot,
-    { silent: true }
-  );
-
-  if (formattedContent.has(filePath)) {
-    writeFileSync(filePath, formattedContent.get(filePath)!, {
-      encoding: 'utf-8',
-    });
-  } else {
-    writeJsonFile(filePath, content, options);
   }
 }
 

--- a/packages/nx/src/utils/analytics-prompt.spec.ts
+++ b/packages/nx/src/utils/analytics-prompt.spec.ts
@@ -2,6 +2,7 @@ import { ensureAnalyticsPreferenceSet } from './analytics-prompt';
 import * as isCi from './is-ci';
 import * as enquirer from 'enquirer';
 import * as fileUtils from './fileutils';
+import * as writeFormattedModule from './write-formatted-json-file';
 import * as nxJson from '../config/nx-json';
 import * as outputModule from './output';
 
@@ -13,7 +14,9 @@ describe('analytics-prompt', () => {
   let mockPrompt = jest.spyOn(enquirer, 'prompt');
   let mockReadNxJson = jest.spyOn(nxJson, 'readNxJson');
   let mockReadJsonFile = jest.spyOn(fileUtils, 'readJsonFile');
-  let mockWriteJsonFile = jest.spyOn(fileUtils, 'writeJsonFile');
+  let mockWriteFormattedJsonFile = jest
+    .spyOn(writeFormattedModule, 'writeFormattedJsonFile')
+    .mockResolvedValue(undefined);
   let mockOutputLog = jest.spyOn(outputModule.output, 'log');
   let mockOutputSuccess = jest.spyOn(outputModule.output, 'success');
 
@@ -42,7 +45,7 @@ describe('analytics-prompt', () => {
       await ensureAnalyticsPreferenceSet();
 
       expect(mockPrompt).not.toHaveBeenCalled();
-      expect(mockWriteJsonFile).not.toHaveBeenCalled();
+      expect(mockWriteFormattedJsonFile).not.toHaveBeenCalled();
     });
 
     it('should skip prompting in non-interactive terminals', async () => {
@@ -55,7 +58,7 @@ describe('analytics-prompt', () => {
       await ensureAnalyticsPreferenceSet();
 
       expect(mockPrompt).not.toHaveBeenCalled();
-      expect(mockWriteJsonFile).not.toHaveBeenCalled();
+      expect(mockWriteFormattedJsonFile).not.toHaveBeenCalled();
     });
 
     it('should skip prompting if analytics is already true', async () => {
@@ -67,7 +70,7 @@ describe('analytics-prompt', () => {
       await ensureAnalyticsPreferenceSet();
 
       expect(mockPrompt).not.toHaveBeenCalled();
-      expect(mockWriteJsonFile).not.toHaveBeenCalled();
+      expect(mockWriteFormattedJsonFile).not.toHaveBeenCalled();
     });
 
     it('should skip prompting if analytics is already false', async () => {
@@ -80,7 +83,7 @@ describe('analytics-prompt', () => {
       await ensureAnalyticsPreferenceSet();
 
       expect(mockPrompt).not.toHaveBeenCalled();
-      expect(mockWriteJsonFile).not.toHaveBeenCalled();
+      expect(mockWriteFormattedJsonFile).not.toHaveBeenCalled();
     });
 
     it('should prompt and save true when user accepts', async () => {
@@ -95,7 +98,7 @@ describe('analytics-prompt', () => {
       await ensureAnalyticsPreferenceSet();
 
       expect(mockPrompt).toHaveBeenCalled();
-      expect(mockWriteJsonFile).toHaveBeenCalledWith(
+      expect(mockWriteFormattedJsonFile).toHaveBeenCalledWith(
         expect.stringContaining('nx.json'),
         expect.objectContaining({ analytics: true })
       );
@@ -112,7 +115,7 @@ describe('analytics-prompt', () => {
       await ensureAnalyticsPreferenceSet();
 
       expect(mockPrompt).toHaveBeenCalled();
-      expect(mockWriteJsonFile).toHaveBeenCalledWith(
+      expect(mockWriteFormattedJsonFile).toHaveBeenCalledWith(
         expect.stringContaining('nx.json'),
         expect.objectContaining({ analytics: false })
       );
@@ -129,7 +132,7 @@ describe('analytics-prompt', () => {
       await ensureAnalyticsPreferenceSet();
 
       expect(mockPrompt).toHaveBeenCalled();
-      expect(mockWriteJsonFile).toHaveBeenCalledWith(
+      expect(mockWriteFormattedJsonFile).toHaveBeenCalledWith(
         expect.stringContaining('nx.json'),
         expect.objectContaining({ analytics: false })
       );

--- a/packages/nx/src/utils/analytics-prompt.ts
+++ b/packages/nx/src/utils/analytics-prompt.ts
@@ -1,14 +1,13 @@
 import { createHash } from 'crypto';
 import { execSync } from 'child_process';
 import { prompt } from 'enquirer';
-import { writeFileSync } from 'fs';
 import { join } from 'path';
 import { output } from './output';
 import { isCI } from './is-ci';
 import { readNxJson } from '../config/nx-json';
-import { writeJsonFile } from './fileutils';
+import { readJsonFile } from './fileutils';
+import { writeFormattedJsonFile } from './write-formatted-json-file';
 import { workspaceRoot } from './workspace-root';
-import { formatFilesWithPrettierIfAvailable } from '../generators/internal-utils/format-changed-files-with-prettier-if-available';
 
 /**
  * Prompts user for analytics preference if not already set in nx.json.
@@ -64,22 +63,9 @@ export async function promptForAnalyticsPreference(): Promise<boolean> {
 async function saveAnalyticsPreference(enabled: boolean): Promise<void> {
   try {
     const nxJsonPath = join(workspaceRoot, 'nx.json');
-    const nxJson = readNxJson(workspaceRoot);
+    const nxJson = readJsonFile(nxJsonPath);
     nxJson.analytics = enabled;
-
-    const formattedContent = await formatFilesWithPrettierIfAvailable(
-      [{ path: nxJsonPath, content: JSON.stringify(nxJson) }],
-      workspaceRoot,
-      { silent: true }
-    );
-
-    if (formattedContent.has(nxJsonPath)) {
-      writeFileSync(nxJsonPath, formattedContent.get(nxJsonPath)!, {
-        encoding: 'utf-8',
-      });
-    } else {
-      writeJsonFile(nxJsonPath, nxJson);
-    }
+    await writeFormattedJsonFile(nxJsonPath, nxJson);
 
     if (enabled) {
       output.success({ title: 'Thank you for helping improve Nx!' });

--- a/packages/nx/src/utils/write-formatted-json-file.ts
+++ b/packages/nx/src/utils/write-formatted-json-file.ts
@@ -1,0 +1,30 @@
+import { writeFileSync } from 'node:fs';
+import { formatFilesWithPrettierIfAvailable } from '../generators/internal-utils/format-changed-files-with-prettier-if-available';
+import { serializeJson } from './json';
+import type { JsonSerializeOptions } from './json';
+import { writeJsonFile, type JsonWriteOptions } from './fileutils';
+import { workspaceRoot } from './workspace-root';
+
+/**
+ * Writes a JSON file, formatting with Prettier if available, otherwise
+ * falling back to standard JSON serialization.
+ */
+export async function writeFormattedJsonFile<T extends object = object>(
+  filePath: string,
+  content: T,
+  options?: JsonWriteOptions
+): Promise<void> {
+  const formattedContent = await formatFilesWithPrettierIfAvailable(
+    [{ path: filePath, content: serializeJson(content) }],
+    workspaceRoot,
+    { silent: true }
+  );
+
+  if (formattedContent.has(filePath)) {
+    writeFileSync(filePath, formattedContent.get(filePath)!, {
+      encoding: 'utf-8',
+    });
+  } else {
+    writeJsonFile(filePath, content, options);
+  }
+}


### PR DESCRIPTION
## Current Behavior

When the analytics prompt saves the user's preference to `nx.json`, it passes unindented JSON (`JSON.stringify(content)`) to Prettier. Prettier produces different output for unindented vs indented input, causing unnecessary whitespace diffs across the entire file. The same `writeFormattedJsonFile` pattern was also duplicated privately in `migrate.ts`.

## Expected Behavior

Use `serializeJson` (2-space indent) before passing to Prettier, matching how the Tree path formats JSON. This produces minimal diffs — only the added `"analytics"` property changes. The `writeFormattedJsonFile` helper is extracted to `fileutils.ts` as a shared utility so both `migrate.ts` and the analytics prompt use the same logic.

## Related Issue(s)

N/A - discovered during analytics prompt testing