### PR TITLE
chore(gradle): bump gradle project graph plugin version to 0.1.15

### DIFF
--- a/packages/gradle/migrations.json
+++ b/packages/gradle/migrations.json
@@ -95,6 +95,12 @@
       "cli": "nx",
       "description": "Change dev.nx.gradle.project-graph to version 0.1.14 in build file",
       "factory": "./src/migrations/22-6-0/change-plugin-version-0-1-14"
+    },
+    "change-plugin-version-0-1-15": {
+      "version": "22.6.0-beta.13",
+      "cli": "nx",
+      "description": "Change dev.nx.gradle.project-graph to version 0.1.15 in build file",
+      "factory": "./src/migrations/22-6-0/change-plugin-version-0-1-15"
     }
   },
   "packageJsonUpdates": {}

--- a/packages/gradle/project-graph/build.gradle.kts
+++ b/packages/gradle/project-graph/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 group = "dev.nx.gradle"
 
-version = "0.1.14"
+version = "0.1.15"
 
 repositories { mavenCentral() }
 

--- a/packages/gradle/src/migrations/22-6-0/change-plugin-version-0-1-15.md
+++ b/packages/gradle/src/migrations/22-6-0/change-plugin-version-0-1-15.md
@@ -1,0 +1,21 @@
+#### Change dev.nx.gradle.project-graph to version 0.1.15
+
+Change dev.nx.gradle.project-graph to version 0.1.15 in build file
+
+#### Sample Code Changes
+
+##### Before
+
+```text title="build.gradle"
+plugins {
+	id "dev.nx.gradle.project-graph" version "0.1.14"
+}
+```
+
+##### After
+
+```text title="build.gradle"
+plugins {
+    id "dev.nx.gradle.project-graph" version "0.1.15"
+}
+```

--- a/packages/gradle/src/migrations/22-6-0/change-plugin-version-0-1-15.ts
+++ b/packages/gradle/src/migrations/22-6-0/change-plugin-version-0-1-15.ts
@@ -1,0 +1,24 @@
+import { Tree, readNxJson } from '@nx/devkit';
+import { hasGradlePlugin } from '../../utils/has-gradle-plugin';
+import { addNxProjectGraphPlugin } from '../../generators/init/gradle-project-graph-plugin-utils';
+import { updateNxPluginVersionInCatalogsAst } from '../../utils/version-catalog-ast-utils';
+
+/* Change the plugin version to 0.1.15
+ */
+export default async function update(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  if (!nxJson) {
+    return;
+  }
+  if (!hasGradlePlugin(tree)) {
+    return;
+  }
+
+  const gradlePluginVersionToUpdate = '0.1.15';
+
+  // Update version in version catalogs using AST-based approach to preserve formatting
+  await updateNxPluginVersionInCatalogsAst(tree, gradlePluginVersionToUpdate);
+
+  // Then update in build.gradle(.kts) files
+  await addNxProjectGraphPlugin(tree, gradlePluginVersionToUpdate);
+}

--- a/packages/gradle/src/utils/versions.ts
+++ b/packages/gradle/src/utils/versions.ts
@@ -1,4 +1,4 @@
 export const nxVersion = require('../../package.json').version;
 
 export const gradleProjectGraphPluginName = 'dev.nx.gradle.project-graph';
-export const gradleProjectGraphVersion = '0.1.14';
+export const gradleProjectGraphVersion = '0.1.15';


### PR DESCRIPTION
## Current Behavior

The gradle project graph plugin version is 0.1.14.

## Expected Behavior

The gradle project graph plugin version is bumped to 0.1.15 with a corresponding migration.

## Related Issue(s)

N/A - Routine version bump.