### PR TITLE
fix(js): stop generating baseUrl in tsconfig, use ./ prefix for path mappings

### DIFF
--- a/e2e/angular/src/module-federation-host-remote.test.ts
+++ b/e2e/angular/src/module-federation-host-remote.test.ts
@@ -68,7 +68,7 @@ describe('Angular Module Federation - Host and Remote', () => {
     updateJson('tsconfig.base.json', (json) => {
       delete json.compilerOptions.paths[`@${proj}/${wildcardLib}`];
       json.compilerOptions.paths[`@${proj}/${wildcardLib}/*`] = [
-        `${wildcardLib}/src/lib/*`,
+        `./${wildcardLib}/src/lib/*`,
       ];
       return json;
     });

--- a/e2e/angular/src/module-federation.rspack.test.ts
+++ b/e2e/angular/src/module-federation.rspack.test.ts
@@ -87,7 +87,7 @@ describe('Angular Module Federation', () => {
     updateJson('tsconfig.base.json', (json) => {
       delete json.compilerOptions.paths[`@${proj}/${wildcardLib}`];
       json.compilerOptions.paths[`@${proj}/${wildcardLib}/*`] = [
-        `${wildcardLib}/src/lib/*`,
+        `./${wildcardLib}/src/lib/*`,
       ];
       return json;
     });

--- a/e2e/angular/src/ng-add.test.ts
+++ b/e2e/angular/src/ng-add.test.ts
@@ -84,7 +84,7 @@ describe('convert Angular CLI workspace to an Nx workspace', () => {
 
     // update tsconfig.json
     const tsConfig = readJson('tsconfig.json');
-    tsConfig.compilerOptions.paths = { a: ['b'] };
+    tsConfig.compilerOptions.paths = { a: ['./b'] };
     updateFile('tsconfig.json', JSON.stringify(tsConfig, null, 2));
 
     // add an extra script file

--- a/e2e/eslint/src/linter.test.ts
+++ b/e2e/eslint/src/linter.test.ts
@@ -247,7 +247,7 @@ describe('Linter', () => {
          * Let's add it so that we can trigger the lint failure
          */
         tsConfig.compilerOptions.paths[`@${projScope}/${myapp2}`] = [
-          `apps/${myapp2}/src/main.ts`,
+          `./apps/${myapp2}/src/main.ts`,
         ];
 
         tsConfig.compilerOptions.paths[`@secondScope/${lazylib}`] =

--- a/e2e/js/src/js-executor-swc.test.ts
+++ b/e2e/js/src/js-executor-swc.test.ts
@@ -40,7 +40,7 @@ describe('js:swc executor', () => {
 
     const tsconfig = readJson(`tsconfig.base.json`);
     expect(tsconfig.compilerOptions.paths).toEqual({
-      [`@${scope}/${lib}`]: [`libs/${lib}/src/index.ts`],
+      [`@${scope}/${lib}`]: [`./libs/${lib}/src/index.ts`],
     });
   }, 240_000);
 

--- a/e2e/js/src/js-executor-tsc.test.ts
+++ b/e2e/js/src/js-executor-tsc.test.ts
@@ -131,8 +131,8 @@ describe('js:tsc executor', () => {
 
     const tsconfig = readJson(`tsconfig.base.json`);
     expect(tsconfig.compilerOptions.paths).toEqual({
-      [`@${scope}/${lib}`]: [`libs/${lib}/src/index.ts`],
-      [`@${scope}/${parentLib}`]: [`libs/${parentLib}/src/index.ts`],
+      [`@${scope}/${lib}`]: [`./libs/${lib}/src/index.ts`],
+      [`@${scope}/${parentLib}`]: [`./libs/${parentLib}/src/index.ts`],
     });
 
     updateFile(`libs/${parentLib}/src/index.ts`, () => {
@@ -243,7 +243,7 @@ describe('js:tsc executor', () => {
 
     updateJson('tsconfig.base.json', (json) => {
       json['compilerOptions']['paths'][`@${scope}/${lib}/*`] = [
-        `libs/${lib}/src/*`,
+        `./libs/${lib}/src/*`,
       ];
       return json;
     });

--- a/e2e/nx/src/graph-ts-solution.test.ts
+++ b/e2e/nx/src/graph-ts-solution.test.ts
@@ -207,11 +207,10 @@ describe('Graph - TS solution setup', () => {
     runCommand(pmc.install);
 
     updateJson('tsconfig.base.json', (json) => {
-      json.compilerOptions.baseUrl = '.';
       json.compilerOptions.paths = {
-        '@proj/pkg8': ['packages/pkg8/src/index.ts'],
-        '@proj/pkg9': ['dist/packages/pkg9'],
-        '@proj/pkg14': ['packages/pkg13/src/index.ts'],
+        '@proj/pkg8': ['./packages/pkg8/src/index.ts'],
+        '@proj/pkg9': ['./dist/packages/pkg9'],
+        '@proj/pkg14': ['./packages/pkg13/src/index.ts'],
       };
       return json;
     });

--- a/e2e/nx/src/workspace.test.ts
+++ b/e2e/nx/src/workspace.test.ts
@@ -339,7 +339,7 @@ describe('Workspace Tests', () => {
         rootTsConfig.compilerOptions.paths[
           `@${proj}/shared-${lib1}-data-access`
         ]
-      ).toEqual([`shared/${lib1}/data-access/src/index.ts`]);
+      ).toEqual([`./shared/${lib1}/data-access/src/index.ts`]);
 
       projects = runCLI('show projects').split('\n');
       expect(projects).not.toContain(`${lib1}-data-access`);
@@ -465,7 +465,7 @@ describe('Workspace Tests', () => {
         rootTsConfig.compilerOptions.paths[
           `@${proj}/shared-${lib1}-data-access`
         ]
-      ).toEqual([`shared/${lib1}/data-access/src/index.ts`]);
+      ).toEqual([`./shared/${lib1}/data-access/src/index.ts`]);
 
       const projects = runCLI('show projects').split('\n');
       expect(projects).not.toContain(`${lib1}-data-access`);
@@ -591,7 +591,7 @@ describe('Workspace Tests', () => {
       ).toBeUndefined();
       expect(
         rootTsConfig.compilerOptions.paths[`@${proj}/${lib1}-data-access`]
-      ).toEqual([`${lib1}/data-access/src/index.ts`]);
+      ).toEqual([`./${lib1}/data-access/src/index.ts`]);
 
       projects = runCLI('show projects').split('\n');
       expect(projects).not.toContain(lib1);
@@ -706,7 +706,7 @@ describe('Workspace Tests', () => {
       ).toBeUndefined();
       expect(
         rootTsConfig.compilerOptions.paths[`shared-${lib1}-data-access`]
-      ).toEqual([`shared/${lib1}/data-access/src/index.ts`]);
+      ).toEqual([`./shared/${lib1}/data-access/src/index.ts`]);
 
       const projects = runCLI('show projects').split('\n');
       expect(projects).not.toContain(`${lib1}-data-access`);

--- a/e2e/vite/src/vite.test.ts
+++ b/e2e/vite/src/vite.test.ts
@@ -173,7 +173,7 @@ describe('@nx/vite/plugin', () => {
         `
       );
       updateJson('tsconfig.base.json', (json) => {
-        json.compilerOptions.paths['~/*'] = [`libs/${mylib}/src/*`];
+        json.compilerOptions.paths['~/*'] = [`./libs/${mylib}/src/*`];
         return json;
       });
 
@@ -202,7 +202,7 @@ describe('@nx/vite/plugin', () => {
         `
       );
       updateJson('tsconfig.base.json', (json) => {
-        json.compilerOptions.paths['~/*'] = [`libs/${mylib}/src/*`];
+        json.compilerOptions.paths['~/*'] = [`./libs/${mylib}/src/*`];
         return json;
       });
 
@@ -239,11 +239,13 @@ describe('@nx/vite/plugin', () => {
         `
       );
       updateJson('tsconfig.base.json', (json) => {
-        json.compilerOptions.paths['match-lib-deep/*'] = [`libs/${lib1}/src/*`];
-        json.compilerOptions.paths['match-lib-top-level'] = [
-          `libs/${lib2}/src/bar.enum.ts`,
+        json.compilerOptions.paths['match-lib-deep/*'] = [
+          `./libs/${lib1}/src/*`,
         ];
-        json.compilerOptions.paths['match-lib/*'] = [`libs/${lib3}/src/*`];
+        json.compilerOptions.paths['match-lib-top-level'] = [
+          `./libs/${lib2}/src/bar.enum.ts`,
+        ];
+        json.compilerOptions.paths['match-lib/*'] = [`./libs/${lib3}/src/*`];
         return json;
       });
 
@@ -259,9 +261,8 @@ describe('@nx/vite/plugin', () => {
       // Add a local path alias in the project's tsconfig.app.json
       updateJson(`apps/${myLocalApp}/tsconfig.app.json`, (json) => {
         json.compilerOptions = json.compilerOptions || {};
-        json.compilerOptions.baseUrl = '.';
         json.compilerOptions.paths = {
-          '~/*': ['src/*'],
+          '~/*': ['./src/*'],
         };
         return json;
       });

--- a/e2e/workspace-create/src/create-nx-workspace-npm.test.ts
+++ b/e2e/workspace-create/src/create-nx-workspace-npm.test.ts
@@ -71,7 +71,7 @@ describe('create-nx-workspace --preset=npm', () => {
     checkFilesExist('tsconfig.base.json');
     const tsconfig = readJson(`tsconfig.base.json`);
     expect(tsconfig.compilerOptions.paths).toEqual({
-      [`@${wsName}/${libName}`]: [`packages/${libName}/src/index.ts`],
+      [`@${wsName}/${libName}`]: [`./packages/${libName}/src/index.ts`],
     });
   }, 1_000_000);
 

--- a/packages/angular/src/generators/federate-module/federate-module.spec.ts
+++ b/packages/angular/src/generators/federate-module/federate-module.spec.ts
@@ -45,7 +45,7 @@ describe('federate-module', () => {
       const tsconfig = JSON.parse(tree.read('tsconfig.base.json', 'utf-8'));
       expect(
         tsconfig.compilerOptions.paths['myremote/my-federated-module']
-      ).toEqual(['apps/myremote/src/my-federated-module.ts']);
+      ).toEqual(['./apps/myremote/src/my-federated-module.ts']);
     });
   });
 
@@ -99,7 +99,7 @@ describe('federate-module', () => {
         tsconfig.compilerOptions.paths[
           `${remoteSchema.name}/my-federated-module`
         ]
-      ).toEqual(['apps/myremote/src/my-federated-module.ts']);
+      ).toEqual(['./apps/myremote/src/my-federated-module.ts']);
     });
   });
 });

--- a/packages/angular/src/generators/library-secondary-entry-point/lib/add-path-mapping.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/lib/add-path-mapping.ts
@@ -10,7 +10,7 @@ export function addPathMapping(
     const c = json.compilerOptions;
     c.paths = c.paths || {};
     c.paths[options.secondaryEntryPoint] = [
-      `${options.libraryProject.root}/${options.name}/src/index.ts`,
+      `./${options.libraryProject.root}/${options.name}/src/index.ts`,
     ];
 
     return json;

--- a/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
@@ -164,7 +164,7 @@ describe('librarySecondaryEntryPoint generator', () => {
     const tsConfig = readJson(tree, 'tsconfig.base.json');
     expect(
       tsConfig.compilerOptions.paths['@my-org/lib1/testing']
-    ).toStrictEqual(['libs/lib1/testing/src/index.ts']);
+    ).toStrictEqual(['./libs/lib1/testing/src/index.ts']);
   });
 
   it('should support a root tsconfig.json instead of tsconfig.base.json', async () => {
@@ -187,7 +187,7 @@ describe('librarySecondaryEntryPoint generator', () => {
     const tsConfig = readJson(tree, 'tsconfig.json');
     expect(
       tsConfig.compilerOptions.paths['@my-org/lib1/testing']
-    ).toStrictEqual(['libs/lib1/testing/src/index.ts']);
+    ).toStrictEqual(['./libs/lib1/testing/src/index.ts']);
   });
 
   it('should update the tsconfig "include" and "exclude" options', async () => {

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -292,7 +292,7 @@ describe('lib', () => {
       // ASSERT
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-lib/src/index.ts',
+        './my-lib/src/index.ts',
       ]);
     });
 
@@ -588,7 +588,7 @@ describe('lib', () => {
       // ASSERT
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-dir/my-lib/src/index.ts',
+        './my-dir/my-lib/src/index.ts',
       ]);
       expect(tsconfigJson.compilerOptions.paths['my-lib/*']).toBeUndefined();
     });
@@ -607,7 +607,7 @@ describe('lib', () => {
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
 
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-dir/my-lib/src/index.ts',
+        './my-dir/my-lib/src/index.ts',
       ]);
       expect(tsconfigJson.compilerOptions.paths['my-lib/*']).toBeUndefined();
     });
@@ -735,7 +735,7 @@ describe('lib', () => {
         {
           path: 'tsconfig.base.json',
           lookupFn: (json) => json.compilerOptions.paths['@myorg/lib'],
-          expectedValue: ['my-dir/my-lib/src/index.ts'],
+          expectedValue: ['./my-dir/my-lib/src/index.ts'],
         },
         {
           path: 'my-dir/my-lib/ng-package.json',
@@ -2173,7 +2173,7 @@ describe('lib', () => {
       // ASSERT
       const tsconfigJson = readJson(tree, 'tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-lib/src/index.ts',
+        './my-lib/src/index.ts',
       ]);
     });
 
@@ -2184,7 +2184,7 @@ describe('lib', () => {
       // ASSERT
       const tsconfigJson = readJson(tree, 'tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-lib/src/index.ts',
+        './my-lib/src/index.ts',
       ]);
     });
   });

--- a/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
+++ b/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
@@ -150,7 +150,6 @@ exports[`workspace move to nx layout should create nx.json 1`] = `
 exports[`workspace move to nx layout should update tsconfig.base.json if present 1`] = `
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {},
     "rootDir": ".",
   },
@@ -164,7 +163,6 @@ exports[`workspace move to nx layout should update tsconfig.base.json if present
 exports[`workspace move to nx layout should work if angular-cli workspace had tsconfig.base.json 1`] = `
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {},
     "rootDir": ".",
   },

--- a/packages/angular/src/generators/ng-add/utilities/workspace.ts
+++ b/packages/angular/src/generators/ng-add/utilities/workspace.ts
@@ -143,7 +143,6 @@ export function updateWorkspaceConfigDefaults(tree: Tree): void {
 export function updateRootTsConfig(tree: Tree): void {
   const tsconfig = readJson(tree, getRootTsConfigPathInTree(tree));
   tsconfig.compilerOptions.paths ??= {};
-  tsconfig.compilerOptions.baseUrl = '.';
   tsconfig.compilerOptions.rootDir = '.';
   tsconfig.exclude = Array.from(
     new Set([...(tsconfig.exclude ?? []), 'node_modules', 'tmp'])

--- a/packages/angular/src/generators/remote/remote.spec.ts
+++ b/packages/angular/src/generators/remote/remote.spec.ts
@@ -34,7 +34,7 @@ describe('MF Remote App Generator', () => {
     expect(tree.read('test/webpack.config.js', 'utf-8')).toMatchSnapshot();
     const tsconfigJson = readJson(tree, getRootTsConfigPathInTree(tree));
     expect(tsconfigJson.compilerOptions.paths['test/Module']).toEqual([
-      'test/src/app/remote-entry/entry-module.ts',
+      './test/src/app/remote-entry/entry-module.ts',
     ]);
   });
 
@@ -93,7 +93,7 @@ describe('MF Remote App Generator', () => {
     `);
     const tsconfigJson = readJson(tree, getRootTsConfigPathInTree(tree));
     expect(tsconfigJson.compilerOptions.paths['test/Module']).toEqual([
-      'test/src/app/remote-entry/entry.module.ts',
+      './test/src/app/remote-entry/entry.module.ts',
     ]);
   });
 
@@ -268,7 +268,7 @@ describe('MF Remote App Generator', () => {
     ).toMatchSnapshot();
     const tsconfigJson = readJson(tree, getRootTsConfigPathInTree(tree));
     expect(tsconfigJson.compilerOptions.paths['test/Routes']).toEqual([
-      'test/src/app/remote-entry/entry.routes.ts',
+      './test/src/app/remote-entry/entry.routes.ts',
     ]);
   });
 

--- a/packages/eslint-plugin/src/utils/ast-utils.ts
+++ b/packages/eslint-plugin/src/utils/ast-utils.ts
@@ -71,10 +71,11 @@ export function getBarrelEntryPointProjectNode(
       .filter((entry) => {
         const sourceFolderPaths = tsConfigBase.compilerOptions.paths[entry];
         return sourceFolderPaths.some((sourceFolderPath) => {
+          const normalizedPath = sourceFolderPath.replace(/^\.\//, '');
           const sourceRoot = getProjectSourceRoot(projectNode.data);
           return (
-            sourceFolderPath === sourceRoot ||
-            sourceFolderPath.indexOf(`${sourceRoot}/`) === 0
+            normalizedPath === sourceRoot ||
+            normalizedPath.indexOf(`${sourceRoot}/`) === 0
           );
         });
       })

--- a/packages/expo/plugins/metro-resolver.ts
+++ b/packages/expo/plugins/metro-resolver.ts
@@ -1,5 +1,6 @@
 import type { MatchPath } from 'tsconfig-paths';
 import { createMatchPath, loadConfig } from 'tsconfig-paths';
+import { resolvePathsBaseUrl } from '@nx/js/src/utils/typescript/ts-config';
 import * as pc from 'picocolors';
 import { CachedInputFileSystem, ResolverFactory } from 'enhanced-resolve';
 import { dirname, join } from 'path';
@@ -211,7 +212,7 @@ function getMatcher(debug: boolean) {
   if (!matcher) {
     const result = loadConfig();
     if (result.resultType === 'success') {
-      absoluteBaseUrl = result.absoluteBaseUrl;
+      absoluteBaseUrl = resolvePathsBaseUrl(result.configFileAbsolutePath);
       paths = result.paths;
       if (debug) {
         console.log(

--- a/packages/expo/src/generators/library/library.spec.ts
+++ b/packages/expo/src/generators/library/library.spec.ts
@@ -58,7 +58,7 @@ describe('lib', () => {
       await expoLibraryGenerator(appTree, defaultSchema);
       const tsconfigJson = readJson(appTree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-lib/src/index.ts',
+        './my-lib/src/index.ts',
       ]);
     });
 
@@ -71,7 +71,7 @@ describe('lib', () => {
       await expoLibraryGenerator(appTree, defaultSchema);
       const tsconfigJson = readJson(appTree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-lib/src/index.ts',
+        './my-lib/src/index.ts',
       ]);
     });
 
@@ -224,7 +224,7 @@ describe('lib', () => {
       });
       const tsconfigJson = readJson(appTree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-dir/src/index.ts',
+        './my-dir/src/index.ts',
       ]);
       expect(tsconfigJson.compilerOptions.paths['my-dir/*']).toBeUndefined();
     });

--- a/packages/jest/plugins/resolver.ts
+++ b/packages/jest/plugins/resolver.ts
@@ -28,6 +28,12 @@ function getCompilerSetup(rootDir: string) {
     dirname(tsConfigPath)
   );
   const compilerOptions = config.options;
+  if (!compilerOptions.baseUrl) {
+    const {
+      resolvePathsBaseUrl,
+    } = require('@nx/js/src/utils/typescript/ts-config');
+    compilerOptions.baseUrl = resolvePathsBaseUrl(tsConfigPath);
+  }
   const host = ts.createCompilerHost(compilerOptions, true);
   return { compilerOptions, host };
 }

--- a/packages/js/src/generators/init/files/non-ts-solution/__fileName__
+++ b/packages/js/src/generators/init/files/non-ts-solution/__fileName__
@@ -13,7 +13,6 @@
     "lib": ["es2020", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
-    "baseUrl": ".",
     "paths": {}
   },
   "exclude": ["node_modules", "tmp"]

--- a/packages/js/src/generators/library/files/tsconfig-lib/ts-solution/tsconfig.lib.json__tmpl__
+++ b/packages/js/src/generators/library/files/tsconfig-lib/ts-solution/tsconfig.lib.json__tmpl__
@@ -1,7 +1,6 @@
 {
   "extends": "<%= offsetFromRoot %>tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist",
     "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -136,7 +136,7 @@ describe('lib', () => {
         });
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
         expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-          'my-lib/src/index.ts',
+          './my-lib/src/index.ts',
         ]);
       });
 
@@ -150,7 +150,7 @@ describe('lib', () => {
 
         const tsconfigJson = readJson(tree, 'tsconfig.json');
         expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-          'my-lib/src/index.ts',
+          './my-lib/src/index.ts',
         ]);
       });
 
@@ -166,7 +166,7 @@ describe('lib', () => {
         });
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
         expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-          'my-lib/src/index.ts',
+          './my-lib/src/index.ts',
         ]);
       });
 
@@ -286,7 +286,7 @@ describe('lib', () => {
         });
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
         expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-          'my-dir/my-lib/src/index.ts',
+          './my-dir/my-lib/src/index.ts',
         ]);
         expect(tsconfigJson.compilerOptions.paths['my-lib/*']).toBeUndefined();
       });
@@ -302,7 +302,7 @@ describe('lib', () => {
 
         const tsconfigJson = readJson(tree, '/tsconfig.json');
         expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-          'my-dir/my-lib/src/index.ts',
+          './my-dir/my-lib/src/index.ts',
         ]);
         expect(tsconfigJson.compilerOptions.paths['my-lib/*']).toBeUndefined();
       });
@@ -730,7 +730,7 @@ describe('lib', () => {
         });
         const tsconfigJson = readJson(tree, '/tsconfig.base.json');
         expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-          'my-lib/src/index.js',
+          './my-lib/src/index.js',
         ]);
       });
 

--- a/packages/js/src/utils/buildable-libs-utils.spec.ts
+++ b/packages/js/src/utils/buildable-libs-utils.spec.ts
@@ -25,8 +25,8 @@ describe('updatePaths', () => {
     };
     updatePaths(deps, paths);
     expect(paths).toEqual({
-      '@proj/lib': ['dist/libs/lib'],
-      '@proj/test': ['libs/test/src/index.ts'],
+      '@proj/lib': ['./dist/libs/lib'],
+      '@proj/test': ['./libs/test/src/index.ts'],
     });
   });
 
@@ -37,11 +37,11 @@ describe('updatePaths', () => {
     };
     updatePaths(deps, paths);
     expect(paths).toEqual({
-      '@proj/lib': ['dist/libs/lib'],
+      '@proj/lib': ['./dist/libs/lib'],
       '@proj/lib/sub': [
-        'dist/libs/lib/sub',
-        'dist/libs/lib/sub/src/index',
-        'dist/libs/lib/sub/src/index.ts',
+        './dist/libs/lib/sub',
+        './dist/libs/lib/sub/src/index',
+        './dist/libs/lib/sub/src/index.ts',
       ],
     });
   });
@@ -75,9 +75,9 @@ describe('updatePaths', () => {
     );
 
     expect(paths).toEqual({
-      '@proj/lib1': ['dist/libs/lib1'],
-      '@proj/lib2': ['dist/libs/lib2'],
-      '@proj/lib3': ['dist/libs/lib3'],
+      '@proj/lib1': ['./dist/libs/lib1'],
+      '@proj/lib2': ['./dist/libs/lib2'],
+      '@proj/lib3': ['./dist/libs/lib3'],
     });
   });
 });

--- a/packages/js/src/utils/buildable-libs-utils.ts
+++ b/packages/js/src/utils/buildable-libs-utils.ts
@@ -14,9 +14,9 @@ import { unlinkSync } from 'fs';
 import { isNpmProject } from 'nx/src/project-graph/operators';
 import { fileExists } from 'nx/src/utils/fileutils';
 import { output } from 'nx/src/utils/output';
-import { dirname, join, relative, extname, resolve } from 'path';
+import { dirname, isAbsolute, join, relative, extname, resolve } from 'path';
 import type * as ts from 'typescript';
-import { readTsConfigPaths } from './typescript/ts-config';
+import { readTsConfigPaths, resolvePathsBaseUrl } from './typescript/ts-config';
 import { randomUUID } from 'crypto';
 import {
   isProjectGraphExternalNode,
@@ -212,10 +212,20 @@ function readTsConfigWithRemappedPaths(
     normalizedGeneratedTsConfigDir,
     normalizedTsConfig
   );
-  generatedTsConfig.compilerOptions.paths = computeCompilerOptionsPaths(
-    normalizedTsConfig,
-    dependencies
-  );
+  const paths = computeCompilerOptionsPaths(normalizedTsConfig, dependencies);
+  // Resolve paths to absolute so they work regardless of the tmp tsconfig
+  // location and without needing baseUrl (deprecated in TS 6, removed in TS 7).
+  const pathsBase = resolvePathsBaseUrl(normalizedTsConfig);
+  for (const key of Object.keys(paths)) {
+    paths[key] = paths[key].map((p) => {
+      if (isAbsolute(p)) {
+        return p;
+      }
+      const stripped = p.startsWith('./') ? p.slice(2) : p;
+      return resolve(pathsBase, stripped).replace(/\\/g, '/');
+    });
+  }
+  generatedTsConfig.compilerOptions.paths = paths;
 
   if (process.env.NX_VERBOSE_LOGGING_PATH_MAPPINGS === 'true') {
     output.log({
@@ -459,11 +469,6 @@ export function createTmpTsConfig(
   );
   process.on('exit', () => cleanupTmpTsConfigFile(tmpTsConfigPath));
 
-  if (useWorkspaceAsBaseUrl) {
-    parsedTSConfig.compilerOptions ??= {};
-    parsedTSConfig.compilerOptions.baseUrl = workspaceRoot;
-  }
-
   writeJsonFile(tmpTsConfigPath, parsedTSConfig);
   return join(tmpTsConfigPath);
 }
@@ -530,6 +535,15 @@ export function updatePaths(
         }
       }
     });
+
+  // Ensure all path values use ./ prefix for TS 6+ compatibility (no baseUrl)
+  for (const key of Object.keys(paths)) {
+    paths[key] = paths[key].map((p) =>
+      p.startsWith('./') || p.startsWith('../') || p.startsWith('/')
+        ? p
+        : `./${p}`
+    );
+  }
 }
 
 /**

--- a/packages/js/src/utils/typescript/create-ts-config.spec.ts
+++ b/packages/js/src/utils/typescript/create-ts-config.spec.ts
@@ -22,9 +22,7 @@ describe('extractTsConfigBase', () => {
 
     expect(readJson(tree, 'tsconfig.base.json')).toEqual({
       compileOnSave: false,
-      compilerOptions: {
-        baseUrl: '.',
-      },
+      compilerOptions: {},
     });
   });
 });

--- a/packages/js/src/utils/typescript/create-ts-config.ts
+++ b/packages/js/src/utils/typescript/create-ts-config.ts
@@ -14,7 +14,6 @@ export const tsConfigBaseOptions = {
   lib: ['es2020', 'dom'],
   skipLibCheck: true,
   skipDefaultLibCheck: true,
-  baseUrl: '.',
   paths: {},
 };
 
@@ -30,10 +29,6 @@ export function extractTsConfigBase(host: Tree) {
         tsconfig.compilerOptions[compilerOption];
       delete tsconfig.compilerOptions[compilerOption];
     }
-  }
-  // If we don't set baseDir then builds will fail when more than one projects exist.
-  if (typeof baseCompilerOptions.baseUrl === 'undefined') {
-    baseCompilerOptions.baseUrl = '.';
   }
   writeJson(host, 'tsconfig.base.json', {
     compileOnSave: false,

--- a/packages/js/src/utils/typescript/ts-config.spec.ts
+++ b/packages/js/src/utils/typescript/ts-config.spec.ts
@@ -1,0 +1,225 @@
+import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
+import { resolvePathsBaseUrl } from './ts-config';
+import { join } from 'path';
+
+describe('resolvePathsBaseUrl', () => {
+  let tempFs: TempFs;
+
+  beforeEach(() => {
+    tempFs = new TempFs('resolve-paths-base-url', false);
+  });
+
+  afterEach(() => {
+    tempFs.cleanup();
+  });
+
+  it('should return the directory of the tsconfig that defines paths', () => {
+    tempFs.createFileSync(
+      'tsconfig.json',
+      JSON.stringify({
+        compilerOptions: { paths: { '@app/*': ['./src/*'] } },
+      })
+    );
+
+    expect(resolvePathsBaseUrl(join(tempFs.tempDir, 'tsconfig.json'))).toBe(
+      tempFs.tempDir
+    );
+  });
+
+  it('should return resolved baseUrl when baseUrl and paths are in the same tsconfig', () => {
+    tempFs.createFileSync(
+      'tsconfig.json',
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: { '@app/*': ['src/*'] },
+        },
+      })
+    );
+
+    expect(resolvePathsBaseUrl(join(tempFs.tempDir, 'tsconfig.json'))).toBe(
+      tempFs.tempDir
+    );
+  });
+
+  it('should resolve non-dot baseUrl relative to its tsconfig directory', () => {
+    tempFs.createFileSync(
+      'tsconfig.json',
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: 'src',
+          paths: { '@app/*': ['app/*'] },
+        },
+      })
+    );
+
+    expect(resolvePathsBaseUrl(join(tempFs.tempDir, 'tsconfig.json'))).toBe(
+      join(tempFs.tempDir, 'src')
+    );
+  });
+
+  it('should walk extends chain to find paths in parent', () => {
+    tempFs.createFileSync(
+      'tsconfig.base.json',
+      JSON.stringify({
+        compilerOptions: { paths: { '@lib/*': ['libs/*/src/index.ts'] } },
+      })
+    );
+    tempFs.createFileSync(
+      'tsconfig.json',
+      JSON.stringify({ extends: './tsconfig.base.json' })
+    );
+
+    expect(resolvePathsBaseUrl(join(tempFs.tempDir, 'tsconfig.json'))).toBe(
+      tempFs.tempDir
+    );
+  });
+
+  it('should use baseUrl from parent when paths are in parent', () => {
+    tempFs.createFileSync(
+      'tsconfig.base.json',
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: { '@lib/*': ['libs/*/src/index.ts'] },
+        },
+      })
+    );
+    tempFs.createFileSync(
+      'tsconfig.json',
+      JSON.stringify({ extends: './tsconfig.base.json' })
+    );
+
+    expect(resolvePathsBaseUrl(join(tempFs.tempDir, 'tsconfig.json'))).toBe(
+      tempFs.tempDir
+    );
+  });
+
+  it('should use baseUrl from parent when paths are in child', () => {
+    tempFs.createFileSync(
+      'tsconfig.base.json',
+      JSON.stringify({
+        compilerOptions: { baseUrl: '.' },
+      })
+    );
+    tempFs.createFileSync(
+      'project/tsconfig.json',
+      JSON.stringify({
+        extends: '../tsconfig.base.json',
+        compilerOptions: { paths: { '@app/*': ['src/*'] } },
+      })
+    );
+
+    expect(
+      resolvePathsBaseUrl(join(tempFs.tempDir, 'project', 'tsconfig.json'))
+    ).toBe(tempFs.tempDir);
+  });
+
+  it('should ignore child baseUrl override when paths are in parent', () => {
+    tempFs.createFileSync(
+      'tsconfig.base.json',
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: { '@lib/*': ['libs/*'] },
+        },
+      })
+    );
+    tempFs.createFileSync(
+      'project/tsconfig.json',
+      JSON.stringify({
+        extends: '../tsconfig.base.json',
+        compilerOptions: { baseUrl: 'src' },
+      })
+    );
+
+    // Child's baseUrl:'src' is ignored because paths are defined in the
+    // parent. The parent's baseUrl:'.' (= tempDir) is used.
+    expect(
+      resolvePathsBaseUrl(join(tempFs.tempDir, 'project', 'tsconfig.json'))
+    ).toBe(tempFs.tempDir);
+  });
+
+  it('should use baseUrl from paths-defining tsconfig with non-dot value', () => {
+    tempFs.createFileSync(
+      'tsconfig.base.json',
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: 'src',
+          paths: { '@app/*': ['app/*'] },
+        },
+      })
+    );
+    tempFs.createFileSync(
+      'project/tsconfig.json',
+      JSON.stringify({ extends: '../tsconfig.base.json' })
+    );
+
+    expect(
+      resolvePathsBaseUrl(join(tempFs.tempDir, 'project', 'tsconfig.json'))
+    ).toBe(join(tempFs.tempDir, 'src'));
+  });
+
+  it('should handle deep extends chains', () => {
+    tempFs.createFileSync(
+      'tsconfig.root.json',
+      JSON.stringify({
+        compilerOptions: { paths: { '@lib/*': ['libs/*'] } },
+      })
+    );
+    tempFs.createFileSync(
+      'tsconfig.base.json',
+      JSON.stringify({ extends: './tsconfig.root.json' })
+    );
+    tempFs.createFileSync(
+      'project/tsconfig.json',
+      JSON.stringify({ extends: '../tsconfig.base.json' })
+    );
+
+    expect(
+      resolvePathsBaseUrl(join(tempFs.tempDir, 'project', 'tsconfig.json'))
+    ).toBe(tempFs.tempDir);
+  });
+
+  it('should handle array extends', () => {
+    tempFs.createFileSync(
+      'tsconfig.paths.json',
+      JSON.stringify({
+        compilerOptions: { paths: { '@lib/*': ['libs/*'] } },
+      })
+    );
+    tempFs.createFileSync(
+      'tsconfig.strict.json',
+      JSON.stringify({
+        compilerOptions: { strict: true },
+      })
+    );
+    tempFs.createFileSync(
+      'tsconfig.json',
+      JSON.stringify({
+        extends: ['./tsconfig.paths.json', './tsconfig.strict.json'],
+      })
+    );
+
+    expect(resolvePathsBaseUrl(join(tempFs.tempDir, 'tsconfig.json'))).toBe(
+      tempFs.tempDir
+    );
+  });
+
+  it('should return tsconfig directory when no paths or baseUrl exist', () => {
+    tempFs.createFileSync(
+      'tsconfig.json',
+      JSON.stringify({ compilerOptions: {} })
+    );
+
+    expect(resolvePathsBaseUrl(join(tempFs.tempDir, 'tsconfig.json'))).toBe(
+      tempFs.tempDir
+    );
+  });
+
+  it('should return tsconfig directory for non-existent file', () => {
+    expect(resolvePathsBaseUrl(join(tempFs.tempDir, 'nonexistent.json'))).toBe(
+      tempFs.tempDir
+    );
+  });
+});

--- a/packages/js/src/utils/typescript/ts-config.ts
+++ b/packages/js/src/utils/typescript/ts-config.ts
@@ -1,6 +1,6 @@
 import { offsetFromRoot, Tree, updateJson, workspaceRoot } from '@nx/devkit';
-import { existsSync } from 'fs';
-import { dirname, join } from 'path';
+import { existsSync, readFileSync } from 'fs';
+import { dirname, isAbsolute, join, resolve } from 'path';
 import type * as ts from 'typescript';
 import { ensureTypescript } from './ensure-typescript';
 
@@ -93,10 +93,113 @@ export function addTsConfigPath(
       );
     }
 
-    c.paths[importPath] = lookupPaths;
+    c.paths[importPath] = lookupPaths.map(ensureRelativePath);
 
     return json;
   });
