### PR TITLE
fix(core): skip analytics prompt for cloud commands

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -104,27 +104,30 @@ async function main() {
       handleMissingLocalInstallation(workspace ? workspace.dir : null);
     }
 
-    // Prompt for analytics preference if not set
-    try {
-      await ensureAnalyticsPreferenceSet();
-    } catch {}
-    await startAnalytics();
-
     // this file is already in the local workspace
     if (isNxCloudCommand(process.argv[2])) {
       // nx-cloud commands can run without local Nx installation
       process.env.NX_DAEMON = 'false';
       require('nx/src/command-line/nx-commands').commandsObject.argv;
-    } else if (isLocalInstall) {
-      await initLocal(workspace);
-    } else if (localNx) {
-      // Nx is being run from globally installed CLI - hand off to the local
-      warnIfUsingOutdatedGlobalInstall(GLOBAL_NX_VERSION, LOCAL_NX_VERSION);
-      if (localNx.includes('.nx')) {
-        const nxWrapperPath = localNx.replace(/\.nx.*/, '.nx/') + 'nxw.js';
-        require(nxWrapperPath);
-      } else {
-        require(localNx);
+    } else {
+      // Prompt for analytics preference if not set (skip for cloud commands
+      // which may run outside a workspace and should not create nx.json)
+      try {
+        await ensureAnalyticsPreferenceSet();
+      } catch {}
+      await startAnalytics();
+
+      if (isLocalInstall) {
+        await initLocal(workspace);
+      } else if (localNx) {
+        // Nx is being run from globally installed CLI - hand off to the local
+        warnIfUsingOutdatedGlobalInstall(GLOBAL_NX_VERSION, LOCAL_NX_VERSION);
+        if (localNx.includes('.nx')) {
+          const nxWrapperPath = localNx.replace(/\.nx.*/, '.nx/') + 'nxw.js';
+          require(nxWrapperPath);
+        } else {
+          require(localNx);
+        }
       }
     }
   }

--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -207,6 +207,7 @@ function isNxCloudCommand(command: string): boolean {
     'fix-ci',
     'record',
     'polygraph',
+    'download-cloud-client',
   ];
   return nxCloudCommands.includes(command);
 }

--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -104,30 +104,27 @@ async function main() {
       handleMissingLocalInstallation(workspace ? workspace.dir : null);
     }
 
+    // Prompt for analytics preference if not set
+    try {
+      await ensureAnalyticsPreferenceSet();
+    } catch {}
+    await startAnalytics();
+
     // this file is already in the local workspace
     if (isNxCloudCommand(process.argv[2])) {
       // nx-cloud commands can run without local Nx installation
       process.env.NX_DAEMON = 'false';
       require('nx/src/command-line/nx-commands').commandsObject.argv;
-    } else {
-      // Prompt for analytics preference if not set (skip for cloud commands
-      // which may run outside a workspace and should not create nx.json)
-      try {
-        await ensureAnalyticsPreferenceSet();
-      } catch {}
-      await startAnalytics();
-
-      if (isLocalInstall) {
-        await initLocal(workspace);
-      } else if (localNx) {
-        // Nx is being run from globally installed CLI - hand off to the local
-        warnIfUsingOutdatedGlobalInstall(GLOBAL_NX_VERSION, LOCAL_NX_VERSION);
-        if (localNx.includes('.nx')) {
-          const nxWrapperPath = localNx.replace(/\.nx.*/, '.nx/') + 'nxw.js';
-          require(nxWrapperPath);
-        } else {
-          require(localNx);
-        }
+    } else if (isLocalInstall) {
+      await initLocal(workspace);
+    } else if (localNx) {
+      // Nx is being run from globally installed CLI - hand off to the local
+      warnIfUsingOutdatedGlobalInstall(GLOBAL_NX_VERSION, LOCAL_NX_VERSION);
+      if (localNx.includes('.nx')) {
+        const nxWrapperPath = localNx.replace(/\.nx.*/, '.nx/') + 'nxw.js';
+        require(nxWrapperPath);
+      } else {
+        require(localNx);
       }
     }
   }

--- a/packages/nx/src/utils/analytics-prompt.ts
+++ b/packages/nx/src/utils/analytics-prompt.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'crypto';
 import { execSync } from 'child_process';
+import { existsSync } from 'fs';
 import { prompt } from 'enquirer';
 import { join } from 'path';
 import { output } from './output';
@@ -21,6 +22,14 @@ export async function ensureAnalyticsPreferenceSet(): Promise<void> {
   // Only prompt in interactive terminals
   const isInteractive = process.stdin.isTTY && process.stdout.isTTY;
   if (!isInteractive) {
+    return;
+  }
+
+  // Only prompt inside a workspace that has nx.json — avoid creating
+  // nx.json in arbitrary directories (e.g. when running cloud commands
+  // outside a workspace).
+  const nxJsonPath = join(workspaceRoot, 'nx.json');
+  if (!existsSync(nxJsonPath)) {
     return;
   }
 


### PR DESCRIPTION
## Current Behavior

The analytics prompt (`ensureAnalyticsPreferenceSet()`) and `startAnalytics()` run for all commands, including cloud commands like `download-cloud-client`. When a cloud command runs outside an Nx workspace, `saveAnalyticsPreference()` creates an almost-empty `nx.json` (`{ "analytics": true }`) in whatever directory you happen to be in.

## Expected Behavior

Cloud commands skip the analytics prompt and `startAnalytics()` entirely, since they may run without a workspace and there is no appropriate `nx.json` to write to.

## Related Issue(s)

Fixes the issue where running `nx download-cloud-client` outside a workspace creates a spurious `nx.json`.