### PR TITLE
fix(core): show pid and cwd when waiting for task in another nx process

### DIFF
--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -146,7 +146,7 @@ export declare class ProcessMetricsCollector {
 
 export declare class RunningTasksService {
   constructor(db: ExternalObject<NxDbConnection>)
-  getRunningTasks(ids: Array<string>): Array<string>
+  getRunningTasks(ids: Array<string>): Array<RunningTaskContext>
   addRunningTask(taskId: string): void
   removeRunningTask(taskId: string): void
 }
@@ -491,6 +491,12 @@ export declare function restoreTerminal(): void
 export declare const enum RunMode {
   RunOne = 0,
   RunMany = 1
+}
+
+export interface RunningTaskContext {
+  taskId: string
+  pid: number
+  cwd: string
 }
 
 export interface RuntimeInput {

--- a/packages/nx/src/native/tasks/running_tasks_service.rs
+++ b/packages/nx/src/native/tasks/running_tasks_service.rs
@@ -15,6 +15,13 @@ pub const SCHEMA: &str = "CREATE TABLE IF NOT EXISTS running_tasks (
     cwd TEXT NOT NULL
 );";
 
+#[napi(object)]
+pub struct RunningTaskContext {
+    pub task_id: String,
+    pub pid: u32,
+    pub cwd: String,
+}
+
 #[napi]
 struct RunningTasksService {
     db: Arc<Mutex<NxDbConnection>>,
@@ -36,12 +43,15 @@ impl RunningTasksService {
     }
 
     #[napi]
-    pub fn get_running_tasks(&mut self, ids: Vec<String>) -> anyhow::Result<Vec<String>> {
-        let mut results = Vec::<String>::with_capacity(ids.len());
+    pub fn get_running_tasks(
+        &mut self,
+        ids: Vec<String>,
+    ) -> anyhow::Result<Vec<RunningTaskContext>> {
+        let mut results = Vec::<RunningTaskContext>::with_capacity(ids.len());
         for id in ids.into_iter() {
-            if self.is_task_running(&id)? {
+            if let Some(context) = self.get_running_task_context(&id)? {
                 debug!("Task {} is running", &id);
-                results.push(id);
+                results.push(context);
             } else {
                 debug!("Task {} is not running", id);
             }
@@ -49,7 +59,10 @@ impl RunningTasksService {
         Ok(results)
     }
 
-    fn is_task_running(&self, task_id: &String) -> anyhow::Result<bool> {
+    fn get_running_task_context(
+        &self,
+        task_id: &String,
+    ) -> anyhow::Result<Option<RunningTaskContext>> {
         if let Some((pid, db_process_command, db_process_cwd)) = self.db.lock().unwrap().query_row(
             "SELECT pid, command, cwd FROM running_tasks WHERE task_id = ?",
             [task_id],
@@ -79,17 +92,27 @@ impl RunningTasksService {
                         .collect::<Vec<_>>()
                         .join(" ");
 
-                    if let Some(cwd_path) = process_info.cwd() {
+                    let is_running = if let Some(cwd_path) = process_info.cwd() {
                         let cwd_str = cwd_path.to_normalized_string();
-                        Ok(cmd_str == db_process_command && cwd_str == db_process_cwd)
+                        cmd_str == db_process_command && cwd_str == db_process_cwd
                     } else {
-                        Ok(cmd_str == db_process_command)
+                        cmd_str == db_process_command
+                    };
+
+                    if is_running {
+                        Ok(Some(RunningTaskContext {
+                            task_id: task_id.clone(),
+                            pid,
+                            cwd: db_process_cwd,
+                        }))
+                    } else {
+                        Ok(None)
                     }
                 }
-                None => Ok(false),
+                None => Ok(None),
             }
         } else {
-            Ok(false)
+            Ok(None)
         }
     }
 

--- a/packages/nx/src/native/tests/running_tasks_service.spec.ts
+++ b/packages/nx/src/native/tests/running_tasks_service.spec.ts
@@ -29,9 +29,11 @@ describe('RunningTasksService', () => {
 
   it('should record a task as running', () => {
     runningTasksService.addRunningTask('app:build');
-    expect(runningTasksService.getRunningTasks(['app:build'])).toEqual([
-      'app:build',
-    ]);
+    const results = runningTasksService.getRunningTasks(['app:build']);
+    expect(results).toHaveLength(1);
+    expect(results[0].taskId).toEqual('app:build');
+    expect(results[0].pid).toBeDefined();
+    expect(results[0].cwd).toBeDefined();
   });
 
   it('should remove a task from running tasks', () => {

--- a/packages/nx/src/tasks-runner/running-tasks/shared-running-task.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/shared-running-task.ts
@@ -27,7 +27,15 @@ export class SharedRunningTask implements RunningTask {
   }
 
   private async waitForTaskToFinish(taskId: string) {
-    console.log(`Waiting for ${taskId} in another nx process`);
+    const runningTasks = this.runningTasksService.getRunningTasks([taskId]);
+    const context = runningTasks[0];
+    if (context) {
+      console.log(
+        `Waiting for ${taskId} in another nx process (pid: ${context.pid}, cwd: ${context.cwd})`
+      );
+    } else {
+      console.log(`Waiting for ${taskId} in another nx process`);
+    }
     // wait for the running task to finish
     do {
       await new Promise((resolve) => setTimeout(resolve, 100));


### PR DESCRIPTION
## Current Behavior

QoL improvement. When a task is already running in another Nx process, the message only says:
```
Waiting for doc-designer:serve in another nx process
```
No indication of where that other process is running, making it hard to identify the source (especially with multiple agents/terminals).

<img width="541" height="187" alt="image" src="https://github.com/user-attachments/assets/b00d5cc7-4b7f-4e4e-9bfd-ee9c937e4741" />

## Expected Behavior

The message now includes the pid and working directory of the other process:
```
Waiting for doc-designer:serve in another nx process (pid: 12345, cwd: /path/to/workspace)
```

<img width="713" height="175" alt="Screenshot 2026-03-16 at 16 49 02" src="https://github.com/user-attachments/assets/b41a9e2b-5dc9-4b91-86f9-70753f43450e" />


## Related Issue(s)

N/A