### PR TITLE
fix(webpack): update e2e snapshot for vitest reportsDirectory change

### DIFF
--- a/e2e/webpack/src/__snapshots__/webpack.legacy.test.ts.snap
+++ b/e2e/webpack/src/__snapshots__/webpack.legacy.test.ts.snap
@@ -92,7 +92,7 @@ exports[`Webpack Plugin (legacy) ConvertConfigToWebpackPlugin, should convert wi
       "executor": "@nx/vitest:test",
       "outputs": ["{options.reportsDirectory}"],
       "options": {
-        "reportsDirectory": "../coverage/app3224373"
+        "reportsDirectory": "coverage/app3224373"
       }
     },
     "serve-static": {


### PR DESCRIPTION
## Current Behavior

The webpack legacy e2e test (`e2e-webpack:e2e-ci--src/webpack.legacy.test.ts`) fails with a snapshot mismatch because the `reportsDirectory` value changed from `../coverage/app3224373` to `coverage/app3224373`.

## Expected Behavior

The snapshot should match the new `reportsDirectory` path format introduced by #34720.

## Related Issue(s)

Fixes the e2e test breakage introduced by #34720 (`fix(vitest)!: resolve reportsDirectory against workspace root`).