### PR TITLE
fix(core): prevent DB corruption from concurrent initialization

### DIFF
--- a/packages/nx/src/native/db/initialize.rs
+++ b/packages/nx/src/native/db/initialize.rs
@@ -125,15 +125,10 @@ fn create_db_error(operation: &str, error: anyhow::Error) -> anyhow::Error {
 
 pub(super) struct LockFile {
     file: File,
-    path: PathBuf,
 }
 
 pub(super) fn unlock_file(lock_file: &LockFile) {
-    if lock_file.path.exists() {
-        fs4::fs_std::FileExt::unlock(&lock_file.file)
-            .and_then(|_| remove_file(&lock_file.path))
-            .ok();
-    }
+    fs4::fs_std::FileExt::unlock(&lock_file.file).ok();
 }
 
 pub(super) fn create_lock_file(db_path: &Path) -> anyhow::Result<LockFile> {
@@ -146,10 +141,7 @@ pub(super) fn create_lock_file(db_path: &Path) -> anyhow::Result<LockFile> {
     fs4::fs_std::FileExt::lock_exclusive(&lock_file)
         .inspect(|_| trace!("Got lock on db lock file"))
         .map_err(|e| create_io_error("acquire exclusive lock", &lock_file_path, e))?;
-    Ok(LockFile {
-        file: lock_file,
-        path: lock_file_path,
-    })
+    Ok(LockFile { file: lock_file })
 }
 
 pub(super) fn initialize_db(nx_version: String, db_path: &Path) -> anyhow::Result<NxDbConnection> {

--- a/packages/nx/src/native/db/initialize.rs
+++ b/packages/nx/src/native/db/initialize.rs
@@ -123,15 +123,11 @@ fn create_db_error(operation: &str, error: anyhow::Error) -> anyhow::Error {
     )
 }
 
-pub(super) struct LockFile {
-    file: File,
+pub(super) fn unlock_file(lock_file: &File) {
+    fs4::fs_std::FileExt::unlock(lock_file).ok();
 }
 
-pub(super) fn unlock_file(lock_file: &LockFile) {
-    fs4::fs_std::FileExt::unlock(&lock_file.file).ok();
-}
-
-pub(super) fn create_lock_file(db_path: &Path) -> anyhow::Result<LockFile> {
+pub(super) fn create_lock_file(db_path: &Path) -> anyhow::Result<File> {
     let lock_file_path = db_path.with_extension("lock");
     trace!("Creating lock file at {:?}", lock_file_path);
     let lock_file = File::create(&lock_file_path)
@@ -141,7 +137,7 @@ pub(super) fn create_lock_file(db_path: &Path) -> anyhow::Result<LockFile> {
     fs4::fs_std::FileExt::lock_exclusive(&lock_file)
         .inspect(|_| trace!("Got lock on db lock file"))
         .map_err(|e| create_io_error("acquire exclusive lock", &lock_file_path, e))?;
-    Ok(LockFile { file: lock_file })
+    Ok(lock_file)
 }
 
 pub(super) fn initialize_db(nx_version: String, db_path: &Path) -> anyhow::Result<NxDbConnection> {
@@ -214,8 +210,8 @@ pub(super) fn initialize_db(nx_version: String, db_path: &Path) -> anyhow::Resul
                         trace!("Incompatible database because: {:?}", reason);
                         trace!("Disconnecting from existing incompatible database");
                         c.close()?;
-                        trace!("Removing existing incompatible database");
-                        remove_file(db_path)?;
+                        trace!("Removing existing incompatible database and auxiliary files");
+                        remove_all_database_files(db_path)?;
 
                         trace!("Initializing a new database");
                         return initialize_db(nx_version, db_path);
@@ -229,8 +225,8 @@ pub(super) fn initialize_db(nx_version: String, db_path: &Path) -> anyhow::Resul
                     "Unable to connect to existing database because: {:?}",
                     reason
                 );
-                trace!("Removing existing incompatible database");
-                remove_file(db_path)?;
+                trace!("Removing existing database and auxiliary files");
+                remove_all_database_files(db_path)?;
 
                 trace!("Initializing a new database");
                 return initialize_db(nx_version, db_path);


### PR DESCRIPTION
## Current Behavior

When multiple processes call `connectToNxDb()` concurrently (plugin workers via `startAnalytics()`, daemon, main CLI), two bugs can corrupt the workspace database:

**Bug 1: Lock file inode race.** `unlock_file()` deletes the lock file after unlocking, allowing a subsequent `File::create()` to produce a new file with a different inode. Two processes can hold "the lock" simultaneously on different file objects, breaking mutual exclusion.

**Bug 2: Partial file cleanup on version mismatch/connection failure.** The `reason` arm and `Err` arm in `initialize_db` call `remove_file(db_path)` which only deletes `.db`, leaving stale `.db-wal` and `.db-shm` on disk. The recursive `initialize_db` creates a fresh `.db`, but SQLite detects the stale WAL (different inode salt) and deletes it — destroying all data that existed only in the WAL.

Both bugs lead to:
```
Database file exists but has no metadata table.
```

## Expected Behavior

1. Lock file persists across lock/unlock cycles — all processes serialize through the same inode
2. When DB recreation is needed, all auxiliary files (`.db`, `.db-wal`, `.db-shm`) are cleaned up together via `remove_all_database_files`