### PR TITLE
fix(core): clean up legacy .gemini/skills during configure-ai-agents

### DIFF
--- a/e2e/nx/src/configure-ai-agents.test.ts
+++ b/e2e/nx/src/configure-ai-agents.test.ts
@@ -1,5 +1,8 @@
 import {
   cleanupProject,
+  createFile,
+  directoryExists,
+  fileExists,
   listFiles,
   newProject,
   readFile,
@@ -246,6 +249,40 @@ describe('configure-ai-agents', () => {
 
       const configToml = readFile('.codex/config.toml');
       expect(configToml).toMatch(/multi_agent\s*=\s*false/);
+    });
+  });
+
+  describe('gemini legacy .gemini/skills cleanup', () => {
+    it('should remove .gemini/skills that also exist in .agents/skills', () => {
+      // Ensure gemini is configured so .agents/skills exists
+      runCLI('configure-ai-agents --agents gemini --no-interactive');
+      expect(listFiles('.agents/skills').length).toBeGreaterThan(0);
+
+      // Simulate legacy .gemini/skills with a skill that matches one in .agents/skills
+      const sharedSkill = listFiles('.agents/skills')[0];
+      createFile(`.gemini/skills/${sharedSkill}/skill.md`, '# Legacy skill');
+
+      // Also create a user-owned custom skill
+      createFile(
+        '.gemini/skills/my-custom-skill/skill.md',
+        '# My Custom Skill'
+      );
+
+      // Make gemini outdated so re-running triggers the generator
+      updateFile('AGENTS.md', (content: string) =>
+        content.replace('nx_docs', 'nx_docs_outdated')
+      );
+
+      // Re-run configure to trigger cleanup
+      runCLI('configure-ai-agents --agents gemini --no-interactive');
+
+      // The shared skill should be removed from .gemini/skills
+      expect(fileExists(`.gemini/skills/${sharedSkill}/skill.md`)).toBeFalsy();
+
+      // The user's custom skill should be preserved
+      expect(
+        fileExists('.gemini/skills/my-custom-skill/skill.md')
+      ).toBeTruthy();
     });
   });
 

--- a/e2e/nx/src/configure-ai-agents.test.ts
+++ b/e2e/nx/src/configure-ai-agents.test.ts
@@ -1,13 +1,13 @@
 import {
   cleanupProject,
   createFile,
-  directoryExists,
   fileExists,
   listFiles,
   newProject,
   readFile,
   removeFile,
   runCLI,
+  tmpProjPath,
   updateFile,
 } from '@nx/e2e-utils';
 
@@ -277,11 +277,13 @@ describe('configure-ai-agents', () => {
       runCLI('configure-ai-agents --agents gemini --no-interactive');
 
       // The shared skill should be removed from .gemini/skills
-      expect(fileExists(`.gemini/skills/${sharedSkill}/skill.md`)).toBeFalsy();
+      expect(
+        fileExists(tmpProjPath(`.gemini/skills/${sharedSkill}/skill.md`))
+      ).toBeFalsy();
 
       // The user's custom skill should be preserved
       expect(
-        fileExists('.gemini/skills/my-custom-skill/skill.md')
+        fileExists(tmpProjPath('.gemini/skills/my-custom-skill/skill.md'))
       ).toBeTruthy();
     });
   });

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
@@ -626,6 +626,88 @@ describe('setup-ai-agents generator', () => {
         expect(content).toContain('Custom Gemini configuration');
         expect(content).toContain('Nx');
       });
