### PR TITLE
feat(core): bring back cloud prompts and templates in CNW

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -717,19 +717,56 @@ async function normalizeArgsMiddleware(
       const aiAgents = await determineAiAgents(argv);
       const defaultBase = await determineDefaultBase(argv);
 
-      // NXC-4020: Restored v22.1.3 simple flow (CI prompt → caching fallback)
-      const nxCloud =
-        argv.skipGit === true ? 'skip' : await determineNxCloud(argv);
-      const useGitHub =
-        nxCloud === 'skip'
-          ? undefined
-          : nxCloud === 'github' || (await determineIfGitHubWillBeUsed(argv));
+      // Check if CLI arg was provided (use rawArgs to check original input)
+      const cliNxCloudArgProvided = rawArgs.nxCloud !== undefined;
+
+      let nxCloud: string;
+      let useGitHub: boolean | undefined;
+      let completionMessageKey: string | undefined;
+      let skipCloudConnect = false;
+      let neverConnectToCloud = false;
+
+      if (argv.skipGit === true) {
+        nxCloud = 'skip';
+        useGitHub = undefined;
+      } else if (cliNxCloudArgProvided) {
+        // CLI arg provided: use existing flow (CI provider selection if needed)
+        nxCloud = await determineNxCloud(argv);
+        useGitHub =
+          nxCloud === 'skip' || nxCloud === 'never'
+            ? undefined
+            : nxCloud === 'github' || (await determineIfGitHubWillBeUsed(argv));
+        if (nxCloud === 'never') {
+          neverConnectToCloud = true;
+        }
+      } else {
+        // No CLI arg: use simplified prompt (same as template flow)
+        const cloudChoice = await determineNxCloudV2(argv);
+        if (cloudChoice === 'yes') {
+          nxCloud = 'yes';
+          skipCloudConnect = false;
+        } else if (cloudChoice === 'skip') {
+          nxCloud = 'skip';
+        } else {
+          nxCloud = 'never';
+          neverConnectToCloud = true;
+        }
+        useGitHub =
+          nxCloud !== 'skip' && nxCloud !== 'never' ? true : undefined;
+        completionMessageKey =
+          cloudChoice === 'never'
+            ? undefined
+            : getCompletionMessageKeyForVariant();
+      }
 
       const analytics = await determineAnalytics(argv);
 
       Object.assign(argv, {
         nxCloud,
         useGitHub,
+        skipCloudConnect,
+        neverConnectToCloud,
+        completionMessageKey,
         packageManager,
         defaultBase,
         aiAgents,
@@ -756,6 +793,10 @@ async function normalizeArgsMiddleware(
   } catch (e) {
     if (e instanceof CnwError) {
       throw e;
+    }
+    // Enquirer throws an empty string when user presses Ctrl+C
+    if (e === '') {
+      process.exit(130);
     }
     const message = e instanceof Error ? e.message : String(e);
     throw new CnwError('UNKNOWN', message);

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -148,7 +148,7 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
       );
     }
   } else {
-    // NXC-4020: Preset flow — restored to match v22.1.3
+    // Preset flow - existing behavior
     if (!preset) {
       throw new Error(
         'Preset is required when not using a template. Please provide --preset or --template.'
@@ -157,12 +157,14 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
     const tmpDir = await createSandbox(packageManager);
     const workspaceGlobs = getWorkspaceGlobsFromPreset(preset);
 
-    // NXC-4020: Pass actual nxCloud value (v22.1.3 behavior) so nxCloudId is set in nx.json
-    // Previous: nxCloud: 'skip' override to defer cloud connection
+    // nx new requires a preset currently. We should probably make it optional.
     directory = await createEmptyWorkspace<T>(tmpDir, name, packageManager, {
       ...options,
       preset,
       workspaceGlobs,
+      // We want new workspaces to have a short URL to finish Cloud onboarding, but not have nxCloudId set up since it will be handled as part of the onboarding flow.
+      // This is skipping nxCloudId for the "custom" flow.
+      nxCloud: 'skip',
     });
 
     // Mark workspace as ready for SIGINT handler
@@ -195,41 +197,11 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
     setAnalyticsPreference(directory, options.analytics);
   }
 
-  // NXC-4020: Preset flow cloud handling matches v22.1.3 exactly:
-  // 1. Read token (cloud was connected during createEmptyWorkspace)
-  // 2. Setup CI for specific providers (not 'yes')
-  // 3. Generate onboarding URL
-  // 4. Git init with connectUrl
-  // 5. Show completion message
-  let connectUrl: string | undefined;
-  let nxCloudInfo: string | undefined;
-
-  if (!isTemplate && nxCloud !== 'skip' && nxCloud !== 'never') {
-    const token = readNxCloudToken(directory) as string;
-
-    if (nxCloud !== 'yes') {
-      await setupCI(directory, nxCloud, packageManager);
-    }
-
-    connectUrl = await createNxCloudOnboardingUrl(
-      nxCloud,
-      token,
-      directory,
-      useGitHub
-    );
-
-    // Store for SIGINT handler
-    cloudConnectUrl = connectUrl;
-  }
-
-  // Template flow: CI setup and cloud connection handled separately
-  if (
-    isTemplate &&
-    nxCloud !== 'skip' &&
-    nxCloud !== 'never' &&
-    nxCloud !== 'yes'
-  ) {
-    await setupCI(directory, nxCloud, packageManager);
+  // Generate CI for preset flow (not template)
+  // When nxCloud === 'yes' (from simplified prompt), use GitHub as the CI provider
+  if (nxCloud !== 'skip' && nxCloud !== 'never' && !isTemplate) {
+    const ciProvider = nxCloud === 'yes' ? 'github' : nxCloud;
+    await setupCI(directory, ciProvider, packageManager);
   }
 
   let pushedToVcs = VcsPushStatus.SkippedGit;
@@ -241,12 +213,16 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
     }
 
     try {
-      // NXC-4020: Pass connectUrl to git init (v22.1.3 behavior)
-      await initializeGitRepo(directory, { defaultBase, commit, connectUrl });
+      await initializeGitRepo(directory, { defaultBase, commit });
 
-      // NXC-4020: Only push for github CI provider (v22.1.3 behavior)
-      // Previous: also pushed for nxCloud === 'yes'
-      if (commit && !skipGitHubPush && nxCloud === 'github') {
+      // Push to GitHub if commit was made, GitHub push is not skipped, and:
+      // - CI provider is GitHub (preset flow with CLI arg), OR
+      // - Nx Cloud enabled via simplified prompt (nxCloud === 'yes')
+      if (
+        commit &&
+        !skipGitHubPush &&
+        (nxCloud === 'github' || nxCloud === 'yes')
+      ) {
         pushedToVcs = await pushToGitHub(directory, {
           skipGitHubPush,
           name,
@@ -256,66 +232,72 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
       }
     } catch (e) {
       if (e instanceof Error) {
-        if (!isAiAgent()) {
+        if (!aiMode) {
           output.error({
             title: 'Could not initialize git repository',
             bodyLines: mapErrorToBodyLines(e),
           });
         }
+        // In AI mode, error will be handled by the caller
       } else {
         console.error(e);
       }
     }
   }
 
-  // NXC-4020: Preset flow completion message matches v22.1.3
-  if (!isTemplate && connectUrl) {
-    nxCloudInfo = await getNxCloudInfo(
+  // Create onboarding URL AFTER git operations so getVcsRemoteInfo() can detect the repo
+  let connectUrl: string | undefined;
+  let nxCloudInfo: string | undefined;
+
+  if (nxCloud !== 'skip' && nxCloud !== 'never') {
+    // "Yes" or "Maybe later" — generate URL, update README, show banner
+    const aiModeForCloud = isAiAgent();
+    if (aiModeForCloud) {
+      logProgress('configuring', 'Configuring Nx Cloud...');
+    }
+    // skipCloudConnect=true (Maybe later): Skip readNxCloudToken() since no token exists
+    // skipCloudConnect=false (Yes): Read the token as before (cloud was connected)
+    const token = options.skipCloudConnect
+      ? undefined
+      : readNxCloudToken(directory);
+
+    connectUrl = await createNxCloudOnboardingUrl(
       nxCloud,
-      connectUrl,
-      pushedToVcs,
-      rawArgs?.nxCloud
+      token,
+      directory,
+      useGitHub
     );
-  }
 
-  // Template flow: cloud URL generation and completion message
-  if (isTemplate) {
-    if (nxCloud !== 'skip' && nxCloud !== 'never') {
-      const aiModeForCloud = isAiAgent();
-      if (aiModeForCloud) {
-        logProgress('configuring', 'Configuring Nx Cloud...');
-      }
-      const token = options.skipCloudConnect
-        ? undefined
-        : readNxCloudToken(directory);
+    // Store for SIGINT handler
+    cloudConnectUrl = connectUrl;
 
-      connectUrl = await createNxCloudOnboardingUrl(
-        nxCloud,
-        token,
-        directory,
-        useGitHub
-      );
-
-      cloudConnectUrl = connectUrl;
-
+    // Update README with connect URL (strips markers, adds connect section)
+    // Then commit the change - amend if not pushed, new commit if already pushed
+    if (isTemplate) {
       const readmeUpdated = addConnectUrlToReadme(directory, connectUrl);
       if (readmeUpdated && !skipGit && commit) {
         const alreadyPushed = pushedToVcs === VcsPushStatus.PushedToVcs;
         await amendOrCommitReadme(directory, alreadyPushed);
       }
+    }
 
-      nxCloudInfo = await getNxCloudInfo(nxCloud, connectUrl, pushedToVcs);
-    } else {
-      // Strip marker comments from README
-      const readmeUpdated = addConnectUrlToReadme(directory, undefined);
-      if (readmeUpdated && !skipGit && commit) {
-        const alreadyPushed = pushedToVcs === VcsPushStatus.PushedToVcs;
-        await amendOrCommitReadme(directory, alreadyPushed);
-      }
+    nxCloudInfo = await getNxCloudInfo(
+      connectUrl,
+      pushedToVcs,
+      options.completionMessageKey,
+      name
+    );
+  } else if (isTemplate && (nxCloud === 'skip' || nxCloud === 'never')) {
+    // Strip marker comments from README
+    const readmeUpdated = addConnectUrlToReadme(directory, undefined);
+    if (readmeUpdated && !skipGit && commit) {
+      const alreadyPushed = pushedToVcs === VcsPushStatus.PushedToVcs;
+      await amendOrCommitReadme(directory, alreadyPushed);
+    }
 
-      if (nxCloud === 'skip') {
-        nxCloudInfo = getSkippedNxCloudInfo();
-      }
+    // Only show "nx connect" message for 'skip', not 'never'
+    if (nxCloud === 'skip') {
+      nxCloudInfo = getSkippedNxCloudInfo();
     }
   }
 

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -107,7 +107,48 @@ export async function determineTemplate(
   }>
 ): Promise<string | 'custom'> {
   if (parsedArgs.template) return parsedArgs.template;
-  return 'custom';
+  if (parsedArgs.preset) return 'custom';
+  if (!parsedArgs.interactive || isCI()) return 'custom';
+  // Docs generation needs preset flow to document all presets
+  if (process.env.NX_GENERATE_DOCS_PROCESS === 'true') return 'custom';
+  // Template flow requires git for cloning - fall back to custom preset if git is not available
+  if (!isGitAvailable()) return 'custom';
+  const { template } = await enquirer.prompt<{ template: string }>([
+    {
+      name: 'template',
+      message: 'Which starter do you want to use?',
+      type: 'autocomplete',
+      choices: [
+        {
+          name: 'nrwl/empty-template',
+          message: 'Minimal           (empty monorepo without projects)',
+        },
+        {
+          name: 'nrwl/react-template',
+          message:
+            'React             (fullstack monorepo with React and Express)',
+        },
+        {
+          name: 'nrwl/angular-template',
+          message:
+            'Angular           (fullstack monorepo with Angular and Express)',
+        },
+        {
+          name: 'nrwl/typescript-template',
+          message:
+            'NPM Packages      (monorepo with TypeScript packages ready to publish)',
+        },
+        {
+          name: 'custom',
+          message:
+            'Custom            (advanced setup with additional frameworks)',
+        },
+      ],
+      initial: 0,
+    },
+  ]);
+
+  return template;
 }
 
 export async function determineAiAgents(

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.spec.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.spec.ts
@@ -99,9 +99,8 @@ describe('ab-testing', () => {
       ).toBe('0');
     });
 
-    // NXC-4020: Locked to variant 0 to match v22.1.3
-    it('should return 0 for standard URLs (NXC-4020)', () => {
-      expect(getBannerVariant('https://cloud.nx.app/connect/abc')).toBe('0');
+    it('should return 2 for standard URLs', () => {
+      expect(getBannerVariant('https://cloud.nx.app/connect/abc')).toBe('2');
     });
   });
 

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -142,7 +142,18 @@ export function isEnterpriseCloudUrl(cloudUrl?: string): boolean {
  * @param cloudUrl - The Nx Cloud URL. If enterprise, always returns '0'.
  */
 export function getBannerVariant(cloudUrl?: string): BannerVariant {
-  return '0';
+  // Enterprise URLs always get plain link (variant 0)
+  if (isEnterpriseCloudUrl(cloudUrl)) {
+    return '0';
+  }
+
+  // Docs generation uses variant 0 for deterministic output
+  if (process.env.NX_GENERATE_DOCS_PROCESS === 'true') {
+    return '0';
+  }
+
+  // Standard URLs get variant 2 banner
+  return '2';
 }
 
 export const NxCloudChoices = [
@@ -181,22 +192,21 @@ const messageOptions: Record<string, MessageData[]> = {
   ],
   /**
    * These messages are a fallback for setting up CI as well as when migrating major versions
-   * NXC-4020: Restored to v22.1.3 wording
+   * Locked to "full platform" messaging (CLOUD-4235)
    */
   setupNxCloud: [
     {
-      code: 'enable-caching2',
-      message: 'Would you like remote caching to make your build faster?',
+      code: 'cloud-v2-full-platform-visit',
+      message: 'Try the full Nx platform?',
       initial: 0,
       choices: [
         { value: 'yes', name: 'Yes' },
-        { value: 'skip', name: 'No - I would not like remote caching' },
+        { value: 'skip', name: 'Skip' },
       ],
       footer:
-        '\nRead more about remote caching at https://nx.dev/ci/features/remote-cache',
-      hint: '(can be disabled any time)',
+        '\nAutomatically fix broken PRs, 70% faster CI: https://nx.dev/nx-cloud',
       fallback: undefined,
-      completionMessage: 'cache-setup',
+      completionMessage: 'platform-setup',
     },
   ],
   /**

--- a/packages/create-nx-workspace/src/utils/nx/messages.spec.ts
+++ b/packages/create-nx-workspace/src/utils/nx/messages.spec.ts
@@ -45,7 +45,7 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
+            "Push your repo (https://github.com/new?name=myworkspace), then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
           ],
           "title": "Your CI setup is almost complete.",
         }
@@ -62,7 +62,7 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
+            "Push your repo (https://github.com/new?name=myworkspace), then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
           ],
           "title": "Your CI setup is almost complete.",
         }
@@ -79,7 +79,7 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then return to Nx Cloud and finish the setup.",
+            "Push your repo (https://github.com/new?name=myworkspace), then return to Nx Cloud and finish the setup.",
           ],
           "title": "Your CI setup is almost complete.",
         }
@@ -96,7 +96,7 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then return to Nx Cloud and finish the setup.",
+            "Push your repo (https://github.com/new?name=myworkspace), then return to Nx Cloud and finish the setup.",
           ],
           "title": "Your CI setup is almost complete.",
         }
@@ -112,7 +112,7 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
+            "Push your repo (https://github.com/new), then go to Nx Cloud and finish the setup: https://nx.app/setup/123",
           ],
           "title": "Your CI setup is almost complete.",
         }
@@ -132,7 +132,7 @@ describe('Nx Cloud Messages', () => {
           "bodyLines": [
             "Go to Nx Cloud and finish the setup: https://nx.app/setup/456",
           ],
-          "title": "Your remote cache is almost complete.",
+          "title": "Your remote cache setup is almost complete.",
         }
       `);
     });
@@ -148,7 +148,7 @@ describe('Nx Cloud Messages', () => {
           "bodyLines": [
             "Return to Nx Cloud and finish the setup.",
           ],
-          "title": "Your remote cache is almost complete.",
+          "title": "Your remote cache setup is almost complete.",
         }
       `);
     });
@@ -163,9 +163,9 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/456",
+            "Push your repo (https://github.com/new?name=myworkspace), then go to Nx Cloud and finish the setup: https://nx.app/setup/456",
           ],
-          "title": "Your remote cache is almost complete.",
+          "title": "Your remote cache setup is almost complete.",
         }
       `);
     });
@@ -180,9 +180,9 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then go to Nx Cloud and finish the setup: https://nx.app/setup/456",
+            "Push your repo (https://github.com/new?name=myworkspace), then go to Nx Cloud and finish the setup: https://nx.app/setup/456",
           ],
-          "title": "Your remote cache is almost complete.",
+          "title": "Your remote cache setup is almost complete.",
         }
       `);
     });
@@ -197,9 +197,9 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then return to Nx Cloud and finish the setup.",
+            "Push your repo (https://github.com/new?name=myworkspace), then return to Nx Cloud and finish the setup.",
           ],
-          "title": "Your remote cache is almost complete.",
+          "title": "Your remote cache setup is almost complete.",
         }
       `);
     });
@@ -214,9 +214,9 @@ describe('Nx Cloud Messages', () => {
       expect(message).toMatchInlineSnapshot(`
         {
           "bodyLines": [
-            "Push your repo, then return to Nx Cloud and finish the setup.",
+            "Push your repo (https://github.com/new?name=myworkspace), then return to Nx Cloud and finish the setup.",
           ],
-          "title": "Your remote cache is almost complete.",
+          "title": "Your remote cache setup is almost complete.",
         }
       `);
     });
@@ -274,8 +274,9 @@ describe('Nx Cloud Messages', () => {
           pushed,
           'myworkspace'
         );
-        // NXC-4020: Restored to v22.1.3 wording
-        expect(message.title).toBe('Your remote cache is almost complete.');
+        expect(message.title).toBe(
+          'Your remote cache setup is almost complete.'
+        );
       });
     });
   });

--- a/packages/create-nx-workspace/src/utils/nx/messages.ts
+++ b/packages/create-nx-workspace/src/utils/nx/messages.ts
@@ -41,17 +41,23 @@ function getBannerLines(variant: BannerVariant, url: string): string[] {
 
 function getSetupMessage(
   url: string | null,
-  pushedToVcs: VcsPushStatus
+  pushedToVcs: VcsPushStatus,
+  workspaceName?: string
 ): string {
+  const githubUrl = workspaceName
+    ? `https://github.com/new?name=${encodeURIComponent(workspaceName)}`
+    : 'https://github.com/new';
+
   if (pushedToVcs === VcsPushStatus.PushedToVcs) {
     return url
       ? `Go to Nx Cloud and finish the setup: ${url}`
       : 'Return to Nx Cloud and finish the setup.';
   }
 
+  // User needs to push first
   const action = url ? 'go' : 'return';
   const urlSuffix = url ? `: ${url}` : '.';
-  return `Push your repo, then ${action} to Nx Cloud and finish the setup${urlSuffix}`;
+  return `Push your repo (${githubUrl}), then ${action} to Nx Cloud and finish the setup${urlSuffix}`;
 }
 
 /**
@@ -63,8 +69,7 @@ const completionMessages = {
     title: 'Your CI setup is almost complete.',
   },
   'cache-setup': {
-    // NXC-4020: Restored to v22.1.3 wording (was "Your remote cache setup is almost complete.")
-    title: 'Your remote cache is almost complete.',
+    title: 'Your remote cache setup is almost complete.',
   },
   'platform-setup': {
     title: 'Your platform setup is almost complete.',
@@ -100,7 +105,7 @@ export function getCompletionMessage(
   }
 
   // Variant 0 (control) or fallback: plain link message
-  const bodyLines = [getSetupMessage(url, pushedToVcs)];
+  const bodyLines = [getSetupMessage(url, pushedToVcs, workspaceName)];
 
   return {
     title,

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -1,7 +1,11 @@
 import { VcsPushStatus } from '../git/git';
 import { CLIOutput } from '../output';
-import { getCompletionMessage, getSkippedCloudMessage } from './messages';
-import { getFlowVariant } from './ab-testing';
+import {
+  getCompletionMessage,
+  getSkippedCloudMessage,
+  CompletionMessageKey,
+} from './messages';
+import { getBannerVariant, getFlowVariant } from './ab-testing';
 import { nxVersion } from './nx-version';
 import * as ora from 'ora';
 
@@ -66,8 +70,7 @@ export function readNxCloudToken(directory: string) {
   ) as typeof import('nx/src/nx-cloud/utilities/get-cloud-options');
 
   const { accessToken, nxCloudId } = getCloudOptions(directory);
-  // NXC-4020: Restored to v22.1.3 wording
-  nxCloudSpinner.succeed('Nx Cloud has been set up successfully');
+  nxCloudSpinner.succeed('Nx Cloud configuration was successfully added');
   return accessToken || nxCloudId;
 }
 
@@ -110,22 +113,32 @@ export async function createNxCloudOnboardingUrl(
   );
 }
 
-// NXC-4020: Restored v22.1.3 signature — determines message from nxCloud value,
-// uses rawNxCloud to decide whether to show URL (hide when user passed --nxCloud explicitly).
-// Previous signature: (connectCloudUrl, pushedToVcs, completionMessageKey?, workspaceName?)
 export async function getNxCloudInfo(
-  nxCloud: NxCloud,
   connectCloudUrl: string,
   pushedToVcs: VcsPushStatus,
-  rawNxCloud?: NxCloud
+  completionMessageKey?: CompletionMessageKey,
+  workspaceName?: string
 ) {
-  const completionMessageKey = nxCloud === 'yes' ? 'cache-setup' : 'ci-setup';
   const out = new CLIOutput(false);
-  // When rawNxCloud is a string (user explicitly passed --nxCloud), hide the URL
-  // because the user "already knows" where to go
-  const url = typeof rawNxCloud === 'string' ? null : connectCloudUrl;
-  const message = getCompletionMessage(completionMessageKey, url, pushedToVcs);
-  out.success(message);
+  // Get the banner variant based on the cloud URL
+  // Enterprise URLs automatically get variant 0 (plain link)
+  const bannerVariant = getBannerVariant(connectCloudUrl);
+  const message = getCompletionMessage(
+    completionMessageKey,
+    connectCloudUrl,
+    pushedToVcs,
+    workspaceName,
+    bannerVariant
+  );
+
+  // Variant 2 (deferred connection): No title, just output the banner directly
+  // without the NX badge since nothing was actually configured
+  if (!message.title) {
+    out.addNewline();
+    out.writeLines(message.bodyLines ?? []);
+  } else {
+    out.success(message);
+  }
   return out.getOutput();
 }
 


### PR DESCRIPTION
## Current Behavior

CNW flow matches v22.1.3 (restored in #34671): no template prompt is shown, the cloud prompt uses simplified "Would you like remote caching?" wording, banner variant is locked to 0, and preset flow connects to cloud during workspace creation.

## Expected Behavior

Restore the template prompt and cloud prompts that were removed in #34671:
- **Template prompt**: "Which starter do you want to use?" with 5 choices (Minimal, React, Angular, NPM Packages, Custom)
- **Cloud prompt**: `determineNxCloudV2` ("Connect to Nx Cloud?") for preset flow when no `--nxCloud` CLI arg; existing CI provider prompt when `--nxCloud` is explicitly provided
- **Banner**: Variant 2 (box banner) for standard Nx Cloud URLs, variant 0 for enterprise
- **Preset flow**: Deferred cloud connection (`nxCloud: 'skip'`) instead of connecting during workspace creation
- **Push logic**: Push to GitHub for both `nxCloud === 'github'` and `nxCloud === 'yes'`
- **Messages**: "Try the full Nx platform?" wording, GitHub repo link in push messages, "Your remote cache setup is almost complete." title

Preserves all subsequent changes (analytics prompt from #34818, SANDBOX_FAILED fix, .gitignore updates).

## Related Issue(s)

Fixes NXC-4096