### PR TITLE
fix(js): use explicit nx/bin/nx path in start-local-registry

### DIFF
--- a/packages/js/src/plugins/jest/start-local-registry.ts
+++ b/packages/js/src/plugins/jest/start-local-registry.ts
@@ -28,7 +28,7 @@ export function startLocalRegistry({
   }
   return new Promise<() => void>((resolve, reject) => {
     const childProcess = fork(
-      require.resolve('nx'),
+      require.resolve('nx/bin/nx'),
       [
         ...`run ${localRegistryTarget} --location none --clear ${
           clearStorage ?? true


### PR DESCRIPTION
## Current Behavior

`start-local-registry.ts` uses `require.resolve('nx')` to find the nx CLI binary for forking a child process. This resolves the package's `main` entry point, which only incidentally points to the binary. In pnpm strict mode, this resolution fails when called from within `@nx/js` because `@nx/js` doesn't declare `nx` as a direct dependency.

## Expected Behavior

Use `require.resolve('nx/bin/nx')` to explicitly resolve the CLI binary entry point. This is semantically correct (the intent is to fork the nx CLI) and doesn't rely on the `main` field or pnpm hoisting behavior.
