### PR TITLE
feat(core): use CNW variant 1 cloud prompt in nx init

### DIFF
--- a/packages/nx/src/command-line/init/implementation/add-nx-to-monorepo.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-monorepo.ts
@@ -10,9 +10,11 @@ import {
   createNxJsonFile,
   initCloud,
   runInstall,
+  setNeverConnectToCloud,
   updateGitIgnore,
 } from './utils';
 import { connectExistingRepoToNxCloudPrompt } from '../../nx-cloud/connect/connect-to-nx-cloud';
+import { MessageOptionKey } from '../../../utils/ab-testing';
 
 type Options = Pick<InitArgs, 'nxCloud' | 'interactive' | 'cacheable'> & {
   legacy?: boolean;
@@ -32,7 +34,7 @@ export async function addNxToMonorepo(
   let targetDefaults: string[];
   let cacheableOperations: string[];
   let scriptOutputs = {} as { [script: string]: string };
-  let useNxCloud: boolean;
+  let nxCloudChoice: MessageOptionKey;
 
   if (options.interactive && scripts.length > 0 && guided) {
     output.log({
@@ -84,16 +86,23 @@ export async function addNxToMonorepo(
       )[scriptName];
     }
 
-    useNxCloud =
-      options.nxCloud ?? (await connectExistingRepoToNxCloudPrompt());
+    nxCloudChoice =
+      options.nxCloud === true
+        ? 'yes'
+        : options.nxCloud === false
+          ? 'skip'
+          : await connectExistingRepoToNxCloudPrompt();
   } else {
     targetDefaults = [];
     cacheableOperations = options.cacheable ?? [];
-    useNxCloud =
-      options.nxCloud ??
-      (options.interactive
-        ? await connectExistingRepoToNxCloudPrompt()
-        : false);
+    nxCloudChoice =
+      options.nxCloud === true
+        ? 'yes'
+        : options.nxCloud === false
+          ? 'skip'
+          : options.interactive
+            ? await connectExistingRepoToNxCloudPrompt()
+            : 'skip';
   }
 
   createNxJsonFile(
@@ -109,9 +118,11 @@ export async function addNxToMonorepo(
   output.log({ title: '📦 Installing dependencies' });
   runInstall(repoRoot);
 
-  if (useNxCloud) {
+  if (nxCloudChoice === 'yes') {
     output.log({ title: '🛠️ Setting up Nx Cloud' });
     await initCloud('nx-init-monorepo');
+  } else if (nxCloudChoice === 'never') {
+    setNeverConnectToCloud(repoRoot);
   }
 }
 

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-nest.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-nest.ts
@@ -18,10 +18,12 @@ import {
   initCloud,
   markRootPackageJsonAsNxProjectLegacy,
   runInstall,
+  setNeverConnectToCloud,
   updateGitIgnore,
 } from './utils';
 import { nxVersion } from '../../../utils/versions';
 import { connectExistingRepoToNxCloudPrompt } from '../../nx-cloud/connect/connect-to-nx-cloud';
+import { MessageOptionKey } from '../../../utils/ab-testing';
 
 type Options = Pick<InitArgs, 'nxCloud' | 'interactive' | 'cacheable'>;
 type NestCLIConfiguration = any;
@@ -66,7 +68,7 @@ export async function addNxToNest(options: Options, packageJson: PackageJson) {
 
   let cacheableOperations: string[];
   let scriptOutputs = {};
-  let useNxCloud: boolean;
+  let nxCloudChoice: MessageOptionKey;
 
   if (options.interactive && scripts.length > 0) {
     output.log({
@@ -101,15 +103,22 @@ export async function addNxToNest(options: Options, packageJson: PackageJson) {
       )[scriptName];
     }
 
-    useNxCloud =
-      options.nxCloud ?? (await connectExistingRepoToNxCloudPrompt());
+    nxCloudChoice =
+      options.nxCloud === true
+        ? 'yes'
+        : options.nxCloud === false
+          ? 'skip'
+          : await connectExistingRepoToNxCloudPrompt();
   } else {
     cacheableOperations = options.cacheable ?? [];
-    useNxCloud =
-      options.nxCloud ??
-      (options.interactive
-        ? await connectExistingRepoToNxCloudPrompt()
-        : false);
+    nxCloudChoice =
+      options.nxCloud === true
+        ? 'yes'
+        : options.nxCloud === false
+          ? 'skip'
+          : options.interactive
+            ? await connectExistingRepoToNxCloudPrompt()
+            : 'skip';
   }
 
   createNxJsonFile(
@@ -138,9 +147,11 @@ export async function addNxToNest(options: Options, packageJson: PackageJson) {
 
   runInstall(repoRoot);
 
-  if (useNxCloud) {
+  if (nxCloudChoice === 'yes') {
     output.log({ title: '🛠️ Setting up Nx Cloud' });
     await initCloud('nx-init-nest');
+  } else if (nxCloudChoice === 'never') {
+    setNeverConnectToCloud(repoRoot);
   }
 }
 

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-npm-repo.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-npm-repo.ts
@@ -11,9 +11,11 @@ import {
   markPackageJsonAsNxProject,
   markRootPackageJsonAsNxProjectLegacy,
   runInstall,
+  setNeverConnectToCloud,
   updateGitIgnore,
 } from './utils';
 import { connectExistingRepoToNxCloudPrompt } from '../../nx-cloud/connect/connect-to-nx-cloud';
+import { MessageOptionKey } from '../../../utils/ab-testing';
 
 type Options = Pick<InitArgs, 'nxCloud' | 'interactive' | 'cacheable'> & {
   legacy?: boolean;
@@ -26,7 +28,7 @@ export async function addNxToNpmRepo(options: Options, guided: boolean = true) {
 
   let cacheableOperations: string[];
   let scriptOutputs = {};
-  let useNxCloud: boolean;
+  let nxCloudChoice: MessageOptionKey;
 
   const packageJson = readJsonFile('package.json');
   const scripts = Object.keys(packageJson.scripts ?? {}).filter(
@@ -68,15 +70,22 @@ export async function addNxToNpmRepo(options: Options, guided: boolean = true) {
       )[scriptName];
     }
 
-    useNxCloud =
-      options.nxCloud ?? (await connectExistingRepoToNxCloudPrompt());
+    nxCloudChoice =
+      options.nxCloud === true
+        ? 'yes'
+        : options.nxCloud === false
+          ? 'skip'
+          : await connectExistingRepoToNxCloudPrompt();
   } else {
     cacheableOperations = options.cacheable ?? [];
-    useNxCloud =
-      options.nxCloud ??
-      (options.interactive
-        ? await connectExistingRepoToNxCloudPrompt()
-        : false);
+    nxCloudChoice =
+      options.nxCloud === true
+        ? 'yes'
+        : options.nxCloud === false
+          ? 'skip'
+          : options.interactive
+            ? await connectExistingRepoToNxCloudPrompt()
+            : 'skip';
   }
 
   createNxJsonFile(repoRoot, [], cacheableOperations, scriptOutputs);
@@ -95,8 +104,10 @@ export async function addNxToNpmRepo(options: Options, guided: boolean = true) {
 
   runInstall(repoRoot, pmc);
 
-  if (useNxCloud) {
+  if (nxCloudChoice === 'yes') {
     output.log({ title: '🛠️ Setting up Nx Cloud' });
     await initCloud('nx-init-npm-repo');
+  } else if (nxCloudChoice === 'never') {
+    setNeverConnectToCloud(repoRoot);
   }
 }

--- a/packages/nx/src/command-line/init/implementation/angular/index.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/index.ts
@@ -12,6 +12,7 @@ import {
   addDepsToPackageJson,
   initCloud,
   runInstall,
+  setNeverConnectToCloud,
   updateGitIgnore,
 } from '../utils';
 import { setupIntegratedWorkspace } from './integrated-workspace';
@@ -19,6 +20,7 @@ import { getLegacyMigrationFunctionIfApplicable } from './legacy-angular-version
 import { setupStandaloneWorkspace } from './standalone-workspace';
 import type { AngularJsonConfig, Options } from './types';
 import { connectExistingRepoToNxCloudPrompt } from '../../../nx-cloud/connect/connect-to-nx-cloud';
+import { MessageOptionKey } from '../../../../utils/ab-testing';
 
 const defaultCacheableOperations: string[] = [
   'build',
@@ -53,9 +55,14 @@ export async function addNxToAngularCliRepo(options: Options) {
   const cacheableOperations = !options.integrated
     ? await collectCacheableOperations(options)
     : [];
-  const useNxCloud =
-    options.nxCloud ??
-    (options.interactive ? await connectExistingRepoToNxCloudPrompt() : false);
+  const nxCloudChoice: MessageOptionKey =
+    options.nxCloud === true
+      ? 'yes'
+      : options.nxCloud === false
+        ? 'skip'
+        : options.interactive
+          ? await connectExistingRepoToNxCloudPrompt()
+          : 'skip';
 
   output.log({ title: '📦 Installing dependencies' });
   installDependencies();
@@ -63,9 +70,11 @@ export async function addNxToAngularCliRepo(options: Options) {
   output.log({ title: '📝 Setting up workspace' });
   await setupWorkspace(cacheableOperations, options.integrated);
 
-  if (useNxCloud) {
+  if (nxCloudChoice === 'yes') {
     output.log({ title: '🛠️ Setting up Nx Cloud' });
     await initCloud('nx-init-angular');
+  } else if (nxCloudChoice === 'never') {
+    setNeverConnectToCloud(repoRoot);
   }
 }
 

--- a/packages/nx/src/command-line/init/implementation/angular/legacy-angular-versions.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/legacy-angular-versions.ts
@@ -13,7 +13,8 @@ import {
   resolvePackageVersionUsingRegistry,
 } from '../../../../utils/package-manager';
 import { connectExistingRepoToNxCloudPrompt } from '../../../nx-cloud/connect/connect-to-nx-cloud';
-import { initCloud } from '../utils';
+import { initCloud, setNeverConnectToCloud } from '../utils';
+import { MessageOptionKey } from '../../../../utils/ab-testing';
 import type { Options } from './types';
 
 // map of Angular major versions to Nx versions to use for legacy `nx init` migrations,
@@ -107,11 +108,14 @@ export async function getLegacyMigrationFunctionIfApplicable(
 
   return async () => {
     output.log({ title: '🐳 Nx initialization' });
-    const useNxCloud =
-      options.nxCloud ??
-      (options.interactive
-        ? await connectExistingRepoToNxCloudPrompt()
-        : false);
+    const nxCloudChoice: MessageOptionKey =
+      options.nxCloud === true
+        ? 'yes'
+        : options.nxCloud === false
+          ? 'skip'
+          : options.interactive
+            ? await connectExistingRepoToNxCloudPrompt()
+            : 'skip';
 
     output.log({ title: '📦 Installing dependencies' });
     const pmc = getPackageManagerCommand();
@@ -132,9 +136,11 @@ export async function getLegacyMigrationFunctionIfApplicable(
       windowsHide: true,
     });
 
-    if (useNxCloud) {
+    if (nxCloudChoice === 'yes') {
       output.log({ title: '🛠️ Setting up Nx Cloud' });
       await initCloud('nx-init-angular');
+    } else if (nxCloudChoice === 'never') {
+      setNeverConnectToCloud(repoRoot);
     }
   };
 }

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -230,7 +230,7 @@ export function runInstall(
   pmc: PackageManagerCommands = getPackageManagerCommand()
 ) {
   execSync(pmc.install, {
-    stdio: [0, 1, 2],
+    stdio: ['ignore', 'ignore', 'inherit'],
     cwd: repoRoot,
     windowsHide: true,
   });
@@ -249,6 +249,13 @@ export async function initCloud(
     installationSource,
   });
   await printSuccessMessage(token, installationSource);
+}
+
+export function setNeverConnectToCloud(repoRoot: string): void {
+  const nxJsonPath = join(repoRoot, 'nx.json');
+  const nxJson = readJsonFile(nxJsonPath);
+  nxJson.neverConnectToCloud = true;
+  writeJsonFile(nxJsonPath, nxJson);
 }
 
 export function addVsCodeRecommendedExtensions(

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -25,6 +25,7 @@ import {
   initCloud,
   isMonorepo,
   printFinalMessage,
+  setNeverConnectToCloud,
   updateGitIgnore,
 } from './implementation/utils';
 import { ensurePackageHasProvenance } from '../../utils/provenance';
@@ -33,7 +34,7 @@ import { handleImport } from '../../utils/handle-import';
 import { isAiAgent } from '../../native';
 import { Agent } from '../../ai/utils';
 import { detectAiAgent } from '../../ai/detect-ai-agent';
-import { recordStat } from '../../utils/ab-testing';
+import { MessageOptionKey, recordStat } from '../../utils/ab-testing';
 import { isCI } from '../../utils/is-ci';
 import { detectPackageManager } from '../../utils/package-manager';
 import {
@@ -340,23 +341,29 @@ async function initHandlerImpl(options: InitArgs): Promise<void> {
     }
   }
 
-  let useNxCloud: any = options.nxCloud;
-  if (useNxCloud === undefined) {
-    output.log({ title: '🛠️ Setting up Self-Healing CI and Remote Caching' });
-    useNxCloud = options.interactive
+  let nxCloudChoice: MessageOptionKey;
+  if (options.nxCloud === true) {
+    nxCloudChoice = 'yes';
+  } else if (options.nxCloud === false) {
+    nxCloudChoice = 'skip';
+  } else {
+    nxCloudChoice = options.interactive
       ? await connectExistingRepoToNxCloudPrompt()
-      : false;
+      : 'skip';
   }
-  if (useNxCloud) {
+  if (nxCloudChoice === 'yes') {
     await initCloud('nx-init');
+  } else if (nxCloudChoice === 'never') {
+    setNeverConnectToCloud(repoRoot);
   }
 
   await recordStat({
     command: 'init',
     nxVersion: version,
-    useCloud: !!useNxCloud,
+    useCloud: nxCloudChoice === 'yes',
     meta: {
       type: 'complete',
+      nxCloudArg: nxCloudChoice,
       nodeVersion: process.versions.node,
       os: process.platform,
       packageManager: detectPackageManager(),

--- a/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
@@ -1,3 +1,4 @@
+import { join } from 'path';
 import { handleImport } from '../../../utils/handle-import';
 import { output } from '../../../utils/output';
 import { readNxJson } from '../../../config/configuration';
@@ -8,6 +9,7 @@ import {
 } from '../../../nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud';
 import { createNxCloudOnboardingURL } from '../../../nx-cloud/utilities/url-shorten';
 import { isNxCloudUsed } from '../../../utils/nx-cloud-utils';
+import { writeJsonFile } from '../../../utils/fileutils';
 import { runNxSync } from '../../../utils/child-process';
 import { NxJsonConfiguration } from '../../../config/nx-json';
 import { NxArgs } from '../../../utils/command-line-utils';
@@ -167,17 +169,16 @@ function sleep(ms: number) {
 export async function connectExistingRepoToNxCloudPrompt(
   command = 'init',
   key: MessageKey = 'setupNxCloud'
-): Promise<boolean> {
-  const res = await nxCloudPrompt(key).then(
-    (value: MessageOptionKey) => value === 'yes'
-  );
+): Promise<MessageOptionKey> {
+  const res = await nxCloudPrompt(key);
   await recordStat({
     command,
     nxVersion,
-    useCloud: res,
+    useCloud: res === 'yes',
     meta: {
       type: 'complete',
       setupCloudPrompt: messages.codeOfSelectedPromptMessage(key) || '',
+      nxCloudArg: res,
       nodeVersion: process.versions.node,
       os: process.platform,
       packageManager: detectPackageManager(),
@@ -190,10 +191,17 @@ export async function connectExistingRepoToNxCloudPrompt(
 
 export async function connectToNxCloudWithPrompt(command: string) {
   const setNxCloud = await nxCloudPrompt('setupNxCloud');
-  const useCloud =
-    setNxCloud === 'yes'
-      ? await connectToNxCloudCommand({ generateToken: false }, command)
-      : false;
+  let useCloud = false;
+  if (setNxCloud === 'yes') {
+    useCloud = await connectToNxCloudCommand({ generateToken: false }, command);
+  } else if (setNxCloud === 'never') {
+    const nxJsonPath = join(workspaceRoot, 'nx.json');
+    const nxJson = readNxJson();
+    if (nxJson) {
+      nxJson.neverConnectToCloud = true;
+      writeJsonFile(nxJsonPath, nxJson);
+    }
+  }
   await recordStat({
     command,
     nxVersion,
@@ -202,6 +210,7 @@ export async function connectToNxCloudWithPrompt(command: string) {
       type: 'complete',
       setupCloudPrompt:
         messages.codeOfSelectedPromptMessage('setupNxCloud') || '',
+      nxCloudArg: setNxCloud,
       nodeVersion: process.versions.node,
       os: process.platform,
       packageManager: detectPackageManager(),

--- a/packages/nx/src/command-line/nx-cloud/connect/view-logs.ts
+++ b/packages/nx/src/command-line/nx-cloud/connect/view-logs.ts
@@ -25,7 +25,7 @@ export async function viewLogs(): Promise<number> {
     'view-logs',
     'setupViewLogs'
   );
-  if (!setupNxCloud) {
+  if (setupNxCloud !== 'yes') {
     return;
   }
 

--- a/packages/nx/src/utils/ab-testing.ts
+++ b/packages/nx/src/utils/ab-testing.ts
@@ -2,6 +2,7 @@ import { execSync } from 'node:child_process';
 import { isCI } from './is-ci';
 import { getPackageManagerCommand } from './package-manager';
 import { getCloudUrl } from '../nx-cloud/utilities/get-cloud-options';
+import * as pc from 'picocolors';
 
 /**
  * Meta payload types for recordStat telemetry (matches CNW format).
@@ -28,20 +29,30 @@ export type RecordStatMeta =
   | RecordStatMetaComplete
   | RecordStatMetaError;
 
-export type MessageOptionKey = 'yes' | 'skip';
+export type MessageOptionKey = 'yes' | 'skip' | 'never';
 
-const messageOptions = {
+interface MessageData {
+  code: string;
+  message: string;
+  initial: number;
+  choices: Array<{ value: string; name: string; hint?: string }>;
+  footer: string;
+  hint?: string;
+}
+
+const messageOptions: Record<string, MessageData[]> = {
   setupNxCloud: [
     {
-      code: 'enable-ci',
-      message: `Would you like to enable AI-powered Self-Healing CI and Remote Caching?`,
+      code: 'cloud-ab-remote-cache-speed',
+      message: 'Enable remote caching to speed up builds with Nx Cloud?',
       initial: 0,
       choices: [
         { value: 'yes', name: 'Yes' },
         { value: 'skip', name: 'Skip for now' },
+        { value: 'never', name: pc.dim("No, don't ask again") },
       ],
-      footer: '\nLearn about it at https://nx.dev/nx-cloud',
-      hint: `\n(it's free and can be disabled any time)`,
+      footer:
+        '\nFree for small teams. 2-minute setup with GitHub — cache locally and in CI: https://nx.dev/nx-cloud',
     },
   ],
   setupViewLogs: [
@@ -61,10 +72,9 @@ const messageOptions = {
       hint: `\n(it's free and can be disabled any time)`,
     },
   ],
-} as const;
+};
 
 export type MessageKey = keyof typeof messageOptions;
-export type MessageData = (typeof messageOptions)[MessageKey][number];
 
 export class PromptMessages {
   private selectedMessages = {};


### PR DESCRIPTION
## Current Behavior

`nx init` uses a different cloud prompt (`code: "enable-ci"`, message: "Would you like to enable AI-powered Self-Healing CI and Remote Caching?") with only Yes/Skip choices. There is no way to permanently opt out of the prompt, and package manager install output is printed during init.

## Expected Behavior

`nx init` now uses CNW's variant 1 prompt copy:
- **Prompt:** "Enable remote caching to speed up builds with Nx Cloud?"
- **Footer:** "Free for small teams. 2-minute setup with GitHub — cache locally and in CI"
- **Choices:** Yes / Skip for now / No, don't ask again

Behavior per choice:
| Choice | Action |
|--------|--------|
| **Yes** | Connect to Nx Cloud (set `nxCloudId`) |
| **Skip for now** | Do nothing |
| **No, don't ask again** | Set `neverConnectToCloud: true` in nx.json |

Additional changes:
- Telemetry now tracks the raw choice via `nxCloudArg` field (yes/skip/never)
- `nx migrate` cloud prompt also supports the "never" choice
- Install stdout suppressed during init (stderr preserved for errors)
<img width="1392" height="978" alt="init" src="https://github.com/user-attachments/assets/fdacc72b-64ed-4e87-b4c3-01a467051e24" />

## Related Issue(s)

Fixes NXC-4189