### PR TITLE
perf(js): remove chalk

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -46,7 +46,6 @@
     "babel-plugin-const-enum": "^1.0.1",
     "babel-plugin-macros": "^3.1.0",
     "babel-plugin-transform-typescript-metadata": "^0.3.1",
-    "chalk": "catalog:",
     "columnify": "^1.6.0",
     "detect-port": "^1.5.1",
     "ignore": "^5.0.4",

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -1,5 +1,5 @@
-import chalk from 'chalk';
 import { ChildProcess, fork } from 'child_process';
+import * as pc from 'picocolors';
 import {
   ExecutorContext,
   isDaemonEnabled,
@@ -47,9 +47,9 @@ export async function* nodeExecutor(
 
   if (!project.data.targets[buildTarget.target]) {
     throw new Error(
-      `Cannot find build target ${chalk.bold(
+      `Cannot find build target ${pc.bold(
         options.buildTarget
-      )} for project ${chalk.bold(context.projectName)}`
+      )} for project ${pc.bold(context.projectName)}`
     );
   }
 
@@ -458,9 +458,9 @@ function getFileToRun(
     const fallbackFile = path.join('dist', project.data.root, 'main.js');
 
     logger.warn(
-      `Build option ${chalk.bold('outputFileName')} not set for ${chalk.bold(
+      `Build option ${pc.bold('outputFileName')} not set for ${pc.bold(
         project.name
-      )}. Using fallback value of ${chalk.bold(fallbackFile)}.`
+      )}. Using fallback value of ${pc.bold(fallbackFile)}.`
     );
     return join(context.root, fallbackFile);
   }

--- a/packages/js/src/executors/release-publish/log-tar.ts
+++ b/packages/js/src/executors/release-publish/log-tar.ts
@@ -1,5 +1,5 @@
 // Adapted from https://github.com/npm/cli/blob/c736b622b8504b07f5a19f631ade42dd40063269/lib/utils/tar.js
-import chalk from 'chalk';
+import * as pc from 'picocolors';
 import columnify from 'columnify';
 import { formatBytes } from './format-bytes';
 
@@ -10,7 +10,7 @@ export const logTar = (tarball, opts = {}) => {
   console.log(
     `${unicode ? '📦 ' : 'package:'} ${tarball.name}@${tarball.version}`
   );
-  console.log(chalk.magenta('=== Tarball Contents ==='));
+  console.log(pc.magenta('=== Tarball Contents ==='));
   if (tarball.files.length) {
     console.log('');
     const columnData = columnify(
@@ -32,10 +32,10 @@ export const logTar = (tarball, opts = {}) => {
     });
   }
   if (tarball.bundled.length) {
-    console.log(chalk.magenta('=== Bundled Dependencies ==='));
+    console.log(pc.magenta('=== Bundled Dependencies ==='));
     tarball.bundled.forEach((name) => console.log('', name));
   }
-  console.log(chalk.magenta('=== Tarball Details ==='));
+  console.log(pc.magenta('=== Tarball Details ==='));
   console.log(
     columnify(
       [

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -12,7 +12,7 @@ import { parseRegistryOptions } from '../../utils/npm-config';
 import { extractNpmPublishJsonData } from './extract-npm-publish-json-data';
 import { logTar } from './log-tar';
 import { PublishExecutorSchema } from './schema';
-import chalk = require('chalk');
+import { orange } from 'nx/src/utils/output';
 
 const LARGE_BUFFER = 1024 * 1000000;
 
@@ -151,7 +151,7 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
   }
 
   const warnFn = (message: string) => {
-    console.log(chalk.keyword('orange')(message));
+    console.log(orange(message));
   };
   const { registry, tag, registryConfigKey } = await parseRegistryOptions(
     context.root,
@@ -227,9 +227,7 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
               );
             } else {
               console.log(
-                `Would add the dist-tag ${tag} to v${currentVersion} for registry ${registry}, but ${chalk.keyword(
-                  'orange'
-                )('[dry-run]')} was set.\n`
+                `Would add the dist-tag ${tag} to v${currentVersion} for registry ${registry}, but ${orange('[dry-run]')} was set.\n`
               );
             }
             return {
@@ -377,9 +375,7 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
     const dryRunVersionPlaceholder = 'X.X.X-dry-run';
 
     const publishSummaryMessage = isDryRun
-      ? `Would publish to ${registry} with tag "${tag}", but ${chalk.keyword(
-          'orange'
-        )('[dry-run]')} was set`
+      ? `Would publish to ${registry} with tag "${tag}", but ${orange('[dry-run]')} was set`
       : `Published to ${registry} with tag "${tag}"`;
 
     // bun publish does not support outputting JSON, so we need to modify and print the output string directly

--- a/packages/js/src/release/version-actions.ts
+++ b/packages/js/src/release/version-actions.ts
@@ -14,8 +14,8 @@ import { AfterAllProjectsVersioned, VersionActions } from 'nx/release';
 import type { NxReleaseVersionConfiguration } from 'nx/src/config/nx-json';
 import { parseRegistryOptions } from '../utils/npm-config';
 import { updateLockFile } from './utils/update-lock-file';
-import chalk = require('chalk');
 import { isMatchingDependencyRange, isValidRange } from './utils/semver';
+import { orange } from 'nx/src/utils/output';
 
 export const afterAllProjectsVersioned: AfterAllProjectsVersioned = async (
   cwd: string,
@@ -84,7 +84,7 @@ export default class JsVersionActions extends VersionActions {
     const tagArg = typeof metadata?.tag === 'string' ? metadata.tag : undefined;
 
     const warnFn = (message: string) => {
-      console.log(chalk.keyword('orange')(message));
+      console.log(orange(message));
     };
     const { registry, tag, registryConfigKey } = await parseRegistryOptions(
       workspaceRoot,

--- a/packages/js/src/utils/code-frames/highlight.ts
+++ b/packages/js/src/utils/code-frames/highlight.ts
@@ -1,23 +1,23 @@
 // Adapted from https://raw.githubusercontent.com/babel/babel/4108524/packages/babel-highlight/src/index.js
 import * as jsTokens from 'js-tokens';
-import chalk from 'chalk';
+import * as pc from 'picocolors';
 import { isKeyword, isReservedWord } from './identifiers';
 
 /**
  * Chalk styles for token types.
  */
-function getDefs(chalk) {
+function getDefs(colors) {
   return {
-    keyword: chalk.cyan,
-    capitalized: chalk.yellow,
-    jsx_tag: chalk.yellow,
-    punctuator: chalk.yellow,
+    keyword: colors.cyan,
+    capitalized: colors.yellow,
+    jsx_tag: colors.yellow,
+    punctuator: colors.yellow,
     // bracket:  intentionally omitted.
-    number: chalk.magenta,
-    string: chalk.green,
-    regex: chalk.magenta,
-    comment: chalk.grey,
-    invalid: chalk.white.bgRed.bold,
+    number: colors.magenta,
+    string: colors.green,
+    regex: colors.magenta,
+    comment: colors.grey,
+    invalid: (str: string) => colors.white(colors.bgRed(colors.bold(str))),
   };
 }
 
@@ -93,6 +93,6 @@ function highlightTokens(defs: Object, text: string) {
 }
 
 export function highlight(code: string): string {
-  const defs = getDefs(chalk);
+  const defs = getDefs(pc);
   return highlightTokens(defs, code);
 }

--- a/packages/js/src/utils/typescript/run-type-check.ts
+++ b/packages/js/src/utils/typescript/run-type-check.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import * as pc from 'picocolors';
 import * as path from 'path';
 import type { BuilderProgram, Diagnostic, Program } from 'typescript';
 import { codeFrameColumns } from 'nx/src/utils/code-frames';
@@ -190,13 +190,13 @@ export function getFormattedDiagnostic(
 
   switch (category) {
     case ts.DiagnosticCategory.Warning: {
-      message += `${chalk.yellow.bold('warning')} ${chalk.gray(
+      message += `${pc.yellow(pc.bold('warning'))} ${pc.gray(
         `TS${diagnostic.code}`
       )}: `;
       break;
     }
     case ts.DiagnosticCategory.Error: {
-      message += `${chalk.red.bold('error')} ${chalk.gray(
+      message += `${pc.red(pc.bold('error'))} ${pc.gray(
         `TS${diagnostic.code}`
       )}: `;
       break;
@@ -204,7 +204,7 @@ export function getFormattedDiagnostic(
     case ts.DiagnosticCategory.Suggestion:
     case ts.DiagnosticCategory.Message:
     default: {
-      message += `${chalk.cyan.bold(category === 2 ? 'suggestion' : 'info')}: `;
+      message += `${pc.cyan(pc.bold(category === 2 ? 'suggestion' : 'info'))}: `;
       break;
     }
   }
@@ -219,7 +219,7 @@ export function getFormattedDiagnostic(
     const column = pos.character + 1;
     const fileName = path.relative(workspaceRoot, diagnostic.file.fileName);
     message =
-      `${chalk.underline.blue(`${fileName}:${line}:${column}`)} - ` + message;
+      `${pc.underline(pc.blue(`${fileName}:${line}:${column}`))} - ` + message;
 
     const code = diagnostic.file.getFullText(diagnostic.file.getSourceFile());
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3183,9 +3183,6 @@ importers:
       babel-plugin-transform-typescript-metadata:
         specifier: ^0.3.1
         version: 0.3.2(@babel/core@7.26.10)(@babel/traverse@7.29.0)
-      chalk:
-        specifier: 'catalog:'
-        version: 4.1.2
       columnify:
         specifier: ^1.6.0
         version: 1.6.0


### PR DESCRIPTION
This removes chalk since we already depend on `picocolors` in the js
package and use it in the other monorepo packages as standard.

## Related Issue(s)

N/A
