### PR TITLE
fix(testing): gracefully handle broken jest configs in alias migration

### DIFF
--- a/packages/jest/src/migrations/update-21-3-0/replace-removed-matcher-aliases.spec.ts
+++ b/packages/jest/src/migrations/update-21-3-0/replace-removed-matcher-aliases.spec.ts
@@ -363,6 +363,22 @@ module.exports = { transform: { '^.+\\.[tj]s$': ['@swc/jest', swcConfig] } };`
       );
     });
 
+    it('should not fail and warn when test path resolution throws (e.g. broken regex)', async () => {
+      const { SearchSource } = require('jest');
+      const spy = jest
+        .spyOn(SearchSource.prototype, 'getTestPaths')
+        .mockRejectedValue(new Error('Invalid regular expression'));
+
+      writeFile(tree, 'packages/broken/jest.config.js', `module.exports = {};`);
+
+      await expect(migration(tree)).resolves.not.toThrow();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('packages/broken/jest.config.js')
+      );
+
+      spy.mockRestore();
+    });
+
     it('should still process valid projects when another has a broken config', async () => {
       // Broken project: references a file that does not exist
       writeFile(

--- a/packages/jest/src/migrations/update-21-3-0/replace-removed-matcher-aliases.spec.ts
+++ b/packages/jest/src/migrations/update-21-3-0/replace-removed-matcher-aliases.spec.ts
@@ -1,4 +1,4 @@
-import type { Tree } from '@nx/devkit';
+import { logger, type Tree } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import migration from './replace-removed-matcher-aliases';
@@ -320,6 +320,79 @@ describe('useAutoSave', () => {
       });
       "
     `);
+  });
+
+  describe('gracefully handles broken jest configs', () => {
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('should not fail and warn when a jest config references a missing file', async () => {
+      // Simulates: jest.config.ts reads a .lib.swcrc that does not exist
+      writeFile(
+        tree,
+        'packages/broken/jest.config.ts',
+        `import { readFileSync } from 'fs';
+const swcConfig = JSON.parse(readFileSync(\`\${__dirname}/.lib.swcrc\`, 'utf-8'));
+module.exports = { transform: { '^.+\\.[tj]s$': ['@swc/jest', swcConfig] } };`
+      );
+
+      await expect(migration(tree)).resolves.not.toThrow();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('packages/broken/jest.config.ts')
+      );
+    });
+
+    it('should not fail and warn when a jest config references a missing preset', async () => {
+      // Simulates: jest.config.ts references jest.preset.ts but only .js exists
+      writeFile(
+        tree,
+        'packages/broken/jest.config.ts',
+        `module.exports = { preset: '../../jest.preset.ts' };`
+      );
+
+      await expect(migration(tree)).resolves.not.toThrow();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('packages/broken/jest.config.ts')
+      );
+    });
+
+    it('should still process valid projects when another has a broken config', async () => {
+      // Broken project: references a file that does not exist
+      writeFile(
+        tree,
+        'packages/broken/jest.config.ts',
+        `import { readFileSync } from 'fs';
+const swcConfig = JSON.parse(readFileSync(\`\${__dirname}/.lib.swcrc\`, 'utf-8'));
+module.exports = { transform: { '^.+\\.[tj]s$': ['@swc/jest', swcConfig] } };`
+      );
+
+      // Valid project with a test file using deprecated aliases
+      writeFile(tree, 'packages/valid/jest.config.js', `module.exports = {};`);
+      writeFile(
+        tree,
+        'packages/valid/src/example.spec.ts',
+        `it('test', () => { expect(fn).toBeCalled(); });`
+      );
+
+      await migration(tree);
+
+      // Broken project was warned about
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('packages/broken/jest.config.ts')
+      );
+
+      // Valid project was still processed
+      const content = tree.read('packages/valid/src/example.spec.ts', 'utf-8');
+      expect(content).toContain('toHaveBeenCalled');
+      expect(content).not.toContain('toBeCalled');
+    });
   });
 
   function writeFile(tree: Tree, path: string, content: string): void {

--- a/packages/jest/src/migrations/update-21-3-0/replace-removed-matcher-aliases.ts
+++ b/packages/jest/src/migrations/update-21-3-0/replace-removed-matcher-aliases.ts
@@ -146,10 +146,19 @@ async function resolveTestPaths(
     return null;
   }
 
-  const source = new SearchSource(jestContext);
-  const specs = await source.getTestPaths(
-    config.globalConfig,
-    config.projectConfig
-  );
+  let specs: Awaited<ReturnType<SearchSource['getTestPaths']>>;
+  try {
+    const source = new SearchSource(jestContext);
+    specs = await source.getTestPaths(
+      config.globalConfig,
+      config.projectConfig
+    );
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    logger.warn(
+      `Could not resolve test paths for "${jestConfigFile}": ${message}. Skipping this project for matcher alias replacement.`
+    );
+    return null;
+  }
   return specs.tests.map((t) => posix.normalize(relative(tree.root, t.path)));
 }

--- a/packages/jest/src/migrations/update-21-3-0/replace-removed-matcher-aliases.ts
+++ b/packages/jest/src/migrations/update-21-3-0/replace-removed-matcher-aliases.ts
@@ -1,4 +1,4 @@
-import { formatFiles, globAsync, type Tree } from '@nx/devkit';
+import { formatFiles, globAsync, logger, type Tree } from '@nx/devkit';
 import { ast, query } from '@phenomnomnominal/tsquery';
 import { SearchSource } from 'jest';
 import { readConfig } from 'jest-config';
