### PR TITLE
fix(gradle): always check disk cache for gradle project graph reports

### DIFF
--- a/packages/gradle/src/plugin-v1/utils/get-gradle-report.spec.ts
+++ b/packages/gradle/src/plugin-v1/utils/get-gradle-report.spec.ts
@@ -22,9 +22,10 @@ describe('processProjectReports', () => {
       Object.keys(Object.fromEntries(report.gradleProjectToTasksTypeMap))
     ).toEqual(['', ':app', ':list', ':utilities']);
 
-    writeGradleReportToCache(tmpFile.name, report);
+    writeGradleReportToCache(tmpFile.name, report, 'test-hash');
     expect(readFileSync(tmpFile.name).toString()).toMatchInlineSnapshot(`
       "{
+        "hash": "test-hash",
         "gradleFileToGradleProjectMap": {},
         "gradleProjectToDepsMap": {
           "": [
@@ -67,9 +68,10 @@ describe('processProjectReports', () => {
       Object.keys(Object.fromEntries(report.gradleProjectToTasksTypeMap))
     ).toEqual(['', ':app', ':list', ':utilities']);
 
-    writeGradleReportToCache(tmpFile.name, report);
+    writeGradleReportToCache(tmpFile.name, report, 'test-hash');
     expect(readFileSync(tmpFile.name).toString()).toMatchInlineSnapshot(`
       "{
+        "hash": "test-hash",
         "gradleFileToGradleProjectMap": {},
         "gradleProjectToDepsMap": {
           "": [

--- a/packages/gradle/src/plugin-v1/utils/get-gradle-report.ts
+++ b/packages/gradle/src/plugin-v1/utils/get-gradle-report.ts
@@ -89,10 +89,11 @@ function readGradleReportCache(
 
 export function writeGradleReportToCache(
   cachePath: string,
-  results: GradleReport
+  results: GradleReport,
+  hash: string
 ) {
   let gradleReportJson: GradleReportJSON = {
-    hash: gradleCurrentConfigHash,
+    hash,
     gradleFileToGradleProjectMap: Object.fromEntries(
       results.gradleFileToGradleProjectMap
     ),
@@ -143,7 +144,6 @@ export function writeGradleReportToCache(
 }
 
 let gradleReportCache: GradleReport;
-let gradleCurrentConfigHash: string;
 let gradleReportCachePath: string = join(
   workspaceDataDirectory,
   'gradle-report-v1.hash'
@@ -183,14 +183,9 @@ export async function populateGradleReport(
   const gradleConfigHash = await hashWithWorkspaceContext(workspaceRoot, [
     gradleConfigAndTestGlob,
   ]);
-  gradleReportCache ??= readGradleReportCache(
-    gradleReportCachePath,
-    gradleConfigHash
-  );
-  if (
-    gradleReportCache &&
-    (!gradleCurrentConfigHash || gradleConfigHash === gradleCurrentConfigHash)
-  ) {
+  const cached = readGradleReportCache(gradleReportCachePath, gradleConfigHash);
+  if (cached) {
+    gradleReportCache = cached;
     return;
   }
 
@@ -216,9 +211,12 @@ export async function populateGradleReport(
     gradleProjectReportStart.name,
     gradleProjectReportEnd.name
   );
-  gradleCurrentConfigHash = gradleConfigHash;
   gradleReportCache = processProjectReports(projectReportLines);
-  writeGradleReportToCache(gradleReportCachePath, gradleReportCache);
+  writeGradleReportToCache(
+    gradleReportCachePath,
+    gradleReportCache,
+    gradleConfigHash
+  );
 }
 
 export function processProjectReports(

--- a/packages/gradle/src/plugin/utils/get-project-graph-from-gradle-plugin.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-from-gradle-plugin.ts
@@ -16,7 +16,7 @@ import { hashWithWorkspaceContext } from 'nx/src/utils/workspace-context';
 import { gradleConfigAndTestGlob } from '../../utils/split-config-files';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { getNxProjectGraphLines } from './get-project-graph-lines';
-import { GradlePluginOptions } from './gradle-plugin-options';
+import { GradlePluginOptions, normalizeOptions } from './gradle-plugin-options';
 import { hashObject } from 'nx/src/devkit-internals';
 
 // the output json file from the gradle plugin
@@ -112,9 +112,10 @@ export async function populateProjectGraph(
   gradlewFiles: string[],
   options: GradlePluginOptions
 ): Promise<void> {
+  const normalizedOptions = normalizeOptions(options);
   const gradleConfigHash = hashArray([
     await hashWithWorkspaceContext(workspaceRoot, [gradleConfigAndTestGlob]),
-    hashObject(options),
+    hashObject(normalizedOptions),
     process.env.CI,
   ]);
   const cached = readProjectGraphReportCache(
@@ -142,7 +143,7 @@ export async function populateProjectGraph(
       const currentLines = await getNxProjectGraphLines(
         gradlewFile,
         gradleConfigHash,
-        options
+        normalizedOptions
       );
       const getNxProjectGraphLinesEnd = performance.mark(
         `${gradlewFile}GetNxProjectGraphLines:end`

--- a/packages/gradle/src/plugin/utils/get-project-graph-from-gradle-plugin.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-from-gradle-plugin.ts
@@ -50,10 +50,11 @@ function readProjectGraphReportCache(
 
 export function writeProjectGraphReportToCache(
   cachePath: string,
-  results: ProjectGraphReport
+  results: ProjectGraphReport,
+  hash: string
 ) {
   let projectGraphReportJson: ProjectGraphReportCache = {
-    hash: gradleCurrentConfigHash,
+    hash,
     ...results,
   };
 
@@ -69,7 +70,6 @@ export function writeProjectGraphReportToCache(
 }
 
 let projectGraphReportCache: ProjectGraphReport;
-let gradleCurrentConfigHash: string;
 let projectGraphReportCachePath: string = join(
   workspaceDataDirectory,
   'gradle-nodes.hash'
@@ -117,14 +117,12 @@ export async function populateProjectGraph(
     hashObject(options),
     process.env.CI,
   ]);
-  projectGraphReportCache ??= readProjectGraphReportCache(
+  const cached = readProjectGraphReportCache(
     projectGraphReportCachePath,
     gradleConfigHash
   );
-  if (
-    projectGraphReportCache &&
-    (!gradleCurrentConfigHash || gradleConfigHash === gradleCurrentConfigHash)
-  ) {
+  if (cached) {
+    projectGraphReportCache = cached;
     return;
   }
 
@@ -167,11 +165,11 @@ export async function populateProjectGraph(
     gradleProjectGraphReportStart.name,
     gradleProjectGraphReportEnd.name
   );
-  gradleCurrentConfigHash = gradleConfigHash;
   projectGraphReportCache = processNxProjectGraph(projectGraphLines);
   writeProjectGraphReportToCache(
     projectGraphReportCachePath,
-    projectGraphReportCache
+    projectGraphReportCache,
+    gradleConfigHash
   );
 }
 


### PR DESCRIPTION
## Current Behavior

The Gradle plugin uses an in-memory `gradleCurrentConfigHash` variable to decide whether to skip re-running `./gradlew nxProjectGraph`. Since plugin workers shut down between graph computations, this variable resets to `undefined` each time. The `??=` operator on the disk cache read means it's only read once per worker lifetime, and the `!gradleCurrentConfigHash` check always evaluates to `true` on fresh workers — making the in-memory hash comparison dead code.

This means the caching logic works despite itself (via disk cache), but is fragile and could cause unnecessary Gradle invocations or stale cache hits if worker lifecycle assumptions change.

There was also another issue with hashing options when calculating the project graph for nodes and dependencies. Options were not normalized when hashing which meant you did not get deterministic hashing when calling dependencies after createNodes.

## Expected Behavior

Always read the disk cache and compare hashes directly. If the hash matches, skip running Gradle. If not, run Gradle and update the disk cache. No in-memory state needed between worker restarts.

Options are normalized before hashing to ensure that regardless of createNodes or dependencies, we will get a deterministic hash.

## Related Issue(s)

<!-- No specific issue — discovered during code review -->