### PR TITLE
chore(repo): update preinstall to vary message based on mise status

### DIFF
--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -3,55 +3,101 @@ This pre-install script will check that the necessary dependencies are installed
 Checks for:
     * Node 20+
     * pnpm 10+
-    * Rust
+    * Rust 1.70+
+    * mise trust status (if applicable)
  */
 
 if (process.env.CI) {
   process.exit(0);
 }
 
-const childProcess = require('child_process');
-const semverLessThan = require('semver/functions/lt');
+const { execSync } = require('child_process');
+const lt = require('semver/functions/lt');
 
-// Check node version
-if (semverLessThan(process.version, '20.19.0')) {
-  console.warn(
-    `Please make sure that your installed Node version (${process.version}) is greater than v20.19.0`
-  );
+function execOrNull(command) {
+  try {
+    return execSync(command, { encoding: 'utf8' }).trim();
+  } catch {
+    return null;
+  }
 }
 
-// Check for pnpm version
-try {
-  let pnpmVersion = childProcess.execSync('pnpm --version', {
-    encoding: 'utf8',
-  });
-  const version = pnpmVersion.trim();
-  if (semverLessThan(version, '10.0.0')) {
-    console.error(
-      `Found pnpm ${version}. Please make sure that your installed pnpm version is 10.0.0 or greater. You can update with: npm install -g pnpm@10`
-    );
-    process.exit(1);
-  }
-} catch {
-  console.error(
-    'Could not find pnpm on this system. Please make sure it is installed with: npm install -g pnpm@10'
-  );
-  process.exit(1);
+function getToolData() {
+  const pnpm = execOrNull('pnpm --version');
+  const rustRaw = execOrNull('rustc --version');
+  const miseRaw = execOrNull('mise trust --show');
+
+  return {
+    node: process.version,
+    pnpm,
+    rust: rustRaw ? rustRaw.split(' ')[1] : null,
+    miseInstalled: miseRaw !== null,
+    miseUntrusted: miseRaw !== null && miseRaw.includes('untrusted'),
+  };
 }
 
-// Check for rust
-try {
-  let rustVersion = childProcess.execSync('rustc --version');
-  if (semverLessThan(rustVersion.toString().split(' ')[1], '1.70.0')) {
-    console.log(`Found ${rustVersion}`);
-    console.error(
-      'Please make sure that your installed Rust version is greater than v1.70. You can update your installed Rust version with `rustup update`'
+function checkNode({ node }) {
+  if (lt(node, '20.19.0')) {
+    console.warn(
+      `Please make sure that your installed Node version (${node}) is greater than v20.19.0`
     );
-    process.exit(1);
   }
-} catch {
-  console.error(
-    'Could not find the Rust compiler on this system. Please make sure that it is installed with https://rustup.rs'
-  );
+  return false;
+}
+
+function checkPnpm({ pnpm }) {
+  if (pnpm === null) {
+    console.error(
+      'Could not find pnpm on this system. Please make sure it is installed with: npm install -g pnpm@10'
+    );
+    return true;
+  }
+  if (lt(pnpm, '10.0.0')) {
+    console.error(
+      `Found pnpm ${pnpm}. Please make sure that your installed pnpm version is 10.0.0 or greater. You can update with: npm install -g pnpm@10`
+    );
+    return true;
+  }
+  return false;
+}
+
+function checkRust({ rust, miseInstalled, miseUntrusted }) {
+  const missing = rust === null;
+  const outdated = !missing && lt(rust, '1.70.0');
+
+  if (!missing && !outdated) {
+    return false;
+  }
+
+  // If mise is installed but untrusted, a simple `mise trust` likely fixes Rust
+  if (miseInstalled && miseUntrusted) {
+    console.error(
+      missing
+        ? 'Could not find the Rust compiler on this system.'
+        : `Found Rust ${rust}, but version 1.70.0 or greater is required.`,
+      '\nmise is installed but this directory is not trusted. Run `mise trust` in this directory to install the correct toolchain.'
+    );
+    return true;
+  }
+
+  if (outdated) {
+    console.log(`Found rustc ${rust}`);
+    console.error(
+      'Please make sure that your installed Rust version is greater than v1.70. You can update with `rustup update`, or install mise (https://mise.jdx.dev/) and run `mise trust` in this directory.'
+    );
+  } else {
+    console.error(
+      'Could not find the Rust compiler on this system. Please install it with https://rustup.rs, or install mise (https://mise.jdx.dev/) and run `mise trust` in this directory.'
+    );
+  }
+  return true;
+}
+
+const toolData = getToolData();
+const hasErrors = [checkNode, checkPnpm, checkRust].some((check) =>
+  check(toolData)
+);
+
+if (hasErrors) {
   process.exit(1);
 }


### PR DESCRIPTION
## Current Behavior
pre-install says rust isn't available if mise isn't trusting the dir, but doesn't mention mise and suggests installing rust. This can trip up AI agents if they see the output and think rust should be installed

## Expected Behavior
Error message mentions mise

## Notes

This pull request significantly refactors and improves the `scripts/preinstall.js` dependency check script. The script now performs more robust version checks for Node, pnpm, and Rust, and adds support for detecting and guiding users regarding `mise` trust status. The refactoring also improves maintainability by modularizing checks and error handling.

**Dependency checks and error handling:**

* Refactored version checks for Node, pnpm, and Rust into separate functions for better readability and maintainability.
* Improved error messages and guidance, including specific instructions for updating or installing missing tools, and added checks for minimum required versions (`Node 20.19.0+`, `pnpm 10.0.0+`, `Rust 1.70.0+`).

**Support for mise integration:**

* Added detection of `mise` installation and trust status, with user guidance to run `mise trust` when the directory is untrusted and Rust is missing or outdated.

**Codebase improvements:**

* Consolidated tool version gathering into a single `getToolData` function and replaced repeated code with a reusable `execOrNull` helper.
* Changed process exit logic to only exit when errors are detected, improving script robustness. (F43b11f