### PR TITLE
fix(core): ensure postTasksExecution fires on SIGINT for continuous tasks

### DIFF
--- a/packages/nx/src/executors/run-commands/running-tasks.ts
+++ b/packages/nx/src/executors/run-commands/running-tasks.ts
@@ -525,8 +525,6 @@ class RunningNodeProcess implements RunningTask {
     });
     process.on('SIGINT', () => {
       this.kill('SIGTERM');
-      // we exit here because we don't need to write anything to cache.
-      process.exit(signalToCode('SIGINT'));
     });
     process.on('SIGTERM', () => {
       this.kill('SIGTERM');
@@ -710,8 +708,6 @@ function registerProcessListener(
   });
   process.on('SIGINT', () => {
     runningTask.kill('SIGTERM');
-    // we exit here because we don't need to write anything to cache.
-    process.exit(signalToCode('SIGINT'));
   });
   process.on('SIGTERM', () => {
     runningTask.kill('SIGTERM');

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -110,7 +110,8 @@ export class TaskOrchestrator {
     { runningTask: RunningTask; stopping: boolean }
   >();
   private discreteTaskExitHandled = new Map<string, Promise<void>>();
-  private cleanupDone = false;
+  private continuousTaskExitHandled = new Map<string, Promise<void>>();
+  private cleanupPromise: Promise<void> | null = null;
 
   // endregion internal state
 
@@ -232,16 +233,7 @@ export class TaskOrchestrator {
         const runningTask = await this.startContinuousTask(task, groupId);
 
         if (this.initializingTaskIds.has(task.id)) {
-          await new Promise<void>((res) => {
-            runningTask.onExit((code) => {
-              if (!this.tuiEnabled) {
-                if (code > 128) {
-                  process.exit(code);
-                }
-              }
-              res();
-            });
-          });
+          await this.continuousTaskExitHandled.get(task.id);
         }
       } else {
         await this.applyFromCacheOrRunTask(doNotSkipCache, task, groupId);
@@ -944,7 +936,15 @@ export class TaskOrchestrator {
         groupId,
         ownsRunningTasksService: false,
       });
-      this.registerContinuousTaskExitHandler(runningTask, task, groupId, false);
+      this.continuousTaskExitHandled.set(
+        task.id,
+        new Promise<void>((resolve) => {
+          runningTask.onExit(async (code) => {
+            await this.handleContinuousTaskExit(code, task, groupId, false);
+            resolve();
+          });
+        })
+      );
 
       // task is already running by another process, we schedule the next tasks
       // and release the threads
@@ -997,7 +997,15 @@ export class TaskOrchestrator {
       groupId,
       ownsRunningTasksService: true,
     });
-    this.registerContinuousTaskExitHandler(childProcess, task, groupId, true);
+    this.continuousTaskExitHandled.set(
+      task.id,
+      new Promise<void>((resolve) => {
+        childProcess.onExit(async (code) => {
+          await this.handleContinuousTaskExit(code, task, groupId, true);
+          resolve();
+        });
+      })
+    );
     await this.scheduleNextTasksAndReleaseThreads();
 
     return childProcess;
@@ -1259,42 +1267,40 @@ export class TaskOrchestrator {
 
   // endregion utils
 
-  private registerContinuousTaskExitHandler(
-    runningTask: RunningTask,
+  private async handleContinuousTaskExit(
+    code: number,
     task: Task,
     groupId: number,
     ownsRunningTasksService: boolean
   ) {
-    runningTask.onExit(async (code) => {
-      // If cleanup already completed this task, nothing left to do
-      if (this.completedTasks[task.id] !== undefined) {
-        return;
-      }
+    // If cleanup already completed this task, nothing left to do
+    if (this.completedTasks[task.id] !== undefined) {
+      return;
+    }
 
-      const stoppingReason = this.runningContinuousTasks.get(
-        task.id
-      )?.stoppingReason;
-      if (stoppingReason || EXPECTED_TERMINATION_SIGNALS.has(code)) {
-        const reason =
-          stoppingReason === 'fulfilled' ? 'fulfilled' : 'interrupted';
-        await this.completeContinuousTask(
-          task,
-          groupId,
-          ownsRunningTasksService,
-          reason
-        );
-      } else {
-        console.error(
-          `Task "${task.id}" is continuous but exited with code ${code}`
-        );
-        await this.completeContinuousTask(
-          task,
-          groupId,
-          ownsRunningTasksService,
-          'crashed'
-        );
-      }
-    });
+    const stoppingReason = this.runningContinuousTasks.get(
+      task.id
+    )?.stoppingReason;
+    if (stoppingReason || EXPECTED_TERMINATION_SIGNALS.has(code)) {
+      const reason =
+        stoppingReason === 'fulfilled' ? 'fulfilled' : 'interrupted';
+      await this.completeContinuousTask(
+        task,
+        groupId,
+        ownsRunningTasksService,
+        reason
+      );
+    } else {
+      console.error(
+        `Task "${task.id}" is continuous but exited with code ${code}`
+      );
+      await this.completeContinuousTask(
+        task,
+        groupId,
+        ownsRunningTasksService,
+        'crashed'
+      );
+    }
   }
 
   private async completeContinuousTask(
@@ -1330,11 +1336,14 @@ export class TaskOrchestrator {
   }
 
   private async cleanup() {
-    if (this.cleanupDone) {
-      return;
+    if (this.cleanupPromise) {
+      return this.cleanupPromise;
     }
-    this.cleanupDone = true;
+    this.cleanupPromise = this.performCleanup();
+    return this.cleanupPromise;
+  }
 
+  private async performCleanup() {
     // Mark all running tasks for intentional stop
     const reason = this.stopRequested ? 'interrupted' : 'fulfilled';
     for (const entry of this.runningContinuousTasks.values()) {
@@ -1396,6 +1405,27 @@ export class TaskOrchestrator {
   private setupSignalHandlers() {
     process.once('SIGINT', () => {
       this.stopRequested = true;
+      if (!this.tuiEnabled) {
+        // Synchronously remove DB entries before async cleanup to prevent
+        // new nx processes from seeing stale "Waiting for ..." messages.
+        // This replicates the cleanup that process.exit() + Rust Drop
+        // previously provided.
+        for (const [taskId, { ownsRunningTasksService }] of this
+          .runningContinuousTasks) {
+          if (ownsRunningTasksService) {
+            this.runningTasksService?.removeRunningTask(taskId);
+          }
+        }
+        // Silence output — pnpm (and similar wrappers) may exit before nx
+        // finishes cleanup, returning the shell prompt. Any output after
+        // that point would appear after the prompt.
+        const noop = (_chunk, _encoding, callback) => {
+          if (callback) callback();
+          return true;
+        };
+        process.stdout.write = noop as any;
+        process.stderr.write = noop as any;
+      }
       this.cleanup().finally(() => {
         if (this.resolveStopPromise) {
           this.resolveStopPromise();
@@ -1405,6 +1435,7 @@ export class TaskOrchestrator {
       });
     });
     process.once('SIGTERM', () => {
+      this.stopRequested = true;
       this.cleanup().finally(() => {
         if (this.resolveStopPromise) {
           this.resolveStopPromise();
@@ -1412,6 +1443,7 @@ export class TaskOrchestrator {
       });
     });
     process.once('SIGHUP', () => {
+      this.stopRequested = true;
       this.cleanup().finally(() => {
         if (this.resolveStopPromise) {
           this.resolveStopPromise();


### PR DESCRIPTION
## Current Behavior

When pressing Ctrl+C on continuous tasks, `postTasksExecution` never fires because `process.exit()` in `running-tasks.ts` SIGINT handlers kills the process before the orchestrator can run async cleanup and lifecycle hooks.

## Expected Behavior

`postTasksExecution` fires reliably on Ctrl+C with complete task results, without causing stale `RunningTasksService` DB entries that block subsequent `nx` invocations with "Waiting for ... in another nx process" messages.

## Technical Details

Re-applies #34623 (reverted in #34869) with fixes for the issues that caused CI failures.

**Root cause of the revert**: Removing `process.exit()` from SIGINT handlers left the nx process alive during async cleanup. The `running_tasks` DB entry persisted with a still-alive PID, so new nx processes saw it as a running task and hung.

**Fix 1 — Early DB cleanup**: Synchronously remove all owned DB entries in the SIGINT handler *before* starting async cleanup. This replicates the cleanup that `process.exit()` + Rust `Drop` previously provided — from any external observer's perspective, the tasks are gone immediately.

**Fix 2 — Always register onExit in startContinuousTask**: The original PR added a guard that skipped `onExit` registration for initiating tasks, assuming `executeNextBatchOfTasksUsingTaskSchedule` would handle it. But `runContinuousTasks()` (used by DTE agents and Playwright) calls `startContinuousTask` directly without going through `run()`. The missing handler meant task exit was never processed — no DB cleanup, no lifecycle hooks. This caused verdaccio (local-registry) to become unreachable on DTE agents. The fix always registers `onExit` in `startContinuousTask` and simplifies the `executeNextBatchOfTasksUsingTaskSchedule` handler to only unblock the thread.

Changes:
- Remove `process.exit()` from `running-tasks.ts` SIGINT handlers (lets orchestrator run)
- Replace `cleanupDone` boolean with `cleanupPromise` (fixes SIGINT/SIGTERM race)
- Set `stopRequested = true` for SIGTERM/SIGHUP (correct task classification)
- Early synchronous DB cleanup in non-TUI SIGINT handler
- Always register `onExit` handler in `startContinuousTask` for both initiating and non-initiating tasks
- Simplify initiating task handler in `executeNextBatchOfTasksUsingTaskSchedule` to only call `res()`