### PR TITLE
feat(gradle): add properties and wrappers to inputs

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -44,17 +44,14 @@ fun processTask(
     target["continuous"] = true
   }
 
-  // Get combined depends on tasks once and reuse
   val dependsOnTasks = getDependsOnTask(task)
 
-  // process outputs
   val outputs = getOutputsForTask(task, projectRoot, workspaceRoot)
   if (!outputs.isNullOrEmpty()) {
     logger.info("${task}: processed ${outputs.size} outputs")
     target["outputs"] = outputs
   }
 
-  // process dependsOn
   val dependsOn =
       getDependsOnForTask(dependsOnTasks, task, dependencies, targetNameOverrides, targetNamePrefix)
 
@@ -63,13 +60,9 @@ fun processTask(
     target["dependsOn"] = dependsOn
   }
 
-  // Check for nx extension to get additional config
   val nxExtension = task.extensions.findByType(NxTaskExtension::class.java)
-
-  // Merge nx.json config into target (this allows users to set any Nx target properties)
   nxExtension?.json?.getOrNull()?.let { nxJson -> target["nxConfig"] = nxJson }
 
-  // process inputs
   val inputs =
       getInputsForTask(
           dependsOnTasks, task, projectRoot, workspaceRoot, externalNodes, gitIgnoreClassifier)
@@ -108,6 +101,12 @@ fun getGradlewCommand(): String {
   }
 }
 
+private val GRADLE_INPUT_FILES =
+    listOf(
+        "gradle/wrapper/gradle-wrapper.jar",
+        "gradle/wrapper/gradle-wrapper.properties",
+        "gradle.properties")
+
 /**
  * Get gradle wrapper and properties files that should be included as inputs. These files affect
  * build behavior and should invalidate cache when changed.
@@ -116,14 +115,7 @@ fun getGradlewCommand(): String {
  * @return list of relative paths to gradle files that exist, empty if none found
  */
 fun getGradleFilesInputs(workspaceRoot: String): List<String> {
-  val gradleFiles =
-      listOf(
-          "gradle/wrapper/gradle-wrapper.jar",
-          "gradle/wrapper/gradle-wrapper.properties",
-          "gradle.properties")
-
-  return gradleFiles
-      .filter { relativePath -> File("$workspaceRoot/$relativePath").exists() }
+  return GRADLE_INPUT_FILES.filter { relativePath -> File("$workspaceRoot/$relativePath").exists() }
       .map { relativePath -> "{workspaceRoot}/$relativePath" }
 }
 
