### PR TITLE
fix(js): generate bundled type definitions for entry points in sub-directories

### DIFF
--- a/packages/rollup/src/plugins/with-nx/type-definitions.spec.ts
+++ b/packages/rollup/src/plugins/with-nx/type-definitions.spec.ts
@@ -68,4 +68,76 @@ describe('typeDefinitions', () => {
       });
     })();
   });
+
+  it('should emit .d.ts files with relative references to source files', () => {
+    const mockBundle = {
+      'index.js': {
+        type: 'chunk',
+        isEntry: true,
+        fileName: 'index.js',
+        facadeModuleId: '/project/src/index.ts',
+        exports: ['default'],
+      },
+      'entry-point.js': {
+        type: 'chunk',
+        isEntry: true,
+        fileName: 'entry-point.js',
+        facadeModuleId: '/project/src/entry-point1/entry-point.ts',
+        exports: [],
+      },
+      'entry-point2/entry-point.js': {
+        type: 'chunk',
+        isEntry: true,
+        fileName: 'entry-point2/entry-point.js',
+        facadeModuleId: '/project/src/entry-point2/entry-point.ts',
+        exports: ['default'],
+      },
+    };
+
+    const mockOpts = {};
+
+    const mockEmitFile = jest.fn();
+
+    const plugin = typeDefinitions({ projectRoot: '/project' });
+
+    const mockContext = {
+      emitFile: mockEmitFile,
+    };
+
+    (async function testPlugin() {
+      await plugin.generateBundle.call(mockContext, mockOpts, mockBundle);
+
+      // The expected relative paths in the emitted .d.ts files should correctly reference the source .d.ts files
+      const expectedReferences = [
+        ['index.d.ts', './src/index', true], // for index.d.ts
+        ['entry-point.d.ts', './src/entry-point1/entry-point', false], // for entry-point.d.ts
+        [
+          'entry-point2/entry-point.d.ts',
+          '../src/entry-point2/entry-point',
+          true,
+        ], // for entry-point2/entry-point.d.ts
+      ];
+
+      mockEmitFile.mock.calls.forEach(([{ fileName }], index) => {
+        const [expectedFileName, expectedRelativePath, expectDefaultExport] =
+          expectedReferences[index];
+        expect(fileName).toBe(expectedFileName);
+
+        const emittedContent = mockEmitFile.mock.calls[index][0].source;
+        expect(emittedContent).toContain(
+          `export * from "${expectedRelativePath}";`
+        );
+
+        if (expectDefaultExport) {
+          expect(emittedContent).toContain(
+            `export { default } from "${expectedRelativePath}";`
+          );
+        } else {
+          expect(emittedContent).not.toContain(
+            `export { default } from "${expectedRelativePath}";`
+          );
+        }
+      });
+    })();
+  });
 });

--- a/packages/rollup/src/plugins/with-nx/type-definitions.ts
+++ b/packages/rollup/src/plugins/with-nx/type-definitions.ts
@@ -1,6 +1,6 @@
 // nx-ignore-next-line
 import type { OutputBundle } from 'rollup'; // only used  for types
-import { relative } from 'path';
+import { dirname, relative } from 'path';
 import { stripIndents } from '@nx/devkit';
 
 /*
@@ -44,7 +44,15 @@ export function typeDefinitions(options: { projectRoot: string }) {
           '.d.ts'
         );
 
-        const relativeSourceDtsName = JSON.stringify('./' + entrySourceDtsName);
+        const relativeSourceDtsFile = relative(
+          dirname(file.fileName),
+          entrySourceDtsName
+        );
+        const relativeSourceDtsName = JSON.stringify(
+          relativeSourceDtsFile.startsWith('.')
+            ? relativeSourceDtsFile
+            : `./${relativeSourceDtsFile}`
+        );
         const dtsFileSource = hasDefaultExport
           ? stripIndents`
               export * from ${relativeSourceDtsName};


### PR DESCRIPTION
When using a custom configuration for rollup (or vite) to add secondary entry points in a sub-directory of the resulting package (in cases where having all of them in root would be undesirable), the dts-bundle plugin generates invalid export statements referencing relative to the root when it should be relative to the entry file's location.

This resolves the path of the source declaration file relative to the location of the generated bundle entry file.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

If I configure a bundler to generate a secondary entrypoint in a sub-directory as suggested by [rollup](https://rollupjs.org/configuration-options/#input) to have my entry file not located in the generated package's root directory, then the generated typings by the `dts-bundle` plugin point to an unknown file (`src` dir relative to a sub-directory of the generated package)

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

When I use said configuration, the generated typings file refers to the source dts by pointing to the directory relative to the entry file's position. (i.e. for `entry/entry-file.d.ts` it exports types from `../src/entry/entry-file`).

Note that the goal of this fix is only to make Nx's well thought-out toolchain work with customized entry points. The goal of this fix is not to allow subdirectory exports through Nx's `additionalEntryPoints`, which would incur more changes in the toolchain.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

None, this is a spontaneous fix from an issue I've encountered requiring me to patch the `dts-bundle` plugin. As this is due to custom configuration, I could well understand this is not meant to be supported as-is (though it makes it difficult to use with pre-configured Nx settings).