### PR TITLE
fix(core): remove unnecessary outputs glob from nx build target

### DIFF
--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -91,7 +91,6 @@
       ],
       "executor": "nx:run-commands",
       "outputs": [
-        "{workspaceRoot}/packages/nx/dist/**/*.{node,wasm,js,mjs,cjs,d.ts}",
         "{workspaceRoot}/packages/nx/dist/src/core/graph",
         "{workspaceRoot}/packages/nx/dist/bin/nx.js",
         "{workspaceRoot}/packages/nx/README.md"


### PR DESCRIPTION
## Current Behavior

The `nx:build` target declares `{workspaceRoot}/packages/nx/dist/**/*.{node,wasm,js,mjs,cjs,d.ts}` in its outputs, but the build target itself doesn't produce those files — they come from the `build-base` and `build-native` dependency targets, which are cached independently.

## Expected Behavior

The `build` target's outputs should only list what it actually produces: the graph client directory, the chmod'd `nx.js` binary, and the generated `README.md`.

## Related Issue(s)

N/A — cleanup discovered during code review.