### PR TITLE
fix(testing): infer dependency tsconfig files as playwright plugin inputs

### DIFF
--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -71,6 +71,7 @@ describe('@nx/playwright/plugin', () => {
                     "command": "playwright test",
                     "inputs": [
                       "default",
+                      "^{projectRoot}/tsconfig*.json",
                       "^production",
                       {
                         "externalDependencies": [
@@ -106,6 +107,7 @@ describe('@nx/playwright/plugin', () => {
                     "executor": "nx:noop",
                     "inputs": [
                       "default",
+                      "^{projectRoot}/tsconfig*.json",
                       "^production",
                       {
                         "externalDependencies": [
@@ -138,6 +140,7 @@ describe('@nx/playwright/plugin', () => {
                     "executor": "@nx/playwright:merge-reports",
                     "inputs": [
                       "default",
+                      "^{projectRoot}/tsconfig*.json",
                       "^production",
                       {
                         "externalDependencies": [
@@ -209,6 +212,7 @@ describe('@nx/playwright/plugin', () => {
                     "command": "playwright test",
                     "inputs": [
                       "default",
+                      "^{projectRoot}/tsconfig*.json",
                       "^production",
                       {
                         "externalDependencies": [
@@ -246,6 +250,7 @@ describe('@nx/playwright/plugin', () => {
                     "executor": "nx:noop",
                     "inputs": [
                       "default",
+                      "^{projectRoot}/tsconfig*.json",
                       "^production",
                       {
                         "externalDependencies": [
@@ -280,6 +285,7 @@ describe('@nx/playwright/plugin', () => {
                     "executor": "@nx/playwright:merge-reports",
                     "inputs": [
                       "default",
+                      "^{projectRoot}/tsconfig*.json",
                       "^production",
                       {
                         "externalDependencies": [
@@ -371,6 +377,7 @@ describe('@nx/playwright/plugin', () => {
         "executor": "nx:noop",
         "inputs": [
           "default",
+          "^{projectRoot}/tsconfig*.json",
           "^production",
           {
             "externalDependencies": [
@@ -407,6 +414,7 @@ describe('@nx/playwright/plugin', () => {
         "command": "playwright test tests/run-me.spec.ts --output=test-results/tests-run-me-spec-ts",
         "inputs": [
           "default",
+          "^{projectRoot}/tsconfig*.json",
           "^production",
           {
             "externalDependencies": [
@@ -450,6 +458,7 @@ describe('@nx/playwright/plugin', () => {
         "command": "playwright test tests/run-me-2.spec.ts --output=test-results/tests-run-me-2-spec-ts",
         "inputs": [
           "default",
+          "^{projectRoot}/tsconfig*.json",
           "^production",
           {
             "externalDependencies": [
@@ -549,6 +558,7 @@ describe('@nx/playwright/plugin', () => {
         "executor": "nx:noop",
         "inputs": [
           "default",
+          "^{projectRoot}/tsconfig*.json",
           "^production",
           {
             "externalDependencies": [
@@ -586,6 +596,7 @@ describe('@nx/playwright/plugin', () => {
         "command": "playwright test tests/run-me.spec.ts --output=test-results/tests-run-me-spec-ts",
         "inputs": [
           "default",
+          "^{projectRoot}/tsconfig*.json",
           "^production",
           {
             "externalDependencies": [
@@ -631,6 +642,7 @@ describe('@nx/playwright/plugin', () => {
         "command": "playwright test tests/run-me-2.spec.ts --output=test-results/tests-run-me-2-spec-ts",
         "inputs": [
           "default",
+          "^{projectRoot}/tsconfig*.json",
           "^production",
           {
             "externalDependencies": [
@@ -676,6 +688,7 @@ describe('@nx/playwright/plugin', () => {
         "executor": "@nx/playwright:merge-reports",
         "inputs": [
           "default",
+          "^{projectRoot}/tsconfig*.json",
           "^production",
           {
             "externalDependencies": [
@@ -738,6 +751,7 @@ describe('@nx/playwright/plugin', () => {
         ],
         "inputs": [
           "default",
+          "^{projectRoot}/tsconfig*.json",
           "^production",
           {
             "externalDependencies": [
@@ -787,6 +801,7 @@ describe('@nx/playwright/plugin', () => {
         "executor": "nx:noop",
         "inputs": [
           "default",
+          "^{projectRoot}/tsconfig*.json",
           "^production",
           {
             "externalDependencies": [
@@ -838,6 +853,7 @@ describe('@nx/playwright/plugin', () => {
         ],
         "inputs": [
           "default",
+          "^{projectRoot}/tsconfig*.json",
           "^production",
           {
             "externalDependencies": [
@@ -882,6 +898,7 @@ describe('@nx/playwright/plugin', () => {
         ],
         "inputs": [
           "default",
+          "^{projectRoot}/tsconfig*.json",
           "^production",
           {
             "externalDependencies": [
@@ -960,6 +977,7 @@ describe('@nx/playwright/plugin', () => {
         ],
         "inputs": [
           "default",
+          "^{projectRoot}/tsconfig*.json",
           "^production",
           {
             "externalDependencies": [
@@ -1009,6 +1027,7 @@ describe('@nx/playwright/plugin', () => {
         "executor": "nx:noop",
         "inputs": [
           "default",
+          "^{projectRoot}/tsconfig*.json",
           "^production",
           {
             "externalDependencies": [
@@ -1067,6 +1086,7 @@ describe('@nx/playwright/plugin', () => {
         ],
         "inputs": [
           "default",
+          "^{projectRoot}/tsconfig*.json",
           "^production",
           {
             "externalDependencies": [
@@ -1118,6 +1138,7 @@ describe('@nx/playwright/plugin', () => {
         ],
         "inputs": [
           "default",
+          "^{projectRoot}/tsconfig*.json",
           "^production",
           {
             "externalDependencies": [

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -171,7 +171,7 @@ async function buildPlaywrightTargets(
     cache: true,
     inputs: [
       ...('production' in namedInputs
-        ? ['default', '^production']
+        ? ['default', '^{projectRoot}/tsconfig*.json', '^production']
         : ['default', '^default']),
       { externalDependencies: ['@playwright/test'] },
     ],
@@ -197,7 +197,7 @@ async function buildPlaywrightTargets(
       cache: true,
       inputs: [
         ...('production' in namedInputs
-          ? ['default', '^production']
+          ? ['default', '^{projectRoot}/tsconfig*.json', '^production']
           : ['default', '^default']),
         { externalDependencies: ['@playwright/test'] },
       ],


### PR DESCRIPTION
## Current Behavior

The Playwright plugin does not include `tsconfig*.json` files from dependency projects as inputs. Playwright resolves these files when running tests, leading to unexpected file reads that aren't tracked for caching.

## Expected Behavior

When the `production` named input is used, the Playwright plugin infers `^{projectRoot}/tsconfig*.json` as an input so dependency tsconfig files are properly tracked. This is not needed for the `^default` branch since it already includes all dependency files.