### PR TITLE
feat(misc): track server page views for AI traffic using Netlify-Agent-Category

### DIFF
--- a/netlify/edge-functions/rewrite-framer-urls.ts
+++ b/netlify/edge-functions/rewrite-framer-urls.ts
@@ -1,6 +1,69 @@
 import type { Context } from 'https://edge.netlify.com';
 
 const framerUrl = Netlify.env.get('NEXT_PUBLIC_FRAMER_URL');
+const GA_MEASUREMENT_ID =
+  Netlify.env.get('GA_MEASUREMENT_ID') || 'G-XXXXXXXXXX';
+const GA_API_SECRET = Netlify.env.get('GA_API_SECRET') || '';
+
+// GA4 tracking — must live here because Framer-proxied responses skip context.next(),
+// so track-page-requests.ts never fires for these paths due to alphabetical ordering.
+// https://docs.netlify.com/build/edge-functions/declarations/#declaration-processing-order
+
+function getClientId(request: Request): string {
+  const cookies = request.headers.get('cookie') || '';
+  const gaMatch = cookies.match(/_ga=GA\d+\.\d+\.(\d+\.\d+)/);
+  if (gaMatch) return gaMatch[1];
+
+  const timestamp = Date.now();
+  const random = Math.floor(Math.random() * 1000000000);
+  return `${random}.${timestamp}`;
+}
+
+async function sendToGA4(
+  request: Request,
+  context: Context,
+  pathname: string
+): Promise<void> {
+  if (!GA_API_SECRET) return;
+
+  const clientId = getClientId(request);
+  const userAgent = request.headers.get('user-agent') || 'unknown';
+  // https://docs.netlify.com/build/user-agent-categories/
+  const agentCategory = request.headers.get('netlify-agent-category') || 'none';
+  const isAITool = agentCategory.startsWith('ai-agent');
+  const isGenericBot = agentCategory.startsWith('crawler');
+
+  const payload = {
+    client_id: clientId,
+    events: [
+      {
+        name: 'server_page_view',
+        params: {
+          page_location: request.url,
+          page_title: pathname,
+          page_path: pathname,
+          content_type: 'text/html',
+          file_extension: '.html',
+          user_agent: userAgent,
+          is_ai_tool: isAITool ? 'true' : 'false',
+          is_bot: isGenericBot ? 'true' : 'false',
+          country: context.geo?.country?.code || 'unknown',
+        },
+      },
+    ],
+  };
+
+  const endpoint = `https://www.google-analytics.com/mp/collect?measurement_id=${GA_MEASUREMENT_ID}&api_secret=${GA_API_SECRET}`;
+
+  try {
+    await fetch(endpoint, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  } catch (error) {
+    console.error('Failed to send to GA4:', error);
+  }
+}
 
 /**
  * Paths that should be served by the Next.js app instead of Framer.
@@ -58,6 +121,8 @@ export default async function handler(
 
   // This handles canonical URLs, og:url, and any other references
   const rewrittenHtml = html.replaceAll(framerUrl, 'https://nx.dev');
+
+  context.waitUntil(sendToGA4(request, context, pathname));
 
   const newHeaders = new Headers(response.headers);
   newHeaders.set('x-nx-edge-function', 'framer-proxy');

--- a/netlify/edge-functions/track-asset-requests.ts
+++ b/netlify/edge-functions/track-asset-requests.ts
@@ -1,20 +1,14 @@
 import type { Context } from 'https://edge.netlify.com';
 
-// Configuration - set these in Netlify environment variables
 const GA_MEASUREMENT_ID =
   Netlify.env.get('GA_MEASUREMENT_ID') || 'G-XXXXXXXXXX';
 const GA_API_SECRET = Netlify.env.get('GA_API_SECRET') || '';
 
 function getClientId(request: Request): string {
-  // Try to extract existing GA client ID from cookie
   const cookies = request.headers.get('cookie') || '';
   const gaMatch = cookies.match(/_ga=GA\d+\.\d+\.(\d+\.\d+)/);
-  if (gaMatch) {
-    return gaMatch[1];
-  }
+  if (gaMatch) return gaMatch[1];
 
-  // Generate a new client ID for this request
-  // For non-browser clients (AI tools), this creates a session-based ID
   const timestamp = Date.now();
   const random = Math.floor(Math.random() * 1000000000);
   return `${random}.${timestamp}`;
@@ -32,22 +26,11 @@ async function sendToGA4(
 
   const clientId = getClientId(request);
   const userAgent = request.headers.get('user-agent') || 'unknown';
-
-  // Anthropic:   ClaudeBot (training), Claude-User (user fetch), Claude-SearchBot (search index),
-  //              Claude-Web (web crawler), anthropic-ai (legacy training)
-  // OpenAI:      GPTBot (training), ChatGPT-User (user browsing), OAI-SearchBot (search index)
-  // Perplexity:  PerplexityBot (search index), Perplexity-User (user fetch)
-  // Google:      Google-Extended (AI/Gemini training)
-  // Other:       Bytespider (ByteDance training)
-  const isAITool =
-    /ClaudeBot|Claude-User|Claude-SearchBot|Claude-Web|anthropic-ai|GPTBot|ChatGPT-User|OAI-SearchBot|PerplexityBot|Perplexity-User|Google-Extended|Bytespider/i.test(
-      userAgent
-    );
-  // Generic bots (SEO crawlers, social previews, etc.)
-  const isGenericBot =
-    /Googlebot|Amazonbot|CCBot|BingBot|YandexBot|DuckDuckBot|Applebot|crawler|spider|slurp|facebook|twitter|linkedin|slack|discord|telegram/i.test(
-      userAgent
-    );
+  // Use Netlify's built-in agent categorization header
+  // See: https://docs.netlify.com/build/user-agent-categories/
+  const agentCategory = request.headers.get('netlify-agent-category') || 'none';
+  const isAITool = agentCategory.startsWith('ai-agent');
+  const isGenericBot = agentCategory.startsWith('crawler');
 
   const payload = {
     client_id: clientId,
@@ -58,7 +41,6 @@ async function sendToGA4(
           page_location: request.url,
           page_title: pathname,
           page_path: pathname,
-          // Custom parameters for filtering
           content_type: pathname.endsWith('.txt')
             ? 'text/plain'
             : 'text/markdown',
@@ -82,7 +64,6 @@ async function sendToGA4(
       body: JSON.stringify(payload),
     });
   } catch (error) {
-    // Log but don't fail the request
     console.error('Failed to send to GA4:', error);
   }
 }
@@ -91,16 +72,11 @@ export default async function handler(
   request: Request,
   context: Context
 ): Promise<Response> {
-  const url = new URL(request.url);
-  const pathname = url.pathname;
+  const pathname = new URL(request.url).pathname;
 
-  // Send analytics in background (non-blocking)
   context.waitUntil(sendToGA4(request, context, pathname));
 
-  // Continue to serve the actual file
   const response = await context.next();
-
-  // Netlify Edge Function responses are immutable, so create a new Response
   const newHeaders = new Headers(response.headers);
   newHeaders.set('x-nx-edge-function', 'track-asset-requests');
 
@@ -113,6 +89,5 @@ export default async function handler(
 
 export const config = {
   path: ['/**/*.txt', '/**/*.md'],
-  // Something is adding .png.md and .svg.md to get image paths, exclude those.
   excludedPath: ['/docs/og/*', '/docs/*.svg.md', '/docs/*.png.md'],
 };

