### PR TITLE
fix(release): skip indirect patch bump for commit types with semverBump "none"

### DIFF
--- a/packages/nx/src/command-line/release/utils/semver.spec.ts
+++ b/packages/nx/src/command-line/release/utils/semver.spec.ts
@@ -373,5 +373,75 @@ describe('semver', () => {
         ).get('default')
       ).toEqual(null);
     });
+
+    it('should not bump dependants when the only non-project-scoped commit has semverBump "none"', () => {
+      const configWithChoreNone: NxReleaseConfig['conventionalCommits'] = {
+        useCommitScope: true,
+        types: {
+          ...config.types,
+          chore: {
+            semverBump: 'none',
+            changelog:
+              DEFAULT_CONVENTIONAL_COMMITS_CONFIG.types.chore.changelog,
+          },
+        },
+      };
+      // Simulate: chore commit scoped to a dependency, affecting a dependant indirectly
+      expect(
+        determineSemverChange(
+          new Map([
+            [
+              'dependant-project',
+              [{ commit: choreCommit, isProjectScopedCommit: false }],
+            ],
+          ]),
+          configWithChoreNone
+        ).get('dependant-project')
+      ).toEqual(null);
+    });
+
+    it('should still bump dependants for breaking non-project-scoped commits even when semverBump is "none"', () => {
+      const configWithChoreNone: NxReleaseConfig['conventionalCommits'] = {
+        useCommitScope: true,
+        types: {
+          ...config.types,
+          chore: {
+            semverBump: 'none',
+            changelog:
+              DEFAULT_CONVENTIONAL_COMMITS_CONFIG.types.chore.changelog,
+          },
+        },
+      };
+      const choreBreakingCommit: GitCommit = {
+        type: 'chore',
+        isBreaking: true,
+      } as GitCommit;
+      expect(
+        determineSemverChange(
+          new Map([
+            [
+              'dependant-project',
+              [{ commit: choreBreakingCommit, isProjectScopedCommit: false }],
+            ],
+          ]),
+          configWithChoreNone
+        ).get('dependant-project')
+      ).toEqual(SemverSpecifier.PATCH);
+    });
+
+    it('should still apply patch for non-project-scoped commits when semverBump is not "none"', () => {
+      // Verify existing behavior is preserved for commit types with non-none semverBump
+      expect(
+        determineSemverChange(
+          new Map([
+            [
+              'dependant-project',
+              [{ commit: featNonBreakingCommit, isProjectScopedCommit: false }],
+            ],
+          ]),
+          config
+        ).get('dependant-project')
+      ).toEqual(SemverSpecifier.PATCH);
+    });
   });
 });

--- a/packages/nx/src/command-line/release/utils/semver.ts
+++ b/packages/nx/src/command-line/release/utils/semver.ts
@@ -43,6 +43,12 @@ export function determineSemverChange(
     for (const { commit, isProjectScopedCommit } of relevantCommit) {
       if (config.useCommitScope && !isProjectScopedCommit) {
         // commit is relevant to the project, but not directly, report patch change to match side-effectful bump behavior in update dependents in release-group-processor
+        const indirectSemverType = config.types[commit.type]?.semverBump;
+        // If the commit type has semverBump 'none' and the commit is not breaking,
+        // skip the indirect patch bump as the dependency itself won't be bumped
+        if (indirectSemverType === 'none' && !commit.isBreaking) {
+          continue;
+        }
         highestChange = Math.max(SemverSpecifier.PATCH, highestChange ?? 0);
         continue;
       }


### PR DESCRIPTION
> [!NOTE]
> 🤖 This PR was created by [@AI-JamesHenry](https://github.com/AI-JamesHenry), an AI assistant account guided and overseen by [@JamesHenry](https://github.com/JamesHenry).

## Current Behavior

When a conventional commit type (e.g. `chore`) is configured with `semverBump: "none"` and `changelog: false`, the project itself is correctly not bumped. However, **dependant projects** (projects that depend on the affected project) are still receiving an indirect patch version bump.

This happens because the `determineSemverChange` function in `semver.ts`, when `useCommitScope` is enabled (the default), applies a PATCH bump to any project affected indirectly through the dependency graph — without checking whether the commit type's `semverBump` configuration is `"none"`.

For example, if a `chore(cdk)` commit is made and `chore` has `semverBump: "none"`, the CDK package correctly stays unbumped, but the ISR package (which depends on CDK) incorrectly receives a patch bump with the changelog message "This was a version bump only for isr to align it with other projects, there were no code changes."

## Expected Behavior

When a commit type has `semverBump: "none"`, dependant projects should **not** receive an indirect version bump, since the dependency itself is not being bumped. The only exception is breaking changes (`!` commits), which should still propagate bumps to dependants regardless of the commit type's `semverBump` setting.

## Related Issue(s)

Fixes #34759