### PR TITLE
fix(core): improve error handling in nx migrate registry fetching

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -2,6 +2,7 @@ import * as pc from 'picocolors';
 import { exec, execSync, type StdioOptions } from 'child_process';
 import { prompt } from 'enquirer';
 import { dirname, join } from 'path';
+import { joinPathFragments } from '../../utils/path';
 import {
   clean,
   coerce,
@@ -978,7 +979,10 @@ function createFetcher() {
         setCache(packageName, resolvedVersion);
         return getPackageMigrationsUsingRegistry(packageName, resolvedVersion);
       })
-      .catch(() => {
+      .catch((e) => {
+        logger.verbose(
+          `Failed to get migrations from registry for ${packageName}@${packageVersion}: ${e.message}. Falling back to install.`
+        );
         logger.info(`Fetching ${packageName}@${packageVersion}`);
 
         return getPackageMigrationsUsingInstall(packageName, packageVersion);
@@ -1115,7 +1119,7 @@ async function downloadPackageMigrationsFromRegistry(
 
     const migrations = await extractFileFromTarball(
       join(dir, tarballPath),
-      join('package', migrationsFilePath),
+      joinPathFragments('package', migrationsFilePath),
       join(dir, migrationsFilePath)
     ).then((path) => readJsonFile<MigrationsJson>(path));
 
@@ -1148,6 +1152,10 @@ async function getPackageMigrationsUsingInstall(
 
     await execAsync(`${pmc.add} ${packageName}@${packageVersion}`, {
       cwd: dir,
+      env: {
+        ...process.env,
+        npm_config_legacy_peer_deps: 'true',
+      },
     });
 
     const {
@@ -1163,11 +1171,9 @@ async function getPackageMigrationsUsingInstall(
 
     result = { ...migrations, packageGroup, version: packageJson.version };
   } catch (e) {
-    output.warn({
-      title: `Failed to fetch migrations for ${packageName}@${packageVersion}`,
-      bodyLines: [e.message],
-    });
-    return {};
+    throw new Error(
+      `Failed to fetch migrations for ${packageName}@${packageVersion}: ${e.message}`
+    );
   } finally {
     await cleanup();
   }

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -610,19 +610,14 @@ export async function packageRegistryPack(
   pkg: string,
   version: string
 ): Promise<{ tarballPath: string }> {
-  let pm = detectPackageManager();
-  if (pm === 'yarn' || pm === 'bun') {
-    /**
-     * `(p)npm pack` will download a tarball of the specified version,
-     * whereas `yarn` pack creates a tarball of the active workspace, so it
-     * does not work for getting the content of a library.
-     *
-     * @see https://github.com/nrwl/nx/pull/9667#discussion_r842553994
-     *
-     * bun doesn't currently support pack
-     */
-    pm = 'npm';
-  }
+  /**
+   * Only `npm pack` supports downloading a tarball of a specified remote
+   * package. `yarn` packs the active workspace, `pnpm pack` only packs
+   * the local project, and `bun` doesn't support pack.
+   *
+   * @see https://github.com/nrwl/nx/pull/9667#discussion_r842553994
+   */
+  const pm = 'npm';
 
   const { stdout } = await execAsync(`${pm} pack ${pkg}@${version}`, {
     cwd,


### PR DESCRIPTION
## Current Behavior

Several issues in `nx migrate` registry fetching cause confusing errors:

- `packageRegistryPack` uses `pnpm pack` for pnpm users, but `pnpm pack` only packs the local project (unlike `npm pack` which downloads remote packages). This silently fails for all pnpm users, always falling back to the slower install path.
- On Windows, `extractFileFromTarball` fails because `join('package', migrationsFilePath)` produces backslash paths that don't match forward-slash tarball entries.
- When the install fallback also fails, `getPackageMigrationsUsingInstall` returns `{}` instead of throwing. The missing `version` property (`undefined`) propagates through `packageUpdates` and `collectedVersions`, producing `Fetching nx@undefined`.
- The install fallback can fail on peer dependency conflicts since `legacy-peer-deps` was removed as a default (PR #33014), even though the install only needs files on disk (not a valid dependency tree).
- The `.catch()` in `fetchMigrations` swallows errors without logging, making it impossible to diagnose registry fetch failures.

## Expected Behavior

- `packageRegistryPack` always uses `npm pack` since it's the only package manager that supports downloading remote packages
- Tarball entry matching uses `joinPathFragments` to normalize paths (forward slashes) for cross-platform compatibility
- `getPackageMigrationsUsingInstall` throws on failure with a descriptive error instead of returning an empty object
- Install fallback sets `npm_config_legacy_peer_deps=true` since it only needs files on disk, not a valid dependency tree
- Registry fetch errors are logged at verbose level (`NX_VERBOSE_LOGGING=true`) for debuggability

## Related Issue(s)

Fixes #33135