### PR TITLE
fix(core): bump axios to 1.13.5 to resolve CVE-2026-25639

### DIFF
--- a/nx-dev/nx-dev/package.json
+++ b/nx-dev/nx-dev/package.json
@@ -38,7 +38,7 @@
     "@yarnpkg/lockfile": "1.1.0",
     "@yarnpkg/parsers": "3.0.2",
     "ai": "3.0.19",
-    "axios": "1.12.0",
+    "axios": "1.13.5",
     "classnames": "2.5.1",
     "cliui": "8.0.1",
     "enquirer": "2.3.6",

--- a/package.json
+++ b/package.json
@@ -372,7 +372,7 @@
     "@types/three": "^0.166.0",
     "@yarnpkg/lockfile": "^1.1.0",
     "@yarnpkg/parsers": "3.0.2",
-    "axios": "1.12.0",
+    "axios": "1.13.5",
     "classnames": "^2.5.1",
     "cliui": "^8.0.1",
     "clsx": "^2.0.0",

--- a/packages/create-nx-workspace/package.json
+++ b/packages/create-nx-workspace/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://nx.dev",
   "dependencies": {
-    "axios": "1.12.0",
+    "axios": "1.13.5",
     "chalk": "catalog:",
     "enquirer": "catalog:",
     "flat": "^5.0.2",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -55,7 +55,7 @@
     "@yarnpkg/lockfile": "^1.1.0",
     "@yarnpkg/parsers": "3.0.2",
     "@zkochan/js-yaml": "catalog:",
-    "axios": "1.12.0",
+    "axios": "1.13.5",
     "picocolors": "catalog:",
     "cli-cursor": "3.1.0",
     "cli-spinners": "2.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,8 +338,8 @@ importers:
         specifier: 3.0.2
         version: 3.0.2
       axios:
-        specifier: 1.12.0
-        version: 1.12.0
+        specifier: 1.13.5
+        version: 1.13.5
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -2229,8 +2229,8 @@ importers:
         specifier: 3.0.19
         version: 3.0.19(react@18.3.1)(solid-js@1.9.7)(svelte@5.35.5)(vue@3.5.30(typescript@5.9.2))(zod@4.3.6)
       axios:
-        specifier: 1.12.0
-        version: 1.12.0
+        specifier: 1.13.5
+        version: 1.13.5
       classnames:
         specifier: 2.5.1
         version: 2.5.1
@@ -2734,8 +2734,8 @@ importers:
   packages/create-nx-workspace:
     dependencies:
       axios:
-        specifier: 1.12.0
-        version: 1.12.0
+        specifier: 1.13.5
+        version: 1.13.5
       chalk:
         specifier: 'catalog:'
         version: 4.1.2
@@ -3481,8 +3481,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.7
       axios:
-        specifier: 1.12.0
-        version: 1.12.0
+        specifier: 1.13.5
+        version: 1.13.5
       cli-cursor:
         specifier: 3.1.0
         version: 3.1.0
@@ -14743,6 +14743,9 @@ packages:
   axios@1.12.0:
     resolution: {integrity: sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==}
 
+  axios@1.13.5:
+    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -17777,6 +17780,10 @@ packages:
 
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+    engines: {node: '>= 6'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -34478,7 +34485,7 @@ snapshots:
       '@module-federation/third-party-dts-extractor': 0.21.2
       adm-zip: 0.5.16
       ansi-colors: 4.1.3
-      axios: 1.12.0
+      axios: 1.13.5
       chalk: 3.0.0
       fs-extra: 9.1.0
       isomorphic-ws: 5.0.0(ws@8.18.0)
@@ -34503,7 +34510,7 @@ snapshots:
       '@module-federation/third-party-dts-extractor': 2.1.0
       adm-zip: 0.5.16
       ansi-colors: 4.1.3
-      axios: 1.12.0
+      axios: 1.13.5
       chalk: 3.0.0
       fs-extra: 9.1.0
       isomorphic-ws: 5.0.0(ws@8.18.0)
@@ -36546,8 +36553,8 @@ snapshots:
   '@nx/key@3.0.0':
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
-      axios: 1.12.0
-      axios-retry: 4.5.0(axios@1.12.0)
+      axios: 1.13.5
+      axios-retry: 4.5.0(axios@1.13.5)
       chalk: 4.1.2
       enquirer: 2.4.1
       ora: 5.4.1
@@ -36567,8 +36574,8 @@ snapshots:
   '@nx/key@4.0.0':
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
-      axios: 1.12.0
-      axios-retry: 4.5.0(axios@1.12.0)
+      axios: 1.13.5
+      axios-retry: 4.5.0(axios@1.13.5)
       chalk: 4.1.2
       enquirer: 2.4.1
       ora: 5.4.1
@@ -42397,15 +42404,23 @@ snapshots:
 
   axe-core@4.10.3: {}
 
-  axios-retry@4.5.0(axios@1.12.0):
+  axios-retry@4.5.0(axios@1.13.5):
     dependencies:
-      axios: 1.12.0
+      axios: 1.13.5
       is-retry-allowed: 2.2.0
 
   axios@1.12.0:
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.1)
       form-data: 4.0.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
+  axios@1.13.5:
+    dependencies:
+      follow-redirects: 1.15.11(debug@4.4.1)
+      form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -46472,6 +46487,14 @@ snapshots:
   form-data-encoder@2.1.4: {}
 
   form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8


### PR DESCRIPTION
## Current Behavior

The `nx`, `create-nx-workspace`, and `nx-dev` packages pin `axios` at version `1.12.0`, which has a known security vulnerability ([CVE-2026-25639](https://github.com/advisories/GHSA-43fc-jf86-j433)).

## Expected Behavior

Axios is pinned at `1.13.5`, which includes the fix for CVE-2026-25639, eliminating the security vulnerability.

## Related Issue(s)

Fixes #35145