### PR TITLE
fix(repo): re-enable Cypress HMR e2e tests after upstream tapable fix

### DIFF
--- a/e2e/nx/src/workspace-legacy.test.ts
+++ b/e2e/nx/src/workspace-legacy.test.ts
@@ -16,8 +16,7 @@ describe('@nx/workspace:convert-to-monorepo', () => {
 
   afterEach(() => cleanupProject());
 
-  // TODO: unskip once Cypress HMR issue is resolved
-  it.skip('should convert a standalone webpack and jest react project to a monorepo (legacy)', async () => {
+  it('should convert a standalone webpack and jest react project to a monorepo (legacy)', async () => {
     const reactApp = uniq('reactapp');
     runCLI(
       `generate @nx/react:app --name=${reactApp} --directory="." --bundler=webpack --unitTestRunner=jest --e2eTestRunner=cypress --no-interactive --linter=eslint`,

--- a/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
@@ -15,8 +15,7 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-// TODO: unskip once Cypress HMR issue is resolved
-describe.skip('React Module Federation - Webpack Basic - Host Remote Generation', () => {
+describe('React Module Federation - Webpack Basic - Host Remote Generation', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
+++ b/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
@@ -14,8 +14,7 @@ import {
 } from '@nx/e2e-utils';
 import { runCLI } from './utils';
 
-// TODO: unskip once Cypress HMR issue is resolved
-describe.skip('Dynamic Module Federation', () => {
+describe('Dynamic Module Federation', () => {
   beforeAll(() => {
     newProject({ packages: ['@nx/react'] });
   });

--- a/e2e/react/src/module-federation/federate-module.webpack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.webpack.test.ts
@@ -10,8 +10,7 @@ import {
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 
-// TODO: unskip once Cypress HMR issue is resolved
-describe.skip('Federate Module', () => {
+describe('Federate Module', () => {
   let proj: string;
 
   beforeAll(() => {

--- a/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
@@ -12,8 +12,7 @@ import {
 import { stripIndents } from 'nx/src/utils/strip-indents';
 import { readPort, runCLI } from './utils';
 
-// TODO: unskip once Cypress HMR issue is resolved
-describe.skip('Independent Deployability', () => {
+describe('Independent Deployability', () => {
   let proj: string;
   beforeAll(() => {
     process.env.NX_ADD_PLUGINS = 'false';

--- a/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
@@ -11,8 +11,7 @@ import {
 import { readPort, runCLI } from './utils';
 import { stripIndents } from 'nx/src/utils/strip-indents';
 
-// TODO: unskip once Cypress HMR issue is resolved
-describe.skip('React Rspack Module Federation Misc - Interoperability', () => {
+describe('React Rspack Module Federation Misc - Interoperability', () => {
   beforeEach(() => {
     process.env.NX_ADD_PLUGINS = 'false';
     newProject({ packages: ['@nx/react'] });


### PR DESCRIPTION
## Current Behavior

Six e2e tests were skipped in #34969 because they were failing with a Cypress uncaught exception: `[HMR] Hot Module Replacement is disabled`. The error originated from the webpack `styles.js` bundle during the `before each` hook due to an upstream tapable issue (webpack/webpack#20693).

Skipped tests:
- `e2e-nx:e2e-ci--src/workspace-legacy.test.ts`
- `e2e-react:e2e-ci--src/module-federation/independent-deployability.webpack.test.ts`
- `e2e-react:e2e-ci--src/module-federation/core-webpack-basic-host-remote-generation.test.ts`
- `e2e-react:e2e-ci--src/module-federation/misc-rspack-interoperability.test.ts`
- `e2e-react:e2e-ci--src/module-federation/dynamic-federation.webpack.test.ts`
- `e2e-react:e2e-ci--src/module-federation/federate-module.webpack.test.ts`

## Expected Behavior

The upstream tapable issue has been resolved (webpack/webpack#20693). All 6 tests should be re-enabled and passing.

## Related Issue(s)

Upstream fix: webpack/webpack#20693
Reverts the skip from #34969