### PR TITLE
chore(repo): add eslint config chain to lint-pnpm-lock inputs

### DIFF
--- a/project.json
+++ b/project.json
@@ -58,7 +58,13 @@
     },
     "lint-pnpm-lock": {
       "cache": true,
-      "inputs": ["{projectRoot}/pnpm-lock.yaml"]
+      "inputs": [
+        "{projectRoot}/pnpm-lock.yaml",
+        "{workspaceRoot}/.eslintrc.json",
+        "{workspaceRoot}/.eslintignore",
+        "{workspaceRoot}/tsconfig.json",
+        "{workspaceRoot}/tools/eslint-rules/**/*"
+      ]
     },
     "prepush": {
       "dependsOn": [


### PR DESCRIPTION
## Current Behavior

The `lint-pnpm-lock` task only declares `pnpm-lock.yaml` as input. ESLint also reads its config chain (`.eslintrc.json`, `.eslintignore`), `tsconfig.json`, and the custom rules plugin (`tools/eslint-rules/**`), causing sandbox violations for 10 undeclared reads.

## Expected Behavior

All files ESLint needs are declared as inputs so sandbox reports no violations for `@nx/nx-source:lint-pnpm-lock`.