### PR TITLE
chore(maven): bump maven plugin version to 0.0.15

### DIFF
--- a/packages/maven/batch-runner-adapters/maven3/pom.xml
+++ b/packages/maven/batch-runner-adapters/maven3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>batch-runner-adapters</artifactId>
-        <version>0.0.14</version>
+        <version>0.0.15</version>
     </parent>
 
     <artifactId>maven3-adapter</artifactId>

--- a/packages/maven/batch-runner-adapters/maven4/pom.xml
+++ b/packages/maven/batch-runner-adapters/maven4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>batch-runner-adapters</artifactId>
-        <version>0.0.14</version>
+        <version>0.0.15</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/batch-runner-adapters/pom.xml
+++ b/packages/maven/batch-runner-adapters/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>nx-maven-parent</artifactId>
-        <version>0.0.14</version>
+        <version>0.0.15</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/batch-runner/pom.xml
+++ b/packages/maven/batch-runner/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>nx-maven-parent</artifactId>
-        <version>0.0.14</version>
+        <version>0.0.15</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/maven-plugin/pom.xml
+++ b/packages/maven/maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.nx.maven</groupId>
     <artifactId>nx-maven-parent</artifactId>
-    <version>0.0.14</version>
+    <version>0.0.15</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/migrations.json
+++ b/packages/maven/migrations.json
@@ -42,6 +42,12 @@
       "version": "22.6.0-beta.1",
       "description": "Update Maven plugin version from 0.0.13 to 0.0.14 in pom.xml files",
       "factory": "./dist/migrations/0-0-14/update-pom-xml-version"
+    },
+    "update-0-0-15": {
+      "cli": "nx",
+      "version": "22.6.0-beta.12",
+      "description": "Update Maven plugin version from 0.0.14 to 0.0.15 in pom.xml files",
+      "factory": "./dist/migrations/0-0-15/update-pom-xml-version"
     }
   }
 }

--- a/packages/maven/pom.xml
+++ b/packages/maven/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.nx.maven</groupId>
     <artifactId>nx-parent</artifactId>
-    <version>0.0.14</version>
+    <version>0.0.15</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/shared/pom.xml
+++ b/packages/maven/shared/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>nx-maven-parent</artifactId>
-        <version>0.0.14</version>
+        <version>0.0.15</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/src/migrations/0-0-15/update-pom-xml-version.ts
+++ b/packages/maven/src/migrations/0-0-15/update-pom-xml-version.ts
@@ -1,0 +1,11 @@
+import { Tree } from '@nx/devkit';
+import { updateNxMavenPluginVersion } from '../../utils/pom-xml-updater';
+
+/**
+ * Migration for @nx/maven v0.0.15
+ * Updates the Maven plugin version to 0.0.15 in pom.xml files
+ */
+export default async function update(tree: Tree) {
+  // Update user pom.xml files
+  updateNxMavenPluginVersion(tree, '0.0.15');
+}

--- a/packages/maven/src/utils/versions.ts
+++ b/packages/maven/src/utils/versions.ts
@@ -1,2 +1,2 @@
 export const nxVersion = require('../../package.json').version;
-export const mavenPluginVersion = '0.0.14';
+export const mavenPluginVersion = '0.0.15';

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>dev.nx.maven</groupId>
   <artifactId>nx-parent</artifactId>
-  <version>0.0.14</version>
+  <version>0.0.15</version>
   <packaging>pom</packaging>
 
   <name>Nx Parent</name>


### PR DESCRIPTION
## Current Behavior

The Maven plugin is at a previous version and needs to be updated.

## Expected Behavior

The Maven plugin version is bumped to `0.0.15`, with a corresponding migration for users upgrading to Nx `22.6.0-beta.12`.

## Related Issue(s)

N/A