### PR TITLE
fix(core): trim memory usage associated with io-tracing service

### DIFF
--- a/packages/nx/src/hasher/hash-task.ts
+++ b/packages/nx/src/hasher/hash-task.ts
@@ -54,12 +54,13 @@ export async function hashTasksThatDoNotDependOnOutputsOfOtherTasks(
 
   const hashes = await hasher.hashTasks(tasksToHash, taskGraph, process.env);
   const ioService = getTaskIOService();
+  const hasInputSubscribers = ioService.hasTaskInputSubscribers();
   for (let i = 0; i < tasksToHash.length; i++) {
     tasksToHash[i].hash = hashes[i].value;
     tasksToHash[i].hashDetails = hashes[i].details;
 
     // Notify TaskIOService of hash inputs
-    if (hashes[i].inputs) {
+    if (hasInputSubscribers && hashes[i].inputs) {
       ioService.notifyTaskInputs(tasksToHash[i].id, hashes[i].inputs);
     }
   }
@@ -111,8 +112,9 @@ export async function hashTask(
   task.hashDetails = details;
 
   // Notify TaskIOService of hash inputs
-  if (inputs) {
-    getTaskIOService().notifyTaskInputs(task.id, inputs);
+  const ioService = getTaskIOService();
+  if (ioService.hasTaskInputSubscribers() && inputs) {
+    ioService.notifyTaskInputs(task.id, inputs);
   }
 
   if (taskDetails?.recordTaskDetails) {
@@ -167,6 +169,7 @@ export async function hashTasks(
 
   // Hash tasks with custom hashers individually
   const ioService = getTaskIOService();
+  const hasInputSubscribers = ioService.hasTaskInputSubscribers();
   const customHasherPromises = tasksWithCustomHashers.map(async (task) => {
     const customHasher = getCustomHasher(task, projectGraph);
     const { value, details, inputs } = await customHasher(task, {
@@ -182,7 +185,7 @@ export async function hashTasks(
     task.hashDetails = details;
 
     // Notify TaskIOService of hash inputs
-    if (inputs) {
+    if (hasInputSubscribers && inputs) {
       ioService.notifyTaskInputs(task.id, inputs);
     }
   });
@@ -198,7 +201,7 @@ export async function hashTasks(
           tasksWithoutCustomHashers[i].hashDetails = hashes[i].details;
 
           // Notify TaskIOService of hash inputs
-          if (hashes[i].inputs) {
+          if (hasInputSubscribers && hashes[i].inputs) {
             ioService.notifyTaskInputs(
               tasksWithoutCustomHashers[i].id,
               hashes[i].inputs

--- a/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
+++ b/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
@@ -4,6 +4,7 @@ import { NxJsonConfiguration } from '../config/nx-json';
 import { createTaskGraph } from '../tasks-runner/create-task-graph';
 import { NativeTaskHasherImpl } from './native-task-hasher-impl';
 import { ProjectGraphBuilder } from '../project-graph/project-graph-builder';
+import { getTaskIOService } from '../tasks-runner/task-io-service';
 
 // Helper to normalize hash results for deterministic snapshot comparison
 // (parallel processing may produce inputs in arbitrary order)
@@ -55,6 +56,10 @@ describe('native task hasher', () => {
   };
 
   beforeEach(async () => {
+    // Register a subscriber so that hasTaskInputSubscribers() returns true,
+    // enabling input collection in the hasher during tests.
+    getTaskIOService().subscribeToTaskInputs(() => {});
+
     tempFs = new TempFs('NativeTaskHasher');
     await tempFs.createFiles({
       'libs/parent/src/index.ts': 'parent-content',

--- a/packages/nx/src/hasher/native-task-hasher-impl.ts
+++ b/packages/nx/src/hasher/native-task-hasher-impl.ts
@@ -13,6 +13,7 @@ import {
 } from '../native';
 import { transformProjectGraphForRust } from '../native/transform-objects';
 import { getRootTsConfigPath } from '../plugins/js/utils/typescript';
+import { getTaskIOService } from '../tasks-runner/task-io-service';
 import { readJsonFile } from '../utils/fileutils';
 import { PartialHash, TaskHasherImpl } from './task-hasher';
 
@@ -70,7 +71,13 @@ export class NativeTaskHasherImpl implements TaskHasherImpl {
     cwd?: string
   ): Promise<PartialHash> {
     const plans = this.planner.getPlansReference([task.id], taskGraph);
-    const hashes = this.hasher.hashPlans(plans, env, cwd ?? process.cwd());
+    const collectInputs = getTaskIOService().hasTaskInputSubscribers();
+    const hashes = this.hasher.hashPlans(
+      plans,
+      env,
+      cwd ?? process.cwd(),
+      collectInputs
+    );
 
     return hashes[task.id];
   }
@@ -85,7 +92,13 @@ export class NativeTaskHasherImpl implements TaskHasherImpl {
       tasks.map((t) => t.id),
       taskGraph
     );
-    const hashes = this.hasher.hashPlans(plans, env, cwd ?? process.cwd());
+    const collectInputs = getTaskIOService().hasTaskInputSubscribers();
+    const hashes = this.hasher.hashPlans(
+      plans,
+      env,
+      cwd ?? process.cwd(),
+      collectInputs
+    );
     return tasks.map((t) => hashes[t.id]);
   }
 }

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -168,7 +168,7 @@ export declare class TaskDetails {
 
 export declare class TaskHasher {
   constructor(workspaceRoot: string, projectGraph: ExternalObject<ProjectGraph>, projectFileMap: ExternalObject<ProjectFiles>, allWorkspaceFiles: ExternalObject<Array<FileData>>, tsConfig: Buffer, tsConfigPaths: Record<string, Array<string>>, rootTsconfigPath?: string | undefined | null, options?: HasherOptions | undefined | null)
-  hashPlans(hashPlans: ExternalObject<Record<string, Array<HashInstruction>>>, jsEnv: Record<string, string>, cwd: string): NapiDashMap<string, HashDetails>
+  hashPlans(hashPlans: ExternalObject<Record<string, Array<HashInstruction>>>, jsEnv: Record<string, string>, cwd: string, collectTaskInputs?: boolean | undefined | null): NapiDashMap<string, HashDetails>
 }
 
 export declare class Watcher {

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -191,11 +191,13 @@ impl TaskHasher {
         hash_plans: &External<HashMap<String, Vec<HashInstruction>>>,
         js_env: HashMap<String, String>,
         cwd: String,
+        collect_task_inputs: Option<bool>,
     ) -> anyhow::Result<NapiDashMap<String, HashDetails>> {
         // Create a fresh task output cache for this invocation
         // This ensures no stale caches across multiple CLI commands when the daemon holds
         // the TaskHasher instance
         let task_output_cache = DashMap::new();
+        let should_collect_inputs = collect_task_inputs.unwrap_or(false);
 
         let function_start = std::time::Instant::now();
 
@@ -223,7 +225,12 @@ impl TaskHasher {
 
         // Use separate maps: one for hash details, one for input accumulation with HashSet
         let hashes: NapiDashMap<String, HashDetails> = NapiDashMap::new();
-        let inputs_accum: DashMap<String, HashInputsBuilder> = DashMap::new();
+        // Only allocate inputs accumulator when someone is listening for inputs
+        let inputs_accum: Option<DashMap<String, HashInputsBuilder>> = if should_collect_inputs {
+            Some(DashMap::new())
+        } else {
+            None
+        };
         let cwd_path = std::path::Path::new(&cwd);
 
         hash_plans
@@ -246,6 +253,7 @@ impl TaskHasher {
                         selectively_hash_tsconfig,
                         task_output_cache: &task_output_cache,
                         cwd: cwd_path,
+                        collect_inputs: should_collect_inputs,
                     },
                 )?;
 
@@ -259,11 +267,10 @@ impl TaskHasher {
                     });
                 entry.details.insert(instruction_key, hash_value);
 
-                // Accumulate inputs using HashSet for O(1) deduplication
-                inputs_accum
-                    .entry(task_id.to_string())
-                    .or_default()
-                    .extend(inputs);
+                // Accumulate inputs using HashSet for O(1) deduplication (only when collecting)
+                if let Some(ref accum) = inputs_accum {
+                    accum.entry(task_id.to_string()).or_default().extend(inputs);
+                }
 
                 Ok::<(), anyhow::Error>(())
             })?;
@@ -285,8 +292,10 @@ impl TaskHasher {
                 hash_details.value = hash;
             });
             // Convert accumulated HashInputsBuilder to HashInputs (sorted Vecs)
-            if let Some((_, builder)) = inputs_accum.remove(hash_id) {
-                hash_details.inputs = builder.into();
+            if let Some(ref accum) = inputs_accum {
+                if let Some((_, builder)) = accum.remove(hash_id) {
+                    hash_details.inputs = builder.into();
+                }
             }
         });
 
@@ -318,10 +327,12 @@ impl TaskHasher {
             selectively_hash_tsconfig,
             task_output_cache,
             cwd,
+            collect_inputs,
         }: HashInstructionArgs,
     ) -> anyhow::Result<(String, String, HashInputsBuilder)> {
         let now = std::time::Instant::now();
         let span = trace_span!("hashing", task_id).entered();
+        let empty = HashInputsBuilder::default();
         let (hash, inputs) = match instruction {
             HashInstruction::WorkspaceFileSet(workspace_file_set) => {
                 let result = hash_workspace_files_with_inputs(
@@ -329,13 +340,16 @@ impl TaskHasher {
                     &self.all_workspace_files,
                 )?;
                 trace!(parent: &span, "hash_workspace_files: {:?}", now.elapsed());
-                (
-                    result.hash,
+                let inputs = if collect_inputs {
                     HashInputsBuilder {
                         files: result.files.into_iter().collect(),
                         ..Default::default()
-                    },
-                )
+                    }
+                } else {
+                    drop(result.files);
+                    empty
+                };
+                (result.hash, inputs)
             }
             HashInstruction::Runtime(runtime) => {
                 let hashed_runtime = hash_runtime(
@@ -345,18 +359,28 @@ impl TaskHasher {
                     Arc::clone(&self.runtime_cache),
                 )?;
                 trace!(parent: &span, "hash_runtime: {:?}", now.elapsed());
-                (hashed_runtime, instruction.into())
+                let inputs = if collect_inputs {
+                    instruction.into()
+                } else {
+                    empty
+                };
+                (hashed_runtime, inputs)
             }
             HashInstruction::Environment(env) => {
                 let hashed_env = hash_env(env, js_env);
                 trace!(parent: &span, "hash_env: {:?}", now.elapsed());
-                (hashed_env, instruction.into())
+                let inputs = if collect_inputs {
+                    instruction.into()
+                } else {
+                    empty
+                };
+                (hashed_env, inputs)
             }
             HashInstruction::Cwd(mode) => {
                 let workspace_root = std::path::Path::new(&self.workspace_root);
                 let hashed_cwd = hash_cwd(workspace_root, cwd, mode.clone());
                 trace!(parent: &span, "hash_cwd: {:?}", now.elapsed());
-                (hashed_cwd, instruction.into())
+                (hashed_cwd, empty)
             }
             HashInstruction::ProjectFileSet(project_name, file_sets) => {
                 let result = hash_project_files_with_inputs(
@@ -365,19 +389,22 @@ impl TaskHasher {
                     &self.project_file_map,
                 )?;
                 trace!(parent: &span, "hash_project_files: {:?}", now.elapsed());
-                (
-                    result.hash,
+                let inputs = if collect_inputs {
                     HashInputsBuilder {
                         files: result.files.into_iter().collect(),
                         ..Default::default()
-                    },
-                )
+                    }
+                } else {
+                    drop(result.files);
+                    empty
+                };
+                (result.hash, inputs)
             }
             HashInstruction::ProjectConfiguration(project_name) => {
                 let hashed_project_config =
                     hash_project_config(project_name, &self.project_graph.nodes)?;
                 trace!(parent: &span, "hash_project_config: {:?}", now.elapsed());
-                (hashed_project_config, instruction.into())
+                (hashed_project_config, empty)
             }
             HashInstruction::TsConfiguration(project_name) => {
                 let ts_config_hash = if !selectively_hash_tsconfig {
@@ -402,45 +429,50 @@ impl TaskHasher {
                     // the unwrap_or is for the case where typescript is not installed
                     .unwrap_or(ts_config_hash);
 
-                let relative_ts_path = if let Some(root_path) = &self.root_tsconfig_path {
-                    Some(
-                        Path::new(root_path)
-                            .strip_prefix(&self.workspace_root)
-                            .unwrap_or(Path::new(root_path))
-                            .to_string_lossy()
-                            .to_string(),
-                    )
-                } else {
-                    None
-                };
+                let inputs = if collect_inputs {
+                    let relative_ts_path = if let Some(root_path) = &self.root_tsconfig_path {
+                        Some(
+                            Path::new(root_path)
+                                .strip_prefix(&self.workspace_root)
+                                .unwrap_or(Path::new(root_path))
+                                .to_string_lossy()
+                                .to_string(),
+                        )
+                    } else {
+                        None
+                    };
 
-                // Convert absolute tsconfig path to relative path
-                let files = if let Some(rel_path) = relative_ts_path {
-                    HashSet::from([rel_path])
-                } else {
-                    HashSet::new()
-                };
+                    let files = if let Some(rel_path) = relative_ts_path {
+                        HashSet::from([rel_path])
+                    } else {
+                        HashSet::new()
+                    };
 
-                trace!(parent: &span, "hash_tsconfig: {:?}", now.elapsed());
-                (
-                    ts_hash,
                     HashInputsBuilder {
                         files,
                         ..Default::default()
-                    },
-                )
+                    }
+                } else {
+                    empty
+                };
+
+                trace!(parent: &span, "hash_tsconfig: {:?}", now.elapsed());
+                (ts_hash, inputs)
             }
             HashInstruction::TaskOutput(glob, outputs) => {
                 let result =
                     hash_task_output(&self.workspace_root, glob, outputs, task_output_cache)?;
                 trace!(parent: &span, "hash_task_output: {:?}", now.elapsed());
-                (
-                    result.hash,
+                let inputs = if collect_inputs {
                     HashInputsBuilder {
                         dep_outputs: result.files.into_iter().collect(),
                         ..Default::default()
-                    },
-                )
+                    }
+                } else {
+                    drop(result.files);
+                    empty
+                };
+                (result.hash, inputs)
             }
             HashInstruction::External(external) => {
                 let hashed_external = hash_external(
@@ -449,7 +481,12 @@ impl TaskHasher {
                     Arc::clone(&self.external_cache),
                 )?;
                 trace!(parent: &span, "hash_external: {:?}", now.elapsed());
-                (hashed_external, instruction.into())
+                let inputs = if collect_inputs {
+                    instruction.into()
+                } else {
+                    empty
+                };
+                (hashed_external, inputs)
             }
             HashInstruction::AllExternalDependencies => {
                 let hashed_all_externals = hash_all_externals(
@@ -458,7 +495,12 @@ impl TaskHasher {
                     Arc::clone(&self.external_cache),
                 )?;
                 trace!(parent: &span, "hash_all_externals: {:?}", now.elapsed());
-                (hashed_all_externals, instruction.into())
+                let inputs = if collect_inputs {
+                    instruction.into()
+                } else {
+                    empty
+                };
+                (hashed_all_externals, inputs)
             }
         };
         Ok((instruction.to_string(), hash, inputs))
@@ -473,4 +515,5 @@ struct HashInstructionArgs<'a> {
     selectively_hash_tsconfig: bool,
     task_output_cache: &'a DashMap<String, CachedTaskOutput>,
     cwd: &'a std::path::Path,
+    collect_inputs: bool,
 }

--- a/packages/nx/src/tasks-runner/task-io-service.ts
+++ b/packages/nx/src/tasks-runner/task-io-service.ts
@@ -1,5 +1,3 @@
-import { ProjectGraph } from '../config/project-graph';
-import { TaskGraph } from '../config/task-graph';
 import { getProcessMetricsService } from './process-metrics-service';
 
 /**
@@ -41,30 +39,16 @@ export type TaskOutputsCallback = (update: TaskOutputsUpdate) => void;
  * Subscribes to ProcessMetricsService for PID discovery.
  * IO information comes from hash inputs (populated during hashing).
  * Output files are reported when tasks are stored to cache.
+ *
+ * Data is only stored when subscribers are registered. Without subscribers,
+ * notifications are no-ops to avoid unbounded memory growth in long-lived
+ * processes (e.g. the Nx daemon).
  */
 class TaskIOService {
-  // Used to call subscribers that were late to the party
-  protected taskToPids: Map<string, number> = new Map();
-  protected taskToInputs: Map<string, TaskInputInfo> = new Map();
-  protected taskToOutputs: Map<string, string[]> = new Map();
-
   // Subscription state
   private pidCallbacks: TaskPidCallback[] = [];
   private taskInputCallbacks: TaskInputCallback[] = [];
   private taskOutputsCallbacks: TaskOutputsCallback[] = [];
-
-  // Project graph and task graph for resolving task information
-  protected projectGraph: ProjectGraph | null = null;
-  protected taskGraph: TaskGraph | null = null;
-
-  constructor(projectGraph?: ProjectGraph, taskGraph?: TaskGraph) {
-    if (projectGraph) {
-      this.projectGraph = projectGraph;
-    }
-    if (taskGraph) {
-      this.taskGraph = taskGraph;
-    }
-  }
 
   /**
    * Subscribe to task PID updates.
@@ -72,14 +56,14 @@ class TaskIOService {
    */
   subscribeToTaskPids(callback: TaskPidCallback): void {
     this.pidCallbacks.push(callback);
+  }
 
-    // Emit current state to new subscriber
-    for (const [taskId, pid] of this.taskToPids) {
-      callback({
-        taskId,
-        pid,
-      });
-    }
+  /**
+   * Returns true if any callbacks are registered for task input notifications.
+   * Used to avoid expensive input collection in the hasher when nobody is listening.
+   */
+  hasTaskInputSubscribers(): boolean {
+    return this.taskInputCallbacks.length > 0;
   }
 
   /**
@@ -88,11 +72,6 @@ class TaskIOService {
    */
   subscribeToTaskInputs(callback: TaskInputCallback): void {
     this.taskInputCallbacks.push(callback);
-
-    // Emit current state to new subscriber
-    for (const [, taskInputInfo] of this.taskToInputs) {
-      callback(taskInputInfo);
-    }
   }
 
   /**
@@ -101,14 +80,6 @@ class TaskIOService {
    */
   subscribeToTaskOutputs(callback: TaskOutputsCallback): void {
     this.taskOutputsCallbacks.push(callback);
-
-    // Emit current state to new subscriber
-    for (const [task, outputs] of this.taskToOutputs) {
-      callback({
-        taskId: task,
-        outputs: outputs,
-      });
-    }
   }
 
   /**
@@ -129,7 +100,6 @@ class TaskIOService {
       taskId,
       inputs,
     };
-    this.taskToInputs.set(taskId, taskInputInfo);
 
     for (const cb of this.taskInputCallbacks) {
       try {
@@ -145,8 +115,6 @@ class TaskIOService {
    * Called from the cache when outputs are stored.
    */
   notifyTaskOutputs(taskId: string, outputs: string[]): void {
-    this.taskToOutputs.set(taskId, outputs);
-
     const update: TaskOutputsUpdate = {
       taskId,
       outputs,
@@ -166,7 +134,6 @@ class TaskIOService {
    * @param update The TaskPidUpdate containing taskId and pid.
    */
   notifyPidUpdate(update: TaskPidUpdate): void {
-    this.taskToPids.set(update.taskId, update.pid);
     for (const cb of this.pidCallbacks) {
       try {
         cb(update);
@@ -182,14 +149,10 @@ let instance: TaskIOService | null = null;
 
 /**
  * Get or create the singleton TaskIOService instance.
- * Optionally provide projectGraph and taskGraph to initialize with context.
  */
-export function getTaskIOService(
-  projectGraph?: ProjectGraph,
-  taskGraph?: TaskGraph
-): TaskIOService {
+export function getTaskIOService(): TaskIOService {
   if (!instance) {
-    instance = new TaskIOService(projectGraph, taskGraph);
+    instance = new TaskIOService();
   }
   return instance;
 }


### PR DESCRIPTION
## Current Behavior
We accumulate `inputs`/`outputs`/`pids` and store them even if no subscriber is subscribed, and then they hang around to notify late subscribers that may never come

## Expected Behavior
`inputs`/`outputs`/`pids` are only sent to current subscribers

## AI Summary 

This pull request optimizes how task input notifications are handled in Nx by ensuring that expensive input collection and storage only occur when there are active subscribers. This change prevents unnecessary memory growth in long-lived processes, such as the Nx daemon, and improves performance by avoiding redundant work.

Notification and input collection optimization:

* Added a `hasTaskInputSubscribers()` method to the `TaskIOService` class, allowing the hasher to check if any input subscribers are registered before collecting and notifying task inputs.
* Updated all hashing functions in `hash-task.ts` to only notify task inputs if there are active subscribers, reducing unnecessary work and memory usage. [[1]](diffhunk://#diff-d061dc5551f692abad009b8284c719466cff2f0d3d19bd52e81b7921a9e543d6R57-R63) [[2]](diffhunk://#diff-d061dc5551f692abad009b8284c719466cff2f0d3d19bd52e81b7921a9e543d6L114-R117) [[3]](diffhunk://#diff-d061dc5551f692abad009b8284c719466cff2f0d3d19bd52e81b7921a9e543d6R172) [[4]](diffhunk://#diff-d061dc5551f692abad009b8284c719466cff2f0d3d19bd52e81b7921a9e543d6L185-R188) [[5]](diffhunk://#diff-d061dc5551f692abad009b8284c719466cff2f0d3d19bd52e81b7921a9e543d6L201-R204)
* Modified the native task hasher implementation (`native-task-hasher-impl.ts` and Rust code) to conditionally collect and return input data only when requested, minimizing overhead and memory allocation. [[1]](diffhunk://#diff-ddf992f97afbcd8b2206b8d1faab7e7f9571ecfe50e2ab8e3da104001f39f0c3L73-R80) [[2]](diffhunk://#diff-ddf992f97afbcd8b2206b8d1faab7e7f9571ecfe50e2ab8e3da104001f39f0c3L88-R101) [[3]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bR194-R200) [[4]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bL226-R233) [[5]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bR256) [[6]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bL262-R273) [[7]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bL288-R299) [[8]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bR330-R352) [[9]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bL348-R383) [[10]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bL368-R407) [[11]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bR432) [[12]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bL417-R475) [[13]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bL452-R489) [[14]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bL461-R503) [[15]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bR518)

Code cleanup and refactoring:

* Removed unused state and redundant code from `TaskIOService` related to storing task-to-PID, task-to-input, and task-to-output mappings, as well as unnecessary graph references and late subscriber emission logic. [[1]](diffhunk://#diff-fc051b28c1ac25926033d157ec2278cc1cf2fcf7e16626eeedaf876c29fc9d62R42-R66) [[2]](diffhunk://#diff-fc051b28c1ac25926033d157ec2278cc1cf2fcf7e16626eeedaf876c29fc9d62L91-L95) [[3]](diffhunk://#diff-fc051b28c1ac25926033d157ec2278cc1cf2fcf7e16626eeedaf876c29fc9d62L104-L111)
* Updated imports and cleaned up constructor logic in `task-io-service.ts` and `native-task-hasher-impl.ts` for clarity and maintainability. [[1]](diffhunk://#diff-ddf992f97afbcd8b2206b8d1faab7e7f9571ecfe50e2ab8e3da104001f39f0c3R16) [[2]](diffhunk://#diff-fc051b28c1ac25926033d157ec2278cc1cf2fcf7e16626eeedaf876c29fc9d62L1-L2)

These changes collectively make task input tracking more efficient and robust, especially in scenarios where Nx runs as a daemon or in environments with no listeners for input notifications.
