### PR TITLE
feat(workspace): handle owners and conformance refs on project move/remove

### DIFF
--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -548,9 +548,111 @@
       },
       "required": ["rules"],
       "additionalProperties": false
+    },
+    "owners": {
+      "description": "Configuration for Nx Owners (CODEOWNERS generation). Set to true to enable with all defaults.",
+      "oneOf": [
+        {
+          "type": "boolean",
+          "enum": [true],
+          "description": "Enable owners with all default settings."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "format": {
+              "type": "string",
+              "description": "The format to use for the generated owners file. Defaults to 'github'.",
+              "enum": ["github", "gitlab", "bitbucket"],
+              "default": "github"
+            },
+            "outputPath": {
+              "type": "string",
+              "description": "The path to write the generated owners file to. Defaults based on format (e.g. '.github/CODEOWNERS')."
+            },
+            "patterns": {
+              "type": "array",
+              "description": "List of ownership patterns to apply.",
+              "items": {
+                "$ref": "#/definitions/ownersPattern"
+              }
+            },
+            "sections": {
+              "type": "array",
+              "description": "List of ownership sections (GitLab only). Sections allow grouping patterns with approval requirements.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The section label."
+                  },
+                  "defaultOwners": {
+                    "type": "array",
+                    "description": "Default owners for all patterns in this section.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "numberOfRequiredApprovals": {
+                    "type": "number",
+                    "description": "Number of required approvals for this section. Mutually exclusive with 'optional'."
+                  },
+                  "optional": {
+                    "type": "boolean",
+                    "description": "Whether this section is optional. Mutually exclusive with 'numberOfRequiredApprovals'."
+                  },
+                  "patterns": {
+                    "type": "array",
+                    "description": "List of ownership patterns within this section.",
+                    "items": {
+                      "$ref": "#/definitions/ownersPattern"
+                    }
+                  }
+                },
+                "required": ["name"],
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     }
   },
   "definitions": {
+    "ownersPattern": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A human-readable description of this ownership pattern."
+        },
+        "projects": {
+          "type": "array",
+          "description": "The projects this pattern applies to. Accepts project names, glob patterns, tag references, or any other valid project filter supported by the --projects flag.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "files": {
+          "type": "array",
+          "description": "File glob patterns this ownership pattern applies to (for non-project-based ownership).",
+          "items": {
+            "type": "string"
+          }
+        },
+        "owners": {
+          "type": "array",
+          "description": "List of owners (e.g. GitHub usernames or team handles) for the matched projects or files.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["owners"],
+      "additionalProperties": false
+    },
     "inputs": {
       "type": "array",
       "items": {

--- a/packages/workspace/src/generators/move/lib/update-owners-and-conformance.spec.ts
+++ b/packages/workspace/src/generators/move/lib/update-owners-and-conformance.spec.ts
@@ -1,0 +1,261 @@
+import { readNxJson, Tree, updateNxJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { NormalizedSchema } from '../schema';
+import { updateOwnersAndConformance } from './update-owners-and-conformance';
+
+describe('updateOwnersAndConformance', () => {
+  let tree: Tree;
+  let schema: NormalizedSchema;
+
+  beforeEach(() => {
+    schema = {
+      projectName: 'my-lib',
+      destination: 'shared/my-destination',
+      importPath: '@proj/my-destination',
+      updateImportPath: true,
+      newProjectName: 'my-destination',
+      relativeToRootDestination: 'libs/shared/my-destination',
+    };
+
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  describe('conformance rules', () => {
+    it('should rename project in conformance rule projects', () => {
+      updateNxJson(tree, {
+        ...readNxJson(tree),
+        conformance: {
+          rules: [
+            {
+              rule: './some-rule',
+              projects: ['my-lib', 'other-lib'],
+            },
+          ],
+        },
+      } as any);
+
+      updateOwnersAndConformance(tree, schema);
+
+      const nxJson = readNxJson(tree) as any;
+      expect(nxJson.conformance.rules[0].projects).toEqual([
+        'my-destination',
+        'other-lib',
+      ]);
+    });
+
+    it('should rename project in conformance rule with matcher objects', () => {
+      updateNxJson(tree, {
+        ...readNxJson(tree),
+        conformance: {
+          rules: [
+            {
+              rule: './some-rule',
+              projects: [
+                { matcher: 'my-lib', explanation: 'reason' },
+                { matcher: 'other-lib' },
+              ],
+            },
+          ],
+        },
+      } as any);
+
+      updateOwnersAndConformance(tree, schema);
+
+      const nxJson = readNxJson(tree) as any;
+      expect(nxJson.conformance.rules[0].projects).toEqual([
+        { matcher: 'my-destination', explanation: 'reason' },
+        { matcher: 'other-lib' },
+      ]);
+    });
+
+    it('should not modify rules without projects', () => {
+      updateNxJson(tree, {
+        ...readNxJson(tree),
+        conformance: {
+          rules: [{ rule: './some-rule' }],
+        },
+      } as any);
+
+      updateOwnersAndConformance(tree, schema);
+
+      const nxJson = readNxJson(tree) as any;
+      expect(nxJson.conformance.rules[0]).toEqual({ rule: './some-rule' });
+    });
+
+    it('should preserve glob patterns and tag references', () => {
+      updateNxJson(tree, {
+        ...readNxJson(tree),
+        conformance: {
+          rules: [
+            {
+              rule: './some-rule',
+              projects: ['my-lib', 'tag:frontend', 'lib-*'],
+            },
+          ],
+        },
+      } as any);
+
+      updateOwnersAndConformance(tree, schema);
+
+      const nxJson = readNxJson(tree) as any;
+      expect(nxJson.conformance.rules[0].projects).toEqual([
+        'my-destination',
+        'tag:frontend',
+        'lib-*',
+      ]);
+    });
+
+    it('should handle multiple rules', () => {
+      updateNxJson(tree, {
+        ...readNxJson(tree),
+        conformance: {
+          rules: [
+            { rule: './rule-a', projects: ['my-lib'] },
+            { rule: './rule-b', projects: ['other-lib'] },
+            { rule: './rule-c', projects: ['my-lib', 'other-lib'] },
+          ],
+        },
+      } as any);
+
+      updateOwnersAndConformance(tree, schema);
+
+      const nxJson = readNxJson(tree) as any;
+      expect(nxJson.conformance.rules[0].projects).toEqual(['my-destination']);
+      expect(nxJson.conformance.rules[1].projects).toEqual(['other-lib']);
+      expect(nxJson.conformance.rules[2].projects).toEqual([
+        'my-destination',
+        'other-lib',
+      ]);
+    });
+
+    it('should not modify nxJson when no conformance config exists', () => {
+      const originalNxJson = readNxJson(tree);
+
+      updateOwnersAndConformance(tree, schema);
+
+      expect(readNxJson(tree)).toEqual(originalNxJson);
+    });
+  });
+
+  describe('owners patterns', () => {
+    it('should rename project in owners pattern projects', () => {
+      updateNxJson(tree, {
+        ...readNxJson(tree),
+        owners: {
+          patterns: [
+            { projects: ['my-lib', 'other-lib'], owners: ['@team-a'] },
+          ],
+        },
+      } as any);
+
+      updateOwnersAndConformance(tree, schema);
+
+      const nxJson = readNxJson(tree) as any;
+      expect(nxJson.owners.patterns[0].projects).toEqual([
+        'my-destination',
+        'other-lib',
+      ]);
+    });
+
+    it('should rename project in section-level patterns', () => {
+      updateNxJson(tree, {
+        ...readNxJson(tree),
+        owners: {
+          sections: [
+            {
+              name: 'Core',
+              defaultOwners: ['@core-team'],
+              patterns: [
+                { projects: ['my-lib'], owners: ['@team-a'] },
+                { projects: ['other-lib'], owners: ['@team-b'] },
+              ],
+            },
+          ],
+        },
+      } as any);
+
+      updateOwnersAndConformance(tree, schema);
+
+      const nxJson = readNxJson(tree) as any;
+      expect(nxJson.owners.sections[0].patterns[0].projects).toEqual([
+        'my-destination',
+      ]);
+      expect(nxJson.owners.sections[0].patterns[1].projects).toEqual([
+        'other-lib',
+      ]);
+    });
+
+    it('should not modify patterns without projects', () => {
+      updateNxJson(tree, {
+        ...readNxJson(tree),
+        owners: {
+          patterns: [{ owners: ['@team-a'] }],
+        },
+      } as any);
+
+      updateOwnersAndConformance(tree, schema);
+
+      const nxJson = readNxJson(tree) as any;
+      expect(nxJson.owners.patterns[0]).toEqual({ owners: ['@team-a'] });
+    });
+
+    it('should preserve glob patterns and tag references', () => {
+      updateNxJson(tree, {
+        ...readNxJson(tree),
+        owners: {
+          patterns: [
+            {
+              projects: ['my-lib', 'tag:frontend', 'lib-*'],
+              owners: ['@team-a'],
+            },
+          ],
+        },
+      } as any);
+
+      updateOwnersAndConformance(tree, schema);
+
+      const nxJson = readNxJson(tree) as any;
+      expect(nxJson.owners.patterns[0].projects).toEqual([
+        'my-destination',
+        'tag:frontend',
+        'lib-*',
+      ]);
+    });
+
+    it('should handle owners set to true', () => {
+      updateNxJson(tree, {
+        ...readNxJson(tree),
+        owners: true,
+      } as any);
+
+      updateOwnersAndConformance(tree, schema);
+
+      const nxJson = readNxJson(tree) as any;
+      expect(nxJson.owners).toBe(true);
+    });
+
+    it('should handle both top-level and section patterns', () => {
+      updateNxJson(tree, {
+        ...readNxJson(tree),
+        owners: {
+          patterns: [{ projects: ['my-lib'], owners: ['@team-a'] }],
+          sections: [
+            {
+              name: 'Section',
+              defaultOwners: ['@default'],
+              patterns: [{ projects: ['my-lib'], owners: ['@team-b'] }],
+            },
+          ],
+        },
+      } as any);
+
+      updateOwnersAndConformance(tree, schema);
+
+      const nxJson = readNxJson(tree) as any;
+      expect(nxJson.owners.patterns[0].projects).toEqual(['my-destination']);
+      expect(nxJson.owners.sections[0].patterns[0].projects).toEqual([
+        'my-destination',
+      ]);
+    });
+  });
+});

--- a/packages/workspace/src/generators/move/lib/update-owners-and-conformance.ts
+++ b/packages/workspace/src/generators/move/lib/update-owners-and-conformance.ts
@@ -1,0 +1,135 @@
+import {
+  NxJsonConfiguration,
+  readNxJson,
+  Tree,
+  updateNxJson,
+} from '@nx/devkit';
+import { NormalizedSchema } from '../schema';
+
+export function updateOwnersAndConformance(
+  tree: Tree,
+  schema: NormalizedSchema
+) {
+  const nxJson = readNxJson(tree);
+  let changed = false;
+
+  if (
+    renameProjectInConformanceRules(
+      nxJson,
+      schema.projectName,
+      schema.newProjectName
+    )
+  ) {
+    changed = true;
+  }
+
+  if (
+    renameProjectInOwnersPatterns(
+      nxJson,
+      schema.projectName,
+      schema.newProjectName
+    )
+  ) {
+    changed = true;
+  }
+
+  if (changed) {
+    updateNxJson(tree, nxJson);
+  }
+}
+
+function renameProjectInConformanceRules(
+  nxJson: NxJsonConfiguration,
+  oldName: string,
+  newName: string
+): boolean {
+  const conformance = nxJson['conformance'] as
+    | { rules?: { projects?: (string | { matcher: string })[] }[] }
+    | undefined;
+
+  if (!conformance?.rules) {
+    return false;
+  }
+
+  let changed = false;
+
+  for (const rule of conformance.rules) {
+    if (!rule.projects) {
+      continue;
+    }
+
+    for (let i = 0; i < rule.projects.length; i++) {
+      const entry = rule.projects[i];
+      if (typeof entry === 'string' && entry === oldName) {
+        rule.projects[i] = newName;
+        changed = true;
+      } else if (typeof entry === 'object' && entry.matcher === oldName) {
+        entry.matcher = newName;
+        changed = true;
+      }
+    }
+  }
+
+  return changed;
+}
+
+function renameProjectInOwnersPatterns(
+  nxJson: NxJsonConfiguration,
+  oldName: string,
+  newName: string
+): boolean {
+  const owners = nxJson['owners'] as
+    | {
+        patterns?: { projects?: string[] }[];
+        sections?: { patterns?: { projects?: string[] }[] }[];
+      }
+    | boolean
+    | undefined;
+
+  if (typeof owners !== 'object' || !owners) {
+    return false;
+  }
+
+  let changed = false;
+
+  if (owners.patterns) {
+    if (renameInPatternsList(owners.patterns, oldName, newName)) {
+      changed = true;
+    }
+  }
+
+  if (owners.sections) {
+    for (const section of owners.sections) {
+      if (section.patterns) {
+        if (renameInPatternsList(section.patterns, oldName, newName)) {
+          changed = true;
+        }
+      }
+    }
+  }
+
+  return changed;
+}
+
+function renameInPatternsList(
+  patterns: { projects?: string[] }[],
+  oldName: string,
+  newName: string
+): boolean {
+  let changed = false;
+
+  for (const pattern of patterns) {
+    if (!pattern.projects) {
+      continue;
+    }
+
+    for (let i = 0; i < pattern.projects.length; i++) {
+      if (pattern.projects[i] === oldName) {
+        pattern.projects[i] = newName;
+        changed = true;
+      }
+    }
+  }
+
+  return changed;
+}

--- a/packages/workspace/src/generators/move/move.ts
+++ b/packages/workspace/src/generators/move/move.ts
@@ -24,6 +24,7 @@ import { updateDefaultProject } from './lib/update-default-project';
 import { updateEslintConfig } from './lib/update-eslint-config';
 import { updateImplicitDependencies } from './lib/update-implicit-dependencies';
 import { updateImports } from './lib/update-imports';
+import { updateOwnersAndConformance } from './lib/update-owners-and-conformance';
 import { updateJestConfig } from './lib/update-jest-config';
 import { updatePackageJson } from './lib/update-package-json';
 import { updateProjectRootFiles } from './lib/update-project-root-files';
@@ -61,6 +62,7 @@ export async function moveGenerator(tree: Tree, rawSchema: Schema) {
   updateBuildTargets(tree, schema);
   updateDefaultProject(tree, schema);
   updateImplicitDependencies(tree, schema);
+  updateOwnersAndConformance(tree, schema);
 
   if (projectConfig.root === '.') {
     // we want to migrate eslint config once the root project files are moved

--- a/packages/workspace/src/generators/remove/lib/remove-project-references-in-config.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/remove-project-references-in-config.spec.ts
@@ -99,4 +99,286 @@ describe('removeProjectReferencesInConfig', () => {
       expect(implicitDependencies).not.toContain('ng-app');
     });
   });
+
+  describe('conformance rules', () => {
+    it('should remove the project from conformance rules projects', () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        conformance: {
+          rules: [
+            {
+              rule: './some-rule',
+              projects: ['ng-app', 'ng-app-e2e', 'other-project'],
+            },
+          ],
+        },
+      } as any);
+
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+
+      removeProjectReferencesInConfig(tree, schema);
+
+      const updatedNxJson = readNxJson(tree) as any;
+      expect(updatedNxJson.conformance.rules[0].projects).toEqual([
+        'ng-app-e2e',
+        'other-project',
+      ]);
+    });
+
+    it('should remove the project from conformance rules with matcher objects', () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        conformance: {
+          rules: [
+            {
+              rule: './some-rule',
+              projects: [
+                { matcher: 'ng-app', explanation: 'some reason' },
+                'other-project',
+              ],
+            },
+          ],
+        },
+      } as any);
+
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+
+      removeProjectReferencesInConfig(tree, schema);
+
+      const updatedNxJson = readNxJson(tree) as any;
+      expect(updatedNxJson.conformance.rules[0].projects).toEqual([
+        'other-project',
+      ]);
+    });
+
+    it('should not modify conformance rules without projects', () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        conformance: {
+          rules: [{ rule: './some-rule' }],
+        },
+      } as any);
+
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+
+      removeProjectReferencesInConfig(tree, schema);
+
+      const updatedNxJson = readNxJson(tree) as any;
+      expect(updatedNxJson.conformance.rules[0].projects).toBeUndefined();
+    });
+
+    it('should not remove glob patterns or tag references from conformance rules', () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        conformance: {
+          rules: [
+            {
+              rule: './some-rule',
+              projects: ['ng-app', 'tag:frontend', 'lib-*'],
+            },
+          ],
+        },
+      } as any);
+
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+
+      removeProjectReferencesInConfig(tree, schema);
+
+      const updatedNxJson = readNxJson(tree) as any;
+      expect(updatedNxJson.conformance.rules[0].projects).toEqual([
+        'tag:frontend',
+        'lib-*',
+      ]);
+    });
+
+    it('should handle multiple conformance rules', () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        conformance: {
+          rules: [
+            {
+              rule: './rule-a',
+              projects: ['ng-app', 'other-project'],
+            },
+            {
+              rule: './rule-b',
+              projects: ['ng-app', 'another-project'],
+            },
+            {
+              rule: './rule-c',
+              projects: ['unrelated-project'],
+            },
+          ],
+        },
+      } as any);
+
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+
+      removeProjectReferencesInConfig(tree, schema);
+
+      const updatedNxJson = readNxJson(tree) as any;
+      expect(updatedNxJson.conformance.rules[0].projects).toEqual([
+        'other-project',
+      ]);
+      expect(updatedNxJson.conformance.rules[1].projects).toEqual([
+        'another-project',
+      ]);
+      expect(updatedNxJson.conformance.rules[2].projects).toEqual([
+        'unrelated-project',
+      ]);
+    });
+  });
+
+  describe('owners patterns', () => {
+    it('should remove the project from owners patterns projects', () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        owners: {
+          patterns: [
+            {
+              projects: ['ng-app', 'ng-app-e2e', 'other-project'],
+              owners: ['@team'],
+            },
+          ],
+        },
+      } as any);
+
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+
+      removeProjectReferencesInConfig(tree, schema);
+
+      const updatedNxJson = readNxJson(tree) as any;
+      expect(updatedNxJson.owners.patterns[0].projects).toEqual([
+        'ng-app-e2e',
+        'other-project',
+      ]);
+    });
+
+    it('should not modify owners patterns without projects', () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        owners: {
+          patterns: [
+            {
+              files: ['.github/workflows/**/*'],
+              owners: ['@devops'],
+            },
+          ],
+        },
+      } as any);
+
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+
+      removeProjectReferencesInConfig(tree, schema);
+
+      const updatedNxJson = readNxJson(tree) as any;
+      expect(updatedNxJson.owners.patterns[0].projects).toBeUndefined();
+    });
+
+    it('should not remove glob patterns or tag references from owners patterns', () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        owners: {
+          patterns: [
+            {
+              projects: ['ng-app', 'tag:rust', 'finance-*'],
+              owners: ['@team'],
+            },
+          ],
+        },
+      } as any);
+
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+
+      removeProjectReferencesInConfig(tree, schema);
+
+      const updatedNxJson = readNxJson(tree) as any;
+      expect(updatedNxJson.owners.patterns[0].projects).toEqual([
+        'tag:rust',
+        'finance-*',
+      ]);
+    });
+
+    it('should handle multiple owners patterns', () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        owners: {
+          patterns: [
+            {
+              projects: ['ng-app', 'other-project'],
+              owners: ['@team-a'],
+            },
+            {
+              projects: ['ng-app', 'another-project'],
+              owners: ['@team-b'],
+            },
+            {
+              projects: ['unrelated-project'],
+              owners: ['@team-c'],
+            },
+          ],
+        },
+      } as any);
+
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+
+      removeProjectReferencesInConfig(tree, schema);
+
+      const updatedNxJson = readNxJson(tree) as any;
+      expect(updatedNxJson.owners.patterns[0].projects).toEqual([
+        'other-project',
+      ]);
+      expect(updatedNxJson.owners.patterns[1].projects).toEqual([
+        'another-project',
+      ]);
+      expect(updatedNxJson.owners.patterns[2].projects).toEqual([
+        'unrelated-project',
+      ]);
+    });
+  });
 });