@@ -98,23 +98,56 @@ async function getTestFilePaths(tree: Tree): Promise<string[]> {
       continue;
     }
 
-    const config = await readConfig(
-      { _: [], $0: undefined },
-      join(tree.root, jestConfigFile)
-    );
-    const jestContext = await Runtime.createContext(config.projectConfig, {
-      maxWorkers: 1,
-      watchman: false,
-    });
-    const source = new SearchSource(jestContext);
-    const specs = await source.getTestPaths(
-      config.globalConfig,
-      config.projectConfig
-    );
-    for (const testPath of specs.tests) {
-      testFilePaths.add(posix.normalize(relative(tree.root, testPath.path)));
+    const resolvedPaths = await resolveTestPaths(tree, jestConfigFile);
+    if (resolvedPaths) {
+      for (const testPath of resolvedPaths) {
+        testFilePaths.add(testPath);
+      }
     }
   }
 
   return Array.from(testFilePaths);
+}
+
+/**
+ * Resolves test file paths for a single jest config by loading the config
+ * through Jest's own resolution. Returns null if the config cannot be
+ * resolved (e.g. missing files, uninstalled transform modules, invalid
+ * presets), logging a warning so the user knows which project was skipped.
+ */
+async function resolveTestPaths(
+  tree: Tree,
+  jestConfigFile: string
+): Promise<string[] | null> {
+  const fullConfigPath = join(tree.root, jestConfigFile);
+
+  let config: Awaited<ReturnType<typeof readConfig>>;
+  try {
+    config = await readConfig({ _: [], $0: undefined }, fullConfigPath);
+  } catch (e) {
+    logger.warn(
+      `Could not read Jest config "${jestConfigFile}": ${e.message}. Skipping this project for matcher alias replacement.`
+    );
+    return null;
+  }
+
+  let jestContext: Awaited<ReturnType<(typeof Runtime)['createContext']>>;
+  try {
+    jestContext = await Runtime.createContext(config.projectConfig, {
+      maxWorkers: 1,
+      watchman: false,
+    });
+  } catch (e) {
+    logger.warn(
+      `Could not create Jest context for "${jestConfigFile}": ${e.message}. Skipping this project for matcher alias replacement.`
+    );
+    return null;
+  }
+
+  const source = new SearchSource(jestContext);
+  const specs = await source.getTestPaths(
+    config.globalConfig,
+    config.projectConfig
+  );
+  return specs.tests.map((t) => posix.normalize(relative(tree.root, t.path)));
 }

--- a/packages/jest/src/migrations/update-21-3-0/replace-removed-matcher-aliases.ts
+++ b/packages/jest/src/migrations/update-21-3-0/replace-removed-matcher-aliases.ts
@@ -125,8 +125,9 @@ async function resolveTestPaths(
   try {
     config = await readConfig({ _: [], $0: undefined }, fullConfigPath);
   } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
     logger.warn(
-      `Could not read Jest config "${jestConfigFile}": ${e.message}. Skipping this project for matcher alias replacement.`
+      `Could not read Jest config "${jestConfigFile}": ${message}. Skipping this project for matcher alias replacement.`
     );
     return null;
   }
@@ -138,8 +139,9 @@ async function resolveTestPaths(
       watchman: false,
     });
   } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
     logger.warn(
-      `Could not create Jest context for "${jestConfigFile}": ${e.message}. Skipping this project for matcher alias replacement.`
+      `Could not create Jest context for "${jestConfigFile}": ${message}. Skipping this project for matcher alias replacement.`
     );
     return null;
   }


### PR DESCRIPTION
## Current Behavior

The `replace-removed-matcher-aliases` migration crashes the entire migration runner when a project has a broken or misconfigured `jest.config.ts`. This was discovered while upgrading nx-labs from Nx 21 to 22 via `nx migrate --run-migrations`.

The migration uses Jest's `readConfig()` and `Runtime.createContext()` to resolve jest configs, but has no error handling around these calls. If any project has issues like:

- A missing file referenced in the config (e.g. `.lib.swcrc` that was renamed to `.swcrc`)
- A missing transform module (e.g. `@swc/jest` not installed)
- A missing preset file (e.g. `jest.preset.ts` instead of `jest.preset.js`)

...the entire migration fails with an opaque error:

```
Error: Command failed: /var/folders/.../node_modules/.bin/nx _migrate --run-migrations
    at checkExecSyncError (node:child_process:925:11)
  status: 1,
  stdout: null,
  stderr: null
```

The actual errors are swallowed by the nested `execSync` call, making it very hard to debug.

## Expected Behavior

The migration should skip projects with broken jest configs and continue processing the rest of the workspace.

## Fix

Wrapped the `readConfig` / `Runtime.createContext` / `SearchSource.getTestPaths` block in a try-catch that skips the failing project. This matches the defensive pattern already used in `packages/jest/src/plugins/plugin.ts` for similar jest config resolution.

## Test Plan

- Added 3 tests covering: missing file reference, missing preset, and verifying valid projects are still processed when a sibling project has a broken config
- All existing tests continue to pass