### PR TITLE
chore(gradle): use transitive deps for excludes

### DIFF
--- a/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/GradleRunner.kt
+++ b/packages/gradle/batch-runner/src/main/kotlin/dev/nx/gradle/runner/GradleRunner.kt
@@ -43,6 +43,10 @@ fun runTasksInParallel(
           "--parallel",
           "-Dorg.gradle.workers.max=$workersMax")
 
+  if (System.getenv("NX_GRADLE_NO_BUILD_CACHE") == "true") {
+    args.add("--no-build-cache")
+  }
+
   if (additionalArgs.isNotBlank()) {
     val splitResult = additionalArgs.split(" ")
     val filteredResult = splitResult.filter { it.isNotBlank() }

--- a/packages/gradle/src/executors/gradle/get-exclude-task.spec.ts
+++ b/packages/gradle/src/executors/gradle/get-exclude-task.spec.ts
@@ -85,7 +85,7 @@ describe('getExcludeTasks', () => {
     const targets = new Set<string>(['app3:deploy']);
     const runningTaskIds = new Set<string>(['app3:deploy']);
     const excludes = getExcludeTasks(targets, nodes, runningTaskIds);
-    expect(excludes).toEqual(new Set(['testApp1']));
+    expect(excludes).toEqual(new Set(['testApp1', 'lintApp1', 'buildApp2']));
   });
 
   it('should not exclude tasks that are in includeDependsOnTasks', () => {

--- a/packages/gradle/src/executors/gradle/get-exclude-task.ts
+++ b/packages/gradle/src/executors/gradle/get-exclude-task.ts
@@ -56,11 +56,10 @@ export function getExcludeTasks(
 
   for (const taskId of taskIds) {
     const [project, target] = taskId.split(':');
-    const taskDeps = nodes[project]?.data?.targets?.[target]?.dependsOn ?? [];
+    const allDeps = getAllDependsOn(nodes, project, target);
 
-    for (const dep of taskDeps) {
-      const depTaskId = resolveDepToTaskId(dep, project);
-      if (depTaskId && !runningTaskIds.has(depTaskId)) {
+    for (const depTaskId of allDeps) {
+      if (!runningTaskIds.has(depTaskId)) {
         const gradleTaskName = getGradleTaskNameWithNxTaskId(depTaskId, nodes);
         if (gradleTaskName && !includeDependsOnTasks.has(gradleTaskName)) {
           excludes.add(gradleTaskName);


### PR DESCRIPTION
## Current Behavior

When computing exclude tasks for Gradle batch execution, only direct `dependsOn` targets are considered. This means transitive dependencies are not excluded, causing Gradle to run tasks that should be skipped. Additionally, there is no way to disable Gradle's build cache during batch runs.

## Expected Behavior

Use `getAllDependsOn` to resolve the full transitive dependency graph when computing exclude tasks, ensuring all non-running dependent tasks are properly excluded from Gradle execution. Also support the `NX_GRADLE_NO_BUILD_CACHE` environment variable to optionally disable Gradle's build cache by passing `--no-build-cache`.

## Related Issue(s)

<!-- No related issue -->