### PR TITLE
fix(core): add explicit exports entry for nx/src/native directory

### DIFF
--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -197,6 +197,11 @@
       "types": "./bin/nx.d.ts",
       "default": "./dist/bin/nx.js"
     },
+    "./src/native": {
+      "@nx/nx-source": "./src/native/index.ts",
+      "types": "./src/native/index.d.ts",
+      "default": "./dist/src/native/index.js"
+    },
     "./src/plugins/js": {
       "@nx/nx-source": "./src/plugins/js/index.ts",
       "types": "./src/plugins/js/index.d.ts",


### PR DESCRIPTION
## Current Behavior

After the nodenext PR (#34111) added an `exports` map to `packages/nx/package.json`, the nx-cloud light client (ocean) fails to import `nx/src/native`. 

The wildcard exports pattern `"./src/*"` resolves `nx/src/native` to `./dist/src/native.js` — but the actual file is `./dist/src/native/index.js` (it's a directory with an index file). Node's exports map does literal `*` substitution and does **not** perform CJS-style directory/index resolution.

The cloud client wraps all its nx imports in a single try/catch, so when the native import fails, `getDbConnection` is never assigned either, causing `getDbConnection is not a function` errors in CI.

This was not an issue with `nx@22.7.0-beta.1` because that version had no `exports` map — Node fell back to normal CJS resolution which handles directory/index lookups.

## Expected Behavior

`require('nx/src/native')` correctly resolves to `dist/src/native/index.js` via an explicit export entry, and the cloud client can load the native module and `getDbConnection` without errors.

## Related Issue(s)

N/A — discovered during version bump CI failure investigation.