--- a/packages/workspace/src/generators/remove/lib/remove-project-references-in-config.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/remove-project-references-in-config.spec.ts
@@ -200,9 +200,7 @@ describe('removeProjectReferencesInConfig', () => {
           rules: [
             {
               rule: './some-rule',
-              projects: [
-                { matcher: 'ng-app', explanation: 'some reason' },
-              ],
+              projects: [{ matcher: 'ng-app', explanation: 'some reason' }],
             },
           ],
         },

--- a/packages/workspace/src/generators/remove/lib/remove-project-references-in-config.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/remove-project-references-in-config.spec.ts
@@ -161,6 +161,65 @@ describe('removeProjectReferencesInConfig', () => {
       ]);
     });
 
+    it('should remove conformance rule when removed project is the only project', () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        conformance: {
+          rules: [
+            {
+              rule: './some-rule',
+              projects: ['ng-app'],
+            },
+            {
+              rule: './other-rule',
+              projects: ['other-project'],
+            },
+          ],
+        },
+      } as any);
+
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+
+      removeProjectReferencesInConfig(tree, schema);
+
+      const updatedNxJson = readNxJson(tree) as any;
+      expect(updatedNxJson.conformance.rules).toHaveLength(1);
+      expect(updatedNxJson.conformance.rules[0].rule).toBe('./other-rule');
+    });
+
+    it('should remove conformance rule with matcher object when it is the only project', () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        conformance: {
+          rules: [
+            {
+              rule: './some-rule',
+              projects: [
+                { matcher: 'ng-app', explanation: 'some reason' },
+              ],
+            },
+          ],
+        },
+      } as any);
+
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+
+      removeProjectReferencesInConfig(tree, schema);
+
+      const updatedNxJson = readNxJson(tree) as any;
+      expect(updatedNxJson.conformance.rules).toHaveLength(0);
+    });
+
     it('should not modify conformance rules without projects', () => {
       const nxJson = readNxJson(tree);
       updateNxJson(tree, {
@@ -281,6 +340,76 @@ describe('removeProjectReferencesInConfig', () => {
       expect(updatedNxJson.owners.patterns[0].projects).toEqual([
         'ng-app-e2e',
         'other-project',
+      ]);
+    });
+
+    it('should remove owners pattern when removed project is the only project', () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        owners: {
+          patterns: [
+            {
+              projects: ['ng-app'],
+              owners: ['@team-a'],
+            },
+            {
+              projects: ['other-project'],
+              owners: ['@team-b'],
+            },
+          ],
+        },
+      } as any);
+
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+
+      removeProjectReferencesInConfig(tree, schema);
+
+      const updatedNxJson = readNxJson(tree) as any;
+      expect(updatedNxJson.owners.patterns).toHaveLength(1);
+      expect(updatedNxJson.owners.patterns[0].owners).toEqual(['@team-b']);
+    });
+
+    it('should remove owners section pattern when removed project is the only project (GitLab)', () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        owners: {
+          format: 'gitlab',
+          sections: [
+            {
+              name: 'Frontend',
+              patterns: [
+                {
+                  projects: ['ng-app'],
+                  owners: ['@frontend-team'],
+                },
+                {
+                  projects: ['other-project'],
+                  owners: ['@backend-team'],
+                },
+              ],
+            },
+          ],
+        },
+      } as any);
+
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+
+      removeProjectReferencesInConfig(tree, schema);
+
+      const updatedNxJson = readNxJson(tree) as any;
+      expect(updatedNxJson.owners.sections[0].patterns).toHaveLength(1);
+      expect(updatedNxJson.owners.sections[0].patterns[0].owners).toEqual([
+        '@backend-team',
       ]);
     });
 

