### PR TITLE
fix(core): detect package manager from workspace root in pnpm workspaces

### DIFF
--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -61,18 +61,28 @@ export interface PackageManagerCommands {
  */
 export function detectPackageManager(dir: string = ''): PackageManager {
   const nxJson = readNxJson();
-  return (
-    nxJson.cli?.packageManager ??
-    (existsSync(join(dir, 'bun.lockb')) || existsSync(join(dir, 'bun.lock'))
-      ? 'bun'
-      : existsSync(join(dir, 'yarn.lock'))
-        ? 'yarn'
-        : existsSync(join(dir, 'pnpm-lock.yaml'))
-          ? 'pnpm'
-          : existsSync(join(dir, 'package-lock.json'))
-            ? 'npm'
-            : detectInvokedPackageManager())
-  );
+  if (nxJson.cli?.packageManager) {
+    return nxJson.cli.packageManager;
+  }
+
+  const dirsToCheck =
+    dir && dir !== workspaceRoot ? [dir, workspaceRoot] : [workspaceRoot];
+  for (const d of dirsToCheck) {
+    if (existsSync(join(d, 'bun.lockb')) || existsSync(join(d, 'bun.lock'))) {
+      return 'bun';
+    }
+    if (existsSync(join(d, 'yarn.lock'))) {
+      return 'yarn';
+    }
+    if (existsSync(join(d, 'pnpm-lock.yaml'))) {
+      return 'pnpm';
+    }
+    if (existsSync(join(d, 'package-lock.json'))) {
+      return 'npm';
+    }
+  }
+
+  return detectInvokedPackageManager();
 }
 
 /**


### PR DESCRIPTION
## Current Behavior

`detectPackageManager` only checks the provided `dir` argument for lockfiles. In a pnpm workspace, the lockfile (`pnpm-lock.yaml`) lives at the workspace root, not in subdirectories. When `nx:run-script` calls `detectPackageManager` from a project subdirectory, no lockfile is found and it incorrectly falls back to npm, causing npm warnings.

## Expected Behavior

`detectPackageManager` should also check `workspaceRoot` as a fallback when no lockfile is found in `dir`. This ensures pnpm workspaces (and other workspace setups where the lockfile is at the root) are correctly detected regardless of the current directory.

## Related Issue(s)

Fixes #32579
