### PR TITLE
fix(core): skip workspace context setup when global bin hands off to local

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -72,10 +72,6 @@ async function main() {
     process.env.NX_DAEMON = 'false';
     require('nx/src/command-line/nx-commands').commandsObject.argv;
   } else {
-    if (!daemonClient.enabled() && workspace !== null) {
-      setupWorkspaceContext(workspace.dir);
-    }
-
     // polyfill rxjs observable to avoid issues with multiple version of Observable installed in node_modules
     // https://twitter.com/BenLesh/status/1192478226385428483?s=20
     if (!(Symbol as any).observable)
@@ -111,17 +107,23 @@ async function main() {
 
     // this file is already in the local workspace
     if (isNxCloudCommand(process.argv[2])) {
+      if (!daemonClient.enabled() && workspace !== null) {
+        setupWorkspaceContext(workspace.dir);
+      }
       await initAnalytics();
       // nx-cloud commands can run without local Nx installation
       process.env.NX_DAEMON = 'false';
       require('nx/src/command-line/nx-commands').commandsObject.argv;
     } else if (isLocalInstall) {
+      if (!daemonClient.enabled() && workspace !== null) {
+        setupWorkspaceContext(workspace.dir);
+      }
       await initAnalytics();
       await initLocal(workspace);
     } else if (localNx) {
       // Nx is being run from globally installed CLI - hand off to the local
-      // Don't start analytics or connect to the DB here — the local Nx
-      // will handle it when it runs its own bin/nx.ts
+      // Don't start analytics, connect to the DB, or set up the workspace
+      // context here — the local Nx will handle it when it runs its own bin/nx.ts
       warnIfUsingOutdatedGlobalInstall(GLOBAL_NX_VERSION, LOCAL_NX_VERSION);
       if (localNx.includes('.nx')) {
         const nxWrapperPath = localNx.replace(/\.nx.*/, '.nx/') + 'nxw.js';


### PR DESCRIPTION
## Current Behavior

When the globally installed Nx binary (`bin/nx.ts`) runs, it calls `setupWorkspaceContext()` **before** determining whether it should hand off to a local Nx installation. If the global Nx version differs from the local version (e.g. global `22.7.0-beta.2` vs local `22.7.0-beta.1`), `isNxVersionMismatch()` returns true, `daemonClient.enabled()` returns false, and `setupWorkspaceContext()` creates an in-process `WorkspaceContext` that locks the workspace data directory.

When the local Nx then tries to start the daemon, it conflicts with this lock and the daemon fails to start. This means running `nx reset` followed by any command (e.g. `nx show projects`) results in the daemon never auto-starting, falling back to in-process graph construction, or erroring out entirely.

## Expected Behavior

The global bin should not set up a workspace context when it's about to hand off to a local Nx installation. The local Nx will handle workspace context setup itself.

`setupWorkspaceContext()` is now only called in the `isLocalInstall` and `isNxCloudCommand` branches — skipped in the handoff path. This matches the existing pattern established in #34914 for analytics and DB connections.

## Related Issue(s)

<!-- No specific issue filed — discovered during development in the nx repo -->
