### PR TITLE
docs(nx-cloud): add DPE information exchange section to Okta SAML docs

### DIFF
--- a/astro-docs/.vale/styles/Nx/Headings.yml
+++ b/astro-docs/.vale/styles/Nx/Headings.yml
@@ -93,6 +93,7 @@ exceptions:
   - ID
   - FAQ
   - SAML
+  - DPE
   - WSL
   - EJS
   - AST

--- a/astro-docs/src/content/docs/enterprise/Single Tenant/okta-saml.mdoc
+++ b/astro-docs/src/content/docs/enterprise/Single Tenant/okta-saml.mdoc
@@ -139,6 +139,19 @@ Select the appropriate `nxCloudAccessSpec` value when you assign your SAML appli
 
 ![Select access specification when assigning application to groups](../../../../assets/enterprise/single-tenant/saml/okta_scim_7.jpg)
 
-## Connect your Nx Cloud installation to your sAML set up
+## Information to exchange with your DPE
 
-Contact your developer productivity engineer to connect your Nx Cloud instance to the SAML configuration.
+Your DPE will provide the following values up front so you can complete both the SAML and SCIM configuration:
+
+### From your DPE
+
+1. **Nx Cloud App URL** (`NX_CLOUD_APP_URL`) — used as the Single Sign On URL (step 3) and the SCIM connector base URL
+2. **JWT Token** — used for SCIM authentication
+3. **Organization ID** (`organization_id`) — used when defining the `nxCloudAccessSpec` enum values
+
+### Send back to your DPE
+
+After completing the setup, send the following so your DPE can finish connecting your Nx Cloud instance:
+
+1. **SAML Certificate** — the one-line certificate string extracted in step 10: `SAML_CERT=<your-cert-string>`
+2. **SAML Entry Point** — the SingleSignOnService URL copied in step 12: `SAML_ENTRY_POINT=<your-sso-url>`


### PR DESCRIPTION
## Current Behavior

The Okta SAML doc ends with a vague "Contact your developer productivity engineer" message. It doesn't specify what information needs to be exchanged between the customer and DPE to enable SAML and SCIM. This section was present in the old combined `auth-saml.md` but was lost during the migration to separate Okta/Azure docs in astro-docs.

## Expected Behavior

The doc now has a clear "Information to exchange with your DPE" section that outlines:
- **From your DPE** (provided up front): Nx Cloud App URL, JWT token, and Organization ID for SCIM setup
- **Send back to your DPE**: SAML certificate and SAML entry point URL

This matches the pattern already used in the Azure SAML doc and assumes SCIM will be configured.

## Related Issue(s)

N/A