### PR TITLE
fix(repo): narrow copy-assets outputs to prevent overlap with build-base

### DIFF
--- a/packages/angular/assets.json
+++ b/packages/angular/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/angular/assets.json
+++ b/packages/angular/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/angular",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/angular/tsconfig.lib.json
+++ b/packages/angular/tsconfig.lib.json
@@ -17,7 +17,7 @@
     "index.ts",
     "mf/**/*"
   ],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../vitest/tsconfig.lib.json"

--- a/packages/create-nx-plugin/assets.json
+++ b/packages/create-nx-plugin/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/create-nx-plugin/assets.json
+++ b/packages/create-nx-plugin/assets.json
@@ -1,15 +1,10 @@
 {
   "outDir": "dist/packages/create-nx-plugin",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/create-nx-plugin/tsconfig.lib.json
+++ b/packages/create-nx-plugin/tsconfig.lib.json
@@ -13,7 +13,7 @@
     "**/*_test.ts",
     "jest.config.ts"
   ],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../create-nx-workspace/tsconfig.lib.json"

--- a/packages/create-nx-workspace/assets.json
+++ b/packages/create-nx-workspace/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/cypress/assets.json
+++ b/packages/cypress/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/cypress",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
-    {
-      "glob": "PLUGIN.md"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
+    { "glob": "PLUGIN.md" },
     "LICENSE"
   ]
 }

