### PR TITLE
feat(release): support multiple version plans for Docker releases

### DIFF
--- a/e2e/docker/src/docker.test.ts
+++ b/e2e/docker/src/docker.test.ts
@@ -70,6 +70,60 @@ describe('Docker E2Es', () => {
     });
 
     it(
+      'should allow releasing docker images with multiple version plans',
+      async () => {
+        const myapp = 'api';
+        createDockerApp(myapp);
+        addDockerReleaseConfiguration(myapp, {
+          skipVersionActions: false,
+          versionPlans: true,
+          versionSchemes: {
+            production: '{versionActionsVersion}',
+          },
+        });
+        addDockerPluginIfNotExists();
+
+        runCLI(`reset`);
+
+        const result = runCLI(`run ${myapp}:docker:build`);
+        expect(result.includes('Successfully ran target')).toBeTruthy();
+
+        createFile(
+          '.nx/version-plans/bump-patch.md',
+          `---
+${myapp}: patch
+---
+
+Patch docker app
+`
+        );
+        createFile(
+          '.nx/version-plans/bump-minor.md',
+          `---
+${myapp}: minor
+---
+
+Minor docker app
+`
+        );
+
+        await runCommandAsync(`git add .nx/version-plans`);
+        await runCommandAsync(
+          `git commit -m "chore: add docker version plans"`
+        );
+
+        const releaseResult = runCLI(
+          'release --dockerVersionScheme=production --yes --verbose'
+        );
+        expect(releaseResult.includes('Successfully ran target')).toBeTruthy();
+        expect(releaseResult).toContain(
+          'Image tagged with localhost:5000/test/api:0.1.0.'
+        );
+      },
+      TEN_MINS_MS
+    );
+
+    it(
       'should skip default tag when skipDefaultTag is true',
       () => {
         const myapp = uniq('myapp');
@@ -158,7 +212,14 @@ function addDockerPluginIfNotExists() {
   });
 }
 
