### PR TITLE
feat(core): add task and project count telemetry via performance lifecycle

### DIFF
--- a/packages/nx/src/analytics/analytics.ts
+++ b/packages/nx/src/analytics/analytics.ts
@@ -8,6 +8,7 @@ import type {
   trackEvent as TrackEventType,
   trackPageView as TrackPageViewType,
   getEventDimensions as GetEventDimensionsType,
+  EventDimensions,
 } from '../native';
 import {
   getPackageManagerVersion,
@@ -37,7 +38,13 @@ if (!IS_WASM) {
   getEventDimensions = nativeModule.getEventDimensions;
 }
 
-const customDimensions = IS_WASM ? null : (getEventDimensions?.() ?? null);
+export const customDimensions = IS_WASM
+  ? null
+  : (getEventDimensions?.() ?? null);
+
+export type EventParameters = Partial<
+  Record<EventDimensions[keyof EventDimensions], string | number | boolean>
+>;
 
 let _telemetryInitialized = false;
 
@@ -127,10 +134,8 @@ export function reportCommandRunEvent(
   trackPageView(command, pageLocation, parameters);
 }
 
-export function reportPerfEvent(name: string, duration: number) {
-  trackEvent(name, {
-    [customDimensions.duration]: duration,
-  });
+export function reportEvent(name: string, eventParameters?: EventParameters) {
+  trackEvent(name, eventParameters);
 }
 
 const SKIP_ARGS_KEYS = new Set([

--- a/packages/nx/src/analytics/index.ts
+++ b/packages/nx/src/analytics/index.ts
@@ -1,8 +1,10 @@
 export {
+  customDimensions,
+  EventParameters,
   startAnalytics,
   reportNxAddCommand,
   reportNxGenerateCommand,
   reportCommandRunEvent,
-  reportPerfEvent,
+  reportEvent,
   flushAnalytics,
 } from './analytics';

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -257,6 +257,9 @@ export interface EventDimensions {
   packageName: string
   packageVersion: string
   duration: string
+  taskCount: string
+  projectCount: string
+  cachedTaskCount: string
 }
 
 export declare const enum EventType {

--- a/packages/nx/src/native/telemetry/constants.rs
+++ b/packages/nx/src/native/telemetry/constants.rs
@@ -55,4 +55,7 @@ pub mod event_dimension {
     pub const PACKAGE_NAME: &str = "ep.package_name";
     pub const PACKAGE_VERSION: &str = "ep.package_version";
     pub const DURATION: &str = "epn.duration";
+    pub const TASK_COUNT: &str = "epn.task_count";
+    pub const PROJECT_COUNT: &str = "epn.project_count";
+    pub const CACHED_TASK_COUNT: &str = "epn.cached_task_count";
 }

--- a/packages/nx/src/native/telemetry/mod.rs
+++ b/packages/nx/src/native/telemetry/mod.rs
@@ -140,6 +140,9 @@ pub struct EventDimensions {
     pub package_name: String,
     pub package_version: String,
     pub duration: String,
+    pub task_count: String,
+    pub project_count: String,
+    pub cached_task_count: String,
 }
 
 /// Returns the canonical event dimension names.
@@ -151,6 +154,9 @@ pub fn get_event_dimensions() -> EventDimensions {
         package_name: event_dimension::PACKAGE_NAME.to_string(),
         package_version: event_dimension::PACKAGE_VERSION.to_string(),
         duration: event_dimension::DURATION.to_string(),
+        task_count: event_dimension::TASK_COUNT.to_string(),
+        project_count: event_dimension::PROJECT_COUNT.to_string(),
+        cached_task_count: event_dimension::CACHED_TASK_COUNT.to_string(),
     }
 }
 

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -1,4 +1,3 @@
-import { measureAndTrack } from '../utils/perf-logging';
 import { workspaceRoot } from '../utils/workspace-root';
 import { join } from 'path';
 import { performance } from 'perf_hooks';
@@ -383,11 +382,11 @@ async function updateProjectGraphWithPlugins(
       }
 
       performance.mark(`${plugin.name}:createDependencies - end`);
-      measureAndTrack(
-        `${plugin.name}:createDependencies`,
-        `${plugin.name}:createDependencies - start`,
-        `${plugin.name}:createDependencies - end`
-      );
+      performance.measure(`${plugin.name}:createDependencies`, {
+        start: `${plugin.name}:createDependencies - start`,
+        end: `${plugin.name}:createDependencies - end`,
+        detail: { track: true },
+      });
     })
   );
   performance.mark('createDependencies:end');

--- a/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
@@ -1,5 +1,4 @@
 import type { ProjectGraph } from '../../config/project-graph';
-import { measureAndTrack } from '../../utils/perf-logging';
 import { type PluginConfiguration } from '../../config/nx-json';
 import {
   AggregateCreateNodesError,
@@ -100,11 +99,11 @@ export class LoadedNxPlugin {
           throw new AggregateCreateNodesError([[null, e]], []);
         } finally {
           performance.mark(`${plugin.name}:createNodes - end`);
-          measureAndTrack(
-            `${plugin.name}:createNodes`,
-            `${plugin.name}:createNodes - start`,
-            `${plugin.name}:createNodes - end`
-          );
+          performance.measure(`${plugin.name}:createNodes`, {
+            start: `${plugin.name}:createNodes - start`,
+            end: `${plugin.name}:createNodes - end`,
+            detail: { track: true },
+          });
         }
       };
     }

