### PR TITLE
feat(core): replace rusqlite with turso crate (pure Rust SQLite)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,18 +885,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,15 +1271,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
-]
 
 [[package]]
 name = "heck"
@@ -1944,17 +1923,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libsqlite3-sys"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2348,7 +2316,6 @@ dependencies = [
  "regex",
  "reqwest",
  "rkyv",
- "rusqlite",
  "serde",
  "serde_json",
  "static_assertions",
@@ -3107,20 +3074,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
-dependencies = [
- "bitflags 2.10.0",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
 ]
 
 [[package]]
@@ -4465,12 +4418,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color-eyre"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1886,34 +1895,37 @@ dependencies = [
 
 [[package]]
 name = "libsql"
-version = "0.6.0"
+version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe18646e4ef8db446bc3e3f5fb96131483203bc5f4998ff149f79a067530c01c"
+checksum = "30fe980ac5693ed1f3db490559fb578885e913a018df64af8a1a46e1959a78df"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
  "bytes",
  "futures",
  "libsql-sys",
+ "parking_lot",
  "thiserror 1.0.69",
  "tracing",
 ]
 
 [[package]]
 name = "libsql-ffi"
-version = "0.5.0"
+version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2a50a585a1184a43621a9133b7702ba5cb7a87ca5e704056b19d8005de6faf"
+checksum = "0be1da6f123ceb2cd23f469883415cab9ee963286a85d61e22afb8b12e15e681"
 dependencies = [
  "bindgen",
  "cc",
+ "cmake",
+ "glob",
 ]
 
 [[package]]
 name = "libsql-sys"
-version = "0.8.0"
+version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c05b61c226781d6f5e26e3e7364617f19c0c1d5332035802e9229d6024cec05"
+checksum = "90725458cc4461bc82f8f7983e80b002ea4f64b5184e1462f252d0dd74b122f5"
 dependencies = [
  "bytes",
  "libsql-ffi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.8.38",
 ]
 
 [[package]]
@@ -237,6 +237,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+dependencies = [
+ "bitflags 2.10.0",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.114",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +328,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +344,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cassowary"
@@ -348,6 +380,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +411,17 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1135,6 +1187,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,7 +1243,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
- "zerocopy",
+ "zerocopy 0.8.38",
 ]
 
 [[package]]
