### PR TITLE
fix(gradle): handle project names containing .json substring

### DIFF
--- a/packages/gradle/src/plugin/utils/get-project-graph-from-gradle-plugin.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-from-gradle-plugin.ts
@@ -189,9 +189,10 @@ export function processNxProjectGraph(
   while (index < projectGraphLines.length) {
     const line = projectGraphLines[index].trim();
     if (line.startsWith('> Task ') && line.endsWith(':nxProjectGraph')) {
+      index++; // Skip the task line before searching for the JSON file path
       while (
         index < projectGraphLines.length &&
-        !projectGraphLines[index].includes('.json')
+        !projectGraphLines[index].trim().endsWith('.json')
       ) {
         index++;
       }


### PR DESCRIPTION
## Current Behavior

The `@nx/gradle` plugin fails to parse the project graph when a Gradle project name contains `.json` as a substring (e.g. `org.acme.util.jsonutils`). The parsing logic in `processNxProjectGraph` checks `includes('.json')` to find the JSON file path, but starts from the task line itself. When the project name contains `.json`, the task line matches immediately and gets used as a file path, causing an `ENOENT` error.

## Expected Behavior

The plugin correctly skips the task line and finds the actual JSON file path on the following line, regardless of whether the project name contains `.json`.

Two changes:
1. Increment `index` after matching the task line to skip it before searching for the JSON path
2. Use `endsWith('.json')` instead of `includes('.json')` for a more precise match

## Related Issue(s)

Fixes #34768