### PR TITLE
chore(repo): use SHAs for GH actions

### DIFF
--- a/.github/workflows/banner-monitor.yml
+++ b/.github/workflows/banner-monitor.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Restore cached hash
         id: cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.0.3
         with:
           path: .banner-hash
           key: banner-content-hash-
@@ -86,7 +86,7 @@ jobs:
 
       - name: Update cache
         if: steps.compare.outputs.changed == 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.0.3
         with:
           path: .banner-hash
           key: banner-content-hash-${{ github.run_id }}


### PR DESCRIPTION
Pin actions versions to SHAs in workflows for improved security.