### PR TITLE
chore(core): abortGraphPhase -> notifyPhaseAborted

### DIFF
--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -556,7 +556,7 @@ function notifyPluginsGraphAborted(plugins: LoadedNxPlugin[]) {
   // createDependencies and createMetadata are called later in
   // createAndSerializeProjectGraph, which hasn't run yet.
   for (const plugin of plugins) {
-    plugin.abortGraphPhase?.('createNodes');
+    plugin.notifyPhaseAborted?.('graph', 'createNodes');
   }
 }
 

--- a/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
@@ -28,7 +28,11 @@ import type {
   PluginWorkerResult,
 } from './messaging';
 import { isPluginWorkerResult, sendMessageOverSocket } from './messaging';
-import { Hook, PluginLifecycleManager } from './plugin-lifecycle-manager';
+import {
+  Hook,
+  Phase,
+  PluginLifecycleManager,
+} from './plugin-lifecycle-manager';
 
 const PLUGIN_TIMEOUT_HINT_TEXT =
   'As a last resort, you can set NX_PLUGIN_NO_TIMEOUTS=true to bypass this timeout.';
@@ -434,8 +438,8 @@ export class IsolatedPlugin implements LoadedNxPlugin {
     this.shutdown();
   }
 
-  abortGraphPhase(lastCompletedHook: Hook): void {
-    if (this.lifecycle?.abortPhase('graph', lastCompletedHook)) {
+  notifyPhaseAborted(phase: Phase, lastCompletedHook: Hook): void {
+    if (this.lifecycle?.notifyPhaseAborted(phase, lastCompletedHook)) {
       this.shutdownIfInactive();
     }
   }

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-lifecycle-manager.spec.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-lifecycle-manager.spec.ts
@@ -349,7 +349,7 @@ describe('PluginLifecycleManager', () => {
     });
   });
 