@@ -1240,6 +1298,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -1796,10 +1863,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "libloading"
@@ -1820,6 +1903,44 @@ dependencies = [
  "bitflags 2.10.0",
  "libc",
  "redox_syscall 0.7.0",
+]
+
+[[package]]
+name = "libsql"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18646e4ef8db446bc3e3f5fb96131483203bc5f4998ff149f79a067530c01c"
+dependencies = [
+ "async-trait",
+ "bitflags 2.10.0",
+ "bytes",
+ "futures",
+ "libsql-sys",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "libsql-ffi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2a50a585a1184a43621a9133b7702ba5cb7a87ca5e704056b19d8005de6faf"
+dependencies = [
+ "bindgen",
+ "cc",
+]
+
+[[package]]
+name = "libsql-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c05b61c226781d6f5e26e3e7364617f19c0c1d5332035802e9229d6024cec05"
+dependencies = [
+ "bytes",
+ "libsql-ffi",
+ "once_cell",
+ "tracing",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -2039,7 +2160,7 @@ version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
 dependencies = [
- "libloading",
+ "libloading 0.9.0",
 ]
 
 [[package]]
@@ -2210,6 +2331,7 @@ dependencies = [
  "interprocess",
  "itertools 0.10.5",
  "jsonrpsee",
+ "libsql",
  "machine-uid",
  "mio",
  "napi",
@@ -2418,6 +2540,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2545,7 +2673,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.38",
 ]
 
 [[package]]
@@ -2579,6 +2707,16 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4646,6 +4784,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5265,11 +5415,32 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.38",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4799,9 +4799,8 @@ dependencies = [
 
 [[package]]
 name = "turso"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7adb377630e2cfc1aa10d44cff1a05edfca9dea1bcf500211a24917f37dbf492"
+version = "0.5.0-pre.20"
+source = "git+https://github.com/tursodatabase/turso?branch=multi-process#1c13fe18ee042d2dd0eda6281ad716927d9747c9"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -4812,9 +4811,8 @@ dependencies = [
 
 [[package]]
 name = "turso_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b2f28e920d1d893fdd5bf4a9bf666dc31f3f0c99832611a6e119b93501707f"
+version = "0.5.0-pre.20"
+source = "git+https://github.com/tursodatabase/turso?branch=multi-process#1c13fe18ee042d2dd0eda6281ad716927d9747c9"
 dependencies = [
  "aegis",
  "aes",
@@ -4877,9 +4875,8 @@ dependencies = [
 
 [[package]]
 name = "turso_ext"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07064bc2fefab2f90478d30fc8fae48d8526f590b70b303a1092081e8ee42a3f"
+version = "0.5.0-pre.20"
+source = "git+https://github.com/tursodatabase/turso?branch=multi-process#1c13fe18ee042d2dd0eda6281ad716927d9747c9"
 dependencies = [
  "chrono",
  "getrandom 0.3.4",
@@ -4888,9 +4885,8 @@ dependencies = [
 
 [[package]]
 name = "turso_macros"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab0703506127013dc1fc7e115b2055aeb16ac8aed7b972a9156abd08406c74c"
+version = "0.5.0-pre.20"
+source = "git+https://github.com/tursodatabase/turso?branch=multi-process#1c13fe18ee042d2dd0eda6281ad716927d9747c9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4899,9 +4895,8 @@ dependencies = [
 
 [[package]]
 name = "turso_parser"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770c38bab784693915ad996c28decbddecb563388ffb5038a4dfe16f4a446a86"
+version = "0.5.0-pre.20"
+source = "git+https://github.com/tursodatabase/turso?branch=multi-process#1c13fe18ee042d2dd0eda6281ad716927d9747c9"
 dependencies = [
  "bitflags 2.10.0",
  "memchr",
@@ -4914,9 +4909,8 @@ dependencies = [
 
 [[package]]
 name = "turso_sdk_kit"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16574ba104b802e2faa7654099d4aa00e769b9baaab347d6d98e9eef2a8d1f8c"
+version = "0.5.0-pre.20"
+source = "git+https://github.com/tursodatabase/turso?branch=multi-process#1c13fe18ee042d2dd0eda6281ad716927d9747c9"
 dependencies = [
  "bindgen",
  "env_logger",
@@ -4930,9 +4924,8 @@ dependencies = [
 
 [[package]]
 name = "turso_sdk_kit_macros"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e92557fe426adaaa096bc33b7953a137020645cf43127ff81a77cea74d37cd4"
+version = "0.5.0-pre.20"
+source = "git+https://github.com/tursodatabase/turso?branch=multi-process#1c13fe18ee042d2dd0eda6281ad716927d9747c9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4941,9 +4934,8 @@ dependencies = [
 
 [[package]]
 name = "turso_sync_engine"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18182aacf9550e0e56cc567d2501d7b999a0eaee072f5623fb9ffd74c34a056a"
+version = "0.5.0-pre.20"
+source = "git+https://github.com/tursodatabase/turso?branch=multi-process#1c13fe18ee042d2dd0eda6281ad716927d9747c9"
 dependencies = [
  "base64",
  "bytes",
@@ -4963,9 +4955,8 @@ dependencies = [
 
 [[package]]
 name = "turso_sync_sdk_kit"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cd8cceccd7b2428a3bf81a9f08cf27138a1a02c831a3599bd277c4dff2f06c"
+version = "0.5.0-pre.20"
+source = "git+https://github.com/tursodatabase/turso?branch=multi-process#1c13fe18ee042d2dd0eda6281ad716927d9747c9"
 dependencies = [
  "bindgen",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aegis"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78412fa53e6da95324e8902c3641b3ff32ab45258582ea997eb9169c68ffa219"
+dependencies = [
+ "cc",
+ "softaes",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,7 +92,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.8.38",
+ "zerocopy",
 ]
 
 [[package]]
@@ -90,6 +135,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
+name = "antithesis_sdk"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dbd97a5b6c21cc9176891cf715f7f0c273caf3959897f43b9bd1231939e675"
+dependencies = [
+ "libc",
+ "libloading 0.8.9",
+ "linkme",
+ "once_cell",
+ "rand 0.8.5",
+ "rustc_version_runtime",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +215,12 @@ dependencies = [
  "predicates-tree",
  "tempfile",
 ]
+
+[[package]]
+name = "assoc"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdc70193dadb9d7287fa4b633f15f90c876915b31f6af17da307fc59c9859a8"
 
 [[package]]
 name = "ast_node"
@@ -237,18 +313,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.66.1"
+name = "bigdecimal"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
- "peeking_take_while",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -284,6 +373,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "branches"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e426eb5cc1900033930ec955317b302e68f19f326cc7bb0c8a86865a826cdf0c"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +389,15 @@ checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "built"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]
@@ -326,6 +433,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "byteorder"
@@ -344,9 +465,6 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "cassowary"
@@ -365,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -401,6 +519,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cfg_block"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +535,16 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -434,15 +568,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "color-eyre"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,7 +578,7 @@ dependencies = [
  "eyre",
  "indenter",
  "once_cell",
- "owo-colors",
+ "owo-colors 4.2.3",
  "tracing-error",
 ]
 
@@ -464,7 +589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
 dependencies = [
  "once_cell",
- "owo-colors",
+ "owo-colors 4.2.3",
  "tracing-core",
  "tracing-error",
 ]
@@ -559,6 +684,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,6 +735,16 @@ version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -653,6 +806,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
 name = "ctor"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +831,15 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "darling"
@@ -851,6 +1024,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+dependencies = [
+ "env_filter 1.0.0",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,6 +1083,24 @@ checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "rand 0.9.2",
+ "siphasher 1.0.2",
 ]
 
 [[package]]
@@ -1141,6 +1351,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "genawaiter"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
+dependencies = [
+ "genawaiter-macro",
+]
+
+[[package]]
+name = "genawaiter-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,6 +1425,16 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1240,7 +1500,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
- "zerocopy 0.8.38",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1286,6 +1546,18 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -1606,6 +1878,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "insta"
 version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +1924,26 @@ dependencies = [
  "tokio",
  "widestring",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset 0.9.1",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd7bddefd0a8833b88a4b68f90dae22c7450d11b354198baee3874fd811b344"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1883,6 +2184,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,44 +2201,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "libsql"
-version = "0.9.30"
+name = "linkme"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30fe980ac5693ed1f3db490559fb578885e913a018df64af8a1a46e1959a78df"
+checksum = "5e3283ed2d0e50c06dd8602e0ab319bb048b6325d0bba739db64ed8205179898"
 dependencies = [
- "async-trait",
- "bitflags 2.10.0",
- "bytes",
- "futures",
- "libsql-sys",
- "parking_lot",
- "thiserror 1.0.69",
- "tracing",
+ "linkme-impl",
 ]
 
 [[package]]
-name = "libsql-ffi"
-version = "0.9.30"
+name = "linkme-impl"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be1da6f123ceb2cd23f469883415cab9ee963286a85d61e22afb8b12e15e681"
+checksum = "e5cec0ec4228b4853bb129c84dbf093a27e6c7a20526da046defc334a1b017f7"
 dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "glob",
-]
-
-[[package]]
-name = "libsql-sys"
-version = "0.9.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90725458cc4461bc82f8f7983e80b002ea4f64b5184e1462f252d0dd74b122f5"
-dependencies = [
- "bytes",
- "libsql-ffi",
- "once_cell",
- "tracing",
- "zerocopy 0.7.35",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1972,6 +2258,19 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "lru"
@@ -2019,6 +2318,15 @@ name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -2159,7 +2467,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
  "pin-utils",
 ]
 
@@ -2311,7 +2619,6 @@ dependencies = [
  "interprocess",
  "itertools 0.10.5",
  "jsonrpsee",
- "libsql",
  "machine-uid",
  "mio",
  "napi",
@@ -2350,6 +2657,7 @@ dependencies = [
  "tracing-subscriber",
  "tui-logger",
  "tui-term 0.2.0 (git+https://github.com/JamesHenry/tui-term?rev=88e3b61425c97220c528ef76c188df10032a75dd)",
+ "turso",
  "urlencoding",
  "uuid",
  "vt100-ctt",
@@ -2462,6 +2770,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2479,9 +2793,24 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+
+[[package]]
+name = "pack1"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6e7cd9bd638dc2c831519a0caa1c006cab771a92b1303403a8322773c5b72d6"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "parking"
@@ -2517,12 +2846,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -2612,6 +2935,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-pty"
 version = "0.8.1"
 source = "git+https://github.com/cammisuli/wezterm?rev=b538ee29e1e89eeb4832fb35ae095564dce34c29#b538ee29e1e89eeb4832fb35ae095564dce34c29"
@@ -2652,7 +3001,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.38",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2728,6 +3077,29 @@ dependencies = [
  "tokio",
  "tracing",
  "windows 0.62.2",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2866,6 +3238,8 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -2875,8 +3249,18 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2894,6 +3278,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -2902,6 +3289,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -3089,6 +3494,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,6 +3527,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
  "semver",
 ]
 
@@ -3380,6 +3805,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3409,6 +3840,26 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shuttle"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab17edba38d63047f46780cf7360acf7467fec2c048928689a5c1dd1c2b4e31"
+dependencies = [
+ "assoc",
+ "bitvec",
+ "cfg-if",
+ "generator",
+ "hex",
+ "owo-colors 3.5.0",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rand_pcg",
+ "scoped-tls",
+ "smallvec",
+ "tracing",
+]
 
 [[package]]
 name = "signal-hook"
@@ -3460,6 +3911,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "simsimd"
+version = "6.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fb3bc3cdce07a7d7d4caa4c54f8aa967f6be41690482b54b24100a2253fa70"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3503,6 +3963,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "softaes"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef461faaeb36c340b6c887167a9054a034f6acfc50a014ead26a02b4356b3de"
 
 [[package]]
 name = "stable_deref_trait"
@@ -4303,7 +4769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "382b7ea88082dbe2236ed1e942552b1bfc59e98fdc5d0599f11a627aae9ee2be"
 dependencies = [
  "chrono",
- "env_filter",
+ "env_filter 0.1.4",
  "lazy_static",
  "log",
  "parking_lot",
@@ -4332,10 +4798,217 @@ dependencies = [
 ]
 
 [[package]]
+name = "turso"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7adb377630e2cfc1aa10d44cff1a05edfca9dea1bcf500211a24917f37dbf492"
+dependencies = [
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
+ "turso_sdk_kit",
+ "turso_sync_sdk_kit",
+]
+
+[[package]]
+name = "turso_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b2f28e920d1d893fdd5bf4a9bf666dc31f3f0c99832611a6e119b93501707f"
+dependencies = [
+ "aegis",
+ "aes",
+ "aes-gcm",
+ "antithesis_sdk",
+ "arc-swap",
+ "bigdecimal",
+ "bitflags 2.10.0",
+ "branches",
+ "built",
+ "bumpalo",
+ "bytemuck",
+ "cfg_block",
+ "chrono",
+ "crc32c",
+ "crossbeam-skiplist",
+ "either",
+ "fallible-iterator",
+ "fastbloom",
+ "hex",
+ "intrusive-collections",
+ "io-uring",
+ "libc",
+ "libloading 0.8.9",
+ "libm",
+ "loom",
+ "miette",
+ "num-bigint",
+ "num-traits",
+ "pack1",
+ "parking_lot",
+ "paste",
+ "polling",
+ "rand 0.9.2",
+ "rapidhash",
+ "regex",
+ "regex-syntax",
+ "roaring",
+ "rustc-hash 2.1.1",
+ "rustix 1.1.3",
+ "ryu",
+ "serde_json",
+ "shuttle",
+ "simsimd",
+ "smallvec",
+ "strum",
+ "strum_macros",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
+ "turso_ext",
+ "turso_macros",
+ "turso_parser",
+ "twox-hash",
+ "uncased",
+ "uuid",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "turso_ext"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07064bc2fefab2f90478d30fc8fae48d8526f590b70b303a1092081e8ee42a3f"
+dependencies = [
+ "chrono",
+ "getrandom 0.3.4",
+ "turso_macros",
+]
+
+[[package]]
+name = "turso_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab0703506127013dc1fc7e115b2055aeb16ac8aed7b972a9156abd08406c74c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "turso_parser"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770c38bab784693915ad996c28decbddecb563388ffb5038a4dfe16f4a446a86"
+dependencies = [
+ "bitflags 2.10.0",
+ "memchr",
+ "miette",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+ "turso_macros",
+]
+
+[[package]]
+name = "turso_sdk_kit"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16574ba104b802e2faa7654099d4aa00e769b9baaab347d6d98e9eef2a8d1f8c"
+dependencies = [
+ "bindgen",
+ "env_logger",
+ "parking_lot",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sdk_kit_macros",
+]
+
+[[package]]
+name = "turso_sdk_kit_macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e92557fe426adaaa096bc33b7953a137020645cf43127ff81a77cea74d37cd4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "turso_sync_engine"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18182aacf9550e0e56cc567d2501d7b999a0eaee072f5623fb9ffd74c34a056a"
+dependencies = [
+ "base64",
+ "bytes",
+ "genawaiter",
+ "http",
+ "libc",
+ "prost",
+ "roaring",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "turso_core",
+ "turso_parser",
+ "uuid",
+]
+
+[[package]]
+name = "turso_sync_sdk_kit"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cd8cceccd7b2428a3bf81a9f08cf27138a1a02c831a3599bd277c4dff2f06c"
+dependencies = [
+ "bindgen",
+ "env_logger",
+ "genawaiter",
+ "parking_lot",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sdk_kit",
+ "turso_sdk_kit_macros",
+ "turso_sync_engine",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.2",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-id"
@@ -4377,6 +5050,16 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -4422,6 +5105,7 @@ checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -5374,32 +6058,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
 dependencies = [
- "zerocopy-derive 0.8.38",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -96,7 +96,7 @@ ratatui = { version = "0.29" }
 reqwest = { version = "0.12.22", default-features = false, features = [
     "rustls-tls-native-roots",
 ] }
-turso = { version = "0.5.1", default-features = false }
+turso = { git = "https://github.com/tursodatabase/turso", branch = "multi-process", default-features = false }
 watchexec = "8.0.1"
 watchexec-events = "6.0.0"
 watchexec-signals = "5.0.1"

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -72,9 +72,6 @@ serde_json = "1.0.140"
 static_assertions = "1.1"
 wrap-ansi = "0.1"
 
-[features]
-turso-backend = ["libsql"]
-
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "psapi"] }
 
@@ -99,8 +96,7 @@ ratatui = { version = "0.29" }
 reqwest = { version = "0.12.22", default-features = false, features = [
     "rustls-tls-native-roots",
 ] }
-rusqlite = { version = "0.32.1", features = ["bundled", "array", "vtab"] }
-libsql = { version = "0.6", optional = true, default-features = false, features = ["core"] }
+libsql = { version = "0.6", default-features = false, features = ["core"] }
 watchexec = "8.0.1"
 watchexec-events = "6.0.0"
 watchexec-signals = "5.0.1"

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -72,6 +72,9 @@ serde_json = "1.0.140"
 static_assertions = "1.1"
 wrap-ansi = "0.1"
 
+[features]
+turso-backend = ["libsql"]
+
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "psapi"] }
 
@@ -97,6 +100,7 @@ reqwest = { version = "0.12.22", default-features = false, features = [
     "rustls-tls-native-roots",
 ] }
 rusqlite = { version = "0.32.1", features = ["bundled", "array", "vtab"] }
+libsql = { version = "0.6", optional = true, default-features = false, features = ["core"] }
 watchexec = "8.0.1"
 watchexec-events = "6.0.0"
 watchexec-signals = "5.0.1"

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -96,7 +96,7 @@ ratatui = { version = "0.29" }
 reqwest = { version = "0.12.22", default-features = false, features = [
     "rustls-tls-native-roots",
 ] }
-libsql = { version = "0.9.30", default-features = false, features = ["core"] }
+turso = { version = "0.5.1", default-features = false }
 watchexec = "8.0.1"
 watchexec-events = "6.0.0"
 watchexec-signals = "5.0.1"

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -96,7 +96,7 @@ ratatui = { version = "0.29" }
 reqwest = { version = "0.12.22", default-features = false, features = [
     "rustls-tls-native-roots",
 ] }
-libsql = { version = "0.6", default-features = false, features = ["core"] }
+libsql = { version = "0.9.30", default-features = false, features = ["core"] }
 watchexec = "8.0.1"
 watchexec-events = "6.0.0"
 watchexec-signals = "5.0.1"

--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -280,25 +280,22 @@ impl NxCache {
         if user_specified_max_cache_size < full_cache_size {
             let mut cache_size = full_cache_size;
             let db = self.db.lock().unwrap();
-            let mut stmt = db.prepare(
-                "SELECT hash, size FROM cache_outputs ORDER BY accessed_at ASC LIMIT 100",
-            )?;
-            'outer: while cache_size > target_cache_size {
-                let rows = stmt.query_map([], |r| {
-                    let hash: String = r.get(0)?;
-                    let size: i64 = r.get(1)?;
-                    Ok((hash, size))
-                })?;
-                for row in rows {
-                    if let Ok((hash, size)) = row {
+            while cache_size > target_cache_size {
+                let rows = db.query_rows(
+                    "SELECT hash, size FROM cache_outputs ORDER BY accessed_at ASC LIMIT 100",
+                    &[],
+                )?;
+                if rows.is_empty() {
+                    break;
+                }
+                for row in &rows {
+                    if let (Ok(hash), Ok(size)) = (row.get_str(0), row.get_i64(1)) {
                         cache_size -= size;
                         db.execute("DELETE FROM cache_outputs WHERE hash = ?1", params![hash])?;
                         remove_items(&[self.cache_path.join(&hash)])?;
                     }
-                    // We've deleted enough cache entries to be under the
-                    // target cache size, stop looking for more.
                     if cache_size < target_cache_size {
-                        break 'outer;
+                        break;
                     }
                 }
             }
@@ -353,24 +350,22 @@ impl NxCache {
 
     #[napi]
     pub fn remove_old_cache_records(&self) -> anyhow::Result<()> {
-        let outdated_cache = self
-            .db
-            .lock()
-            .unwrap()
-            .prepare(
-                "DELETE FROM cache_outputs WHERE accessed_at < datetime('now', '-7 days') RETURNING hash",
-            )?
-            .query_map(params![], |row| {
-                let hash: String = row.get(0)?;
+        let rows = self.db.lock().unwrap().query_rows(
+            "DELETE FROM cache_outputs WHERE accessed_at < datetime('now', '-7 days') RETURNING hash",
+            &[],
+        )?;
 
-                Ok(vec![
+        let outdated_cache: Vec<_> = rows
+            .iter()
+            .filter_map(|row| {
+                let hash = row.get_str(0).ok()?;
+                Some(vec![
                     self.cache_path.join(&hash),
                     self.get_task_outputs_path_internal(&hash),
                 ])
-            })?
-            .filter_map(anyhow::Result::ok)
+            })
             .flatten()
-            .collect::<Vec<_>>();
+            .collect();
 
         remove_items(&outdated_cache)?;
 

--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -5,12 +5,11 @@ use tracing::{debug, trace};
 
 use fs_extra::remove_items;
 use regex::Regex;
-use rusqlite::params;
 use sysinfo::Disks;
 
 use crate::native::cache::expand_outputs::_expand_outputs;
 use crate::native::cache::file_ops::_copy;
-use crate::native::db::connection::NxDbConnection;
+use crate::native::db::connection::{DbValue, NxDbConnection};
 use crate::native::utils::Normalize;
 use napi::bindgen_prelude::External;
 use std::sync::{Arc, Mutex};
@@ -90,11 +89,7 @@ impl NxCache {
             "
         };
 
-        self.db
-            .lock()
-            .unwrap()
-            .execute(query, [])
-            .map_err(anyhow::Error::from)?;
+        self.db.lock().unwrap().execute_batch(query)?;
         Ok(())
     }
 
@@ -103,10 +98,9 @@ impl NxCache {
         let start = Instant::now();
         trace!("GET {}", &hash);
         let task_dir = self.cache_path.join(&hash);
-
         let terminal_output_path = self.get_task_outputs_path_internal(&hash);
 
-        let r = self
+        let row = self
             .db
             .lock()
             .unwrap()
@@ -115,25 +109,26 @@ impl NxCache {
                     SET accessed_at = CURRENT_TIMESTAMP
                     WHERE hash = ?1
                     RETURNING code, size",
-                params![hash],
-                |row| {
-                    let code: i16 = row.get(0)?;
-                    let size: i64 = row.get(1)?;
-
-                    let start = Instant::now();
-                    let terminal_output =
-                        read_to_string(terminal_output_path).unwrap_or(String::from(""));
-                    trace!("TIME reading terminal outputs {:?}", start.elapsed());
-
-                    Ok(CachedResult {
-                        code,
-                        terminal_output: Some(terminal_output),
-                        outputs_path: task_dir.to_normalized_string(),
-                        size: Some(size),
-                    })
-                },
+                &[DbValue::from(hash.as_str())],
             )
             .map_err(|e| anyhow::anyhow!("Unable to get {}: {:?}", &hash, e))?;
+
+        let r = row.map(|row| {
+            let code = row.get_i64(0).unwrap_or(0) as i16;
+            let size = row.get_i64(1).unwrap_or(0);
+
+            let start = Instant::now();
+            let terminal_output = read_to_string(terminal_output_path).unwrap_or(String::from(""));
+            trace!("TIME reading terminal outputs {:?}", start.elapsed());
+
+            CachedResult {
+                code,
+                terminal_output: Some(terminal_output),
+                outputs_path: task_dir.to_normalized_string(),
+                size: Some(size),
+            }
+        });
+
         trace!("GET {} {:?}", &hash, start.elapsed());
         Ok(r)
     }
@@ -238,7 +233,11 @@ impl NxCache {
         trace!("Recording to cache: {}, {}, {}", &hash, code, size);
         self.db.lock().unwrap().execute(
             "INSERT OR REPLACE INTO cache_outputs (hash, code, size) VALUES (?1, ?2, ?3)",
-            params![hash, code, size],
+            &[
+                DbValue::from(hash.as_str()),
+                DbValue::Integer(code as i64),
+                DbValue::Integer(size),
+            ],
         )?;
         if self.max_cache_size != 0 {
             self.ensure_cache_size_within_limit()?
@@ -248,23 +247,16 @@ impl NxCache {
 
     #[napi]
     pub fn get_cache_size(&self) -> anyhow::Result<i64> {
-        self.db
+        let row = self
+            .db
             .lock()
             .unwrap()
-            .query_row("SELECT SUM(size) FROM cache_outputs", [], |row| {
-                row.get::<_, Option<i64>>(0)
-                    // If there are no cache entries, the result is
-                    // a single row with a NULL value. This would look like:
-                    // Ok(None). We need to convert this to Ok(0).
-                    .transpose()
-                    .unwrap_or(Ok(0))
-            })
-            // The query_row returns an Result<Option<T>> to account for
-            // a query that returned no rows. This isn't possible when using
-            // SUM, so we can safely unwrap the Option, but need to transpose
-            // to access it. The result represents a db error or mapping error.
-            .transpose()
-            .unwrap_or(Ok(0))
+            .query_row("SELECT SUM(size) FROM cache_outputs", &[])?;
+        // SUM returns NULL when there are no rows
+        match row {
+            Some(r) => r.get_i64(0).or(Ok(0)),
+            None => Ok(0),
+        }
     }
 
     fn ensure_cache_size_within_limit(&self) -> anyhow::Result<()> {
@@ -291,7 +283,10 @@ impl NxCache {
                 for row in &rows {
                     if let (Ok(hash), Ok(size)) = (row.get_str(0), row.get_i64(1)) {
                         cache_size -= size;
-                        db.execute("DELETE FROM cache_outputs WHERE hash = ?1", params![hash])?;
+                        db.execute(
+                            "DELETE FROM cache_outputs WHERE hash = ?1",
+                            &[DbValue::from(hash.as_str())],
+                        )?;
                         remove_items(&[self.cache_path.join(&hash)])?;
                     }
                     if cache_size < target_cache_size {
@@ -377,14 +372,15 @@ impl NxCache {
         // Checks that the number of cache records in the database
         // matches the number of cache directories on the filesystem.
         // If they don't match, it means that the cache is out of sync.
-        let cache_records_exist = self
+        let row = self
             .db
             .lock()
             .unwrap()
-            .query_row("SELECT EXISTS (SELECT 1 FROM cache_outputs)", [], |row| {
-                let exists: bool = row.get(0)?;
-                Ok(exists)
-            })?
+            .query_row("SELECT EXISTS (SELECT 1 FROM cache_outputs)", &[])?;
+
+        let cache_records_exist = row
+            .and_then(|r| r.get_i64(0).ok())
+            .map(|v| v == 1)
             .unwrap_or(false);
 
         if !cache_records_exist {

--- a/packages/nx/src/native/db/connection.rs
+++ b/packages/nx/src/native/db/connection.rs
@@ -1,15 +1,11 @@
 use anyhow::Result;
-
-use rusqlite::{Connection, DatabaseName, Error, OptionalExtension, Params, Row, ToSql};
-use std::thread;
-use std::time::Duration;
 use tracing::trace;
 
 // =============================================================================
-// DbValue / DbRow — backend-agnostic data types for query_rows()
+// DbValue / DbRow — parameter and result types
 // =============================================================================
 
-/// A backend-agnostic parameter value for queries.
+/// A parameter value for queries.
 #[derive(Clone, Debug)]
 pub enum DbValue {
     Text(String),
@@ -42,18 +38,19 @@ impl From<f64> for DbValue {
     }
 }
 
-impl rusqlite::types::ToSql for DbValue {
-    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
-        match self {
-            DbValue::Text(s) => s.to_sql(),
-            DbValue::Integer(i) => i.to_sql(),
-            DbValue::Real(f) => f.to_sql(),
-            DbValue::Null => rusqlite::types::Null.to_sql(),
-        }
-    }
+fn to_libsql_params(params: &[DbValue]) -> Vec<libsql::Value> {
+    params
+        .iter()
+        .map(|v| match v {
+            DbValue::Text(s) => libsql::Value::Text(s.clone()),
+            DbValue::Integer(i) => libsql::Value::Integer(*i),
+            DbValue::Real(f) => libsql::Value::Real(*f),
+            DbValue::Null => libsql::Value::Null,
+        })
+        .collect()
 }
 
-/// A backend-agnostic row of query results (eagerly collected).
+/// A row of query results (eagerly collected, fully owned).
 #[derive(Clone, Debug)]
 pub struct DbRow {
     values: Vec<DbValue>,
@@ -79,7 +76,6 @@ impl DbRow {
     pub fn get_f64(&self, idx: usize) -> Result<f64> {
         match self.values.get(idx) {
             Some(DbValue::Real(f)) => Ok(*f),
-            // SQLite often returns integers for AVG() etc, coerce to f64
             Some(DbValue::Integer(i)) => Ok(*i as f64),
             Some(other) => anyhow::bail!("Column {} is not real: {:?}", idx, other),
             None => anyhow::bail!("Column index {} out of range", idx),
@@ -96,138 +92,74 @@ impl DbRow {
     }
 }
 
-// =============================================================================
-// DbBackend enum — dispatches to either rusqlite or libsql (turso)
-// =============================================================================
-
-pub(crate) enum DbBackend {
-    Rusqlite(Connection),
-    #[cfg(feature = "turso-backend")]
-    Turso {
-        rt: tokio::runtime::Runtime,
-        conn: libsql::Connection,
-        /// Keep the Database alive — Connection borrows from it internally.
-        _db: libsql::Database,
-    },
+/// Extract a DbValue from a libsql row column.
+fn value_from_row(row: &libsql::Row, idx: i32) -> DbValue {
+    match row.get_value(idx) {
+        Ok(libsql::Value::Integer(i)) => DbValue::Integer(i),
+        Ok(libsql::Value::Real(f)) => DbValue::Real(f),
+        Ok(libsql::Value::Text(s)) => DbValue::Text(s),
+        Ok(libsql::Value::Null) => DbValue::Null,
+        Ok(libsql::Value::Blob(_)) => DbValue::Null, // blobs not supported in DbValue
+        Err(_) => DbValue::Null,
+    }
 }
 
 // =============================================================================
-// NxDbConnection
+// NxDbConnection — wraps libsql::Connection (MVCC, no file locks needed)
 // =============================================================================
-
-const MAX_RETRIES: u32 = 20;
-const RETRY_DELAY: u64 = 25;
-
-/// macro for handling the db when its busy
-/// This is a macro instead of a function because some database operations need to take a &mut Connection, while returning a reference
-/// This causes some quite complex lifetime issues that are quite hard to solve
-///
-/// Using a macro inlines the retry operation where it was called, and the lifetime issues are avoided
-macro_rules! retry_db_operation_when_busy {
-    ($operation:expr) => {{
-        let connection = 'retry: {
-            for i in 1..MAX_RETRIES {
-                match $operation {
-                    r @ Ok(_) => break 'retry r,
-                    Err(Error::SqliteFailure(err, _))
-                        if err.code == rusqlite::ErrorCode::DatabaseBusy =>
-                    {
-                        trace!("Database busy. Retrying {} of {}", i, MAX_RETRIES);
-                        let sleep = Duration::from_millis(RETRY_DELAY * 2_u64.pow(i));
-                        let max_sleep = Duration::from_secs(12);
-                        if (sleep >= max_sleep) {
-                            thread::sleep(max_sleep);
-                        } else {
-                            thread::sleep(sleep);
-                        }
-                    }
-                    err => break 'retry err,
-                };
-            }
-            break 'retry Err(Error::SqliteFailure(
-                rusqlite::ffi::Error {
-                    code: rusqlite::ErrorCode::DatabaseBusy,
-                    extended_code: 0,
-                },
-                Some("Database busy. Retried maximum number of times.".to_string()),
-            ));
-        };
-
-        connection
-    }};
-}
 
 pub struct NxDbConnection {
-    backend: Option<DbBackend>,
+    rt: Option<tokio::runtime::Runtime>,
+    conn: Option<libsql::Connection>,
+    /// Keep the Database alive — Connection may reference it internally.
+    _db: Option<libsql::Database>,
 }
 
 impl Default for NxDbConnection {
     fn default() -> Self {
-        Self { backend: None }
+        Self {
+            rt: None,
+            conn: None,
+            _db: None,
+        }
     }
 }
 
 impl NxDbConnection {
-    /// Create from a rusqlite connection (existing path).
-    pub fn new(connection: Connection) -> Self {
+    pub fn new(
+        rt: tokio::runtime::Runtime,
+        db: libsql::Database,
+        conn: libsql::Connection,
+    ) -> Self {
         Self {
-            backend: Some(DbBackend::Rusqlite(connection)),
+            rt: Some(rt),
+            conn: Some(conn),
+            _db: Some(db),
         }
     }
 
-    /// Create from a turso/libsql connection.
-    #[cfg(feature = "turso-backend")]
-    pub fn new_turso(db: libsql::Database, conn: libsql::Connection) -> Self {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("Failed to create tokio runtime for turso backend");
-        Self {
-            backend: Some(DbBackend::Turso { rt, conn, _db: db }),
-        }
+    /// Get the runtime, or bail.
+    fn rt(&self) -> Result<&tokio::runtime::Runtime> {
+        self.rt.as_ref().ok_or_else(|| anyhow::anyhow!("No database runtime available"))
+    }
+
+    /// Get the connection, or bail.
+    fn conn(&self) -> Result<&libsql::Connection> {
+        self.conn.as_ref().ok_or_else(|| anyhow::anyhow!("No database connection available"))
     }
 
     // =========================================================================
     // execute
     // =========================================================================
 
-    pub fn execute<P: Params + Clone>(&self, sql: &str, params: P) -> Result<usize> {
-        match self.backend.as_ref() {
-            Some(DbBackend::Rusqlite(conn)) => {
-                retry_db_operation_when_busy!(conn.execute(sql, params.clone()))
-                    .map_err(|e| anyhow::anyhow!("DB execute error: \"{}\", {:?}", sql, e))
-            }
-            #[cfg(feature = "turso-backend")]
-            Some(DbBackend::Turso { rt, conn, .. }) => {
-                // libsql execute returns u64, convert to usize
-                let n = rt
-                    .block_on(conn.execute(sql, ()))
-                    .map_err(|e| anyhow::anyhow!("DB execute error: \"{}\", {:?}", sql, e))?;
-                Ok(n as usize)
-            }
-            None => anyhow::bail!("No database connection available"),
-        }
-    }
-
-    /// Execute with DbValue params — works identically across both backends.
-    pub fn execute_with_values(&self, sql: &str, params: &[DbValue]) -> Result<usize> {
-        match self.backend.as_ref() {
-            Some(DbBackend::Rusqlite(conn)) => {
-                let param_refs: Vec<&dyn ToSql> =
-                    params.iter().map(|v| v as &dyn ToSql).collect();
-                retry_db_operation_when_busy!(conn.execute(sql, param_refs.as_slice()))
-                    .map_err(|e| anyhow::anyhow!("DB execute error: \"{}\", {:?}", sql, e))
-            }
-            #[cfg(feature = "turso-backend")]
-            Some(DbBackend::Turso { rt, conn, .. }) => {
-                let libsql_params = db_values_to_libsql_params(params);
-                let n = rt
-                    .block_on(conn.execute(sql, libsql_params))
-                    .map_err(|e| anyhow::anyhow!("DB execute error: \"{}\", {:?}", sql, e))?;
-                Ok(n as usize)
-            }
-            None => anyhow::bail!("No database connection available"),
-        }
+    pub fn execute(&self, sql: &str, params: &[DbValue]) -> Result<usize> {
+        let rt = self.rt()?;
+        let conn = self.conn()?;
+        let libsql_params = to_libsql_params(params);
+        let n = rt
+            .block_on(conn.execute(sql, libsql_params))
+            .map_err(|e| anyhow::anyhow!("DB execute error: \"{}\", {:?}", sql, e))?;
+        Ok(n as usize)
     }
 
     // =========================================================================
@@ -235,220 +167,71 @@ impl NxDbConnection {
     // =========================================================================
 
     pub fn execute_batch(&self, sql: &str) -> Result<()> {
-        match self.backend.as_ref() {
-            Some(DbBackend::Rusqlite(conn)) => {
-                retry_db_operation_when_busy!(conn.execute_batch(sql))
-                    .map_err(|e| anyhow::anyhow!("DB execute batch error: \"{}\", {:?}", sql, e))
-            }
-            #[cfg(feature = "turso-backend")]
-            Some(DbBackend::Turso { rt, conn, .. }) => {
-                rt.block_on(conn.execute_batch(sql))
-                    .map(|_| ())
-                    .map_err(|e| anyhow::anyhow!("DB execute batch error: \"{}\", {:?}", sql, e))
-            }
-            None => anyhow::bail!("No database connection available"),
-        }
+        let rt = self.rt()?;
+        let conn = self.conn()?;
+        rt.block_on(conn.execute_batch(sql))
+            .map(|_| ())
+            .map_err(|e| anyhow::anyhow!("DB execute batch error: \"{}\", {:?}", sql, e))
     }
 
     // =========================================================================
-    // prepare  (rusqlite-only — returns rusqlite::Statement)
-    // Callers should migrate to query_rows() for backend-agnostic access.
+    // query_rows — returns eagerly-collected Vec<DbRow>
     // =========================================================================
 
-    pub fn prepare(&self, sql: &str) -> Result<rusqlite::Statement> {
-        match self.backend.as_ref() {
-            Some(DbBackend::Rusqlite(conn)) => {
-                retry_db_operation_when_busy!(conn.prepare(sql))
-                    .map_err(|e| anyhow::anyhow!("DB prepare error: \"{}\", {:?}", sql, e))
-            }
-            #[cfg(feature = "turso-backend")]
-            Some(DbBackend::Turso { .. }) => {
-                anyhow::bail!(
-                    "prepare() is not supported with turso backend — use query_rows() instead"
-                )
-            }
-            None => anyhow::bail!("No database connection available"),
-        }
-    }
-
-    // =========================================================================
-    // query_rows — backend-agnostic, returns eagerly-collected Vec<DbRow>
-    // =========================================================================
-
-    /// Execute a query and collect all rows into `Vec<DbRow>`.
-    ///
-    /// Column count is auto-detected from the first row. All values are
-    /// eagerly read as Text, Integer, Real, or Null.
     pub fn query_rows(&self, sql: &str, params: &[DbValue]) -> Result<Vec<DbRow>> {
-        match self.backend.as_ref() {
-            Some(DbBackend::Rusqlite(conn)) => {
-                let param_refs: Vec<&dyn ToSql> =
-                    params.iter().map(|v| v as &dyn ToSql).collect();
-                let mut stmt =
-                    retry_db_operation_when_busy!(conn.prepare(sql)).map_err(|e| {
-                        anyhow::anyhow!("DB query_rows prepare error: \"{}\", {:?}", sql, e)
-                    })?;
-                let col_count = stmt.column_count();
-                let rows = retry_db_operation_when_busy!(
-                    stmt.query_map(param_refs.as_slice(), |row| {
-                        let mut values = Vec::with_capacity(col_count);
-                        for i in 0..col_count {
-                            let val = rusqlite_value_from_row(row, i);
-                            values.push(val);
-                        }
-                        Ok(DbRow { values })
-                    })
-                )
-                .map_err(|e| {
-                    anyhow::anyhow!("DB query_rows error: \"{}\", {:?}", sql, e)
-                })?;
-                rows.map(|r| r.map_err(|e| anyhow::anyhow!("Row read error: {:?}", e)))
-                    .collect()
-            }
-            #[cfg(feature = "turso-backend")]
-            Some(DbBackend::Turso { rt, conn, .. }) => {
-                let libsql_params = db_values_to_libsql_params(params);
-                let mut rows = rt
-                    .block_on(conn.query(sql, libsql_params))
-                    .map_err(|e| {
-                        anyhow::anyhow!("DB query_rows error: \"{}\", {:?}", sql, e)
-                    })?;
-                let mut result = Vec::new();
-                loop {
-                    match rt.block_on(rows.next()) {
-                        Ok(Some(row)) => {
-                            let col_count = rows.column_count() as usize;
-                            let mut values = Vec::with_capacity(col_count);
-                            for i in 0..col_count {
-                                let val = libsql_value_from_row(&row, i as i32);
-                                values.push(val);
-                            }
-                            result.push(DbRow { values });
-                        }
-                        Ok(None) => break,
-                        Err(e) => {
-                            return Err(anyhow::anyhow!("Row read error: {:?}", e));
-                        }
+        let rt = self.rt()?;
+        let conn = self.conn()?;
+        let libsql_params = to_libsql_params(params);
+        let mut rows = rt
+            .block_on(conn.query(sql, libsql_params))
+            .map_err(|e| anyhow::anyhow!("DB query_rows error: \"{}\", {:?}", sql, e))?;
+
+        let col_count = rows.column_count() as usize;
+        let mut result = Vec::new();
+        loop {
+            match rt.block_on(rows.next()) {
+                Ok(Some(row)) => {
+                    let mut values = Vec::with_capacity(col_count);
+                    for i in 0..col_count {
+                        values.push(value_from_row(&row, i as i32));
                     }
+                    result.push(DbRow { values });
                 }
-                Ok(result)
+                Ok(None) => break,
+                Err(e) => return Err(anyhow::anyhow!("Row read error: {:?}", e)),
             }
-            None => anyhow::bail!("No database connection available"),
         }
+        Ok(result)
     }
 
     // =========================================================================
-    // transaction (rusqlite-style with &Connection callback)
+    // query_row — returns at most one DbRow
     // =========================================================================
 
-    pub fn transaction<T>(
-        &mut self,
-        transaction_operation: impl Fn(&Connection) -> rusqlite::Result<T>,
-    ) -> Result<T> {
-        match self.backend.as_mut() {
-            Some(DbBackend::Rusqlite(conn)) => {
-                retry_db_operation_when_busy!(conn.transaction().and_then(|tx| {
-                    let result = transaction_operation(&tx)?;
-                    tx.commit()?;
-                    Ok(result)
-                }))
-                .map_err(|e| anyhow::anyhow!("DB transaction error: {:?}", e))
-            }
-            #[cfg(feature = "turso-backend")]
-            Some(DbBackend::Turso { .. }) => {
-                anyhow::bail!(
-                    "transaction() with rusqlite callback is not supported on turso backend — use begin_transaction/commit_transaction instead"
-                )
-            }
-            None => anyhow::bail!("No database connection available"),
-        }
+    pub fn query_row(&self, sql: &str, params: &[DbValue]) -> Result<Option<DbRow>> {
+        let rows = self.query_rows(sql, params)?;
+        Ok(rows.into_iter().next())
     }
 
     // =========================================================================
-    // begin / commit / rollback — backend-agnostic transaction control
+    // begin / commit / rollback — MVCC transaction control
     // =========================================================================
 
-    /// Begin a transaction. For turso, uses `BEGIN CONCURRENT` (MVCC).
+    /// Begin a transaction.
+    /// TODO: Switch to `BEGIN CONCURRENT` once libsql MVCC support is enabled.
     pub fn begin_transaction(&self) -> Result<()> {
-        match self.backend.as_ref() {
-            Some(DbBackend::Rusqlite(conn)) => {
-                retry_db_operation_when_busy!(conn.execute_batch("BEGIN"))
-                    .map_err(|e| anyhow::anyhow!("DB begin transaction error: {:?}", e))
-            }
-            #[cfg(feature = "turso-backend")]
-            Some(DbBackend::Turso { rt, conn, .. }) => {
-                rt.block_on(conn.execute("BEGIN CONCURRENT", ()))
-                    .map_err(|e| anyhow::anyhow!("DB begin transaction error: {:?}", e))?;
-                Ok(())
-            }
-            None => anyhow::bail!("No database connection available"),
-        }
+        self.execute("BEGIN", &[])?;
+        Ok(())
     }
 
     pub fn commit_transaction(&self) -> Result<()> {
-        match self.backend.as_ref() {
-            Some(DbBackend::Rusqlite(conn)) => {
-                retry_db_operation_when_busy!(conn.execute_batch("COMMIT"))
-                    .map_err(|e| anyhow::anyhow!("DB commit error: {:?}", e))
-            }
-            #[cfg(feature = "turso-backend")]
-            Some(DbBackend::Turso { rt, conn, .. }) => {
-                rt.block_on(conn.execute("COMMIT", ()))
-                    .map_err(|e| anyhow::anyhow!("DB commit error: {:?}", e))?;
-                Ok(())
-            }
-            None => anyhow::bail!("No database connection available"),
-        }
+        self.execute("COMMIT", &[])?;
+        Ok(())
     }
 
     pub fn rollback_transaction(&self) -> Result<()> {
-        match self.backend.as_ref() {
-            Some(DbBackend::Rusqlite(conn)) => {
-                retry_db_operation_when_busy!(conn.execute_batch("ROLLBACK"))
-                    .map_err(|e| anyhow::anyhow!("DB rollback error: {:?}", e))
-            }
-            #[cfg(feature = "turso-backend")]
-            Some(DbBackend::Turso { rt, conn, .. }) => {
-                rt.block_on(conn.execute("ROLLBACK", ()))
-                    .map_err(|e| anyhow::anyhow!("DB rollback error: {:?}", e))?;
-                Ok(())
-            }
-            None => anyhow::bail!("No database connection available"),
-        }
-    }
-
-    // =========================================================================
-    // query_row
-    // =========================================================================
-
-    pub fn query_row<T, P, F>(&self, sql: &str, params: P, f: F) -> Result<Option<T>>
-    where
-        P: Params + Clone,
-        F: FnOnce(&Row<'_>) -> rusqlite::Result<T> + Clone,
-    {
-        match self.backend.as_ref() {
-            Some(DbBackend::Rusqlite(conn)) => {
-                retry_db_operation_when_busy!(
-                    conn.query_row(sql, params.clone(), f.clone()).optional()
-                )
-                .map_err(|e| anyhow::anyhow!("DB query error: \"{}\", {:?}", sql, e))
-            }
-            #[cfg(feature = "turso-backend")]
-            Some(DbBackend::Turso { .. }) => {
-                // query_row() with rusqlite Row mapper can't work on turso — callers
-                // should use query_row_values() or query_rows() instead.
-                anyhow::bail!(
-                    "query_row() with rusqlite Row mapper is not supported on turso backend — use query_row_values() instead"
-                )
-            }
-            None => anyhow::bail!("No database connection available"),
-        }
-    }
-
-    /// Backend-agnostic query_row — returns at most one DbRow.
-    pub fn query_row_values(&self, sql: &str, params: &[DbValue]) -> Result<Option<DbRow>> {
-        let rows = self.query_rows(sql, params)?;
-        Ok(rows.into_iter().next())
+        self.execute("ROLLBACK", &[])?;
+        Ok(())
     }
 
     // =========================================================================
@@ -457,135 +240,10 @@ impl NxDbConnection {
 
     pub fn close(self) -> Result<()> {
         trace!("Closing database connection");
-        match self.backend {
-            Some(DbBackend::Rusqlite(conn)) => conn
-                .close()
-                .map_err(|(_, err)| anyhow::anyhow!("Unable to close connection: {:?}", err)),
-            #[cfg(feature = "turso-backend")]
-            Some(DbBackend::Turso { .. }) => {
-                // libsql connections are closed on drop
-                Ok(())
-            }
-            None => anyhow::bail!("No database connection available"),
-        }
+        // libsql connections are closed on drop
+        drop(self.conn);
+        drop(self._db);
+        drop(self.rt);
+        Ok(())
     }
-
-    // =========================================================================
-    // pragma_update
-    // =========================================================================
-
-    pub fn pragma_update<V>(
-        &self,
-        schema_name: Option<DatabaseName<'_>>,
-        pragma_name: &str,
-        pragma_value: V,
-    ) -> Result<()>
-    where
-        V: ToSql + Clone,
-    {
-        match self.backend.as_ref() {
-            Some(DbBackend::Rusqlite(conn)) => {
-                retry_db_operation_when_busy!(conn.pragma_update(
-                    schema_name,
-                    pragma_name,
-                    pragma_value.clone()
-                ))
-                .map_err(|e| anyhow::anyhow!("DB pragma update error: {:?}", e))
-            }
-            #[cfg(feature = "turso-backend")]
-            Some(DbBackend::Turso { .. }) => {
-                // Turso/libsql handles pragmas internally — no-op for now.
-                // WAL/journal mode and busy handler are irrelevant with MVCC.
-                trace!(
-                    "Turso backend: pragma {} — skipped (handled by MVCC engine)",
-                    pragma_name
-                );
-                Ok(())
-            }
-            None => anyhow::bail!("No database connection available"),
-        }
-    }
-
-    // =========================================================================
-    // busy_handler
-    // =========================================================================
-
-    pub fn busy_handler(&self, callback: Option<fn(i32) -> bool>) -> Result<()> {
-        match self.backend.as_ref() {
-            Some(DbBackend::Rusqlite(conn)) => {
-                retry_db_operation_when_busy!(conn.busy_handler(callback))
-                    .map_err(|e| anyhow::anyhow!("DB busy handler error: {:?}", e))
-            }
-            #[cfg(feature = "turso-backend")]
-            Some(DbBackend::Turso { .. }) => {
-                // MVCC eliminates SQLITE_BUSY — no-op for turso
-                trace!("Turso backend: busy_handler is a no-op (MVCC handles concurrency)");
-                Ok(())
-            }
-            None => anyhow::bail!("No database connection available"),
-        }
-    }
-
-    // =========================================================================
-    // Backend query helper
-    // =========================================================================
-
-    /// Returns true if this connection uses the turso backend.
-    #[allow(dead_code)]
-    pub fn is_turso(&self) -> bool {
-        #[cfg(feature = "turso-backend")]
-        if let Some(DbBackend::Turso { .. }) = &self.backend {
-            return true;
-        }
-        false
-    }
-}
-
-// =============================================================================
-// Helper functions
-// =============================================================================
-
-/// Extract a DbValue from a rusqlite row column.
-fn rusqlite_value_from_row(row: &Row<'_>, idx: usize) -> DbValue {
-    // Try types in order: integer, real, text, null
-    if let Ok(v) = row.get::<_, i64>(idx) {
-        return DbValue::Integer(v);
-    }
-    if let Ok(v) = row.get::<_, f64>(idx) {
-        return DbValue::Real(v);
-    }
-    if let Ok(v) = row.get::<_, String>(idx) {
-        return DbValue::Text(v);
-    }
-    DbValue::Null
-}
-
-/// Convert DbValue slice to libsql params.
-#[cfg(feature = "turso-backend")]
-fn db_values_to_libsql_params(params: &[DbValue]) -> Vec<libsql::Value> {
-    params
-        .iter()
-        .map(|v| match v {
-            DbValue::Text(s) => libsql::Value::Text(s.clone()),
-            DbValue::Integer(i) => libsql::Value::Integer(*i),
-            DbValue::Real(f) => libsql::Value::Real(*f),
-            DbValue::Null => libsql::Value::Null,
-        })
-        .collect()
-}
-
-/// Extract a DbValue from a libsql row column.
-#[cfg(feature = "turso-backend")]
-fn libsql_value_from_row(row: &libsql::Row, idx: i32) -> DbValue {
-    // Try types in order: integer, real, text, null
-    if let Ok(v) = row.get::<i64>(idx) {
-        return DbValue::Integer(v);
-    }
-    if let Ok(v) = row.get::<f64>(idx) {
-        return DbValue::Real(v);
-    }
-    if let Ok(v) = row.get::<String>(idx) {
-        return DbValue::Text(v);
-    }
-    DbValue::Null
 }

--- a/packages/nx/src/native/db/connection.rs
+++ b/packages/nx/src/native/db/connection.rs
@@ -38,14 +38,14 @@ impl From<f64> for DbValue {
     }
 }
 
-fn to_libsql_params(params: &[DbValue]) -> Vec<libsql::Value> {
+fn to_turso_params(params: &[DbValue]) -> Vec<turso::Value> {
     params
         .iter()
         .map(|v| match v {
-            DbValue::Text(s) => libsql::Value::Text(s.clone()),
-            DbValue::Integer(i) => libsql::Value::Integer(*i),
-            DbValue::Real(f) => libsql::Value::Real(*f),
-            DbValue::Null => libsql::Value::Null,
+            DbValue::Text(s) => turso::Value::Text(s.clone()),
+            DbValue::Integer(i) => turso::Value::Integer(*i),
+            DbValue::Real(f) => turso::Value::Real(*f),
+            DbValue::Null => turso::Value::Null,
         })
         .collect()
 }
@@ -92,27 +92,27 @@ impl DbRow {
     }
 }
 
-/// Extract a DbValue from a libsql row column.
-fn value_from_row(row: &libsql::Row, idx: i32) -> DbValue {
+/// Extract a DbValue from a turso row column.
+fn value_from_row(row: &turso::Row, idx: usize) -> DbValue {
     match row.get_value(idx) {
-        Ok(libsql::Value::Integer(i)) => DbValue::Integer(i),
-        Ok(libsql::Value::Real(f)) => DbValue::Real(f),
-        Ok(libsql::Value::Text(s)) => DbValue::Text(s),
-        Ok(libsql::Value::Null) => DbValue::Null,
-        Ok(libsql::Value::Blob(_)) => DbValue::Null, // blobs not supported in DbValue
+        Ok(turso::Value::Integer(i)) => DbValue::Integer(i),
+        Ok(turso::Value::Real(f)) => DbValue::Real(f),
+        Ok(turso::Value::Text(s)) => DbValue::Text(s),
+        Ok(turso::Value::Null) => DbValue::Null,
+        Ok(turso::Value::Blob(_)) => DbValue::Null,
         Err(_) => DbValue::Null,
     }
 }
 
 // =============================================================================
-// NxDbConnection — wraps libsql::Connection (MVCC, no file locks needed)
+// NxDbConnection — wraps turso::Connection (MVCC, no file locks needed)
 // =============================================================================
 
 pub struct NxDbConnection {
     rt: Option<tokio::runtime::Runtime>,
-    conn: Option<libsql::Connection>,
+    conn: Option<turso::Connection>,
     /// Keep the Database alive — Connection may reference it internally.
-    _db: Option<libsql::Database>,
+    _db: Option<turso::Database>,
 }
 
 impl Default for NxDbConnection {
@@ -128,8 +128,8 @@ impl Default for NxDbConnection {
 impl NxDbConnection {
     pub fn new(
         rt: tokio::runtime::Runtime,
-        db: libsql::Database,
-        conn: libsql::Connection,
+        db: turso::Database,
+        conn: turso::Connection,
     ) -> Self {
         Self {
             rt: Some(rt),
@@ -144,7 +144,7 @@ impl NxDbConnection {
     }
 
     /// Get the connection, or bail.
-    fn conn(&self) -> Result<&libsql::Connection> {
+    fn conn(&self) -> Result<&turso::Connection> {
         self.conn.as_ref().ok_or_else(|| anyhow::anyhow!("No database connection available"))
     }
 
@@ -155,9 +155,9 @@ impl NxDbConnection {
     pub fn execute(&self, sql: &str, params: &[DbValue]) -> Result<usize> {
         let rt = self.rt()?;
         let conn = self.conn()?;
-        let libsql_params = to_libsql_params(params);
+        let turso_params = to_turso_params(params);
         let n = rt
-            .block_on(conn.execute(sql, libsql_params))
+            .block_on(conn.execute(sql, turso_params))
             .map_err(|e| anyhow::anyhow!("DB execute error: \"{}\", {:?}", sql, e))?;
         Ok(n as usize)
     }
@@ -181,9 +181,9 @@ impl NxDbConnection {
     pub fn query_rows(&self, sql: &str, params: &[DbValue]) -> Result<Vec<DbRow>> {
         let rt = self.rt()?;
         let conn = self.conn()?;
-        let libsql_params = to_libsql_params(params);
+        let turso_params = to_turso_params(params);
         let mut rows = rt
-            .block_on(conn.query(sql, libsql_params))
+            .block_on(conn.query(sql, turso_params))
             .map_err(|e| anyhow::anyhow!("DB query_rows error: \"{}\", {:?}", sql, e))?;
 
         let col_count = rows.column_count() as usize;
@@ -193,7 +193,7 @@ impl NxDbConnection {
                 Ok(Some(row)) => {
                     let mut values = Vec::with_capacity(col_count);
                     for i in 0..col_count {
-                        values.push(value_from_row(&row, i as i32));
+                        values.push(value_from_row(&row, i));
                     }
                     result.push(DbRow { values });
                 }
@@ -217,10 +217,17 @@ impl NxDbConnection {
     // begin / commit / rollback — MVCC transaction control
     // =========================================================================
 
-    /// Begin a transaction.
-    // NOTE: `BEGIN CONCURRENT` (MVCC) requires engine-level enablement in libsql.
-    // Investigate libsql Builder options or compile flags to enable it.
+    /// Begin a concurrent transaction (MVCC).
+    /// Allows multiple writers without SQLITE_BUSY errors.
+    /// Use `begin_exclusive_transaction()` for DDL (CREATE TABLE, etc.).
     pub fn begin_transaction(&self) -> Result<()> {
+        self.execute("BEGIN CONCURRENT", &[])?;
+        Ok(())
+    }
+
+    /// Begin an exclusive transaction for DDL statements (CREATE TABLE, etc.).
+    /// DDL requires exclusive access and cannot use BEGIN CONCURRENT.
+    pub fn begin_exclusive_transaction(&self) -> Result<()> {
         self.execute("BEGIN", &[])?;
         Ok(())
     }
@@ -241,7 +248,7 @@ impl NxDbConnection {
 
     pub fn close(self) -> Result<()> {
         trace!("Closing database connection");
-        // libsql connections are closed on drop
+        // turso connections are closed on drop
         drop(self.conn);
         drop(self._db);
         drop(self.rt);

--- a/packages/nx/src/native/db/connection.rs
+++ b/packages/nx/src/native/db/connection.rs
@@ -105,7 +105,7 @@ fn value_from_row(row: &turso::Row, idx: usize) -> DbValue {
 }
 
 // =============================================================================
-// NxDbConnection — wraps turso::Connection (MVCC, no file locks needed)
+// NxDbConnection — wraps turso::Connection (WAL mode, pure Rust)
 // =============================================================================
 
 pub struct NxDbConnection {
@@ -126,11 +126,7 @@ impl Default for NxDbConnection {
 }
 
 impl NxDbConnection {
-    pub fn new(
-        rt: tokio::runtime::Runtime,
-        db: turso::Database,
-        conn: turso::Connection,
-    ) -> Self {
+    pub fn new(rt: tokio::runtime::Runtime, db: turso::Database, conn: turso::Connection) -> Self {
         Self {
             rt: Some(rt),
             conn: Some(conn),
@@ -140,12 +136,16 @@ impl NxDbConnection {
 
     /// Get the runtime, or bail.
     fn rt(&self) -> Result<&tokio::runtime::Runtime> {
-        self.rt.as_ref().ok_or_else(|| anyhow::anyhow!("No database runtime available"))
+        self.rt
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("No database runtime available"))
     }
 
     /// Get the connection, or bail.
     fn conn(&self) -> Result<&turso::Connection> {
-        self.conn.as_ref().ok_or_else(|| anyhow::anyhow!("No database connection available"))
+        self.conn
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("No database connection available"))
     }
 
     // =========================================================================
@@ -214,20 +214,10 @@ impl NxDbConnection {
     }
 
     // =========================================================================
-    // begin / commit / rollback — MVCC transaction control
+    // begin / commit / rollback — transaction control
     // =========================================================================
 
-    /// Begin a concurrent transaction (MVCC).
-    /// Allows multiple writers without SQLITE_BUSY errors.
-    /// Use `begin_exclusive_transaction()` for DDL (CREATE TABLE, etc.).
     pub fn begin_transaction(&self) -> Result<()> {
-        self.execute("BEGIN CONCURRENT", &[])?;
-        Ok(())
-    }
-
-    /// Begin an exclusive transaction for DDL statements (CREATE TABLE, etc.).
-    /// DDL requires exclusive access and cannot use BEGIN CONCURRENT.
-    pub fn begin_exclusive_transaction(&self) -> Result<()> {
         self.execute("BEGIN", &[])?;
         Ok(())
     }

--- a/packages/nx/src/native/db/connection.rs
+++ b/packages/nx/src/native/db/connection.rs
@@ -1,14 +1,119 @@
 use anyhow::Result;
 
-use rusqlite::{Connection, DatabaseName, Error, OptionalExtension, Params, Row, Statement, ToSql};
+use rusqlite::{Connection, DatabaseName, Error, OptionalExtension, Params, Row, ToSql};
 use std::thread;
 use std::time::Duration;
 use tracing::trace;
 
-#[derive(Default)]
-pub struct NxDbConnection {
-    pub conn: Option<Connection>,
+// =============================================================================
+// DbValue / DbRow — backend-agnostic data types for query_rows()
+// =============================================================================
+
+/// A backend-agnostic parameter value for queries.
+#[derive(Clone, Debug)]
+pub enum DbValue {
+    Text(String),
+    Integer(i64),
+    Real(f64),
+    Null,
 }
+
+impl From<String> for DbValue {
+    fn from(s: String) -> Self {
+        DbValue::Text(s)
+    }
+}
+
+impl From<&str> for DbValue {
+    fn from(s: &str) -> Self {
+        DbValue::Text(s.to_string())
+    }
+}
+
+impl From<i64> for DbValue {
+    fn from(v: i64) -> Self {
+        DbValue::Integer(v)
+    }
+}
+
+impl From<f64> for DbValue {
+    fn from(v: f64) -> Self {
+        DbValue::Real(v)
+    }
+}
+
+impl rusqlite::types::ToSql for DbValue {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        match self {
+            DbValue::Text(s) => s.to_sql(),
+            DbValue::Integer(i) => i.to_sql(),
+            DbValue::Real(f) => f.to_sql(),
+            DbValue::Null => rusqlite::types::Null.to_sql(),
+        }
+    }
+}
+
+/// A backend-agnostic row of query results (eagerly collected).
+#[derive(Clone, Debug)]
+pub struct DbRow {
+    values: Vec<DbValue>,
+}
+
+impl DbRow {
+    pub fn get_str(&self, idx: usize) -> Result<String> {
+        match self.values.get(idx) {
+            Some(DbValue::Text(s)) => Ok(s.clone()),
+            Some(other) => anyhow::bail!("Column {} is not text: {:?}", idx, other),
+            None => anyhow::bail!("Column index {} out of range", idx),
+        }
+    }
+
+    pub fn get_i64(&self, idx: usize) -> Result<i64> {
+        match self.values.get(idx) {
+            Some(DbValue::Integer(i)) => Ok(*i),
+            Some(other) => anyhow::bail!("Column {} is not integer: {:?}", idx, other),
+            None => anyhow::bail!("Column index {} out of range", idx),
+        }
+    }
+
+    pub fn get_f64(&self, idx: usize) -> Result<f64> {
+        match self.values.get(idx) {
+            Some(DbValue::Real(f)) => Ok(*f),
+            // SQLite often returns integers for AVG() etc, coerce to f64
+            Some(DbValue::Integer(i)) => Ok(*i as f64),
+            Some(other) => anyhow::bail!("Column {} is not real: {:?}", idx, other),
+            None => anyhow::bail!("Column index {} out of range", idx),
+        }
+    }
+
+    pub fn get_optional_str(&self, idx: usize) -> Result<Option<String>> {
+        match self.values.get(idx) {
+            Some(DbValue::Text(s)) => Ok(Some(s.clone())),
+            Some(DbValue::Null) => Ok(None),
+            Some(other) => anyhow::bail!("Column {} is not text/null: {:?}", idx, other),
+            None => anyhow::bail!("Column index {} out of range", idx),
+        }
+    }
+}
+
+// =============================================================================
+// DbBackend enum — dispatches to either rusqlite or libsql (turso)
+// =============================================================================
+
+pub(crate) enum DbBackend {
+    Rusqlite(Connection),
+    #[cfg(feature = "turso-backend")]
+    Turso {
+        rt: tokio::runtime::Runtime,
+        conn: libsql::Connection,
+        /// Keep the Database alive — Connection borrows from it internally.
+        _db: libsql::Database,
+    },
+}
+
+// =============================================================================
+// NxDbConnection
+// =============================================================================
 
 const MAX_RETRIES: u32 = 20;
 const RETRY_DELAY: u64 = 25;
@@ -52,78 +157,322 @@ macro_rules! retry_db_operation_when_busy {
     }};
 }
 
+pub struct NxDbConnection {
+    backend: Option<DbBackend>,
+}
+
+impl Default for NxDbConnection {
+    fn default() -> Self {
+        Self { backend: None }
+    }
+}
+
 impl NxDbConnection {
+    /// Create from a rusqlite connection (existing path).
     pub fn new(connection: Connection) -> Self {
         Self {
-            conn: Some(connection),
+            backend: Some(DbBackend::Rusqlite(connection)),
         }
     }
+
+    /// Create from a turso/libsql connection.
+    #[cfg(feature = "turso-backend")]
+    pub fn new_turso(db: libsql::Database, conn: libsql::Connection) -> Self {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Failed to create tokio runtime for turso backend");
+        Self {
+            backend: Some(DbBackend::Turso { rt, conn, _db: db }),
+        }
+    }
+
+    // =========================================================================
+    // execute
+    // =========================================================================
 
     pub fn execute<P: Params + Clone>(&self, sql: &str, params: P) -> Result<usize> {
-        if let Some(conn) = &self.conn {
-            retry_db_operation_when_busy!(conn.execute(sql, params.clone()))
-                .map_err(|e| anyhow::anyhow!("DB execute error: \"{}\", {:?}", sql, e))
-        } else {
-            anyhow::bail!("No database connection available")
+        match self.backend.as_ref() {
+            Some(DbBackend::Rusqlite(conn)) => {
+                retry_db_operation_when_busy!(conn.execute(sql, params.clone()))
+                    .map_err(|e| anyhow::anyhow!("DB execute error: \"{}\", {:?}", sql, e))
+            }
+            #[cfg(feature = "turso-backend")]
+            Some(DbBackend::Turso { rt, conn, .. }) => {
+                // libsql execute returns u64, convert to usize
+                let n = rt
+                    .block_on(conn.execute(sql, ()))
+                    .map_err(|e| anyhow::anyhow!("DB execute error: \"{}\", {:?}", sql, e))?;
+                Ok(n as usize)
+            }
+            None => anyhow::bail!("No database connection available"),
         }
     }
+
+    /// Execute with DbValue params — works identically across both backends.
+    pub fn execute_with_values(&self, sql: &str, params: &[DbValue]) -> Result<usize> {
+        match self.backend.as_ref() {
+            Some(DbBackend::Rusqlite(conn)) => {
+                let param_refs: Vec<&dyn ToSql> =
+                    params.iter().map(|v| v as &dyn ToSql).collect();
+                retry_db_operation_when_busy!(conn.execute(sql, param_refs.as_slice()))
+                    .map_err(|e| anyhow::anyhow!("DB execute error: \"{}\", {:?}", sql, e))
+            }
+            #[cfg(feature = "turso-backend")]
+            Some(DbBackend::Turso { rt, conn, .. }) => {
+                let libsql_params = db_values_to_libsql_params(params);
+                let n = rt
+                    .block_on(conn.execute(sql, libsql_params))
+                    .map_err(|e| anyhow::anyhow!("DB execute error: \"{}\", {:?}", sql, e))?;
+                Ok(n as usize)
+            }
+            None => anyhow::bail!("No database connection available"),
+        }
+    }
+
+    // =========================================================================
+    // execute_batch
+    // =========================================================================
 
     pub fn execute_batch(&self, sql: &str) -> Result<()> {
-        if let Some(conn) = &self.conn {
-            retry_db_operation_when_busy!(conn.execute_batch(sql))
-                .map_err(|e| anyhow::anyhow!("DB execute batch error: \"{}\", {:?}", sql, e))
-        } else {
-            anyhow::bail!("No database connection available")
+        match self.backend.as_ref() {
+            Some(DbBackend::Rusqlite(conn)) => {
+                retry_db_operation_when_busy!(conn.execute_batch(sql))
+                    .map_err(|e| anyhow::anyhow!("DB execute batch error: \"{}\", {:?}", sql, e))
+            }
+            #[cfg(feature = "turso-backend")]
+            Some(DbBackend::Turso { rt, conn, .. }) => {
+                rt.block_on(conn.execute_batch(sql))
+                    .map(|_| ())
+                    .map_err(|e| anyhow::anyhow!("DB execute batch error: \"{}\", {:?}", sql, e))
+            }
+            None => anyhow::bail!("No database connection available"),
         }
     }
 
-    pub fn prepare(&self, sql: &str) -> Result<Statement> {
-        if let Some(conn) = &self.conn {
-            retry_db_operation_when_busy!(conn.prepare(sql))
-                .map_err(|e| anyhow::anyhow!("DB prepare error: \"{}\", {:?}", sql, e))
-        } else {
-            anyhow::bail!("No database connection available")
+    // =========================================================================
+    // prepare  (rusqlite-only — returns rusqlite::Statement)
+    // Callers should migrate to query_rows() for backend-agnostic access.
+    // =========================================================================
+
+    pub fn prepare(&self, sql: &str) -> Result<rusqlite::Statement> {
+        match self.backend.as_ref() {
+            Some(DbBackend::Rusqlite(conn)) => {
+                retry_db_operation_when_busy!(conn.prepare(sql))
+                    .map_err(|e| anyhow::anyhow!("DB prepare error: \"{}\", {:?}", sql, e))
+            }
+            #[cfg(feature = "turso-backend")]
+            Some(DbBackend::Turso { .. }) => {
+                anyhow::bail!(
+                    "prepare() is not supported with turso backend — use query_rows() instead"
+                )
+            }
+            None => anyhow::bail!("No database connection available"),
         }
     }
+
+    // =========================================================================
+    // query_rows — backend-agnostic, returns eagerly-collected Vec<DbRow>
+    // =========================================================================
+
+    /// Execute a query and collect all rows into `Vec<DbRow>`.
+    ///
+    /// Column count is auto-detected from the first row. All values are
+    /// eagerly read as Text, Integer, Real, or Null.
+    pub fn query_rows(&self, sql: &str, params: &[DbValue]) -> Result<Vec<DbRow>> {
+        match self.backend.as_ref() {
+            Some(DbBackend::Rusqlite(conn)) => {
+                let param_refs: Vec<&dyn ToSql> =
+                    params.iter().map(|v| v as &dyn ToSql).collect();
+                let mut stmt =
+                    retry_db_operation_when_busy!(conn.prepare(sql)).map_err(|e| {
+                        anyhow::anyhow!("DB query_rows prepare error: \"{}\", {:?}", sql, e)
+                    })?;
+                let col_count = stmt.column_count();
+                let rows = retry_db_operation_when_busy!(
+                    stmt.query_map(param_refs.as_slice(), |row| {
+                        let mut values = Vec::with_capacity(col_count);
+                        for i in 0..col_count {
+                            let val = rusqlite_value_from_row(row, i);
+                            values.push(val);
+                        }
+                        Ok(DbRow { values })
+                    })
+                )
+                .map_err(|e| {
+                    anyhow::anyhow!("DB query_rows error: \"{}\", {:?}", sql, e)
+                })?;
+                rows.map(|r| r.map_err(|e| anyhow::anyhow!("Row read error: {:?}", e)))
+                    .collect()
+            }
+            #[cfg(feature = "turso-backend")]
+            Some(DbBackend::Turso { rt, conn, .. }) => {
+                let libsql_params = db_values_to_libsql_params(params);
+                let mut rows = rt
+                    .block_on(conn.query(sql, libsql_params))
+                    .map_err(|e| {
+                        anyhow::anyhow!("DB query_rows error: \"{}\", {:?}", sql, e)
+                    })?;
+                let mut result = Vec::new();
+                loop {
+                    match rt.block_on(rows.next()) {
+                        Ok(Some(row)) => {
+                            let col_count = rows.column_count() as usize;
+                            let mut values = Vec::with_capacity(col_count);
+                            for i in 0..col_count {
+                                let val = libsql_value_from_row(&row, i as i32);
+                                values.push(val);
+                            }
+                            result.push(DbRow { values });
+                        }
+                        Ok(None) => break,
+                        Err(e) => {
+                            return Err(anyhow::anyhow!("Row read error: {:?}", e));
+                        }
+                    }
+                }
+                Ok(result)
+            }
+            None => anyhow::bail!("No database connection available"),
+        }
+    }
+
+    // =========================================================================
+    // transaction (rusqlite-style with &Connection callback)
+    // =========================================================================
 
     pub fn transaction<T>(
         &mut self,
         transaction_operation: impl Fn(&Connection) -> rusqlite::Result<T>,
     ) -> Result<T> {
-        if let Some(conn) = self.conn.as_mut() {
-            retry_db_operation_when_busy!(conn.transaction().and_then(|tx| {
-                let result = transaction_operation(&tx)?;
-                tx.commit()?;
-                Ok(result)
-            }))
-            .map_err(|e| anyhow::anyhow!("DB transaction error: {:?}", e))
-        } else {
-            anyhow::bail!("No database connection available")
+        match self.backend.as_mut() {
+            Some(DbBackend::Rusqlite(conn)) => {
+                retry_db_operation_when_busy!(conn.transaction().and_then(|tx| {
+                    let result = transaction_operation(&tx)?;
+                    tx.commit()?;
+                    Ok(result)
+                }))
+                .map_err(|e| anyhow::anyhow!("DB transaction error: {:?}", e))
+            }
+            #[cfg(feature = "turso-backend")]
+            Some(DbBackend::Turso { .. }) => {
+                anyhow::bail!(
+                    "transaction() with rusqlite callback is not supported on turso backend — use begin_transaction/commit_transaction instead"
+                )
+            }
+            None => anyhow::bail!("No database connection available"),
         }
     }
+
+    // =========================================================================
+    // begin / commit / rollback — backend-agnostic transaction control
+    // =========================================================================
+
+    /// Begin a transaction. For turso, uses `BEGIN CONCURRENT` (MVCC).
+    pub fn begin_transaction(&self) -> Result<()> {
+        match self.backend.as_ref() {
+            Some(DbBackend::Rusqlite(conn)) => {
+                retry_db_operation_when_busy!(conn.execute_batch("BEGIN"))
+                    .map_err(|e| anyhow::anyhow!("DB begin transaction error: {:?}", e))
+            }
+            #[cfg(feature = "turso-backend")]
+            Some(DbBackend::Turso { rt, conn, .. }) => {
+                rt.block_on(conn.execute("BEGIN CONCURRENT", ()))
+                    .map_err(|e| anyhow::anyhow!("DB begin transaction error: {:?}", e))?;
+                Ok(())
+            }
+            None => anyhow::bail!("No database connection available"),
+        }
+    }
+
+    pub fn commit_transaction(&self) -> Result<()> {
+        match self.backend.as_ref() {
+            Some(DbBackend::Rusqlite(conn)) => {
+                retry_db_operation_when_busy!(conn.execute_batch("COMMIT"))
+                    .map_err(|e| anyhow::anyhow!("DB commit error: {:?}", e))
+            }
+            #[cfg(feature = "turso-backend")]
+            Some(DbBackend::Turso { rt, conn, .. }) => {
+                rt.block_on(conn.execute("COMMIT", ()))
+                    .map_err(|e| anyhow::anyhow!("DB commit error: {:?}", e))?;
+                Ok(())
+            }
+            None => anyhow::bail!("No database connection available"),
+        }
+    }
+
+    pub fn rollback_transaction(&self) -> Result<()> {
+        match self.backend.as_ref() {
+            Some(DbBackend::Rusqlite(conn)) => {
+                retry_db_operation_when_busy!(conn.execute_batch("ROLLBACK"))
+                    .map_err(|e| anyhow::anyhow!("DB rollback error: {:?}", e))
+            }
+            #[cfg(feature = "turso-backend")]
+            Some(DbBackend::Turso { rt, conn, .. }) => {
+                rt.block_on(conn.execute("ROLLBACK", ()))
+                    .map_err(|e| anyhow::anyhow!("DB rollback error: {:?}", e))?;
+                Ok(())
+            }
+            None => anyhow::bail!("No database connection available"),
+        }
+    }
+
+    // =========================================================================
+    // query_row
+    // =========================================================================
 
     pub fn query_row<T, P, F>(&self, sql: &str, params: P, f: F) -> Result<Option<T>>
     where
         P: Params + Clone,
         F: FnOnce(&Row<'_>) -> rusqlite::Result<T> + Clone,
     {
-        if let Some(conn) = &self.conn {
-            retry_db_operation_when_busy!(conn.query_row(sql, params.clone(), f.clone()).optional())
+        match self.backend.as_ref() {
+            Some(DbBackend::Rusqlite(conn)) => {
+                retry_db_operation_when_busy!(
+                    conn.query_row(sql, params.clone(), f.clone()).optional()
+                )
                 .map_err(|e| anyhow::anyhow!("DB query error: \"{}\", {:?}", sql, e))
-        } else {
-            anyhow::bail!("No database connection available")
+            }
+            #[cfg(feature = "turso-backend")]
+            Some(DbBackend::Turso { .. }) => {
+                // query_row() with rusqlite Row mapper can't work on turso — callers
+                // should use query_row_values() or query_rows() instead.
+                anyhow::bail!(
+                    "query_row() with rusqlite Row mapper is not supported on turso backend — use query_row_values() instead"
+                )
+            }
+            None => anyhow::bail!("No database connection available"),
         }
     }
 
+    /// Backend-agnostic query_row — returns at most one DbRow.
+    pub fn query_row_values(&self, sql: &str, params: &[DbValue]) -> Result<Option<DbRow>> {
+        let rows = self.query_rows(sql, params)?;
+        Ok(rows.into_iter().next())
+    }
+
+    // =========================================================================
+    // close
+    // =========================================================================
+
     pub fn close(self) -> Result<()> {
         trace!("Closing database connection");
-        if let Some(conn) = self.conn {
-            conn.close()
-                .map_err(|(_, err)| anyhow::anyhow!("Unable to close connection: {:?}", err))
-        } else {
-            anyhow::bail!("No database connection available")
+        match self.backend {
+            Some(DbBackend::Rusqlite(conn)) => conn
+                .close()
+                .map_err(|(_, err)| anyhow::anyhow!("Unable to close connection: {:?}", err)),
+            #[cfg(feature = "turso-backend")]
+            Some(DbBackend::Turso { .. }) => {
+                // libsql connections are closed on drop
+                Ok(())
+            }
+            None => anyhow::bail!("No database connection available"),
         }
     }
+
+    // =========================================================================
+    // pragma_update
+    // =========================================================================
 
     pub fn pragma_update<V>(
         &self,
@@ -134,24 +483,109 @@ impl NxDbConnection {
     where
         V: ToSql + Clone,
     {
-        if let Some(conn) = &self.conn {
-            retry_db_operation_when_busy!(conn.pragma_update(
-                schema_name,
-                pragma_name,
-                pragma_value.clone()
-            ))
-            .map_err(|e| anyhow::anyhow!("DB pragma update error: {:?}", e))
-        } else {
-            anyhow::bail!("No database connection available")
+        match self.backend.as_ref() {
+            Some(DbBackend::Rusqlite(conn)) => {
+                retry_db_operation_when_busy!(conn.pragma_update(
+                    schema_name,
+                    pragma_name,
+                    pragma_value.clone()
+                ))
+                .map_err(|e| anyhow::anyhow!("DB pragma update error: {:?}", e))
+            }
+            #[cfg(feature = "turso-backend")]
+            Some(DbBackend::Turso { .. }) => {
+                // Turso/libsql handles pragmas internally — no-op for now.
+                // WAL/journal mode and busy handler are irrelevant with MVCC.
+                trace!(
+                    "Turso backend: pragma {} — skipped (handled by MVCC engine)",
+                    pragma_name
+                );
+                Ok(())
+            }
+            None => anyhow::bail!("No database connection available"),
         }
     }
 
+    // =========================================================================
+    // busy_handler
+    // =========================================================================
+
     pub fn busy_handler(&self, callback: Option<fn(i32) -> bool>) -> Result<()> {
-        if let Some(conn) = &self.conn {
-            retry_db_operation_when_busy!(conn.busy_handler(callback))
-                .map_err(|e| anyhow::anyhow!("DB busy handler error: {:?}", e))
-        } else {
-            anyhow::bail!("No database connection available")
+        match self.backend.as_ref() {
+            Some(DbBackend::Rusqlite(conn)) => {
+                retry_db_operation_when_busy!(conn.busy_handler(callback))
+                    .map_err(|e| anyhow::anyhow!("DB busy handler error: {:?}", e))
+            }
+            #[cfg(feature = "turso-backend")]
+            Some(DbBackend::Turso { .. }) => {
+                // MVCC eliminates SQLITE_BUSY — no-op for turso
+                trace!("Turso backend: busy_handler is a no-op (MVCC handles concurrency)");
+                Ok(())
+            }
+            None => anyhow::bail!("No database connection available"),
         }
     }
+
+    // =========================================================================
+    // Backend query helper
+    // =========================================================================
+
+    /// Returns true if this connection uses the turso backend.
+    #[allow(dead_code)]
+    pub fn is_turso(&self) -> bool {
+        #[cfg(feature = "turso-backend")]
+        if let Some(DbBackend::Turso { .. }) = &self.backend {
+            return true;
+        }
+        false
+    }
+}
+
+// =============================================================================
+// Helper functions
+// =============================================================================
+
+/// Extract a DbValue from a rusqlite row column.
+fn rusqlite_value_from_row(row: &Row<'_>, idx: usize) -> DbValue {
+    // Try types in order: integer, real, text, null
+    if let Ok(v) = row.get::<_, i64>(idx) {
+        return DbValue::Integer(v);
+    }
+    if let Ok(v) = row.get::<_, f64>(idx) {
+        return DbValue::Real(v);
+    }
+    if let Ok(v) = row.get::<_, String>(idx) {
+        return DbValue::Text(v);
+    }
+    DbValue::Null
+}
+
+/// Convert DbValue slice to libsql params.
+#[cfg(feature = "turso-backend")]
+fn db_values_to_libsql_params(params: &[DbValue]) -> Vec<libsql::Value> {
+    params
+        .iter()
+        .map(|v| match v {
+            DbValue::Text(s) => libsql::Value::Text(s.clone()),
+            DbValue::Integer(i) => libsql::Value::Integer(*i),
+            DbValue::Real(f) => libsql::Value::Real(*f),
+            DbValue::Null => libsql::Value::Null,
+        })
+        .collect()
+}
+
+/// Extract a DbValue from a libsql row column.
+#[cfg(feature = "turso-backend")]
+fn libsql_value_from_row(row: &libsql::Row, idx: i32) -> DbValue {
+    // Try types in order: integer, real, text, null
+    if let Ok(v) = row.get::<i64>(idx) {
+        return DbValue::Integer(v);
+    }
+    if let Ok(v) = row.get::<f64>(idx) {
+        return DbValue::Real(v);
+    }
+    if let Ok(v) = row.get::<String>(idx) {
+        return DbValue::Text(v);
+    }
+    DbValue::Null
 }

--- a/packages/nx/src/native/db/connection.rs
+++ b/packages/nx/src/native/db/connection.rs
@@ -218,7 +218,8 @@ impl NxDbConnection {
     // =========================================================================
 
     /// Begin a transaction.
-    /// TODO: Switch to `BEGIN CONCURRENT` once libsql MVCC support is enabled.
+    // NOTE: `BEGIN CONCURRENT` (MVCC) requires engine-level enablement in libsql.
+    // Investigate libsql Builder options or compile flags to enable it.
     pub fn begin_transaction(&self) -> Result<()> {
         self.execute("BEGIN", &[])?;
         Ok(())

--- a/packages/nx/src/native/db/initialize.rs
+++ b/packages/nx/src/native/db/initialize.rs
@@ -2,12 +2,13 @@ use crate::native::db::connection::NxDbConnection;
 use crate::native::tasks::details::SCHEMA as TASK_DETAILS_SCHEMA;
 use crate::native::tasks::running_tasks_service::SCHEMA as RUNNING_TASKS_SCHEMA;
 use crate::native::tasks::task_history::SCHEMA as TASK_HISTORY_SCHEMA;
+use std::ffi::OsString;
 use std::fs::remove_file;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tracing::{debug, trace};
 
 pub(super) fn initialize_db(nx_version: String, db_path: &Path) -> anyhow::Result<NxDbConnection> {
-    trace!("Initializing libsql database at {:?}", db_path);
+    trace!("Initializing turso database at {:?}", db_path);
 
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -15,7 +16,7 @@ pub(super) fn initialize_db(nx_version: String, db_path: &Path) -> anyhow::Resul
         .map_err(|e| anyhow::anyhow!("Failed to create tokio runtime: {:?}", e))?;
 
     let db = rt
-        .block_on(libsql::Builder::new_local(db_path).build())
+        .block_on(turso::Builder::new_local(&db_path.to_string_lossy()).build())
         .map_err(|e| anyhow::anyhow!("Failed to open database: {:?}", e))?;
 
     let conn = db
@@ -23,6 +24,10 @@ pub(super) fn initialize_db(nx_version: String, db_path: &Path) -> anyhow::Resul
         .map_err(|e| anyhow::anyhow!("Failed to connect to database: {:?}", e))?;
 
     let c = NxDbConnection::new(rt, db, conn);
+
+    // Enable MVCC journal mode for concurrent write support
+    c.query_row("PRAGMA journal_mode = 'mvcc'", &[])?;
+    trace!("MVCC journal mode enabled");
 
     // Check if the database already has the right version
     let db_version = c.query_row(
@@ -39,7 +44,7 @@ pub(super) fn initialize_db(nx_version: String, db_path: &Path) -> anyhow::Resul
             } else {
                 trace!("Incompatible version {} (need {}), recreating", version, nx_version);
                 c.close()?;
-                remove_file(db_path)?;
+                remove_database_files(db_path)?;
                 initialize_db(nx_version, db_path)
             }
         }
@@ -60,7 +65,7 @@ pub(super) fn initialize_db(nx_version: String, db_path: &Path) -> anyhow::Resul
         Err(e) => {
             trace!("Database error: {:?}, recreating", e);
             c.close()?;
-            let _ = remove_file(db_path);
+            remove_database_files(db_path)?;
             initialize_db(nx_version, db_path)
         }
     }
@@ -68,7 +73,7 @@ pub(super) fn initialize_db(nx_version: String, db_path: &Path) -> anyhow::Resul
 
 fn create_metadata_table(c: &NxDbConnection, nx_version: &str) -> anyhow::Result<()> {
     debug!("Creating metadata table");
-    c.begin_transaction()?;
+    c.begin_exclusive_transaction()?;
     c.execute(
         "CREATE TABLE metadata (
             key TEXT NOT NULL PRIMARY KEY,
@@ -87,13 +92,32 @@ fn create_metadata_table(c: &NxDbConnection, nx_version: &str) -> anyhow::Result
 
 fn create_all_tables(c: &NxDbConnection) -> anyhow::Result<()> {
     debug!("Creating all database tables");
-    c.begin_transaction()?;
+    c.begin_exclusive_transaction()?;
     // Order matters: tables with no FK dependencies first
     c.execute_batch(TASK_DETAILS_SCHEMA)?;
     c.execute_batch(RUNNING_TASKS_SCHEMA)?;
     // Tables with FK dependencies
     c.execute_batch(TASK_HISTORY_SCHEMA)?;
     c.commit_transaction()?;
+    Ok(())
+}
+
+/// Remove the database file and all associated files (WAL, SHM, MVCC logs).
+fn remove_database_files(db_path: &Path) -> anyhow::Result<()> {
+    let _ = remove_file(db_path);
+    // Clean up all auxiliary files by globbing for files with same prefix
+    let db_name = db_path.as_os_str().to_os_string();
+    if let Some(parent) = db_path.parent() {
+        if let Ok(entries) = std::fs::read_dir(parent) {
+            for entry in entries.flatten() {
+                let name = entry.path().as_os_str().to_os_string();
+                if name.len() > db_name.len() && name.to_string_lossy().starts_with(&db_name.to_string_lossy().as_ref()) {
+                    trace!("Removing auxiliary file: {:?}", entry.path());
+                    let _ = remove_file(entry.path());
+                }
+            }
+        }
+    }
     Ok(())
 }
 

--- a/packages/nx/src/native/db/initialize.rs
+++ b/packages/nx/src/native/db/initialize.rs
@@ -2,538 +2,13 @@ use crate::native::db::connection::NxDbConnection;
 use crate::native::tasks::details::SCHEMA as TASK_DETAILS_SCHEMA;
 use crate::native::tasks::running_tasks_service::SCHEMA as RUNNING_TASKS_SCHEMA;
 use crate::native::tasks::task_history::SCHEMA as TASK_HISTORY_SCHEMA;
-use rusqlite::vtab::array;
-use rusqlite::{Connection, OpenFlags};
-use std::fs::{File, remove_file, write};
-use std::io::ErrorKind;
-use std::path::{Path, PathBuf};
+use std::fs::remove_file;
+use std::path::Path;
 use tracing::{debug, trace};
 
-// Error reporting constants - static strings to avoid allocations in error paths
-const REPORTING_INSTRUCTIONS_PERSISTENT: &str = "If the issue persists, please help us improve Nx by capturing logs and reporting this issue:\n\
-      1. Run: NX_NATIVE_FILE_LOGGING=nx::native::db=trace nx <your-command>\n\
-      2. Create an issue at https://github.com/nrwl/nx/issues/new/choose and include the .nx/workspace-data/nx.log file";
-
-const REPORTING_INSTRUCTIONS_IMMEDIATE: &str = "Please help us improve Nx by capturing logs and reporting this issue:\n\
-      1. Run: NX_NATIVE_FILE_LOGGING=nx::native::db=trace nx <your-command>\n\
-      2. Create an issue at https://github.com/nrwl/nx/issues/new/choose and include the .nx/workspace-data/nx.log file";
-
-/// Returns reporting instructions for error messages.
-///
-/// # Parameters
-/// * `is_known_error` - When `true`, returns instructions with "If the issue persists" prefix
-///   for errors with user-actionable guidance. When `false`, returns immediate reporting
-///   instructions for unexpected errors.
-fn reporting_instructions(is_known_error: bool) -> &'static str {
-    if is_known_error {
-        REPORTING_INSTRUCTIONS_PERSISTENT
-    } else {
-        REPORTING_INSTRUCTIONS_IMMEDIATE
-    }
-}
-
-/// Returns appropriate reset instruction based on whether error has user-actionable guidance.
-///
-/// # Parameters
-/// * `is_known_error` - When `true`, returns "Then try" for errors with guidance already provided.
-///   When `false`, returns more explicit instruction for unexpected errors.
-fn reset_instruction(is_known_error: bool) -> &'static str {
-    if is_known_error {
-        "Then try: nx reset"
-    } else {
-        "To try to fix this, run: nx reset"
-    }
-}
-
-/// Creates a user-friendly error message for filesystem IO errors with specific guidance based on error type
-fn create_io_error(operation: &str, path: &Path, error: std::io::Error) -> anyhow::Error {
-    let specific_guidance = match error.kind() {
-        ErrorKind::PermissionDenied => {
-            format!(
-                "Try:\n\
-                - Verify you have read and write permissions for: {}\n\
-                - Check that you own the file/directory or your user has access\n\
-                - Ensure the filesystem is not mounted read-only\n\
-                - If using Docker, ensure volume has correct permissions\n\
-                - If running in a restricted environment, you may need administrator privileges",
-                path.display()
-            )
-        }
-        ErrorKind::StorageFull => "Try:\n\
-            - Free up disk space on the drive containing the workspace\n\
-            - Move the workspace to a drive with more available space\n\
-            - Check for large files that can be removed"
-            .to_string(),
-        ErrorKind::AlreadyExists => {
-            "This may indicate a previous Nx process did not clean up properly.\n\
-            \n\
-            Try:\n\
-            - Ensure no other Nx processes are running\n\
-            - Run nx reset to clean up stale files"
-                .to_string()
-        }
-        _ => {
-            return anyhow::anyhow!(
-                "An unexpected error occurred while initializing the workspace data:\n\
-                \n\
-                {}\n\
-                \n\
-                {}\n\
-                \n\
-                {}",
-                error,
-                reporting_instructions(false),
-                reset_instruction(false)
-            );
-        }
-    };
-
-    anyhow::anyhow!(
-        "Unable to initialize workspace data while attempting to {}:\n\
-        \n\
-        {}\n\
-        \n\
-        {}\n\
-        \n\
-        {}\n\
-        \n\
-        {}",
-        operation,
-        error,
-        specific_guidance,
-        reporting_instructions(true),
-        reset_instruction(true)
-    )
-}
-
-/// Creates a user-friendly error message for database errors
-fn create_db_error(operation: &str, error: anyhow::Error) -> anyhow::Error {
-    anyhow::anyhow!(
-        "An unexpected error occurred while attempting to {}:\n\
-        \n\
-        {}\n\
-        \n\
-        {}\n\
-        \n\
-        {}",
-        operation,
-        error,
-        reporting_instructions(false),
-        reset_instruction(false)
-    )
-}
-
-pub(super) fn unlock_file(lock_file: &File) {
-    fs4::fs_std::FileExt::unlock(lock_file).ok();
-}
-
-pub(super) fn create_lock_file(db_path: &Path) -> anyhow::Result<File> {
-    let lock_file_path = db_path.with_extension("lock");
-    trace!("Creating lock file at {:?}", lock_file_path);
-    let lock_file = File::create(&lock_file_path)
-        .map_err(|e| create_io_error("create lock file", &lock_file_path, e))?;
-
-    trace!("Getting lock on db lock file");
-    fs4::fs_std::FileExt::lock_exclusive(&lock_file)
-        .inspect(|_| trace!("Got lock on db lock file"))
-        .map_err(|e| create_io_error("acquire exclusive lock", &lock_file_path, e))?;
-    Ok(lock_file)
-}
-
 pub(super) fn initialize_db(nx_version: String, db_path: &Path) -> anyhow::Result<NxDbConnection> {
-    // Track if DB existed before we opened it for safety check on new DB creation
-    let db_existed_before_open = db_path.exists();
-    let mut database_recreated = false;
+    trace!("Initializing libsql database at {:?}", db_path);
 
-    loop {
-        match open_database_connection(db_path) {
-            Ok(mut c) => {
-                trace!(
-                    "Checking if current existing database is compatible with Nx {}",
-                    nx_version
-                );
-                let db_version = c.query_row(
-                    "SELECT value FROM metadata WHERE key='NX_VERSION'",
-                    [],
-                    |row| {
-                        let r: String = row.get(0)?;
-                        Ok(r)
-                    },
-                );
-                let c = match db_version {
-                    Ok(Some(version)) if version == nx_version => {
-                        trace!("Database is compatible with Nx {}", nx_version);
-                        c
-                    }
-                    // No metadata table found - database needs initialization
-                    // (either newly created or missing metadata from previous incomplete setup)
-                    Err(s) if s.to_string().contains("metadata") => {
-                        // Check if DB file existed before we opened it. If it did, it may be open
-                        // by another process (e.g., daemon) and it's not safe to configure it.
-                        if db_existed_before_open {
-                            c.close()?;
-                            return Err(anyhow::anyhow!(
-                                "Database file exists but has no metadata table.\n\
-                                This may indicate database corruption or incomplete initialization from a previous crash.\n\
-                                \n\
-                                To fix this issue:\n\
-                                1. Run: nx reset\n\
-                                2. Try your command again\n\
-                                \n\
-                                {}\n\
-                                \n\
-                                {}",
-                                reporting_instructions(true),
-                                reset_instruction(true)
-                            ));
-                        }
-
-                        // Safe: DB didn't exist before, we just created it, no other process has it open
-                        match configure_database(&c, db_path, database_recreated) {
-                            Ok(_) => {
-                                create_metadata_table(&mut c, &nx_version)?;
-                                create_all_tables(&mut c)?;
-                                c
-                            }
-                            Err(config_error) if !database_recreated => {
-                                trace!("Failed to configure new database: {:?}", config_error);
-                                c.close()?;
-                                trace!("Removing new database files and retrying with fallback");
-                                remove_all_database_files(db_path)?;
-                                database_recreated = true;
-                                continue;
-                            }
-                            Err(config_error) => return Err(config_error),
-                        }
-                    }
-                    reason => {
-                        trace!("Incompatible database because: {:?}", reason);
-                        trace!("Disconnecting from existing incompatible database");
-                        c.close()?;
-                        trace!("Removing existing incompatible database and auxiliary files");
-                        remove_all_database_files(db_path)?;
-
-                        trace!("Initializing a new database");
-                        return initialize_db(nx_version, db_path);
-                    }
-                };
-
-                return Ok(c);
-            }
-            Err(reason) => {
-                trace!(
-                    "Unable to connect to existing database because: {:?}",
-                    reason
-                );
-                trace!("Removing existing database and auxiliary files");
-                remove_all_database_files(db_path)?;
-
-                trace!("Initializing a new database");
-                return initialize_db(nx_version, db_path);
-            }
-        }
-    }
-}
-
-fn create_metadata_table(c: &mut NxDbConnection, nx_version: &str) -> anyhow::Result<()> {
-    debug!("Creating table for metadata");
-    c.transaction(|conn| {
-        conn.execute(
-            "CREATE TABLE metadata (
-                key TEXT NOT NULL PRIMARY KEY,
-                value TEXT NOT NULL
-            )",
-            [],
-        )?;
-        trace!("Recording Nx Version: {}", nx_version);
-        conn.execute(
-            "INSERT INTO metadata (key, value) VALUES ('NX_VERSION', ?)",
-            [nx_version],
-        )?;
-        Ok(())
-    })?;
-
-    Ok(())
-}
-
-fn create_all_tables(c: &mut NxDbConnection) -> anyhow::Result<()> {
-    debug!("Creating all database tables");
-
-    c.transaction(|conn| {
-        // Order matters: tables with no FK dependencies first
-        conn.execute_batch(TASK_DETAILS_SCHEMA)?;
-        conn.execute_batch(RUNNING_TASKS_SCHEMA)?;
-
-        // Tables with FK dependencies
-        conn.execute_batch(TASK_HISTORY_SCHEMA)?;
-        // TODO: cache_outputs table is created by NxCache with conditional FK constraint
-
-        Ok(())
-    })?;
-
-    Ok(())
-}
-
-fn open_database_connection(db_path: &Path) -> anyhow::Result<NxDbConnection> {
-    trace!("Opening database connection to {:?}", db_path);
-    let conn = Connection::open_with_flags(
-        db_path,
-        OpenFlags::SQLITE_OPEN_READ_WRITE
-            | OpenFlags::SQLITE_OPEN_CREATE
-            | OpenFlags::SQLITE_OPEN_URI
-            | OpenFlags::SQLITE_OPEN_FULL_MUTEX,
-    )
-    .map_err(|e| create_db_error("open database", e.into()))?;
-
-    // Load array module for rarray() functionality - needed per connection
-    trace!("Loading SQLite array module");
-    array::load_module(&conn)
-        .map_err(|e| create_db_error("load SQLite array extension", e.into()))?;
-
-    Ok(NxDbConnection::new(conn))
-}
-
-fn configure_database(
-    connection: &NxDbConnection,
-    db_path: &Path,
-    allow_wal_fallback: bool,
-) -> anyhow::Result<()> {
-    // Try to set journal mode with automatic fallback
-    let journal_mode = set_journal_mode(connection, db_path, allow_wal_fallback)?;
-    trace!("Database configured with {} journal mode", journal_mode);
-
-    // Set other pragmas
-    trace!("Configuring database pragmas");
-    connection
-        .pragma_update(None, "synchronous", "NORMAL")
-        .map_err(|e| create_db_error("configure database synchronous mode", e.into()))?;
-
-    connection
-        .busy_handler(Some(|tries| tries <= 12))
-        .map_err(|e| create_db_error("configure database busy handler", e.into()))?;
-
-    Ok(())
-}
-
-fn set_journal_mode(
-    connection: &NxDbConnection,
-    db_path: &Path,
-    allow_wal_fallback: bool,
-) -> anyhow::Result<&'static str> {
-    // Proactively skip WAL on known-incompatible environments
-    if is_known_incompatible_environment() {
-        debug!("Detected environment with known WAL incompatibilities");
-        debug!("Using DELETE journal mode");
-        connection
-            .pragma_update(None, "journal_mode", "DELETE")
-            .map_err(|e| {
-                diagnose_filesystem_issue(
-                    db_path,
-                    e.into(),
-                    "DELETE (required for this environment)",
-                )
-            })?;
-        trace!("Successfully enabled DELETE journal mode");
-        return Ok("DELETE");
-    }
-
-    // Try WAL mode (best performance)
-    match connection.pragma_update(None, "journal_mode", "WAL") {
-        Ok(_) => {
-            trace!("Successfully enabled WAL journal mode");
-            return Ok("WAL");
-        }
-        Err(wal_error) => {
-            trace!("WAL mode failed: {:?}", wal_error);
-
-            // If fallback is not allowed yet, WAL failure might be due to stale auxiliary files
-            // Return error to trigger cleanup and retry
-            if !allow_wal_fallback {
-                trace!("WAL failed before cleanup");
-                trace!("Will clean up database files and retry");
-                return Err(anyhow::anyhow!(
-                    "WAL mode failed - cleanup needed: {}",
-                    wal_error
-                ));
-            }
-
-            // After cleanup, WAL still not supported - fall back to DELETE mode
-            debug!("WAL not supported on this system after cleanup");
-        }
-    }
-
-    // Fallback to DELETE mode (universal compatibility)
-    connection
-        .pragma_update(None, "journal_mode", "DELETE")
-        .map_err(|e| {
-            diagnose_filesystem_issue(db_path, e.into(), "DELETE (fallback after WAL failed)")
-        })?;
-
-    trace!("Successfully enabled DELETE journal mode");
-    Ok("DELETE")
-}
-
-fn is_known_incompatible_environment() -> bool {
-    #[cfg(target_os = "linux")]
-    {
-        if is_wsl1() {
-            debug!("WSL1 detected - will use DELETE journal mode");
-            return true;
-        }
-    }
-    false
-}
-
-#[cfg(target_os = "linux")]
-fn is_wsl1() -> bool {
-    use std::sync::OnceLock;
-    static IS_WSL1: OnceLock<bool> = OnceLock::new();
-
-    *IS_WSL1.get_or_init(|| {
-        // WSL1 has "Microsoft" in /proc/version but not "WSL2"
-        std::fs::read_to_string("/proc/version")
-            .map(|contents| contents.contains("Microsoft") && !contents.contains("WSL2"))
-            .unwrap_or(false)
-    })
-}
-
-/// Creates an auxiliary database file path by appending a suffix to the database path.
-/// Uses OsString operations to avoid UTF-8 conversion and handle all valid paths correctly.
-fn auxiliary_path(db_path: &Path, suffix: &str) -> PathBuf {
-    let mut path = db_path.as_os_str().to_os_string();
-    path.push(suffix);
-    PathBuf::from(path)
-}
-
-fn remove_all_database_files(db_path: &Path) -> anyhow::Result<()> {
-    // Build list of all database-related files to remove
-    let files_to_remove = [
-        (db_path.to_path_buf(), "database file"),
-        (auxiliary_path(db_path, "-wal"), "WAL file"),
-        (auxiliary_path(db_path, "-shm"), "shared memory file"),
-    ];
-
-    // Remove all files with consistent error handling
-    for (path, description) in files_to_remove {
-        if path.exists() {
-            match remove_file(&path) {
-                Ok(_) => trace!("Removed {}: {:?}", description, path),
-                Err(e) => trace!("Warning: failed to remove {}: {}", description, e),
-            }
-        }
-    }
-
-    Ok(())
-}
-
-/// Diagnose specific filesystem issues when setting journal mode fails
-fn diagnose_filesystem_issue(
-    db_path: &Path,
-    original_error: anyhow::Error,
-    context: &str,
-) -> anyhow::Error {
-    // Try to get the parent directory from the database path
-    if let Some(parent_dir) = db_path.parent() {
-        // Check if directory is writable by attempting to create a test file
-        let test_file = parent_dir.join(".nx-write-test");
-        match write(&test_file, b"test") {
-            Ok(_) => {
-                // Successfully wrote, clean up test file
-                remove_file(&test_file).ok();
-
-                // Directory is writable, so the issue is something else
-                return anyhow::anyhow!(
-                    "Unable to configure workspace database:\n\
-                    \n\
-                    Failed to set {} journal mode.\n\
-                    \n\
-                    {}\n\
-                    \n\
-                    The directory at {} exists and is writable, but SQLite cannot set the journal mode.\n\
-                    This typically indicates:\n\
-                    - The filesystem doesn't support SQLite's locking requirements (e.g., NFS, network drive)\n\
-                    - The filesystem lacks support for required features\n\
-                    - There are conflicting locks from another process\n\
-                    \n\
-                    Try:\n\
-                    - Move your workspace to a local filesystem\n\
-                    - Check for other processes accessing the cache directory\n\
-                    \n\
-                    {}\n\
-                    \n\
-                    {}",
-                    context,
-                    original_error,
-                    parent_dir.display(),
-                    reporting_instructions(true),
-                    reset_instruction(true)
-                );
-            }
-            Err(write_error) => {
-                // Directory exists but is not writable
-                return anyhow::anyhow!(
-                    "Unable to configure workspace database:\n\
-                    \n\
-                    Failed to set {} journal mode.\n\
-                    \n\
-                    {}\n\
-                    \n\
-                    The directory at {} exists but has restricted permissions.\n\
-                    SQLite successfully created the database file but cannot configure it due to filesystem restrictions.\n\
-                    \n\
-                    Try:\n\
-                    - Verify you have read and write permissions for the cache directory\n\
-                    - Check that you own the directory or your user has access\n\
-                    - Ensure the filesystem is not mounted read-only\n\
-                    - If using Docker, ensure volume has correct permissions\n\
-                    - If running in a restricted environment, you may need administrator privileges\n\
-                    \n\
-                    {}\n\
-                    \n\
-                    {}\n\
-                    \n\
-                    Write error: {}",
-                    context,
-                    original_error,
-                    parent_dir.display(),
-                    reporting_instructions(true),
-                    reset_instruction(true),
-                    write_error
-                );
-            }
-        }
-    }
-
-    // Fallback if we can't get the parent directory path
-    anyhow::anyhow!(
-        "Unable to configure workspace database:\n\
-        \n\
-        Failed to set {} journal mode.\n\
-        \n\
-        {}\n\
-        \n\
-        {}\n\
-        \n\
-        {}",
-        context,
-        original_error,
-        reporting_instructions(false),
-        reset_instruction(false)
-    )
-}
-
-// =============================================================================
-// Turso / libsql initialization — skips file locking and WAL pragma dance
-// =============================================================================
-
-#[cfg(feature = "turso-backend")]
-pub(super) fn initialize_turso_db(
-    nx_version: String,
-    db_path: &Path,
-) -> anyhow::Result<NxDbConnection> {
-    trace!("Initializing turso/libsql database at {:?}", db_path);
-
-    // Build a local libsql database — no lock file needed (MVCC)
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -541,72 +16,82 @@ pub(super) fn initialize_turso_db(
 
     let db = rt
         .block_on(libsql::Builder::new_local(db_path).build())
-        .map_err(|e| create_db_error("open turso database", e.into()))?;
+        .map_err(|e| anyhow::anyhow!("Failed to open database: {:?}", e))?;
 
-    let conn_handle = db
+    let conn = db
         .connect()
-        .map_err(|e| create_db_error("connect to turso database", e.into()))?;
+        .map_err(|e| anyhow::anyhow!("Failed to connect to database: {:?}", e))?;
 
-    let c = NxDbConnection::new_turso(db, conn_handle);
+    let c = NxDbConnection::new(rt, db, conn);
 
     // Check if the database already has the right version
     let db_version = c.query_row(
         "SELECT value FROM metadata WHERE key='NX_VERSION'",
-        [],
-        |row| {
-            let r: String = row.get(0)?;
-            Ok(r)
-        },
+        &[],
     );
 
     match db_version {
-        Ok(Some(version)) if version == nx_version => {
-            trace!("Turso database is compatible with Nx {}", nx_version);
-            Ok(c)
+        Ok(Some(row)) => {
+            let version = row.get_str(0)?;
+            if version == nx_version {
+                trace!("Database is compatible with Nx {}", nx_version);
+                Ok(c)
+            } else {
+                trace!("Incompatible version {} (need {}), recreating", version, nx_version);
+                c.close()?;
+                remove_file(db_path)?;
+                initialize_db(nx_version, db_path)
+            }
         }
+        // No metadata table — fresh database, create schema
         Err(s) if s.to_string().contains("metadata") => {
-            // No metadata table — fresh database, create schema
-            trace!("Turso: creating metadata and schema tables");
-            turso_create_metadata_table(&c, &nx_version)?;
-            turso_create_all_tables(&c)?;
+            trace!("Creating metadata and schema tables");
+            create_metadata_table(&c, &nx_version)?;
+            create_all_tables(&c)?;
             Ok(c)
         }
-        _ => {
-            // Incompatible version — drop and recreate
-            trace!("Turso: incompatible version, recreating database");
+        Ok(None) => {
+            // Metadata table exists but no NX_VERSION row — recreate
+            trace!("Missing NX_VERSION in metadata, recreating");
             c.close()?;
-            std::fs::remove_file(db_path)?;
-            initialize_turso_db(nx_version, db_path)
+            remove_file(db_path)?;
+            initialize_db(nx_version, db_path)
+        }
+        Err(e) => {
+            trace!("Database error: {:?}, recreating", e);
+            c.close()?;
+            let _ = remove_file(db_path);
+            initialize_db(nx_version, db_path)
         }
     }
 }
 
-#[cfg(feature = "turso-backend")]
-fn turso_create_metadata_table(c: &NxDbConnection, nx_version: &str) -> anyhow::Result<()> {
-    debug!("Turso: creating metadata table");
+fn create_metadata_table(c: &NxDbConnection, nx_version: &str) -> anyhow::Result<()> {
+    debug!("Creating metadata table");
     c.begin_transaction()?;
     c.execute(
         "CREATE TABLE metadata (
             key TEXT NOT NULL PRIMARY KEY,
             value TEXT NOT NULL
         )",
-        [],
+        &[],
     )?;
     trace!("Recording Nx Version: {}", nx_version);
     c.execute(
         "INSERT INTO metadata (key, value) VALUES ('NX_VERSION', ?1)",
-        [nx_version],
+        &[nx_version.into()],
     )?;
     c.commit_transaction()?;
     Ok(())
 }
 
-#[cfg(feature = "turso-backend")]
-fn turso_create_all_tables(c: &NxDbConnection) -> anyhow::Result<()> {
-    debug!("Turso: creating all database tables");
+fn create_all_tables(c: &NxDbConnection) -> anyhow::Result<()> {
+    debug!("Creating all database tables");
     c.begin_transaction()?;
+    // Order matters: tables with no FK dependencies first
     c.execute_batch(TASK_DETAILS_SCHEMA)?;
     c.execute_batch(RUNNING_TASKS_SCHEMA)?;
+    // Tables with FK dependencies
     c.execute_batch(TASK_HISTORY_SCHEMA)?;
     c.commit_transaction()?;
     Ok(())
@@ -614,8 +99,6 @@ fn turso_create_all_tables(c: &NxDbConnection) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::native::logger::enable_logger;
-
     use super::*;
 
     #[test]
@@ -623,16 +106,12 @@ mod tests {
         let temp_dir = tempfile::tempdir()?;
         let db_path = temp_dir.path().join("test.db");
 
-        let _ = initialize_db("1.0.0".to_string(), &db_path)?;
+        let conn = initialize_db("1.0.0".to_string(), &db_path)?;
 
-        let conn = Connection::open(&db_path)?;
-        let version: String = conn.query_row(
-            "SELECT value FROM metadata WHERE key='NX_VERSION'",
-            [],
-            |row| row.get(0),
-        )?;
-
-        assert_eq!(version, "1.0.0");
+        let row = conn
+            .query_row("SELECT value FROM metadata WHERE key='NX_VERSION'", &[])?
+            .expect("should have NX_VERSION row");
+        assert_eq!(row.get_str(0)?, "1.0.0");
         Ok(())
     }
 
@@ -641,42 +120,28 @@ mod tests {
         let temp_dir = tempfile::tempdir()?;
         let db_path = temp_dir.path().join("test.db");
 
-        // Create initial db
         let _ = initialize_db("1.0.0".to_string(), &db_path)?;
+        let conn = initialize_db("1.0.0".to_string(), &db_path)?;
 
-        // Try to initialize again with same version
-        let _ = initialize_db("1.0.0".to_string(), &db_path)?;
-
-        let conn = Connection::open(&db_path)?;
-        let version: String = conn.query_row(
-            "SELECT value FROM metadata WHERE key='NX_VERSION'",
-            [],
-            |row| row.get(0),
-        )?;
-
-        assert_eq!(version, "1.0.0");
+        let row = conn
+            .query_row("SELECT value FROM metadata WHERE key='NX_VERSION'", &[])?
+            .expect("should have NX_VERSION row");
+        assert_eq!(row.get_str(0)?, "1.0.0");
         Ok(())
     }
 
     #[test]
     fn initialize_db_recreates_incompatible_db() -> anyhow::Result<()> {
-        enable_logger();
         let temp_dir = tempfile::tempdir()?;
         let db_path = temp_dir.path().join("test.db");
-        //
-        // Create initial db
-        let _ = initialize_db("1.0.0".to_string(), &db_path)?;
 
-        // Try to initialize with different version
+        let _ = initialize_db("1.0.0".to_string(), &db_path)?;
         let conn = initialize_db("2.0.0".to_string(), &db_path)?;
 
-        let version: Option<String> = conn.query_row(
-            "SELECT value FROM metadata WHERE key='NX_VERSION'",
-            [],
-            |row| row.get(0),
-        )?;
-
-        assert_eq!(version.unwrap(), "2.0.0");
+        let row = conn
+            .query_row("SELECT value FROM metadata WHERE key='NX_VERSION'", &[])?
+            .expect("should have NX_VERSION row");
+        assert_eq!(row.get_str(0)?, "2.0.0");
         Ok(())
     }
 }

--- a/packages/nx/src/native/db/initialize.rs
+++ b/packages/nx/src/native/db/initialize.rs
@@ -23,6 +23,11 @@ pub(super) fn initialize_db(nx_version: String, db_path: &Path) -> anyhow::Resul
         .connect()
         .map_err(|e| anyhow::anyhow!("Failed to connect to database: {:?}", e))?;
 
+    // Set busy timeout — retries internally with exponential backoff (1ms, 2ms, ... up to 100ms)
+    // when another process holds the write lock
+    conn.busy_timeout(std::time::Duration::from_secs(12))
+        .map_err(|e| anyhow::anyhow!("Failed to set busy timeout: {:?}", e))?;
+
     let c = NxDbConnection::new(rt, db, conn);
 
     // Enable WAL mode for multi-process read/write access

--- a/packages/nx/src/native/db/initialize.rs
+++ b/packages/nx/src/native/db/initialize.rs
@@ -25,15 +25,13 @@ pub(super) fn initialize_db(nx_version: String, db_path: &Path) -> anyhow::Resul
 
     let c = NxDbConnection::new(rt, db, conn);
 
-    // Enable MVCC journal mode for concurrent write support
-    c.query_row("PRAGMA journal_mode = 'mvcc'", &[])?;
-    trace!("MVCC journal mode enabled");
+    // Enable WAL mode for multi-process read/write access
+    c.query_row("PRAGMA journal_mode = 'wal'", &[])?;
+    c.execute("PRAGMA synchronous = NORMAL", &[])?;
+    trace!("WAL journal mode enabled");
 
     // Check if the database already has the right version
-    let db_version = c.query_row(
-        "SELECT value FROM metadata WHERE key='NX_VERSION'",
-        &[],
-    );
+    let db_version = c.query_row("SELECT value FROM metadata WHERE key='NX_VERSION'", &[]);
 
     match db_version {
         Ok(Some(row)) => {
@@ -42,7 +40,10 @@ pub(super) fn initialize_db(nx_version: String, db_path: &Path) -> anyhow::Resul
                 trace!("Database is compatible with Nx {}", nx_version);
                 Ok(c)
             } else {
-                trace!("Incompatible version {} (need {}), recreating", version, nx_version);
+                trace!(
+                    "Incompatible version {} (need {}), recreating",
+                    version, nx_version
+                );
                 c.close()?;
                 remove_database_files(db_path)?;
                 initialize_db(nx_version, db_path)
@@ -73,7 +74,7 @@ pub(super) fn initialize_db(nx_version: String, db_path: &Path) -> anyhow::Resul
 
 fn create_metadata_table(c: &NxDbConnection, nx_version: &str) -> anyhow::Result<()> {
     debug!("Creating metadata table");
-    c.begin_exclusive_transaction()?;
+    c.begin_transaction()?;
     c.execute(
         "CREATE TABLE metadata (
             key TEXT NOT NULL PRIMARY KEY,
@@ -92,7 +93,7 @@ fn create_metadata_table(c: &NxDbConnection, nx_version: &str) -> anyhow::Result
 
 fn create_all_tables(c: &NxDbConnection) -> anyhow::Result<()> {
     debug!("Creating all database tables");
-    c.begin_exclusive_transaction()?;
+    c.begin_transaction()?;
     // Order matters: tables with no FK dependencies first
     c.execute_batch(TASK_DETAILS_SCHEMA)?;
     c.execute_batch(RUNNING_TASKS_SCHEMA)?;
@@ -111,7 +112,11 @@ fn remove_database_files(db_path: &Path) -> anyhow::Result<()> {
         if let Ok(entries) = std::fs::read_dir(parent) {
             for entry in entries.flatten() {
                 let name = entry.path().as_os_str().to_os_string();
-                if name.len() > db_name.len() && name.to_string_lossy().starts_with(&db_name.to_string_lossy().as_ref()) {
+                if name.len() > db_name.len()
+                    && name
+                        .to_string_lossy()
+                        .starts_with(&db_name.to_string_lossy().as_ref())
+                {
                     trace!("Removing auxiliary file: {:?}", entry.path());
                     let _ = remove_file(entry.path());
                 }

--- a/packages/nx/src/native/db/initialize.rs
+++ b/packages/nx/src/native/db/initialize.rs
@@ -165,6 +165,48 @@ mod tests {
     }
 
     #[test]
+    fn initialize_db_concurrent_connections() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let db_path = temp_dir.path().join("test.db");
+
+        // Open first connection
+        let conn1 = initialize_db("1.0.0".to_string(), &db_path)?;
+
+        // Open second connection to the same DB — this used to fail with
+        // "Locking error: Failed locking file. File is locked by another process"
+        let conn2 = initialize_db("1.0.0".to_string(), &db_path)?;
+
+        // Both connections should be able to read
+        let row1 = conn1
+            .query_row("SELECT value FROM metadata WHERE key='NX_VERSION'", &[])?
+            .expect("conn1 should read NX_VERSION");
+        let row2 = conn2
+            .query_row("SELECT value FROM metadata WHERE key='NX_VERSION'", &[])?
+            .expect("conn2 should read NX_VERSION");
+
+        assert_eq!(row1.get_str(0)?, "1.0.0");
+        assert_eq!(row2.get_str(0)?, "1.0.0");
+
+        // Both connections should be able to write
+        conn1.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('test1', 'from_conn1')",
+            &[],
+        )?;
+        conn2.execute(
+            "INSERT OR REPLACE INTO metadata (key, value) VALUES ('test2', 'from_conn2')",
+            &[],
+        )?;
+
+        // Verify writes are visible
+        let r = conn1
+            .query_row("SELECT value FROM metadata WHERE key='test2'", &[])?
+            .expect("conn1 should see conn2's write");
+        assert_eq!(r.get_str(0)?, "from_conn2");
+
+        Ok(())
+    }
+
+    #[test]
     fn initialize_db_recreates_incompatible_db() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let db_path = temp_dir.path().join("test.db");

--- a/packages/nx/src/native/db/initialize.rs
+++ b/packages/nx/src/native/db/initialize.rs
@@ -522,6 +522,96 @@ fn diagnose_filesystem_issue(
     )
 }
 
+// =============================================================================
+// Turso / libsql initialization — skips file locking and WAL pragma dance
+// =============================================================================
+
+#[cfg(feature = "turso-backend")]
+pub(super) fn initialize_turso_db(
+    nx_version: String,
+    db_path: &Path,
+) -> anyhow::Result<NxDbConnection> {
+    trace!("Initializing turso/libsql database at {:?}", db_path);
+
+    // Build a local libsql database — no lock file needed (MVCC)
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| anyhow::anyhow!("Failed to create tokio runtime: {:?}", e))?;
+
+    let db = rt
+        .block_on(libsql::Builder::new_local(db_path).build())
+        .map_err(|e| create_db_error("open turso database", e.into()))?;
+
+    let conn_handle = db
+        .connect()
+        .map_err(|e| create_db_error("connect to turso database", e.into()))?;
+
+    let c = NxDbConnection::new_turso(db, conn_handle);
+
+    // Check if the database already has the right version
+    let db_version = c.query_row(
+        "SELECT value FROM metadata WHERE key='NX_VERSION'",
+        [],
+        |row| {
+            let r: String = row.get(0)?;
+            Ok(r)
+        },
+    );
+
+    match db_version {
+        Ok(Some(version)) if version == nx_version => {
+            trace!("Turso database is compatible with Nx {}", nx_version);
+            Ok(c)
+        }
+        Err(s) if s.to_string().contains("metadata") => {
+            // No metadata table — fresh database, create schema
+            trace!("Turso: creating metadata and schema tables");
+            turso_create_metadata_table(&c, &nx_version)?;
+            turso_create_all_tables(&c)?;
+            Ok(c)
+        }
+        _ => {
+            // Incompatible version — drop and recreate
+            trace!("Turso: incompatible version, recreating database");
+            c.close()?;
+            std::fs::remove_file(db_path)?;
+            initialize_turso_db(nx_version, db_path)
+        }
+    }
+}
+
+#[cfg(feature = "turso-backend")]
+fn turso_create_metadata_table(c: &NxDbConnection, nx_version: &str) -> anyhow::Result<()> {
+    debug!("Turso: creating metadata table");
+    c.begin_transaction()?;
+    c.execute(
+        "CREATE TABLE metadata (
+            key TEXT NOT NULL PRIMARY KEY,
+            value TEXT NOT NULL
+        )",
+        [],
+    )?;
+    trace!("Recording Nx Version: {}", nx_version);
+    c.execute(
+        "INSERT INTO metadata (key, value) VALUES ('NX_VERSION', ?1)",
+        [nx_version],
+    )?;
+    c.commit_transaction()?;
+    Ok(())
+}
+
+#[cfg(feature = "turso-backend")]
+fn turso_create_all_tables(c: &NxDbConnection) -> anyhow::Result<()> {
+    debug!("Turso: creating all database tables");
+    c.begin_transaction()?;
+    c.execute_batch(TASK_DETAILS_SCHEMA)?;
+    c.execute_batch(RUNNING_TASKS_SCHEMA)?;
+    c.execute_batch(TASK_HISTORY_SCHEMA)?;
+    c.commit_transaction()?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::native::logger::enable_logger;

--- a/packages/nx/src/native/db/mod.rs
+++ b/packages/nx/src/native/db/mod.rs
@@ -31,6 +31,16 @@ pub fn connect_to_nx_db(
 
     trace_span!("process", id = process::id()).in_scope(|| {
         trace!("Creating connection to {:?}", db_path);
+
+        // Check if turso backend is requested via env var
+        #[cfg(feature = "turso-backend")]
+        if std::env::var("NX_DB_ENGINE").unwrap_or_default() == "turso" {
+            trace!("NX_DB_ENGINE=turso — using turso/libsql backend (MVCC)");
+            let c = initialize::initialize_turso_db(nx_version, &db_path)?;
+            return Ok(External::new(Arc::new(Mutex::new(c))));
+        }
+
+        // Default: rusqlite backend
         let lock_file = initialize::create_lock_file(&db_path)?;
 
         let c = initialize::initialize_db(nx_version, &db_path)

--- a/packages/nx/src/native/db/mod.rs
+++ b/packages/nx/src/native/db/mod.rs
@@ -31,23 +31,7 @@ pub fn connect_to_nx_db(
 
     trace_span!("process", id = process::id()).in_scope(|| {
         trace!("Creating connection to {:?}", db_path);
-
-        // Check if turso backend is requested via env var
-        #[cfg(feature = "turso-backend")]
-        if std::env::var("NX_DB_ENGINE").unwrap_or_default() == "turso" {
-            trace!("NX_DB_ENGINE=turso — using turso/libsql backend (MVCC)");
-            let c = initialize::initialize_turso_db(nx_version, &db_path)?;
-            return Ok(External::new(Arc::new(Mutex::new(c))));
-        }
-
-        // Default: rusqlite backend
-        let lock_file = initialize::create_lock_file(&db_path)?;
-
-        let c = initialize::initialize_db(nx_version, &db_path)
-            .inspect_err(|_| initialize::unlock_file(&lock_file))?;
-
-        initialize::unlock_file(&lock_file);
-
+        let c = initialize::initialize_db(nx_version, &db_path)?;
         Ok(External::new(Arc::new(Mutex::new(c))))
     })
 }

--- a/packages/nx/src/native/tasks/details.rs
+++ b/packages/nx/src/native/tasks/details.rs
@@ -41,7 +41,7 @@ impl TaskDetails {
         let db = self.db.lock().unwrap();
         db.begin_transaction()?;
         for task in tasks.iter() {
-            db.execute_with_values(
+            db.execute(
                 "INSERT OR REPLACE INTO task_details (hash, project, target, configuration) VALUES (?1, ?2, ?3, ?4)",
                 &[
                     DbValue::from(task.hash.as_str()),

--- a/packages/nx/src/native/tasks/details.rs
+++ b/packages/nx/src/native/tasks/details.rs
@@ -1,6 +1,5 @@
-use crate::native::db::connection::NxDbConnection;
+use crate::native::db::connection::{DbValue, NxDbConnection};
 use napi::bindgen_prelude::External;
-use rusqlite::params;
 use std::sync::{Arc, Mutex};
 use tracing::trace;
 
@@ -39,16 +38,23 @@ impl TaskDetails {
     #[napi]
     pub fn record_task_details(&mut self, tasks: Vec<HashedTask>) -> anyhow::Result<()> {
         trace!("Recording task details");
-        self.db.lock().unwrap().transaction(|conn| {
-            let mut stmt = conn.prepare("INSERT OR REPLACE INTO task_details (hash, project, target, configuration) VALUES (?1, ?2, ?3, ?4)")?;
-            for task in tasks.iter() {
-                stmt.execute(
-                    params![task.hash, task.project, task.target, task.configuration],
-                )?;
-            }
-            Ok(())
-        })?;
-
+        let db = self.db.lock().unwrap();
+        db.begin_transaction()?;
+        for task in tasks.iter() {
+            db.execute_with_values(
+                "INSERT OR REPLACE INTO task_details (hash, project, target, configuration) VALUES (?1, ?2, ?3, ?4)",
+                &[
+                    DbValue::from(task.hash.as_str()),
+                    DbValue::from(task.project.as_str()),
+                    DbValue::from(task.target.as_str()),
+                    match &task.configuration {
+                        Some(c) => DbValue::from(c.as_str()),
+                        None => DbValue::Null,
+                    },
+                ],
+            )?;
+        }
+        db.commit_transaction()?;
         Ok(())
     }
 }

--- a/packages/nx/src/native/tasks/running_tasks_service.rs
+++ b/packages/nx/src/native/tasks/running_tasks_service.rs
@@ -1,4 +1,4 @@
-use crate::native::db::connection::NxDbConnection;
+use crate::native::db::connection::{DbValue, NxDbConnection};
 use crate::native::utils::Normalize;
 use hashbrown::HashSet;
 use napi::bindgen_prelude::External;
@@ -50,17 +50,16 @@ impl RunningTasksService {
     }
 
     fn is_task_running(&self, task_id: &String) -> anyhow::Result<bool> {
-        if let Some((pid, db_process_command, db_process_cwd)) = self.db.lock().unwrap().query_row(
+        let row = self.db.lock().unwrap().query_row(
             "SELECT pid, command, cwd FROM running_tasks WHERE task_id = ?",
-            [task_id],
-            |row| {
-                let pid: u32 = row.get(0)?;
-                let command: String = row.get(1)?;
-                let cwd: String = row.get(2)?;
+            &[DbValue::from(task_id.as_str())],
+        )?;
 
-                Ok((pid, command, cwd))
-            },
-        )? {
+        if let Some(row) = row {
+            let pid = row.get_i64(0)? as u32;
+            let db_process_command = row.get_str(1)?;
+            let db_process_cwd = row.get_str(2)?;
+
             debug!("Checking if {} exists", pid);
 
             let mut sys = System::new();
@@ -108,8 +107,13 @@ impl RunningTasksService {
             .expect("The current working directory does not exist")
             .to_normalized_string();
         self.db.lock().unwrap().execute(
-            "INSERT OR REPLACE INTO running_tasks (task_id, pid, command, cwd) VALUES (?, ?, ?, ?)",
-            [&task_id, &pid.to_string(), &command_str, &cwd],
+            "INSERT OR REPLACE INTO running_tasks (task_id, pid, command, cwd) VALUES (?1, ?2, ?3, ?4)",
+            &[
+                DbValue::from(task_id.as_str()),
+                DbValue::from(pid.to_string().as_str()),
+                DbValue::from(command_str.as_str()),
+                DbValue::from(cwd.as_str()),
+            ],
         )?;
         debug!("Added {} to running tasks", &task_id);
         self.added_tasks.insert(task_id);
@@ -121,7 +125,10 @@ impl RunningTasksService {
         self.db
             .lock()
             .unwrap()
-            .execute("DELETE FROM running_tasks WHERE task_id = ?", [&task_id])?;
+            .execute(
+                "DELETE FROM running_tasks WHERE task_id = ?",
+                &[DbValue::from(task_id.as_str())],
+            )?;
         debug!("Removed {} from running tasks", task_id);
         Ok(())
     }

--- a/packages/nx/src/native/tasks/running_tasks_service.rs
+++ b/packages/nx/src/native/tasks/running_tasks_service.rs
@@ -122,13 +122,10 @@ impl RunningTasksService {
 
     #[napi]
     pub fn remove_running_task(&self, task_id: String) -> anyhow::Result<()> {
-        self.db
-            .lock()
-            .unwrap()
-            .execute(
-                "DELETE FROM running_tasks WHERE task_id = ?",
-                &[DbValue::from(task_id.as_str())],
-            )?;
+        self.db.lock().unwrap().execute(
+            "DELETE FROM running_tasks WHERE task_id = ?",
+            &[DbValue::from(task_id.as_str())],
+        )?;
         debug!("Removed {} from running tasks", task_id);
         Ok(())
     }

--- a/packages/nx/src/native/tasks/task_history.rs
+++ b/packages/nx/src/native/tasks/task_history.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 use tracing::trace;
 
 pub const SCHEMA: &str = "CREATE TABLE IF NOT EXISTS task_history (
-    id INTEGER PRIMARY KEY NOT NULL,
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     hash TEXT NOT NULL,
     status TEXT NOT NULL,
     code INTEGER NOT NULL,
@@ -84,9 +84,7 @@ impl NxTaskHistory {
         let params: Vec<DbValue> = hashes.into_iter().map(DbValue::from).collect();
 
         let rows = self.db.lock().unwrap().query_rows(&sql, &params)?;
-        rows.iter()
-            .map(|row| row.get_str(0))
-            .collect()
+        rows.iter().map(|row| row.get_str(0)).collect()
     }
 
     #[napi]
@@ -109,8 +107,9 @@ impl NxTaskHistory {
             .collect();
 
         // Use IN (?,?,?) with dynamic placeholders instead of rarray
-        let placeholders: Vec<String> =
-            (1..=target_strings.len()).map(|i| format!("?{}", i)).collect();
+        let placeholders: Vec<String> = (1..=target_strings.len())
+            .map(|i| format!("?{}", i))
+            .collect();
         let sql = format!(
             "SELECT
                 CONCAT_WS(':', project, target, configuration) AS target_string,

--- a/packages/nx/src/native/tasks/task_history.rs
+++ b/packages/nx/src/native/tasks/task_history.rs
@@ -48,7 +48,7 @@ impl NxTaskHistory {
         let db = self.db.lock().unwrap();
         db.begin_transaction()?;
         for task_run in task_runs.iter() {
-            db.execute_with_values(
+            db.execute(
                 "INSERT OR REPLACE INTO task_history
                     (hash, status, code, start, end)
                     VALUES (?1, ?2, ?3, ?4, ?5)",
@@ -73,7 +73,6 @@ impl NxTaskHistory {
         }
 
         // Use IN (?,?,?) with dynamic placeholders instead of rarray
-        // for compatibility with both rusqlite and turso backends
         let placeholders: Vec<String> = (1..=hashes.len()).map(|i| format!("?{}", i)).collect();
         let sql = format!(
             "SELECT hash FROM task_history

--- a/packages/nx/src/native/tasks/task_history.rs
+++ b/packages/nx/src/native/tasks/task_history.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 use tracing::trace;
 
 pub const SCHEMA: &str = "CREATE TABLE IF NOT EXISTS task_history (
-    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    id INTEGER PRIMARY KEY NOT NULL,
     hash TEXT NOT NULL,
     status TEXT NOT NULL,
     code INTEGER NOT NULL,

--- a/packages/nx/src/native/tasks/task_history.rs
+++ b/packages/nx/src/native/tasks/task_history.rs
@@ -1,9 +1,7 @@
-use crate::native::db::connection::NxDbConnection;
+use crate::native::db::connection::{DbValue, NxDbConnection};
 use crate::native::tasks::types::TaskTarget;
 use napi::bindgen_prelude::External;
-use rusqlite::{params, types::Value};
 use std::collections::HashMap;
-use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use tracing::trace;
 
@@ -47,48 +45,48 @@ impl NxTaskHistory {
     #[napi]
     pub fn record_task_runs(&mut self, task_runs: Vec<TaskRun>) -> anyhow::Result<()> {
         trace!("Recording task runs");
-        self.db.lock().unwrap().transaction(|conn| {
-            let mut stmt = conn.prepare(
+        let db = self.db.lock().unwrap();
+        db.begin_transaction()?;
+        for task_run in task_runs.iter() {
+            db.execute_with_values(
                 "INSERT OR REPLACE INTO task_history
-        (hash, status, code, start, end)
-        VALUES (?1, ?2, ?3, ?4, ?5)",
-            )?;
-            for task_run in task_runs.iter() {
-                stmt.execute(params![
-                    task_run.hash,
-                    task_run.status,
-                    task_run.code,
-                    task_run.start,
-                    task_run.end
-                ])
-                .inspect_err(|e| trace!("Error trying to insert {:?}: {:?}", &task_run.hash, e))?;
-            }
-            Ok(())
-        })?;
+                    (hash, status, code, start, end)
+                    VALUES (?1, ?2, ?3, ?4, ?5)",
+                &[
+                    DbValue::from(task_run.hash.as_str()),
+                    DbValue::from(task_run.status.as_str()),
+                    DbValue::Integer(task_run.code as i64),
+                    DbValue::Integer(task_run.start),
+                    DbValue::Integer(task_run.end),
+                ],
+            )
+            .inspect_err(|e| trace!("Error trying to insert {:?}: {:?}", &task_run.hash, e))?;
+        }
+        db.commit_transaction()?;
         Ok(())
     }
 
     #[napi]
     pub fn get_flaky_tasks(&self, hashes: Vec<String>) -> anyhow::Result<Vec<String>> {
-        let values = Rc::new(
-            hashes
-                .iter()
-                .map(|s| Value::from(s.clone()))
-                .collect::<Vec<Value>>(),
-        );
+        if hashes.is_empty() {
+            return Ok(vec![]);
+        }
 
-        self.db
-            .lock()
-            .unwrap()
-            .prepare(
-                "SELECT hash from task_history
-                    WHERE hash IN rarray(?1) AND status != 'stopped'
-                    GROUP BY hash
-                    HAVING COUNT(DISTINCT code) > 1
-                ",
-            )?
-            .query_map([values], |row| row.get(0))?
-            .map(|r| r.map_err(anyhow::Error::from))
+        // Use IN (?,?,?) with dynamic placeholders instead of rarray
+        // for compatibility with both rusqlite and turso backends
+        let placeholders: Vec<String> = (1..=hashes.len()).map(|i| format!("?{}", i)).collect();
+        let sql = format!(
+            "SELECT hash FROM task_history
+                WHERE hash IN ({}) AND status != 'stopped'
+                GROUP BY hash
+                HAVING COUNT(DISTINCT code) > 1",
+            placeholders.join(", ")
+        );
+        let params: Vec<DbValue> = hashes.into_iter().map(DbValue::from).collect();
+
+        let rows = self.db.lock().unwrap().query_rows(&sql, &params)?;
+        rows.iter()
+            .map(|row| row.get_str(0))
             .collect()
     }
 
@@ -97,41 +95,42 @@ impl NxTaskHistory {
         &self,
         targets: Vec<TaskTarget>,
     ) -> anyhow::Result<HashMap<String, f64>> {
-        let values = Rc::new(
-            targets
-                .iter()
-                .map(|t| {
-                    Value::from(match &t.configuration {
-                        Some(configuration) => {
-                            format!("{}:{}:{}", t.project, t.target, configuration)
-                        }
-                        _ => format!("{}:{}", t.project, t.target),
-                    })
-                })
-                .collect::<Vec<Value>>(),
-        );
+        if targets.is_empty() {
+            return Ok(HashMap::new());
+        }
 
-        // for older query sql version, need to select:  (project || ':' || target || (CASE WHEN coalesce(configuration, '') <> '' THEN ':' || configuration ELSE '' END)) AS target_string,
-        self.db
-            .lock()
-            .unwrap()
-            .prepare(
-                "
-                SELECT
-                    CONCAT_WS(':', project, target, configuration) AS target_string,
-                    AVG(end - start) AS duration
-                    FROM task_history
-                        JOIN task_details ON task_history.hash = task_details.hash
-                    WHERE target_string in rarray(?1) AND status = 'success'
-                    GROUP BY target_string
-                ",
-            )?
-            .query_map([values], |row| {
-                let target_string: String = row.get(0)?;
-                let duration: f64 = row.get(1)?;
-                Ok((target_string, duration))
-            })?
-            .map(|r| r.map_err(anyhow::Error::from))
-            .collect()
+        let target_strings: Vec<String> = targets
+            .iter()
+            .map(|t| match &t.configuration {
+                Some(configuration) => {
+                    format!("{}:{}:{}", t.project, t.target, configuration)
+                }
+                _ => format!("{}:{}", t.project, t.target),
+            })
+            .collect();
+
+        // Use IN (?,?,?) with dynamic placeholders instead of rarray
+        let placeholders: Vec<String> =
+            (1..=target_strings.len()).map(|i| format!("?{}", i)).collect();
+        let sql = format!(
+            "SELECT
+                CONCAT_WS(':', project, target, configuration) AS target_string,
+                AVG(end - start) AS duration
+                FROM task_history
+                    JOIN task_details ON task_history.hash = task_details.hash
+                WHERE target_string IN ({}) AND status = 'success'
+                GROUP BY target_string",
+            placeholders.join(", ")
+        );
+        let params: Vec<DbValue> = target_strings.into_iter().map(DbValue::from).collect();
+
+        let rows = self.db.lock().unwrap().query_rows(&sql, &params)?;
+        let mut result = HashMap::new();
+        for row in &rows {
+            let target_string = row.get_str(0)?;
+            let duration = row.get_f64(1)?;
+            result.insert(target_string, duration);
+        }
+        Ok(result)
     }
 }

--- a/packages/nx/src/native/telemetry/mod.rs
+++ b/packages/nx/src/native/telemetry/mod.rs
@@ -241,12 +241,14 @@ fn get_or_create_session_id(connection: &External<Arc<Mutex<NxDbConnection>>>) -
                  AND (strftime('%s', 'now') - strftime('%s', m2.value)) < {}",
                 SESSION_TIMEOUT_SECS as i64
             ),
-            [],
-            |row| row.get::<_, String>(0),
+            &[],
         )
         .map_err(|e| Error::from_reason(format!("Failed to query session: {}", e)))?;
 
-    let session_id = if let Some(id) = active_session {
+    let session_id = if let Some(row) = active_session {
+        let id = row
+            .get_str(0)
+            .map_err(|e| Error::from_reason(format!("Failed to read session ID: {}", e)))?;
         tracing::trace!("Reusing existing analytics session: {}", id);
         id
     } else {

--- a/packages/nx/src/native/telemetry/service.rs
+++ b/packages/nx/src/native/telemetry/service.rs
@@ -409,16 +409,17 @@ pub(crate) fn persist_session_to_db(
     conn: &mut crate::native::db::connection::NxDbConnection,
     session_id: &str,
 ) {
+    use crate::native::db::connection::DbValue;
     let _ = (|| -> anyhow::Result<()> {
         conn.begin_transaction()?;
         conn.execute(
             "INSERT OR REPLACE INTO metadata (key, value) VALUES ('SESSION_ID', ?1)",
-            [session_id],
+            &[DbValue::from(session_id)],
         )?;
         conn.execute(
             "INSERT OR REPLACE INTO metadata (key, value) \
              VALUES ('SESSION_LAST_ACTIVITY', datetime('now'))",
-            [],
+            &[],
         )?;
         conn.commit_transaction()?;
         Ok(())

--- a/packages/nx/src/native/telemetry/service.rs
+++ b/packages/nx/src/native/telemetry/service.rs
@@ -409,19 +409,20 @@ pub(crate) fn persist_session_to_db(
     conn: &mut crate::native::db::connection::NxDbConnection,
     session_id: &str,
 ) {
-    let sid = session_id.to_string();
-    let _ = conn.transaction(move |tx| {
-        tx.execute(
+    let _ = (|| -> anyhow::Result<()> {
+        conn.begin_transaction()?;
+        conn.execute(
             "INSERT OR REPLACE INTO metadata (key, value) VALUES ('SESSION_ID', ?1)",
-            [&sid],
+            [session_id],
         )?;
-        tx.execute(
+        conn.execute(
             "INSERT OR REPLACE INTO metadata (key, value) \
              VALUES ('SESSION_LAST_ACTIVITY', datetime('now'))",
             [],
         )?;
+        conn.commit_transaction()?;
         Ok(())
-    });
+    })();
 }
 
 /// Tracks the current session ID and refreshes it after inactivity.


### PR DESCRIPTION
## Current Behavior

Nx uses rusqlite (C SQLite bindings) with a hand-rolled retry/backoff/lock-file layer to handle SQLite concurrency across daemon, CLI, and plugin workers. Rusqlite bundles C SQLite, which blocks WASM compilation and requires a C compiler for every target platform.

## Expected Behavior

Replace rusqlite with the `turso` crate (v0.5.1) — a pure Rust SQLite rewrite. **Primary motivation: WASM support.** Turso has no C dependencies, so it can compile to WASM natively.

Secondary benefits:
- **~960 lines of workarounds removed** (retry macro, lock files, WAL negotiation, WSL1 detection, filesystem diagnostics)
- **Simpler API** — no lifetime-laden `Statement` types leaking through the codebase
- **Future MVCC option** — if Nx moves to single-daemon architecture

Uses WAL mode for multi-process access (daemon + CLI + workers sharing the same DB file).

### Files changed

| File | Change |
|------|--------|
| `Cargo.toml` | `rusqlite` → `turso` (pure Rust, no C deps, WASM-ready) |
| `connection.rs` | ~500 → ~150 lines. `turso::Connection` wrapper with `DbValue`/`DbRow` |
| `initialize.rs` | ~600 → ~130 lines. Simple open → WAL pragma → version check → create tables |
| `mod.rs` | Simplified connection setup (no lock file) |
| `cache.rs` | `DbValue` params, `query_rows()` instead of `prepare()+query_map()` |
| `task_history.rs` | `rarray()` → `IN (?,?,?)`, `DbValue` params |
| `details.rs` | `begin/commit_transaction()` |
| `running_tasks_service.rs` | `DbValue` params |
| `telemetry/service.rs`, `telemetry/mod.rs` | `DbValue` params, `DbRow` results |

### Known limitations (spike)

- `turso` crate is beta (v0.5.1)
- No busy handler — if SQLITE_BUSY occurs under WAL, there's no retry (may need a simpler version for edge cases)
- `DbValue`/`DbRow` wrapper types could be simplified to use turso types directly
- Extra tokio runtime per connection (bridging turso's async API to NAPI's sync boundary)

## Related Issue(s)

Spike — no issue linked.