### PR TITLE
chore(repo): add update-repos target and restore update-all-repos

### DIFF
--- a/tools/update-repos/project.json
+++ b/tools/update-repos/project.json
@@ -39,9 +39,21 @@
         "command": "node dist/update-repos/src/update-repo.js nx-console"
       }
     },
-    "update-all-repos": {
+    "update-repos": {
       "executor": "nx:run-commands",
       "dependsOn": ["update-ocean-repo", "update-nx-console-repo"],
+      "options": {
+        "command": "echo '🎉 Ocean and NxConsole repositories updated successfully!'"
+      }
+    },
+    "update-all-repos": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        "update-nx-repo",
+        "update-ocean-repo",
+        "update-nx-examples-repo",
+        "update-nx-console-repo"
+      ],
       "options": {
         "command": "echo '🎉 All repositories updated successfully!'"
       }


### PR DESCRIPTION
## Current Behavior

`update-all-repos` only updates ocean and nx-console repositories. There is no way to update just those two repos separately from the full set.

## Expected Behavior

- `update-all-repos` now includes all four repos: nx, ocean, nx-examples, and nx-console
- A new `update-repos` target updates only ocean and nx-console (the most commonly used subset)

## Related Issue(s)

Internal tooling improvement — no external issue.
