### PR TITLE
fix(core): add null guards for runningTasksService in WASM fallback

### DIFF
--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -991,7 +991,7 @@ export class TaskOrchestrator {
       temporaryOutputPath,
       pipeOutput
     );
-    this.runningTasksService.addRunningTask(task.id);
+    this.runningTasksService?.addRunningTask(task.id);
     this.runningContinuousTasks.set(task.id, {
       runningTask: childProcess,
       groupId,
@@ -1307,7 +1307,7 @@ export class TaskOrchestrator {
 
     this.runningContinuousTasks.delete(task.id);
     if (ownsRunningTasksService) {
-      this.runningTasksService.removeRunningTask(task.id);
+      this.runningTasksService?.removeRunningTask(task.id);
     }
 
     task.endTime = Date.now();


### PR DESCRIPTION
## Summary
- When native bindings fail to load (`IS_WASM = true`), `runningTasksService` is `null`
- Two call sites in `task-orchestrator.ts` accessed it without null checks, causing `Cannot read properties of null (reading 'addRunningTask')` during `nx serve`
- Added optional chaining (`?.`) at both sites, matching the existing guard pattern already used elsewhere in the same file

## Test plan
- [ ] Run `nx serve` in an environment where native bindings are unavailable (e.g. missing `@nx/nx-<platform>`)
- [ ] Verify no crash on `addRunningTask` or `removeRunningTask`

Fixes #34573