### PR TITLE
docs(misc): add tutorial series ToC to all tutorial pages

### DIFF
--- a/astro-docs/src/content/docs/getting-started/Tutorials/caching.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/caching.mdoc
@@ -23,6 +23,7 @@ Why rebuild something that hasn't changed? Nx caching replays previous results i
 The examples below use Vite and Vitest, but the concepts apply to any tool. Substitute your own build and test commands as needed.
 
 {% aside type="note" title="Tutorial Series" %}
+
 1. [Crafting your workspace](/docs/getting-started/tutorials/crafting-your-workspace)
 2. [Managing dependencies](/docs/getting-started/tutorials/managing-dependencies)
 3. [Configuring tasks](/docs/getting-started/tutorials/configuring-tasks)

--- a/astro-docs/src/content/docs/getting-started/Tutorials/caching.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/caching.mdoc
@@ -22,7 +22,19 @@ Why rebuild something that hasn't changed? Nx caching replays previous results i
 
 The examples below use Vite and Vitest, but the concepts apply to any tool. Substitute your own build and test commands as needed.
 
-If you haven't already, set up your workspace ([Crafting Your Workspace](/docs/getting-started/tutorials/crafting-your-workspace)) and try [running some tasks](/docs/getting-started/tutorials/running-tasks) first.
+{% aside type="note" title="Tutorial Series" %}
+1. [Crafting your workspace](/docs/getting-started/tutorials/crafting-your-workspace)
+2. [Managing dependencies](/docs/getting-started/tutorials/managing-dependencies)
+3. [Configuring tasks](/docs/getting-started/tutorials/configuring-tasks)
+4. [Running tasks](/docs/getting-started/tutorials/running-tasks)
+5. **Caching** (you are here)
+6. [Understanding your workspace](/docs/getting-started/tutorials/understanding-your-workspace)
+7. [Reducing boilerplate](/docs/getting-started/tutorials/reducing-configuration-boilerplate)
+8. [Setting up CI](/docs/getting-started/tutorials/self-healing-ci-tutorial)
+
+{% /aside %}
+
+This tutorial assumes you have an Nx workspace with tasks you can run. If you're starting fresh, complete [Crafting Your Workspace](/docs/getting-started/tutorials/crafting-your-workspace) and [Running Tasks](/docs/getting-started/tutorials/running-tasks) first.
 
 ## Enabling caching
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/configuring-tasks.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/configuring-tasks.mdoc
@@ -16,9 +16,23 @@ Stay on-topic: only teach what's covered on this page. Do not introduce concepts
 Tutorial: {pageUrl}
 {% /llm_copy_prompt %}
 
-Every project needs tasks: `build`, `test`, `lint`, `serve`. Nx needs to know about your tasks so it can run them, cache the results, and orchestrate them in the correct order across your workspace. If you don't have a workspace yet, see [Crafting Your Workspace](/docs/getting-started/tutorials/crafting-your-workspace).
+Every project needs tasks: `build`, `test`, `lint`, `serve`. Nx needs to know about your tasks so it can run them, cache the results, and orchestrate them in the correct order across your workspace.
 
 The examples below use Vite and Vitest, but the concepts apply to any tool. Substitute your own build and test commands as needed.
