### PR TITLE
fix(vitest): resolve addPlugin default in init generator

### DIFF
--- a/packages/vitest/src/generators/init/init.spec.ts
+++ b/packages/vitest/src/generators/init/init.spec.ts
@@ -1,0 +1,182 @@
+import {
+  ProjectGraph,
+  readJson,
+  readNxJson,
+  Tree,
+  updateJson,
+  NxJsonConfiguration,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+
+import { initGenerator } from './init';
+
+let projectGraph: ProjectGraph;
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual<any>('@nx/devkit'),
+  createProjectGraphAsync: jest.fn().mockImplementation(async () => {
+    return projectGraph;
+  }),
+}));
+
+describe('@nx/vitest:init', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    projectGraph = {
+      nodes: {},
+      dependencies: {},
+    };
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should add the plugin by default when addPlugin is not provided', async () => {
+    await initGenerator(tree, {
+      skipFormat: true,
+      skipPackageJson: true,
+    });
+    const nxJson = readNxJson(tree);
+    expect(nxJson.plugins).toContainEqual(
+      expect.objectContaining({ plugin: '@nx/vitest' })
+    );
+  });
+
+  it('should update namedInputs for production', async () => {
+    updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      json.namedInputs ??= {};
+      json.namedInputs.production = ['default'];
+      return json;
+    });
+
+    await initGenerator(tree, {
+      skipFormat: true,
+      skipPackageJson: true,
+    });
+
+    const nxJson = readNxJson(tree);
+    expect(nxJson.namedInputs.production).toContain(
+      '!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)'
+    );
+    expect(nxJson.namedInputs.production).toContain(
+      '!{projectRoot}/tsconfig.spec.json'
+    );
+  });
+
+  it('should add required packages to package.json', async () => {
+    await initGenerator(tree, {
+      skipFormat: true,
+      skipPackageJson: false,
+    });
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.devDependencies['vitest']).toBeDefined();
+    expect(packageJson.devDependencies['vite']).toBeDefined();
+    expect(packageJson.devDependencies['@nx/vitest']).toBeDefined();
+  });
+
+  it('should not add packages when skipPackageJson is true', async () => {
+    await initGenerator(tree, {
+      skipFormat: true,
+      skipPackageJson: true,
+    });
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.devDependencies['vitest']).toBeUndefined();
+  });
+
+  it('should not add the plugin when NX_ADD_PLUGINS is false', async () => {
+    const original = process.env.NX_ADD_PLUGINS;
+    process.env.NX_ADD_PLUGINS = 'false';
+
+    try {
+      await initGenerator(tree, {
+        skipFormat: true,
+        skipPackageJson: true,
+      });
+      const nxJson = readNxJson(tree);
+      expect(nxJson.plugins).toBeUndefined();
+    } finally {
+      process.env.NX_ADD_PLUGINS = original;
+    }
+  });
+
+  describe('with addPlugin: true', () => {
+    it('should add the vitest plugin to nx.json', async () => {
+      await initGenerator(tree, {
+        skipFormat: true,
+        addPlugin: true,
+        skipPackageJson: true,
+      });
+
+      const nxJson = readNxJson(tree);
+      expect(nxJson.plugins).toContainEqual(
+        expect.objectContaining({ plugin: '@nx/vitest' })
+      );
+    });
+
+    it('should not add plugin if already in array', async () => {
+      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+        json.plugins = ['@nx/vitest'];
+        return json;
+      });
+
+      await initGenerator(tree, {
+        skipFormat: true,
+        addPlugin: true,
+        skipPackageJson: true,
+      });
+
+      const nxJson = readNxJson(tree);
+      expect(nxJson.plugins).toEqual(['@nx/vitest']);
+    });
+
+    it('should not add target defaults when plugin is registered', async () => {
+      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+        json.namedInputs ??= {};
+        json.namedInputs.production = ['default'];
+        return json;
+      });
+
+      await initGenerator(tree, {
+        skipFormat: true,
+        addPlugin: true,
+        skipPackageJson: true,
+      });
+
+      const nxJson = readNxJson(tree);
+      expect(nxJson.targetDefaults?.['@nx/vitest:test']).toBeUndefined();
+    });
+  });
+
+  describe('with addPlugin: false', () => {
+    it('should not add the vitest plugin to nx.json', async () => {
+      await initGenerator(tree, {
+        skipFormat: true,
+        addPlugin: false,
+        skipPackageJson: true,
+      });
+
+      const nxJson = readNxJson(tree);
+      expect(nxJson.plugins).toBeUndefined();
+    });
+
+    it('should add target defaults for @nx/vitest:test', async () => {
+      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+        json.namedInputs ??= {};
+        json.namedInputs.production = ['default'];
+        return json;
+      });
+
+      await initGenerator(tree, {
+        skipFormat: true,
+        addPlugin: false,
+        skipPackageJson: true,
+      });
+
+      const nxJson = readNxJson(tree);
+      expect(nxJson.targetDefaults['@nx/vitest:test']).toEqual({
+        cache: true,
+        inputs: ['default', '^production'],
+      });
+    });
+  });
+});

--- a/packages/vitest/src/generators/init/init.ts
+++ b/packages/vitest/src/generators/init/init.ts
@@ -71,14 +71,7 @@ export function updateNxJsonSettings(tree: Tree) {
   updateNxJson(tree, nxJson);
 }
 
-export function initGenerator(tree: Tree, schema: InitGeneratorSchema) {
-  return initGeneratorInternal(tree, { addPlugin: false, ...schema });
-}
-
-export async function initGeneratorInternal(
-  tree: Tree,
-  schema: InitGeneratorSchema
-) {
+export async function initGenerator(tree: Tree, schema: InitGeneratorSchema) {
   const nxJson = readNxJson(tree);
   const addPluginDefault =
     process.env.NX_ADD_PLUGINS !== 'false' &&


### PR DESCRIPTION
## Current Behavior

Running `nx add @nx/vitest` does not register the `@nx/vitest` plugin in `nx.json`. The init generator had a wrapper function (`initGenerator`) that hardcoded `addPlugin: false` before spreading the user-provided schema. Since `nx add` calls the generator via CLI without passing `addPlugin`, the value stayed `false` — and the `??=` default logic in `initGeneratorInternal` never fired because `false` is not nullish.

## Expected Behavior

Running `nx add @nx/vitest` should register the `@nx/vitest` plugin in `nx.json`, matching the behavior of other plugins like `@nx/jest`, `@nx/vite`, and `@nx/playwright`.

## Related Issue(s)

<!-- No existing issue tracked for this -->

## Changes

- Merged `initGenerator` and `initGeneratorInternal` into a single `initGenerator` function that uses the `??=` default logic directly
- Added unit tests for the init generator covering plugin registration defaults, `NX_ADD_PLUGINS` env var, `addPlugin: true` vs `false` behavior, package.json handling, and namedInputs