### PR TITLE
fix(bundling): prevent treeshaking of CSS modules in extract mode

### DIFF
--- a/e2e/rollup/src/rollup.test.ts
+++ b/e2e/rollup/src/rollup.test.ts
@@ -3,6 +3,7 @@ import {
   cleanupProject,
   newProject,
   packageInstall,
+  readFile,
   readJson,
   rmDist,
   runCLI,
@@ -232,6 +233,45 @@ export default config;
     expect(output).toContain('Successfully ran target build for project test');
     checkFilesExist(`libs/test/dist/bundle.js`);
     checkFilesExist(`libs/test/dist/bundle.es.js`);
+  });
+
+  it('should extract imported CSS files into the output', () => {
+    const myPkg = uniq('my-pkg');
+    runCLI(
+      `generate @nx/js:lib ${myPkg} --directory=libs/${myPkg} --bundler=rollup`
+    );
+
+    // Add a CSS file and import it from the main entry point
+    updateFile(
+      `libs/${myPkg}/src/styles.css`,
+      `.container { max-width: 1200px; margin: 0 auto; }`
+    );
+    updateFile(
+      `libs/${myPkg}/src/index.ts`,
+      `import './styles.css';\nexport const greeting = 'hello';\n`
+    );
+    updateFile(
+      `libs/${myPkg}/rollup.config.cjs`,
+      `
+      const { withNx } = require('@nx/rollup/with-nx');
+      module.exports = withNx({
+        outputPath: '../../dist/libs/${myPkg}',
+        main: './src/index.ts',
+        tsConfig: './tsconfig.lib.json',
+        compiler: 'swc',
+        format: ['esm'],
+      });
+    `
+    );
+
+    rmDist();
+    runCLI(`build ${myPkg}`);
+
+    // CSS should be extracted into the dist output
+    checkFilesExist(`dist/libs/${myPkg}/index.esm.css`);
+    const cssContent = readFile(`dist/libs/${myPkg}/index.esm.css`);
+    expect(cssContent).toContain('.container');
+    expect(cssContent).toContain('max-width: 1200px');
   });
 
   describe('useLegacyTypescriptPlugin', () => {

--- a/e2e/rollup/src/rollup.test.ts
+++ b/e2e/rollup/src/rollup.test.ts
@@ -250,21 +250,7 @@ export default config;
       `libs/${myPkg}/src/index.ts`,
       `import './styles.css';\nexport const greeting = 'hello';\n`
     );
-    updateFile(
-      `libs/${myPkg}/rollup.config.cjs`,
-      `
-      const { withNx } = require('@nx/rollup/with-nx');
-      module.exports = withNx({
-        outputPath: '../../dist/libs/${myPkg}',
-        main: './src/index.ts',
-        tsConfig: './tsconfig.lib.json',
-        compiler: 'swc',
-        format: ['esm'],
-      });
-    `
-    );
 
-    rmDist();
     runCLI(`build ${myPkg}`);
 
     // CSS should be extracted into the dist output

--- a/packages/rollup/src/plugins/postcss/postcss-plugin.spec.ts
+++ b/packages/rollup/src/plugins/postcss/postcss-plugin.spec.ts
@@ -133,6 +133,19 @@ describe('postcss plugin', () => {
       expect(result.code).not.toContain('styleInject');
     });
 
+    it('should set moduleSideEffects to prevent treeshaking of CSS modules', async () => {
+      const plugin = postcss({ inject: false, extract: true });
+      const transform = plugin.transform as Function;
+
+      const result = await transform.call(
+        mockContext,
+        '.foo { color: red; }',
+        '/path/to/styles.css'
+      );
+
+      expect(result.moduleSideEffects).toBe(true);
+    });
+
     it('should process .scss files', async () => {
       const plugin = postcss();
       const transform = plugin.transform as Function;

--- a/packages/rollup/src/plugins/postcss/postcss-plugin.spec.ts
+++ b/packages/rollup/src/plugins/postcss/postcss-plugin.spec.ts
@@ -231,6 +231,59 @@ describe('postcss plugin', () => {
     });
   });
 
+  describe('generateBundle', () => {
+    let mockContext: Partial<PluginContext>;
+
+    beforeEach(() => {
+      mockContext = {
+        warn: jest.fn(),
+        addWatchFile: jest.fn(),
+      };
+    });
+
+    it('should emit extracted CSS even when CSS module is not in chunk.modules', async () => {
+      const plugin = postcss({ inject: false, extract: true });
+      const transform = plugin.transform as Function;
+      const generateBundle = plugin.generateBundle as Function;
+
+      // Transform the CSS file so it gets stored in the extracted map
+      await transform.call(
+        mockContext,
+        '.foo { color: red; }',
+        '/path/to/styles.css'
+      );
+
+      // Simulate a bundle where the CSS module is NOT in chunk.modules
+      // (this happens when Rollup tree-shakes the empty CSS module away)
+      const emittedFiles: Array<{
+        type: string;
+        fileName: string;
+        source: string;
+      }> = [];
+      const bundleContext = {
+        emitFile: (file: any) => emittedFiles.push(file),
+      };
+      const bundle = {
+        'index.esm.js': {
+          type: 'chunk' as const,
+          isEntry: true,
+          fileName: 'index.esm.js',
+          modules: {
+            '/path/to/index.ts': {},
+          },
+        },
+      };
+
+      await generateBundle.call(bundleContext, {}, bundle);
+
+      // The CSS should still be emitted via the fallback path
+      expect(emittedFiles.length).toBe(1);
+      expect(emittedFiles[0].fileName).toBe('index.esm.css');
+      expect(emittedFiles[0].source).toContain('.foo');
+      expect(emittedFiles[0].source).toContain('color: red');
+    });
+  });
+
   describe('file filtering', () => {
     let mockContext: Partial<PluginContext>;
 

--- a/packages/rollup/src/plugins/postcss/postcss-plugin.ts
+++ b/packages/rollup/src/plugins/postcss/postcss-plugin.ts
@@ -312,6 +312,32 @@ export function postcss(pluginOptions: PostCSSPluginOptions = {}): Plugin {
         }
       }
 
+      // Fallback: if extracted CSS was not matched to any chunk
+      // (e.g. because Rollup tree-shook the CSS module out of the chunk),
+      // associate it with the first entry chunk so it still gets emitted.
+      const emittedCSSIds = new Set<string>();
+      for (const cssFiles of cssPerChunk.values()) {
+        for (const css of cssFiles) {
+          emittedCSSIds.add(css.id);
+        }
+      }
+      const unmatched: ExtractedCSS[] = [];
+      for (const [id, css] of extracted) {
+        if (!emittedCSSIds.has(id)) {
+          unmatched.push(css);
+        }
+      }
+      if (unmatched.length > 0) {
+        const entryChunkId = Object.keys(bundle).find((key) => {
+          const item = bundle[key];
+          return item.type === 'chunk' && item.isEntry;
+        });
+        if (entryChunkId) {
+          const existing = cssPerChunk.get(entryChunkId) || [];
+          cssPerChunk.set(entryChunkId, [...existing, ...unmatched]);
+        }
+      }
+
       // Emit CSS files for each chunk
       for (const [chunkId, cssFiles] of cssPerChunk) {
         const chunk = bundle[chunkId];

--- a/packages/rollup/src/plugins/postcss/postcss-plugin.ts
+++ b/packages/rollup/src/plugins/postcss/postcss-plugin.ts
@@ -234,6 +234,11 @@ export function postcss(pluginOptions: PostCSSPluginOptions = {}): Plugin {
       return {
         code: result.code,
         map: toRollupSourceMap(result.map) ?? { mappings: '' },
+        // Prevent Rollup from treeshaking CSS modules away.
+        // In extract mode the transform produces an empty export which
+        // Rollup would otherwise remove, causing generateBundle to miss
+        // the CSS content entirely.
+        moduleSideEffects: true,
       };
     },
 


### PR DESCRIPTION
## Current Behavior

When using `@nx/rollup` with CSS extraction (the default), CSS files imported from JavaScript are silently dropped from the build output. The postcss plugin's `transform` hook replaces CSS imports with `export default {}` — a side-effect-free module that Rollup treeshakes away. When the `generateBundle` hook later scans chunk modules for extracted CSS, the treeshaken modules are gone, so no CSS is emitted.

This is a regression introduced in #34110 which replaced the external `rollup-plugin-postcss` with an inlined version.

## Expected Behavior

CSS files imported from JavaScript should be extracted and emitted in the dist folder, regardless of Rollup's treeshaking behavior. The fix adds `moduleSideEffects: true` to the transform return value for CSS files, which tells Rollup to keep these modules in the bundle since CSS imports are inherently side-effectful.

## Related Issue(s)

Fixes #34776