### PR TITLE
fix(core): prevent batch executor error on prematurely completed tasks

### DIFF
--- a/packages/nx/src/tasks-runner/tasks-schedule.spec.ts
+++ b/packages/nx/src/tasks-runner/tasks-schedule.spec.ts
@@ -1115,6 +1115,139 @@ describe('TasksSchedule', () => {
     });
   });
 
+  describe('batch scheduling with prematurely completed tasks', () => {
+    let taskSchedule: TasksSchedule;
+    let taskGraph: TaskGraph;
+    let lib1Build: Task;
+    let app1Build: Task;
+    let originalBatchMode: string | undefined;
+
+    beforeEach(async () => {
+      originalBatchMode = process.env['NX_BATCH_MODE'];
+      process.env['NX_BATCH_MODE'] = 'true';
+
+      lib1Build = createMockTask('lib1:build');
+      app1Build = createMockTask('app1:build');
+      const app2Build = createMockTask('app2:build');
+
+      taskGraph = {
+        tasks: {
+          'lib1:build': lib1Build,
+          'app1:build': app1Build,
+          'app2:build': app2Build,
+        },
+        dependencies: {
+          'lib1:build': [],
+          'app1:build': ['lib1:build'],
+          'app2:build': ['lib1:build'],
+        },
+        continuousDependencies: {
+          'lib1:build': [],
+          'app1:build': [],
+          'app2:build': [],
+        },
+        roots: ['lib1:build'],
+      };
+
+      jest.spyOn(nxJsonUtils, 'readNxJson').mockReturnValue({});
+      jest.spyOn(executorUtils, 'getExecutorInformation').mockReturnValue({
+        schema: {
+          version: 2,
+          properties: {},
+        },
+        implementationFactory: jest.fn(),
+        batchImplementationFactory: jest.fn(),
+        isNgCompat: true,
+        isNxExecutor: true,
+      });
+
+      const projectGraph: ProjectGraph = {
+        nodes: {
+          lib1: {
+            name: 'lib1',
+            type: 'lib',
+            data: {
+              root: 'lib1',
+              targets: {
+                build: {
+                  executor: 'awesome-executors:build',
+                },
+              },
+            },
+          },
+          app1: {
+            name: 'app1',
+            type: 'app',
+            data: {
+              root: 'app1',
+              targets: {
+                build: {
+                  executor: 'awesome-executors:build',
+                },
+              },
+            },
+          },
+          app2: {
+            name: 'app2',
+            type: 'app',
+            data: {
+              root: 'app2',
+              targets: {
+                build: {
+                  executor: 'awesome-executors:build',
+                },
+              },
+            },
+          },
+        } as any,
+        dependencies: {
+          lib1: [],
+          app1: [
+            {
+              source: 'app1',
+              target: 'lib1',
+              type: DependencyType.static,
+            },
+          ],
+          app2: [
+            {
+              source: 'app2',
+              target: 'lib1',
+              type: DependencyType.static,
+            },
+          ],
+        },
+        externalNodes: {},
+        version: '5',
+      };
+
+      taskHistory.getEstimatedTaskTimings.mockReturnValue({});
+      taskSchedule = new TasksSchedule(projectGraph, taskGraph, {
+        lifeCycle,
+      });
+      await taskSchedule.init();
+    });
+
+    afterEach(() => {
+      process.env['NX_BATCH_MODE'] = originalBatchMode;
+    });
+
+    it('should not crash when a dependent task was prematurely completed before batch scheduling', async () => {
+      // Simulate a premature task failure: app1:build is completed
+      // before it or its dependency lib1:build are scheduled.
+      // This removes app1 from notScheduledTaskGraph.
+      taskSchedule.complete(['app1:build']);
+
+      await taskSchedule.scheduleNextTasks();
+
+      const batch = taskSchedule.nextBatch();
+      expect(batch).not.toBeNull();
+      expect(batch.taskGraph.tasks).not.toHaveProperty('app1:build');
+      expect(batch.taskGraph.tasks).toHaveProperty('lib1:build');
+      expect(batch.taskGraph.tasks).toHaveProperty('app2:build');
+    });
+  });
+
   describe('nextTask with filter', () => {
     let taskSchedule: TasksSchedule;
     let discreteTask: Task;

--- a/packages/nx/src/tasks-runner/tasks-schedule.ts
+++ b/packages/nx/src/tasks-runner/tasks-schedule.ts
@@ -75,6 +75,11 @@ export class TasksSchedule {
     for (const taskId of taskIds) {
       this.completedTasks.add(taskId);
       this.runningTasks.delete(taskId);
+      delete this.reverseTaskDeps[taskId];
+    }
+    const removedSet = new Set(taskIds);
+    for (const [key, deps] of Object.entries(this.reverseTaskDeps)) {
+      this.reverseTaskDeps[key] = deps.filter((d) => !removedSet.has(d));
     }
     this.notScheduledTaskGraph = removeTasksFromTaskGraph(
       this.notScheduledTaskGraph,


### PR DESCRIPTION
## Current Behavior

When a task is prematurely completed (e.g., due to a failure that causes early termination) before its dependents have been scheduled, calling `scheduleNextTasks` crashes the batch executor. The crash occurs in `processTaskForBatches`, which traverses reverse dependencies and attempts to read `notScheduledTaskGraph.dependencies[task.id]` for a task that was already removed from `notScheduledTaskGraph` via `complete()`. This yields `undefined` for the dependencies array, causing downstream code to throw.

## Expected Behavior

When a task has been prematurely completed before batch scheduling runs, `processTaskForBatches` should skip that task gracefully rather than crashing. Tasks that were removed from `notScheduledTaskGraph` early should be detected and skipped during batch traversal.

## Related Issue(s)

Fixes NXC-4144