### PR TITLE
fix(angular): update duplicate migration keys

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -2400,7 +2400,7 @@
         }
       }
     },
-    "22.6.0": {
+    "22.6.0-module-federation": {
       "version": "22.6.0-beta.10",
       "x-prompt": "Bump @module-federation packages to v2.x to resolve koa CVE-2026-27959 (via dts-plugin)",
       "packages": {


### PR DESCRIPTION
Fix duplicate migrations keys as only the last migration was getting picked up.

## Current Behavior
When running nx migrate only the module federation migration is picked up and not updating the core angular packages.

## Expected Behavior
Both migrations should be added to migrations.json.