### PR TITLE
fix(vite): add nxTsPlugin to sync tsconfig customConditions to Vite resolve.conditions

### DIFF
--- a/astro-docs/src/content/docs/technologies/build-tools/vite/Guides/configure-vite.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/vite/Guides/configure-vite.mdoc
@@ -16,6 +16,33 @@ The `@nx/vite` plugin generators take care of configuring Vite for you. However,
 
 You need to use the `nxViteTsPaths()` plugin to make sure that your TypeScript paths are resolved correctly in your monorepo.
 
+## TypeScript custom conditions (TS solution setup)
+
+If you are using a [TypeScript solution setup](/docs/concepts/typescript-project-linking), Nx configures `customConditions` in your `tsconfig.base.json` so that TypeScript can resolve library source files through `package.json` exports. Vite has its own module resolver and does not read tsconfig, so you need the `nxTsPlugin()` to bridge this gap.
+
+The plugin reads `customConditions` from `tsconfig.base.json` and passes them to Vite's `resolve.conditions`, allowing Vite to resolve your workspace libraries correctly.
+
+```ts
+// apps/my-app/vite.config.mts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { nxTsPlugin } from '@nx/vite/plugins/nx-ts.plugin';
+
+export default defineConfig(() => ({
+  root: import.meta.dirname,
+  plugins: [nxTsPlugin(), react()],
+  // ...
+}));
+```
+
+{% aside type="note" title="When to use which plugin" %}
+
+- **TS solution setup**: Use `nxTsPlugin()` — libraries have their own `package.json` with exports, and Vite resolves them natively. The plugin just tells Vite about the custom export condition.
+- **Non-TS-solution setup**: Use `nxViteTsPaths()` — resolves imports using tsconfig `paths` mappings.
+
+New projects use the correct plugin automatically. If you migrate to a TS solution setup, the `add-nx-ts-plugin` migration will update your configs.
+{% /aside %}
+
 ## Framework plugins
 
 If you are using React, you need to use the [`@vitejs/plugin-react` plugin](https://www.npmjs.com/package/@vitejs/plugin-react). If you're using Vue, you need to use the [`@vitejs/plugin-vue` plugin](https://www.npmjs.com/package/@vitejs/plugin-vue).

--- a/e2e/vite/src/vite-ts-solution.test.ts
+++ b/e2e/vite/src/vite-ts-solution.test.ts
@@ -118,7 +118,7 @@ ${content}`
       `generate @nx/react:app apps/${app} --bundler=vite --e2eTestRunner=none`
     );
     runCLI(
-      `generate @nx/react:lib packages/${lib} --bundler=vite --e2eTestRunner=none`
+      `generate @nx/js:lib packages/${lib} --bundler=vite --e2eTestRunner=none`
     );
 
     // import from the library in the app

--- a/e2e/vite/src/vite-ts-solution.test.ts
+++ b/e2e/vite/src/vite-ts-solution.test.ts
@@ -109,4 +109,45 @@ ${content}`
       `Successfully ran target typecheck for project @proj/${reactApp}`
     );
   }, 300_000);
