### PR TITLE
fix(maven): make install targets noop when maven.install.skip=true

### DIFF
--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/NxTargetFactory.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/NxTargetFactory.kt
@@ -41,6 +41,25 @@ class NxTargetFactory(
 ) {
   private val log: Logger = LoggerFactory.getLogger(NxTargetFactory::class.java)
 
+  /**
+   * Maps lifecycle phases to the Maven property that skips them.
+   * When a property is set to "true", the corresponding phase becomes a cacheable noop.
+   */
+  private val phaseSkipProperties = mapOf(
+    "process-resources" to "maven.resources.skip",
+    "compile" to "maven.main.skip",
+    "test" to "maven.test.skip",
+    "install" to "maven.install.skip",
+    "deploy" to "maven.deploy.skip"
+  )
+
+  /**
+   * Check if a phase should be skipped based on Maven properties.
+   */
+  private fun isPhaseSkipped(phase: String, project: MavenProject): Boolean {
+    val skipProperty = phaseSkipProperties[phase] ?: return false
+    return project.properties.getProperty(skipProperty)?.toBoolean() == true
+  }
 
   fun createNxTargets(
     project: MavenProject,
@@ -268,15 +287,15 @@ class NxTargetFactory(
     val goalsForPhase = phaseGoals[phase]
     val hasGoals = goalsForPhase?.isNotEmpty() == true
 
-    // If maven.install.skip=true, make install phase a cacheable noop
+    // If the phase has a skip property set to true, make it a cacheable noop.
     // The target still acts as a sync point in the task graph but avoids
-    // spinning up the batch runner for a goal that would just skip anyway
-    val isSkippedInstall = phase == "install" &&
-      project.properties.getProperty("maven.install.skip")?.toBoolean() == true
+    // spinning up the batch runner for a goal that would just skip anyway.
+    val isSkipped = isPhaseSkipped(phase, project)
 
     // Create target for all phases - either with goals or as noop
-    val target = if (isSkippedInstall) {
-      log.info("Creating noop install target for ${project.artifactId} (maven.install.skip=true)")
+    val target = if (isSkipped) {
+      val skipProp = phaseSkipProperties[phase]
+      log.info("Creating noop $phase target for ${project.artifactId} ($skipProp=true)")
       createNoopPhaseTarget(phase)
     } else {
       createPhaseBatchTarget(project, phase, goalsForPhase ?: emptyList(), externalDependencies)
@@ -326,19 +345,19 @@ class NxTargetFactory(
     val hasGoals = goalsForPhase?.isNotEmpty() == true
     val ciPhaseName = "${applyPrefix(phase)}-ci"
 
-    // If maven.install.skip=true, make install CI phase a cacheable noop
-    val isSkippedInstall = phase == "install" &&
-      project.properties.getProperty("maven.install.skip")?.toBoolean() == true
+    // If the phase has a skip property set to true, make it a cacheable noop
+    val isSkipped = isPhaseSkipped(phase, project)
 
     // Test and later phases get a CI counterpart - but only if they have goals
-    if (!isSkippedInstall && !shouldCreateCiPhase(hasGoals, phase)) {
+    if (!isSkipped && !shouldCreateCiPhase(hasGoals, phase)) {
       log.info("Skipping noop CI phase target '$ciPhaseName' (no goals)")
       return
     }
 
     // Create CI targets for phases with goals, or noop for test/structural phases
-    val ciTarget = if (isSkippedInstall) {
-      log.info("Creating noop install CI target for ${project.artifactId} (maven.install.skip=true)")
+    val ciTarget = if (isSkipped) {
+      val skipProp = phaseSkipProperties[phase]
+      log.info("Creating noop $phase CI target for ${project.artifactId} ($skipProp=true)")
       createNoopPhaseTarget(phase)
     } else if (hasGoals && phase != "test") {
       createPhaseBatchTarget(project, phase, goalsForPhase!!, externalDependencies)

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/NxTargetFactory.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/NxTargetFactory.kt
@@ -268,8 +268,19 @@ class NxTargetFactory(
     val goalsForPhase = phaseGoals[phase]
     val hasGoals = goalsForPhase?.isNotEmpty() == true
 
+    // If maven.install.skip=true, make install phase a cacheable noop
+    // The target still acts as a sync point in the task graph but avoids
+    // spinning up the batch runner for a goal that would just skip anyway
+    val isSkippedInstall = phase == "install" &&
+      project.properties.getProperty("maven.install.skip")?.toBoolean() == true
+
     // Create target for all phases - either with goals or as noop
-    val target = createPhaseBatchTarget(project, phase, goalsForPhase ?: emptyList(), externalDependencies)
+    val target = if (isSkippedInstall) {
+      log.info("Creating noop install target for ${project.artifactId} (maven.install.skip=true)")
+      createNoopPhaseTarget(phase)
+    } else {
+      createPhaseBatchTarget(project, phase, goalsForPhase ?: emptyList(), externalDependencies)
+    }
 
 
     target.dependsOn = target.dependsOn ?: JsonArray()
@@ -315,14 +326,21 @@ class NxTargetFactory(
     val hasGoals = goalsForPhase?.isNotEmpty() == true
     val ciPhaseName = "${applyPrefix(phase)}-ci"
 
+    // If maven.install.skip=true, make install CI phase a cacheable noop
+    val isSkippedInstall = phase == "install" &&
+      project.properties.getProperty("maven.install.skip")?.toBoolean() == true
+
     // Test and later phases get a CI counterpart - but only if they have goals
-    if (!shouldCreateCiPhase(hasGoals, phase)) {
+    if (!isSkippedInstall && !shouldCreateCiPhase(hasGoals, phase)) {
       log.info("Skipping noop CI phase target '$ciPhaseName' (no goals)")
       return
     }
 
     // Create CI targets for phases with goals, or noop for test/structural phases
-    val ciTarget = if (hasGoals && phase != "test") {
+    val ciTarget = if (isSkippedInstall) {
+      log.info("Creating noop install CI target for ${project.artifactId} (maven.install.skip=true)")
+      createNoopPhaseTarget(phase)
+    } else if (hasGoals && phase != "test") {
       createPhaseBatchTarget(project, phase, goalsForPhase!!, externalDependencies)
     } else {
       // Noop for test phase (will be orchestrated by atomized tests) or structural phases

--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/NxTargetFactory.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/NxTargetFactory.kt
@@ -296,7 +296,7 @@ class NxTargetFactory(
     val target = if (isSkipped) {
       val skipProp = phaseSkipProperties[phase]
       log.info("Creating noop $phase target for ${project.artifactId} ($skipProp=true)")
-      createNoopPhaseTarget(phase)
+      createSkippedPhaseTarget(project, phase)
     } else {
       createPhaseBatchTarget(project, phase, goalsForPhase ?: emptyList(), externalDependencies)
     }
@@ -358,7 +358,7 @@ class NxTargetFactory(
     val ciTarget = if (isSkipped) {
       val skipProp = phaseSkipProperties[phase]
       log.info("Creating noop $phase CI target for ${project.artifactId} ($skipProp=true)")
-      createNoopPhaseTarget(phase)
+      createSkippedPhaseTarget(project, phase)
     } else if (hasGoals && phase != "test") {
       createPhaseBatchTarget(project, phase, goalsForPhase!!, externalDependencies)
     } else {
@@ -529,6 +529,18 @@ class NxTargetFactory(
   ): NxTarget {
     log.info("Creating noop target for phase '$phase' (no goals)")
     return NxTarget("nx:noop", null, cache = true, continuous = false)
+  }
+
+  private fun createSkippedPhaseTarget(
+    project: MavenProject,
+    phase: String
+  ): NxTarget {
+    log.info("Creating skipped phase target for '$phase' (no goals)")
+    val options = JsonObject()
+    options.addProperty("phase", phase)
+    options.add("goals", JsonArray())
+    options.addProperty("project", "${project.groupId}:${project.artifactId}")
+    return NxTarget("@nx/maven:maven", options, cache = true, continuous = false)
   }
 
   private fun createSimpleGoalTarget(


### PR DESCRIPTION
When a Maven project sets maven.install.skip=true, the install:install goal is a no-op at runtime. However, the NxTargetFactory still generated a full batch executor target with cache:false, causing unnecessary Maven invocations on every CI agent. This led to flaky failures in DTE when the batch runner's graph setup failed on some agents.

Now detects maven.install.skip=true and emits an nx:noop target with cache:true instead. The target still acts as a synchronization point in the task graph (dependsOn chain is preserved) but avoids spinning up the batch runner entirely.

<img width="2124" height="842" alt="image" src="https://github.com/user-attachments/assets/b6c09b3e-c34e-45f8-9c33-2d6ce493bc3d" />

