### PR TITLE
fix(linter): prepend framework configs before baseConfig in flat config generation

### DIFF
--- a/packages/angular/src/generators/add-linting/__snapshots__/add-linting.spec.ts.snap
+++ b/packages/angular/src/generators/add-linting/__snapshots__/add-linting.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`addLinting generator should correctly generate the .eslintrc.json file 1`] = `
 {

--- a/packages/angular/src/generators/add-linting/add-linting.spec.ts
+++ b/packages/angular/src/generators/add-linting/add-linting.spec.ts
@@ -125,6 +125,8 @@ describe('addLinting generator', () => {
       import baseConfig from "../../eslint.config.mjs";
 
       export default [
+          ...nx.configs["flat/angular"],
+          ...nx.configs["flat/angular-template"],
           ...baseConfig,
           {
               files: [
@@ -144,8 +146,6 @@ describe('addLinting generator', () => {
                   parser: await import("jsonc-eslint-parser")
               }
           },
-          ...nx.configs["flat/angular"],
-          ...nx.configs["flat/angular-template"],
           {
               files: [
                   "**/*.ts"

--- a/packages/angular/src/generators/add-linting/add-linting.ts
+++ b/packages/angular/src/generators/add-linting/add-linting.ts
@@ -56,12 +56,14 @@ export async function addLintingGenerator(
       addPredefinedConfigToFlatLintConfig(
         tree,
         options.projectRoot,
-        'flat/angular'
+        'flat/angular',
+        { checkBaseConfig: true }
       );
       addPredefinedConfigToFlatLintConfig(
         tree,
         options.projectRoot,
-        'flat/angular-template'
+        'flat/angular-template',
+        { checkBaseConfig: true }
       );
       addOverrideToLintConfig(tree, options.projectRoot, {
         files: ['*.ts'],

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -761,6 +761,8 @@ describe('app', () => {
           const baseConfig = require("../eslint.config.cjs");
 
           module.exports = [
+              ...nx.configs["flat/angular"],
+              ...nx.configs["flat/angular-template"],
               ...baseConfig,
               {
                   files: [
@@ -777,8 +779,6 @@ describe('app', () => {
                       }
                   }
               },
-              ...nx.configs["flat/angular"],
-              ...nx.configs["flat/angular-template"],
               {
                   files: [
                       "**/*.ts"

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -1222,9 +1222,9 @@ describe('lib', () => {
           const baseConfig = require("../eslint.config.cjs");
 
           module.exports = [
-              ...baseConfig,
               ...nx.configs["flat/angular"],
               ...nx.configs["flat/angular-template"],
+              ...baseConfig,
               {
                   files: [
                       "**/*.ts"
@@ -1274,6 +1274,8 @@ describe('lib', () => {
           const baseConfig = require("../eslint.config.cjs");
 
           module.exports = [
+              ...nx.configs["flat/angular"],
+              ...nx.configs["flat/angular-template"],
               ...baseConfig,
               {
                   files: [
@@ -1290,8 +1292,6 @@ describe('lib', () => {
                       }
                   }
               },
-              ...nx.configs["flat/angular"],
-              ...nx.configs["flat/angular-template"],
               {
                   files: [
                       "**/*.ts"

--- a/packages/cypress/src/utils/add-linter.ts
+++ b/packages/cypress/src/utils/add-linter.ts
@@ -98,10 +98,12 @@ export async function addLinterToCyProject(
         tree,
         projectConfig.root,
         'recommended',
-        'cypress',
-        'eslint-plugin-cypress/flat',
-        false,
-        false
+        {
+          moduleName: 'cypress',
+          moduleImportPath: 'eslint-plugin-cypress/flat',
+          spread: false,
+          insertAtTheEnd: false,
+        }
       );
       addOverrideToLintConfig(tree, projectConfig.root, {
         files: ['*.ts', '*.js'],

--- a/packages/detox/src/generators/application/lib/add-linting.ts
+++ b/packages/detox/src/generators/application/lib/add-linting.ts
@@ -38,7 +38,8 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
       addPredefinedConfigToFlatLintConfig(
         host,
         options.e2eProjectRoot,
-        'flat/react'
+        'flat/react',
+        { checkBaseConfig: true }
       );
       // Add an empty rules object to users know how to add/override rules
       addOverrideToLintConfig(host, options.e2eProjectRoot, {

--- a/packages/eslint-plugin/src/flat-configs/angular.ts
+++ b/packages/eslint-plugin/src/flat-configs/angular.ts
@@ -23,6 +23,7 @@ const config: ConfigArray = tseslint.config(
     ...c,
   })),
   {
+    files: ['**/*.ts'],
     languageOptions: {
       globals: {
         ...globals.browser,

--- a/packages/eslint-plugin/src/flat-configs/javascript.ts
+++ b/packages/eslint-plugin/src/flat-configs/javascript.ts
@@ -28,6 +28,7 @@ const config: ConfigArray = tseslint.config(
     extends: [eslint.configs.recommended, ...tseslint.configs.recommended],
   },
   {
+    files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
     languageOptions: {
       parser: tseslint.parser,
       ecmaVersion: 2020,

--- a/packages/eslint-plugin/src/flat-configs/typescript.ts
+++ b/packages/eslint-plugin/src/flat-configs/typescript.ts
@@ -19,6 +19,7 @@ const config: ConfigArray = tseslint.config(
     extends: [eslint.configs.recommended, ...tseslint.configs.recommended],
   },
   {
+    files: ['**/*.ts', '**/*.tsx', '**/*.cts', '**/*.mts'],
     plugins: { '@typescript-eslint': tseslint.plugin },
     languageOptions: {
       parser: tseslint.parser,

--- a/packages/eslint/src/generators/utils/eslint-file.ts
+++ b/packages/eslint/src/generators/utils/eslint-file.ts
@@ -535,11 +535,22 @@ export function addPredefinedConfigToFlatLintConfig(
   tree: Tree,
   root: string,
   predefinedConfigName: string,
-  moduleName = 'nx',
-  moduleImportPath = '@nx/eslint-plugin',
-  spread = true,
-  insertAtTheEnd = true
+  options: {
+    moduleName?: string;
+    moduleImportPath?: string;
+    spread?: boolean;
+    insertAtTheEnd?: boolean;
+    checkBaseConfig?: boolean;
+  } = {}
 ): void {
+  const {
+    moduleName = 'nx',
+    moduleImportPath = '@nx/eslint-plugin',
+    spread = true,
+    insertAtTheEnd = true,
+    checkBaseConfig = false,
+  } = options;
+
   if (!useFlatConfig(tree))
     throw new Error('Predefined configs can only be used with flat configs');
 
@@ -556,7 +567,7 @@ export function addPredefinedConfigToFlatLintConfig(
   content = addBlockToFlatConfigExport(
     content,
     generateFlatPredefinedConfig(predefinedConfigName, moduleName, spread),
-    { insertAtTheEnd }
+    { insertAtTheEnd, checkBaseConfig }
   );
 
   tree.write(fileName, content);

--- a/packages/eslint/src/generators/utils/flat-config/ast-utils.spec.ts
+++ b/packages/eslint/src/generators/utils/flat-config/ast-utils.spec.ts
@@ -5,6 +5,7 @@ import {
   addImportToFlatConfig,
   generateAst,
   generateFlatOverride,
+  generateFlatPredefinedConfig,
   generatePluginExtendsElementWithCompatFixup,
   hasOverride,
   removeCompatExtends,
@@ -270,6 +271,85 @@ describe('ast-utils', () => {
             { ignores: ["my-lib/.cache/**/*"] }
         ];
         "
+      `);
+    });
+
+    it('should insert before baseConfig when checkBaseConfig is true (ESM)', () => {
+      const content = `import baseConfig from "../../eslint.config.mjs";
+    export default [
+        ...baseConfig,
+        {
+            files: ["**/*.ts"],
+            rules: {}
+        },
+    ];`;
+      const result = addBlockToFlatConfigExport(
+        content,
+        generateFlatPredefinedConfig('flat/react', 'nx', true),
+        { checkBaseConfig: true }
+      );
+      expect(result).toMatchInlineSnapshot(`
+        "import baseConfig from "../../eslint.config.mjs";
+
+        export default [
+            ...nx.configs["flat/react"],
+            ...baseConfig,
+            {
+                files: ["**/*.ts"],
+                rules: {}
+            }
+        ];
+        "
+      `);
+    });
+
+    it('should append when checkBaseConfig is true but no baseConfig exists (ESM)', () => {
+      const content = `import nx from "@nx/eslint-plugin";
+    export default [
+        ...nx.configs["flat/base"],
+        ...nx.configs["flat/typescript"],
+    ];`;
+      const result = addBlockToFlatConfigExport(
+        content,
+        generateFlatPredefinedConfig('flat/react', 'nx', true),
+        { checkBaseConfig: true }
+      );
+      expect(result).toMatchInlineSnapshot(`
+        "import nx from "@nx/eslint-plugin";
+
+        export default [
+            ...nx.configs["flat/base"],
+            ...nx.configs["flat/typescript"],
+            ...nx.configs["flat/react"]
+        ];
+        "
+      `);
+    });
+
+    it('should insert before baseConfig when checkBaseConfig is true (CJS)', () => {
+      const content = `const baseConfig = require("../../eslint.config.cjs");
+module.exports = [
+    ...baseConfig,
+    {
+        files: ["**/*.ts"],
+        rules: {}
+    },
+];`;
+      const result = addBlockToFlatConfigExport(
+        content,
+        generateFlatPredefinedConfig('flat/react', 'nx', true),
+        { checkBaseConfig: true }
+      );
+      expect(result).toMatchInlineSnapshot(`
+        "const baseConfig = require("../../eslint.config.cjs");
+        module.exports = [
+            ...nx.configs["flat/react"],
+            ...baseConfig,
+            {
+                files: ["**/*.ts"],
+                rules: {}
+            },
+        ];"
       `);
     });
   });