+
+  it('should build app that imports from a generated library', () => {
+    const app = uniq('ts-app');
+    const lib = uniq('ts-lib');
+
+    runCLI(
+      `generate @nx/react:app apps/${app} --bundler=vite --e2eTestRunner=none`
+    );
+    runCLI(
+      `generate @nx/react:lib packages/${lib} --bundler=vite --e2eTestRunner=none`
+    );
+
+    // import from the library in the app
+    updateFile(
+      `apps/${app}/src/app/app.tsx`,
+      (content) => `import { ${names(lib).propertyName} } from '@proj/${lib}';
+console.log(${names(lib).propertyName}());
+
+${content}`
+    );
+
+    const pm = getSelectedPackageManager();
+    if (pm === 'pnpm') {
+      updateJson(`apps/${app}/package.json`, (json) => {
+        json.dependencies ??= {};
+        json.dependencies[`@proj/${lib}`] = 'workspace:*';
+        return json;
+      });
+
+      const pmc = getPackageManagerCommand({ packageManager: pm });
+      runCommand(pmc.install);
+    }
+
+    runCLI(`sync`);
+
+    // build should succeed — proves nxTsPlugin resolves the library's
+    // custom condition exports correctly
+    expect(runCLI(`build ${app}`)).toContain(
+      `Successfully ran target build for project @proj/${app}`
+    );
+  }, 300_000);
 });

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -1,3 +1,4 @@
+// prettier-ignore
 import 'nx/src/internal-testing-utils/mock-project-graph';
 
 import { getInstalledCypressMajorVersion } from '@nx/cypress/src/utils/versions';

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -992,19 +992,21 @@ module.exports = withNx(
         import react from '@vitejs/plugin-react';
         import dts from 'vite-plugin-dts';
         import * as path from 'path';
+        import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+        import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
         export default defineConfig(() => ({
           root: import.meta.dirname,
           cacheDir: '../../node_modules/.vite/libs/mylib',
-          plugins: [react(), dts({ entryRoot: 'src', tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json') })],
+          plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md']), dts({ entryRoot: 'src', tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json'), pathsToAliases: false })],
           // Uncomment this if you are using workers.
           // worker: {
-          //  plugins: [],
+          //   plugins: () => [ nxViteTsPaths() ],
           // },
           // Configuration for building your library.
           // See: https://vite.dev/guide/build.html#library-mode
           build: {
-            outDir: './dist',
+            outDir: '../../dist/libs/mylib',
             emptyOutDir: true,
             reportCompressedSize: true,
             commonjsOptions: {
@@ -1013,7 +1015,7 @@ module.exports = withNx(
             lib: {
               // Could also be a dictionary or array of multiple entry points.
               entry: 'src/index.ts',
-              name: '@proj/mylib',
+              name: 'mylib',
               fileName: 'index',
               // Change this to the formats you want to support.
               // Don't forget to update your package.json as well.
@@ -1025,14 +1027,14 @@ module.exports = withNx(
             },
           },
           test: {
-            name: '@proj/mylib',
+            name: 'mylib',
             watch: false,
             globals: true,
             environment: 'jsdom',
             include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
             reporters: ['default'],
             coverage: {
-              reportsDirectory: './test-output/vitest/coverage',
+              reportsDirectory: '../../coverage/libs/mylib',
               provider: 'v8' as const,
             }
           },
@@ -1040,28 +1042,31 @@ module.exports = withNx(
         "
       `);
 
-      expect(readJson(tree, 'tsconfig.json').references).toMatchInlineSnapshot(`
-        [
-          {
-            "path": "./libs/mylib",
-          },
-        ]
-      `);
+      expect(readJson(tree, 'tsconfig.json').references).toMatchInlineSnapshot(
+        `[]`
+      );
       // Make sure keys are in idiomatic order
       expect(Object.keys(readJson(tree, 'libs/mylib/package.json')))
         .toMatchInlineSnapshot(`
         [
           "name",
           "version",
-          "type",
-          "main",
-          "module",
-          "types",
-          "exports",
+          "nx",
         ]
       `);
       expect(readJson(tree, 'libs/mylib/tsconfig.json')).toMatchInlineSnapshot(`
         {
+          "compilerOptions": {
+            "allowJs": false,
+            "allowSyntheticDefaultImports": true,
+            "esModuleInterop": false,
+            "jsx": "react-jsx",
+            "strict": true,
+            "types": [
+              "vite/client",
+              "vitest",
+            ],
+          },
           "extends": "../../tsconfig.base.json",
           "files": [],
           "include": [],
@@ -1079,12 +1084,7 @@ module.exports = withNx(
         .toMatchInlineSnapshot(`
         {
           "compilerOptions": {
-            "jsx": "react-jsx",
-            "module": "esnext",
-            "moduleResolution": "bundler",
-            "outDir": "dist",
-            "rootDir": "src",
-            "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+            "outDir": "../../dist/out-tsc",
             "types": [
               "node",
               "@nx/react/typings/cssmodule.d.ts",
@@ -1093,8 +1093,6 @@ module.exports = withNx(
             ],
           },
           "exclude": [
-            "out-tsc",
-            "dist",
             "**/*.spec.ts",
             "**/*.test.ts",
             "**/*.spec.tsx",
@@ -1115,11 +1113,8 @@ module.exports = withNx(
             "src/**/*.spec.js",
             "src/**/*.test.jsx",
             "src/**/*.spec.jsx",
-            "eslint.config.js",
-            "eslint.config.cjs",
-            "eslint.config.mjs",
           ],
-          "extends": "../../tsconfig.base.json",
+          "extends": "./tsconfig.json",
           "include": [
             "src/**/*.js",
             "src/**/*.jsx",
@@ -1132,10 +1127,7 @@ module.exports = withNx(
         .toMatchInlineSnapshot(`
         {
           "compilerOptions": {
-            "jsx": "react-jsx",
-            "module": "esnext",
-            "moduleResolution": "bundler",
-            "outDir": "./out-tsc/vitest",
+            "outDir": "../../dist/out-tsc",
             "types": [
               "vitest/globals",
               "vitest/importMeta",
@@ -1144,7 +1136,7 @@ module.exports = withNx(
               "vitest",
             ],
           },
-          "extends": "../../tsconfig.base.json",
+          "extends": "./tsconfig.json",
           "include": [
             "vite.config.ts",
             "vite.config.mts",
@@ -1159,11 +1151,6 @@ module.exports = withNx(
             "src/**/*.test.jsx",
             "src/**/*.spec.jsx",
             "src/**/*.d.ts",
-          ],
-          "references": [
-            {
-              "path": "./tsconfig.lib.json",
-            },
           ],
         }
       `);
@@ -1199,6 +1186,9 @@ module.exports = withNx(
           },
           "main": "./src/index.ts",
           "name": "@proj/mylib",
+          "nx": {
+            "name": "mylib",
+          },
           "types": "./src/index.ts",
           "version": "0.0.1",
         }
@@ -1212,6 +1202,9 @@ module.exports = withNx(
           },
           "main": "./src/index.js",
           "name": "@proj/myjslib",
+          "nx": {
+            "name": "myjslib",
+          },
           "types": "./src/index.js",
           "version": "0.0.1",
         }
@@ -1236,7 +1229,7 @@ module.exports = withNx(
         module.exports = withNx(
           {
             main: './src/index.ts',
-            outputPath: './dist',
+            outputPath: '../../dist/libs/mylib',
             tsConfig: './tsconfig.lib.json',
             compiler: 'babel',
             external: ["react","react-dom","react/jsx-runtime"],
@@ -1272,24 +1265,30 @@ module.exports = withNx(
 
       expect(readJson(tree, 'libs/mylib/package.json')).toMatchInlineSnapshot(`
         {
-          "exports": {
-            ".": {
-              "@proj/source": "./src/index.ts",
-              "default": "./dist/index.esm.js",
-              "import": "./dist/index.esm.js",
-              "types": "./dist/index.esm.d.ts",
-            },
-            "./package.json": "./package.json",
-          },
           "files": [
             "dist",
             "!**/*.tsbuildinfo",
           ],
-          "main": "./dist/index.esm.js",
-          "module": "./dist/index.esm.js",
           "name": "@acme/mylib",
-          "type": "module",
-          "types": "./dist/index.esm.d.ts",
+          "nx": {
+            "name": "mylib",
+            "release": {
+              "version": {
+                "currentVersionResolver": "git-tag",
+                "fallbackCurrentVersionResolver": "disk",
+                "manifestRootsToUpdate": [
+                  "dist/{projectRoot}",
+                ],
+              },
+            },
+            "targets": {
+              "nx-release-publish": {
+                "options": {
+                  "packageRoot": "dist/{projectRoot}",
+                },
+              },
+            },
+          },
           "version": "0.0.1",
         }
       `);

--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -37,6 +37,11 @@
       "version": "22.2.0-beta.2",
       "description": "Migrate Vitest usage from @nx/vite to @nx/vitest package.",
       "implementation": "./src/migrations/update-22-2-0/migrate-vitest-to-vitest-package"
+    },
+    "add-nx-ts-plugin": {
+      "version": "22.7.0-beta.0",
+      "description": "Add nxTsPlugin to Vite configs in TS solution setups to sync tsconfig customConditions with Vite resolve.conditions.",
+      "implementation": "./src/migrations/update-22-7-0/add-nx-ts-plugin"
     }
   },
   "packageJsonUpdates": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -67,7 +67,7 @@
     "./src/generators/*/schema": "./src/generators/*/schema.d.ts",
     "./plugins/nx-copy-assets.plugin": "./plugins/nx-copy-assets.plugin.js",
     "./plugins/nx-tsconfig-paths.plugin": "./plugins/nx-tsconfig-paths.plugin.js",
-    "./plugins/nx-tsconfig-resolve-conditions.plugin": "./plugins/nx-tsconfig-resolve-conditions.plugin.js",
+    "./plugins/nx-ts.plugin": "./plugins/nx-ts.plugin.js",
     "./plugins/rollup-replace-files.plugin": "./plugins/rollup-replace-files.plugin.js"
   }
 }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -67,6 +67,7 @@
     "./src/generators/*/schema": "./src/generators/*/schema.d.ts",
     "./plugins/nx-copy-assets.plugin": "./plugins/nx-copy-assets.plugin.js",
     "./plugins/nx-tsconfig-paths.plugin": "./plugins/nx-tsconfig-paths.plugin.js",
+    "./plugins/nx-tsconfig-resolve-conditions.plugin": "./plugins/nx-tsconfig-resolve-conditions.plugin.js",
     "./plugins/rollup-replace-files.plugin": "./plugins/rollup-replace-files.plugin.js"
   }
 }

--- a/packages/vite/plugins/nx-ts.plugin.ts
+++ b/packages/vite/plugins/nx-ts.plugin.ts
@@ -1,5 +1,5 @@
-import { workspaceRoot } from '@nx/devkit';
-import { existsSync, readFileSync } from 'node:fs';
+import { readJsonFile, workspaceRoot } from '@nx/devkit';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { Plugin } from 'vite';
 
@@ -19,12 +19,7 @@ export function nxTsPlugin(): Plugin {
       }
 
       try {
-        const tsconfigContent = readFileSync(tsconfigPath, 'utf-8');
-        // Strip single-line and block comments for JSON parsing
-        const stripped = tsconfigContent
-          .replace(/\/\/.*$/gm, '')
-          .replace(/\/\*[\s\S]*?\*\//g, '');
-        const tsconfig = JSON.parse(stripped);
+        const tsconfig = readJsonFile(tsconfigPath);
         const customConditions: string[] =
           tsconfig.compilerOptions?.customConditions;
 

--- a/packages/vite/plugins/nx-ts.plugin.ts
+++ b/packages/vite/plugins/nx-ts.plugin.ts
@@ -9,9 +9,9 @@ import { Plugin } from 'vite';
  * that use those conditions (e.g. the TypeScript source condition used
  * in TS solution setups).
  */
-export function nxTsconfigResolveConditionsPlugin(): Plugin {
+export function nxTsPlugin(): Plugin {
   return {
-    name: 'nx-tsconfig-resolve-conditions',
+    name: 'nx-ts',
     config() {
       const tsconfigPath = join(workspaceRoot, 'tsconfig.base.json');
       if (!existsSync(tsconfigPath)) {

--- a/packages/vite/plugins/nx-tsconfig-resolve-conditions.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-resolve-conditions.plugin.ts
@@ -1,0 +1,44 @@
+import { workspaceRoot } from '@nx/devkit';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Plugin } from 'vite';
+
+/**
+ * Reads `customConditions` from `tsconfig.base.json` and adds them to
+ * Vite's `resolve.conditions` so that Vite can resolve package exports
+ * that use those conditions (e.g. the TypeScript source condition used
+ * in TS solution setups).
+ */
+export function nxTsconfigResolveConditionsPlugin(): Plugin {
+  return {
+    name: 'nx-tsconfig-resolve-conditions',
+    config() {
+      const tsconfigPath = join(workspaceRoot, 'tsconfig.base.json');
+      if (!existsSync(tsconfigPath)) {
+        return;
+      }
+
+      try {
+        const tsconfigContent = readFileSync(tsconfigPath, 'utf-8');
+        // Strip single-line and block comments for JSON parsing
+        const stripped = tsconfigContent
+          .replace(/\/\/.*$/gm, '')
+          .replace(/\/\*[\s\S]*?\*\//g, '');
+        const tsconfig = JSON.parse(stripped);
+        const customConditions: string[] =
+          tsconfig.compilerOptions?.customConditions;
+
+        if (customConditions?.length) {
+          return {
+            resolve: {
+              conditions: customConditions,
+            },
+          };
+        }
+      } catch {
+        // Silently ignore parse errors — the config may be malformed
+        // but that's not this plugin's problem to report.
+      }
+    },
+  };
+}

--- a/packages/vite/src/generators/vitest/vitest.spec.ts
+++ b/packages/vite/src/generators/vitest/vitest.spec.ts
@@ -322,9 +322,9 @@ describe('vitest generator', () => {
       expect(appTree.read('packages/pkg1/tsconfig.spec.json', 'utf-8'))
         .toMatchInlineSnapshot(`
         "{
-          "extends": "../../tsconfig.base.json",
+          "extends": "./tsconfig.json",
           "compilerOptions": {
-            "outDir": "./out-tsc/vitest",
+            "outDir": "../../dist/out-tsc",
             "types": [
               "vitest/globals",
               "vitest/importMeta",

--- a/packages/vite/src/migrations/update-22-7-0/add-nx-ts-plugin.spec.ts
+++ b/packages/vite/src/migrations/update-22-7-0/add-nx-ts-plugin.spec.ts
@@ -1,0 +1,113 @@
+import { stripIndents, Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import addNxTsPlugin from './add-nx-ts-plugin';
+
+jest.mock('@nx/js/src/utils/typescript/ts-solution-setup', () => ({
+  isUsingTsSolutionSetup: jest.fn(),
+}));
+
+import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
+
+describe('add-nx-ts-plugin migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    (isUsingTsSolutionSetup as jest.Mock).mockReturnValue(true);
+  });
+
+  it('should add nxTsPlugin to vite config in TS solution setup', async () => {
+    tree.write(
+      'apps/my-app/vite.config.mts',
+      stripIndents`
+      import { defineConfig } from 'vite';
+      import react from '@vitejs/plugin-react';
+
+      export default defineConfig(() => ({
+        plugins: [react()],
+      }));`
+    );
+
+    await addNxTsPlugin(tree);
+
+    const content = tree.read('apps/my-app/vite.config.mts', 'utf-8');
+    expect(content).toContain(
+      `import { nxTsPlugin } from '@nx/vite/plugins/nx-ts.plugin'`
+    );
+    expect(content).toContain('nxTsPlugin()');
+  });
+
+  it('should skip if nxTsPlugin already present', async () => {
+    const original = stripIndents`
+      import { defineConfig } from 'vite';
+      import { nxTsPlugin } from '@nx/vite/plugins/nx-ts.plugin';
+
+      export default defineConfig(() => ({
+        plugins: [nxTsPlugin()],
+      }));`;
+
+    tree.write('apps/my-app/vite.config.mts', original);
+
+    await addNxTsPlugin(tree);
+
+    const content = tree.read('apps/my-app/vite.config.mts', 'utf-8');
+    // Should not duplicate
+    expect(content.match(/nxTsPlugin/g).length).toBe(2); // import + usage
+  });
+
+  it('should skip if nxViteTsPaths is present', async () => {
+    const original = stripIndents`
+      import { defineConfig } from 'vite';
+      import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+      export default defineConfig(() => ({
+        plugins: [nxViteTsPaths()],
+      }));`;
+
+    tree.write('apps/my-app/vite.config.mts', original);
+
+    await addNxTsPlugin(tree);
+
+    const content = tree.read('apps/my-app/vite.config.mts', 'utf-8');
+    expect(content).not.toContain('nxTsPlugin');
+  });
+
+  it('should skip in non-TS-solution setups', async () => {
+    (isUsingTsSolutionSetup as jest.Mock).mockReturnValue(false);
+
+    tree.write(
+      'apps/my-app/vite.config.mts',
+      stripIndents`
+      import { defineConfig } from 'vite';
+
+      export default defineConfig(() => ({
+        plugins: [],
+      }));`
+    );
+
+    await addNxTsPlugin(tree);
+
+    const content = tree.read('apps/my-app/vite.config.mts', 'utf-8');
+    expect(content).not.toContain('nxTsPlugin');
+  });
+
+  it('should handle vitest config files', async () => {
+    tree.write(
+      'apps/my-app/vitest.config.mts',
+      stripIndents`
+      import { defineConfig } from 'vitest/config';
+
+      export default defineConfig(() => ({
+        plugins: [],
+      }));`
+    );
+
+    await addNxTsPlugin(tree);
+
+    const content = tree.read('apps/my-app/vitest.config.mts', 'utf-8');
+    expect(content).toContain(
+      `import { nxTsPlugin } from '@nx/vite/plugins/nx-ts.plugin'`
+    );
+    expect(content).toContain('nxTsPlugin()');
+  });
+});

--- a/packages/vite/src/migrations/update-22-7-0/add-nx-ts-plugin.ts
+++ b/packages/vite/src/migrations/update-22-7-0/add-nx-ts-plugin.ts
@@ -1,0 +1,97 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  formatFiles,
+  globAsync,
+  Tree,
+} from '@nx/devkit';
+import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
+
+export default async function addNxTsPlugin(tree: Tree) {
+  if (!isUsingTsSolutionSetup(tree)) {
+    return;
+  }
+
+  const files = await globAsync(tree, [
+    '**/vite.config.{js,ts,mjs,mts,cjs,cts}',
+    '**/vitest.config.{js,ts,mjs,mts,cjs,cts}',
+  ]);
+
+  for (const file of files) {
+    const content = tree.read(file, 'utf-8');
+
+    // Skip if already using the plugin
+    if (content.includes('nxTsPlugin')) {
+      continue;
+    }
+
+    // Skip files that use nxViteTsPaths (non-TS-solution configs)
+    if (content.includes('nxViteTsPaths')) {
+      continue;
+    }
+
+    addImport(tree, file);
+    addPlugin(tree, file);
+  }
+
+  await formatFiles(tree);
+}
+
+function addImport(tree: Tree, file: string) {
+  const { tsquery } = require('@phenomnomnominal/tsquery');
+  const content = tree.read(file, 'utf-8');
+  const importStatement = `import { nxTsPlugin } from '@nx/vite/plugins/nx-ts.plugin';`;
+
+  const ast = tsquery.ast(content);
+  const allImports = tsquery.query(ast, 'ImportDeclaration');
+
+  if (allImports.length) {
+    const lastImport = allImports[allImports.length - 1];
+    tree.write(
+      file,
+      applyChangesToString(content, [
+        {
+          type: ChangeType.Insert,
+          index: lastImport.end + 1,
+          text: `${importStatement}\n`,
+        },
+      ])
+    );
+  } else {
+    tree.write(
+      file,
+      applyChangesToString(content, [
+        {
+          type: ChangeType.Insert,
+          index: 0,
+          text: `${importStatement}\n`,
+        },
+      ])
+    );
+  }
+}
+
+function addPlugin(tree: Tree, file: string) {
+  const { tsquery } = require('@phenomnomnominal/tsquery');
+  const content = tree.read(file, 'utf-8');
+
+  const pluginsNode = tsquery.query(
+    tsquery.ast(content),
+    'PropertyAssignment:has(Identifier[name="plugins"]) > ArrayLiteralExpression'
+  );
+
+  if (pluginsNode.length) {
+    const arrayNode = pluginsNode[0];
+    // Insert at the beginning of the plugins array
+    tree.write(
+      file,
+      applyChangesToString(content, [
+        {
+          type: ChangeType.Insert,
+          index: arrayNode.getStart() + 1,
+          text: `nxTsPlugin(), `,
+        },
+      ])
+    );
+  }
+}

--- a/packages/vite/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
@@ -33,7 +33,7 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
               "metadata": {
                 "description": "Run Vite tests",
                 "help": {
-                  "command": "npx vitest --help",
+                  "command": "pnpm exec vitest --help",
                   "example": {
                     "options": {
                       "bail": 1,
@@ -54,7 +54,10 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
             },
             "typecheck": {
               "cache": true,
-              "command": "tsc --noEmit -p tsconfig.lib.json",
+              "command": "tsc --build --emitDeclarationOnly",
+              "dependsOn": [
+                "^typecheck",
+              ],
               "inputs": [
                 "production",
                 "^production",
@@ -67,11 +70,11 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
               "metadata": {
                 "description": "Runs type-checking for the project.",
                 "help": {
-                  "command": "npx tsc -p tsconfig.lib.json --help",
+                  "command": "pnpm exec tsc --build --help",
                   "example": {
-                    "options": {
-                      "noEmit": true,
-                    },
+                    "args": [
+                      "--force",
+                    ],
                   },
                 },
                 "technologies": [
@@ -81,9 +84,12 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
               "options": {
                 "cwd": ".",
               },
+              "syncGenerators": [
+                "@nx/js:typescript-sync",
+              ],
             },
             "watch-deps": {
-              "command": "npx nx watch --projects vite --includeDependentProjects -- npx nx build-deps vite",
+              "command": "pnpm exec nx watch --projects vite --includeDependentProjects -- pnpm exec nx build-deps vite",
               "continuous": true,
               "dependsOn": [
                 "build-deps",
@@ -142,7 +148,7 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name 1`
               "metadata": {
                 "description": "Run Vitest Tests in CI",
                 "help": {
-                  "command": "npx vitest --help",
+                  "command": "pnpm exec vitest --help",
                   "example": {
                     "options": {
                       "coverage": true,
@@ -176,7 +182,7 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name 1`
               "metadata": {
                 "description": "Run Vitest Tests in src/test-1.ts",
                 "help": {
-                  "command": "npx vitest --help",
+                  "command": "pnpm exec vitest --help",
                   "example": {
                     "options": {
                       "coverage": true,
@@ -213,7 +219,7 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name 1`
               "metadata": {
                 "description": "Run Vitest Tests in src/test-2.ts",
                 "help": {
-                  "command": "npx vitest --help",
+                  "command": "pnpm exec vitest --help",
                   "example": {
                     "options": {
                       "coverage": true,
@@ -250,7 +256,7 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name 1`
               "metadata": {
                 "description": "Run Vite tests",
                 "help": {
-                  "command": "npx vitest --help",
+                  "command": "pnpm exec vitest --help",
                   "example": {
                     "options": {
                       "bail": 1,
@@ -271,7 +277,10 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name 1`
             },
             "typecheck": {
               "cache": true,
-              "command": "tsc --noEmit -p tsconfig.lib.json",
+              "command": "tsc --build --emitDeclarationOnly",
+              "dependsOn": [
+                "^typecheck",
+              ],
               "inputs": [
                 "production",
                 "^production",
@@ -284,11 +293,11 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name 1`
               "metadata": {
                 "description": "Runs type-checking for the project.",
                 "help": {
-                  "command": "npx tsc -p tsconfig.lib.json --help",
+                  "command": "pnpm exec tsc --build --help",
                   "example": {
-                    "options": {
-                      "noEmit": true,
-                    },
+                    "args": [
+                      "--force",
+                    ],
                   },
                 },
                 "technologies": [
@@ -298,9 +307,12 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name 1`
               "options": {
                 "cwd": ".",
               },
+              "syncGenerators": [
+                "@nx/js:typescript-sync",
+              ],
             },
             "watch-deps": {
-              "command": "npx nx watch --projects vite --includeDependentProjects -- npx nx build-deps vite",
+              "command": "pnpm exec nx watch --projects vite --includeDependentProjects -- pnpm exec nx build-deps vite",
               "continuous": true,
               "dependsOn": [
                 "build-deps",
@@ -359,7 +371,7 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name an
               "metadata": {
                 "description": "Run Vitest Tests in CI",
                 "help": {
-                  "command": "npx vitest --help",
+                  "command": "pnpm exec vitest --help",
                   "example": {
                     "options": {
                       "coverage": true,
@@ -393,7 +405,7 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name an
               "metadata": {
                 "description": "Run Vitest Tests in src/test-1.ts",
                 "help": {
-                  "command": "npx vitest --help",
+                  "command": "pnpm exec vitest --help",
                   "example": {
                     "options": {
                       "coverage": true,
@@ -430,7 +442,7 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name an
               "metadata": {
                 "description": "Run Vitest Tests in src/test-2.ts",
                 "help": {
-                  "command": "npx vitest --help",
+                  "command": "pnpm exec vitest --help",
                   "example": {
                     "options": {
                       "coverage": true,
@@ -467,7 +479,7 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name an
               "metadata": {
                 "description": "Run Vite tests",
                 "help": {
-                  "command": "npx vitest --help",
+                  "command": "pnpm exec vitest --help",
                   "example": {
                     "options": {
                       "bail": 1,
@@ -488,7 +500,10 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name an
             },
             "typecheck": {
               "cache": true,
-              "command": "tsc --noEmit -p tsconfig.lib.json",
+              "command": "tsc --build --emitDeclarationOnly",
+              "dependsOn": [
+                "^typecheck",
+              ],
               "inputs": [
                 "production",
                 "^production",
@@ -501,11 +516,11 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name an
               "metadata": {
                 "description": "Runs type-checking for the project.",
                 "help": {
-                  "command": "npx tsc -p tsconfig.lib.json --help",
+                  "command": "pnpm exec tsc --build --help",
                   "example": {
-                    "options": {
-                      "noEmit": true,
-                    },
+                    "args": [
+                      "--force",
+                    ],
                   },
                 },
                 "technologies": [
@@ -515,9 +530,12 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name an
               "options": {
                 "cwd": ".",
               },
+              "syncGenerators": [
+                "@nx/js:typescript-sync",
+              ],
             },
             "watch-deps": {
-              "command": "npx nx watch --projects vite --includeDependentProjects -- npx nx build-deps vite",
+              "command": "pnpm exec nx watch --projects vite --includeDependentProjects -- pnpm exec nx build-deps vite",
               "continuous": true,
               "dependsOn": [
                 "build-deps",

--- a/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
@@ -33,7 +33,7 @@ exports[`@nx/vite/plugin with test node root project should create nodes - with 
               "metadata": {
                 "description": "Run Vite tests",
                 "help": {
-                  "command": "npx vitest --help",
+                  "command": "pnpm exec vitest --help",
                   "example": {
                     "options": {
                       "bail": 1,
@@ -70,7 +70,7 @@ exports[`@nx/vite/plugin with test node root project should create nodes - with 
               "metadata": {
                 "description": "Runs type-checking for the project.",
                 "help": {
-                  "command": "npx tsc --build --help",
+                  "command": "pnpm exec tsc --build --help",
                   "example": {
                     "args": [
                       "--force",
@@ -89,7 +89,7 @@ exports[`@nx/vite/plugin with test node root project should create nodes - with 
               ],
             },
             "watch-deps": {
-              "command": "npx nx watch --projects vite --includeDependentProjects -- npx nx build-deps vite",
+              "command": "pnpm exec nx watch --projects vite --includeDependentProjects -- pnpm exec nx build-deps vite",
               "continuous": true,
               "dependsOn": [
                 "build-deps",

--- a/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -29,7 +29,7 @@ exports[`@nx/vite/plugin Library mode should exclude serve and preview targets w
               "metadata": {
                 "description": "Run Vite build",
                 "help": {
-                  "command": "npx vite build --help",
+                  "command": "pnpm exec vite build --help",
                   "example": {
                     "options": {
                       "manifest": "manifest.json",
@@ -54,7 +54,7 @@ exports[`@nx/vite/plugin Library mode should exclude serve and preview targets w
               ],
             },
             "watch-deps": {
-              "command": "npx nx watch --projects my-lib --includeDependentProjects -- npx nx build-deps my-lib",
+              "command": "pnpm exec nx watch --projects my-lib --includeDependentProjects -- pnpm exec nx build-deps my-lib",
               "continuous": true,
               "dependsOn": [
                 "build-deps",
@@ -102,7 +102,7 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
               "metadata": {
                 "description": "Run Vite build",
                 "help": {
-                  "command": "npx vite build --help",
+                  "command": "pnpm exec vite build --help",
                   "example": {
                     "options": {
                       "manifest": "manifest.json",
@@ -127,7 +127,7 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
               "metadata": {
                 "description": "Starts Vite dev server",
                 "help": {
-                  "command": "npx vite --help",
+                  "command": "pnpm exec vite --help",
                   "example": {
                     "options": {
                       "port": 3000,
@@ -149,7 +149,7 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
                 "deprecated": "Use devTargetName instead. This option will be removed in Nx 22.",
                 "description": "Starts Vite dev server",
                 "help": {
-                  "command": "npx vite --help",
+                  "command": "pnpm exec vite --help",
                   "example": {
                     "options": {
                       "port": 3000,
@@ -173,7 +173,7 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
               "metadata": {
                 "description": "Locally preview Vite production build",
                 "help": {
-                  "command": "npx vite preview --help",
+                  "command": "pnpm exec vite preview --help",
                   "example": {
                     "options": {
                       "port": 3000,
@@ -197,7 +197,7 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
               },
             },
             "watch-deps": {
-              "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+              "command": "pnpm exec nx watch --projects my-app --includeDependentProjects -- pnpm exec nx build-deps my-app",
               "continuous": true,
               "dependsOn": [
                 "build-deps",
@@ -240,7 +240,7 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
               "metadata": {
                 "description": "Run Vite build",
                 "help": {
-                  "command": "npx vite build --help",
+                  "command": "pnpm exec vite build --help",
                   "example": {
                     "options": {
                       "manifest": "manifest.json",
@@ -265,7 +265,7 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
               "metadata": {
                 "description": "Starts Vite dev server",
                 "help": {
-                  "command": "npx vite --help",
+                  "command": "pnpm exec vite --help",
                   "example": {
                     "options": {
                       "port": 3000,
@@ -289,7 +289,7 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
               "metadata": {
                 "description": "Locally preview Vite production build",
                 "help": {
-                  "command": "npx vite preview --help",
+                  "command": "pnpm exec vite preview --help",
                   "example": {
                     "options": {
                       "port": 3000,
@@ -311,7 +311,7 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
                 "deprecated": "Use devTargetName instead. This option will be removed in Nx 22.",
                 "description": "Starts Vite dev server",
                 "help": {
-                  "command": "npx vite --help",
+                  "command": "pnpm exec vite --help",
                   "example": {
                     "options": {
                       "port": 3000,

--- a/packages/vite/src/plugins/plugin.spec.ts
+++ b/packages/vite/src/plugins/plugin.spec.ts
@@ -152,7 +152,7 @@ describe('@nx/vite/plugin', () => {
         {
           "description": "Runs type-checking for the project.",
           "help": {
-            "command": "npx tsc -p tsconfig.json --help",
+            "command": "pnpm exec tsc -p tsconfig.json --help",
             "example": {
               "options": {
                 "noEmit": true,
@@ -196,7 +196,7 @@ describe('@nx/vite/plugin', () => {
         {
           "description": "Runs type-checking for the project.",
           "help": {
-            "command": "npx tsc --build --help",
+            "command": "pnpm exec tsc --build --help",
             "example": {
               "args": [
                 "--force",
@@ -428,7 +428,7 @@ describe('@nx/vite/plugin', () => {
                       "metadata": {
                         "description": "Run Vite build",
                         "help": {
-                          "command": "npx vite build --help",
+                          "command": "pnpm exec vite build --help",
                           "example": {
                             "options": {
                               "manifest": "manifest.json",
@@ -458,7 +458,7 @@ describe('@nx/vite/plugin', () => {
                       "metadata": {
                         "description": "Starts Vite dev server",
                         "help": {
-                          "command": "npx vite --help",
+                          "command": "pnpm exec vite --help",
                           "example": {
                             "options": {
                               "port": 3000,
@@ -482,7 +482,7 @@ describe('@nx/vite/plugin', () => {
                       "metadata": {
                         "description": "Locally preview Vite production build",
                         "help": {
-                          "command": "npx vite preview --help",
+                          "command": "pnpm exec vite preview --help",
                           "example": {
                             "options": {
                               "port": 3000,
@@ -504,7 +504,7 @@ describe('@nx/vite/plugin', () => {
                         "deprecated": "Use devTargetName instead. This option will be removed in Nx 22.",
                         "description": "Starts Vite dev server",
                         "help": {
-                          "command": "npx vite --help",
+                          "command": "pnpm exec vite --help",
                           "example": {
                             "options": {
                               "port": 3000,
@@ -528,7 +528,7 @@ describe('@nx/vite/plugin', () => {
                       },
                     },
                     "watch-deps": {
-                      "command": "npx nx watch --projects my-lib --includeDependentProjects -- npx nx build-deps my-lib",
+                      "command": "pnpm exec nx watch --projects my-lib --includeDependentProjects -- pnpm exec nx build-deps my-lib",
                       "continuous": true,
                       "dependsOn": [
                         "build-deps",

--- a/packages/vite/src/utils/e2e-web-server-info-utils.spec.ts
+++ b/packages/vite/src/utils/e2e-web-server-info-utils.spec.ts
@@ -38,10 +38,10 @@ describe('getViteE2EWebServerInfo', () => {
     expect(e2eWebServerInfo).toMatchInlineSnapshot(`
       {
         "e2eCiBaseUrl": "http://localhost:4300",
-        "e2eCiWebServerCommand": "npx nx run app:preview",
+        "e2eCiWebServerCommand": "pnpm exec nx run app:preview",
         "e2eDevServerTarget": "app:dev",
         "e2eWebServerAddress": "http://localhost:4200",
-        "e2eWebServerCommand": "npx nx run app:dev",
+        "e2eWebServerCommand": "pnpm exec nx run app:dev",
       }
     `);
   });
@@ -64,10 +64,10 @@ describe('getViteE2EWebServerInfo', () => {
     expect(e2eWebServerInfo).toMatchInlineSnapshot(`
       {
         "e2eCiBaseUrl": "http://localhost:4300",
-        "e2eCiWebServerCommand": "npx nx run app:preview",
+        "e2eCiWebServerCommand": "pnpm exec nx run app:preview",
         "e2eDevServerTarget": "app:dev",
         "e2eWebServerAddress": "http://localhost:4200",
-        "e2eWebServerCommand": "npx nx run app:dev",
+        "e2eWebServerCommand": "pnpm exec nx run app:dev",
       }
     `);
   });
@@ -97,10 +97,10 @@ describe('getViteE2EWebServerInfo', () => {
     expect(e2eWebServerInfo).toMatchInlineSnapshot(`
       {
         "e2eCiBaseUrl": "http://localhost:4300",
-        "e2eCiWebServerCommand": "npx nx run app:vite:preview",
+        "e2eCiWebServerCommand": "pnpm exec nx run app:vite:preview",
         "e2eDevServerTarget": "app:dev",
         "e2eWebServerAddress": "http://localhost:4200",
-        "e2eWebServerCommand": "npx nx run app:dev",
+        "e2eWebServerCommand": "pnpm exec nx run app:dev",
       }
     `);
   });
@@ -139,10 +139,10 @@ describe('getViteE2EWebServerInfo', () => {
     expect(e2eWebServerInfo).toMatchInlineSnapshot(`
       {
         "e2eCiBaseUrl": "http://localhost:4300",
-        "e2eCiWebServerCommand": "npx nx run app:vite-preview",
+        "e2eCiWebServerCommand": "pnpm exec nx run app:vite-preview",
         "e2eDevServerTarget": "app:dev",
         "e2eWebServerAddress": "http://localhost:4200",
-        "e2eWebServerCommand": "npx nx run app:dev",
+        "e2eWebServerCommand": "pnpm exec nx run app:dev",
       }
     `);
   });

--- a/packages/vite/src/utils/generator-utils.spec.ts
+++ b/packages/vite/src/utils/generator-utils.spec.ts
@@ -1,3 +1,4 @@
+// prettier-ignore
 import {
   addProjectConfiguration,
   readProjectConfiguration,

--- a/packages/vite/src/utils/generator-utils.spec.ts
+++ b/packages/vite/src/utils/generator-utils.spec.ts
@@ -289,19 +289,21 @@ describe('generator utils', () => {
         import { defineConfig } from 'vite';
         import dts from 'vite-plugin-dts';
         import * as path from 'path';
+        import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+        import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
         export default defineConfig(() => ({
           root: import.meta.dirname,
           cacheDir: '../../node_modules/.vite/apps/myproj',
-          plugins: [dts({ entryRoot: 'src', tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json') })],
+          plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md']), dts({ entryRoot: 'src', tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json'), pathsToAliases: false })],
           // Uncomment this if you are using workers.
           // worker: {
-          //  plugins: [],
+          //   plugins: () => [ nxViteTsPaths() ],
           // },
           // Configuration for building your library.
           // See: https://vite.dev/guide/build.html#library-mode
           build: {
-            outDir: './dist',
+            outDir: '../../dist/apps/myproj',
             emptyOutDir: true,
             reportCompressedSize: true,
             commonjsOptions: {
@@ -333,7 +335,7 @@ describe('generator utils', () => {
             includeSource: ['src/**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
             reporters: ['default'],
             coverage: {
-              reportsDirectory: './test-output/vitest/coverage',
+              reportsDirectory: '../../coverage/apps/myproj',
               provider: 'v8' as const,
             }
           },

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -448,7 +448,12 @@ export function createOrEditViteConfig(
     );
   }
 
-  if (!isTsSolutionSetup) {
+  if (isTsSolutionSetup) {
+    imports.push(
+      `import { nxTsconfigResolveConditionsPlugin } from '@nx/vite/plugins/nx-tsconfig-resolve-conditions.plugin'`
+    );
+    plugins.push(`nxTsconfigResolveConditionsPlugin()`);
+  } else {
     imports.push(
       `import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'`,
       `import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'`

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -449,10 +449,8 @@ export function createOrEditViteConfig(
   }
 
   if (isTsSolutionSetup) {
-    imports.push(
-      `import { nxTsconfigResolveConditionsPlugin } from '@nx/vite/plugins/nx-tsconfig-resolve-conditions.plugin'`
-    );
-    plugins.push(`nxTsconfigResolveConditionsPlugin()`);
+    imports.push(`import { nxTsPlugin } from '@nx/vite/plugins/nx-ts.plugin'`);
+    plugins.push(`nxTsPlugin()`);
   } else {
     imports.push(
       `import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'`,

--- a/packages/vitest/src/utils/generator-utils.ts
+++ b/packages/vitest/src/utils/generator-utils.ts
@@ -163,10 +163,8 @@ export function createOrEditViteConfig(
   }
 
   if (isTsSolutionSetup) {
-    imports.push(
-      `import { nxTsconfigResolveConditionsPlugin } from '@nx/vite/plugins/nx-tsconfig-resolve-conditions.plugin'`
-    );
-    plugins.push(`nxTsconfigResolveConditionsPlugin()`);
+    imports.push(`import { nxTsPlugin } from '@nx/vite/plugins/nx-ts.plugin'`);
+    plugins.push(`nxTsPlugin()`);
   } else {
     imports.push(
       `import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'`,

--- a/packages/vitest/src/utils/generator-utils.ts
+++ b/packages/vitest/src/utils/generator-utils.ts
@@ -162,7 +162,12 @@ export function createOrEditViteConfig(
     );
   }
 
-  if (!isTsSolutionSetup) {
+  if (isTsSolutionSetup) {
+    imports.push(
+      `import { nxTsconfigResolveConditionsPlugin } from '@nx/vite/plugins/nx-tsconfig-resolve-conditions.plugin'`
+    );
+    plugins.push(`nxTsconfigResolveConditionsPlugin()`);
+  } else {
     imports.push(
       `import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'`,
       `import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'`


### PR DESCRIPTION
## Current Behavior

In TS solution setups, Nx configures `customConditions` in `tsconfig.base.json` (e.g., `@nx-bug2/source`) and uses that condition as the export key in each library's `package.json` exports map to point to the TypeScript source files. TypeScript understands this via `customConditions`, but Vite has its own module resolver that doesn't read tsconfig — it uses `resolve.conditions` in the Vite config instead.

Because nothing bridges this gap, Vite fails to resolve library imports with:
```
Failed to resolve entry for package "@nx-bug2/ui-lib". The package may have incorrect main/module/exports specified in its package.json.
```

## Expected Behavior

Vite should automatically resolve library imports that use tsconfig `customConditions` in their package.json exports. This PR adds a new Vite plugin (`nxTsPlugin`) that reads `customConditions` from `tsconfig.base.json` and injects them into Vite's `resolve.conditions` at startup.

The plugin is automatically included in generated Vite configs for TS solution setups. For existing projects, users can add the plugin manually:

```ts
import { nxTsPlugin } from '@nx/vite/plugins/nx-ts.plugin';

export default defineConfig(() => ({
  plugins: [nxTsPlugin()],
  // ...
}));
```

## Related Issue(s)

Fixes #34290
