### PR TITLE
fix(gradle): increase project graph timeout defaults

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ env:
   CYPRESS_INSTALL_BINARY: 0
   NODE_VERSION: 22.16.0
   PNPM_VERSION: 10.28.2 # Aligned with root package.json (pnpm/action-setup will helpfully error if out of sync)
+  NX_GRADLE_PROJECT_GRAPH_TIMEOUT: 600
 
 jobs:
   # We first need to determine the version we are releasing, and if we need a custom repo or ref to use for the git checkout in subsequent steps.

--- a/packages/gradle/src/plugin/utils/get-project-graph-lines.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-lines.ts
@@ -1,8 +1,9 @@
 import { AggregateCreateNodesError, output, workspaceRoot } from '@nx/devkit';
+import { isCI } from 'nx/src/devkit-internals';
 import { execGradleAsync, newLineSeparator } from '../../utils/exec-gradle';
 import { GradlePluginOptions } from './gradle-plugin-options';
 
-const DEFAULT_GRAPH_TIMEOUT_SECONDS = 60;
+const DEFAULT_GRAPH_TIMEOUT_SECONDS = isCI() ? 600 : 180;
 
 export function getGraphTimeoutMs(): number {
   const envTimeout = process.env.NX_GRADLE_PROJECT_GRAPH_TIMEOUT;

--- a/packages/gradle/src/plugin/utils/get-project-graph-lines.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-lines.ts
@@ -3,7 +3,7 @@ import { isCI } from 'nx/src/devkit-internals';
 import { execGradleAsync, newLineSeparator } from '../../utils/exec-gradle';
 import { GradlePluginOptions } from './gradle-plugin-options';
 
-const DEFAULT_GRAPH_TIMEOUT_SECONDS = isCI() ? 600 : 180;
+const DEFAULT_GRAPH_TIMEOUT_SECONDS = isCI() ? 600 : 120;
 
 export function getGraphTimeoutMs(): number {
   const envTimeout = process.env.NX_GRADLE_PROJECT_GRAPH_TIMEOUT;


### PR DESCRIPTION
## Current Behavior

The Gradle plugin's `createNodes` project graph generation has a fixed 60-second timeout. For large Gradle workspaces, this is too short and causes timeouts — especially in CI environments where builds may be slower.

## Expected Behavior

- **Local**: Default timeout increased to 2 minutes (120s)
- **CI**: Default timeout increased to 10 minutes (600s)
- The `NX_GRADLE_PROJECT_GRAPH_TIMEOUT` env var still works as an override
- The publish workflow explicitly sets `NX_GRADLE_PROJECT_GRAPH_TIMEOUT=600` for extra safety