### PR TITLE
feat(core): prompt for analytics preference during workspace creation

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -19,6 +19,7 @@ import { getPackageNameFromThirdPartyPreset } from '../src/utils/preset/get-thir
 import { detectInvokedPackageManager } from '../src/utils/package-manager';
 import {
   determineAiAgents,
+  determineAnalytics,
   determineDefaultBase,
   determineIfGitHubWillBeUsed,
   determineNxCloud,
@@ -28,6 +29,7 @@ import {
 } from '../src/internal-utils/prompts';
 import {
   withAllPrompts,
+  withAnalytics,
   withGitOptions,
   withNxCloud,
   withOptions,
@@ -292,7 +294,8 @@ export const commandsObject: yargs.Argv<Arguments> = yargs
         withUseGitHub,
         withAllPrompts,
         withPackageManager,
-        withGitOptions
+        withGitOptions,
+        withAnalytics
       ),
 
     async function handler(argv: yargs.ArgumentsCamelCase<Arguments>) {
@@ -662,6 +665,7 @@ async function normalizeArgsMiddleware(
             : getCompletionMessageKeyForVariant();
       }
 
+      const analytics = await determineAnalytics(argv);
       packageManager = argv.packageManager ?? detectInvokedPackageManager();
       Object.assign(argv, {
         nxCloud,
@@ -673,6 +677,7 @@ async function normalizeArgsMiddleware(
         defaultBase: 'main',
         aiAgents,
         ghAvailable,
+        analytics,
       });
 
       await recordStat({
@@ -720,12 +725,15 @@ async function normalizeArgsMiddleware(
           ? undefined
           : nxCloud === 'github' || (await determineIfGitHubWillBeUsed(argv));
 
+      const analytics = await determineAnalytics(argv);
+
       Object.assign(argv, {
         nxCloud,
         useGitHub,
         packageManager,
         defaultBase,
         aiAgents,
+        analytics,
       });
 
       chosenPreset = argv.preset ?? '';

--- a/packages/create-nx-workspace/src/create-workspace-options.ts
+++ b/packages/create-nx-workspace/src/create-workspace-options.ts
@@ -55,6 +55,10 @@ export interface CreateWorkspaceOptions {
    * @description Whether GitHub CLI (gh) is available on the system (for telemetry)
    */
   ghAvailable?: boolean;
+  /**
+   * @description Enable or disable usage analytics
+   */
+  analytics?: boolean;
 }
 
 export const supportedAgents = [

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -189,6 +189,12 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
     setNeverConnectToCloud(directory);
   }
 
+  // For template flow, save analytics preference directly to nx.json.
+  // For preset flow, this is handled by the workspace generator via createNxJson.
+  if (isTemplate && typeof options.analytics === 'boolean') {
+    setAnalyticsPreference(directory, options.analytics);
+  }
+
   // NXC-4020: Preset flow cloud handling matches v22.1.3 exactly:
   // 1. Read token (cloud was connected during createEmptyWorkspace)
   // 2. Setup CI for specific providers (not 'yes')
@@ -319,6 +325,14 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
     pushedToVcs,
     connectUrl,
   };
+}
+
+function setAnalyticsPreference(directory: string, enabled: boolean): void {
+  const { readFileSync, writeFileSync } = require('fs');
+  const nxJsonPath = join(directory, 'nx.json');
+  const nxJson = JSON.parse(readFileSync(nxJsonPath, 'utf-8'));
+  nxJson.analytics = enabled;
+  writeFileSync(nxJsonPath, JSON.stringify(nxJson, null, 2) + '\n');
 }
 
 export function extractConnectUrl(text: string): string | null {

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -142,6 +142,37 @@ async function aiAgentsPrompt(): Promise<Agent[]> {
   return (await enquirer.prompt<{ agents: Agent[] }>([promptConfig])).agents;
 }
 
+export async function determineAnalytics(
+  parsedArgs: yargs.Arguments<{ analytics?: boolean }>
+): Promise<boolean> {
+  if (typeof parsedArgs.analytics === 'boolean') {
+    return parsedArgs.analytics;
+  }
+
+  if (!parsedArgs.interactive || isCI()) {
+    // Default to false in non-interactive/CI
+    return false;
+  }
+
+  try {
+    const { enableAnalytics } = await enquirer.prompt<{
+      enableAnalytics: 'Yes' | 'No';
+    }>([
+      {
+        name: 'enableAnalytics',
+        message: 'Help improve Nx by sharing your usage data?',
+        type: 'autocomplete',
+        choices: [{ name: 'Yes' }, { name: 'No' }],
+        initial: 0,
+      },
+    ]);
+    return enableAnalytics === 'Yes';
+  } catch {
+    // User cancelled (Ctrl+C) — default to false
+    return false;
+  }
+}
+
 export async function determineDefaultBase(
   parsedArgs: yargs.Arguments<{ defaultBase?: string }>
 ): Promise<string> {

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -154,23 +154,18 @@ export async function determineAnalytics(
     return false;
   }
 
-  try {
-    const { enableAnalytics } = await enquirer.prompt<{
-      enableAnalytics: 'Yes' | 'No';
-    }>([
-      {
-        name: 'enableAnalytics',
-        message: 'Help improve Nx by sharing your usage data?',
-        type: 'autocomplete',
-        choices: [{ name: 'Yes' }, { name: 'No' }],
-        initial: 0,
-      },
-    ]);
-    return enableAnalytics === 'Yes';
-  } catch {
-    // User cancelled (Ctrl+C) — default to false
-    return false;
-  }
+  const { enableAnalytics } = await enquirer.prompt<{
+    enableAnalytics: 'Yes' | 'No';
+  }>([
+    {
+      name: 'enableAnalytics',
+      message: 'Help improve Nx by sharing your usage data?',
+      type: 'autocomplete',
+      choices: [{ name: 'Yes' }, { name: 'No' }],
+      initial: 0,
+    },
+  ]);
+  return enableAnalytics === 'Yes';
 }
 
 export async function determineDefaultBase(

--- a/packages/create-nx-workspace/src/internal-utils/yargs-options.ts
+++ b/packages/create-nx-workspace/src/internal-utils/yargs-options.ts
@@ -81,6 +81,13 @@ export function withGitOptions<T = unknown>(argv: yargs.Argv<T>) {
     });
 }
 
+export function withAnalytics<T = unknown>(argv: yargs.Argv<T>) {
+  return argv.option('analytics', {
+    describe: chalk.dim`Help improve Nx by sharing your usage data.`,
+    type: 'boolean',
+  });
+}
+
 export function withOptions<T>(
   argv: yargs.Argv<T>,
   ...options: ((argv: yargs.Argv<T>) => yargs.Argv<T>)[]

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -227,7 +227,7 @@ function setPresetProperty(tree: Tree, options: NormalizedSchema) {
 
 function createNxJson(
   tree: Tree,
-  { directory, defaultBase, preset }: NormalizedSchema
+  { directory, defaultBase, preset, analytics }: NormalizedSchema
 ) {
   const nxJson: NxJsonConfiguration & { $schema: string } = {
     $schema: './node_modules/nx/schemas/nx-schema.json',
@@ -244,6 +244,7 @@ function createNxJson(
             },
           }
         : undefined,
+    analytics,
   };
 
   if (defaultBase === 'main') {

--- a/packages/workspace/src/generators/new/new.ts
+++ b/packages/workspace/src/generators/new/new.ts
@@ -41,6 +41,7 @@ interface Schema {
   zoneless?: boolean;
   useGitHub?: boolean;
   nxCloud?: 'yes' | 'skip' | 'circleci' | 'github';
+  analytics?: boolean;
   formatter?: string;
   workspaces?: boolean;
   workspaceGlobs?: string | string[];


### PR DESCRIPTION
## Current Behavior

When a user creates a new workspace with `create-nx-workspace`, they are not asked about analytics. The analytics prompt only appears later on the first `nx` command run, or via the 22.6.0 migration.

## Expected Behavior

Users are prompted to opt in or out of usage analytics during `create-nx-workspace`, so the preference is set from the start. The prompt matches the style of other prompts in the flow (autocomplete with Yes/No choices).

- **Preset flow**: The `analytics` property is set via the workspace generator's `createNxJson`, so `nx.json` is properly formatted by prettier through `formatFiles(tree)`
- **Template flow**: The `analytics` property is written directly to `nx.json` (matching the pattern used by `setNeverConnectToCloud`)
- Supports `--analytics` CLI flag for non-interactive usage
- Skips the prompt in CI and non-interactive environments (defaults to `false`)