### PR TITLE
feat(misc): lock in CNW cloud prompt A/B winner and add new variants

### DIFF
--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.spec.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.spec.ts
@@ -118,8 +118,8 @@ describe('ab-testing', () => {
 
     it.each([
       { flowVariant: '0', expectedCode: 'connect-to-cloud' },
-      { flowVariant: '1', expectedCode: 'cloud-ab-remote-cache-speed' },
-      { flowVariant: '2', expectedCode: 'cloud-ab-fast-ci-setup' },
+      { flowVariant: '1', expectedCode: 'cloud-ab-never-rebuild' },
+      { flowVariant: '2', expectedCode: 'cloud-ab-ci-providers-speed' },
     ])(
       'should select $expectedCode for flow variant $flowVariant',
       ({ flowVariant, expectedCode }) => {

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -210,20 +210,6 @@ const messageOptions: Record<string, MessageData[]> = {
   setupNxCloudV2: [
     {
       code: 'connect-to-cloud',
-      message: 'Connect to Nx Cloud?',
-      initial: 0,
-      choices: [
-        { value: 'yes', name: 'Yes' },
-        { value: 'skip', name: 'Skip for now' },
-        { value: 'never', name: chalk.dim("No, don't ask again") },
-      ],
-      footer:
-        '\nAutomatically fix broken PRs, 70% faster CI: https://nx.dev/nx-cloud',
-      fallback: undefined,
-      completionMessage: 'platform-setup',
-    },
-    {
-      code: 'cloud-ab-remote-cache-speed',
       message: 'Enable remote caching to speed up builds with Nx Cloud?',
       initial: 0,
       choices: [
@@ -237,8 +223,8 @@ const messageOptions: Record<string, MessageData[]> = {
       completionMessage: 'platform-setup',
     },
     {
-      code: 'cloud-ab-fast-ci-setup',
-      message: 'Speed up your CI with Nx Cloud?',
+      code: 'cloud-ab-never-rebuild',
+      message: 'Never rebuild the same code twice \u2014 enable Nx Cloud?',
       initial: 0,
       choices: [
         { value: 'yes', name: 'Yes' },
@@ -246,7 +232,21 @@ const messageOptions: Record<string, MessageData[]> = {
         { value: 'never', name: chalk.dim("No, don't ask again") },
       ],
       footer:
-        '\n70% faster CI on GitHub, GitLab, and more. Free tier, 2-minute setup: https://nx.dev/nx-cloud',
+        '\nFree for small teams. Remote caching for local dev and CI. 2-minute setup: https://nx.dev/nx-cloud',
+      fallback: undefined,
+      completionMessage: 'platform-setup',
+    },
+    {
+      code: 'cloud-ab-ci-providers-speed',
+      message: 'Speed up GitHub Actions, GitLab CI, and more with Nx Cloud?',
+      initial: 0,
+      choices: [
+        { value: 'yes', name: 'Yes' },
+        { value: 'skip', name: 'Skip for now' },
+        { value: 'never', name: chalk.dim("No, don't ask again") },
+      ],
+      footer:
+        '\nFree remote caching and task distribution. 2-minute setup: https://nx.dev/nx-cloud',
       fallback: undefined,
       completionMessage: 'platform-setup',
     },


### PR DESCRIPTION
## Current Behavior

The CNW cloud prompt A/B test (NXC-4113, shipped in 22.6.3) has three variants with these results (~2,900 completions across 22.6.3+22.6.4):

| FV | Completions | Yes% | Never% |
| -- | -- | -- | -- |
| 0 ("Connect to Nx Cloud?") | 915 | 7.5% | 27.7% |
| 1 ("Enable remote caching...") | 1,040 | **12.2%** | 18.8% |
| 2 ("Speed up your CI...") | 974 | 10.0% | 19.5% |

FV 1 is the clear winner — 63% relative lift in "yes" over FV 0, nearly halving the "never" rate.

## Expected Behavior

Lock in FV 1 as the new baseline (FV 0) and introduce two new A/B variants:

| FV | Code | Prompt | Footer |
| -- | -- | -- | -- |
| 0 (new baseline) | `connect-to-cloud` | "Enable remote caching to speed up builds with Nx Cloud?" | "Free for small teams. 2-minute setup with GitHub — cache locally and in CI" |
| 1 | `cloud-ab-never-rebuild` | "Never rebuild the same code twice — enable Nx Cloud?" | "Free for small teams. Remote caching for local dev and CI. 2-minute setup" |
| 2 | `cloud-ab-ci-providers-speed` | "Speed up GitHub Actions, GitLab CI, and more with Nx Cloud?" | "Free remote caching and task distribution. 2-minute setup" |

Variant 0 (new baseline):
<img width="1392" height="1004" alt="variant_0_baseline" src="https://github.com/user-attachments/assets/8b05dc5d-64ae-42bb-98cb-942ef1856c96" />

Variant 1 (never rebuild same code twice - remote cache in footer):
<img width="1392" height="970" alt="variant_1" src="https://github.com/user-attachments/assets/eac6bdab-9c7d-41b7-a110-fa73ed188c67" />

Variant 2 (speed up CI and mention providers - remote caching in footer):
<img width="1392" height="1004" alt="variant_2" src="https://github.com/user-attachments/assets/c962a408-c4b5-4b68-8d79-5cc046841316" />

## Related Issue(s)

Fixes NXC-4190