@@ -151,7 +143,6 @@ fun getInputsForTask(
     val externalDependencies = mutableListOf<String>()
     val dependentTaskOutputExtensions = mutableSetOf<String>()
 
-    // Add gradle wrapper and properties files as inputs if they exist
     inputs.addAll(getGradleFilesInputs(workspaceRoot))
 
     // Collect outputs from dependent tasks - group by extension for glob patterns
@@ -204,7 +195,6 @@ fun getInputsForTask(
       inputs.add(mapOf("dependentTasksOutputFiles" to "**/*.$extension"))
     }
 
-    // Add external dependencies if any
     if (externalDependencies.isNotEmpty()) {
       inputs.add(mapOf("externalDependencies" to externalDependencies))
     }
@@ -360,7 +350,6 @@ fun getDependsOnForTask(
   if (dependsOnTasks == null) {
     try {
       cache[taskKey] = null
-      // Compute dependencies
       val combinedDependsOn = getDependsOnTask(task)
       val result =
           if (combinedDependsOn.isNotEmpty()) {
@@ -368,7 +357,6 @@ fun getDependsOnForTask(
           } else {
             null
           }
-      // Cache the actual result before returning
       cache[taskKey] = result
       return result
     } catch (e: Exception) {
@@ -382,7 +370,6 @@ fun getDependsOnForTask(
       }
     }
   } else {
-    // When using pre-computed dependencies, don't use cache
     return try {
       val result =
           if (dependsOnTasks.isNotEmpty()) {

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -109,6 +109,25 @@ fun getGradlewCommand(): String {
 }
 
 /**
+ * Get gradle wrapper and properties files that should be included as inputs. These files affect
+ * build behavior and should invalidate cache when changed.
+ *
+ * @param workspaceRoot the workspace root path
+ * @return list of relative paths to gradle files that exist, empty if none found
+ */
+fun getGradleFilesInputs(workspaceRoot: String): List<String> {
+  val gradleFiles =
+      listOf(
+          "gradle/wrapper/gradle-wrapper.jar",
+          "gradle/wrapper/gradle-wrapper.properties",
+          "gradle.properties")
+
+  return gradleFiles
+      .filter { relativePath -> File("$workspaceRoot/$relativePath").exists() }
+      .map { relativePath -> "{workspaceRoot}/$relativePath" }
+}
+
+/**
  * Parse task and get inputs for this task
  *
  * @param dependsOnTasks set of tasks this task depends on
@@ -131,6 +150,9 @@ fun getInputsForTask(
     val inputs = mutableListOf<Any>()
     val externalDependencies = mutableListOf<String>()
     val dependentTaskOutputExtensions = mutableSetOf<String>()
+
+    // Add gradle wrapper and properties files as inputs if they exist
+    inputs.addAll(getGradleFilesInputs(workspaceRoot))
 
     // Collect outputs from dependent tasks - group by extension for glob patterns
     val tasksToProcess = dependsOnTasks ?: getDependsOnTask(task)

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -566,6 +566,184 @@ class ProcessTaskUtilsTest {
   }
 
   @Nested
+  inner class GradleFilesInputsTests {
+
+    @Test
+    fun `getGradleFilesInputs returns empty list when no gradle files exist`() {
+      val tempDir =
+          java.io.File.createTempFile("workspace", "").apply {
+            delete()
+            mkdirs()
+          }
+
+      try {
+        val result = getGradleFilesInputs(tempDir.path)
+        assertTrue(result.isEmpty(), "Expected empty list when no gradle files exist")
+      } finally {
+        tempDir.deleteRecursively()
+      }
+    }
+
+    @Test
+    fun `getGradleFilesInputs returns gradle-wrapper files when they exist`() {
+      val tempDir =
+          java.io.File.createTempFile("workspace", "").apply {
+            delete()
+            mkdirs()
+          }
+
+      try {
+        // Create gradle wrapper directory and files
+        val gradleWrapperDir = java.io.File(tempDir, "gradle/wrapper")
+        gradleWrapperDir.mkdirs()
+        java.io.File(gradleWrapperDir, "gradle-wrapper.jar").writeBytes(ByteArray(0))
+        java.io.File(gradleWrapperDir, "gradle-wrapper.properties").writeText("distributionUrl=...")
+
+        val result = getGradleFilesInputs(tempDir.path)
+
+        assertEquals(2, result.size, "Expected 2 gradle wrapper files")
+        assertTrue(
+            result.contains("{workspaceRoot}/gradle/wrapper/gradle-wrapper.jar"),
+            "Expected gradle-wrapper.jar in $result")
+        assertTrue(
+            result.contains("{workspaceRoot}/gradle/wrapper/gradle-wrapper.properties"),
+            "Expected gradle-wrapper.properties in $result")
+      } finally {
+        tempDir.deleteRecursively()
+      }
+    }
+
+    @Test
+    fun `getGradleFilesInputs returns gradle properties when it exists`() {
+      val tempDir =
+          java.io.File.createTempFile("workspace", "").apply {
+            delete()
+            mkdirs()
+          }
+
+      try {
+        // Create only gradle.properties
+        java.io.File(tempDir, "gradle.properties").writeText("org.gradle.jvmargs=-Xmx2g")
+
+        val result = getGradleFilesInputs(tempDir.path)
+
+        assertEquals(1, result.size, "Expected 1 gradle file")
+        assertTrue(
+            result.contains("{workspaceRoot}/gradle.properties"),
+            "Expected gradle.properties in $result")
+      } finally {
+        tempDir.deleteRecursively()
+      }
+    }
+
+    @Test
+    fun `getGradleFilesInputs returns all gradle files when all exist`() {
+      val tempDir =
+          java.io.File.createTempFile("workspace", "").apply {
+            delete()
+            mkdirs()
+          }
+
+      try {
+        // Create all gradle files
+        val gradleWrapperDir = java.io.File(tempDir, "gradle/wrapper")
+        gradleWrapperDir.mkdirs()
+        java.io.File(gradleWrapperDir, "gradle-wrapper.jar").writeBytes(ByteArray(0))
+        java.io.File(gradleWrapperDir, "gradle-wrapper.properties").writeText("distributionUrl=...")
+        java.io.File(tempDir, "gradle.properties").writeText("org.gradle.jvmargs=-Xmx2g")
+
+        val result = getGradleFilesInputs(tempDir.path)
+
+        assertEquals(3, result.size, "Expected 3 gradle files")
+        assertTrue(
+            result.contains("{workspaceRoot}/gradle/wrapper/gradle-wrapper.jar"),
+            "Expected gradle-wrapper.jar")
+        assertTrue(
+            result.contains("{workspaceRoot}/gradle/wrapper/gradle-wrapper.properties"),
+            "Expected gradle-wrapper.properties")
+        assertTrue(result.contains("{workspaceRoot}/gradle.properties"), "Expected gradle.properties")
+      } finally {
+        tempDir.deleteRecursively()
+      }
+    }
+
+    @Test
+    fun `getInputsForTask includes gradle files when they exist`() {
+      val tempDir =
+          java.io.File.createTempFile("workspace", "").apply {
+            delete()
+            mkdirs()
+          }
+
+      try {
+        // Create gradle.properties only
+        java.io.File(tempDir, "gradle.properties").writeText("org.gradle.jvmargs=-Xmx2g")
+
+        // Create a subproject directory to differentiate projectRoot from workspaceRoot
+        val projectDir = java.io.File(tempDir, "app").apply { mkdirs() }
+        val project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+        val workspaceRoot = tempDir.path
+        val projectRoot = projectDir.path
+
+        val mainTask = project.tasks.register("mainTask").get()
+        val inputFile = java.io.File("$projectRoot/src/main.kt")
+        mainTask.inputs.files(inputFile)
+
+        val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+        val result =
+            getInputsForTask(
+                null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+
+        assertNotNull(result)
+        assertTrue(
+            result!!.any { it == "{workspaceRoot}/gradle.properties" },
+            "Expected gradle.properties in inputs: $result")
+        assertTrue(
+            result.any { it == "{projectRoot}/src/main.kt" }, "Expected src/main.kt in inputs: $result")
+      } finally {
+        tempDir.deleteRecursively()
+      }
+    }
+
+    @Test
+    fun `getInputsForTask does not include gradle files when they do not exist`() {
+      val tempDir =
+          java.io.File.createTempFile("workspace", "").apply {
+            delete()
+            mkdirs()
+          }
+
+      try {
+        // Don't create any gradle files
+        // Create a subproject directory to differentiate projectRoot from workspaceRoot
+        val projectDir = java.io.File(tempDir, "app").apply { mkdirs() }
+        val project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+        val workspaceRoot = tempDir.path
+        val projectRoot = projectDir.path
+
+        val mainTask = project.tasks.register("mainTask").get()
+        val inputFile = java.io.File("$projectRoot/src/main.kt")
+        mainTask.inputs.files(inputFile)
+
+        val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+        val result =
+            getInputsForTask(
+                null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+
+        assertNotNull(result)
+        // Should have src/main.kt but no gradle files
+        assertTrue(
+            result!!.any { it == "{projectRoot}/src/main.kt" }, "Expected src/main.kt in inputs: $result")
+        assertFalse(
+            result.any { it.toString().contains("gradle") },
+            "Did not expect any gradle files in inputs: $result")
+      } finally {
+        tempDir.deleteRecursively()
+      }
+    }
+  }
+
+  @Nested
   inner class SubprojectNamingTests {
 
     @Test

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -661,7 +661,8 @@ class ProcessTaskUtilsTest {
         assertTrue(
             result.contains("{workspaceRoot}/gradle/wrapper/gradle-wrapper.properties"),
             "Expected gradle-wrapper.properties")
-        assertTrue(result.contains("{workspaceRoot}/gradle.properties"), "Expected gradle.properties")
+        assertTrue(
+            result.contains("{workspaceRoot}/gradle.properties"), "Expected gradle.properties")
       } finally {
         tempDir.deleteRecursively()
       }
@@ -699,7 +700,8 @@ class ProcessTaskUtilsTest {
             result!!.any { it == "{workspaceRoot}/gradle.properties" },
             "Expected gradle.properties in inputs: $result")
         assertTrue(
-            result.any { it == "{projectRoot}/src/main.kt" }, "Expected src/main.kt in inputs: $result")
+            result.any { it == "{projectRoot}/src/main.kt" },
+            "Expected src/main.kt in inputs: $result")
       } finally {
         tempDir.deleteRecursively()
       }
@@ -733,7 +735,8 @@ class ProcessTaskUtilsTest {
         assertNotNull(result)
         // Should have src/main.kt but no gradle files
         assertTrue(
-            result!!.any { it == "{projectRoot}/src/main.kt" }, "Expected src/main.kt in inputs: $result")
+            result!!.any { it == "{projectRoot}/src/main.kt" },
+            "Expected src/main.kt in inputs: $result")
         assertFalse(
             result.any { it.toString().contains("gradle") },
             "Did not expect any gradle files in inputs: $result")


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Gradle task inputs in Nx do not includ configuration files like gradle.properties, gradle/wrapper/gradle-wrapper.jar, and gradle/wrapper/gradle-wrapper.properties. When these files change, Nx's cache does not invalidate, potentially causing builds to use stale cached results despite configuration changes that affect build behavior.

## Expected Behavior
Gradle wrapper and properties files are now automatically included as inputs for all Gradle tasks when they exist in the workspace. This ensures that changes to Gradle version (via wrapper files) or build configuration (via gradle.properties) properly invalidate Nx's task cache, guaranteeing accurate incremental builds and cache hits.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
