### PR TITLE
fix(misc): use workspaceRoot in workspaceModule path

### DIFF
--- a/packages/js/src/executors/copy-workspace-modules/copy-workspace-modules.ts
+++ b/packages/js/src/executors/copy-workspace-modules/copy-workspace-modules.ts
@@ -76,7 +76,10 @@ function handleWorkspaceModules(
     logger.verbose(`Copying ${pkgName}.`);
 
     const workspaceModuleProject = workspaceModules.get(pkgName);
-    const workspaceModuleRoot = workspaceModuleProject.data.root;
+    const workspaceModuleRoot = join(
+      workspaceRoot,
+      workspaceModuleProject.data.root
+    );
     const newWorkspaceModulePath = join(workspaceModulesDir, pkgName);
 
     // Copy the module


### PR DESCRIPTION
copy-workspace-modules should prepend the workspaceRoot when copying the workspaceModule to ensure that the executor can successfully copy the module regardless of where in the workspace it is run from.

## Current Behavior
Running the `copy-workspace-modules` from anywhere other than the root of the workspace results in `ENOENT: no such file or directory` for the package.

## Expected Behavior
Running `copy-workspace-modules` should copy the modules successfully regardless of where the process is run from.
