### PR TITLE
fix(repo): clean Angular CLI restore target before cache copy

### DIFF
--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -517,6 +517,10 @@ export function runNgNew(
     // we need to reuse the same name that's cached in order to avoid issues
     // with tests relying on a different name
     projName = Object.keys(angularJson.projects)[0];
+    // The cached Angular CLI workspace includes symlinked node_modules/.bin entries.
+    // If cleanup left the destination behind, fs-extra will fail while overwriting
+    // those links, so always start from a clean restore target.
+    removeSync(tmpProjPath());
     copySync(tmpBackupNgCliProjPath(), tmpProjPath());
 
     if (isVerboseE2ERun()) {


### PR DESCRIPTION
## Current Behavior

Nightly `e2e-nx-init` runs can fail when the Angular CLI legacy suite restores a cached workspace into an already-existing temp project directory. With `NX_E2E_SKIP_CLEANUP=true`, the previous test workspace is intentionally left on disk, and `fs-extra.copySync` then hits symlinked `node_modules/.bin` entries and aborts with errors like `Cannot copy '../which/bin/which.js' to a subdirectory of itself`.

## Expected Behavior

Restoring the cached Angular CLI workspace should be idempotent even when cleanup is skipped between tests. The restore step should start from a clean target directory so the suite can reuse the cached baseline without tripping over stale symlinks from the previous test run.

## Related Issue(s)

No tracked issue. Investigated from nightly GitHub Actions run `23833817151`.

Validation:
- `pnpm nx typecheck e2e-nx-init`
- Focused local repro on macOS/npm with `NX_E2E_SKIP_CLEANUP=true` failing before the change and passing after it