### PR TITLE
fix(js): recognize tsgo in dependency-checks lint rule

### DIFF
--- a/packages/js/src/utils/find-npm-dependencies.spec.ts
+++ b/packages/js/src/utils/find-npm-dependencies.spec.ts
@@ -170,12 +170,14 @@ describe('findNpmDependencies', () => {
   });
 
   it.each`
-    fileName
-    ${'tsconfig.base.json'}
-    ${'tsconfig.json'}
+    fileName                | command
+    ${'tsconfig.base.json'} | ${'tsc --build tsconfig.lib.json --pretty --verbose'}
+    ${'tsconfig.json'}      | ${'tsc --build tsconfig.lib.json --pretty --verbose'}
+    ${'tsconfig.base.json'} | ${'tsgo --build tsconfig.lib.json'}
+    ${'tsconfig.json'}      | ${'tsgo --build tsconfig.lib.json'}
   `(
-    'should pick up helper npm dependencies when using tsc and run-commands',
-    ({ fileName }) => {
+    'should pick up helper npm dependencies when using "$command" and run-commands',
+    ({ fileName, command }) => {
       vol.fromJSON(
         {
           [`./${fileName}`]: JSON.stringify({
@@ -199,7 +201,7 @@ describe('findNpmDependencies', () => {
             build: {
               executor: 'nx:run-commands',
               options: {
-                command: 'tsc --build tsconfig.lib.json --pretty --verbose',
+                command,
               },
             },
           },

--- a/packages/js/src/utils/find-npm-dependencies.ts
+++ b/packages/js/src/utils/find-npm-dependencies.ts
@@ -244,7 +244,7 @@ function collectHelperDependencies(
   // For inferred targets or manually added run-commands, check if user is using `tsc` in build target.
   if (
     target.executor === 'nx:run-commands' &&
-    /\btsc\b/.test(target.options.command)
+    /\b(tsc|tsgo)\b/.test(target.options.command)
   ) {
     const tsConfigFileName = getRootTsConfigFileName();
     if (tsConfigFileName) {


### PR DESCRIPTION
## Current Behavior

The `@nx/dependency-checks` lint rule detects `tslib` as a required dependency by checking if the build command contains `tsc` (via `/\btsc\b/` regex). When a project uses `tsgo` as its compiler, the build command is `tsgo --build` which doesn't match — causing a false positive "tslib is not used" lint error.

## Expected Behavior

The regex also matches `tsgo`, so projects using either `tsc` or `tsgo` correctly detect `tslib` as needed when `importHelpers: true` is set.

## Related Issue(s)

N/A — discovered while enabling tsgo for the nx package