### PR TITLE
fix(linter): use root config to determine ESLint class in plugin

### DIFF
--- a/packages/eslint/src/plugins/plugin.spec.ts
+++ b/packages/eslint/src/plugins/plugin.spec.ts
@@ -9,6 +9,16 @@ jest.mock('nx/src/utils/cache-directory', () => ({
   workspaceDataDirectory: 'tmp/project-graph-cache',
 }));
 
+const resolveESLintClassSpy = jest.fn();
+jest.mock('../utils/resolve-eslint-class', () => ({
+  resolveESLintClass: (...args) => {
+    resolveESLintClassSpy(...args);
+    return jest
+      .requireActual('../utils/resolve-eslint-class')
+      .resolveESLintClass(...args);
+  },
+}));
+
 describe('@nx/eslint/plugin', () => {
   let context: CreateNodesContextV2;
   let tempFs: TempFs;
@@ -37,6 +47,7 @@ describe('@nx/eslint/plugin', () => {
 
   afterEach(() => {
     jest.resetModules();
+    resolveESLintClassSpy.mockClear();
     tempFs.cleanup();
     tempFs = null;
     rmSync('tmp/project-graph-cache', { recursive: true, force: true });
@@ -780,6 +791,33 @@ describe('@nx/eslint/plugin', () => {
           },
         }
       `);
+    });
+
+    it('should determine ESLint class from root config, not nested stray configs', async () => {
+      createFiles({
+        'eslint.config.mjs': `export default [];`,
+        'package.json': `{}`,
+        'eslint-local-rules/.eslintrc.json': `{}`,
+        'apps/my-app/project.json': `{}`,
+        'apps/my-app/index.ts': `console.log('hello world')`,
+      });
+      // FlatESLint instantiation may fail in jest due to dynamic imports,
+      // but we only need to verify the correct config type was selected
+      try {
+        await invokeCreateNodesOnMatchingFiles(context, {
+          targetName: 'lint',
+        });
+      } catch (e) {
+        // Re-throw if failure happened before resolveESLintClass was called
+        if (resolveESLintClassSpy.mock.calls.length === 0) {
+          throw e;
+        }
+      }
+      // Root config is eslint.config.mjs (flat) — should use flat config
+      // regardless of stray .eslintrc.json in eslint-local-rules/
+      expect(resolveESLintClassSpy).toHaveBeenCalledWith({
+        useFlatConfigOverrideVal: true,
+      });
     });
   });
 

--- a/packages/eslint/src/plugins/plugin.ts
+++ b/packages/eslint/src/plugins/plugin.ts
@@ -186,8 +186,16 @@ export const createNodes: CreateNodesV2<EslintPluginOptions> = [
       if (eslintConfigFiles.length === 0) {
         return [];
       }
+      // Determine flat vs legacy from root config, matching ESLint's own
+      // behavior (find-up from cwd). Nested .eslintrc.* files are irrelevant
+      // when a root flat config exists. Prefer flat config at root when both
+      // flat and legacy root configs coexist (e.g., mid-migration).
+      const rootConfigs = eslintConfigFiles.filter((f) => dirname(f) === '.');
+      const rootConfig = rootConfigs.find(isFlatConfig) ?? rootConfigs[0];
       const ESLint = await resolveESLintClass({
-        useFlatConfigOverrideVal: isFlatConfig(eslintConfigFiles[0]),
+        useFlatConfigOverrideVal: isFlatConfig(
+          rootConfig ?? eslintConfigFiles[0]
+        ),
       });
       return await createNodesFromFiles(
         (configFile, options, context) =>


### PR DESCRIPTION
## Current Behavior

The `@nx/eslint/plugin` uses `eslintConfigFiles[0]` to decide between `FlatESLint` and `LegacyESLint`. Due to glob pattern ordering, `.eslintrc.*` files sort before `eslint.config.*`, so a stray nested `.eslintrc.json` (e.g., in `eslint-local-rules/`) causes the plugin to pick `LegacyESLint` even when the root has a flat config — crashing with "No ESLint configuration found" during project graph creation.

## Expected Behavior

The ESLint class is determined from the root config, matching ESLint's own behavior where `find-up` from cwd decides the mode. Nested legacy config files are irrelevant when a root flat config exists. When both flat and legacy configs exist at root (mid-migration), flat config is preferred.

## Related Issue(s)

Fixes #32110