### PR TITLE
feat(misc): update nx init telemetry meta from CSV to JSON format

### DIFF
--- a/packages/nx/src/command-line/init/command-object.ts
+++ b/packages/nx/src/command-line/init/command-object.ts
@@ -8,6 +8,10 @@ import {
   writeErrorLog,
   determineErrorCode,
 } from './utils/ai-output';
+import { recordStat } from '../../utils/ab-testing';
+import { nxVersion } from '../../utils/versions';
+import { isCI } from '../../utils/is-ci';
+import { detectPackageManager } from '../../utils/package-manager';
 
 export const yargsInitCommand: CommandModule = {
   command: 'init',
@@ -38,20 +42,63 @@ export const yargsInitCommand: CommandModule = {
       throw error;
     });
 
+    const aiAgent = isAiAgent();
+
+    recordStat({
+      command: 'init',
+      nxVersion,
+      useCloud: false,
+      meta: {
+        type: 'start',
+        nodeVersion: process.versions.node,
+        os: process.platform,
+        packageManager: detectPackageManager(),
+        aiAgent,
+        isCI: isCI(),
+      },
+    });
+
     try {
       const useV2 = await isInitV2();
       if (useV2) {
+        // v2 records its own complete event with richer context
         await require('./init-v2').initHandler(args);
       } else {
         await require('./init-v1').initHandler(args);
+        await recordStat({
+          command: 'init',
+          nxVersion,
+          useCloud: false,
+          meta: {
+            type: 'complete',
+            nodeVersion: process.versions.node,
+            os: process.platform,
+            packageManager: detectPackageManager(),
+            aiAgent,
+            isCI: isCI(),
+          },
+        });
       }
       process.exit(0);
     } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      const errorCode = determineErrorCode(error);
+
+      await recordStat({
+        command: 'init',
+        nxVersion,
+        useCloud: false,
+        meta: {
+          type: 'error',
+          errorCode,
+          errorMessage: errorMessage.substring(0, 250),
+          aiAgent,
+        },
+      });
+
       // Output structured error for AI agents
-      if (isAiAgent()) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        const errorCode = determineErrorCode(error);
+      if (aiAgent) {
         const errorLogPath = writeErrorLog(error);
         writeAiOutput(buildErrorResult(errorMessage, errorCode, errorLogPath));
       } else {

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -33,6 +33,9 @@ import { handleImport } from '../../utils/handle-import';
 import { isAiAgent } from '../../native';
 import { Agent } from '../../ai/utils';
 import { detectAiAgent } from '../../ai/detect-ai-agent';
+import { recordStat } from '../../utils/ab-testing';
+import { isCI } from '../../utils/is-ci';
+import { detectPackageManager } from '../../utils/package-manager';
 import {
   logProgress,
   writeAiOutput,
@@ -347,6 +350,21 @@ async function initHandlerImpl(options: InitArgs): Promise<void> {
   if (useNxCloud) {
     await initCloud('nx-init');
   }
+
+  await recordStat({
+    command: 'init',
+    nxVersion: version,
+    useCloud: !!useNxCloud,
+    meta: {
+      type: 'complete',
+      nodeVersion: process.versions.node,
+      os: process.platform,
+      packageManager: detectPackageManager(),
+      aiAgent: aiMode,
+      isCI: isCI(),
+      pluginsInstalled: pluginsToInstall.join(','),
+    },
+  });
 
   // Output success result for AI agents
   if (aiMode) {

--- a/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
@@ -18,6 +18,9 @@ import {
   messages,
 } from '../../../utils/ab-testing';
 import { nxVersion } from '../../../utils/versions';
+import { isCI } from '../../../utils/is-ci';
+import { isAiAgent } from '../../../native';
+import { detectPackageManager } from '../../../utils/package-manager';
 import { workspaceRoot } from '../../../utils/workspace-root';
 import { getVcsRemoteInfo } from '../../../utils/git-utils';
 import * as pc from 'picocolors';
@@ -172,7 +175,15 @@ export async function connectExistingRepoToNxCloudPrompt(
     command,
     nxVersion,
     useCloud: res,
-    meta: messages.codeOfSelectedPromptMessage(key),
+    meta: {
+      type: 'complete',
+      setupCloudPrompt: messages.codeOfSelectedPromptMessage(key) || '',
+      nodeVersion: process.versions.node,
+      os: process.platform,
+      packageManager: detectPackageManager(),
+      aiAgent: isAiAgent(),
+      isCI: isCI(),
+    },
   });
   return res;
 }
@@ -187,7 +198,16 @@ export async function connectToNxCloudWithPrompt(command: string) {
     command,
     nxVersion,
     useCloud,
-    meta: messages.codeOfSelectedPromptMessage('setupNxCloud'),
+    meta: {
+      type: 'complete',
+      setupCloudPrompt:
+        messages.codeOfSelectedPromptMessage('setupNxCloud') || '',
+      nodeVersion: process.versions.node,
+      os: process.platform,
+      packageManager: detectPackageManager(),
+      aiAgent: isAiAgent(),
+      isCI: isCI(),
+    },
   });
 }
 

--- a/packages/nx/src/utils/ab-testing.ts
+++ b/packages/nx/src/utils/ab-testing.ts
@@ -3,6 +3,31 @@ import { isCI } from './is-ci';
 import { getPackageManagerCommand } from './package-manager';
 import { getCloudUrl } from '../nx-cloud/utilities/get-cloud-options';
 
+/**
+ * Meta payload types for recordStat telemetry (matches CNW format).
+ */
+export interface RecordStatMetaStart {
+  type: 'start';
+  [key: string]: string | boolean;
+}
+
+export interface RecordStatMetaComplete {
+  type: 'complete';
+  [key: string]: string | boolean;
+}
+
+export interface RecordStatMetaError {
+  type: 'error';
+  errorCode: string;
+  errorMessage: string;
+  [key: string]: string | boolean;
+}
+
+export type RecordStatMeta =
+  | RecordStatMetaStart
+  | RecordStatMetaComplete
+  | RecordStatMetaError;
+
 export type MessageOptionKey = 'yes' | 'skip';
 
 const messageOptions = {
@@ -73,7 +98,7 @@ export async function recordStat(opts: {
   command: string;
   nxVersion: string;
   useCloud: boolean;
-  meta?: string;
+  meta?: RecordStatMeta;
 }) {
   try {
     if (!shouldRecordStats()) {
@@ -89,7 +114,9 @@ export async function recordStat(opts: {
         command: opts.command,
         isCI: isCI(),
         useCloud: opts.useCloud,
-        meta: `${opts.nxVersion}${opts.meta ? ',' + opts.meta : ''}`,
+        meta: opts.meta
+          ? JSON.stringify({ ...opts.meta, nxVersion: opts.nxVersion })
+          : opts.nxVersion,
       });
   } catch (e) {
     if (process.env.NX_VERBOSE_LOGGING === 'true') {


### PR DESCRIPTION
## Current Behavior

`nx init` emits telemetry meta as a CSV string (e.g. "22.6.3,enable-ci")
via `recordStat`, only at the cloud prompt step. There is no start or
error tracking, no AI detection, and no environment context.

## Expected Behavior

`recordStat` now accepts a typed `RecordStatMeta` object and serializes
as JSON, matching the CNW format. Three lifecycle events are recorded:

- **start**: nodeVersion, os, packageManager, aiAgent, isCI
- **complete**: same env info plus pluginsInstalled, useCloud
- **error**: errorCode, errorMessage, aiAgent

The existing cloud prompt `recordStat` calls also now include env info.

## Related Issue(s)

Closes NXC-4168