+
+{% aside type="note" title="Tutorial Series" %}
+1. [Crafting your workspace](/docs/getting-started/tutorials/crafting-your-workspace)
+2. [Managing dependencies](/docs/getting-started/tutorials/managing-dependencies)
+3. **Configuring tasks** (you are here)
+4. [Running tasks](/docs/getting-started/tutorials/running-tasks)
+5. [Caching](/docs/getting-started/tutorials/caching)
+6. [Understanding your workspace](/docs/getting-started/tutorials/understanding-your-workspace)
+7. [Reducing boilerplate](/docs/getting-started/tutorials/reducing-configuration-boilerplate)
+8. [Setting up CI](/docs/getting-started/tutorials/self-healing-ci-tutorial)
+
+{% /aside %}
+
+This tutorial assumes you have an Nx workspace. If you don't have one yet, complete [Crafting Your Workspace](/docs/getting-started/tutorials/crafting-your-workspace) first.
 
 ## What is a task?
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/configuring-tasks.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/configuring-tasks.mdoc
@@ -21,6 +21,7 @@ Every project needs tasks: `build`, `test`, `lint`, `serve`. Nx needs to know ab
 The examples below use Vite and Vitest, but the concepts apply to any tool. Substitute your own build and test commands as needed.
 
 {% aside type="note" title="Tutorial Series" %}
+
 1. [Crafting your workspace](/docs/getting-started/tutorials/crafting-your-workspace)
 2. [Managing dependencies](/docs/getting-started/tutorials/managing-dependencies)
 3. **Configuring tasks** (you are here)

--- a/astro-docs/src/content/docs/getting-started/Tutorials/crafting-your-workspace.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/crafting-your-workspace.mdoc
@@ -24,6 +24,7 @@ The Nx CLI is a task orchestrator, caching layer, and intelligence layer for mon
 Nx works with any repo structure and plays well with tools you already use: pnpm workspaces, yarn workspaces, uv for Python, Gradle for Java, and more. The conventions shown below are recommendations, not requirements. Bring your own structure and Nx adapts to it.
 
 {% aside type="note" title="Tutorial Series" %}
+
 1. **Crafting your workspace** (you are here)
 2. [Managing dependencies](/docs/getting-started/tutorials/managing-dependencies)
 3. [Configuring tasks](/docs/getting-started/tutorials/configuring-tasks)

--- a/astro-docs/src/content/docs/getting-started/Tutorials/crafting-your-workspace.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/crafting-your-workspace.mdoc
@@ -23,8 +23,16 @@ The Nx CLI is a task orchestrator, caching layer, and intelligence layer for mon
 
 Nx works with any repo structure and plays well with tools you already use: pnpm workspaces, yarn workspaces, uv for Python, Gradle for Java, and more. The conventions shown below are recommendations, not requirements. Bring your own structure and Nx adapts to it.
 
-{% aside type="tip" title="Tutorial series" %}
-These tutorials work best when followed in order, but you can jump to any topic you need. Each page is self-contained with links to prerequisites.
+{% aside type="note" title="Tutorial Series" %}
+1. **Crafting your workspace** (you are here)
+2. [Managing dependencies](/docs/getting-started/tutorials/managing-dependencies)
+3. [Configuring tasks](/docs/getting-started/tutorials/configuring-tasks)
+4. [Running tasks](/docs/getting-started/tutorials/running-tasks)
+5. [Caching](/docs/getting-started/tutorials/caching)
+6. [Understanding your workspace](/docs/getting-started/tutorials/understanding-your-workspace)
+7. [Reducing boilerplate](/docs/getting-started/tutorials/reducing-configuration-boilerplate)
+8. [Setting up CI](/docs/getting-started/tutorials/self-healing-ci-tutorial)
+
 {% /aside %}
 
 {% llm_only %}

--- a/astro-docs/src/content/docs/getting-started/Tutorials/managing-dependencies.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/managing-dependencies.mdoc
@@ -21,6 +21,7 @@ Tutorial: {pageUrl}
 As your workspace grows, projects start depending on each other and on external packages. Nx automatically tracks these relationships so it can build projects in the right order, cache intelligently, and tell you what's affected by a change.
 
 {% aside type="note" title="Tutorial Series" %}
+
 1. [Crafting your workspace](/docs/getting-started/tutorials/crafting-your-workspace)
 2. **Managing dependencies** (you are here)
 3. [Configuring tasks](/docs/getting-started/tutorials/configuring-tasks)

