### PR TITLE
feat(core): persist analytics session ID across CLI invocations

### DIFF
--- a/packages/nx/src/analytics/analytics.spec.ts
+++ b/packages/nx/src/analytics/analytics.spec.ts
@@ -1,16 +1,37 @@
 import { argsToQueryString } from './analytics';
 
 describe('argsToQueryString', () => {
-  it('should convert simple non-sensitive args to query string', () => {
-    const result = argsToQueryString({ verbose: true, parallel: 3 });
-    expect(result).toBe('verbose=true&parallel=3');
+  it('should include boolean args', () => {
+    const result = argsToQueryString({ verbose: true, skipNxCache: false });
+    expect(result).toBe('verbose=true&skipNxCache=false');
   });
 
-  it('should handle array values by repeating the key', () => {
+  it('should include number args', () => {
+    const result = argsToQueryString({ parallel: 3, port: 4200 });
+    expect(result).toBe('parallel=3&port=4200');
+  });
+
+  it('should include allowed string args', () => {
+    const result = argsToQueryString({ outputStyle: 'dynamic', type: 'app' });
+    expect(result).toBe('outputStyle=dynamic&type=app');
+  });
+
+  it('should drop unknown string args', () => {
     const result = argsToQueryString({
-      targets: ['build', 'test'],
+      verbose: true,
+      project: 'my-secret-app',
+      file: '/path/to/file.json',
     });
-    expect(result).toBe('targets=build&targets=test');
+    expect(result).toBe('verbose=true');
+  });
+
+  it('should drop array args', () => {
+    const result = argsToQueryString({
+      verbose: true,
+      targets: ['build', 'test'],
+      projects: ['app1', 'app2'],
+    });
+    expect(result).toBe('verbose=true');
   });
 
   it('should filter out internal yargs keys', () => {
@@ -33,140 +54,48 @@ describe('argsToQueryString', () => {
     expect(result).toBe('verbose=true');
   });
 
-  it('should skip nested objects (non-array)', () => {
-    const result = argsToQueryString({
-      verbose: true,
-      nested: { deep: 'value' },
-    });
-    expect(result).toBe('verbose=true');
-  });
-
   it('should return empty string for empty args', () => {
     const result = argsToQueryString({});
     expect(result).toBe('');
   });
 
-  it('should return empty string when all keys are internal', () => {
+  it('should handle a real-world run-many scenario', () => {
     const result = argsToQueryString({
+      targets: ['build', 'test'],
+      projects: ['cart', 'checkout'],
+      parallel: 3,
+      verbose: false,
+      skipNxCache: false,
+      nxBail: true,
+      outputStyle: 'stream',
       $0: 'nx',
-      _: [],
+      _: ['run-many'],
     });
-    expect(result).toBe('');
+    expect(result).toBe(
+      'parallel=3&verbose=false&skipNxCache=false&nxBail=true&outputStyle=stream'
+    );
   });
 
-  it('should handle numeric values for non-sensitive keys', () => {
-    const result = argsToQueryString({ port: 4200 });
-    expect(result).toBe('port=4200');
+  it('should drop sensitive data like paths, URLs, git refs', () => {
+    const result = argsToQueryString({
+      file: 'output.json',
+      focus: 'my-secret-app',
+      host: '192.168.1.1',
+      base: 'feature/secret-branch',
+      head: 'main',
+      baseUrl: 'https://internal.company.com',
+      port: 4200,
+      watch: true,
+    });
+    // Only boolean and number values pass through
+    expect(result).toBe('port=4200&watch=true');
   });
 
-  it('should handle false boolean values', () => {
-    const result = argsToQueryString({ verbose: false });
-    expect(result).toBe('verbose=false');
-  });
-
-  describe('sensitive args sanitization', () => {
-    it('should redact sensitive file paths', () => {
-      const result = argsToQueryString({ file: '/path/to/file.json' });
-      expect(result).toBe('file=%3Credacted%3E');
+  it('should drop nested objects', () => {
+    const result = argsToQueryString({
+      verbose: true,
+      nested: { deep: 'value' },
     });
-
-    it('should redact sensitive project identifiers', () => {
-      const result = argsToQueryString({
-        project: 'my-secret-app',
-        focus: 'internal-lib',
-      });
-      expect(result).toBe('project=%3Credacted%3E&focus=%3Credacted%3E');
-    });
-
-    it('should preserve boolean values on sensitive keys', () => {
-      const result = argsToQueryString({ runMigrations: true });
-      expect(result).toBe('runMigrations=true');
-    });
-
-    it('should preserve false boolean values on sensitive keys', () => {
-      const result = argsToQueryString({ graph: false });
-      expect(result).toBe('graph=false');
-    });
-
-    it('should redact non-boolean values on sensitive keys', () => {
-      const result = argsToQueryString({
-        runMigrations: 'migrations.json',
-      });
-      expect(result).toBe('runMigrations=%3Credacted%3E');
-    });
-
-    it('should pass through non-sensitive keys unchanged', () => {
-      const result = argsToQueryString({
-        verbose: true,
-        port: 4200,
-        parallel: 3,
-      });
-      expect(result).toBe('verbose=true&port=4200&parallel=3');
-    });
-
-    it('should redact each element of array values for sensitive keys', () => {
-      const result = argsToQueryString({
-        projects: ['secret-app', 'internal-lib'],
-      });
-      expect(result).toBe('projects=%3Credacted%3E&projects=%3Credacted%3E');
-    });
-
-    it('should preserve each element of array values for non-sensitive keys', () => {
-      const result = argsToQueryString({
-        targets: ['build', 'test'],
-      });
-      expect(result).toBe('targets=build&targets=test');
-    });
-
-    it('should catch kebab-case sensitive keys', () => {
-      const result = argsToQueryString({ 'output-path': 'dist/app' });
-      expect(result).toBe('output-path=%3Credacted%3E');
-    });
-
-    it('should handle a real-world graph command scenario', () => {
-      const result = argsToQueryString({
-        file: 'output.json',
-        focus: 'my-secret-app',
-        exclude: 'internal-lib',
-        host: '192.168.1.1',
-        port: 4200,
-        targets: 'build',
-        watch: true,
-      });
-      expect(result).toBe(
-        'file=%3Credacted%3E&focus=%3Credacted%3E&exclude=%3Credacted%3E&host=%3Credacted%3E&port=4200&targets=build&watch=true'
-      );
-    });
-
-    it('should always redact credentials', () => {
-      const result = argsToQueryString({ otp: '123456' });
-      expect(result).toBe('otp=%3Credacted%3E');
-    });
-
-    it('should redact git refs', () => {
-      const result = argsToQueryString({
-        base: 'feature/secret-branch',
-        head: 'main',
-      });
-      expect(result).toBe('base=%3Credacted%3E&head=%3Credacted%3E');
-    });
-
-    it('should redact URLs and hosts', () => {
-      const result = argsToQueryString({
-        baseUrl: 'https://internal.company.com',
-        deployUrl: 'https://staging.company.com/app',
-      });
-      expect(result).toBe('baseUrl=%3Credacted%3E&deployUrl=%3Credacted%3E');
-    });
-
-    it('should handle kebab-case config keys', () => {
-      const result = argsToQueryString({
-        'ts-config': 'tsconfig.app.json',
-        'webpack-config': 'webpack.config.js',
-      });
-      expect(result).toBe(
-        'ts-config=%3Credacted%3E&webpack-config=%3Credacted%3E'
-      );
-    });
+    expect(result).toBe('verbose=true');
   });
 });

--- a/packages/nx/src/analytics/analytics.ts
+++ b/packages/nx/src/analytics/analytics.ts
@@ -18,6 +18,7 @@ import * as os from 'os';
 import { getCurrentMachineId } from '../utils/machine-id-cache';
 import { isCI } from '../utils/is-ci';
 import { generateWorkspaceId } from '../utils/analytics-prompt';
+import { getDbConnection } from '../utils/db-connection';
 
 // Conditionally import telemetry functions only on non-WASM platforms
 let initializeTelemetry: typeof InitializeTelemetryType;
@@ -66,7 +67,10 @@ export async function startAnalytics() {
     : 'unknown';
 
   try {
+    const dbConnection = getDbConnection();
+
     initializeTelemetry(
+      dbConnection,
       workspaceId,
       userId,
       nxVersion,

--- a/packages/nx/src/analytics/analytics.ts
+++ b/packages/nx/src/analytics/analytics.ts
@@ -133,155 +133,38 @@ export function reportProjectGraphCreationEvent(duration: number) {
   });
 }
 
-const INTERNAL_ARGS_KEYS = new Set([
+const SKIP_ARGS_KEYS = new Set([
   '$0',
   '_',
   '__overrides_unparsed__',
   '__overrides__',
 ]);
 
-const SENSITIVE_ARGS_KEYS = new Set([
-  // Project identifiers — could reveal internal project/business names
-  'project',
-  'projects',
-  'projectName',
-  'focus',
-  'exclude',
-  'groups',
-  'group',
-  'appProject',
-  'e2eProject',
-  'backendProject',
-  'name',
-
-  // File paths — could reveal usernames, directory structure, client names
-  'file',
-  'files',
-  'cwd',
-  'envFile',
-  'outputPath',
-  'tsConfig',
-  'directory',
-  'source',
-  'destination',
-  'sourceDirectory',
-  'destinationDirectory',
-  'main',
-  'index',
-  'polyfills',
-  'config',
-  'configFile',
-  'webpackConfig',
-  'rspackConfig',
-  'viteConfig',
-  'jestConfig',
-  'cypressConfig',
-  'entryFile',
-  'coverageDirectory',
-  'projectRoot',
-  'sourceRoot',
-  'workspaceRoot',
-  'input',
-  'output',
-
-  // URLs and hosts — could expose internal infrastructure
-  'host',
-  'baseUrl',
-  'baseHref',
-  'deployUrl',
-  'publicUrl',
-  'publicPath',
-  'url',
-  'remote',
-  'registry',
-  'sourceRepository',
-
-  // Package/module names — could reveal private packages
-  'importPath',
-  'npmScope',
-  'packageName',
-  'moduleName',
-  'packageSpecifier',
-  'packageAndVersion',
-  'generator',
-  'collection',
-  'plugin',
-  'bundleName',
-  'entryName',
-  'outputFileName',
-
-  // Free-form text — could contain anything
-  'message',
-  'commitPrefix',
-  'gitCommitMessage',
-  'gitTagMessage',
-  'gitCommitArgs',
-  'gitTagArgs',
-  'gitPushArgs',
-  'command',
-  'commands',
-  'script',
-  'description',
-  'prefix',
-  'displayName',
-  'tags',
-  'title',
-  'label',
-  'scope',
-  'tag',
-
-  // Credentials and auth
-  'otp',
-  'key',
+// String args with fixed enum values that are safe to include in analytics.
+// All boolean and number args are included automatically.
+const ALLOWED_STRING_ARGS = new Set([
+  'outputStyle',
+  'type',
+  'view',
   'access',
-  'ciBuildId',
-
-  // Git refs — could reveal branch naming conventions
-  'base',
-  'head',
-  'ref',
-  'from',
-  'to',
-
-  // Keys that can be string paths (not just booleans)
-  'runMigrations',
-  'graph',
+  'preset',
+  'interactive',
+  'printConfig',
+  'resolveVersionPlans',
 ]);
-
-function isSensitiveKey(key: string): boolean {
-  if (SENSITIVE_ARGS_KEYS.has(key)) return true;
-  // Normalize kebab-case to camelCase and re-check
-  if (key.includes('-')) {
-    const camelKey = key.replace(/-(.)/g, (_, c) => c.toUpperCase());
-    return SENSITIVE_ARGS_KEYS.has(camelKey);
-  }
-  return false;
-}
-
-function sanitizeValue(value: any): string {
-  // Preserve booleans — we still want to know true vs false
-  if (typeof value === 'boolean') {
-    return String(value);
-  }
-  return '<redacted>';
-}
 
 export function argsToQueryString(args: Record<string, any>): string {
   const params = new URLSearchParams();
   for (const [key, value] of Object.entries(args)) {
-    if (INTERNAL_ARGS_KEYS.has(key)) continue;
+    if (SKIP_ARGS_KEYS.has(key)) continue;
     if (value === undefined || value === null) continue;
-    if (typeof value === 'object' && !Array.isArray(value)) continue;
 
-    const sensitive = isSensitiveKey(key);
-
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        params.append(key, sensitive ? sanitizeValue(item) : String(item));
-      }
-    } else {
-      params.append(key, sensitive ? sanitizeValue(value) : String(value));
+    if (typeof value === 'boolean' || typeof value === 'number') {
+      params.append(key, String(value));
+    } else if (typeof value === 'string' && ALLOWED_STRING_ARGS.has(key)) {
+      params.append(key, value);
     }
+    // All other types (strings, arrays, objects) are dropped
   }
   return params.toString();
 }

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -37,6 +37,7 @@ import {
   readJsonFile,
   writeJsonFile,
 } from '../../utils/fileutils';
+import { writeFormattedJsonFile } from '../../utils/write-formatted-json-file';
 import { logger } from '../../utils/logger';
 import { commitChanges } from '../../utils/git-utils';
 import {
@@ -1481,26 +1482,6 @@ async function generateMigrationsJsonAndUpdatePackageJson(
       title: `The migrate command failed.`,
     });
     throw e;
-  }
-}
-
-async function writeFormattedJsonFile(
-  filePath: string,
-  content: any,
-  options?: JsonWriteOptions
-): Promise<void> {
-  const formattedContent = await formatFilesWithPrettierIfAvailable(
-    [{ path: filePath, content: JSON.stringify(content) }],
-    workspaceRoot,
-    { silent: true }
-  );
-
-  if (formattedContent.has(filePath)) {
-    writeFileSync(filePath, formattedContent.get(filePath)!, {
-      encoding: 'utf-8',
-    });
-  } else {
-    writeJsonFile(filePath, content, options);
   }
 }
 

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -126,7 +126,10 @@ export const commandsObject = yargs
   .command(resolveConformanceCheckCommandObject())
   .scriptName('nx')
   .middleware((args) => {
-    const command = (args._ ?? []).join(' ');
+    const context = (commandsObject as any).getInternalMethods().getContext();
+    const command =
+      (context.commands ?? []).join(' ') ||
+      (args._ ?? []).slice(0, 1).join(' ');
     if (command) {
       reportCommandRunEvent(command, undefined, args);
     }

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -377,10 +377,11 @@ export interface HashInputs {
 }
 
 /**
- * Initialize the global telemetry service
- * This should be called once at startup from TypeScript
+ * Initialize the global telemetry service.
+ * Reads or creates a session ID from the database so that multiple CLI
+ * invocations within 30 minutes share the same GA4 session.
  */
-export declare function initializeTelemetry(workspaceId: string, userId: string, nxVersion: string, packageManagerName: string, packageManagerVersion: string | undefined | null, nodeVersion: string, osArch: string, osPlatform: string, osRelease: string, isCi: boolean, isNxCloud: boolean): void
+export declare function initializeTelemetry(connection: ExternalObject<NxDbConnection>, workspaceId: string, userId: string, nxVersion: string, packageManagerName: string, packageManagerVersion: string | undefined | null, nodeVersion: string, osArch: string, osPlatform: string, osRelease: string, isCi: boolean, isNxCloud: boolean): void
 
 export interface InputsInput {
   input: string

--- a/packages/nx/src/native/telemetry/mod.rs
+++ b/packages/nx/src/native/telemetry/mod.rs
@@ -178,68 +178,40 @@ fn get_or_create_session_id(connection: &External<Arc<Mutex<NxDbConnection>>>) -
         .lock()
         .map_err(|e| Error::from_reason(format!("Failed to lock database connection: {}", e)))?;
 
-    // Try to get existing session
-    let existing = conn
+    // Return session ID only if it exists and last activity was within 30 minutes
+    let active_session = conn
         .query_row(
-            "SELECT m1.value, m2.value FROM metadata m1, metadata m2 \
-             WHERE m1.key = 'SESSION_ID' AND m2.key = 'SESSION_LAST_ACTIVITY'",
+            &format!(
+                "SELECT m1.value FROM metadata m1, metadata m2 \
+                 WHERE m1.key = 'SESSION_ID' AND m2.key = 'SESSION_LAST_ACTIVITY' \
+                 AND (strftime('%s', 'now') - strftime('%s', m2.value)) < {}",
+                SESSION_TIMEOUT_SECS
+            ),
             [],
-            |row| {
-                let session_id: String = row.get(0)?;
-                let last_activity: String = row.get(1)?;
-                Ok((session_id, last_activity))
-            },
+            |row| row.get::<_, String>(0),
         )
         .map_err(|e| Error::from_reason(format!("Failed to query session: {}", e)))?;
 
-    if let Some((session_id, last_activity)) = existing {
-        // Check if session is still active (within timeout)
-        let is_active = conn
-            .query_row(
-                &format!(
-                    "SELECT (strftime('%s', 'now') - strftime('%s', '{}')) < {}",
-                    last_activity, SESSION_TIMEOUT_SECS
-                ),
-                [],
-                |row| {
-                    let active: bool = row.get(0)?;
-                    Ok(active)
-                },
-            )
-            .map_err(|e| Error::from_reason(format!("Failed to check session timeout: {}", e)))?
-            .unwrap_or(false);
+    let session_id = if let Some(id) = active_session {
+        tracing::trace!("Reusing existing analytics session: {}", id);
+        id
+    } else {
+        let id = uuid::Uuid::new_v4().to_string();
+        conn.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('SESSION_ID', ?1)",
+            [&id],
+        )
+        .map_err(|e| Error::from_reason(format!("Failed to save session ID: {}", e)))?;
+        tracing::trace!("Created new analytics session: {}", id);
+        id
+    };
 
-        if is_active {
-            // Update last activity and reuse session
-            conn.execute(
-                "INSERT OR REPLACE INTO metadata (key, value) VALUES ('SESSION_LAST_ACTIVITY', datetime('now'))",
-                [],
-            )
-            .map_err(|e| {
-                Error::from_reason(format!("Failed to update session activity: {}", e))
-            })?;
-
-            tracing::trace!("Reusing existing analytics session: {}", session_id);
-            return Ok(session_id);
-        }
-    }
-
-    // Create new session
-    let session_id = uuid::Uuid::new_v4().to_string();
-    conn.execute(
-        "INSERT OR REPLACE INTO metadata (key, value) VALUES ('SESSION_ID', ?1)",
-        [&session_id],
-    )
-    .map_err(|e| Error::from_reason(format!("Failed to save session ID: {}", e)))?;
-
+    // Always update last activity timestamp
     conn.execute(
         "INSERT OR REPLACE INTO metadata (key, value) VALUES ('SESSION_LAST_ACTIVITY', datetime('now'))",
         [],
     )
-    .map_err(|e| {
-        Error::from_reason(format!("Failed to save session activity: {}", e))
-    })?;
+    .map_err(|e| Error::from_reason(format!("Failed to update session activity: {}", e)))?;
 
-    tracing::trace!("Created new analytics session: {}", session_id);
     Ok(session_id)
 }

--- a/packages/nx/src/native/telemetry/mod.rs
+++ b/packages/nx/src/native/telemetry/mod.rs
@@ -23,10 +23,14 @@ mod service;
 use napi::bindgen_prelude::*;
 use once_cell::sync::OnceCell;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
+use crate::native::db::connection::NxDbConnection;
 use constants::event_dimension;
 use service::TelemetryService;
+
+/// Session timeout in seconds (30 minutes)
+const SESSION_TIMEOUT_SECS: i64 = 30 * 60;
 
 // Global telemetry instance for Rust code to use directly
 static GLOBAL_TELEMETRY: OnceCell<Arc<TelemetryService>> = OnceCell::new();
@@ -35,10 +39,14 @@ static GLOBAL_TELEMETRY: OnceCell<Arc<TelemetryService>> = OnceCell::new();
 // Public NAPI API
 // =============================================================================
 
-/// Initialize the global telemetry service
-/// This should be called once at startup from TypeScript
+/// Initialize the global telemetry service.
+/// Reads or creates a session ID from the database so that multiple CLI
+/// invocations within 30 minutes share the same GA4 session.
 #[napi]
 pub fn initialize_telemetry(
+    #[napi(ts_arg_type = "ExternalObject<NxDbConnection>")] connection: &External<
+        Arc<Mutex<NxDbConnection>>,
+    >,
     workspace_id: String,
     user_id: String,
     nx_version: String,
@@ -56,9 +64,12 @@ pub fn initialize_telemetry(
         workspace_id
     );
 
+    let session_id = get_or_create_session_id(connection)?;
+
     let service = TelemetryService::new(
         workspace_id,
         user_id,
+        session_id,
         nx_version,
         package_manager_name,
         package_manager_version,
@@ -157,4 +168,78 @@ pub fn track_rust_event(event_name: impl Into<String>, parameters: HashMap<Strin
             tracing::trace!("Failed to track event: {}", e);
         }
     }
+}
+
+/// Get or create an analytics session ID from the database.
+/// Reuses an existing session if the last activity was within 30 minutes,
+/// otherwise creates a new session.
+fn get_or_create_session_id(connection: &External<Arc<Mutex<NxDbConnection>>>) -> Result<String> {
+    let conn = connection
+        .lock()
+        .map_err(|e| Error::from_reason(format!("Failed to lock database connection: {}", e)))?;
+
+    // Try to get existing session
+    let existing = conn
+        .query_row(
+            "SELECT m1.value, m2.value FROM metadata m1, metadata m2 \
+             WHERE m1.key = 'SESSION_ID' AND m2.key = 'SESSION_LAST_ACTIVITY'",
+            [],
+            |row| {
+                let session_id: String = row.get(0)?;
+                let last_activity: String = row.get(1)?;
+                Ok((session_id, last_activity))
+            },
+        )
+        .map_err(|e| Error::from_reason(format!("Failed to query session: {}", e)))?;
+
+    if let Some((session_id, last_activity)) = existing {
+        // Check if session is still active (within timeout)
+        let is_active = conn
+            .query_row(
+                &format!(
+                    "SELECT (strftime('%s', 'now') - strftime('%s', '{}')) < {}",
+                    last_activity, SESSION_TIMEOUT_SECS
+                ),
+                [],
+                |row| {
+                    let active: bool = row.get(0)?;
+                    Ok(active)
+                },
+            )
+            .map_err(|e| Error::from_reason(format!("Failed to check session timeout: {}", e)))?
+            .unwrap_or(false);
+
+        if is_active {
+            // Update last activity and reuse session
+            conn.execute(
+                "INSERT OR REPLACE INTO metadata (key, value) VALUES ('SESSION_LAST_ACTIVITY', datetime('now'))",
+                [],
+            )
+            .map_err(|e| {
+                Error::from_reason(format!("Failed to update session activity: {}", e))
+            })?;
+
+            tracing::trace!("Reusing existing analytics session: {}", session_id);
+            return Ok(session_id);
+        }
+    }
+
+    // Create new session
+    let session_id = uuid::Uuid::new_v4().to_string();
+    conn.execute(
+        "INSERT OR REPLACE INTO metadata (key, value) VALUES ('SESSION_ID', ?1)",
+        [&session_id],
+    )
+    .map_err(|e| Error::from_reason(format!("Failed to save session ID: {}", e)))?;
+
+    conn.execute(
+        "INSERT OR REPLACE INTO metadata (key, value) VALUES ('SESSION_LAST_ACTIVITY', datetime('now'))",
+        [],
+    )
+    .map_err(|e| {
+        Error::from_reason(format!("Failed to save session activity: {}", e))
+    })?;
+
+    tracing::trace!("Created new analytics session: {}", session_id);
+    Ok(session_id)
 }

--- a/packages/nx/src/native/telemetry/service.rs
+++ b/packages/nx/src/native/telemetry/service.rs
@@ -35,6 +35,7 @@ impl TelemetryService {
     pub fn new(
         workspace_id: String,
         user_id: String,
+        session_id: String,
         nx_version: String,
         package_manager_name: String,
         package_manager_version: Option<String>,
@@ -51,9 +52,6 @@ impl TelemetryService {
 
         // Detect AI agent from environment variables
         let is_ai_agent = crate::native::utils::ai::is_ai_agent();
-
-        // Session ID - generate a unique ID for this session
-        let session_id = uuid::Uuid::new_v4().to_string();
 
         let mut common_request_parameters = HashMap::new();
         common_request_parameters

--- a/packages/nx/src/utils/analytics-prompt.spec.ts
+++ b/packages/nx/src/utils/analytics-prompt.spec.ts
@@ -2,6 +2,7 @@ import { ensureAnalyticsPreferenceSet } from './analytics-prompt';
 import * as isCi from './is-ci';
 import * as enquirer from 'enquirer';
 import * as fileUtils from './fileutils';
+import * as writeFormattedModule from './write-formatted-json-file';
 import * as nxJson from '../config/nx-json';
 import * as outputModule from './output';
 
@@ -13,7 +14,9 @@ describe('analytics-prompt', () => {
   let mockPrompt = jest.spyOn(enquirer, 'prompt');
   let mockReadNxJson = jest.spyOn(nxJson, 'readNxJson');
   let mockReadJsonFile = jest.spyOn(fileUtils, 'readJsonFile');
-  let mockWriteJsonFile = jest.spyOn(fileUtils, 'writeJsonFile');
+  let mockWriteFormattedJsonFile = jest
+    .spyOn(writeFormattedModule, 'writeFormattedJsonFile')
+    .mockResolvedValue(undefined);
   let mockOutputLog = jest.spyOn(outputModule.output, 'log');
   let mockOutputSuccess = jest.spyOn(outputModule.output, 'success');
 
@@ -42,7 +45,7 @@ describe('analytics-prompt', () => {
       await ensureAnalyticsPreferenceSet();
 
       expect(mockPrompt).not.toHaveBeenCalled();
-      expect(mockWriteJsonFile).not.toHaveBeenCalled();
+      expect(mockWriteFormattedJsonFile).not.toHaveBeenCalled();
     });
 
     it('should skip prompting in non-interactive terminals', async () => {
@@ -55,7 +58,7 @@ describe('analytics-prompt', () => {
       await ensureAnalyticsPreferenceSet();
 
       expect(mockPrompt).not.toHaveBeenCalled();
-      expect(mockWriteJsonFile).not.toHaveBeenCalled();
+      expect(mockWriteFormattedJsonFile).not.toHaveBeenCalled();
     });
 
     it('should skip prompting if analytics is already true', async () => {
@@ -67,7 +70,7 @@ describe('analytics-prompt', () => {
       await ensureAnalyticsPreferenceSet();
 
       expect(mockPrompt).not.toHaveBeenCalled();
-      expect(mockWriteJsonFile).not.toHaveBeenCalled();
+      expect(mockWriteFormattedJsonFile).not.toHaveBeenCalled();
     });
 
     it('should skip prompting if analytics is already false', async () => {
@@ -80,7 +83,7 @@ describe('analytics-prompt', () => {
       await ensureAnalyticsPreferenceSet();
 
       expect(mockPrompt).not.toHaveBeenCalled();
-      expect(mockWriteJsonFile).not.toHaveBeenCalled();
+      expect(mockWriteFormattedJsonFile).not.toHaveBeenCalled();
     });
 
     it('should prompt and save true when user accepts', async () => {
@@ -95,7 +98,7 @@ describe('analytics-prompt', () => {
       await ensureAnalyticsPreferenceSet();
 
       expect(mockPrompt).toHaveBeenCalled();
-      expect(mockWriteJsonFile).toHaveBeenCalledWith(
+      expect(mockWriteFormattedJsonFile).toHaveBeenCalledWith(
         expect.stringContaining('nx.json'),
         expect.objectContaining({ analytics: true })
       );
@@ -112,7 +115,7 @@ describe('analytics-prompt', () => {
       await ensureAnalyticsPreferenceSet();
 
       expect(mockPrompt).toHaveBeenCalled();
-      expect(mockWriteJsonFile).toHaveBeenCalledWith(
+      expect(mockWriteFormattedJsonFile).toHaveBeenCalledWith(
         expect.stringContaining('nx.json'),
         expect.objectContaining({ analytics: false })
       );
@@ -129,7 +132,7 @@ describe('analytics-prompt', () => {
       await ensureAnalyticsPreferenceSet();
 
       expect(mockPrompt).toHaveBeenCalled();
-      expect(mockWriteJsonFile).toHaveBeenCalledWith(
+      expect(mockWriteFormattedJsonFile).toHaveBeenCalledWith(
         expect.stringContaining('nx.json'),
         expect.objectContaining({ analytics: false })
       );

--- a/packages/nx/src/utils/analytics-prompt.ts
+++ b/packages/nx/src/utils/analytics-prompt.ts
@@ -1,14 +1,13 @@
 import { createHash } from 'crypto';
 import { execSync } from 'child_process';
 import { prompt } from 'enquirer';
-import { writeFileSync } from 'fs';
 import { join } from 'path';
 import { output } from './output';
 import { isCI } from './is-ci';
 import { readNxJson } from '../config/nx-json';
-import { writeJsonFile } from './fileutils';
+import { readJsonFile } from './fileutils';
+import { writeFormattedJsonFile } from './write-formatted-json-file';
 import { workspaceRoot } from './workspace-root';
-import { formatFilesWithPrettierIfAvailable } from '../generators/internal-utils/format-changed-files-with-prettier-if-available';
 
 /**
  * Prompts user for analytics preference if not already set in nx.json.
@@ -64,22 +63,9 @@ export async function promptForAnalyticsPreference(): Promise<boolean> {
 async function saveAnalyticsPreference(enabled: boolean): Promise<void> {
   try {
     const nxJsonPath = join(workspaceRoot, 'nx.json');
-    const nxJson = readNxJson(workspaceRoot);
+    const nxJson = readJsonFile(nxJsonPath);
     nxJson.analytics = enabled;
-
-    const formattedContent = await formatFilesWithPrettierIfAvailable(
-      [{ path: nxJsonPath, content: JSON.stringify(nxJson) }],
-      workspaceRoot,
-      { silent: true }
-    );
-
-    if (formattedContent.has(nxJsonPath)) {
-      writeFileSync(nxJsonPath, formattedContent.get(nxJsonPath)!, {
-        encoding: 'utf-8',
-      });
-    } else {
-      writeJsonFile(nxJsonPath, nxJson);
-    }
+    await writeFormattedJsonFile(nxJsonPath, nxJson);
 
     if (enabled) {
       output.success({ title: 'Thank you for helping improve Nx!' });

--- a/packages/nx/src/utils/write-formatted-json-file.ts
+++ b/packages/nx/src/utils/write-formatted-json-file.ts
@@ -1,0 +1,30 @@
+import { writeFileSync } from 'node:fs';
+import { formatFilesWithPrettierIfAvailable } from '../generators/internal-utils/format-changed-files-with-prettier-if-available';
+import { serializeJson } from './json';
+import type { JsonSerializeOptions } from './json';
+import { writeJsonFile, type JsonWriteOptions } from './fileutils';
+import { workspaceRoot } from './workspace-root';
+
+/**
+ * Writes a JSON file, formatting with Prettier if available, otherwise
+ * falling back to standard JSON serialization.
+ */
+export async function writeFormattedJsonFile<T extends object = object>(
+  filePath: string,
+  content: T,
+  options?: JsonWriteOptions
+): Promise<void> {
+  const formattedContent = await formatFilesWithPrettierIfAvailable(
+    [{ path: filePath, content: serializeJson(content) }],
+    workspaceRoot,
+    { silent: true }
+  );
+
+  if (formattedContent.has(filePath)) {
+    writeFileSync(filePath, formattedContent.get(filePath)!, {
+      encoding: 'utf-8',
+    });
+  } else {
+    writeJsonFile(filePath, content, options);
+  }
+}


### PR DESCRIPTION
## Current Behavior

Each `nx` CLI invocation generates a new random session ID for GA4 analytics. This means GA4 cannot correlate multiple commands from the same user working session, making active user tracking inaccurate.

## Expected Behavior

Session IDs are persisted in the SQLite metadata table with a 30-minute timeout. Consecutive `nx` commands within that window share the same session ID, enabling accurate GA4 active user tracking. After 30 minutes of inactivity, a new session is automatically created.

## Related Issue(s)

N/A — internal analytics improvement