### PR TITLE
fix(core): suppress postinstall error output when nx is not yet built

### DIFF
--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/nx"
   },
   "scripts": {
-    "postinstall": "node ./dist/bin/post-install || exit 0"
+    "postinstall": "node -e \"try{require('./dist/bin/post-install')}catch(e){}\""
   },
   "keywords": [
     "Monorepo",


### PR DESCRIPTION
## Current Behavior

The `postinstall` script in `packages/nx/package.json` runs `node ./dist/bin/post-install` which prints noisy error logs to stderr when the `dist` directory hasn't been built yet (e.g. during `pnpm install` in the workspace). The script already exits cleanly via `|| exit 0`, but the error output is confusing.

## Expected Behavior

The postinstall script silently succeeds when the dist directory doesn't exist, without printing error logs to the console.

## Related Issue(s)

N/A - minor DX improvement