### PR TITLE
fix(repo): skip flaky Cypress HMR e2e tests

### DIFF
--- a/e2e/nx/src/workspace-legacy.test.ts
+++ b/e2e/nx/src/workspace-legacy.test.ts
@@ -16,7 +16,8 @@ describe('@nx/workspace:convert-to-monorepo', () => {
 
   afterEach(() => cleanupProject());
 
-  it('should convert a standalone webpack and jest react project to a monorepo (legacy)', async () => {
+  // TODO: unskip once Cypress HMR issue is resolved
+  it.skip('should convert a standalone webpack and jest react project to a monorepo (legacy)', async () => {
     const reactApp = uniq('reactapp');
     runCLI(
       `generate @nx/react:app --name=${reactApp} --directory="." --bundler=webpack --unitTestRunner=jest --e2eTestRunner=cypress --no-interactive --linter=eslint`,

--- a/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
@@ -15,7 +15,8 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-describe('React Module Federation - Webpack Basic - Host Remote Generation', () => {
+// TODO: unskip once Cypress HMR issue is resolved
+describe.skip('React Module Federation - Webpack Basic - Host Remote Generation', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
+++ b/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
@@ -14,7 +14,8 @@ import {
 } from '@nx/e2e-utils';
 import { runCLI } from './utils';
 
-describe('Dynamic Module Federation', () => {
+// TODO: unskip once Cypress HMR issue is resolved
+describe.skip('Dynamic Module Federation', () => {
   beforeAll(() => {
     newProject({ packages: ['@nx/react'] });
   });

--- a/e2e/react/src/module-federation/federate-module.webpack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.webpack.test.ts
@@ -10,7 +10,8 @@ import {
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 
-describe('Federate Module', () => {
+// TODO: unskip once Cypress HMR issue is resolved
+describe.skip('Federate Module', () => {
   let proj: string;
 
   beforeAll(() => {

--- a/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
@@ -12,7 +12,8 @@ import {
 import { stripIndents } from 'nx/src/utils/strip-indents';
 import { readPort, runCLI } from './utils';
 
-describe('Independent Deployability', () => {
+// TODO: unskip once Cypress HMR issue is resolved
+describe.skip('Independent Deployability', () => {
   let proj: string;
   beforeAll(() => {
     process.env.NX_ADD_PLUGINS = 'false';

--- a/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
@@ -11,7 +11,8 @@ import {
 import { readPort, runCLI } from './utils';
 import { stripIndents } from 'nx/src/utils/strip-indents';
 
-describe('React Rspack Module Federation Misc - Interoperability', () => {
+// TODO: unskip once Cypress HMR issue is resolved
+describe.skip('React Rspack Module Federation Misc - Interoperability', () => {
   beforeEach(() => {
     process.env.NX_ADD_PLUGINS = 'false';
     newProject({ packages: ['@nx/react'] });


### PR DESCRIPTION
## Current Behavior

Six e2e tests are failing on master due to a Cypress uncaught exception: `[HMR] Hot Module Replacement is disabled`. The error originates from the webpack `styles.js` bundle during the `before each` hook, causing Cypress to abort the test suite. This appears to be triggered by an external dependency update.

Failing tests:
- `e2e-nx:e2e-ci--src/workspace-legacy.test.ts`
- `e2e-react:e2e-ci--src/module-federation/independent-deployability.webpack.test.ts`
- `e2e-react:e2e-ci--src/module-federation/core-webpack-basic-host-remote-generation.test.ts`
- `e2e-react:e2e-ci--src/module-federation/misc-rspack-interoperability.test.ts`
- `e2e-react:e2e-ci--src/module-federation/dynamic-federation.webpack.test.ts`
- `e2e-react:e2e-ci--src/module-federation/federate-module.webpack.test.ts`

## Expected Behavior

The flaky tests are skipped so that master CI is green while the root cause (likely an external dependency update) is investigated separately.

## Related Issue(s)

N/A — CI stabilization fix.
