### PR TITLE
fix(js): preserve tsconfig fields in typescript plugin cache

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -114,7 +114,7 @@ interface ConfigContext {
 let ts: typeof import('typescript');
 const pmc = getPackageManagerCommand();
 
-const TSCONFIG_CACHE_VERSION = 1;
+const TSCONFIG_CACHE_VERSION = 2;
 const TS_CONFIG_CACHE_PATH = join(
   workspaceDataDirectory,
   'tsconfig-files.hash'
@@ -1646,12 +1646,28 @@ function toAbsolutePaths(
   for (const [key, { data, extendedFilesHash, hash }] of Object.entries(
     cache
   )) {
+    const raw: Record<string, unknown> = {
+      nx: { addTypecheckTarget: data.raw?.['nx']?.addTypecheckTarget },
+    };
+    if (data.raw?.include) {
+      raw.include = data.raw.include;
+    }
+    if (data.raw?.exclude) {
+      raw.exclude = data.raw.exclude;
+    }
+    if (data.raw?.files) {
+      raw.files = data.raw.files;
+    }
     updatedCache[key] = {
       data: {
-        options: { noEmit: data.options.noEmit },
-        raw: {
-          nx: { addTypecheckTarget: data.raw?.['nx']?.addTypecheckTarget },
+        options: {
+          noEmit: data.options.noEmit,
+          allowJs: data.options.allowJs,
+          resolveJsonModule: data.options.resolveJsonModule,
+          emitDeclarationOnly: data.options.emitDeclarationOnly,
+          declarationMap: data.options.declarationMap,
         },
+        raw,
         extendedConfigFiles: data.extendedConfigFiles,
       },
       extendedFilesHash,
@@ -1704,12 +1720,28 @@ function toRelativePaths(
   for (const [key, { data, extendedFilesHash, hash }] of Object.entries(
     cache
   )) {
+    const raw: Record<string, unknown> = {
+      nx: { addTypecheckTarget: data.raw?.['nx']?.addTypecheckTarget },
+    };
+    if (data.raw?.include) {
+      raw.include = data.raw.include;
+    }
+    if (data.raw?.exclude) {
+      raw.exclude = data.raw.exclude;
+    }
+    if (data.raw?.files) {
+      raw.files = data.raw.files;
+    }
     updatedCache[key] = {
       data: {
-        options: { noEmit: data.options.noEmit },
-        raw: {
-          nx: { addTypecheckTarget: data.raw?.['nx']?.addTypecheckTarget },
+        options: {
+          noEmit: data.options.noEmit,
+          allowJs: data.options.allowJs,
+          resolveJsonModule: data.options.resolveJsonModule,
+          emitDeclarationOnly: data.options.emitDeclarationOnly,
+          declarationMap: data.options.declarationMap,
         },
+        raw,
         extendedConfigFiles: data.extendedConfigFiles,
       },
       extendedFilesHash,


### PR DESCRIPTION
## Current Behavior

After certain cache state transitions (e.g., tsconfig parsing cache warm but targets cache cold), the `@nx/js/typescript` plugin falls back to the `production` named input instead of deriving precise inputs from tsconfig `include`/`exclude` paths. This results in broader cache invalidation than necessary, and in projects with `allowJs` or `resolveJsonModule`, the wrong file extensions are tracked as inputs. Output inference is also affected when `emitDeclarationOnly` or `declarationMap` are set.

Running `nx reset` restores correct behavior, but the issue recurs.

## Expected Behavior

Inferred inputs and outputs are consistent regardless of cache state — always matching what the tsconfig actually specifies.

The root cause was the tsconfig parsing cache serialization (`toAbsolutePaths`/`toRelativePaths`) dropping fields the plugin relies on: `raw.include`, `raw.exclude`, `raw.files`, and `options.allowJs`, `options.resolveJsonModule`, `options.emitDeclarationOnly`, `options.declarationMap`. These are now preserved, and `TSCONFIG_CACHE_VERSION` is bumped to invalidate stale caches.