### PR TITLE
fix(core): restore metadata table for telemetry session tracking

### DIFF
--- a/packages/nx/src/native/db/initialize.rs
+++ b/packages/nx/src/native/db/initialize.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use tracing::{debug, trace};
 
 /// Bump this ONLY when the database schema changes.
-pub const DB_VERSION: &str = "1";
+pub const DB_VERSION: &str = "2";
 
 // Error reporting constants - static strings to avoid allocations in error paths
 const REPORTING_INSTRUCTIONS_PERSISTENT: &str = "If the issue persists, please help us improve Nx by capturing logs and reporting this issue:\n\
@@ -143,7 +143,7 @@ pub(super) fn create_lock_file(db_path: &Path) -> anyhow::Result<File> {
     Ok(lock_file)
 }
 
-pub(super) fn initialize_db(db_path: &Path) -> anyhow::Result<NxDbConnection> {
+pub(crate) fn initialize_db(db_path: &Path) -> anyhow::Result<NxDbConnection> {
     // Track if DB existed before we opened it for safety check on new DB creation
     let db_existed_before_open = db_path.exists();
     let mut database_recreated = false;
@@ -197,6 +197,11 @@ fn create_all_tables(c: &mut NxDbConnection) -> anyhow::Result<()> {
         // Order matters: tables with no FK dependencies first
         conn.execute_batch(TASK_DETAILS_SCHEMA)?;
         conn.execute_batch(RUNNING_TASKS_SCHEMA)?;
+
+        // Metadata table (used by telemetry for session tracking)
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS metadata (key TEXT PRIMARY KEY, value TEXT)",
+        )?;
 
         // Tables with FK dependencies
         conn.execute_batch(TASK_HISTORY_SCHEMA)?;
@@ -460,22 +465,26 @@ fn diagnose_filesystem_issue(
 mod tests {
     use super::*;
 
+    fn has_table(conn: &NxDbConnection, table_name: &str) -> bool {
+        conn.query_row(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1",
+            [table_name],
+            |_| Ok(true),
+        )
+        .unwrap()
+        .unwrap_or(false)
+    }
+
     #[test]
     fn initialize_db_creates_new_db() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let db_path = temp_dir.path().join("test.db");
 
-        let _ = initialize_db(&db_path)?;
+        let conn = initialize_db(&db_path)?;
 
-        // Verify tables were created
-        let conn = Connection::open(&db_path)?;
-        let has_table: bool = conn.query_row(
-            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='task_details'",
-            [],
-            |_| Ok(true),
-        )?;
+        assert!(has_table(&conn, "task_details"));
+        assert!(has_table(&conn, "metadata"));
 
-        assert!(has_table);
         Ok(())
     }
 
@@ -488,16 +497,9 @@ mod tests {
         let _ = initialize_db(&db_path)?;
 
         // Try to initialize again — should reuse existing db
-        let _ = initialize_db(&db_path)?;
+        let conn = initialize_db(&db_path)?;
 
-        let conn = Connection::open(&db_path)?;
-        let has_table: bool = conn.query_row(
-            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='task_details'",
-            [],
-            |_| Ok(true),
-        )?;
-
-        assert!(has_table);
+        assert!(has_table(&conn, "task_details"));
         Ok(())
     }
 }

--- a/packages/nx/src/native/db/mod.rs
+++ b/packages/nx/src/native/db/mod.rs
@@ -1,5 +1,5 @@
 pub mod connection;
-mod initialize;
+pub(crate) mod initialize;
 
 use crate::native::logger::enable_logger;
 use crate::native::machine_id::get_machine_id;

--- a/packages/nx/src/native/telemetry/mod.rs
+++ b/packages/nx/src/native/telemetry/mod.rs
@@ -260,3 +260,61 @@ fn get_or_create_session_id(connection: &External<Arc<Mutex<NxDbConnection>>>) -
 
     Ok(session_id)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::native::db::initialize::initialize_db;
+
+    use super::*;
+
+    #[test]
+    fn session_query_works_on_fresh_db() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let conn = initialize_db(&db_path).unwrap();
+
+        // The same query telemetry uses to find an active session.
+        // If the metadata table is missing, this will fail with "no such table".
+        let result: Option<String> = conn
+            .query_row(
+                &format!(
+                    "SELECT m1.value FROM metadata m1, metadata m2 \
+                     WHERE m1.key = 'SESSION_ID' AND m2.key = 'SESSION_LAST_ACTIVITY' \
+                     AND (strftime('%s', 'now') - strftime('%s', m2.value)) < {}",
+                    SESSION_TIMEOUT_SECS as i64
+                ),
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .expect("Session query should succeed on a freshly initialized database");
+
+        // No session yet, so result should be None
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn persist_and_retrieve_session() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let mut conn = initialize_db(&db_path).unwrap();
+
+        let session_id = "test-session-123";
+        persist_session_to_db(&mut conn, session_id);
+
+        // Now the session query should return the persisted session
+        let result: Option<String> = conn
+            .query_row(
+                &format!(
+                    "SELECT m1.value FROM metadata m1, metadata m2 \
+                     WHERE m1.key = 'SESSION_ID' AND m2.key = 'SESSION_LAST_ACTIVITY' \
+                     AND (strftime('%s', 'now') - strftime('%s', m2.value)) < {}",
+                    SESSION_TIMEOUT_SECS as i64
+                ),
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .expect("Session query should succeed");
+
+        assert_eq!(result, Some(session_id.to_string()));
+    }
+}


### PR DESCRIPTION
## Current Behavior

Telemetry initialization fails with `no such table: metadata` because the metadata table was removed during the DB schema refactor that decoupled DB version from Nx version. The telemetry service depends on this table to store and retrieve session IDs for analytics tracking.

## Expected Behavior

The metadata table is created as part of DB initialization alongside the other tables (`task_details`, `running_tasks`, `task_history`). Telemetry session tracking works without errors. The DB version is bumped from `1` to `2` so existing databases without the table are recreated with the correct schema.

### Changes

- Add metadata table creation to `create_all_tables` in `initialize.rs`
- Bump `DB_VERSION` from `1` to `2` to trigger fresh DB creation for users with v1 databases
- Widen `initialize` module and `initialize_db` visibility to `pub(crate)` for testability
- Add regression tests in `telemetry/mod.rs` that verify the session query works against a freshly initialized DB and that session persist/retrieve round-trips correctly
- Refactor `initialize.rs` tests to use `NxDbConnection` instead of raw rusqlite `Connection`

## Related Issue(s)

<!-- No open issue for this bug -->