-function addDockerReleaseConfiguration(name: string) {
+function addDockerReleaseConfiguration(
+  name: string,
+  options: {
+    skipVersionActions?: boolean;
+    versionPlans?: boolean;
+    versionSchemes?: Record<string, string>;
+  } = {}
+) {
   updateJson(`packages/${name}/project.json`, (projectJson) => {
     projectJson.release = {
       docker: {
@@ -172,10 +233,12 @@ function addDockerReleaseConfiguration(name: string) {
     nxJson.release = {
       projects: [name],
       projectsRelationship: 'independent',
+      versionPlans: options.versionPlans ?? false,
       releaseTagPattern: 'release/{projectName}/{version}',
       docker: {
         registryUrl: 'localhost:5000',
-        skipVersionActions: true,
+        skipVersionActions: options.skipVersionActions ?? true,
+        versionSchemes: options.versionSchemes,
       },
     };
     return nxJson;

--- a/packages/docker/src/release/version-utils.spec.ts
+++ b/packages/docker/src/release/version-utils.spec.ts
@@ -136,4 +136,25 @@ describe('handleDockerVersion {versionActionsVersion} integration', () => {
 
     expect(newVersion).toBe('9.9.9');
   });
+
+  it('ignores non-string versionActionsVersion values', async () => {
+    const finalConfigForProject: any = {
+      dockerOptions: {
+        repositoryName: 'repo',
+        registryUrl: undefined,
+        versionSchemes: { prod: '{versionActionsVersion}' },
+      },
+    };
+
+    const { newVersion } = await handleDockerVersion(
+      process.cwd(),
+      mockProjectNode,
+      finalConfigForProject,
+      'prod',
+      undefined,
+      { invalid: true }
+    );
+
+    expect(newVersion).toBeNull();
+  });
 });

--- a/packages/docker/src/release/version-utils.ts
+++ b/packages/docker/src/release/version-utils.ts
@@ -24,13 +24,17 @@ export async function handleDockerVersion(
   finalConfigForProject: FinalConfigForProject,
   dockerVersionScheme?: string,
   dockerVersion?: string,
-  versionActionsVersion?: string
+  versionActionsVersion?: unknown
 ) {
   // If the full docker image reference is provided, use it directly
   const nxDockerImageRefEnvOverride =
     process.env.NX_DOCKER_IMAGE_REF?.trim() || undefined;
   // If an explicit dockerVersion is provided, use it directly
   let newVersion: string | undefined;
+  const resolvedVersionActionsVersion =
+    typeof versionActionsVersion === 'string'
+      ? versionActionsVersion
+      : undefined;
 
   if (!nxDockerImageRefEnvOverride) {
     if (dockerVersion) {
@@ -52,7 +56,7 @@ export async function handleDockerVersion(
         projectGraphNode.name,
         versionScheme,
         availableVersionSchemes,
-        versionActionsVersion
+        resolvedVersionActionsVersion
       );
     }
   }

--- a/packages/nx/src/command-line/release/version/deriver-specifier-from-version-plans.ts
+++ b/packages/nx/src/command-line/release/version/deriver-specifier-from-version-plans.ts
@@ -1,4 +1,4 @@
-import { gt, inc, ReleaseType } from 'semver';
+import { compare, inc, ReleaseType } from 'semver';
 import type { ProjectGraphProjectNode } from '../../../config/project-graph';
 import { ReleaseGroupWithName } from '../config/filter-release-groups';
 import { GroupVersionPlan, ProjectsVersionPlan } from '../config/version-plans';
@@ -34,12 +34,17 @@ export async function deriveSpecifierFromVersionPlan(
           };
         }
         if (plan.projectVersionBumps[projectName]) {
-          const prevNewVersion = inc(currentVersion, acc.spec);
-          const nextNewVersion = inc(
+          const prevNewVersion = resolveDerivedVersion(
+            inc(currentVersion, acc.spec),
+            currentVersion,
+            acc.spec
+          );
+          const nextNewVersion = resolveDerivedVersion(
+            inc(currentVersion, plan.projectVersionBumps[projectName]),
             currentVersion,
             plan.projectVersionBumps[projectName]
           );
-          return gt(nextNewVersion, prevNewVersion)
+          return compare(nextNewVersion, prevNewVersion) > 0
             ? {
                 spec: plan.projectVersionBumps[projectName],
                 path: plan.relativePath,
@@ -67,9 +72,17 @@ export async function deriveSpecifierFromVersionPlan(
           };
         }
 
-        const prevNewVersion = inc(currentVersion, acc.spec);
-        const nextNewVersion = inc(currentVersion, plan.groupVersionBump);
-        return gt(nextNewVersion, prevNewVersion)
+        const prevNewVersion = resolveDerivedVersion(
+          inc(currentVersion, acc.spec),
+          currentVersion,
+          acc.spec
+        );
+        const nextNewVersion = resolveDerivedVersion(
+          inc(currentVersion, plan.groupVersionBump),
+          currentVersion,
+          plan.groupVersionBump
+        );
+        return compare(nextNewVersion, prevNewVersion) > 0
           ? {
               spec: plan.groupVersionBump,
               path: plan.relativePath,
@@ -90,4 +103,18 @@ export async function deriveSpecifierFromVersionPlan(
     bumpType: bumpType ?? 'none',
     versionPlanPath,
   };
+}
+
+function resolveDerivedVersion(
+  value: string | { version: string } | null | undefined,
+  currentVersion: string,
+  bumpType: ReleaseType
+): string {
+  if (!value) {
+    throw new Error(
+      `Unable to derive a version from current version "${currentVersion}" and version plan bump "${bumpType}".`
+    );
+  }
+
+  return typeof value === 'string' ? value : value.version;
 }

--- a/packages/nx/src/command-line/release/version/deriver-specifier-from-version-plans.ts
+++ b/packages/nx/src/command-line/release/version/deriver-specifier-from-version-plans.ts
@@ -9,7 +9,7 @@ export async function deriveSpecifierFromVersionPlan(
   projectLogger: ProjectLogger,
   releaseGroup: ReleaseGroupWithName,
   projectGraphNode: ProjectGraphProjectNode,
-  currentVersion: string
+  currentVersion: string | null
 ): Promise<{
   bumpType: SemverBumpType;
   versionPlanPath: string;
@@ -34,6 +34,9 @@ export async function deriveSpecifierFromVersionPlan(
           };
         }
         if (plan.projectVersionBumps[projectName]) {
+          if (!currentVersion) {
+            return acc;
+          }
           const prevNewVersion = resolveDerivedVersion(
             inc(currentVersion, acc.spec),
             currentVersion,
@@ -72,6 +75,9 @@ export async function deriveSpecifierFromVersionPlan(
           };
         }
 
+        if (!currentVersion) {
+          return acc;
+        }
         const prevNewVersion = resolveDerivedVersion(
           inc(currentVersion, acc.spec),
           currentVersion,
@@ -107,7 +113,7 @@ export async function deriveSpecifierFromVersionPlan(
 
 function resolveDerivedVersion(
   value: string | { version: string } | null | undefined,
-  currentVersion: string,
+  currentVersion: string | null,
   bumpType: ReleaseType
 ): string {
   if (!value) {

--- a/packages/nx/src/command-line/release/version/release-group-processor.spec.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.spec.ts
@@ -2,6 +2,7 @@
 const mocks = {
   deriveSpecifierFromConventionalCommits: jest.fn(),
   deriveSpecifierFromVersionPlan: jest.fn(),
+  handleDockerVersion: jest.fn(),
   resolveVersionActionsForProject: jest.fn(),
   resolveCurrentVersion: jest.fn(),
 };
@@ -10,6 +11,7 @@ const mocks = {
 const mockDeriveSpecifierFromConventionalCommits =
   mocks.deriveSpecifierFromConventionalCommits;
 const mockDeriveSpecifierFromVersionPlan = mocks.deriveSpecifierFromVersionPlan;
+const mockHandleDockerVersion = mocks.handleDockerVersion;
 const mockResolveVersionActionsForProject =
   mocks.resolveVersionActionsForProject;
 const mockResolveCurrentVersion = mocks.resolveCurrentVersion;
@@ -17,6 +19,10 @@ const mockResolveCurrentVersion = mocks.resolveCurrentVersion;
 jest.mock('./derive-specifier-from-conventional-commits', () => ({
   deriveSpecifierFromConventionalCommits: (...args: any[]) =>
     mocks.deriveSpecifierFromConventionalCommits(...args),
+}));
+
+jest.mock('@nx/docker/release/version-utils', () => ({
+  handleDockerVersion: (...args: any[]) => mocks.handleDockerVersion(...args),
 }));
 
 jest.mock('./version-actions', () => {
@@ -50,6 +56,7 @@ jest.mock('./resolve-current-version', () => ({
 import { createTreeWithEmptyWorkspace } from '../../../generators/testing-utils/create-tree-with-empty-workspace';
 import type { Tree } from '../../../generators/tree';
 import { readJson, updateJson } from '../../../generators/utils/json';
+import { ProjectsVersionPlan } from '../config/version-plans';
 import {
   createNxReleaseConfigAndPopulateWorkspace,
   createTestReleaseGroupProcessor,
@@ -1882,6 +1889,115 @@ describe('ReleaseGroupProcessor', () => {
           },
         }
       `);
+    });
+  });
+
+  describe('docker version handoff', () => {
+    it('should pass a string version to docker processing when multiple version plans exist', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          __default__ ({ "projectsRelationship": "independent" }):
+            - docker-app@0.0.1 [js] ({ "targets": { "docker:build": { "metadata": { "technologies": ["docker"] } } }, "release": { "docker": { "repositoryName": "test/docker-app" } } })
+        `,
+          {
+            versionPlans: true,
+            docker: {
+              versionSchemes: {
+                production: '{versionActionsVersion}',
+              },
+            },
+          },
+          mockResolveCurrentVersion
+        );
+
+      mockHandleDockerVersion.mockResolvedValue({
+        newVersion: '0.1.0',
+        logs: [],
+      });
+
+      const processor = await createTestReleaseGroupProcessor(
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters
+      );
+      const releaseGroup = processor['releaseGraph'].releaseGroups[0];
+      releaseGroup.resolvedVersionPlans = [
+        {
+          absolutePath: '/tmp/plan-patch.md',
+          relativePath: '.nx/version-plans/plan-patch.md',
+          fileName: 'plan-patch.md',
+          createdOnMs: 1,
+          message: 'Patch docker release',
+          projectVersionBumps: {
+            'docker-app': 'patch',
+          },
+          commit: null,
+        },
+        {
+          absolutePath: '/tmp/plan-minor.md',
+          relativePath: '.nx/version-plans/plan-minor.md',
+          fileName: 'plan-minor.md',
+          createdOnMs: 2,
+          message: 'Minor docker release',
+          projectVersionBumps: {
+            'docker-app': 'minor',
+          },
+          commit: null,
+        },
+      ] as ProjectsVersionPlan[];
+
+      await processor.processGroups();
+      await processor.processDockerProjects('production');
+
+      expect(mockHandleDockerVersion).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ name: 'docker-app' }),
+        expect.any(Object),
+        'production',
+        undefined,
+        '0.1.0'
+      );
+    });
+
+    it('should throw a clear error when docker processing receives a non-string project version', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          __default__ ({ "projectsRelationship": "independent" }):
+            - docker-app@0.0.1 [js] ({ "targets": { "docker:build": { "metadata": { "technologies": ["docker"] } } }, "release": { "docker": { "repositoryName": "test/docker-app" } } })
+        `,
+          {
+            docker: {
+              versionSchemes: {
+                production: '{versionActionsVersion}',
+              },
+            },
+          },
+          mockResolveCurrentVersion
+        );
+
+      const processor = await createTestReleaseGroupProcessor(
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters
+      );
+      const originalVersionData = processor['versionData'].get('docker-app');
+      processor['versionData'].set('docker-app', {
+        ...originalVersionData,
+        newVersion: { invalid: true },
+      });
+
+      await expect(
+        processor.processDockerProjects('production')
+      ).rejects.toThrow(
+        'Expected project "docker-app" to produce a string version before Docker versioning'
+      );
+      expect(mockHandleDockerVersion).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/nx/src/command-line/release/version/release-group-processor.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.ts
@@ -40,6 +40,23 @@ export const BUMP_TYPE_REASON_TEXT = {
     ', because this project uses docker and has been configured to skip VersionActions, ',
 } as const;
 
+function resolveVersionActionsVersionForDocker(
+  projectName: string,
+  newVersion: unknown
+): string | undefined {
+  if (newVersion == null) {
+    return undefined;
+  }
+
+  if (typeof newVersion === 'string') {
+    return newVersion;
+  }
+
+  throw new Error(
+    `Expected project "${projectName}" to produce a string version before Docker versioning, but received ${typeof newVersion}. This suggests a bug in Nx release version data handling.`
+  );
+}
+
 interface ReleaseGroupProcessorOptions {
   dryRun: boolean;
   verbose: boolean;
@@ -298,13 +315,17 @@ export class ReleaseGroupProcessor {
     for (const [project, finalConfigForProject] of dockerProjects.entries()) {
       const projectNode = this.projectGraph.nodes[project];
       const projectVersionData = this.versionData.get(project);
+      const versionActionsVersion = resolveVersionActionsVersionForDocker(
+        project,
+        projectVersionData?.newVersion
+      );
       const { newVersion, logs } = await handleDockerVersion(
         workspaceRoot,
         projectNode,
         finalConfigForProject,
         dockerVersionScheme,
         dockerVersion,
-        projectVersionData.newVersion
+        versionActionsVersion
       );
 
       logs.forEach((log) =>


### PR DESCRIPTION
## Current Behavior

When using Docker releases with version plans, if multiple version plans exist for a single project (e.g., both a patch and a minor bump), the version derivation logic would not correctly handle the comparison between different bump types. Additionally, there was no defensive type checking to ensure `versionActionsVersion` was a valid string before being passed to Docker version processing, which could lead to unexpected behavior when the version data contained non-string values.

## Expected Behavior

- Docker releases correctly support multiple version plans, selecting the highest version bump when multiple plans exist
- Only string values are passed to Docker version processing, with clear errors thrown for invalid types
- The `deriveSpecifierFromVersionPlan` function correctly handles `null` current versions by using the first available plan without comparison

## Summary of Changes

1. **Added `resolveVersionActionsVersionForDocker` helper function** (`packages/nx/src/command-line/release/version/release-group-processor.ts:43-57`)
   - Validates that `newVersion` is a string before passing to Docker versioning
   - Throws a clear error message for non-string values

2. **Updated `handleDockerVersion` to accept `unknown` type** (`packages/docker/src/release/version-utils.ts:27-30`)
   - Added defensive type checking to resolve only string values
   - Non-string values are treated as `undefined`

3. **Improved `deriveSpecifierFromVersionPlan` null handling** (`packages/nx/src/command-line/release/version/deriver-specifier-from-version-plans.ts`)
   - Added early return when `currentVersion` is null (first version plan is used without comparison)
   - Replaced `gt()` with `compare() > 0` for version comparison
   - Added `resolveDerivedVersion` helper to handle semver `inc()` return types

4. **Added comprehensive tests**
   - Unit test for multiple version plans with Docker releases
   - Unit test for non-string `versionActionsVersion` handling
   - E2E test for Docker releases with multiple version plans

## Test Plan

- [x] Unit tests pass: `nx run-many -t test -p nx docker`
- [x] E2E test added for multiple version plans scenario
- [x] Prepush validation passes

### Validation (tests fail without the fixes)

Reverted the fixes from `release-group-processor.ts` and `version-utils.ts`, then ran the test suites to confirm the new tests catch the bugs:

| Test | File | Failure without fix |
|------|------|---------------------|
| `should throw a clear error when docker processing receives a non-string project version` | `release-group-processor.spec.ts` | Passes `{invalid: true}` object through to Docker instead of throwing |
| `ignores non-string versionActionsVersion values` | `docker/version-utils.spec.ts` | Returns `"[object Object]"` instead of `null` |

All tests pass again after restoring the fixes. No other tests were affected.


-----
The code was written with help from:
* GPT-5.2 Extra High via Codex
* GLM 5.0 via OpenCode