### PR TITLE
fix(core): share .agents skills dir across codex, cursor, gemini

### DIFF
--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -276,18 +276,27 @@ export async function setupAiAgentsGeneratorImpl(
   if (aiConfigRepoPath) {
     const repoPath = aiConfigRepoPath;
 
+    // Shared skills directory used by codex, cursor, and gemini
+    const sharedSkillsSrc = join(repoPath, 'generated/.agents');
+    if (existsSync(sharedSkillsSrc)) {
+      generateFiles(
+        tree,
+        sharedSkillsSrc,
+        join(options.directory, '.agents'),
+        {}
+      );
+    }
+
+    // Agent-specific directories (commands, agents, config)
     const agentDirs: { agent: Agent; src: string; dest: string }[] = [
       { agent: 'opencode', src: 'generated/.opencode', dest: '.opencode' },
       { agent: 'copilot', src: 'generated/.github', dest: '.github' },
       { agent: 'cursor', src: 'generated/.cursor', dest: '.cursor' },
-      { agent: 'cursor', src: 'generated/.agents', dest: '.agents' },
-      { agent: 'codex', src: 'generated/.agents', dest: '.agents' },
       {
         agent: 'codex',
         src: 'generated/.codex/agents',
         dest: '.codex/agents',
       },
-      { agent: 'gemini', src: 'generated/.agents', dest: '.agents' },
       { agent: 'gemini', src: 'generated/.gemini', dest: '.gemini' },
     ];
 

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -276,23 +276,22 @@ export async function setupAiAgentsGeneratorImpl(
   if (aiConfigRepoPath) {
     const repoPath = aiConfigRepoPath;
 
-    const agentDirs: { agent: Agent | Agent[]; src: string; dest: string }[] =
-      [
-        { agent: 'opencode', src: 'generated/.opencode', dest: '.opencode' },
-        { agent: 'copilot', src: 'generated/.github', dest: '.github' },
-        { agent: 'cursor', src: 'generated/.cursor', dest: '.cursor' },
-        {
-          agent: ['codex', 'cursor', 'gemini'],
-          src: 'generated/.agents',
-          dest: '.agents',
-        },
-        {
-          agent: 'codex',
-          src: 'generated/.codex/agents',
-          dest: '.codex/agents',
-        },
-        { agent: 'gemini', src: 'generated/.gemini', dest: '.gemini' },
-      ];
+    const agentDirs: { agent: Agent | Agent[]; src: string; dest: string }[] = [
+      { agent: 'opencode', src: 'generated/.opencode', dest: '.opencode' },
+      { agent: 'copilot', src: 'generated/.github', dest: '.github' },
+      { agent: 'cursor', src: 'generated/.cursor', dest: '.cursor' },
+      {
+        agent: ['codex', 'cursor', 'gemini'],
+        src: 'generated/.agents',
+        dest: '.agents',
+      },
+      {
+        agent: 'codex',
+        src: 'generated/.codex/agents',
+        dest: '.codex/agents',
+      },
+      { agent: 'gemini', src: 'generated/.gemini', dest: '.gemini' },
+    ];
 
     for (const { agent, src, dest } of agentDirs) {
       const agents = Array.isArray(agent) ? agent : [agent];

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -277,14 +277,16 @@ export async function setupAiAgentsGeneratorImpl(
     const repoPath = aiConfigRepoPath;
 
     // Shared skills directory used by codex, cursor, and gemini
-    const sharedSkillsSrc = join(repoPath, 'generated/.agents');
-    if (existsSync(sharedSkillsSrc)) {
-      generateFiles(
-        tree,
-        sharedSkillsSrc,
-        join(options.directory, '.agents'),
-        {}
-      );
+    if (hasAgent('codex') || hasAgent('cursor') || hasAgent('gemini')) {
+      const sharedSkillsSrc = join(repoPath, 'generated/.agents');
+      if (existsSync(sharedSkillsSrc)) {
+        generateFiles(
+          tree,
+          sharedSkillsSrc,
+          join(options.directory, '.agents'),
+          {}
+        );
+      }
     }
 
     // Agent-specific directories (commands, agents, config)

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -276,21 +276,27 @@ export async function setupAiAgentsGeneratorImpl(
   if (aiConfigRepoPath) {
     const repoPath = aiConfigRepoPath;
 
-    const agentDirs: { agent: Agent; src: string; dest: string }[] = [
-      { agent: 'opencode', src: 'generated/.opencode', dest: '.opencode' },
-      { agent: 'copilot', src: 'generated/.github', dest: '.github' },
-      { agent: 'cursor', src: 'generated/.cursor', dest: '.cursor' },
-      { agent: 'codex', src: 'generated/.agents', dest: '.agents' },
-      {
-        agent: 'codex',
-        src: 'generated/.codex/agents',
-        dest: '.codex/agents',
-      },
-      { agent: 'gemini', src: 'generated/.gemini', dest: '.gemini' },
-    ];
+    const agentDirs: { agent: Agent | Agent[]; src: string; dest: string }[] =
+      [
+        { agent: 'opencode', src: 'generated/.opencode', dest: '.opencode' },
+        { agent: 'copilot', src: 'generated/.github', dest: '.github' },
+        { agent: 'cursor', src: 'generated/.cursor', dest: '.cursor' },
+        {
+          agent: ['codex', 'cursor', 'gemini'],
+          src: 'generated/.agents',
+          dest: '.agents',
+        },
+        {
+          agent: 'codex',
+          src: 'generated/.codex/agents',
+          dest: '.codex/agents',
+        },
+        { agent: 'gemini', src: 'generated/.gemini', dest: '.gemini' },
+      ];
 
     for (const { agent, src, dest } of agentDirs) {
-      if (hasAgent(agent)) {
+      const agents = Array.isArray(agent) ? agent : [agent];
+      if (agents.some((a) => hasAgent(a))) {
         const srcPath = join(repoPath, src);
         if (existsSync(srcPath)) {
           generateFiles(tree, srcPath, join(options.directory, dest), {});

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -276,26 +276,23 @@ export async function setupAiAgentsGeneratorImpl(
   if (aiConfigRepoPath) {
     const repoPath = aiConfigRepoPath;
 
-    const agentDirs: { agent: Agent | Agent[]; src: string; dest: string }[] = [
+    const agentDirs: { agent: Agent; src: string; dest: string }[] = [
       { agent: 'opencode', src: 'generated/.opencode', dest: '.opencode' },
       { agent: 'copilot', src: 'generated/.github', dest: '.github' },
       { agent: 'cursor', src: 'generated/.cursor', dest: '.cursor' },
-      {
-        agent: ['codex', 'cursor', 'gemini'],
-        src: 'generated/.agents',
-        dest: '.agents',
-      },
+      { agent: 'cursor', src: 'generated/.agents', dest: '.agents' },
+      { agent: 'codex', src: 'generated/.agents', dest: '.agents' },
       {
         agent: 'codex',
         src: 'generated/.codex/agents',
         dest: '.codex/agents',
       },
+      { agent: 'gemini', src: 'generated/.agents', dest: '.agents' },
       { agent: 'gemini', src: 'generated/.gemini', dest: '.gemini' },
     ];
 
     for (const { agent, src, dest } of agentDirs) {
-      const agents = Array.isArray(agent) ? agent : [agent];
-      if (agents.some((a) => hasAgent(a))) {
+      if (hasAgent(agent)) {
         const srcPath = join(repoPath, src);
         if (existsSync(srcPath)) {
           generateFiles(tree, srcPath, join(options.directory, dest), {});


### PR DESCRIPTION
## Summary
- The upstream config repo (nx-ai-agents-config) now generates skills into a shared `.agents/skills/` directory instead of separate per-agent skills directories for codex, cursor, and gemini.
- Updated the `agentDirs` mapping so `.agents` is copied when any of codex, cursor, or gemini are enabled, not just codex.
- Widened the `agent` field type from `Agent` to `Agent | Agent[]` to support mapping a single directory to multiple agents.

## Key decisions
- Used `Agent | Agent[]` union type rather than always-array to minimize changes to existing single-agent entries. The loop normalizes with `Array.isArray` before checking.