### PR TITLE
docs(misc): replace cloud onboarding with CNW in tutorials

### DIFF
--- a/astro-docs/netlify.toml
+++ b/astro-docs/netlify.toml
@@ -54,6 +54,10 @@ to = "/docs/guides/adopting-nx/adding-to-monorepo"
 from = "/docs/technologies/angular/migration/angular-multiple"
 to = "/docs/technologies/angular/migration/angular"
 
+[[redirects]]
+from = "/docs/getting-started/nx-cloud"
+to = "/docs/features/ci-features"
+
 # Rewrite for base path handling (keeps URL the same)
 [[redirects]]
 from = "/docs/*"

--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -20,44 +20,44 @@ export interface SidebarTab {
 
 const learnGroups: SidebarItems = [
   {
-    label: 'Getting Started',
+    label: 'Getting started',
     collapsed: false,
     items: [
       { label: 'Intro to Nx', link: 'getting-started/intro' },
       { label: 'Installation', link: 'getting-started/installation' },
       {
-        label: 'Start a New Project',
+        label: 'Start a new project',
         link: 'getting-started/start-new-project',
       },
       {
-        label: 'Add to Existing Project',
+        label: 'Add to existing project',
         link: 'getting-started/start-with-existing-project',
       },
-      { label: 'Editor Setup', link: 'getting-started/editor-setup' },
-      { label: 'AI Integrations', link: 'getting-started/ai-setup' },
-      {
-        label: 'Nx Cloud',
-        link: 'getting-started/nx-cloud',
-      },
+      { label: 'AI integrations', link: 'getting-started/ai-setup' },
+      { label: 'Editor setup', link: 'getting-started/editor-setup' },
       {
         label: 'Tutorials',
-        collapsed: true,
+        collapsed: false,
         items: [
           {
-            label: 'Angular Monorepo',
-            link: 'getting-started/tutorials/angular-monorepo-tutorial',
-          },
-          {
-            label: 'Gradle Monorepo',
-            link: 'getting-started/tutorials/gradle-tutorial',
-          },
-          {
-            label: 'React Monorepo',
+            label: 'React monorepo',
             link: 'getting-started/tutorials/react-monorepo-tutorial',
           },
           {
-            label: 'TypeScript Monorepo',
+            label: 'Angular monorepo',
+            link: 'getting-started/tutorials/angular-monorepo-tutorial',
+          },
+          {
+            label: 'TypeScript monorepo',
             link: 'getting-started/tutorials/typescript-packages-tutorial',
+          },
+          {
+            label: 'Gradle monorepo',
+            link: 'getting-started/tutorials/gradle-tutorial',
+          },
+          {
+            label: 'Setting up CI',
+            link: 'getting-started/tutorials/self-healing-ci-tutorial',
           },
         ],
       },
@@ -65,59 +65,59 @@ const learnGroups: SidebarItems = [
   },
 
   {
-    label: 'How Nx Works',
+    label: 'How Nx works',
     collapsed: false,
     items: [
-      { label: 'Mental Model', link: 'concepts/mental-model' },
-      { label: 'How Caching Works', link: 'concepts/how-caching-works' },
+      { label: 'Mental model', link: 'concepts/mental-model' },
+      { label: 'How caching works', link: 'concepts/how-caching-works' },
       {
-        label: 'Task Pipeline Configuration',
+        label: 'Task pipeline configuration',
         link: 'concepts/task-pipeline-configuration',
       },
       {
-        label: 'Types of Configuration',
+        label: 'Types of configuration',
         link: 'concepts/types-of-configuration',
       },
       {
-        label: 'Executors and Configurations',
+        label: 'Executors and configurations',
         link: 'concepts/executors-and-configurations',
       },
-      { label: 'Nx Plugins', link: 'concepts/nx-plugins' },
-      { label: 'Inferred Tasks', link: 'concepts/inferred-tasks' },
+      { label: 'Nx plugins', link: 'concepts/nx-plugins' },
+      { label: 'Inferred tasks', link: 'concepts/inferred-tasks' },
       {
-        label: 'Building Blocks of Fast CI',
+        label: 'Building blocks of fast CI',
         link: 'concepts/ci-concepts/building-blocks-fast-ci',
       },
       {
-        label: 'Parallelization and Distribution',
+        label: 'Parallelization and distribution',
         link: 'concepts/ci-concepts/parallelization-distribution',
       },
       { label: 'Nx Daemon', link: 'concepts/nx-daemon' },
       {
-        label: 'Synthetic Monorepos',
+        label: 'Synthetic monorepos',
         link: 'concepts/synthetic-monorepos',
       },
     ],
   },
   {
-    label: 'Platform Features',
+    label: 'Platform features',
     collapsed: false,
     items: [
-      { label: 'Run Tasks', link: 'features/run-tasks' },
+      { label: 'Run tasks', link: 'features/run-tasks' },
       {
-        label: 'Cache Task Results',
+        label: 'Cache task results',
         link: 'features/cache-task-results',
       },
-      { label: 'Enhance Your LLM', link: 'features/enhance-ai' },
+      { label: 'Enhance your LLM', link: 'features/enhance-ai' },
       {
-        label: 'Code Organization',
+        label: 'Code organization',
         collapsed: true,
         items: [
-          { label: 'Explore Graph', link: 'features/explore-graph' },
-          { label: 'Generate Code', link: 'features/generate-code' },
-          { label: 'Sync Generators', link: 'concepts/sync-generators' },
+          { label: 'Explore graph', link: 'features/explore-graph' },
+          { label: 'Generate code', link: 'features/generate-code' },
+          { label: 'Sync generators', link: 'concepts/sync-generators' },
           {
-            label: 'Enforce Module Boundaries',
+            label: 'Enforce module boundaries',
             collapsed: true,
             items: [
               {
@@ -125,19 +125,19 @@ const learnGroups: SidebarItems = [
                 link: 'features/enforce-module-boundaries',
               },
               {
-                label: 'Ban Dependencies with Tags',
+                label: 'Ban dependencies with tags',
                 link: 'guides/enforce-module-boundaries/ban-dependencies-with-tags',
               },
               {
-                label: 'Ban External Imports',
+                label: 'Ban external imports',
                 link: 'guides/enforce-module-boundaries/ban-external-imports',
               },
               {
-                label: 'Tag Multiple Dimensions',
+                label: 'Tag multiple dimensions',
                 link: 'guides/enforce-module-boundaries/tag-multiple-dimensions',
               },
               {
-                label: 'Tags Allow List',
+                label: 'Tags allow list',
                 link: 'guides/enforce-module-boundaries/tags-allow-list',
               },
             ],
@@ -148,42 +148,46 @@ const learnGroups: SidebarItems = [
         label: 'Orchestration & CI',
         collapsed: true,
         items: [
+          {
+            label: 'Overview',
+            link: 'features/ci-features',
+          },
           { label: 'Affected', link: 'features/ci-features/affected' },
           {
-            label: 'Remote Cache (Nx Replay)',
+            label: 'Remote cache (Nx Replay)',
             link: 'features/ci-features/remote-cache',
           },
           {
-            label: 'Self-Healing CI',
+            label: 'Self-healing CI',
             link: 'features/ci-features/self-healing-ci',
           },
-          { label: 'Flaky Tasks', link: 'features/ci-features/flaky-tasks' },
+          { label: 'Flaky tasks', link: 'features/ci-features/flaky-tasks' },
           {
-            label: 'Distribute Task Execution (Nx Agents)',
+            label: 'Distribute task execution (Nx Agents)',
             link: 'features/ci-features/distribute-task-execution',
           },
           {
-            label: 'Split E2E Tasks',
+            label: 'Split E2E tasks',
             link: 'features/ci-features/split-e2e-tasks',
           },
           {
-            label: 'Dynamically Allocate Agents',
+            label: 'Dynamically allocate agents',
             link: 'features/ci-features/dynamic-agents',
           },
           {
-            label: 'CI Resource Usage',
+            label: 'CI resource usage',
             link: 'guides/nx-cloud/ci-resource-usage',
           },
           {
-            label: 'Optimize Your TTG',
+            label: 'Optimize your TTG',
             link: 'guides/nx-cloud/optimize-your-ttg',
           },
           {
-            label: 'Record Commands',
+            label: 'Record commands',
             link: 'guides/nx-cloud/record-commands',
           },
           {
-            label: 'GitHub Integration',
+            label: 'GitHub integration',
             link: 'features/ci-features/github-integration',
           },
           {
@@ -192,68 +196,68 @@ const learnGroups: SidebarItems = [
             badge: 'New',
           },
           {
-            label: 'CIPE Affected Project Graph',
+            label: 'CIPE affected project graph',
             link: 'guides/nx-cloud/cipe-affected-project-graph',
           },
           { label: 'Encryption', link: 'guides/nx-cloud/encryption' },
-          { label: 'Google Auth', link: 'guides/nx-cloud/google-auth' },
+          { label: 'Google auth', link: 'guides/nx-cloud/google-auth' },
         ],
       },
       {
-        label: 'Release & Publishing',
+        label: 'Release & publishing',
         collapsed: true,
         items: [
-          { label: 'Nx Release Overview', link: 'features/manage-releases' },
+          { label: 'Nx Release overview', link: 'features/manage-releases' },
           {
             label: 'Publish in CI/CD',
             link: 'guides/nx-release/publish-in-ci-cd',
           },
           {
-            label: 'Automatic Versioning with Conventional Commits',
+            label: 'Automatic versioning with conventional commits',
             link: 'guides/nx-release/automatically-version-with-conventional-commits',
           },
           {
-            label: 'Customize Conventional Commit Types',
+            label: 'Customize conventional commit types',
             link: 'guides/nx-release/customize-conventional-commit-types',
           },
           {
-            label: 'Configure Changelog Format',
+            label: 'Configure changelog format',
             link: 'guides/nx-release/configure-changelog-format',
           },
           {
-            label: 'Configure Custom Registries',
+            label: 'Configure custom registries',
             link: 'guides/nx-release/configure-custom-registries',
           },
           {
-            label: 'Configure Version Prefix',
+            label: 'Configure version prefix',
             link: 'guides/nx-release/configuration-version-prefix',
           },
           {
-            label: 'File-Based Versioning (Version Plans)',
+            label: 'File-based versioning (version plans)',
             link: 'guides/nx-release/file-based-versioning-version-plans',
           },
           {
-            label: 'Release Groups',
+            label: 'Release groups',
             link: 'guides/nx-release/release-groups',
           },
           {
-            label: 'Release Projects Independently',
+            label: 'Release projects independently',
             link: 'guides/nx-release/release-projects-independently',
           },
           {
-            label: 'Build Before Versioning',
+            label: 'Build before versioning',
             link: 'guides/nx-release/build-before-versioning',
           },
           {
-            label: 'Update Dependents',
+            label: 'Update dependents',
             link: 'guides/nx-release/update-dependents',
           },
           {
-            label: 'Updating Version References',
+            label: 'Updating version references',
             link: 'guides/nx-release/updating-version-references',
           },
           {
-            label: 'Update Local Registry Setup',
+            label: 'Update local registry setup',
             link: 'guides/nx-release/update-local-registry-setup',
           },
           {
@@ -267,23 +271,23 @@ const learnGroups: SidebarItems = [
         collapsed: true,
         items: [
           {
-            label: 'Nx Console Migration Assistance',
+            label: 'Nx Console migration assistance',
             link: 'guides/nx-console/console-migrate-ui',
           },
           {
-            label: 'Advanced Update Process',
+            label: 'Advanced update process',
             link: 'guides/tips-n-tricks/advanced-update',
           },
           {
-            label: 'Automate Importing Projects',
+            label: 'Automate importing projects',
             link: 'guides/adopting-nx/import-project',
           },
           {
-            label: 'Manual Migrations',
+            label: 'Manual migrations',
             link: 'guides/adopting-nx/manual',
           },
           {
-            label: 'Preserving Git Histories',
+            label: 'Preserving Git histories',
             link: 'guides/adopting-nx/preserving-git-histories',
           },
           {
@@ -302,23 +306,23 @@ const learnGroups: SidebarItems = [
         items: [
           { label: 'Conformance', link: 'enterprise/conformance' },
           {
-            label: 'Configure Conformance Rules in Nx Cloud',
+            label: 'Configure conformance rules in Nx Cloud',
             link: 'enterprise/configure-conformance-rules-in-nx-cloud',
           },
           {
-            label: 'Publish Conformance Rules to Nx Cloud',
+            label: 'Publish conformance rules to Nx Cloud',
             link: 'enterprise/publish-conformance-rules-to-nx-cloud',
           },
           { label: 'Owners', link: 'enterprise/owners' },
           { label: 'Polygraph', link: 'enterprise/polygraph' },
-          { label: 'Custom Workflows', link: 'enterprise/custom-workflows' },
+          { label: 'Custom workflows', link: 'enterprise/custom-workflows' },
           {
-            label: 'Metadata Only Workspace',
+            label: 'Metadata only workspace',
             link: 'enterprise/metadata-only-workspace',
           },
-          { label: 'Activate License', link: 'enterprise/activate-license' },
+          { label: 'Activate license', link: 'enterprise/activate-license' },
           {
-            label: 'Single Tenant',
+            label: 'Single tenant',
             collapsed: true,
             items: [
               {
@@ -342,7 +346,7 @@ const learnGroups: SidebarItems = [
                 link: 'enterprise/single-tenant/auth-bitbucket-data-center',
               },
               {
-                label: 'Custom GitHub App',
+                label: 'Custom GitHub app',
                 link: 'enterprise/single-tenant/custom-github-app',
               },
               {
@@ -356,7 +360,7 @@ const learnGroups: SidebarItems = [
             ],
           },
           {
-            label: 'Conformance Reference',
+            label: 'Conformance reference',
             collapsed: true,
             items: [
               {
@@ -364,11 +368,11 @@ const learnGroups: SidebarItems = [
                 link: 'reference/conformance/overview',
               },
               {
-                label: 'Create Conformance Rule',
+                label: 'Create conformance rule',
                 link: 'reference/conformance/create-conformance-rule',
               },
               {
-                label: 'Test Conformance Rule',
+                label: 'Test conformance rule',
                 link: 'reference/conformance/test-conformance-rule',
               },
               {
@@ -382,7 +386,7 @@ const learnGroups: SidebarItems = [
             ],
           },
           {
-            label: 'Enterprise Release Notes',
+            label: 'Enterprise release notes',
             link: 'reference/nx-cloud/release-notes',
           },
         ],
@@ -393,11 +397,11 @@ const learnGroups: SidebarItems = [
 
 const technologiesGroups: SidebarItems = [
   {
-    label: 'Technologies & Tools',
+    label: 'Technologies & tools',
     collapsed: true,
     items: [
       {
-        label: 'Frameworks & Libraries',
+        label: 'Frameworks & libraries',
         collapsed: false,
         items: [
           {
@@ -453,7 +457,7 @@ const technologiesGroups: SidebarItems = [
         ],
       },
       {
-        label: 'Build Tools',
+        label: 'Build tools',
         collapsed: false,
         items: [
           {
@@ -483,7 +487,7 @@ const technologiesGroups: SidebarItems = [
         ],
       },
       {
-        label: 'Test Tools',
+        label: 'Test tools',
         collapsed: false,
         items: [
           {
@@ -513,7 +517,7 @@ const technologiesGroups: SidebarItems = [
         ],
       },
       {
-        label: 'Plugin Registry',
+        label: 'Plugin registry',
         link: 'plugin-registry',
       },
     ],
@@ -522,7 +526,7 @@ const technologiesGroups: SidebarItems = [
 
 const knowledgeBaseGroups: SidebarItems = [
   {
-    label: 'Knowledge Base',
+    label: 'Knowledge base',
     collapsed: true,
     items: [
       {
@@ -530,35 +534,35 @@ const knowledgeBaseGroups: SidebarItems = [
         collapsed: true,
         items: [
           {
-            label: 'CI Execution Failed',
+            label: 'CI execution failed',
             link: 'troubleshooting/ci-execution-failed',
           },
           {
-            label: 'Unknown Local Cache Error',
+            label: 'Unknown local cache error',
             link: 'troubleshooting/unknown-local-cache',
           },
           {
-            label: 'Troubleshoot Convert to Inferred',
+            label: 'Troubleshoot convert to inferred',
             link: 'troubleshooting/troubleshoot-convert-to-inferred',
           },
           {
-            label: 'Profiling Performance',
+            label: 'Profiling performance',
             link: 'troubleshooting/performance-profiling',
           },
           {
-            label: 'Troubleshoot Nx Console Issues',
+            label: 'Troubleshoot Nx Console issues',
             link: 'troubleshooting/console-troubleshooting',
           },
           {
-            label: 'Troubleshoot Cache Misses',
+            label: 'Troubleshoot cache misses',
             link: 'troubleshooting/troubleshoot-cache-misses',
           },
           {
-            label: 'Troubleshoot Nx Installations',
+            label: 'Troubleshoot Nx installations',
             link: 'troubleshooting/troubleshoot-nx-install-issues',
           },
           {
-            label: 'Resolve Circular Dependencies',
+            label: 'Resolve circular dependencies',
             link: 'troubleshooting/resolve-circular-dependencies',
           },
         ],
@@ -568,11 +572,11 @@ const knowledgeBaseGroups: SidebarItems = [
         collapsed: true,
         items: [
           {
-            label: 'Include All package.json Files',
+            label: 'Include all package.json files',
             link: 'guides/tips-n-tricks/include-all-packagejson',
           },
           {
-            label: 'Disable Graph Links from Source Analysis',
+            label: 'Disable graph links from source analysis',
             link: 'guides/tips-n-tricks/analyze-source-files',
           },
           {
@@ -580,57 +584,57 @@ const knowledgeBaseGroups: SidebarItems = [
             link: 'guides/tips-n-tricks/yarn-pnp',
           },
           {
-            label: 'Identify Dependencies Between Folders',
+            label: 'Identify dependencies between folders',
             link: 'guides/tips-n-tricks/identify-dependencies-between-folders',
           },
           {
-            label: 'Feature-Based Testing',
+            label: 'Feature-based testing',
             link: 'guides/tips-n-tricks/feature-based-testing',
           },
           {
-            label: 'Configuring Browser Support',
+            label: 'Configuring browser support',
             link: 'guides/tips-n-tricks/browser-support',
           },
           {
-            label: 'Define Environment Variables',
+            label: 'Define environment variables',
             link: 'guides/tips-n-tricks/define-environment-variables',
           },
           {
-            label: 'Including Assets in Your Build',
+            label: 'Including assets in your build',
             link: 'guides/tips-n-tricks/include-assets-in-build',
           },
           {
-            label: 'Keep Nx Versions in Sync',
+            label: 'Keep Nx versions in sync',
             link: 'guides/tips-n-tricks/keep-nx-versions-in-sync',
           },
           {
-            label: 'Standalone to Monorepo',
+            label: 'Standalone to monorepo',
             link: 'guides/tips-n-tricks/standalone-to-monorepo',
           },
         ],
       },
       {
-        label: 'Creating Releases',
+        label: 'Creating releases',
         collapsed: true,
         items: [
           {
-            label: 'Release NPM Packages',
+            label: 'Release NPM packages',
             link: 'guides/nx-release/release-npm-packages',
           },
           {
-            label: 'Release Rust Crates',
+            label: 'Release Rust crates',
             link: 'guides/nx-release/publish-rust-crates',
           },
           {
-            label: 'Release Docker Images',
+            label: 'Release Docker images',
             link: 'guides/nx-release/release-docker-images',
           },
           {
-            label: 'Automate GitHub Releases',
+            label: 'Automate GitHub releases',
             link: 'guides/nx-release/automate-github-releases',
           },
           {
-            label: 'Automate GitLab Releases',
+            label: 'Automate GitLab releases',
             link: 'guides/nx-release/automate-gitlab-releases',
           },
         ],
@@ -644,19 +648,19 @@ const knowledgeBaseGroups: SidebarItems = [
             link: 'guides/nx-console/console-telemetry',
           },
           {
-            label: 'Run Command',
+            label: 'Run command',
             link: 'guides/nx-console/console-run-command',
           },
           {
-            label: 'Nx Cloud Integration',
+            label: 'Nx Cloud integration',
             link: 'guides/nx-console/console-nx-cloud',
           },
           {
-            label: 'Generate Command',
+            label: 'Generate command',
             link: 'guides/nx-console/console-generate-command',
           },
           {
-            label: 'Project Details View',
+            label: 'Project details view',
             link: 'guides/nx-console/console-project-details',
           },
           {
@@ -670,45 +674,45 @@ const knowledgeBaseGroups: SidebarItems = [
         collapsed: true,
         items: [
           {
-            label: 'Install Nx in Non-JavaScript Repo',
+            label: 'Install Nx in non-JavaScript repo',
             link: 'guides/installation/install-non-javascript',
           },
           {
-            label: 'Update Global Installation',
+            label: 'Update global installation',
             link: 'guides/installation/update-global-installation',
           },
         ],
       },
       {
-        label: 'Organizational Decisions',
+        label: 'Organizational decisions',
         collapsed: true,
         items: [
           {
-            label: 'Why Monorepos',
+            label: 'Why monorepos',
             link: 'concepts/decisions/why-monorepos',
           },
           {
-            label: 'Monorepo or Polyrepo',
+            label: 'Monorepo or polyrepo',
             link: 'concepts/decisions/overview',
           },
           {
-            label: 'Dependency Management',
+            label: 'Dependency management',
             link: 'concepts/decisions/dependency-management',
           },
           {
-            label: 'Folder Structure',
+            label: 'Folder structure',
             link: 'concepts/decisions/folder-structure',
           },
           {
-            label: 'Project Size',
+            label: 'Project size',
             link: 'concepts/decisions/project-size',
           },
           {
-            label: 'Code Ownership',
+            label: 'Code ownership',
             link: 'concepts/decisions/code-ownership',
           },
           {
-            label: 'Project Dependency Rules',
+            label: 'Project dependency rules',
             link: 'concepts/decisions/project-dependency-rules',
           },
         ],
@@ -718,177 +722,177 @@ const knowledgeBaseGroups: SidebarItems = [
         collapsed: true,
         items: [
           { label: 'Intro', link: 'extending-nx/intro' },
-          { label: 'Local Generators', link: 'extending-nx/local-generators' },
+          { label: 'Local generators', link: 'extending-nx/local-generators' },
           {
-            label: 'Composing Generators',
+            label: 'Composing generators',
             link: 'extending-nx/composing-generators',
           },
           {
-            label: 'Creating Files',
+            label: 'Creating files',
             link: 'extending-nx/creating-files',
           },
           {
-            label: 'Modifying Files',
+            label: 'Modifying files',
             link: 'extending-nx/modifying-files',
           },
           {
-            label: 'Migration Generators',
+            label: 'Migration generators',
             link: 'extending-nx/migration-generators',
           },
           {
-            label: 'Create Sync Generator',
+            label: 'Create sync generator',
             link: 'extending-nx/create-sync-generator',
           },
-          { label: 'Local Executors', link: 'extending-nx/local-executors' },
+          { label: 'Local executors', link: 'extending-nx/local-executors' },
           {
-            label: 'Compose Executors',
+            label: 'Compose executors',
             link: 'extending-nx/compose-executors',
           },
           {
-            label: 'Task Running Lifecycle',
+            label: 'Task running lifecycle',
             link: 'extending-nx/task-running-lifecycle',
           },
           {
-            label: 'Project Graph Plugins',
+            label: 'Project graph plugins',
             link: 'extending-nx/project-graph-plugins',
           },
           {
-            label: 'CreateNodes Compatibility',
+            label: 'CreateNodes compatibility',
             link: 'extending-nx/createnodes-compatibility',
           },
           {
-            label: 'Organization-Specific Plugin',
+            label: 'Organization-specific plugin',
             link: 'extending-nx/organization-specific-plugin',
           },
           {
-            label: 'Tooling Plugin',
+            label: 'Tooling plugin',
             link: 'extending-nx/tooling-plugin',
           },
           {
-            label: 'Custom Plugin Preset',
+            label: 'Custom plugin preset',
             link: 'extending-nx/create-preset',
           },
           {
-            label: 'Creating an Install Package',
+            label: 'Creating an install package',
             link: 'extending-nx/create-install-package',
           },
           {
-            label: 'Publish Your Plugin',
+            label: 'Publish your plugin',
             link: 'extending-nx/publish-plugin',
           },
         ],
       },
       {
-        label: 'Continuous Integration',
+        label: 'Continuous integration',
         collapsed: true,
         items: [
           { label: 'Setup CI', link: 'guides/nx-cloud/setup-ci' },
-          { label: 'Access Tokens', link: 'guides/nx-cloud/access-tokens' },
+          { label: 'Access tokens', link: 'guides/nx-cloud/access-tokens' },
           {
-            label: 'Personal Access Tokens',
+            label: 'Personal access tokens',
             link: 'guides/nx-cloud/personal-access-tokens',
           },
           { label: 'Manual DTE', link: 'guides/nx-cloud/manual-dte' },
           {
-            label: 'Source Control Integration',
+            label: 'Source control integration',
             link: 'guides/nx-cloud/source-control-integration',
           },
           {
-            label: 'Set Up CI with Bun',
+            label: 'Set up CI with Bun',
             link: 'guides/nx-cloud/use-bun',
           },
           {
-            label: 'GitHub App Permissions',
+            label: 'GitHub app permissions',
             link: 'guides/nx-cloud/source-control-integration/github-app-permissions',
           },
           {
-            label: 'Configuring the Cloud Runner',
+            label: 'Configuring the cloud runner',
             link: 'reference/nx-cloud/config',
           },
           {
-            label: 'Custom Images',
+            label: 'Custom images',
             link: 'reference/nx-cloud/custom-images',
           },
           {
-            label: 'Assignment Rules',
+            label: 'Assignment rules',
             link: 'reference/nx-cloud/assignment-rules',
           },
           {
-            label: 'Custom Steps',
+            label: 'Custom steps',
             link: 'reference/nx-cloud/custom-steps',
           },
           {
-            label: 'Launch Templates',
+            label: 'Launch templates',
             link: 'reference/nx-cloud/launch-templates',
           },
           {
-            label: 'Reduce Waste in CI',
+            label: 'Reduce waste in CI',
             link: 'concepts/ci-concepts/reduce-waste',
           },
           {
-            label: 'Cache Security',
+            label: 'Cache security',
             link: 'concepts/ci-concepts/cache-security',
           },
           {
-            label: 'Heartbeat and Manual Shutdown Handling',
+            label: 'Heartbeat and manual shutdown handling',
             link: 'concepts/ci-concepts/heartbeat-and-manual-shutdown-handling',
           },
         ],
       },
       {
-        label: 'Tasks & Caching',
+        label: 'Tasks & caching',
         collapsed: true,
         items: [
           {
-            label: 'Configure Inputs',
+            label: 'Configure inputs',
             link: 'guides/tasks--caching/configure-inputs',
           },
           {
-            label: 'Configure Outputs',
+            label: 'Configure outputs',
             link: 'guides/tasks--caching/configure-outputs',
           },
           {
-            label: 'Defining Task Pipeline',
+            label: 'Defining task pipeline',
             link: 'guides/tasks--caching/defining-task-pipeline',
           },
           {
-            label: 'Run Tasks in Parallel',
+            label: 'Run tasks in parallel',
             link: 'guides/tasks--caching/run-tasks-in-parallel',
           },
           {
-            label: 'Pass Args to Commands',
+            label: 'Pass args to commands',
             link: 'guides/tasks--caching/pass-args-to-commands',
           },
           {
-            label: 'Run Commands Executor',
+            label: 'Run commands executor',
             link: 'guides/tasks--caching/run-commands-executor',
           },
           {
-            label: 'Reduce Repetitive Configuration',
+            label: 'Reduce repetitive configuration',
             link: 'guides/tasks--caching/reduce-repetitive-configuration',
           },
           {
-            label: 'Root Level Scripts',
+            label: 'Root level scripts',
             link: 'guides/tasks--caching/root-level-scripts',
           },
           {
-            label: 'Convert to Inferred',
+            label: 'Convert to inferred',
             link: 'guides/tasks--caching/convert-to-inferred',
           },
           {
-            label: 'Change Cache Location',
+            label: 'Change cache location',
             link: 'guides/tasks--caching/change-cache-location',
           },
           {
-            label: 'Self-Hosted Caching',
+            label: 'Self-hosted caching',
             link: 'guides/tasks--caching/self-hosted-caching',
           },
           {
-            label: 'Skipping Cache',
+            label: 'Skipping cache',
             link: 'guides/tasks--caching/skipping-cache',
           },
           {
-            label: 'Workspace Watching',
+            label: 'Workspace watching',
             link: 'guides/tasks--caching/workspace-watching',
           },
           { label: 'Terminal UI', link: 'guides/tasks--caching/terminal-ui' },
@@ -899,15 +903,15 @@ const knowledgeBaseGroups: SidebarItems = [
         collapsed: true,
         items: [
           {
-            label: 'Nx Agents at Scale',
+            label: 'Nx Agents at scale',
             link: 'reference/benchmarks/nx-agents',
           },
           {
-            label: 'Large Next.js Apps with Caching',
+            label: 'Large Next.js apps with caching',
             link: 'reference/benchmarks/caching',
           },
           {
-            label: 'TSC Batch Mode',
+            label: 'TSC batch mode',
             link: 'reference/benchmarks/tsc-batch-mode',
           },
         ],
@@ -917,16 +921,16 @@ const knowledgeBaseGroups: SidebarItems = [
         collapsed: true,
         items: [
           {
-            label: 'Maintain TypeScript Monorepos',
+            label: 'Maintain TypeScript monorepos',
             link: 'features/maintain-typescript-monorepos',
           },
           ...getTechnologyKBItems('typescript'),
           {
-            label: 'Buildable and Publishable Libraries',
+            label: 'Buildable and publishable libraries',
             link: 'concepts/buildable-and-publishable-libraries',
           },
           {
-            label: 'TypeScript Project Linking',
+            label: 'TypeScript project linking',
             link: 'concepts/typescript-project-linking',
           },
         ],
@@ -1016,19 +1020,19 @@ const referenceGroups: SidebarItems = [
     items: [
       { label: 'nx.json', link: 'reference/nx-json' },
       {
-        label: 'Project Configuration',
+        label: 'Project configuration',
         link: 'reference/project-configuration',
       },
       { label: 'Inputs', link: 'reference/inputs' },
       {
-        label: 'Environment Variables',
+        label: 'Environment variables',
         link: 'reference/environment-variables',
       },
       { label: 'nxignore', link: 'reference/nxignore' },
       { label: 'Glossary', link: 'reference/glossary' },
       { label: 'Releases', link: 'reference/releases' },
       { label: 'Nx MCP', link: 'reference/nx-mcp' },
-      { label: 'Nx Console Settings', link: 'reference/nx-console-settings' },
+      { label: 'Nx Console settings', link: 'reference/nx-console-settings' },
       { label: 'Nx Cloud CLI', link: 'reference/nx-cloud-cli' },
       { label: 'Telemetry', link: 'reference/telemetry' },
       {
@@ -1173,11 +1177,11 @@ const referenceGroups: SidebarItems = [
         items: [...getTechnologyAPIItems('vitest', 'test-tools')],
       },
       {
-        label: 'Nx Cloud Credit Pricing',
+        label: 'Nx Cloud credit pricing',
         link: 'reference/nx-cloud/credits-pricing',
       },
       {
-        label: 'Remote Cache Plugins',
+        label: 'Remote cache plugins',
         link: 'reference/remote-cache-plugins',
       },
       {

--- a/astro-docs/src/content/docs/features/CI Features/index.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/index.mdoc
@@ -1,9 +1,51 @@
 ---
-title: CI Features
+title: Orchestration & CI with Nx Cloud
 sidebar:
   hidden: true
-description: Continuous Integration features in Nx
-pagefind: false
+description: Speed up CI, reduce costs, and eliminate flakiness with Nx Cloud's task-based CI execution model.
+filter: 'type:Features'
 ---
 
+{% youtube src="https://www.youtube.com/watch?v=cDBihpB3SbI" title="Nx and Nx Cloud" width="100%" /%}
+
+CI is challenging and it's **not your fault**. It's a fundamental issue with how the current, traditional CI execution model works. Nx Cloud adopts a new **task-based** CI model that overcomes slowness and unreliability of the current VM-based CI model.
+
+Nx Cloud improves many aspects of the CI/CD process:
+
+- **Speed** - 30% - 70% faster CI (based on reports from our clients)
+- **Cost** - 40% - 75% reduction in CI costs (observed on the Nx OSS monorepo)
+- **Reliability** - by automatically identifying flaky tasks (e2e tests in particular) and re-running them
+
+## Connect your workspace to Nx Cloud
+
+Run the following command in your Nx workspace (make sure you have it pushed to a remote repository first):
+
+```shell
+npx nx connect
+```
+
+This connects your workspace to Nx Cloud and enables remote caching and CI features. For more details, [follow our in-depth guide](/docs/guides/nx-cloud/setup-ci) for setting up CI with Nx.
+
+## How Nx Cloud improves CI
+
+In traditional CI models, work is statically assigned to CI machines. This creates inefficiencies that many teams experience at scale.
+
+Nx Cloud uses a **task-based approach to dynamically assign tasks** to agent machines. CI becomes scalable, maintainable, and more reliable because Nx Cloud coordinates work among agent machines automatically and acts on individual tasks directly.
+
+For example:
+
+- An agent machine fails in a setup step — Nx Cloud automatically reassigns the work to other agent machines.
+- More work needs to run in CI — add more agent machines, Nx Cloud automatically assigns available work.
+- Known flaky tasks waste CI time on needed reruns — Nx Cloud automatically detects flaky tasks and reruns them in the current CI execution.
+
+[Learn how our customers use Nx Cloud](https://nx.dev/blog?filterBy=customer+story) to scale their workspaces and be more efficient.
+
+## Nx Cloud features
+
 {% index_page_cards path="features/ci-features" /%}
+
+## Learn more
+
+- [Blog post: Reliable CI: A new execution model fixing both flakiness and slowness](https://nx.dev/blog/reliable-ci-a-new-execution-model-fixing-both-flakiness-and-slowness)
+- [Live stream: Unlock the secret of fast CI - Hands-on session](https://www.youtube.com/live/rkLKaqLeDa0)
+- [YouTube: 10x Faster e2e Tests](https://www.youtube.com/watch?v=0YxcxIR7QU0)

--- a/astro-docs/src/content/docs/features/CI Features/self-healing-ci.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/self-healing-ci.mdoc
@@ -396,4 +396,4 @@ After your CI runs, navigate to the CIPE → **Configurations** tab to see:
 
 - [Nx AI Documentation](/docs/features/enhance-ai)
 - [Nx Console Editor Setup](/docs/getting-started/editor-setup)
-- [Nx Cloud](/docs/getting-started/nx-cloud)
+- [Nx Cloud](/docs/features/ci-features)

--- a/astro-docs/src/content/docs/features/enhance-AI.mdoc
+++ b/astro-docs/src/content/docs/features/enhance-AI.mdoc
@@ -29,6 +29,10 @@ This sets up:
 - **Agent skills**: Domain-specific knowledge for monorepo workflows — workspace exploration, code generation, task execution, CI monitoring, and package linking. Skills teach agents _how_ to work with Nx rather than dumping data into context.
 - **Nx MCP server**: Provides connectivity to Nx Cloud CI pipelines, self-healing fixes, running processes, and Nx documentation — things agents can't easily reach on their own
 
+### Creating new workspaces
+
+For creating new Nx workspaces, use `npx create-nx-workspace@latest --template=nrwl/<name>-template` (e.g. `react-template`, `angular-template`, `typescript-template`). For existing projects, use `npx nx init`.
+
 ## What this enables
 
 ### Self-healing CI integration

--- a/astro-docs/src/content/docs/getting-started/Tutorials/angular-monorepo-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/angular-monorepo-tutorial.mdoc
@@ -18,65 +18,55 @@ What you'll learn:
 
 ## Prerequisite: Tutorial setup
 
-{% aside type="note" title="Prerequisites" %}
-This tutorial requires a [GitHub account](https://github.com) to demonstrate the full value of **Nx** - including task running, caching, and CI integration.
-{% /aside %}
+This tutorial requires [Node.js](https://nodejs.org) (v20.19 or later) installed on your machine.
 
 ### Step 1: Creating a new Nx Angular workspace
 
-Let's [create your workspace](https://cloud.nx.app/create-nx-workspace/angular/github) with our Angular preset to get started quickly.
+Run the following command to create a new Nx workspace with the Angular template:
 
-{% call_to_action variant="default" title="Create Angular Workspace" url="https://cloud.nx.app/create-nx-workspace/angular/github" /%}
+```shell
+npx create-nx-workspace@latest my-nx-repo --template=nrwl/angular-template
+```
+
+Or [create your workspace in the browser](https://cloud.nx.app/create-nx-workspace/angular/github) with CI pre-configured.
+
+{% llm_only %}
+IMPORTANT: Always use the CLI command above (`npx create-nx-workspace`) to create workspaces. Do NOT use the cloud.nx.app browser-based flow — it requires interactive GitHub OAuth and is not suitable for AI agents.
+{% /llm_only %}
 
 ### Step 2: verify your setup
 
-Please verify closely that you have the following setup:
-
-1. A new Nx workspace on your local machine
-2. A corresponding GitHub repository for the workspace with a `.github/workflows/ci.yml` pipeline preconfigured
-3. You completed the full Nx Cloud onboarding and you now have a Nx Cloud dashboard that is connected to your example repository on GitHub.
-
-Clone your repository to your local machine:
+Once the workspace is created, navigate into it and install dependencies:
 
 ```shell
-git clone <your-repository-url>
-cd <your-repository-name>
-```
-
-Install dependencies:
-
-```shell
+cd my-nx-repo
 npm install
 ```
-
-You should see your workspace in your [Nx Cloud organization](https://cloud.nx.app/orgs).
-
-![](../../../../assets/tutorials/connected-workspace.avif)
-
-This is important for using remote caching and self-healing in CI later in the tutorial.
 
 ## Explore the Nx workspace setup
 
 Let's take a look at the structure of our new Nx workspace:
 {%filetree%}
 
-- apps/
-  - angular-demo/
-- .github/
-- eslint.config.mjs
-- nx.json
-- package-lock.json
-- package.json
-- tsconfig.base.json
-- vitest.workspace.ts
+- my-nx-repo/
+  - apps/
+    - api/
+    - shop/
+    - shop-e2e/
+  - libs/
+    - api/
+    - shared/
+    - shop/
+  - eslint.config.mjs
+  - nx.json
+  - package-lock.json
+  - package.json
+  - tsconfig.base.json
+  - vitest.workspace.ts
 
 {%/filetree%}
 
-Here are some files that might jump to your eyes:
-
-- The `.nx` folder is where Nx stores local metadata about your workspaces using the [Nx Daemon](/docs/concepts/nx-daemon).
-- The [`nx.json` file](/docs/reference/nx-json) contains configuration settings for Nx itself and global default settings that individual projects inherit.
-- The `.github/workflows/ci.yml` file preconfigures your CI in GitHub Actions to run build and test through Nx.
+The [`nx.json` file](/docs/reference/nx-json) contains configuration settings for Nx itself and global default settings that individual projects inherit.
 
 Now, let's build some features and see how Nx helps get us to production faster.
 
@@ -85,23 +75,21 @@ Now, let's build some features and see how Nx helps get us to production faster.
 To serve your new Angular app, run:
 
 ```shell
-npx nx serve angular-demo
+npx nx serve shop
 ```
 
 The app is served at [http://localhost:4200](http://localhost:4200).
 
-Nx uses the following syntax to run tasks:
-
-![Syntax for Running Tasks in Nx](../../../../assets/getting-started/run-target-syntax.svg)
+You can also use `npx nx run shop:serve` as an alternative syntax. The `<project>:<task>` format works for any task in any project, which is useful when task names overlap with Nx commands.
 
 ### Project configuration
 
 The project tasks are defined in the `project.json` file.
 
 ```json
-// apps/angular-demo/project.json
+// apps/shop/project.json
 {
-  "name": "angular-demo",
+  "name": "shop",
   ...
   "targets": {
     "build": { ... },
@@ -119,22 +107,22 @@ Each target contains a configuration object that tells Nx how to run that target
 ```json
 // project.json
 {
-  "name": "angular-demo",
+  "name": "shop",
   ...
   "targets": {
     "serve": {
       "executor": "@angular/build:dev-server",
       "defaultConfiguration": "development",
       "options": {
-        "buildTarget": "angular-demo:build"
+        "buildTarget": "shop:build"
       },
       "configurations": {
         "development": {
-          "buildTarget": "angular-demo:build:development",
+          "buildTarget": "shop:build:development",
           "hmr": true
         },
         "production": {
-          "buildTarget": "angular-demo:build:production",
+          "buildTarget": "shop:build:production",
           "hmr": false
         }
       }
@@ -152,7 +140,7 @@ The most critical parts are:
 To view all tasks for a project, look in the [Nx Console](/docs/getting-started/editor-setup) project detail view or run:
 
 ```shell
-npx nx show project angular-demo
+npx nx show project shop
 ```
 
 {% project_details title="Project Details View (Simplified)" %}
@@ -160,26 +148,26 @@ npx nx show project angular-demo
 ```json
 {
   "project": {
-    "name": "angular-demo",
+    "name": "shop",
     "type": "app",
     "data": {
-      "root": "apps/angular-demo",
+      "root": "apps/shop",
       "targets": {
         "build": {
           "executor": "@angular/build:application",
           "outputs": ["{options.outputPath}"],
           "options": {
-            "outputPath": "dist/apps/angular-demo",
-            "browser": "apps/angular-demo/src/main.ts",
+            "outputPath": "dist/apps/shop",
+            "browser": "apps/shop/src/main.ts",
             "polyfills": ["zone.js"],
-            "tsConfig": "apps/angular-demo/tsconfig.app.json",
+            "tsConfig": "apps/shop/tsconfig.app.json",
             "assets": [
               {
                 "glob": "**/*",
-                "input": "apps/angular-demo/public"
+                "input": "apps/shop/public"
               }
             ],
-            "styles": ["apps/angular-demo/src/styles.css"]
+            "styles": ["apps/shop/src/styles.css"]
           },
           "configurations": {
             "production": {
@@ -213,14 +201,14 @@ npx nx show project angular-demo
     }
   },
   "sourceMap": {
-    "root": ["apps/angular-demo/project.json", "nx/core/project-json"],
-    "targets": ["apps/angular-demo/project.json", "nx/core/project-json"],
-    "targets.build": ["apps/angular-demo/project.json", "nx/core/project-json"],
-    "name": ["apps/angular-demo/project.json", "nx/core/project-json"],
-    "$schema": ["apps/angular-demo/project.json", "nx/core/project-json"],
-    "sourceRoot": ["apps/angular-demo/project.json", "nx/core/project-json"],
-    "projectType": ["apps/angular-demo/project.json", "nx/core/project-json"],
-    "tags": ["apps/angular-demo/project.json", "nx/core/project-json"]
+    "root": ["apps/shop/project.json", "nx/core/project-json"],
+    "targets": ["apps/shop/project.json", "nx/core/project-json"],
+    "targets.build": ["apps/shop/project.json", "nx/core/project-json"],
+    "name": ["apps/shop/project.json", "nx/core/project-json"],
+    "$schema": ["apps/shop/project.json", "nx/core/project-json"],
+    "sourceRoot": ["apps/shop/project.json", "nx/core/project-json"],
+    "projectType": ["apps/shop/project.json", "nx/core/project-json"],
+    "tags": ["apps/shop/project.json", "nx/core/project-json"]
   }
 }
 ```
@@ -233,14 +221,15 @@ When you develop your Angular application, usually all your logic sits in the ap
 
 {% filetree %}
 
-- apps/
-  - angular-demo/
-    - src/
-      - app/
-      - cart/
-      - products/
-      - orders/
-      - ui/
+- my-nx-repo/
+  - apps/
+    - shop/
+      - src/
+        - app/
+        - cart/
+        - products/
+        - orders/
+        - ui/
 
 {%/filetree %}
 
@@ -257,7 +246,7 @@ Nx allows you to separate this logic into "local libraries." The main benefits i
 Let's create a reusable design system library called `ui` that we can use across our workspace. This library will contain reusable components such as buttons, inputs, and other UI elements.
 
 ```shell
-npx nx g @nx/angular:library packages/ui --unitTestRunner=vitest
+npx nx g @nx/angular:library libs/ui --unitTestRunner=vitest
 ```
 
 Note how we type out the full path in the command to place the library into a subfolder. You can choose whatever folder structure you like to organize your projects.
@@ -266,20 +255,20 @@ Running the above command should lead to the following directory structure:
 
 {% filetree %}
 
-- apps/
-  - angular-demo/
-- packages/
-  - ui/
-- eslint.config.mjs
-- nx.json
-- package-lock.json
-- package.json
-- tsconfig.base.json
-- vitest.workspace.ts
+- my-nx-repo/
+  - apps/
+    - shop/
+  - libs/
+    - ui/
+  - eslint.config.mjs
+  - nx.json
+  - package.json
+  - tsconfig.base.json
+  - vitest.workspace.ts
 
 {%/filetree %}
 
-Just as with the `angular-demo` app, Nx automatically infers the tasks for the `ui` library from its configuration files. You can view them by running:
+Just as with the `shop` app, Nx automatically infers the tasks for the `ui` library from its configuration files. You can view them by running:
 
 ```shell
 npx nx show project ui
@@ -292,7 +281,7 @@ npx nx lint ui
 npx nx test ui
 ```
 
-### Import libraries into the demo app
+### Import libraries into the shop app
 
 All libraries that we generate are automatically included in the TypeScript path mappings configured in the root-level `tsconfig.base.json`.
 
@@ -302,7 +291,7 @@ All libraries that we generate are automatically included in the TypeScript path
   "compilerOptions": {
     ...
     "paths": {
-      "@angular-demo/ui": ["packages/ui/src/index.ts"]
+      "@org/ui": ["libs/ui/src/index.ts"]
     },
     ...
   },
@@ -314,14 +303,14 @@ Hence, we can easily import them into other libraries and our Angular applicatio
 You can see that the `Ui` component is exported via the `index.ts` file of our `ui` library so that other projects in the repository can use it. This is our public API with the rest of the workspace and is enforced by the library's build configuration. Only export what's necessary to be usable outside the library itself.
 
 ```ts
-// packages/ui/src/index.ts
+// libs/ui/src/index.ts
 export * from './lib/ui/ui';
 ```
 
-Let's add a simple `Hero` component that we can use in our demo app.
+Let's add a simple `Hero` component that we can use in our shop app.
 
 ```ts
-// packages/ui/src/lib/hero/hero.ts
+// libs/ui/src/lib/hero/hero.ts
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
@@ -382,7 +371,7 @@ export class Hero {
 Then, export it from `index.ts`.
 
 ```ts
-// packages/ui/src/index.ts
+// libs/ui/src/index.ts
 export * from './lib/hero/hero';
 export * from './lib/ui/ui';
 ```
@@ -390,12 +379,12 @@ export * from './lib/ui/ui';
 We're ready to import it into our main application now.
 
 ```ts
-// apps/angular-demo/src/app/app.ts
+// apps/shop/src/app/app.ts
 import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { NxWelcome } from './nx-welcome';
 // importing the component from the library
-import { Hero } from '@angular-demo/ui';
+import { Hero } from '@org/ui';
 
 @Component({
   selector: 'app-root',
@@ -405,23 +394,23 @@ import { Hero } from '@angular-demo/ui';
   styleUrl: './app.css',
 })
 export class App {
-  protected title = 'angular-demo';
+  protected title = 'shop';
 }
 ```
 
 Now update the template file to use the Hero component:
 
 ```html
-<!-- apps/angular-demo/src/app/app.html -->
+<!-- apps/shop/src/app/app.html -->
 <lib-hero
-  title="Welcmoe angular-demo"
+  title="Welcmoe shop"
   subtitle="Build something amazing today"
   cta="Get Started"
 ></lib-hero>
 <router-outlet></router-outlet>
 ```
 
-Serve your app again (`npx nx serve angular-demo`) and you should see the new Hero component from the `ui` library rendered on the home page.
+Serve your app again (`npx nx serve shop`) and you should see the new Hero component from the `ui` library rendered on the home page.
 
 ![](../../../../assets/tutorials/angular-demo-with-hero.avif)
 
@@ -445,7 +434,7 @@ You should be able to see something similar to the following in your browser.
 {
   "projects": [
     {
-      "name": "angular-demo",
+      "name": "shop",
       "type": "app",
       "data": {
         "tags": []
@@ -460,9 +449,7 @@ You should be able to see something similar to the following in your browser.
     }
   ],
   "dependencies": {
-    "angular-demo": [
-      { "source": "angular-demo", "target": "ui", "type": "static" }
-    ],
+    "shop": [{ "source": "shop", "target": "ui", "type": "static" }],
     "ui": []
   },
   "affectedProjectIds": [],
@@ -486,7 +473,7 @@ git commit -m 'add hero component'
 Our current setup not only has targets for serving and building the Angular application, but also has targets for unit testing, e2e testing and linting. The `test` and `lint` targets are defined in the application `project.json` file. We can use the same syntax as before to run these tasks:
 
 ```shell
-npx nx test angular-demo # runs the tests for angular-demo
+npx nx test shop # runs the tests for shop
 npx nx lint ui           # runs the linter on ui
 ```
 
@@ -498,7 +485,7 @@ npx nx run-many -t test lint
 
 This is exactly what is configured in `.github/workflows/ci.yml` for the CI pipeline. The `run-many` command allows you to run multiple tasks across multiple projects in parallel, which is particularly useful in a monorepo setup.
 
-There is a test failure for the `angular-demo` app due to the updated content. Don't worry about it for now, we'll fix it in a moment with the help of Nx Cloud's self-healing feature.
+There is a test failure for the `shop` app due to the updated content. Don't worry about it for now, we'll fix it in a moment with the help of Nx Cloud's self-healing feature.
 
 ### Local task cache
 
@@ -509,8 +496,8 @@ Note that all of these targets are automatically cached by Nx. If you re-run a s
 ```text {% title="npx nx run-many -t test lint" frame="terminal" %}
    ✔  nx run ui:lint
    ✔  nx run ui:test
-   ✔  nx run angular-demo:lint
-   ✖  nx run angular-demo:test
+   ✔  nx run shop:lint
+   ✖  nx run shop:test
 
 —————————————————————————————————————————————————————————————————————————————————————————————————————————
 
@@ -520,104 +507,18 @@ Note that all of these targets are automatically cached by Nx. If you re-run a s
 
    ✖  1/4 targets failed, including the following:
 
-      - nx run angular-demo:test
+      - nx run shop:test
 ```
 
-Again, the `angular-demo:test` task failed, but notice that the remaining three tasks were read from cache.
+Again, the `shop:test` task failed, but notice that the remaining three tasks were read from cache.
 
 Not all tasks might be cacheable though. You can configure the `cache` settings in the `targetDefaults` property of the `nx.json` file. You can also [learn more about how caching works](/docs/features/cache-task-results).
-
-## Self-Healing CI with Nx Cloud
-
-Explore how Nx Cloud can help your pull request get to green faster with self-healing CI. Recall that our angular-demo app has a test failure, so let's see how this can be automatically resolved.
-
-The `npx nx fix-ci` command that is already included in your GitHub Actions workflow (`github/workflows/ci.yml`) is responsible for enabling self-healing CI and will automatically suggest fixes to your failing tasks.
-
-```yaml {% meta="{32,33}" %}
-# .github/workflows/ci.yml
-name: CI
-
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-
-permissions:
-  actions: read
-  contents: read
-
-jobs:
-  main:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          filter: tree:0
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      - run: npm ci
-
-      - run: npx nx run-many -t lint test build
-
-      - run: npx nx fix-ci
-        if: always()
-```
-
-You will also need to install the [Nx Console](/docs/getting-started/editor-setup) editor extension for VS Code, Cursor, or IntelliJ. For the complete AI setup guide, see our [AI integration documentation](/docs/getting-started/ai-setup).
-
-{% install_nx_console /%}
-
-Now, let's push the `add-hero-component` branch to GitHub and open a new pull request.
-
-```shell
-git push origin add-hero-component
-# Don't forget to open a pull request on GitHub
-```
-
-As expected, the CI check fails because of the test failure in the `angular-demo` app. But rather than looking at the pull request, Nx Console notifies you that the run has completed, and that it has a suggested fix for the failing test. This means that you don't have to waste time **babysitting your PRs**, and the fix can be applied directly from your editor.
-
-![Nx Console with failure notification](../../../../assets/tutorials/angular-ci-notification.avif)
-
-### Fix CI from your editor
-
-From the Nx Console notification, you can click `Show Suggested Fix` button. Review the suggested fix, which in this case is to change the typo `Welcmoe` to the correct `Welcome` spelling. Approve this fix by clicking `ApplyFix` and that's it!
-
-![Suggestion to fix the typo in the editor](../../../../assets/tutorials/angular-ci-suggestion.avif)
-
-You didn't have to leave your editor or do any manual work to fix it. This is the power of self-healing CI with Nx Cloud.
-
-### Remote cache for faster time to green
-
-After the fix has been applied and committed, CI will re-run automatically, and you will be notified of the results in your editor.
-
-![Tasks with remote cache hit](../../../../assets/tutorials/angular-remote-cache-notification.avif)
-
-When you click `View Results` to show the run in Nx Cloud, you'll notice something interesting. The lint and test tasks for the `ui` library were read from remote cache and did not have to run again, thus each taking less than a second to complete.
-
-![Nx Cloud run showing remote cache hits](../../../../assets/tutorials/angular-remote-cache-cloud.avif)
-
-This happens because Nx Cloud caches the results of tasks and reuses them across different CI runs. As long as the inputs for each task have not changed (e.g. source code), then their results can be replayed from Nx Cloud's [Remote Cache](/docs/features/ci-features/remote-cache). In this case, since the last fix was applied only to the `angular-demo` app's source code, none of the tasks for `ui` library had to be run again.
-
-This significantly speeds up the time to green for your pull requests, because subsequent changes to them have a good chance to replay tasks from cache.
-
-{% callout type="note" title="Remote Cache Outputs" %}
-Outputs from cached tasks, such as the `dist` folder for builds or `coverage` folder for tests, are also read from cache. Even though a task was not run again, its outputs are available. The [Cache Task Results](/docs/features/cache-task-results) page provides more details on caching.
-{% /callout %}
-
-This pull request is now ready to be merged with the help of Nx Cloud's self-healing CI and remote caching.
-
-![Pull request is green](../../../../assets/tutorials/angular-ci-green.avif)
 
 ## Next steps
 
 Here are some things you can dive into next:
 
+- [Set up CI](/docs/getting-started/tutorials/self-healing-ci-tutorial) with remote caching and self-healing
 - Read more about [how Nx compares to the Angular CLI](/docs/technologies/angular/guides/nx-and-angular)
 - Learn more about the [underlying mental model of Nx](/docs/concepts/mental-model)
 - Learn about popular generators such as [how to setup Tailwind](/docs/technologies/angular/guides/using-tailwind-css-with-angular-projects)

--- a/astro-docs/src/content/docs/getting-started/Tutorials/react-monorepo-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/react-monorepo-tutorial.mdoc
@@ -18,31 +18,29 @@ What you'll learn:
 
 ## Prerequisite: Tutorial setup
 
-{% aside type="note" title="Prerequisites" %}
-This tutorial requires a [GitHub account](https://github.com) to demonstrate the full value of **Nx** - including task running, caching, and CI integration.
-{% /aside %}
+This tutorial requires [Node.js](https://nodejs.org) (v20.19 or later) installed on your machine.
 
 ### Step 1: Creating a new Nx React workspace
 
-Let's [create your workspace](https://cloud.nx.app/create-nx-workspace/react/github) with our React preset to get started quickly.
+Run the following command to create a new Nx workspace with the React template:
 
-{% call_to_action variant="simple" title="Create Workspace" url="https://cloud.nx.app/create-nx-workspace/react/github" /%}
+```shell
+npx create-nx-workspace@latest my-nx-repo --template=nrwl/react-template
+```
+
+Or [create your workspace in the browser](https://cloud.nx.app/create-nx-workspace/react/github) with CI pre-configured.
+
+{% llm_only %}
+IMPORTANT: Always use the CLI command above (`npx create-nx-workspace`) to create workspaces. Do NOT use the cloud.nx.app browser-based flow — it requires interactive GitHub OAuth and is not suitable for AI agents.
+{% /llm_only %}
 
 ### Step 2: verify your setup
 
-Please verify closely that you have the following setup:
+Once the workspace is created, navigate into it and verify the structure:
 
-1. A new Nx workspace on your local machine
-2. A corresponding GitHub repository for the workspace with a `.github/workflows/ci.yml` pipeline preconfigured
-3. You completed the full Nx Cloud onboarding and you now have a Nx Cloud dashboard that is connected to your example repository on GitHub.
-
-You should see your workspace in your [Nx Cloud organization](https://cloud.nx.app/orgs).
-
-![](../../../../assets/tutorials/connected-workspace.avif)
-
-If you do not see your workspace in Nx Cloud then please follow the steps outlined in the [Nx Cloud setup](https://cloud.nx.app/create-nx-workspace/react/github).
-
-This is important for using remote caching and self-healing in CI later in the tutorial.
+```shell
+cd my-nx-repo
+```
 
 ## Explore the Nx workspace setup
 
@@ -50,13 +48,15 @@ Let's take a look at the structure of our new Nx workspace:
 
 {%filetree%}
 
-- acme/
-  - .github/
-    - workflows/
-      - ci.yml
+- my-nx-repo/
   - apps/
-    - demo/
-  - README.md
+    - api/
+    - shop/
+    - shop-e2e/
+  - libs/
+    - api/
+    - shared/
+    - shop/
   - eslint.config.mjs
   - nx.json
   - package-lock.json
@@ -67,11 +67,7 @@ Let's take a look at the structure of our new Nx workspace:
 
 {%/filetree%}
 
-Here are some files that might jump to your eyes:
-
-- The `.nx` folder is where Nx stores local metadata about your workspaces using the [Nx Daemon](/docs/concepts/nx-daemon).
-- The [`nx.json` file](/docs/reference/nx-json) contains configuration settings for Nx itself and global default settings that individual projects inherit.
-- The `.github/workflows/ci.yml` file preconfigures your CI in GitHub Actions to run build and test through Nx.
+The [`nx.json` file](/docs/reference/nx-json) contains configuration settings for Nx itself and global default settings that individual projects inherit.
 
 Now, let's build some features and see how Nx helps get us to production faster.
 
@@ -80,20 +76,18 @@ Now, let's build some features and see how Nx helps get us to production faster.
 To serve your new React app, run:
 
 ```shell
-npx nx serve demo
+npx nx serve shop
 ```
 
 The app is served at [http://localhost:4200](http://localhost:4200).
 
-Nx uses the following syntax to run tasks:
-
-![Syntax for Running Tasks in Nx](../../../../assets/getting-started/run-target-syntax.svg)
+You can also use `npx nx run shop:serve` as an alternative syntax. The `<project>:<task>` format works for any task in any project, which is useful when task names overlap with Nx commands.
 
 ### Inferred tasks
 
 By default Nx simply runs your `package.json` scripts. However, you can also adopt [Nx technology plugins](/docs/technologies) that help abstract away some of the lower-level config and have Nx manage that. One such thing is to automatically identify tasks that can be run for your project from [tooling configuration files](/docs/concepts/inferred-tasks) such as `package.json` scripts and `vite.config.ts`.
 
-In `nx.json` there's already the `@nx/vite` plugin registered which automatically identifies `build`, `test`, `serve`, and other Vite-related targets.
+In `nx.json` there's already the `@nx/vite` plugin registered which automatically identifies `build`, `serve`, and other Vite-related tasks.
 
 ```json
 // nx.json
@@ -104,7 +98,6 @@ In `nx.json` there's already the `@nx/vite` plugin registered which automaticall
       "plugin": "@nx/vite/plugin",
       "options": {
         "buildTargetName": "build",
-        "testTargetName": "test",
         "serveTargetName": "serve",
         "devTargetName": "dev",
         "previewTargetName": "preview",
@@ -121,7 +114,7 @@ In `nx.json` there's already the `@nx/vite` plugin registered which automaticall
 To view the tasks that Nx has detected, look in the [Nx Console](/docs/getting-started/editor-setup) project detail view or run:
 
 ```shell
-npx nx show project demo
+npx nx show project shop
 ```
 
 {% project_details title="Project Details View (Simplified)" %}
@@ -129,14 +122,14 @@ npx nx show project demo
 ```json
 {
   "project": {
-    "name": "@acme/demo",
+    "name": "@org/shop",
     "type": "app",
     "data": {
-      "root": "apps/demo",
+      "root": "apps/shop",
       "targets": {
         "build": {
           "options": {
-            "cwd": "apps/demo",
+            "cwd": "apps/shop",
             "command": "vite build"
           },
           "cache": true,
@@ -148,38 +141,38 @@ npx nx show project demo
               "externalDependencies": ["vite"]
             }
           ],
-          "outputs": ["{workspaceRoot}/dist/apps/demo"],
+          "outputs": ["{workspaceRoot}/dist/apps/shop"],
           "executor": "nx:run-commands",
           "configurations": {}
         }
       },
-      "name": "demo",
+      "name": "shop",
       "$schema": "../../node_modules/nx/schemas/project-schema.json",
-      "sourceRoot": "apps/demo/src",
+      "sourceRoot": "apps/shop/src",
       "projectType": "application",
       "tags": [],
       "implicitDependencies": []
     }
   },
   "sourceMap": {
-    "root": ["apps/demo/project.json", "nx/core/project-json"],
-    "targets": ["apps/demo/project.json", "nx/core/project-json"],
-    "targets.build": ["apps/demo/vite.config.ts", "@nx/vite/plugin"],
-    "targets.build.command": ["apps/demo/vite.config.ts", "@nx/vite/plugin"],
-    "targets.build.options": ["apps/demo/vite.config.ts", "@nx/vite/plugin"],
-    "targets.build.cache": ["apps/demo/vite.config.ts", "@nx/vite/plugin"],
-    "targets.build.dependsOn": ["apps/demo/vite.config.ts", "@nx/vite/plugin"],
-    "targets.build.inputs": ["apps/demo/vite.config.ts", "@nx/vite/plugin"],
-    "targets.build.outputs": ["apps/demo/vite.config.ts", "@nx/vite/plugin"],
+    "root": ["apps/shop/project.json", "nx/core/project-json"],
+    "targets": ["apps/shop/project.json", "nx/core/project-json"],
+    "targets.build": ["apps/shop/vite.config.ts", "@nx/vite/plugin"],
+    "targets.build.command": ["apps/shop/vite.config.ts", "@nx/vite/plugin"],
+    "targets.build.options": ["apps/shop/vite.config.ts", "@nx/vite/plugin"],
+    "targets.build.cache": ["apps/shop/vite.config.ts", "@nx/vite/plugin"],
+    "targets.build.dependsOn": ["apps/shop/vite.config.ts", "@nx/vite/plugin"],
+    "targets.build.inputs": ["apps/shop/vite.config.ts", "@nx/vite/plugin"],
+    "targets.build.outputs": ["apps/shop/vite.config.ts", "@nx/vite/plugin"],
     "targets.build.options.cwd": [
-      "apps/demo/vite.config.ts",
+      "apps/shop/vite.config.ts",
       "@nx/vite/plugin"
     ],
-    "name": ["apps/demo/project.json", "nx/core/project-json"],
-    "$schema": ["apps/demo/project.json", "nx/core/project-json"],
-    "sourceRoot": ["apps/demo/project.json", "nx/core/project-json"],
-    "projectType": ["apps/demo/project.json", "nx/core/project-json"],
-    "tags": ["apps/demo/project.json", "nx/core/project-json"]
+    "name": ["apps/shop/project.json", "nx/core/project-json"],
+    "$schema": ["apps/shop/project.json", "nx/core/project-json"],
+    "sourceRoot": ["apps/shop/project.json", "nx/core/project-json"],
+    "projectType": ["apps/shop/project.json", "nx/core/project-json"],
+    "tags": ["apps/shop/project.json", "nx/core/project-json"]
   }
 }
 ```
@@ -189,7 +182,7 @@ npx nx show project demo
 If you expand the `build` task, you can see that it was created by the `@nx/vite` plugin by analyzing your `vite.config.ts` file. Notice the outputs are defined as `{projectRoot}/dist`. This value is being read from the `build.outDir` defined in your `vite.config.ts` file. Let's change that value in your `vite.config.ts` file:
 
 ```ts
-// apps/demo/vite.config.ts
+// apps/shop/vite.config.ts
 export default defineConfig({
   // ...
   build: {
@@ -211,9 +204,9 @@ When you develop your React application, usually all your logic sits in the app'
 
 {%filetree%}
 
-- acme/
+- my-nx-repo/
   - apps/
-    - demo/
+    - shop/
       - src/
         - app/
         - cart/
@@ -236,7 +229,7 @@ Nx allows you to separate this logic into "local libraries." The main benefits i
 Let's create a reusable design system library called `ui` that we can use across our workspace. This library will contain reusable components such as buttons, inputs, and other UI elements.
 
 ```shell
-npx nx g @nx/react:library packages/ui --unitTestRunner=vitest --bundler=none
+npx nx g @nx/react:library libs/ui --unitTestRunner=vitest --bundler=none
 ```
 
 Note how we type out the full path in the `directory` flag to place the library into a subfolder. You can choose whatever folder structure you like to organize your projects.
@@ -245,14 +238,13 @@ Running the above commands should lead to the following directory structure:
 
 {% filetree %}
 
-- acme/
+- my-nx-repo/
   - apps/
-    - demo/
-  - packages/
+    - shop/
+  - libs/
     - ui/
   - eslint.config.mjs
   - nx.json
-  - package-lock.json
   - package.json
   - tsconfig.base.json
   - tsconfig.json
@@ -260,7 +252,7 @@ Running the above commands should lead to the following directory structure:
 
 {% /filetree %}
 
-Just as with the `demo` app, Nx automatically infers the tasks for the `ui` library from its configuration files. You can view them by running:
+Just as with the `shop` app, Nx automatically infers the tasks for the `ui` library from its configuration files. You can view them by running:
 
 ```shell
 npx nx show project ui
@@ -273,14 +265,14 @@ npx nx lint ui
 npx nx test ui
 ```
 
-### Import libraries into the demo app
+### Import libraries into the shop app
 
 All libraries that we generate are automatically included in the `workspaces` defined in the root-level `package.json`.
 
 ```json
 // package.json
 {
-  "workspaces": ["apps/*", "packages/*"]
+  "workspaces": ["apps/*", "libs/*"]
 }
 ```
 
@@ -289,14 +281,14 @@ Hence, we can easily import them into other libraries and our React application.
 You can see that the `AcmeUi` component is exported via the `index.ts` file of our `ui` library so that other projects in the repository can use it. This is our public API with the rest of the workspace and is enforced by the `exports` field in the `package.json` file. Only export what's necessary to be usable outside the library itself.
 
 ```ts
-// packages/ui/src/index.ts
+// libs/ui/src/index.ts
 export * from './lib/ui';
 ```
 
-Let's add a simple `Hero` component that we can use in our demo app.
+Let's add a simple `Hero` component that we can use in our shop app.
 
 ```tsx
-// packages/ui/src/lib/hero.tsx
+// libs/ui/src/lib/hero.tsx
 export function Hero(props: {
   title: string;
   subtitle: string;
@@ -350,7 +342,7 @@ export function Hero(props: {
 Then, export it from `index.ts`.
 
 ```ts
-// packages/ui/src/index.ts
+// libs/ui/src/index.ts
 export * from './lib/hero';
 export * from './lib/ui';
 ```
@@ -358,10 +350,10 @@ export * from './lib/ui';
 We're ready to import it into our main application now.
 
 ```tsx
-// apps/demo/src/app/app.tsx
+// apps/shop/src/app/app.tsx
 import { Route, Routes } from 'react-router-dom';
 // importing the component from the library
-import { Hero } from '@acme/ui';
+import { Hero } from '@org/ui';
 
 export function App() {
   return (
@@ -379,7 +371,7 @@ export function App() {
 export default App;
 ```
 
-Serve your app again (`npx nx serve demo`) and you should see the new Hero component from the `ui` library rendered on the home page.
+Serve your app again (`npx nx serve shop`) and you should see the new Hero component from the `ui` library rendered on the home page.
 
 ![](../../../../assets/tutorials/react-demo-with-hero.avif)
 
@@ -403,14 +395,14 @@ You should be able to see something similar to the following in your browser.
 {
   "projects": [
     {
-      "name": "@acme/demo",
+      "name": "@org/shop",
       "type": "app",
       "data": {
         "tags": []
       }
     },
     {
-      "name": "@acme/ui",
+      "name": "@org/ui",
       "type": "lib",
       "data": {
         "tags": []
@@ -418,10 +410,10 @@ You should be able to see something similar to the following in your browser.
     }
   ],
   "dependencies": {
-    "@acme/demo": [
-      { "source": "@acme/demo", "target": "@acme/ui", "type": "static" }
+    "@org/shop": [
+      { "source": "@org/shop", "target": "@org/ui", "type": "static" }
     ],
-    "@acme/ui": []
+    "@org/ui": []
   },
   "affectedProjectIds": [],
   "focus": null,
@@ -444,7 +436,7 @@ git commit -m 'add hero component'
 Our current setup doesn't just come with targets for serving and building the React application, but also has targets for testing and linting. We can use the same syntax as before to run these tasks:
 
 ```shell
-npx nx test demo # runs the tests for demo
+npx nx test shop # runs the tests for shop
 npx nx lint ui   # runs the linter on ui
 ```
 
@@ -456,7 +448,7 @@ npx nx run-many -t test lint
 
 This is exactly what is configured in `.github/workflows/ci.yml` for the CI pipeline. The `run-many` command allows you to run multiple tasks across multiple projects in parallel, which is particularly useful in a monorepo setup.
 
-There is a test failure for the `demo` app due to the updated content. Don't worry about it for now, we'll fix it in a moment with the help of Nx Cloud's self-healing feature.
+There is a test failure for the `shop` app due to the updated content. Don't worry about it for now, we'll fix it in a moment with the help of Nx Cloud's self-healing feature.
 
 ### Local task cache
 
@@ -465,10 +457,10 @@ One thing to highlight is that Nx is able to [cache the tasks you run](/docs/fea
 Note that all of these targets are automatically cached by Nx. If you re-run a single one or all of them again, you'll see that the task completes immediately. In addition, (as can be seen in the output example below) there will be a note that a matching cache result was found and therefore the task was not run again.
 
 ```text {% title="npx nx run-many -t test lint" frame="terminal" %}
-   ✔  nx run @acme/ui:lint
-   ✔  nx run @acme/ui:test
-   ✔  nx run @acme/demo:lint
-   ✖  nx run @acme/demo:test
+   ✔  nx run @org/ui:lint
+   ✔  nx run @org/ui:test
+   ✔  nx run @org/shop:lint
+   ✖  nx run @org/shop:test
 
 —————————————————————————————————————————————————————————————————————————————————————————————————————————
 
@@ -478,104 +470,18 @@ Note that all of these targets are automatically cached by Nx. If you re-run a s
 
    ✖  1/4 targets failed, including the following:
 
-      - nx run @acme/demo:test
+      - nx run @org/shop:test
 ```
 
-Again, the `@acme/demo:test` task failed, but notice that the remaining three tasks were read from cache.
+Again, the `@org/shop:test` task failed, but notice that the remaining three tasks were read from cache.
 
 Not all tasks might be cacheable though. You can configure the `cache` settings in the `targetDefaults` property of the `nx.json` file. You can also [learn more about how caching works](/docs/features/cache-task-results).
-
-## Self-Healing CI with Nx Cloud
-
-Explore how Nx Cloud can help your pull request get to green faster with self-healing CI. Recall that our demo app has a test failure, so let's see how this can be automatically resolved.
-
-The `npx nx-cloud fix-ci` command that is already included in your GitHub Actions workflow (`github/workflows/ci.yml`) is responsible for enabling self-healing CI and will automatically suggest fixes to your failing tasks.
-
-```yaml {% meta="{32,33}" %}
-# .github/workflows/ci.yml
-name: CI
-
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-
-permissions:
-  actions: read
-  contents: read
-
-jobs:
-  main:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          filter: tree:0
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      - run: npm ci
-
-      - run: npx nx run-many -t lint test build
-
-      - run: npx nx-cloud fix-ci
-        if: always()
-```
-
-You will also need to install the [Nx Console](/docs/getting-started/editor-setup) editor extension for VS Code, Cursor, or IntelliJ. For the complete AI setup guide, see our [AI integration documentation](/docs/getting-started/ai-setup).
-
-{% install_nx_console /%}
-
-Now, let's push the `add-hero-component` branch to GitHub and open a new pull request.
-
-```shell
-git push origin add-hero-component
-# Don't forget to open a pull request on GitHub
-```
-
-As expected, the CI check fails because of the test failure in the `demo` app. But rather than looking at the pull request, Nx Console notifies you that the run has completed, and that it has a suggested fix for the failing test. This means that you don't have to waste time **babysitting your PRs**, and the fix can be applied directly from your editor.
-
-![Nx Console with failure notification](../../../../assets/tutorials/react-ci-notification.avif)
-
-### Fix CI from your editor
-
-From the Nx Console notification, you can click `Show Suggested Fix` button. Review the suggested fix, which in this case is to change the typo `Welcmoe`to the correct `Welcome` spelling. Approve this fix by clicking `ApplyFix` and that's it!
-
-![Suggestion to fix the typo in the editor](../../../../assets/tutorials/react-ci-suggestion.avif)
-
-You didn't have to leave your editor or do any manual work to fix it. This is the power of self-healing CI with Nx Cloud.
-
-### Remote cache for faster time to green
-
-After the fix has been applied and committed, CI will re-run automatically, and you will be notified of the results in your editor.
-
-![Tasks with remote cache hit](../../../../assets/tutorials/react-remote-cache-notification.avif)
-
-When you click `View Results` to show the run in Nx Cloud, you'll notice something interesting. The lint and test tasks for the `ui` library were read from remote cache and did not have to run again, thus each taking less than a second to complete.
-
-![Nx Cloud run showing remote cache hits](../../../../assets/tutorials/react-remote-cache-cloud.avif)
-
-This happens because Nx Cloud caches the results of tasks and reuses them across different CI runs. As long as the inputs for each task have not changed (e.g. source code), then their results can be replayed from Nx Cloud's [Remote Cache](/docs/features/ci-features/remote-cache). In this case, since the last fix was applied only to the `demo` app's source code, none of the tasks for `ui` library had to be run again.
-
-This significantly speeds up the time to green for your pull requests, because subsequent changes to them have a good chance to replay tasks from cache.
-
-{% aside type="note" title="Remote Cache Outputs" %}
-Outputs from cached tasks, such as the `dist` folder for builds or `coverage` folder for tests, are also read from cache. Even though a task was not run again, its outputs are available. The [Cache Task Results](/docs/features/cache-task-results) page provides more details on caching.
-{% /aside %}
-
-This pull request is now ready to be merged with the help of Nx Cloud's self-healing CI and remote caching.
-
-![Pull request is green](../../../../assets/tutorials/react-ci-green.avif)
 
 ## Next steps
 
 Here are some things you can dive into next:
 
+- [Set up CI](/docs/getting-started/tutorials/self-healing-ci-tutorial) with remote caching and self-healing
 - Learn more about the [underlying mental model of Nx](/docs/concepts/mental-model)
 - Learn how to [migrate your existing project to Nx](/docs/guides/adopting-nx/adding-to-existing-project)
 - [Setup Storybook for our shared UI library](/docs/technologies/test-tools/storybook/guides/overview-react)

--- a/astro-docs/src/content/docs/getting-started/Tutorials/self-healing-ci-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/self-healing-ci-tutorial.mdoc
@@ -1,0 +1,141 @@
+---
+title: 'Setting Up CI'
+description: Configure CI for your Nx workspace with remote caching and self-healing to keep your pipeline fast and reliable.
+sidebar:
+  label: 'Setting Up CI'
+filter: 'type:Guides'
+---
+
+This tutorial walks you through configuring CI for your Nx workspace. You'll set up a CI pipeline, enable remote caching to speed up runs, and configure self-healing CI to automatically fix failures.
+
+What you'll learn:
+
+- How to connect your workspace to Nx Cloud
+- How to generate a CI workflow for GitHub Actions
+- How remote caching avoids redundant work across CI runs
+- How self-healing CI detects and fixes failures automatically
+
+## Prerequisites
+
+{% aside type="note" title="Prerequisites" %}
+
+- An existing Nx workspace (see our [React](/docs/getting-started/tutorials/react-monorepo-tutorial), [Angular](/docs/getting-started/tutorials/angular-monorepo-tutorial), or [TypeScript](/docs/getting-started/tutorials/typescript-packages-tutorial) tutorials)
+- A [GitHub account](https://github.com) with a repository for your workspace
+- [Node.js](https://nodejs.org) (v20.19 or later)
+
+{% /aside %}
+
+## Step 1: Connect to Nx Cloud
+
+Connect your workspace to Nx Cloud to enable remote caching and CI features:
+
+```shell
+npx nx connect
+```
+
+This creates an Nx Cloud account (if you don't have one) and connects your workspace. Once connected, you can see your workspace in your [Nx Cloud organization](https://cloud.nx.app/orgs).
+
+## Step 2: Generate a CI workflow
+
+Generate a CI workflow configuration for GitHub Actions:
+
+```shell
+npx nx g ci-workflow
+```
+
+This creates a `.github/workflows/ci.yml` file that runs your tasks through Nx and includes the `fix-ci` command for self-healing:
+
+```yaml {% meta="{24,25}" %}
+# .github/workflows/ci.yml
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npx nx run-many -t lint test build
+
+      - run: npx nx-cloud fix-ci
+        if: always()
+```
+
+The `npx nx-cloud fix-ci` command at the end is responsible for enabling self-healing CI. It analyzes any failing tasks and automatically suggests fixes.
+
+## Step 3: Install Nx Console
+
+You will need the [Nx Console](/docs/getting-started/editor-setup) editor extension for VS Code, Cursor, or IntelliJ to receive CI notifications and apply fixes directly from your editor.
+
+{% install_nx_console /%}
+
+For the complete AI setup guide, see our [AI integration documentation](/docs/getting-started/ai-setup).
+
+## Step 4: Push a PR and see self-healing in action
+
+Create a branch, make a change (or introduce an intentional test failure), and push it:
+
+```shell
+git checkout -b my-feature
+git add .
+git commit -m 'my changes'
+git push origin my-feature
+# Don't forget to open a pull request on GitHub
+```
+
+When CI runs and encounters a failure, Nx Console notifies you that the run has completed and that it has a suggested fix. You don't have to waste time **babysitting your PRs** — the fix can be applied directly from your editor.
+
+### Fix CI from your editor
+
+From the Nx Console notification, click the `Show Suggested Fix` button. Review the suggested fix and approve it by clicking `Apply Fix`.
+
+You don't have to leave your editor or do any manual work to fix it. This is the power of self-healing CI with Nx Cloud.
+
+### Remote cache for faster time to green
+
+After the fix has been applied and committed, CI will re-run automatically, and you will be notified of the results in your editor.
+
+When you view the results in Nx Cloud, you'll notice something interesting. Tasks for projects that weren't affected by your change were read from remote cache and did not have to run again, each taking less than a second to complete.
+
+This happens because Nx Cloud caches the results of tasks and reuses them across different CI runs. As long as the inputs for each task have not changed (e.g. source code), then their results can be replayed from Nx Cloud's [Remote Cache](/docs/features/ci-features/remote-cache).
+
+This significantly speeds up the time to green for your pull requests, because subsequent changes to them have a good chance to replay tasks from cache.
+
+{% aside type="note" title="Remote Cache Outputs" %}
+Outputs from cached tasks, such as the `dist` folder for builds or `coverage` folder for tests, are also read from cache. Even though a task was not run again, its outputs are available. The [Cache Task Results](/docs/features/cache-task-results) page provides more details on caching.
+{% /aside %}
+
+## Next steps
+
+- Learn more about [Self-Healing CI](/docs/features/ci-features/self-healing-ci)
+- Learn about [Remote Cache](/docs/features/ci-features/remote-cache) and how it works
+- [Set up AI integration](/docs/getting-started/ai-setup) for enhanced AI-powered CI workflows
+- Learn more about the [underlying mental model of Nx](/docs/concepts/mental-model)
+
+Also, make sure you
+
+- ⭐️ [Star us on GitHub](https://github.com/nrwl/nx) to show your support and stay updated on new releases!
+- [Join the Official Nx Discord Server](https://go.nx.dev/community) to ask questions and find out the latest news about Nx.
+- [Follow Nx on Twitter](https://twitter.com/nxdevtools) to stay up to date with Nx news
+- [Read our Nx blog](https://nx.dev/blog)
+- [Subscribe to our Youtube channel](https://www.youtube.com/@nxdevtools) for demos and Nx insights

--- a/astro-docs/src/content/docs/getting-started/Tutorials/typescript-packages-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/typescript-packages-tutorial.mdoc
@@ -18,31 +18,29 @@ What you'll learn:
 
 ## Ready to start?
 
-{% aside type="note" title="Prerequisites" %}
-This tutorial requires a [GitHub account](https://github.com) to demonstrate the full value of **Nx** - including task running, caching, and CI integration.
-{% /aside %}
+This tutorial requires [Node.js](https://nodejs.org) (v20.19 or later) installed on your machine.
 
-### Step 1: Creating a new Nx TypeScript workspace (required)
+### Step 1: Creating a new Nx TypeScript workspace
 
-Let's [create your workspace](https://cloud.nx.app/create-nx-workspace/typescript/github) with our TypeScript preset to get started quickly.
+Run the following command to create a new Nx workspace with the TypeScript template:
 
-{% call_to_action variant="simple" title="Create TypeScript Workspace" url="https://cloud.nx.app/create-nx-workspace/typescript/github" /%}
+```shell
+npx create-nx-workspace@latest my-nx-repo --template=nrwl/typescript-template
+```
+
+Or [create your workspace in the browser](https://cloud.nx.app/create-nx-workspace/typescript/github) with CI pre-configured.
+
+{% llm_only %}
+IMPORTANT: Always use the CLI command above (`npx create-nx-workspace`) to create workspaces. Do NOT use the cloud.nx.app browser-based flow — it requires interactive GitHub OAuth and is not suitable for AI agents.
+{% /llm_only %}
 
 ### Step 2: verify your setup
 
-Please verify closely that you have the following setup:
+Once the workspace is created, navigate into it:
 
-1. A new Nx workspace on your local machine
-2. A corresponding GitHub repository for the workspace with a `.github/workflows/ci.yml` pipeline preconfigured
-3. You completed the full Nx Cloud onboarding and you now have a Nx Cloud dashboard that is connected to your example repository on GitHub.
-
-You should see your workspace in your [Nx Cloud organization](https://cloud.nx.app/orgs).
-
-![](../../../../assets/tutorials/connected-workspace.avif)
-
-If you do not see your workspace in Nx Cloud then please follow the steps outlined in the [Nx Cloud setup](https://cloud.nx.app/create-nx-workspace/typescript/github).
-
-This is important for using remote caching and self-healing in CI later in the tutorial.
+```shell
+cd my-nx-repo
+```
 
 ## Explore the Nx workspace setup
 
@@ -50,30 +48,23 @@ Let's take a look at the structure of our new Nx workspace:
 
 {%filetree %}
 
-- acme/
-  - .github/
-    - workflows/
-      - ci.yml
-  - .nx/
-    - ...
+- my-nx-repo/
   - packages/
-    - .gitkeep
-  - README.md
-  - .prettierignore
-  - .prettierrc
+    - async/
+    - colors/
+    - strings/
+    - utils/
+  - eslint.config.mjs
   - nx.json
   - package-lock.json
   - package.json
   - tsconfig.base.json
   - tsconfig.json
+  - vitest.workspace.ts
 
 {% /filetree %}
 
-Here are some files that might jump to your eyes:
-
-- The `.nx` folder is where Nx stores local metadata about your workspaces using the [Nx Daemon](/docs/concepts/nx-daemon).
-- The [`nx.json` file](/docs/reference/nx-json) contains configuration settings for Nx itself and global default settings that individual projects inherit.
-- The `.github/workflows/ci.yml` file preconfigures your CI in GitHub Actions to run build and test through Nx.
+The [`nx.json` file](/docs/reference/nx-json) contains configuration settings for Nx itself and global default settings that individual projects inherit.
 
 Now, let's build some features and see how Nx helps get us to production faster.
 
@@ -97,7 +88,7 @@ Running these commands should lead to new directories and files in your workspac
 
 {%filetree %}
 
-- acme/
+- my-nx-repo/
   - packages/
     - animal/
     - zoo/
@@ -134,7 +125,7 @@ Now let's update the `zoo` package to use the `animal` package:
 
 ```ts
 // packages/zoo/src/lib/zoo.ts
-import { getRandomAnimal } from '@acme/animal';
+import { getRandomAnimal } from '@org/animal';
 
 export function zoo(): string {
   const result = getRandomAnimal();
@@ -142,13 +133,13 @@ export function zoo(): string {
 }
 ```
 
-Add the `@acme/animal` dependency to `zoo`'s `package.json` (use `*` for npm or `workspace:*` for pnpm/yarn):
+Add the `@org/animal` dependency to `zoo`'s `package.json` (use `*` for npm or `workspace:*` for pnpm/yarn):
 
 ```json {% meta="{3-5}" %}
 // packages/zoo/package.json
 {
   "dependencies": {
-    "@acme/animal": "*"
+    "@org/animal": "*"
   }
 }
 ```
@@ -174,6 +165,8 @@ To build your packages, run:
 npx nx build animal
 ```
 
+You can also use `npx nx run animal:build` as an alternative syntax. The `<project>:<task>` format works for any task in any project, which is useful when task names overlap with Nx commands.
+
 This creates a compiled version of your package in the `dist/packages/animal` folder. Since the `zoo` package depends on `animal`, building `zoo` will automatically build `animal` first:
 
 ```shell
@@ -187,10 +180,6 @@ You can also run the `zoo` package to see it in action:
 ```shell
 node packages/zoo/dist/index.js
 ```
-
-Nx uses the following syntax to run tasks:
-
-![Syntax for Running Tasks in Nx](../../../../assets/getting-started/run-target-syntax.svg)
 
 ### Inferred tasks
 
@@ -232,7 +221,7 @@ npx nx show project animal
 ```json
 {
   "project": {
-    "name": "@acme/animal",
+    "name": "@org/animal",
     "type": "lib",
     "data": {
       "root": "packages/animal",
@@ -382,7 +371,7 @@ Now we have:
 
 {%filetree %}
 
-- acme/
+- my-nx-repo/
   - packages/
     - animal/
     - util/
@@ -414,7 +403,7 @@ This allows us to easily import them into other packages. Let's update our `anim
 
 ```ts {% meta="{2,19-21}" %}
 // packages/animals/src/lib/animals.ts
-import { getRandomItem } from '@acme/util';
+import { getRandomItem } from '@org/util';
 
 export function animal(): string {
   return 'animal';
@@ -440,8 +429,8 @@ And update the `zoo` package to use the formatting utility:
 
 ```ts {% meta="{3,7,8}" %}
 // packages/zoo/src/lib/zoo.ts
-import { getRandomAnimal } from '@acme/animal';
-import { formatMessage } from '@acme/util';
+import { getRandomAnimal } from '@org/animal';
+import { formatMessage } from '@org/util';
 
 export function zoo(): string {
   const result = getRandomAnimal();
@@ -456,7 +445,7 @@ Update the dependencies in each package's `package.json`:
 // packages/animal/package.json
 {
   "dependencies": {
-    "@acme/util": "*"
+    "@org/util": "*"
   }
 }
 ```
@@ -465,8 +454,8 @@ Update the dependencies in each package's `package.json`:
 // packages/zoo/package.json
 {
   "dependencies": {
-    "@acme/animal": "*",
-    "@acme/util": "*"
+    "@org/animal": "*",
+    "@org/util": "*"
   }
 }
 ```
@@ -503,21 +492,21 @@ You should be able to see something similar to the following in your browser.
 {
   "projects": [
     {
-      "name": "@acme/animal",
+      "name": "@org/animal",
       "type": "lib",
       "data": {
         "tags": []
       }
     },
     {
-      "name": "@acme/util",
+      "name": "@org/util",
       "type": "lib",
       "data": {
         "tags": []
       }
     },
     {
-      "name": "@acme/zoo",
+      "name": "@org/zoo",
       "type": "lib",
       "data": {
         "tags": []
@@ -525,13 +514,13 @@ You should be able to see something similar to the following in your browser.
     }
   ],
   "dependencies": {
-    "@acme/animal": [
-      { "source": "@acme/animal", "target": "@acme/util", "type": "static" }
+    "@org/animal": [
+      { "source": "@org/animal", "target": "@org/util", "type": "static" }
     ],
-    "@acme/util": [],
-    "@acme/zoo": [
-      { "source": "@acme/zoo", "target": "@acme/animal", "type": "static" },
-      { "source": "@acme/zoo", "target": "@acme/util", "type": "static" }
+    "@org/util": [],
+    "@org/zoo": [
+      { "source": "@org/zoo", "target": "@org/animal", "type": "static" },
+      { "source": "@org/zoo", "target": "@org/util", "type": "static" }
     ]
   },
   "affectedProjectIds": [],
@@ -577,12 +566,12 @@ One thing to highlight is that Nx is able to [cache the tasks you run](/docs/fea
 Note that all of these targets are automatically cached by Nx. If you re-run a single one or all of them again, you'll see that the task completes immediately. In addition, there will be a note that a matching cache result was found and therefore the task was not run again.
 
 ```text {% title="npx nx run-many -t built test" frame="terminal" %}
-      ✔  nx run @acme/util:build
-   ✔  nx run @acme/util:test
-   ✔  nx run @acme/animal:test
-   ✔  nx run @acme/animal:build
-   ✖  nx run @acme/zoo:test
-   ✔  nx run @acme/zoo:build
+      ✔  nx run @org/util:build
+   ✔  nx run @org/util:test
+   ✔  nx run @org/animal:test
+   ✔  nx run @org/animal:build
+   ✖  nx run @org/zoo:test
+   ✔  nx run @org/zoo:build
 
 ——————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
 
@@ -592,97 +581,10 @@ Note that all of these targets are automatically cached by Nx. If you re-run a s
 
    ✖  1/6 targets failed, including the following:
 
-      - nx run @acme/zoo:test
+      - nx run @org/zoo:test
 ```
 
 Not all tasks might be cacheable though. You can configure the `cache` settings in the `targetDefaults` property of the `nx.json` file. You can also [learn more about how caching works](/docs/features/cache-task-results).
-
-## Self-Healing CI with Nx Cloud
-
-Explore how Nx Cloud can help your pull request get to green faster with self-healing CI. Recall that our zoo package has a test with a typo, so let's see how this can be automatically resolved.
-
-The `npx nx-cloud fix-ci` command that is already included in your GitHub Actions workflow (`github/workflows/ci.yml`) is responsible for enabling self-healing CI and will automatically suggest fixes to your failing tasks.
-
-```yaml {% meta="{32,33}" %}
-# .github/workflows/ci.yml
-name: CI
-
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-
-permissions:
-  actions: read
-  contents: read
-
-jobs:
-  main:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          filter: tree:0
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      - run: npm ci
-
-      - run: npx nx run-many -t lint test build
-
-      - run: npx nx-cloud fix-ci
-        if: always()
-```
-
-You will also need to install the [Nx Console](/docs/getting-started/editor-setup) editor extension for VS Code, Cursor, or IntelliJ. For the complete AI setup guide, see our [AI integration documentation](/docs/getting-started/ai-setup).
-
-{% install_nx_console /%}
-
-Now, let's push the `add-zoo-packages` branch to GitHub and open a new pull request.
-
-```shell
-git push origin add-zoo-packages
-# Don't forget to open a pull request on GitHub
-```
-
-As expected, the CI check may show failures or issues. But rather than looking at the pull request, Nx Console notifies you that the run has completed, and if there are any issues, it may have suggested fixes. This means that you don't have to waste time **babysitting your PRs**, and fixes can be applied directly from your editor.
-
-![Nx Console with notification](../../../../assets/tutorials/ts-ci-notification.avif)
-
-### Fix CI from your editor
-
-From the Nx Console notification, if there's a suggested fix (such as fixing the typo "formated" to "formatted"), you can click `Show Suggested Fix` button. Review the suggested fix and approve it by clicking `Apply Fix`.
-
-![Suggestion to fix the typo in the editor](../../../../assets/tutorials/ts-ci-suggestion.avif)
-
-You didn't have to leave your editor or do any manual work to fix it. This is the power of self-healing CI with Nx Cloud.
-
-### Remote cache for faster time to green
-
-After the fix has been applied and committed, CI will re-run automatically, and you will be notified of the results in your editor.
-
-![Notication of successful run](../../../../assets/tutorials/ts-remote-cache-notification.avif)
-
-When you click `View Results` to show the run in Nx Cloud, you'll notice something interesting. The tasks for packages that weren't affected by your change were read from remote cache and did not have to run again, thus each taking less than a second to complete.
-
-![Nx Cloud run showing remote cache hits](../../../../assets/tutorials/ts-remote-cache-cloud.avif)
-
-This happens because Nx Cloud caches the results of tasks and reuses them across different CI runs. As long as the inputs for each task have not changed (e.g. source code), then their results can be replayed from Nx Cloud's [Remote Cache](/docs/features/ci-features/remote-cache).
-
-This significantly speeds up the time to green for your pull requests, because subsequent changes to them have a good chance to replay tasks from cache.
-
-{% aside type="note" title="Remote Cache Outputs" %}
-Outputs from cached tasks, such as the `dist` folder for builds or `coverage` folder for tests, are also read from cache. Even though a task was not run again, its outputs are available. The [Cache Task Results](/docs/features/cache-task-results) page provides more details on caching.
-{% /aside %}
-
-This pull request is now ready to be merged with the help of Nx Cloud's self-healing CI and remote caching.
-
-![Pull request is green](../../../../assets/tutorials/ts-ci-green.avif)
 
 The next section deals with publishing packages to a registry like NPM, but if you are not interested in publishing your packages, you can skip to [the end](#next-steps).
 
@@ -724,6 +626,7 @@ After this first release, you can remove the `--first-release` flag and just run
 
 Here are some things you can dive into next:
 
+- [Set up CI](/docs/getting-started/tutorials/self-healing-ci-tutorial) with remote caching and self-healing
 - Learn more about the [underlying mental model of Nx](/docs/concepts/mental-model)
 - Learn how to [migrate your existing project to Nx](/docs/guides/adopting-nx/adding-to-existing-project)
 - [Learn more about Nx release for publishing packages](/docs/features/manage-releases)

--- a/astro-docs/src/content/docs/getting-started/ai-setup.mdoc
+++ b/astro-docs/src/content/docs/getting-started/ai-setup.mdoc
@@ -48,6 +48,20 @@ The Nx AI integration provides your coding assistant with powerful capabilities:
 - **Autonomous CI Workflows** - The CI monitor skill bridges your local agent with Nx Cloud. Push, monitor, get failures, fix, repeat until CI is green. Enables autonomous CI workflows ("Ralph Wiggum loop")—you review the final PR, not every intermediate fix.
 - **Cross-project Impact Analysis** - Understanding the implications of changes across your entire monorepo.
 
+## Creating new workspaces
+
+When using AI assistants to create new Nx workspaces, use the CLI command:
+
+```shell
+npx create-nx-workspace@latest --template=nrwl/<name>-template
+```
+
+Available templates include `react-template`, `angular-template`, and `typescript-template`. For adding Nx to an existing project, use `npx nx init`.
+
+{% llm_only %}
+Do not direct users to cloud.nx.app for workspace creation — the CLI command is the recommended path. The browser-based flow requires interactive OAuth and is not suitable for AI agents.
+{% /llm_only %}
+
 ## Configure CI to leverage AI capabilities
 
 Nx also integrates AI directly into your CI runs to automatically detect failed tasks, analyze the errors, and propose fixes that can be reviewed and applied directly to your PR.

--- a/astro-docs/src/content/docs/getting-started/intro.mdoc
+++ b/astro-docs/src/content/docs/getting-started/intro.mdoc
@@ -95,28 +95,11 @@ Yes, Nx provides value even for single-project repositories. You get fast task c
 Nx can also connect multiple repositories into a synthetic monorepo, letting you orchestrate large changes across all connected repos.
 {% /callout %}
 
-## Where to Go from here
+## Where to go from here
 
-{% callout type="note" title="Choose Your Path" %}
-**Starting fresh?** → [Create a new workspace](/docs/getting-started/start-new-project)
-
-**Have an existing project?** → [Add Nx to your project](/docs/getting-started/start-with-existing-project)
-
-**Want hands-on learning?** → [Follow a tutorial](/docs/getting-started/tutorials)
-
-**Prefer video?** → [Learn with our video courses](https://nx.dev/courses)
-{% /callout %}
-
-{% cardgrid %}
-
-{% linkcard title="Quickstart" description="Get your first Nx project running in minutes." href="/docs/quickstart" /%}
-
-{% linkcard title="Plugins" description="Find plugins for React, Angular, Node, Gradle, Maven, .NET, and more." href="/docs/plugin-registry" /%}
-
-{% linkcard title="Concepts" description="Improve your understanding of how Nx works under the hood." href="/docs/concepts" /%}
-
-{% linkcard title="Features" description="Explore Nx features like caching, task orchestration, and CI optimization." href="/docs/features" /%}
-
-{% /cardgrid %}
+- **Starting fresh?** → [Create a new workspace](/docs/getting-started/start-new-project)
+- **Have an existing project?** → [Add Nx to your project](/docs/getting-started/start-with-existing-project)
+- **Want hands-on learning?** → [Follow a tutorial](/docs/getting-started/tutorials)
+- **Prefer video?** → [Learn with our video courses](https://nx.dev/courses)
 
 **Stay up to date** with our latest news by [⭐️ starring us on Github](https://github.com/nrwl/nx), [subscribing to our Youtube channel](https://www.youtube.com/@nxdevtools), [joining our Discord](https://go.nx.dev/community), [subscribing to our monthly tech newsletter](https://go.nrwl.io/nx-newsletter) or follow us [on X](https://x.com/nxdevtools), [Bluesky](https://bsky.app/profile/nx.dev) and [LinkedIn](https://www.linkedin.com/company/nxdevtools).

--- a/astro-docs/src/content/docs/getting-started/start-new-project.mdoc
+++ b/astro-docs/src/content/docs/getting-started/start-new-project.mdoc
@@ -27,11 +27,13 @@ npx create-nx-workspace@latest
 This interactive command guides you through the setup:
 
 - **Workspace name** - The name of your root directory
-- **Template** - Choose from [various technology stacks](/docs/reference/create-nx-workspace#presets) (React, Angular, Node, etc.)
-- **Package manager** - npm, yarn, pnpm, or bun
-- **Additional options** - Styling, testing frameworks, and more depending on your template
+- **Starter template** - Choose from [various technology stacks](/docs/reference/create-nx-workspace#presets) (React, Angular, Node, etc.)
 
-For a minimal setup, choose the **empty workspace** template (`--preset=ts`). This gives you a bare TypeScript monorepo that you can extend incrementally.
+For a minimal setup, use the empty template. This gives you a bare TypeScript monorepo that you can extend incrementally.
+
+```shell
+npx create-nx-workspace@latest --template=nrwl/empty-template
+```
 
 ## Option 2: Create via Nx Cloud
 

--- a/astro-docs/src/content/docs/quickstart.mdoc
+++ b/astro-docs/src/content/docs/quickstart.mdoc
@@ -62,10 +62,9 @@ Get up and running with Nx in just a few minutes by following these simple steps
    npx nx@latest init
    ```
 
-   **Get the complete experience:**
-   For a fully integrated development workflow with AI-powered CI features, [start directly from Nx Cloud](https://cloud.nx.app/get-started).
+   Want remote caching and CI? Connect to [Nx Cloud](/docs/features/ci-features) after setup.
 
-   Learn more: [Start New Project](/docs/getting-started/start-new-project) • [Add to Existing](/docs/getting-started/start-with-existing-project) • [Complete Nx Experience](https://cloud.nx.app/get-started)
+   Learn more: [Start New Project](/docs/getting-started/start-new-project) • [Add to Existing](/docs/getting-started/start-with-existing-project)
 
 3. Run Your First Commands
 
@@ -96,7 +95,7 @@ Get up and running with Nx in just a few minutes by following these simple steps
 
    {% linkcard title="I learn better with videos" description="Check out our bite-sized video lessons that teach you about Nx 101, Nx Release and how to incrementally adopt Nx in an existing project."  href="https://nx.dev/courses" /%}
 
-   {% linkcard title="Tell me more about Nx on CI" description="Understand how Nx works on CI, how to configure it and how Nx Cloud helps ensure CI runs fast and efficiently."  href="/docs/getting-started/nx-cloud" /%}
+   {% linkcard title="Tell me more about Nx on CI" description="Understand how Nx works on CI, how to configure it and how Nx Cloud helps ensure CI runs fast and efficiently."  href="/docs/features/ci-features" /%}
 
    {% linkcard title="Is Nx just for JavaScript projects?" description="Explore Nx technology integrations and how it can support your specific stack. Even beyond just JavaScript-based projects."  href="/docs/technologies"  /%}
 


### PR DESCRIPTION
## Current Behavior

Tutorials direct users to cloud.nx.app CTAs requiring GitHub account + full cloud onboarding before the tutorial starts. CNW starts dropped to ~1,800/day weekday (target ~2,700). Self-healing CI content buried at bottom of tutorials where only 15-20% of users scroll.

## Expected Behavior

- Tutorials use npx create-nx-workspace as primary path, cloud link kept as secondary text link
- llm_only tags added to tell AI agents to use CLI only (they can't handle the browser OAuth flow)
- Tutorial file trees, app names, and scopes updated to match what CNW actually generates
- Self-healing CI extracted to standalone "Setting up CI" tutorial
- Nx Cloud page moved from Getting Started to Orchestration & CI overview (redirect added)
- Sidebar labels converted to sentence case per style guide
- AI integrations moved before Editor setup in sidebar (higher traffic)
- Tutorials expanded by default in sidebar
- Intro page now shows CNW and nx init commands directly

## Notes

A follow-up to break tutorials down into smaller, more focused topics will be the next step.

<img width="547" height="400" alt="image" src="https://github.com/user-attachments/assets/b717ee54-0dc6-4c08-b1d3-0d80c9dce1df" />


## Related Issue(s)

Closes DOC-448