### PR TITLE
fix(gradle): prevent Gradle and Maven daemon accumulation during project graph recalculation

### DIFF
--- a/packages/gradle/package.json
+++ b/packages/gradle/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@nx/devkit": "workspace:*",
     "toml-eslint-parser": "^0.10.0",
+    "tree-kill": "^1.2.2",
     "tslib": "catalog:typescript"
   },
   "devDependencies": {

--- a/packages/gradle/src/plugin/utils/get-project-graph-from-gradle-plugin.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-from-gradle-plugin.ts
@@ -74,8 +74,6 @@ let projectGraphReportCachePath: string = join(
   workspaceDataDirectory,
   'gradle-nodes.hash'
 );
-let currentAbortController: AbortController | undefined;
-
 export function getCurrentProjectGraphReport(): ProjectGraphReport {
   if (!projectGraphReportCache) {
     throw new AggregateCreateNodesError(
@@ -113,13 +111,6 @@ export async function populateProjectGraph(
   gradlewFiles: string[],
   options: GradlePluginOptions
 ): Promise<void> {
-  // Cancel any in-flight Gradle process from a previous call
-  if (currentAbortController) {
-    currentAbortController.abort();
-  }
-  currentAbortController = new AbortController();
-  const signal = currentAbortController.signal;
-
   const normalizedOptions = normalizeOptions(options);
   const gradleConfigHash = hashArray([
     await hashWithWorkspaceContext(workspaceRoot, [gradleConfigAndTestGlob]),
@@ -153,8 +144,7 @@ export async function populateProjectGraph(
         const currentLines = await getNxProjectGraphLines(
           gradlewFile,
           gradleConfigHash,
-          normalizedOptions,
-          signal
+          normalizedOptions
         );
         const getNxProjectGraphLinesEnd = performance.mark(
           `${gradlewFile}GetNxProjectGraphLines:end`
@@ -169,7 +159,10 @@ export async function populateProjectGraph(
       Promise.resolve([])
     );
   } catch (e) {
-    if (signal.aborted) {
+    if (
+      e instanceof Error &&
+      e.message === 'Gradle project graph generation was cancelled'
+    ) {
       // Cancelled by a newer populateProjectGraph call — silently return
       return;
     }

--- a/packages/gradle/src/plugin/utils/get-project-graph-from-gradle-plugin.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-from-gradle-plugin.ts
@@ -74,6 +74,7 @@ let projectGraphReportCachePath: string = join(
   workspaceDataDirectory,
   'gradle-nodes.hash'
 );
+let currentAbortController: AbortController | undefined;
 
 export function getCurrentProjectGraphReport(): ProjectGraphReport {
   if (!projectGraphReportCache) {
@@ -112,6 +113,13 @@ export async function populateProjectGraph(
   gradlewFiles: string[],
   options: GradlePluginOptions
 ): Promise<void> {
+  // Cancel any in-flight Gradle process from a previous call
+  if (currentAbortController) {
+    currentAbortController.abort();
+  }
+  currentAbortController = new AbortController();
+  const signal = currentAbortController.signal;
+
   const normalizedOptions = normalizeOptions(options);
   const gradleConfigHash = hashArray([
     await hashWithWorkspaceContext(workspaceRoot, [gradleConfigAndTestGlob]),
@@ -131,32 +139,42 @@ export async function populateProjectGraph(
     'gradleProjectGraphReport:start'
   );
 
-  const projectGraphLines = await gradlewFiles.reduce(
-    async (
-      projectGraphLines: Promise<string[]>,
-      gradlewFile: string
-    ): Promise<string[]> => {
-      const getNxProjectGraphLinesStart = performance.mark(
-        `${gradlewFile}GetNxProjectGraphLines:start`
-      );
-      const allLines = await projectGraphLines;
-      const currentLines = await getNxProjectGraphLines(
-        gradlewFile,
-        gradleConfigHash,
-        normalizedOptions
-      );
-      const getNxProjectGraphLinesEnd = performance.mark(
-        `${gradlewFile}GetNxProjectGraphLines:end`
-      );
-      performance.measure(
-        `${gradlewFile}GetNxProjectGraphLines`,
-        getNxProjectGraphLinesStart.name,
-        getNxProjectGraphLinesEnd.name
-      );
-      return [...allLines, ...currentLines];
-    },
-    Promise.resolve([])
-  );
+  let projectGraphLines: string[];
+  try {
+    projectGraphLines = await gradlewFiles.reduce(
+      async (
+        projectGraphLines: Promise<string[]>,
+        gradlewFile: string
+      ): Promise<string[]> => {
+        const getNxProjectGraphLinesStart = performance.mark(
+          `${gradlewFile}GetNxProjectGraphLines:start`
+        );
+        const allLines = await projectGraphLines;
+        const currentLines = await getNxProjectGraphLines(
+          gradlewFile,
+          gradleConfigHash,
+          normalizedOptions,
+          signal
+        );
+        const getNxProjectGraphLinesEnd = performance.mark(
+          `${gradlewFile}GetNxProjectGraphLines:end`
+        );
+        performance.measure(
+          `${gradlewFile}GetNxProjectGraphLines`,
+          getNxProjectGraphLinesStart.name,
+          getNxProjectGraphLinesEnd.name
+        );
+        return [...allLines, ...currentLines];
+      },
+      Promise.resolve([])
+    );
+  } catch (e) {
+    if (signal.aborted) {
+      // Cancelled by a newer populateProjectGraph call — silently return
+      return;
+    }
+    throw e;
+  }
 
   const gradleProjectGraphReportEnd = performance.mark(
     'gradleProjectGraphReport:end'

--- a/packages/gradle/src/plugin/utils/get-project-graph-lines.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-lines.ts
@@ -19,7 +19,8 @@ export function getGraphTimeoutMs(): number {
 export async function getNxProjectGraphLines(
   gradlewFile: string,
   gradleConfigHash: string,
-  gradlePluginOptions: GradlePluginOptions
+  gradlePluginOptions: GradlePluginOptions,
+  externalSignal?: AbortSignal
 ): Promise<string[]> {
   let nxProjectGraphBuffer: Buffer;
 
@@ -32,6 +33,17 @@ export async function getNxProjectGraphLines(
   const timeoutSeconds = timeoutMs / 1000;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  // If already cancelled before we even start, bail out immediately.
+  if (externalSignal?.aborted) {
+    clearTimeout(timer);
+    throw new Error('Gradle project graph generation was cancelled');
+  }
+
+  // If the external signal aborts (e.g. a newer project graph request),
+  // also abort our local controller to kill the Gradle process.
+  const onExternalAbort = () => controller.abort();
+  externalSignal?.addEventListener('abort', onExternalAbort);
 
   try {
     nxProjectGraphBuffer = await execGradleAsync(
@@ -51,6 +63,9 @@ export async function getNxProjectGraphLines(
       { signal: controller.signal }
     );
   } catch (e: any) {
+    if (externalSignal?.aborted) {
+      throw e; // Let populateProjectGraph handle cancellation
+    }
     if (controller.signal.aborted) {
       throw new AggregateCreateNodesError(
         [
@@ -105,6 +120,7 @@ export async function getNxProjectGraphLines(
     }
   } finally {
     clearTimeout(timer);
+    externalSignal?.removeEventListener('abort', onExternalAbort);
   }
 
   const projectGraphLines = nxProjectGraphBuffer

--- a/packages/gradle/src/plugin/utils/get-project-graph-lines.ts
+++ b/packages/gradle/src/plugin/utils/get-project-graph-lines.ts
@@ -5,6 +5,19 @@ import { GradlePluginOptions } from './gradle-plugin-options';
 
 const DEFAULT_GRAPH_TIMEOUT_SECONDS = isCI() ? 600 : 120;
 
+let currentAbortController: AbortController | undefined;
+
+/**
+ * Cancel any in-flight Gradle project graph process.
+ * Safe to call even if nothing is running.
+ */
+export function cancelPendingProjectGraphRequest(): void {
+  if (currentAbortController) {
+    currentAbortController.abort('cancelled');
+    currentAbortController = undefined;
+  }
+}
+
 export function getGraphTimeoutMs(): number {
   const envTimeout = process.env.NX_GRADLE_PROJECT_GRAPH_TIMEOUT;
   if (envTimeout) {
@@ -19,8 +32,7 @@ export function getGraphTimeoutMs(): number {
 export async function getNxProjectGraphLines(
   gradlewFile: string,
   gradleConfigHash: string,
-  gradlePluginOptions: GradlePluginOptions,
-  externalSignal?: AbortSignal
+  gradlePluginOptions: GradlePluginOptions
 ): Promise<string[]> {
   let nxProjectGraphBuffer: Buffer;
 
@@ -31,19 +43,13 @@ export async function getNxProjectGraphLines(
 
   const timeoutMs = getGraphTimeoutMs();
   const timeoutSeconds = timeoutMs / 1000;
+
+  // Cancel any in-flight Gradle process from a previous call, then create a fresh controller.
+  cancelPendingProjectGraphRequest();
   const controller = new AbortController();
+  currentAbortController = controller;
+  const signal = controller.signal;
   const timer = setTimeout(() => controller.abort(), timeoutMs);
-
-  // If already cancelled before we even start, bail out immediately.
-  if (externalSignal?.aborted) {
-    clearTimeout(timer);
-    throw new Error('Gradle project graph generation was cancelled');
-  }
-
-  // If the external signal aborts (e.g. a newer project graph request),
-  // also abort our local controller to kill the Gradle process.
-  const onExternalAbort = () => controller.abort();
-  externalSignal?.addEventListener('abort', onExternalAbort);
 
   try {
     nxProjectGraphBuffer = await execGradleAsync(
@@ -60,13 +66,14 @@ export async function getNxProjectGraphLines(
         `-PworkspaceRoot=${workspaceRoot}`,
         process.env.NX_GRADLE_VERBOSE_LOGGING ? '--info' : '',
       ],
-      { signal: controller.signal }
+      { signal }
     );
   } catch (e: any) {
-    if (externalSignal?.aborted) {
-      throw e; // Let populateProjectGraph handle cancellation
+    // Cancelled by a newer populateProjectGraph call — let the caller handle it
+    if (signal.reason === 'cancelled') {
+      throw new Error('Gradle project graph generation was cancelled');
     }
-    if (controller.signal.aborted) {
+    if (signal.aborted) {
       throw new AggregateCreateNodesError(
         [
           [
@@ -120,7 +127,6 @@ export async function getNxProjectGraphLines(
     }
   } finally {
     clearTimeout(timer);
-    externalSignal?.removeEventListener('abort', onExternalAbort);
   }
 
   const projectGraphLines = nxProjectGraphBuffer

--- a/packages/gradle/src/utils/exec-gradle.ts
+++ b/packages/gradle/src/utils/exec-gradle.ts
@@ -9,6 +9,7 @@ import { dirname, join, isAbsolute } from 'node:path';
 import { LARGE_BUFFER } from 'nx/src/executors/run-commands/run-commands.impl';
 import { GradlePluginOptions } from '../plugin/utils/gradle-plugin-options';
 import { signalToCode } from 'nx/src/utils/exit-codes';
+import treeKill from 'tree-kill';
 
 export const fileSeparator = process.platform.startsWith('win')
   ? 'file:///'
@@ -38,6 +39,10 @@ export function execGradleAsync(
   args: ReadonlyArray<string>,
   execOptions: ExecFileOptions = {}
 ): Promise<Buffer> {
+  // Extract signal so we can handle cancellation with tree-kill
+  // instead of Node's default which only kills the immediate child.
+  const { signal, ...restOptions } = execOptions;
+
   return new Promise<Buffer>((res, rej: (stdout: Buffer) => void) => {
     const cp = execFile(
       gradleBinaryPath,
@@ -48,10 +53,19 @@ export function execGradleAsync(
         windowsHide: true,
         env: process.env,
         maxBuffer: LARGE_BUFFER,
-        ...execOptions,
+        ...restOptions,
       },
       undefined
     );
+
+    // Use tree-kill on abort to kill the entire process tree
+    // (cmd.exe → gradlew.bat → java.exe), not just the shell.
+    const onAbort = () => {
+      if (cp.pid) {
+        treeKill(cp.pid);
+      }
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
 
     let stdout = Buffer.from('');
     cp.stdout?.on('data', (data) => {
@@ -61,8 +75,9 @@ export function execGradleAsync(
       stdout += data;
     });
 
-    cp.on('exit', (code, signal) => {
-      if (code === null) code = signalToCode(signal);
+    cp.on('exit', (code, s) => {
+      signal?.removeEventListener('abort', onAbort);
+      if (code === null) code = signalToCode(s);
       if (code === 0) {
         res(stdout);
       } else {

--- a/packages/maven/package.json
+++ b/packages/maven/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@nx/devkit": "workspace:*",
     "@xmldom/xmldom": "^0.8.10",
+    "tree-kill": "^1.2.2",
     "tslib": "catalog:typescript"
   },
   "devDependencies": {

--- a/packages/maven/src/plugins/maven-analyzer.ts
+++ b/packages/maven/src/plugins/maven-analyzer.ts
@@ -2,9 +2,37 @@ import { join } from 'path';
 import { existsSync } from 'fs';
 import { spawn } from 'child_process';
 import { logger, readJsonFile } from '@nx/devkit';
+import { isCI } from 'nx/src/devkit-internals';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { MavenAnalysisData, MavenPluginOptions } from './types';
 import { detectMavenExecutable } from '../utils/detect-maven-executable';
+import treeKill from 'tree-kill';
+
+const DEFAULT_ANALYSIS_TIMEOUT_SECONDS = isCI() ? 600 : 120;
+
+let currentAbortController: AbortController | undefined;
+
+/**
+ * Cancel any in-flight Maven analysis process.
+ * Safe to call even if nothing is running.
+ */
+export function cancelPendingMavenAnalysis(): void {
+  if (currentAbortController) {
+    currentAbortController.abort('cancelled');
+    currentAbortController = undefined;
+  }
+}
+
+function getAnalysisTimeoutMs(): number {
+  const envTimeout = process.env.NX_MAVEN_ANALYSIS_TIMEOUT;
+  if (envTimeout) {
+    const parsed = Number(envTimeout);
+    if (!Number.isNaN(parsed) && parsed > 0) {
+      return parsed * 1000;
+    }
+  }
+  return DEFAULT_ANALYSIS_TIMEOUT_SECONDS * 1000;
+}
 
 /**
  * Run Maven analysis using our Kotlin analyzer plugin
@@ -60,67 +88,102 @@ export async function runMavenAnalysis(
     );
   }
 
+  // Cancel any in-flight Maven process from a previous call, then create a fresh controller.
+  cancelPendingMavenAnalysis();
+  const controller = new AbortController();
+  currentAbortController = controller;
+  const signal = controller.signal;
+  const timeoutMs = getAnalysisTimeoutMs();
+  const timeoutSeconds = timeoutMs / 1000;
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
   // Run Maven plugin
   logger.verbose(`[Maven Analyzer] Spawning Maven process...`);
-  await new Promise<void>((resolve, reject) => {
-    const child = spawn(mavenExecutable, mavenArgs, {
-      cwd: workspaceRoot,
-      windowsHide: true,
-      shell: true,
-      stdio: 'pipe', // Always use pipe so we can control output
-    });
-
-    logger.verbose(`[Maven Analyzer] Process spawned with PID: ${child.pid}`);
-
-    let stdout = '';
-    let stderr = '';
-
-    // In verbose mode, forward output to console in real-time
-    if (isVerbose) {
-      child.stdout?.on('data', (data) => {
-        const text = data.toString();
-        stdout += text;
-        process.stdout.write(text); // Forward to stdout
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn(mavenExecutable, mavenArgs, {
+        cwd: workspaceRoot,
+        windowsHide: true,
+        shell: true,
+        stdio: 'pipe', // Always use pipe so we can control output
       });
-      child.stderr?.on('data', (data) => {
-        const text = data.toString();
-        stderr += text;
-        process.stderr.write(text); // Forward to stderr
-      });
-    } else {
-      child.stdout?.on('data', (data) => {
-        const text = data.toString();
-        stdout += text;
-        logger.verbose(`[Maven Analyzer] Stdout chunk: ${text.trim()}`);
-      });
-      child.stderr?.on('data', (data) => {
-        const text = data.toString();
-        stderr += text;
-        logger.verbose(`[Maven Analyzer] Stderr chunk: ${text.trim()}`);
-      });
-    }
 
-    child.on('close', (code) => {
-      logger.verbose(`[Maven Analyzer] Process closed with code: ${code}`);
-      if (code === 0) {
-        logger.verbose(
-          `[Maven Analyzer] Maven analysis completed successfully`
-        );
-        resolve();
+      // Use tree-kill on abort to kill the entire process tree
+      const onAbort = () => {
+        if (child.pid) {
+          treeKill(child.pid);
+        }
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+
+      logger.verbose(`[Maven Analyzer] Process spawned with PID: ${child.pid}`);
+
+      let stdout = '';
+      let stderr = '';
+
+      // In verbose mode, forward output to console in real-time
+      if (isVerbose) {
+        child.stdout?.on('data', (data) => {
+          const text = data.toString();
+          stdout += text;
+          process.stdout.write(text); // Forward to stdout
+        });
+        child.stderr?.on('data', (data) => {
+          const text = data.toString();
+          stderr += text;
+          process.stderr.write(text); // Forward to stderr
+        });
       } else {
-        let errorMsg = `Maven analysis failed with code ${code}`;
-        if (stderr) errorMsg += `\nStderr: ${stderr}`;
-        if (stdout && !isVerbose) errorMsg += `\nStdout: ${stdout}`;
-        console.error(`[Maven Analyzer] Error: ${errorMsg}`);
-        reject(new Error(errorMsg));
+        child.stdout?.on('data', (data) => {
+          const text = data.toString();
+          stdout += text;
+          logger.verbose(`[Maven Analyzer] Stdout chunk: ${text.trim()}`);
+        });
+        child.stderr?.on('data', (data) => {
+          const text = data.toString();
+          stderr += text;
+          logger.verbose(`[Maven Analyzer] Stderr chunk: ${text.trim()}`);
+        });
       }
-    });
 
-    child.on('error', (error) => {
-      console.error(`[Maven Analyzer] Process error: ${error.message}`);
-      reject(new Error(`Failed to spawn Maven process: ${error.message}`));
+      child.on('close', (code) => {
+        signal.removeEventListener('abort', onAbort);
+        logger.verbose(`[Maven Analyzer] Process closed with code: ${code}`);
+        if (code === 0) {
+          logger.verbose(
+            `[Maven Analyzer] Maven analysis completed successfully`
+          );
+          resolve();
+        } else {
+          let errorMsg = `Maven analysis failed with code ${code}`;
+          if (stderr) errorMsg += `\nStderr: ${stderr}`;
+          if (stdout && !isVerbose) errorMsg += `\nStdout: ${stdout}`;
+          console.error(`[Maven Analyzer] Error: ${errorMsg}`);
+          reject(new Error(errorMsg));
+        }
+      });
+
+      child.on('error', (error) => {
+        signal.removeEventListener('abort', onAbort);
+        console.error(`[Maven Analyzer] Process error: ${error.message}`);
+        reject(new Error(`Failed to spawn Maven process: ${error.message}`));
+      });
     });
-  });
+  } catch (e: any) {
+    if (signal.reason === 'cancelled') {
+      throw new Error('Maven analysis was cancelled');
+    }
+    if (signal.aborted) {
+      throw new Error(
+        `Maven analysis timed out after ${timeoutSeconds} ${timeoutSeconds === 1 ? 'second' : 'seconds'}.\n` +
+          `  1. If the issue persists, set the environment variable NX_MAVEN_ANALYSIS_TIMEOUT to a higher value (in seconds) to increase the timeout.\n` +
+          `  2. If the issue still persists, set NX_MAVEN_DISABLE=true to disable the Maven plugin entirely.`
+      );
+    }
+    throw e;
+  } finally {
+    clearTimeout(timer);
+  }
 
   // Read and parse the JSON output
   logger.verbose(`[Maven Analyzer] Checking for output file: ${outputFile}`);

--- a/packages/maven/src/plugins/nodes.ts
+++ b/packages/maven/src/plugins/nodes.ts
@@ -58,10 +58,21 @@ export const createNodes: CreateNodesV2<MavenPluginOptions> = [
 
       // If no cached data or cache is stale, run fresh Maven analysis
       if (!mavenData) {
-        mavenData = await runMavenAnalysis(context.workspaceRoot, {
-          ...opts,
-          verbose: isVerbose,
-        });
+        try {
+          mavenData = await runMavenAnalysis(context.workspaceRoot, {
+            ...opts,
+            verbose: isVerbose,
+          });
+        } catch (e) {
+          if (
+            e instanceof Error &&
+            e.message === 'Maven analysis was cancelled'
+          ) {
+            // Cancelled by a newer createNodes call — silently return empty
+            return [];
+          }
+          throw e;
+        }
         // Cache the results with the hash
         mavenCache.set(hash, mavenData);
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3241,6 +3241,9 @@ importers:
       '@xmldom/xmldom':
         specifier: ^0.8.10
         version: 0.8.11
+      tree-kill:
+        specifier: ^1.2.2
+        version: 1.2.2
       tslib:
         specifier: catalog:typescript
         version: 2.8.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3082,6 +3082,9 @@ importers:
       toml-eslint-parser:
         specifier: ^0.10.0
         version: 0.10.0
+      tree-kill:
+        specifier: ^1.2.2
+        version: 1.2.2
       tslib:
         specifier: catalog:typescript
         version: 2.8.1


### PR DESCRIPTION
## Current Behavior

When file changes trigger rapid project graph recalculations (e.g., during development with `nx graph` or a dev server running), each call to `populateProjectGraph` spawns a new Gradle process via `execGradleAsync`. If the previous Gradle daemon is still busy processing the prior request, Gradle spawns a **new daemon**. These daemons persist for 3 hours by default (Gradle's idle timeout), leading to dozens of orphaned `java.exe` processes consuming significant memory.

Maven has a similar issue — `runMavenAnalysis` spawns a long-lived process with no timeout or cancellation support at all.

### Root Cause Analysis

The daemon explosion happens due to three compounding issues:

1. **No cancellation of in-flight processes**: When a newer project graph request arrives, the previous invocation continues running. Each concurrent invocation finds the existing daemon busy and spawns a new one.

2. **Windows process tree issue**: On Windows, `execFile` with `shell: true` runs `cmd.exe → gradlew.bat → java.exe`. Node's `AbortSignal` only terminates `cmd.exe` (the immediate child process), leaving `java.exe` running as an orphan.

3. **No timeout for Maven**: Maven analysis could run indefinitely with no way to cancel or time out.

### Reproduction

1. Run `nx graph` in a workspace with `@nx/gradle` registered
2. Rapidly modify a `build.gradle.kts` file (e.g., `while true; do echo "// tick" >> build.gradle.kts; sleep 0.01; done`)
3. Watch `java.exe` processes accumulate: `tasklist | grep java` (Windows) or `ps aux | grep java` (Unix)
4. Without this fix: **15+ Gradle daemons** within seconds, persisting for 3 hours each
5. With this fix: **1 Gradle daemon** remains stable under the same conditions

## Expected Behavior

When rapid file changes trigger multiple project graph recalculations:
- The previous invocation is cancelled before starting a new one
- Cancelled calls that have already spawned a process get their entire process tree killed (not just the shell wrapper)
- Only 1 daemon remains active at any time, rather than accumulating dozens
- Both Gradle and Maven have configurable timeouts with clear error messages

## Changes

### Gradle

#### 1. Self-contained cancellation in `get-project-graph-lines.ts`
Moved the `AbortController` from `get-project-graph-from-gradle-plugin.ts` into `get-project-graph-lines.ts`, closer to where processes are spawned. `getNxProjectGraphLines` now manages its own abort controller — cancelling any in-flight request before starting a new one. Uses `abort('cancelled')` reason to distinguish external cancellation from timeout.

#### 2. Tree-kill on abort (`exec-gradle.ts`)
Instead of passing the `AbortSignal` directly to Node's `execFile` (which only kills the immediate child process), we intercept the signal and use `tree-kill` to terminate the entire process tree. This ensures `java.exe` is killed along with `cmd.exe` and `gradlew.bat` on Windows.

### Maven

#### 3. Timeout and cancellation support for `maven-analyzer.ts`
Added the same abort controller + tree-kill + timeout pattern to Maven analysis:
- Configurable timeout via `NX_MAVEN_ANALYSIS_TIMEOUT` env var (default: 120s local, 600s CI)
- `cancelPendingMavenAnalysis()` cancels in-flight processes on repeated calls
- `tree-kill` ensures the entire Maven process tree is killed on abort
- Clear timeout error messages with actionable steps

Closes NXC-4147