### PR TITLE
fix(js): include transitive dep outputs in typecheck inputs

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -1684,6 +1684,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                       "{projectRoot}/**/*.cy.ts",
                       {
                         "dependentTasksOutputFiles": "**/*.{d.ts,tsbuildinfo}",
+                        "transitive": true,
                       },
                     ],
                     "metadata": {
@@ -2454,6 +2455,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                       "{projectRoot}/src/**/*.spec.ts",
                       {
                         "dependentTasksOutputFiles": "**/*.{d.ts,tsbuildinfo}",
+                        "transitive": true,
                       },
                     ],
                     "metadata": {
@@ -4259,6 +4261,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                       "{projectRoot}/src/**/foo.ts",
                       {
                         "dependentTasksOutputFiles": "**/*.{d.ts,tsbuildinfo}",
+                        "transitive": true,
                       },
                     ],
                     "metadata": {

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -883,6 +883,7 @@ function getInputs(
     // https://www.typescriptlang.org/docs/handbook/project-references.html#what-is-a-project-reference
     inputs.push({
       dependentTasksOutputFiles: '**/*.{d.ts,tsbuildinfo}',
+      transitive: true,
     });
   } else {
     inputs.push('production' in namedInputs ? '^production' : '^default');


### PR DESCRIPTION
## Current Behavior

The `@nx/js/typescript` plugin infers `dependentTasksOutputFiles: '**/*.{d.ts,tsbuildinfo}'` as inputs for typecheck tasks, but only tracks `.d.ts` outputs from **direct** dependencies. TypeScript project references transitively read `.d.ts` files from the full dependency chain, so when a project typechecks, it reads `.d.ts` outputs from transitive deps too. These undeclared inputs can cause incorrect cache hits.

## Expected Behavior

The inferred inputs for typecheck tasks include `.d.ts` and `.tsbuildinfo` outputs from the entire transitive dependency graph by setting `transitive: true` on the `dependentTasksOutputFiles` input.