### PR TITLE
fix(angular): prevent default compiler options from overriding user tsconfig

### DIFF
--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -53,10 +53,24 @@ export async function setupCompilation(
   options: SetupCompilationOptions
 ) {
   const { readConfiguration } = await loadCompilerCli();
+  const tsConfigPath = config.source?.tsconfigPath ?? options.tsConfig;
+
+  // Read the user's raw tsconfig to discover which compilerOptions they've
+  // explicitly set so we don't override them with our defaults.
+  const userTsConfig = ts.readConfigFile(tsConfigPath, ts.sys.readFile);
+  const userCompilerOptions = userTsConfig.config?.compilerOptions ?? {};
+
+  // Only apply defaults for keys the user hasn't explicitly configured.
+  const defaults = Object.fromEntries(
+    Object.entries(DEFAULT_NG_COMPILER_OPTIONS).filter(
+      ([key]) => !(key in userCompilerOptions)
+    )
+  );
+
   const { options: tsCompilerOptions, rootNames } = readConfiguration(
-    config.source?.tsconfigPath ?? options.tsConfig,
+    tsConfigPath,
     {
-      ...DEFAULT_NG_COMPILER_OPTIONS,
+      ...defaults,
       ...(options.useTsProjectReferences
         ? {
             sourceMap: false,


### PR DESCRIPTION
## Current Behavior

`DEFAULT_NG_COMPILER_OPTIONS` is spread as `existingOptions` into `readConfiguration`, which gives them higher precedence than values in the user's tsconfig. This silently overrides user-defined `compilerOptions` like `sourceMap`, `declaration`, etc.

## Expected Behavior

User-defined `compilerOptions` in tsconfig should always take precedence over `DEFAULT_NG_COMPILER_OPTIONS`. The defaults should only fill in values the user hasn't explicitly configured.

## Related Issue(s)

Fixes #32595
