### PR TITLE
fix(bundling): disable swc input source map resolution

### DIFF
--- a/packages/rollup/src/plugins/swc.ts
+++ b/packages/rollup/src/plugins/swc.ts
@@ -7,6 +7,7 @@ export function swc(): Plugin {
     transform(code, filename) {
       return transform(code, {
         filename,
+        inputSourceMap: false,
         jsc: {
           transform: {
             react: { runtime: 'automatic' },


### PR DESCRIPTION
## Current Behavior

When using `compiler: 'swc'` with `useLegacyTypescriptPlugin: false` in rollup config, builds fail with errors like:

```
ERROR failed to read input source map: failed to find input source map file "index.js.map"
```

SWC defaults `inputSourceMap` to `true`, causing it to look for `.js.map` files for TypeScript source inputs that obviously don't have them.

## Expected Behavior

Builds should succeed without source map resolution errors. Rollup handles source maps via its own output pipeline — the SWC transform step should not independently try to resolve input source maps.

## Related Issue(s)

Fixes #32671