### PR TITLE
feat(repo): add nx-labs repo target and use glob pattern for update-all-repos

### DIFF
--- a/tools/update-repos/project.json
+++ b/tools/update-repos/project.json
@@ -39,6 +39,13 @@
         "command": "node dist/update-repos/src/update-repo.js nx-console"
       }
     },
+    "update-nx-labs-repo": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build-base"],
+      "options": {
+        "command": "node dist/update-repos/src/update-repo.js nx-labs"
+      }
+    },
     "update-repos": {
       "executor": "nx:run-commands",
       "dependsOn": ["update-ocean-repo", "update-nx-console-repo"],
@@ -48,12 +55,7 @@
     },
     "update-all-repos": {
       "executor": "nx:run-commands",
-      "dependsOn": [
-        "update-nx-repo",
-        "update-ocean-repo",
-        "update-nx-examples-repo",
-        "update-nx-console-repo"
-      ],
+      "dependsOn": ["update-*-repo"],
       "options": {
         "command": "echo '🎉 All repositories updated successfully!'"
       }


### PR DESCRIPTION
## Current Behavior

The `update-all-repos` target explicitly lists each repo target in its `dependsOn`. Adding a new repo requires updating this list manually. There is no target for updating the nx-labs repo.

## Expected Behavior

- New `update-nx-labs-repo` target added for updating the nx-labs repository
- `update-all-repos` uses a `update-*-repo` glob pattern in `dependsOn`, so new repo targets are automatically picked up