### PR TITLE
fix(vite): bump sass version for vue/nuxt presets for Vite 8 compat

### DIFF
--- a/packages/vue/src/utils/versions.ts
+++ b/packages/vue/src/utils/versions.ts
@@ -21,5 +21,5 @@ export const tailwindcssVersion = '3.2.7';
 export const autoprefixerVersion = '10.4.13';
 
 // other deps
-export const sassVersion = '1.62.1';
+export const sassVersion = '^1.70.0';
 export const lessVersion = '3.12.2';


### PR DESCRIPTION
## Current Behavior

CNW vue-monorepo and nuxt presets pin sass@1.62.1, but Vite 8 requires sass >= ^1.70.0, causing ERESOLVE failures on npm during workspace creation.

## Expected Behavior

Workspaces created with vue-monorepo and nuxt presets install successfully with Vite 8 by using a compatible sass version range.

## Related Issue(s)

Fixes NXC-4171