--- a/astro-docs/src/content/docs/getting-started/Tutorials/managing-dependencies.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/managing-dependencies.mdoc
@@ -20,9 +20,19 @@ Tutorial: {pageUrl}
 
 As your workspace grows, projects start depending on each other and on external packages. Nx automatically tracks these relationships so it can build projects in the right order, cache intelligently, and tell you what's affected by a change.
 
-{% aside type="note" title="Prerequisites" %}
-This tutorial assumes you have an Nx workspace with at least two projects. If you're starting fresh, complete [Crafting Your Workspace](/docs/getting-started/tutorials/crafting-your-workspace) first.
+{% aside type="note" title="Tutorial Series" %}
+1. [Crafting your workspace](/docs/getting-started/tutorials/crafting-your-workspace)
+2. **Managing dependencies** (you are here)
+3. [Configuring tasks](/docs/getting-started/tutorials/configuring-tasks)
+4. [Running tasks](/docs/getting-started/tutorials/running-tasks)
+5. [Caching](/docs/getting-started/tutorials/caching)
+6. [Understanding your workspace](/docs/getting-started/tutorials/understanding-your-workspace)
+7. [Reducing boilerplate](/docs/getting-started/tutorials/reducing-configuration-boilerplate)
+8. [Setting up CI](/docs/getting-started/tutorials/self-healing-ci-tutorial)
+
 {% /aside %}
+
+This tutorial assumes you have an Nx workspace with at least two projects. If you're starting fresh, complete [Crafting Your Workspace](/docs/getting-started/tutorials/crafting-your-workspace) first.
 
 ## Workspace libraries
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/reducing-configuration-boilerplate.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/reducing-configuration-boilerplate.mdoc
@@ -23,6 +23,7 @@ Manually configuring tasks, caching, inputs, and outputs for every project works
 The examples below use Vite and Vitest, but the concepts apply to any tool. Substitute your own build and test commands as needed.
 
 {% aside type="note" title="Tutorial Series" %}
+
 1. [Crafting your workspace](/docs/getting-started/tutorials/crafting-your-workspace)
 2. [Managing dependencies](/docs/getting-started/tutorials/managing-dependencies)
 3. [Configuring tasks](/docs/getting-started/tutorials/configuring-tasks)

--- a/astro-docs/src/content/docs/getting-started/Tutorials/reducing-configuration-boilerplate.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/reducing-configuration-boilerplate.mdoc
@@ -22,9 +22,19 @@ Manually configuring tasks, caching, inputs, and outputs for every project works
 
 The examples below use Vite and Vitest, but the concepts apply to any tool. Substitute your own build and test commands as needed.
 
-{% aside type="note" title="Prerequisites" %}
-This tutorial assumes you have an Nx workspace with configured tasks. If you're starting fresh, complete [Configuring Tasks](/docs/getting-started/tutorials/configuring-tasks) first.
+{% aside type="note" title="Tutorial Series" %}
+1. [Crafting your workspace](/docs/getting-started/tutorials/crafting-your-workspace)
+2. [Managing dependencies](/docs/getting-started/tutorials/managing-dependencies)
+3. [Configuring tasks](/docs/getting-started/tutorials/configuring-tasks)
+4. [Running tasks](/docs/getting-started/tutorials/running-tasks)
+5. [Caching](/docs/getting-started/tutorials/caching)
+6. [Understanding your workspace](/docs/getting-started/tutorials/understanding-your-workspace)
+7. **Reducing boilerplate** (you are here)
+8. [Setting up CI](/docs/getting-started/tutorials/self-healing-ci-tutorial)
+
 {% /aside %}
+
+This tutorial assumes you have an Nx workspace with configured tasks. If you're starting fresh, complete [Configuring Tasks](/docs/getting-started/tutorials/configuring-tasks) first.
 
 ## The scaling problem
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/running-tasks.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/running-tasks.mdoc
@@ -21,6 +21,7 @@ You've configured your tasks. Now how do you run them — for one project, for m
 The examples below use Vite and Vitest, but the concepts apply to any tool. Substitute your own build and test commands as needed.
 
 {% aside type="note" title="Tutorial Series" %}
