### PR TITLE
fix(core): detect npm from package-lock.json before falling back to invoking PM

### DIFF
--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -156,10 +156,33 @@ describe('package-manager', () => {
       try {
         const packageManager = detectPackageManager();
         expect(packageManager).toEqual('npm');
-        expect(fs.existsSync).toHaveBeenCalledTimes(4);
+        expect(fs.existsSync).toHaveBeenCalledTimes(5);
       } finally {
         process.env.npm_config_user_agent = originalUserAgent;
       }
+    });
+
+    it('should detect npm package manager from package-lock.json', () => {
+      jest.spyOn(configModule, 'readNxJson').mockReturnValueOnce({});
+      jest.spyOn(fs, 'existsSync').mockImplementation((p) => {
+        switch (p) {
+          case 'yarn.lock':
+            return false;
+          case 'pnpm-lock.yaml':
+            return false;
+          case 'package-lock.json':
+            return true;
+          case 'bun.lockb':
+            return false;
+          case 'bun.lock':
+            return false;
+          default:
+            return jest.requireActual('fs').existsSync(p);
+        }
+      });
+      const packageManager = detectPackageManager();
+      expect(packageManager).toEqual('npm');
+      expect(fs.existsSync).toHaveBeenCalledTimes(5);
     });
 
     it('should detect pnpm from npm_config_user_agent when no lock file exists', () => {

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -69,7 +69,9 @@ export function detectPackageManager(dir: string = ''): PackageManager {
         ? 'yarn'
         : existsSync(join(dir, 'pnpm-lock.yaml'))
           ? 'pnpm'
-          : detectInvokedPackageManager())
+          : existsSync(join(dir, 'package-lock.json'))
+            ? 'npm'
+            : detectInvokedPackageManager())
   );
 }
 


### PR DESCRIPTION
## Current Behavior

When `detectPackageManager()` finds no lock file for bun, yarn, or pnpm, it falls back to `detectInvokedPackageManager()` which checks `npm_config_user_agent`. This causes misdetection when a workspace is created with npm (has `package-lock.json`) but the parent process uses pnpm — the detection picks up pnpm from the user agent instead of npm from the lock file.

This has been causing **every nightly E2E run to fail since March 4th** (when #34691 was merged), particularly in e2e-angular where `ng-add` tests create npm workspaces but `installPackagesTask` incorrectly invokes `pnpm install --no-frozen-lockfile`.

## Expected Behavior

`detectPackageManager()` should check for `package-lock.json` (npm's lock file) before falling back to the invoking package manager detection. This ensures that workspaces with a `package-lock.json` are correctly identified as npm workspaces regardless of what package manager invoked the current process.

## Related Issue(s)

Fixes the nightly E2E matrix failures in e2e-angular (`ng-add.test.ts`, `plugin.test.ts`), e2e-nx-init, and e2e-workspace-create that have been consistently failing since #34691 was merged.