### PR TITLE
fix(devkit): add timing guidance to TaskResult and remove unintentional spread

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycle.ts
@@ -9,6 +9,10 @@ import { TaskStatus } from './tasks-runner';
 
 /**
  * The result of a completed {@link Task}
+ *
+ * Task timing information (start and end timestamps) is available
+ * on the {@link Task} object itself via {@link Task.startTime} and
+ * {@link Task.endTime}.
  */
 export interface TaskResult {
   task: Task;

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -622,7 +622,6 @@ export class TaskOrchestrator {
         task.startTime = result.startTime;
         task.endTime = result.endTime;
         return {
-          ...result,
           code: result.success ? 0 : 1,
           task,
           status: (result.success ? 'success' : 'failure') as TaskStatus,


### PR DESCRIPTION
## Current Behavior

The `TaskResult` interface has no JSDoc guidance about where to find task timing information. Users looking at the [TaskResult reference docs](https://nx.dev/docs/reference/devkit/TaskResult) don't see `startTime`/`endTime` and have no indication that timing is available on the nested `Task` object.

Additionally, the batch execution path in [`task-orchestrator.ts`](https://github.com/nrwl/nx/blob/master/packages/nx/src/tasks-runner/task-orchestrator.ts#L625) uses `...result` to spread the batch `TaskResult` (from `misc-interfaces.ts`) onto the lifecycle `TaskResult`, which unintentionally leaks `startTime`, `endTime`, and `success` properties onto the object. This only happens for batch tasks, not for regular tasks, making the behavior inconsistent.

## Expected Behavior

- The `TaskResult` JSDoc now points users to `Task.startTime` and `Task.endTime` for timing information, which will surface on the [generated reference docs](https://nx.dev/docs/reference/devkit/TaskResult)
- The `...result` spread is removed from the batch path so that only the intended `TaskResult` properties (`code`, `task`, `status`, `terminalOutput`) are set — timing stays on the `Task` object where it belongs (already copied via `task.startTime = result.startTime` / `task.endTime = result.endTime` on the lines above)

## Related Issue(s)

N/A