### PR TITLE
fix(repo): copy-assets plugin and e2e improvements

### DIFF
--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -748,6 +748,10 @@ export function cleanupProject({
   skipReset,
   ...opts
 }: RunCmdOpts & { skipReset?: boolean } = {}) {
+  if (process.env.NX_E2E_SKIP_CLEANUP) {
+    resetWorkspaceContext();
+    return;
+  }
   if (isCI) {
     // Stopping the daemon is not required for tests to pass, but it cleans up background processes
     try {

--- a/tools/workspace-plugin/src/executors/copy-assets/executor.ts
+++ b/tools/workspace-plugin/src/executors/copy-assets/executor.ts
@@ -55,7 +55,9 @@ export async function copyAssetsExecutor(
   try {
     await assetHandler.processAllAssetsOnce();
   } catch (error) {
-    logger.error(`Error processing assets: ${error.message || error}`);
+    logger.error(
+      `Error processing assets: ${error instanceof Error ? error.message : error}`
+    );
     return { success: false };
   }
 

--- a/tools/workspace-plugin/src/plugins/copy-assets-plugin.ts
+++ b/tools/workspace-plugin/src/plugins/copy-assets-plugin.ts
@@ -59,6 +59,7 @@ export const createNodesV2: CreateNodesV2 = [
               input === projectRoot
                 ? [
                     `${relative(projectRoot, assetsJson.outDir)}/**`,
+                    'assets.json',
                     ...(asset.ignore ?? []),
                   ]
                 : asset.ignore;


### PR DESCRIPTION
## Current Behavior

- The copy-assets plugin copies `assets.json` into the output directory (it doesn't exclude itself)
- The copy-assets executor catches errors with `error.message` but `error` is typed as `unknown`, which can fail at runtime
- No way to skip e2e cleanup when debugging locally

## Expected Behavior

- `assets.json` is excluded from being copied into the output directory
- Error handling properly checks `instanceof Error` before accessing `.message`
- Setting `NX_E2E_SKIP_CLEANUP=true` preserves the test project directory for debugging

## Related Issue(s)

Follow-up to #34994 — addresses review comments from that PR.