### PR TITLE
fix(maven): filter out external-to-external dependencies in createDependencies

### DIFF
--- a/packages/maven/src/plugins/dependencies.spec.ts
+++ b/packages/maven/src/plugins/dependencies.spec.ts
@@ -1,0 +1,195 @@
+import { CreateDependenciesContext, ProjectConfiguration } from '@nx/devkit';
+import { DependencyType } from 'nx/src/config/project-graph';
+import { RawProjectGraphDependency } from 'nx/src/project-graph/project-graph-builder';
+import { setCurrentMavenData } from './maven-data-cache';
+import { MavenAnalysisData } from './types';
+
+// Must import after mocks are set up
+let createDependencies: typeof import('./dependencies').createDependencies;
+
+describe('Maven createDependencies', () => {
+  const projects: Record<string, ProjectConfiguration> = {
+    app: { root: 'app', name: 'app' },
+    lib: { root: 'lib', name: 'lib' },
+  };
+
+  const baseContext: CreateDependenciesContext = {
+    projects,
+    externalNodes: {},
+    workspaceRoot: '/workspace',
+    nxJsonConfiguration: {},
+    fileMap: { projectFileMap: {}, nonProjectFiles: [] },
+    filesToProcess: { projectFileMap: {}, nonProjectFiles: [] },
+  };
+
+  beforeEach(async () => {
+    jest.resetModules();
+    const mod = await import('./dependencies');
+    createDependencies = mod.createDependencies;
+    const cache = await import('./maven-data-cache');
+    cache.setCurrentMavenData(null);
+  });
+
+  it('should return empty array when no maven data is available', async () => {
+    const result = await createDependencies({}, {
+      ...baseContext,
+    } as CreateDependenciesContext);
+    expect(result).toEqual([]);
+  });
+
+  it('should transform workspace-to-workspace dependencies', async () => {
+    const deps: RawProjectGraphDependency[] = [
+      {
+        source: 'app',
+        target: 'lib',
+        type: DependencyType.static,
+        sourceFile: 'app/pom.xml',
+      },
+    ];
+    const { setCurrentMavenData } = await import('./maven-data-cache');
+    setCurrentMavenData({
+      createNodesResults: [],
+      createDependenciesResults: deps,
+    });
+
+    const result = await createDependencies({}, {
+      ...baseContext,
+    } as CreateDependenciesContext);
+
+    expect(result).toEqual([
+      {
+        source: 'app',
+        target: 'lib',
+        type: DependencyType.static,
+        sourceFile: 'app/pom.xml',
+      },
+    ]);
+  });
+
+  it('should transform workspace-to-external dependencies', async () => {
+    const deps: RawProjectGraphDependency[] = [
+      {
+        source: 'app',
+        target: 'maven:org.springframework:spring-core',
+        type: DependencyType.static,
+        sourceFile: 'app/pom.xml',
+      },
+    ];
+    const { setCurrentMavenData } = await import('./maven-data-cache');
+    setCurrentMavenData({
+      createNodesResults: [],
+      createDependenciesResults: deps,
+    });
+
+    const result = await createDependencies({}, {
+      ...baseContext,
+    } as CreateDependenciesContext);
+
+    expect(result).toEqual([
+      {
+        source: 'app',
+        target: 'maven:org.springframework:spring-core',
+        type: DependencyType.static,
+        sourceFile: 'app/pom.xml',
+      },
+    ]);
+  });
+
+  it('should filter out external-to-external dependencies', async () => {
+    const deps: RawProjectGraphDependency[] = [
+      // workspace -> workspace (keep)
+      {
+        source: 'app',
+        target: 'lib',
+        type: DependencyType.static,
+        sourceFile: 'app/pom.xml',
+      },
+      // workspace -> external (keep)
+      {
+        source: 'app',
+        target: 'maven:org.springframework.boot:spring-boot-starter-web',
+        type: DependencyType.static,
+        sourceFile: 'app/pom.xml',
+      },
+      // external -> external (drop — source can't resolve to workspace project)
+      {
+        source: 'maven:org.springframework:spring-core',
+        target: 'maven:org.springframework:spring-jcl',
+        type: DependencyType.static,
+      },
+      {
+        source: 'maven:org.springframework.boot:spring-boot-starter-web',
+        target: 'maven:org.springframework:spring-web',
+        type: DependencyType.static,
+      },
+    ];
+    const { setCurrentMavenData } = await import('./maven-data-cache');
+    setCurrentMavenData({
+      createNodesResults: [],
+      createDependenciesResults: deps,
+    });
+
+    const result = await createDependencies({}, {
+      ...baseContext,
+    } as CreateDependenciesContext);
+
+    expect(result).toEqual([
+      {
+        source: 'app',
+        target: 'lib',
+        type: DependencyType.static,
+        sourceFile: 'app/pom.xml',
+      },
+      {
+        source: 'app',
+        target: 'maven:org.springframework.boot:spring-boot-starter-web',
+        type: DependencyType.static,
+        sourceFile: 'app/pom.xml',
+      },
+    ]);
+  });
+
+  it('should filter out deps where source root is unknown', async () => {
+    const deps: RawProjectGraphDependency[] = [
+      {
+        source: 'nonexistent-root',
+        target: 'lib',
+        type: DependencyType.static,
+        sourceFile: 'nonexistent-root/pom.xml',
+      },
+    ];
+    const { setCurrentMavenData } = await import('./maven-data-cache');
+    setCurrentMavenData({
+      createNodesResults: [],
+      createDependenciesResults: deps,
+    });
+
+    const result = await createDependencies({}, {
+      ...baseContext,
+    } as CreateDependenciesContext);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should filter out deps where target root is unknown', async () => {
+    const deps: RawProjectGraphDependency[] = [
+      {
+        source: 'app',
+        target: 'nonexistent-root',
+        type: DependencyType.static,
+        sourceFile: 'app/pom.xml',
+      },
+    ];
+    const { setCurrentMavenData } = await import('./maven-data-cache');
+    setCurrentMavenData({
+      createNodesResults: [],
+      createDependenciesResults: deps,
+    });
+
+    const result = await createDependencies({}, {
+      ...baseContext,
+    } as CreateDependenciesContext);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/maven/src/plugins/dependencies.ts
+++ b/packages/maven/src/plugins/dependencies.ts
@@ -32,18 +32,22 @@ export const createDependencies: CreateDependencies = async (
   );
 
   // Extract and transform dependencies from the mavenData
-  const transformedDependencies = mavenData.createDependenciesResults.map(
-    (dep) => ({
-      ...dep,
-      source: dep.source.startsWith('maven:')
-        ? dep.source
-        : rootToProjectMap.get(dep.source),
-      // External deps use maven: prefix — pass through as-is
-      target: dep.target.startsWith('maven:')
-        ? dep.target
-        : rootToProjectMap.get(dep.target),
-    })
-  );
+  const transformedDependencies = [];
+  for (const dep of mavenData.createDependenciesResults) {
+    // External-to-external edges (e.g., maven:org.foo:bar -> maven:org.baz:qux)
+    // are emitted by the Kotlin plugin but cannot be dependency sources
+    if (dep.source.startsWith('maven:')) {
+      continue;
+    }
+    const source = rootToProjectMap.get(dep.source);
+    // Pass through external targets (maven: prefix) as-is
+    const target = dep.target.startsWith('maven:')
+      ? dep.target
+      : rootToProjectMap.get(dep.target);
+    if (source && target) {
+      transformedDependencies.push({ ...dep, source, target });
+    }
+  }
 
   return transformedDependencies;
 };


### PR DESCRIPTION
## Current Behavior

When `nx-maven-plugin` v0.0.15 emits external-to-external Maven dependency edges (e.g., `maven:org.springframework:spring-core` → `maven:org.springframework:spring-jcl`), the `createDependencies()` function in `@nx/maven` attempts to resolve both source and target through `rootToProjectMap.get()`. Since external Maven identifiers are not workspace project roots, this returns `undefined`, which then crashes Nx core's `fileDataDepTarget()` with:

```
TypeError: Cannot read properties of undefined (reading '1')
```

This makes all Nx commands that build the project graph (`nx show projects`, `nx graph`, etc.) fail in any Maven workspace that has transitive external dependencies.

## Expected Behavior

External-to-external Maven dependency edges should be silently filtered out in `createDependencies()`, since they cannot be resolved to workspace projects. Only workspace-to-workspace and workspace-to-external dependencies should be returned.

After this fix, `nx show projects`, `nx graph`, and all other Nx commands work correctly in Maven workspaces with transitive external dependencies.

## Related Issue(s)

Fixes #34840

## Changes

- **`packages/maven/src/plugins/dependencies.ts`**: Added validation to filter out dependencies where the source or target cannot be resolved to a workspace project. This matches the pattern used in the Gradle plugin fix (#29943).
- **`packages/maven/src/plugins/dependencies.spec.ts`**: Added comprehensive test coverage for `createDependencies()` with 6 test cases covering:
  - No maven data available
  - Workspace-to-workspace dependencies
  - Workspace-to-external dependencies
  - External-to-external dependencies (filtered out)
  - Unknown source roots (filtered out)
  - Unknown target roots (filtered out)