+}
+
+function ensureRelativePath(p: string): string {
+  if (p.startsWith('./') || p.startsWith('../') || p.startsWith('/')) {
+    return p;
+  }
+  return `./${p}`;
+}
+
+/**
+ * When `baseUrl` is not set and `paths` are inherited via `extends`,
+ * tools like `tsconfig-paths` resolve from the loaded file's directory
+ * instead of the file where `paths` is defined. This walks the `extends`
+ * chain to find the correct resolution base.
+ *
+ * Returns the directory that `paths` values should be resolved relative to.
+ * Walks the tsconfig `extends` chain to find where `paths` is defined, then
+ * looks for the applicable `baseUrl` from that point toward the root of the
+ * chain (ignoring child overrides that don't apply to the paths-defining
+ * tsconfig). When no `baseUrl` applies, returns the directory of the
+ * tsconfig that defines `paths`.
+ */
+export function resolvePathsBaseUrl(tsconfigPath: string): string {
+  const chain: { dir: string; raw: any }[] = [];
+  const queue: string[] = [tsconfigPath];
+  while (queue.length > 0) {
+    const absolute = resolve(queue.shift()!);
+    const dir = dirname(absolute);
+    try {
+      const raw = JSON.parse(readFileSync(absolute, 'utf-8'));
+      chain.push({ dir, raw });
+      const exts: string[] = raw.extends
+        ? Array.isArray(raw.extends)
+          ? raw.extends
+          : [raw.extends]
+        : [];
+      for (const ext of exts) {
+        const resolved = resolveExtendsPath(ext, dir);
+        if (resolved) {
+          queue.push(resolved);
+        }
+      }
+    } catch {
+      // skip unreadable files
+    }
+  }
+
+  // Find where paths is defined.
+  let pathsIndex = -1;
+  for (let i = 0; i < chain.length; i++) {
+    if (
+      chain[i].raw.compilerOptions?.paths &&
+      Object.keys(chain[i].raw.compilerOptions.paths).length > 0
+    ) {
+      pathsIndex = i;
+      break;
+    }
+  }
+
+  // Find the applicable baseUrl: search from the paths-defining tsconfig
+  // toward the root. Child overrides before the paths-defining tsconfig
+  // are ignored — they don't apply to the paths that were written for a
+  // different baseUrl context.
+  const searchStart = pathsIndex >= 0 ? pathsIndex : 0;
+  for (let i = searchStart; i < chain.length; i++) {
+    if (chain[i].raw.compilerOptions?.baseUrl) {
+      return resolve(chain[i].dir, chain[i].raw.compilerOptions.baseUrl);
+    }
+  }
+
+  return pathsIndex >= 0
+    ? chain[pathsIndex].dir
+    : dirname(resolve(tsconfigPath));
+}
+
+/**
+ * Resolves a tsconfig `extends` entry to an absolute path.
+ * Handles relative paths, absolute paths, and package names
+ * (e.g., `@tsconfig/node20/tsconfig.json` or `@tsconfig/strictest`).
+ * Mirrors TypeScript's resolution: relative/absolute paths are resolved
+ * directly (with `.json` fallback), package names use `require.resolve`
+ * with a `tsconfig.json` fallback for bare package names.
+ */
+function resolveExtendsPath(ext: string, fromDir: string): string | null {
+  if (ext.startsWith('.') || isAbsolute(ext)) {
+    let resolved = resolve(fromDir, ext);
+    if (existsSync(resolved)) return resolved;
+    if (!resolved.endsWith('.json')) {
+      resolved += '.json';
+      if (existsSync(resolved)) return resolved;
+    }
+    return null;
+  }
+  // Package name — try as-is, then with /tsconfig.json appended
+  try {
+    return require.resolve(ext, { paths: [fromDir] });
+  } catch {
+    try {
+      return require.resolve(`${ext}/tsconfig.json`, { paths: [fromDir] });
+    } catch {
+      return null;
+    }
+  }
 }
 
 export function readTsConfigPaths(tsConfig?: string | ts.ParsedCommandLine) {

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/angular/nx-module-federation-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/angular/nx-module-federation-plugin.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../utils/models';
 import { getModuleFederationConfigSync } from '../../../with-module-federation/angular/utils';
 import { normalizeProjectName } from '../../../utils';
+import { workspaceRoot } from '@nx/devkit';
 
 export class NxModuleFederationPlugin implements RspackPluginInstance {
   constructor(
@@ -37,6 +38,13 @@ export class NxModuleFederationPlugin implements RspackPluginInstance {
       ? 'auto'
       : compiler.options.output.publicPath;
     compiler.options.output.uniqueName = this._options.config.name;
+    // Ensure workspace root is in resolve.modules so that expose paths
+    // like "apps/remote/src/..." resolve correctly without baseUrl.
+    compiler.options.resolve ??= {};
+    compiler.options.resolve.modules = [
+      ...(compiler.options.resolve.modules ?? ['node_modules']),
+      workspaceRoot,
+    ];
 
     if (this._options.isServer) {
       compiler.options.target = 'async-node';

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-plugin.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../utils/models';
 import { getModuleFederationConfig } from '../../../with-module-federation/rspack/utils';
 import { normalizeProjectName } from '../../../utils';
+import { workspaceRoot } from '@nx/devkit';
 
 export class NxModuleFederationPlugin implements RspackPluginInstance {
   constructor(
@@ -29,6 +30,13 @@ export class NxModuleFederationPlugin implements RspackPluginInstance {
       compiler.options.optimization.splitChunks.cacheGroups.common = false;
     }
     compiler.options.output.uniqueName = this._options.config.name;
+    // Ensure workspace root is in resolve.modules so that expose paths
+    // like "apps/remote/src/..." resolve correctly without baseUrl.
+    compiler.options.resolve ??= {};
+    compiler.options.resolve.modules = [
+      ...(compiler.options.resolve.modules ?? ['node_modules']),
+      workspaceRoot,
+    ];
     if (compiler.options.output.scriptType === 'module') {
       compiler.options.output.scriptType = undefined;
       compiler.options.output.module = undefined;

--- a/packages/module-federation/src/with-module-federation/angular/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/angular/with-module-federation-ssr.ts
@@ -4,6 +4,7 @@ import {
   type NxModuleFederationConfigOverride,
 } from '../../utils';
 import { getModuleFederationConfig } from './utils';
+import { workspaceRoot } from '@nx/devkit';
 
 export async function withModuleFederationForSSR(
   options: ModuleFederationConfig,
@@ -39,6 +40,10 @@ export async function withModuleFederationForSSR(
       },
       resolve: {
         ...(config.resolve ?? {}),
+        modules: [
+          ...(config.resolve?.modules ?? ['node_modules']),
+          workspaceRoot,
+        ],
         alias: {
           ...(config.resolve?.alias ?? {}),
           ...sharedLibraries.getAliases(),

--- a/packages/module-federation/src/with-module-federation/angular/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/angular/with-module-federation.ts
@@ -5,6 +5,7 @@ import {
 } from '../../utils';
 import { getModuleFederationConfig } from './utils';
 import { ModuleFederationPlugin } from '@module-federation/enhanced/webpack';
+import { workspaceRoot } from '@nx/devkit';
 
 export async function withModuleFederation(
   options: ModuleFederationConfig,
@@ -39,6 +40,12 @@ export async function withModuleFederation(
       },
       resolve: {
         ...(config.resolve ?? {}),
+        // Ensure workspace root is in resolve.modules so that expose paths
+        // like "apps/remote/src/..." resolve correctly without baseUrl.
+        modules: [
+          ...(config.resolve?.modules ?? ['node_modules']),
+          workspaceRoot,
+        ],
         alias: {
           ...(config.resolve?.alias ?? {}),
           ...sharedLibraries.getAliases(),

--- a/packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts
@@ -5,6 +5,7 @@ import {
   NxModuleFederationConfigOverride,
 } from '../../utils';
 import { getModuleFederationConfig } from './utils';
+import { workspaceRoot } from '@nx/devkit';
 
 export async function withModuleFederationForSSR(
   options: ModuleFederationConfig,
@@ -26,6 +27,11 @@ export async function withModuleFederationForSSR(
     config.output.library = {
       type: 'commonjs-module',
     };
+    config.resolve ??= {};
+    config.resolve.modules = [
+      ...(config.resolve.modules ?? ['node_modules']),
+      workspaceRoot,
+    ];
     config.optimization = {
       ...(config.optimization ?? {}),
       runtimeChunk: isDevServer

--- a/packages/module-federation/src/with-module-federation/rspack/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/with-module-federation.ts
@@ -7,6 +7,7 @@ import {
   NxModuleFederationConfigOverride,
 } from '../../utils';
 import { getModuleFederationConfig } from './utils';
+import { workspaceRoot } from '@nx/devkit';
 
 const isVarOrWindow = (libType?: string) =>
   libType === 'var' || libType === 'window';
@@ -41,6 +42,11 @@ export async function withModuleFederation(
       config.output.scriptType = 'text/javascript';
     }
 
+    config.resolve ??= {};
+    config.resolve.modules = [
+      ...(config.resolve.modules ?? ['node_modules']),
+      workspaceRoot,
+    ];
     config.optimization = {
       ...(config.optimization ?? {}),
       runtimeChunk:

--- a/packages/module-federation/src/with-module-federation/webpack/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/webpack/with-module-federation-ssr.ts
@@ -5,6 +5,7 @@ import {
 } from '../../utils';
 import { getModuleFederationConfig } from './utils';
 import type { NormalModuleReplacementPlugin } from 'webpack';
+import { workspaceRoot } from '@nx/devkit';
 
 export async function withModuleFederationForSSR(
   options: ModuleFederationConfig,
@@ -27,6 +28,11 @@ export async function withModuleFederationForSSR(
   return (config) => {
     config.target = 'async-node';
     config.output.uniqueName = options.name;
+    config.resolve ??= {};
+    config.resolve.modules = [
+      ...(config.resolve.modules ?? ['node_modules']),
+      workspaceRoot,
+    ];
     config.optimization = {
       ...(config.optimization ?? {}),
       runtimeChunk: isDevServer

--- a/packages/module-federation/src/with-module-federation/webpack/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/webpack/with-module-federation.ts
@@ -6,6 +6,7 @@ import {
 import { getModuleFederationConfig } from './utils';
 import { ModuleFederationPlugin } from '@module-federation/enhanced/webpack';
 import type { NormalModuleReplacementPlugin } from 'webpack';
+import { workspaceRoot } from '@nx/devkit';
 
 /**
  * @param {ModuleFederationConfig} options
@@ -27,6 +28,11 @@ export async function withModuleFederation(
     config.output.publicPath = 'auto';
 
     config.output.scriptType = 'text/javascript';
+    config.resolve ??= {};
+    config.resolve.modules = [
+      ...(config.resolve.modules ?? ['node_modules']),
+      workspaceRoot,
+    ];
     config.optimization = {
       ...(config.optimization ?? {}),
       runtimeChunk:

--- a/packages/nest/src/generators/library/library.spec.ts
+++ b/packages/nest/src/generators/library/library.spec.ts
@@ -114,7 +114,7 @@ describe('lib', () => {
 
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths[`@proj/my-lib`]).toEqual([
-        `my-lib/src/index.ts`,
+        `./my-lib/src/index.ts`,
       ]);
     });
 
@@ -195,7 +195,7 @@ describe('lib', () => {
 
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths[`@proj/my-lib`]).toEqual([
-        `my-dir/my-lib/src/index.ts`,
+        `./my-dir/my-lib/src/index.ts`,
       ]);
       expect(tsconfigJson.compilerOptions.paths[`my-lib/*`]).toBeUndefined();
     });
@@ -425,7 +425,6 @@ describe('lib', () => {
       expect(readJson(tree, 'mylib/tsconfig.lib.json')).toMatchInlineSnapshot(`
         {
           "compilerOptions": {
-            "baseUrl": ".",
             "emitDeclarationOnly": true,
             "emitDecoratorMetadata": true,
             "experimentalDecorators": true,

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -1272,7 +1272,18 @@ describe('app', () => {
           testEnvironment: 'jsdom',
         };
 
-        module.exports = createJestConfig(config);
+        const jestConfig = createJestConfig(config);
+
+        module.exports = async () => {
+          const resolved = await jestConfig();
+          // Disable SWC path alias resolution — handled by Nx jest resolver.
+          for (const value of Object.values(resolved.transform)) {
+            if (Array.isArray(value) && value[1]?.resolvedBaseUrl) {
+              value[1] = { ...value[1], resolvedBaseUrl: undefined };
+            }
+          }
+          return resolved;
+        };
         "
       `);
     });
@@ -1305,7 +1316,18 @@ describe('app', () => {
           testEnvironment: 'jsdom',
         };
 
-        module.exports = createJestConfig(config);
+        const jestConfig = createJestConfig(config);
+
+        module.exports = async () => {
+          const resolved = await jestConfig();
+          // Disable SWC path alias resolution — handled by Nx jest resolver.
+          for (const value of Object.values(resolved.transform)) {
+            if (Array.isArray(value) && value[1]?.resolvedBaseUrl) {
+              value[1] = { ...value[1], resolvedBaseUrl: undefined };
+            }
+          }
+          return resolved;
+        };
         "
       `);
     });
@@ -1379,7 +1401,18 @@ describe('app (legacy)', () => {
           testEnvironment: 'jsdom',
         };
 
-        module.exports = createJestConfig(config);
+        const jestConfig = createJestConfig(config);
+
+        module.exports = async () => {
+          const resolved = await jestConfig();
+          // Disable SWC path alias resolution — handled by Nx jest resolver.
+          for (const value of Object.values(resolved.transform)) {
+            if (Array.isArray(value) && value[1]?.resolvedBaseUrl) {
+              value[1] = { ...value[1], resolvedBaseUrl: undefined };
+            }
+          }
+          return resolved;
+        };
         "
       `);
     });
@@ -1412,7 +1445,18 @@ describe('app (legacy)', () => {
           testEnvironment: 'jsdom',
         };
 
-        module.exports = createJestConfig(config);
+        const jestConfig = createJestConfig(config);
+
+        module.exports = async () => {
+          const resolved = await jestConfig();
+          // Disable SWC path alias resolution — handled by Nx jest resolver.
+          for (const value of Object.values(resolved.transform)) {
+            if (Array.isArray(value) && value[1]?.resolvedBaseUrl) {
+              value[1] = { ...value[1], resolvedBaseUrl: undefined };
+            }
+          }
+          return resolved;
+        };
         "
       `);
     });

--- a/packages/next/src/generators/library/library.spec.ts
+++ b/packages/next/src/generators/library/library.spec.ts
@@ -142,8 +142,8 @@ describe('next library', () => {
     expect(
       readJson(appTree, 'tsconfig.base.json').compilerOptions.paths
     ).toMatchObject({
-      '@proj/my-lib': ['my-lib/src/index.ts'],
-      '@proj/my-lib/server': ['my-lib/src/server.ts'],
+      '@proj/my-lib': ['./my-lib/src/index.ts'],
+      '@proj/my-lib/server': ['./my-lib/src/server.ts'],
     });
   });
 

--- a/packages/next/src/utils/jest-config-util.ts
+++ b/packages/next/src/utils/jest-config-util.ts
@@ -34,6 +34,10 @@ export function updateJestConfig(
   const isCommonJS = configPath.endsWith('.js') || configPath.endsWith('.cts');
 
   // Easier to override the whole file rather than replace content since the structure has changed with `next/jest.js` being used.
+  // The wrapper around createJestConfig disables SWC path alias resolution.
+  // Without explicit baseUrl, Next.js resolves aliases from the app root instead
+  // of the workspace root, producing wrong paths. The Nx jest resolver handles
+  // alias resolution correctly, so we let it take over.
   const newContent = isCommonJS
     ? `const nextJest = require('next/jest.js');
 
@@ -52,7 +56,18 @@ const config = {
   testEnvironment: 'jsdom',
 };
 
-module.exports = createJestConfig(config);
+const jestConfig = createJestConfig(config);
+
+module.exports = async () => {
+  const resolved = await jestConfig();
+  // Disable SWC path alias resolution — handled by Nx jest resolver.
+  for (const value of Object.values(resolved.transform)) {
+    if (Array.isArray(value) && value[1]?.resolvedBaseUrl) {
+      value[1] = { ...value[1], resolvedBaseUrl: undefined };
+    }
+  }
+  return resolved;
+};
 `
     : `import type { Config } from 'jest';
 import nextJest from 'next/jest.js';
@@ -72,7 +87,18 @@ const config: Config = {
   testEnvironment: 'jsdom',
 };
 
-export default createJestConfig(config);
+const jestConfig = createJestConfig(config);
+
+export default async () => {
+  const resolved = await jestConfig();
+  // Disable SWC path alias resolution — handled by Nx jest resolver.
+  for (const value of Object.values(resolved.transform)) {
+    if (Array.isArray(value) && value[1]?.resolvedBaseUrl) {
+      value[1] = { ...value[1], resolvedBaseUrl: undefined };
+    }
+  }
+  return resolved;
+};
 `;
 
   host.write(configPath, newContent);

--- a/packages/node/src/generators/library/files/ts-solution/tsconfig.lib.json
+++ b/packages/node/src/generators/library/files/ts-solution/tsconfig.lib.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "src",
     "module": "nodenext",
     "moduleResolution": "nodenext",

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -70,7 +70,7 @@ describe('lib', () => {
       await libraryGenerator(tree, baseLibraryConfig);
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-lib/src/index.ts',
+        './my-lib/src/index.ts',
       ]);
     });
 
@@ -232,7 +232,7 @@ describe('lib', () => {
       });
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-dir/my-lib/src/index.ts',
+        './my-dir/my-lib/src/index.ts',
       ]);
       expect(tsconfigJson.compilerOptions.paths['my-lib/*']).toBeUndefined();
     });
@@ -489,7 +489,7 @@ describe('lib', () => {
       await libraryGenerator(tree, { directory: 'my-lib', js: true } as Schema);
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-lib/src/index.js',
+        './my-lib/src/index.js',
       ]);
     });
 
@@ -606,7 +606,6 @@ describe('lib', () => {
       expect(readJson(tree, 'mylib/tsconfig.lib.json')).toMatchInlineSnapshot(`
         {
           "compilerOptions": {
-            "baseUrl": ".",
             "emitDeclarationOnly": true,
             "module": "nodenext",
             "moduleResolution": "nodenext",

--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -1,4 +1,5 @@
-import { join, sep } from 'path';
+import { dirname, isAbsolute, join, resolve, sep } from 'path';
+import { existsSync, readFileSync } from 'fs';
 import type { TsConfigOptions } from 'ts-node';
 import type { CompilerOptions } from 'typescript';
 import { logger, NX_PREFIX, stripIndent } from '../../../utils/logger';
@@ -387,7 +388,7 @@ export function registerTsConfigPaths(tsConfigPath): () => void {
      */
     if (tsConfigResult.resultType === 'success') {
       return tsconfigPaths.register({
-        baseUrl: tsConfigResult.absoluteBaseUrl,
+        baseUrl: resolvePathsBaseUrl(tsConfigPath),
         paths: tsConfigResult.paths,
       });
     }
@@ -551,3 +552,72 @@ export function getTsNodeCompilerOptions(compilerOptions: CompilerOptions) {
 type RemoveIndex<T> = {
   [K in keyof T as {} extends Record<K, 1> ? never : K]: T[K];
 };
+
+function resolvePathsBaseUrl(tsconfigPath: string): string {
+  const chain: { dir: string; raw: any }[] = [];
+  const queue: string[] = [tsconfigPath];
+  while (queue.length > 0) {
+    const absolute = resolve(queue.shift()!);
+    const dir = dirname(absolute);
+    try {
+      const raw = JSON.parse(readFileSync(absolute, 'utf-8'));
+      chain.push({ dir, raw });
+      const exts: string[] = raw.extends
+        ? Array.isArray(raw.extends)
+          ? raw.extends
+          : [raw.extends]
+        : [];
+      for (const ext of exts) {
+        const resolved = resolveExtendsPath(ext, dir);
+        if (resolved) {
+          queue.push(resolved);
+        }
+      }
+    } catch {
+      // skip unreadable files
+    }
+  }
+
+  let pathsIndex = -1;
+  for (let i = 0; i < chain.length; i++) {
+    if (
+      chain[i].raw.compilerOptions?.paths &&
+      Object.keys(chain[i].raw.compilerOptions.paths).length > 0
+    ) {
+      pathsIndex = i;
+      break;
+    }
+  }
+
+  const searchStart = pathsIndex >= 0 ? pathsIndex : 0;
+  for (let i = searchStart; i < chain.length; i++) {
+    if (chain[i].raw.compilerOptions?.baseUrl) {
+      return resolve(chain[i].dir, chain[i].raw.compilerOptions.baseUrl);
+    }
+  }
+
+  return pathsIndex >= 0
+    ? chain[pathsIndex].dir
+    : dirname(resolve(tsconfigPath));
+}
+
+function resolveExtendsPath(ext: string, fromDir: string): string | null {
+  if (ext.startsWith('.') || isAbsolute(ext)) {
+    let resolved = resolve(fromDir, ext);
+    if (existsSync(resolved)) return resolved;
+    if (!resolved.endsWith('.json')) {
+      resolved += '.json';
+      if (existsSync(resolved)) return resolved;
+    }
+    return null;
+  }
+  try {
+    return require.resolve(ext, { paths: [fromDir] });
+  } catch {
+    try {
+      return require.resolve(`${ext}/tsconfig.json`, { paths: [fromDir] });
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/plugin/src/generators/plugin/plugin.spec.ts
+++ b/packages/plugin/src/generators/plugin/plugin.spec.ts
@@ -496,7 +496,6 @@ describe('NxPlugin Plugin Generator', () => {
         .toMatchInlineSnapshot(`
         {
           "compilerOptions": {
-            "baseUrl": ".",
             "emitDeclarationOnly": false,
             "module": "nodenext",
             "moduleResolution": "nodenext",

--- a/packages/react-native/plugins/metro-resolver.ts
+++ b/packages/react-native/plugins/metro-resolver.ts
@@ -1,5 +1,6 @@
 import type { MatchPath } from 'tsconfig-paths';
 import { createMatchPath, loadConfig } from 'tsconfig-paths';
+import { resolvePathsBaseUrl } from '@nx/js/src/utils/typescript/ts-config';
 import * as pc from 'picocolors';
 import { CachedInputFileSystem, ResolverFactory } from 'enhanced-resolve';
 import { dirname, join } from 'path';
@@ -204,7 +205,7 @@ function getMatcher(debug: boolean) {
   if (!matcher) {
     const result = loadConfig();
     if (result.resultType === 'success') {
-      absoluteBaseUrl = result.absoluteBaseUrl;
+      absoluteBaseUrl = resolvePathsBaseUrl(result.configFileAbsolutePath);
       paths = result.paths;
       if (debug) {
         console.log(

--- a/packages/react-native/src/generators/library/library.spec.ts
+++ b/packages/react-native/src/generators/library/library.spec.ts
@@ -35,7 +35,7 @@ describe('lib', () => {
       await libraryGenerator(appTree, defaultSchema);
       const tsconfigJson = readJson(appTree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-lib/src/index.ts',
+        './my-lib/src/index.ts',
       ]);
     });
 
@@ -46,7 +46,7 @@ describe('lib', () => {
 
       const tsconfigJson = readJson(appTree, '/tsconfig.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-lib/src/index.ts',
+        './my-lib/src/index.ts',
       ]);
     });
 
@@ -59,7 +59,7 @@ describe('lib', () => {
       await libraryGenerator(appTree, defaultSchema);
       const tsconfigJson = readJson(appTree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-lib/src/index.ts',
+        './my-lib/src/index.ts',
       ]);
     });
 
@@ -146,7 +146,7 @@ describe('lib', () => {
       });
       const tsconfigJson = readJson(appTree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-dir/src/index.ts',
+        './my-dir/src/index.ts',
       ]);
       expect(
         tsconfigJson.compilerOptions.paths['my-dir-my-lib/*']
@@ -164,7 +164,7 @@ describe('lib', () => {
 
       const tsconfigJson = readJson(appTree, '/tsconfig.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-dir/src/index.ts',
+        './my-dir/src/index.ts',
       ]);
       expect(
         tsconfigJson.compilerOptions.paths['my-dir-my-lib/*']

--- a/packages/react/plugins/component-testing/webpack-fallback.ts
+++ b/packages/react/plugins/component-testing/webpack-fallback.ts
@@ -1,6 +1,7 @@
 import { TsconfigPathsPlugin } from 'tsconfig-paths-webpack-plugin';
 import { Configuration } from 'webpack';
 import { getCSSModuleLocalIdent } from '@nx/webpack';
+import { resolvePathsBaseUrl } from '@nx/js/src/utils/typescript/ts-config';
 
 export function buildBaseWebpackConfig({
   tsConfigPath = 'tsconfig.cy.json',
@@ -17,6 +18,7 @@ export function buildBaseWebpackConfig({
       plugins: [
         new TsconfigPathsPlugin({
           configFile: tsConfigPath,
+          baseUrl: resolvePathsBaseUrl(tsConfigPath),
           extensions,
         }) as never,
       ],

--- a/packages/react/src/generators/federate-module/federate-module.spec.ts
+++ b/packages/react/src/generators/federate-module/federate-module.spec.ts
@@ -60,7 +60,7 @@ describe('federate-module', () => {
       const tsconfig = JSON.parse(tree.read('tsconfig.base.json', 'utf-8'));
       expect(
         tsconfig.compilerOptions.paths['myremote/my-federated-module']
-      ).toEqual(['myremote/src/my-federated-module.ts']);
+      ).toEqual(['./myremote/src/my-federated-module.ts']);
     });
 
     it('should error when invalid path is provided', async () => {
@@ -117,7 +117,7 @@ describe('federate-module', () => {
       const tsconfig = JSON.parse(tree.read('tsconfig.base.json', 'utf-8'));
       expect(
         tsconfig.compilerOptions.paths[`${schema.remote}/my-federated-module`]
-      ).toEqual(['myremote/src/my-federated-module.ts']);
+      ).toEqual(['./myremote/src/my-federated-module.ts']);
     });
   });
 });

--- a/packages/react/src/generators/host/lib/update-module-federation-tsconfig.ts
+++ b/packages/react/src/generators/host/lib/update-module-federation-tsconfig.ts
@@ -16,13 +16,7 @@ export function updateModuleFederationTsconfig(
   );
   if (!host.exists(tsconfigPath) || !host.exists(tsconfigRuntimePath)) return;
 
-  // Not setting `baseUrl` does not work with MF.
   if (isUsingTsSolutionSetup(host)) {
-    updateJson(host, 'tsconfig.base.json', (json) => {
-      json.compilerOptions.baseUrl = '.';
-      return json;
-    });
-
     // Update references to match what `nx sync` does.
     if (options.remotes?.length) {
       updateJson(host, tsconfigPath, (json) => {

--- a/packages/react/src/generators/library/library.spec.ts
+++ b/packages/react/src/generators/library/library.spec.ts
@@ -122,7 +122,7 @@ describe('lib', () => {
     await libraryGenerator(tree, defaultSchema);
     const tsconfigJson = readJson(tree, '/tsconfig.base.json');
     expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-      'my-lib/src/index.ts',
+      './my-lib/src/index.ts',
     ]);
   });
 
@@ -134,7 +134,7 @@ describe('lib', () => {
     expect(tree.exists('tsconfig.base.json')).toEqual(true);
     const tsconfigJson = readJson(tree, 'tsconfig.base.json');
     expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-      'my-lib/src/index.ts',
+      './my-lib/src/index.ts',
     ]);
   });
 
@@ -147,7 +147,7 @@ describe('lib', () => {
     await libraryGenerator(tree, defaultSchema);
     const tsconfigJson = readJson(tree, '/tsconfig.base.json');
     expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-      'my-lib/src/index.ts',
+      './my-lib/src/index.ts',
     ]);
   });
 
@@ -357,7 +357,7 @@ describe('lib', () => {
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
 
       expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-        'my-dir/my-lib/src/index.ts',
+        './my-dir/my-lib/src/index.ts',
       ]);
       expect(
         tsconfigJson.compilerOptions.paths['my-dir-my-lib/*']

--- a/packages/react/src/generators/remote/remote.rspack.spec.ts
+++ b/packages/react/src/generators/remote/remote.rspack.spec.ts
@@ -164,7 +164,7 @@ describe('remote generator', () => {
 
       const tsconfigJson = readJson(tree, getRootTsConfigPathInTree(tree));
       expect(tsconfigJson.compilerOptions.paths['test/Module']).toEqual([
-        'test/src/remote-entry.ts',
+        './test/src/remote-entry.ts',
       ]);
     });
 
@@ -197,7 +197,7 @@ describe('remote generator', () => {
 
       const tsconfigJson = readJson(tree, getRootTsConfigPathInTree(tree));
       expect(tsconfigJson.compilerOptions.paths['test/Module']).toEqual([
-        'test/src/remote-entry.js',
+        './test/src/remote-entry.js',
       ]);
     });
 

--- a/packages/react/src/generators/remote/remote.webpack.spec.ts
+++ b/packages/react/src/generators/remote/remote.webpack.spec.ts
@@ -142,7 +142,7 @@ describe('remote generator', () => {
 
       const tsconfigJson = readJson(tree, getRootTsConfigPathInTree(tree));
       expect(tsconfigJson.compilerOptions.paths['test/Module']).toEqual([
-        'test/src/remote-entry.ts',
+        './test/src/remote-entry.ts',
       ]);
     });
 
@@ -175,7 +175,7 @@ describe('remote generator', () => {
 
       const tsconfigJson = readJson(tree, getRootTsConfigPathInTree(tree));
       expect(tsconfigJson.compilerOptions.paths['test/Module']).toEqual([
-        'test/src/remote-entry.js',
+        './test/src/remote-entry.js',
       ]);
     });
 

--- a/packages/remix/src/generators/library/__snapshots__/library.impl.spec.ts.snap
+++ b/packages/remix/src/generators/library/__snapshots__/library.impl.spec.ts.snap
@@ -42,10 +42,10 @@ exports[`Remix Library Generator should generate a library correctly 1`] = `
 exports[`Remix Library Generator should generate a library correctly 2`] = `
 {
   "@proj/test": [
-    "test/src/index.ts",
+    "./test/src/index.ts",
   ],
   "@proj/test/server": [
-    "test/src/server.ts",
+    "./test/src/server.ts",
   ],
 }
 `;

--- a/packages/remix/src/generators/library/lib/add-tsconfig-entry-points.ts
+++ b/packages/remix/src/generators/library/lib/add-tsconfig-entry-points.ts
@@ -29,7 +29,7 @@ export function addTsconfigEntryPoints(
     ) {
       json.compilerOptions.paths[
         joinPathFragments(options.importPath, 'server')
-      ] = [serverFilePath];
+      ] = [`./${serverFilePath}`];
     }
 
     return json;

--- a/packages/rollup/src/plugins/with-nx/with-nx.ts
+++ b/packages/rollup/src/plugins/with-nx/with-nx.ts
@@ -6,6 +6,7 @@ import {
   readJsonFile,
   workspaceRoot,
 } from '@nx/devkit';
+import { isAbsolute, resolve } from 'path';
 import { typeDefinitions } from '@nx/js/src/plugins/rollup/type-definitions';
 import {
   calculateProjectBuildableDependencies,
@@ -17,6 +18,7 @@ import {
   getProjectSourceRoot,
   isUsingTsSolutionSetup,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { resolvePathsBaseUrl } from '@nx/js/src/utils/typescript/ts-config';
 import { getBabelInputPlugin } from '@rollup/plugin-babel';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import autoprefixer from 'autoprefixer';
@@ -232,9 +234,11 @@ export function withNx(
       options.generatePackageJson ??= true;
     }
 
+    const originalTsConfigPath = join(workspaceRoot, options.tsConfig);
     const compilerOptions: Record<string, unknown> = createTsCompilerOptions(
       projectRoot,
       tsConfig,
+      originalTsConfigPath,
       options,
       dependencies
     );
@@ -366,6 +370,7 @@ function createInput(
 function createTsCompilerOptions(
   projectRoot: string,
   config: ReturnType<typeof ts.parseJsonConfigFileContent>,
+  tsConfigPath: string,
   options: RollupWithNxPluginOptions,
   dependencies?: DependentBuildableProjectNode[]
 ) {
@@ -373,6 +378,18 @@ function createTsCompilerOptions(
     config,
     dependencies ?? []
   );
+  // Resolve paths to absolute so they work without baseUrl and regardless
+  // of which tsconfig the plugin reads (project vs workspace root).
+  const pathsBase = resolvePathsBaseUrl(tsConfigPath);
+  for (const key of Object.keys(compilerOptionPaths)) {
+    compilerOptionPaths[key] = compilerOptionPaths[key].map((p) => {
+      if (isAbsolute(p)) {
+        return p;
+      }
+      const stripped = p.startsWith('./') ? p.slice(2) : p;
+      return resolve(pathsBase, stripped).replace(/\\/g, '/');
+    });
+  }
   const compilerOptions = {
     rootDir: projectRoot,
     allowJs: options.allowJs,

--- a/packages/rspack/src/plugins/utils/plugins/nx-tsconfig-paths-rspack-plugin.ts
+++ b/packages/rspack/src/plugins/utils/plugins/nx-tsconfig-paths-rspack-plugin.ts
@@ -75,8 +75,7 @@ export class NxTsconfigPathsRspackPlugin {
         options.tsConfig,
         options.root,
         target.data.root,
-        dependencies,
-        true // There is an issue with Rspack that requires the baseUrl to be set in the generated tsconfig
+        dependencies
       );
       this.tmpTsConfigPath = options.tsConfig;
 

--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -7,6 +7,7 @@ import {
   calculateProjectBuildableDependencies,
   createTmpTsConfig,
 } from '@nx/js/src/utils/buildable-libs-utils';
+import { resolvePathsBaseUrl } from '@nx/js/src/utils/typescript/ts-config';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { copyFileSync, existsSync } from 'node:fs';
 import { join, relative, resolve } from 'node:path';
@@ -151,7 +152,7 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
       tsConfigPathsEsm = parsed;
 
       matchTsPathEsm = createMatchPath(
-        parsed.absoluteBaseUrl,
+        resolvePathsBaseUrl(foundTsConfigPath),
         parsed.paths,
         options.mainFields
       );
@@ -164,7 +165,7 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
       if (rootLevelParsed.resultType === 'success') {
         tsConfigPathsFallback = rootLevelParsed;
         matchTsPathFallback = createMatchPath(
-          rootLevelParsed.absoluteBaseUrl,
+          resolvePathsBaseUrl(rootLevelTsConfig),
           rootLevelParsed.paths,
           ['main', 'module']
         );

--- a/packages/vue/src/generators/library/library.spec.ts
+++ b/packages/vue/src/generators/library/library.spec.ts
@@ -76,7 +76,7 @@ describe('library', () => {
     await libraryGenerator(tree, defaultSchema);
     const tsconfigJson = readJson(tree, '/tsconfig.base.json');
     expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-      'my-lib/src/index.ts',
+      './my-lib/src/index.ts',
     ]);
   });
 
@@ -88,7 +88,7 @@ describe('library', () => {
     expect(tree.exists('tsconfig.base.json')).toEqual(true);
     const tsconfigJson = readJson(tree, 'tsconfig.base.json');
     expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-      'my-lib/src/index.ts',
+      './my-lib/src/index.ts',
     ]);
   });
 
@@ -101,7 +101,7 @@ describe('library', () => {
     await libraryGenerator(tree, defaultSchema);
     const tsconfigJson = readJson(tree, '/tsconfig.base.json');
     expect(tsconfigJson.compilerOptions.paths['@proj/my-lib']).toEqual([
-      'my-lib/src/index.ts',
+      './my-lib/src/index.ts',
     ]);
   });
 
@@ -351,7 +351,7 @@ module.exports = [
       });
       const tsconfigJson = readJson(tree, '/tsconfig.base.json');
       expect(tsconfigJson.compilerOptions.paths['@proj/my-dir/my-lib']).toEqual(
-        ['my-dir/my-lib/src/index.ts']
+        ['./my-dir/my-lib/src/index.ts']
       );
       expect(
         tsconfigJson.compilerOptions.paths['my-dir-my-lib/*']

--- a/packages/webpack/src/plugins/nx-typescript-webpack-plugin/nx-tsconfig-paths-webpack-plugin.ts
+++ b/packages/webpack/src/plugins/nx-typescript-webpack-plugin/nx-tsconfig-paths-webpack-plugin.ts
@@ -10,6 +10,7 @@ import {
   calculateProjectBuildableDependencies,
   createTmpTsConfig,
 } from '@nx/js/src/utils/buildable-libs-utils';
+import { resolvePathsBaseUrl } from '@nx/js/src/utils/typescript/ts-config';
 import { NormalizedNxAppWebpackPluginOptions } from '../nx-webpack-plugin/nx-app-webpack-plugin-options';
 import { WebpackNxBuildCoordinationPlugin } from '../webpack-nx-build-coordination-plugin';
 
@@ -33,11 +34,13 @@ export class NxTsconfigPathsWebpackPlugin {
       ...compiler.options.resolve,
       plugins: compiler.options.resolve?.plugins ?? [],
     };
+    const configFile = !path.isAbsolute(this.options.tsConfig)
+      ? path.join(workspaceRoot, this.options.tsConfig)
+      : this.options.tsConfig;
     compiler.options.resolve.plugins.push(
       new TsconfigPathsPlugin({
-        configFile: !path.isAbsolute(this.options.tsConfig)
-          ? path.join(workspaceRoot, this.options.tsConfig)
-          : this.options.tsConfig,
+        configFile,
+        baseUrl: resolvePathsBaseUrl(configFile),
         extensions: Array.from(extensions),
         mainFields: ['module', 'main'],
       })

--- a/packages/workspace/src/generators/move/lib/update-imports.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.spec.ts
@@ -376,7 +376,7 @@ export MyExtendedClass extends MyClass {};`
 
     const tsConfig = readJson(tree, '/tsconfig.base.json');
     expect(tsConfig.compilerOptions.paths).toEqual({
-      '@proj/my-destination': ['my-destination/src/index.ts'],
+      '@proj/my-destination': ['./my-destination/src/index.ts'],
     });
   });
 
@@ -386,10 +386,10 @@ export MyExtendedClass extends MyClass {};`
     });
     updateJson(tree, '/tsconfig.base.json', (json) => {
       json.compilerOptions.paths['@proj/my-source/testing'] = [
-        'my-source/testing/src/index.ts',
+        './my-source/testing/src/index.ts',
       ];
       json.compilerOptions.paths['@proj/different-alias'] = [
-        'my-source/some-path/src/index.ts',
+        './my-source/some-path/src/index.ts',
       ];
       return json;
     });
@@ -403,9 +403,9 @@ export MyExtendedClass extends MyClass {};`
 
     const tsConfig = readJson(tree, '/tsconfig.base.json');
     expect(tsConfig.compilerOptions.paths).toEqual({
-      '@proj/my-destination': ['my-destination/src/index.ts'],
-      '@proj/my-destination/testing': ['my-destination/testing/src/index.ts'],
-      '@proj/different-alias': ['my-destination/some-path/src/index.ts'],
+      '@proj/my-destination': ['./my-destination/src/index.ts'],
+      '@proj/my-destination/testing': ['./my-destination/testing/src/index.ts'],
+      '@proj/different-alias': ['./my-destination/some-path/src/index.ts'],
     });
   });
 
@@ -424,7 +424,7 @@ export MyExtendedClass extends MyClass {};`
 
     const tsConfig = readJson(tree, '/tsconfig.base.json');
     expect(tsConfig.compilerOptions.paths).toEqual({
-      '@proj/my-destination': ['my-destination/src/index.ts'],
+      '@proj/my-destination': ['./my-destination/src/index.ts'],
     });
   });
 
@@ -443,7 +443,7 @@ export MyExtendedClass extends MyClass {};`
 
     const tsConfig = readJson(tree, '/tsconfig.json');
     expect(tsConfig.compilerOptions.paths).toEqual({
-      '@proj/my-destination': ['my-destination/src/index.ts'],
+      '@proj/my-destination': ['./my-destination/src/index.ts'],
     });
   });
 
@@ -466,7 +466,7 @@ export MyExtendedClass extends MyClass {};`
 
     const tsConfig = readJson(tree, '/tsconfig.json');
     expect(tsConfig.compilerOptions.paths).toEqual({
-      '@proj/my-destination': ['my-destination/src/index.ts'],
+      '@proj/my-destination': ['./my-destination/src/index.ts'],
     });
   });
 
@@ -492,7 +492,7 @@ export MyExtendedClass extends MyClass {};`
 
     const tsConfig = readJson(tree, '/tsconfig.base.json');
     expect(tsConfig.compilerOptions.paths).toEqual({
-      '@proj/my-source': ['my-destination/src/index.ts'],
+      '@proj/my-source': ['./my-destination/src/index.ts'],
     });
   });
 
@@ -505,7 +505,7 @@ export MyExtendedClass extends MyClass {};`
 
     updateJson(tree, '/tsconfig.base.json', (json) => {
       json.compilerOptions.paths['@proj/my-source/server'] = [
-        'my-source/src/server.ts',
+        './my-source/src/server.ts',
       ];
       return json;
     });
@@ -527,8 +527,8 @@ export MyExtendedClass extends MyClass {};`
 
     const tsConfig = readJson(tree, '/tsconfig.base.json');
     expect(tsConfig.compilerOptions.paths).toEqual({
-      '@proj/my-source': ['my-destination/src/index.ts'],
-      '@proj/my-source/server': ['my-destination/src/server.ts'],
+      '@proj/my-source': ['./my-destination/src/index.ts'],
+      '@proj/my-source/server': ['./my-destination/src/server.ts'],
     });
   });
 

--- a/packages/workspace/src/generators/move/lib/update-imports.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.ts
@@ -63,7 +63,7 @@ export function updateImports(
       tsConfig.compilerOptions?.paths ?? {}
     ).find((path) =>
       tsConfig.compilerOptions.paths[path].some((x) =>
-        x.startsWith(ensureTrailingSlash(sourceRoot))
+        stripDotSlash(x).startsWith(ensureTrailingSlash(sourceRoot))
       )
     );
     secondaryEntryPointImportPaths = Object.keys(
@@ -71,8 +71,8 @@ export function updateImports(
     ).filter((path) =>
       tsConfig.compilerOptions.paths[path].some(
         (x) =>
-          x.startsWith(ensureTrailingSlash(project.root)) &&
-          !x.startsWith(ensureTrailingSlash(sourceRoot))
+          stripDotSlash(x).startsWith(ensureTrailingSlash(project.root)) &&
+          !stripDotSlash(x).startsWith(ensureTrailingSlash(sourceRoot))
       )
     );
 
@@ -83,7 +83,7 @@ export function updateImports(
     ).find((path) =>
       tsConfig.compilerOptions.paths[path].some(
         (x) =>
-          x.startsWith(ensureTrailingSlash(sourceRoot)) &&
+          stripDotSlash(x).startsWith(ensureTrailingSlash(sourceRoot)) &&
           x.includes('server') &&
           path.endsWith('server')
       )
@@ -225,9 +225,14 @@ function updateTsConfigPaths(
       ].join(' ')
     );
   }
-  const updatedPath = path.map((x) =>
-    joinPathFragments(projectRoot.to, relative(projectRoot.from, x))
-  );
+  const updatedPath = path.map((x) => {
+    const hadDotSlash = x.startsWith('./');
+    const result = joinPathFragments(
+      projectRoot.to,
+      relative(projectRoot.from, stripDotSlash(x))
+    );
+    return hadDotSlash && !result.startsWith('./') ? `./${result}` : result;
+  });
 
   if (schema.updateImportPath && projectRef.to) {
     tsConfig.compilerOptions.paths[projectRef.to] = updatedPath;
@@ -241,6 +246,10 @@ function updateTsConfigPaths(
 
 function ensureTrailingSlash(path: string): string {
   return path.endsWith('/') ? path : `${path}/`;
+}
+
+function stripDotSlash(path: string): string {
+  return path.startsWith('./') ? path.slice(2) : path;
 }
 
 /**

--- a/packages/workspace/src/generators/remove/lib/update-tsconfig.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/update-tsconfig.spec.ts
@@ -210,7 +210,7 @@ describe('updateTsconfig', () => {
 
     const tsConfig = readJson(tree, '/tsconfig.base.json');
     expect(tsConfig.compilerOptions.paths).toEqual({
-      '@proj/nested/whatever-name': ['libs/my-lib/nested-lib/src/index.ts'],
+      '@proj/nested/whatever-name': ['./libs/my-lib/nested-lib/src/index.ts'],
     });
   });
 

--- a/packages/workspace/src/generators/remove/lib/update-tsconfig.ts
+++ b/packages/workspace/src/generators/remove/lib/update-tsconfig.ts
@@ -44,10 +44,8 @@ export async function updateTsconfig(tree: Tree, schema: Schema) {
       } else {
         for (const importPath in json.compilerOptions.paths) {
           for (const path of json.compilerOptions.paths[importPath]) {
-            const project = findProjectForPath(
-              normalizePath(path),
-              projectMapping
-            );
+            const normalized = normalizePath(path).replace(/^\.\//, '');
+            const project = findProjectForPath(normalized, projectMapping);
             if (project === schema.projectName) {
               delete json.compilerOptions.paths[importPath];
               break;


### PR DESCRIPTION
## Current Behavior

Nx generators set `compilerOptions.baseUrl: "."` in generated tsconfig files and write path mappings as bare relative paths (e.g., `my-lib/src/index.ts`). `baseUrl` is deprecated in TS 6 and removed in TS 7.

## Expected Behavior

Nx no longer generates `baseUrl` in any tsconfig. Path mappings use `./` prefix (e.g., `./my-lib/src/index.ts`), making them relative to the tsconfig file without needing `baseUrl`. Existing user tsconfigs with `baseUrl` continue to work correctly.

### Generator and template changes
- Remove `baseUrl` from all templates and generator code
- `addTsConfigPath` normalizes lookup paths with `./` prefix
- Move and remove generators handle `./`-prefixed paths correctly
- Angular secondary entry points and Remix server entry paths use `./` prefix

### `resolvePathsBaseUrl` helper
New function (in `ts-config.ts`, duplicated in `register.ts`) that walks the tsconfig `extends` chain to determine the correct directory for resolving `paths` values. Finds where `paths` is defined, then looks for the applicable `baseUrl` from that point toward the root — ignoring child overrides that don't apply to the paths-defining tsconfig. When no `baseUrl` applies, returns the directory of the tsconfig that defines `paths`. All path resolver plugins and buildable-libs-utils use this helper.

### Runtime and bundler fixes for baseUrl-less tsconfigs
- **Rollup**: resolve path mappings to absolute in compiler options override using `resolvePathsBaseUrl`; use original tsconfig path (not tmp) for resolution base
- **Module Federation**: add `workspaceRoot` to `resolve.modules` in all 8 MF plugin variants (Angular/React webpack, Angular/React rspack, webpack SSR, rspack SSR, Angular rspack plugin, rspack plugin) so workspace-relative expose paths resolve without `baseUrl`
- **Next.js/Jest**: null out SWC `resolvedBaseUrl` in generated jest configs to prevent SWC from doing incorrect path alias resolution; Nx jest resolver handles this via `resolvePathsBaseUrl`
- **register.ts**: use `resolvePathsBaseUrl` for correct path alias registration
- **Path resolver plugins** (webpack, rspack, vite, expo, react-native, jest, react component testing): use `resolvePathsBaseUrl` for correct path resolution
- **buildable-libs-utils**: resolve tmp tsconfig paths to absolute so they work without `baseUrl`
- **eslint-plugin**: handle `./`-prefixed paths in AST utils

## Related Issue(s)

Fixes #32958 