### PR TITLE
fix(core): convert legacy-post-build to pre-build to prevent race condition

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -96,13 +96,7 @@
       }
     },
     "build": {
-      "dependsOn": [
-        "^build",
-        "typecheck",
-        "legacy-post-build",
-        "build-base",
-        "build-native"
-      ],
+      "dependsOn": ["^build", "typecheck", "build-base", "build-native"],
       "inputs": ["production", "^production"],
       "cache": true
     },
@@ -111,7 +105,7 @@
       "cache": true
     },
     "build-base": {
-      "dependsOn": ["^build-base", "build-native"],
+      "dependsOn": ["^build-base", "build-native", "legacy-pre-build"],
       "cache": true
     },
     "test-native": {
@@ -198,8 +192,7 @@
     "copy-docs": {
       "cache": true
     },
-    "legacy-post-build": {
-      "dependsOn": ["build-base"],
+    "legacy-pre-build": {
       "cache": true,
       "inputs": ["production", "^production"],
       "outputs": ["{workspaceRoot}/dist/packages/{projectName}"]

--- a/packages/angular/project.json
+++ b/packages/angular/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build-ng": {
-      "dependsOn": ["build-base", "typecheck", "legacy-post-build"],
+      "dependsOn": ["build-base", "typecheck", "legacy-pre-build"],
       "executor": "@nx/angular:package",
       "options": {
         "project": "packages/angular/ng-package.json",
@@ -14,7 +14,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/angular"]
     },
 
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",
@@ -64,7 +64,7 @@
       "dependsOn": [
         "^build",
         "build-ng",
-        "legacy-post-build",
+        "legacy-pre-build",
         "typecheck",
         "build-base"
       ],

--- a/packages/create-nx-plugin/project.json
+++ b/packages/create-nx-plugin/project.json
@@ -26,7 +26,7 @@
       }
     },
 
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/create-nx-workspace/project.json
+++ b/packages/create-nx-workspace/project.json
@@ -24,9 +24,9 @@
         ],
         "parallel": false
       },
-      "dependsOn": ["^build", "build-base", "legacy-post-build"]
+      "dependsOn": ["^build", "build-base", "legacy-pre-build"]
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/cypress/project.json
+++ b/packages/cypress/project.json
@@ -7,9 +7,9 @@
     "build": {
       "outputs": ["{workspaceRoot}/dist/packages/cypress/README.md"],
       "command": "node ./scripts/copy-readme.js cypress",
-      "dependsOn": ["^build", "build-base", "legacy-post-build"]
+      "dependsOn": ["^build", "build-base", "legacy-pre-build"]
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/detox/project.json
+++ b/packages/detox/project.json
@@ -7,9 +7,9 @@
     "build": {
       "outputs": ["{workspaceRoot}/dist/packages/detox/README.md"],
       "command": "node ./scripts/copy-readme.js detox",
-      "dependsOn": ["^build", "build-base", "legacy-post-build"]
+      "dependsOn": ["^build", "build-base", "legacy-pre-build"]
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/devkit/project.json
+++ b/packages/devkit/project.json
@@ -7,10 +7,10 @@
     "build": {
       "outputs": ["{workspaceRoot}/dist/packages/devkit/README.md"],
       "command": "node ./scripts/copy-readme.js devkit",
-      "dependsOn": ["^build", "build-base", "legacy-post-build"]
+      "dependsOn": ["^build", "build-base", "legacy-pre-build"]
     },
 
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/docker/project.json
+++ b/packages/docker/project.json
@@ -8,7 +8,7 @@
       "command": "node ./scripts/copy-readme.js docker",
       "outputs": ["{workspaceRoot}/build/packages/docker/README.md"]
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/dotnet/project.json
+++ b/packages/dotnet/project.json
@@ -54,7 +54,7 @@
         }
       }
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "dependsOn": ["build-base", "build-analyzer"],
       "outputs": ["{projectRoot}/dist"],

