### PR TITLE
fix(repo): use @nx/nx-source export condition in jest resolver

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -27,7 +27,7 @@
     ],
     "e2eInputs": [
       "default",
-      "{workspaceRoot}/jest.preset.js",
+      "{workspaceRoot}/e2e/jest.preset.e2e.js",
       "{workspaceRoot}/.verdaccio/config.yml",
       "{workspaceRoot}/scripts/local-registry/**/*",
       "{workspaceRoot}/scripts/nx-release.ts",

--- a/nx.json
+++ b/nx.json
@@ -88,7 +88,6 @@
     },
     "test": {
       "dependsOn": ["test-native", "build-native", "^build-native"],
-      "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
       "options": {
         "args": ["--passWithNoTests", "--detectOpenHandles", "--forceExit"],
         "env": { "NODE_OPTIONS": "--experimental-vm-modules" }

--- a/scripts/patched-jest-resolver.js
+++ b/scripts/patched-jest-resolver.js
@@ -101,12 +101,13 @@ module.exports = function (modulePath, options) {
   }
 
   try {
-    // Detect if we're running from e2e directory
-    const isE2E = options.rootDir.includes('/e2e/');
-
-    // For e2e tests, skip workspace resolution and use default resolver
-    if (isE2E) {
-      return options.defaultResolver(modulePath, options);
+    // For nx/* imports, use @nx/nx-source condition to resolve to .ts
+    // source files instead of dist/*.js files.
+    if (modulePath.startsWith('nx/') || modulePath === 'nx') {
+      return options.defaultResolver(modulePath, {
+        ...options,
+        conditions: ['@nx/nx-source', 'require', 'node', 'default'],
+      });
     }
 
     // Find workspace root - avoid filesystem lookups inside node_modules
@@ -196,54 +197,6 @@ module.exports = function (modulePath, options) {
         ) {
           return possiblePath;
         }
-      }
-    }
-
-    // Handle nx/src/* imports (direct nx package imports)
-    const nxSrcMatch = modulePath.match(/^nx\/src\/(.+)$/);
-    if (nxSrcMatch) {
-      const subpath = nxSrcMatch[1];
-      // Check for direct file (e.g., nx/src/devkit-exports -> devkit-exports.ts)
-      const resolvedPath = path.join(
-        packagesPath,
-        'nx',
-        'src',
-        subpath + '.ts'
-      );
-      if (fs.existsSync(resolvedPath) && fs.lstatSync(resolvedPath).isFile()) {
-        return resolvedPath;
-      }
-      // Check for directory with index.ts (e.g., nx/src/plugins/package-json -> plugins/package-json/index.ts)
-      const indexPath = path.join(
-        packagesPath,
-        'nx',
-        'src',
-        subpath,
-        'index.ts'
-      );
-      if (fs.existsSync(indexPath) && fs.lstatSync(indexPath).isFile()) {
-        return indexPath;
-      }
-    }
-
-    // Handle nx/package.json specifically
-    if (modulePath === 'nx/package.json') {
-      return path.join(packagesPath, 'nx', 'package.json');
-    }
-
-    // Handle other nx/* patterns
-    const nxOtherPatternMatch = modulePath.match(/^nx\/(.+)$/);
-    if (nxOtherPatternMatch) {
-      const subpath = nxOtherPatternMatch[1];
-      // Check for direct file
-      const resolvedPath = path.join(packagesPath, 'nx', subpath + '.ts');
-      if (fs.existsSync(resolvedPath) && fs.lstatSync(resolvedPath).isFile()) {
-        return resolvedPath;
-      }
-      // Check for directory with index.ts
-      const indexPath = path.join(packagesPath, 'nx', subpath, 'index.ts');
-      if (fs.existsSync(indexPath) && fs.lstatSync(indexPath).isFile()) {
-        return indexPath;
       }
     }
 


### PR DESCRIPTION
## Current Behavior

The patched jest resolver handles `nx/*` imports differently for unit tests and e2e tests:
- **Unit tests**: Manual filesystem-based resolution with regex matching and `fs.existsSync` checks to find `.ts` source files
- **E2e tests**: Falls through to `options.defaultResolver`, which follows pnpm `workspace:*` symlinks to `packages/nx/` and resolves via the package.json exports map — landing on `dist/*.js` files instead of `.ts` source

This causes ~200 sandbox warnings for undeclared file reads from `packages/nx/dist/` during e2e task execution, since those files aren't listed as task inputs.

Additionally, `e2eInputs` in `nx.json` references `{workspaceRoot}/jest.preset.js` (the root unit test preset) instead of the actual e2e preset at `{workspaceRoot}/e2e/jest.preset.e2e.js`.

## Expected Behavior

Both unit and e2e tests resolve `nx/*` imports using the `@nx/nx-source` custom export condition via `options.defaultResolver`. This leverages the existing exports map in `packages/nx/package.json` to resolve to `.ts` source files, eliminating:
- The manual filesystem resolution code for `nx/*` (regex matching, `fs.existsSync` calls)
- The e2e-specific code path that fell through to compiled `.js` files
- Sandbox warnings for undeclared reads from `packages/nx/dist/`

The `e2eInputs` preset reference is corrected to point to the actual e2e preset file.

## Related Issue(s)

<!-- No specific issue — this was discovered during sandbox warning investigation -->
