### PR TITLE
fix(core): prevent TUI crash when task output arrives after completion

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/tui-summary-life-cycle.ts
@@ -74,6 +74,10 @@ export function getTuiTerminalSummaryLifeCycle({
   };
 
   lifeCycle.appendTaskOutput = (taskId, output) => {
+    // Task already completed and output was finalized by endTasks — discard late-arriving data
+    if (!taskOutputChunks[taskId]) {
+      return;
+    }
     taskOutputChunks[taskId].push(output);
   };
 


### PR DESCRIPTION
## Current Behavior

`nx run-many` with TUI enabled crashes with `TypeError: Cannot read properties of undefined (reading 'push')` in `tui-summary-life-cycle.ts` when `appendTaskOutput` is called for a task whose output entry was already cleaned up by `endTasks`.

## Expected Behavior

Late-arriving task output after `endTasks` has finalized the task is silently discarded instead of crashing. The output is redundant since it was already captured when the task completed.

## Related Issue(s)

Fixes #34677