### PR TITLE
docs(misc): revert conformance doc changes from nx-cloud to nx rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,13 +100,13 @@ jobs:
         run: |
           pids=()
 
-          pnpm nx-cloud record -- nx format:check &
+          pnpm nx record -- nx format:check &
           pids+=($!)
 
-          pnpm nx-cloud record -- nx sync:check
+          pnpm nx record -- nx sync:check
           pids+=($!)
 
-          pnpm nx build workspace-plugin && pnpm nx-cloud record -- pnpm nx conformance:check
+          pnpm nx build workspace-plugin && pnpm nx record -- pnpm nx-cloud conformance:check
           pids+=($!)
 
           pnpm nx run-many -t check-imports check-lock-files check-codeowners --parallel=1 --no-dte &
@@ -120,7 +120,7 @@ jobs:
           done
         timeout-minutes: 100
       - name: Fix CI
-        run: pnpm nx-cloud fix-ci
+        run: pnpm nx fix-ci
         if: failure()
 
   main-macos:

--- a/astro-docs/src/content/docs/enterprise/conformance.mdoc
+++ b/astro-docs/src/content/docs/enterprise/conformance.mdoc
@@ -106,7 +106,7 @@ Here we are using the `nx-cloud` CLI to run the `conformance:check` command so t
 {% /tabitem %}
 {% /tabs %}
 
-If a valid license is not available to the workspace (either locally or via Nx Cloud), the `nx conformance` and `nx conformance:check` commands will fail without checking any rules.
+If a valid license is not available to the workspace (either locally or via Nx Cloud), the `conformance` and `conformance:check` commands will fail without checking any rules.
 
 ## Taking things further with Nx Cloud Enterprise
 

--- a/astro-docs/src/content/docs/enterprise/conformance.mdoc
+++ b/astro-docs/src/content/docs/enterprise/conformance.mdoc
@@ -98,10 +98,10 @@ Use `npx nx record --` to capture the logs for `nx conformance:check` in the Nx 
 
 ```yaml
 - name: Enforce all conformance rules
-  run: npx nx record -- npx nx conformance:check
+  run: npx nx record -- npx nx-cloud conformance:check
 ```
 
-Here we are using the `nx` CLI to run the `conformance:check` command so that we can hook into the power of Conformance rules configured in your Nx Cloud Enterprise organization. Learn more about [conformance rules in Nx Cloud](/docs/enterprise/configure-conformance-rules-in-nx-cloud).
+Here we are using the `nx-cloud` CLI to run the `conformance:check` command so that we can hook into the power of Conformance rules configured in your Nx Cloud Enterprise organization. Learn more about [conformance rules in Nx Cloud](/docs/enterprise/configure-conformance-rules-in-nx-cloud).
 
 {% /tabitem %}
 {% /tabs %}
