### PR TITLE
fix(webpack): bump fork-ts-checker-webpack-plugin to 9.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "figures": "3.2.0",
     "file-type": "^16.2.0",
     "flat": "^5.0.2",
-    "fork-ts-checker-webpack-plugin": "7.2.13",
+    "fork-ts-checker-webpack-plugin": "9.1.0",
     "fs-extra": "^11.1.0",
     "github-slugger": "^2.0.0",
     "globals": "^15.9.0",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -40,7 +40,7 @@
     "copy-webpack-plugin": "^14.0.0",
     "css-loader": "^6.4.0",
     "css-minimizer-webpack-plugin": "^8.0.0",
-    "fork-ts-checker-webpack-plugin": "7.2.13",
+    "fork-ts-checker-webpack-plugin": "9.1.0",
     "less": ">=4.1.3 <4.6.0",
     "less-loader": "^12.2.0",
     "license-webpack-plugin": "^4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -996,8 +996,8 @@ importers:
         specifier: ^5.0.2
         version: 5.0.2
       fork-ts-checker-webpack-plugin:
-        specifier: 7.2.13
-        version: 7.2.13(typescript@5.9.2)(webpack@5.101.3)
+        specifier: 9.1.0
+        version: 9.1.0(typescript@5.9.2)(webpack@5.101.3)
       fs-extra:
         specifier: ^11.1.0
         version: 11.3.0
@@ -4114,8 +4114,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0(esbuild@0.25.0)(lightningcss@1.30.1)(webpack@5.101.3)
       fork-ts-checker-webpack-plugin:
-        specifier: 7.2.13
-        version: 7.2.13(typescript@5.9.2)(webpack@5.101.3)
+        specifier: 9.1.0
+        version: 9.1.0(typescript@5.9.2)(webpack@5.101.3)
       less:
         specifier: '>=4.1.3 <4.6.0'
         version: 4.1.3
@@ -29993,7 +29993,7 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.28.3
     transitivePeerDependencies:
       - supports-color
@@ -30970,7 +30970,7 @@ snapshots:
 
   '@babel/traverse@7.28.5':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
       '@babel/parser': 7.28.5
@@ -39383,7 +39383,7 @@ snapshots:
 
   '@testing-library/dom@10.4.0':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@babel/runtime': 7.28.6
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -46795,7 +46795,7 @@ snapshots:
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
-      tapable: 2.2.2
+      tapable: 2.3.0
     optionalDependencies:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
       webpack: 5.101.3(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
@@ -46806,7 +46806,7 @@ snapshots:
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
-      tapable: 2.2.2
+      tapable: 2.3.0
     optionalDependencies:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
       webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3))
@@ -49580,7 +49580,7 @@ snapshots:
 
   metro@0.82.4:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.0
       '@babel/core': 7.28.3
       '@babel/generator': 7.29.1
       '@babel/parser': 7.28.3
@@ -58245,7 +58245,7 @@ snapshots:
   webpack-dev-middleware@7.4.2(webpack@5.101.3):
     dependencies:
       colorette: 2.0.20
-      memfs: 4.17.2
+      memfs: 4.51.1
       mime-types: 2.1.35
       on-finished: 2.4.1
       range-parser: 1.2.1


### PR DESCRIPTION
## Summary
- Bumps `fork-ts-checker-webpack-plugin` from `7.2.13` to `9.1.0` in root `package.json` and `packages/webpack/package.json`
- v7 depends on `memfs` v3 which uses a deprecated `fs.stat` API, causing console warnings on Node 22+
- v9 uses updated `memfs` and has no breaking API changes for the constructor pattern used by Nx

## Test plan
- [ ] Run Angular webpack app and verify no `fstat` deprecation warnings
- [ ] Run Node webpack build and verify no regressions
- [ ] Verify type checking still works via the plugin

Fixes #34404