### PR TITLE
fix(module-federation): enable ESM output for Angular rspack MF plugin

### DIFF
--- a/e2e/angular/src/module-federation.rspack.test.ts
+++ b/e2e/angular/src/module-federation.rspack.test.ts
@@ -1,4 +1,4 @@
-import { names } from '@nx/devkit';
+import { names, stripIndents } from '@nx/devkit';
 import {
   checkFilesExist,
   cleanupProject,
@@ -7,6 +7,7 @@ import {
   readFile,
   runCLI,
   runCommandUntil,
+  runE2ETests,
   uniq,
   updateFile,
   updateJson,
@@ -173,5 +174,51 @@ describe('Angular Module Federation', () => {
         output.includes(`Build at:`)
     );
     await killProcessAndPorts(processSwc.pid, remotePort);
+  }, 20_000_000);
+
+  it('should load remote app in the browser via ESM module federation', async () => {
+    const hostApp = uniq('host');
+    const remoteApp = uniq('remote');
+    const hostPort = 4200;
+    const remotePort = 4401;
+
+    // generate host with playwright e2e runner
+    runCLI(
+      `generate @nx/angular:host ${hostApp} --style=css --bundler=rspack --e2eTestRunner=playwright --no-interactive`
+    );
+
+    // generate remote
+    runCLI(
+      `generate @nx/angular:remote ${remoteApp} --host=${hostApp} --bundler=rspack --port=${remotePort} --style=css --no-interactive`
+    );
+
+    // Write playwright e2e test that navigates to the remote route.
+    // This catches ESM-related runtime errors like "Unexpected token 'export'"
+    // which only surface in the browser when loading remoteEntry.js.
+    updateFile(
+      `${hostApp}-e2e/src/example.spec.ts`,
+      stripIndents`
+        import { test, expect } from '@playwright/test';
+
+        test('should load the host app', async ({ page }) => {
+          await page.goto('/');
+          expect(await page.locator('h1').innerText()).toContain('Welcome');
+        });
+
+        test('should load the remote app via module federation', async ({ page }) => {
+          await page.goto('/${remoteApp}');
+          expect(await page.locator('app-nx-welcome').count()).toBeGreaterThan(0);
+        });
+      `
+    );
+
+    if (runE2ETests('playwright')) {
+      const e2eProcess = await runCommandUntil(
+        `e2e ${hostApp}-e2e`,
+        (output) => output.includes('Successfully ran target e2e for project'),
+        { timeout: 120000 }
+      );
+      await killProcessAndPorts(e2eProcess.pid, hostPort, remotePort);
+    }
   }, 20_000_000);
 });

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/angular/nx-module-federation-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/angular/nx-module-federation-plugin.ts
@@ -44,6 +44,13 @@ export class NxModuleFederationPlugin implements RspackPluginInstance {
         type: 'commonjs-module',
       };
       compiler.options.output.library.type = 'commonjs-module';
+    } else {
+      // Ensure ESM output is enabled when using library type 'module'.
+      // Without these, remoteEntry.js emits `export` statements but the
+      // runtime loads it as a classic script, causing "Unexpected token 'export'".
+      compiler.options.experiments ??= {};
+      compiler.options.experiments.outputModule = true;
+      compiler.options.output.module = true;
     }
 
     const config = getModuleFederationConfigSync(


### PR DESCRIPTION
## Current Behavior

When using Angular + Rspack + Module Federation, the `NxModuleFederationPlugin` (Angular variant) sets `library: { type: 'module' }` on the Module Federation plugin config, which causes `remoteEntry.js` to emit ESM `export` statements. However, the compiler's `experiments.outputModule` and `output.module` flags are not set, so the MF runtime tries to load the remote entry as a classic script. This results in:

```
Uncaught SyntaxError: Unexpected token 'export' (at remoteEntry.js:48774:1)
```

This is especially broken during `nx serve` (dev server), because `@nx/angular-rspack`'s `createConfig` only sets `experiments.outputModule = true` for production builds, not dev server builds.

## Expected Behavior

The Angular rspack `NxModuleFederationPlugin` should ensure `experiments.outputModule = true` and `output.module = true` are set on the compiler when using `library: { type: 'module' }`, so that Module Federation works out of the box in both dev and production modes.

This aligns with how the Angular **webpack** MF config already handles it (in `with-module-federation/angular/with-module-federation.ts`).

## Related Issue(s)

Fixes #34584
Fixes #33992