### PR TITLE
fix(module-federation): honor cached project graph during config setup

### DIFF
--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/angular/nx-module-federation-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/angular/nx-module-federation-plugin.ts
@@ -4,7 +4,10 @@ import {
   NxModuleFederationConfigOverride,
 } from '../../../utils/models';
 import { getModuleFederationConfigSync } from '../../../with-module-federation/angular/utils';
-import { normalizeProjectName } from '../../../utils';
+import {
+  normalizeProjectName,
+  shouldSkipModuleFederationSetup,
+} from '../../../utils';
 
 export class NxModuleFederationPlugin implements RspackPluginInstance {
   constructor(
@@ -16,7 +19,7 @@ export class NxModuleFederationPlugin implements RspackPluginInstance {
   ) {}
 
   apply(compiler: Compiler) {
-    if (global.NX_GRAPH_CREATION) {
+    if (shouldSkipModuleFederationSetup()) {
       return;
     }
 

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-plugin.ts
@@ -4,7 +4,10 @@ import {
   NxModuleFederationConfigOverride,
 } from '../../../utils/models';
 import { getModuleFederationConfig } from '../../../with-module-federation/rspack/utils';
-import { normalizeProjectName } from '../../../utils';
+import {
+  normalizeProjectName,
+  shouldSkipModuleFederationSetup,
+} from '../../../utils';
 
 export class NxModuleFederationPlugin implements RspackPluginInstance {
   constructor(
@@ -16,7 +19,7 @@ export class NxModuleFederationPlugin implements RspackPluginInstance {
   ) {}
 
   apply(compiler: Compiler) {
-    if (global.NX_GRAPH_CREATION) {
+    if (shouldSkipModuleFederationSetup()) {
       return;
     }
 

--- a/packages/module-federation/src/utils/index.ts
+++ b/packages/module-federation/src/utils/index.ts
@@ -7,5 +7,6 @@ export * from './normalize-project-name';
 export * from './get-remotes-for-host';
 export * from './parse-static-remotes-config';
 export * from './port-utils';
+export * from './should-skip-module-federation-setup';
 export * from './start-remote-proxies';
 export * from './start-ssr-remote-proxies';

--- a/packages/module-federation/src/utils/should-skip-module-federation-setup.spec.ts
+++ b/packages/module-federation/src/utils/should-skip-module-federation-setup.spec.ts
@@ -1,0 +1,39 @@
+import { readCachedProjectGraph } from '@nx/devkit';
+import { shouldSkipModuleFederationSetup } from './should-skip-module-federation-setup';
+
+jest.mock('@nx/devkit', () => ({
+  readCachedProjectGraph: jest.fn(),
+}));
+
+describe('shouldSkipModuleFederationSetup', () => {
+  const mockedReadCachedProjectGraph = jest.mocked(readCachedProjectGraph);
+
+  afterEach(() => {
+    delete global.NX_GRAPH_CREATION;
+    mockedReadCachedProjectGraph.mockReset();
+  });
+
+  it('does not skip setup when project graph creation is not in progress', () => {
+    expect(shouldSkipModuleFederationSetup()).toBe(false);
+    expect(mockedReadCachedProjectGraph).not.toHaveBeenCalled();
+  });
+
+  it('skips setup when project graph creation is in progress and the cache is unavailable', () => {
+    global.NX_GRAPH_CREATION = true;
+    mockedReadCachedProjectGraph.mockImplementation(() => {
+      throw new Error('No cached project graph');
+    });
+
+    expect(shouldSkipModuleFederationSetup()).toBe(true);
+  });
+
+  it('continues setup when project graph creation is in progress but the cache is ready', () => {
+    global.NX_GRAPH_CREATION = true;
+    mockedReadCachedProjectGraph.mockReturnValue({
+      nodes: {},
+      dependencies: {},
+    } as any);
+
+    expect(shouldSkipModuleFederationSetup()).toBe(false);
+  });
+});

--- a/packages/module-federation/src/utils/should-skip-module-federation-setup.ts
+++ b/packages/module-federation/src/utils/should-skip-module-federation-setup.ts
@@ -1,0 +1,14 @@
+import { readCachedProjectGraph } from '@nx/devkit';
+
+export function shouldSkipModuleFederationSetup(): boolean {
+  if (!global.NX_GRAPH_CREATION) {
+    return false;
+  }
+
+  try {
+    readCachedProjectGraph();
+    return false;
+  } catch {
+    return true;
+  }
+}

--- a/packages/module-federation/src/with-module-federation/angular/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/angular/with-module-federation-ssr.ts
@@ -1,5 +1,6 @@
 import {
   normalizeProjectName,
+  shouldSkipModuleFederationSetup,
   type ModuleFederationConfig,
   type NxModuleFederationConfigOverride,
 } from '../../utils';
@@ -9,7 +10,7 @@ export async function withModuleFederationForSSR(
   options: ModuleFederationConfig,
   configOverride?: NxModuleFederationConfigOverride
 ) {
-  if (global.NX_GRAPH_CREATION) {
+  if (shouldSkipModuleFederationSetup()) {
     return (config) => config;
   }
   const isDevServer = process.env['WEBPACK_SERVE'];

--- a/packages/module-federation/src/with-module-federation/angular/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/angular/with-module-federation.ts
@@ -1,5 +1,6 @@
 import {
   normalizeProjectName,
+  shouldSkipModuleFederationSetup,
   type ModuleFederationConfig,
   type NxModuleFederationConfigOverride,
 } from '../../utils';
@@ -10,7 +11,7 @@ export async function withModuleFederation(
   options: ModuleFederationConfig,
   configOverride?: NxModuleFederationConfigOverride
 ) {
-  if (global.NX_GRAPH_CREATION) {
+  if (shouldSkipModuleFederationSetup()) {
     return (config) => config;
   }
   // This is required to ensure that the webpack version used by the Angular CLI is used

--- a/packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts
@@ -3,6 +3,7 @@ import {
   ModuleFederationConfig,
   normalizeProjectName,
   NxModuleFederationConfigOverride,
+  shouldSkipModuleFederationSetup,
 } from '../../utils';
 import { getModuleFederationConfig } from './utils';
 
@@ -10,7 +11,7 @@ export async function withModuleFederationForSSR(
   options: ModuleFederationConfig,
   configOverride?: NxModuleFederationConfigOverride
 ) {
-  if (global.NX_GRAPH_CREATION) {
+  if (shouldSkipModuleFederationSetup()) {
     return (config) => config;
   }
   const isDevServer = process.env['WEBPACK_SERVE'];

--- a/packages/module-federation/src/with-module-federation/rspack/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/rspack/with-module-federation.ts
@@ -5,6 +5,7 @@ import {
   ModuleFederationConfig,
   normalizeProjectName,
   NxModuleFederationConfigOverride,
+  shouldSkipModuleFederationSetup,
 } from '../../utils';
 import { getModuleFederationConfig } from './utils';
 
@@ -19,7 +20,7 @@ export async function withModuleFederation(
   options: ModuleFederationConfig,
   configOverride?: NxModuleFederationConfigOverride
 ) {
-  if (global.NX_GRAPH_CREATION) {
+  if (shouldSkipModuleFederationSetup()) {
     return function makeConfig(config: Configuration): Configuration {
       return config;
     };

--- a/packages/module-federation/src/with-module-federation/webpack/with-module-federation-ssr.ts
+++ b/packages/module-federation/src/with-module-federation/webpack/with-module-federation-ssr.ts
@@ -2,6 +2,7 @@ import {
   ModuleFederationConfig,
   normalizeProjectName,
   NxModuleFederationConfigOverride,
+  shouldSkipModuleFederationSetup,
 } from '../../utils';
 import { getModuleFederationConfig } from './utils';
 import type { NormalModuleReplacementPlugin } from 'webpack';
@@ -10,7 +11,7 @@ export async function withModuleFederationForSSR(
   options: ModuleFederationConfig,
   configOverride?: NxModuleFederationConfigOverride
 ) {
-  if (global.NX_GRAPH_CREATION) {
+  if (shouldSkipModuleFederationSetup()) {
     return (config) => config;
   }
   const isDevServer = process.env['WEBPACK_SERVE'];

--- a/packages/module-federation/src/with-module-federation/webpack/with-module-federation.ts
+++ b/packages/module-federation/src/with-module-federation/webpack/with-module-federation.ts
@@ -2,6 +2,7 @@ import {
   ModuleFederationConfig,
   normalizeProjectName,
   NxModuleFederationConfigOverride,
+  shouldSkipModuleFederationSetup,
 } from '../../utils';
 import { getModuleFederationConfig } from './utils';
 import { ModuleFederationPlugin } from '@module-federation/enhanced/webpack';
@@ -14,7 +15,7 @@ export async function withModuleFederation(
   options: ModuleFederationConfig,
   configOverride?: NxModuleFederationConfigOverride
 ) {
-  if (global.NX_GRAPH_CREATION) {
+  if (shouldSkipModuleFederationSetup()) {
     return (config) => config;
   }
   const isDevServer = process.env['WEBPACK_SERVE'];


### PR DESCRIPTION
## Current behavior
When the Angular Module Federation dev server starts multiple remotes, `global.NX_GRAPH_CREATION` can still be true while a cached project graph is already available. The current guard returns a no-op config loader in that case, so real remote webpack/module federation config never gets applied.

## This PR
- replaces the raw `global.NX_GRAPH_CREATION` no-op guard with a helper that first checks whether a cached graph is already readable
- keeps the existing no-op escape hatch when graph creation is still in progress and the cache is not ready yet
- reuses that helper across the module-federation config entry points so the behavior stays consistent
- adds a regression spec covering the cached-graph-during-graph-creation case

Fixes #35051.

## Validation
- `pnpm exec jest packages/module-federation/src/utils/should-skip-module-federation-setup.spec.ts --config packages/module-federation/jest.config.cts --runInBand`
- `pnpm exec prettier --check packages/module-federation/src/utils/should-skip-module-federation-setup.ts packages/module-federation/src/utils/should-skip-module-federation-setup.spec.ts packages/module-federation/src/utils/index.ts packages/module-federation/src/with-module-federation/angular/with-module-federation.ts packages/module-federation/src/with-module-federation/angular/with-module-federation-ssr.ts packages/module-federation/src/with-module-federation/webpack/with-module-federation.ts packages/module-federation/src/with-module-federation/webpack/with-module-federation-ssr.ts packages/module-federation/src/with-module-federation/rspack/with-module-federation.ts packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts packages/module-federation/src/plugins/nx-module-federation-plugin/angular/nx-module-federation-plugin.ts packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-plugin.ts`
- `pnpm exec eslint packages/module-federation/src/utils/should-skip-module-federation-setup.ts packages/module-federation/src/utils/should-skip-module-federation-setup.spec.ts packages/module-federation/src/utils/index.ts packages/module-federation/src/with-module-federation/angular/with-module-federation.ts packages/module-federation/src/with-module-federation/angular/with-module-federation-ssr.ts packages/module-federation/src/with-module-federation/webpack/with-module-federation.ts packages/module-federation/src/with-module-federation/webpack/with-module-federation-ssr.ts packages/module-federation/src/with-module-federation/rspack/with-module-federation.ts packages/module-federation/src/with-module-federation/rspack/with-module-federation-ssr.ts packages/module-federation/src/plugins/nx-module-federation-plugin/angular/nx-module-federation-plugin.ts packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-plugin.ts --rule "@nx/workspace/valid-command-object: off" --rule "@nx/workspace/require-windows-hide: off"`
- `git diff --check`

Notes:
- the sparse checkout on this Windows host did not load the repo-local `@nx/workspace/valid-command-object` and `@nx/workspace/require-windows-hide` rule definitions, so I disabled only those two rules for the touched-file ESLint pass
- `@nx/enforce-module-boundaries` warned that no cached project graph was available during direct file linting in this sparse checkout, but it did not report any violations on the changed files