### PR TITLE
chore(misc): add dist to eslint ignorePatterns

### DIFF
--- a/packages/angular-rspack-compiler/.eslintrc.json
+++ b/packages/angular-rspack-compiler/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../.eslintrc.json",
   "rules": {},
-  "ignorePatterns": ["!**/*", "node_modules"],
+  "ignorePatterns": ["!**/*", "node_modules", "dist"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],

--- a/packages/dotnet/.eslintrc.json
+++ b/packages/dotnet/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../.eslintrc.json",
   "rules": {},
-  "ignorePatterns": ["!**/*", "node_modules"],
+  "ignorePatterns": ["!**/*", "node_modules", "dist"],
   "overrides": [
     {
       "files": [

--- a/packages/maven/.eslintrc.json
+++ b/packages/maven/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*", "node_modules"],
+  "ignorePatterns": ["!**/*", "node_modules", "dist"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],


### PR DESCRIPTION
## Current Behavior

Packages that build to `{projectRoot}/dist` (`maven`, `dotnet`, `angular-rspack-compiler`) use `!**/*` in their project-level `.eslintrc.json` `ignorePatterns` to un-ignore dotfiles. This negation also overrides the root config's `**/dist` ignore pattern, causing `eslint .` to traverse and read build artifacts in `dist/` during linting. This produces sandbox violations (46 unexpected reads for `@nx/maven:lint`).

## Expected Behavior

ESLint skips the `dist/` directory during linting, matching the behavior already in place for `packages/nx` and `packages/angular-rspack` which explicitly re-ignore `dist` after the `!**/*` pattern.