### PR TITLE
chore(repo): add root tsconfig.json to nx-dev-e2e lint inputs

### DIFF
--- a/nx-dev/nx-dev-e2e/tsconfig.json
+++ b/nx-dev/nx-dev-e2e/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.base.json"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -396,6 +396,9 @@
     },
     {
       "path": "./examples/angular-rspack/ssr-css"
+    },
+    {
+      "path": "./nx-dev/nx-dev-e2e"
     }
   ],
   "extends": "./tsconfig.base.json"


### PR DESCRIPTION
## Current Behavior

`nx-dev-e2e` has no `tsconfig.json`. When `eslint .` runs, `@typescript-eslint/parser` walks up from the project root to the workspace root `tsconfig.json`. This read is not declared as a lint input, causing a sandbox violation.

## Expected Behavior

A minimal `tsconfig.json` extending `tsconfig.base.json` exists in the project, so the parser resolves locally and the sandbox violation is eliminated.

## Why not fix in the `@nx/eslint/plugin`?

The plugin would need to resolve the ESLint config chain, identify which parser is in use, and replicate that parser's tsconfig resolution logic (walking up directories, following `extends` chains). This adds file I/O and config parsing to `createNodesV2`, which runs on the critical path during project graph computation — every `nx` command pays the cost. Not worth it for an edge case that only surfaces when a project has no local tsconfig.

## Why not an input override?

An input override in `project.json` would duplicate the plugin's inferred inputs and could drift if the plugin changes what it infers in the future.