+
+      it('should delete .gemini/skills that also exist in .agents/skills', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+          agents: ['gemini'],
+        };
+
+        // Simulate shared .agents/skills (the new location)
+        tree.write(
+          '.agents/skills/nx-workspace/SKILL.md',
+          '# Nx Workspace Skill'
+        );
+        tree.write(
+          '.agents/skills/nx-generate/SKILL.md',
+          '# Nx Generate Skill'
+        );
+
+        // Simulate legacy .gemini/skills with matching + user-created skills
+        tree.write(
+          '.gemini/skills/nx-workspace/skill.md',
+          '# Legacy Nx Workspace'
+        );
+        tree.write(
+          '.gemini/skills/nx-generate/skill.md',
+          '# Legacy Nx Generate'
+        );
+        tree.write(
+          '.gemini/skills/my-custom-skill/skill.md',
+          '# My Custom Skill'
+        );
+
+        await setupAiAgentsGenerator(tree, options);
+
+        // Migrated skills should be deleted
+        expect(tree.exists('.gemini/skills/nx-workspace')).toBe(false);
+        expect(tree.exists('.gemini/skills/nx-generate')).toBe(false);
+        // User-created skill should be preserved
+        expect(tree.exists('.gemini/skills/my-custom-skill/skill.md')).toBe(
+          true
+        );
+        // Other .gemini files should still exist
+        expect(tree.exists('.gemini/settings.json')).toBe(true);
+      });
+
+      it('should not delete .gemini/skills when .agents/skills does not exist', async () => {
+        // Mock getAiConfigRepoPath to fail so .agents/skills is not created
+        const spy = jest
+          .spyOn(cloneModule, 'getAiConfigRepoPath')
+          .mockImplementation(() => {
+            throw new Error('no network');
+          });
+
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+          agents: ['gemini'],
+        };
+
+        // Only legacy skills, no shared .agents/skills
+        tree.write(
+          '.gemini/skills/nx-workspace/skill.md',
+          '# Legacy Nx Workspace'
+        );
+
+        await setupAiAgentsGenerator(tree, options);
+
+        // Should be preserved since there's no .agents/skills to compare against
+        expect(tree.exists('.gemini/skills/nx-workspace/skill.md')).toBe(true);
+
+        spy.mockRestore();
+      });
+
+      it('should not error when .gemini/skills does not exist', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+          agents: ['gemini'],
+        };
+
+        await setupAiAgentsGenerator(tree, options);
+
+        expect(tree.exists('.gemini/skills')).toBe(false);
+        expect(tree.exists('.gemini/settings.json')).toBe(true);
+      });
     });
 
     describe('multiple agents', () => {

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -313,6 +313,21 @@ export async function setupAiAgentsGeneratorImpl(
     }
   }
 
+  // Clean up legacy .gemini/skills that have been migrated to shared .agents/skills.
+  // Only delete skills that exist in both locations to preserve user-created skills.
+  if (hasAgent('gemini')) {
+    const geminiSkillsDir = join(options.directory, '.gemini', 'skills');
+    const sharedSkillsDir = join(options.directory, '.agents', 'skills');
+    if (tree.exists(geminiSkillsDir) && tree.exists(sharedSkillsDir)) {
+      const sharedSkills = new Set(tree.children(sharedSkillsDir));
+      for (const skill of tree.children(geminiSkillsDir)) {
+        if (sharedSkills.has(skill)) {
+          tree.delete(join(geminiSkillsDir, skill));
+        }
+      }
+    }
+  }
+
   addEntryToGitIgnore(
     tree,
     join(options.directory, '.gitignore'),


### PR DESCRIPTION
## Current Behavior

When `configure-ai-agents` runs for Gemini, it copies skills to the shared `.agents/skills` directory (used by Codex, Cursor, and Gemini). However, workspaces that were configured with an older version of Nx still have a `.gemini/skills` directory containing duplicate Nx-managed skills. These legacy files are never cleaned up, leaving stale duplicates in the workspace.

## Expected Behavior

When `configure-ai-agents` runs for Gemini, it should remove any `.gemini/skills` entries that also exist in `.agents/skills` (indicating they are Nx-managed skills that have been migrated). User-created custom skills in `.gemini/skills` that have no counterpart in `.agents/skills` are preserved.

## Related Issue(s)

N/A — discovered during investigation of template repo AI agent configurations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)