### PR TITLE
fix(core): restore nx package exports compatibility

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -389,6 +389,9 @@
       },
       {
         "rule": "./dist/workspace-plugin/src/conformance-rules/relative-image-imports"
+      },
+      {
+        "rule": "./dist/workspace-plugin/src/conformance-rules/types-versions-exports-sync"
       }
     ]
   },

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -179,13 +179,46 @@
   },
   "typesVersions": {
     "*": {
-      "bin/nx": [
-        "dist/bin/nx.d.ts"
+      "bin/*": [
+        "dist/bin/*.d.ts"
       ],
-      "bin/nx.js": [
-        "dist/bin/nx.d.ts"
+      "bin/*.js": [
+        "dist/bin/*.d.ts"
+      ],
+      "plugins/*": [
+        "dist/plugins/*.d.ts"
+      ],
+      "plugins/*.js": [
+        "dist/plugins/*.d.ts"
       ],
       "src/native": [
+        "src/native/index.d.ts"
+      ],
+      "src": [
+        "dist/src/index.d.ts"
+      ],
+      "src/analytics": [
+        "dist/src/analytics/index.d.ts"
+      ],
+      "src/command-line": [
+        "dist/src/command-line/index.d.ts"
+      ],
+      "src/command-line/init/implementation/angular": [
+        "dist/src/command-line/init/implementation/angular/index.d.ts"
+      ],
+      "src/command-line/release": [
+        "dist/src/command-line/release/index.d.ts"
+      ],
+      "src/project-graph/plugins": [
+        "dist/src/project-graph/plugins/index.d.ts"
+      ],
+      "src/project-graph/plugins/isolation": [
+        "dist/src/project-graph/plugins/isolation/index.d.ts"
+      ],
+      "src/native/index": [
+        "src/native/index.d.ts"
+      ],
+      "src/native/index.js": [
         "src/native/index.d.ts"
       ],
       "src/plugins/js": [
@@ -194,20 +227,14 @@
       "src/plugins/package-json": [
         "dist/src/plugins/package-json/index.d.ts"
       ],
-      "src/plugins/*": [
-        "dist/src/plugins/*.d.ts"
-      ],
       "src/utils/plugins": [
         "dist/src/utils/plugins/index.d.ts"
-      ],
-      "src/utils/plugins/*": [
-        "dist/src/utils/plugins/*.d.ts"
       ],
       "src/utils/catalog": [
         "dist/src/utils/catalog/index.d.ts"
       ],
-      "src/utils/catalog/*": [
-        "dist/src/utils/catalog/*.d.ts"
+      "src/*.js": [
+        "dist/src/*.d.ts"
       ],
       "src/*": [
         "dist/src/*.d.ts"
@@ -215,8 +242,20 @@
       "release": [
         "dist/release/index.d.ts"
       ],
-      "tasks-runners/default": [
-        "dist/tasks-runners/default.d.ts"
+      "release/changelog-renderer": [
+        "dist/release/changelog-renderer/index.d.ts"
+      ],
+      "release/*": [
+        "dist/release/*.d.ts"
+      ],
+      "release/*.js": [
+        "dist/release/*.d.ts"
+      ],
+      "tasks-runners/*": [
+        "dist/tasks-runners/*.d.ts"
+      ],
+      "tasks-runners/*.js": [
+        "dist/tasks-runners/*.d.ts"
       ]
     }
   },
@@ -227,25 +266,86 @@
       "default": "./dist/bin/nx.js"
     },
     "./package.json": "./package.json",
+    "./package": "./package.json",
     "./migrations.json": "./migrations.json",
+    "./migrations": "./migrations.json",
     "./generators.json": "./generators.json",
+    "./generators": "./generators.json",
     "./executors.json": "./executors.json",
+    "./executors": "./executors.json",
+    "./schemas/*": "./schemas/*.json",
     "./schemas/*.json": "./schemas/*.json",
-    "./src/*.json": "./dist/src/*.json",
-    "./bin/nx": {
-      "@nx/nx-source": "./bin/nx.ts",
-      "types": "./dist/bin/nx.d.ts",
-      "default": "./dist/bin/nx.js"
+    "./presets/*": {
+      "@nx/nx-source": "./presets/*.json",
+      "default": "./dist/presets/*.json"
     },
-    "./bin/nx.js": {
-      "@nx/nx-source": "./bin/nx.ts",
-      "types": "./dist/bin/nx.d.ts",
-      "default": "./dist/bin/nx.js"
+    "./presets/*.json": {
+      "@nx/nx-source": "./presets/*.json",
+      "default": "./dist/presets/*.json"
+    },
+    "./bin/*": {
+      "@nx/nx-source": "./bin/*.ts",
+      "types": "./dist/bin/*.d.ts",
+      "default": "./dist/bin/*.js"
+    },
+    "./bin/*.js": {
+      "@nx/nx-source": "./bin/*.ts",
+      "types": "./dist/bin/*.d.ts",
+      "default": "./dist/bin/*.js"
+    },
+    "./plugins/*": {
+      "@nx/nx-source": "./plugins/*.ts",
+      "types": "./dist/plugins/*.d.ts",
+      "default": "./dist/plugins/*.js"
+    },
+    "./plugins/*.js": {
+      "@nx/nx-source": "./plugins/*.ts",
+      "types": "./dist/plugins/*.d.ts",
+      "default": "./dist/plugins/*.js"
+    },
+    "./src": {
+      "@nx/nx-source": "./src/index.ts",
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    },
+    "./src/analytics": {
+      "@nx/nx-source": "./src/analytics/index.ts",
+      "types": "./dist/src/analytics/index.d.ts",
+      "default": "./dist/src/analytics/index.js"
+    },
+    "./src/command-line": {
+      "@nx/nx-source": "./src/command-line/index.ts",
+      "types": "./dist/src/command-line/index.d.ts",
+      "default": "./dist/src/command-line/index.js"
+    },
+    "./src/command-line/init/implementation/angular": {
+      "@nx/nx-source": "./src/command-line/init/implementation/angular/index.ts",
+      "types": "./dist/src/command-line/init/implementation/angular/index.d.ts",
+      "default": "./dist/src/command-line/init/implementation/angular/index.js"
+    },
+    "./src/command-line/release": {
+      "@nx/nx-source": "./src/command-line/release/index.ts",
+      "types": "./dist/src/command-line/release/index.d.ts",
+      "default": "./dist/src/command-line/release/index.js"
     },
     "./src/native": {
-      "@nx/nx-source": "./src/native/index.ts",
+      "@nx/nx-source": "./src/native/index.js",
       "types": "./src/native/index.d.ts",
       "default": "./dist/src/native/index.js"
+    },
+    "./src/native/index": {
+      "@nx/nx-source": "./src/native/index.js",
+      "types": "./src/native/index.d.ts",
+      "default": "./dist/src/native/index.js"
+    },
+    "./src/native/index.js": {
+      "@nx/nx-source": "./src/native/index.js",
+      "types": "./src/native/index.d.ts",
+      "default": "./dist/src/native/index.js"
+    },
+    "./src/native/*.js": {
+      "@nx/nx-source": "./src/native/*.js",
+      "default": "./dist/src/native/*.js"
     },
     "./src/plugins/js": {
       "@nx/nx-source": "./src/plugins/js/index.ts",
@@ -257,30 +357,49 @@
       "types": "./dist/src/plugins/package-json/index.d.ts",
       "default": "./dist/src/plugins/package-json/index.js"
     },
-    "./src/plugins/*": {
-      "@nx/nx-source": "./src/plugins/*.ts",
-      "types": "./dist/src/plugins/*.d.ts",
-      "default": "./dist/src/plugins/*.js"
-    },
     "./src/utils/plugins": {
       "@nx/nx-source": "./src/utils/plugins/index.ts",
       "types": "./dist/src/utils/plugins/index.d.ts",
       "default": "./dist/src/utils/plugins/index.js"
-    },
-    "./src/utils/plugins/*": {
-      "@nx/nx-source": "./src/utils/plugins/*.ts",
-      "types": "./dist/src/utils/plugins/*.d.ts",
-      "default": "./dist/src/utils/plugins/*.js"
     },
     "./src/utils/catalog": {
       "@nx/nx-source": "./src/utils/catalog/index.ts",
       "types": "./dist/src/utils/catalog/index.d.ts",
       "default": "./dist/src/utils/catalog/index.js"
     },
-    "./src/utils/catalog/*": {
-      "@nx/nx-source": "./src/utils/catalog/*.ts",
-      "types": "./dist/src/utils/catalog/*.d.ts",
-      "default": "./dist/src/utils/catalog/*.js"
+    "./src/command-line/migrate/run-migration-process": {
+      "@nx/nx-source": "./src/command-line/migrate/run-migration-process.js",
+      "default": "./dist/src/command-line/migrate/run-migration-process.js"
+    },
+    "./src/command-line/migrate/run-migration-process.js": {
+      "@nx/nx-source": "./src/command-line/migrate/run-migration-process.js",
+      "default": "./dist/src/command-line/migrate/run-migration-process.js"
+    },
+    "./src/project-graph/plugins": {
+      "@nx/nx-source": "./src/project-graph/plugins/index.ts",
+      "types": "./dist/src/project-graph/plugins/index.d.ts",
+      "default": "./dist/src/project-graph/plugins/index.js"
+    },
+    "./src/project-graph/plugins/isolation": {
+      "@nx/nx-source": "./src/project-graph/plugins/isolation/index.ts",
+      "types": "./dist/src/project-graph/plugins/isolation/index.d.ts",
+      "default": "./dist/src/project-graph/plugins/isolation/index.js"
+    },
+    "./src/*/schema": {
+      "@nx/nx-source": "./src/*/schema.json",
+      "default": "./dist/src/*/schema.json"
+    },
+    "./src/*/schema.json": {
+      "@nx/nx-source": "./src/*/schema.json",
+      "default": "./dist/src/*/schema.json"
+    },
+    "./src/native/*.cjs": {
+      "@nx/nx-source": "./src/native/*.cjs",
+      "default": "./dist/src/native/*.cjs"
+    },
+    "./src/native/*.mjs": {
+      "@nx/nx-source": "./src/native/*.mjs",
+      "default": "./dist/src/native/*.mjs"
     },
     "./src/*.js": {
       "@nx/nx-source": "./src/*.ts",
@@ -302,14 +421,25 @@
       "types": "./dist/release/changelog-renderer/index.d.ts",
       "default": "./dist/release/changelog-renderer/index.js"
     },
-    "./presets/*": {
-      "@nx/nx-source": "./presets/*",
-      "default": "./dist/presets/*"
+    "./release/*": {
+      "@nx/nx-source": "./release/*.ts",
+      "types": "./dist/release/*.d.ts",
+      "default": "./dist/release/*.js"
     },
-    "./tasks-runners/default": {
-      "@nx/nx-source": "./tasks-runners/default.ts",
-      "types": "./dist/tasks-runners/default.d.ts",
-      "default": "./dist/tasks-runners/default.js"
+    "./release/*.js": {
+      "@nx/nx-source": "./release/*.ts",
+      "types": "./dist/release/*.d.ts",
+      "default": "./dist/release/*.js"
+    },
+    "./tasks-runners/*": {
+      "@nx/nx-source": "./tasks-runners/*.ts",
+      "types": "./dist/tasks-runners/*.d.ts",
+      "default": "./dist/tasks-runners/*.js"
+    },
+    "./tasks-runners/*.js": {
+      "@nx/nx-source": "./tasks-runners/*.ts",
+      "types": "./dist/tasks-runners/*.d.ts",
+      "default": "./dist/tasks-runners/*.js"
     }
   }
 }

--- a/tools/workspace-plugin/src/conformance-rules/types-versions-exports-sync/index.spec.ts
+++ b/tools/workspace-plugin/src/conformance-rules/types-versions-exports-sync/index.spec.ts
@@ -1,0 +1,240 @@
+import { validateTypesVersionsExportsSync } from './index';
+
+const SOURCE_PROJECT = 'test-project';
+const PACKAGE_JSON_PATH = '/path/to/test-project/package.json';
+
+describe('types-versions-exports-sync', () => {
+  describe('validateTypesVersionsExportsSync()', () => {
+    it('should return no violations when both fields are fully in sync', () => {
+      const violations = validateTypesVersionsExportsSync(
+        {
+          typesVersions: {
+            '*': {
+              'src/utils': ['dist/src/utils/index.d.ts'],
+              'src/*': ['dist/src/*.d.ts'],
+            },
+          },
+          exports: {
+            '.': {
+              types: './dist/index.d.ts',
+              default: './dist/index.js',
+            },
+            './src/utils': {
+              types: './dist/src/utils/index.d.ts',
+              default: './dist/src/utils/index.js',
+            },
+            './src/*': {
+              types: './dist/src/*.d.ts',
+              default: './dist/src/*.js',
+            },
+          },
+        },
+        SOURCE_PROJECT,
+        PACKAGE_JSON_PATH
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('should return no violations when package has only exports', () => {
+      const violations = validateTypesVersionsExportsSync(
+        {
+          exports: {
+            '.': {
+              types: './dist/index.d.ts',
+              default: './dist/index.js',
+            },
+          },
+        },
+        SOURCE_PROJECT,
+        PACKAGE_JSON_PATH
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('should return no violations when package has only typesVersions', () => {
+      const violations = validateTypesVersionsExportsSync(
+        {
+          typesVersions: {
+            '*': {
+              'src/*': ['dist/src/*.d.ts'],
+            },
+          },
+        },
+        SOURCE_PROJECT,
+        PACKAGE_JSON_PATH
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('should return no violations for exports string shorthand entries', () => {
+      const violations = validateTypesVersionsExportsSync(
+        {
+          typesVersions: {
+            '*': {
+              'src/*': ['dist/src/*.d.ts'],
+            },
+          },
+          exports: {
+            './package.json': './package.json',
+            './src/*': {
+              types: './dist/src/*.d.ts',
+              default: './dist/src/*.js',
+            },
+          },
+        },
+        SOURCE_PROJECT,
+        PACKAGE_JSON_PATH
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('should return no violations for exports entries without a types condition', () => {
+      const violations = validateTypesVersionsExportsSync(
+        {
+          typesVersions: {
+            '*': {
+              'src/*': ['dist/src/*.d.ts'],
+            },
+          },
+          exports: {
+            './presets/*': {
+              default: './dist/presets/*',
+            },
+            './src/*': {
+              types: './dist/src/*.d.ts',
+              default: './dist/src/*.js',
+            },
+          },
+        },
+        SOURCE_PROJECT,
+        PACKAGE_JSON_PATH
+      );
+      expect(violations).toEqual([]);
+    });
+
+    it('should return a violation when exports has types but no typesVersions entry', () => {
+      const violations = validateTypesVersionsExportsSync(
+        {
+          typesVersions: {
+            '*': {
+              'src/*': ['dist/src/*.d.ts'],
+            },
+          },
+          exports: {
+            './src/*': {
+              types: './dist/src/*.d.ts',
+              default: './dist/src/*.js',
+            },
+            './release': {
+              types: './dist/release/index.d.ts',
+              default: './dist/release/index.js',
+            },
+          },
+        },
+        SOURCE_PROJECT,
+        PACKAGE_JSON_PATH
+      );
+      expect(violations).toMatchInlineSnapshot(`
+        [
+          {
+            "file": "/path/to/test-project/package.json",
+            "message": "The exports entry './release' has a 'types' condition but no corresponding 'typesVersions' entry. Add 'release' to 'typesVersions' to support node10 module resolution.",
+            "sourceProject": "test-project",
+          },
+        ]
+      `);
+    });
+
+    it('should return a violation when types paths mismatch', () => {
+      const violations = validateTypesVersionsExportsSync(
+        {
+          typesVersions: {
+            '*': {
+              'src/utils': ['dist/src/utils.d.ts'],
+            },
+          },
+          exports: {
+            './src/utils': {
+              types: './dist/src/utils/index.d.ts',
+              default: './dist/src/utils/index.js',
+            },
+          },
+        },
+        SOURCE_PROJECT,
+        PACKAGE_JSON_PATH
+      );
+      expect(violations).toMatchInlineSnapshot(`
+        [
+          {
+            "file": "/path/to/test-project/package.json",
+            "message": "The 'typesVersions' entry 'src/utils' maps to 'dist/src/utils.d.ts' but 'exports' maps types to 'dist/src/utils/index.d.ts'. These must match.",
+            "sourceProject": "test-project",
+          },
+        ]
+      `);
+    });
+
+    it('should return a violation for stale typesVersions entry with no matching export', () => {
+      const violations = validateTypesVersionsExportsSync(
+        {
+          typesVersions: {
+            '*': {
+              'src/*': ['dist/src/*.d.ts'],
+              'old-module': ['dist/old-module/index.d.ts'],
+            },
+          },
+          exports: {
+            './src/*': {
+              types: './dist/src/*.d.ts',
+              default: './dist/src/*.js',
+            },
+          },
+        },
+        SOURCE_PROJECT,
+        PACKAGE_JSON_PATH
+      );
+      expect(violations).toMatchInlineSnapshot(`
+        [
+          {
+            "file": "/path/to/test-project/package.json",
+            "message": "The 'typesVersions' entry 'old-module' has no corresponding 'exports' entry with a 'types' condition. Remove it from 'typesVersions' or add a matching export with a 'types' condition.",
+            "sourceProject": "test-project",
+          },
+        ]
+      `);
+    });
+
+    it('should require separate typesVersions entries for extensionless and extension-bearing subpaths', () => {
+      const violations = validateTypesVersionsExportsSync(
+        {
+          typesVersions: {
+            '*': {
+              'src/*': ['dist/src/*.d.ts'],
+            },
+          },
+          exports: {
+            './src/*': {
+              types: './dist/src/*.d.ts',
+              default: './dist/src/*.js',
+            },
+            './src/*.js': {
+              types: './dist/src/*.d.ts',
+              default: './dist/src/*.js',
+            },
+          },
+        },
+        SOURCE_PROJECT,
+        PACKAGE_JSON_PATH
+      );
+      expect(violations).toMatchInlineSnapshot(`
+        [
+          {
+            "file": "/path/to/test-project/package.json",
+            "message": "The exports entry './src/*.js' has a 'types' condition but no corresponding 'typesVersions' entry. Add 'src/*.js' to 'typesVersions' to support node10 module resolution.",
+            "sourceProject": "test-project",
+          },
+        ]
+      `);
+    });
+  });
+});

--- a/tools/workspace-plugin/src/conformance-rules/types-versions-exports-sync/index.ts
+++ b/tools/workspace-plugin/src/conformance-rules/types-versions-exports-sync/index.ts
@@ -1,0 +1,133 @@
+import {
+  createConformanceRule,
+  type ConformanceViolation,
+} from '@nx/conformance';
+import { readJsonFile, workspaceRoot } from '@nx/devkit';
+import { existsSync } from 'fs';
+import { join } from 'node:path';
+
+export default createConformanceRule<object>({
+  name: 'types-versions-exports-sync',
+  category: 'consistency',
+  description:
+    'Ensures every "exports" entry with a "types" condition has a matching "typesVersions" entry and vice versa',
+  implementation: async ({ projectGraph }) => {
+    const violations: ConformanceViolation[] = [];
+
+    for (const project of Object.values(projectGraph.nodes)) {
+      const packageJsonPath = join(
+        workspaceRoot,
+        project.data.root,
+        'package.json'
+      );
+      if (existsSync(packageJsonPath)) {
+        const packageJson = readJsonFile(packageJsonPath);
+        violations.push(
+          ...validateTypesVersionsExportsSync(
+            packageJson,
+            project.name,
+            packageJsonPath
+          )
+        );
+      }
+    }
+
+    return {
+      severity: 'medium',
+      details: {
+        violations,
+      },
+    };
+  },
+});
+
+function normalizePath(p: string): string {
+  return p.replace(/^\.\//, '');
+}
+
+export function validateTypesVersionsExportsSync(
+  packageJson: Record<string, unknown>,
+  sourceProject: string,
+  packageJsonPath: string
+): ConformanceViolation[] {
+  const violations: ConformanceViolation[] = [];
+
+  const typesVersions = packageJson.typesVersions as
+    | Record<string, Record<string, string[]>>
+    | undefined;
+  const exports = packageJson.exports as Record<string, unknown> | undefined;
+
+  if (!typesVersions || !exports) {
+    return [];
+  }
+
+  const tvMap = typesVersions['*'];
+  if (!tvMap) {
+    return [];
+  }
+
+  // Check 1: exports entries with "types" that are missing from typesVersions
+  for (const [exportKey, exportValue] of Object.entries(exports)) {
+    if (typeof exportValue === 'string') {
+      continue;
+    }
+
+    if (typeof exportValue !== 'object' || exportValue === null) {
+      continue;
+    }
+
+    const typesPath = (exportValue as Record<string, string>)['types'];
+    if (!typesPath) {
+      continue;
+    }
+
+    // Skip the root "." entry — typesVersions doesn't map the root
+    if (exportKey === '.') {
+      continue;
+    }
+
+    const subpath = normalizePath(exportKey);
+    const normalizedTypesPath = normalizePath(typesPath);
+
+    const tvEntry = tvMap[subpath];
+    if (!tvEntry) {
+      violations.push({
+        message: `The exports entry './${subpath}' has a 'types' condition but no corresponding 'typesVersions' entry. Add '${subpath}' to 'typesVersions' to support node10 module resolution.`,
+        sourceProject,
+        file: packageJsonPath,
+      });
+      continue;
+    }
+
+    const tvPath = tvEntry[0];
+    if (tvPath !== normalizedTypesPath) {
+      violations.push({
+        message: `The 'typesVersions' entry '${subpath}' maps to '${tvPath}' but 'exports' maps types to '${normalizedTypesPath}'. These must match.`,
+        sourceProject,
+        file: packageJsonPath,
+      });
+    }
+  }
+
+  // Check 2: stale typesVersions entries with no matching export
+  for (const tvKey of Object.keys(tvMap)) {
+    const exportKey = `./${tvKey}`;
+    const exportValue = exports[exportKey];
+
+    if (
+      exportValue &&
+      typeof exportValue === 'object' &&
+      (exportValue as Record<string, string>)['types']
+    ) {
+      continue;
+    }
+
+    violations.push({
+      message: `The 'typesVersions' entry '${tvKey}' has no corresponding 'exports' entry with a 'types' condition. Remove it from 'typesVersions' or add a matching export with a 'types' condition.`,
+      sourceProject,
+      file: packageJsonPath,
+    });
+  }
+
+  return violations;
+}

--- a/tools/workspace-plugin/src/conformance-rules/types-versions-exports-sync/schema.json
+++ b/tools/workspace-plugin/src/conformance-rules/types-versions-exports-sync/schema.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Current Behavior

The `nx` package's `exports` field uses conditional exports that restrict subpath access. Consumers relying on deep imports (e.g., `nx/src/command-line`, `nx/src/project-graph/plugins`) or importing with file extensions (e.g., `nx/bin/nx.js`) can't resolve modules or types. The `typesVersions` field is also incomplete and out of sync with `exports`, breaking type resolution for consumers using `moduleResolution: "node"` (node10).

## Expected Behavior

The `nx` package exposes all necessary subpaths through both `exports` (for modern resolution) and `typesVersions` (for node10 resolution), keeping them in sync. A new conformance rule prevents future drift between the two fields.

> **Note:** This restores backwards compatibility to avoid breaking changes in the current major version. Deep imports into `nx/src/*` access private/internal APIs that are not part of the public contract — they are not guaranteed to be stable and may break without notice. In Nx v23, we plan to constrain the exports to a well-defined public API, which will be a breaking change.

## Changes

- **Restore `nx` package exports**: expand `exports` and `typesVersions` to cover all public subpaths including `bin/*`, `plugins/*`, `src/command-line`, `src/project-graph/plugins`, `release/*`, `tasks-runners/*`, and their `.js` extension variants
- **Add `types-versions-exports-sync` conformance rule**: enforces that every `exports` entry with a `types` condition has a corresponding `typesVersions` entry and vice versa, preventing future drift