### PR TITLE
fix(webpack): bump postcss-loader to ^8.2.1 to eliminate transitive yaml@1.x CVE

### DIFF
--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -50,7 +50,7 @@
     "parse5": "4.0.0",
     "postcss": "^8.4.38",
     "postcss-import": "~14.1.0",
-    "postcss-loader": "^6.1.1",
+    "postcss-loader": "^8.2.1",
     "rxjs": "^7.8.0",
     "sass": "^1.85.0",
     "sass-embedded": "^1.83.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4252,8 +4252,8 @@ importers:
         specifier: ~14.1.0
         version: 14.1.0(postcss@8.5.3)
       postcss-loader:
-        specifier: ^6.1.1
-        version: 6.2.1(postcss@8.5.3)(webpack@5.101.3)
+        specifier: ^8.2.1
+        version: 8.2.1(@rspack/core@1.6.8(@swc/helpers@0.5.18))(postcss@8.5.3)(typescript@5.9.2)(webpack@5.101.3(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4))
       rxjs:
         specifier: ^7.8.0
         version: 7.8.2
@@ -22274,6 +22274,19 @@ packages:
       webpack:
         optional: true
 
+  postcss-loader@8.2.1:
+    resolution: {integrity: sha512-k98jtRzthjj3f76MYTs9JTpRqV1RaaMhEU0Lpw9OTmQZQdppg4B30VZ74BojuBHt3F4KyubHJoXCMUeM8Bqeow==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
+      postcss: ^7.0.0 || ^8.0.1
+      webpack: ^5.0.0
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
+
   postcss-logical@5.0.4:
     resolution: {integrity: sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==}
     engines: {node: ^12 || ^14 || >=16}
@@ -25758,8 +25771,8 @@ packages:
   underscore.string@2.4.0:
     resolution: {integrity: sha512-yxkabuCaIBnzfIvX3kBxQqCs0ar/bfJwDnFEHJUm/ZrRVhT3IItdRF5cZjARLzEnyQYtIUhsZ2LG2j3HidFOFQ==}
 
-  underscore@1.13.7:
-    resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -27277,8 +27290,8 @@ packages:
     resolution: {integrity: sha512-N47AqBDCMQmh6mBLmI6oqxryHRzi33aPFPsJhYy3VTUGCdLHYjGh4FZzpUjRlphaADBBkDmnkM/++KNIOHi5Rw==}
     hasBin: true
 
-  yaml@1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+  yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
   yaml@2.2.2:
@@ -41579,7 +41592,7 @@ snapshots:
 
   argparse@0.1.16:
     dependencies:
-      underscore: 1.13.7
+      underscore: 1.13.8
       underscore.string: 2.4.0
 
   argparse@1.0.10:
@@ -43515,7 +43528,7 @@ snapshots:
       import-fresh: 3.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 1.10.2
+      yaml: 1.10.3
 
   cosmiconfig@8.3.6(typescript@5.7.2):
     dependencies:
@@ -43989,7 +44002,7 @@ snapshots:
       cssnano-preset-default: 5.2.14(postcss@8.4.38)
       lilconfig: 2.1.0
       postcss: 8.4.38
-      yaml: 1.10.2
+      yaml: 1.10.3
 
   cssnano@6.1.2(postcss@8.5.3):
     dependencies:
@@ -52557,7 +52570,7 @@ snapshots:
   postcss-load-config@3.1.4(postcss@8.4.38)(ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(typescript@5.9.2)):
     dependencies:
       lilconfig: 2.1.0
-      yaml: 1.10.2
+      yaml: 1.10.3
     optionalDependencies:
       postcss: 8.4.38
       ts-node: 10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(typescript@5.9.2)
@@ -52641,6 +52654,18 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
       webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4)
+    transitivePeerDependencies:
+      - typescript
+
+  postcss-loader@8.2.1(@rspack/core@1.6.8(@swc/helpers@0.5.18))(postcss@8.5.3)(typescript@5.9.2)(webpack@5.101.3(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)):
+    dependencies:
+      cosmiconfig: 9.0.0(typescript@5.9.2)
+      jiti: 2.6.1
+      postcss: 8.5.3
+      semver: 7.7.4
+    optionalDependencies:
+      '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
+      webpack: 5.101.3(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - typescript
 
@@ -57045,7 +57070,7 @@ snapshots:
 
   underscore.string@2.4.0: {}
 
-  underscore@1.13.7: {}
+  underscore@1.13.8: {}
 
   undici-types@5.26.5: {}
 
@@ -59163,7 +59188,7 @@ snapshots:
     optionalDependencies:
       prettier: 2.8.7
 
-  yaml@1.10.2: {}
+  yaml@1.10.3: {}
 
   yaml@2.2.2: {}
 


### PR DESCRIPTION
## Current Behavior

`@nx/webpack` depends on `postcss-loader@^6.1.1`, which pulls in `cosmiconfig@7` → `yaml@1.x`. The `yaml@1.x` package has a known stack overflow vulnerability ([GHSA-48c2-rrv3-qjmp](https://github.com/advisories/GHSA-48c2-rrv3-qjmp)).

## Expected Behavior

By bumping `postcss-loader` to `^8.2.1`, the transitive dependency chain is eliminated entirely — `postcss-loader@8` uses `cosmiconfig@9`, which no longer depends on `yaml` at all. This is a cleaner fix than applying a `pnpm.overrides` workaround.

The upgrade is safe because:
- `postcss-loader@8` peer deps (`postcss ^7||^8`, `webpack ^5`) are unchanged
- The `implementation` option and function-based `postcssOptions` API used by `@nx/webpack` are fully supported in v8
- Nx already requires Node 18+, matching postcss-loader@8's engine requirement

## Related Issue(s)

Fixes #35025