+
 1. [Crafting your workspace](/docs/getting-started/tutorials/crafting-your-workspace)
 2. [Managing dependencies](/docs/getting-started/tutorials/managing-dependencies)
 3. [Configuring tasks](/docs/getting-started/tutorials/configuring-tasks)

--- a/astro-docs/src/content/docs/getting-started/Tutorials/running-tasks.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/running-tasks.mdoc
@@ -16,9 +16,23 @@ Stay on-topic: only teach what's covered on this page. Do not introduce concepts
 Tutorial: {pageUrl}
 {% /llm_copy_prompt %}
 
-You've [configured your tasks](/docs/getting-started/tutorials/configuring-tasks). Now how do you run them, for one project, for many, or only for what changed?
+You've configured your tasks. Now how do you run them — for one project, for many, or only for what changed?
 
 The examples below use Vite and Vitest, but the concepts apply to any tool. Substitute your own build and test commands as needed.
+
+{% aside type="note" title="Tutorial Series" %}
+1. [Crafting your workspace](/docs/getting-started/tutorials/crafting-your-workspace)
+2. [Managing dependencies](/docs/getting-started/tutorials/managing-dependencies)
+3. [Configuring tasks](/docs/getting-started/tutorials/configuring-tasks)
+4. **Running tasks** (you are here)
+5. [Caching](/docs/getting-started/tutorials/caching)
+6. [Understanding your workspace](/docs/getting-started/tutorials/understanding-your-workspace)
+7. [Reducing boilerplate](/docs/getting-started/tutorials/reducing-configuration-boilerplate)
+8. [Setting up CI](/docs/getting-started/tutorials/self-healing-ci-tutorial)
+
+{% /aside %}
+
+This tutorial assumes you have an Nx workspace with configured tasks. If you're starting fresh, complete [Configuring Tasks](/docs/getting-started/tutorials/configuring-tasks) first.
 
 ## Running a single task
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/self-healing-ci-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/self-healing-ci-tutorial.mdoc
@@ -19,6 +19,7 @@ Tutorial: {pageUrl}
 Connect your workspace to Nx Cloud, generate a CI workflow, and enable remote caching, affected commands, distributed task execution, and self-healing to keep your pipeline fast and reliable.
 
 {% aside type="note" title="Tutorial Series" %}
+
 1. [Crafting your workspace](/docs/getting-started/tutorials/crafting-your-workspace)
 2. [Managing dependencies](/docs/getting-started/tutorials/managing-dependencies)
 3. [Configuring tasks](/docs/getting-started/tutorials/configuring-tasks)

--- a/astro-docs/src/content/docs/getting-started/Tutorials/self-healing-ci-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/self-healing-ci-tutorial.mdoc
@@ -18,13 +18,19 @@ Tutorial: {pageUrl}
 
 Connect your workspace to Nx Cloud, generate a CI workflow, and enable remote caching, affected commands, distributed task execution, and self-healing to keep your pipeline fast and reliable.
 
