### PR TITLE
chore(repo): make build-base depend on copy-assets instead of reverse

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -77,7 +77,6 @@
       "dependsOn": [
         "^build",
         "typecheck",
-        "copy-assets",
         "build-base",
         "build-native"
       ],
@@ -86,7 +85,7 @@
     },
     "build-native": { "inputs": ["native"], "cache": true },
     "build-base": {
-      "dependsOn": ["^build-base", "build-native"],
+      "dependsOn": ["^build-base", "build-native", "copy-assets"],
       "cache": true
     },
     "test-native": {

--- a/nx.json
+++ b/nx.json
@@ -74,7 +74,7 @@
       "options": { "packageRoot": "dist/packages/{projectName}" }
     },
     "build": {
-      "dependsOn": ["^build", "typecheck", "build-base", "build-native"],
+      "dependsOn": ["^build", "typecheck", "build-base"],
       "inputs": ["production", "^production"],
       "cache": true
     },

--- a/nx.json
+++ b/nx.json
@@ -74,12 +74,7 @@
       "options": { "packageRoot": "dist/packages/{projectName}" }
     },
     "build": {
-      "dependsOn": [
-        "^build",
-        "typecheck",
-        "build-base",
-        "build-native"
-      ],
+      "dependsOn": ["^build", "typecheck", "build-base", "build-native"],
       "inputs": ["production", "^production"],
       "cache": true
     },

--- a/packages/angular/project.json
+++ b/packages/angular/project.json
@@ -5,7 +5,7 @@
   "projectType": "library",
   "targets": {
     "build-ng": {
-      "dependsOn": ["build-base", "typecheck", "copy-assets"],
+      "dependsOn": ["build-base", "typecheck"],
       "executor": "@nx/angular:package",
       "options": {
         "project": "packages/angular/ng-package.json",
@@ -19,8 +19,7 @@
         "^build",
         "build-ng",
         "typecheck",
-        "build-base",
-        "copy-assets"
+        "build-base"
       ],
       "outputs": ["{workspaceRoot}/dist/packages/angular/README.md"],
       "command": "node ./scripts/copy-readme.js angular",

--- a/packages/angular/project.json
+++ b/packages/angular/project.json
@@ -15,12 +15,7 @@
     },
 
     "build": {
-      "dependsOn": [
-        "^build",
-        "build-ng",
-        "typecheck",
-        "build-base"
-      ],
+      "dependsOn": ["^build", "build-ng", "typecheck", "build-base"],
       "outputs": ["{workspaceRoot}/dist/packages/angular/README.md"],
       "command": "node ./scripts/copy-readme.js angular",
       "inputs": ["copyReadme"]

--- a/packages/devkit/project.json
+++ b/packages/devkit/project.json
@@ -8,7 +8,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/devkit/README.md"],
       "command": "node ./scripts/copy-readme.js devkit",
       "inputs": ["copyReadme"],
-      "dependsOn": ["^build", "nx:copy-assets", "build-base"]
+      "dependsOn": ["^build", "build-base"]
     }
   }
 }

--- a/packages/dotnet/project.json
+++ b/packages/dotnet/project.json
@@ -51,7 +51,7 @@
       }
     },
     "copy-assets": {
-      "dependsOn": ["build-base", "build-analyzer"]
+      "dependsOn": ["build-analyzer"]
     },
     "nx-release-publish": {
       "executor": "@nx/js:release-publish",

--- a/packages/gradle/project.json
+++ b/packages/gradle/project.json
@@ -15,12 +15,13 @@
       "outputs": ["{workspaceRoot}/dist/packages/gradle/README.md"],
       "command": "node ./scripts/copy-readme.js gradle",
       "inputs": ["copyReadme"],
-      "dependsOn": ["^build", "build-native", "build-base", "copy-assets"]
+      "dependsOn": ["^build", "build-native", "build-base"]
     },
     "build-base": {
       "dependsOn": [
         "^build-base",
         "build-native",
+        "copy-assets",
         ":gradle-batch-runner:gradle:assemble"
       ]
     }

--- a/packages/gradle/project.json
+++ b/packages/gradle/project.json
@@ -17,6 +17,9 @@
       "inputs": ["copyReadme"],
       "dependsOn": ["^build", "build-base"]
     },
