### PR TITLE
fix(nx-dev): correct YouTube channel URL on courses page

### DIFF
--- a/nx-dev/ui-video-courses/src/lib/course-hero.tsx
+++ b/nx-dev/ui-video-courses/src/lib/course-hero.tsx
@@ -14,7 +14,7 @@ export function CourseHero(): JSX.Element {
           skills and productivity.
         </SectionHeading>
         <a
-          href="https://www.youtube.com/@naborx"
+          href="https://www.youtube.com/@nxdevtools"
           target="_blank"
           rel="noopener noreferrer"
           className="mt-6 inline-flex items-center gap-2 rounded-md bg-slate-100 px-4 py-2 text-sm text-slate-700 transition-colors hover:bg-slate-200 dark:bg-white/10 dark:text-slate-300 dark:hover:bg-white/15"


### PR DESCRIPTION
## Current Behavior

The courses page YouTube link points to `https://www.youtube.com/@naborx` which is incorrect.

## Expected Behavior

The link points to `https://www.youtube.com/@nxdevtools`, the actual Nx YouTube channel.

## Related Issue(s)

N/A