### PR TITLE
fix(core): avoid overwhelming DB with connections during analytics init

### DIFF
--- a/packages/nx/src/analytics/analytics.ts
+++ b/packages/nx/src/analytics/analytics.ts
@@ -4,6 +4,7 @@ import { nxVersion } from '../utils/versions';
 import { IS_WASM } from '../native';
 import type {
   initializeTelemetry as InitializeTelemetryType,
+  initializeTelemetryWithSessionId as InitializeTelemetryWithSessionIdType,
   flushTelemetry as FlushTelemetryType,
   trackEvent as TrackEventType,
   trackPageView as TrackPageViewType,
@@ -23,6 +24,7 @@ import { getDbConnection } from '../utils/db-connection';
 
 // Conditionally import telemetry functions only on non-WASM platforms
 let initializeTelemetry: typeof InitializeTelemetryType;
+let initializeTelemetryWithSessionId: typeof InitializeTelemetryWithSessionIdType;
 let flushTelemetry: typeof FlushTelemetryType;
 let trackEventNative: typeof TrackEventType;
 let trackPageViewNative: typeof TrackPageViewType;
@@ -32,6 +34,8 @@ let getEventDimensions: typeof GetEventDimensionsType;
 if (!IS_WASM) {
   const nativeModule = require('../native');
   initializeTelemetry = nativeModule.initializeTelemetry;
+  initializeTelemetryWithSessionId =
+    nativeModule.initializeTelemetryWithSessionId;
   flushTelemetry = nativeModule.flushTelemetry;
   trackEventNative = nativeModule.trackEvent;
   trackPageViewNative = nativeModule.trackPageView;
@@ -73,23 +77,33 @@ export async function startAnalytics() {
     ? `${nodeVersion.major}.${nodeVersion.minor}.${nodeVersion.patch}`
     : 'unknown';
 
-  try {
-    const dbConnection = getDbConnection();
+  const commonArgs = [
+    workspaceId,
+    userId,
+    nxVersion,
+    packageManagerInfo.name,
+    packageManagerInfo.version,
+    nodeVersionString,
+    os.arch(),
+    os.platform(),
+    os.release(),
+    !!isCI(),
+    isNxCloud,
+  ] as const;
 
-    initializeTelemetry(
-      dbConnection,
-      workspaceId,
-      userId,
-      nxVersion,
-      packageManagerInfo.name,
-      packageManagerInfo.version,
-      nodeVersionString,
-      os.arch(),
-      os.platform(),
-      os.release(),
-      !!isCI(),
-      isNxCloud
-    );
+  try {
+    const sessionId = process.env.NX_ANALYTICS_SESSION_ID;
+
+    if (sessionId) {
+      // Plugin worker path — reuse session ID from parent, no DB needed
+      initializeTelemetryWithSessionId(sessionId, ...commonArgs);
+    } else {
+      // CLI/daemon path — get session from DB, set env var for children
+      const dbConnection = getDbConnection();
+      const newSessionId = initializeTelemetry(dbConnection, ...commonArgs);
+      process.env.NX_ANALYTICS_SESSION_ID = newSessionId;
+    }
+
     _telemetryInitialized = true;
 
     // Flush analytics automatically on process exit so every code path

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -380,11 +380,20 @@ export interface HashInputs {
 }
 
 /**
- * Initialize the global telemetry service.
- * Reads or creates a session ID from the database so that multiple CLI
- * invocations within 30 minutes share the same GA4 session.
+ * Initialize telemetry using a DB connection.
+ * Gets/creates the session ID from the DB, stores the connection
+ * for persisting session refreshes on flush, and returns the session ID
+ * so the caller can set it as an env var for child processes.
+ * Used by CLI and daemon.
  */
-export declare function initializeTelemetry(connection: ExternalObject<NxDbConnection>, workspaceId: string, userId: string, nxVersion: string, packageManagerName: string, packageManagerVersion: string | undefined | null, nodeVersion: string, osArch: string, osPlatform: string, osRelease: string, isCi: boolean, isNxCloud: boolean): void
+export declare function initializeTelemetry(connection: ExternalObject<NxDbConnection>, workspaceId: string, userId: string, nxVersion: string, packageManagerName: string, packageManagerVersion: string | undefined | null, nodeVersion: string, osArch: string, osPlatform: string, osRelease: string, isCi: boolean, isNxCloud: boolean): string
+
+/**
+ * Initialize telemetry with a pre-fetched session ID.
+ * No DB connection — used by plugin workers that inherit the
+ * session ID from their parent process via env var.
+ */
+export declare function initializeTelemetryWithSessionId(sessionId: string, workspaceId: string, userId: string, nxVersion: string, packageManagerName: string, packageManagerVersion: string | undefined | null, nodeVersion: string, osArch: string, osPlatform: string, osRelease: string, isCi: boolean, isNxCloud: boolean): void
 
 export interface InputsInput {
   input: string

--- a/packages/nx/src/native/native-bindings.js
+++ b/packages/nx/src/native/native-bindings.js
@@ -613,6 +613,7 @@ module.exports.GroupType = nativeBinding.GroupType
 module.exports.hashArray = nativeBinding.hashArray
 module.exports.hashFile = nativeBinding.hashFile
 module.exports.initializeTelemetry = nativeBinding.initializeTelemetry
+module.exports.initializeTelemetryWithSessionId = nativeBinding.initializeTelemetryWithSessionId
 module.exports.installNxConsole = nativeBinding.installNxConsole
 module.exports.installNxConsoleForEditor = nativeBinding.installNxConsoleForEditor
 module.exports.IS_WASM = nativeBinding.IS_WASM

--- a/packages/nx/src/native/telemetry/constants.rs
+++ b/packages/nx/src/native/telemetry/constants.rs
@@ -1,6 +1,9 @@
 pub const TRACKING_ID_PROD: &str = "G-BGPKPJK4PY";
 pub const GA_ENDPOINT: &str = "https://www.google-analytics.com/g/collect";
 pub const BATCH_INTERVAL_MS: u64 = 50;
+/// Session timeout in seconds (30 minutes). If no events are received
+/// within this window, a new session ID is generated.
+pub const SESSION_TIMEOUT_SECS: u64 = 30 * 60;
 
 // Google Analytics Measurement Protocol limits
 pub const MAX_EVENT_NAME_LENGTH: usize = 40;

--- a/packages/nx/src/native/telemetry/mod.rs
+++ b/packages/nx/src/native/telemetry/mod.rs
@@ -26,11 +26,9 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use crate::native::db::connection::NxDbConnection;
+use constants::SESSION_TIMEOUT_SECS;
 use constants::event_dimension;
-use service::TelemetryService;
-
-/// Session timeout in seconds (30 minutes)
-const SESSION_TIMEOUT_SECS: i64 = 30 * 60;
+use service::{TelemetryOptions, TelemetryService, persist_session_to_db};
 
 // Global telemetry instance for Rust code to use directly
 static GLOBAL_TELEMETRY: OnceCell<Arc<TelemetryService>> = OnceCell::new();
@@ -39,61 +37,12 @@ static GLOBAL_TELEMETRY: OnceCell<Arc<TelemetryService>> = OnceCell::new();
 // Public NAPI API
 // =============================================================================
 
-/// Initialize the global telemetry service.
-/// Reads or creates a session ID from the database so that multiple CLI
-/// invocations within 30 minutes share the same GA4 session.
-#[napi]
-pub fn initialize_telemetry(
-    #[napi(ts_arg_type = "ExternalObject<NxDbConnection>")] connection: &External<
-        Arc<Mutex<NxDbConnection>>,
-    >,
-    workspace_id: String,
-    user_id: String,
-    nx_version: String,
-    package_manager_name: String,
-    package_manager_version: Option<String>,
-    node_version: String,
-    os_arch: String,
-    os_platform: String,
-    os_release: String,
-    is_ci: bool,
-    is_nx_cloud: bool,
-) -> Result<()> {
-    tracing::trace!(
-        "Initializing telemetry service for workspace: {}",
-        workspace_id
-    );
-
-    let session_id = get_or_create_session_id(connection)?;
-
-    let service = TelemetryService::new(
-        workspace_id,
-        user_id,
-        session_id,
-        nx_version,
-        package_manager_name,
-        package_manager_version,
-        node_version,
-        os_arch,
-        os_platform,
-        os_release,
-        is_ci,
-        is_nx_cloud,
-    )?;
-
-    GLOBAL_TELEMETRY
-        .set(Arc::new(service))
-        .map_err(|_| Error::from_reason("Telemetry already initialized"))?;
-
-    tracing::debug!("Telemetry service initialized successfully");
-    Ok(())
-}
-
 /// Track an event using the global telemetry instance
 #[napi]
 pub fn track_event(event_name: String, parameters: Option<HashMap<String, String>>) -> Result<()> {
     tracing::trace!("Tracking event: {}", event_name);
     if let Some(telemetry) = GLOBAL_TELEMETRY.get() {
+        telemetry.persist_session_refreshes();
         telemetry.track_event_impl(event_name, parameters)?;
     } else {
         tracing::trace!("Telemetry not initialized, skipping event");
@@ -114,10 +63,110 @@ pub fn track_page_view(
         page_location
     );
     if let Some(telemetry) = GLOBAL_TELEMETRY.get() {
+        telemetry.persist_session_refreshes();
         telemetry.track_page_view_impl(page_title, page_location, parameters)?;
     } else {
         tracing::trace!("Telemetry not initialized, skipping page view");
     }
+    Ok(())
+}
+
+/// Initialize telemetry using a DB connection.
+/// Gets/creates the session ID from the DB, stores the connection
+/// for persisting session refreshes on flush, and returns the session ID
+/// so the caller can set it as an env var for child processes.
+/// Used by CLI and daemon.
+#[napi]
+pub fn initialize_telemetry(
+    #[napi(ts_arg_type = "ExternalObject<NxDbConnection>")] connection: &External<
+        Arc<Mutex<NxDbConnection>>,
+    >,
+    workspace_id: String,
+    user_id: String,
+    nx_version: String,
+    package_manager_name: String,
+    package_manager_version: Option<String>,
+    node_version: String,
+    os_arch: String,
+    os_platform: String,
+    os_release: String,
+    is_ci: bool,
+    is_nx_cloud: bool,
+) -> Result<String> {
+    tracing::trace!(
+        "Initializing telemetry service for workspace: {}",
+        workspace_id
+    );
+
+    let session_id = get_or_create_session_id(connection)?;
+
+    init_service(TelemetryOptions {
+        session_id: session_id.clone(),
+        db_connection: Some((**connection).clone()),
+        workspace_id,
+        user_id,
+        nx_version,
+        package_manager_name,
+        package_manager_version,
+        node_version,
+        os_arch,
+        os_platform,
+        os_release,
+        is_ci,
+        is_nx_cloud,
+    })?;
+
+    Ok(session_id)
+}
+
+/// Initialize telemetry with a pre-fetched session ID.
+/// No DB connection — used by plugin workers that inherit the
+/// session ID from their parent process via env var.
+#[napi]
+pub fn initialize_telemetry_with_session_id(
+    session_id: String,
+    workspace_id: String,
+    user_id: String,
+    nx_version: String,
+    package_manager_name: String,
+    package_manager_version: Option<String>,
+    node_version: String,
+    os_arch: String,
+    os_platform: String,
+    os_release: String,
+    is_ci: bool,
+    is_nx_cloud: bool,
+) -> Result<()> {
+    tracing::trace!(
+        "Initializing telemetry service (session from env) for workspace: {}",
+        workspace_id
+    );
+
+    init_service(TelemetryOptions {
+        session_id,
+        workspace_id,
+        user_id,
+        nx_version,
+        package_manager_name,
+        package_manager_version,
+        node_version,
+        os_arch,
+        os_platform,
+        os_release,
+        is_ci,
+        is_nx_cloud,
+        db_connection: None,
+    })
+}
+
+fn init_service(opts: TelemetryOptions) -> Result<()> {
+    let service = TelemetryService::new(opts)?;
+
+    GLOBAL_TELEMETRY
+        .set(Arc::new(service))
+        .map_err(|_| Error::from_reason("Telemetry already initialized"))?;
+
+    tracing::debug!("Telemetry service initialized successfully");
     Ok(())
 }
 
@@ -126,6 +175,7 @@ pub fn track_page_view(
 #[napi]
 pub fn flush_telemetry() -> Result<()> {
     if let Some(telemetry) = GLOBAL_TELEMETRY.get() {
+        telemetry.persist_session_refreshes();
         telemetry.flush()?;
     }
     Ok(())
@@ -178,7 +228,7 @@ pub fn track_rust_event(event_name: impl Into<String>, parameters: HashMap<Strin
 /// Reuses an existing session if the last activity was within 30 minutes,
 /// otherwise creates a new session.
 fn get_or_create_session_id(connection: &External<Arc<Mutex<NxDbConnection>>>) -> Result<String> {
-    let conn = connection
+    let mut conn = connection
         .lock()
         .map_err(|e| Error::from_reason(format!("Failed to lock database connection: {}", e)))?;
 
@@ -189,7 +239,7 @@ fn get_or_create_session_id(connection: &External<Arc<Mutex<NxDbConnection>>>) -
                 "SELECT m1.value FROM metadata m1, metadata m2 \
                  WHERE m1.key = 'SESSION_ID' AND m2.key = 'SESSION_LAST_ACTIVITY' \
                  AND (strftime('%s', 'now') - strftime('%s', m2.value)) < {}",
-                SESSION_TIMEOUT_SECS
+                SESSION_TIMEOUT_SECS as i64
             ),
             [],
             |row| row.get::<_, String>(0),
@@ -201,21 +251,12 @@ fn get_or_create_session_id(connection: &External<Arc<Mutex<NxDbConnection>>>) -
         id
     } else {
         let id = uuid::Uuid::new_v4().to_string();
-        conn.execute(
-            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('SESSION_ID', ?1)",
-            [&id],
-        )
-        .map_err(|e| Error::from_reason(format!("Failed to save session ID: {}", e)))?;
         tracing::trace!("Created new analytics session: {}", id);
         id
     };
 
-    // Always update last activity timestamp
-    conn.execute(
-        "INSERT OR REPLACE INTO metadata (key, value) VALUES ('SESSION_LAST_ACTIVITY', datetime('now'))",
-        [],
-    )
-    .map_err(|e| Error::from_reason(format!("Failed to update session activity: {}", e)))?;
+    // Persist session ID and update activity timestamp
+    persist_session_to_db(&mut conn, &session_id);
 
     Ok(session_id)
 }

--- a/packages/nx/src/native/telemetry/service.rs
+++ b/packages/nx/src/native/telemetry/service.rs
@@ -24,28 +24,43 @@ pub(crate) struct PageViewData {
     pub parameters: ParameterMap,
 }
 
+/// Configuration for initializing the telemetry service.
+pub(crate) struct TelemetryOptions {
+    pub session_id: String,
+    pub workspace_id: String,
+    pub user_id: String,
+    pub nx_version: String,
+    pub package_manager_name: String,
+    pub package_manager_version: Option<String>,
+    pub node_version: String,
+    pub os_arch: String,
+    pub os_platform: String,
+    pub os_release: String,
+    pub is_ci: bool,
+    pub is_nx_cloud: bool,
+    pub db_connection: Option<DbConnection>,
+}
+
+/// Type alias for the DB connection shared between modules.
+pub(crate) type DbConnection =
+    std::sync::Arc<std::sync::Mutex<crate::native::db::connection::NxDbConnection>>;
+
 /// Internal telemetry service - not exposed to JavaScript
 pub struct TelemetryService {
     event_tx: Mutex<Option<Sender<EventData>>>,
     page_view_tx: Mutex<Option<Sender<PageViewData>>>,
     flush_tx: Sender<Sender<Result<()>>>,
+    /// Receives new session IDs from the background thread when it
+    /// refreshes a stale session. The main thread drains this and
+    /// persists to the DB.
+    session_refresh_rx: Receiver<String>,
+    /// Optional DB connection for persisting session refreshes.
+    /// Only set by CLI/daemon, not by plugin workers.
+    db_connection: Option<DbConnection>,
 }
 
 impl TelemetryService {
-    pub fn new(
-        workspace_id: String,
-        user_id: String,
-        session_id: String,
-        nx_version: String,
-        package_manager_name: String,
-        package_manager_version: Option<String>,
-        node_version: String,
-        os_arch: String,
-        os_platform: String,
-        os_release: String,
-        is_ci: bool,
-        is_nx_cloud: bool,
-    ) -> Result<Self> {
+    pub fn new(opts: TelemetryOptions) -> Result<Self> {
         let client = ClientBuilder::new()
             .build()
             .map_err(|e| Error::from_reason(format!("Failed to create HTTP client: {}", e)))?;
@@ -56,23 +71,26 @@ impl TelemetryService {
         let mut common_request_parameters = HashMap::new();
         common_request_parameters
             .insert(request_param::PROTOCOL_VERSION.to_string(), "2".to_string());
-        common_request_parameters
-            .insert(request_param::CLIENT_ID.to_string(), workspace_id.clone());
-        common_request_parameters.insert(request_param::USER_ID.to_string(), user_id.clone());
+        common_request_parameters.insert(
+            request_param::CLIENT_ID.to_string(),
+            opts.workspace_id.clone(),
+        );
+        common_request_parameters.insert(request_param::USER_ID.to_string(), opts.user_id.clone());
         common_request_parameters.insert(
             request_param::TRACKING_ID.to_string(),
             TRACKING_ID_PROD.to_string(),
         );
-        common_request_parameters.insert(request_param::SESSION_ID.to_string(), session_id);
         common_request_parameters.insert(
             request_param::USER_AGENT_ARCHITECTURE.to_string(),
-            os_arch.clone(),
+            opts.os_arch.clone(),
         );
-        common_request_parameters
-            .insert(request_param::USER_AGENT_PLATFORM.to_string(), os_platform);
+        common_request_parameters.insert(
+            request_param::USER_AGENT_PLATFORM.to_string(),
+            opts.os_platform,
+        );
         common_request_parameters.insert(
             request_param::USER_AGENT_PLATFORM_VERSION.to_string(),
-            os_release,
+            opts.os_release,
         );
         common_request_parameters.insert(
             request_param::USER_AGENT_MOBILE.to_string(),
@@ -91,32 +109,36 @@ impl TelemetryService {
         }
 
         let mut user_parameters = HashMap::new();
-        user_parameters.insert(user_dimension::OS_ARCHITECTURE.to_string(), os_arch);
-        user_parameters.insert(user_dimension::USER_ID.to_string(), user_id);
-        user_parameters.insert(user_dimension::NODE_VERSION.to_string(), node_version);
+        user_parameters.insert(user_dimension::OS_ARCHITECTURE.to_string(), opts.os_arch);
+        user_parameters.insert(user_dimension::USER_ID.to_string(), opts.user_id);
+        user_parameters.insert(user_dimension::NODE_VERSION.to_string(), opts.node_version);
         user_parameters.insert(
             user_dimension::PACKAGE_MANAGER.to_string(),
-            package_manager_name,
+            opts.package_manager_name,
         );
-        if let Some(version) = package_manager_version {
+        if let Some(version) = opts.package_manager_version {
             user_parameters.insert(user_dimension::PACKAGE_MANAGER_VERSION.to_string(), version);
         }
-        user_parameters.insert(user_dimension::NX_VERSION.to_string(), nx_version.clone());
-        user_parameters.insert(event_dimension::NX_VERSION.to_string(), nx_version);
+        user_parameters.insert(
+            user_dimension::NX_VERSION.to_string(),
+            opts.nx_version.clone(),
+        );
+        user_parameters.insert(event_dimension::NX_VERSION.to_string(), opts.nx_version);
         user_parameters.insert(
             event_dimension::IS_AI_AGENT.to_string(),
             is_ai_agent.to_string(),
         );
-        user_parameters.insert(user_dimension::IS_CI.to_string(), is_ci.to_string());
+        user_parameters.insert(user_dimension::IS_CI.to_string(), opts.is_ci.to_string());
         user_parameters.insert(
             user_dimension::NX_CLOUD_ENABLED.to_string(),
-            is_nx_cloud.to_string(),
+            opts.is_nx_cloud.to_string(),
         );
 
         // Create channels
         let (event_tx, event_rx) = crossbeam_channel::unbounded();
         let (page_view_tx, page_view_rx) = crossbeam_channel::unbounded();
         let (flush_tx, flush_rx) = crossbeam_channel::unbounded();
+        let (session_refresh_tx, session_refresh_rx) = crossbeam_channel::unbounded();
 
         // Spawn background sender thread
         let common_params = common_request_parameters.clone();
@@ -126,9 +148,11 @@ impl TelemetryService {
                 client,
                 common_params,
                 user_params,
+                opts.session_id,
                 event_rx,
                 page_view_rx,
                 flush_rx,
+                session_refresh_tx,
             )
         });
 
@@ -136,7 +160,33 @@ impl TelemetryService {
             event_tx: Mutex::new(Some(event_tx)),
             page_view_tx: Mutex::new(Some(page_view_tx)),
             flush_tx,
+            session_refresh_rx,
+            db_connection: opts.db_connection,
         })
+    }
+
+    /// Drain any session refreshes from the background thread, persist
+    /// the latest one to the DB (if a connection is available), and
+    /// update the env var so child processes inherit the new session.
+    pub fn persist_session_refreshes(&self) {
+        let mut latest = None;
+        while let Ok(session_id) = self.session_refresh_rx.try_recv() {
+            latest = Some(session_id);
+        }
+        if let Some(ref new_session_id) = latest {
+            // SAFETY: Called from Node's main JS thread during flush.
+            // No concurrent env access — Node is single-threaded for JS
+            // and our Rust background thread doesn't read env vars.
+            unsafe {
+                std::env::set_var("NX_ANALYTICS_SESSION_ID", new_session_id);
+            }
+
+            if let Some(conn) = &self.db_connection {
+                if let Ok(mut conn) = conn.lock() {
+                    persist_session_to_db(&mut conn, new_session_id);
+                }
+            }
+        }
     }
 
     pub fn track_event_impl(
@@ -257,15 +307,25 @@ fn background_sender(
     client: Client,
     common_params: ParameterMap,
     user_params: ParameterMap,
+    initial_session_id: String,
     event_rx: Receiver<EventData>,
     page_view_rx: Receiver<PageViewData>,
     flush_rx: Receiver<Sender<Result<()>>>,
+    session_refresh_tx: Sender<String>,
 ) {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
         .expect("Failed to create tokio runtime for telemetry");
 
+    let mut common_params = common_params;
+    // Insert initial session ID into common params. SessionState.touch()
+    // will update it in-place only when the session actually refreshes.
+    common_params.insert(
+        request_param::SESSION_ID.to_string(),
+        initial_session_id.clone(),
+    );
+    let mut session = SessionState::new(initial_session_id, session_refresh_tx);
     let mut event_queue = Vec::new();
     let mut page_view_queue = Vec::new();
     let mut last_send = std::time::Instant::now();
@@ -289,6 +349,7 @@ fn background_sender(
             recv(page_view_rx) -> msg => {
                 match msg {
                     Ok(page_view) => {
+                        session.touch(&mut common_params);
                         tracing::trace!("Queuing page view: {}", page_view.title);
                         enqueue_page_view(page_view, &user_params, &mut page_view_queue);
                     }
@@ -298,6 +359,7 @@ fn background_sender(
             recv(event_rx) -> msg => {
                 match msg {
                     Ok(event) => {
+                        session.touch(&mut common_params);
                         tracing::trace!("Queuing event: {}", event.name);
                         enqueue_event(event, &user_params, &mut event_queue);
                     }
@@ -339,6 +401,64 @@ fn background_sender(
         &mut event_queue,
         &mut page_view_queue,
     ));
+}
+
+/// Write a session ID and activity timestamp to the metadata table
+/// inside a single transaction.
+pub(crate) fn persist_session_to_db(
+    conn: &mut crate::native::db::connection::NxDbConnection,
+    session_id: &str,
+) {
+    let sid = session_id.to_string();
+    let _ = conn.transaction(move |tx| {
+        tx.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('SESSION_ID', ?1)",
+            [&sid],
+        )?;
+        tx.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) \
+             VALUES ('SESSION_LAST_ACTIVITY', datetime('now'))",
+            [],
+        )?;
+        Ok(())
+    });
+}
+
+/// Tracks the current session ID and refreshes it after inactivity.
+/// When a refresh happens, the new session ID is sent to the main thread
+/// via a channel so it can be persisted to the DB.
+struct SessionState {
+    session_id: String,
+    last_activity: std::time::Instant,
+    refresh_tx: Sender<String>,
+}
+
+impl SessionState {
+    fn new(session_id: String, refresh_tx: Sender<String>) -> Self {
+        Self {
+            session_id,
+            last_activity: std::time::Instant::now(),
+            refresh_tx,
+        }
+    }
+
+    /// Called when a new event or page view is received.
+    /// If the session has been idle for longer than the timeout,
+    /// generates a new session ID, updates common_params in-place,
+    /// and notifies the main thread so it can persist to the DB.
+    fn touch(&mut self, common_params: &mut ParameterMap) {
+        if self.last_activity.elapsed() >= Duration::from_secs(SESSION_TIMEOUT_SECS) {
+            self.session_id = uuid::Uuid::new_v4().to_string();
+            let id = self.session_id.clone();
+            common_params.insert(request_param::SESSION_ID.to_string(), id.clone());
+            let _ = self.refresh_tx.send(id);
+            tracing::debug!(
+                "Session idle for >30 min, starting new session: {}",
+                self.session_id
+            );
+        }
+        self.last_activity = std::time::Instant::now();
+    }
 }
 
 fn log_page_view(level: &str, prefix: &str, title: &Option<String>, location: &Option<String>) {


### PR DESCRIPTION
## Current Behavior

Every process that initializes analytics opens its own DB connection to get/create a session ID. This includes the CLI, the daemon, and **every plugin worker**. In workspaces with many plugins, dozens of plugin workers spawn simultaneously, each opening a DB connection and querying/writing session metadata. This overwhelms the SQLite database with concurrent connections and causes failures.

## How This Fixes It

The root cause is that plugin workers each independently open a DB connection just to read the session ID. The fix eliminates this by having the parent process (CLI or daemon) fetch the session ID once and pass it to child processes via the `NX_ANALYTICS_SESSION_ID` environment variable. Plugin workers inherit this env var and initialize telemetry without touching the DB at all.

| Process | Before | After |
|---------|--------|-------|
| CLI | Opens DB connection | Opens DB connection (1x) |
| Daemon | Opens DB connection | Opens DB connection (1x) |
| Plugin worker (×N) | Each opens DB connection | Reads env var, **no DB connection** |

In a workspace with 20 plugins, this reduces DB connections from 22 (CLI + daemon + 20 workers) down to 2 (CLI + daemon only).

## Two Initialization Paths

- **`initializeTelemetry(dbConnection, ...)`** — Used by CLI and daemon. Gets/creates the session ID from the DB via a transaction, stores the connection for persisting session refreshes on flush, and returns the session ID so the caller can set it as an env var for child processes.
- **`initializeTelemetryWithSessionId(sessionId, ...)`** — Used by plugin workers. Takes the session ID inherited from the parent process env var. No DB connection, no DB queries.

## Session Refresh for Long-Lived Processes

The daemon is long-lived and could hold a stale session ID for hours. The telemetry background thread now tracks activity and generates a new session ID after 30 minutes of inactivity (matching the existing GA4 session timeout). When a session refreshes, the background thread notifies the main thread via a channel, which persists the new session to the DB in a transaction on flush.

## Other Changes

- Extracted `TelemetryOptions` struct to replace the long parameter list in `TelemetryService::new`
- Moved `SESSION_TIMEOUT_SECS` to `constants.rs` so it can be shared between modules
- Extracted `init_service` helper to deduplicate between the two init paths
- Extracted `persist_session_to_db` helper that wraps both metadata writes in a transaction
- Separated session ID retrieval (`get_or_create_session_id`) from telemetry service initialization

## Related Issue(s)

Fixes database connection exhaustion when many plugin workers initialize analytics simultaneously.