### PR TITLE
fix(nx-dev): remove nx-cloud paths from Framer excluded URL rewrites

### DIFF
--- a/netlify/edge-functions/rewrite-framer-urls.ts
+++ b/netlify/edge-functions/rewrite-framer-urls.ts
@@ -116,8 +116,6 @@ export const config = {
     '/module-federation/*',
     '/nx-api',
     '/nx-api/*',
-    '/nx-cloud',
-    '/nx-cloud/*',
     '/nx-enterprise',
     '/nx-enterprise/*',
     '/packages',


### PR DESCRIPTION
The change removes Nx Cloud routes from the list of excluded URL rewrite paths in the Framer edge rewrite configuration. This means requests to those Nx Cloud paths will now be eligible for the rewrite behavior instead of being skipped.