### PR TITLE
fix(core): add bin wrapper scripts for workspace-linked nx resolution

### DIFF
--- a/packages/nx/bin/nx-cloud.js
+++ b/packages/nx/bin/nx-cloud.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+// Wrapper script that works in both compiled (dist/) and source (TS) contexts.
+// See nx.js for details.
+
+const path = require('path');
+const fs = require('fs');
+
+const distEntry = path.join(__dirname, '..', 'dist', 'bin', 'nx-cloud.js');
+
+if (fs.existsSync(distEntry)) {
+  require(distEntry);
+} else {
+  require('@swc-node/register/register');
+  require('./nx-cloud.ts');
+}

--- a/packages/nx/bin/nx.js
+++ b/packages/nx/bin/nx.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+// Wrapper script that works in both compiled (dist/) and source (TS) contexts.
+// When installed from npm, dist/bin/nx.js exists and is used directly.
+// When workspace-linked in the nx repo, dist/ may not exist, so we fall back
+// to registering swc-node and loading the TypeScript source.
+
+const path = require('path');
+const fs = require('fs');
+
+const distEntry = path.join(__dirname, '..', 'dist', 'bin', 'nx.js');
+
+if (fs.existsSync(distEntry)) {
+  require(distEntry);
+} else {
+  require('@swc-node/register/register');
+  require('./nx.ts');
+}

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -28,8 +28,8 @@
     "Mobile"
   ],
   "bin": {
-    "nx": "./dist/bin/nx.js",
-    "nx-cloud": "./dist/bin/nx-cloud.js"
+    "nx": "./bin/nx.js",
+    "nx-cloud": "./bin/nx-cloud.js"
   },
   "author": "Victor Savkin",
   "license": "MIT",


### PR DESCRIPTION
## Current Behavior

After the nodenext commit (#34111), the nx package's `bin` entries in `package.json` point to `./dist/bin/nx.js`. When other workspace packages (e.g. `workspace-plugin`) are linked to `packages/nx` via pnpm workspace resolution, the `dist/` directory doesn't exist on a fresh checkout because it's a build artifact (gitignored).

This causes:
- **Broken bin symlinks** — pnpm can't create `nx` and `nx-cloud` binaries for workspace-linked packages
- **`getDbConnection is not a function`** — module resolution fails when `dist/` doesn't exist, causing runtime errors
- **CI failures** when updating nx to a version that includes the nodenext changes

## Expected Behavior

Add thin JS wrapper scripts at `bin/nx.js` and `bin/nx-cloud.js` that are committed to git. These wrappers:
1. Check if the compiled `dist/bin/nx.js` exists → use it (npm-installed packages)
2. Otherwise, register `@swc-node/register` and load the TypeScript source (workspace-linked dev)

Update `package.json` `bin` entries to point to these wrappers instead of `dist/`.

This ensures nx works in both contexts:
- **From npm**: `dist/` exists, wrappers delegate to compiled output
- **Workspace-linked in dev/CI**: `dist/` absent, wrappers load TS source via swc-node

## Related Issue(s)

Fixes regression from #34111
