### PR TITLE
fix(repo): resolve FreeBSD build disk space issue

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -419,21 +419,18 @@ jobs:
           NX_PREFER_TS_NODE: true
           PLAYWRIGHT_BROWSERS_PATH: 0
           NODE_VERSION: 22.16.0
+          NX_GRADLE_DISABLE: 'true'
         with:
           operating_system: freebsd
           version: '14.0'
           architecture: x86-64
-          environment_variables: DEBUG RUSTUP_IO_THREADS CI NX_PREFER_TS_NODE PLAYWRIGHT_BROWSERS_PATH NODE_VERSION
+          environment_variables: DEBUG RUSTUP_IO_THREADS CI NX_PREFER_TS_NODE PLAYWRIGHT_BROWSERS_PATH NODE_VERSION NX_GRADLE_DISABLE
           shell: bash
           run: |
             env
             whoami
-            sudo pkg install -y -f node libnghttp2 www/npm git openjdk17
+            sudo pkg install -y -f node libnghttp2 www/npm git ca_root_nss
             sudo npm install --location=global --ignore-scripts pnpm@10.28.2
-            # Set up Java 17
-            export JAVA_HOME=/usr/local/openjdk17
-            export PATH="$JAVA_HOME/bin:$PATH"
-            java --version
             curl https://sh.rustup.rs -sSf --output rustup.sh
             sh rustup.sh -y --profile minimal --default-toolchain stable
             source "$HOME/.cargo/env"
@@ -489,9 +486,7 @@ jobs:
             pnpm store prune || true
             rm -rf ~/.npm || true
             rm -rf ~/.pnpm-store || true
-            # Remove Rust build artifacts if any
-            rm -rf ~/.cargo/registry || true
-            rm -rf ~/.cargo/git || true
+            # Clean Rust extras but keep registry/git (needed for cargo to resolve deps)
             rm -rf ~/.rustup/toolchains/*/share || true
             # Remove other development tool caches
             rm -rf ~/.cache/* || true

--- a/packages/nx/src/native/utils/command.rs
+++ b/packages/nx/src/native/utils/command.rs
@@ -11,10 +11,16 @@ const CREATE_NO_WINDOW: u32 = 0x08000000;
 /// Use this instead of `Command::new()` directly to avoid spawning visible
 /// console windows from background/daemon processes.
 pub fn create_command(program: &str) -> Command {
-    let cmd = Command::new(program);
     #[cfg(target_os = "windows")]
-    cmd.creation_flags(CREATE_NO_WINDOW);
-    cmd
+    {
+        let mut cmd = Command::new(program);
+        cmd.creation_flags(CREATE_NO_WINDOW);
+        cmd
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        Command::new(program)
+    }
 }
 
 /// Creates a shell `Command` (`cmd /C` on Windows, `sh -c` elsewhere)


### PR DESCRIPTION
## Current Behavior

The FreeBSD native build in the publish workflow runs out of disk space (`No space left on device`). The VM has an 11G disk and the Rust build fills it completely. The build was already on the edge — the Mar 25 run succeeded with only 11MB to spare, and the Mar 26 run failed after rustc 1.94.1 slightly increased artifact sizes.

A major contributor is OpenJDK17 and its ~30 X11/font dependencies (~500MB) being installed solely for the `@nx/gradle` plugin's project graph step, which is irrelevant to building native Rust bindings.

## Expected Behavior

The FreeBSD build completes successfully with comfortable disk headroom by disabling the Gradle plugin via `NX_GRADLE_DISABLE=true`, which eliminates the need for Java and its heavy dependency tree.

## Related Issue(s)

Fixes the FreeBSD build failure: https://github.com/nrwl/nx/actions/runs/23613960439/job/68776656960