### PR TITLE
fix(core): show json by default for agentic ai

### DIFF
--- a/packages/nx/src/command-line/show/command-object.ts
+++ b/packages/nx/src/command-line/show/command-object.ts
@@ -1,5 +1,6 @@
 import { CommandModule, showHelp } from 'yargs';
 import type { ProjectGraphProjectNode } from '../../config/project-graph';
+import { isAiAgent } from '../../native';
 import { handleErrors } from '../../utils/handle-errors';
 import {
   parseCSV,
@@ -65,6 +66,11 @@ export const yargsShowCommand: CommandModule<
       .option('json', {
         type: 'boolean',
         description: 'Output JSON.',
+      })
+      .middleware((args) => {
+        if (args.json == null && isAiAgent()) {
+          args.json = true;
+        }
       })
       .example(
         '$0 show projects',


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
`nx show *` doesn't default to JSON

## Expected Behavior
For agents, it defaults to JSON

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
