### PR TITLE
docs(misc): add Node 22 and Node 24 agent images to launch templates reference

### DIFF
--- a/astro-docs/src/content/docs/guides/Nx Cloud/use-bun.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/use-bun.mdoc
@@ -140,7 +140,7 @@ common-init-steps: &common-init-steps
 launch-templates:
   linux-large:
     resource-class: 'docker_linux_amd64/large'
-    image: 'ubuntu22.04-node20.19-v2'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-init-steps
 ```
 

--- a/astro-docs/src/content/docs/reference/Nx Cloud/custom-images.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/custom-images.mdoc
@@ -20,7 +20,7 @@ It's recommended to extend our base image. If you cannot extend our image, manua
 
 ```yaml
 //nx-agent-base-image.dockerfile
-FROM us-east1-docker.pkg.dev/nxcloudoperations/nx-cloud-enterprise-public/nx-agents-base-images:ubuntu22.04-node20.19-v2 as base
+FROM us-east1-docker.pkg.dev/nxcloudoperations/nx-cloud-enterprise-public/nx-agents-base-images:ubuntu22.04-node24.14-v1 as base
 
 # Add any steps you need such as installing required software
 RUN sudo apt-get install....

--- a/astro-docs/src/content/docs/reference/Nx Cloud/custom-steps.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/custom-steps.mdoc
@@ -87,7 +87,7 @@ When specifying the location for the custom step, you must include a branch or t
 launch-templates:
   custom-template:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.11-v7'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       - name: Custom Step
         uses: 'your-org/your-repo/main/.nx/workflows/custom-steps.yaml'

--- a/astro-docs/src/content/docs/reference/Nx Cloud/launch-template-examples.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/launch-template-examples.mdoc
@@ -71,7 +71,7 @@ launch-templates:
   # You can define as many templates as you need, commonly used to make different sizes or toolchains depending on your workspace needs
   my-linux-medium-js:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.19-v3'
+    image: 'ubuntu22.04-node24.14-v1'
     # Define environment variables shared among all steps in this launch template
     env:
       MY_ENV_VAR: shared
@@ -84,7 +84,7 @@ launch-templates:
   # You're not required to define a template for every resource class, only define what you need!
   my-linux-large-js:
     resource-class: 'docker_linux_amd64/large'
-    image: 'ubuntu22.04-node20.19-v3'
+    image: 'ubuntu22.04-node24.14-v1'
     env:
       MY_ENV_VAR: shared
     # note we are using yaml anchors to reduce duplication with the above launch-template (they have the same init-steps)
@@ -93,7 +93,7 @@ launch-templates:
   # template that installs rust
   my-linux-rust-large:
     resource-class: 'docker_linux_amd64/large'
-    image: 'ubuntu22.04-node20.19-v3'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps: *common-rust-init-steps
 ```
 
@@ -153,7 +153,7 @@ If your project consumes packages from a private registry, you'll have to set up
 launch-templates:
   my-linux-medium-js:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.19-v3'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
@@ -189,7 +189,7 @@ You can use [mise](#install-tools-with-mise) to manage node versions alongside o
 launch-templates:
   node-21:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.19-v3'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
@@ -215,7 +215,7 @@ launch-templates:
     resource-class: 'docker_linux_amd64/medium'
     # note the image version of v9,
     # earlier versions of the base image will not work
-    image: 'ubuntu22.04-node20.19-v3'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
@@ -243,7 +243,7 @@ The steps follow the general pattern of:
 launch-templates:
   node-21:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.19-v3'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
@@ -296,7 +296,7 @@ For example, you can install the [GitHub CLI](https://cli.github.com/) on the ag
 launch-templates:
   my-linux-medium-js:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.19-v3'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       - name: Install Extras
         script: |
@@ -323,7 +323,7 @@ If your repo already has a `mise.toml` file, mise automatically installs the too
 launch-templates:
   my-linux-medium-js:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.19-v3'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
@@ -343,7 +343,7 @@ You can define tools inline using the `tools` input. Each line specifies a tool 
 launch-templates:
   my-linux-medium-js:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.19-v3'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       - name: Checkout
         uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
@@ -388,7 +388,7 @@ Using the pre-built step simplifies and provides debugging checks to make sure t
 launch-templates:
   my-linux-medium-js:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.19-v3'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       - name: Install AWS CLI
         uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-aws-cli/main.yaml'
@@ -407,7 +407,7 @@ It is helpful to run `aws sts get-caller-identity` command to make sure you're p
 launch-templates:
   my-linux-medium-js:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.19-v3'
+    image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       # step assumes you've passed all required AWS_* environment variables from the main agent via --with-env-vars
       - name: Install AWS CLI
@@ -465,7 +465,7 @@ Exercise caution when printing out environment variables, they will be shown in 
 launch-templates:
   my-linux-medium-js:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.19-v3'
+    image: 'ubuntu22.04-node24.14-v1'
     env:
       # enable verbose logging for all steps
       NX_VERBOSE_LOGGING: true
@@ -519,7 +519,7 @@ If your Nx workspace is in a subdirectory of your repository, set `NX_WORKING_DI
 launch-templates:
   my-template:
     resource-class: 'docker_linux_amd64/medium'
