### PR TITLE
fix(core): display actual error message when plugin loading fails

### DIFF
--- a/packages/nx/src/project-graph/plugins/get-plugins.spec.ts
+++ b/packages/nx/src/project-graph/plugins/get-plugins.spec.ts
@@ -1,0 +1,36 @@
+import { createSerializableError } from '../../utils/serializable-error';
+import { reasonToError } from './get-plugins';
+
+describe('reasonToError', () => {
+  it('should return the same Error instance when given a real Error', () => {
+    const error = new Error('real error');
+    const result = reasonToError(error);
+    expect(result).toBe(error);
+  });
+
+  it('should extract message from a serialized error object', () => {
+    const original = new Error('Cannot find module @repro/my-plugin/plugin');
+    const serialized = createSerializableError(original);
+
+    // Serialized errors are plain objects, not Error instances
+    expect(serialized).not.toBeInstanceOf(Error);
+
+    const result = reasonToError(serialized);
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe('Cannot find module @repro/my-plugin/plugin');
+    expect(result.stack).toBe(original.stack);
+  });
+
+  it('should handle a plain object with only a message property', () => {
+    const result = reasonToError({ message: 'something went wrong' });
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe('something went wrong');
+  });
+
+  it('should fall back to String() for non-object reasons', () => {
+    expect(reasonToError('string reason').message).toBe('string reason');
+    expect(reasonToError(42).message).toBe('42');
+    expect(reasonToError(null).message).toBe('null');
+    expect(reasonToError(undefined).message).toBe('undefined');
+  });
+});

--- a/packages/nx/src/project-graph/plugins/get-plugins.ts
+++ b/packages/nx/src/project-graph/plugins/get-plugins.ts
@@ -287,7 +287,7 @@ async function loadSpecifiedNxPlugins(
   return plugins;
 }
 
-function reasonToError(reason: unknown): Error {
+export function reasonToError(reason: unknown): Error {
   if (reason instanceof Error) {
     return reason;
   }

--- a/packages/nx/src/project-graph/plugins/get-plugins.ts
+++ b/packages/nx/src/project-graph/plugins/get-plugins.ts
@@ -63,11 +63,7 @@ export async function getPlugins(
     if (result.status === 'fulfilled') {
       (i === 0 ? defaultPlugins : specifiedPlugins).push(...result.value);
     } else {
-      errors.push(
-        result.reason instanceof Error
-          ? result.reason
-          : new Error(String(result.reason))
-      );
+      errors.push(reasonToError(result.reason));
     }
   }
 
@@ -164,10 +160,7 @@ async function loadDefaultNxPlugins(root = workspaceRoot) {
     } else {
       errors.push({
         pluginName: plugins[i],
-        error:
-          result.reason instanceof Error
-            ? result.reason
-            : new Error(String(result.reason)),
+        error: reasonToError(result.reason),
       });
     }
   }
@@ -263,10 +256,7 @@ async function loadSpecifiedNxPlugins(
         typeof pluginConfig === 'string' ? pluginConfig : pluginConfig.plugin;
       errors.push({
         pluginName,
-        error:
-          result.reason instanceof Error
-            ? result.reason
-            : new Error(String(result.reason)),
+        error: reasonToError(result.reason),
       });
     }
   }
@@ -295,6 +285,20 @@ async function loadSpecifiedNxPlugins(
   };
 
   return plugins;
+}
+
+function reasonToError(reason: unknown): Error {
+  if (reason instanceof Error) {
+    return reason;
+  }
+  if (typeof reason === 'object' && reason !== null && 'message' in reason) {
+    const error = new Error(String((reason as { message: unknown }).message));
+    if ('stack' in reason) {
+      error.stack = String((reason as { stack: unknown }).stack);
+    }
+    return error;
+  }
+  return new Error(String(reason));
 }
 
 function getDefaultPlugins(root: string) {

--- a/packages/nx/src/project-graph/plugins/get-plugins.ts
+++ b/packages/nx/src/project-graph/plugins/get-plugins.ts
@@ -292,9 +292,9 @@ export function reasonToError(reason: unknown): Error {
     return reason;
   }
   if (typeof reason === 'object' && reason !== null && 'message' in reason) {
-    const error = new Error(String((reason as { message: unknown }).message));
+    const error = new Error(String(reason.message));
     if ('stack' in reason) {
-      error.stack = String((reason as { stack: unknown }).stack);
+      error.stack = String(reason.stack);
     }
     return error;
   }


### PR DESCRIPTION
## Current Behavior

When a workspace-local Nx plugin cannot be resolved (e.g., the `node_modules` symlink for a workspace package is missing), the error message displays `[object Object]` instead of the underlying module resolution error:

```
NX   Failed to load 1 Nx plugin(s):

  - @repro/my-plugin/plugin: [object Object]
```

This happens because plugin workers serialize errors as plain objects via `createSerializableError()`. When these serialized errors are received back in the parent process, the `instanceof Error` check fails, and `String(reason)` on a plain object produces `[object Object]`.

## Expected Behavior

The actual error message is displayed:

```
NX   Failed to load 1 Nx plugin(s):

  - @repro/my-plugin/plugin: Cannot find module '@repro/my-plugin/plugin'
```

The fix adds a `reasonToError` helper that checks for an object with a `message` property (serialized error) before falling back to `String()` conversion. This properly handles:
- Real `Error` instances (unchanged behavior)
- Serialized error objects from plugin workers (now extracts `message` and `stack`)
- Other non-error rejection reasons (unchanged `String()` fallback)

## Screenshot of fix
<img width="972" height="244" alt="image" src="https://github.com/user-attachments/assets/ca87d9a6-43a4-4fd4-a215-71277f6dcc8b" />


## Related Issue(s)

Fixes #35137