### PR TITLE
fix(misc): handle non-interactive mode and add template shorthand names for CNW

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -317,15 +317,15 @@ if (isAiAgent()) {
   commandsObject
     .example(chalk.green('AI AGENTS (RECOMMENDED):'), '')
     .example(
-      '  npx create-nx-workspace@latest myorg --template=nrwl/empty-template --nxCloud=yes --interactive=false',
+      '  npx create-nx-workspace@latest myorg --template=empty --nxCloud=yes --interactive=false',
       ''
     )
     .example('', '')
     .example(chalk.green('AVAILABLE TEMPLATES:'), '')
-    .example('  --template=nrwl/empty-template       Empty monorepo', '')
-    .example('  --template=nrwl/react-template       React fullstack', '')
-    .example('  --template=nrwl/angular-template     Angular fullstack', '')
-    .example('  --template=nrwl/typescript-template  NPM packages', '')
+    .example('  --template=empty                     Empty monorepo', '')
+    .example('  --template=react                     React fullstack', '')
+    .example('  --template=angular                   Angular fullstack', '')
+    .example('  --template=typescript                NPM packages', '')
     .epilogue(
       `${chalk.cyan('AI Agent Mode:')}
   Set CLAUDECODE=1 or OPENCODE=1 for JSON output and non-interactive mode.

--- a/packages/create-nx-workspace/src/create-workspace.spec.ts
+++ b/packages/create-nx-workspace/src/create-workspace.spec.ts
@@ -1,4 +1,7 @@
-import { extractConnectUrl } from './create-workspace';
+import {
+  extractConnectUrl,
+  resolveTemplateShorthand,
+} from './create-workspace';
 
 describe('extractConnectUrl', () => {
   test('should extract the correct URL from the given string', () => {
@@ -55,5 +58,37 @@ describe('extractConnectUrl', () => {
     const expectedUrl =
       'https://example.com/connect/abcd1234?query=param#fragment';
     expect(extractConnectUrl(inputString)).toBe(expectedUrl);
+  });
+});
+
+describe('resolveTemplateShorthand', () => {
+  test('should resolve angular shorthand', () => {
+    expect(resolveTemplateShorthand('angular')).toBe('nrwl/angular-template');
+  });
+
+  test('should resolve react shorthand', () => {
+    expect(resolveTemplateShorthand('react')).toBe('nrwl/react-template');
+  });
+
+  test('should resolve typescript shorthand', () => {
+    expect(resolveTemplateShorthand('typescript')).toBe(
+      'nrwl/typescript-template'
+    );
+  });
+
+  test('should resolve empty shorthand', () => {
+    expect(resolveTemplateShorthand('empty')).toBe('nrwl/empty-template');
+  });
+
+  test('should pass through full template names unchanged', () => {
+    expect(resolveTemplateShorthand('nrwl/angular-template')).toBe(
+      'nrwl/angular-template'
+    );
+  });
+
+  test('should pass through unknown values unchanged', () => {
+    expect(resolveTemplateShorthand('nrwl/custom-template')).toBe(
+      'nrwl/custom-template'
+    );
   });
 });

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -72,6 +72,9 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
   let directory: string;
 
   if (options.template) {
+    // Resolve shorthand template names to full GitHub org/repo format
+    options.template = resolveTemplateShorthand(options.template);
+
     if (!options.template.startsWith('nrwl/'))
       throw new Error(
         `Invalid template. Only templates from the 'nrwl' GitHub org are supported.`
@@ -345,6 +348,17 @@ export function extractConnectUrl(text: string): string | null {
   const urlPattern = /(https:\/\/[^\s]+\/connect\/[^\s]+)/g;
   const match = text.match(urlPattern);
   return match ? match[0] : null;
+}
+
+const templateShorthands: Record<string, string> = {
+  angular: 'nrwl/angular-template',
+  react: 'nrwl/react-template',
+  typescript: 'nrwl/typescript-template',
+  empty: 'nrwl/empty-template',
+};
+
+export function resolveTemplateShorthand(template: string): string {
+  return templateShorthands[template] ?? template;
 }
 
 function getWorkspaceGlobsFromPreset(preset: string): string[] {

--- a/packages/create-nx-workspace/src/internal-utils/prompts.spec.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.spec.ts
@@ -1,0 +1,56 @@
+import { determineTemplate } from './prompts';
+
+jest.mock('../utils/ci/is-ci', () => ({
+  isCI: jest.fn(() => false),
+}));
+
+jest.mock('../utils/git/git', () => ({
+  isGitAvailable: jest.fn(() => true),
+}));
+
+describe('determineTemplate', () => {
+  describe('non-interactive mode', () => {
+    it('should return nrwl/empty-template when no preset or template is provided', async () => {
+      const result = await determineTemplate({
+        _: [],
+        $0: '',
+        interactive: false,
+      });
+      expect(result).toBe('nrwl/empty-template');
+    });
+
+    it('should return the provided template when --template is set', async () => {
+      const result = await determineTemplate({
+        _: [],
+        $0: '',
+        interactive: false,
+        template: 'nrwl/react-template',
+      });
+      expect(result).toBe('nrwl/react-template');
+    });
+
+    it('should return custom when --preset is set', async () => {
+      const result = await determineTemplate({
+        _: [],
+        $0: '',
+        interactive: false,
+        preset: 'react-monorepo',
+      });
+      expect(result).toBe('custom');
+    });
+  });
+
+  describe('CI mode', () => {
+    it('should return nrwl/empty-template in CI without preset or template', async () => {
+      const { isCI } = require('../utils/ci/is-ci');
+      (isCI as jest.Mock).mockReturnValueOnce(true);
+
+      const result = await determineTemplate({
+        _: [],
+        $0: '',
+        interactive: true,
+      });
+      expect(result).toBe('nrwl/empty-template');
+    });
+  });
+});

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -108,7 +108,7 @@ export async function determineTemplate(
 ): Promise<string | 'custom'> {
   if (parsedArgs.template) return parsedArgs.template;
   if (parsedArgs.preset) return 'custom';
-  if (!parsedArgs.interactive || isCI()) return 'custom';
+  if (!parsedArgs.interactive || isCI()) return 'nrwl/empty-template';
   // Docs generation needs preset flow to document all presets
   if (process.env.NX_GENERATE_DOCS_PROCESS === 'true') return 'custom';
   // Template flow requires git for cloning - fall back to custom preset if git is not available


### PR DESCRIPTION
This PR address some common errors seen during CNW around `--template` and `--preset` during non-interactive flows that are not AI agents. Also sees that some template names are not qualified with `nrwl/<name>-template` so we can normal though (which also makes it shorter in docs).

## Current Behavior

In non-interactive contexts (IDE terminals, scripts, SSH without `-t`), `determineTemplate()` returns `'custom'` which routes to the preset flow. Without `--preset` provided, this throws "Preset is required", which affects ~15 users/day (~145 occurrences Mar 18-27).

Users must also pass full template paths like `--template=nrwl/angular-template`.

## Expected Behavior

Non-interactive mode defaults to `nrwl/empty-template` (template flow) instead of `'custom'` (preset flow) when neither `--preset` nor `--template` is provided.

Shorthand template names are supported:
- `--template=angular` → `nrwl/angular-template`
- `--template=react` → `nrwl/react-template`
- `--template=typescript` → `nrwl/typescript-template`
- `--template=empty` → `nrwl/empty-template`

## Related Issue(s)

Fixes NXC-4153