--- a/netlify/edge-functions/track-page-requests.ts
+++ b/netlify/edge-functions/track-page-requests.ts
@@ -26,21 +26,11 @@ async function sendToGA4(
 
   const clientId = getClientId(request);
   const userAgent = request.headers.get('user-agent') || 'unknown';
-  // Anthropic:   ClaudeBot (training), Claude-User (user fetch), Claude-SearchBot (search index),
-  //              Claude-Web (web crawler), anthropic-ai (legacy training)
-  // OpenAI:      GPTBot (training), ChatGPT-User (user browsing), OAI-SearchBot (search index)
-  // Perplexity:  PerplexityBot (search index), Perplexity-User (user fetch)
-  // Google:      Google-Extended (AI/Gemini training)
-  // Other:       Bytespider (ByteDance training)
-  const isAITool =
-    /ClaudeBot|Claude-User|Claude-SearchBot|Claude-Web|anthropic-ai|GPTBot|ChatGPT-User|OAI-SearchBot|PerplexityBot|Perplexity-User|Google-Extended|Bytespider/i.test(
-      userAgent
-    );
-  // Generic bots (SEO crawlers, social previews, etc.)
-  const isGenericBot =
-    /Googlebot|Amazonbot|CCBot|BingBot|YandexBot|DuckDuckBot|Applebot|crawler|spider|slurp|facebook|twitter|linkedin|slack|discord|telegram/i.test(
-      userAgent
-    );
+  // Use Netlify's built-in agent categorization header
+  // See: https://docs.netlify.com/build/user-agent-categories/
+  const agentCategory = request.headers.get('netlify-agent-category') || 'none';
+  const isAITool = agentCategory.startsWith('ai-agent');
+  const isGenericBot = agentCategory.startsWith('crawler');
 
   const payload = {
     client_id: clientId,
@@ -82,7 +72,6 @@ export default async function handler(
 ): Promise<Response> {
   const pathname = new URL(request.url).pathname;
 
-  // Always track - filtering is done at config level via `accept: ['text/html']`
   context.waitUntil(sendToGA4(request, context, pathname));
 
   const response = await context.next();
@@ -97,32 +86,44 @@ export default async function handler(
 }
 
 export const config = {
-  path: ['/docs/*'],
-  // Only track requests from clients that want HTML (browsers)
-  // This filters out curl, AI agents, and other non-browser clients
+  path: ['/*'],
   accept: ['text/html'],
   excludedPath: [
-    // Text/code files (handled by track-asset-requests or not tracked)
-    '/docs/*.md',
-    '/docs/*.js',
-    '/docs/*.txt',
+    // API routes
+    '/api/*',
+    // Next.js internals
+    '/_next/*',
+    '/.netlify/*',
+    // Static assets
+    '/assets/*',
+    '/images/*',
+    '/fonts/*',
+    '/videos/*',
+    '/data/*',
+    '/socials/*',
+    '/favicon/*',
+    '/favicon.ico',
+    '/sitemap.xml',
+    '/sitemap-*.xml',
+    // Text/code files (handled by track-asset-requests)
+    '/**/*.md',
+    '/**/*.js',
+    '/**/*.txt',
     // Images
-    '/docs/*.svg',
-    '/docs/*.png',
-    '/docs/*.jpg',
-    '/docs/*.jpeg',
-    '/docs/*.gif',
-    '/docs/*.webp',
-    '/docs/*.ico',
-    '/docs/images/*',
-    '/docs/og/*',
+    '/**/*.svg',
+    '/**/*.png',
+    '/**/*.jpg',
+    '/**/*.jpeg',
+    '/**/*.gif',
+    '/**/*.webp',
+    '/**/*.ico',
     // Fonts
-    '/docs/fonts/*',
-    '/docs/*.woff',
-    '/docs/*.woff2',
-    // Search index (pagefind)
-    '/docs/pagefind/*',
+    '/**/*.woff',
+    '/**/*.woff2',
     // Astro build assets
     '/docs/_*',
+    // Search index (pagefind)
+    '/docs/pagefind/*',
+    '/docs/og/*',
   ],
 };


### PR DESCRIPTION
## Current Behavior

Only the astro-docs (nx-docs) Netlify app tracks server-side page views via edge functions. AI tool and bot detection relies on fragile User-Agent regex matching against a hardcoded list of known bot strings.

## Expected Behavior

Both nx-dev and nx-docs page views are tracked server-side via GA4, using Netlify's built-in `Netlify-Agent-Category` header to distinguish `ai-agent` from `crawler` traffic.

Tracking edge functions are consolidated into the nx-dev app (`netlify/edge-functions/`) since all traffic flows through it before being rewritten to nx-docs. Framer-proxied pages are tracked inline in `rewrite-framer-urls.ts` because the proxy short-circuits `context.next()`, preventing downstream edge functions from firing.

**Changes:**
- Moved `track-page-requests.ts` and `track-asset-requests.ts` from `astro-docs/netlify/edge-functions/` to `netlify/edge-functions/`
- Replaced User-Agent regex with `Netlify-Agent-Category` header checks in all tracking functions
- Added GA4 tracking to `rewrite-framer-urls.ts` for Framer-proxied pages

## Related Issue(s)

Fixes DOC-445