### PR TITLE
fix(linter): convert project-level eslint configs and log when skipped

### DIFF
--- a/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
@@ -6,6 +6,7 @@ import {
   ProjectConfiguration,
   Tree,
   addProjectConfiguration,
+  logger,
   readJson,
   updateJson,
 } from '@nx/devkit';
@@ -578,6 +579,39 @@ describe('convert-to-flat-config generator', () => {
       await convertToFlatConfigGenerator(tree, options);
       expect(tree.exists('eslint.config.cjs')).toBeTruthy();
       expect(tree.exists('libs/test-lib/eslint.config.cjs')).toBeTruthy();
+    });
+
+    it('should warn and skip project with eslint config but no lint target', async () => {
+      addProjectConfiguration(tree, 'no-lint-lib', {
+        root: 'libs/no-lint-lib',
+        targets: {},
+      });
+      tree.write(
+        'libs/no-lint-lib/.eslintrc.json',
+        JSON.stringify({ extends: ['../../.eslintrc.json'] })
+      );
+      updateJson(tree, 'nx.json', (json: NxJsonConfiguration) => {
+        delete json.plugins;
+        return json;
+      });
+
+      await lintProjectGenerator(tree, {
+        skipFormat: false,
+        linter: 'eslint',
+        project: 'test-lib',
+        setParserOptionsProject: false,
+        eslintConfigFormat: 'cjs',
+      });
+
+      const warnSpy = jest.spyOn(logger, 'warn');
+      await convertToFlatConfigGenerator(tree, options);
+
+      expect(tree.exists('libs/no-lint-lib/.eslintrc.json')).toBeTruthy();
+      expect(tree.exists('libs/no-lint-lib/eslint.config.cjs')).toBeFalsy();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Skipping "no-lint-lib"')
+      );
+      warnSpy.mockRestore();
     });
 
     it('should handle parser options even if parser is extended', async () => {

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.ts
@@ -5,6 +5,7 @@ import {
   getDependencyVersionFromPackageJson,
   getProjects,
   installPackagesTask,
+  logger,
   NxJsonConfiguration,
   ProjectConfiguration,
   readJson,
@@ -15,6 +16,7 @@ import {
 } from '@nx/devkit';
 import { ConvertToFlatConfigGeneratorSchema } from './schema';
 import { findEslintFile } from '../utils/eslint-file';
+import { hasEslintPlugin } from '../utils/plugin';
 import { join } from 'path';
 import {
   eslint9__eslintVersion,
@@ -101,6 +103,15 @@ function convertRootToFlatConfig(
   );
 }
 
+const ESLINT_LINT_EXECUTOR = '@nx/eslint:lint';
+
+function isEslintTarget(target: { executor?: string; command?: string }) {
+  return (
+    target.executor === ESLINT_LINT_EXECUTOR ||
+    target.command?.includes('eslint')
+  );
+}
+
 function convertProjectToFlatConfig(
   tree: Tree,
   project: string,
@@ -110,53 +121,60 @@ function convertProjectToFlatConfig(
   format: 'cjs' | 'mjs'
 ) {
   const eslintFile = findEslintFile(tree, projectConfig.root);
-  if (eslintFile && !eslintFile.endsWith('.js')) {
-    if (projectConfig.targets) {
-      const eslintTargets = Object.keys(projectConfig.targets || {}).filter(
-        (t) =>
-          projectConfig.targets[t].executor === '@nx/eslint:lint' ||
-          projectConfig.targets[t].command?.includes('eslint')
-      );
-      let ignorePath: string | undefined;
-      for (const target of eslintTargets) {
-        // remove any obsolete `eslintConfig` options pointing to the old config file
-        if (projectConfig.targets[target].options?.eslintConfig) {
-          delete projectConfig.targets[target].options.eslintConfig;
-        }
-        if (projectConfig.targets[target].options?.ignorePath) {
-          ignorePath = projectConfig.targets[target].options.ignorePath;
-          delete projectConfig.targets[target].options.ignorePath;
-        }
-        updateProjectConfiguration(tree, project, projectConfig);
-      }
-      const nxHasEsLintTargets = Object.keys(nxJson.targetDefaults || {}).some(
-        (t) =>
-          (t === '@nx/eslint:lint' ||
-            nxJson.targetDefaults[t].executor === '@nx/eslint:lint' ||
-            nxJson.targetDefaults[t].command?.includes('eslint')) &&
-          projectConfig.targets?.[t]
-      );
-      const nxHasEsLintPlugin = (nxJson.plugins || []).some((p) =>
-        typeof p === 'string'
-          ? p === '@nx/eslint/plugin'
-          : p.plugin === '@nx/eslint/plugin'
-      );
+  if (!eslintFile || eslintFile.endsWith('.js')) {
+    return;
+  }
 
-      if (nxHasEsLintTargets || nxHasEsLintPlugin || eslintTargets.length > 0) {
-        convertConfigToFlatConfig(
-          tree,
-          projectConfig.root,
-          eslintFile,
-          `eslint.config.${format}`,
-          format,
-          ignorePath
-        );
-        eslintIgnoreFiles.add(`${projectConfig.root}/.eslintignore`);
-        if (ignorePath) {
-          eslintIgnoreFiles.add(ignorePath);
-        }
-      }
+  // Clean up obsolete target options and detect explicit ESLint targets
+  let ignorePath: string | undefined;
+  const eslintTargets = projectConfig.targets
+    ? Object.keys(projectConfig.targets).filter((t) =>
+        isEslintTarget(projectConfig.targets[t])
+      )
+    : [];
+  for (const target of eslintTargets) {
+    if (projectConfig.targets[target].options?.eslintConfig) {
+      delete projectConfig.targets[target].options.eslintConfig;
     }
+    if (projectConfig.targets[target].options?.ignorePath) {
+      ignorePath = projectConfig.targets[target].options.ignorePath;
+      delete projectConfig.targets[target].options.ignorePath;
+    }
+  }
+  if (eslintTargets.length > 0) {
+    updateProjectConfiguration(tree, project, projectConfig);
+  }
+  const hasEslintTargetDefaults =
+    projectConfig.targets &&
+    Object.keys(nxJson.targetDefaults || {}).some(
+      (t) =>
+        (t === ESLINT_LINT_EXECUTOR ||
+          isEslintTarget(nxJson.targetDefaults[t])) &&
+        projectConfig.targets[t]
+    );
+
+  if (
+    eslintTargets.length === 0 &&
+    !hasEslintTargetDefaults &&
+    !hasEslintPlugin(tree)
+  ) {
+    logger.warn(
+      `Skipping "${project}": found ${eslintFile} but no ESLint lint target detected. Convert manually if needed.`
+    );
+    return;
+  }
+
+  convertConfigToFlatConfig(
+    tree,
+    projectConfig.root,
+    eslintFile,
+    `eslint.config.${format}`,
+    format,
+    ignorePath
+  );
+  eslintIgnoreFiles.add(`${projectConfig.root}/.eslintignore`);
+  if (ignorePath) {
+    eslintIgnoreFiles.add(ignorePath);
   }
 }
 


### PR DESCRIPTION
## Current Behavior

The `convert-to-flat-config` generator silently skips project-level `.eslintrc.json` files when `projectConfig.targets` is undefined (e.g., package.json-only projects in pnpm workspaces). The `@nx/eslint/plugin` check is gated behind the targets check and never reached.

## Expected Behavior

Projects with `.eslintrc.json` are converted when `@nx/eslint/plugin` is registered, even without explicit targets. When a project is skipped because no ESLint lint target is detected, a warning is logged so users know which projects were not converted and why.

## Related Issue(s)

Fixes #29458