--- a/packages/workspace/src/generators/remove/lib/remove-project-references-in-config.spec.ts
+++ b/packages/workspace/src/generators/remove/lib/remove-project-references-in-config.spec.ts
@@ -380,5 +380,59 @@ describe('removeProjectReferencesInConfig', () => {
         'unrelated-project',
       ]);
     });
+
+    it('should remove the project from owners section patterns (GitLab)', () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        owners: {
+          format: 'gitlab',
+          sections: [
+            {
+              name: 'Frontend',
+              patterns: [
+                {
+                  projects: ['ng-app', 'other-project'],
+                  owners: ['@frontend-team'],
+                },
+              ],
+            },
+          ],
+        },
+      } as any);
+
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+
+      removeProjectReferencesInConfig(tree, schema);
+
+      const updatedNxJson = readNxJson(tree) as any;
+      expect(updatedNxJson.owners.sections[0].patterns[0].projects).toEqual([
+        'other-project',
+      ]);
+    });
+
+    it('should handle owners set to true', () => {
+      const nxJson = readNxJson(tree);
+      updateNxJson(tree, {
+        ...nxJson,
+        owners: true,
+      } as any);
+
+      schema = {
+        projectName: 'ng-app',
+        skipFormat: false,
+        forceRemove: false,
+      };
+
+      // Should not throw
+      removeProjectReferencesInConfig(tree, schema);
+
+      const updatedNxJson = readNxJson(tree) as any;
+      expect(updatedNxJson.owners).toBe(true);
+    });
   });
 });