--- a/packages/esbuild/project.json
+++ b/packages/esbuild/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/esbuild/README.md"],
       "commands": ["node ./scripts/copy-readme.js esbuild"]
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/eslint-plugin/project.json
+++ b/packages/eslint-plugin/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/eslint-plugin/README.md"],
       "command": "node ./scripts/copy-readme.js eslint-plugin"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/eslint/project.json
+++ b/packages/eslint/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/eslint/README.md"],
       "command": "node ./scripts/copy-readme.js eslint"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/expo/project.json
+++ b/packages/expo/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/expo/README.md"],
       "command": "node ./scripts/copy-readme.js expo"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/express/project.json
+++ b/packages/express/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/express/README.md"],
       "command": "node ./scripts/copy-readme.js express"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/gradle/project.json
+++ b/packages/gradle/project.json
@@ -14,7 +14,7 @@
     "build": {
       "outputs": ["{workspaceRoot}/dist/packages/gradle/README.md"],
       "command": "node ./scripts/copy-readme.js gradle",
-      "dependsOn": ["^build", "build-native", "build-base", "legacy-post-build"]
+      "dependsOn": ["^build", "build-native", "build-base", "legacy-pre-build"]
     },
     "build-base": {
       "dependsOn": [
@@ -23,7 +23,7 @@
         ":gradle-batch-runner:gradle:assemble"
       ]
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/jest/project.json
+++ b/packages/jest/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/jest/README.md"],
       "command": "node ./scripts/copy-readme.js jest"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/js/project.json
+++ b/packages/js/project.json
@@ -4,7 +4,7 @@
   "sourceRoot": "packages/js/src",
   "projectType": "library",
   "targets": {
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/maven/project.json
+++ b/packages/maven/project.json
@@ -19,7 +19,7 @@
       ],
       "outputs": ["{projectRoot}/README.md"]
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "outputs": ["{options.outputPath}"],
       "dependsOn": ["build-base", "maven-batch-runner:_package"],

--- a/packages/module-federation/project.json
+++ b/packages/module-federation/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/module-federation/README.md"],
       "command": "node ./scripts/copy-readme.js module-federation"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/nest/project.json
+++ b/packages/nest/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/nest/README.md"],
       "command": "node ./scripts/copy-readme.js nest"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/next/project.json
+++ b/packages/next/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/next/README.md"],
       "command": "node ./scripts/copy-readme.js next"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/node/project.json
+++ b/packages/node/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/node/README.md"],
       "command": "node ./scripts/copy-readme.js node"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/nuxt/project.json
+++ b/packages/nuxt/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/nuxt/README.md"],
       "command": "node ./scripts/copy-readme.js nuxt"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -65,7 +65,7 @@
         "^build-client",
         "build-base",
         "build-native",
-        "legacy-post-build"
+        "legacy-pre-build"
       ],
       "inputs": [
         "production",
@@ -133,7 +133,7 @@
         }
       }
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "main": "./bin/nx.js",

