### PR TITLE
fix(js): normalize cwd path separator in typescript plugin targets

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -590,7 +590,7 @@ function buildTscTargets(
       targets[targetName] = {
         dependsOn,
         command,
-        options: { cwd: config.project.root },
+        options: { cwd: config.project.normalized },
         cache: true,
         inputs: getInputs(
           namedInputs,
@@ -647,7 +647,7 @@ function buildTscTargets(
       command: `${compiler} --build ${options.build.configName}${
         options.verboseOutput ? ' --verbose' : ''
       }`,
-      options: { cwd: config.project.root },
+      options: { cwd: config.project.normalized },
       cache: true,
       inputs: getInputs(
         namedInputs,


### PR DESCRIPTION
## Current Behavior

On Windows, the TypeScript plugin produces `cwd` with backslash separators (e.g., `cwd: "packages\\nx"`) for both the typecheck and build targets. All paths in Nx targets should use `/` separators.

## Expected Behavior

The `cwd` option uses forward slashes on all platforms (e.g., `cwd: "packages/nx"`).

## Related Issue(s)

Fixes NXC-4105