### PR TITLE
fix(core): remove unnecessary CORS wildcard from graph server

### DIFF
--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -649,8 +649,6 @@ async function startServer(
     // e.g curl --path-as-is http://localhost:9000/../fileInDanger.txt
     // by limiting the path to current directory only
 
-    res.setHeader('Access-Control-Allow-Origin', '*');
-
     const sanitizePath = basename(parsedUrl.pathname);
     if (sanitizePath === 'project-graph.json') {
       const requestFull = parsedUrl.searchParams.get('full') === 'true';


### PR DESCRIPTION
## Current Behavior

The `nx graph` HTTP server sets `Access-Control-Allow-Origin: *` on all responses, which is unnecessarily permissive.

## Expected Behavior

No CORS headers are set, since the graph UI is served from the same origin and does not require cross-origin access. NX Console uses injected JS functions rather than HTTP requests, so it is also unaffected.

## Related Issue(s)

N/A - cleanup of unnecessary header added in #20744