### PR TITLE
docs(nx-dev): add auto-apply suggestions video to self-healing CI page

### DIFF
--- a/astro-docs/src/content/docs/features/CI Features/self-healing-ci.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/self-healing-ci.mdoc
@@ -187,6 +187,11 @@ You can also specify **Never fix** patterns to exclude certain tasks from ever b
 
 ### Auto-apply verified code changes
 
+{% youtube
+src="https://youtu.be/30qh5W8zXTY"
+title="Self-Healing CI Auto-Apply Suggestions"
+/%}
+
 Automatically commit code change suggestions to the PR branch **when ALL of these are true**:
 
 1. The task **matches the glob patterns** configured below


### PR DESCRIPTION
## Current Behavior

The self-healing CI docs page has no video walkthrough for the auto-apply verified code changes feature and its suggestion notifications.

## Expected Behavior

Embed the auto-apply suggestions video (https://youtu.be/30qh5W8zXTY) in the ["Auto-apply verified code changes" section](https://deploy-preview-34769--nx-docs.netlify.app/docs/features/ci-features/self-healing-ci#auto-apply-verified-code-changes) so users can see a visual walkthrough of configuring auto-apply and acting on suggestion notifications.

## Related Issue(s)

N/A