### PR TITLE
docs(misc): add link to syncpack documentation

### DIFF
--- a/astro-docs/src/content/docs/getting-started/Tutorials/managing-dependencies.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/managing-dependencies.mdoc
@@ -205,7 +205,7 @@ catalogs:
 {% /tabitem %}
 {% tabitem label="npm" %}
 
-npm does not have catalog support. Enforce a single version policy by defining all dependencies in the root `package.json` and using tools like `syncpack` or the `@nx/dependency-checks` ESLint rule to catch version mismatches.
+npm does not have catalog support. Enforce a single version policy by defining all dependencies in the root `package.json` and using tools like [`syncpack`](https://syncpack.dev/) or the `@nx/dependency-checks` ESLint rule to catch version mismatches.
 
 {% /tabitem %}
 {% tabitem label="bun" %}


### PR DESCRIPTION
Hey all,
Thanks a lot for mentioning [syncpack](https://syncpack.dev/) in the [Managing Dependencies](https://nx.dev/docs/getting-started/tutorials/managing-dependencies) tutorial, this PR asks if you would kindly add a link to the official site 🙏 

Thanks a lot,

Jamie

