### PR TITLE
fix(repo): address remaining high-severity dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -412,7 +412,9 @@
   "pnpm": {
     "overrides": {
       "handlebars": "4.7.9",
-      "underscore": "^1.13.8"
+      "underscore": "^1.13.8",
+      "express>path-to-regexp": "0.1.13",
+      "router>path-to-regexp": "8.4.0"
     }
   },
   "nx": {

--- a/packages/maven/maven-plugin/pom.xml
+++ b/packages/maven/maven-plugin/pom.xml
@@ -184,14 +184,6 @@
     </dependency>
 
 
-    <!-- Plexus Utils for XML parsing -->
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-      <version>3.5.1</version>
-    </dependency>
-
-
   </dependencies>
 
   <build>

--- a/packages/maven/pom.xml
+++ b/packages/maven/pom.xml
@@ -59,13 +59,6 @@
         <version>6.8.0.202311291450-r</version>
       </dependency>
 
-      <!-- Plexus Utils for XML parsing -->
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-utils</artifactId>
-        <version>3.5.1</version>
-      </dependency>
-
       <!-- Maven Plugin Testing Harness -->
       <dependency>
         <groupId>org.apache.maven.plugin-testing</groupId>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,8 @@ catalogs:
 overrides:
   handlebars: 4.7.9
   underscore: ^1.13.8
+  express>path-to-regexp: 0.1.13
+  router>path-to-regexp: 8.4.0
 
 patchedDependencies:
   '@astrojs/starlight':
@@ -21828,11 +21830,8 @@ packages:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
 
-  path-to-regexp@0.1.12:
-    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
-
-  path-to-regexp@0.1.7:
-    resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
+  path-to-regexp@0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
   path-to-regexp@1.9.0:
     resolution: {integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==}
@@ -21843,9 +21842,8 @@ packages:
   path-to-regexp@3.3.0:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
 
-  path-to-regexp@8.2.0:
-    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
-    engines: {node: '>=16'}
+  path-to-regexp@8.4.0:
+    resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
 
   path-type@3.0.0:
     resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
@@ -45962,7 +45960,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.7
+      path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
       qs: 6.11.0
       range-parser: 1.2.1
@@ -45998,7 +45996,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.12
+      path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
       qs: 6.13.0
       range-parser: 1.2.1
@@ -46034,7 +46032,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.12
+      path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
       qs: 6.14.1
       range-parser: 1.2.1
@@ -52369,9 +52367,7 @@ snapshots:
       lru-cache: 11.2.4
       minipass: 7.1.3
 
-  path-to-regexp@0.1.12: {}
-
-  path-to-regexp@0.1.7: {}
+  path-to-regexp@0.1.13: {}
 
   path-to-regexp@1.9.0:
     dependencies:
@@ -52381,7 +52377,7 @@ snapshots:
 
   path-to-regexp@3.3.0: {}
 
-  path-to-regexp@8.2.0: {}
+  path-to-regexp@8.4.0: {}
 
   path-type@3.0.0:
     dependencies:
@@ -55266,7 +55262,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.2.0
+      path-to-regexp: 8.4.0
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Current Behavior

4 high-severity Dependabot alerts remain from real dependencies (not test fixtures):

| Package | Alert | Source | Vulnerability |
|---------|-------|--------|---------------|
| `path-to-regexp` | [#1531](https://github.com/nrwl/nx/security/dependabot/1531) | `express@5.2.1` → `router@2.2.0` → `8.2.0` | ReDoS via sequential optional groups |
| `path-to-regexp` | [#1530](https://github.com/nrwl/nx/security/dependabot/1530) | `@nestjs/platform-express@9.4.3` → `express@4.18.2` → `0.1.7` | ReDoS via multiple route parameters |
| `plexus-utils` | [#1521](https://github.com/nrwl/nx/security/dependabot/1521) | `packages/maven/pom.xml` | Directory traversal in extractFile (CVE-2025-67030) |
| `plexus-utils` | [#1520](https://github.com/nrwl/nx/security/dependabot/1520) | `packages/maven/maven-plugin/pom.xml` | Directory traversal in extractFile (CVE-2025-67030) |

Note: 15 of the original 19 alerts were already resolved by #35072 (test fixture lockfile cleanup).

## Expected Behavior

All 4 remaining alerts resolved:

- **path-to-regexp**: Added scoped `pnpm.overrides` to bump transitive deps to patched versions (`0.1.7`/`0.1.12` → `0.1.13`, `8.2.0` → `8.4.0`). These are patch/minor bumps within existing semver ranges.
- **plexus-utils**: Removed the unused direct dependency from both Maven pom files. Code analysis confirmed no classes from `plexus-utils` are imported anywhere — the comment said "for XML parsing" but actual XML/container classes come from `plexus-classworlds` and `plexus-container-default` (separate artifacts). Removing prevents future alert noise from this unused dep.

## Related Issue(s)

Fixes NXC-4170