@@ -110,15 +110,15 @@ If a valid license is not available to the workspace (either locally or via Nx C
 
 ## Taking things further with Nx Cloud Enterprise
 
-Organizations on the Nx Cloud Enterprise plan can [publish custom conformance rules](/docs/enterprise/publish-conformance-rules-to-nx-cloud) to their Nx Cloud organization without the friction of a custom registry, and then [configure the rules](/docs/enterprise/configure-conformance-rules-in-nx-cloud) to apply to the workspaces in their organization automatically when `nx conformance` or `nx conformance:check` is run (note that the `nx-cloud` CLI is used in this case in order to handle the authentication with Nx Cloud).
+Organizations on the Nx Cloud Enterprise plan can [publish custom conformance rules](/docs/enterprise/publish-conformance-rules-to-nx-cloud) to their Nx Cloud organization without the friction of a custom registry, and then [configure the rules](/docs/enterprise/configure-conformance-rules-in-nx-cloud) to apply to the workspaces in their organization automatically when `nx-cloud conformance` or `nx-cloud conformance:check` is run (note that the `nx-cloud` CLI is used in this case in order to handle the authentication with Nx Cloud).
 
 The license will be applied automatically via Nx Cloud in all contexts, and so there is zero setup required for the end developer.
 
-Simply add an appropriate invocation of the `nx conformance:check` command to your CI process and all cloud configured rules will be applied and merged with any local rules:
+Simply add an appropriate invocation of the `nx-cloud conformance:check` command to your CI process and all cloud configured rules will be applied and merged with any local rules:
 
 ```yaml
 - name: Enforce all conformance rules
-  run: npx nx record -- npx nx conformance:check
+  run: npx nx record -- npx nx-cloud conformance:check
 ```
 
 Learn more about [publishing](/docs/enterprise/publish-conformance-rules-to-nx-cloud) and [configuring conformance rules in Nx Cloud](/docs/enterprise/configure-conformance-rules-in-nx-cloud).

--- a/astro-docs/src/content/docs/reference/nx-cloud-cli.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-cloud-cli.mdoc
@@ -11,7 +11,7 @@ Below is a complete reference for all available commands and their options.
 
 ## Available commands
 
-### `nx login`
+### `nx-cloud login`
 
 Provision a local personal access token to access Nx Cloud features. This will open your browser to the Nx Cloud application and after signing in will generate a personal access token and save it in a configuration file locally called `nxcloud.ini`.
 
@@ -20,7 +20,7 @@ This command is the same as running `nx login`.
 **Usage:**
 
 ```shell
-npx nx login [nxCloudUrl]
+npx nx-cloud login [nxCloudUrl]
 ```
 
 #### Options
@@ -58,14 +58,16 @@ personalAccessToken=SOME_ACCESS_TOKEN
 
 If you have access to multiple instances of the Nx Cloud application (e.g. self-hosted Enterprise and our managed instance), each instance will be saved to this file under its URL.
 
-### `nx logout`
+### `nx-cloud logout`
 
 Revoke a personal access token from your local environment. This will remove the personal access token from the locally initialized configuration file and also invalidate the token from the Nx Cloud application. You will be prompted to remove a single token or all tokens from your local environment.
+
+This command is the same as running `nx logout`.
 
 **Usage:**
 
 ```shell
-npx nx logout
+npx nx-cloud logout
 ```
 
 ### `nx-cloud configure`
@@ -348,17 +350,19 @@ npx nx-cloud onboard workspace create --org=org_123 --template=tmpl_react --name
 
 ### `nx-cloud start-ci-run`
 
-At the beginning of your main job, invoke `npx nx start-ci-run`. This tells Nx Cloud that the following series of command correspond to the same CI run.
+At the beginning of your main job, invoke `npx nx-cloud start-ci-run`. This tells Nx Cloud that the following series of command correspond to the same CI run.
+
+This command is the same as running `nx start-ci-run`.
 
 **Usage:**
 
 ```shell
-npx nx start-ci-run
+npx nx-cloud start-ci-run
 ```
 
 {% aside type="caution" title="Do not run start-ci-run locally" %}
-`npx nx start-ci-run` generates a temporary marker file that can cause a local Nx repo to behave as if it is a part of a CI run. This can cause strange behavior like Nx commands timing out or throwing unexpected errors.
-To discourage this from happening, this command will run a check to see if it is running in a CI environment. You can bypass this check with `npx nx start-ci-run --force`.
+`start-ci-run` generates a temporary marker file that can cause a local Nx repo to behave as if it is a part of a CI run. This can cause strange behavior like Nx commands timing out or throwing unexpected errors.
+To discourage this from happening, this command will run a check to see if it is running in a CI environment. You can bypass this check with `npx nx-cloud start-ci-run --force`.
 
 If you accidentally run this command locally, remove all generated marker files with `npx nx-cloud cleanup`.
 
@@ -383,14 +387,14 @@ If you accidentally run this command locally, remove all generated marker files 
 
 ##### `--distribute-on`
 
-By default, `npx nx start-ci-run` is intended for use with [Nx Agents](/docs/features/ci-features/distribute-task-execution) and expects `--distribute-on` to be configured. It will output a warning if this flag is not set. If you are running a distributed execution with a legacy setup without Nx Agents, you can pass `--distribute-on=manual` to disable this warning.
+By default, `start-ci-run` is intended for use with [Nx Agents](/docs/features/ci-features/distribute-task-execution) and expects `--distribute-on` to be configured. It will output a warning if this flag is not set. If you are running a distributed execution with a legacy setup without Nx Agents, you can pass `--distribute-on=manual` to disable this warning.
 
 This command tells Nx Cloud how many agents to use (and what launch templates to use) to distribute tasks. E.g.,
-`npx nx start-ci-run --distribute-on="8 linux-medium-js"` will distribute CI using 8 agents that are initialized
+`npx nx-cloud start-ci-run --distribute-on="8 linux-medium-js"` will distribute CI using 8 agents that are initialized
 using the `linux-medium-js` launch template.
 
 You can also [define the configuration in a file](/docs/features/ci-features/dynamic-agents) and reference it as follows:
-`npx nx start-ci-run --distribute-on=".nx/workflows/dynamic-changesets.yaml"`.
+`npx nx-cloud start-ci-run --distribute-on=".nx/workflows/dynamic-changesets.yaml"`.
 
 ```yaml
 // .nx/workflows/dynamic-changesets.yaml
@@ -403,7 +407,7 @@ distribute-on:
 ##### --stop-agents-after
 
 You can tell Nx Cloud to terminate agents after it sees a certain
-target or group of targets: `npx nx start-ci-run --stop-agents-after=build,test,e2e`.
+target or group of targets: `npx nx-cloud start-ci-run --stop-agents-after=build,test,e2e`.
 
 {% aside type="tip" title="Be specific!" %}
 For the best results, always tell Nx Cloud about all targets that should be expected during your pipeline. This will
@@ -420,7 +424,7 @@ include one or more targets from each command.
 #### Incorrect example:
 
 ```yaml
-- run: npx nx start-ci-run --stop-agents-after=build
+- run: npx nx-cloud start-ci-run --stop-agents-after=build
 - run: nx affected -t build
 - run: nx affected -t lint
 - run: nx affected -t test
@@ -433,7 +437,7 @@ executed.
 #### Corrected example:
 
 ```yaml
-- run: npx nx start-ci-run --stop-agents-after=lint,test,build
+- run: npx nx-cloud start-ci-run --stop-agents-after=lint,test,build
 - run: nx affected -t lint
 - run: nx affected -t test
 - run: nx affected -t build
@@ -445,7 +449,7 @@ executed.
 #### Incorrect example:
 
 ```yaml
-- run: npx nx start-ci-run --stop-agents-after=test
+- run: npx nx-cloud start-ci-run --stop-agents-after=test
 - run: nx affected -t build & nx affected -t lint & nx affected -t test
 ```
 
@@ -456,7 +460,7 @@ In this case, Nx Cloud will stop your pipeline, leaving work incomplete for both
 #### Corrected example:
 
 ```yaml
-- run: npx nx start-ci-run --stop-agents-after=lint,test,build
+- run: npx nx-cloud start-ci-run --stop-agents-after=lint,test,build
 - run: nx affected -t build & nx affected -t lint & nx affected -t test
 ```
 
@@ -469,7 +473,7 @@ In advanced pipeline setups, it is possible that you want to run multiple comman
 distinct configurations. An example of this may be doing static translations for different locales during your builds.
 
 ```yaml
-- run: npx nx start-ci-run --stop-agents-after=build
+- run: npx nx-cloud start-ci-run --stop-agents-after=build
 - run: nx affected -t build --configuration=locale-en
 - run: nx affected -t build --configuration=locale-es
 ```
@@ -481,14 +485,14 @@ Execution can be marked complete.
 To address this, you can pass an optional `configuration` to make your `target`s more specific.
 
 ```yaml
-- run: npx nx start-ci-run --stop-agents-after=build:locale-en,build:locale-es
+- run: npx nx-cloud start-ci-run --stop-agents-after=build:locale-en,build:locale-es
 - run: nx affected -t build --configuration=locale-en
 - run: nx affected -t build --configuration=locale-es
 ```
 
 ##### --with-env-vars (Nx Agents only)
 
-By default, invoking `npx nx start-ci-run` will take all environment variables prefixed with `NX_` and send them over to Nx Agents.
+By default, invoking `npx nx-cloud start-ci-run` will take all environment variables prefixed with `NX_` and send them over to Nx Agents.
 This means that your access token, verbose logging configuration and other Nx-related environment variables will be the same on your
 main CI jobs and the Nx Agent machines.
 
@@ -505,10 +509,10 @@ Examples:
 
 ```shell
 # Enable for lint and format tasks only
-npx nx start-ci-run --fix-tasks="*lint*,*format*" --no-distribution
+npx nx-cloud start-ci-run --fix-tasks="*lint*,*format*" --no-distribution
 
 # Enable for all tasks except deploy and test
-npx nx start-ci-run --fix-tasks="!*deploy*,!*test*" --no-distribution
+npx nx-cloud start-ci-run --fix-tasks="!*deploy*,!*test*" --no-distribution
 ```
 
 The patterns support:
@@ -525,15 +529,15 @@ Examples:
 
 ```shell
 # Auto-apply fixes for linting tasks only
-npx nx start-ci-run --auto-apply-fixes="*lint*" --no-distribution
+npx nx-cloud start-ci-run --auto-apply-fixes="*lint*" --no-distribution
 
 # Auto-apply fixes for both lint and format tasks
-npx nx start-ci-run --auto-apply-fixes="*lint*,*format*" --no-distribution
+npx nx-cloud start-ci-run --auto-apply-fixes="*lint*,*format*" --no-distribution
 ```
 
 #### Enabling/Disabling distribution
 
-Invoking `npx nx start-ci-run` will tell Nx to distribute by default. You can enable/disable distribution for
+Invoking `npx nx-cloud start-ci-run` will tell Nx to distribute by default. You can enable/disable distribution for
 individual commands as follows:
 
 {% tabs %}
@@ -569,14 +573,16 @@ nx affected -t build --no-dte
 {% /tabitem %}
 {% /tabs %}
 
-### `nx start-agent`
+### `nx-cloud start-agent`
 
 Starts an agent process for [manual distributed task execution](/docs/guides/nx-cloud/manual-dte). The agent waits for Nx Cloud to assign tasks that have been distributed by the main CI job via `start-ci-run`. For automatic agent management, use [Nx Agents](/docs/features/ci-features/distribute-task-execution) instead.
+
+This command is the same as running `nx start-agent`.
 
 **Usage:**
 
 ```shell
-npx nx start-agent
+npx nx-cloud start-agent
 ```
 
 #### Options
@@ -590,14 +596,14 @@ npx nx start-agent
 Use the `NX_AGENT_NAME` environment variable to assign a name to the agent for identification in logs and the Nx Cloud UI:
 
 ```shell
-NX_AGENT_NAME=agent-1 npx nx start-agent
+NX_AGENT_NAME=agent-1 npx nx-cloud start-agent
 ```
 
 For complete examples across different CI providers, see the [Manual Distributed Task Execution guide](/docs/guides/nx-cloud/manual-dte).
 
-### `nx stop-all-agents`
+### `nx-cloud stop-all-agents`
 
-Same as `npx nx complete-ci-run`.
+Same as `nx-cloud complete-ci-run`, `nx stop-all-agents` and `nx complete-ci-run`.
 
 This command tells Nx Cloud to terminate all agents associated with this CI pipeline execution.
 Invoking this command is not needed anymore. New versions of Nx Cloud can track when the main job terminates
@@ -606,17 +612,17 @@ and terminate associated agents automatically.
 **Usage:**
 
 ```shell
-npx nx stop-all-agents
+npx nx-cloud stop-all-agents
 ```
 
-### `nx complete-ci-run`
+### `nx-cloud complete-ci-run`
 
 Explicitly complete a CI run when using `--require-explicit-completion` with `start-ci-run`.
 
 **Usage:**
 
 ```shell
-npx nx complete-ci-run
+npx nx-cloud complete-ci-run
 ```
 
 ### `nx-cloud cleanup`


### PR DESCRIPTION
Conformance commands should remain as `nx-cloud conformance` not `nx conformance`.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
