### PR TITLE
fix(js): track tsconfig files from dependency reference chain as inputs

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -1761,8 +1761,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                         "dependentTasksOutputFiles": "**/*.{d.ts,tsbuildinfo}",
                         "transitive": true,
                       },
-                      "{projectRoot}/nested-project/tsconfig.json",
-                      "{workspaceRoot}/libs/other-lib/tsconfig.json",
+                      "^{projectRoot}/tsconfig.json",
                     ],
                     "metadata": {
                       "description": "Runs type-checking for the project.",
@@ -1842,6 +1841,113 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
             },
           }
         `);
+      });
+
+      it('should collect distinct tsconfig patterns from file-specific external project references', async () => {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+          'libs/my-lib/tsconfig.json': JSON.stringify({
+            include: ['src/**/*.ts'],
+            references: [
+              { path: './tsconfig.lib.json' },
+              { path: './tsconfig.spec.json' },
+            ],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            include: ['src/**/*.ts'],
+            exclude: ['src/**/*.spec.ts'],
+            references: [
+              { path: '../other-lib/tsconfig.lib.json' }, // file-specific external ref
+            ],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/my-lib/tsconfig.spec.json': JSON.stringify({
+            include: ['src/**/*.spec.ts'],
+            references: [
+              { path: './tsconfig.lib.json' },
+              { path: '../other-lib/tsconfig.spec.json' }, // file-specific external ref
+            ],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/my-lib/package.json': `{}`,
+          'libs/other-lib/tsconfig.json': JSON.stringify({
+            references: [
+              { path: './tsconfig.lib.json' },
+              { path: './tsconfig.spec.json' },
+            ],
+          }),
+          'libs/other-lib/tsconfig.lib.json': JSON.stringify({
+            include: ['src/**/*.ts'],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/other-lib/tsconfig.spec.json': JSON.stringify({
+            include: ['src/**/*.spec.ts'],
+            compilerOptions: { outDir: 'dist' },
+          }),
+        });
+        const result = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          {}
+        );
+        const myLibTargets = result.projects['libs/my-lib']?.targets;
+        // typecheck collects both tsconfig.lib.json and tsconfig.spec.json
+        // because both internal refs have file-specific external references
+        expect(myLibTargets.typecheck.inputs).toContain(
+          '^{projectRoot}/tsconfig.lib.json'
+        );
+        expect(myLibTargets.typecheck.inputs).toContain(
+          '^{projectRoot}/tsconfig.spec.json'
+        );
+      });
+
+      it('should use relative paths for nested tsconfig references in external deps', async () => {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+          'libs/my-lib/tsconfig.json': JSON.stringify({
+            include: ['src/**/*.ts'],
+            references: [
+              { path: './tsconfig.lib.json' },
+              { path: '../other-lib' }, // directory ref to external dep
+            ],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            include: ['src/**/*.ts'],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/my-lib/package.json': `{}`,
+          'libs/other-lib/tsconfig.json': JSON.stringify({
+            references: [
+              { path: './tsconfig.lib.json' },
+              { path: './cypress/tsconfig.json' }, // nested dir inner ref
+            ],
+          }),
+          'libs/other-lib/tsconfig.lib.json': JSON.stringify({
+            include: ['src/**/*.ts'],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/other-lib/cypress/tsconfig.json': JSON.stringify({
+            include: ['**/*.cy.ts'],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/other-lib/package.json': `{}`,
+        });
+        const result = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          {}
+        );
+        const myLibTargets = result.projects['libs/my-lib']?.targets;
+        // should include nested path, not just the basename
+        expect(myLibTargets.typecheck.inputs).toContain(
+          '^{projectRoot}/cypress/tsconfig.json'
+        );
+        expect(myLibTargets.typecheck.inputs).toContain(
+          '^{projectRoot}/tsconfig.lib.json'
+        );
+        expect(myLibTargets.typecheck.inputs).toContain(
+          '^{projectRoot}/tsconfig.json'
+        );
       });
 
       it('should normalize and add directories in `include` from internal project references', async () => {
@@ -2573,8 +2679,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                         "dependentTasksOutputFiles": "**/*.{d.ts,tsbuildinfo}",
                         "transitive": true,
                       },
-                      "{projectRoot}/nested-project/tsconfig.json",
-                      "{workspaceRoot}/libs/other-lib/tsconfig.json",
+                      "^{projectRoot}/tsconfig.json",
                     ],
                     "metadata": {
                       "description": "Runs type-checking for the project.",
@@ -4450,7 +4555,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                         "dependentTasksOutputFiles": "**/*.{d.ts,tsbuildinfo}",
                         "transitive": true,
                       },
-                      "{workspaceRoot}/libs/other-lib/tsconfig.json",
+                      "^{projectRoot}/tsconfig.json",
                     ],
                     "metadata": {
                       "description": "Builds the project with \`tsc\`.",
@@ -4481,6 +4586,48 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
             },
           }
         `);
