### PR TITLE
fix(linter): use native nx.configs in convert-to-flat-config for Nx plugins

### DIFF
--- a/packages/eslint/src/generators/convert-to-flat-config/__snapshots__/generator.spec.ts.snap
+++ b/packages/eslint/src/generators/convert-to-flat-config/__snapshots__/generator.spec.ts.snap
@@ -1,21 +1,14 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`convert-to-flat-config generator CJS should add env configuration 1`] = `
-"const { FlatCompat } = require('@eslint/eslintrc');
-const js = require('@eslint/js');
-const nxEslintPlugin = require('@nx/eslint-plugin');
+"const nx = require('@nx/eslint-plugin');
 const globals = require('globals');
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-});
 
 module.exports = [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   { languageOptions: { globals: { ...globals.browser, ...globals.node } } },
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -35,48 +28,21 @@ module.exports = [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
 
 exports[`convert-to-flat-config generator CJS should add global and env configuration 1`] = `
-"const { FlatCompat } = require('@eslint/eslintrc');
-const js = require('@eslint/js');
-const nxEslintPlugin = require('@nx/eslint-plugin');
+"const nx = require('@nx/eslint-plugin');
 const globals = require('globals');
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-});
 
 module.exports = [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   {
     languageOptions: {
       globals: { ...globals.browser, myCustomGlobal: 'readonly' },
@@ -100,47 +66,20 @@ module.exports = [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
 
 exports[`convert-to-flat-config generator CJS should add global configuration 1`] = `
-"const { FlatCompat } = require('@eslint/eslintrc');
-const js = require('@eslint/js');
-const nxEslintPlugin = require('@nx/eslint-plugin');
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-});
+"const nx = require('@nx/eslint-plugin');
 
 module.exports = [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   { languageOptions: { globals: { myCustomGlobal: 'readonly' } } },
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -160,47 +99,20 @@ module.exports = [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
 
 exports[`convert-to-flat-config generator CJS should add global eslintignores 1`] = `
-"const { FlatCompat } = require('@eslint/eslintrc');
-const js = require('@eslint/js');
-const nxEslintPlugin = require('@nx/eslint-plugin');
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-});
+"const nx = require('@nx/eslint-plugin');
 
 module.exports = [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
     rules: {
@@ -219,28 +131,8 @@ module.exports = [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
   {
     ignores: ['ignore/me'],
   },
@@ -249,21 +141,14 @@ module.exports = [
 `;
 
 exports[`convert-to-flat-config generator CJS should add parser 1`] = `
-"const { FlatCompat } = require('@eslint/eslintrc');
-const js = require('@eslint/js');
-const nxEslintPlugin = require('@nx/eslint-plugin');
+"const nx = require('@nx/eslint-plugin');
 const typescriptEslintParser = require('@typescript-eslint/parser');
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-});
 
 module.exports = [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   { languageOptions: { parser: typescriptEslintParser } },
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -283,44 +168,18 @@ module.exports = [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
 
 exports[`convert-to-flat-config generator CJS should add plugins 1`] = `
-"const { FlatCompat } = require('@eslint/eslintrc');
-const js = require('@eslint/js');
-const eslintPluginImport = require('eslint-plugin-import');
+"const eslintPluginImport = require('eslint-plugin-import');
 const eslintPluginSingleName = require('eslint-plugin-single-name');
 const scopeEslintPluginWithName = require('@scope/eslint-plugin-with-name');
 const justScopeEslintPlugin = require('@just-scope/eslint-plugin');
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-});
+const nx = require('@nx/eslint-plugin');
 
 module.exports = [
   {
@@ -352,47 +211,20 @@ module.exports = [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
 
 exports[`convert-to-flat-config generator CJS should add settings 1`] = `
-"const { FlatCompat } = require('@eslint/eslintrc');
-const js = require('@eslint/js');
-const nxEslintPlugin = require('@nx/eslint-plugin');
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-});
+"const nx = require('@nx/eslint-plugin');
 
 module.exports = [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   {
     settings: {
       sharedData: 'Hello',
@@ -416,47 +248,20 @@ module.exports = [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
 
 exports[`convert-to-flat-config generator CJS should convert json successfully 1`] = `
-"const { FlatCompat } = require('@eslint/eslintrc');
-const js = require('@eslint/js');
-const nxEslintPlugin = require('@nx/eslint-plugin');
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-});
+"const nx = require('@nx/eslint-plugin');
 
 module.exports = [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
     rules: {
@@ -475,28 +280,8 @@ module.exports = [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
@@ -529,20 +314,13 @@ module.exports = [
 `;
 
 exports[`convert-to-flat-config generator CJS should convert yaml successfully 1`] = `
-"const { FlatCompat } = require('@eslint/eslintrc');
-const js = require('@eslint/js');
-const nxEslintPlugin = require('@nx/eslint-plugin');
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-});
+"const nx = require('@nx/eslint-plugin');
 
 module.exports = [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
     rules: {
@@ -561,28 +339,8 @@ module.exports = [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
@@ -615,20 +373,13 @@ module.exports = [
 `;
 
 exports[`convert-to-flat-config generator CJS should convert yml successfully 1`] = `
-"const { FlatCompat } = require('@eslint/eslintrc');
-const js = require('@eslint/js');
-const nxEslintPlugin = require('@nx/eslint-plugin');
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-});
+"const nx = require('@nx/eslint-plugin');
 
 module.exports = [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
     rules: {
@@ -647,28 +398,8 @@ module.exports = [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
@@ -734,23 +465,14 @@ module.exports = [
 `;
 
 exports[`convert-to-flat-config generator MJS should add env configuration 1`] = `
-"import { FlatCompat } from '@eslint/eslintrc';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
-import js from '@eslint/js';
-import nxEslintPlugin from '@nx/eslint-plugin';
+"import nx from '@nx/eslint-plugin';
 import globals from 'globals';
-
-const compat = new FlatCompat({
-  baseDirectory: dirname(fileURLToPath(import.meta.url)),
-  recommendedConfig: js.configs.recommended,
-});
 
 export default [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   { languageOptions: { globals: { ...globals.browser, ...globals.node } } },
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -770,50 +492,21 @@ export default [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
 
 exports[`convert-to-flat-config generator MJS should add global and env configuration 1`] = `
-"import { FlatCompat } from '@eslint/eslintrc';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
-import js from '@eslint/js';
-import nxEslintPlugin from '@nx/eslint-plugin';
+"import nx from '@nx/eslint-plugin';
 import globals from 'globals';
-
-const compat = new FlatCompat({
-  baseDirectory: dirname(fileURLToPath(import.meta.url)),
-  recommendedConfig: js.configs.recommended,
-});
 
 export default [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   {
     languageOptions: {
       globals: { ...globals.browser, myCustomGlobal: 'readonly' },
@@ -837,49 +530,20 @@ export default [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
 
 exports[`convert-to-flat-config generator MJS should add global configuration 1`] = `
-"import { FlatCompat } from '@eslint/eslintrc';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
-import js from '@eslint/js';
-import nxEslintPlugin from '@nx/eslint-plugin';
-
-const compat = new FlatCompat({
-  baseDirectory: dirname(fileURLToPath(import.meta.url)),
-  recommendedConfig: js.configs.recommended,
-});
+"import nx from '@nx/eslint-plugin';
 
 export default [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   { languageOptions: { globals: { myCustomGlobal: 'readonly' } } },
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -899,49 +563,20 @@ export default [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
 
 exports[`convert-to-flat-config generator MJS should add global eslintignores 1`] = `
-"import { FlatCompat } from '@eslint/eslintrc';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
-import js from '@eslint/js';
-import nxEslintPlugin from '@nx/eslint-plugin';
-
-const compat = new FlatCompat({
-  baseDirectory: dirname(fileURLToPath(import.meta.url)),
-  recommendedConfig: js.configs.recommended,
-});
+"import nx from '@nx/eslint-plugin';
 
 export default [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
     rules: {
@@ -960,28 +595,8 @@ export default [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
   {
     ignores: ['ignore/me'],
   },
@@ -990,23 +605,14 @@ export default [
 `;
 
 exports[`convert-to-flat-config generator MJS should add parser 1`] = `
-"import { FlatCompat } from '@eslint/eslintrc';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
-import js from '@eslint/js';
-import nxEslintPlugin from '@nx/eslint-plugin';
+"import nx from '@nx/eslint-plugin';
 import typescriptEslintParser from '@typescript-eslint/parser';
-
-const compat = new FlatCompat({
-  baseDirectory: dirname(fileURLToPath(import.meta.url)),
-  recommendedConfig: js.configs.recommended,
-});
 
 export default [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   { languageOptions: { parser: typescriptEslintParser } },
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -1026,46 +632,18 @@ export default [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
 
 exports[`convert-to-flat-config generator MJS should add plugins 1`] = `
-"import { FlatCompat } from '@eslint/eslintrc';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
-import js from '@eslint/js';
-import eslintPluginImport from 'eslint-plugin-import';
+"import eslintPluginImport from 'eslint-plugin-import';
 import eslintPluginSingleName from 'eslint-plugin-single-name';
 import scopeEslintPluginWithName from '@scope/eslint-plugin-with-name';
 import justScopeEslintPlugin from '@just-scope/eslint-plugin';
-
-const compat = new FlatCompat({
-  baseDirectory: dirname(fileURLToPath(import.meta.url)),
-  recommendedConfig: js.configs.recommended,
-});
+import nx from '@nx/eslint-plugin';
 
 export default [
   {
@@ -1097,49 +675,20 @@ export default [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
 
 exports[`convert-to-flat-config generator MJS should add settings 1`] = `
-"import { FlatCompat } from '@eslint/eslintrc';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
-import js from '@eslint/js';
-import nxEslintPlugin from '@nx/eslint-plugin';
-
-const compat = new FlatCompat({
-  baseDirectory: dirname(fileURLToPath(import.meta.url)),
-  recommendedConfig: js.configs.recommended,
-});
+"import nx from '@nx/eslint-plugin';
 
 export default [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   {
     settings: {
       sharedData: 'Hello',
@@ -1163,49 +712,20 @@ export default [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
 
 exports[`convert-to-flat-config generator MJS should convert json successfully 1`] = `
-"import { FlatCompat } from '@eslint/eslintrc';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
-import js from '@eslint/js';
-import nxEslintPlugin from '@nx/eslint-plugin';
-
-const compat = new FlatCompat({
-  baseDirectory: dirname(fileURLToPath(import.meta.url)),
-  recommendedConfig: js.configs.recommended,
-});
+"import nx from '@nx/eslint-plugin';
 
 export default [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
     rules: {
@@ -1224,28 +744,8 @@ export default [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
@@ -1278,22 +778,13 @@ export default [
 `;
 
 exports[`convert-to-flat-config generator MJS should convert yaml successfully 1`] = `
-"import { FlatCompat } from '@eslint/eslintrc';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
-import js from '@eslint/js';
-import nxEslintPlugin from '@nx/eslint-plugin';
-
-const compat = new FlatCompat({
-  baseDirectory: dirname(fileURLToPath(import.meta.url)),
-  recommendedConfig: js.configs.recommended,
-});
+"import nx from '@nx/eslint-plugin';
 
 export default [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
     rules: {
@@ -1312,28 +803,8 @@ export default [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;
@@ -1366,22 +837,13 @@ export default [
 `;
 
 exports[`convert-to-flat-config generator MJS should convert yml successfully 1`] = `
-"import { FlatCompat } from '@eslint/eslintrc';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
-import js from '@eslint/js';
-import nxEslintPlugin from '@nx/eslint-plugin';
-
-const compat = new FlatCompat({
-  baseDirectory: dirname(fileURLToPath(import.meta.url)),
-  recommendedConfig: js.configs.recommended,
-});
+"import nx from '@nx/eslint-plugin';
 
 export default [
   {
     ignores: ['**/dist', '**/out-tsc'],
   },
-  { plugins: { '@nx': nxEslintPlugin } },
+  ...nx.configs['flat/base'],
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
     rules: {
@@ -1400,28 +862,8 @@ export default [
       ],
     },
   },
-  ...compat
-    .config({
-      extends: ['plugin:@nx/typescript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-      rules: {
-        ...config.rules,
-      },
-    })),
-  ...compat
-    .config({
-      extends: ['plugin:@nx/javascript'],
-    })
-    .map((config) => ({
-      ...config,
-      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-      rules: {
-        ...config.rules,
-      },
-    })),
+  ...nx.configs['flat/typescript'],
+  ...nx.configs['flat/javascript'],
 ];
 "
 `;

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.spec.ts
@@ -79,7 +79,7 @@ describe('convertEslintJsonToFlatConfig', () => {
         import { dirname } from "path";
         import { fileURLToPath } from "url";
         import js from "@eslint/js";
-        import nxEslintPlugin from "@nx/eslint-plugin";
+        import nx from "@nx/eslint-plugin";
 
         const compat = new FlatCompat({
           baseDirectory: dirname(fileURLToPath(import.meta.url)),
@@ -94,7 +94,7 @@ describe('convertEslintJsonToFlatConfig', () => {
                     "**/out-tsc"
                 ]
             },
-            { plugins: { "@nx": nxEslintPlugin } },
+            ...nx.configs["flat/base"],
             {
                 files: [
                     "**/*.ts",
@@ -120,38 +120,8 @@ describe('convertEslintJsonToFlatConfig', () => {
                     ]
                 }
             },
-            ...compat.config({
-                extends: [
-                    "plugin:@nx/typescript"
-                ]
-            }).map(config => ({
-                ...config,
-                files: [
-                    "**/*.ts",
-                    "**/*.tsx",
-                    "**/*.cts",
-                    "**/*.mts"
-                ],
-                rules: {
-                    ...config.rules
-                }
-            })),
-            ...compat.config({
-                extends: [
-                    "plugin:@nx/javascript"
-                ]
-            }).map(config => ({
-                ...config,
-                files: [
-                    "**/*.js",
-                    "**/*.jsx",
-                    "**/*.cjs",
-                    "**/*.mjs"
-                ],
-                rules: {
-                    ...config.rules
-                }
-            })),
+            ...nx.configs["flat/typescript"],
+            ...nx.configs["flat/javascript"],
             ...compat.config({
                 env: {
                     jest: true
@@ -245,6 +215,7 @@ describe('convertEslintJsonToFlatConfig', () => {
         import { fileURLToPath } from "url";
         import js from "@eslint/js";
         import baseConfig from "../../eslint.config.mjs";
+        import nx from "@nx/eslint-plugin";
         import globals from "globals";
 
         const compat = new FlatCompat({
@@ -261,7 +232,8 @@ describe('convertEslintJsonToFlatConfig', () => {
                 ]
             },
             ...baseConfig,
-            ...compat.extends("plugin:@nx/react-typescript", "next", "next/core-web-vitals"),
+            ...nx.configs["flat/react-typescript"],
+            ...compat.extends("next", "next/core-web-vitals"),
             { languageOptions: { globals: { ...globals.jest } } },
             {
                 rules: {
@@ -319,6 +291,132 @@ describe('convertEslintJsonToFlatConfig', () => {
                     "something/else"
                 ]
             }
+        ];
+        "
+      `);
+    });
+
+    it('should preserve custom rules when converting Nx plugin overrides', async () => {
+      tree.write(
+        '.eslintrc.json',
+        JSON.stringify({
+          root: true,
+          ignorePatterns: ['**/*'],
+          plugins: ['@nx'],
+          overrides: [
+            {
+              files: ['*.ts', '*.tsx'],
+              extends: ['plugin:@nx/typescript'],
+              rules: {
+                '@typescript-eslint/no-unused-vars': 'error',
+              },
+            },
+          ],
+        })
+      );
+
+      const { content } = convertEslintJsonToFlatConfig(
+        tree,
+        '',
+        readJson(tree, '.eslintrc.json'),
+        [],
+        'mjs'
+      );
+
+      expect(content).toMatchInlineSnapshot(`
+        "import nx from "@nx/eslint-plugin";
+
+        export default [
+            {
+                ignores: [
+                    "**/dist",
+                    "**/out-tsc"
+                ]
+            },
+            ...nx.configs["flat/base"],
+            ...nx.configs["flat/typescript"],
+            {
+                files: [
+                    "**/*.ts",
+                    "**/*.tsx"
+                ],
+                rules: {
+                    "@typescript-eslint/no-unused-vars": "error"
+                }
+            }
+        ];
+        "
+      `);
+    });
+
+    it('should handle overrides with mixed Nx and non-Nx extends', async () => {
+      tree.write(
+        '.eslintrc.json',
+        JSON.stringify({
+          root: true,
+          ignorePatterns: ['**/*'],
+          plugins: ['@nx'],
+          overrides: [
+            {
+              files: ['*.ts', '*.tsx'],
+              extends: [
+                'plugin:@nx/typescript',
+                'plugin:storybook/recommended',
+              ],
+              rules: {
+                'some-rule': 'warn',
+              },
+            },
+          ],
+        })
+      );
+
+      const { content, addESLintRC } = convertEslintJsonToFlatConfig(
+        tree,
+        '',
+        readJson(tree, '.eslintrc.json'),
+        [],
+        'mjs'
+      );
+
+      expect(addESLintRC).toBe(true);
+      expect(content).toMatchInlineSnapshot(`
+        "import { FlatCompat } from "@eslint/eslintrc";
+        import { dirname } from "path";
+        import { fileURLToPath } from "url";
+        import js from "@eslint/js";
+        import nx from "@nx/eslint-plugin";
+
+        const compat = new FlatCompat({
+          baseDirectory: dirname(fileURLToPath(import.meta.url)),
+          recommendedConfig: js.configs.recommended,
+        });
+
+
+        export default [
+            {
+                ignores: [
+                    "**/dist",
+                    "**/out-tsc"
+                ]
+            },
+            ...nx.configs["flat/base"],
+            ...nx.configs["flat/typescript"],
+            ...compat.config({
+                extends: [
+                    "plugin:storybook/recommended"
+                ]
+            }).map(config => ({
+                ...config,
+                files: [
+                    "**/*.ts",
+                    "**/*.tsx"
+                ],
+                rules: {
+                    ...config.rules,
+                    "some-rule": "warn"
+                }
+            }))
         ];
         "
       `);
@@ -392,7 +490,7 @@ describe('convertEslintJsonToFlatConfig', () => {
       expect(content).toMatchInlineSnapshot(`
         "const { FlatCompat } = require("@eslint/eslintrc");
         const js = require("@eslint/js");
-        const nxEslintPlugin = require("@nx/eslint-plugin");
+        const nx = require("@nx/eslint-plugin");
 
         const compat = new FlatCompat({
           baseDirectory: __dirname,
@@ -406,7 +504,7 @@ describe('convertEslintJsonToFlatConfig', () => {
                     "**/out-tsc"
                 ]
             },
-            { plugins: { "@nx": nxEslintPlugin } },
+            ...nx.configs["flat/base"],
             {
                 files: [
                     "**/*.ts",
@@ -432,38 +530,8 @@ describe('convertEslintJsonToFlatConfig', () => {
                     ]
                 }
             },
-            ...compat.config({
-                extends: [
-                    "plugin:@nx/typescript"
-                ]
-            }).map(config => ({
-                ...config,
-                files: [
-                    "**/*.ts",
-                    "**/*.tsx",
-                    "**/*.cts",
-                    "**/*.mts"
-                ],
-                rules: {
-                    ...config.rules
-                }
-            })),
-            ...compat.config({
-                extends: [
-                    "plugin:@nx/javascript"
-                ]
-            }).map(config => ({
-                ...config,
-                files: [
-                    "**/*.js",
-                    "**/*.jsx",
-                    "**/*.cjs",
-                    "**/*.mjs"
-                ],
-                rules: {
-                    ...config.rules
-                }
-            })),
+            ...nx.configs["flat/typescript"],
+            ...nx.configs["flat/javascript"],
             ...compat.config({
                 env: {
                     jest: true
@@ -555,6 +623,7 @@ describe('convertEslintJsonToFlatConfig', () => {
         "const { FlatCompat } = require("@eslint/eslintrc");
         const js = require("@eslint/js");
         const baseConfig = require("../../eslint.config.cjs");
+        const nx = require("@nx/eslint-plugin");
         const globals = require("globals");
 
         const compat = new FlatCompat({
@@ -570,7 +639,8 @@ describe('convertEslintJsonToFlatConfig', () => {
                 ]
             },
             ...baseConfig,
-            ...compat.extends("plugin:@nx/react-typescript", "next", "next/core-web-vitals"),
+            ...nx.configs["flat/react-typescript"],
+            ...compat.extends("next", "next/core-web-vitals"),
             { languageOptions: { globals: { ...globals.jest } } },
             {
                 rules: {

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
@@ -6,6 +6,7 @@ import {
   createNodeList,
   generateAst,
   generateFlatOverride,
+  generateFlatPredefinedConfig,
   generatePluginExtendsElement,
   generateSpreadElement,
   stringifyNodeList,
@@ -154,6 +155,61 @@ export function convertEslintJsonToFlatConfig(
 
   if (config.overrides) {
     config.overrides.forEach((override) => {
+      if (override.extends) {
+        const extendsArr = Array.isArray(override.extends)
+          ? override.extends
+          : [override.extends];
+        const mapped = extendsArr.map((e) => ({
+          original: e,
+          flatConfig: mapNxPluginToFlatConfig(e),
+        }));
+        const nxExtends = mapped.filter((m) => m.flatConfig);
+        const nonNxExtends = mapped
+          .filter((m) => !m.flatConfig)
+          .map((m) => m.original);
+
+        if (nxExtends.length > 0) {
+          const nxVar = (importsMap.get('@nx/eslint-plugin') as string) ?? 'nx';
+          importsMap.set('@nx/eslint-plugin', nxVar);
+          nxExtends.forEach((ext) => {
+            exportElements.push(
+              generateFlatPredefinedConfig(ext.flatConfig, nxVar, true)
+            );
+          });
+
+          // Build remaining override without Nx extends
+          const remainingOverride = { ...override };
+          if (nonNxExtends.length > 0) {
+            remainingOverride.extends = nonNxExtends;
+          } else {
+            delete remainingOverride.extends;
+          }
+
+          // Emit remaining override if it has content beyond files and empty rules
+          const {
+            files: _files,
+            rules: remainingRules,
+            ...remainingRest
+          } = remainingOverride;
+          const hasNonEmptyRules =
+            remainingRules && Object.keys(remainingRules).length > 0;
+          if (Object.keys(remainingRest).length > 0 || hasNonEmptyRules) {
+            if (
+              remainingOverride.env ||
+              remainingOverride.extends ||
+              remainingOverride.plugins ||
+              remainingOverride.parser
+            ) {
+              isFlatCompatNeeded = true;
+            }
+            exportElements.push(
+              generateFlatOverride(remainingOverride, format)
+            );
+          }
+          return;
+        }
+      }
+
       if (
         override.env ||
         override.extends ||
@@ -246,7 +302,17 @@ function addExtends(
       imp.startsWith('eslint:')
     );
     pluginExtends.forEach((imp) => {
-      if (!imp.startsWith('eslint:')) {
+      if (imp.startsWith('eslint:')) {
+        return;
+      }
+      const nxFlatConfig = mapNxPluginToFlatConfig(imp);
+      if (nxFlatConfig) {
+        const nxVar = (importsMap.get('@nx/eslint-plugin') as string) ?? 'nx';
+        importsMap.set('@nx/eslint-plugin', nxVar);
+        configBlocks.push(
+          generateFlatPredefinedConfig(nxFlatConfig, nxVar, true)
+        );
+      } else {
         eslintrcConfigs.push(imp);
       }
     });
@@ -283,10 +349,24 @@ function addPlugins(
   configBlocks: ts.Expression[],
   config: ESLint.ConfigData
 ) {
+  // Replace @nx plugin with flat/base predefined config to match fresh generation.
+  // flat/base registers the @nx plugin and ignores .nx directory.
+  // This runs before overrides are processed, so we set the import name here
+  // for Nx extends that may appear in overrides later.
+  if (config.plugins.includes('@nx')) {
+    importsMap.set('@nx/eslint-plugin', 'nx');
+    configBlocks.push(generateFlatPredefinedConfig('flat/base', 'nx', true));
+  }
+
+  const remainingPlugins = config.plugins.filter((name) => name !== '@nx');
+  if (remainingPlugins.length === 0) {
+    return;
+  }
+
   const mappedPlugins: { name: string; varName: string; imp: string }[] = [];
-  config.plugins.forEach((name) => {
+  remainingPlugins.forEach((name) => {
     const imp = getPluginImport(name);
-    const varName = names(imp).propertyName;
+    const varName = (importsMap.get(imp) as string) ?? names(imp).propertyName;
     mappedPlugins.push({ name, varName, imp });
   });
   mappedPlugins.forEach(({ varName, imp }) => {
@@ -318,4 +398,21 @@ function addPlugins(
     false
   );
   configBlocks.push(pluginsAst);
+}
+
+const nxPluginToFlatConfigMap: Record<string, string> = {
+  'plugin:@nx/typescript': 'flat/typescript',
+  'plugin:@nx/javascript': 'flat/javascript',
+  'plugin:@nx/react': 'flat/react',
+  'plugin:@nx/react-base': 'flat/react-base',
+  'plugin:@nx/react-typescript': 'flat/react-typescript',
+  'plugin:@nx/react-jsx': 'flat/react-jsx',
+  'plugin:@nx/angular': 'flat/angular',
+  'plugin:@nx/angular-template': 'flat/angular-template',
+  'plugin:@nrwl/nx/typescript': 'flat/typescript',
+  'plugin:@nrwl/nx/javascript': 'flat/javascript',
+};
+
+function mapNxPluginToFlatConfig(pluginExtend: string): string | undefined {
+  return nxPluginToFlatConfigMap[pluginExtend];
 }

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
@@ -64,7 +64,6 @@ describe('convert-to-flat-config generator', () => {
           "name": "@proj/source",
           "dependencies": {},
           "devDependencies": {
-            "@eslint/eslintrc": "^2.1.1",
             "@nx/eslint": "0.0.1",
             "@nx/eslint-plugin": "0.0.1",
             "@typescript-eslint/eslint-plugin": "^8.40.0",
@@ -183,7 +182,7 @@ describe('convert-to-flat-config generator', () => {
       expect(tree.read('eslint.config.cjs', 'utf-8')).toMatchInlineSnapshot(`
         "const { FlatCompat } = require('@eslint/eslintrc');
         const js = require('@eslint/js');
-        const nxEslintPlugin = require('@nx/eslint-plugin');
+        const nx = require('@nx/eslint-plugin');
 
         const compat = new FlatCompat({
           baseDirectory: __dirname,
@@ -195,7 +194,7 @@ describe('convert-to-flat-config generator', () => {
             ignores: ['**/dist', '**/out-tsc'],
           },
           ...compat.extends('plugin:storybook/recommended'),
-          { plugins: { '@nx': nxEslintPlugin } },
+          ...nx.configs['flat/base'],
           {
             files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
             rules: {
@@ -214,28 +213,8 @@ describe('convert-to-flat-config generator', () => {
               ],
             },
           },
-          ...compat
-            .config({
-              extends: ['plugin:@nx/typescript'],
-            })
-            .map((config) => ({
-              ...config,
-              files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-              rules: {
-                ...config.rules,
-              },
-            })),
-          ...compat
-            .config({
-              extends: ['plugin:@nx/javascript'],
-            })
-            .map((config) => ({
-              ...config,
-              files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-              rules: {
-                ...config.rules,
-              },
-            })),
+          ...nx.configs['flat/typescript'],
+          ...nx.configs['flat/javascript'],
         ];
         "
       `);
@@ -451,20 +430,13 @@ describe('convert-to-flat-config generator', () => {
       await convertToFlatConfigGenerator(tree, options);
 
       expect(tree.read('eslint.config.cjs', 'utf-8')).toMatchInlineSnapshot(`
-        "const { FlatCompat } = require('@eslint/eslintrc');
-        const js = require('@eslint/js');
-        const nxEslintPlugin = require('@nx/eslint-plugin');
-
-        const compat = new FlatCompat({
-          baseDirectory: __dirname,
-          recommendedConfig: js.configs.recommended,
-        });
+        "const nx = require('@nx/eslint-plugin');
 
         module.exports = [
           {
             ignores: ['**/dist', '**/out-tsc'],
           },
-          { plugins: { '@nx': nxEslintPlugin } },
+          ...nx.configs['flat/base'],
           {
             linterOptions: {
               noInlineConfig: true,
@@ -488,28 +460,8 @@ describe('convert-to-flat-config generator', () => {
               ],
             },
           },
-          ...compat
-            .config({
-              extends: ['plugin:@nx/typescript'],
-            })
-            .map((config) => ({
-              ...config,
-              files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-              rules: {
-                ...config.rules,
-              },
-            })),
-          ...compat
-            .config({
-              extends: ['plugin:@nx/javascript'],
-            })
-            .map((config) => ({
-              ...config,
-              files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-              rules: {
-                ...config.rules,
-              },
-            })),
+          ...nx.configs['flat/typescript'],
+          ...nx.configs['flat/javascript'],
         ];
         "
       `);
@@ -679,7 +631,6 @@ describe('convert-to-flat-config generator', () => {
           "name": "@proj/source",
           "dependencies": {},
           "devDependencies": {
-            "@eslint/eslintrc": "^2.1.1",
             "@nx/eslint": "0.0.1",
             "@nx/eslint-plugin": "0.0.1",
             "@typescript-eslint/eslint-plugin": "^8.40.0",
@@ -800,7 +751,7 @@ describe('convert-to-flat-config generator', () => {
         import { dirname } from 'path';
         import { fileURLToPath } from 'url';
         import js from '@eslint/js';
-        import nxEslintPlugin from '@nx/eslint-plugin';
+        import nx from '@nx/eslint-plugin';
 
         const compat = new FlatCompat({
           baseDirectory: dirname(fileURLToPath(import.meta.url)),
@@ -812,7 +763,7 @@ describe('convert-to-flat-config generator', () => {
             ignores: ['**/dist', '**/out-tsc'],
           },
           ...compat.extends('plugin:storybook/recommended'),
-          { plugins: { '@nx': nxEslintPlugin } },
+          ...nx.configs['flat/base'],
           {
             files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
             rules: {
@@ -831,28 +782,8 @@ describe('convert-to-flat-config generator', () => {
               ],
             },
           },
-          ...compat
-            .config({
-              extends: ['plugin:@nx/typescript'],
-            })
-            .map((config) => ({
-              ...config,
-              files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-              rules: {
-                ...config.rules,
-              },
-            })),
-          ...compat
-            .config({
-              extends: ['plugin:@nx/javascript'],
-            })
-            .map((config) => ({
-              ...config,
-              files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-              rules: {
-                ...config.rules,
-              },
-            })),
+          ...nx.configs['flat/typescript'],
+          ...nx.configs['flat/javascript'],
         ];
         "
       `);
@@ -1068,22 +999,13 @@ describe('convert-to-flat-config generator', () => {
       await convertToFlatConfigGenerator(tree, options);
 
       expect(tree.read('eslint.config.mjs', 'utf-8')).toMatchInlineSnapshot(`
-        "import { FlatCompat } from '@eslint/eslintrc';
-        import { dirname } from 'path';
-        import { fileURLToPath } from 'url';
-        import js from '@eslint/js';
-        import nxEslintPlugin from '@nx/eslint-plugin';
-
-        const compat = new FlatCompat({
-          baseDirectory: dirname(fileURLToPath(import.meta.url)),
-          recommendedConfig: js.configs.recommended,
-        });
+        "import nx from '@nx/eslint-plugin';
 
         export default [
           {
             ignores: ['**/dist', '**/out-tsc'],
           },
-          { plugins: { '@nx': nxEslintPlugin } },
+          ...nx.configs['flat/base'],
           {
             linterOptions: {
               noInlineConfig: true,
@@ -1107,28 +1029,8 @@ describe('convert-to-flat-config generator', () => {
               ],
             },
           },
-          ...compat
-            .config({
-              extends: ['plugin:@nx/typescript'],
-            })
-            .map((config) => ({
-              ...config,
-              files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
-              rules: {
-                ...config.rules,
-              },
-            })),
-          ...compat
-            .config({
-              extends: ['plugin:@nx/javascript'],
-            })
-            .map((config) => ({
-              ...config,
-              files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
-              rules: {
-                ...config.rules,
-              },
-            })),
+          ...nx.configs['flat/typescript'],
+          ...nx.configs['flat/javascript'],
         ];
         "
       `);


### PR DESCRIPTION
## Current Behavior

The `convert-to-flat-config` generator wraps all plugin extends with `FlatCompat`, including Nx-specific ones like `plugin:@nx/typescript`. The output doesn't match what freshly generated projects produce (`nx.configs['flat/typescript']`). The `@nx` plugin registration uses a manual `{ plugins: { '@nx': nxEslintPlugin } }` block instead of `flat/base`.

## Expected Behavior

Nx plugin extends are converted to native `nx.configs['flat/X']` entries. The `@nx` plugin registration uses `flat/base`. `FlatCompat` is only used for third-party plugins. The import variable is normalized to `nx` to match fresh generation.

## Related Issue(s)

Fixes #31736