### PR TITLE
fix(core): copy pnpm install configuration to generated package.json

### DIFF
--- a/packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
@@ -878,6 +878,64 @@ describe('createPackageJson', () => {
       });
     });
 
+    it('should copy pnpm install configuration from root', () => {
+      spies.push(
+        jest
+          .spyOn(fs, 'existsSync')
+          .mockImplementation(
+            (path) =>
+              path === 'libs/lib1/package.json' || path === 'package.json'
+          )
+      );
+      spies.push(
+        jest
+          .spyOn(fileutilsModule, 'readJsonFile')
+          .mockImplementation((path) => {
+            if (path === 'package.json') {
+              return {
+                ...rootPackageJson(),
+                pnpm: {
+                  onlyBuiltDependencies: ['sharp', 'bcrypt'],
+                  neverBuiltDependencies: ['fsevents'],
+                  allowBuilds: { esbuild: true, rollup: false },
+                  supportedArchitectures: {
+                    os: ['linux'],
+                    cpu: ['x64'],
+                  },
+                  ignoredOptionalDependencies: ['fsevents'],
+                },
+              };
+            }
+            if (path === 'libs/lib1/package.json') {
+              return projectPackageJson();
+            }
+          })
+      );
+
+      expect(
+        createPackageJson('lib1', graph, {
+          root: '',
+        })
+      ).toEqual({
+        dependencies: {
+          random: '1.0.0',
+          typescript: '^4.8.4',
+        },
+        name: 'other-name',
+        version: '1.2.3',
+        pnpm: {
+          onlyBuiltDependencies: ['sharp', 'bcrypt'],
+          neverBuiltDependencies: ['fsevents'],
+          allowBuilds: { esbuild: true, rollup: false },
+          supportedArchitectures: {
+            os: ['linux'],
+            cpu: ['x64'],
+          },
+          ignoredOptionalDependencies: ['fsevents'],
+        },
+      });
+    });
+
     it('should add overrides (npm)', () => {
       spies.push(
         jest

--- a/packages/nx/src/plugins/js/package-json/create-package-json.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.ts
@@ -256,14 +256,19 @@ export function createPackageJson(
     }
 
     // object fields — merge with project-level overrides
-    for (const field of ['allowBuilds', 'supportedArchitectures'] as const) {
-      if (rootPnpm[field]) {
-        packageJson.pnpm ??= {};
-        packageJson.pnpm[field] = {
-          ...rootPnpm[field],
-          ...packageJson.pnpm[field],
-        };
-      }
+    if (rootPnpm.allowBuilds) {
+      packageJson.pnpm ??= {};
+      packageJson.pnpm.allowBuilds = {
+        ...rootPnpm.allowBuilds,
+        ...packageJson.pnpm.allowBuilds,
+      };
+    }
+    if (rootPnpm.supportedArchitectures) {
+      packageJson.pnpm ??= {};
+      packageJson.pnpm.supportedArchitectures = {
+        ...rootPnpm.supportedArchitectures,
+        ...packageJson.pnpm.supportedArchitectures,
+      };
     }
   }
 

--- a/packages/nx/src/plugins/js/package-json/create-package-json.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.ts
@@ -240,6 +240,33 @@ export function createPackageJson(
     };
   }
 
+  // pnpm install configuration
+  const rootPnpm = rootPackageJson.pnpm;
+  if (rootPnpm) {
+    // string[] fields — copy from root
+    for (const field of [
+      'onlyBuiltDependencies',
+      'neverBuiltDependencies',
+      'ignoredOptionalDependencies',
+    ] as const) {
+      if (rootPnpm[field]) {
+        packageJson.pnpm ??= {};
+        packageJson.pnpm[field] = rootPnpm[field];
+      }
+    }
+
+    // object fields — merge with project-level overrides
+    for (const field of ['allowBuilds', 'supportedArchitectures'] as const) {
+      if (rootPnpm[field]) {
+        packageJson.pnpm ??= {};
+        packageJson.pnpm[field] = {
+          ...rootPnpm[field],
+          ...packageJson.pnpm[field],
+        };
+      }
+    }
+  }
+
   // yarn
   if (rootPackageJson.resolutions && !options.skipOverrides) {
     packageJson.resolutions = {

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -85,6 +85,15 @@ export interface PackageJson {
   resolutions?: Record<string, string>;
   pnpm?: {
     overrides?: PackageOverride;
+    onlyBuiltDependencies?: string[];
+    neverBuiltDependencies?: string[];
+    allowBuilds?: Record<string, boolean>;
+    supportedArchitectures?: {
+      os?: string[];
+      cpu?: string[];
+      libc?: string[];
+    };
+    ignoredOptionalDependencies?: string[];
   };
   overrides?: PackageOverride;
   bin?: Record<string, string> | string;


### PR DESCRIPTION
## Current Behavior

The generated package.json (used for deployment) only copies `pnpm.overrides` from the root package.json. Other pnpm fields that affect `pnpm install` behavior are missing, causing issues like lifecycle scripts not running (pnpm v10+) or wrong platform-specific dependencies being installed.

## Expected Behavior

All pnpm configuration fields that affect `pnpm install` in a deployment context should be copied to the generated package.json:

- `onlyBuiltDependencies` — allowlist for lifecycle scripts (pnpm v10 requirement)
- `neverBuiltDependencies` — denylist for lifecycle scripts
- `allowBuilds` — unified replacement for the above two (pnpm 10.26+)
- `supportedArchitectures` — platform-specific dependency selection
- `ignoredOptionalDependencies` — skip optional dependencies

## Related Issue(s)

Fixes #30240