### PR TITLE
feat(misc): a/b test cloud prompt copy in create-nx-workspace

### DIFF
--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.spec.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.spec.ts
@@ -1,8 +1,8 @@
 import {
   isEnterpriseCloudUrl,
   getBannerVariant,
-  shouldShowCloudPrompt,
   getFlowVariant,
+  PromptMessages,
 } from './ab-testing';
 
 describe('ab-testing', () => {
@@ -104,9 +104,40 @@ describe('ab-testing', () => {
     });
   });
 
-  describe('shouldShowCloudPrompt', () => {
-    it('should always return false (variant 2 locked in CLOUD-4255)', () => {
-      expect(shouldShowCloudPrompt()).toBe(false);
+  describe('setupNxCloudV2 prompt variants', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      jest.resetModules();
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it.each([
+      { flowVariant: '0', expectedCode: 'connect-to-cloud' },
+      { flowVariant: '1', expectedCode: 'cloud-ab-remote-cache-speed' },
+      { flowVariant: '2', expectedCode: 'cloud-ab-fast-ci-setup' },
+    ])(
+      'should select $expectedCode for flow variant $flowVariant',
+      ({ flowVariant, expectedCode }) => {
+        jest.resetModules();
+        process.env.NX_CNW_FLOW_VARIANT = flowVariant;
+        const { PromptMessages: FreshPromptMessages } = require('./ab-testing');
+        const pm = new FreshPromptMessages();
+        expect(pm.getPrompt('setupNxCloudV2').code).toBe(expectedCode);
+      }
+    );
+
+    it('should select variant 0 for docs generation', () => {
+      process.env.NX_GENERATE_DOCS_PROCESS = 'true';
+      const { PromptMessages: FreshPromptMessages } = jest.requireActual(
+        './ab-testing'
+      ) as typeof import('./ab-testing');
+      const pm = new FreshPromptMessages();
+      expect(pm.getPrompt('setupNxCloudV2').code).toBe('connect-to-cloud');
     });
   });
 });

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -8,6 +8,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import chalk from 'chalk';
 import { isCI } from '../ci/is-ci';
 import type { BannerVariant, CompletionMessageKey } from './messages';
 
@@ -96,12 +97,6 @@ export function getFlowVariant(): string {
  */
 export function getCompletionMessageKeyForVariant(): CompletionMessageKey {
   return 'platform-setup';
-}
-
-export function shouldShowCloudPrompt(): boolean {
-  // CLOUD-4255: Lock to variant 2 behavior (no prompt)
-  // To re-enable A/B testing: return getFlowVariant() !== '2';
-  return false;
 }
 
 // ============================================================================
@@ -220,10 +215,38 @@ const messageOptions: Record<string, MessageData[]> = {
       choices: [
         { value: 'yes', name: 'Yes' },
         { value: 'skip', name: 'Skip for now' },
-        { value: 'never', name: "No, don't ask again" },
+        { value: 'never', name: chalk.dim("No, don't ask again") },
       ],
       footer:
         '\nAutomatically fix broken PRs, 70% faster CI: https://nx.dev/nx-cloud',
+      fallback: undefined,
+      completionMessage: 'platform-setup',
+    },
+    {
+      code: 'cloud-ab-remote-cache-speed',
+      message: 'Enable remote caching to speed up builds with Nx Cloud?',
+      initial: 0,
+      choices: [
+        { value: 'yes', name: 'Yes' },
+        { value: 'skip', name: 'Skip for now' },
+        { value: 'never', name: chalk.dim("No, don't ask again") },
+      ],
+      footer:
+        '\nFree for small teams. 2-minute setup with GitHub — cache locally and in CI: https://nx.dev/nx-cloud',
+      fallback: undefined,
+      completionMessage: 'platform-setup',
+    },
+    {
+      code: 'cloud-ab-fast-ci-setup',
+      message: 'Speed up your CI with Nx Cloud?',
+      initial: 0,
+      choices: [
+        { value: 'yes', name: 'Yes' },
+        { value: 'skip', name: 'Skip for now' },
+        { value: 'never', name: chalk.dim("No, don't ask again") },
+      ],
+      footer:
+        '\n70% faster CI on GitHub, GitLab, and more. Free tier, 2-minute setup: https://nx.dev/nx-cloud',
       fallback: undefined,
       completionMessage: 'platform-setup',
     },
@@ -250,9 +273,9 @@ export class PromptMessages {
       if (process.env.NX_GENERATE_DOCS_PROCESS === 'true') {
         this.selectedMessages[key] = 0;
       } else {
-        this.selectedMessages[key] = Math.floor(
-          Math.random() * messageOptions[key].length
-        );
+        const variant = Number(getFlowVariant());
+        this.selectedMessages[key] =
+          variant < messageOptions[key].length ? variant : 0;
       }
     }
     return messageOptions[key][this.selectedMessages[key]!];


### PR DESCRIPTION
## Current Behavior

The cloud prompt in CNW is disabled (shouldShowCloudPrompt returns false). Users see no cloud prompt during workspace creation.

## Expected Behavior

Re-enables the cloud prompt with 3 copy variants tied to the flow variant (NX_CNW_FLOW_VARIANT), using the existing A/B testing infrastructure:
- Variant 0 (baseline): "Connect to Nx Cloud?"
- Variant 1 (remote caching): "Enable remote caching to speed up builds and CI?"
- Variant 2 (CI-first): "Speed up your CI with Nx Cloud?"

Each variant has a unique tracking code for measuring yes/skip/never rates. New variants emphasize concrete benefits (remote caching, CI speed), mention CI providers (GitHub, GitLab), and note free tier and 2-minute setup.

Also removes unused shouldShowCloudPrompt() function.

## Screenshots

Variant 0 (current prompts):

<img width="1392" height="935" alt="cnw-variant-0" src="https://github.com/user-attachments/assets/38187e44-5c8f-41b1-b2d9-bdb0eead3f7d" />

Variant 1 (remote cache to speed up builds, free for small teams):

<img width="1392" height="939" alt="image" src="https://github.com/user-attachments/assets/ba7ab127-c91e-4566-bae6-6f7fe797959e" />

Variant 2 (speed up CI, mention CI provides):

<img width="1392" height="935" alt="cnw-variant-2" src="https://github.com/user-attachments/assets/05bc027a-dcc9-47c4-944c-35ca2fce2007" />

## Related Issue(s)

Closes NXC-4113