### PR TITLE
fix(vitest): support passing mode through to vitest

### DIFF
--- a/packages/vitest/src/executors/test/vitest.impl.ts
+++ b/packages/vitest/src/executors/test/vitest.impl.ts
@@ -40,7 +40,10 @@ export async function* vitestExecutor(
   const ctx = await startVitest(
     options.runMode ?? 'test',
     cliFilters,
-    resolvedOptions
+    resolvedOptions,
+    {
+      mode: options.mode ?? 'test',
+    }
   );
 
   let hasErrors = false;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

When Nx loads the Vitest config it correctly loads with the specified mode. However, when passing the config over to Vitest the mode is not forwarded along and on the second time the config is loaded the mode resorts back to `test`.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

The mode should be consistent across when Nx loads the config and when Vitest loads the config.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