+      });
+
+      it('should only collect tsconfig patterns from the build reference chain', async () => {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+          'libs/my-lib/tsconfig.json': '{}',
+          'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            include: ['src/**/*.ts'],
+            references: [
+              { path: '../other-lib/tsconfig.lib.json' }, // file-specific external ref
+            ],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
+          'libs/other-lib/tsconfig.json': JSON.stringify({
+            references: [
+              { path: './tsconfig.lib.json' },
+              { path: './tsconfig.spec.json' },
+            ],
+          }),
+          'libs/other-lib/tsconfig.lib.json': JSON.stringify({
+            include: ['src/**/*.ts'],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/other-lib/tsconfig.spec.json': JSON.stringify({
+            include: ['src/**/*.spec.ts'],
+            compilerOptions: { outDir: 'dist' },
+          }),
+        });
+        const result = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          { typecheck: false, build: true }
+        );
+        const myLibTargets = result.projects['libs/my-lib']?.targets;
+        // build only collects tsconfig.lib.json because the reference chain
+        // from tsconfig.lib.json only goes through dep/tsconfig.lib.json
+        expect(myLibTargets.build.inputs).toContain(
+          '^{projectRoot}/tsconfig.lib.json'
+        );
+        expect(myLibTargets.build.inputs).not.toContain(
+          '^{projectRoot}/tsconfig.spec.json'
+        );
       });
 
       it('should normalize and add directories in `include` from internal project references', async () => {

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -880,24 +880,14 @@ function getInputs(
     transitive: true,
   });
 
-  const externalRefConfigFiles = getExternalProjectReferenceConfigFiles(
+  const externalRefPatterns = getExternalProjectReferenceTsconfigPatterns(
     tsConfig,
     internalProjectReferences,
     workspaceRoot,
     config.project,
-    cache,
-    configFiles
+    cache
   );
-  if (externalRefConfigFiles.length > 0) {
-    // tsc --build also reads the tsconfig files from external project
-    // references (and their extended configs) when processing project
-    // references, so we need to add them as inputs
-    inputs.push(
-      ...externalRefConfigFiles.map((p) =>
-        pathToInputOrOutput(p, workspaceRoot, config.project)
-      )
-    );
-  }
+  inputs.push(...externalRefPatterns);
 
   // inputs.push({ externalDependencies });
 
@@ -1228,17 +1218,17 @@ function resolveShallowExternalProjectReferences(
 }
 
 /**
- * Collects config file paths from external project references, including their
- * extended config files. It checks the root tsconfig and all internal project
- * references for their direct external references.
+ * Collects unique tsconfig paths (relative to their project root) from the
+ * project reference chain and returns them as `^{projectRoot}/...` input
+ * patterns. We only need to discover the full set of distinct relative paths
+ * from the reference chain.
  */
-function getExternalProjectReferenceConfigFiles(
+function getExternalProjectReferenceTsconfigPatterns(
   tsConfig: ParsedTsconfigData,
   internalProjectReferences: Record<string, ParsedTsconfigData>,
   workspaceRoot: string,
   project: ProjectContext,
-  cache: InvocationCache,
-  existingConfigFiles: Set<string>
+  cache: InvocationCache
 ): string[] {
   const externalRefs: Record<string, ParsedTsconfigData> = {};
 
@@ -1262,27 +1252,75 @@ function getExternalProjectReferenceConfigFiles(
     );
   }
 
-  const result: string[] = [];
-  const seen = new Set<string>();
-  for (const [refConfigPath, refTsConfig] of Object.entries(externalRefs)) {
-    if (!existingConfigFiles.has(refConfigPath) && !seen.has(refConfigPath)) {
-      result.push(refConfigPath);
-      seen.add(refConfigPath);
-    }
-    const extendedFiles = getExtendedConfigFiles(
-      refTsConfig,
-      workspaceRoot,
-      cache
+  // Collect unique tsconfig paths (relative to project root) from the
+  // reference chain, seeded with the external refs.
+  const uniqueRelPaths = new Set<string>();
+  const visited = new Set<string>();
+  const worklist: { configPath: string; ownerProject: ProjectContext }[] = [];
+
+  for (const refConfigPath of Object.keys(externalRefs)) {
+    const refContext = getConfigContext(refConfigPath, workspaceRoot, cache);
+    uniqueRelPaths.add(
+      posixRelative(refContext.project.absolute, refConfigPath)
     );
-    for (const extFile of extendedFiles.files) {
-      if (!existingConfigFiles.has(extFile) && !seen.has(extFile)) {
-        result.push(extFile);
-        seen.add(extFile);
+    worklist.push({
+      configPath: refConfigPath,
+      ownerProject: refContext.project,
+    });
+  }
+
+  for (let i = 0; i < worklist.length; i++) {
+    const { configPath, ownerProject } = worklist[i];
+
+    if (visited.has(configPath)) {
+      continue;
+    }
+    visited.add(configPath);
+
+    const wsRelPath = posixRelative(workspaceRoot, configPath);
+    const tsConfigData = tsConfigCacheData[wsRelPath]?.data;
+    if (!tsConfigData?.projectReferences?.length) {
+      continue;
+    }
+
+    for (const ref of tsConfigData.projectReferences) {
+      let refPath = ref.path;
+      if (!refPath.endsWith('.json')) {
+        refPath = join(refPath, 'tsconfig.json');
+      }
+
+      // Skip references not found in the tsconfig cache
+      const refWsRelPath = posixRelative(workspaceRoot, refPath);
+      if (!tsConfigCacheData[refWsRelPath]) {
+        continue;
+      }
+
+      const refContext = getConfigContext(refPath, workspaceRoot, cache);
+
+      // Collect paths for references within the same project
+      if (
+        !isExternalProjectReference(
+          refContext,
+          ownerProject,
+          workspaceRoot,
+          cache
+        )
+      ) {
+        uniqueRelPaths.add(posixRelative(ownerProject.absolute, refPath));
+      }
+
+      if (!visited.has(refPath)) {
+        worklist.push({
+          configPath: refPath,
+          ownerProject: refContext.project,
+        });
       }
     }
   }
 
-  return result;
+  return Array.from(uniqueRelPaths).map(
+    (relPath) => `^{projectRoot}/${relPath}`
+  );
 }
 
 function isExternalProjectReference(


### PR DESCRIPTION
## Current Behavior

The `@nx/js/typescript` plugin adds dependency project `tsconfig.json` files as inputs but doesn't resolve nested `projectReferences` within those files. When `tsc -b` runs, it follows the full reference chain — reading `tsconfig.lib.json`, `tsconfig.spec.json`, `tsconfig.storybook.json`, etc. from dependencies — but these files aren't declared as inputs, causing potential cache correctness issues.

## Expected Behavior

The plugin now walks the full project reference chain from external dependencies and collects all distinct tsconfig relative paths (e.g., `tsconfig.lib.json`, `tsconfig.spec.json`, `cypress/tsconfig.json`). These are emitted as `^{projectRoot}/...` input patterns, ensuring that any tsconfig file read by `tsc -b` through the reference chain is tracked as an input.

Key changes:
- Renamed `getExternalProjectReferenceConfigFiles` → `getExternalProjectReferenceTsconfigPatterns` to reflect it now returns input patterns instead of absolute paths
- Uses a worklist algorithm to traverse the reference chain (breadth-first, cycle-safe)
- Collects relative paths per dependency project root, deduplicates, and emits `^{projectRoot}/...` patterns
- For build targets, only tsconfig files reachable from the build reference chain are included (not all refs from the solution tsconfig)