--- a/packages/cypress/assets.json
+++ b/packages/cypress/assets.json
@@ -5,15 +5,7 @@
       "glob": "**/files/**"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     {
       "glob": "PLUGIN.md"

--- a/packages/cypress/tsconfig.lib.json
+++ b/packages/cypress/tsconfig.lib.json
@@ -7,7 +7,7 @@
     "tsBuildInfoFile": "../../dist/packages/cypress/tsconfig.tsbuildinfo"
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../nx/tsconfig.lib.json"

--- a/packages/detox/assets.json
+++ b/packages/detox/assets.json
@@ -1,12 +1,10 @@
 {
   "outDir": "dist/packages/detox",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/detox/assets.json
+++ b/packages/detox/assets.json
@@ -1,10 +1,11 @@
 {
   "outDir": "dist/packages/detox",
   "assets": [
-    { "glob": "**/files/**" },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json"]
+      "glob": "**/files/**"
+    },
+    {
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/detox/tsconfig.lib.json
+++ b/packages/detox/tsconfig.lib.json
@@ -7,7 +7,7 @@
     "tsBuildInfoFile": "../../dist/packages/detox/tsconfig.tsbuildinfo"
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../nx/tsconfig.lib.json"

--- a/packages/devkit/assets.json
+++ b/packages/devkit/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/docker/assets.json
+++ b/packages/docker/assets.json
@@ -2,15 +2,13 @@
   "outDir": "dist/packages/docker",
   "assets": [
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
+      "glob": "**/files/**"
     },
     {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
+      "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/docker/assets.json
+++ b/packages/docker/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/docker",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/docker/tsconfig.lib.json
+++ b/packages/docker/tsconfig.lib.json
@@ -4,7 +4,7 @@
     "outDir": "../../dist/packages/docker",
     "types": ["node"]
   },
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
     {

--- a/packages/dotnet/assets.json
+++ b/packages/dotnet/assets.json
@@ -1,17 +1,11 @@
 {
   "outDir": "packages/dotnet/dist",
   "assets": [
-    { "glob": "*.md" },
     {
-      "glob": "**/*.{d.ts,json}",
-      "input": "packages/dotnet/src",
-      "ignore": [
-        ".eslintrc.json",
-        "generators.json",
-        "executors.json",
-        "migrations.json"
-      ]
+      "glob": "*.md"
     },
+    { "glob": "**/schema.json", "input": "packages/dotnet/src" },
+    { "glob": "**/schema.d.ts", "input": "packages/dotnet/src" },
     {
       "glob": "**/*",
       "input": "dist/msbuild-analyzer",

--- a/packages/esbuild/assets.json
+++ b/packages/esbuild/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/esbuild/assets.json
+++ b/packages/esbuild/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/esbuild",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/esbuild/tsconfig.lib.json
+++ b/packages/esbuild/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "types": ["node"],
     "tsBuildInfoFile": "../../dist/packages/esbuild/tsconfig.tsbuildinfo"
   },
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
     {

--- a/packages/eslint-plugin/assets.json
+++ b/packages/eslint-plugin/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/eslint-plugin/assets.json
+++ b/packages/eslint-plugin/assets.json
@@ -1,15 +1,10 @@
 {
   "outDir": "dist/packages/eslint-plugin",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/eslint-plugin/tsconfig.lib.json
+++ b/packages/eslint-plugin/tsconfig.lib.json
@@ -15,7 +15,7 @@
     "**/*_test.ts",
     "jest.config.ts"
   ],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../js/tsconfig.lib.json"

--- a/packages/eslint/assets.json
+++ b/packages/eslint/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/eslint/assets.json
+++ b/packages/eslint/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/eslint",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/eslint/tsconfig.lib.json
+++ b/packages/eslint/tsconfig.lib.json
@@ -13,7 +13,7 @@
     "**/*_test.ts",
     "jest.config.ts"
   ],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../nx/tsconfig.lib.json"

--- a/packages/expo/assets.json
+++ b/packages/expo/assets.json
@@ -1,13 +1,20 @@
 {
   "outDir": "dist/packages/expo",
   "assets": [
-    { "glob": "**/files/**" },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "**/project.json"]
+      "glob": "**/files/**"
     },
-    { "glob": "**/*.d.ts" },
-    { "glob": "**/*.md" },
+    {
+      "glob": "**/files/**/.gitkeep"
+    },
+    { "glob": "src/**/schema.d.ts" },
+    { "glob": "typings/**/*.d.ts" },
+    {
+      "glob": "src/executors/build-list/build-fragment.d.ts"
+    },
+    {
+      "glob": "**/*.md"
+    },
     "LICENSE"
   ]
 }

--- a/packages/expo/assets.json
+++ b/packages/expo/assets.json
@@ -1,20 +1,14 @@
 {
   "outDir": "dist/packages/expo",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
     { "glob": "src/**/schema.d.ts" },
     { "glob": "typings/**/*.d.ts" },
-    {
-      "glob": "src/executors/build-list/build-fragment.d.ts"
-    },
-    {
-      "glob": "**/*.md"
-    },
+    { "glob": "src/executors/build-list/build-fragment.d.ts" },
+    { "glob": "**/*.md" },
     "LICENSE"
   ]
 }

--- a/packages/expo/tsconfig.lib.json
+++ b/packages/expo/tsconfig.lib.json
@@ -8,7 +8,7 @@
     "tsBuildInfoFile": "../../dist/packages/expo/tsconfig.tsbuildinfo"
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../rollup/tsconfig.lib.json"

--- a/packages/express/assets.json
+++ b/packages/express/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/express/assets.json
+++ b/packages/express/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/express",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/express/tsconfig.lib.json
+++ b/packages/express/tsconfig.lib.json
@@ -14,7 +14,7 @@
     "jest.config.ts",
     "jest.config.cts"
   ],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../devkit/tsconfig.lib.json"

--- a/packages/gradle/assets.json
+++ b/packages/gradle/assets.json
@@ -2,18 +2,12 @@
   "outDir": "dist/packages/gradle",
   "assets": [
     { "glob": "**/files/**" },
-    {
-      "glob": "**/*.json",
-      "ignore": [
-        "tsconfig*.json",
-        "project.json",
-        ".eslintrc.json",
-        "batch-runner/**",
-        "project-graph/**"
-      ]
-    },
-    { "glob": "**/*.js", "ignore": ["**/jest.config.js"] },
-    { "glob": "**/*.d.ts" },
+    { "glob": "package.json" },
+    { "glob": "executors.json" },
+    { "glob": "generators.json" },
+    { "glob": "migrations.json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
     {
       "glob": "**/*.jar",
       "input": "packages/gradle/batch-runner",

--- a/packages/jest/assets.json
+++ b/packages/jest/assets.json
@@ -5,15 +5,7 @@
       "glob": "**/@(files|files-angular)/**"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     {
       "glob": "PLUGIN.md"

--- a/packages/jest/assets.json
+++ b/packages/jest/assets.json
@@ -1,15 +1,10 @@
 {
   "outDir": "dist/packages/jest",
   "assets": [
-    {
-      "glob": "**/@(files|files-angular)/**"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
-    {
-      "glob": "PLUGIN.md"
-    },
+    { "glob": "**/@(files|files-angular)/**" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.d.ts" },
+    { "glob": "PLUGIN.md" },
     "LICENSE"
   ]
 }

--- a/packages/jest/tsconfig.lib.json
+++ b/packages/jest/tsconfig.lib.json
@@ -7,7 +7,7 @@
     "tsBuildInfoFile": "../../dist/packages/jest/tsconfig.tsbuildinfo"
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts", "src/**/schema.json"],
   "references": [
     {
       "path": "../js/tsconfig.lib.json"

--- a/packages/js/assets.json
+++ b/packages/js/assets.json
@@ -7,16 +7,13 @@
     {
       "glob": "**/files/**/.gitkeep"
     },
+    { "glob": "package.json" },
+    { "glob": "executors.json" },
+    { "glob": "generators.json" },
+    { "glob": "migrations.json" },
+    { "glob": "src/**/schema.json" },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js", "src/index.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/maven/assets.json
+++ b/packages/maven/assets.json
@@ -1,18 +1,9 @@
 {
   "outDir": "packages/maven/dist",
   "assets": [
-    {
-      "glob": "**/files/**",
-      "input": "packages/maven/src"
-    },
-    {
-      "glob": "**/*.json",
-      "input": "packages/maven/src",
-      "ignore": ["maven-plugin/**/*"]
-    },
-    {
-      "glob": "@(generators|executors).json"
-    },
+    { "glob": "**/files/**", "input": "packages/maven/src" },
+    { "glob": "**/schema.json", "input": "packages/maven/src" },
+    { "glob": "@(generators|executors).json" },
     {
       "glob": "**/*.jar",
       "input": "packages/maven/batch-runner/target",

--- a/packages/module-federation/assets.json
+++ b/packages/module-federation/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/module-federation/assets.json
+++ b/packages/module-federation/assets.json
@@ -1,15 +1,10 @@
 {
   "outDir": "dist/packages/module-federation",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/module-federation/tsconfig.lib.json
+++ b/packages/module-federation/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "types": ["node"],
     "tsBuildInfoFile": "../../dist/packages/module-federation/tsconfig.tsbuildinfo"
   },
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../web/tsconfig.lib.json"

--- a/packages/nest/assets.json
+++ b/packages/nest/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/nest/assets.json
+++ b/packages/nest/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/nest",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/nest/tsconfig.lib.json
+++ b/packages/nest/tsconfig.lib.json
@@ -15,7 +15,7 @@
     "jest.config.cts",
     "test-setup.ts"
   ],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../node/tsconfig.lib.json"

--- a/packages/next/assets.json
+++ b/packages/next/assets.json
@@ -7,17 +7,8 @@
     {
       "glob": "**/files/**/.gitkeep"
     },
-    {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
-    },
+    { "glob": "src/**/schema.d.ts" },
+    { "glob": "typings/**/*.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/next/assets.json
+++ b/packages/next/assets.json
@@ -1,12 +1,10 @@
 {
   "outDir": "dist/packages/next",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
     { "glob": "src/**/schema.d.ts" },
     { "glob": "typings/**/*.d.ts" },
     "LICENSE"

--- a/packages/next/tsconfig.lib.json
+++ b/packages/next/tsconfig.lib.json
@@ -14,7 +14,7 @@
     "jest.config.ts",
     "jest.config.cts"
   ],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../webpack/tsconfig.lib.json"

--- a/packages/node/assets.json
+++ b/packages/node/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/node/assets.json
+++ b/packages/node/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/node",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/node/tsconfig.lib.json
+++ b/packages/node/tsconfig.lib.json
@@ -14,7 +14,7 @@
     "jest.config.ts",
     "jest.config.cts"
   ],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../docker/tsconfig.lib.json"

--- a/packages/nuxt/assets.json
+++ b/packages/nuxt/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/nuxt/assets.json
+++ b/packages/nuxt/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/nuxt",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/nuxt/tsconfig.lib.json
+++ b/packages/nuxt/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "types": ["node"],
     "tsBuildInfoFile": "../../dist/packages/nuxt/tsconfig.tsbuildinfo"
   },
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
     {

--- a/packages/nx/assets.json
+++ b/packages/nx/assets.json
@@ -1,29 +1,21 @@
 {
   "outDir": "packages/nx/dist",
   "assets": [
-    { "glob": "**/files/**" },
-    { "glob": "**/files/**/.gitkeep" },
-    {
-      "glob": "**/*.json",
-      "ignore": [
-        "tsconfig*.json",
-        "**/project.json",
-        "**/__fixtures__/**",
-        ".eslintrc.json",
-        "executors.json",
-        "generators.json",
-        "migrations.json",
-        "package.json"
-      ]
-    },
-    {
-      "glob": "**/*.{mjs,cjs,js,css,html,svg}",
-      "ignore": ["**/jest.config.js", "**/__fixtures__/**"]
-    },
-    {
-      "glob": "**/*.{node,wasm}",
-      "includeIgnoredFiles": true
-    },
+    { "glob": "presets/*.json" },
+    { "glob": "src/command-line/migrate/run-migration-process.js" },
+    { "glob": "src/ai/set-up-ai-agents/schema.d.ts" },
+    { "glob": "src/utils/perf-hooks.d.ts" },
+    { "glob": "src/native/browser.js" },
+    { "glob": "src/native/index.js" },
+    { "glob": "src/native/index.d.ts" },
+    { "glob": "src/native/native-bindings.js" },
+    { "glob": "src/native/nx.wasi-browser.js" },
+    { "glob": "src/native/nx.wasi.cjs" },
+    { "glob": "src/native/wasi-worker-browser.mjs" },
+    { "glob": "src/native/wasi-worker.mjs" },
+    { "glob": "src/native/*.{node,wasm}", "includeIgnoredFiles": true },
+    { "glob": "schemas/*.json" },
+    { "glob": "native-packages/*/package.json" },
     {
       "glob": "**/*",
       "input": "dist/apps/graph",

--- a/packages/playwright/assets.json
+++ b/packages/playwright/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/playwright",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
-    {
-      "glob": "PLUGIN.md"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
+    { "glob": "PLUGIN.md" },
     "LICENSE"
   ]
 }

--- a/packages/playwright/assets.json
+++ b/packages/playwright/assets.json
@@ -5,15 +5,7 @@
       "glob": "**/files/**"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     {
       "glob": "PLUGIN.md"

--- a/packages/playwright/tsconfig.lib.json
+++ b/packages/playwright/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "types": ["node"],
     "tsBuildInfoFile": "../../dist/packages/playwright/tsconfig.tsbuildinfo"
   },
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
   "references": [
     {

--- a/packages/plugin/assets.json
+++ b/packages/plugin/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/plugin/assets.json
+++ b/packages/plugin/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/plugin",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/plugin/tsconfig.lib.json
+++ b/packages/plugin/tsconfig.lib.json
@@ -13,7 +13,7 @@
     "**/*_test.ts",
     "jest.config.ts"
   ],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../eslint/tsconfig.lib.json"

--- a/packages/react-native/assets.json
+++ b/packages/react-native/assets.json
@@ -1,13 +1,15 @@
 {
   "outDir": "dist/packages/react-native",
   "assets": [
-    "packages/react-native/*.md",
-    { "glob": "**/files/**" },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json"]
+      "glob": "**/files/**"
     },
-    { "glob": "**/*.d.ts" },
+    {
+      "glob": "**/files/**/.gitkeep"
+    },
+    { "glob": "src/**/schema.d.ts" },
+    { "glob": "typings/**/*.d.ts" },
+    "packages/react-native/*.md",
     "LICENSE"
   ]
 }

--- a/packages/react-native/assets.json
+++ b/packages/react-native/assets.json
@@ -1,15 +1,13 @@
 {
   "outDir": "dist/packages/react-native",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
     { "glob": "src/**/schema.d.ts" },
     { "glob": "typings/**/*.d.ts" },
-    "packages/react-native/*.md",
-    "LICENSE"
+    "LICENSE",
+    "packages/react-native/*.md"
   ]
 }

--- a/packages/react-native/tsconfig.lib.json
+++ b/packages/react-native/tsconfig.lib.json
@@ -7,7 +7,7 @@
     "tsBuildInfoFile": "../../dist/packages/react-native/tsconfig.tsbuildinfo"
   },
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "jest.config.ts"],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../react/tsconfig.lib.json"

--- a/packages/react/assets.json
+++ b/packages/react/assets.json
@@ -1,12 +1,10 @@
 {
   "outDir": "dist/packages/react",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
     { "glob": "src/**/schema.d.ts" },
     { "glob": "typings/**/*.d.ts" },
     "LICENSE"

--- a/packages/react/assets.json
+++ b/packages/react/assets.json
@@ -7,17 +7,8 @@
     {
       "glob": "**/files/**/.gitkeep"
     },
-    {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.d.ts"
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
+    { "glob": "src/**/schema.d.ts" },
+    { "glob": "typings/**/*.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/react/tsconfig.lib.json
+++ b/packages/react/tsconfig.lib.json
@@ -14,7 +14,7 @@
     "jest.config.ts",
     "jest.config.cts"
   ],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../rollup/tsconfig.lib.json"

--- a/packages/remix/assets.json
+++ b/packages/remix/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/remix",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
-    {
-      "glob": "**/*.md"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
+    { "glob": "**/*.md" },
     "LICENSE"
   ]
 }

--- a/packages/remix/assets.json
+++ b/packages/remix/assets.json
@@ -1,13 +1,15 @@
 {
   "outDir": "dist/packages/remix",
   "assets": [
-    { "glob": "**/files/**" },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
+      "glob": "**/files/**"
     },
-    { "glob": "**/*.d.ts" },
-    { "glob": "**/*.md" },
+    {
+      "glob": "src/**/schema.d.ts"
+    },
+    {
+      "glob": "**/*.md"
+    },
     "LICENSE"
   ]
 }

--- a/packages/remix/tsconfig.lib.json
+++ b/packages/remix/tsconfig.lib.json
@@ -13,7 +13,7 @@
     "jest.config.ts",
     "jest.config.cts"
   ],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../vitest/tsconfig.lib.json"

--- a/packages/rollup/assets.json
+++ b/packages/rollup/assets.json
@@ -8,15 +8,10 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
+      "glob": "src/**/schema.d.ts"
     },
     {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/plugins/postcss/types/concat-with-sourcemaps.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/rollup/assets.json
+++ b/packages/rollup/assets.json
@@ -1,18 +1,12 @@
 {
   "outDir": "dist/packages/rollup",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
-    {
-      "glob": "src/plugins/postcss/types/concat-with-sourcemaps.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
+    { "glob": "src/plugins/postcss/types/concat-with-sourcemaps.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/rollup/tsconfig.lib.json
+++ b/packages/rollup/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "types": ["node"],
     "tsBuildInfoFile": "../../dist/packages/rollup/tsconfig.tsbuildinfo"
   },
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
     {

--- a/packages/rsbuild/assets.json
+++ b/packages/rsbuild/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/rsbuild/assets.json
+++ b/packages/rsbuild/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/rsbuild",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/rsbuild/tsconfig.lib.json
+++ b/packages/rsbuild/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "types": ["node"],
     "tsBuildInfoFile": "../../dist/packages/rsbuild/tsconfig.tsbuildinfo"
   },
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
     {

--- a/packages/rspack/assets.json
+++ b/packages/rspack/assets.json
@@ -1,13 +1,11 @@
 {
   "outDir": "dist/packages/rspack",
   "assets": [
-    {
-      "glob": "src/**/schema.d.ts"
-    },
-    {
-      "glob": "src/**/*.md"
-    },
-    "packages/rspack/*.md",
-    "LICENSE"
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
+    { "glob": "src/**/*.md" },
+    "LICENSE",
+    "packages/rspack/*.md"
   ]
 }

--- a/packages/rspack/assets.json
+++ b/packages/rspack/assets.json
@@ -1,13 +1,13 @@
 {
   "outDir": "dist/packages/rspack",
   "assets": [
-    "packages/rspack/*.md",
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
+      "glob": "src/**/schema.d.ts"
     },
-    { "glob": "**/*.d.ts" },
-    { "glob": "src/**/*.md" },
+    {
+      "glob": "src/**/*.md"
+    },
+    "packages/rspack/*.md",
     "LICENSE"
   ]
 }

--- a/packages/rspack/tsconfig.lib.json
+++ b/packages/rspack/tsconfig.lib.json
@@ -7,7 +7,7 @@
     "types": ["node"],
     "tsBuildInfoFile": "../../dist/packages/rspack/tsconfig.tsbuildinfo"
   },
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
     {

--- a/packages/storybook/assets.json
+++ b/packages/storybook/assets.json
@@ -5,26 +5,10 @@
       "glob": "**/files/**"
     },
     {
-      "glob": "**/project-files/.storybook/**"
+      "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/project-files-ts/.storybook/**"
-    },
-    {
-      "glob": "**/*.json",
-      "ignore": [
-        "tsconfig*.json",
-        "project.json",
-        ".eslintrc.json",
-        "**/test-configs/**"
-      ]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/storybook/assets.json
+++ b/packages/storybook/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/storybook",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/storybook/tsconfig.lib.json
+++ b/packages/storybook/tsconfig.lib.json
@@ -14,7 +14,7 @@
     "jest.config.ts",
     "src/**/test-configs"
   ],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../eslint/tsconfig.lib.json"

--- a/packages/vite/assets.json
+++ b/packages/vite/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/vite/assets.json
+++ b/packages/vite/assets.json
@@ -1,15 +1,10 @@
 {
   "outDir": "dist/packages/vite",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/vite/tsconfig.lib.json
+++ b/packages/vite/tsconfig.lib.json
@@ -5,8 +5,13 @@
     "types": ["node"],
     "tsBuildInfoFile": "../../dist/packages/vite/tsconfig.tsbuildinfo"
   },
-  "include": ["**/*.ts", "**/*.json"],
-  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts", "src/**/schema.json"],
+  "exclude": [
+    "jest.config.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "src/utils/test-utils.ts"
+  ],
   "references": [
     {
       "path": "../vitest/tsconfig.lib.json"

--- a/packages/vite/tsconfig.spec.json
+++ b/packages/vite/tsconfig.spec.json
@@ -17,6 +17,8 @@
     "**/*.test.jsx",
     "**/*.d.ts",
     "jest.config.ts",
+    "src/utils/test-utils.ts",
+    "src/utils/test-files/*.json",
     "*.json"
   ],
   "references": [

--- a/packages/vitest/assets.json
+++ b/packages/vitest/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/vitest",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
-    {
-      "glob": "PLUGIN.md"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
+    { "glob": "PLUGIN.md" },
     "LICENSE"
   ]
 }

--- a/packages/vitest/assets.json
+++ b/packages/vitest/assets.json
@@ -5,15 +5,7 @@
       "glob": "**/files/**"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     {
       "glob": "PLUGIN.md"

--- a/packages/vitest/tsconfig.lib.json
+++ b/packages/vitest/tsconfig.lib.json
@@ -4,7 +4,7 @@
     "outDir": "../../dist/packages/vitest",
     "types": ["node"]
   },
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
     {

--- a/packages/vue/assets.json
+++ b/packages/vue/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/vue/assets.json
+++ b/packages/vue/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/vue",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/vue/tsconfig.lib.json
+++ b/packages/vue/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "types": ["node"],
     "tsBuildInfoFile": "../../dist/packages/vue/tsconfig.tsbuildinfo"
   },
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
     {

--- a/packages/web/assets.json
+++ b/packages/web/assets.json
@@ -8,18 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/files/**/.babelrc__tmpl__"
-    },
-    {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/web/assets.json
+++ b/packages/web/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/web",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/web/tsconfig.lib.json
+++ b/packages/web/tsconfig.lib.json
@@ -13,7 +13,7 @@
     "**/*_test.ts",
     "jest.config.ts"
   ],
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "references": [
     {
       "path": "../vitest/tsconfig.lib.json"

--- a/packages/webpack/assets.json
+++ b/packages/webpack/assets.json
@@ -8,15 +8,7 @@
       "glob": "**/files/**/.gitkeep"
     },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.js",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]

--- a/packages/webpack/assets.json
+++ b/packages/webpack/assets.json
@@ -1,15 +1,11 @@
 {
   "outDir": "dist/packages/webpack",
   "assets": [
-    {
-      "glob": "**/files/**"
-    },
-    {
-      "glob": "**/files/**/.gitkeep"
-    },
-    {
-      "glob": "src/**/schema.d.ts"
-    },
+    { "glob": "**/files/**" },
+    { "glob": "**/files/**/.gitkeep" },
+    { "glob": "@(package|executors|generators|migrations).json" },
+    { "glob": "src/**/schema.json" },
+    { "glob": "src/**/schema.d.ts" },
     "LICENSE"
   ]
 }

--- a/packages/webpack/tsconfig.lib.json
+++ b/packages/webpack/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "types": ["node"],
     "tsBuildInfoFile": "../../dist/packages/webpack/tsconfig.tsbuildinfo"
   },
-  "include": ["**/*.ts", "**/*.json"],
+  "include": ["**/*.ts"],
   "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],
   "references": [
     {

--- a/packages/workspace/assets.json
+++ b/packages/workspace/assets.json
@@ -22,16 +22,14 @@
     {
       "glob": "**/files-root-app/**"
     },
+    { "glob": "presets/*.json" },
+    { "glob": "package.json" },
+    { "glob": "executors.json" },
+    { "glob": "generators.json" },
+    { "glob": "migrations.json" },
+    { "glob": "src/**/schema.json" },
     {
-      "glob": "**/*.json",
-      "ignore": ["tsconfig*.json", "project.json", ".eslintrc.json"]
-    },
-    {
-      "glob": "**/*.{js,css,html,svg}",
-      "ignore": ["**/jest.config.js"]
-    },
-    {
-      "glob": "**/*.d.ts"
+      "glob": "src/**/schema.d.ts"
     },
     "LICENSE"
   ]


### PR DESCRIPTION
## Current Behavior

Broad globs in `assets.json` (`**/*.json`, `**/*.js`, `**/*.d.ts`) cause `copy-assets` targets to claim cache ownership over files also produced by `build-base` (tsc). Even though a recent change reordered `copy-assets` to run before `build-base` (reducing the likelihood of the race condition), the underlying task ownership model is still broken — both targets claim overlapping files in their output patterns.

## Expected Behavior

Each target exclusively owns its output files. `copy-assets` only claims non-tsc assets (templates, type declarations, native artifacts), and `build-base` owns all compiler outputs.

## Changes

**37 `assets.json` files** — replaced broad extension globs with narrow, destination-safe patterns: template dirs (`**/files/**`), schema type declarations (`src/**/schema.d.ts`), non-tsc extensions (`.jar`, `.node`, `.wasm`, `.md`), and explicit file paths for package-specific assets.

**30 `tsconfig.lib.json` files** — removed `**/*.json` from `include` so tsc only compiles TypeScript. JSON files are now handled by copy-assets with explicit entries (`@(package|executors|generators|migrations).json`, `src/**/schema.json`).

**Exception:** jest and vite use `import('./schema.json')` which requires JSON in tsconfig scope with `composite: true`. These keep `src/**/schema.json` in tsconfig.

**vite** — excludes `test-utils.ts` from lib build (only used by specs) and includes it in `tsconfig.spec.json`.