### PR TITLE
fix(core): runtime inputs shouldn't be cached at task_hasher layer and filesets should be in the hash_plans layer

### DIFF
--- a/packages/nx/src/native/tasks/hashers/hash_runtime.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_runtime.rs
@@ -2,14 +2,13 @@ use crate::native::hasher::hash;
 use crate::native::utils::command::create_shell_command;
 use dashmap::DashMap;
 use std::collections::HashMap;
-use std::sync::Arc;
 use tracing::trace;
 
 pub fn hash_runtime(
     workspace_root: &str,
     command: &str,
     env: &HashMap<String, String>,
-    cache: Arc<DashMap<String, String>>,
+    cache: &DashMap<String, String>,
 ) -> anyhow::Result<String> {
     let cache_key = runtime_cache_key(command, env);
 
@@ -51,16 +50,15 @@ mod tests {
     use super::*;
     use dashmap::DashMap;
     use std::collections::HashMap;
-    use std::sync::Arc;
 
     #[test]
     fn test_hash_runtime() {
         let workspace_root = if cfg!(windows) { "C:\\" } else { "/tmp" };
         let command = "echo runtime";
         let env: HashMap<String, String> = HashMap::new();
-        let cache = Arc::new(DashMap::new());
+        let cache = DashMap::new();
 
-        let result = hash_runtime(workspace_root, command, &env, Arc::clone(&cache)).unwrap();
+        let result = hash_runtime(workspace_root, command, &env, &cache).unwrap();
         assert_eq!(result, "10571312846059850300");
     }
 

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -139,6 +139,14 @@ pub struct HasherOptions {
     pub selectively_hash_ts_config: bool,
 }
 
+/// Cached result for project/workspace file hashing.
+/// Stores both the hash value and the matched file paths (for input collection).
+#[derive(Clone)]
+struct CachedFileSetHash {
+    hash: String,
+    files: Vec<String>,
+}
+
 #[napi]
 pub struct TaskHasher {
     workspace_root: String,
@@ -150,7 +158,6 @@ pub struct TaskHasher {
     root_tsconfig_path: Option<String>,
     options: Option<HasherOptions>,
     external_cache: Arc<DashMap<String, String>>,
-    runtime_cache: Arc<DashMap<String, String>>,
 }
 #[napi]
 impl TaskHasher {
@@ -181,7 +188,6 @@ impl TaskHasher {
             root_tsconfig_path,
             options,
             external_cache: Arc::new(DashMap::new()),
-            runtime_cache: Arc::new(DashMap::new()),
         }
     }
 
@@ -193,10 +199,13 @@ impl TaskHasher {
         cwd: String,
         collect_task_inputs: Option<bool>,
     ) -> anyhow::Result<NapiDashMap<String, HashDetails>> {
-        // Create a fresh task output cache for this invocation
+        // Create fresh caches for this invocation.
         // This ensures no stale caches across multiple CLI commands when the daemon holds
-        // the TaskHasher instance
+        // the TaskHasher instance.
         let task_output_cache = DashMap::new();
+        let runtime_cache: DashMap<String, String> = DashMap::new();
+        let project_file_set_cache: DashMap<String, CachedFileSetHash> = DashMap::new();
+        let workspace_file_set_cache: DashMap<String, CachedFileSetHash> = DashMap::new();
         let should_collect_inputs = collect_task_inputs.unwrap_or(false);
 
         let function_start = std::time::Instant::now();
@@ -252,6 +261,9 @@ impl TaskHasher {
                         sorted_externals: &sorted_externals,
                         selectively_hash_tsconfig,
                         task_output_cache: &task_output_cache,
+                        runtime_cache: &runtime_cache,
+                        project_file_set_cache: &project_file_set_cache,
+                        workspace_file_set_cache: &workspace_file_set_cache,
                         cwd: cwd_path,
                         collect_inputs: should_collect_inputs,
                     },
@@ -326,6 +338,9 @@ impl TaskHasher {
             sorted_externals,
             selectively_hash_tsconfig,
             task_output_cache,
+            runtime_cache,
+            project_file_set_cache,
+            workspace_file_set_cache,
             cwd,
             collect_inputs,
         }: HashInstructionArgs,
@@ -335,29 +350,36 @@ impl TaskHasher {
         let empty = HashInputsBuilder::default();
         let (hash, inputs) = match instruction {
             HashInstruction::WorkspaceFileSet(workspace_file_set) => {
-                let result = hash_workspace_files_with_inputs(
-                    workspace_file_set,
-                    &self.all_workspace_files,
-                )?;
+                let cache_key = instruction.to_string();
+                // Check cache first; clone and drop the Ref before any insert
+                let cached_entry = if let Some(entry) = workspace_file_set_cache.get(&cache_key) {
+                    entry.clone()
+                } else {
+                    let result = hash_workspace_files_with_inputs(
+                        workspace_file_set,
+                        &self.all_workspace_files,
+                    )?;
+                    let entry = CachedFileSetHash {
+                        hash: result.hash,
+                        files: result.files,
+                    };
+                    workspace_file_set_cache.insert(cache_key, entry.clone());
+                    entry
+                };
                 trace!(parent: &span, "hash_workspace_files: {:?}", now.elapsed());
                 let inputs = if collect_inputs {
                     HashInputsBuilder {
-                        files: result.files.into_iter().collect(),
+                        files: cached_entry.files.into_iter().collect(),
                         ..Default::default()
                     }
                 } else {
-                    drop(result.files);
                     empty
                 };
-                (result.hash, inputs)
+                (cached_entry.hash, inputs)
             }
             HashInstruction::Runtime(runtime) => {
-                let hashed_runtime = hash_runtime(
-                    &self.workspace_root,
-                    runtime,
-                    js_env,
-                    Arc::clone(&self.runtime_cache),
-                )?;
+                let hashed_runtime =
+                    hash_runtime(&self.workspace_root, runtime, js_env, runtime_cache)?;
                 trace!(parent: &span, "hash_runtime: {:?}", now.elapsed());
                 let inputs = if collect_inputs {
                     instruction.into()
@@ -383,22 +405,33 @@ impl TaskHasher {
                 (hashed_cwd, empty)
             }
             HashInstruction::ProjectFileSet(project_name, file_sets) => {
-                let result = hash_project_files_with_inputs(
-                    project_name,
-                    file_sets,
-                    &self.project_file_map,
-                )?;
+                let cache_key = instruction.to_string();
+                // Check cache first; clone and drop the Ref before any insert
+                let cached_entry = if let Some(entry) = project_file_set_cache.get(&cache_key) {
+                    entry.clone()
+                } else {
+                    let result = hash_project_files_with_inputs(
+                        project_name,
+                        file_sets,
+                        &self.project_file_map,
+                    )?;
+                    let entry = CachedFileSetHash {
+                        hash: result.hash,
+                        files: result.files,
+                    };
+                    project_file_set_cache.insert(cache_key, entry.clone());
+                    entry
+                };
                 trace!(parent: &span, "hash_project_files: {:?}", now.elapsed());
                 let inputs = if collect_inputs {
                     HashInputsBuilder {
-                        files: result.files.into_iter().collect(),
+                        files: cached_entry.files.into_iter().collect(),
                         ..Default::default()
                     }
                 } else {
-                    drop(result.files);
                     empty
                 };
-                (result.hash, inputs)
+                (cached_entry.hash, inputs)
             }
             HashInstruction::ProjectConfiguration(project_name) => {
                 let hashed_project_config =
@@ -514,6 +547,9 @@ struct HashInstructionArgs<'a> {
     sorted_externals: &'a [&'a String],
     selectively_hash_tsconfig: bool,
     task_output_cache: &'a DashMap<String, CachedTaskOutput>,
+    runtime_cache: &'a DashMap<String, String>,
+    project_file_set_cache: &'a DashMap<String, CachedFileSetHash>,
+    workspace_file_set_cache: &'a DashMap<String, CachedFileSetHash>,
     cwd: &'a std::path::Path,
     collect_inputs: bool,
 }


### PR DESCRIPTION
This pull request refactors the caching strategy in the task hashing logic to improve cache isolation and correctness. The main change is to eliminate shared, long-lived caches in favor of creating fresh caches for each invocation, preventing stale data from persisting across CLI commands. Additionally, new caches for project and workspace file set hashes are introduced, and cache handling is streamlined for better maintainability.

**Cache management improvements:**

* Removed the `runtime_cache` field from the `TaskHasher` struct and now create fresh `DashMap` caches for runtime, project file set, and workspace file set hashes within each invocation of the main hash function. This ensures no stale cache data persists across CLI commands. [[1]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bL153) [[2]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bL184) [[3]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bL196-R208)
* Updated the `hash_runtime` function and its usage to accept a reference to a `DashMap` instead of an `Arc<DashMap>`, simplifying ownership and concurrency concerns. [[1]](diffhunk://#diff-77cbfff0572545027ac8ad107859d5135e6f78ee7c32babc56b2c9bbf89cfaccL5-R11) [[2]](diffhunk://#diff-77cbfff0572545027ac8ad107859d5135e6f78ee7c32babc56b2c9bbf89cfaccL54-R61)

**File set hash caching:**

* Introduced the `CachedFileSetHash` struct to store both the hash value and the list of matched files for project and workspace file set hashing, enabling more efficient input collection and cache lookups.
* Added per-invocation caches for project and workspace file set hashes, with logic to check the cache before computing a new hash and to insert results after computation. [[1]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bL196-R208) [[2]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bR353-R385) [[3]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bR412-R438) [[4]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bR554-R556)

**Function signature and argument updates:**

* Updated function signatures and argument passing to propagate the new cache references throughout the hashing logic, including `HashInstructionArgs` and related functions. [[1]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bR264-R266) [[2]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bR341-R343) [[3]](diffhunk://#diff-d81ca7875513ef544822c24671104ce52cd09409a41a796768aba507d87b3c0bR554-R556)

Fixes #30170