--- a/packages/workspace/src/generators/remove/lib/remove-project-references-in-config.ts
+++ b/packages/workspace/src/generators/remove/lib/remove-project-references-in-config.ts
@@ -90,15 +90,46 @@ function removeProjectFromOwnersPatterns(
   projectName: string
 ): boolean {
   const owners = nxJson['owners'] as
-    | { patterns?: { projects?: string[] }[] }
+    | {
+        patterns?: { projects?: string[] }[];
+        sections?: { patterns?: { projects?: string[] }[] }[];
+      }
+    | boolean
     | undefined;
 
-  if (!owners?.patterns) {
+  if (typeof owners !== 'object' || !owners) {
     return false;
   }
 
   let changed = false;
-  for (const pattern of owners.patterns) {
+
+  // Filter top-level patterns
+  if (owners.patterns) {
+    if (filterOwnersPatternsList(owners.patterns, projectName)) {
+      changed = true;
+    }
+  }
+
+  // Filter section-level patterns (GitLab)
+  if (owners.sections) {
+    for (const section of owners.sections) {
+      if (section.patterns) {
+        if (filterOwnersPatternsList(section.patterns, projectName)) {
+          changed = true;
+        }
+      }
+    }
+  }
+
+  return changed;
+}
+
+function filterOwnersPatternsList(
+  patterns: { projects?: string[] }[],
+  projectName: string
+): boolean {
+  let changed = false;
+  for (const pattern of patterns) {
     if (!pattern.projects) {
       continue;
     }
@@ -110,6 +141,5 @@ function removeProjectFromOwnersPatterns(
       changed = true;
     }
   }
-
   return changed;
 }

--- a/packages/workspace/src/generators/remove/lib/remove-project-references-in-config.ts
+++ b/packages/workspace/src/generators/remove/lib/remove-project-references-in-config.ts
@@ -61,9 +61,10 @@ function removeProjectFromConformanceRules(
   }
 
   let changed = false;
-  for (const rule of conformance.rules) {
+
+  const filteredRules = conformance.rules.filter((rule) => {
     if (!rule.projects) {
-      continue;
+      return true;
     }
 
     const filtered = rule.projects.filter((entry) => {
@@ -77,9 +78,18 @@ function removeProjectFromConformanceRules(
     });
 
     if (filtered.length !== rule.projects.length) {
-      rule.projects = filtered;
       changed = true;
+      if (filtered.length === 0) {
+        return false;
+      }
+      rule.projects = filtered;
     }
+
+    return true;
+  });
+
+  if (changed) {
+    conformance.rules = filteredRules;
   }
 
   return changed;
@@ -129,17 +139,30 @@ function filterOwnersPatternsList(
   projectName: string
 ): boolean {
   let changed = false;
-  for (const pattern of patterns) {
+
+  const remaining = patterns.filter((pattern) => {
     if (!pattern.projects) {
-      continue;
+      return true;
     }
 
     const filtered = pattern.projects.filter((entry) => entry !== projectName);
 
     if (filtered.length !== pattern.projects.length) {
-      pattern.projects = filtered;
       changed = true;
+      if (filtered.length === 0) {
+        return false;
+      }
+      pattern.projects = filtered;
     }
+
+    return true;
+  });
+
+  if (changed) {
+    // Mutate the array in-place so callers see the removal
+    patterns.length = 0;
+    patterns.push(...remaining);
   }
+
   return changed;
 }

--- a/packages/workspace/src/generators/remove/lib/remove-project-references-in-config.ts
+++ b/packages/workspace/src/generators/remove/lib/remove-project-references-in-config.ts
@@ -62,12 +62,15 @@ function removeProjectFromConformanceRules(
 
   let changed = false;
 
-  const filteredRules = conformance.rules.filter((rule) => {
+  // Iterate backwards so that splicing doesn't shift unvisited indices
+  for (let i = conformance.rules.length - 1; i >= 0; i--) {
+    const rule = conformance.rules[i];
     if (!rule.projects) {
-      return true;
+      continue;
     }
 
-    const filtered = rule.projects.filter((entry) => {
+    const originalLength = rule.projects.length;
+    rule.projects = rule.projects.filter((entry) => {
       if (typeof entry === 'string') {
         return entry !== projectName;
       }
@@ -77,19 +80,12 @@ function removeProjectFromConformanceRules(
       return true;
     });
 
-    if (filtered.length !== rule.projects.length) {
+    if (rule.projects.length !== originalLength) {
       changed = true;
-      if (filtered.length === 0) {
-        return false;
+      if (rule.projects.length === 0) {
+        conformance.rules.splice(i, 1);
       }
-      rule.projects = filtered;
     }
-
-    return true;
-  });
-
-  if (changed) {
-    conformance.rules = filteredRules;
   }
 
   return changed;
@@ -140,28 +136,24 @@ function filterOwnersPatternsList(
 ): boolean {
   let changed = false;
 
-  const remaining = patterns.filter((pattern) => {
+  // Iterate backwards so that splicing doesn't shift unvisited indices
+  for (let i = patterns.length - 1; i >= 0; i--) {
+    const pattern = patterns[i];
     if (!pattern.projects) {
-      return true;
+      continue;
     }
 
-    const filtered = pattern.projects.filter((entry) => entry !== projectName);
+    const originalLength = pattern.projects.length;
+    pattern.projects = pattern.projects.filter(
+      (entry) => entry !== projectName
+    );
 
-    if (filtered.length !== pattern.projects.length) {
+    if (pattern.projects.length !== originalLength) {
       changed = true;
-      if (filtered.length === 0) {
-        return false;
+      if (pattern.projects.length === 0) {
+        patterns.splice(i, 1);
       }
-      pattern.projects = filtered;
     }
-
-    return true;
-  });
-
-  if (changed) {
-    // Mutate the array in-place so callers see the removal
-    patterns.length = 0;
-    patterns.push(...remaining);
   }
 
   return changed;

--- a/packages/workspace/src/generators/remove/lib/remove-project-references-in-config.ts
+++ b/packages/workspace/src/generators/remove/lib/remove-project-references-in-config.ts
@@ -1,6 +1,7 @@
 import { Schema } from '../schema';
 import {
   getProjects,
+  NxJsonConfiguration,
   readNxJson,
   Tree,
   updateNxJson,
@@ -8,10 +9,26 @@ import {
 } from '@nx/devkit';
 
 export function removeProjectReferencesInConfig(tree: Tree, schema: Schema) {
-  // Unset default project if deleting the default project
   const nxJson = readNxJson(tree);
+  let nxJsonChanged = false;
+
+  // Unset default project if deleting the default project
   if (nxJson.defaultProject && nxJson.defaultProject === schema.projectName) {
     delete nxJson.defaultProject;
+    nxJsonChanged = true;
+  }
+
+  // Remove project from conformance rules
+  if (removeProjectFromConformanceRules(nxJson, schema.projectName)) {
+    nxJsonChanged = true;
+  }
+
+  // Remove project from owners patterns
+  if (removeProjectFromOwnersPatterns(nxJson, schema.projectName)) {
+    nxJsonChanged = true;
+  }
+
+  if (nxJsonChanged) {
     updateNxJson(tree, nxJson);
   }
 
@@ -29,4 +46,70 @@ export function removeProjectReferencesInConfig(tree: Tree, schema: Schema) {
       updateProjectConfiguration(tree, projectName, project);
     }
   });
+}
+
+function removeProjectFromConformanceRules(
+  nxJson: NxJsonConfiguration,
+  projectName: string
+): boolean {
+  const conformance = nxJson['conformance'] as
+    | { rules?: { projects?: (string | { matcher: string })[] }[] }
+    | undefined;
+
+  if (!conformance?.rules) {
+    return false;
+  }
+
+  let changed = false;
+  for (const rule of conformance.rules) {
+    if (!rule.projects) {
+      continue;
+    }
+
+    const filtered = rule.projects.filter((entry) => {
+      if (typeof entry === 'string') {
+        return entry !== projectName;
+      }
+      if (typeof entry === 'object' && entry.matcher) {
+        return entry.matcher !== projectName;
+      }
+      return true;
+    });
+
+    if (filtered.length !== rule.projects.length) {
+      rule.projects = filtered;
+      changed = true;
+    }
+  }
+
+  return changed;
+}
+
+function removeProjectFromOwnersPatterns(
+  nxJson: NxJsonConfiguration,
+  projectName: string
+): boolean {
+  const owners = nxJson['owners'] as
+    | { patterns?: { projects?: string[] }[] }
+    | undefined;
+
+  if (!owners?.patterns) {
+    return false;
+  }
+
+  let changed = false;
+  for (const pattern of owners.patterns) {
+    if (!pattern.projects) {
+      continue;
+    }
+
+    const filtered = pattern.projects.filter((entry) => entry !== projectName);
+
+    if (filtered.length !== pattern.projects.length) {
+      pattern.projects = filtered;
+      changed = true;
+    }
+  }
+
+  return changed;
 }


### PR DESCRIPTION
## Current Behavior

When removing or moving a project in an Nx workspace, the `owners` and `conformance` sections in `nx.json` are not updated. This means:
- Removed projects leave stale references in owners patterns and conformance rule project lists
- Moved/renamed projects are not updated in owners patterns or conformance configurations
- Empty entries (patterns with no projects, rules with no projects) are left behind after removal

## Expected Behavior

- **On project removal**: Clean up all references to the removed project in `nx.json` owners patterns and conformance rules. Remove entries that become empty after cleanup.
- **On project move/rename**: Update all references to the old project name with the new name in owners patterns and conformance rules (including section-level patterns for GitLab-style owners).
- **Schema support**: The `owners` configuration schema is added to `nx-schema.json` for proper validation and IDE support, including support for sections (GitLab CODEOWNERS).

## Related Issue(s)

<!-- No specific issue linked -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)