### PR TITLE
feat(core): auto-open browser for Cloud setup URL during create-nx-workspace

### DIFF
--- a/packages/create-nx-workspace/package.json
+++ b/packages/create-nx-workspace/package.json
@@ -34,6 +34,7 @@
     "chalk": "catalog:",
     "enquirer": "catalog:",
     "flat": "^5.0.2",
+    "open": "^8.4.0",
     "ora": "5.3.0",
     "tmp": "~0.2.1",
     "tslib": "catalog:typescript",

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -16,6 +16,7 @@ import {
   createNxCloudOnboardingUrl,
   getNxCloudInfo,
   getSkippedNxCloudInfo,
+  openCloudSetupUrl,
   readNxCloudToken,
   setNeverConnectToCloud,
 } from './utils/nx/nx-cloud';
@@ -287,6 +288,11 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
       options.completionMessageKey,
       name
     );
+
+    // Auto-open the Cloud setup URL in the browser when user selected 'yes'
+    if (!options.skipCloudConnect) {
+      await openCloudSetupUrl(connectUrl);
+    }
   } else if (isTemplate && (nxCloud === 'skip' || nxCloud === 'never')) {
     // Strip marker comments from README
     const readmeUpdated = addConnectUrlToReadme(directory, undefined);

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -1,4 +1,5 @@
 import { VcsPushStatus } from '../git/git';
+import { isCI } from '../ci/is-ci';
 import { CLIOutput } from '../output';
 import {
   getCompletionMessage,
@@ -146,6 +147,19 @@ export function getSkippedNxCloudInfo() {
   const out = new CLIOutput(false);
   out.success(getSkippedCloudMessage());
   return out.getOutput();
+}
+
+export async function openCloudSetupUrl(connectUrl: string): Promise<void> {
+  if (isCI()) {
+    return;
+  }
+
+  try {
+    const open = require('open');
+    await open(connectUrl);
+  } catch {
+    // Fail gracefully — the URL is already displayed in the terminal banner
+  }
 }
 
 export function setNeverConnectToCloud(directory: string): void {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2745,6 +2745,9 @@ importers:
       flat:
         specifier: ^5.0.2
         version: 5.0.2
+      open:
+        specifier: ^8.4.0
+        version: 8.4.2
       ora:
         specifier: 5.3.0
         version: 5.3.0


### PR DESCRIPTION
## Current Behavior

When a user selects "yes" to connect to Nx Cloud during `create-nx-workspace`, the Cloud setup URL is only displayed in the terminal banner. The user must manually click or copy the link to complete onboarding.

## Expected Behavior

After displaying the banner, the setup URL is automatically opened in the user's default browser, removing friction at the critical Cloud conversion moment.

- Skips browser open in CI environments (`CI=true`, GitHub Actions, etc.)
- Fails gracefully if the browser cannot be opened (e.g., headless/no display server) — the URL remains visible in the terminal
- Only triggers when user actually connected to Cloud (not for "Maybe later" / `skipCloudConnect`)

## Related Issue(s)

Fixes NXC-4112