### PR TITLE
fix(bundling): bump esbuild for new projects to a version compatible with vite 8

### DIFF
--- a/packages/esbuild/src/generators/init/init.spec.ts
+++ b/packages/esbuild/src/generators/init/init.spec.ts
@@ -20,4 +20,20 @@ describe('esbuildInitGenerator', () => {
       esbuild: expect.any(String),
     });
   });
+
+  it('should keep the installed esbuild version', async () => {
+    writeJson(tree, 'package.json', {
+      devDependencies: {
+        esbuild: '^0.19.2',
+      },
+    });
+
+    await esbuildInitGenerator(tree, {});
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.devDependencies).toEqual({
+      '@nx/esbuild': expect.any(String),
+      esbuild: '^0.19.2',
+    });
+  });
 });

--- a/packages/esbuild/src/generators/init/init.ts
+++ b/packages/esbuild/src/generators/init/init.ts
@@ -2,6 +2,7 @@ import {
   addDependenciesToPackageJson,
   formatFiles,
   GeneratorCallback,
+  getDependencyVersionFromPackageJson,
   Tree,
 } from '@nx/devkit';
 import { esbuildVersion } from '@nx/js/src/utils/versions';
@@ -16,7 +17,9 @@ export async function esbuildInitGenerator(tree: Tree, schema: Schema) {
       {},
       {
         '@nx/esbuild': nxVersion,
-        esbuild: esbuildVersion,
+        esbuild:
+          getDependencyVersionFromPackageJson(tree, 'esbuild') ??
+          esbuildVersion,
       },
       undefined,
       schema.keepExistingVersions

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1637,6 +1637,27 @@ describe('lib', () => {
         },
       });
     });
