### PR TITLE
docs(core): show supported version range for  subcommand

### DIFF
--- a/astro-docs/src/content/docs/features/CI Features/sandboxing.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/sandboxing.mdoc
@@ -149,6 +149,10 @@ the JSON report.
 Check what your tasks currently declare before enabling sandboxing.
 Use `nx show target` to inspect a specific target's resolved inputs and outputs:
 
+{% aside type="caution" title="Nx 22.6+ Required" %}
+The `--inputs` and `--outputs` flags for `nx show target` require Nx 22.6 or later.
+{% /aside %}
+
 ```shell
 nx show target <project>:<target> --inputs --outputs
 ```

--- a/astro-docs/src/plugins/utils/cli-subprocess.cjs
+++ b/astro-docs/src/plugins/utils/cli-subprocess.cjs
@@ -18,7 +18,7 @@ require('ts-node').register({
 
 // TypeScript paths are now handled by pnpm workspaces, no need for tsconfig-paths
 
-const { examples: cliExamples } = importFresh(
+const { examples: cliExamples, cliDocsCommandMetadata } = importFresh(
   join(workspaceRoot, 'packages/nx/src/command-line/examples')
 );
 
@@ -29,7 +29,7 @@ function getCommands(command) {
   return command.getInternalMethods().getCommandInstance().getCommandHandlers();
 }
 
-async function parseCommand(name, command) {
+async function parseCommand(name, command, fullName = name) {
   // If it's not a function, return a stripped down version
   if (
     !(
@@ -47,6 +47,8 @@ async function parseCommand(name, command) {
       aliases: [],
       options: [],
       examples: cliExamples[name] || [],
+      supportedVersionRange:
+        cliDocsCommandMetadata[fullName]?.supportedVersionRange,
     };
   }
 
@@ -102,7 +104,13 @@ async function parseCommand(name, command) {
     }
 
     try {
-      const parsedSub = await parseCommand(subName, subConfig);
+      const subcommandFullName =
+        subName === '$0' ? fullName : `${fullName} ${subName}`.trim();
+      const parsedSub = await parseCommand(
+        subName,
+        subConfig,
+        subcommandFullName
+      );
       subcommands.push(parsedSub);
     } catch (error) {
       console.warn(`⚠️ Could not parse subcommand ${subName}:`, error.message);
@@ -117,6 +125,8 @@ async function parseCommand(name, command) {
     options,
     subcommands: subcommands.length > 0 ? subcommands : undefined,
     examples: cliExamples[name] || [],
+    supportedVersionRange:
+      cliDocsCommandMetadata[fullName]?.supportedVersionRange,
   };
 }
 

--- a/astro-docs/src/plugins/utils/nx-cli-generation.ts
+++ b/astro-docs/src/plugins/utils/nx-cli-generation.ts
@@ -8,6 +8,7 @@ export interface ParsedCliCommand {
   name?: string;
   command?: string;
   description?: string;
+  supportedVersionRange?: string;
   aliases?: string[];
   options?: Array<{
     name: string[];
@@ -205,6 +206,17 @@ function generateExamplesSection(
   return section;
 }
 
+function generateVersionNote(
+  commandName: string,
+  supportedVersionRange?: string
+): string {
+  if (!supportedVersionRange) {
+    return '';
+  }
+
+  return `\n**Requires ${supportedVersionRange}**\n\n`;
+}
+
 function generateCLIMarkdown(
   commands: Record<string, ParsedCliCommand>
 ): string {
@@ -222,6 +234,7 @@ ${flattenedCommands
 
     let section = `${headingLevel} \`nx ${fullName}\`\n`;
 
+    section += generateVersionNote(fullName, cmd.supportedVersionRange);
     section += cmd.description || 'No description available';
 
     if (cmd.aliases && cmd.aliases.length > 0) {

--- a/packages/nx/src/command-line/examples.ts
+++ b/packages/nx/src/command-line/examples.ts
@@ -3,6 +3,19 @@ export interface Example {
   description: string;
 }
 
+export interface CliDocsCommandMetadata {
+  supportedVersionRange?: string;
+}
+
+/**
+ * Docs-only metadata keyed by the full command name as rendered in the CLI docs.
+ */
+export const cliDocsCommandMetadata: Record<string, CliDocsCommandMetadata> = {
+  'show target': {
+    supportedVersionRange: 'Nx 22.6+',
+  },
+};
+
 export const examples: Record<string, Example[]> = {
   affected: [
     {
@@ -413,6 +426,36 @@ export const examples: Record<string, Example[]> = {
       command: 'show project my-app --web',
       description:
         'Opens a web browser to explore the configuration of "my-app"',
+    },
+
+    {
+      command: 'show target my-app:build',
+      description:
+        'Prints the specified + inferred configuration for `my-app:build`',
+    },
+
+    {
+      command: 'show target my-app:build inputs',
+      description: 'Prints the resolved inputs for `my-app:build`',
+    },
+
+    {
+      command:
+        'show target my-app:build inputs --check packages/my-app/index.html',
+      description:
+        'Checks if `packages/my-app/index.html` is an input for `my-app:build`',
+    },
+
+    {
+      command: 'show target my-app:build outputs',
+      description: 'Prints the outputs detected on disk for `my-app:build`',
+    },
+
+    {
+      command:
+        'show target my-app:build outputs --check packages/my-app/dist/index.html',
+      description:
+        'Checks if `packages/my-app/dist/index.html` is an output for `my-app:build`',
     },
   ],
   watch: [

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -1,7 +1,9 @@
 import * as pc from 'picocolors';
 import * as yargs from 'yargs';
 
-import { yargsRegisterCommand } from './register/command-object';
+import { reportCommandRunEvent } from '../analytics';
+import { output } from '../utils/output';
+import { yargsAddCommand } from './add/command-object';
 import {
   yargsAffectedBuildCommand,
   yargsAffectedCommand,
@@ -9,54 +11,52 @@ import {
   yargsAffectedLintCommand,
   yargsAffectedTestCommand,
 } from './affected/command-object';
-import {
-  yargsConnectCommand,
-  yargsViewLogsCommand,
-} from './nx-cloud/connect/command-object';
+import { yargsConfigureAiAgentsCommand } from './configure-ai-agents/command-object';
 import { yargsDaemonCommand } from './daemon/command-object';
-import { yargsGraphCommand } from './graph/command-object';
+import {
+  yargsAffectedGraphCommand,
+  yargsPrintAffectedCommand,
+} from './deprecated/command-objects';
 import { yargsExecCommand } from './exec/command-object';
 import {
   yargsFormatCheckCommand,
   yargsFormatWriteCommand,
 } from './format/command-object';
 import { yargsGenerateCommand } from './generate/command-object';
+import { yargsGraphCommand } from './graph/command-object';
 import { yargsImportCommand } from './import/command-object';
 import { yargsInitCommand } from './init/command-object';
 import { yargsListCommand } from './list/command-object';
+import { yargsMcpCommand } from './mcp/command-object';
 import {
   yargsInternalMigrateCommand,
   yargsMigrateCommand,
 } from './migrate/command-object';
 import { yargsNewCommand } from './new/command-object';
-import { yargsRepairCommand } from './repair/command-object';
-import { yargsReportCommand } from './report/command-object';
-import { yargsNxInfixCommand, yargsRunCommand } from './run/command-object';
-import { yargsRunManyCommand } from './run-many/command-object';
-import { yargsShowCommand } from './show/command-object';
-import { yargsWatchCommand } from './watch/command-object';
-import { yargsResetCommand } from './reset/command-object';
-import { yargsReleaseCommand } from './release/command-object';
-import { yargsAddCommand } from './add/command-object';
-import { yargsConfigureAiAgentsCommand } from './configure-ai-agents/command-object';
+import { yargsApplyLocallyCommand } from './nx-cloud/apply-locally/command-object';
+import { yargsStopAllAgentsCommand } from './nx-cloud/complete-run/command-object';
+import {
+  yargsConnectCommand,
+  yargsViewLogsCommand,
+} from './nx-cloud/connect/command-object';
+import { yargsDownloadCloudClientCommand } from './nx-cloud/download-cloud-client/command-object';
+import { yargsFixCiCommand } from './nx-cloud/fix-ci/command-object';
 import { yargsLoginCommand } from './nx-cloud/login/command-object';
 import { yargsLogoutCommand } from './nx-cloud/logout/command-object';
-import { yargsRecordCommand } from './nx-cloud/record/command-object';
-import { yargsStartCiRunCommand } from './nx-cloud/start-ci-run/command-object';
-import { yargsStartAgentCommand } from './nx-cloud/start-agent/command-object';
-import { yargsStopAllAgentsCommand } from './nx-cloud/complete-run/command-object';
-import { yargsFixCiCommand } from './nx-cloud/fix-ci/command-object';
 import { yargsPolygraphCommand } from './nx-cloud/polygraph/command-object';
-import { yargsApplyLocallyCommand } from './nx-cloud/apply-locally/command-object';
-import { yargsDownloadCloudClientCommand } from './nx-cloud/download-cloud-client/command-object';
-import {
-  yargsPrintAffectedCommand,
-  yargsAffectedGraphCommand,
-} from './deprecated/command-objects';
+import { yargsRecordCommand } from './nx-cloud/record/command-object';
+import { yargsStartAgentCommand } from './nx-cloud/start-agent/command-object';
+import { yargsStartCiRunCommand } from './nx-cloud/start-ci-run/command-object';
+import { yargsRegisterCommand } from './register/command-object';
+import { yargsReleaseCommand } from './release/command-object';
+import { yargsRepairCommand } from './repair/command-object';
+import { yargsReportCommand } from './report/command-object';
+import { yargsResetCommand } from './reset/command-object';
+import { yargsRunManyCommand } from './run-many/command-object';
+import { yargsNxInfixCommand, yargsRunCommand } from './run/command-object';
+import { yargsShowCommand } from './show/command-object';
 import { yargsSyncCheckCommand, yargsSyncCommand } from './sync/command-object';
-import { output } from '../utils/output';
-import { yargsMcpCommand } from './mcp/command-object';
-import { reportCommandRunEvent } from '../analytics';
+import { yargsWatchCommand } from './watch/command-object';
 
 // Ensure that the output takes up the available width of the terminal.
 yargs.wrap(yargs.terminalWidth());


### PR DESCRIPTION
## Current Behavior
There's not a great way to attach metadata to CLI commands to influence rendering the markdown docs for them

## Expected Behavior
There's a metadata system currently used to express minimum support version for the show target command

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
