### PR TITLE
chore(repo): skip react-router typecheck e2e test due to vite version conflict

### DIFF
--- a/e2e/react/src/react-router-ts-solution.test.ts
+++ b/e2e/react/src/react-router-ts-solution.test.ts
@@ -37,7 +37,8 @@ describe('React Router Applications - TS Solution', () => {
     checkFilesExist(`${appName}/vite.config.mts`);
   });
 
-  it('should be able to build, lint, test and typecheck a react-router application', async () => {
+  // TODO: re-enable once @react-router/dev supports Vite 8 — currently pnpm can resolve both vite 7 and 8, causing typecheck failures
+  xit('should be able to build, lint, test and typecheck a react-router application', async () => {
     const buildResult = runCLI(`build ${appName}`);
     const lintResult = runCLI(`lint ${appName}`);
     const testResult = runCLI(`test ${appName}`);


### PR DESCRIPTION
## Current Behavior

The react-router typecheck e2e test fails in CI because pnpm resolves both vite 7 and vite 8 in the generated project. `@react-router/dev` picks up vite 8 plugin types while `defineConfig` uses vite 7 types, causing a TypeScript incompatibility.

## Expected Behavior

The test is skipped until `@react-router/dev` adds Vite 8 support, at which point the `useViteV7` workaround and this skip can both be removed.

## Related Issue(s)

Follow-up to #35101