+
+    it('should keep esbuild aligned with vite when generating mixed bundler libraries', async () => {
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        directory: 'esbuild-lib',
+        bundler: 'esbuild',
+        unitTestRunner: 'none',
+      });
+      const esbuildVersion = readJson(tree, 'package.json').devDependencies
+        .esbuild;
+
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        directory: 'vite-lib',
+        bundler: 'vite',
+        unitTestRunner: 'none',
+      });
+
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies.esbuild).toBe(esbuildVersion);
+    });
   });
 
   describe('--bundler=rollup', () => {

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -5,6 +5,7 @@ import {
   formatFiles,
   generateFiles,
   GeneratorCallback,
+  getDependencyVersionFromPackageJson,
   installPackagesTask,
   joinPathFragments,
   names,
@@ -923,7 +924,9 @@ function addProjectDependencies(
       {
         '@nx/esbuild': nxVersion,
         '@types/node': typesNodeVersion,
-        esbuild: esbuildVersion,
+        esbuild:
+          getDependencyVersionFromPackageJson(tree, 'esbuild') ??
+          esbuildVersion,
       }
     );
   } else if (options.bundler == 'rollup') {

--- a/packages/js/src/utils/versions.ts
+++ b/packages/js/src/utils/versions.ts
@@ -1,6 +1,6 @@
 export const nxVersion = require('../../package.json').version;
 
-export const esbuildVersion = '^0.19.2';
+export const esbuildVersion = '^0.27.0';
 export const prettierVersion = '~3.6.2';
 export const swcCliVersion = '~0.8.0';
 export const swcCoreVersion = '~1.15.5';

--- a/packages/node/src/generators/application/lib/add-dependencies.ts
+++ b/packages/node/src/generators/application/lib/add-dependencies.ts
@@ -1,6 +1,7 @@
 import {
   addDependenciesToPackageJson,
   GeneratorCallback,
+  getDependencyVersionFromPackageJson,
   joinPathFragments,
   Tree,
   updateJson,
@@ -34,7 +35,8 @@ export function addProjectDependencies(
     },
     esbuild: {
       '@nx/esbuild': nxVersion,
-      esbuild: esbuildVersion,
+      esbuild:
+        getDependencyVersionFromPackageJson(tree, 'esbuild') ?? esbuildVersion,
     },
   };
 

--- a/packages/vite/src/generators/init/init.spec.ts
+++ b/packages/vite/src/generators/init/init.spec.ts
@@ -1,6 +1,7 @@
 import {
   addDependenciesToPackageJson,
   NxJsonConfiguration,
+  output,
   ProjectGraph,
   readJson,
   readNxJson,
@@ -52,6 +53,29 @@ describe('@nx/vite:init', () => {
       await initGenerator(tree, { addPlugin: true });
       const packageJson = readJson(tree, 'package.json');
       expect(packageJson.devDependencies['vite']).toEqual('^8.0.0');
+    });
+
+    it('should default to vite 7 when an older esbuild is already installed', async () => {
+      const warnSpy = jest.spyOn(output, 'warn').mockImplementation(() => {
+        // no-op
+      });
+      updateJson(tree, 'package.json', (json) => {
+        json.devDependencies = { esbuild: '^0.19.2' };
+        return json;
+      });
+
+      await initGenerator(tree, { addPlugin: true });
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['vite']).toEqual('^7.0.0');
+      expect(packageJson.devDependencies['esbuild']).toEqual('^0.19.2');
+      expect(warnSpy).toHaveBeenCalledWith({
+        title: 'Installed esbuild is incompatible with Vite 8. Using Vite 7.',
+        bodyLines: [
+          'Found esbuild version "^0.19.2" in the workspace root package.json.',
+          'Update esbuild to a range compatible with ^0.27.0 if you want newly generated Vite projects to use Vite 8 by default.',
+        ],
+      });
+      warnSpy.mockRestore();
     });
 
     it('should preserve vite 7 when already installed', async () => {

--- a/packages/vite/src/generators/init/lib/utils.ts
+++ b/packages/vite/src/generators/init/lib/utils.ts
@@ -1,11 +1,15 @@
 import {
   addDependenciesToPackageJson,
+  getDependencyVersionFromPackageJson,
   installPackagesTask,
+  output,
   readNxJson,
   Tree,
   updateJson,
   updateNxJson,
 } from '@nx/devkit';
+import { esbuildVersion } from '@nx/js/src/utils/versions';
+import { intersects } from 'semver';
 import {
   jitiVersion,
   nxVersion,
@@ -20,6 +24,25 @@ import {
   getVitestDependenciesVersionsToInstall,
 } from '../../../utils/version-utils';
 
+function hasIncompatibleInstalledEsbuild(host: Tree): boolean {
+  const installedEsbuildVersion = getDependencyVersionFromPackageJson(
+    host,
+    'esbuild'
+  );
+
+  if (!installedEsbuildVersion) {
+    return false;
+  }
+
+  try {
+    return !intersects(installedEsbuildVersion, esbuildVersion, {
+      includePrerelease: true,
+    });
+  } catch {
+    return true;
+  }
+}
+
 export async function checkDependenciesInstalled(
   host: Tree,
   schema: InitGeneratorSchema
@@ -29,13 +52,33 @@ export async function checkDependenciesInstalled(
   // Determine which vite version to install:
   // 1. Explicit flags take priority (useViteV5/V6/V7)
   // 2. If vite is already installed, keep the matching major version
-  // 3. Otherwise, use the latest default (^8.0.0)
+  // 3. If esbuild is already installed but incompatible with Vite 8, use Vite 7
+  // 4. Otherwise, use the latest default (^8.0.0)
   const installedMajor = getInstalledViteMajorVersion(host);
+  const installedEsbuildVersion = getDependencyVersionFromPackageJson(
+    host,
+    'esbuild'
+  );
+  const useViteV7ForEsbuildCompatibility =
+    installedMajor == null && hasIncompatibleInstalledEsbuild(host);
+
+  if (useViteV7ForEsbuildCompatibility) {
+    output.warn({
+      title: 'Installed esbuild is incompatible with Vite 8. Using Vite 7.',
+      bodyLines: [
+        `Found esbuild version "${installedEsbuildVersion}" in the workspace root package.json.`,
+        `Update esbuild to a range compatible with ${esbuildVersion} if you want newly generated Vite projects to use Vite 8 by default.`,
+      ],
+    });
+  }
+
   const viteVersionToInstall = schema.useViteV5
     ? viteV5Version
     : schema.useViteV6
       ? viteV6Version
-      : schema.useViteV7 || installedMajor === 7
+      : schema.useViteV7 ||
+          installedMajor === 7 ||
+          useViteV7ForEsbuildCompatibility
         ? viteV7Version
         : installedMajor === 6
           ? viteV6Version


### PR DESCRIPTION
## Current Behavior

Newly generated JS/esbuild-based projects still default `esbuild` to `^0.19.2`. That conflicts with Vite 8 which requires `esbuild ^0.27.0`.

## Expected Behavior

Newly generated projects should default to an `esbuild` version compatible with Vite 8. If a workspace already has `esbuild` installed, generators should preserve that version instead of blindly bumping it, and Vite init should fall back to Vite 7 with a warning when the installed `esbuild` range is incompatible with Vite 8.