### PR TITLE
chore(repo): isolate astro-docs build

### DIFF
--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -78,6 +78,7 @@ assignment-rules:
   # These projects should not need to be isolated.
   - projects:
       - nx-dev
+      - astro-docs
     targets:
       - build*
     run-on:


### PR DESCRIPTION
## Current Behavior

The `astro-docs` project is not listed in the isolated build assignment rules in the dynamic changesets CI workflow. This means it runs alongside other projects instead of being isolated like `nx-dev`.

## Expected Behavior

The `astro-docs` project is added to the isolated build assignment rules alongside `nx-dev`, ensuring its build runs in isolation during CI.

## Related Issue(s)

N/A — internal CI configuration improvement.