--- a/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
@@ -1,5 +1,6 @@
 import type { ProjectGraph } from '../../config/project-graph';
 import { type PluginConfiguration } from '../../config/nx-json';
+import { customDimensions } from '../../analytics';
 import {
   AggregateCreateNodesError,
   isAggregateCreateNodesError,
@@ -89,8 +90,13 @@ export class LoadedNxPlugin {
       const inner = this.createNodes[1];
       this.createNodes[1] = async (...args) => {
         performance.mark(`${plugin.name}:createNodes - start`);
+        let projectCount = 0;
         try {
-          return await inner(...args);
+          const result = await inner(...args);
+          for (const [, , r] of result) {
+            projectCount += Object.keys(r.projects ?? {}).length;
+          }
+          return result;
         } catch (e) {
           if (isAggregateCreateNodesError(e)) {
             throw e;
@@ -102,7 +108,12 @@ export class LoadedNxPlugin {
           performance.measure(`${plugin.name}:createNodes`, {
             start: `${plugin.name}:createNodes - start`,
             end: `${plugin.name}:createNodes - end`,
-            detail: { track: true },
+            detail: {
+              track: true,
+              ...(customDimensions && {
+                [customDimensions.projectCount]: projectCount,
+              }),
+            },
           });
         }
       };

--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -301,9 +301,11 @@ export async function createProjectGraphAndSourceMapsAsync(
         end: 'createProjectGraphAsync:end',
         detail: {
           track: true,
-          [customDimensions?.projectCount]: Object.keys(
-            currentProjectGraph.nodes
-          ).length,
+          ...(customDimensions && {
+            [customDimensions.projectCount]: Object.keys(
+              currentProjectGraph.nodes
+            ).length,
+          }),
         },
       });
       return {
@@ -388,8 +390,10 @@ export async function createProjectGraphAndSourceMapsAsync(
         end: 'createProjectGraphAsync:end',
         detail: {
           track: true,
-          [customDimensions?.projectCount]: Object.keys(res.projectGraph.nodes)
-            .length,
+          ...(customDimensions && {
+            [customDimensions.projectCount]: Object.keys(res.projectGraph.nodes)
+              .length,
+          }),
         },
       });
       return res;
@@ -408,9 +412,11 @@ export async function createProjectGraphAndSourceMapsAsync(
         end: 'createProjectGraphAsync:end',
         detail: {
           track: true,
-          [customDimensions?.projectCount]: Object.keys(
-            projectGraphAndSourceMaps.projectGraph.nodes
-          ).length,
+          ...(customDimensions && {
+            [customDimensions.projectCount]: Object.keys(
+              projectGraphAndSourceMaps.projectGraph.nodes
+            ).length,
+          }),
         },
       });
       return projectGraphAndSourceMaps;

--- a/packages/nx/src/project-graph/project-graph.ts
+++ b/packages/nx/src/project-graph/project-graph.ts
@@ -1,6 +1,7 @@
 import { performance } from 'perf_hooks';
 
 import { join } from 'path';
+import { customDimensions } from '../analytics';
 import { readNxJson } from '../config/nx-json';
 import { ProjectGraph } from '../config/project-graph';
 import {
@@ -9,7 +10,6 @@ import {
 } from '../config/workspace-json-project-json';
 import { daemonClient } from '../daemon/client/client';
 import { isOnDaemon } from '../daemon/is-on-daemon';
-import { measureAndTrack } from '../utils/perf-logging';
 import { markDaemonAsDisabled, writeDaemonLogs } from '../daemon/tmp-dir';
 import { FileLock, IS_WASM } from '../native';
 import { workspaceDataDirectory } from '../utils/cache-directory';
@@ -296,11 +296,16 @@ export async function createProjectGraphAndSourceMapsAsync(
     );
     if (currentProjectGraph) {
       performance.mark('createProjectGraphAsync:end');
-      measureAndTrack(
-        'createProjectGraphAsync',
-        'createProjectGraphAsync:start',
-        'createProjectGraphAsync:end'
-      );
+      performance.measure('createProjectGraphAsync', {
+        start: 'createProjectGraphAsync:start',
+        end: 'createProjectGraphAsync:end',
+        detail: {
+          track: true,
+          [customDimensions?.projectCount]: Object.keys(
+            currentProjectGraph.nodes
+          ).length,
+        },
+      });
       return {
         projectGraph: currentProjectGraph,
         sourceMaps: currentSourceMaps,
@@ -378,11 +383,15 @@ export async function createProjectGraphAndSourceMapsAsync(
         'build-project-graph-using-project-file-map:end'
       );
       performance.mark('createProjectGraphAsync:end');
-      measureAndTrack(
-        'createProjectGraphAsync',
-        'createProjectGraphAsync:start',
-        'createProjectGraphAsync:end'
-      );
+      performance.measure('createProjectGraphAsync', {
+        start: 'createProjectGraphAsync:start',
+        end: 'createProjectGraphAsync:end',
+        detail: {
+          track: true,
+          [customDimensions?.projectCount]: Object.keys(res.projectGraph.nodes)
+            .length,
+        },
+      });
       return res;
     } catch (e) {
       handleProjectGraphError(opts, e);
@@ -394,11 +403,16 @@ export async function createProjectGraphAndSourceMapsAsync(
       const projectGraphAndSourceMaps =
         await daemonClient.getProjectGraphAndSourceMaps();
       performance.mark('createProjectGraphAsync:end');
-      measureAndTrack(
-        'createProjectGraphAsync',
-        'createProjectGraphAsync:start',
-        'createProjectGraphAsync:end'
-      );
+      performance.measure('createProjectGraphAsync', {
+        start: 'createProjectGraphAsync:start',
+        end: 'createProjectGraphAsync:end',
+        detail: {
+          track: true,
+          [customDimensions?.projectCount]: Object.keys(
+            projectGraphAndSourceMaps.projectGraph.nodes
+          ).length,
+        },
+      });
       return projectGraphAndSourceMaps;
     } catch (e) {
       if (e.message && e.message.indexOf('inotify_add_watch') > -1) {

--- a/packages/nx/src/tasks-runner/life-cycles/task-telemetry-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/task-telemetry-life-cycle.ts
@@ -1,0 +1,42 @@
+import { performance } from 'perf_hooks';
+
+import { customDimensions } from '../../analytics';
+import type { LifeCycle, TaskResult, TaskMetadata } from '../life-cycle';
+
+export class TaskTelemetryLifeCycle implements LifeCycle {
+  private taskCount = 0;
+  private cachedTaskCount = 0;
+  private projects = new Set<string>();
+
+  startCommand(): void {
+    performance.mark('task-execution-lifecycle:start');
+  }
+
+  endTasks(taskResults: TaskResult[], metadata: TaskMetadata): void {
+    for (const r of taskResults) {
+      this.taskCount++;
+      this.projects.add(r.task.target.project);
+      if (
+        r.status === 'local-cache' ||
+        r.status === 'local-cache-kept-existing' ||
+        r.status === 'remote-cache'
+      ) {
+        this.cachedTaskCount++;
+      }
+    }
+  }
+
+  endCommand(): void {
+    performance.mark('task-execution-lifecycle:end');
+    performance.measure('task-execution', {
+      start: 'task-execution-lifecycle:start',
+      end: 'task-execution-lifecycle:end',
+      detail: {
+        track: true,
+        [customDimensions?.taskCount]: this.taskCount,
+        [customDimensions?.cachedTaskCount]: this.cachedTaskCount,
+        [customDimensions?.projectCount]: this.projects.size,
+      },
+    });
+  }
+}

--- a/packages/nx/src/tasks-runner/life-cycles/task-telemetry-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/task-telemetry-life-cycle.ts
@@ -33,9 +33,11 @@ export class TaskTelemetryLifeCycle implements LifeCycle {
       end: 'task-execution-lifecycle:end',
       detail: {
         track: true,
-        [customDimensions?.taskCount]: this.taskCount,
-        [customDimensions?.cachedTaskCount]: this.cachedTaskCount,
-        [customDimensions?.projectCount]: this.projects.size,
+        ...(customDimensions && {
+          [customDimensions.taskCount]: this.taskCount,
+          [customDimensions.cachedTaskCount]: this.cachedTaskCount,
+          [customDimensions.projectCount]: this.projects.size,
+        }),
       },
     });
   }

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -55,6 +55,7 @@ import { StoreRunInformationLifeCycle } from './life-cycles/store-run-informatio
 import { getTasksHistoryLifeCycle } from './life-cycles/task-history-life-cycle';
 import { TaskProfilingLifeCycle } from './life-cycles/task-profiling-life-cycle';
 import { TaskResultsLifeCycle } from './life-cycles/task-results-life-cycle';
+import { TaskTelemetryLifeCycle } from './life-cycles/task-telemetry-life-cycle';
 import { TaskTimingsLifeCycle } from './life-cycles/task-timings-life-cycle';
 import { getTuiTerminalSummaryLifeCycle } from './life-cycles/tui-summary-life-cycle';
 import {
@@ -1066,6 +1067,7 @@ export function constructLifeCycles(lifeCycle: LifeCycle): LifeCycle[] {
   if (process.env.NX_PROFILE) {
     lifeCycles.push(new TaskProfilingLifeCycle(process.env.NX_PROFILE));
   }
+  lifeCycles.push(new TaskTelemetryLifeCycle());
   const historyLifeCycle = getTasksHistoryLifeCycle();
   lifeCycles.push(historyLifeCycle);
   return lifeCycles;

--- a/packages/nx/src/utils/perf-hooks.d.ts
+++ b/packages/nx/src/utils/perf-hooks.d.ts
@@ -1,10 +1,15 @@
 import type { EventParameters } from '../analytics/analytics';
 
+export interface TrackedDetail extends EventParameters {
+  track: true;
+  [key: string]: string | number | boolean;
+}
+
 interface TrackedMeasureOptions {
   start?: string | number;
   end?: string | number;
   duration?: number;
-  detail: { track: true } & EventParameters;
+  detail: TrackedDetail;
 }
 
 declare module 'perf_hooks' {

--- a/packages/nx/src/utils/perf-hooks.d.ts
+++ b/packages/nx/src/utils/perf-hooks.d.ts
@@ -1,0 +1,14 @@
+import type { EventParameters } from '../analytics/analytics';
+
+interface TrackedMeasureOptions {
+  start?: string | number;
+  end?: string | number;
+  duration?: number;
+  detail: { track: true } & EventParameters;
+}
+
+declare module 'perf_hooks' {
+  interface Performance {
+    measure(name: string, options: TrackedMeasureOptions): PerformanceMeasure;
+  }
+}

--- a/packages/nx/src/utils/perf-logging.ts
+++ b/packages/nx/src/utils/perf-logging.ts
@@ -1,21 +1,13 @@
 import { PerformanceObserver } from 'perf_hooks';
 
-import { reportPerfEvent } from '../analytics';
+import { customDimensions, reportEvent } from '../analytics';
+import type { EventParameters } from '../analytics';
 import { isOnDaemon } from '../daemon/is-on-daemon';
 import { serverLogger } from '../daemon/logger';
 
-const TRACK_PREFIX = '[track] ';
-
-/**
- * Like `performance.measure()` but automatically reports to telemetry.
- */
-export function measureAndTrack(
-  name: string,
-  startMark: string,
-  endMark: string
-) {
-  performance.measure(`${TRACK_PREFIX}${name}`, startMark, endMark);
-}
+const dimensionValues = customDimensions
+  ? new Set(Object.values(customDimensions))
+  : null;
 
 let initialized = false;
 
@@ -24,13 +16,11 @@ if (!initialized) {
 
   const obs = new PerformanceObserver((list) => {
     for (const entry of list.getEntries()) {
-      const shouldTrack = entry.name.startsWith(TRACK_PREFIX);
-      const displayName = shouldTrack
-        ? entry.name.slice(TRACK_PREFIX.length)
-        : entry.name;
+      const detail = (entry as any).detail;
+      const shouldTrack = detail?.track === true;
 
       if (process.env.NX_PERF_LOGGING === 'true') {
-        const message = `Time taken for '${displayName}' ${entry.duration}ms`;
+        const message = `Time taken for '${entry.name}' ${entry.duration}ms`;
         if (isOnDaemon()) {
           serverLogger.log(message);
         } else {
@@ -38,8 +28,17 @@ if (!initialized) {
         }
       }
 
-      if (shouldTrack) {
-        reportPerfEvent(displayName, entry.duration);
+      if (shouldTrack && dimensionValues) {
+        const { track, ...rest } = detail;
+        const eventParameters: EventParameters = {
+          [customDimensions.duration]: entry.duration,
+        };
+        for (const [key, value] of Object.entries(rest)) {
+          if (dimensionValues.has(key)) {
+            eventParameters[key] = value as string | number | boolean;
+          }
+        }
+        reportEvent(entry.name, eventParameters);
       }
     }
   });

--- a/packages/nx/src/utils/perf-logging.ts
+++ b/packages/nx/src/utils/perf-logging.ts
@@ -2,8 +2,17 @@ import { PerformanceObserver } from 'perf_hooks';
 
 import { customDimensions, reportEvent } from '../analytics';
 import type { EventParameters } from '../analytics';
+import type { TrackedDetail } from './perf-hooks';
 import { isOnDaemon } from '../daemon/is-on-daemon';
 import { serverLogger } from '../daemon/logger';
+
+function isTrackedDetail(detail: unknown): detail is TrackedDetail {
+  return (
+    typeof detail === 'object' &&
+    detail !== null &&
+    (detail as any).track === true
+  );
+}
 
 const dimensionValues = customDimensions
   ? new Set(Object.values(customDimensions))
@@ -16,8 +25,7 @@ if (!initialized) {
 
   const obs = new PerformanceObserver((list) => {
     for (const entry of list.getEntries()) {
-      const detail = (entry as any).detail;
-      const shouldTrack = detail?.track === true;
+      const { detail } = entry;
 
       if (process.env.NX_PERF_LOGGING === 'true') {
         const message = `Time taken for '${entry.name}' ${entry.duration}ms`;
@@ -28,14 +36,14 @@ if (!initialized) {
         }
       }
 
-      if (shouldTrack && dimensionValues) {
+      if (isTrackedDetail(detail) && dimensionValues) {
         const { track, ...rest } = detail;
         const eventParameters: EventParameters = {
           [customDimensions.duration]: entry.duration,
         };
         for (const [key, value] of Object.entries(rest)) {
           if (dimensionValues.has(key)) {
-            eventParameters[key] = value as string | number | boolean;
+            eventParameters[key] = value;
           }
         }
         reportEvent(entry.name, eventParameters);


### PR DESCRIPTION
## Current Behavior

Telemetry only reports event duration via the `measureAndTrack` helper, which uses a `[track] ` prefix convention. No task-level metrics (count, cache hits, project count) are reported.

## Expected Behavior

- New event dimensions: `taskCount`, `projectCount`, `cachedTaskCount` available for telemetry events
- `TaskTelemetryLifeCycle` reports task execution metrics (duration, task count, project count, cached task count) — only runs on the main CLI process, not on DTE agents
- `performance.measure()` with `detail: { track: true, ... }` replaces the `measureAndTrack` / `[track] ` prefix pattern
- Perf observer automatically forwards detail entries matching known GA4 dimension keys
- `reportEvent` simplified to a pass-through — callers use `customDimensions` keys directly
- `customDimensions` and `EventParameters` exported for use by callers