### PR TITLE
fix(core): resolve published nx migrate package resolution

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -3,6 +3,7 @@ import { exec, execSync, type StdioOptions } from 'child_process';
 import { prompt } from 'enquirer';
 import { handleImport } from '../../utils/handle-import';
 import { dirname, join } from 'path';
+import { createRequire } from 'module';
 import { joinPathFragments } from '../../utils/path';
 import {
   clean,
@@ -898,20 +899,46 @@ function createInstalledPackageVersionsResolver(
   root: string
 ): MigratorOptions['getInstalledPackageVersion'] {
   const cache: Record<string, string> = {};
+  const nxRequires = getNxRequirePaths(root).map((path) =>
+    createRequire(join(path, 'package.json'))
+  );
 
   function getInstalledPackageVersion(
     packageName: string,
     overrides?: Record<string, string>
   ): string | null {
-    try {
-      if (overrides?.[packageName]) {
-        return overrides[packageName];
+    if (overrides?.[packageName]) {
+      return overrides[packageName];
+    }
+
+    if (packageName === 'nx') {
+      const nxVersion =
+        cache[packageName] ??
+        (() => {
+          for (const req of nxRequires) {
+            try {
+              const packageJsonPath = req.resolve('nx/package.json');
+              if (packageJsonPath.startsWith(workspaceRoot)) {
+                return readJsonFile<PackageJson>(packageJsonPath).version;
+              }
+            } catch {}
+          }
+
+          return getInstalledPackageVersion('@nrwl/workspace', overrides);
+        })();
+
+      if (nxVersion) {
+        cache[packageName] = nxVersion;
       }
 
+      return nxVersion;
+    }
+
+    try {
       if (!cache[packageName]) {
         const { packageJson, path } = readModulePackageJson(
           packageName,
-          getNxRequirePaths()
+          getNxRequirePaths(root)
         );
         // old workspaces would have the temp installation of nx in the cache,
         // so the resolved package is not the one we need
@@ -923,14 +950,6 @@ function createInstalledPackageVersionsResolver(
 
       return cache[packageName];
     } catch {
-      // Support migrating old workspaces without nx package
-      if (packageName === 'nx') {
-        cache[packageName] = getInstalledPackageVersion(
-          '@nrwl/workspace',
-          overrides
-        );
-        return cache[packageName];
-      }
       return null;
     }
   }

--- a/packages/nx/src/utils/provenance.ts
+++ b/packages/nx/src/utils/provenance.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'child_process';
+import { createRequire } from 'module';
 import { join } from 'path';
 import { promisify } from 'util';
 import { readJsonFile } from './fileutils';
@@ -168,7 +169,7 @@ export class ProvenanceError extends Error {
 }
 
 export function getNxPackageGroup(): string[] {
-  const packageJsonPath = join(__dirname, '../../package.json');
+  const packageJsonPath = createRequire(__filename).resolve('nx/package.json');
   const packageJson = readJsonFile(packageJsonPath);
 
   if (!packageJson['nx-migrations']?.packageGroup) {


### PR DESCRIPTION
## Current Behavior

When `nx migrate latest` runs, it installs the target version of `nx` into a temporary directory and executes that published CLI. During migration, Nx checks whether `nx` is already installed in the workspace by resolving `nx/package.json`.

This used to resolve through the workspace-oriented lookup paths, so migrate correctly detected the workspace-installed `nx` package and expanded the first-party Nx package group.

That changed recently with `chore(core): build nx to local dist and use nodenext (#34111)`. As part of that work, the published `nx` package gained an `exports` map. In Node, a package with `name: "nx"` and `exports` can self-reference by package name. As a result, when code running inside the temporary published `nx` package resolves `nx/package.json`, Node now resolves that request back to the temporary package itself.

The resolved path points outside the workspace root, so migrate's existing safety check treats `nx` as not installed in the workspace. Once that happens, migrate only updates `nx` and never expands the rest of the first-party Nx package group.

Separately, provenance package-group lookup assumes a source-layout-relative path to `package.json`, which does not hold for published artifacts built into local `dist/`.

## Expected Behavior

Published temporary migrate CLIs should still resolve the workspace-installed `nx` package when migrate determines what is installed in the workspace. That preserves the existing package-group migration behavior even after the recent `exports`-based packaging change.

Provenance package-group lookup should resolve the manifest of the currently running `nx` package in a way that works for published artifacts as well as source checkouts.