### PR TITLE
fix(react): force Vite 7 when using React Router in framework mode

### DIFF
--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -1167,6 +1167,20 @@ describe('app', () => {
       expect(packageJson.devDependencies['@react-router/dev']).toBeDefined();
     });
 
+    it('should use Vite 7 since React Router does not support Vite 8', async () => {
+      await applicationGenerator(appTree, {
+        ...schema,
+        skipFormat: false,
+        useReactRouter: true,
+        routing: true,
+        bundler: 'vite',
+        unitTestRunner: 'vitest',
+      });
+
+      const rootPackageJson = readJson(appTree, 'package.json');
+      expect(rootPackageJson.devDependencies['vite']).toMatch(/^\^7\./);
+    });
+
     it('should be configured to work with jest', async () => {
       await applicationGenerator(appTree, {
         ...schema,

--- a/packages/react/src/generators/application/lib/bundlers/add-vite.ts
+++ b/packages/react/src/generators/application/lib/bundlers/add-vite.ts
@@ -43,6 +43,8 @@ export async function setupViteConfiguration(
     addPlugin: options.addPlugin,
     projectType: 'application',
     port: options.port,
+    // React Router does not yet support Vite 8, so force Vite 7.
+    ...(options.useReactRouter ? { useViteV7: true } : {}),
   });
   tasks.push(viteTask);
   createOrEditViteConfig(

--- a/packages/vite/src/generators/configuration/schema.d.ts
+++ b/packages/vite/src/generators/configuration/schema.d.ts
@@ -13,4 +13,5 @@ export interface ViteConfigurationGeneratorSchema {
   addPlugin?: boolean;
   projectType?: 'application' | 'library';
   previewPort?: number;
+  useViteV7?: boolean;
 }


### PR DESCRIPTION
## Current Behavior

Creating a custom React workspace with React Router for server rendering (framework mode) fails due to a peer dependency conflict between Vite 8 and React Router. Vite 8 is the current default for new workspaces, but `@react-router/dev` does not yet support it.

## Expected Behavior

The React application generator uses Vite 7 when React Router is selected, avoiding the peer dependency conflict until React Router adds Vite 8 support.

<img width="1270" height="1204" alt="image" src="https://github.com/user-attachments/assets/87495e85-20df-4086-a1f0-eb3380a78771" />


## Related Issue(s)

Fixes NXC-4176