### PR TITLE
fix(nx-cloud): download light client to tmp dir when outside nx workspace

### DIFF
--- a/packages/nx/src/nx-cloud/update-manager.ts
+++ b/packages/nx/src/nx-cloud/update-manager.ts
@@ -11,6 +11,7 @@ import {
 } from 'fs';
 import { createGunzip } from 'zlib';
 import { join } from 'path';
+import { tmpdir } from 'os';
 import { createApiAxiosInstance } from './utilities/axios';
 import { debugLog } from './debug-logger';
 import type { CloudTaskRunnerOptions } from './nx-cloud-tasks-runner-shell';
@@ -156,6 +157,18 @@ export async function verifyOrUpdateNxCloudClient(options?: {
 }
 
 export function getBundleInstallDefaultLocation() {
+  // When not in an Nx workspace (no nx.json), avoid creating a .nx folder
+  // in the current directory. Instead, use a temp directory unique to the
+  // NX_CLOUD_API URL so different cloud instances don't conflict.
+  if (!existsSync(join(workspaceRoot, 'nx.json'))) {
+    const apiUrl = process.env.NX_CLOUD_API || 'https://cloud.nx.app';
+    const apiHash = createHash('sha256')
+      .update(apiUrl)
+      .digest('hex')
+      .slice(0, 16);
+    return join(tmpdir(), 'nx-cloud-client', apiHash);
+  }
+
   const legacyPath = join(
     workspaceRoot,
     'node_modules',


### PR DESCRIPTION
## Current Behavior
When running nx commands outside of an Nx workspace (no nx.json), the light client is downloaded to .nx/cache/cloud relative to process.cwd(). This creates an unwanted .nx folder in whatever directory the user happens to be in.

## Expected Behavior
When outside an Nx workspace, the light client is downloaded to a temp directory (os.tmpdir()/nx-cloud-client/hash) where hash is derived from the NX_CLOUD_API URL. This avoids polluting arbitrary directories with .nx folders while ensuring different cloud instances get separate directories.

When inside an Nx workspace, behavior is unchanged.