### PR TITLE
fix(core): prevent nx watch infinite loop from overly broad output globs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -262,7 +262,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 2,
+  "bust": 3,
   "defaultBase": "master",
   "sync": { "applyChanges": true },
   "conformance": {

--- a/package.json
+++ b/package.json
@@ -368,7 +368,6 @@
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "0.5.13",
     "@types/license-checker": "^25.0.3",
-    "@types/minimatch": "^5.1.2",
     "@types/three": "^0.166.0",
     "@yarnpkg/lockfile": "^1.1.0",
     "@yarnpkg/parsers": "3.0.2",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -177,6 +177,49 @@
       "x86_64-unknown-freebsd"
     ]
   },
+  "typesVersions": {
+    "*": {
+      "bin/nx": [
+        "dist/bin/nx.d.ts"
+      ],
+      "bin/nx.js": [
+        "dist/bin/nx.d.ts"
+      ],
+      "src/native": [
+        "src/native/index.d.ts"
+      ],
+      "src/plugins/js": [
+        "dist/src/plugins/js/index.d.ts"
+      ],
+      "src/plugins/package-json": [
+        "dist/src/plugins/package-json/index.d.ts"
+      ],
+      "src/plugins/*": [
+        "dist/src/plugins/*.d.ts"
+      ],
+      "src/utils/plugins": [
+        "dist/src/utils/plugins/index.d.ts"
+      ],
+      "src/utils/plugins/*": [
+        "dist/src/utils/plugins/*.d.ts"
+      ],
+      "src/utils/catalog": [
+        "dist/src/utils/catalog/index.d.ts"
+      ],
+      "src/utils/catalog/*": [
+        "dist/src/utils/catalog/*.d.ts"
+      ],
+      "src/*": [
+        "dist/src/*.d.ts"
+      ],
+      "release": [
+        "dist/release/index.d.ts"
+      ],
+      "tasks-runners/default": [
+        "dist/tasks-runners/default.d.ts"
+      ]
+    }
+  },
   "exports": {
     ".": {
       "@nx/nx-source": "./bin/nx.ts",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -201,7 +201,7 @@
     },
     "./src/native": {
       "@nx/nx-source": "./src/native/index.ts",
-      "types": "./dist/src/native/index.d.ts",
+      "types": "./src/native/index.d.ts",
       "default": "./dist/src/native/index.js"
     },
     "./src/plugins/js": {

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -188,7 +188,7 @@
     "./generators.json": "./generators.json",
     "./executors.json": "./executors.json",
     "./schemas/*.json": "./schemas/*.json",
-    "./src/**/*.json": "./dist/src/**/*.json",
+    "./src/*.json": "./dist/src/*.json",
     "./bin/nx": {
       "@nx/nx-source": "./bin/nx.ts",
       "types": "./dist/bin/nx.d.ts",
@@ -214,10 +214,10 @@
       "types": "./dist/src/plugins/package-json/index.d.ts",
       "default": "./dist/src/plugins/package-json/index.js"
     },
-    "./src/plugins/**/*": {
-      "@nx/nx-source": "./src/plugins/**/*.ts",
-      "types": "./dist/src/plugins/**/*.d.ts",
-      "default": "./dist/src/plugins/**/*.js"
+    "./src/plugins/*": {
+      "@nx/nx-source": "./src/plugins/*.ts",
+      "types": "./dist/src/plugins/*.d.ts",
+      "default": "./dist/src/plugins/*.js"
     },
     "./src/utils/plugins": {
       "@nx/nx-source": "./src/utils/plugins/index.ts",
@@ -238,16 +238,6 @@
       "@nx/nx-source": "./src/utils/catalog/*.ts",
       "types": "./dist/src/utils/catalog/*.d.ts",
       "default": "./dist/src/utils/catalog/*.js"
-    },
-    "./src/**/*.js": {
-      "@nx/nx-source": "./src/**/*.ts",
-      "types": "./dist/src/**/*.d.ts",
-      "default": "./dist/src/**/*.js"
-    },
-    "./src/**/*": {
-      "@nx/nx-source": "./src/**/*.ts",
-      "types": "./dist/src/**/*.d.ts",
-      "default": "./dist/src/**/*.js"
     },
     "./src/*.js": {
       "@nx/nx-source": "./src/*.ts",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -180,7 +180,7 @@
   "exports": {
     ".": {
       "@nx/nx-source": "./bin/nx.ts",
-      "types": "./bin/nx.d.ts",
+      "types": "./dist/bin/nx.d.ts",
       "default": "./dist/bin/nx.js"
     },
     "./package.json": "./package.json",
@@ -191,77 +191,77 @@
     "./src/**/*.json": "./dist/src/**/*.json",
     "./bin/nx": {
       "@nx/nx-source": "./bin/nx.ts",
-      "types": "./bin/nx.d.ts",
+      "types": "./dist/bin/nx.d.ts",
       "default": "./dist/bin/nx.js"
     },
     "./bin/nx.js": {
       "@nx/nx-source": "./bin/nx.ts",
-      "types": "./bin/nx.d.ts",
+      "types": "./dist/bin/nx.d.ts",
       "default": "./dist/bin/nx.js"
     },
     "./src/native": {
       "@nx/nx-source": "./src/native/index.ts",
-      "types": "./src/native/index.d.ts",
+      "types": "./dist/src/native/index.d.ts",
       "default": "./dist/src/native/index.js"
     },
     "./src/plugins/js": {
       "@nx/nx-source": "./src/plugins/js/index.ts",
-      "types": "./src/plugins/js/index.d.ts",
+      "types": "./dist/src/plugins/js/index.d.ts",
       "default": "./dist/src/plugins/js/index.js"
     },
     "./src/plugins/package-json": {
       "@nx/nx-source": "./src/plugins/package-json/index.ts",
-      "types": "./src/plugins/package-json/index.d.ts",
+      "types": "./dist/src/plugins/package-json/index.d.ts",
       "default": "./dist/src/plugins/package-json/index.js"
     },
     "./src/plugins/**/*": {
       "@nx/nx-source": "./src/plugins/**/*.ts",
-      "types": "./src/plugins/**/*.d.ts",
+      "types": "./dist/src/plugins/**/*.d.ts",
       "default": "./dist/src/plugins/**/*.js"
     },
     "./src/utils/plugins": {
       "@nx/nx-source": "./src/utils/plugins/index.ts",
-      "types": "./src/utils/plugins/index.d.ts",
+      "types": "./dist/src/utils/plugins/index.d.ts",
       "default": "./dist/src/utils/plugins/index.js"
     },
     "./src/utils/plugins/*": {
       "@nx/nx-source": "./src/utils/plugins/*.ts",
-      "types": "./src/utils/plugins/*.d.ts",
+      "types": "./dist/src/utils/plugins/*.d.ts",
       "default": "./dist/src/utils/plugins/*.js"
     },
     "./src/utils/catalog": {
       "@nx/nx-source": "./src/utils/catalog/index.ts",
-      "types": "./src/utils/catalog/index.d.ts",
+      "types": "./dist/src/utils/catalog/index.d.ts",
       "default": "./dist/src/utils/catalog/index.js"
     },
     "./src/utils/catalog/*": {
       "@nx/nx-source": "./src/utils/catalog/*.ts",
-      "types": "./src/utils/catalog/*.d.ts",
+      "types": "./dist/src/utils/catalog/*.d.ts",
       "default": "./dist/src/utils/catalog/*.js"
     },
     "./src/**/*.js": {
       "@nx/nx-source": "./src/**/*.ts",
-      "types": "./src/**/*.d.ts",
+      "types": "./dist/src/**/*.d.ts",
       "default": "./dist/src/**/*.js"
     },
     "./src/**/*": {
       "@nx/nx-source": "./src/**/*.ts",
-      "types": "./src/**/*.d.ts",
+      "types": "./dist/src/**/*.d.ts",
       "default": "./dist/src/**/*.js"
     },
     "./src/*.js": {
       "@nx/nx-source": "./src/*.ts",
-      "types": "./src/*.d.ts",
+      "types": "./dist/src/*.d.ts",
       "default": "./dist/src/*.js"
     },
     "./src/*": {
       "@nx/nx-source": "./src/*.ts",
-      "types": "./src/*.d.ts",
+      "types": "./dist/src/*.d.ts",
       "default": "./dist/src/*.js"
     },
     "./release": {
       "@nx/nx-source": "./release/index.ts",
-      "types": "./release/index.d.ts",
+      "types": "./dist/release/index.d.ts",
       "default": "./dist/release/index.js"
     },
     "./presets/*": {
@@ -270,7 +270,7 @@
     },
     "./tasks-runners/default": {
       "@nx/nx-source": "./tasks-runners/default.ts",
-      "types": "./tasks-runners/default.d.ts",
+      "types": "./dist/tasks-runners/default.d.ts",
       "default": "./dist/tasks-runners/default.js"
     }
   }

--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -156,8 +156,7 @@
       "inputs": ["production", "^production", "native"],
       "outputs": ["{projectRoot}/dist"],
       "options": {
-        "main": "./bin/nx.js",
-        "types": "./bin/nx.d.ts",
+        "addPackageJsonFields": false,
         "tsConfig": "./tsconfig.lib.json",
         "assets": [
           {

--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -101,7 +101,7 @@
       ],
       "executor": "nx:run-commands",
       "outputs": [
-        "{workspaceRoot}/packages/nx/dist/**/*.{node,wasm,js,mjs,cjs}",
+        "{workspaceRoot}/packages/nx/dist/**/*.{node,wasm,js,mjs,cjs,d.ts}",
         "{workspaceRoot}/packages/nx/dist/src/core/graph",
         "{workspaceRoot}/packages/nx/dist/bin/nx.js",
         "{workspaceRoot}/packages/nx/README.md"

--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -77,16 +77,7 @@
       "dependsOn": ["echo"]
     },
     "build-base": {
-      "dependsOn": ["copy-local-native"],
-      "outputs": [
-        "{projectRoot}/dist/**/*.{js,cjs,mjs,d.ts}",
-        "{projectRoot}/src/**/*.d.ts",
-        "{projectRoot}/bin/*.d.ts",
-        "{projectRoot}/release/**/*.d.ts",
-        "{projectRoot}/plugins/**/*.d.ts",
-        "{projectRoot}/presets/**/*.d.ts",
-        "{projectRoot}/tasks-runner/**/*.d.ts"
-      ]
+      "dependsOn": ["copy-local-native"]
     },
     "build": {
       "dependsOn": [
@@ -163,11 +154,7 @@
       "dependsOn": ["build-base", "copy-local-native"],
       "executor": "@nx/workspace-plugin:legacy-post-build",
       "inputs": ["production", "^production", "native"],
-      "outputs": [
-        "{projectRoot}/dist",
-        "{projectRoot}/src/native",
-        "{projectRoot}/**/*.d.ts"
-      ],
+      "outputs": ["{projectRoot}/dist"],
       "options": {
         "main": "./bin/nx.js",
         "types": "./bin/nx.d.ts",

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -638,22 +638,27 @@ const handleWorkspaceChanges: FileWatcherCallback = async (
       }
     }
 
-    if (process.env.NX_VERBOSE_LOGGING === 'true') {
+    {
       const cap = 10;
       const summarize = (files: string[]) =>
         files.length === 0
           ? '(none)'
           : files.length <= cap
-            ? files.join(', ')
-            : files.slice(0, cap).join(', ') +
-              ` ... and ${files.length - cap} more`;
+            ? files.map((f) => `  - ${f}`).join('\n')
+            : files
+                .slice(0, cap)
+                .map((f) => `  - ${f}`)
+                .join('\n') + `\n  ... and ${files.length - cap} more`;
       if (
         createdFilesToHash.length ||
         updatedFilesToHash.length ||
         deletedFiles.length
       ) {
         serverLogger.watcherLog(
-          `created=[${summarize(createdFilesToHash)}] updated=[${summarize(updatedFilesToHash)}] deleted=[${summarize(deletedFiles)}]`
+          `File changes detected:\n` +
+            `Created:\n${summarize(createdFilesToHash)}\n` +
+            `Updated:\n${summarize(updatedFilesToHash)}\n` +
+            `Deleted:\n${summarize(deletedFiles)}`
         );
       }
     }

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -638,29 +638,27 @@ const handleWorkspaceChanges: FileWatcherCallback = async (
       }
     }
 
-    {
-      const cap = 10;
-      const summarize = (files: string[]) =>
-        files.length === 0
-          ? '(none)'
-          : files.length <= cap
-            ? files.map((f) => `  - ${f}`).join('\n')
-            : files
-                .slice(0, cap)
-                .map((f) => `  - ${f}`)
-                .join('\n') + `\n  ... and ${files.length - cap} more`;
-      if (
-        createdFilesToHash.length ||
-        updatedFilesToHash.length ||
-        deletedFiles.length
-      ) {
-        serverLogger.watcherLog(
-          `File changes detected:\n` +
-            `Created:\n${summarize(createdFilesToHash)}\n` +
-            `Updated:\n${summarize(updatedFilesToHash)}\n` +
-            `Deleted:\n${summarize(deletedFiles)}`
-        );
-      }
+    const cap = 10;
+    const summarize = (files: string[]) =>
+      files.length === 0
+        ? '(none)'
+        : files.length <= cap
+          ? files.map((f) => `  - ${f}`).join('\n')
+          : files
+              .slice(0, cap)
+              .map((f) => `  - ${f}`)
+              .join('\n') + `\n  ... and ${files.length - cap} more`;
+    if (
+      createdFilesToHash.length ||
+      updatedFilesToHash.length ||
+      deletedFiles.length
+    ) {
+      serverLogger.watcherLog(
+        `File changes detected:\n` +
+          `Created:\n${summarize(createdFilesToHash)}\n` +
+          `Updated:\n${summarize(updatedFilesToHash)}\n` +
+          `Deleted:\n${summarize(deletedFiles)}`
+      );
     }
 
     addUpdatedAndDeletedFiles(

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -638,6 +638,26 @@ const handleWorkspaceChanges: FileWatcherCallback = async (
       }
     }
 
+    if (process.env.NX_VERBOSE_LOGGING === 'true') {
+      const cap = 10;
+      const summarize = (files: string[]) =>
+        files.length === 0
+          ? '(none)'
+          : files.length <= cap
+            ? files.join(', ')
+            : files.slice(0, cap).join(', ') +
+              ` ... and ${files.length - cap} more`;
+      if (
+        createdFilesToHash.length ||
+        updatedFilesToHash.length ||
+        deletedFiles.length
+      ) {
+        serverLogger.watcherLog(
+          `created=[${summarize(createdFilesToHash)}] updated=[${summarize(updatedFilesToHash)}] deleted=[${summarize(deletedFiles)}]`
+        );
+      }
+    }
+
     addUpdatedAndDeletedFiles(
       createdFilesToHash,
       updatedFilesToHash,

--- a/packages/nx/tsconfig.lib.json
+++ b/packages/nx/tsconfig.lib.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
-    "declarationDir": ".",
+    "declarationDir": "dist",
     "declarationMap": false,
     "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "types": ["node"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,9 +328,6 @@ importers:
       '@types/license-checker':
         specifier: ^25.0.3
         version: 25.0.6
-      '@types/minimatch':
-        specifier: ^5.1.2
-        version: 5.1.2
       '@types/three':
         specifier: ^0.166.0
         version: 0.166.0
@@ -21328,9 +21325,6 @@ packages:
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
 
-  oniguruma-to-es@4.3.3:
-    resolution: {integrity: sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==}
-
   oniguruma-to-es@4.3.5:
     resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
 
@@ -23577,9 +23571,6 @@ packages:
 
   regex-utilities@2.3.0:
     resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
-
-  regex@6.0.1:
-    resolution: {integrity: sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==}
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
@@ -33109,8 +33100,8 @@ snapshots:
       hast-util-to-html: 9.0.5
       hast-util-to-text: 4.0.2
       hastscript: 9.0.1
-      postcss: 8.5.3
-      postcss-nested: 6.2.0(postcss@8.5.3)
+      postcss: 8.4.38
+      postcss-nested: 6.2.0(postcss@8.4.38)
       unist-util-visit: 5.0.0
       unist-util-visit-parents: 6.0.1
 
@@ -38877,7 +38868,7 @@ snapshots:
     dependencies:
       '@shikijs/types': 3.8.1
       '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.3
+      oniguruma-to-es: 4.3.5
 
   '@shikijs/engine-javascript@4.0.2':
     dependencies:
@@ -49218,8 +49209,8 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
   magicast@0.5.2:
@@ -51492,12 +51483,6 @@ snapshots:
 
   oniguruma-parser@0.12.1: {}
 
-  oniguruma-to-es@4.3.3:
-    dependencies:
-      oniguruma-parser: 0.12.1
-      regex: 6.0.1
-      regex-recursion: 6.0.2
-
   oniguruma-to-es@4.3.5:
     dependencies:
       oniguruma-parser: 0.12.1
@@ -52936,6 +52921,11 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.3)
       string-hash: 1.1.3
 
+  postcss-nested@6.2.0(postcss@8.4.38):
+    dependencies:
+      postcss: 8.4.38
+      postcss-selector-parser: 6.1.2
+
   postcss-nested@6.2.0(postcss@8.5.3):
     dependencies:
       postcss: 8.5.3
@@ -54308,10 +54298,6 @@ snapshots:
 
   regex-utilities@2.3.0: {}
 
-  regex@6.0.1:
-    dependencies:
-      regex-utilities: 2.3.0
-
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
@@ -55551,7 +55537,7 @@ snapshots:
       '@types/node': 17.0.45
       '@types/sax': 1.2.7
       arg: 5.0.2
-      sax: 1.4.1
+      sax: 1.6.0
 
   skin-tone@2.0.0:
     dependencies:
@@ -57135,7 +57121,7 @@ snapshots:
   unifont@0.5.2:
     dependencies:
       css-tree: 3.1.0
-      ofetch: 1.4.1
+      ofetch: 1.5.1
       ohash: 2.0.11
 
   unimport@5.1.0:
@@ -58506,7 +58492,7 @@ snapshots:
   webpack-bundle-analyzer@4.10.2:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      acorn: 8.15.0
+      acorn: 8.16.0
       acorn-walk: 8.3.4
       commander: 7.2.0
       debounce: 1.2.1


### PR DESCRIPTION
## Current Behavior

Running `nx watch --projects nx -i -- nx build nx` enters an infinite rebuild loop. Two issues cause this:

1. **Overly broad output globs**: `build-base` declared `{projectRoot}/src/**/*.d.ts` and `legacy-post-build` declared `{projectRoot}/**/*.d.ts` as outputs. Cache restore deletes and recreates committed `.d.ts` files (like `schema.d.ts`, `perf-hooks.d.ts`) that aren't actual build outputs, triggering the file watcher.

2. **`declarationDir` in source tree**: With `declarationDir: "."`, tsc wrote `.d.ts` files into the source tree, making them vulnerable to cache restore churn.

## Expected Behavior

`nx watch` should not loop when the build produces the same outputs. Only files actually produced by a build target should be declared as outputs.

## Changes

- **Move `declarationDir` to `dist`**: Declaration files now go to `dist/` alongside `.js` output, keeping the source tree clean
- **Remove manual output overrides from `build-base`**: The `@nx/js/typescript` plugin correctly infers `{projectRoot}/dist`
- **Narrow `legacy-post-build` outputs**: Only declares `{projectRoot}/dist` since that's the only directory the executor writes to
- **Fix package.json exports**: Replace invalid `**` subpath patterns with `*` (Node.js exports only support `*` as wildcard)
- **Add `typesVersions`**: Ensures TypeScript projects using `moduleResolution: "node"` (which ignores exports maps) can still resolve `.d.ts` files in `dist/`
- **Remove `@types/minimatch`**: `minimatch@10` ships its own types; the `@types` package was outdated and conflicted
- **Add verbose watcher logging**: Behind `NX_VERBOSE_LOGGING`, shows which files were created/updated/deleted by the workspace watcher