### PR TITLE
chore(repo): fix inputs for CNW and CNP

### DIFF
--- a/packages/create-nx-plugin/project.json
+++ b/packages/create-nx-plugin/project.json
@@ -24,7 +24,12 @@
         ],
         "parallel": false
       },
-      "inputs": ["copyReadme"]
+      "inputs": [
+        "copyReadme",
+        { "dependentTasksOutputFiles": "**/bin/create-nx-plugin.js" },
+        "{workspaceRoot}/scripts/replace-versions.js",
+        "{workspaceRoot}/scripts/chmod.js"
+      ]
     }
   },
   "implicitDependencies": ["plugin"]

--- a/packages/create-nx-workspace/project.json
+++ b/packages/create-nx-workspace/project.json
@@ -24,7 +24,12 @@
         ],
         "parallel": false
       },
-      "inputs": ["copyReadme"]
+      "inputs": [
+        "copyReadme",
+        { "dependentTasksOutputFiles": "**/bin/create-nx-workspace.js" },
+        "{workspaceRoot}/scripts/replace-versions.js",
+        "{workspaceRoot}/scripts/chmod.js"
+      ]
     }
   },
   "implicitDependencies": [


### PR DESCRIPTION
They don't specify the right inputs, so you will get the wrong bin file whenever you build CNW and CNP.

The problem is ordering:

1. `build-base` runs → sees source change → compiles fresh `bin/create-nx-workspace.js` into `dist/`
2. `build` runs next → checks inputs (`copyReadme`) → cache hit → restores its cached outputs
3. That cached output includes the old `bin/create-nx-workspace.js`, which overwrites the fresh one from step 1

So even though the `build-base` is compiling new source with `tsc`, the `build` task overrides just the bin. This is for both CNW and CNP.