-  describe('abortPhase', () => {
+  describe('notifyPhaseAborted', () => {
     it('should decrement session count when last completed hook is not the last registered hook', () => {
       const lifecycle = new PluginLifecycleManager([
         'createNodes',
@@ -363,7 +363,10 @@ describe('PluginLifecycleManager', () => {
       expect(lifecycle.getPhaseRefCount('graph')).toBe(1);
 
       // Abort after createNodes — createDependencies and createMetadata remain
-      const shouldShutdown = lifecycle.abortPhase('graph', 'createNodes');
+      const shouldShutdown = lifecycle.notifyPhaseAborted(
+        'graph',
+        'createNodes'
+      );
       expect(lifecycle.getPhaseRefCount('graph')).toBe(0);
       expect(shouldShutdown).toBe(true); // graph is the only registered phase
     });
@@ -377,8 +380,11 @@ describe('PluginLifecycleManager', () => {
       lifecycle.exitHook('createNodes');
       expect(lifecycle.getPhaseRefCount('graph')).toBe(0);
 
-      // abortPhase with createNodes as last completed — it's the last registered hook
-      const shouldShutdown = lifecycle.abortPhase('graph', 'createNodes');
+      // notifyPhaseAborted with createNodes as last completed — it's the last registered hook
+      const shouldShutdown = lifecycle.notifyPhaseAborted(
+        'graph',
+        'createNodes'
+      );
       expect(shouldShutdown).toBe(false);
       expect(lifecycle.getPhaseRefCount('graph')).toBe(0);
     });
@@ -397,7 +403,7 @@ describe('PluginLifecycleManager', () => {
       expect(lifecycle.getPhaseRefCount('graph')).toBe(0);
 
       // Abort after createDependencies — it's the last registered hook, session closed
-      const shouldShutdown = lifecycle.abortPhase(
+      const shouldShutdown = lifecycle.notifyPhaseAborted(
         'graph',
         'createDependencies'
       );
@@ -417,7 +423,10 @@ describe('PluginLifecycleManager', () => {
       expect(lifecycle.getPhaseRefCount('graph')).toBe(1);
 
       // Caller A aborts — createNodes is the last registered hook, no-op
-      const shouldShutdown = lifecycle.abortPhase('graph', 'createNodes');
+      const shouldShutdown = lifecycle.notifyPhaseAborted(
+        'graph',
+        'createNodes'
+      );
       expect(shouldShutdown).toBe(false);
       expect(lifecycle.getPhaseRefCount('graph')).toBe(1);
 
@@ -431,7 +440,10 @@ describe('PluginLifecycleManager', () => {
       const lifecycle = new PluginLifecycleManager(['createDependencies']);
 
       // Abort with createNodes — not registered, so no session was opened
-      const shouldShutdown = lifecycle.abortPhase('graph', 'createNodes');
+      const shouldShutdown = lifecycle.notifyPhaseAborted(
+        'graph',
+        'createNodes'
+      );
       expect(shouldShutdown).toBe(false);
     });
 
@@ -441,7 +453,10 @@ describe('PluginLifecycleManager', () => {
         'createDependencies',
       ]);
 
-      const shouldShutdown = lifecycle.abortPhase('graph', 'createNodes');
+      const shouldShutdown = lifecycle.notifyPhaseAborted(
+        'graph',
+        'createNodes'
+      );
       expect(shouldShutdown).toBe(false);
       expect(lifecycle.getPhaseRefCount('graph')).toBe(0);
     });
@@ -449,7 +464,7 @@ describe('PluginLifecycleManager', () => {
     it('should return false for unregistered phase', () => {
       const lifecycle = new PluginLifecycleManager(['createNodes']);
 
-      const shouldShutdown = lifecycle.abortPhase(
+      const shouldShutdown = lifecycle.notifyPhaseAborted(
         'pre-task',
         'preTasksExecution'
       );
@@ -465,7 +480,10 @@ describe('PluginLifecycleManager', () => {
 
       lifecycle.enterHook('createNodes');
       lifecycle.exitHook('createNodes');
-      const shouldShutdown = lifecycle.abortPhase('graph', 'createNodes');
+      const shouldShutdown = lifecycle.notifyPhaseAborted(
+        'graph',
+        'createNodes'
+      );
       expect(lifecycle.getPhaseRefCount('graph')).toBe(0);
       expect(shouldShutdown).toBe(false); // post-task phase still registered
     });
@@ -485,11 +503,11 @@ describe('PluginLifecycleManager', () => {
       expect(lifecycle.getPhaseRefCount('graph')).toBe(2);
 
       // First caller aborts after createNodes
-      expect(lifecycle.abortPhase('graph', 'createNodes')).toBe(false);
+      expect(lifecycle.notifyPhaseAborted('graph', 'createNodes')).toBe(false);
       expect(lifecycle.getPhaseRefCount('graph')).toBe(1);
 
       // Second caller aborts after createNodes
-      expect(lifecycle.abortPhase('graph', 'createNodes')).toBe(true);
+      expect(lifecycle.notifyPhaseAborted('graph', 'createNodes')).toBe(true);
       expect(lifecycle.getPhaseRefCount('graph')).toBe(0);
     });
 
@@ -508,7 +526,7 @@ describe('PluginLifecycleManager', () => {
       expect(lifecycle.getPhaseRefCount('graph')).toBe(1); // session still open
 
       // Abort after createDependencies — createMetadata remains
-      const shouldShutdown = lifecycle.abortPhase(
+      const shouldShutdown = lifecycle.notifyPhaseAborted(
         'graph',
         'createDependencies'
       );
@@ -526,7 +544,7 @@ describe('PluginLifecycleManager', () => {
       // First recomputation enters but gets aborted after createNodes
       lifecycle.enterHook('createNodes');
       lifecycle.exitHook('createNodes');
-      lifecycle.abortPhase('graph', 'createNodes');
+      lifecycle.notifyPhaseAborted('graph', 'createNodes');
       expect(lifecycle.getPhaseRefCount('graph')).toBe(0);
 
       // Second recomputation runs to completion

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-lifecycle-manager.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-lifecycle-manager.ts
@@ -191,7 +191,7 @@ export class PluginLifecycleManager {
    *   the session — decrementing again would steal another caller's count.
    * @returns true if the worker should shut down, false otherwise
    */
-  abortPhase(phase: Phase, lastCompletedHook: Hook): boolean {
+  notifyPhaseAborted(phase: Phase, lastCompletedHook: Hook): boolean {
     const phaseHooks = this.registeredPhases[phase];
     if (!phaseHooks) {
       return false;

--- a/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
@@ -56,14 +56,15 @@ export class LoadedNxPlugin {
   readonly exclude?: string[];
 
   /**
-   * Notifies the plugin that graph construction was aborted mid-flight.
+   * Notifies the plugin that a phase was aborted mid-flight.
    * Overridden by IsolatedPlugin to reset lifecycle phase tracking so
    * the worker can still shut down properly.
    *
-   * @param lastCompletedHook The name of the last graph-phase hook that
-   *   was called before the abort (e.g. 'createNodes').
+   * @param phase The phase that was aborted (e.g. 'graph').
+   * @param lastCompletedHook The last hook that was called before the
+   *   abort (e.g. 'createNodes').
    */
-  abortGraphPhase?(lastCompletedHook: string): void;
+  notifyPhaseAborted?(phase: string, lastCompletedHook: string): void;
 
   constructor(
     plugin: NxPluginV2,


### PR DESCRIPTION
## Current Behavior
#34799 has some method names that could have been better

## Expected Behavior
The methods are named to signify they are notifications, not instructions

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
