### PR TITLE
docs(nx-cloud): add guide for configuring node on Nx Agents

### DIFF
--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -802,6 +802,10 @@ const knowledgeBaseGroups: SidebarItems = [
             link: 'guides/nx-cloud/use-bun',
           },
           {
+            label: 'Configure Node version',
+            link: 'guides/nx-cloud/configure-node-version',
+          },
+          {
             label: 'GitHub app permissions',
             link: 'guides/nx-cloud/source-control-integration/github-app-permissions',
           },

--- a/astro-docs/src/content/docs/guides/Nx Cloud/configure-node-version.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/configure-node-version.mdoc
@@ -1,0 +1,129 @@
+---
+title: Configure Node Version for Nx Agents
+description: Learn how to control which Node.js version Nx Agents use when running distributed tasks with Nx Cloud
+sidebar:
+  label: Configure Node version
+filter: 'type:Guides'
+---
+
+When you distribute tasks with `--distribute-on`,
+the Nx Agents that run your tasks use a pre-built
+[launch template](/docs/reference/nx-cloud/launch-templates)
+such as `linux-medium-js`.
+These templates include an `install-node` step that determines which
+Node.js version to use on the agent.
+
+Your CI runner (for example, a GitHub Actions `ubuntu-latest` machine)
+only orchestrates the run. It doesn't execute the actual tasks.
+The Nx Agents do.
+If your CI workflow sets Node 24 via `actions/setup-node` but the
+agents default to Node 20, your tasks run on Node 20.
+
+## How the agent resolves the Node version
+
+The `install-node` workflow step checks for a Node version
+in this order:
+
+1. The `node_version` step input
+   (set via `NX_CLOUD_INPUT_node_version` or `NODE_VERSION` env var)
+1. A `.nvmrc` file in the repo root
+1. A Volta `node` pin in the root `package.json`
+1. The base image default (Node 20)
+
+The first match wins.
+If none of these are set, the agent falls back to whatever
+version the base image ships.
+
+## Set the node version
+
+Pick **one** of the following approaches.
+
+### Option 1: Add a `.nvmrc` file
+
+The quickest option.
+Create a `.nvmrc` file at the workspace root:
+
+```plaintext
+// .nvmrc
+24
+```
+
+The `install-node` step picks this up automatically.
+You can also reference the same file from `actions/setup-node`
+to keep both environments in sync:
+
+```yaml
+- uses: actions/setup-node@v4
+  with:
+    node-version-file: '.nvmrc'
+```
+
+### Option 2: Create a custom launch template
+
+If you'd rather keep Node version configuration
+in the launch template itself, create `.nx/workflows/agents.yaml`:
+
+```yaml
+// .nx/workflows/agents.yaml
+launch-templates:
+  linux-medium-js:
+    resource-class: 'docker_linux_amd64/medium'
+    image: 'ubuntu22.04-node20.19-v2'
+    init-steps:
+      - name: Checkout
+        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
+      - name: Restore Node Modules Cache
+        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/cache/main.yaml'
+        inputs:
+          key: 'package-lock.json|yarn.lock|pnpm-lock.yaml|patches/**|.yarn/patches/**'
+          paths: 'node_modules'
+          base-branch: 'main'
+      - name: Install Node
+        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-node/main.yaml'
+        inputs:
+          node_version: '24'
+      - name: Install Node Modules
+        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-node-modules/main.yaml'
+      - name: Install Browsers (if needed)
+        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-browsers/main.yaml'
+```
+
+The `node_version` input on the `Install Node` step
+overrides all other resolution methods.
+
+For more details on custom launch templates, see the
+[launch templates reference](/docs/reference/nx-cloud/launch-templates).
+
+### Option 3: Set an environment variable
+
+Set the `NODE_VERSION` env var in your CI workflow.
+The `install-node` step reads it as a fallback
+when no step input is provided:
+
+```yaml {% meta="{8}" %}
+// .github/workflows/ci.yml
+name: CI
+# ...
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    env:
+      NODE_VERSION: '24'
+    steps:
+      # ...
+      - run: npx nx-cloud start-ci-run --distribute-on="3 linux-medium-js"
+```
+
+{% aside type="caution" title="Env var propagation" %}
+The env var must be available in the CI runner environment
+where `start-ci-run` is called.
+Nx Cloud forwards it to the agents during provisioning.
+{% /aside %}
+
+## Verify the Node version on agents
+
+To confirm agents are using the expected version,
+add a verification step to your CI workflow
+or check the agent logs in the Nx Cloud dashboard.
+The `install-node` step logs the resolved Node version
+during initialization.

