### PR TITLE
fix(core): preserve sibling dependency inputs in native hashing

### DIFF
--- a/packages/gradle/tsconfig.lib.json
+++ b/packages/gradle/tsconfig.lib.json
@@ -6,7 +6,12 @@
     "tsBuildInfoFile": "../../dist/packages/gradle/tsconfig.tsbuildinfo"
   },
   "include": ["**/*.ts"],
-  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],
+  "exclude": [
+    "jest.config.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "project-graph/**"
+  ],
   "references": [
     {
       "path": "../nx/tsconfig.lib.json"

--- a/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
+++ b/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
@@ -410,6 +410,263 @@ describe('native task hasher', () => {
     `);
   });
 
+  it.each([
+    [
+      'before production',
+      ['default', '^{projectRoot}/tsconfig*.json', '^prod'],
+    ],
+    ['after production', ['default', '^prod', '^{projectRoot}/tsconfig*.json']],
+  ])(
+    'should apply multiple dependency inputs to the same dependency when tsconfig inputs are listed %s',
+    async (_, targetInputs) => {
+      await tempFs.createFiles({
+        'libs/child/tsconfig.spec.json': JSON.stringify({
+          extends: '../../tsconfig.base.json',
+        }),
+        'libs/child/src/runtime.ts': 'export const runtime = true;',
+        'libs/child/src/runtime.spec.ts': 'export {};',
+      });
+
+      const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, {
+        'libs/parent': 'parent',
+        'libs/child': 'child',
+      });
+      const builder = new ProjectGraphBuilder(
+        undefined,
+        workspaceFiles.fileMap.projectFileMap
+      );
+
+      builder.addNode({
+        name: 'parent',
+        type: 'e2e',
+        data: {
+          root: 'libs/parent',
+          targets: {
+            e2e: {
+              executor: 'nx:run-commands',
+              inputs: targetInputs,
+            },
+          },
+        },
+      });
+      builder.addNode({
+        name: 'child',
+        type: 'lib',
+        data: {
+          root: 'libs/child',
+          targets: {},
+        },
+      });
+      builder.addStaticDependency(
+        'parent',
+        'child',
+        'libs/parent/src/index.ts'
+      );
+
+      const projectGraph = builder.getUpdatedProjectGraph();
+      const taskGraph = createTaskGraph(
+        projectGraph,
+        {},
+        ['parent'],
+        ['e2e'],
+        undefined,
+        {}
+      );
+
+      const localNxJson: NxJsonConfiguration = {
+        namedInputs: {
+          default: ['{projectRoot}/**/*'],
+          prod: [
+            '!{projectRoot}/**/*.spec.ts',
+            '!{projectRoot}/tsconfig.spec.json',
+          ],
+        },
+      };
+
+      const hash = await new NativeTaskHasherImpl(
+        tempFs.tempDir,
+        localNxJson,
+        projectGraph,
+        workspaceFiles.rustReferences,
+        { selectivelyHashTsConfig: false }
+      ).hashTask(taskGraph.tasks['parent:e2e'], taskGraph, {});
+
+      expect(hash.inputs.files).toEqual(
+        expect.arrayContaining([
+          'libs/child/src/runtime.ts',
+          'libs/child/tsconfig.spec.json',
+        ])
+      );
+      expect(hash.inputs.files).not.toContain('libs/child/src/runtime.spec.ts');
+    }
+  );
+
+  it('should apply multiple dependency inputs to shared transitive dependencies', async () => {
+    await tempFs.createFiles({
+      'libs/left/src/index.ts': 'export const left = true;',
+      'libs/right/src/index.ts': 'export const right = true;',
+      'libs/shared/tsconfig.spec.json': JSON.stringify({
+        extends: '../../tsconfig.base.json',
+      }),
+      'libs/shared/src/runtime.ts': 'export const runtime = true;',
+      'libs/shared/src/runtime.spec.ts': 'export {};',
+    });
+
+    const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, {
+      'libs/parent': 'parent',
+      'libs/left': 'left',
+      'libs/right': 'right',
+      'libs/shared': 'shared',
+    });
+    const builder = new ProjectGraphBuilder(
+      undefined,
+      workspaceFiles.fileMap.projectFileMap
+    );
+
+    builder.addNode({
+      name: 'parent',
+      type: 'e2e',
+      data: {
+        root: 'libs/parent',
+        targets: {
+          e2e: {
+            executor: 'nx:run-commands',
+            inputs: ['default', '^{projectRoot}/tsconfig*.json', '^prod'],
+          },
+        },
+      },
+    });
+    for (const name of ['left', 'right', 'shared']) {
+      builder.addNode({
+        name,
+        type: 'lib',
+        data: {
+          root: `libs/${name}`,
+          targets: {},
+        },
+      });
+    }
+    builder.addStaticDependency('parent', 'left', 'libs/parent/src/index.ts');
+    builder.addStaticDependency('parent', 'right', 'libs/parent/src/index.ts');
+    builder.addStaticDependency('left', 'shared', 'libs/left/src/index.ts');
+    builder.addStaticDependency('right', 'shared', 'libs/right/src/index.ts');
+
+    const projectGraph = builder.getUpdatedProjectGraph();
+    const taskGraph = createTaskGraph(
+      projectGraph,
+      {},
+      ['parent'],
+      ['e2e'],
+      undefined,
+      {}
+    );
+
+    const localNxJson: NxJsonConfiguration = {
+      namedInputs: {
+        default: ['{projectRoot}/**/*'],
+        prod: [
+          '!{projectRoot}/**/*.spec.ts',
+          '!{projectRoot}/tsconfig.spec.json',
+        ],
+      },
+    };
+
+    const hash = await new NativeTaskHasherImpl(
+      tempFs.tempDir,
+      localNxJson,
+      projectGraph,
+      workspaceFiles.rustReferences,
+      { selectivelyHashTsConfig: false }
+    ).hashTask(taskGraph.tasks['parent:e2e'], taskGraph, {});
+
+    expect(hash.inputs.files).toEqual(
+      expect.arrayContaining([
+        'libs/shared/src/runtime.ts',
+        'libs/shared/tsconfig.spec.json',
+      ])
+    );
+    expect(hash.inputs.files).not.toContain('libs/shared/src/runtime.spec.ts');
+  });
+
+  it('should apply multiple dependency inputs in circular dependencies', async () => {
+    await tempFs.createFiles({
+      'libs/child/tsconfig.spec.json': JSON.stringify({
+        extends: '../../tsconfig.base.json',
+      }),
+      'libs/child/src/runtime.ts': 'export const runtime = true;',
+      'libs/child/src/runtime.spec.ts': 'export {};',
+    });
+
+    const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, {
+      'libs/parent': 'parent',
+      'libs/child': 'child',
+    });
+    const builder = new ProjectGraphBuilder(
+      undefined,
+      workspaceFiles.fileMap.projectFileMap
+    );
+
+    builder.addNode({
+      name: 'parent',
+      type: 'e2e',
+      data: {
+        root: 'libs/parent',
+        targets: {
+          e2e: {
+            executor: 'nx:run-commands',
+            inputs: ['default', '^{projectRoot}/tsconfig*.json', '^prod'],
+          },
+        },
+      },
+    });
+    builder.addNode({
+      name: 'child',
+      type: 'lib',
+      data: {
+        root: 'libs/child',
+        targets: {},
+      },
+    });
+    builder.addStaticDependency('parent', 'child', 'libs/parent/src/index.ts');
+    builder.addStaticDependency('child', 'parent', 'libs/child/src/index.ts');
+
+    const projectGraph = builder.getUpdatedProjectGraph();
+    const taskGraph = createTaskGraph(
+      projectGraph,
+      {},
+      ['parent'],
+      ['e2e'],
+      undefined,
+      {}
+    );
+
+    const localNxJson: NxJsonConfiguration = {
+      namedInputs: {
+        default: ['{projectRoot}/**/*'],
+        prod: [
+          '!{projectRoot}/**/*.spec.ts',
+          '!{projectRoot}/tsconfig.spec.json',
+        ],
+      },
+    };
+
+    const hash = await new NativeTaskHasherImpl(
+      tempFs.tempDir,
+      localNxJson,
+      projectGraph,
+      workspaceFiles.rustReferences,
+      { selectivelyHashTsConfig: false }
+    ).hashTask(taskGraph.tasks['parent:e2e'], taskGraph, {});
+
+    expect(hash.inputs.files).toEqual(
+      expect.arrayContaining([
+        'libs/child/src/runtime.ts',
+        'libs/child/tsconfig.spec.json',
+      ])
+    );
+    expect(hash.inputs.files).not.toContain('libs/child/src/runtime.spec.ts');
+  });
+
   it('should make a plan with multiple filesets of a project', async () => {
     let nxJson = {
       namedInputs: {

--- a/packages/nx/src/native/tasks/hash_plan_inspector.rs
+++ b/packages/nx/src/native/tasks/hash_plan_inspector.rs
@@ -1,5 +1,6 @@
 use crate::native::tasks::hashers::{
-    hash_project_files_with_inputs, hash_workspace_files_with_inputs, resolve_task_output_files,
+    ProjectFileSetCache, hash_project_files_with_inputs_cached, hash_workspace_files_with_inputs,
+    resolve_task_output_files,
 };
 use crate::native::tasks::task_hasher::{HashInputs, HashInputsBuilder};
 use crate::native::tasks::types::HashInstruction;
@@ -41,6 +42,7 @@ impl HashPlanInspector {
         &self,
         hash_plans: &External<HashMap<String, Vec<HashInstruction>>>,
     ) -> anyhow::Result<HashMap<String, Vec<String>>> {
+        let project_file_set_cache = ProjectFileSetCache::new();
         let results: Vec<(&String, Vec<String>)> = hash_plans
             .iter()
             .flat_map(|(task_id, instructions)| {
@@ -54,7 +56,8 @@ impl HashPlanInspector {
                     // File-set instructions: resolve to actual file paths
                     HashInstruction::WorkspaceFileSet(_)
                     | HashInstruction::ProjectFileSet(_, _) => {
-                        let builder = self.resolve_instruction_inputs(instruction)?;
+                        let builder =
+                            self.resolve_instruction_inputs(instruction, &project_file_set_cache)?;
                         builder
                             .files
                             .into_iter()
@@ -85,6 +88,7 @@ impl HashPlanInspector {
         &self,
         hash_plans: &External<HashMap<String, Vec<HashInstruction>>>,
     ) -> anyhow::Result<HashMap<String, HashInputs>> {
+        let project_file_set_cache = ProjectFileSetCache::new();
         let results: Vec<(&String, HashInputsBuilder)> = hash_plans
             .iter()
             .flat_map(|(task_id, instructions)| {
@@ -94,7 +98,8 @@ impl HashPlanInspector {
             })
             .par_bridge()
             .map(|(task_id, instruction)| {
-                let builder = self.resolve_instruction_inputs(instruction)?;
+                let builder =
+                    self.resolve_instruction_inputs(instruction, &project_file_set_cache)?;
                 Ok::<_, anyhow::Error>((task_id, builder))
             })
             .collect::<anyhow::Result<_>>()?;
@@ -118,6 +123,7 @@ impl HashPlanInspector {
     fn resolve_instruction_inputs(
         &self,
         instruction: &HashInstruction,
+        project_file_set_cache: &ProjectFileSetCache,
     ) -> anyhow::Result<HashInputsBuilder> {
         match instruction {
             HashInstruction::WorkspaceFileSet(workspace_file_set) => {
@@ -131,13 +137,14 @@ impl HashPlanInspector {
                 })
             }
             HashInstruction::ProjectFileSet(project_name, file_sets) => {
-                let result = hash_project_files_with_inputs(
+                let result = hash_project_files_with_inputs_cached(
                     project_name,
                     file_sets,
                     &self.project_file_map,
+                    project_file_set_cache,
                 )?;
                 Ok(HashInputsBuilder {
-                    files: result.files.into_iter().collect(),
+                    files: result.files.iter().cloned().collect(),
                     ..Default::default()
                 })
             }

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -313,43 +313,80 @@ impl HashPlanner {
         external_deps_mapped: &hashbrown::HashMap<&String, Vec<&'a String>>,
         visited: &mut Box<hashbrown::HashSet<&'a str>>,
     ) -> anyhow::Result<Vec<HashInstruction>> {
+        if inputs.len() == 1 {
+            return self.gather_dependency_input(
+                task,
+                &inputs[0],
+                task_graph,
+                project_deps,
+                external_deps_mapped,
+                visited,
+            );
+        }
+
         let mut deps_inputs: Vec<HashInstruction> =
             Vec::with_capacity(inputs.len() * project_deps.len());
 
         for input in inputs {
-            for dep in project_deps {
-                if visited.contains(dep.as_str()) {
-                    continue;
-                }
-                visited.insert(dep.as_str());
+            // Dependency inputs are independent. Scope cycle detection to each
+            // input so sibling inputs all apply to the same dependency.
+            let mut visited_for_input = Box::new((**visited).clone());
+            deps_inputs.extend(self.gather_dependency_input(
+                task,
+                input,
+                task_graph,
+                project_deps,
+                external_deps_mapped,
+                &mut visited_for_input,
+            )?);
+        }
 
-                if self.project_graph.nodes.contains_key(dep) {
-                    let Some(dep_inputs) = get_inputs_for_dependency(
-                        &self.project_graph.nodes[dep],
-                        &self.nx_json,
-                        input,
-                    )?
-                    else {
-                        continue;
-                    };
-                    deps_inputs.extend(self.self_and_deps_inputs(
-                        dep,
-                        task,
-                        &dep_inputs,
-                        task_graph,
-                        external_deps_mapped,
-                        visited,
-                    )?);
-                } else {
-                    // todo(jcammisuli): add a check to skip this when the new task hasher is ready, and when `AllExternalDependencies` is used
-                    if let Some(external_deps) = external_deps_mapped.get(dep) {
-                        deps_inputs.push(HashInstruction::External(dep.to_string()));
-                        deps_inputs.extend(
-                            external_deps
-                                .iter()
-                                .map(|s| HashInstruction::External(s.to_string())),
-                        );
-                    }
+        Ok(deps_inputs)
+    }
+
+    fn gather_dependency_input<'a>(
+        &'a self,
+        task: &Task,
+        input: &Input,
+        task_graph: &TaskGraph,
+        project_deps: &'a [String],
+        external_deps_mapped: &hashbrown::HashMap<&String, Vec<&'a String>>,
+        visited: &mut Box<hashbrown::HashSet<&'a str>>,
+    ) -> anyhow::Result<Vec<HashInstruction>> {
+        let mut deps_inputs: Vec<HashInstruction> = Vec::with_capacity(project_deps.len());
+
+        for dep in project_deps {
+            if visited.contains(dep.as_str()) {
+                continue;
+            }
+            visited.insert(dep.as_str());
+
+            if self.project_graph.nodes.contains_key(dep) {
+                let Some(dep_inputs) = get_inputs_for_dependency(
+                    &self.project_graph.nodes[dep],
+                    &self.nx_json,
+                    input,
+                )?
+                else {
+                    continue;
+                };
+                deps_inputs.extend(self.self_and_deps_inputs(
+                    dep,
+                    task,
+                    &dep_inputs,
+                    task_graph,
+                    external_deps_mapped,
+                    visited,
+                )?);
+            } else {
+                // todo(jcammisuli): add a check to skip this when the new task hasher is ready, and when `AllExternalDependencies` is used
+                if let Some(external_deps) = external_deps_mapped.get(dep) {
+                    deps_inputs.push(HashInstruction::External(dep.to_string()));
+                    deps_inputs.extend(
+                        external_deps
+                            .iter()
+                            .map(|s| HashInstruction::External(s.to_string())),
+                    );
                 }
             }
         }

--- a/packages/nx/src/native/tasks/hashers.rs
+++ b/packages/nx/src/native/tasks/hashers.rs
@@ -12,7 +12,10 @@ pub use hash_cwd::*;
 pub use hash_env::*;
 pub use hash_external::*;
 pub use hash_project_config::*;
-pub use hash_project_files::*;
+pub(crate) use hash_project_files::{ProjectFileSetCache, hash_project_files_with_inputs_cached};
+pub use hash_project_files::{
+    ProjectFilesHashResult, collect_project_files, hash_project_files_with_inputs,
+};
 pub use hash_runtime::*;
 pub use hash_task_output::*;
 pub use hash_tsconfig::*;

--- a/packages/nx/src/native/tasks/hashers/hash_project_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_project_files.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use anyhow::*;
+use dashmap::DashMap;
+use once_cell::sync::OnceCell;
 use tracing::{trace, trace_span};
 
 use crate::native::glob::build_glob_set;
@@ -10,6 +13,19 @@ use crate::native::types::FileData;
 pub struct ProjectFilesHashResult {
     pub hash: String,
     pub files: Vec<String>,
+}
+
+pub(crate) type ProjectFileSetCache = DashMap<String, Arc<OnceCell<Arc<ProjectFilesHashResult>>>>;
+
+fn project_file_set_cache_key(project_name: &str, file_sets: &[String]) -> String {
+    let mut sorted_file_sets: Vec<&str> = file_sets.iter().map(String::as_str).collect();
+    sorted_file_sets.sort();
+
+    format!(
+        "{project_name}\0{}\0{}",
+        sorted_file_sets.len(),
+        sorted_file_sets.join("\0")
+    )
 }
 
 /// Hashes project files and returns both the hash and the list of matched file paths.
@@ -38,6 +54,25 @@ pub fn hash_project_files_with_inputs(
         hash: hasher.digest().to_string(),
         files,
     })
+}
+
+pub(crate) fn hash_project_files_with_inputs_cached(
+    project_name: &str,
+    file_sets: &[String],
+    project_file_map: &HashMap<String, Vec<FileData>>,
+    cache: &ProjectFileSetCache,
+) -> Result<Arc<ProjectFilesHashResult>> {
+    let cache_key = project_file_set_cache_key(project_name, file_sets);
+    let cache_cell = cache
+        .entry(cache_key)
+        .or_insert_with(|| Arc::new(OnceCell::new()))
+        .clone();
+
+    cache_cell
+        .get_or_try_init(|| {
+            hash_project_files_with_inputs(project_name, file_sets, project_file_map).map(Arc::new)
+        })
+        .cloned()
 }
 
 /// base function that should be testable (to make sure that we're getting the proper files back)
@@ -220,5 +255,43 @@ mod tests {
                 .concat()
             )
         );
+    }
+
+    #[test]
+    fn should_cache_by_project_and_fileset_combo_regardless_of_order() {
+        let proj_name = "test_project";
+        let first_file_sets = &[
+            "test/root/**/*".to_string(),
+            "!test/root/**/*.spec.ts".to_string(),
+        ];
+        let second_file_sets = &[
+            "!test/root/**/*.spec.ts".to_string(),
+            "test/root/**/*".to_string(),
+        ];
+        let mut file_map = HashMap::new();
+        file_map.insert(
+            String::from(proj_name),
+            vec![
+                FileData {
+                    file: "test/root/test1.ts".into(),
+                    hash: "file_data1".into(),
+                },
+                FileData {
+                    file: "test/root/test.spec.ts".into(),
+                    hash: "file_data2".into(),
+                },
+            ],
+        );
+
+        let cache = ProjectFileSetCache::new();
+        let first =
+            hash_project_files_with_inputs_cached(proj_name, first_file_sets, &file_map, &cache)
+                .unwrap();
+        let second =
+            hash_project_files_with_inputs_cached(proj_name, second_file_sets, &file_map, &cache)
+                .unwrap();
+
+        assert_eq!(cache.len(), 1);
+        assert!(Arc::ptr_eq(&first, &second));
     }
 }

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -16,9 +16,9 @@ use crate::native::{
 };
 use crate::native::{
     tasks::hashers::{
-        CachedTaskOutput, hash_all_externals, hash_external, hash_project_config,
-        hash_project_files_with_inputs, hash_task_output, hash_tsconfig_selectively,
-        hash_workspace_files_with_inputs,
+        CachedTaskOutput, ProjectFileSetCache, hash_all_externals, hash_external,
+        hash_project_config, hash_project_files_with_inputs_cached, hash_task_output,
+        hash_tsconfig_selectively, hash_workspace_files_with_inputs,
     },
     types::FileData,
     workspace::types::ProjectFiles,
@@ -203,7 +203,7 @@ impl TaskHasher {
         // the TaskHasher instance.
         let task_output_cache = DashMap::new();
         let runtime_cache: DashMap<String, String> = DashMap::new();
-        let project_file_set_cache: DashMap<String, CachedFileSetHash> = DashMap::new();
+        let project_file_set_cache = ProjectFileSetCache::new();
         let workspace_file_set_cache: DashMap<String, CachedFileSetHash> = DashMap::new();
         let should_collect_inputs = collect_task_inputs.unwrap_or(false);
 
@@ -404,33 +404,22 @@ impl TaskHasher {
                 (hashed_cwd, empty)
             }
             HashInstruction::ProjectFileSet(project_name, file_sets) => {
-                let cache_key = instruction.to_string();
-                // Check cache first; clone and drop the Ref before any insert
-                let cached_entry = if let Some(entry) = project_file_set_cache.get(&cache_key) {
-                    entry.clone()
-                } else {
-                    let result = hash_project_files_with_inputs(
-                        project_name,
-                        file_sets,
-                        &self.project_file_map,
-                    )?;
-                    let entry = CachedFileSetHash {
-                        hash: result.hash,
-                        files: result.files,
-                    };
-                    project_file_set_cache.insert(cache_key, entry.clone());
-                    entry
-                };
+                let cached_entry = hash_project_files_with_inputs_cached(
+                    project_name,
+                    file_sets,
+                    &self.project_file_map,
+                    project_file_set_cache,
+                )?;
                 trace!(parent: &span, "hash_project_files: {:?}", now.elapsed());
                 let inputs = if collect_inputs {
                     HashInputsBuilder {
-                        files: cached_entry.files.into_iter().collect(),
+                        files: cached_entry.files.iter().cloned().collect(),
                         ..Default::default()
                     }
                 } else {
                     empty
                 };
-                (cached_entry.hash, inputs)
+                (cached_entry.hash.clone(), inputs)
             }
             HashInstruction::ProjectConfiguration(project_name) => {
                 let hashed_project_config =
@@ -547,7 +536,7 @@ struct HashInstructionArgs<'a> {
     selectively_hash_tsconfig: bool,
     task_output_cache: &'a DashMap<String, CachedTaskOutput>,
     runtime_cache: &'a DashMap<String, String>,
-    project_file_set_cache: &'a DashMap<String, CachedFileSetHash>,
+    project_file_set_cache: &'a ProjectFileSetCache,
     workspace_file_set_cache: &'a DashMap<String, CachedFileSetHash>,
     cwd: &'a std::path::Path,
     collect_inputs: bool,

--- a/packages/nx/src/native/tests/planner.spec.ts
+++ b/packages/nx/src/native/tests/planner.spec.ts
@@ -252,6 +252,230 @@ describe('task planner', () => {
     expect(plans).toMatchSnapshot();
   });
 
+  it.each([
+    [
+      'before production',
+      ['default', '^{projectRoot}/tsconfig*.json', '^prod'],
+    ],
+    ['after production', ['default', '^prod', '^{projectRoot}/tsconfig*.json']],
+  ])(
+    'should apply multiple dependency inputs to the same dependency when tsconfig inputs are listed %s',
+    async (_, targetInputs) => {
+      const projectFileMap = {
+        parent: [{ file: 'libs/parent/e2e.spec.ts', hash: 'parent.hash' }],
+        child: [
+          { file: 'libs/child/src/index.ts', hash: 'child.hash' },
+          { file: 'libs/child/src/index.spec.ts', hash: 'child.spec.hash' },
+          {
+            file: 'libs/child/tsconfig.spec.json',
+            hash: 'child.tsconfig.hash',
+          },
+        ],
+      };
+
+      const builder = new ProjectGraphBuilder(undefined, projectFileMap);
+      builder.addNode({
+        name: 'parent',
+        type: 'lib',
+        data: {
+          root: 'libs/parent',
+          targets: {
+            e2e: {
+              inputs: targetInputs,
+              executor: 'nx:run-commands',
+            },
+          },
+        },
+      });
+      builder.addNode({
+        name: 'child',
+        type: 'lib',
+        data: {
+          root: 'libs/child',
+          targets: {},
+        },
+      });
+      builder.addStaticDependency('parent', 'child', 'libs/parent/e2e.spec.ts');
+
+      const projectGraph = builder.getUpdatedProjectGraph();
+      const taskGraph = createTaskGraph(
+        projectGraph,
+        {},
+        ['parent'],
+        ['e2e'],
+        undefined,
+        {}
+      );
+      const nxJson = {
+        namedInputs: {
+          prod: [
+            '!{projectRoot}/**/*.spec.ts',
+            '!{projectRoot}/tsconfig.spec.json',
+          ],
+        },
+      } as any;
+
+      const planner = new HashPlanner(
+        nxJson,
+        transferProjectGraph(transformProjectGraphForRust(projectGraph))
+      );
+      const plans = planner.getPlans(['parent:e2e'], taskGraph);
+
+      expect(plans['parent:e2e']).toEqual(
+        expect.arrayContaining([
+          'child:libs/child/tsconfig*.json',
+          'child:!libs/child/**/*.spec.ts,!libs/child/tsconfig.spec.json',
+        ])
+      );
+    }
+  );
+
+  it('should apply multiple dependency inputs to shared transitive dependencies', async () => {
+    const projectFileMap = {
+      parent: [{ file: 'libs/parent/e2e.spec.ts', hash: 'parent.hash' }],
+      left: [{ file: 'libs/left/src/index.ts', hash: 'left.hash' }],
+      right: [{ file: 'libs/right/src/index.ts', hash: 'right.hash' }],
+      shared: [
+        { file: 'libs/shared/src/index.ts', hash: 'shared.hash' },
+        { file: 'libs/shared/src/index.spec.ts', hash: 'shared.spec.hash' },
+        {
+          file: 'libs/shared/tsconfig.spec.json',
+          hash: 'shared.tsconfig.hash',
+        },
+      ],
+    };
+
+    const builder = new ProjectGraphBuilder(undefined, projectFileMap);
+    builder.addNode({
+      name: 'parent',
+      type: 'lib',
+      data: {
+        root: 'libs/parent',
+        targets: {
+          e2e: {
+            inputs: ['default', '^{projectRoot}/tsconfig*.json', '^prod'],
+            executor: 'nx:run-commands',
+          },
+        },
+      },
+    });
+    for (const name of ['left', 'right', 'shared']) {
+      builder.addNode({
+        name,
+        type: 'lib',
+        data: {
+          root: `libs/${name}`,
+          targets: {},
+        },
+      });
+    }
+    builder.addStaticDependency('parent', 'left', 'libs/parent/e2e.spec.ts');
+    builder.addStaticDependency('parent', 'right', 'libs/parent/e2e.spec.ts');
+    builder.addStaticDependency('left', 'shared', 'libs/left/src/index.ts');
+    builder.addStaticDependency('right', 'shared', 'libs/right/src/index.ts');
+
+    const projectGraph = builder.getUpdatedProjectGraph();
+    const taskGraph = createTaskGraph(
+      projectGraph,
+      {},
+      ['parent'],
+      ['e2e'],
+      undefined,
+      {}
+    );
+    const nxJson = {
+      namedInputs: {
+        prod: [
+          '!{projectRoot}/**/*.spec.ts',
+          '!{projectRoot}/tsconfig.spec.json',
+        ],
+      },
+    } as any;
+
+    const planner = new HashPlanner(
+      nxJson,
+      transferProjectGraph(transformProjectGraphForRust(projectGraph))
+    );
+    const plans = planner.getPlans(['parent:e2e'], taskGraph);
+
+    expect(plans['parent:e2e']).toEqual(
+      expect.arrayContaining([
+        'shared:libs/shared/tsconfig*.json',
+        'shared:!libs/shared/**/*.spec.ts,!libs/shared/tsconfig.spec.json',
+      ])
+    );
+  });
+
+  it('should apply multiple dependency inputs in circular dependencies', async () => {
+    const projectFileMap = {
+      parent: [{ file: 'libs/parent/e2e.spec.ts', hash: 'parent.hash' }],
+      child: [
+        { file: 'libs/child/src/index.ts', hash: 'child.hash' },
+        { file: 'libs/child/src/index.spec.ts', hash: 'child.spec.hash' },
+        {
+          file: 'libs/child/tsconfig.spec.json',
+          hash: 'child.tsconfig.hash',
+        },
+      ],
+    };
+
+    const builder = new ProjectGraphBuilder(undefined, projectFileMap);
+    builder.addNode({
+      name: 'parent',
+      type: 'lib',
+      data: {
+        root: 'libs/parent',
+        targets: {
+          e2e: {
+            inputs: ['default', '^{projectRoot}/tsconfig*.json', '^prod'],
+            executor: 'nx:run-commands',
+          },
+        },
+      },
+    });
+    builder.addNode({
+      name: 'child',
+      type: 'lib',
+      data: {
+        root: 'libs/child',
+        targets: {},
+      },
+    });
+    builder.addStaticDependency('parent', 'child', 'libs/parent/e2e.spec.ts');
+    builder.addStaticDependency('child', 'parent', 'libs/child/src/index.ts');
+
+    const projectGraph = builder.getUpdatedProjectGraph();
+    const taskGraph = createTaskGraph(
+      projectGraph,
+      {},
+      ['parent'],
+      ['e2e'],
+      undefined,
+      {}
+    );
+    const nxJson = {
+      namedInputs: {
+        prod: [
+          '!{projectRoot}/**/*.spec.ts',
+          '!{projectRoot}/tsconfig.spec.json',
+        ],
+      },
+    } as any;
+
+    const planner = new HashPlanner(
+      nxJson,
+      transferProjectGraph(transformProjectGraphForRust(projectGraph))
+    );
+    const plans = planner.getPlans(['parent:e2e'], taskGraph);
+
+    expect(plans['parent:e2e']).toEqual(
+      expect.arrayContaining([
+        'child:libs/child/tsconfig*.json',
+        'child:!libs/child/**/*.spec.ts,!libs/child/tsconfig.spec.json',
+      ])
+    );
+  });
+
   it('should make a plan with multiple filesets of a project', async () => {
     let projectFileMap = {
       parent: [

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -71,8 +71,8 @@ describe('@nx/playwright/plugin', () => {
                     "command": "playwright test",
                     "inputs": [
                       "default",
-                      "^{projectRoot}/tsconfig*.json",
                       "^production",
+                      "^{projectRoot}/tsconfig*.json",
                       {
                         "externalDependencies": [
                           "@playwright/test",
@@ -107,8 +107,8 @@ describe('@nx/playwright/plugin', () => {
                     "executor": "nx:noop",
                     "inputs": [
                       "default",
-                      "^{projectRoot}/tsconfig*.json",
                       "^production",
+                      "^{projectRoot}/tsconfig*.json",
                       {
                         "externalDependencies": [
                           "@playwright/test",
@@ -140,8 +140,8 @@ describe('@nx/playwright/plugin', () => {
                     "executor": "@nx/playwright:merge-reports",
                     "inputs": [
                       "default",
-                      "^{projectRoot}/tsconfig*.json",
                       "^production",
+                      "^{projectRoot}/tsconfig*.json",
                       {
                         "externalDependencies": [
                           "@playwright/test",
@@ -212,8 +212,8 @@ describe('@nx/playwright/plugin', () => {
                     "command": "playwright test",
                     "inputs": [
                       "default",
-                      "^{projectRoot}/tsconfig*.json",
                       "^production",
+                      "^{projectRoot}/tsconfig*.json",
                       {
                         "externalDependencies": [
                           "@playwright/test",
@@ -250,8 +250,8 @@ describe('@nx/playwright/plugin', () => {
                     "executor": "nx:noop",
                     "inputs": [
                       "default",
-                      "^{projectRoot}/tsconfig*.json",
                       "^production",
+                      "^{projectRoot}/tsconfig*.json",
                       {
                         "externalDependencies": [
                           "@playwright/test",
@@ -285,8 +285,8 @@ describe('@nx/playwright/plugin', () => {
                     "executor": "@nx/playwright:merge-reports",
                     "inputs": [
                       "default",
-                      "^{projectRoot}/tsconfig*.json",
                       "^production",
+                      "^{projectRoot}/tsconfig*.json",
                       {
                         "externalDependencies": [
                           "@playwright/test",
@@ -377,8 +377,8 @@ describe('@nx/playwright/plugin', () => {
         "executor": "nx:noop",
         "inputs": [
           "default",
-          "^{projectRoot}/tsconfig*.json",
           "^production",
+          "^{projectRoot}/tsconfig*.json",
           {
             "externalDependencies": [
               "@playwright/test",
@@ -414,8 +414,8 @@ describe('@nx/playwright/plugin', () => {
         "command": "playwright test tests/run-me.spec.ts --output=test-results/tests-run-me-spec-ts",
         "inputs": [
           "default",
-          "^{projectRoot}/tsconfig*.json",
           "^production",
+          "^{projectRoot}/tsconfig*.json",
           {
             "externalDependencies": [
               "@playwright/test",
@@ -458,8 +458,8 @@ describe('@nx/playwright/plugin', () => {
         "command": "playwright test tests/run-me-2.spec.ts --output=test-results/tests-run-me-2-spec-ts",
         "inputs": [
           "default",
-          "^{projectRoot}/tsconfig*.json",
           "^production",
+          "^{projectRoot}/tsconfig*.json",
           {
             "externalDependencies": [
               "@playwright/test",
@@ -558,8 +558,8 @@ describe('@nx/playwright/plugin', () => {
         "executor": "nx:noop",
         "inputs": [
           "default",
-          "^{projectRoot}/tsconfig*.json",
           "^production",
+          "^{projectRoot}/tsconfig*.json",
           {
             "externalDependencies": [
               "@playwright/test",
@@ -596,8 +596,8 @@ describe('@nx/playwright/plugin', () => {
         "command": "playwright test tests/run-me.spec.ts --output=test-results/tests-run-me-spec-ts",
         "inputs": [
           "default",
-          "^{projectRoot}/tsconfig*.json",
           "^production",
+          "^{projectRoot}/tsconfig*.json",
           {
             "externalDependencies": [
               "@playwright/test",
@@ -642,8 +642,8 @@ describe('@nx/playwright/plugin', () => {
         "command": "playwright test tests/run-me-2.spec.ts --output=test-results/tests-run-me-2-spec-ts",
         "inputs": [
           "default",
-          "^{projectRoot}/tsconfig*.json",
           "^production",
+          "^{projectRoot}/tsconfig*.json",
           {
             "externalDependencies": [
               "@playwright/test",
@@ -688,8 +688,8 @@ describe('@nx/playwright/plugin', () => {
         "executor": "@nx/playwright:merge-reports",
         "inputs": [
           "default",
-          "^{projectRoot}/tsconfig*.json",
           "^production",
+          "^{projectRoot}/tsconfig*.json",
           {
             "externalDependencies": [
               "@playwright/test",
@@ -751,8 +751,8 @@ describe('@nx/playwright/plugin', () => {
         ],
         "inputs": [
           "default",
-          "^{projectRoot}/tsconfig*.json",
           "^production",
+          "^{projectRoot}/tsconfig*.json",
           {
             "externalDependencies": [
               "@playwright/test",
@@ -801,8 +801,8 @@ describe('@nx/playwright/plugin', () => {
         "executor": "nx:noop",
         "inputs": [
           "default",
-          "^{projectRoot}/tsconfig*.json",
           "^production",
+          "^{projectRoot}/tsconfig*.json",
           {
             "externalDependencies": [
               "@playwright/test",
@@ -853,8 +853,8 @@ describe('@nx/playwright/plugin', () => {
         ],
         "inputs": [
           "default",
-          "^{projectRoot}/tsconfig*.json",
           "^production",
+          "^{projectRoot}/tsconfig*.json",
           {
             "externalDependencies": [
               "@playwright/test",
@@ -898,8 +898,8 @@ describe('@nx/playwright/plugin', () => {
         ],
         "inputs": [
           "default",
-          "^{projectRoot}/tsconfig*.json",
           "^production",
+          "^{projectRoot}/tsconfig*.json",
           {
             "externalDependencies": [
               "@playwright/test",
@@ -977,8 +977,8 @@ describe('@nx/playwright/plugin', () => {
         ],
         "inputs": [
           "default",
-          "^{projectRoot}/tsconfig*.json",
           "^production",
+          "^{projectRoot}/tsconfig*.json",
           {
             "externalDependencies": [
               "@playwright/test",
@@ -1027,8 +1027,8 @@ describe('@nx/playwright/plugin', () => {
         "executor": "nx:noop",
         "inputs": [
           "default",
-          "^{projectRoot}/tsconfig*.json",
           "^production",
+          "^{projectRoot}/tsconfig*.json",
           {
             "externalDependencies": [
               "@playwright/test",
@@ -1086,8 +1086,8 @@ describe('@nx/playwright/plugin', () => {
         ],
         "inputs": [
           "default",
-          "^{projectRoot}/tsconfig*.json",
           "^production",
+          "^{projectRoot}/tsconfig*.json",
           {
             "externalDependencies": [
               "@playwright/test",
@@ -1138,8 +1138,8 @@ describe('@nx/playwright/plugin', () => {
         ],
         "inputs": [
           "default",
-          "^{projectRoot}/tsconfig*.json",
           "^production",
+          "^{projectRoot}/tsconfig*.json",
           {
             "externalDependencies": [
               "@playwright/test",

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -171,7 +171,7 @@ async function buildPlaywrightTargets(
     cache: true,
     inputs: [
       ...('production' in namedInputs
-        ? ['default', '^{projectRoot}/tsconfig*.json', '^production']
+        ? ['default', '^production', '^{projectRoot}/tsconfig*.json']
         : ['default', '^default']),
       { externalDependencies: ['@playwright/test'] },
     ],
@@ -197,7 +197,7 @@ async function buildPlaywrightTargets(
       cache: true,
       inputs: [
         ...('production' in namedInputs
-          ? ['default', '^{projectRoot}/tsconfig*.json', '^production']
+          ? ['default', '^production', '^{projectRoot}/tsconfig*.json']
           : ['default', '^default']),
         { externalDependencies: ['@playwright/test'] },
       ],


### PR DESCRIPTION
## Current Behavior

When a target combines multiple dependency inputs such as `^{projectRoot}/tsconfig*.json` and `^production`, the native hash planner shares one visited set across sibling dependency inputs. The first dependency input that reaches a dependency suppresses later ones, so Playwright-generated E2E targets can miss the actual `^production` files from dependencies and incorrectly reuse cache results.

Separately, native project file hashing can re-evaluate the same shared dependency fileset multiple times during a single hashing pass. That inefficiency already existed, but it becomes more visible once sibling dependency inputs are handled correctly, especially in large monorepos where many projects depend on the same project.

Additionally, the gradle package's `tsconfig.lib.json` includes `**/*.ts` without excluding the nested `:gradle-project-graph` project directory, causing tsc to compile files it doesn't need to (e.g. a standalone Maven publishing script).

## Expected Behavior

Sibling dependency inputs should be unioned for the same dependency regardless of order. `^production` should continue excluding dependency `tsconfig.spec.json` files, while an explicit `^{projectRoot}/tsconfig*.json` dependency input should still include them.

The native task hasher and hash plan inspector should also reuse a given `project + fileset combo` once per invocation instead of re-globbing the same shared dependency repeatedly.

Nested Nx projects within a package should be excluded from the parent's tsconfig so tsc only compiles files that are part of the library.

## Related Issue(s)

Fixes #35008