### PR TITLE
docs(core): add telemetry documentation page

### DIFF
--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -1026,6 +1026,7 @@ const referenceGroups: SidebarItems = [
       { label: 'Nx MCP', link: 'reference/nx-mcp' },
       { label: 'Nx Console Settings', link: 'reference/nx-console-settings' },
       { label: 'Nx Cloud CLI', link: 'reference/nx-cloud-cli' },
+      { label: 'Telemetry', link: 'reference/telemetry' },
       {
         label: 'TypeScript',
         collapsed: true,

--- a/astro-docs/src/content/docs/reference/nx-json.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-json.mdoc
@@ -90,7 +90,8 @@ The following is an expanded example showing all options. Your `nx.json` will li
         "projects": ["*"]
       }
     ]
-  }
+  },
+  "analytics": true
 }
 ```
 
@@ -1052,3 +1053,16 @@ You can also use objects with `matcher` and `explanation` properties to document
 - **enforced** (default): Rule violations will cause the conformance check to fail (exit code 1)
 - **evaluated**: Rule violations are reported but don't cause failures (exit code 0)
 - **disabled**: Rule is not evaluated at all
+
+## Analytics
+
+The `analytics` property controls whether Nx collects usage telemetry. When not set, Nx prompts you on first run in an interactive terminal.
+
+```json
+// nx.json
+{
+  "analytics": true
+}
+```
+
+For more information, see [telemetry](/docs/reference/telemetry).

--- a/astro-docs/src/content/docs/reference/telemetry.mdoc
+++ b/astro-docs/src/content/docs/reference/telemetry.mdoc
@@ -1,0 +1,58 @@
+---
+title: Telemetry
+description: Learn about the usage data Nx collects, why it's collected, and how to opt out.
+filter: 'type:References'
+---
+
+Nx collects usage data to help improve the developer experience. Telemetry is completely optional and can be disabled at any time.
+
+## Why Nx collects telemetry
+
+Telemetry helps the Nx team understand how Nx is used in practice. This data guides decisions about which features to prioritize, identifies common issues, and helps improve performance. No project-specific or personally identifiable information is collected.
+
+## What is collected
+
+Nx collects general usage data in the following categories:
+
+- **Command usage**: which Nx commands are run (e.g., `build`, `test`, `generate`), how long they take, and how many tasks were executed or cached.
+- **Environment info**: operating system, CPU architecture, Node.js version, package manager and version, Nx version, and whether the command runs in CI.
+- **General configuration**: whether [Nx Cloud](https://nx.dev/nx-cloud) is connected.
+
+## What about sensitive data?
+
+Nx does **not** collect any metrics that may contain sensitive data.
+This includes, but is not limited to: environment variables, personally identifiable information, file paths, contents of files, logs, or git remote information.
+
+For more information, see the [privacy policy](https://cloud.nx.app/privacy).
+
+## How to opt out
+
+When you first run an Nx command in an interactive terminal, Nx asks whether you'd like to share usage data.
+If you decline, telemetry is disabled for that workspace.
+
+You can also disable telemetry at any time by setting `analytics` to `false` in your `nx.json`:
+
+```json
+// nx.json
+{
+  "analytics": false
+}
+```
+
+In CI environments, Nx does not prompt for telemetry. Telemetry only runs in CI if `analytics` is explicitly set to `true` in `nx.json`.
+
+## How to re-enable
+
+To re-enable telemetry, set `analytics` to `true` in your `nx.json`:
+
+```json
+// nx.json
+{
+  "analytics": true
+}
+```
+
+## Nx Console telemetry
+
+The Nx Console editor extensions (VS Code and JetBrains) collect their own telemetry, separate from the Nx CLI.
+For more information, see [Nx Console telemetry](/docs/guides/nx-console/console-telemetry).


### PR DESCRIPTION
## Current Behavior

There is no documentation for Nx CLI telemetry, which was added in Nx 22.6.0. Users who are prompted to opt in have no reference page to learn what data is collected or how to opt out.

## Expected Behavior

A dedicated telemetry reference page at `/reference/telemetry` explains what is collected, what is not collected, and how to disable telemetry via `nx.json`. The `nx.json` reference page also documents the `analytics` property.

Changes:
- New page: `astro-docs/src/content/docs/reference/telemetry.mdoc`
- Sidebar entry added under Reference
- `analytics` property added to nx.json reference (expanded example + new section)

## Related Issue(s)

Fixes DOC-446