### PR TITLE
fix(gradle): ensure that ci test target depends on take overrides into account

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
@@ -21,7 +21,9 @@ fun addTestCiTargets(
     projectRoot: String,
     workspaceRoot: String,
     ciTestTargetName: String,
-    gitIgnoreClassifier: GitIgnoreClassifier
+    gitIgnoreClassifier: GitIgnoreClassifier,
+    targetNameOverrides: Map<String, String> = emptyMap(),
+    targetNamePrefix: String = ""
 ) {
   ensureTargetGroupExists(targetGroups, testCiTargetGroup)
 
@@ -37,7 +39,9 @@ fun addTestCiTargets(
       workspaceRoot,
       ciTestTargetName,
       ciDependsOn,
-      gitIgnoreClassifier)
+      gitIgnoreClassifier,
+      targetNameOverrides,
+      targetNamePrefix)
 
   ensureParentCiTarget(
       targets,
@@ -61,7 +65,9 @@ private fun processTestFiles(
     workspaceRoot: String,
     ciTestTargetName: String,
     ciDependsOn: MutableList<DependsOnEntry>,
-    gitIgnoreClassifier: GitIgnoreClassifier
+    gitIgnoreClassifier: GitIgnoreClassifier,
+    targetNameOverrides: Map<String, String>,
+    targetNamePrefix: String
 ) {
   testFiles
       .filter { isTestFile(it, workspaceRoot) }
@@ -77,7 +83,9 @@ private fun processTestFiles(
                   testTask,
                   projectRoot,
                   workspaceRoot,
-                  gitIgnoreClassifier)
+                  gitIgnoreClassifier,
+                  targetNameOverrides,
+                  targetNamePrefix)
           targetGroups[testCiTargetGroup]?.add(targetName)
 
           ciDependsOn.add(DependsOnEntry(target = targetName, params = DependsOnParams.FORWARD))
@@ -106,7 +114,9 @@ private fun buildTestCiTarget(
     testTask: Task,
     projectRoot: String,
     workspaceRoot: String,
-    gitIgnoreClassifier: GitIgnoreClassifier
+    gitIgnoreClassifier: GitIgnoreClassifier,
+    targetNameOverrides: Map<String, String>,
+    targetNamePrefix: String
 ): MutableMap<String, Any?> {
   val taskInputs =
       getInputsForTask(null, testTask, projectRoot, workspaceRoot, null, gitIgnoreClassifier)
@@ -131,7 +141,9 @@ private fun buildTestCiTarget(
         target["outputs"] = it
       }
 
-  getDependsOnForTask(null, testTask)?.takeIf { it.isNotEmpty() }?.let { target["dependsOn"] = it }
+  getDependsOnForTask(null, testTask, null, targetNameOverrides, targetNamePrefix)
+      ?.takeIf { it.isNotEmpty() }
+      ?.let { target["dependsOn"] = it }
 
   return target
 }

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
@@ -193,7 +193,9 @@ fun processTargetsForProject(
               projectRoot,
               workspaceRoot,
               ciTestTargetName,
-              gitIgnoreClassifier)
+              gitIgnoreClassifier,
+              targetNameOverrides,
+              targetNamePrefix)
         }
       }
 

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/AddTestCiTargetsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/AddTestCiTargetsTest.kt
@@ -21,6 +21,7 @@ class AddTestCiTargetsTest {
 
   @BeforeEach
   fun setup() {
+    taskDependencyCache.get().clear()
     projectRoot = File(workspaceRoot, "project-a").apply { mkdirs() }
 
     project = ProjectBuilder.builder().withProjectDir(projectRoot).build()
@@ -232,5 +233,114 @@ class AddTestCiTargetsTest {
     assertTrue(
         targets.containsKey("ci--ConcreteTest"), "Concrete test classes should create CI targets")
     assertTrue(targets.containsKey("ci"))
+  }
+
+  @Test
+  fun `should apply targetNamePrefix to dependsOn entries`() {
+    File(projectRoot, "build.gradle").apply { writeText("// test build file") }
+
+    val testFile =
+        File(projectRoot, "src/test/kotlin/PrefixedTest.kt").apply {
+          parentFile.mkdirs()
+          writeText("class PrefixedTest { @Test fun testMethod() {} }")
+        }
+
+    val compileTask = project.tasks.register("compileTestKotlin").get()
+    val classesTask = project.tasks.register("classes").get()
+    testTask.dependsOn(compileTask)
+    testTask.dependsOn(classesTask)
+
+    val testFiles = project.files(testFile)
+    testTask.inputs.files(testFiles)
+
+    val targets = mutableMapOf<String, MutableMap<String, Any?>>()
+    val targetGroups = mutableMapOf<String, MutableList<String>>()
+    val ciTestTargetName = "gradle-ci"
+    val gitIgnoreClassifier = GitIgnoreClassifier(workspaceRoot)
+    val targetNamePrefix = "gradle-"
+
+    addTestCiTargets(
+        testFiles = testFiles,
+        projectBuildPath = ":project-a",
+        testTask = testTask,
+        targets = targets,
+        targetGroups = targetGroups,
+        projectRoot = projectRoot.absolutePath,
+        workspaceRoot = workspaceRoot.absolutePath,
+        ciTestTargetName = ciTestTargetName,
+        gitIgnoreClassifier = gitIgnoreClassifier,
+        targetNameOverrides = emptyMap(),
+        targetNamePrefix = targetNamePrefix)
+
+    val ciTarget = targets["gradle-ci--PrefixedTest"]
+    assertTrue(ciTarget != null, "CI target should be created")
+
+    val dependsOn = ciTarget?.get("dependsOn") as? List<*>
+    assertNotNull(dependsOn, "dependsOn should be present")
+    assertTrue(dependsOn!!.isNotEmpty(), "dependsOn should not be empty")
+
+    val targetNames = dependsOn.mapNotNull { (it as? DependsOnEntry)?.target }
+    assertTrue(
+        targetNames.all { it.startsWith("gradle-") },
+        "All dependsOn targets should have the prefix 'gradle-', got: $targetNames")
+    assertTrue(
+        targetNames.contains("gradle-compileTestKotlin"),
+        "Expected dependsOn to contain 'gradle-compileTestKotlin', got: $targetNames")
+    assertTrue(
+        targetNames.contains("gradle-classes"),
+        "Expected dependsOn to contain 'gradle-classes', got: $targetNames")
+  }
+
+  @Test
+  fun `should apply targetNameOverrides in combination with targetNamePrefix`() {
+    File(projectRoot, "build.gradle").apply { writeText("// test build file") }
+
+    val testFile =
+        File(projectRoot, "src/test/kotlin/OverriddenTest.kt").apply {
+          parentFile.mkdirs()
+          writeText("class OverriddenTest { @Test fun testMethod() {} }")
+        }
+
+    val libProject = ProjectBuilder.builder()
+        .withProjectDir(File(workspaceRoot, "lib").apply { mkdirs() })
+        .withParent(project)
+        .build()
+    File(libProject.projectDir, "build.gradle").apply { writeText("// lib build file") }
+    val libTestTask = libProject.tasks.register("test").get()
+    testTask.dependsOn(libTestTask)
+
+    val testFiles = project.files(testFile)
+    testTask.inputs.files(testFiles)
+
+    val targets = mutableMapOf<String, MutableMap<String, Any?>>()
+    val targetGroups = mutableMapOf<String, MutableList<String>>()
+    val ciTestTargetName = "gradle-ci"
+    val gitIgnoreClassifier = GitIgnoreClassifier(workspaceRoot)
+    val targetNamePrefix = "gradle-"
+    val targetNameOverrides = mapOf("testTargetName" to "unit-test")
+
+    addTestCiTargets(
+        testFiles = testFiles,
+        projectBuildPath = ":project-a",
+        testTask = testTask,
+        targets = targets,
+        targetGroups = targetGroups,
+        projectRoot = projectRoot.absolutePath,
+        workspaceRoot = workspaceRoot.absolutePath,
+        ciTestTargetName = ciTestTargetName,
+        gitIgnoreClassifier = gitIgnoreClassifier,
+        targetNameOverrides = targetNameOverrides,
+        targetNamePrefix = targetNamePrefix)
+
+    val ciTarget = targets["gradle-ci--OverriddenTest"]
+    assertTrue(ciTarget != null, "CI target should be created")
+
+    val dependsOn = ciTarget?.get("dependsOn") as? List<*>
+    assertNotNull(dependsOn, "dependsOn should be present")
+
+    val targetNames = dependsOn.mapNotNull { (it as? DependsOnEntry)?.target }
+    assertTrue(
+        targetNames.contains("gradle-unit-test"),
+        "Expected dependsOn to contain 'gradle-unit-test' (prefixed overridden name for 'test' task), got: $targetNames")
   }
 }

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/AddTestCiTargetsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/AddTestCiTargetsTest.kt
@@ -301,10 +301,11 @@ class AddTestCiTargetsTest {
           writeText("class OverriddenTest { @Test fun testMethod() {} }")
         }
 
-    val libProject = ProjectBuilder.builder()
-        .withProjectDir(File(workspaceRoot, "lib").apply { mkdirs() })
-        .withParent(project)
-        .build()
+    val libProject =
+        ProjectBuilder.builder()
+            .withProjectDir(File(workspaceRoot, "lib").apply { mkdirs() })
+            .withParent(project)
+            .build()
     File(libProject.projectDir, "build.gradle").apply { writeText("// lib build file") }
     val libTestTask = libProject.tasks.register("test").get()
     testTask.dependsOn(libTestTask)


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

  When generating atomized CI test targets for Gradle projects, the dependsOn entries do not respect targetNameOverrides or targetNamePrefix configuration. This means that if a test task depends on other tasks (like compileTestKotlin or classes), and those tasks have been renamed via overrides or prefixed (e.g., gradle-compileTestKotlin), the generated CI test targets reference the original, non-transformed task names. This creates broken dependencies in the project graph.

## Expected Behavior

  Atomized CI test targets now correctly apply both targetNameOverrides and targetNamePrefix to their dependsOn entries. When a test task depends on other tasks, the generated CI targets will reference the properly transformed target names, ensuring dependency integrity throughout the project graph. The fix passes these configuration parameters through the entire CI target generation pipeline in CiTargetsUtils.kt.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
