### PR TITLE
docs(js): use `require.resolve('nx/bin/nx')` which is more reliable

### DIFF
--- a/astro-docs/src/content/docs/guides/Nx Release/update-local-registry-setup.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/update-local-registry-setup.mdoc
@@ -29,7 +29,7 @@ export default async () => {
     storage,
     verbose: false,
   });
-  const nx = require.resolve('nx');
+  const nx = require.resolve('nx/bin/nx');
   execFileSync(
     nx,
     ['run-many', '--targets', 'publish', '--ver', '0.0.0-e2e', '--tag', 'e2e'],


### PR DESCRIPTION
`require.resolve('nx)` can fail for a number of reasons:
- If `./nx` exists, it'll resolve to that first, and fail
- If module resolution is set differently it may resolve to the index file, or something unexpected