--- a/astro-docs/src/content/docs/guides/Nx Cloud/configure-node-version.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/configure-node-version.mdoc
@@ -58,7 +58,65 @@ to keep both environments in sync:
     node-version-file: '.nvmrc'
 ```
 
-### Option 2: Create a custom launch template
+### Option 2: Use mise
+
+[Mise](https://mise.jdx.dev/) is a polyglot toolchain manager that can pin
+Node.js (and other tools) in a single `mise.toml` file.
+Nx Cloud launch templates have built-in support for mise
+via the [`install-mise`](https://github.com/nrwl/nx-cloud-workflows/tree/main/workflow-steps/install-mise)
+workflow step.
+
+Create a `mise.toml` at the workspace root:
+
+```toml
+// mise.toml
+[tools]
+node = "24"
+```
+
+Then create a custom launch template in `.nx/workflows/agents.yaml`
+that uses `install-mise` instead of `install-node`:
+
+```yaml
+// .nx/workflows/agents.yaml
+launch-templates:
+  linux-medium-js:
+    resource-class: 'docker_linux_amd64/medium'
+    image: 'ubuntu22.04-node20.19-v2'
+    init-steps:
+      - name: Checkout
+        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
+      - name: Setup toolchains
+        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-mise/main.yaml'
+      - name: Restore Node Modules Cache
+        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/cache/main.yaml'
+        inputs:
+          key: 'package-lock.json|yarn.lock|pnpm-lock.yaml|patches/**|.yarn/patches/**'
+          paths: 'node_modules'
+          base-branch: 'main'
+      - name: Install Node Modules
+        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-node-modules/main.yaml'
+```
+
+The `install-mise` step reads `mise.toml` and installs the specified Node version on the agent.
+This is especially useful when you need to manage multiple tools
+(Node, bun, Rust, Python, etc.) through a single config file.
+
+On your CI runner, use the [jdx/mise-action](https://github.com/jdx/mise-action)
+to keep versions in sync:
+
+```yaml
+- name: Setup toolchains with mise
+  uses: jdx/mise-action@v3
+```
+
+{% aside type="tip" title="Use mise with bun" %}
+If you also use bun as your package manager, see the
+[Set Up Bun with Mise on CI](/docs/guides/nx-cloud/use-bun) guide
+for a complete setup including custom `bun install` steps.
+{% /aside %}
+
+### Option 3: Create a custom launch template
 
 If you'd rather keep Node version configuration
 in the launch template itself, create `.nx/workflows/agents.yaml`:
@@ -94,7 +152,7 @@ overrides all other resolution methods.
 For more details on custom launch templates, see the
 [launch templates reference](/docs/reference/nx-cloud/launch-templates).
 
-### Option 3: Set an environment variable
+### Option 4: Set an environment variable
 
 Set the `NODE_VERSION` env var in your CI workflow.
 The `install-node` step reads it as a fallback


### PR DESCRIPTION
## Current Behavior

The "Configure Node Version for Nx Agents" guide covers `.nvmrc`, custom launch template with `install-node` step input, and `NODE_VERSION` env var. It doesn't mention mise as an option, even though the `install-mise` workflow step is available and already documented in the bun guide.

## Expected Behavior

The guide includes mise as Option 2, showing how to use `mise.toml` + the `install-mise` workflow step to pin Node (and other tools) on agents. Cross-links to the bun guide for users who also use bun.

https://deploy-preview-34952--nx-docs.netlify.app/docs/guides/nx-cloud/configure-node-version

## Related Issue(s)

N/A - docs improvement for completeness.