### PR TITLE
fix(nx-dev): add clickjacking protection headers to Netlify configs

### DIFF
--- a/astro-docs/netlify.toml
+++ b/astro-docs/netlify.toml
@@ -1,3 +1,9 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    Content-Security-Policy = "frame-ancestors 'none'"
+
 # Disable gradle and maven plugins on Netlify
 # (Netlify only supports Java 8 but these plugins require Java 17)
 [build.environment]

--- a/netlify/edge-functions/rewrite-framer-urls.ts
+++ b/netlify/edge-functions/rewrite-framer-urls.ts
@@ -127,6 +127,8 @@ export default async function handler(
   const newHeaders = new Headers(response.headers);
   newHeaders.set('x-nx-edge-function', 'framer-proxy');
   newHeaders.set('Cache-Control', 'public, max-age=3600, must-revalidate');
+  newHeaders.set('X-Frame-Options', 'DENY');
+  newHeaders.set('Content-Security-Policy', "frame-ancestors 'none'");
 
   return new Response(rewrittenHtml, {
     status: response.status,

--- a/nx-dev/nx-dev/netlify.toml
+++ b/nx-dev/nx-dev/netlify.toml
@@ -1,3 +1,9 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    Content-Security-Policy = "frame-ancestors 'none'"
+
 [[plugins]]
   package = "@netlify/plugin-nextjs"
 


### PR DESCRIPTION
Add X-Frame-Options and Content-Security-Policy frame-ancestors headers to prevent clickjacking on nx.dev marketing and docs sites.

Fixes DOC-449
