### PR TITLE
fix(gradle): use object notation for exclude tasks

### DIFF
--- a/packages/gradle/src/executors/gradle/get-exclude-task.spec.ts
+++ b/packages/gradle/src/executors/gradle/get-exclude-task.spec.ts
@@ -65,7 +65,9 @@ describe('getExcludeTasks', () => {
   });
 
   it('should not exclude tasks if direct dependencies are running', () => {
-    const targets = new Set<ProjectTarget>([createProjectTarget('app1', 'test')]);
+    const targets = new Set<ProjectTarget>([
+      createProjectTarget('app1', 'test'),
+    ]);
     const runningTasks = new Set<ProjectTarget>([
       createProjectTarget('app1', 'test'),
       createProjectTarget('app1', 'lint'),
@@ -76,7 +78,9 @@ describe('getExcludeTasks', () => {
   });
 
   it('should handle targets with no dependencies', () => {
-    const targets = new Set<ProjectTarget>([createProjectTarget('app2', 'build')]);
+    const targets = new Set<ProjectTarget>([
+      createProjectTarget('app2', 'build'),
+    ]);
     const runningTasks = new Set<ProjectTarget>([
       createProjectTarget('app2', 'build'),
     ]);
@@ -94,7 +98,9 @@ describe('getExcludeTasks', () => {
   });
 
   it('should handle dependencies that are also running tasks', () => {
-    const targets = new Set<ProjectTarget>([createProjectTarget('app1', 'test')]);
+    const targets = new Set<ProjectTarget>([
+      createProjectTarget('app1', 'test'),
+    ]);
     const runningTasks = new Set<ProjectTarget>([
       createProjectTarget('app1', 'test'),
       createProjectTarget('app1', 'lint'),
@@ -104,7 +110,9 @@ describe('getExcludeTasks', () => {
   });
 
   it('should handle recursive dependencies', () => {
-    const targets = new Set<ProjectTarget>([createProjectTarget('app3', 'deploy')]);
+    const targets = new Set<ProjectTarget>([
+      createProjectTarget('app3', 'deploy'),
+    ]);
     const runningTasks = new Set<ProjectTarget>([
       createProjectTarget('app3', 'deploy'),
     ]);
@@ -113,7 +121,9 @@ describe('getExcludeTasks', () => {
   });
 
   it('should not exclude tasks that are in includeDependsOnTasks', () => {
-    const targets = new Set<ProjectTarget>([createProjectTarget('app1', 'test')]);
+    const targets = new Set<ProjectTarget>([
+      createProjectTarget('app1', 'test'),
+    ]);
     const runningTasks = new Set<ProjectTarget>([
       createProjectTarget('app1', 'test'),
     ]);
@@ -128,7 +138,9 @@ describe('getExcludeTasks', () => {
   });
 
   it('should not exclude any tasks if all are in includeDependsOnTasks', () => {
-    const targets = new Set<ProjectTarget>([createProjectTarget('app1', 'test')]);
+    const targets = new Set<ProjectTarget>([
+      createProjectTarget('app1', 'test'),
+    ]);
     const runningTasks = new Set<ProjectTarget>([
       createProjectTarget('app1', 'test'),
     ]);
@@ -172,7 +184,9 @@ describe('getExcludeTasks', () => {
         },
       },
     };
-    const targets = new Set<ProjectTarget>([createProjectTarget('app1', 'build')]);
+    const targets = new Set<ProjectTarget>([
+      createProjectTarget('app1', 'build'),
+    ]);
     const runningTasks = new Set<ProjectTarget>([
       createProjectTarget('app1', 'build'),
     ]);
@@ -347,7 +361,10 @@ describe('getAllDependsOn', () => {
     };
     const dependencies = getAllDependsOn(objectNodes, 'app', 'build');
     expect(dependencies).toEqual(
-      new Set([createProjectTarget('app', 'compileJava'), createProjectTarget('lib', 'jar')])
+      new Set([
+        createProjectTarget('app', 'compileJava'),
+        createProjectTarget('lib', 'jar'),
+      ])
     );
   });
 });

--- a/packages/gradle/src/executors/gradle/get-exclude-task.spec.ts
+++ b/packages/gradle/src/executors/gradle/get-exclude-task.spec.ts
@@ -1,10 +1,7 @@
-import {
-  getExcludeTasks,
-  getAllDependsOn,
-  ProjectTarget,
-} from './get-exclude-task';
+import { getExcludeTasks, getAllDependsOn } from './get-exclude-task';
+import { Target } from '@nx/devkit';
 
-function createProjectTarget(project: string, target: string): ProjectTarget {
+function createTarget(project: string, target: string): Target {
   return { project, target };
 }
 
@@ -53,80 +50,60 @@ describe('getExcludeTasks', () => {
   };
 
   it('should exclude tasks that are not in runningTasks and have excludeDependsOn true', () => {
-    const targets = new Set<ProjectTarget>([
-      createProjectTarget('app1', 'test'),
-      createProjectTarget('app2', 'build'),
+    const targets = new Set<Target>([
+      createTarget('app1', 'test'),
+      createTarget('app2', 'build'),
     ]);
-    const runningTasks = new Set<ProjectTarget>([
-      createProjectTarget('app1', 'test'),
-    ]);
+    const runningTasks = new Set<Target>([createTarget('app1', 'test')]);
     const excludes = getExcludeTasks(targets, nodes, runningTasks);
     expect(excludes).toEqual(new Set(['lintApp1', 'buildApp2']));
   });
 
   it('should not exclude tasks if direct dependencies are running', () => {
-    const targets = new Set<ProjectTarget>([
-      createProjectTarget('app1', 'test'),
-    ]);
-    const runningTasks = new Set<ProjectTarget>([
-      createProjectTarget('app1', 'test'),
-      createProjectTarget('app1', 'lint'),
-      createProjectTarget('app2', 'build'),
+    const targets = new Set<Target>([createTarget('app1', 'test')]);
+    const runningTasks = new Set<Target>([
+      createTarget('app1', 'test'),
+      createTarget('app1', 'lint'),
+      createTarget('app2', 'build'),
     ]);
     const excludes = getExcludeTasks(targets, nodes, runningTasks);
     expect(excludes).toEqual(new Set());
   });
 
   it('should handle targets with no dependencies', () => {
-    const targets = new Set<ProjectTarget>([
-      createProjectTarget('app2', 'build'),
-    ]);
-    const runningTasks = new Set<ProjectTarget>([
-      createProjectTarget('app2', 'build'),
-    ]);
+    const targets = new Set<Target>([createTarget('app2', 'build')]);
+    const runningTasks = new Set<Target>([createTarget('app2', 'build')]);
     const excludes = getExcludeTasks(targets, nodes, runningTasks);
     expect(excludes).toEqual(new Set());
   });
 
   it('should handle missing project or target', () => {
-    const targets = new Set<ProjectTarget>([
-      createProjectTarget('nonexistent', 'test'),
-    ]);
-    const runningTasks = new Set<ProjectTarget>();
+    const targets = new Set<Target>([createTarget('nonexistent', 'test')]);
+    const runningTasks = new Set<Target>();
     const excludes = getExcludeTasks(targets, nodes, runningTasks);
     expect(excludes).toEqual(new Set());
   });
 
   it('should handle dependencies that are also running tasks', () => {
-    const targets = new Set<ProjectTarget>([
-      createProjectTarget('app1', 'test'),
-    ]);
-    const runningTasks = new Set<ProjectTarget>([
-      createProjectTarget('app1', 'test'),
-      createProjectTarget('app1', 'lint'),
+    const targets = new Set<Target>([createTarget('app1', 'test')]);
+    const runningTasks = new Set<Target>([
+      createTarget('app1', 'test'),
+      createTarget('app1', 'lint'),
     ]);
     const excludes = getExcludeTasks(targets, nodes, runningTasks);
     expect(excludes).toEqual(new Set(['buildApp2']));
   });
 
   it('should handle recursive dependencies', () => {
-    const targets = new Set<ProjectTarget>([
-      createProjectTarget('app3', 'deploy'),
-    ]);
-    const runningTasks = new Set<ProjectTarget>([
-      createProjectTarget('app3', 'deploy'),
-    ]);
+    const targets = new Set<Target>([createTarget('app3', 'deploy')]);
+    const runningTasks = new Set<Target>([createTarget('app3', 'deploy')]);
     const excludes = getExcludeTasks(targets, nodes, runningTasks);
     expect(excludes).toEqual(new Set(['testApp1']));
   });
 
   it('should not exclude tasks that are in includeDependsOnTasks', () => {
-    const targets = new Set<ProjectTarget>([
-      createProjectTarget('app1', 'test'),
-    ]);
-    const runningTasks = new Set<ProjectTarget>([
-      createProjectTarget('app1', 'test'),
-    ]);
+    const targets = new Set<Target>([createTarget('app1', 'test')]);
+    const runningTasks = new Set<Target>([createTarget('app1', 'test')]);
     const includeDependsOnTasks = new Set<string>(['lintApp1']);
     const excludes = getExcludeTasks(
       targets,
@@ -138,12 +115,8 @@ describe('getExcludeTasks', () => {
   });
 
   it('should not exclude any tasks if all are in includeDependsOnTasks', () => {
-    const targets = new Set<ProjectTarget>([
-      createProjectTarget('app1', 'test'),
-    ]);
-    const runningTasks = new Set<ProjectTarget>([
-      createProjectTarget('app1', 'test'),
-    ]);
+    const targets = new Set<Target>([createTarget('app1', 'test')]);
+    const runningTasks = new Set<Target>([createTarget('app1', 'test')]);
     const includeDependsOnTasks = new Set<string>(['lintApp1', 'buildApp2']);
     const excludes = getExcludeTasks(
       targets,
@@ -184,12 +157,8 @@ describe('getExcludeTasks', () => {
         },
       },
     };
-    const targets = new Set<ProjectTarget>([
-      createProjectTarget('app1', 'build'),
-    ]);
-    const runningTasks = new Set<ProjectTarget>([
-      createProjectTarget('app1', 'build'),
-    ]);
+    const targets = new Set<Target>([createTarget('app1', 'build')]);
+    const runningTasks = new Set<Target>([createTarget('app1', 'build')]);
     const excludes = getExcludeTasks(targets, objectNodes, runningTasks);
     expect(excludes).toEqual(new Set([':app1:compileJava', ':app2:build']));
   });
@@ -229,11 +198,11 @@ describe('getExcludeTasks', () => {
         },
       },
     };
-    const targets = new Set<ProjectTarget>([
-      createProjectTarget(':sub:project', 'compile:java'),
+    const targets = new Set<Target>([
+      createTarget(':sub:project', 'compile:java'),
     ]);
-    const runningTasks = new Set<ProjectTarget>([
-      createProjectTarget(':sub:project', 'compile:java'),
+    const runningTasks = new Set<Target>([
+      createTarget(':sub:project', 'compile:java'),
     ]);
     const excludes = getExcludeTasks(targets, colonNodes, runningTasks);
     expect(excludes).toEqual(
@@ -305,9 +274,9 @@ describe('getAllDependsOn', () => {
     const dependencies = getAllDependsOn(nodes, 'a', 'build');
     expect(dependencies).toEqual(
       new Set([
-        createProjectTarget('b', 'build'),
-        createProjectTarget('c', 'build'),
-        createProjectTarget('d', 'build'),
+        createTarget('b', 'build'),
+        createTarget('c', 'build'),
+        createTarget('d', 'build'),
       ])
     );
   });
@@ -324,7 +293,7 @@ describe('getAllDependsOn', () => {
 
   it('should handle circular dependencies gracefully', () => {
     const dependencies = getAllDependsOn(nodes, 'e', 'build');
-    expect(dependencies).toEqual(new Set([createProjectTarget('f', 'build')]));
+    expect(dependencies).toEqual(new Set([createTarget('f', 'build')]));
   });
 
   it('should not include the starting task in the result', () => {
@@ -361,10 +330,7 @@ describe('getAllDependsOn', () => {
     };
     const dependencies = getAllDependsOn(objectNodes, 'app', 'build');
     expect(dependencies).toEqual(
-      new Set([
-        createProjectTarget('app', 'compileJava'),
-        createProjectTarget('lib', 'jar'),
-      ])
+      new Set([createTarget('app', 'compileJava'), createTarget('lib', 'jar')])
     );
   });
 });

--- a/packages/gradle/src/executors/gradle/get-exclude-task.spec.ts
+++ b/packages/gradle/src/executors/gradle/get-exclude-task.spec.ts
@@ -1,4 +1,12 @@
-import { getExcludeTasks, getAllDependsOn } from './get-exclude-task';
+import {
+  getExcludeTasks,
+  getAllDependsOn,
+  ProjectTarget,
+} from './get-exclude-task';
+
+function createProjectTarget(project: string, target: string): ProjectTarget {
+  return { project, target };
+}
 
 describe('getExcludeTasks', () => {
   const nodes: any = {
@@ -9,7 +17,10 @@ describe('getExcludeTasks', () => {
         root: 'app1',
         targets: {
           test: {
-            dependsOn: ['app1:lint', 'app2:build'],
+            dependsOn: [
+              { target: 'lint' },
+              { target: 'build', projects: ['app2'] },
+            ],
             options: { taskName: 'testApp1' },
           },
           lint: { options: { taskName: 'lintApp1' } },
@@ -33,7 +44,7 @@ describe('getExcludeTasks', () => {
         root: 'app3',
         targets: {
           deploy: {
-            dependsOn: ['app1:test'],
+            dependsOn: [{ target: 'test', projects: ['app1'] }],
             options: { taskName: 'deployApp3' },
           },
         },
@@ -41,75 +52,91 @@ describe('getExcludeTasks', () => {
     },
   };
 
-  it('should exclude tasks that are not in runningTaskIds and have excludeDependsOn true', () => {
-    const targets = new Set<string>(['app1:test', 'app2:build']);
-    const runningTaskIds = new Set<string>(['app1:test']);
-    const excludes = getExcludeTasks(targets, nodes, runningTaskIds);
+  it('should exclude tasks that are not in runningTasks and have excludeDependsOn true', () => {
+    const targets = new Set<ProjectTarget>([
+      createProjectTarget('app1', 'test'),
+      createProjectTarget('app2', 'build'),
+    ]);
+    const runningTasks = new Set<ProjectTarget>([
+      createProjectTarget('app1', 'test'),
+    ]);
+    const excludes = getExcludeTasks(targets, nodes, runningTasks);
     expect(excludes).toEqual(new Set(['lintApp1', 'buildApp2']));
   });
 
   it('should not exclude tasks if direct dependencies are running', () => {
-    const targets = new Set<string>(['app1:test']);
-    const runningTaskIds = new Set<string>([
-      'app1:test',
-      'app1:lint',
-      'app2:build',
+    const targets = new Set<ProjectTarget>([createProjectTarget('app1', 'test')]);
+    const runningTasks = new Set<ProjectTarget>([
+      createProjectTarget('app1', 'test'),
+      createProjectTarget('app1', 'lint'),
+      createProjectTarget('app2', 'build'),
     ]);
-    const excludes = getExcludeTasks(targets, nodes, runningTaskIds);
+    const excludes = getExcludeTasks(targets, nodes, runningTasks);
     expect(excludes).toEqual(new Set());
   });
 
   it('should handle targets with no dependencies', () => {
-    const targets = new Set<string>(['app2:build']);
-    const runningTaskIds = new Set<string>(['app2:build']);
-    const excludes = getExcludeTasks(targets, nodes, runningTaskIds);
+    const targets = new Set<ProjectTarget>([createProjectTarget('app2', 'build')]);
+    const runningTasks = new Set<ProjectTarget>([
+      createProjectTarget('app2', 'build'),
+    ]);
+    const excludes = getExcludeTasks(targets, nodes, runningTasks);
     expect(excludes).toEqual(new Set());
   });
 
   it('should handle missing project or target', () => {
-    const targets = new Set<string>(['nonexistent:test']);
-    const runningTaskIds = new Set<string>();
-    const excludes = getExcludeTasks(targets, nodes, runningTaskIds);
+    const targets = new Set<ProjectTarget>([
+      createProjectTarget('nonexistent', 'test'),
+    ]);
+    const runningTasks = new Set<ProjectTarget>();
+    const excludes = getExcludeTasks(targets, nodes, runningTasks);
     expect(excludes).toEqual(new Set());
   });
 
   it('should handle dependencies that are also running tasks', () => {
-    const targets = new Set<string>(['app1:test']);
-    const runningTaskIds = new Set<string>(['app1:test', 'app1:lint']);
-    const excludes = getExcludeTasks(targets, nodes, runningTaskIds);
+    const targets = new Set<ProjectTarget>([createProjectTarget('app1', 'test')]);
+    const runningTasks = new Set<ProjectTarget>([
+      createProjectTarget('app1', 'test'),
+      createProjectTarget('app1', 'lint'),
+    ]);
+    const excludes = getExcludeTasks(targets, nodes, runningTasks);
     expect(excludes).toEqual(new Set(['buildApp2']));
   });
 
   it('should handle recursive dependencies', () => {
-    // Assuming app3:deploy depends on app1:test, which in turn depends on app1:lint and app2:build
-    const targets = new Set<string>(['app3:deploy']);
-    const runningTaskIds = new Set<string>(['app3:deploy']);
-    const excludes = getExcludeTasks(targets, nodes, runningTaskIds);
+    const targets = new Set<ProjectTarget>([createProjectTarget('app3', 'deploy')]);
+    const runningTasks = new Set<ProjectTarget>([
+      createProjectTarget('app3', 'deploy'),
+    ]);
+    const excludes = getExcludeTasks(targets, nodes, runningTasks);
     expect(excludes).toEqual(new Set(['testApp1']));
   });
 
   it('should not exclude tasks that are in includeDependsOnTasks', () => {
-    const targets = new Set<string>(['app1:test']);
-    const runningTaskIds = new Set<string>(['app1:test']);
+    const targets = new Set<ProjectTarget>([createProjectTarget('app1', 'test')]);
+    const runningTasks = new Set<ProjectTarget>([
+      createProjectTarget('app1', 'test'),
+    ]);
     const includeDependsOnTasks = new Set<string>(['lintApp1']);
     const excludes = getExcludeTasks(
       targets,
       nodes,
-      runningTaskIds,
+      runningTasks,
       includeDependsOnTasks
     );
-    // lintApp1 should not be excluded because it's in includeDependsOnTasks
     expect(excludes).toEqual(new Set(['buildApp2']));
   });
 
   it('should not exclude any tasks if all are in includeDependsOnTasks', () => {
-    const targets = new Set<string>(['app1:test']);
-    const runningTaskIds = new Set<string>(['app1:test']);
+    const targets = new Set<ProjectTarget>([createProjectTarget('app1', 'test')]);
+    const runningTasks = new Set<ProjectTarget>([
+      createProjectTarget('app1', 'test'),
+    ]);
     const includeDependsOnTasks = new Set<string>(['lintApp1', 'buildApp2']);
     const excludes = getExcludeTasks(
       targets,
       nodes,
-      runningTaskIds,
+      runningTasks,
       includeDependsOnTasks
     );
     expect(excludes).toEqual(new Set());
@@ -145,10 +172,59 @@ describe('getExcludeTasks', () => {
         },
       },
     };
-    const targets = new Set<string>(['app1:build']);
-    const runningTaskIds = new Set<string>(['app1:build']);
-    const excludes = getExcludeTasks(targets, objectNodes, runningTaskIds);
+    const targets = new Set<ProjectTarget>([createProjectTarget('app1', 'build')]);
+    const runningTasks = new Set<ProjectTarget>([
+      createProjectTarget('app1', 'build'),
+    ]);
+    const excludes = getExcludeTasks(targets, objectNodes, runningTasks);
     expect(excludes).toEqual(new Set([':app1:compileJava', ':app2:build']));
+  });
+
+  it('should handle project and target names containing colons', () => {
+    const colonNodes: any = {
+      ':sub:project': {
+        name: ':sub:project',
+        type: 'app',
+        data: {
+          root: 'sub/project',
+          targets: {
+            'compile:java': {
+              dependsOn: [
+                { target: 'process:resources' },
+                { target: 'compile:java', projects: [':other:lib'] },
+              ],
+              options: { taskName: ':sub:project:compileJava' },
+            },
+            'process:resources': {
+              options: { taskName: ':sub:project:processResources' },
+            },
+          },
+        },
+      },
+      ':other:lib': {
+        name: ':other:lib',
+        type: 'lib',
+        data: {
+          root: 'other/lib',
+          targets: {
+            'compile:java': {
+              dependsOn: [],
+              options: { taskName: ':other:lib:compileJava' },
+            },
+          },
+        },
+      },
+    };
+    const targets = new Set<ProjectTarget>([
+      createProjectTarget(':sub:project', 'compile:java'),
+    ]);
+    const runningTasks = new Set<ProjectTarget>([
+      createProjectTarget(':sub:project', 'compile:java'),
+    ]);
+    const excludes = getExcludeTasks(targets, colonNodes, runningTasks);
+    expect(excludes).toEqual(
+      new Set([':sub:project:processResources', ':other:lib:compileJava'])
+    );
   });
 });
 
@@ -159,13 +235,25 @@ describe('getAllDependsOn', () => {
       type: 'lib',
       data: {
         root: 'a',
-        targets: { build: { dependsOn: ['b:build', 'c:build'] } },
+        targets: {
+          build: {
+            dependsOn: [
+              { target: 'build', projects: ['b'] },
+              { target: 'build', projects: ['c'] },
+            ],
+          },
+        },
       },
     },
     b: {
       name: 'b',
       type: 'lib',
-      data: { root: 'b', targets: { build: { dependsOn: ['d:build'] } } },
+      data: {
+        root: 'b',
+        targets: {
+          build: { dependsOn: [{ target: 'build', projects: ['d'] }] },
+        },
+      },
     },
     c: {
       name: 'c',
@@ -180,18 +268,34 @@ describe('getAllDependsOn', () => {
     e: {
       name: 'e',
       type: 'lib',
-      data: { root: 'e', targets: { build: { dependsOn: ['f:build'] } } },
+      data: {
+        root: 'e',
+        targets: {
+          build: { dependsOn: [{ target: 'build', projects: ['f'] }] },
+        },
+      },
     },
     f: {
       name: 'f',
       type: 'lib',
-      data: { root: 'f', targets: { build: { dependsOn: ['e:build'] } } }, // Circular dependency
+      data: {
+        root: 'f',
+        targets: {
+          build: { dependsOn: [{ target: 'build', projects: ['e'] }] },
+        },
+      },
     },
   };
 
   it('should return all transitive dependencies excluding the starting task', () => {
     const dependencies = getAllDependsOn(nodes, 'a', 'build');
-    expect(dependencies).toEqual(new Set(['b:build', 'c:build', 'd:build']));
+    expect(dependencies).toEqual(
+      new Set([
+        createProjectTarget('b', 'build'),
+        createProjectTarget('c', 'build'),
+        createProjectTarget('d', 'build'),
+      ])
+    );
   });
 
   it('should handle no dependencies', () => {
@@ -206,12 +310,15 @@ describe('getAllDependsOn', () => {
 
   it('should handle circular dependencies gracefully', () => {
     const dependencies = getAllDependsOn(nodes, 'e', 'build');
-    expect(dependencies).toEqual(new Set(['f:build']));
+    expect(dependencies).toEqual(new Set([createProjectTarget('f', 'build')]));
   });
 
   it('should not include the starting task in the result', () => {
     const dependencies = getAllDependsOn(nodes, 'a', 'build');
-    expect(dependencies).not.toContain('a:build');
+    const hasStart = Array.from(dependencies).some(
+      (d) => d.project === 'a' && d.target === 'build'
+    );
+    expect(hasStart).toBe(false);
   });
 
   it('should handle object-format dependsOn entries', () => {
@@ -239,6 +346,8 @@ describe('getAllDependsOn', () => {
       },
     };
     const dependencies = getAllDependsOn(objectNodes, 'app', 'build');
-    expect(dependencies).toEqual(new Set(['app:compileJava', 'lib:jar']));
+    expect(dependencies).toEqual(
+      new Set([createProjectTarget('app', 'compileJava'), createProjectTarget('lib', 'jar')])
+    );
   });
 });

--- a/packages/gradle/src/executors/gradle/get-exclude-task.ts
+++ b/packages/gradle/src/executors/gradle/get-exclude-task.ts
@@ -58,9 +58,7 @@ export function getExcludeTasks(
   includeDependsOnTasks: Set<string> = new Set()
 ): Set<string> {
   const excludes = new Set<string>();
-  const runningKeys = new Set(
-    Array.from(runningTasks).map(projectTargetKey)
-  );
+  const runningKeys = new Set(Array.from(runningTasks).map(projectTargetKey));
 
   for (const task of tasks) {
     const taskDeps =
@@ -87,7 +85,6 @@ export function getGradleTaskName(
   return nodes[pt.project]?.data?.targets?.[pt.target]?.options?.taskName;
 }
 
-
 export function getAllDependsOn(
   nodes: Record<string, ProjectGraphProjectNode>,
   projectName: string,
@@ -95,7 +92,10 @@ export function getAllDependsOn(
 ): Set<ProjectTarget> {
   const allDependsOn = new Set<string>();
   const result = new Set<ProjectTarget>();
-  const startKey = projectTargetKey({ project: projectName, target: targetName });
+  const startKey = projectTargetKey({
+    project: projectName,
+    target: targetName,
+  });
   const stack: ProjectTarget[] = [{ project: projectName, target: targetName }];
 
   while (stack.length > 0) {

--- a/packages/gradle/src/executors/gradle/get-exclude-task.ts
+++ b/packages/gradle/src/executors/gradle/get-exclude-task.ts
@@ -1,24 +1,19 @@
-import { ProjectGraphProjectNode } from 'nx/src/config/project-graph';
-
-export interface ProjectTarget {
-  project: string;
-  target: string;
-}
-
-function projectTargetKey(pt: ProjectTarget): string {
-  return `${pt.project}:${pt.target}`;
-}
+import {
+  ProjectGraphProjectNode,
+  Target,
+  targetToTargetString,
+} from '@nx/devkit';
 
 /**
- * Resolves a dependsOn entry to a ProjectTarget.
+ * Resolves a dependsOn entry to a Target.
  * Handles both string format ("target") and object format
  * ({ target: "name", projects?: ["proj1"] }).
  * For same-project object deps (no projects field), uses the owning project name.
  */
-function resolveDepToProjectTarget(
+function resolveDepToTarget(
   dep: string | { target?: string; projects?: string | string[] },
   owningProject: string
-): ProjectTarget | null {
+): Target | null {
   if (typeof dep === 'string') {
     return { project: owningProject, target: dep };
   }
@@ -45,28 +40,30 @@ function resolveDepToProjectTarget(
  * For example, if a project defines `dependsOn: ['lint']` for the `test` target,
  * and only `test` is running, this will return: ['lint']
  *
- * @param tasks - Set of ProjectTarget to process
+ * @param tasks - Set of Target to process
  * @param nodes - Project graph nodes
- * @param runningTasks - Set of ProjectTarget that are currently running (won't be excluded)
+ * @param runningTasks - Set of Target that are currently running (won't be excluded)
  * @param includeDependsOnTasks - Set of Gradle task names that should be included (not excluded)
  *   (typically provider-based dependencies that Gradle must resolve)
  */
 export function getExcludeTasks(
-  tasks: Set<ProjectTarget>,
+  tasks: Set<Target>,
   nodes: Record<string, ProjectGraphProjectNode>,
-  runningTasks: Set<ProjectTarget> = new Set(),
+  runningTasks: Set<Target> = new Set(),
   includeDependsOnTasks: Set<string> = new Set()
 ): Set<string> {
   const excludes = new Set<string>();
-  const runningKeys = new Set(Array.from(runningTasks).map(projectTargetKey));
+  const runningKeys = new Set(
+    Array.from(runningTasks).map(targetToTargetString)
+  );
 
   for (const task of tasks) {
     const taskDeps =
       nodes[task.project]?.data?.targets?.[task.target]?.dependsOn ?? [];
 
     for (const dep of taskDeps) {
-      const depPt = resolveDepToProjectTarget(dep, task.project);
-      if (depPt && !runningKeys.has(projectTargetKey(depPt))) {
+      const depPt = resolveDepToTarget(dep, task.project);
+      if (depPt && !runningKeys.has(targetToTargetString(depPt))) {
         const gradleTaskName = getGradleTaskName(depPt, nodes);
         if (gradleTaskName && !includeDependsOnTasks.has(gradleTaskName)) {
           excludes.add(gradleTaskName);
@@ -79,7 +76,7 @@ export function getExcludeTasks(
 }
 
 export function getGradleTaskName(
-  pt: ProjectTarget,
+  pt: Target,
   nodes: Record<string, ProjectGraphProjectNode>
 ): string | null {
   return nodes[pt.project]?.data?.targets?.[pt.target]?.options?.taskName;
@@ -89,18 +86,18 @@ export function getAllDependsOn(
   nodes: Record<string, ProjectGraphProjectNode>,
   projectName: string,
   targetName: string
-): Set<ProjectTarget> {
+): Set<Target> {
   const allDependsOn = new Set<string>();
-  const result = new Set<ProjectTarget>();
-  const startKey = projectTargetKey({
+  const result = new Set<Target>();
+  const startKey = targetToTargetString({
     project: projectName,
     target: targetName,
   });
-  const stack: ProjectTarget[] = [{ project: projectName, target: targetName }];
+  const stack: Target[] = [{ project: projectName, target: targetName }];
 
   while (stack.length > 0) {
     const current = stack.pop();
-    const key = projectTargetKey(current);
+    const key = targetToTargetString(current);
     if (!allDependsOn.has(key)) {
       allDependsOn.add(key);
       if (key !== startKey) {
@@ -112,8 +109,8 @@ export function getAllDependsOn(
         [];
 
       for (const dep of directDependencies) {
-        const depPt = resolveDepToProjectTarget(dep, current.project);
-        if (depPt && !allDependsOn.has(projectTargetKey(depPt))) {
+        const depPt = resolveDepToTarget(dep, current.project);
+        if (depPt && !allDependsOn.has(targetToTargetString(depPt))) {
           stack.push(depPt);
         }
       }

--- a/packages/gradle/src/executors/gradle/get-exclude-task.ts
+++ b/packages/gradle/src/executors/gradle/get-exclude-task.ts
@@ -1,20 +1,26 @@
-import {
-  ProjectGraph,
-  ProjectGraphProjectNode,
-} from 'nx/src/config/project-graph';
+import { ProjectGraphProjectNode } from 'nx/src/config/project-graph';
+
+export interface ProjectTarget {
+  project: string;
+  target: string;
+}
+
+function projectTargetKey(pt: ProjectTarget): string {
+  return `${pt.project}:${pt.target}`;
+}
 
 /**
- * Resolves a dependsOn entry to an Nx task ID (project:target format).
- * Handles both string format ("project:target") and object format
+ * Resolves a dependsOn entry to a ProjectTarget.
+ * Handles both string format ("target") and object format
  * ({ target: "name", projects?: ["proj1"] }).
  * For same-project object deps (no projects field), uses the owning project name.
  */
-function resolveDepToTaskId(
+function resolveDepToProjectTarget(
   dep: string | { target?: string; projects?: string | string[] },
   owningProject: string
-): string | null {
+): ProjectTarget | null {
   if (typeof dep === 'string') {
-    return dep;
+    return { project: owningProject, target: dep };
   }
   const target = dep?.target;
   if (!target) {
@@ -24,13 +30,12 @@ function resolveDepToTaskId(
     const projectList = Array.isArray(dep.projects)
       ? dep.projects
       : [dep.projects];
-    // For cross-project deps, use the first project
-    return projectList[0] !== 'self'
-      ? `${projectList[0]}:${target}`
-      : `${owningProject}:${target}`;
+    return {
+      project: projectList[0] !== 'self' ? projectList[0] : owningProject,
+      target,
+    };
   }
-  // Same-project dep (no projects field)
-  return `${owningProject}:${target}`;
+  return { project: owningProject, target };
 }
 
 /**
@@ -40,28 +45,31 @@ function resolveDepToTaskId(
  * For example, if a project defines `dependsOn: ['lint']` for the `test` target,
  * and only `test` is running, this will return: ['lint']
  *
- * @param taskIds - Set of Nx task IDs to process
+ * @param tasks - Set of ProjectTarget to process
  * @param nodes - Project graph nodes
- * @param runningTaskIds - Set of task IDs that are currently running (won't be excluded)
+ * @param runningTasks - Set of ProjectTarget that are currently running (won't be excluded)
  * @param includeDependsOnTasks - Set of Gradle task names that should be included (not excluded)
  *   (typically provider-based dependencies that Gradle must resolve)
  */
 export function getExcludeTasks(
-  taskIds: Set<string>,
+  tasks: Set<ProjectTarget>,
   nodes: Record<string, ProjectGraphProjectNode>,
-  runningTaskIds: Set<string> = new Set(),
+  runningTasks: Set<ProjectTarget> = new Set(),
   includeDependsOnTasks: Set<string> = new Set()
 ): Set<string> {
   const excludes = new Set<string>();
+  const runningKeys = new Set(
+    Array.from(runningTasks).map(projectTargetKey)
+  );
 
-  for (const taskId of taskIds) {
-    const [project, target] = taskId.split(':');
-    const taskDeps = nodes[project]?.data?.targets?.[target]?.dependsOn ?? [];
+  for (const task of tasks) {
+    const taskDeps =
+      nodes[task.project]?.data?.targets?.[task.target]?.dependsOn ?? [];
 
     for (const dep of taskDeps) {
-      const depTaskId = resolveDepToTaskId(dep, project);
-      if (depTaskId && !runningTaskIds.has(depTaskId)) {
-        const gradleTaskName = getGradleTaskNameWithNxTaskId(depTaskId, nodes);
+      const depPt = resolveDepToProjectTarget(dep, task.project);
+      if (depPt && !runningKeys.has(projectTargetKey(depPt))) {
+        const gradleTaskName = getGradleTaskName(depPt, nodes);
         if (gradleTaskName && !includeDependsOnTasks.has(gradleTaskName)) {
           excludes.add(gradleTaskName);
         }
@@ -72,43 +80,45 @@ export function getExcludeTasks(
   return excludes;
 }
 
-export function getGradleTaskNameWithNxTaskId(
-  nxTaskId: string,
+export function getGradleTaskName(
+  pt: ProjectTarget,
   nodes: Record<string, ProjectGraphProjectNode>
 ): string | null {
-  const [projectName, targetName] = nxTaskId.split(':');
-  const gradleTaskName =
-    nodes[projectName]?.data?.targets?.[targetName]?.options?.taskName;
-  return gradleTaskName;
+  return nodes[pt.project]?.data?.targets?.[pt.target]?.options?.taskName;
 }
+
 
 export function getAllDependsOn(
   nodes: Record<string, ProjectGraphProjectNode>,
   projectName: string,
   targetName: string
-): Set<string> {
+): Set<ProjectTarget> {
   const allDependsOn = new Set<string>();
-  const stack: string[] = [`${projectName}:${targetName}`];
+  const result = new Set<ProjectTarget>();
+  const startKey = projectTargetKey({ project: projectName, target: targetName });
+  const stack: ProjectTarget[] = [{ project: projectName, target: targetName }];
 
   while (stack.length > 0) {
-    const currentTaskId = stack.pop();
-    if (currentTaskId && !allDependsOn.has(currentTaskId)) {
-      allDependsOn.add(currentTaskId);
+    const current = stack.pop();
+    const key = projectTargetKey(current);
+    if (!allDependsOn.has(key)) {
+      allDependsOn.add(key);
+      if (key !== startKey) {
+        result.add(current);
+      }
 
-      const [currentProjectName, currentTargetName] = currentTaskId.split(':');
       const directDependencies =
-        nodes[currentProjectName]?.data?.targets?.[currentTargetName]
-          ?.dependsOn ?? [];
+        nodes[current.project]?.data?.targets?.[current.target]?.dependsOn ??
+        [];
 
       for (const dep of directDependencies) {
-        const depTaskId = resolveDepToTaskId(dep, currentProjectName);
-        if (depTaskId && !allDependsOn.has(depTaskId)) {
-          stack.push(depTaskId);
+        const depPt = resolveDepToProjectTarget(dep, current.project);
+        if (depPt && !allDependsOn.has(projectTargetKey(depPt))) {
+          stack.push(depPt);
         }
       }
     }
   }
-  allDependsOn.delete(`${projectName}:${targetName}`); // Exclude the starting task itself
 
-  return allDependsOn;
+  return result;
 }

--- a/packages/gradle/src/executors/gradle/gradle-batch.impl.spec.ts
+++ b/packages/gradle/src/executors/gradle/gradle-batch.impl.spec.ts
@@ -16,7 +16,10 @@ describe('getGradlewTasksToRun', () => {
           root: 'app1',
           targets: {
             test: {
-              dependsOn: ['app1:lint', 'app2:build'],
+              dependsOn: [
+                { target: 'lint' },
+                { target: 'build', projects: ['app2'] },
+              ],
               options: { taskName: 'testApp1' },
             },
             lint: {
@@ -45,7 +48,7 @@ describe('getGradlewTasksToRun', () => {
           root: 'app3',
           targets: {
             deploy: {
-              dependsOn: ['app1:test'],
+              dependsOn: [{ target: 'test', projects: ['app1'] }],
               options: { taskName: 'deployApp3' },
             },
           },

--- a/packages/gradle/src/executors/gradle/gradle-batch.impl.ts
+++ b/packages/gradle/src/executors/gradle/gradle-batch.impl.ts
@@ -121,7 +121,7 @@ export function getGradlewTasksToRun(
   for (const taskId of taskIds) {
     const task = taskGraph.tasks[taskId];
     const input = inputs[task.id];
-    const pt: ProjectTarget = {
+    const taskTarget: ProjectTarget = {
       project: task.target.project,
       target: task.target.target,
     };
@@ -136,12 +136,12 @@ export function getGradlewTasksToRun(
 
     if (input.excludeDependsOn) {
       if (input.testClassName) {
-        testTasksWithExclude.add(pt);
+        testTasksWithExclude.add(taskTarget);
       } else {
-        tasksWithExclude.add(pt);
+        tasksWithExclude.add(taskTarget);
       }
     } else {
-      tasksWithoutExclude.add(pt);
+      tasksWithoutExclude.add(taskTarget);
     }
   }
 
@@ -151,8 +151,8 @@ export function getGradlewTasksToRun(
       target: taskGraph.tasks[id].target.target,
     }))
   );
-  for (const pt of tasksWithoutExclude) {
-    const dependencies = getAllDependsOn(nodes, pt.project, pt.target);
+  for (const task of tasksWithoutExclude) {
+    const dependencies = getAllDependsOn(nodes, task.project, task.target);
     dependencies.forEach((dep) => allRunning.add(dep));
   }
 
@@ -164,13 +164,13 @@ export function getGradlewTasksToRun(
   );
 
   const allTestsDependsOn = new Set<ProjectTarget>();
-  for (const pt of testTasksWithExclude) {
-    const taskDependsOn = getAllDependsOn(nodes, pt.project, pt.target);
+  for (const task of testTasksWithExclude) {
+    const taskDependsOn = getAllDependsOn(nodes, task.project, task.target);
     taskDependsOn.forEach((dep) => allTestsDependsOn.add(dep));
   }
   const excludeTestTasks = new Set<string>();
-  for (const pt of allTestsDependsOn) {
-    const gradleTaskName = getGradleTaskName(pt, nodes);
+  for (const task of allTestsDependsOn) {
+    const gradleTaskName = getGradleTaskName(task, nodes);
     if (gradleTaskName) {
       excludeTestTasks.add(gradleTaskName);
     }

--- a/packages/gradle/src/executors/gradle/gradle-batch.impl.ts
+++ b/packages/gradle/src/executors/gradle/gradle-batch.impl.ts
@@ -20,7 +20,8 @@ import { execSync } from 'child_process';
 import {
   getAllDependsOn,
   getExcludeTasks,
-  getGradleTaskNameWithNxTaskId,
+  getGradleTaskName,
+  ProjectTarget,
 } from './get-exclude-task';
 import { GradlePluginOptions } from '../../plugin/utils/gradle-plugin-options';
 
@@ -111,59 +112,65 @@ export function getGradlewTasksToRun(
   inputs: Record<string, GradleExecutorSchema>,
   nodes: Record<string, ProjectGraphProjectNode>
 ) {
-  const taskIdsWithExclude: Set<string> = new Set([]);
-  const testTaskIdsWithExclude: Set<string> = new Set([]);
-  const taskIdsWithoutExclude: Set<string> = new Set([]);
+  const tasksWithExclude: Set<ProjectTarget> = new Set();
+  const testTasksWithExclude: Set<ProjectTarget> = new Set();
+  const tasksWithoutExclude: Set<ProjectTarget> = new Set();
   const gradlewTasksToRun: Record<string, GradleExecutorSchema> = {};
   const includeDependsOnTasks: Set<string> = new Set();
 
   for (const taskId of taskIds) {
     const task = taskGraph.tasks[taskId];
     const input = inputs[task.id];
+    const pt: ProjectTarget = {
+      project: task.target.project,
+      target: task.target.target,
+    };
 
     gradlewTasksToRun[taskId] = input;
 
-    // Collect tasks that should be included (not excluded) - typically provider-based dependencies
     if (input.includeDependsOnTasks) {
-      for (const task of input.includeDependsOnTasks) {
-        includeDependsOnTasks.add(task);
+      for (const t of input.includeDependsOnTasks) {
+        includeDependsOnTasks.add(t);
       }
     }
 
     if (input.excludeDependsOn) {
       if (input.testClassName) {
-        testTaskIdsWithExclude.add(taskId);
+        testTasksWithExclude.add(pt);
       } else {
-        taskIdsWithExclude.add(taskId);
+        tasksWithExclude.add(pt);
       }
     } else {
-      taskIdsWithoutExclude.add(taskId);
+      tasksWithoutExclude.add(pt);
     }
   }
 
-  const allDependsOn = new Set<string>(taskIds);
-  for (const taskId of taskIdsWithoutExclude) {
-    const [projectName, targetName] = taskId.split(':');
-    const dependencies = getAllDependsOn(nodes, projectName, targetName);
-    dependencies.forEach((dep) => allDependsOn.add(dep));
+  const allRunning = new Set<ProjectTarget>(
+    taskIds.map((id) => ({
+      project: taskGraph.tasks[id].target.project,
+      target: taskGraph.tasks[id].target.target,
+    }))
+  );
+  for (const pt of tasksWithoutExclude) {
+    const dependencies = getAllDependsOn(nodes, pt.project, pt.target);
+    dependencies.forEach((dep) => allRunning.add(dep));
   }
 
   const excludeTasks = getExcludeTasks(
-    taskIdsWithExclude,
+    tasksWithExclude,
     nodes,
-    allDependsOn,
+    allRunning,
     includeDependsOnTasks
   );
 
-  const allTestsDependsOn = new Set<string>();
-  for (const taskId of testTaskIdsWithExclude) {
-    const [projectName, targetName] = taskId.split(':');
-    const taskDependsOn = getAllDependsOn(nodes, projectName, targetName);
+  const allTestsDependsOn = new Set<ProjectTarget>();
+  for (const pt of testTasksWithExclude) {
+    const taskDependsOn = getAllDependsOn(nodes, pt.project, pt.target);
     taskDependsOn.forEach((dep) => allTestsDependsOn.add(dep));
   }
   const excludeTestTasks = new Set<string>();
-  for (let taskId of allTestsDependsOn) {
-    const gradleTaskName = getGradleTaskNameWithNxTaskId(taskId, nodes);
+  for (const pt of allTestsDependsOn) {
+    const gradleTaskName = getGradleTaskName(pt, nodes);
     if (gradleTaskName) {
       excludeTestTasks.add(gradleTaskName);
     }

--- a/packages/gradle/src/executors/gradle/gradle-batch.impl.ts
+++ b/packages/gradle/src/executors/gradle/gradle-batch.impl.ts
@@ -2,6 +2,7 @@ import {
   ExecutorContext,
   output,
   ProjectGraphProjectNode,
+  Target,
   TaskGraph,
   workspaceRoot,
 } from '@nx/devkit';
@@ -21,7 +22,6 @@ import {
   getAllDependsOn,
   getExcludeTasks,
   getGradleTaskName,
-  ProjectTarget,
 } from './get-exclude-task';
 import { GradlePluginOptions } from '../../plugin/utils/gradle-plugin-options';
 
@@ -112,16 +112,16 @@ export function getGradlewTasksToRun(
   inputs: Record<string, GradleExecutorSchema>,
   nodes: Record<string, ProjectGraphProjectNode>
 ) {
-  const tasksWithExclude: Set<ProjectTarget> = new Set();
-  const testTasksWithExclude: Set<ProjectTarget> = new Set();
-  const tasksWithoutExclude: Set<ProjectTarget> = new Set();
+  const tasksWithExclude: Set<Target> = new Set();
+  const testTasksWithExclude: Set<Target> = new Set();
+  const tasksWithoutExclude: Set<Target> = new Set();
   const gradlewTasksToRun: Record<string, GradleExecutorSchema> = {};
   const includeDependsOnTasks: Set<string> = new Set();
 
   for (const taskId of taskIds) {
     const task = taskGraph.tasks[taskId];
     const input = inputs[task.id];
-    const taskTarget: ProjectTarget = {
+    const taskTarget: Target = {
       project: task.target.project,
       target: task.target.target,
     };
@@ -145,7 +145,7 @@ export function getGradlewTasksToRun(
     }
   }
 
-  const allRunning = new Set<ProjectTarget>(
+  const allRunning = new Set<Target>(
     taskIds.map((id) => ({
       project: taskGraph.tasks[id].target.project,
       target: taskGraph.tasks[id].target.target,
@@ -163,7 +163,7 @@ export function getGradlewTasksToRun(
     includeDependsOnTasks
   );
 
-  const allTestsDependsOn = new Set<ProjectTarget>();
+  const allTestsDependsOn = new Set<Target>();
   for (const task of testTasksWithExclude) {
     const taskDependsOn = getAllDependsOn(nodes, task.project, task.target);
     taskDependsOn.forEach((dep) => allTestsDependsOn.add(dep));

--- a/packages/gradle/src/executors/gradle/gradle.impl.ts
+++ b/packages/gradle/src/executors/gradle/gradle.impl.ts
@@ -64,7 +64,7 @@ export default async function gradleExecutor(
   if (options.excludeDependsOn) {
     const includeDependsOnTasks = new Set(options.includeDependsOnTasks ?? []);
     getExcludeTasks(
-      new Set([{project: context.projectName, target: context.targetName}]),
+      new Set([{ project: context.projectName, target: context.targetName }]),
       context.projectGraph.nodes,
       new Set(),
       includeDependsOnTasks

--- a/packages/gradle/src/executors/gradle/gradle.impl.ts
+++ b/packages/gradle/src/executors/gradle/gradle.impl.ts
@@ -64,7 +64,7 @@ export default async function gradleExecutor(
   if (options.excludeDependsOn) {
     const includeDependsOnTasks = new Set(options.includeDependsOnTasks ?? []);
     getExcludeTasks(
-      new Set([`${context.projectName}:${context.targetName}`]),
+      new Set([{project: context.projectName, target: context.targetName}]),
       context.projectGraph.nodes,
       new Set(),
       includeDependsOnTasks


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->
## Current Behavior
                  
The Gradle executor's task exclusion logic represents running tasks and dependency relationships using colon-delimited string IDs (e.g. "project:target"). Parsing task identity by splitting on : breaks silently when project or target names contain colons — a common pattern in Gradle (e.g. :sub:project, compile:java).
                                                                                                                                       
## Expected Behavior     

Task identity is represented as a structured ProjectTarget object with explicit project and target fields, eliminating string-splitting ambiguity. The getExcludeTasks, getAllDependsOn, and getGradleTaskName functions now accept and return typed objects, and test fixtures use object-notation dependsOn entries. A new test case verifies correct behavior when names contain colons.             

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
