### PR TITLE
fix(core): hide forked windows child processes

### DIFF
--- a/packages/angular-rspack/src/lib/plugins/angular-ssr-dev-server.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-ssr-dev-server.ts
@@ -52,7 +52,9 @@ export class AngularSsrDevServer implements RspackPluginInstance {
             if (!existsSync(serverPath)) {
               await new Promise<void>((res) => setTimeout(res, 50));
             }
-            this.#devServerProcess = fork(serverPath);
+            this.#devServerProcess = fork(serverPath, [], {
+              windowsHide: true,
+            });
             this.#devServerProcess.on('spawn', () => {
               this.#wsServer.sendReload();
             });

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -185,6 +185,7 @@ export async function* nodeExecutor(
               {
                 execArgv: getExecArgv(options),
                 stdio: [0, 'pipe', 'pipe', 'ipc'],
+                windowsHide: true,
                 env: {
                   ...process.env,
                   NX_FILE_TO_RUN: fileToRunCorrectPath(fileToRun),
@@ -306,6 +307,7 @@ export async function* nodeExecutor(
             {
               cwd: context.root,
               stdio: 'inherit',
+              windowsHide: true,
             }
           );
           childProcess.once('exit', (code) => {

--- a/packages/module-federation/src/executors/utils/build-static-remotes.ts
+++ b/packages/module-federation/src/executors/utils/build-static-remotes.ts
@@ -44,6 +44,7 @@ export async function buildStaticRemotes(
       {
         cwd: context.root,
         stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+        windowsHide: true,
         env: {
           ...process.env,
           // Ensure that webpack serve env var is not passed to static remotes

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/angular/nx-module-federation-ssr-dev-server-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/angular/nx-module-federation-ssr-dev-server-plugin.ts
@@ -127,7 +127,9 @@ export class NxModuleFederationSSRDevServerPlugin
         }
       }
 
-      this.devServerProcess = fork(serverPath);
+      this.devServerProcess = fork(serverPath, [], {
+        windowsHide: true,
+      });
       process.on('exit', () => {
         this.devServerProcess?.kill('SIGKILL');
       });

--- a/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-ssr-dev-server-plugin.ts
+++ b/packages/module-federation/src/plugins/nx-module-federation-plugin/rspack/nx-module-federation-ssr-dev-server-plugin.ts
@@ -127,7 +127,9 @@ export class NxModuleFederationSSRDevServerPlugin
         }
       }
 
-      this.devServerProcess = fork(serverPath);
+      this.devServerProcess = fork(serverPath, [], {
+        windowsHide: true,
+      });
       process.on('exit', () => {
         this.devServerProcess?.kill('SIGKILL');
       });

--- a/packages/module-federation/src/plugins/utils/build-static-remotes.ts
+++ b/packages/module-federation/src/plugins/utils/build-static-remotes.ts
@@ -35,6 +35,7 @@ export async function buildStaticRemotes(
       {
         cwd: workspaceRoot,
         stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+        windowsHide: true,
         env: {
           ...process.env,
           WEBPACK_SERVE: 'false',

--- a/packages/module-federation/src/plugins/utils/start-static-remotes-file-server.ts
+++ b/packages/module-federation/src/plugins/utils/start-static-remotes-file-server.ts
@@ -52,6 +52,7 @@ export function startStaticRemotesFileServer(
     {
       stdio: 'pipe',
       cwd: root,
+      windowsHide: true,
       env: {
         FORCE_COLOR: 'true',
         ...process.env,

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -107,6 +107,7 @@ export default async function* serveExecutor(
         {
           cwd: options.dev ? projectRoot : nextDir,
           stdio: 'inherit',
+          windowsHide: true,
         }
       );
 

--- a/packages/nx/src/tasks-runner/fork.ts
+++ b/packages/nx/src/tasks-runner/fork.ts
@@ -18,6 +18,7 @@ const childProcess = fork(script, {
   stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
   env: process.env,
   execArgv,
+  windowsHide: true,
 });
 
 const pseudoIPC = new PseudoIPCClient(pseudoIPCPath);

--- a/packages/nx/src/tasks-runner/forked-process-task-runner.ts
+++ b/packages/nx/src/tasks-runner/forked-process-task-runner.ts
@@ -67,6 +67,7 @@ export class ForkedProcessTaskRunner {
 
     const p = fork(workerPath, {
       stdio: ['inherit', 'pipe', 'pipe', 'ipc'],
+      windowsHide: true,
       env: {
         ...env,
         NX_FORKED_TASK_EXECUTOR: 'true',
@@ -283,6 +284,7 @@ export class ForkedProcessTaskRunner {
 
       const p = fork(this.cliPath, {
         stdio: ['inherit', 'pipe', 'pipe', 'ipc'],
+        windowsHide: true,
         env: {
           ...env,
           NX_FORKED_TASK_EXECUTOR: 'true',
@@ -349,6 +351,7 @@ export class ForkedProcessTaskRunner {
       }
       const p = fork(this.cliPath, {
         stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+        windowsHide: true,
         env: {
           ...env,
           NX_FORKED_TASK_EXECUTOR: 'true',

--- a/packages/react/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
+++ b/packages/react/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
@@ -97,6 +97,7 @@ async function buildHost(
       {
         cwd: context.root,
         stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+        windowsHide: true,
       }
     );
     staticProcess.stdout.on('data', (data) => {

--- a/packages/remix/src/executors/serve/serve.impl.ts
+++ b/packages/remix/src/executors/serve/serve.impl.ts
@@ -65,6 +65,7 @@ export default async function* serveExecutor(
       const server = fork(remixBin, ['dev', ...args], {
         cwd: join(workspaceRoot, projectRoot),
         stdio: 'inherit',
+        windowsHide: true,
       });
 
       server.once('exit', (code) => {

--- a/packages/rspack/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
+++ b/packages/rspack/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
@@ -97,6 +97,7 @@ async function buildHost(
       {
         cwd: context.root,
         stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+        windowsHide: true,
       }
     );
     staticProcess.stdout.on('data', (data) => {

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -242,6 +242,7 @@ export default async function* fileServerExecutor(
   const serve = fork(pathToHttpServer, [outputPath, ...args], {
     stdio: 'pipe',
     cwd: context.root,
+    windowsHide: true,
     env: {
       FORCE_COLOR: 'true',
       ...process.env,

--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -38,6 +38,7 @@ export function generatePreset(host: Tree, opts: NormalizedSchema) {
   const forkOptions: ForkOptions = {
     stdio: 'inherit',
     cwd: newWorkspaceRoot,
+    windowsHide: true,
   };
   const pmc = getPackageManagerCommand();
   const nxInstallationPaths = getNxRequirePaths(newWorkspaceRoot);


### PR DESCRIPTION
## Current behavior
On Windows, several Nx watch/dev code paths still use bare `child_process.fork()` calls. Those child processes can surface visible console windows during background restarts or dependent rebuilds, which matches the flashing-window regressions reported in #35036 and the earlier watcher issue.

## This PR
- adds `windowsHide: true` to the fork-based task runner paths used for background executor work
- applies the same Windows console suppression to the fork-based dev/server helpers that restart child processes during local development
- keeps the change narrowly behavioral on Windows without changing the command arguments or process wiring

## Validation
- `git diff --check`
- attempted `npx prettier --check` on the touched files, but the repo-local config requires `prettier-plugin-tailwindcss` which is not installed in this sparse worker clone