### PR TITLE
fix(maven): use mutable lists for Maven session projects

### DIFF
--- a/packages/maven/batch-runner-adapters/maven3/src/main/kotlin/dev/nx/maven/adapter/maven3/NxMaven3.kt
+++ b/packages/maven/batch-runner-adapters/maven3/src/main/kotlin/dev/nx/maven/adapter/maven3/NxMaven3.kt
@@ -98,8 +98,8 @@ class NxMaven3(
             cachedProjectGraph = graph
             projectBySelector = graph.allProjects.associateBy { "${it.groupId}:${it.artifactId}" }
 
-            session.projects = graph.sortedProjects
-            session.allProjects = graph.allProjects
+            session.projects = graph.sortedProjects?.toMutableList()
+            session.allProjects = graph.allProjects.toMutableList()
             session.projectDependencyGraph = graph
 
             BuildStateManager.applyBuildStates(graph.allProjects)
@@ -168,17 +168,19 @@ class NxMaven3(
         graph: ProjectDependencyGraph,
         request: MavenExecutionRequest
     ) {
-        session.allProjects = graph.allProjects
+        session.allProjects = graph.allProjects.toMutableList()
         session.projectDependencyGraph = graph
 
+        // Use toMutableList() because Maven's MojoExecutor.executeForkedExecutions
+        // calls list.set() which requires a mutable list
         val selectedProjects = if (request.selectedProjects.isNotEmpty()) {
             request.selectedProjects.mapNotNull { selector ->
                 projectBySelector[selector]
                     ?: graph.allProjects.find { it.artifactId == selector }
-            }
+            }.toMutableList()
         } else {
             graph.allProjects.filter { it.file?.absolutePath == request.pom?.absolutePath }
-                .ifEmpty { graph.sortedProjects ?: emptyList() }
+                .ifEmpty { graph.sortedProjects ?: emptyList() }.toMutableList()
         }
 
         session.projects = selectedProjects

--- a/packages/maven/batch-runner-adapters/maven4/src/main/kotlin/dev/nx/maven/adapter/maven4/NxMaven.kt
+++ b/packages/maven/batch-runner-adapters/maven4/src/main/kotlin/dev/nx/maven/adapter/maven4/NxMaven.kt
@@ -197,13 +197,15 @@ class NxMaven(
     request: MavenExecutionRequest
   ) {
     log.debug("Applying project dependency graph to session for ${request.pom}: ${request.goals}")
-    session.allProjects = graph.allProjects
+    session.allProjects = graph.allProjects.toMutableList()
     session.projectDependencyGraph = graph
 
     // Find the selected project(s) to build
+    // Use toMutableList() because Maven's MojoExecutor.executeForkedExecutions
+    // calls list.set() which requires a mutable list
     val selectedProjects = listOfNotNull(
       request.selectedProjects.firstOrNull()?.let { projectBySelector[it] }
-    )
+    ).toMutableList()
 
     // session.projects controls what lifecycleStarter builds - keep it to selected projects only
     session.projects = selectedProjects


### PR DESCRIPTION
## Current Behavior

When using Maven plugins that fork executions (e.g. `maven-pmd-plugin`), the Nx Maven batch executor crashes with `java.lang.UnsupportedOperationException`. This happens because Kotlin's `listOfNotNull()`, `mapNotNull()`, and `filter()` return immutable lists, but Maven's `MojoExecutor.executeForkedExecutions` calls `list.set()` on `session.projects`, which requires a mutable list.

## Expected Behavior

Maven plugins that fork executions (PMD, Checkstyle, etc.) should work correctly with the Nx Maven batch executor. All lists assigned to `session.projects` and `session.allProjects` are now wrapped with `toMutableList()` to ensure Maven can mutate them as needed.

The fix is applied to both the Maven 3 and Maven 4 adapters.

## Related Issue(s)

Fixes #34758