### PR TITLE
fix(angular-rspack): ensure rebuild chunks emitted summary accurate

### DIFF
--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -45,6 +45,9 @@ export const DEFAULT_NG_COMPILER_OPTIONS: ts.CompilerOptions = {
   supportJitMode: false,
 };
 
+let COMPONENT_STYLESHEET_BUNDLER: ComponentStylesheetBundler | undefined =
+  undefined;
+
 export async function setupCompilation(
   config: Pick<RsbuildConfig, 'mode' | 'source'>,
   options: SetupCompilationOptions
@@ -86,7 +89,7 @@ export async function setupCompilation(
     }
   }
 
-  const componentStylesheetBundler = new ComponentStylesheetBundler(
+  COMPONENT_STYLESHEET_BUNDLER ??= new ComponentStylesheetBundler(
     {
       workspaceRoot: options.root,
       optimization: config.mode === 'production',
@@ -116,7 +119,7 @@ export async function setupCompilation(
   return {
     rootNames,
     compilerOptions,
-    componentStylesheetBundler,
+    componentStylesheetBundler: COMPONENT_STYLESHEET_BUNDLER,
   };
 }
 

--- a/packages/angular-rspack/src/lib/utils/stats.ts
+++ b/packages/angular-rspack/src/lib/utils/stats.ts
@@ -101,6 +101,7 @@ function generateBundleStats(info: {
 
 // Ideally, we should create the logging callback as a factory, but that would need a refactoring.
 const runsCache = new Set<string>();
+const chunkHashCache = new Map<string, Map<string | number, string>>();
 
 function statsToString(
   stats: Stats,
@@ -125,11 +126,20 @@ function statsToString(
   let hasEstimatedTransferSizes = false;
 
   const isFirstRun = !runsCache.has(json.outputPath || '');
+  const prevHashes =
+    chunkHashCache.get(json.outputPath || '') ??
+    new Map<string | number, string>();
+  const nextHashes = new Map<string | number, string>();
 
   for (const chunk of json.chunks) {
-    // During first build we want to display unchanged chunks
-    // but unchanged cached chunks are always marked as not rendered.
-    if (!isFirstRun && !chunk.rendered) {
+    const key = chunk.id ?? chunk.names?.[0] ?? '';
+    const hash = chunk.hash ?? '';
+    nextHashes.set(key, hash);
+
+    // During first build we want to display all chunks.
+    // On rebuilds, skip chunks whose hash hasn't changed.
+    if (!isFirstRun && prevHashes.get(key) === hash) {
+      unchangedChunkNumber++;
       continue;
     }
 
@@ -199,9 +209,8 @@ function statsToString(
       generateBundleStats({ ...chunk, rawSize, estimatedTransferSize })
     );
   }
-  unchangedChunkNumber = json.chunks.length - changedChunksStats.length;
-
   runsCache.add(json.outputPath || '');
+  chunkHashCache.set(json.outputPath || '', nextHashes);
 
   const statsTable = generateBuildStatsTable(
     changedChunksStats,
@@ -421,11 +430,18 @@ export function generateBuildEventStats(
 
   const allChunksCount = chunks.length;
   const isFirstRun = !runsCache.has(rspackStats.outputPath || '');
+  const prevHashes =
+    chunkHashCache.get(rspackStats.outputPath || '') ??
+    new Map<string | number, string>();
 
   const chunkFiles = new Set<string>();
   for (const chunk of chunks) {
-    if (!isFirstRun && chunk.rendered) {
-      changedChunksCount++;
+    if (!isFirstRun) {
+      const key = chunk.id ?? chunk.names?.[0] ?? '';
+      const hash = chunk.hash ?? '';
+      if (prevHashes.get(key) !== hash) {
+        changedChunksCount++;
+      }
     }
 
     if (chunk.initial) {


### PR DESCRIPTION
## Current Behavior
Currently, rebuilds produce a summary table that is not accurate.
A key difference in how Rspack sets `chunks.rendered` compared to Webpack resulted in the logic for determining rebuilt chunks to be incorrect.

## Expected Behavior
Ensure the summary table for emitted chunks is accurate on rebuild

## Related Issues

It does not _fully_ solve #34936, however it should be a good first step to finding out if too many chunks are being emitted
