### PR TITLE
fix(core): pass collectInputs flag through daemon IPC for task hashing

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -349,7 +349,8 @@ export class DaemonClient {
     tasks: Task[],
     taskGraph: TaskGraph,
     env: NodeJS.ProcessEnv,
-    cwd: string
+    cwd: string,
+    collectInputs?: boolean
   ): Promise<Hash[]> {
     return this.sendToDaemonViaQueue({
       type: 'HASH_TASKS',
@@ -361,6 +362,7 @@ export class DaemonClient {
       tasks,
       taskGraph,
       cwd,
+      collectInputs,
     });
   }
 

--- a/packages/nx/src/daemon/server/handle-hash-tasks.ts
+++ b/packages/nx/src/daemon/server/handle-hash-tasks.ts
@@ -16,6 +16,7 @@ export async function handleHashTasks(payload: {
   tasks: Task[];
   taskGraph: TaskGraph;
   cwd: string;
+  collectInputs?: boolean;
 }) {
   const { error, projectGraph, allWorkspaceFiles, fileMap, rustReferences } =
     await getCachedSerializedProjectGraphPromise();
@@ -39,7 +40,8 @@ export async function handleHashTasks(payload: {
     payload.tasks,
     payload.taskGraph,
     payload.env,
-    payload.cwd
+    payload.cwd,
+    payload.collectInputs
   );
   return {
     response,

--- a/packages/nx/src/hasher/native-task-hasher-impl.ts
+++ b/packages/nx/src/hasher/native-task-hasher-impl.ts
@@ -68,15 +68,17 @@ export class NativeTaskHasherImpl implements TaskHasherImpl {
     task: Task,
     taskGraph: TaskGraph,
     env: NodeJS.ProcessEnv,
-    cwd?: string
+    cwd?: string,
+    collectInputs?: boolean
   ): Promise<PartialHash> {
     const plans = this.planner.getPlansReference([task.id], taskGraph);
-    const collectInputs = getTaskIOService().hasTaskInputSubscribers();
+    const shouldCollectInputs =
+      collectInputs ?? getTaskIOService().hasTaskInputSubscribers();
     const hashes = this.hasher.hashPlans(
       plans,
       env,
       cwd ?? process.cwd(),
-      collectInputs
+      shouldCollectInputs
     );
 
     return hashes[task.id];
@@ -86,18 +88,20 @@ export class NativeTaskHasherImpl implements TaskHasherImpl {
     tasks: Task[],
     taskGraph: TaskGraph,
     env: NodeJS.ProcessEnv,
-    cwd?: string
+    cwd?: string,
+    collectInputs?: boolean
   ): Promise<PartialHash[]> {
     const plans = this.planner.getPlansReference(
       tasks.map((t) => t.id),
       taskGraph
     );
-    const collectInputs = getTaskIOService().hasTaskInputSubscribers();
+    const shouldCollectInputs =
+      collectInputs ?? getTaskIOService().hasTaskInputSubscribers();
     const hashes = this.hasher.hashPlans(
       plans,
       env,
       cwd ?? process.cwd(),
-      collectInputs
+      shouldCollectInputs
     );
     return tasks.map((t) => hashes[t.id]);
   }

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -12,6 +12,7 @@ import { minimatch } from 'minimatch';
 import { NativeTaskHasherImpl } from './native-task-hasher-impl';
 import { workspaceRoot } from '../utils/workspace-root';
 import { HashInputs, NxWorkspaceFilesExternals } from '../native';
+import { getTaskIOService } from '../tasks-runner/task-io-service';
 
 // Re-export HashInputs from native module for public API
 export { HashInputs };
@@ -84,14 +85,16 @@ export interface TaskHasherImpl {
     tasks: Task[],
     taskGraph: TaskGraph,
     env: NodeJS.ProcessEnv,
-    cwd?: string
+    cwd?: string,
+    collectInputs?: boolean
   ): Promise<PartialHash[]>;
 
   hashTask(
     task: Task,
     taskGraph: TaskGraph,
     env: NodeJS.ProcessEnv,
-    cwd?: string
+    cwd?: string,
+    collectInputs?: boolean
   ): Promise<PartialHash>;
 }
 
@@ -108,12 +111,14 @@ export class DaemonBasedTaskHasher implements TaskHasher {
     taskGraph?: TaskGraph,
     env?: NodeJS.ProcessEnv
   ): Promise<Hash[]> {
+    const collectInputs = getTaskIOService().hasTaskInputSubscribers();
     return this.daemonClient.hashTasks(
       this.runnerOptions,
       tasks,
       taskGraph,
       env ?? process.env,
-      process.cwd()
+      process.cwd(),
+      collectInputs
     );
   }
 
@@ -122,13 +127,15 @@ export class DaemonBasedTaskHasher implements TaskHasher {
     taskGraph?: TaskGraph,
     env?: NodeJS.ProcessEnv
   ): Promise<Hash> {
+    const collectInputs = getTaskIOService().hasTaskInputSubscribers();
     return (
       await this.daemonClient.hashTasks(
         this.runnerOptions,
         [task],
         taskGraph,
         env ?? process.env,
-        process.cwd()
+        process.cwd(),
+        collectInputs
       )
     )[0];
   }
@@ -158,13 +165,15 @@ export class InProcessTaskHasher implements TaskHasher {
     tasks: Task[],
     taskGraph?: TaskGraph,
     env?: NodeJS.ProcessEnv,
-    cwd?: string
+    cwd?: string,
+    collectInputs?: boolean
   ): Promise<Hash[]> {
     const hashes = await this.taskHasher.hashTasks(
       tasks,
       taskGraph,
       env ?? process.env,
-      cwd ?? process.cwd()
+      cwd ?? process.cwd(),
+      collectInputs
     );
     return tasks.map((task, index) =>
       this.createHashDetails(task, hashes[index])
@@ -175,13 +184,15 @@ export class InProcessTaskHasher implements TaskHasher {
     task: Task,
     taskGraph?: TaskGraph,
     env?: NodeJS.ProcessEnv,
-    cwd?: string
+    cwd?: string,
+    collectInputs?: boolean
   ): Promise<Hash> {
     const res = await this.taskHasher.hashTask(
       task,
       taskGraph,
       env ?? process.env,
-      cwd ?? process.cwd()
+      cwd ?? process.cwd(),
+      collectInputs
     );
     return this.createHashDetails(task, res);
   }


### PR DESCRIPTION
When the daemon handles task hashing, the `NativeTaskHasherImpl` checked `hasTaskInputSubscribers()` in the daemon process where no subscribers exist, causing the native Rust hasher to skip input collection entirely. This resulted in empty input arrays in IO tracing signals.

The fix passes collectInputs from the client process (where subscribers are registered) through the daemon IPC to the hasher, so the daemon uses the client's subscriber state instead of its own.
