### PR TITLE
fix(core): patch proxy-from-env to fix url.parse() deprecation

### DIFF
--- a/patches/proxy-from-env@1.1.0.patch
+++ b/patches/proxy-from-env@1.1.0.patch
@@ -1,0 +1,27 @@
+diff --git a/index.js b/index.js
+index df75004aed7007aaf4624aaa1847a6fedc1bdf09..9181f8ea533baa5c9e94b3e2fc2c1b192d60296d 100644
+--- a/index.js
++++ b/index.js
+@@ -1,6 +1,12 @@
+ 'use strict';
+ 
+-var parseUrl = require('url').parse;
++function parseUrl(urlString) {
++  try {
++    return new URL(urlString);
++  } catch {
++    return null;
++  }
++}
+ 
+ var DEFAULT_PORTS = {
+   ftp: 21,
+@@ -22,7 +28,7 @@ var stringEndsWith = String.prototype.endsWith || function(s) {
+  *  given URL. If no proxy is set, this will be an empty string.
+  */
+ function getProxyForUrl(url) {
+-  var parsedUrl = typeof url === 'string' ? parseUrl(url) : url || {};
++  var parsedUrl = (typeof url === 'string' ? parseUrl(url) : url) || {};
+   var proto = parsedUrl.protocol;
+   var hostname = parsedUrl.host;
+   var port = parsedUrl.port;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,9 @@ patchedDependencies:
   '@astrojs/starlight':
     hash: 228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235
     path: patches/@astrojs__starlight.patch
+  proxy-from-env@1.1.0:
+    hash: ced53adeecce42baaa980515d857b9b20b05b90226160a0c6bf1ad587c75132b
+    path: patches/proxy-from-env@1.1.0.patch
 
 importers:
 
@@ -41815,7 +41818,7 @@ snapshots:
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.1)
       form-data: 4.0.4
-      proxy-from-env: 1.1.0
+      proxy-from-env: 1.1.0(patch_hash=ced53adeecce42baaa980515d857b9b20b05b90226160a0c6bf1ad587c75132b)
     transitivePeerDependencies:
       - debug
 
@@ -53500,7 +53503,7 @@ snapshots:
 
   proxy-from-env@1.0.0: {}
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@1.1.0(patch_hash=ced53adeecce42baaa980515d857b9b20b05b90226160a0c6bf1ad587c75132b): {}
 
   prr@1.0.1:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,53 +1,47 @@
 packages:
-  - 'packages/*'
-  - 'e2e/*'
-  - 'graph/*'
-  - 'nx-dev/*'
-  - 'tools/*'
-  - 'astro-docs'
-  - 'examples/*/*'
-  - 'examples/angular-rspack/module-federation/host'
-  - 'examples/angular-rspack/module-federation/remote'
-  - 'packages/nx/native-packages/*'
-overrides:
-  minimist: '^1.2.6'
-  underscore: '^1.12.1'
-onlyBuiltDependencies:
-  - '@nestjs/core'
-  - 'nx'
-patchedDependencies:
-  '@astrojs/starlight': 'patches/@astrojs__starlight.patch'
+  - packages/*
+  - e2e/*
+  - graph/*
+  - nx-dev/*
+  - tools/*
+  - astro-docs
+  - examples/*/*
+  - examples/angular-rspack/module-federation/host
+  - examples/angular-rspack/module-federation/remote
+  - packages/nx/native-packages/*
+
 catalog:
-  '@zkochan/js-yaml': '0.0.7'
-  chalk: '^4.1.0'
-  enquirer: '~2.3.6'
-  minimatch: '10.2.4'
-  picomatch: '4.0.2'
-  picocolors: '^1.1.0'
-  semver: '^7.6.3'
-  tinyglobby: '^0.2.12'
-  yargs: '^17.6.2'
-  yargs-parser: '21.1.1'
+  '@zkochan/js-yaml': 0.0.7
+  chalk: ^4.1.0
+  enquirer: ~2.3.6
+  minimatch: 10.2.4
+  picocolors: ^1.1.0
+  picomatch: 4.0.2
+  semver: ^7.6.3
+  tinyglobby: ^0.2.12
+  yargs: ^17.6.2
+  yargs-parser: 21.1.1
+
 catalogs:
   angular:
-    '@angular-devkit/architect': '~0.2102.0'
-    '@angular-devkit/build-angular': '~21.2.0'
-    '@angular-devkit/core': '~21.2.0'
-    '@angular-devkit/schematics': '~21.2.0'
-    '@angular/build': '~21.2.0'
-    '@angular/cli': '~21.2.0'
-    '@angular/common': '~21.2.0'
-    '@angular/compiler': '~21.2.0'
-    '@angular/compiler-cli': '~21.2.0'
-    '@angular/core': '~21.2.0'
-    '@angular/localize': '~21.2.0'
-    '@angular/platform-browser': '~21.2.0'
-    '@angular/platform-server': '~21.2.0'
-    '@angular/router': '~21.2.0'
-    '@angular/ssr': '~21.2.0'
-    '@schematics/angular': '~21.2.0'
-    ng-packagr: '~21.2.0'
-    zone.js: '~0.16.0'
+    '@angular-devkit/architect': ~0.2102.0
+    '@angular-devkit/build-angular': ~21.2.0
+    '@angular-devkit/core': ~21.2.0
+    '@angular-devkit/schematics': ~21.2.0
+    '@angular/build': ~21.2.0
+    '@angular/cli': ~21.2.0
+    '@angular/common': ~21.2.0
+    '@angular/compiler': ~21.2.0
+    '@angular/compiler-cli': ~21.2.0
+    '@angular/core': ~21.2.0
+    '@angular/localize': ~21.2.0
+    '@angular/platform-browser': ~21.2.0
+    '@angular/platform-server': ~21.2.0
+    '@angular/router': ~21.2.0
+    '@angular/ssr': ~21.2.0
+    '@schematics/angular': ~21.2.0
+    ng-packagr: ~21.2.0
+    zone.js: ~0.16.0
   angular-supported-versions:
     '@angular-devkit/build-angular': '>= 19.0.0 < 22.0.0'
     '@angular-devkit/core': '>= 19.0.0 < 22.0.0'
@@ -59,50 +53,62 @@ catalogs:
     '@angular/ssr': '>= 19.0.0 < 22.0.0'
     '@schematics/angular': '>= 19.0.0 < 22.0.0'
     ng-packagr: '>= 19.0.0 < 22.0.0'
-    rxjs: '^6.5.3 || ^7.5.0'
-    zone.js: '~0.15.0 || ~0.16.0'
+    rxjs: ^6.5.3 || ^7.5.0
+    zone.js: ~0.15.0 || ~0.16.0
   eslint:
-    '@angular-eslint/eslint-plugin': '21.2.0'
-    '@angular-eslint/eslint-plugin-template': '21.2.0'
-    '@angular-eslint/template-parser': '21.2.0'
-    angular-eslint: '21.2.0'
+    '@angular-eslint/eslint-plugin': 21.2.0
+    '@angular-eslint/eslint-plugin-template': 21.2.0
+    '@angular-eslint/template-parser': 21.2.0
+    angular-eslint: 21.2.0
   jest:
-    '@jest/reporters': '^30.0.2'
-    '@jest/test-result': '^30.0.2'
-    '@jest/types': '30.0.1'
-    '@types/jest': '30.0.0'
-    babel-jest: '^30.0.2'
-    identity-obj-proxy: '3.0.0'
-    jest: '^30.0.2'
-    jest-config: '^30.0.2'
-    jest-diff: '^30.0.2'
-    jest-environment-jsdom: '^30.0.2'
-    jest-environment-node: '^30.0.2'
-    jest-resolve: '^30.0.2'
-    jest-runtime: '^30.0.2'
-    jest-util: '^30.0.2'
-    ts-jest: '^29.4.0'
+    '@jest/reporters': ^30.0.2
+    '@jest/test-result': ^30.0.2
+    '@jest/types': 30.0.1
+    '@types/jest': 30.0.0
+    babel-jest: ^30.0.2
+    identity-obj-proxy: 3.0.0
+    jest: ^30.0.2
+    jest-config: ^30.0.2
+    jest-diff: ^30.0.2
+    jest-environment-jsdom: ^30.0.2
+    jest-environment-node: ^30.0.2
+    jest-resolve: ^30.0.2
+    jest-runtime: ^30.0.2
+    jest-util: ^30.0.2
+    ts-jest: ^29.4.0
   react:
-    '@types/react': '18.3.1'
-    '@types/react-dom': '18.3.1'
-    react: '18.3.1'
-    react-dom: '18.3.1'
+    '@types/react': 18.3.1
+    '@types/react-dom': 18.3.1
+    react: 18.3.1
+    react-dom: 18.3.1
   rspack:
-    '@rspack/cli': '1.6.8'
-    '@rspack/core': '1.6.8'
-    '@rspack/dev-server': '^1.1.4'
-    '@rspack/plugin-react-refresh': '^1.0.0'
-    ts-checker-rspack-plugin: '^1.1.1'
-  typescript:
-    '@phenomnomnominal/tsquery': '~6.1.4'
-    '@types/node': '^20.19.10'
-    ts-morph: '^27.0.2'
-    ts-node: '10.9.1'
-    tsconfig-paths: '^4.1.2'
-    tslib: '^2.3.0'
-    typescript: '~5.9.2'
+    '@rspack/cli': 1.6.8
+    '@rspack/core': 1.6.8
+    '@rspack/dev-server': ^1.1.4
+    '@rspack/plugin-react-refresh': ^1.0.0
+    ts-checker-rspack-plugin: ^1.1.1
   swc:
-    '@swc/core': '^1.15.8'
-    '@swc/helpers': '0.5.18'
-    '@swc/cli': '0.8.0'
-    '@swc-node/register': '^1.11.1'
+    '@swc-node/register': ^1.11.1
+    '@swc/cli': 0.8.0
+    '@swc/core': ^1.15.8
+    '@swc/helpers': 0.5.18
+  typescript:
+    '@phenomnomnominal/tsquery': ~6.1.4
+    '@types/node': ^20.19.10
+    ts-morph: ^27.0.2
+    ts-node: 10.9.1
+    tsconfig-paths: ^4.1.2
+    tslib: ^2.3.0
+    typescript: ~5.9.2
+
+onlyBuiltDependencies:
+  - '@nestjs/core'
+  - nx
+
+overrides:
+  minimist: ^1.2.6
+  underscore: ^1.12.1
+
+patchedDependencies:
+  '@astrojs/starlight': patches/@astrojs__starlight.patch
+  proxy-from-env@1.1.0: patches/proxy-from-env@1.1.0.patch


### PR DESCRIPTION
## Current Behavior

On Node 22+, every `nx` command emits a `[DEP0169] DeprecationWarning: url.parse()` warning because `axios@1.12.0` depends on `proxy-from-env@1.1.0`, which calls the deprecated `url.parse()`.

`proxy-from-env@2.0.0` fixes this but is ESM-only, so axios cannot bump to it. No upstream CJS fix currently exists.

## Expected Behavior

No `DEP0169` deprecation warning when running `nx` commands on Node 22+.

This PR applies a pnpm patch to `proxy-from-env@1.1.0` that replaces the deprecated `require('url').parse` call with the WHATWG `URL` constructor, which is the recommended replacement and available in all supported Node.js versions.

## Related Issue(s)

Fixes #33894