### PR TITLE
fix(core): make isAiAgent and detectAiAgent WASM-compatible

### DIFF
--- a/packages/nx/src/ai/detect-ai-agent.ts
+++ b/packages/nx/src/ai/detect-ai-agent.ts
@@ -2,7 +2,7 @@ import { detectAiAgent as nativeDetectAiAgent } from '../native';
 import { Agent, supportedAgents } from './utils';
 
 export function detectAiAgent(): Agent | null {
-  const detected = nativeDetectAiAgent();
+  const detected = nativeDetectAiAgent(process.env);
   if (detected && supportedAgents.includes(detected as Agent)) {
     return detected as Agent;
   }

--- a/packages/nx/src/command-line/ai/ai-output.ts
+++ b/packages/nx/src/command-line/ai/ai-output.ts
@@ -51,7 +51,7 @@ export interface PluginWarning {
  * Each message is a single line of JSON.
  */
 export function writeAiOutput(message: Record<string, any>): void {
-  if (isAiAgent()) {
+  if (isAiAgent(process.env)) {
     process.stdout.write(JSON.stringify(message) + '\n');
 
     // For success results, output plain text instructions that the agent can show the user

--- a/packages/nx/src/command-line/import/command-object.ts
+++ b/packages/nx/src/command-line/import/command-object.ts
@@ -62,7 +62,7 @@ export const yargsImportCommand: CommandModule = {
       try {
         return await (await import('./import')).importHandler(args as any);
       } catch (error) {
-        if (isAiAgent()) {
+        if (isAiAgent(process.env)) {
           const errorMessage =
             error instanceof Error ? error.message : String(error);
           const errorCode = determineImportErrorCode(error);

--- a/packages/nx/src/command-line/import/import.ts
+++ b/packages/nx/src/command-line/import/import.ts
@@ -80,7 +80,7 @@ export interface ImportOptions {
 export async function importHandler(options: ImportOptions) {
   process.env.NX_RUNNING_NX_IMPORT = 'true';
   let { sourceRepository, ref, source, destination, verbose } = options;
-  const aiMode = isAiAgent();
+  const aiMode = isAiAgent(process.env);
   if (aiMode) {
     options.interactive = false;
     logProgress('starting', 'Importing repository...');

--- a/packages/nx/src/command-line/init/command-object.ts
+++ b/packages/nx/src/command-line/init/command-object.ts
@@ -47,7 +47,7 @@ export const yargsInitCommand: CommandModule = {
       process.exit(0);
     } catch (error) {
       // Output structured error for AI agents
-      if (isAiAgent()) {
+      if (isAiAgent(process.env)) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
         const errorCode = determineErrorCode(error);

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -95,7 +95,7 @@ async function initHandlerImpl(options: InitArgs): Promise<void> {
   }
 
   // AI agent mode: apply defaults for non-interactive operation
-  const aiMode = isAiAgent();
+  const aiMode = isAiAgent(process.env);
   if (aiMode) {
     options.interactive = false; // Force non-interactive
 

--- a/packages/nx/src/command-line/show/command-object.ts
+++ b/packages/nx/src/command-line/show/command-object.ts
@@ -68,7 +68,7 @@ export const yargsShowCommand: CommandModule<
         description: 'Output JSON.',
       })
       .middleware((args) => {
-        if (args.json == null && isAiAgent()) {
+        if (args.json == null && isAiAgent(process.env)) {
           args.json = true;
         }
       })

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -241,7 +241,7 @@ export interface DepsOutputsInput {
  * Returns None if no agent is detected.
  * Filtering against supported agents should be done on the TypeScript side.
  */
-export declare function detectAiAgent(): string | null
+export declare function detectAiAgent(envVars: Record<string, string>): string | null
 
 export interface EnvironmentInput {
   env: string
@@ -408,7 +408,7 @@ export declare function installNxConsoleForEditor(editor: SupportedEditor): Prom
 export const IS_WASM: boolean
 
 /** Detects if the current process is being run by an AI agent */
-export declare function isAiAgent(): boolean
+export declare function isAiAgent(envVars: Record<string, string>): boolean
 
 export declare function isEditorInstalled(editor: SupportedEditor): Promise<boolean>
 

--- a/packages/nx/src/native/telemetry/service.rs
+++ b/packages/nx/src/native/telemetry/service.rs
@@ -66,7 +66,7 @@ impl TelemetryService {
             .map_err(|e| Error::from_reason(format!("Failed to create HTTP client: {}", e)))?;
 
         // Detect AI agent from environment variables
-        let is_ai_agent = crate::native::utils::ai::is_ai_agent();
+        let is_ai_agent = crate::native::utils::ai::is_ai_agent(std::env::vars().collect());
 
         let mut common_request_parameters = HashMap::new();
         common_request_parameters

--- a/packages/nx/src/native/utils/ai.rs
+++ b/packages/nx/src/native/utils/ai.rs
@@ -1,41 +1,43 @@
-use std::env;
+use std::collections::HashMap;
 use tracing::debug;
 
+fn has_var(env_vars: &HashMap<String, String>, key: &str) -> bool {
+    env_vars.contains_key(key)
+}
+
+fn get_var(env_vars: &HashMap<String, String>, key: &str) -> Option<String> {
+    env_vars.get(key).cloned()
+}
+
 /// Detects if the current process is being run by Claude Code
-fn is_claude_ai() -> bool {
-    match env::var("CLAUDECODE") {
-        Ok(_) => {
-            debug!("Claude AI detected via CLAUDECODE environment variable");
-            true
-        }
-        Err(_) => match env::var("CLAUDE_CODE") {
-            Ok(_) => {
-                debug!("Claude AI detected via CLAUDE_CODE environment variable");
-                true
-            }
-            Err(_) => false,
-        },
+fn is_claude_ai(env_vars: &HashMap<String, String>) -> bool {
+    if has_var(env_vars, "CLAUDECODE") {
+        debug!("Claude AI detected via CLAUDECODE environment variable");
+        return true;
     }
+    if has_var(env_vars, "CLAUDE_CODE") {
+        debug!("Claude AI detected via CLAUDE_CODE environment variable");
+        return true;
+    }
+    false
 }
 
 /// Detects if the current process is being run by Repl.it
-fn is_replit_ai() -> bool {
-    match env::var("REPL_ID") {
-        Ok(_) => {
-            debug!("Repl.it AI detected via REPL_ID environment variable");
-            true
-        }
-        Err(_) => false,
+fn is_replit_ai(env_vars: &HashMap<String, String>) -> bool {
+    if has_var(env_vars, "REPL_ID") {
+        debug!("Repl.it AI detected via REPL_ID environment variable");
+        return true;
     }
+    false
 }
 
 /// Detects if the current process is being run by Cursor AI
-fn is_cursor_ai() -> bool {
-    let pager_matches = env::var("PAGER")
+fn is_cursor_ai(env_vars: &HashMap<String, String>) -> bool {
+    let pager_matches = get_var(env_vars, "PAGER")
         .map(|v| v == "head -n 10000 | cat")
         .unwrap_or(false);
-    let has_cursor_trace_id = env::var("CURSOR_TRACE_ID").is_ok();
-    let has_composer_no_interaction = env::var("COMPOSER_NO_INTERACTION").is_ok();
+    let has_cursor_trace_id = has_var(env_vars, "CURSOR_TRACE_ID");
+    let has_composer_no_interaction = has_var(env_vars, "COMPOSER_NO_INTERACTION");
 
     let is_cursor = pager_matches && has_cursor_trace_id && has_composer_no_interaction;
 
@@ -49,41 +51,37 @@ fn is_cursor_ai() -> bool {
 }
 
 /// Detects if the current process is being run by OpenCode
-fn is_opencode_ai() -> bool {
-    match env::var("OPENCODE") {
-        Ok(_) => {
-            debug!("OpenCode AI detected via OPENCODE environment variable");
-            true
-        }
-        Err(_) => false,
+fn is_opencode_ai(env_vars: &HashMap<String, String>) -> bool {
+    if has_var(env_vars, "OPENCODE") {
+        debug!("OpenCode AI detected via OPENCODE environment variable");
+        return true;
     }
+    false
 }
 
 /// Detects if the current process is being run by Gemini CLI
-fn is_gemini_ai() -> bool {
-    match env::var("GEMINI_CLI") {
-        Ok(_) => {
-            debug!("Gemini CLI detected via GEMINI_CLI environment variable");
-            true
-        }
-        Err(_) => false,
+fn is_gemini_ai(env_vars: &HashMap<String, String>) -> bool {
+    if has_var(env_vars, "GEMINI_CLI") {
+        debug!("Gemini CLI detected via GEMINI_CLI environment variable");
+        return true;
     }
+    false
 }
 
 /// Detects which AI agent is running and returns its name.
 /// Returns None if no agent is detected.
 /// Filtering against supported agents should be done on the TypeScript side.
 #[napi]
-pub fn detect_ai_agent() -> Option<String> {
-    if is_claude_ai() {
+pub fn detect_ai_agent(env_vars: HashMap<String, String>) -> Option<String> {
+    if is_claude_ai(&env_vars) {
         Some("claude".to_string())
-    } else if is_cursor_ai() {
+    } else if is_cursor_ai(&env_vars) {
         Some("cursor".to_string())
-    } else if is_opencode_ai() {
+    } else if is_opencode_ai(&env_vars) {
         Some("opencode".to_string())
-    } else if is_gemini_ai() {
+    } else if is_gemini_ai(&env_vars) {
         Some("gemini".to_string())
-    } else if is_replit_ai() {
+    } else if is_replit_ai(&env_vars) {
         Some("replit".to_string())
     } else {
         None
@@ -92,9 +90,12 @@ pub fn detect_ai_agent() -> Option<String> {
 
 /// Detects if the current process is being run by an AI agent
 #[napi]
-pub fn is_ai_agent() -> bool {
-    let is_ai =
-        is_claude_ai() || is_replit_ai() || is_cursor_ai() || is_opencode_ai() || is_gemini_ai();
+pub fn is_ai_agent(env_vars: HashMap<String, String>) -> bool {
+    let is_ai = is_claude_ai(&env_vars)
+        || is_replit_ai(&env_vars)
+        || is_cursor_ai(&env_vars)
+        || is_opencode_ai(&env_vars)
+        || is_gemini_ai(&env_vars);
 
     if is_ai {
         debug!("AI agent detected");
@@ -107,226 +108,78 @@ pub fn is_ai_agent() -> bool {
 mod tests {
     use super::*;
 
-    fn clear_ai_env_vars() {
-        let ai_vars = [
-            "CLAUDECODE",
-            "CLAUDE_CODE",
-            "REPL_ID",
-            "PAGER",
-            "CURSOR_TRACE_ID",
-            "COMPOSER_NO_INTERACTION",
-            "OPENCODE",
-            "GEMINI_CLI",
-        ];
-        for var in &ai_vars {
-            unsafe {
-                std::env::remove_var(var);
-            }
-        }
+    fn make_env(vars: &[(&str, &str)]) -> HashMap<String, String> {
+        vars.iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
     }
 
     #[test]
-    fn test_ai_agent_detection() {
-        // Save original environment state
-        let original_claudecode = env::var("CLAUDECODE").ok();
-        let original_claude_code = env::var("CLAUDE_CODE").ok();
-        let original_repl_id = env::var("REPL_ID").ok();
-        let original_pager = env::var("PAGER").ok();
-        let original_cursor_trace_id = env::var("CURSOR_TRACE_ID").ok();
-        let original_composer_no_interaction = env::var("COMPOSER_NO_INTERACTION").ok();
-        let original_opencode = env::var("OPENCODE").ok();
-        let original_gemini_cli = env::var("GEMINI_CLI").ok();
+    fn test_no_ai_detected() {
+        let env = make_env(&[]);
+        assert!(!is_ai_agent(env.clone()));
+        assert_eq!(detect_ai_agent(env), None);
+    }
 
-        // Start with clean environment
-        clear_ai_env_vars();
+    #[test]
+    fn test_claude_via_claudecode() {
+        let env = make_env(&[("CLAUDECODE", "1")]);
+        assert!(is_ai_agent(env.clone()));
+        assert_eq!(detect_ai_agent(env), Some("claude".to_string()));
+    }
 
-        // Test no AI detection
-        assert!(
-            !is_claude_ai(),
-            "Should not detect Claude AI without CLAUDECODE"
-        );
-        assert!(
-            !is_replit_ai(),
-            "Should not detect Repl.it AI without REPL_ID"
-        );
-        assert!(
-            !is_cursor_ai(),
-            "Should not detect Cursor AI without all variables"
-        );
-        assert!(
-            !is_opencode_ai(),
-            "Should not detect OpenCode AI without OPENCODE"
-        );
-        assert!(
-            !is_gemini_ai(),
-            "Should not detect Gemini CLI without GEMINI_CLI"
-        );
-        assert!(!is_ai_agent(), "Should not detect any AI agent");
+    #[test]
+    fn test_claude_via_claude_code() {
+        let env = make_env(&[("CLAUDE_CODE", "1")]);
+        assert!(is_ai_agent(env.clone()));
+        assert_eq!(detect_ai_agent(env), Some("claude".to_string()));
+    }
 
-        // Test Claude AI detection via CLAUDECODE
-        unsafe {
-            env::set_var("CLAUDECODE", "1");
-        }
-        assert!(is_claude_ai(), "Should detect Claude AI with CLAUDECODE");
-        assert!(is_ai_agent(), "Main function should detect Claude AI");
-        assert_eq!(
-            detect_ai_agent(),
-            Some("claude".to_string()),
-            "detect_ai_agent should return claude"
-        );
-        unsafe {
-            env::remove_var("CLAUDECODE");
-        }
+    #[test]
+    fn test_replit() {
+        let env = make_env(&[("REPL_ID", "some-repl-id")]);
+        assert!(is_ai_agent(env.clone()));
+        assert_eq!(detect_ai_agent(env), Some("replit".to_string()));
+    }
 
-        // Test Claude AI detection via CLAUDE_CODE (underscore variant)
-        unsafe {
-            env::set_var("CLAUDE_CODE", "1");
-        }
-        assert!(is_claude_ai(), "Should detect Claude AI with CLAUDE_CODE");
-        assert!(
-            is_ai_agent(),
-            "Main function should detect Claude AI via CLAUDE_CODE"
-        );
-        assert_eq!(
-            detect_ai_agent(),
-            Some("claude".to_string()),
-            "detect_ai_agent should return claude for CLAUDE_CODE"
-        );
-        unsafe {
-            env::remove_var("CLAUDE_CODE");
-        }
+    #[test]
+    fn test_cursor_requires_all_vars() {
+        // Wrong PAGER value
+        let env = make_env(&[
+            ("PAGER", "wrong-value"),
+            ("CURSOR_TRACE_ID", "trace-123"),
+            ("COMPOSER_NO_INTERACTION", "1"),
+        ]);
+        assert!(!is_cursor_ai(&env));
 
-        // Test Repl.it AI detection
-        unsafe {
-            env::set_var("REPL_ID", "some-repl-id");
-        }
-        assert!(is_replit_ai(), "Should detect Repl.it AI with REPL_ID");
-        assert!(is_ai_agent(), "Main function should detect Repl.it AI");
-        assert_eq!(
-            detect_ai_agent(),
-            Some("replit".to_string()),
-            "detect_ai_agent should return replit"
-        );
-        unsafe {
-            env::remove_var("REPL_ID");
-        }
+        // Correct PAGER value
+        let env = make_env(&[
+            ("PAGER", "head -n 10000 | cat"),
+            ("CURSOR_TRACE_ID", "trace-123"),
+            ("COMPOSER_NO_INTERACTION", "1"),
+        ]);
+        assert!(is_ai_agent(env.clone()));
+        assert_eq!(detect_ai_agent(env), Some("cursor".to_string()));
+    }
 
-        // Test OpenCode AI detection
-        unsafe {
-            env::set_var("OPENCODE", "1");
-        }
-        assert!(is_opencode_ai(), "Should detect OpenCode AI with OPENCODE");
-        assert!(is_ai_agent(), "Main function should detect OpenCode AI");
-        assert_eq!(
-            detect_ai_agent(),
-            Some("opencode".to_string()),
-            "detect_ai_agent should return opencode"
-        );
-        unsafe {
-            env::remove_var("OPENCODE");
-        }
+    #[test]
+    fn test_opencode() {
+        let env = make_env(&[("OPENCODE", "1")]);
+        assert!(is_ai_agent(env.clone()));
+        assert_eq!(detect_ai_agent(env), Some("opencode".to_string()));
+    }
 
-        // Test Cursor AI detection with wrong PAGER
-        unsafe {
-            env::set_var("PAGER", "wrong-value");
-            env::set_var("CURSOR_TRACE_ID", "trace-123");
-            env::set_var("COMPOSER_NO_INTERACTION", "1");
-        }
-        assert!(
-            !is_cursor_ai(),
-            "Should not detect Cursor AI with wrong PAGER value"
-        );
+    #[test]
+    fn test_gemini() {
+        let env = make_env(&[("GEMINI_CLI", "1")]);
+        assert!(is_ai_agent(env.clone()));
+        assert_eq!(detect_ai_agent(env), Some("gemini".to_string()));
+    }
 
-        // Test Cursor AI detection with correct PAGER
-        unsafe {
-            env::set_var("PAGER", "head -n 10000 | cat");
-        }
-        assert!(
-            is_cursor_ai(),
-            "Should detect Cursor AI with correct PAGER and all variables"
-        );
-        assert!(is_ai_agent(), "Main function should detect Cursor AI");
-        assert_eq!(
-            detect_ai_agent(),
-            Some("cursor".to_string()),
-            "detect_ai_agent should return cursor"
-        );
-        clear_ai_env_vars();
-
-        // Test Gemini CLI detection
-        unsafe {
-            env::set_var("GEMINI_CLI", "1");
-        }
-        assert!(is_gemini_ai(), "Should detect Gemini CLI with GEMINI_CLI");
-        assert!(is_ai_agent(), "Main function should detect Gemini CLI");
-        assert_eq!(
-            detect_ai_agent(),
-            Some("gemini".to_string()),
-            "detect_ai_agent should return gemini"
-        );
-        unsafe {
-            env::remove_var("GEMINI_CLI");
-        }
-
-        // Test multiple AI agents
-        unsafe {
-            env::set_var("CLAUDECODE", "1");
-            env::set_var("REPL_ID", "some-repl-id");
-        }
-        assert!(
-            is_ai_agent(),
-            "Should detect AI when multiple agents are present"
-        );
-
-        // Test detect_ai_agent with no agents
-        clear_ai_env_vars();
-        assert_eq!(
-            detect_ai_agent(),
-            None,
-            "detect_ai_agent should return None when no agent is detected"
-        );
-
-        // Restore original environment
-        clear_ai_env_vars();
-        if let Some(val) = original_claudecode {
-            unsafe {
-                env::set_var("CLAUDECODE", val);
-            }
-        }
-        if let Some(val) = original_claude_code {
-            unsafe {
-                env::set_var("CLAUDE_CODE", val);
-            }
-        }
-        if let Some(val) = original_repl_id {
-            unsafe {
-                env::set_var("REPL_ID", val);
-            }
-        }
-        if let Some(val) = original_pager {
-            unsafe {
-                env::set_var("PAGER", val);
-            }
-        }
-        if let Some(val) = original_cursor_trace_id {
-            unsafe {
-                env::set_var("CURSOR_TRACE_ID", val);
-            }
-        }
-        if let Some(val) = original_composer_no_interaction {
-            unsafe {
-                env::set_var("COMPOSER_NO_INTERACTION", val);
-            }
-        }
-        if let Some(val) = original_opencode {
-            unsafe {
-                env::set_var("OPENCODE", val);
-            }
-        }
-        if let Some(val) = original_gemini_cli {
-            unsafe {
-                env::set_var("GEMINI_CLI", val);
-            }
-        }
+    #[test]
+    fn test_claude_takes_priority_over_replit() {
+        let env = make_env(&[("CLAUDECODE", "1"), ("REPL_ID", "some-repl-id")]);
+        assert!(is_ai_agent(env.clone()));
+        assert_eq!(detect_ai_agent(env), Some("claude".to_string()));
     }
 }

--- a/packages/nx/src/tasks-runner/is-tui-enabled.ts
+++ b/packages/nx/src/tasks-runner/is-tui-enabled.ts
@@ -76,7 +76,7 @@ export function shouldUseTui(
     // Interactive TUI doesn't make sense on CI
     isCI() ||
     // Interactive TUI doesn't make sense in an AI agent context
-    isAiAgent() ||
+    isAiAgent(process.env) ||
     // WASM needs further testing
     IS_WASM
   ) {

--- a/packages/nx/src/utils/workspace-context.ts
+++ b/packages/nx/src/utils/workspace-context.ts
@@ -7,8 +7,11 @@ import { daemonClient } from '../daemon/client/client';
 let workspaceContext: WorkspaceContext | undefined;
 
 export function setupWorkspaceContext(workspaceRoot: string) {
-  const { WorkspaceContext } =
+  const { WorkspaceContext, IS_WASM } =
     require('../native') as typeof import('../native');
+  if (IS_WASM) {
+    return;
+  }
   performance.mark('workspace-context');
   workspaceContext = new WorkspaceContext(
     workspaceRoot,


### PR DESCRIPTION
## Current Behavior

`isAiAgent()` and `detectAiAgent()` use `std::env::var()` in Rust, which doesn't work in WASM/WASI builds. The functions fail to register in the WASM module, causing `TypeError: isAiAgent is not a function` when running with `NAPI_RS_FORCE_WASI=true`.

Additionally, `setupWorkspaceContext` crashes under WASM because `WorkspaceContext` is not available.

## Expected Behavior

AI agent detection works in both native and WASM builds. `setupWorkspaceContext` gracefully handles WASM.

## Changes

- **`ai.rs`**: Accept `HashMap<String, String>` instead of reading `std::env` directly
- **All TS callers**: Pass `process.env` to `isAiAgent()` and `detectAiAgent()`
- **`telemetry/service.rs`**: Internal Rust caller passes `std::env::vars().collect()`
- **`workspace-context.ts`**: Add `IS_WASM` guard to `setupWorkspaceContext`
- **Tests**: Simplified — no more `unsafe` env var manipulation, just pass a HashMap

## Related Issue(s)

<!-- N/A - internal improvement -->