### PR TITLE
chore(repo): remove redundant tsc command from workspace-plugin build

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4355,9 +4355,6 @@ importers:
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.0
-      nx:
-        specifier: 22.7.0-beta.9
-        version: 22.7.0-beta.9(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))
       semver:
         specifier: 'catalog:'
         version: 7.7.4

--- a/tools/workspace-plugin/.eslintrc.json
+++ b/tools/workspace-plugin/.eslintrc.json
@@ -18,7 +18,7 @@
       "files": ["*.json"],
       "parser": "jsonc-eslint-parser",
       "rules": {
-        "@nx/dependency-checks": "error"
+        "@nx/dependency-checks": ["error", { "buildTargets": ["build-base"] }]
       }
     },
     {

--- a/tools/workspace-plugin/package.json
+++ b/tools/workspace-plugin/package.json
@@ -12,7 +12,6 @@
     "@xmldom/xmldom": "^0.8.10",
     "glob": "7.1.4",
     "js-yaml": "^4.1.0",
-    "nx": "22.7.0-beta.9",
     "semver": "catalog:",
     "shiki": "^4.0.2",
     "tslib": "catalog:typescript"

--- a/tools/workspace-plugin/project.json
+++ b/tools/workspace-plugin/project.json
@@ -4,12 +4,7 @@
   "sourceRoot": "tools/workspace-plugin/src",
   "projectType": "library",
   "targets": {
-    "build": {
-      "command": "tsc --build tsconfig.lib.json",
-      "options": {
-        "cwd": "tools/workspace-plugin"
-      }
-    }
+    "build": {}
   },
   "tags": []
 }


### PR DESCRIPTION
## Current Behavior

The `workspace-plugin:build` target explicitly runs `tsc --build tsconfig.lib.json`, which is the same command the inferred `build-base` target runs. Since `build` depends on `build-base`, tsc runs twice — the second time finding nothing to do.

The `nx` package was listed as a dependency but is only referenced in generator template files, not in compiled source.

## Expected Behavior

- The `build` target is a pure dependency orchestrator with no command. `build-base` (inferred by `@nx/js/typescript`) handles the actual compilation.
- The `@nx/dependency-checks` rule is configured with `buildTargets: ["build-base"]` to align with all other packages in the repo.
- The `nx` package is removed from dependencies since it's not imported in any source file.