### PR TITLE
docs(misc): add consistent next steps and tutorial links across getting started pages

### DIFF
--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -65,7 +65,7 @@ const learnGroups: SidebarItems = [
             link: 'getting-started/tutorials/understanding-your-workspace',
           },
           {
-            label: 'Reduce boilerplate',
+            label: 'Reducing boilerplate',
             link: 'getting-started/tutorials/reducing-configuration-boilerplate',
           },
           {

--- a/astro-docs/src/content/docs/getting-started/installation.mdoc
+++ b/astro-docs/src/content/docs/getting-started/installation.mdoc
@@ -124,3 +124,9 @@ nx migrate --run-migrations
 {% aside type="note" title="Update One Major Version at a Time" %}
 To avoid potential issues, it is [recommended to update one major version of Nx at a time](/docs/guides/tips-n-tricks/advanced-update#one-major-version-at-a-time-small-steps).
 {% /aside %}
+
+## Next steps
+
+- **Starting fresh?** → [Create a new workspace](/docs/getting-started/start-new-project)
+- **Have an existing project?** → [Add Nx to your project](/docs/getting-started/start-with-existing-project)
+- **New to Nx?** → [Follow the tutorial series](/docs/getting-started/tutorials/crafting-your-workspace) to learn core concepts hands-on

--- a/astro-docs/src/content/docs/getting-started/intro.mdoc
+++ b/astro-docs/src/content/docs/getting-started/intro.mdoc
@@ -99,7 +99,7 @@ Nx can also connect multiple repositories into a synthetic monorepo, letting you
 
 - **Starting fresh?** → [Create a new workspace](/docs/getting-started/start-new-project)
 - **Have an existing project?** → [Add Nx to your project](/docs/getting-started/start-with-existing-project)
-- **Want hands-on learning?** → [Follow a tutorial](/docs/getting-started/tutorials)
+- **New to Nx?** → [Follow the tutorial series](/docs/getting-started/tutorials/crafting-your-workspace) to learn core concepts hands-on
 - **Prefer video?** → [Learn with our video courses](https://nx.dev/courses)
 
 **Stay up to date** with our latest news by [⭐️ starring us on Github](https://github.com/nrwl/nx), [subscribing to our Youtube channel](https://www.youtube.com/@nxdevtools), [joining our Discord](https://go.nx.dev/community), [subscribing to our monthly tech newsletter](https://go.nrwl.io/nx-newsletter) or follow us [on X](https://x.com/nxdevtools), [Bluesky](https://bsky.app/profile/nx.dev) and [LinkedIn](https://www.linkedin.com/company/nxdevtools).

--- a/astro-docs/src/content/docs/getting-started/start-new-project.mdoc
+++ b/astro-docs/src/content/docs/getting-started/start-new-project.mdoc
@@ -48,3 +48,11 @@ This option gives you:
 - [Self-healing CI](/docs/features/ci-features/self-healing-ci) that automatically fixes common failures
 
 [Get started with Nx Cloud →](https://cloud.nx.app/get-started?utm_source=nx-docs&utm_medium=nx-cloud-onboarding&utm_campaign=start-new-project)
+
+## Next steps
+
+Once your workspace is set up:
+
+- **New to Nx?** → [Follow the tutorial series](/docs/getting-started/tutorials/crafting-your-workspace) to learn core concepts hands-on
+- **Set up your editor** → Install [Nx Console](/docs/getting-started/editor-setup) for VSCode or JetBrains
+- **Speed up CI** → Connect to [Nx Cloud](/docs/getting-started/nx-cloud) for remote caching and distributed tasks

--- a/astro-docs/src/content/docs/getting-started/start-with-existing-project.mdoc
+++ b/astro-docs/src/content/docs/getting-started/start-with-existing-project.mdoc
@@ -39,16 +39,14 @@ From here you can:
 
 ## In-depth guides
 
-{% cardgrid %}
+- [Add to an existing monorepo](/docs/guides/adopting-nx/adding-to-monorepo)
+- [Add to any project](/docs/guides/adopting-nx/adding-to-existing-project)
+- [Migrate from Angular CLI](/docs/technologies/angular/migration/angular)
+- [Import projects into your Nx workspace](/docs/guides/adopting-nx/import-project)
+- [And more...](/docs/guides/adopting-nx)
 
-{% linkcard title="Add to Existing Monorepo" href="/docs/guides/adopting-nx/adding-to-monorepo" /%}
+## Keep learning
 
-{% linkcard title="Add to Any Project" href="/docs/guides/adopting-nx/adding-to-existing-project" /%}
-
-{% linkcard title="Migrate from Angular CLI" href="/docs/technologies/angular/migration/angular" /%}
-
-{% linkcard title="Import Projects into Your Nx Workspace" href="/docs/guides/adopting-nx/import-project" /%}
-
-{% /cardgrid %}
-
-{% linkcard title="See more options" href="/docs/guides/adopting-nx" /%}
+- **New to Nx?** → [Follow the tutorial series](/docs/getting-started/tutorials/crafting-your-workspace) to learn core concepts hands-on
+- **Set up your editor** → Install [Nx Console](/docs/getting-started/editor-setup) for VSCode or JetBrains
+- **Prefer video?** → [Learn with our video courses](https://nx.dev/courses)


### PR DESCRIPTION
## Current Behavior

Getting started pages have inconsistent navigation patterns. Some use card grids, some use bullet lists, and some have no next steps at all. The new tutorial series is not linked from most getting started pages.

## Expected Behavior

All getting started pages use consistent bullet-list navigation with clear next steps. Every page links to the tutorial series so first-time users can discover it from any entry point.

For example, on the "Add to an existing project" page:

<img width="1011" height="709" alt="image" src="https://github.com/user-attachments/assets/6534d490-1bdf-4026-9962-0a60506564ce" />

### Changes

- **intro.mdoc**: Updated tutorial link from generic "Follow a tutorial" to "Follow the tutorial series" pointing to the first tutorial
- **installation.mdoc**: Added "Next steps" section linking to new project, existing project, and tutorial series
- **start-new-project.mdoc**: Added "Next steps" section with tutorial series, editor setup, and CI setup links
- **start-with-existing-project.mdoc**: Replaced card grid with bullet list for in-depth guides, added "Keep learning" section with tutorial series link
- **sidebar.mts**: Fixed label consistency ("Reduce boilerplate" → "Reducing boilerplate")