### PR TITLE
fix(linter): detect require() calls in enforce-module-boundaries rule

### DIFF
--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
@@ -1161,6 +1161,95 @@ Violation detected in:
       expect(failures[1].message).toEqual(message);
     });
 
+    it('should error when using require() to import another library', () => {
+      const failures = runRule(
+        {},
+        `${process.cwd()}/proj/libs/mylib/src/main.ts`,
+        `
+          require('../../other');
+          require.resolve('../../other');
+        `,
+        {
+          nodes: {
+            mylibName: {
+              name: 'mylibName',
+              type: 'lib',
+              data: {
+                root: 'libs/mylib',
+                tags: [],
+                implicitDependencies: [],
+                targets: {},
+              },
+            },
+            otherName: {
+              name: 'otherName',
+              type: 'lib',
+              data: {
+                root: 'libs/other',
+                tags: [],
+                implicitDependencies: [],
+                targets: {},
+              },
+            },
+          },
+          dependencies: {},
+        },
+        {
+          mylibName: [createFile(`libs/mylib/src/main.ts`)],
+          otherName: [createFile('libs/other/src/index.ts')],
+        }
+      );
+
+      const message =
+        'Projects cannot be imported by a relative or absolute path, and must begin with a npm scope';
+      expect(failures.length).toEqual(2);
+      expect(failures[0].message).toEqual(message);
+      expect(failures[1].message).toEqual(message);
+    });
+
+    it('should not error for require() with non-string arguments', () => {
+      const failures = runRule(
+        {},
+        `${process.cwd()}/proj/libs/mylib/src/main.ts`,
+        `
+          const name = '../../other';
+          require(name);
+          require(\`\${name}\`);
+        `,
+        {
+          nodes: {
+            mylibName: {
+              name: 'mylibName',
+              type: 'lib',
+              data: {
+                root: 'libs/mylib',
+                tags: [],
+                implicitDependencies: [],
+                targets: {},
+              },
+            },
+            otherName: {
+              name: 'otherName',
+              type: 'lib',
+              data: {
+                root: 'libs/other',
+                tags: [],
+                implicitDependencies: [],
+                targets: {},
+              },
+            },
+          },
+          dependencies: {},
+        },
+        {
+          mylibName: [createFile(`libs/mylib/src/main.ts`)],
+          otherName: [createFile('libs/other/src/index.ts')],
+        }
+      );
+
+      expect(failures.length).toEqual(0);
+    });
+
     it('should error when relatively importing the src directory of another library', () => {
       const failures = runRule(
         {},

--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.ts
@@ -255,25 +255,14 @@ export default ESLintUtils.RuleCreator(
       );
 
     function run(
+      imp: string,
       node:
         | TSESTree.ImportDeclaration
         | TSESTree.ImportExpression
         | TSESTree.ExportAllDeclaration
         | TSESTree.ExportNamedDeclaration
+        | TSESTree.CallExpression
     ) {
-      // Ignoring ExportNamedDeclarations like:
-      // export class Foo {}
-      if (!node.source) {
-        return;
-      }
-
-      // accept only literals because template literals have no value
-      if (node.source.type !== AST_NODE_TYPES.Literal) {
-        return;
-      }
-
-      const imp = node.source.value as string;
-
       // whitelisted import
       if (allow.some((a) => matchImportWithWildcard(a, imp))) {
         return;
@@ -649,7 +638,9 @@ export default ESLintUtils.RuleCreator(
       }
 
       // if we import a library using loadChildren, we should not import it using es6imports
+      // this check only applies to ES import/export statements, not require() calls
       if (
+        node.type !== AST_NODE_TYPES.CallExpression &&
         !checkDynamicDependenciesExceptions.some((a) =>
           matchImportWithWildcard(a, imp)
         ) &&
@@ -794,18 +785,79 @@ export default ESLintUtils.RuleCreator(
       }
     }
 
+    function getImportFromSourceNode(
+      node:
+        | TSESTree.ImportDeclaration
+        | TSESTree.ImportExpression
+        | TSESTree.ExportAllDeclaration
+        | TSESTree.ExportNamedDeclaration
+    ): string | undefined {
+      if (!node.source) {
+        return undefined;
+      }
+      if (node.source.type !== AST_NODE_TYPES.Literal) {
+        return undefined;
+      }
+      return node.source.value as string;
+    }
+
+    function getImportFromRequireCall(
+      node: TSESTree.CallExpression
+    ): string | undefined {
+      const callee = node.callee;
+      const isRequire =
+        callee.type === AST_NODE_TYPES.Identifier && callee.name === 'require';
+      const isRequireResolve =
+        callee.type === AST_NODE_TYPES.MemberExpression &&
+        callee.object.type === AST_NODE_TYPES.Identifier &&
+        callee.object.name === 'require' &&
+        callee.property.type === AST_NODE_TYPES.Identifier &&
+        callee.property.name === 'resolve';
+
+      if (!isRequire && !isRequireResolve) {
+        return undefined;
+      }
+
+      const arg = node.arguments[0];
+      if (
+        arg?.type === AST_NODE_TYPES.Literal &&
+        typeof arg.value === 'string'
+      ) {
+        return arg.value;
+      }
+      return undefined;
+    }
+
     return {
       ImportDeclaration(node: TSESTree.ImportDeclaration) {
-        run(node);
+        const imp = getImportFromSourceNode(node);
+        if (imp !== undefined) {
+          run(imp, node);
+        }
       },
       ImportExpression(node: TSESTree.ImportExpression) {
-        run(node);
+        const imp = getImportFromSourceNode(node);
+        if (imp !== undefined) {
+          run(imp, node);
+        }
       },
       ExportAllDeclaration(node: TSESTree.ExportAllDeclaration) {
-        run(node);
+        const imp = getImportFromSourceNode(node);
+        if (imp !== undefined) {
+          run(imp, node);
+        }
       },
       ExportNamedDeclaration(node: TSESTree.ExportNamedDeclaration) {
-        run(node);
+        const imp = getImportFromSourceNode(node);
+        if (imp !== undefined) {
+          run(imp, node);
+        }
+      },
+      CallExpression(node: TSESTree.CallExpression) {
+        const imp = getImportFromRequireCall(node);
+        if (imp !== undefined) {
+          run(imp, node);
+        }
       },
     };
   },


### PR DESCRIPTION
## Current Behavior

The `enforce-module-boundaries` rule only visits ESM AST nodes (`ImportDeclaration`, `ImportExpression`, `ExportAllDeclaration`, `ExportNamedDeclaration`). CommonJS `require()` calls bypass all boundary checks entirely.

## Expected Behavior

`require()` and `require.resolve()` calls are detected and validated against the same module boundary rules as ESM imports. Auto-fix is skipped for `require()` nodes since they have no `specifiers`.

## Related Issue(s)

Fixes #34096