### PR TITLE
fix(core): preserve params and options when expanding wildcard dependsOn targets

### DIFF
--- a/packages/nx/src/tasks-runner/utils.spec.ts
+++ b/packages/nx/src/tasks-runner/utils.spec.ts
@@ -736,6 +736,36 @@ describe('utils', () => {
         },
       ]);
     });
+
+    it('should preserve params and options when expanding wildcards', () => {
+      const allTargets = ['build', 'build:test', 'build:prod'];
+      const results = expandWildcardTargetConfiguration(
+        {
+          target: 'build*',
+          projects: ['a'],
+          params: 'forward',
+        },
+        allTargets
+      );
+
+      expect(results).toEqual([
+        {
+          target: 'build',
+          projects: ['a'],
+          params: 'forward',
+        },
+        {
+          target: 'build:test',
+          projects: ['a'],
+          params: 'forward',
+        },
+        {
+          target: 'build:prod',
+          projects: ['a'],
+          params: 'forward',
+        },
+      ]);
+    });
   });
 
   describe('validateOutputs', () => {

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -156,9 +156,8 @@ export function expandWildcardTargetConfiguration(
   );
 
   return matchingTargets.map((t) => ({
+    ...dependencyConfig,
     target: t,
-    projects: dependencyConfig.projects,
-    dependencies: dependencyConfig.dependencies,
   }));
 }
 


### PR DESCRIPTION
## Summary

- `expandWildcardTargetConfiguration` was explicitly copying only `projects` and `dependencies` when expanding glob patterns in `dependsOn` target names, dropping `params` and `options`
- This meant `"params": "forward"` (and `"options": "forward"`) had no effect when the `dependsOn` target used a wildcard like `"target": "build*"`
- Fix uses object spread (`...dependencyConfig`) to preserve all properties from the original dependency config

## Bug

Given this `project.json`:
```json
{
  "targets": {
    "build-all": {
      "executor": "nx:noop",
      "dependsOn": [
        {
          "target": "build*",
          "params": "forward"
        }
      ]
    }
  }
}
```

Running `nx run project:build-all --myParam=value` would correctly resolve the wildcard to match targets like `build`, `build:test`, `build:prod`, etc. — but `--myParam=value` was never forwarded to those targets because `params: "forward"` was dropped during expansion.

## Root Cause

In `expandWildcardTargetConfiguration` (`packages/nx/src/tasks-runner/utils.ts`), the matched targets were mapped with only `target`, `projects`, and `dependencies`:

```typescript
return matchingTargets.map((t) => ({
    target: t,
    projects: dependencyConfig.projects,
    dependencies: dependencyConfig.dependencies,
    // params and options were missing!
}));
```

## Fix

Use object spread to carry over all properties:

```typescript
return matchingTargets.map((t) => ({
    ...dependencyConfig,
    target: t,
}));
```

## Test plan

- [x] Added test case verifying `params: "forward"` is preserved after wildcard expansion
- [x] All 45 existing tests in `utils.spec.ts` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)