### PR TITLE
feat(vite): add configurable ts paths build/test targets and stabilize build coordination

### DIFF
--- a/e2e/vite/src/vite.test.ts
+++ b/e2e/vite/src/vite.test.ts
@@ -192,12 +192,22 @@ describe('@nx/vite/plugin', () => {
         `generate @nx/react:library ${myBuildableLib} --directory=libs/${myBuildableLib} --bundler=vite --unitTestRunner=vitest --buildable`
       );
 
+      // Note: target names must not collide with the inferred targets or the
+      // atomized targets from ciTargetName (e.g. `test-ci`).
       updateJson(`apps/${myApp}/project.json`, (json) => {
-        json.targets['test-ci'] = { ...json.targets.test };
+        json.targets ??= {};
+        json.targets['custom-test'] = {
+          command: 'vitest run',
+          options: { cwd: `apps/${myApp}` },
+        };
         return json;
       });
       updateJson(`libs/${myBuildableLib}/project.json`, (json) => {
-        json.targets['build-ci'] = { ...json.targets.build };
+        json.targets ??= {};
+        json.targets['custom-build'] = {
+          command: 'vite build',
+          options: { cwd: `libs/${myBuildableLib}` },
+        };
         return json;
       });
 
@@ -223,8 +233,8 @@ export default defineConfig({
     react(),
     nxViteTsPaths({
       buildLibsFromSource: false,
-      buildTarget: 'build-ci',
-      testTarget: 'test-ci',
+      buildTarget: 'custom-build',
+      testTarget: 'custom-test',
     }),
   ],
   build: {
@@ -257,12 +267,16 @@ export default defineConfig({
         import { render } from '@testing-library/react';
         import { App } from './app';
         import { ${exportedLibraryComponent} } from 'multi-path-lib';
+        // Extensionless .tsx subpath is only resolvable through the plugin's
+        // own file matching, which must try every mapped path value.
+        import { ${exportedLibraryComponent} as FromSubpath } from 'multi-path-lib/lib/${myBuildableLib}';
 
         describe('App', () => {
           it('should render successfully', () => {
             const { baseElement } = render(<App />);
             expect(baseElement).toBeTruthy();
             expect(${exportedLibraryComponent}).toBeDefined();
+            expect(FromSubpath).toBeDefined();
           });
         });
         `
@@ -273,11 +287,25 @@ export default defineConfig({
           `libs/does-not-exist/src/index.ts`,
           `libs/${myBuildableLib}/src/index.ts`,
         ];
+        json.compilerOptions.paths['multi-path-lib/*'] = [
+          `libs/does-not-exist/src/*`,
+          `libs/${myBuildableLib}/src/*`,
+        ];
         return json;
       });
 
-      expect(() => runCLI(`run ${myApp}:test-ci --watch=false`)).not.toThrow();
-    });
+      try {
+        expect(() => runCLI(`run ${myApp}:custom-test`)).not.toThrow();
+      } finally {
+        // Clean up the shared tsconfig so the path alias does not leak into
+        // subsequent tests.
+        updateJson('tsconfig.base.json', (json) => {
+          delete json.compilerOptions.paths['multi-path-lib'];
+          delete json.compilerOptions.paths['multi-path-lib/*'];
+          return json;
+        });
+      }
+    }, 300_000);
 
     it('should support importing files with "." in the name in tsconfig path', () => {
       const mylib = uniq('mylib');

--- a/e2e/vite/src/vite.test.ts
+++ b/e2e/vite/src/vite.test.ts
@@ -182,6 +182,103 @@ describe('@nx/vite/plugin', () => {
       expect(() => runCLI(`test ${mylib}`)).not.toThrow();
     });
 
+    it('should resolve second tsconfig path value with custom build and test targets', () => {
+      const myApp = uniq('myapp');
+      const myBuildableLib = uniq('mybuildablelib');
+      runCLI(
+        `generate @nx/react:app ${myApp} --directory=apps/${myApp} --bundler=vite --unitTestRunner=vitest`
+      );
+      runCLI(
+        `generate @nx/react:library ${myBuildableLib} --directory=libs/${myBuildableLib} --bundler=vite --unitTestRunner=vitest --buildable`
+      );
+
+      updateJson(`apps/${myApp}/project.json`, (json) => {
+        json.targets['test-ci'] = { ...json.targets.test };
+        return json;
+      });
+      updateJson(`libs/${myBuildableLib}/project.json`, (json) => {
+        json.targets['build-ci'] = { ...json.targets.build };
+        return json;
+      });
+
+      updateFile(
+        `apps/${myApp}/vite.config.mts`,
+        `/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+export default defineConfig({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/${myApp}',
+  server: {
+    port: 4200,
+    host: 'localhost',
+  },
+  preview: {
+    port: 4300,
+    host: 'localhost',
+  },
+  plugins: [
+    react(),
+    nxViteTsPaths({
+      buildLibsFromSource: false,
+      buildTarget: 'build-ci',
+      testTarget: 'test-ci',
+    }),
+  ],
+  build: {
+    outDir: '../../dist/apps/${myApp}',
+    emptyOutDir: true,
+    reportCompressedSize: true,
+    commonjsOptions: {
+      transformMixedEsModules: true,
+    },
+  },
+  test: {
+    watch: false,
+    globals: true,
+    environment: 'jsdom',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../../coverage/apps/${myApp}',
+      provider: 'v8',
+    },
+  },
+});
+`
+      );
+
+      const exportedLibraryComponent = names(myBuildableLib).className;
+      updateFile(
+        `apps/${myApp}/src/app/app.spec.tsx`,
+        `
+        import { render } from '@testing-library/react';
+        import { App } from './app';
+        import { ${exportedLibraryComponent} } from 'multi-path-lib';
+
+        describe('App', () => {
+          it('should render successfully', () => {
+            const { baseElement } = render(<App />);
+            expect(baseElement).toBeTruthy();
+            expect(${exportedLibraryComponent}).toBeDefined();
+          });
+        });
+        `
+      );
+
+      updateJson('tsconfig.base.json', (json) => {
+        json.compilerOptions.paths['multi-path-lib'] = [
+          `libs/does-not-exist/src/index.ts`,
+          `libs/${myBuildableLib}/src/index.ts`,
+        ];
+        return json;
+      });
+
+      expect(() => runCLI(`run ${myApp}:test-ci --watch=false`)).not.toThrow();
+    });
+
     it('should support importing files with "." in the name in tsconfig path', () => {
       const mylib = uniq('mylib');
       runCLI(

--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -277,27 +277,33 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
         importPath === normalizedImport ||
         importPath.startsWith(normalizedImport + '/')
       ) {
-        const joinedPath = joinPathFragments(
-          tsconfig.absoluteBaseUrl,
-          paths[0].replace(/\/\*$/, '')
-        );
-
-        resolvedFile = findFile(
-          importPath.replace(normalizedImport, joinedPath),
-          options.extensions
-        );
-
-        if (
-          resolvedFile === undefined &&
-          options.extensions.some((ext) => importPath.endsWith(ext))
-        ) {
-          const foundExtension = options.extensions.find((ext) =>
-            importPath.endsWith(ext)
+        for (const path of paths) {
+          const joinedPath = joinPathFragments(
+            tsconfig.absoluteBaseUrl,
+            path.replace(/\/\*$/, '')
           );
-          const pathWithoutExtension = importPath
-            .replace(normalizedImport, joinedPath)
-            .slice(0, -foundExtension.length);
-          resolvedFile = findFile(pathWithoutExtension, options.extensions);
+
+          resolvedFile = findFile(
+            importPath.replace(normalizedImport, joinedPath),
+            options.extensions
+          );
+
+          if (
+            resolvedFile === undefined &&
+            options.extensions.some((ext) => importPath.endsWith(ext))
+          ) {
+            const foundExtension = options.extensions.find((ext) =>
+              importPath.endsWith(ext)
+            );
+            const pathWithoutExtension = importPath
+              .replace(normalizedImport, joinedPath)
+              .slice(0, -foundExtension.length);
+            resolvedFile = findFile(pathWithoutExtension, options.extensions);
+          }
+
+          if (resolvedFile !== undefined) {
+            return resolvedFile;
+          }
         }
       }
     }

--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -48,6 +48,16 @@ export interface nxViteTsPathsOptions {
    * @default true
    */
   buildLibsFromSource?: boolean;
+  /**
+   * The target to use for building the library dependencies.
+   * @default 'build'
+   */
+  buildTarget?: string;
+  /**
+   * The target to use for testing the library.
+   * @default 'test'
+   */
+  testTarget?: string;
 }
 
 /**
@@ -80,6 +90,8 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
     '.less',
   ];
   options.mainFields ??= [['exports', '.', 'import'], 'module', 'main'];
+  options.buildTarget ??= 'build';
+  options.testTarget ??= 'test';
   options.buildLibsFromSource ??= true;
   let projectRoot = '';
   let projectRootFromWorkspaceRoot: string;
@@ -114,8 +126,8 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
         // we need to get the deps for the 'build' target instead.
         const depsBuildTarget =
           process.env.NX_TASK_TARGET_TARGET === 'serve' ||
-          process.env.NX_TASK_TARGET_TARGET === 'test'
-            ? 'build'
+          process.env.NX_TASK_TARGET_TARGET === options.testTarget
+            ? options.buildTarget
             : process.env.NX_TASK_TARGET_TARGET;
         const { dependencies } = calculateProjectBuildableDependencies(
           undefined,

--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -141,14 +141,16 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
             true
           );
           process.env.NX_GENERATED_TSCONFIG_PATH = foundTsConfigPath;
-        }
-        if (config.command === 'serve') {
-          const buildableLibraryDependencies = dependencies
-            .filter((dep) => dep.node.type === 'lib')
-            .map((dep) => dep.node.name)
-            .join(',');
-          const buildCommand = `npx nx run-many --target=${depsBuildTarget} --projects=${buildableLibraryDependencies}`;
-          config.plugins.push(nxViteBuildCoordinationPlugin({ buildCommand }));
+          if (config.command === 'serve') {
+            const buildableLibraryDependencies = dependencies
+              .filter((dep) => dep.node.type === 'lib')
+              .map((dep) => dep.node.name)
+              .join(',');
+            const buildCommand = `npx nx run-many --target=${depsBuildTarget} --projects=${buildableLibraryDependencies}`;
+            config.plugins.push(
+              nxViteBuildCoordinationPlugin({ buildCommand })
+            );
+          }
         }
       }
 

--- a/packages/vite/plugins/nx-vite-build-coordination.plugin.ts
+++ b/packages/vite/plugins/nx-vite-build-coordination.plugin.ts
@@ -37,7 +37,7 @@ export function nxViteBuildCoordinationPlugin(
     const runner = new BatchFunctionRunner(() => buildChangedProjects());
     return daemonClient.registerFileWatcher(
       { watchProjects: 'all' },
-      (err, { changedProjects, changedFiles }) => {
+      (err, data) => {
         if (err === 'reconnecting') {
           // Silent - daemon restarts automatically on lockfile changes
           return;
@@ -60,7 +60,10 @@ export function nxViteBuildCoordinationPlugin(
           activeBuildProcess = undefined;
         }
 
-        runner.enqueue(changedProjects, changedFiles);
+        if (data) {
+          const { changedProjects, changedFiles } = data;
+          runner.enqueue(changedProjects, changedFiles);
+        }
       }
     );
   }

--- a/packages/vite/plugins/nx-vite-build-coordination.plugin.ts
+++ b/packages/vite/plugins/nx-vite-build-coordination.plugin.ts
@@ -17,28 +17,44 @@ export function nxViteBuildCoordinationPlugin(
   let unregisterFileWatcher: UnregisterCallback | undefined;
 
   async function buildChangedProjects() {
-    await new Promise<void>((res, rej) => {
-      activeBuildProcess = exec(options.buildCommand, {
-        windowsHide: true,
-      });
-      activeBuildProcess.stdout.pipe(process.stdout);
-      activeBuildProcess.stderr.pipe(process.stderr);
-      activeBuildProcess.on('exit', (code) => {
-        if (code !== 0) {
-          rej(new Error(`Build failed with exit code ${code}`));
-        } else {
-          res();
-        }
-      });
-      activeBuildProcess.on('error', () => {
-        res();
-      });
+    const buildProcess = exec(options.buildCommand, {
+      windowsHide: true,
     });
-    activeBuildProcess = undefined;
+    activeBuildProcess = buildProcess;
+    try {
+      await new Promise<void>((res, rej) => {
+        buildProcess.stdout.pipe(process.stdout);
+        buildProcess.stderr.pipe(process.stderr);
+        buildProcess.on('exit', (code, signal) => {
+          // A build killed by the file watcher (new changes arrived) is not a failure.
+          if (buildProcess.killed || signal || code === 0) {
+            res();
+          } else {
+            rej(new Error(`Build failed with exit code ${code}`));
+          }
+        });
+        buildProcess.on('error', (error) => {
+          rej(error);
+        });
+      });
+    } finally {
+      if (activeBuildProcess === buildProcess) {
+        activeBuildProcess = undefined;
+      }
+    }
   }
 
   function createFileWatcher() {
-    const runner = new BatchFunctionRunner(() => buildChangedProjects());
+    // Failed rebuilds in watch mode should not crash the dev server. Log and
+    // keep watching so the next file change can rebuild.
+    const runner = new BatchFunctionRunner(() =>
+      buildChangedProjects().catch((error: Error) => {
+        output.error({
+          title: 'Failed to rebuild projects. Fix the errors and save again.',
+          bodyLines: error?.message ? [error.message] : undefined,
+        });
+      })
+    );
     return daemonClient.registerFileWatcher(
       { watchProjects: 'all' },
       (err, data) => {

--- a/packages/vite/plugins/nx-vite-build-coordination.plugin.ts
+++ b/packages/vite/plugins/nx-vite-build-coordination.plugin.ts
@@ -17,14 +17,18 @@ export function nxViteBuildCoordinationPlugin(
   let unregisterFileWatcher: UnregisterCallback | undefined;
 
   async function buildChangedProjects() {
-    await new Promise<void>((res) => {
+    await new Promise<void>((res, rej) => {
       activeBuildProcess = exec(options.buildCommand, {
         windowsHide: true,
       });
       activeBuildProcess.stdout.pipe(process.stdout);
       activeBuildProcess.stderr.pipe(process.stderr);
-      activeBuildProcess.on('exit', () => {
-        res();
+      activeBuildProcess.on('exit', (code) => {
+        if (code !== 0) {
+          rej(new Error(`Build failed with exit code ${code}`));
+        } else {
+          res();
+        }
       });
       activeBuildProcess.on('error', () => {
         res();


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

When using the Vite Nx plugins:
- `nxViteTsPaths` assumes fixed target names (`build`/`test`) and does not support custom target naming for dependency builds.
- Path alias resolution may fail when a tsconfig path key has multiple candidate values because only the first path is tried.
- Build coordination in watch/serve can fail silently or behave inconsistently:
  - non-zero build exits are not surfaced clearly
  - watcher callbacks may receive undefined payloads
  - vitest browser workflows can trigger duplicate builds in some scenarios

## Expected Behavior

With these changes:
- `nxViteTsPaths` supports configurable `buildTarget` and `testTarget` options, with backward-compatible defaults.
- Tsconfig path resolution correctly iterates through multiple mapped paths and resolves the first valid file.
- Build coordination behavior is more robust and predictable:
  - failed dependency builds are surfaced and forcing the process to stop instead of silently failing and letting vitest browser mode open the browser (for example)
  - undefined watcher payloads are safely handled
  - build coordination is only attached in the right execution path, preventing duplicate builds in vitest browser mode


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

