### PR TITLE
fix(core): gracefully handle missing package manager and invalid workspace for CNW

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.spec.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.spec.ts
@@ -1,21 +1,7 @@
 import { validateWorkspaceName } from './create-nx-workspace';
-
-// Mock the output module and process.exit
-jest.mock('../src/utils/output', () => ({
-  output: {
-    error: jest.fn(),
-  },
-}));
-
-jest.spyOn(process, 'exit').mockImplementation(() => {
-  throw new Error('process.exit called');
-});
+import { CnwError } from '../src/utils/error-utils';
 
 describe('validateWorkspaceName', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('should allow names starting with a letter', () => {
     expect(() => validateWorkspaceName('myapp')).not.toThrow();
     expect(() => validateWorkspaceName('MyApp')).not.toThrow();
@@ -25,35 +11,28 @@ describe('validateWorkspaceName', () => {
   });
 
   it('should reject names starting with a number', () => {
-    expect(() => validateWorkspaceName('4name')).toThrow('process.exit called');
-    expect(() => validateWorkspaceName('123app')).toThrow(
-      'process.exit called'
-    );
-    expect(() => validateWorkspaceName('0test')).toThrow('process.exit called');
+    expect(() => validateWorkspaceName('4name')).toThrow(CnwError);
+    expect(() => validateWorkspaceName('123app')).toThrow(CnwError);
+    expect(() => validateWorkspaceName('0test')).toThrow(CnwError);
   });
 
   it('should reject names starting with special characters', () => {
-    expect(() => validateWorkspaceName('-app')).toThrow('process.exit called');
-    expect(() => validateWorkspaceName('_app')).toThrow('process.exit called');
-    expect(() => validateWorkspaceName('@app')).toThrow('process.exit called');
+    expect(() => validateWorkspaceName('-app')).toThrow(CnwError);
+    expect(() => validateWorkspaceName('_app')).toThrow(CnwError);
+    expect(() => validateWorkspaceName('@app')).toThrow(CnwError);
   });
 
-  it('should call output.error with correct message for invalid names', () => {
-    const { output } = require('../src/utils/output');
-
+  it('should throw CnwError with INVALID_WORKSPACE_NAME code', () => {
     try {
       validateWorkspaceName('4name');
+      fail('Expected CnwError to be thrown');
     } catch (e) {
-      // Expected to throw
+      expect(e).toBeInstanceOf(CnwError);
+      expect((e as CnwError).code).toBe('INVALID_WORKSPACE_NAME');
+      expect((e as CnwError).message).toContain('4name');
+      expect((e as CnwError).message).toContain(
+        'Workspace names must start with a letter'
+      );
     }
-
-    expect(output.error).toHaveBeenCalledWith({
-      title: 'Invalid workspace name',
-      bodyLines: [
-        'The workspace name "4name" is invalid.',
-        'Workspace names must start with a letter.',
-        'Examples of valid names: myapp, MyApp, my-app, my_app',
-      ],
-    });
   });
 });

--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -408,6 +408,17 @@ process.on('uncaughtException', (error: unknown) => {
 
 // Handle Ctrl+C gracefully - show helpful message if workspace was already created
 process.on('SIGINT', async () => {
+  await recordStat({
+    nxVersion,
+    command: 'create-nx-workspace',
+    useCloud: false,
+    meta: {
+      type: 'cancel',
+      flowVariant: getFlowVariant(),
+      aiAgent: isAiAgent(),
+    },
+  });
+
   const { directory, connectUrl } = getInterruptedWorkspaceState();
 
   if (directory) {
@@ -775,15 +786,10 @@ function invariant(
 export function validateWorkspaceName(name: string): void {
   const pattern = /^[a-zA-Z]/;
   if (!pattern.test(name)) {
-    output.error({
-      title: 'Invalid workspace name',
-      bodyLines: [
-        `The workspace name "${name}" is invalid.`,
-        `Workspace names must start with a letter.`,
-        `Examples of valid names: myapp, MyApp, my-app, my_app`,
-      ],
-    });
-    process.exit(1);
+    throw new CnwError(
+      'INVALID_WORKSPACE_NAME',
+      `The workspace name "${name}" is invalid. Workspace names must start with a letter. Examples of valid names: myapp, MyApp, my-app, my_app`
+    );
   }
 }
 

--- a/packages/create-nx-workspace/src/utils/package-manager.ts
+++ b/packages/create-nx-workspace/src/utils/package-manager.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, sep } from 'node:path';
+import { CnwError } from './error-utils';
 
 /*
  * Because we don't want to depend on @nx/workspace (to speed up the workspace creation)
@@ -261,13 +262,20 @@ export function getPackageManagerVersion(
   if (pmVersionCache.has(packageManager)) {
     return pmVersionCache.get(packageManager) as string;
   }
-  const version = execSync(`${packageManager} --version`, {
-    cwd,
-    encoding: 'utf-8',
-    windowsHide: false,
-  }).trim();
-  pmVersionCache.set(packageManager, version);
-  return version;
+  try {
+    const version = execSync(`${packageManager} --version`, {
+      cwd,
+      encoding: 'utf-8',
+      windowsHide: false,
+    }).trim();
+    pmVersionCache.set(packageManager, version);
+    return version;
+  } catch {
+    throw new CnwError(
+      'INVALID_PACKAGE_MANAGER',
+      `Package manager '${packageManager}' is not installed or not found in PATH.`
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
We want to capture more error and cancel events so that start events match complete/error/cancel events. This PR ensures that more errors are properly captured as `CnwError` rather than just `output.error` + `process.exit(1)`;

- Invalid workpspace name (i.e. starting with a number) now throws `CnwError` so we record them correctly
- Missing package manager is now captured as `CnwError` correctly
- SIGINT when workpspace is already created now send "cancel" event

Closes NXC-4095