-{% aside type="note" title="Prerequisites" %}
-
-- An existing Nx workspace (see [Crafting Your Workspace](/docs/getting-started/tutorials/crafting-your-workspace) or the [Gradle tutorial](/docs/getting-started/tutorials/gradle-tutorial))
-- A [GitHub account](https://github.com) with a repository for your workspace
-- [Node.js](https://nodejs.org) (v20.19 or later)
+{% aside type="note" title="Tutorial Series" %}
+1. [Crafting your workspace](/docs/getting-started/tutorials/crafting-your-workspace)
+2. [Managing dependencies](/docs/getting-started/tutorials/managing-dependencies)
+3. [Configuring tasks](/docs/getting-started/tutorials/configuring-tasks)
+4. [Running tasks](/docs/getting-started/tutorials/running-tasks)
+5. [Caching](/docs/getting-started/tutorials/caching)
+6. [Understanding your workspace](/docs/getting-started/tutorials/understanding-your-workspace)
+7. [Reducing boilerplate](/docs/getting-started/tutorials/reducing-configuration-boilerplate)
+8. **Setting up CI** (you are here)
 
 {% /aside %}
+
+This tutorial assumes you have an existing Nx workspace (see [Crafting Your Workspace](/docs/getting-started/tutorials/crafting-your-workspace) or the [Gradle tutorial](/docs/getting-started/tutorials/gradle-tutorial)), a [GitHub account](https://github.com) with a repository for your workspace, and [Node.js](https://nodejs.org) v20.19 or later.
 
 ## Connect to Nx Cloud
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/understanding-your-workspace.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/understanding-your-workspace.mdoc
@@ -21,6 +21,7 @@ Tutorial: {pageUrl}
 As your workspace grows to dozens or hundreds of projects, you need tools to explore it, debug unexpected behavior, and verify your configuration. Nx provides several commands and visualizations for this.
 
 {% aside type="note" title="Tutorial Series" %}
+
 1. [Crafting your workspace](/docs/getting-started/tutorials/crafting-your-workspace)
 2. [Managing dependencies](/docs/getting-started/tutorials/managing-dependencies)
 3. [Configuring tasks](/docs/getting-started/tutorials/configuring-tasks)

--- a/astro-docs/src/content/docs/getting-started/Tutorials/understanding-your-workspace.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/understanding-your-workspace.mdoc
@@ -20,9 +20,19 @@ Tutorial: {pageUrl}
 
 As your workspace grows to dozens or hundreds of projects, you need tools to explore it, debug unexpected behavior, and verify your configuration. Nx provides several commands and visualizations for this.
 
-{% aside type="note" title="Prerequisites" %}
-This tutorial assumes you have an Nx workspace with projects and configured tasks. If you're starting fresh, complete [Crafting Your Workspace](/docs/getting-started/tutorials/crafting-your-workspace) first.
+{% aside type="note" title="Tutorial Series" %}
+1. [Crafting your workspace](/docs/getting-started/tutorials/crafting-your-workspace)
+2. [Managing dependencies](/docs/getting-started/tutorials/managing-dependencies)
+3. [Configuring tasks](/docs/getting-started/tutorials/configuring-tasks)
+4. [Running tasks](/docs/getting-started/tutorials/running-tasks)
+5. [Caching](/docs/getting-started/tutorials/caching)
+6. **Understanding your workspace** (you are here)
+7. [Reducing boilerplate](/docs/getting-started/tutorials/reducing-configuration-boilerplate)
+8. [Setting up CI](/docs/getting-started/tutorials/self-healing-ci-tutorial)
+
 {% /aside %}
+
+This tutorial assumes you have an Nx workspace with projects and configured tasks. If you're starting fresh, complete [Crafting Your Workspace](/docs/getting-started/tutorials/crafting-your-workspace) first.
 
 ## The project graph
 


### PR DESCRIPTION
## Current Behavior

Tutorial pages are standalone with no visible series navigation. Path analysis shows most users drop off after the first tutorial, even though they generally follow the intended path.

## Expected Behavior

Each of the 8 tutorial pages now shows a "Tutorial Series" aside after the intro paragraph, listing all tutorials with the current one bolded. This makes the series feel connected while still allowing users to jump around or skip as needed.

Additionally, prerequisites are standardized as plain paragraphs (not asides) across all tutorial pages for a cleaner, less noisy layout.

<img width="971" height="816" alt="image" src="https://github.com/user-attachments/assets/b5389d98-4809-4400-8f9f-ab9834caba94" />


## Related Issue(s)

Closes DOC-466