### PR TITLE
feat(nx-dev): add conditional blog/changelog proxy in edge function

### DIFF
--- a/netlify/edge-functions/rewrite-framer-urls.ts
+++ b/netlify/edge-functions/rewrite-framer-urls.ts
@@ -1,6 +1,7 @@
 import type { Context } from 'https://edge.netlify.com';
 
 const framerUrl = Netlify.env.get('NEXT_PUBLIC_FRAMER_URL');
+const blogUrl = Netlify.env.get('BLOG_URL');
 const GA_MEASUREMENT_ID =
   Netlify.env.get('GA_MEASUREMENT_ID') || 'G-XXXXXXXXXX';
 const GA_API_SECRET = Netlify.env.get('GA_API_SECRET') || '';
@@ -67,15 +68,16 @@ async function sendToGA4(
 
 /**
  * Paths that should be served by the Next.js app instead of Framer.
- * Everything else is proxied to Framer.
+ * Everything else is proxied to Framer (or the blog site if configured).
  */
 const nextjsPaths = new Set([
-  '/blog',
+  // When BLOG_URL is set, blog/changelog are proxied to the
+  // standalone blog site instead of falling through to Next.js.
+  ...(blogUrl ? [] : ['/blog', '/changelog']),
   '/courses',
   '/pricing',
   '/podcast',
   '/ai-chat',
-  '/changelog',
   '/resources-library',
   '/whitepaper-fast-ci',
   '/500',
@@ -98,7 +100,55 @@ export default async function handler(
   const url = new URL(request.url);
   const pathname = url.pathname;
 
-  if (!framerUrl || nextjsPaths.has(pathname)) return context.next();
+  if (nextjsPaths.has(pathname)) return context.next();
+
+  // Blog/changelog routing: proxy to standalone blog site, or fall through to Next.js.
+  const isBlogPath =
+    pathname === '/blog' ||
+    pathname.startsWith('/blog/') ||
+    pathname === '/changelog' ||
+    pathname.startsWith('/changelog/');
+
+  if (isBlogPath && !blogUrl) return context.next();
+
+  if (isBlogPath && blogUrl) {
+    const blogDestination = new URL(pathname, blogUrl);
+    url.searchParams.forEach((value, key) => {
+      blogDestination.searchParams.set(key, value);
+    });
+
+    const response = await fetch(blogDestination.toString(), {
+      headers: {
+        'User-Agent': request.headers.get('User-Agent') || '',
+        Accept: request.headers.get('Accept') || 'text/html',
+        'Accept-Language': request.headers.get('Accept-Language') || '',
+      },
+    });
+
+    const contentType = response.headers.get('content-type') || '';
+    let body: ReadableStream<Uint8Array> | string | null = response.body;
+
+    // Rewrite blog site URLs to nx.dev in HTML responses (canonical, og:url, etc.)
+    if (contentType.includes('text/html')) {
+      const html = await response.text();
+      body = html.replaceAll(blogUrl, 'https://nx.dev');
+    }
+
+    context.waitUntil(sendToGA4(request, context, pathname));
+
+    const newHeaders = new Headers(response.headers);
+    newHeaders.set('x-nx-edge-function', 'blog-proxy');
+    newHeaders.set('X-Frame-Options', 'DENY');
+    newHeaders.set('Content-Security-Policy', "frame-ancestors 'none'");
+
+    return new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: newHeaders,
+    });
+  }
+
+  if (!framerUrl) return context.next();
 
   const framerDestination = new URL(pathname, framerUrl);
   url.searchParams.forEach((value, key) => {
@@ -145,9 +195,7 @@ export const config = {
     '/docs',
     '/docs/*',
     '/api/*',
-    '/blog/*',
     '/courses/*',
-    '/changelog',
     '/_next/*',
     '/.netlify/*',
     // Legacy docs paths — must bypass Framer so _redirects 301 rules fire

--- a/nx-dev/nx-dev/_redirects
+++ b/nx-dev/nx-dev/_redirects
@@ -4,6 +4,10 @@
 # Netlify processes these top-to-bottom, first match wins.
 # Specific rules MUST come before wildcard rules.
 
+# --- favicon ---
+/favicon.ico /favicon/favicon.ico 301
+/favicon.svg /favicon/favicon.svg 301
+
 # --- docs ---
 /docs /docs/getting-started/intro 301
 


### PR DESCRIPTION
## Current Behavior

`/blog` and `/changelog` paths are always served by the Next.js app. The Netlify edge function excludes these paths (`/blog/*` in `excludedPath`, `/blog` and `/changelog` in `nextjsPaths`) so they bypass the Framer proxy and fall through to Next.js.

## Expected Behavior

When the `BLOG_URL` env var is set in Netlify, `/blog/*` and `/changelog/*` requests are proxied to the standalone blog site (e.g., `nrwl-blog.netlify.app`) via the existing Netlify edge function. When `BLOG_URL` is **not** set, behavior is unchanged — paths fall through to Next.js as before.

**Changes to `netlify/edge-functions/rewrite-framer-urls.ts`:**

- Read `BLOG_URL` env var
- Conditionally remove `/blog` and `/changelog` from `nextjsPaths` when `BLOG_URL` is set
- Remove `/blog/*` and `/changelog` from static `excludedPath` so the edge function can intercept these paths
- Add blog proxy branch: when `BLOG_URL` is set and path matches, proxy to blog site with URL rewriting (`blogUrl` → `https://nx.dev`) and security headers (`X-Frame-Options`, `CSP`)
- When `BLOG_URL` is unset, blog/changelog paths fall through to Next.js via explicit `context.next()` guard

**Asset resolution note:** The edge function only handles `text/html` requests. Blog site assets (CSS, JS) will need to be served from the blog site's own CDN (via `build.assetsPrefix` or equivalent in the blog repo). All existing `/_next/*` assets remain in `excludedPath` and are unaffected.

## Related Issue(s)

Fixes DOC-455