### PR TITLE
fix(repo): correct build target outputs for docker and vue packages

### DIFF
--- a/packages/docker/project.json
+++ b/packages/docker/project.json
@@ -7,7 +7,7 @@
     "build": {
       "command": "node ./scripts/copy-readme.js docker",
       "inputs": ["copyReadme"],
-      "outputs": ["{workspaceRoot}/build/packages/docker/README.md"]
+      "outputs": ["{workspaceRoot}/dist/packages/docker/README.md"]
     }
   }
 }

--- a/packages/vue/project.json
+++ b/packages/vue/project.json
@@ -4,6 +4,10 @@
   "sourceRoot": "packages/vue",
   "projectType": "library",
   "targets": {
-    "build": {}
+    "build": {
+      "outputs": ["{workspaceRoot}/dist/packages/vue/README.md"],
+      "command": "node ./scripts/copy-readme.js vue",
+      "inputs": ["copyReadme"]
+    }
   }
 }


### PR DESCRIPTION
## Current Behavior

- The `docker` package has its build output path pointing to `{workspaceRoot}/build/packages/docker/README.md`, but the `copy-readme.js` script writes to `dist/packages/docker/README.md`. This means the cache output doesn't match the actual output location.
- The `vue` package has an empty build target (`{}`) with no README copy step, unlike every other publishable package.

## Expected Behavior

- The `docker` package output path correctly points to `{workspaceRoot}/dist/packages/docker/README.md`.
- The `vue` package has a proper build target that copies and processes the README, matching the pattern used by all other packages.

## Related Issue(s)

N/A — found during audit of build target outputs.