### PR TITLE
feat(next): add initial vitest support

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 bun = "1.3"
-java = "24"
+java = "17"
 node = "{{ env['NODE_VERSION'] | default(value='24.11.0') }}"
 maven = "3.9.11"
 rust = "1.90.0"

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -1,16 +1,16 @@
-import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import {
-    getProjects,
-    readJson,
-    readProjectConfiguration,
-    Tree,
-    updateJson,
+  getProjects,
+  readJson,
+  readProjectConfiguration,
+  Tree,
+  updateJson,
   writeJson,
 } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 
-import { Schema } from './schema';
-import { applicationGenerator } from './application';
 import { join } from 'path';
+import { applicationGenerator } from './application';
+import { Schema } from './schema';
 
 describe('app', () => {
   let tree: Tree;
@@ -1342,6 +1342,36 @@ describe('app', () => {
       });
 
       expect(tree.exists(`${name}/vitest.config.mts`)).toBeTruthy();
+      expect(tree.read(`${name}/vitest.config.mts`, 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import react from '@vitejs/plugin-react-swc';
+        import { defineConfig } from 'vite';
+        import react from '@vitejs/plugin-react';
+        import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+        import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+        export default defineConfig(() => ({
+          root: __dirname,
+          cacheDir: '../node_modules/.vite/myapp',
+          plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+          // Uncomment this if you are using workers.
+          // worker: {
+          //   plugins: () => [ nxViteTsPaths() ],
+          // },
+          test: {
+            name: 'myapp',
+            watch: false,
+            globals: true,
+            environment: 'jsdom',
+            include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+            reporters: ['default'],
+            coverage: {
+              reportsDirectory: '../coverage/myapp',
+              provider: 'v8' as const,
+            },
+          },
+        }));
+        "
+      `);
       expect(tree.exists(`${name}/jest.config.cts`)).toBeFalsy();
       expect(tree.exists(`${name}/jest.config.ts`)).toBeFalsy();
     });
@@ -1366,9 +1396,7 @@ describe('app', () => {
       });
 
       expect(
-        readJson(tree, 'package.json').devDependencies[
-          '@testing-library/react'
-        ]
+        readJson(tree, 'package.json').devDependencies['@testing-library/react']
       ).toBeDefined();
     });
   });

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -1,11 +1,10 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import {
-  getProjects,
-  readJson,
-  readNxJson,
-  readProjectConfiguration,
-  Tree,
-  updateJson,
+    getProjects,
+    readJson,
+    readProjectConfiguration,
+    Tree,
+    updateJson,
   writeJson,
 } from '@nx/devkit';
 
@@ -1330,6 +1329,47 @@ describe('app', () => {
         };
         "
       `);
+    });
+  });
+
+  describe('--unit-test-runner vitest', () => {
+    it('should generate vitest configuration', async () => {
+      const name = 'myapp';
+      await applicationGenerator(tree, {
+        directory: name,
+        style: 'css',
+        unitTestRunner: 'vitest',
+      });
+
+      expect(tree.exists(`${name}/vitest.config.mts`)).toBeTruthy();
+      expect(tree.exists(`${name}/jest.config.cts`)).toBeFalsy();
+      expect(tree.exists(`${name}/jest.config.ts`)).toBeFalsy();
+    });
+
+    it('should generate spec file', async () => {
+      const name = uniq();
+      await applicationGenerator(tree, {
+        directory: name,
+        style: 'css',
+        unitTestRunner: 'vitest',
+      });
+
+      expect(tree.exists(`${name}/specs/${name}.spec.tsx`)).toBeTruthy();
+    });
+
+    it('should add testing-library dependencies', async () => {
+      const name = uniq();
+      await applicationGenerator(tree, {
+        directory: name,
+        style: 'css',
+        unitTestRunner: 'vitest',
+      });
+
+      expect(
+        readJson(tree, 'package.json').devDependencies[
+          '@testing-library/react'
+        ]
+      ).toBeDefined();
     });
   });
 });

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -1333,20 +1333,63 @@ describe('app', () => {
   });
 
   describe('--unit-test-runner vitest', () => {
-    it('should generate vitest configuration', async () => {
+    it('should generate vitest configuration - no swc', async () => {
       const name = 'myapp';
       await applicationGenerator(tree, {
         directory: name,
         style: 'css',
         unitTestRunner: 'vitest',
+        swc: false,
       });
 
       expect(tree.exists(`${name}/vitest.config.mts`)).toBeTruthy();
       expect(tree.read(`${name}/vitest.config.mts`, 'utf-8'))
         .toMatchInlineSnapshot(`
-        "import react from '@vitejs/plugin-react-swc';
-        import { defineConfig } from 'vite';
+        "import { defineConfig } from 'vite';
         import react from '@vitejs/plugin-react';
+        import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+        import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+        export default defineConfig(() => ({
+          root: __dirname,
+          cacheDir: '../node_modules/.vite/myapp',
+          plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+          // Uncomment this if you are using workers.
+          // worker: {
+          //   plugins: () => [ nxViteTsPaths() ],
+          // },
+          test: {
+            name: 'myapp',
+            watch: false,
+            globals: true,
+            environment: 'jsdom',
+            include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+            reporters: ['default'],
+            coverage: {
+              reportsDirectory: '../coverage/myapp',
+              provider: 'v8' as const,
+            },
+          },
+        }));
+        "
+      `);
+      expect(tree.exists(`${name}/jest.config.cts`)).toBeFalsy();
+      expect(tree.exists(`${name}/jest.config.ts`)).toBeFalsy();
+    });
+
+    it('should generate vitest configuration - with swc', async () => {
+      const name = 'myapp';
+      await applicationGenerator(tree, {
+        directory: name,
+        style: 'css',
+        unitTestRunner: 'vitest',
+        swc: true,
+      });
+
+      expect(tree.exists(`${name}/vitest.config.mts`)).toBeTruthy();
+      expect(tree.read(`${name}/vitest.config.mts`, 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { defineConfig } from 'vite';
+        import react from '@vitejs/plugin-react-swc';
         import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
         import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
         export default defineConfig(() => ({
@@ -1384,7 +1427,7 @@ describe('app', () => {
         unitTestRunner: 'vitest',
       });
 
-      expect(tree.exists(`${name}/specs/${name}.spec.tsx`)).toBeTruthy();
+      expect(tree.exists(`${name}/specs/index.spec.tsx`)).toBeTruthy();
     });
 
     it('should add testing-library dependencies', async () => {

--- a/packages/next/src/generators/application/application.ts
+++ b/packages/next/src/generators/application/application.ts
@@ -19,6 +19,7 @@ import { normalizeOptions } from './lib/normalize-options';
 import { Schema } from './schema';
 import { addE2e } from './lib/add-e2e';
 import { addJest } from './lib/add-jest';
+import { addVitest } from './lib/add-vitest';
 import { addProject } from './lib/add-project';
 import { createApplicationFiles } from './lib/create-application-files';
 import { setDefaults } from './lib/set-defaults';
@@ -38,7 +39,7 @@ import {
 import { sortPackageJsonFields } from '@nx/js/src/utils/package-json/sort-fields';
 import { configureForSwc } from '../../utils/add-swc-to-custom-server';
 import { updateJestConfig } from '../../utils/jest-config-util';
-import { isNext14, isNext15, isNext16 } from '../../utils/version-utils';
+import { isNext16 } from '../../utils/version-utils';
 
 export async function applicationGenerator(host: Tree, schema: Schema) {
   return await applicationGeneratorInternal(host, {
@@ -93,6 +94,9 @@ export async function applicationGeneratorInternal(host: Tree, schema: Schema) {
 
   const jestTask = await addJest(host, options);
   tasks.push(jestTask);
+
+  const vitestTask = await addVitest(host, options);
+  tasks.push(vitestTask);
 
   if (options.style === 'tailwind') {
     const tailwindTask = await setupTailwindGenerator(host, {

--- a/packages/next/src/generators/application/lib/add-vitest.ts
+++ b/packages/next/src/generators/application/lib/add-vitest.ts
@@ -1,0 +1,69 @@
+import {
+    ensurePackage,
+    GeneratorCallback,
+    joinPathFragments,
+    Tree,
+} from '@nx/devkit';
+
+import { nxVersion } from '../../../utils/versions';
+import { NormalizedSchema } from './normalize-options';
+
+export async function addVitest(
+  host: Tree,
+  options: NormalizedSchema
+): Promise<GeneratorCallback> {
+  if (options.unitTestRunner !== 'vitest') {
+    return () => {};
+  }
+
+  const { createOrEditViteConfig } = ensurePackage<typeof import('@nx/vite')>(
+    '@nx/vite',
+    nxVersion
+  );
+  ensurePackage('@nx/vitest', nxVersion);
+  const { configurationGenerator } = await import('@nx/vitest/generators');
+
+  const vitestTask = await configurationGenerator(host, {
+    project: options.projectName,
+    uiFramework: 'react',
+    coverageProvider: 'v8',
+    testEnvironment: 'jsdom',
+    skipFormat: true,
+    addPlugin: options.addPlugin,
+    runtimeTsconfigFileName: 'tsconfig.json',
+    projectType: 'application',
+  });
+
+  createOrEditViteConfig(
+    host,
+    {
+      project: options.projectName,
+      includeLib: false,
+      includeVitest: true,
+      inSourceTests: false,
+      imports: [
+        options.swc
+          ? `import react from '@vitejs/plugin-react-swc'`
+          : `import react from '@vitejs/plugin-react'`,
+      ],
+      plugins: ['react()'],
+      useEsmExtension: true,
+    },
+    true
+  );
+
+  // Rename to vitest.config.mts since Next.js uses its own bundler (not Vite)
+  const viteConfigPath = joinPathFragments(
+    options.appProjectRoot,
+    'vite.config.mts'
+  );
+  const vitestConfigPath = joinPathFragments(
+    options.appProjectRoot,
+    'vitest.config.mts'
+  );
+  if (host.exists(viteConfigPath)) {
+    host.rename(viteConfigPath, vitestConfigPath);
+  }
+
+  return vitestTask;
+}

--- a/packages/next/src/generators/application/lib/add-vitest.ts
+++ b/packages/next/src/generators/application/lib/add-vitest.ts
@@ -1,8 +1,8 @@
 import {
-    ensurePackage,
-    GeneratorCallback,
-    joinPathFragments,
-    Tree,
+  ensurePackage,
+  GeneratorCallback,
+  joinPathFragments,
+  Tree,
 } from '@nx/devkit';
 
 import { nxVersion } from '../../../utils/versions';
@@ -32,6 +32,7 @@ export async function addVitest(
     addPlugin: options.addPlugin,
     runtimeTsconfigFileName: 'tsconfig.json',
     projectType: 'application',
+    compiler: options.swc ? 'swc' : 'babel',
   });
 
   createOrEditViteConfig(

--- a/packages/next/src/generators/application/schema.d.ts
+++ b/packages/next/src/generators/application/schema.d.ts
@@ -7,7 +7,7 @@ export interface Schema {
   style?: SupportedStyles;
   skipFormat?: boolean;
   tags?: string;
-  unitTestRunner?: 'jest' | 'none';
+  unitTestRunner?: 'jest' | 'vitest' | 'none';
   e2eTestRunner?: 'cypress' | 'playwright' | 'none';
   linter?: Linter | LinterType;
   js?: boolean;

--- a/packages/next/src/generators/application/schema.json
+++ b/packages/next/src/generators/application/schema.json
@@ -82,7 +82,7 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "description": "Test runner to use for unit tests.",
       "default": "none",
       "x-prompt": "What unit test runner should be used?",


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Next application generator only offer jest as test runner
<!-- This is the behavior we have today -->

## Expected Behavior
Next application generator should also offer vitest as an option

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #34360