--- a/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
+++ b/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
@@ -912,9 +912,26 @@ function addBlockToFlatConfigExportESM(
   const exportArrayLiteral =
     exportDefaultStatement.expression as ts.ArrayLiteralExpression;
 
-  const updatedArrayElements = options.insertAtTheEnd
-    ? [...exportArrayLiteral.elements, config]
-    : [config, ...exportArrayLiteral.elements];
+  let updatedArrayElements: ts.Expression[];
+  if (options.checkBaseConfig) {
+    const baseConfigIndex = exportArrayLiteral.elements.findIndex(
+      (el) =>
+        ts.isSpreadElement(el) &&
+        ts.isIdentifier(el.expression) &&
+        el.expression.text === 'baseConfig'
+    );
+    if (baseConfigIndex >= 0) {
+      const before = exportArrayLiteral.elements.slice(0, baseConfigIndex);
+      const after = exportArrayLiteral.elements.slice(baseConfigIndex);
+      updatedArrayElements = [...before, config, ...after];
+    } else {
+      updatedArrayElements = [...exportArrayLiteral.elements, config];
+    }
+  } else {
+    updatedArrayElements = options.insertAtTheEnd
+      ? [...exportArrayLiteral.elements, config]
+      : [config, ...exportArrayLiteral.elements];
+  }
 
   const updatedExportDefault = ts.factory.createExportAssignment(
     undefined,
@@ -964,6 +981,33 @@ function addBlockToFlatConfigExportCJS(
     printer
       .printNode(ts.EmitHint.Expression, config, source)
       .replaceAll(/\n/g, '\n    ');
+
+  if (options.checkBaseConfig) {
+    const baseConfigElement = exportsArray.find(
+      (el) =>
+        ts.isSpreadElement(el) &&
+        ts.isIdentifier(el.expression) &&
+        el.expression.text === 'baseConfig'
+    );
+    if (baseConfigElement) {
+      // Match baseConfig's indentation for consistent formatting
+      const baseConfigStart = baseConfigElement.getStart();
+      const lineStart = content.lastIndexOf('\n', baseConfigStart) + 1;
+      const indentation = content.substring(lineStart, baseConfigStart);
+      const configText = printer
+        .printNode(ts.EmitHint.Expression, config, source)
+        .replaceAll(/\n/g, `\n${indentation}`);
+      return applyChangesToString(content, [
+        {
+          type: ChangeType.Insert,
+          index: baseConfigStart,
+          text: `${configText},\n${indentation}`,
+        },
+      ]);
+    }
+    // baseConfig not found — fall through to insertAtTheEnd behavior
+  }
+
   if (options.insertAtTheEnd) {
     const index =
       exportsArray.length > 0

--- a/packages/expo/src/generators/library/library.spec.ts
+++ b/packages/expo/src/generators/library/library.spec.ts
@@ -341,16 +341,16 @@ describe('lib', () => {
           moduleFileExtensions: ['ts', 'js', 'html', 'tsx', 'jsx'],
           setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
           moduleNameMapper: {
-            '\\\\.svg$': '@nx/expo/plugins/jest/svg-mock',
+            '[.]svg$': '@nx/expo/plugins/jest/svg-mock',
           },
           transform: {
-            '\\\\.[jt]sx?$': [
+            '[.][jt]sx?$': [
               'babel-jest',
               {
                 configFile: __dirname + '/.babelrc.js',
               },
             ],
-            '^.+\\\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp|ttf|otf|m4v|mov|mp4|mpeg|mpg|webm|aac|aiff|caf|m4a|mp3|wav|html|pdf|obj)$':
+            '^.+[.](bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp|ttf|otf|m4v|mov|mp4|mpeg|mpg|webm|aac|aiff|caf|m4a|mp3|wav|html|pdf|obj)$':
               require.resolve('jest-expo/src/preset/assetFileTransformer.js'),
           },
           coverageDirectory: '../coverage/my-lib',

--- a/packages/expo/src/utils/add-linting.ts
+++ b/packages/expo/src/utils/add-linting.ts
@@ -84,7 +84,8 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
       addPredefinedConfigToFlatLintConfig(
         host,
         options.projectRoot,
-        'flat/react'
+        'flat/react',
+        { checkBaseConfig: true }
       );
       // Add an empty rules object to users know how to add/override rules
       addOverrideToLintConfig(host, options.projectRoot, {

--- a/packages/expo/src/utils/jest/add-jest.ts
+++ b/packages/expo/src/utils/jest/add-jest.ts
@@ -55,16 +55,16 @@ module.exports = {
   moduleFileExtensions: ['ts', 'js', 'html', 'tsx', 'jsx'],
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.${js ? 'js' : 'ts'}'],
   moduleNameMapper: {
-    '\\\\.svg$': '@nx/expo/plugins/jest/svg-mock'
+    '[.]svg$': '@nx/expo/plugins/jest/svg-mock'
   },
   transform: {
-    '\\\\.[jt]sx?$': [
+    '[.][jt]sx?$': [
       'babel-jest',
       {
         configFile: __dirname + '/.babelrc.js',
       },
     ],
-    '^.+\\\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp|ttf|otf|m4v|mov|mp4|mpeg|mpg|webm|aac|aiff|caf|m4a|mp3|wav|html|pdf|obj)$': require.resolve(
+    '^.+[.](bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp|ttf|otf|m4v|mov|mp4|mpeg|mpg|webm|aac|aiff|caf|m4a|mp3|wav|html|pdf|obj)$': require.resolve(
       'jest-expo/src/preset/assetFileTransformer.js'
     ),
   },

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -596,8 +596,8 @@ describe('app', () => {
 
           export default [
             { plugins: { '@next/next': nextEslintPluginNext } },
-            ...baseConfig,
             ...nx.configs['flat/react-typescript'],
+            ...baseConfig,
             {
               ignores: ['.next/**/*'],
             },
@@ -624,8 +624,8 @@ describe('app', () => {
           module.exports = [
             { plugins: { '@next/next': nextEslintPluginNext } },
 
-            ...baseConfig,
             ...nx.configs['flat/react-typescript'],
+            ...baseConfig,
             {
               ignores: ['.next/**/*'],
             },

--- a/packages/next/src/generators/application/lib/add-linting.spec.ts
+++ b/packages/next/src/generators/application/lib/add-linting.spec.ts
@@ -110,8 +110,8 @@ describe('updateEslint', () => {
       module.exports = [
           { plugins: { "@next/next": nextEslintPluginNext } },
 
-          ...baseConfig,
           ...nx.configs["flat/react-typescript"],
+          ...baseConfig,
           {
               ignores: [
                   ".next/**/*"

--- a/packages/next/src/generators/application/lib/add-linting.ts
+++ b/packages/next/src/generators/application/lib/add-linting.ts
@@ -51,7 +51,8 @@ export async function addLinting(
       addPredefinedConfigToFlatLintConfig(
         host,
         options.appProjectRoot,
-        'flat/react-typescript'
+        'flat/react-typescript',
+        { checkBaseConfig: true }
       );
       if (await isNext16(host)) {
         addPluginsToLintConfig(host, options.appProjectRoot, ['@next/next']);

--- a/packages/playwright/src/utils/add-linter.ts
+++ b/packages/playwright/src/utils/add-linter.ts
@@ -83,10 +83,12 @@ export async function addLinterToPlaywrightProject(
         tree,
         projectConfig.root,
         'flat/recommended',
-        'playwright',
-        'eslint-plugin-playwright',
-        false,
-        false
+        {
+          moduleName: 'playwright',
+          moduleImportPath: 'eslint-plugin-playwright',
+          spread: false,
+          insertAtTheEnd: false,
+        }
       );
       addOverrideToLintConfig(tree, projectConfig.root, {
         files: ['*.ts', '*.js'],

--- a/packages/react-native/src/generators/application/application.spec.ts
+++ b/packages/react-native/src/generators/application/application.spec.ts
@@ -80,16 +80,16 @@ describe('app', () => {
         moduleFileExtensions: ['ts', 'js', 'html', 'tsx', 'jsx'],
         setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
         moduleNameMapper: {
-          '\\\\.svg$': '@nx/react-native/plugins/jest/svg-mock',
+          '[.]svg$': '@nx/react-native/plugins/jest/svg-mock',
         },
         transform: {
-          '^.+\\.(js|ts|tsx)$': [
+          '^.+[.](js|ts|tsx)$': [
             'babel-jest',
             {
               configFile: __dirname + '/.babelrc.js',
             },
           ],
-          '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': require.resolve(
+          '^.+[.](bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': require.resolve(
             'react-native/jest/assetFileTransformer.js',
           ),
         },

--- a/packages/react-native/src/generators/library/library.spec.ts
+++ b/packages/react-native/src/generators/library/library.spec.ts
@@ -292,16 +292,16 @@ describe('lib', () => {
           moduleFileExtensions: ['ts', 'js', 'html', 'tsx', 'jsx'],
           setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
           moduleNameMapper: {
-            '\\\\.svg$': '@nx/react-native/plugins/jest/svg-mock',
+            '[.]svg$': '@nx/react-native/plugins/jest/svg-mock',
           },
           transform: {
-            '^.+\\.(js|ts|tsx)$': [
+            '^.+[.](js|ts|tsx)$': [
               'babel-jest',
               {
                 configFile: __dirname + '/.babelrc.js',
               },
             ],
-            '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': require.resolve(
+            '^.+[.](bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': require.resolve(
               'react-native/jest/assetFileTransformer.js',
             ),
           },

--- a/packages/react-native/src/utils/add-jest.ts
+++ b/packages/react-native/src/utils/add-jest.ts
@@ -45,16 +45,16 @@ module.exports = {
   moduleFileExtensions: ['ts', 'js', 'html', 'tsx', 'jsx'],
   setupFilesAfterEnv: ['<rootDir>/src/test-setup.${js ? 'js' : 'ts'}'],
   moduleNameMapper: {
-    '\\\\.svg$': '@nx/react-native/plugins/jest/svg-mock'
+    '[.]svg$': '@nx/react-native/plugins/jest/svg-mock'
   },
   transform: {
-    '^.+\\.(js|ts|tsx)$': [
+    '^.+[.](js|ts|tsx)$': [
       'babel-jest',
       {
         configFile: __dirname + '/.babelrc.js',
       },
     ],
-    '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': require.resolve(
+    '^.+[.](bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': require.resolve(
       'react-native/jest/assetFileTransformer.js'
     ),
   },

--- a/packages/react-native/src/utils/add-linting.ts
+++ b/packages/react-native/src/utils/add-linting.ts
@@ -84,7 +84,8 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
       addPredefinedConfigToFlatLintConfig(
         host,
         options.projectRoot,
-        'flat/react'
+        'flat/react',
+        { checkBaseConfig: true }
       );
       // Add an empty rules object to users know how to add/override rules
       addOverrideToLintConfig(host, options.projectRoot, {

--- a/packages/react/src/generators/application/lib/add-linting.ts
+++ b/packages/react/src/generators/application/lib/add-linting.ts
@@ -41,7 +41,8 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
         addPredefinedConfigToFlatLintConfig(
           host,
           options.appProjectRoot,
-          'flat/react'
+          'flat/react',
+          { checkBaseConfig: true }
         );
         // Add an empty rules object to users know how to add/override rules
         addOverrideToLintConfig(host, options.appProjectRoot, {

--- a/packages/react/src/generators/library/lib/add-linting.ts
+++ b/packages/react/src/generators/library/lib/add-linting.ts
@@ -40,7 +40,8 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
         addPredefinedConfigToFlatLintConfig(
           host,
           options.projectRoot,
-          'flat/react'
+          'flat/react',
+          { checkBaseConfig: true }
         );
         // Add an empty rules object to users know how to add/override rules
         addOverrideToLintConfig(host, options.projectRoot, {

--- a/packages/vue/src/utils/add-linting.ts
+++ b/packages/vue/src/utils/add-linting.ts
@@ -135,8 +135,7 @@ function editEslintConfigFiles(tree: Tree, projectRoot: string) {
         tree,
         projectRoot,
         'flat/recommended',
-        'vue',
-        'eslint-plugin-vue'
+        { moduleName: 'vue', moduleImportPath: 'eslint-plugin-vue' }
       );
       // This allows .vue files to be parsed
       addOverrideToLintConfig(


### PR DESCRIPTION
## Current Behavior

Framework generators append predefined configs (`flat/react`, `flat/angular`, etc.) after `baseConfig` in the flat config array. In flat config, later entries override earlier ones, so framework rules override user root rules.

Additionally, the parser/plugins config entries in `flat/typescript`, `flat/javascript`, and `flat/angular` have no `files` restriction, applying the TypeScript parser to all files globally — including `.html`, `.json`, and other non-TS/JS files. This was partially fixed in PR #28381 (which scoped rules/extends) but the parser entries were missed.

## Expected Behavior

Framework configs are inserted before `baseConfig`, giving user root config higher priority. Root standalone projects (no `baseConfig`) are unaffected.

Parser/plugins entries are scoped to their respective file types, so `.html` files get the correct parser (Angular template parser, or ESLint default) instead of the TypeScript parser.

## Changes

- Implement `checkBaseConfig` option in `addBlockToFlatConfigExport` to insert before `...baseConfig` when present
- Framework generators (`@nx/react`, `@nx/angular`, `@nx/next`, etc.) pass `checkBaseConfig: true`
- Scope parser entries in `flat/typescript` to `**/*.ts, **/*.tsx, **/*.cts, **/*.mts`
- Scope parser entries in `flat/javascript` to `**/*.js, **/*.jsx, **/*.cjs, **/*.mjs`
- Scope processor/plugins entry in `flat/angular` to `**/*.ts`
- Refactor `addPredefinedConfigToFlatLintConfig` to use an options object for optional params
- Fix regex patterns in react-native and expo jest config templates to use `[.]` instead of `\.` — avoids `no-useless-escape` lint errors and fixes a latent bug where `\.` in a string literal matched any character instead of a literal dot

## Related Issue(s)

Fixes #32923