### PR TITLE
chore(repo): add mise trust step and nx-labs to update-repos

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,10 @@ maven = "3.9.11"
 rust = "1.90.0"
 vale = "3.13.1"
 
+# Ensure that the packageManager field gets used to resolve the correct version of pnpm
+# https://github.com/jdx/mise/discussions/3549#discussioncomment-11918572
+"npm:corepack" = "latest"
+
 # dotnet via mise only works on Linux/macOS.
 # On Windows, the vfox plugin is buggy: https://github.com/jdx/mise/discussions/4738
 [tools.dotnet]

--- a/tools/update-repos/config/repos.json
+++ b/tools/update-repos/config/repos.json
@@ -19,6 +19,11 @@
       "repo": "nrwl/nx-console",
       "branch": "master",
       "packageManager": "yarn"
+    },
+    "nx-labs": {
+      "repo": "nrwl/nx-labs",
+      "branch": "main",
+      "packageManager": "bun"
     }
   }
 }

--- a/tools/update-repos/src/update-repo.ts
+++ b/tools/update-repos/src/update-repo.ts
@@ -417,6 +417,17 @@ async function updateRepository(repoName: string): Promise<void> {
       `Creating update branch '${updateBranch}' from origin/${mainBranch}`
     );
 
+    // Trust mise config if present so correct tool versions are used
+    const miseToml = path.join(repoDir, 'mise.toml');
+    const dotMiseToml = path.join(repoDir, '.mise.toml');
+    if (fs.existsSync(miseToml) || fs.existsSync(dotMiseToml)) {
+      await execWithOutput(
+        'mise trust',
+        repoDir,
+        'Trusting mise configuration'
+      );
+    }
+
     // Detect package manager
     const detectedPm = detectPackageManager(repoDir);
     log(`🔍 Detected package manager: ${detectedPm}`);

--- a/tools/update-repos/src/update-repo.ts
+++ b/tools/update-repos/src/update-repo.ts
@@ -426,6 +426,11 @@ async function updateRepository(repoName: string): Promise<void> {
         repoDir,
         'Trusting mise configuration'
       );
+      await execWithOutput(
+        'mise install',
+        repoDir,
+        'Installing mise-managed tools'
+      );
     }
 
     // Detect package manager


### PR DESCRIPTION
## Current Behavior

The `update-repos` tool clones repositories into `/tmp` and runs `pnpm install` / `nx migrate` without trusting the repo's mise configuration. This means the wrong tool versions (node, bun, etc.) may be used. Additionally, `nrwl/nx-labs` is not included in the update-repos config.

## Expected Behavior

- Run `mise trust` before installing dependencies if the cloned repo has a `mise.toml` or `.mise.toml`, ensuring correct tool versions are activated.
- Include `nrwl/nx-labs` in the repos that get updated.

## Related Issue(s)

N/A - internal tooling improvement