### PR TITLE
fix(gradle): remove annotations from atomizer

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/parsing/KotlinAstTestParser.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/parsing/KotlinAstTestParser.kt
@@ -99,11 +99,12 @@ private fun processClass(
     return
   }
 
-  // Only include regular classes - skip data classes, object declarations, enum classes, etc.
+  // Only include regular classes - skip data classes, object declarations, enum classes, annotation classes, etc.
   if (ktClass.hasModifier(KtTokens.DATA_KEYWORD) ||
       ktClass.hasModifier(KtTokens.ENUM_KEYWORD) ||
       ktClass.hasModifier(KtTokens.SEALED_KEYWORD) ||
-      ktClass.hasModifier(KtTokens.ABSTRACT_KEYWORD)) {
+      ktClass.hasModifier(KtTokens.ABSTRACT_KEYWORD) ||
+      ktClass.isAnnotation()) {
     return
   }
 

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/parsing/KotlinAstTestParser.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/parsing/KotlinAstTestParser.kt
@@ -99,7 +99,8 @@ private fun processClass(
     return
   }
 
-  // Only include regular classes - skip data classes, object declarations, enum classes, annotation classes, etc.
+  // Only include regular classes - skip data classes, object declarations, enum classes,
+  // annotation classes, etc.
   if (ktClass.hasModifier(KtTokens.DATA_KEYWORD) ||
       ktClass.hasModifier(KtTokens.ENUM_KEYWORD) ||
       ktClass.hasModifier(KtTokens.SEALED_KEYWORD) ||

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/parsing/RegexTestParser.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/parsing/RegexTestParser.kt
@@ -14,6 +14,9 @@ private val fakeClassRegex =
 private val abstractClassRegex =
     Regex(
         """^\s*(?:@\w+\s*)*(?:public\s+|protected\s+)?abstract\s+class\s+([A-Za-z_][A-Za-z0-9_]*)""")
+private val annotationClassRegex =
+    Regex(
+        """^\s*(?:@\w+\s*)*(?:public\s+|protected\s+)?annotation\s+class\s+([A-Za-z_][A-Za-z0-9_]*)""")
 
 /** Fallback to original regex-based parsing when AST parsing fails */
 fun parseTestClassesWithRegex(file: File): MutableMap<String, String>? {
@@ -30,9 +33,10 @@ fun parseTestClassesWithRegex(file: File): MutableMap<String, String>? {
     val trimmed = line.trimStart()
     val indent = line.indexOfFirst { !it.isWhitespace() }.takeIf { it >= 0 } ?: 0
 
-    // Skip private, internal, abstract, and fake classes
+    // Skip private, internal, abstract, annotation, and fake classes
     if (excludedClassRegex.containsMatchIn(trimmed)) continue
     if (abstractClassRegex.containsMatchIn(trimmed)) continue
+    if (annotationClassRegex.containsMatchIn(trimmed)) continue
     if (fakeClassRegex.containsMatchIn(trimmed)) continue
 
     val match = classDeclarationRegex.find(trimmed)

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/parsing/TestClassParserTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/parsing/TestClassParserTest.kt
@@ -1,0 +1,147 @@
+package dev.nx.gradle.utils.parsing
+
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class TestClassParserTest {
+
+  @TempDir lateinit var tempDir: File
+
+  @Test
+  fun `should exclude annotation classes from Kotlin files`() {
+    val file =
+        File(tempDir, "AnnotationTest.kt").apply {
+          writeText(
+              """
+              package com.example
+              import org.junit.jupiter.api.Test
+
+              @Target(AnnotationTarget.CLASS)
+              @Retention(AnnotationRetention.RUNTIME)
+              annotation class CustomTestAnnotation
+
+              @CustomTestAnnotation
+              class ActualTestClass {
+                @Test
+                fun testMethod() {}
+              }
+              """
+                  .trimIndent())
+        }
+
+    val result = getAllVisibleClassesWithNestedAnnotation(file)
+
+    assertNotNull(result)
+    assertTrue(result.containsKey("ActualTestClass"))
+    assertFalse(
+        result.containsKey("CustomTestAnnotation"),
+        "Annotation classes should not be included as test targets")
+  }
+
+  @Test
+  fun `should exclude annotation classes from regex fallback`() {
+    val file =
+        File(tempDir, "AnnotationTest.kt").apply {
+          writeText(
+              """
+              package com.example
+              import org.junit.jupiter.api.Test
+
+              annotation class SomeAnnotation
+
+              class RealTest {
+                @Test
+                fun testMethod() {}
+              }
+              """
+                  .trimIndent())
+        }
+
+    val result = parseTestClassesWithRegex(file)
+
+    assertNotNull(result)
+    assertTrue(result.containsKey("RealTest"))
+    assertFalse(
+        result.containsKey("SomeAnnotation"),
+        "Annotation classes should not be included as test targets")
+  }
+
+  @Test
+  fun `should exclude multiple annotation classes in same file`() {
+    val file =
+        File(tempDir, "MultiAnnotation.kt").apply {
+          writeText(
+              """
+              package com.example
+              import org.junit.jupiter.api.Test
+
+              @Target(AnnotationTarget.CLASS)
+              annotation class FirstAnnotation
+
+              @Target(AnnotationTarget.CLASS)
+              annotation class SecondAnnotation
+
+              @FirstAnnotation
+              @SecondAnnotation
+              class AnnotatedTest {
+                @Test
+                fun testMethod() {}
+              }
+              """
+                  .trimIndent())
+        }
+
+    val result = getAllVisibleClassesWithNestedAnnotation(file)
+
+    assertNotNull(result)
+    assertTrue(result.containsKey("AnnotatedTest"))
+    assertFalse(result.containsKey("FirstAnnotation"))
+    assertFalse(result.containsKey("SecondAnnotation"))
+  }
+
+  @Test
+  fun `should still include regular test classes alongside annotation classes`() {
+    val file =
+        File(tempDir, "MixedFile.kt").apply {
+          writeText(
+              """
+              package com.example
+              import org.junit.jupiter.api.Test
+              import org.junit.jupiter.api.extension.ExtendWith
+
+              annotation class AssertFileChannelDataBlocksClosed
+
+              @ExtendWith(value = [])
+              class ExtendWithTestClass {
+                @Test
+                fun testMethod() {}
+              }
+
+              @AssertFileChannelDataBlocksClosed
+              class CustomAnnotatedTestClass {
+                @Test
+                fun testMethod() {}
+              }
+
+              annotation class TestAnnotation
+              """
+                  .trimIndent())
+        }
+
+    val result = getAllVisibleClassesWithNestedAnnotation(file)
+
+    assertNotNull(result)
+    assertTrue(result.containsKey("ExtendWithTestClass"))
+    assertTrue(result.containsKey("CustomAnnotatedTestClass"))
+    assertFalse(
+        result.containsKey("AssertFileChannelDataBlocksClosed"),
+        "Annotation class should not be a test target")
+    assertFalse(
+        result.containsKey("TestAnnotation"), "Annotation class should not be a test target")
+  }
+}

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/parsing/TestClassParserTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/parsing/TestClassParserTest.kt
@@ -1,7 +1,6 @@
 package dev.nx.gradle.utils.parsing
 
 import java.io.File
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
The Gradle plugin's test class atomizer was incorrectly treating Kotlin annotation class declarations as test targets, generating invalid test tasks for them. This caused issues when projects defined custom annotations alongside their test classes—the atomizer would attempt to run annotation classes as tests.                                        

## Expected Behavior
                                                                                                                                                
              
Both the AST-based parser and the regex fallback parser now skip annotation classes, matching the existing behavior for data classes, enum classes, sealed classes, and abstract classes. A new test suite covers all annotation class exclusion scenarios for both parsers, including files with multiple annotation classes and mixed annotation/test class files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
