### PR TITLE
fix(gradle): ignore test enums when atomizing

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/parsing/RegexTestParser.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/parsing/RegexTestParser.kt
@@ -17,6 +17,9 @@ private val abstractClassRegex =
 private val annotationClassRegex =
     Regex(
         """^\s*(?:@\w+\s*)*(?:public\s+|protected\s+)?annotation\s+class\s+([A-Za-z_][A-Za-z0-9_]*)""")
+private val enumClassRegex =
+    Regex(
+        """^\s*(?:@\w+\s*)*(?:public\s+|protected\s+|internal\s+|open\s+)*enum\s+class\s+([A-Za-z_][A-Za-z0-9_]*)""")
 
 /** Fallback to original regex-based parsing when AST parsing fails */
 fun parseTestClassesWithRegex(file: File): MutableMap<String, String>? {
@@ -33,10 +36,11 @@ fun parseTestClassesWithRegex(file: File): MutableMap<String, String>? {
     val trimmed = line.trimStart()
     val indent = line.indexOfFirst { !it.isWhitespace() }.takeIf { it >= 0 } ?: 0
 
-    // Skip private, internal, abstract, annotation, and fake classes
+    // Skip private, internal, abstract, annotation, enum, and fake classes
     if (excludedClassRegex.containsMatchIn(trimmed)) continue
     if (abstractClassRegex.containsMatchIn(trimmed)) continue
     if (annotationClassRegex.containsMatchIn(trimmed)) continue
+    if (enumClassRegex.containsMatchIn(trimmed)) continue
     if (fakeClassRegex.containsMatchIn(trimmed)) continue
 
     val match = classDeclarationRegex.find(trimmed)

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/parsing/TestClassParserTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/parsing/TestClassParserTest.kt
@@ -104,6 +104,97 @@ class TestClassParserTest {
   }
 
   @Test
+  fun `should exclude enum classes from Kotlin files`() {
+    val file =
+        File(tempDir, "EnumTest.kt").apply {
+          writeText(
+              """
+              package com.example
+              import org.junit.jupiter.api.Test
+
+              enum class TestStatus {
+                PASSED, FAILED, SKIPPED
+              }
+
+              class ActualTestClass {
+                @Test
+                fun testMethod() {}
+              }
+              """
+                  .trimIndent())
+        }
+
+    val result = getAllVisibleClassesWithNestedAnnotation(file)
+
+    assertNotNull(result)
+    assertTrue(result.containsKey("ActualTestClass"))
+    assertFalse(
+        result.containsKey("TestStatus"), "Enum classes should not be included as test targets")
+  }
+
+  @Test
+  fun `should exclude enum classes from regex fallback`() {
+    val file =
+        File(tempDir, "EnumTest.kt").apply {
+          writeText(
+              """
+              package com.example
+              import org.junit.jupiter.api.Test
+
+              enum class TestStatus {
+                PASSED, FAILED, SKIPPED
+              }
+
+              class RealTest {
+                @Test
+                fun testMethod() {}
+              }
+              """
+                  .trimIndent())
+        }
+
+    val result = parseTestClassesWithRegex(file)
+
+    assertNotNull(result)
+    assertTrue(result.containsKey("RealTest"))
+    assertFalse(
+        result.containsKey("TestStatus"), "Enum classes should not be included as test targets")
+  }
+
+  @Test
+  fun `should exclude multiple enum classes in same file`() {
+    val file =
+        File(tempDir, "MultiEnum.kt").apply {
+          writeText(
+              """
+              package com.example
+              import org.junit.jupiter.api.Test
+
+              enum class TestStatus {
+                PASSED, FAILED, SKIPPED
+              }
+
+              enum class Priority {
+                HIGH, MEDIUM, LOW
+              }
+
+              class EnumUserTest {
+                @Test
+                fun testMethod() {}
+              }
+              """
+                  .trimIndent())
+        }
+
+    val result = getAllVisibleClassesWithNestedAnnotation(file)
+
+    assertNotNull(result)
+    assertTrue(result.containsKey("EnumUserTest"))
+    assertFalse(result.containsKey("TestStatus"))
+    assertFalse(result.containsKey("Priority"))
+  }
+
+  @Test
   fun `should still include regular test classes alongside annotation classes`() {
     val file =
         File(tempDir, "MixedFile.kt").apply {
@@ -142,5 +233,76 @@ class TestClassParserTest {
         "Annotation class should not be a test target")
     assertFalse(
         result.containsKey("TestAnnotation"), "Annotation class should not be a test target")
+  }
+
+  @Test
+  fun `should exclude both enum and annotation classes in mixed file`() {
+    val file =
+        File(tempDir, "MixedEnumAnnotation.kt").apply {
+          writeText(
+              """
+              package com.example
+              import org.junit.jupiter.api.Test
+
+              enum class TestStatus {
+                PASSED, FAILED, SKIPPED
+              }
+
+              annotation class CustomAnnotation
+
+              class MixedTest {
+                @Test
+                fun testMethod() {}
+              }
+              """
+                  .trimIndent())
+        }
+
+    val result = getAllVisibleClassesWithNestedAnnotation(file)
+
+    assertNotNull(result)
+    assertTrue(result.containsKey("MixedTest"))
+    assertFalse(
+        result.containsKey("TestStatus"), "Enum classes should not be included as test targets")
+    assertFalse(
+        result.containsKey("CustomAnnotation"),
+        "Annotation classes should not be included as test targets")
+  }
+
+  @Test
+  fun `should exclude enum classes with visibility modifiers from regex fallback`() {
+    val file =
+        File(tempDir, "VisibilityEnumTest.kt").apply {
+          writeText(
+              """
+              package com.example
+              import org.junit.jupiter.api.Test
+
+              public enum class PublicStatus {
+                ACTIVE, INACTIVE
+              }
+
+              internal enum class InternalStatus {
+                PENDING, DONE
+              }
+
+              class VisibilityTest {
+                @Test
+                fun testMethod() {}
+              }
+              """
+                  .trimIndent())
+        }
+
+    val result = parseTestClassesWithRegex(file)
+
+    assertNotNull(result)
+    assertTrue(result.containsKey("VisibilityTest"))
+    assertFalse(
+        result.containsKey("PublicStatus"),
+        "Public enum classes should not be included as test targets")
+    assertFalse(
+        result.containsKey("InternalStatus"),
+        "Internal enum classes should not be included as test targets")
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior                                                                                                         
                                                                                                                           
When the Gradle plugin's regex-based test parser (used as a fallback when AST parsing fails) encounters a Kotlin file    
containing enum classes, those enum classes are incorrectly included as test atomization targets. This causes spurious   
test entries to appear for enum types like TestStatus or Priority that are not actual test classes.                      
                                                                                                                           
## Expected Behavior                                                                                                        

Enum classes are excluded from the list of discovered test classes during atomization, consistent with how abstract      
classes and annotation classes are already filtered out. Only real test classes should be identified as atomization targets.  

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