-    image: 'ubuntu22.04-node20.19-v3'
+    image: 'ubuntu22.04-node24.14-v1'
     env:
       NX_WORKING_DIRECTORY: './client'
     init-steps:

--- a/astro-docs/src/content/docs/reference/Nx Cloud/launch-templates.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/launch-templates.mdoc
@@ -99,6 +99,8 @@ Nx Cloud provides the following images:
 - `ubuntu22.04-node20.19-v1`: upgrade default node version to Node 20.19.1
 - `ubuntu22.04-node20.19-v2`: updated Playwright system dependencies
 - `ubuntu22.04-node20.19-v3`: upgraded Docker from 24.0.2 to 28.3.1
+- `ubuntu22.04-node22.22-v1`: upgrade default node version to Node 22.22
+- `ubuntu22.04-node24.14-v1`: upgrade default node version to Node 24.14
 
 **Windows:**
 

--- a/astro-docs/src/content/docs/reference/Nx Cloud/launch-templates.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/launch-templates.mdoc
@@ -99,8 +99,8 @@ Nx Cloud provides the following images:
 - `ubuntu22.04-node20.19-v1`: upgrade default node version to Node 20.19.1
 - `ubuntu22.04-node20.19-v2`: updated Playwright system dependencies
 - `ubuntu22.04-node20.19-v3`: upgraded Docker from 24.0.2 to 28.3.1
-- `ubuntu22.04-node22.22-v1`: upgrade default node version to Node 22.22
-- `ubuntu22.04-node24.14-v1`: upgrade default node version to Node 24.14
+- `ubuntu22.04-node22.22-v1`: upgrade default node version to Node 22.22.2
+- `ubuntu22.04-node24.14-v1`: upgrade default node version to Node 24.14.1
 
 **Windows:**
 

--- a/astro-docs/src/content/docs/reference/Nx Cloud/launch-templates.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/launch-templates.mdoc
@@ -76,7 +76,7 @@ A launch template's `image` defines the available base software for the agent ma
 // .nx/workflows/agents.yaml
 launch-templates:
   template-one:
-    image: 'ubuntu22.04-node20.19-v3'
+    image: 'ubuntu22.04-node24.14-v1'
 ```
 
 Nx Cloud provides the following images:


### PR DESCRIPTION
## Current Behavior

The launch templates reference page only lists Node 20-based agent images (`ubuntu22.04-node20.11-*` and `ubuntu22.04-node20.19-*`).

## Expected Behavior

The launch templates reference page also lists the new Node 22 and Node 24 agent images:

- `ubuntu22.04-node22.22-v1`
- `ubuntu22.04-node24.14-v1`

These images were added to the cloud infrastructure config map via [CLOUD-4403](https://linear.app/nxdev/issue/CLOUD-4403).

## Related Issue(s)

N/A (documentation update to reflect infrastructure changes from CLOUD-4403)