### PR TITLE
fix(core): show continuous property in nx show target

### DIFF
--- a/e2e/nx/src/__snapshots__/misc.test.ts.snap
+++ b/e2e/nx/src/__snapshots__/misc.test.ts.snap
@@ -86,5 +86,6 @@ Outputs:
 Configurations: production
 Cache: true
 Parallelism: true
+Continuous: false
 "
 `;

--- a/packages/nx/src/command-line/show/target.ts
+++ b/packages/nx/src/command-line/show/target.ts
@@ -366,6 +366,7 @@ function resolveTargetInfoData(
       : {}),
     cache: targetConfig.cache ?? false,
     parallelism: targetConfig.parallelism ?? true,
+    continuous: targetConfig.continuous ?? false,
   };
 }
 
@@ -657,6 +658,7 @@ function renderTargetInfo(
 
   console.log(`${c.bold('Cache')}: ${data.cache}`);
   console.log(`${c.bold('Parallelism')}: ${data.parallelism}`);
+  console.log(`${c.bold('Continuous')}: ${data.continuous}`);
 }
 
 function renderInputs(


### PR DESCRIPTION
Add the continuous property to the nx show target output. Previously the command showed cache and parallelism but not whether a target is continuous.

Fixes NXC-4084