+    "copy-assets": {
+      "dependsOn": [":gradle-batch-runner:gradle:assemble"]
+    },
     "build-base": {
       "dependsOn": [
         "^build-base",

--- a/packages/gradle/project.json
+++ b/packages/gradle/project.json
@@ -15,7 +15,7 @@
       "outputs": ["{workspaceRoot}/dist/packages/gradle/README.md"],
       "command": "node ./scripts/copy-readme.js gradle",
       "inputs": ["copyReadme"],
-      "dependsOn": ["^build", "build-native", "build-base"]
+      "dependsOn": ["^build", "build-base"]
     },
     "build-base": {
       "dependsOn": [

--- a/packages/nx/assets.json
+++ b/packages/nx/assets.json
@@ -23,6 +23,13 @@
     {
       "glob": "**/*.{node,wasm}",
       "includeIgnoredFiles": true
+    },
+    {
+      "glob": "**/*",
+      "input": "dist/apps/graph",
+      "output": "/src/core/graph",
+      "ignore": ["assets/**"],
+      "includeIgnoredFiles": true
     }
   ]
 }

--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -69,10 +69,10 @@
       "dependsOn": ["echo"]
     },
     "copy-assets": {
-      "dependsOn": ["build-native"]
+      "dependsOn": ["build-native", "^build-client"]
     },
     "build": {
-      "dependsOn": ["^build-client", "build-base", "build-native"],
+      "dependsOn": ["build-base", "build-native"],
       "inputs": [
         "production",
         "^production",
@@ -80,21 +80,16 @@
           "dependentTasksOutputFiles": "**/*.node",
           "transitive": true
         },
-        "{workspaceRoot}/scripts/copy-graph-client.js",
         "{workspaceRoot}/scripts/chmod.js",
         "copyReadme"
       ],
       "executor": "nx:run-commands",
       "outputs": [
-        "{workspaceRoot}/packages/nx/dist/src/core/graph",
         "{workspaceRoot}/packages/nx/dist/bin/nx.js",
         "{workspaceRoot}/packages/nx/README.md"
       ],
       "options": {
         "commands": [
-          {
-            "command": "node ./scripts/copy-graph-client.js"
-          },
           {
             "command": "node ./scripts/chmod packages/nx/dist/bin/nx.js"
           },

--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -72,11 +72,7 @@
       "dependsOn": ["build-native"]
     },
     "build": {
-      "dependsOn": [
-        "^build-client",
-        "build-base",
-        "build-native"
-      ],
+      "dependsOn": ["^build-client", "build-base", "build-native"],
       "inputs": [
         "production",
         "^production",

--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -69,14 +69,13 @@
       "dependsOn": ["echo"]
     },
     "copy-assets": {
-      "dependsOn": ["build-base", "build-native"]
+      "dependsOn": ["build-native"]
     },
     "build": {
       "dependsOn": [
         "^build-client",
         "build-base",
-        "build-native",
-        "copy-assets"
+        "build-native"
       ],
       "inputs": [
         "production",

--- a/packages/nx/project.json
+++ b/packages/nx/project.json
@@ -72,7 +72,7 @@
       "dependsOn": ["build-native", "^build-client"]
     },
     "build": {
-      "dependsOn": ["build-base", "build-native"],
+      "dependsOn": ["build-base"],
       "inputs": [
         "production",
         "^production",

--- a/scripts/copy-graph-client.js
+++ b/scripts/copy-graph-client.js
@@ -1,5 +1,0 @@
-const fs = require('fs-extra');
-
-fs.copySync('dist/apps/graph', 'packages/nx/dist/src/core/graph', {
-  filter: (src) => !src.includes('assets'),
-});

--- a/tools/workspace-plugin/src/plugins/copy-assets-plugin.ts
+++ b/tools/workspace-plugin/src/plugins/copy-assets-plugin.ts
@@ -132,7 +132,6 @@ export const createNodesV2: CreateNodesV2 = [
 
         const target: TargetConfiguration = {
           executor: '@nx/workspace-plugin:copy-assets',
-          dependsOn: ['build-base'],
           cache: true,
           inputs,
           outputs,


### PR DESCRIPTION
## Current Behavior

`copy-assets` depends on `build-base`, which means it has to wait for the entire `build-native` → `build-base` chain to finish before it can start — even though asset copying doesn't need compiled output.

## Expected Behavior

`build-base` depends on `copy-assets` instead. This lets `copy-assets` start immediately (in parallel with `build-native` and `^build-base`) rather than waiting for them to complete first.

<img width="767" height="721" alt="image" src="https://github.com/user-attachments/assets/6a1d8090-8390-4075-850e-bfd309cdc6c9" />


### Changes

- Removed `dependsOn: ['build-base']` from the `copy-assets` target generated by `copy-assets-plugin.ts`
- Added `copy-assets` to `build-base.dependsOn` in `nx.json` and project-level overrides (`gradle`)
- Removed now-transitive `copy-assets` references from `build.dependsOn` in `nx.json`, `packages/nx`, `packages/angular`, and `packages/gradle`
- Removed `build-base` from `copy-assets.dependsOn` in `packages/nx` and `packages/dotnet` project overrides