### PR TITLE
chore(maven): bump maven plugin version to 0.0.16

### DIFF
--- a/packages/maven/batch-runner-adapters/maven3/pom.xml
+++ b/packages/maven/batch-runner-adapters/maven3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>batch-runner-adapters</artifactId>
-        <version>0.0.15</version>
+        <version>0.0.16</version>
     </parent>
 
     <artifactId>maven3-adapter</artifactId>

--- a/packages/maven/batch-runner-adapters/maven4/pom.xml
+++ b/packages/maven/batch-runner-adapters/maven4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>batch-runner-adapters</artifactId>
-        <version>0.0.15</version>
+        <version>0.0.16</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/batch-runner-adapters/pom.xml
+++ b/packages/maven/batch-runner-adapters/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>nx-maven-parent</artifactId>
-        <version>0.0.15</version>
+        <version>0.0.16</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/batch-runner/pom.xml
+++ b/packages/maven/batch-runner/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>nx-maven-parent</artifactId>
-        <version>0.0.15</version>
+        <version>0.0.16</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/maven-plugin/pom.xml
+++ b/packages/maven/maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.nx.maven</groupId>
     <artifactId>nx-maven-parent</artifactId>
-    <version>0.0.15</version>
+    <version>0.0.16</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/migrations.json
+++ b/packages/maven/migrations.json
@@ -48,6 +48,12 @@
       "version": "22.6.0-beta.12",
       "description": "Update Maven plugin version from 0.0.14 to 0.0.15 in pom.xml files",
       "factory": "./dist/migrations/0-0-15/update-pom-xml-version"
+    },
+    "update-0-0-16": {
+      "cli": "nx",
+      "version": "22.6.0-beta.14",
+      "description": "Update Maven plugin version from 0.0.15 to 0.0.16 in pom.xml files",
+      "factory": "./dist/migrations/0-0-16/update-pom-xml-version"
     }
   }
 }

--- a/packages/maven/pom.xml
+++ b/packages/maven/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>dev.nx.maven</groupId>
     <artifactId>nx-parent</artifactId>
-    <version>0.0.15</version>
+    <version>0.0.16</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/packages/maven/shared/pom.xml
+++ b/packages/maven/shared/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>dev.nx.maven</groupId>
         <artifactId>nx-maven-parent</artifactId>
-        <version>0.0.15</version>
+        <version>0.0.16</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/packages/maven/src/migrations/0-0-16/update-pom-xml-version.ts
+++ b/packages/maven/src/migrations/0-0-16/update-pom-xml-version.ts
@@ -1,0 +1,11 @@
+import { Tree } from '@nx/devkit';
+import { updateNxMavenPluginVersion } from '../../utils/pom-xml-updater';
+
+/**
+ * Migration for @nx/maven v0.0.16
+ * Updates the Maven plugin version to 0.0.16 in pom.xml files
+ */
+export default async function update(tree: Tree) {
+  // Update user pom.xml files
+  updateNxMavenPluginVersion(tree, '0.0.16');
+}

--- a/packages/maven/src/utils/versions.ts
+++ b/packages/maven/src/utils/versions.ts
@@ -1,2 +1,2 @@
 export const nxVersion = require('../../package.json').version;
-export const mavenPluginVersion = '0.0.15';
+export const mavenPluginVersion = '0.0.16';

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>dev.nx.maven</groupId>
   <artifactId>nx-parent</artifactId>
-  <version>0.0.15</version>
+  <version>0.0.16</version>
   <packaging>pom</packaging>
 
   <name>Nx Parent</name>


### PR DESCRIPTION
## Current Behavior

The Maven plugin version is at 0.0.15.

## Expected Behavior

The Maven plugin version is bumped to 0.0.16 with a corresponding migration entry for Nx 22.6.0-beta.14.

## Related Issue(s)

N/A - routine version bump.

### Changes

- Updated all pom.xml files to version 0.0.16
- Updated `mavenPluginVersion` constant in `versions.ts`
- Added migration entry in `migrations.json`
- Created migration file `update-pom-xml-version.ts` for 0.0.16