--- a/packages/nx/src/native/cache/http_remote_cache.rs
+++ b/packages/nx/src/native/cache/http_remote_cache.rs
@@ -226,7 +226,12 @@ impl HttpRemoteCache {
                 let path_on_disk = output_dir.join(entry_path);
                 trace!("Extracting entry to {}", path_on_disk.display());
                 fs::create_dir_all(path_on_disk.parent().expect("This will have a parent, we just joined it above so there is at least one dir."))?;
-                // Ensure the directory exists before extracting
+                // Use current mtime instead of the archived mtime.
+                // tsc --build checks if source files are newer than outputs
+                // to determine staleness. Preserved mtimes from the archive
+                // can be older than freshly cloned source files, causing
+                // false TS6305 "output has not been built from source" errors.
+                entry.set_preserve_mtime(false);
                 match entry.unpack(&path_on_disk) {
                     Err(e) => {
                         return Err(anyhow::anyhow!("Failed to unpack entry: {}", e));

--- a/packages/playwright/project.json
+++ b/packages/playwright/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/playwright/README.md"],
       "commands": ["node ./scripts/copy-readme.js playwright"]
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/plugin/project.json
+++ b/packages/plugin/project.json
@@ -8,7 +8,7 @@
       "command": "node ./scripts/copy-readme.js plugin",
       "outputs": ["{workspaceRoot}/dist/packages/plugin/README.md"]
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/react-native/project.json
+++ b/packages/react-native/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/react-native/README.md"],
       "command": "node ./scripts/copy-readme.js react-native"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/react/project.json
+++ b/packages/react/project.json
@@ -8,7 +8,7 @@
       "command": "node ./scripts/copy-readme.js react",
       "outputs": ["{workspaceRoot}/dist/packages/react/README.md"]
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/remix/project.json
+++ b/packages/remix/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/remix/README.md"],
       "command": "node ./scripts/copy-readme.js remix"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/rollup/project.json
+++ b/packages/rollup/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/rollup/README.md"],
       "command": "node ./scripts/copy-readme.js rollup"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/rsbuild/project.json
+++ b/packages/rsbuild/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/rsbuild/README.md"],
       "command": "node ./scripts/copy-readme.js rsbuild"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/rspack/project.json
+++ b/packages/rspack/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/rspack/README.md"],
       "command": "node ./scripts/copy-readme.js rspack"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/storybook/project.json
+++ b/packages/storybook/project.json
@@ -15,7 +15,7 @@
       },
       "dependsOn": ["^nx-release-publish"]
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/vite/project.json
+++ b/packages/vite/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/vite/README.md"],
       "command": "node ./scripts/copy-readme.js vite"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/vitest/project.json
+++ b/packages/vitest/project.json
@@ -8,7 +8,7 @@
       "command": "node ./scripts/copy-readme.js vitest",
       "outputs": ["{workspaceRoot}/dist/packages/vitest/README.md"]
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/vue/project.json
+++ b/packages/vue/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {},
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/web/project.json
+++ b/packages/web/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/web/README.md"],
       "command": "node ./scripts/copy-readme.js web"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/webpack/project.json
+++ b/packages/webpack/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/webpack/README.md"],
       "command": "node ./scripts/copy-readme.js webpack"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",

--- a/packages/workspace/project.json
+++ b/packages/workspace/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/workspace/README.md"],
       "command": "node ./scripts/copy-readme.js workspace"
     },
-    "legacy-post-build": {
+    "legacy-pre-build": {
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "options": {
         "tsConfig": "./tsconfig.lib.json",


### PR DESCRIPTION
## Current Behavior

`legacy-post-build` runs after `build-base` and writes to the same output directory (`dist/packages/<name>`). Since downstream `build-base` tasks (e.g. `vue:build-base`) only depend on their upstream `build-base` — not `legacy-post-build` — both can run concurrently.

When `legacy-post-build` is a cache hit, Nx restores the entire `dist/packages/<name>/` directory, including tsc-generated `.d.ts` files captured at cache time. If this restore happens while a downstream `tsc --build` is reading from the same directory, TypeScript sees inconsistent output files and emits TS6305 ("output has not been built from source").

This is timing-dependent — it only fails when `legacy-post-build` cache restore overlaps with a downstream `tsc --build` read.

## Expected Behavior

Asset copying should complete before `tsc --build` runs, so there are no concurrent writes to the output directory. By converting `legacy-post-build` to `legacy-pre-build` (a dependency of `build-base` rather than the reverse), the execution order becomes:

```
legacy-pre-build → build-base → downstream build-base
```

`tsc` gets the final word on its output files, and no concurrent writes occur.

## Related Issue(s)

Fixes intermittent TS6305 errors in CI when remote cache is involved.