### PR TITLE
fix(core): add download-cloud-client to cloud command bypass list

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -207,6 +207,7 @@ function isNxCloudCommand(command: string): boolean {
     'fix-ci',
     'record',
     'polygraph',
+    'download-cloud-client',
   ];
   return nxCloudCommands.includes(command);
 }


### PR DESCRIPTION
## Current Behavior

Running `npx nx@next download-cloud-client` outside an Nx workspace fails with "The current directory isn't part of an Nx workspace" because `download-cloud-client` is not in the `isNxCloudCommand` list in `packages/nx/bin/nx.ts`. This means the process exits at the `handleNoWorkspace` guard before ever reaching the handler fixed in #34746.

## Expected Behavior

`download-cloud-client` runs successfully outside an Nx workspace, like `login`, `logout`, `polygraph`, and other cloud commands that don't need workspace context.

## Related Issue(s)

Follows up on #34728 and #34746 — `download-cloud-client` was added before the cloud command bypass existed and was missed when the bypass was introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)