### PR TITLE
fix(gradle): infer input extensions on project graph generation

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -150,8 +150,8 @@ fun getGradleFilesInputs(workspaceRoot: String): List<String> {
 /**
  * Infer file extensions consumed by a task from its dependents' outputs using task type checks.
  *
- * Test tasks consume .class + .jar (compiled code and library jars on the test classpath).
- * Compile tasks consume .class from upstream compile tasks (e.g. compileTestKotlin → compileKotlin).
+ * Test tasks consume .class + .jar (compiled code and library jars on the test classpath). Compile
+ * tasks consume .class from upstream compile tasks (e.g. compileTestKotlin → compileKotlin).
  * Archive dependents declare their own extension (jar, war, etc).
  *
  * Works at configuration time without requiring files to exist on disk.

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -182,7 +182,7 @@ fun inferExtensionsFromInputProperties(task: Task, dependentTasks: Set<Task>): S
     }
   }
 
-  return extensions
+  return extensions.toSet()
 }
 
 /**
@@ -271,9 +271,7 @@ private fun getInputsForTaskImpl(
 
     // Supplement with extensions inferred from Gradle metadata (handles clean builds where
     // output directories exist but are empty, so file-based extension discovery misses them)
-    if (tasksToProcess.isNotEmpty()) {
-      dependentTaskOutputExtensions.addAll(inferExtensionsFromInputProperties(task, tasksToProcess))
-    }
+    dependentTaskOutputExtensions.addAll(inferExtensionsFromInputProperties(task, tasksToProcess))
 
     // Add consolidated dependentTasksOutputFiles entries using glob patterns by extension
     dependentTaskOutputExtensions.forEach { extension ->

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -15,6 +15,8 @@ import org.gradle.api.internal.provider.TransformBackedProvider
 import org.gradle.api.internal.tasks.DefaultTaskDependency
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
+import org.gradle.api.tasks.compile.AbstractCompile
+import org.gradle.api.tasks.testing.Test as GradleTest
 
 /**
  * Process a task and convert it into target Going to populate:
@@ -159,11 +161,12 @@ fun getGradleFilesInputs(workspaceRoot: String): List<String> {
 fun inferExtensionsFromInputProperties(task: Task, dependentTasks: Set<Task>): Set<String> {
   val extensions = mutableSetOf<String>()
 
-  if (task is org.gradle.api.tasks.testing.Test) {
-    extensions.add("class")
-    extensions.add("jar")
-  } else if (task is org.gradle.api.tasks.compile.AbstractCompile) {
-    extensions.add("class")
+  when (task) {
+    is GradleTest -> {
+      extensions.add("class")
+      extensions.add("jar")
+    }
+    is AbstractCompile -> extensions.add("class")
   }
 
   dependentTasks.forEach { depTask ->
@@ -174,7 +177,7 @@ fun inferExtensionsFromInputProperties(task: Task, dependentTasks: Set<Task>): S
         task.logger.debug("Could not read archiveExtension for ${depTask.path}: ${e.message}")
       }
     }
-    if (depTask is org.gradle.api.tasks.compile.AbstractCompile) {
+    if (depTask is AbstractCompile) {
       extensions.add("class")
     }
   }

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -14,6 +14,7 @@ import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.internal.provider.TransformBackedProvider
 import org.gradle.api.internal.tasks.DefaultTaskDependency
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
 
 /**
  * Process a task and convert it into target Going to populate:
@@ -147,6 +148,37 @@ fun getGradleFilesInputs(workspaceRoot: String): List<String> {
 }
 
 /**
+ * Infer file extensions produced/consumed by a task and its dependents using task type checks.
+ *
+ * Test and compile tasks consume .class + .jar from their dependencies.
+ * Compile dependents produce .class files. Archive dependents declare their extension (jar, war,
+ * etc).
+ *
+ * Works at configuration time without requiring files to exist on disk.
+ */
+fun inferExtensionsFromInputProperties(task: Task, dependentTasks: Set<Task>): Set<String> {
+  val extensions = mutableSetOf<String>()
+
+  if (task is org.gradle.api.tasks.testing.Test || task is org.gradle.api.tasks.compile.AbstractCompile) {
+    extensions.add("class")
+    extensions.add("jar")
+  }
+
+  dependentTasks.forEach { depTask ->
+    if (depTask is AbstractArchiveTask) {
+      try {
+        depTask.archiveExtension.get().takeIf { it.isNotEmpty() }?.let { extensions.add(it) }
+      } catch (_: Exception) {}
+    }
+    if (depTask is org.gradle.api.tasks.compile.AbstractCompile) {
+      extensions.add("class")
+    }
+  }
+
+  return extensions
+}
+
+/**
  * Parse task and get inputs for this task
  *
  * @param dependsOnTasks set of tasks this task depends on
@@ -228,6 +260,12 @@ private fun getInputsForTaskImpl(
           inputs.add(relativePath)
         }
       }
+    }
+
+    // Supplement with extensions inferred from Gradle metadata (handles clean builds where
+    // output directories exist but are empty, so file-based extension discovery misses them)
+    if (tasksToProcess.isNotEmpty()) {
+      dependentTaskOutputExtensions.addAll(inferExtensionsFromInputProperties(task, tasksToProcess))
     }
 
     // Add consolidated dependentTasksOutputFiles entries using glob patterns by extension

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -148,20 +148,22 @@ fun getGradleFilesInputs(workspaceRoot: String): List<String> {
 }
 
 /**
- * Infer file extensions produced/consumed by a task and its dependents using task type checks.
+ * Infer file extensions consumed by a task from its dependents' outputs using task type checks.
  *
- * Test and compile tasks consume .class + .jar from their dependencies.
- * Compile dependents produce .class files. Archive dependents declare their extension (jar, war,
- * etc).
+ * Test tasks consume .class + .jar (compiled code and library jars on the test classpath).
+ * Compile tasks consume .class from upstream compile tasks (e.g. compileTestKotlin → compileKotlin).
+ * Archive dependents declare their own extension (jar, war, etc).
  *
  * Works at configuration time without requiring files to exist on disk.
  */
 fun inferExtensionsFromInputProperties(task: Task, dependentTasks: Set<Task>): Set<String> {
   val extensions = mutableSetOf<String>()
 
-  if (task is org.gradle.api.tasks.testing.Test || task is org.gradle.api.tasks.compile.AbstractCompile) {
+  if (task is org.gradle.api.tasks.testing.Test) {
     extensions.add("class")
     extensions.add("jar")
+  } else if (task is org.gradle.api.tasks.compile.AbstractCompile) {
+    extensions.add("class")
   }
 
   dependentTasks.forEach { depTask ->

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -170,7 +170,9 @@ fun inferExtensionsFromInputProperties(task: Task, dependentTasks: Set<Task>): S
     if (depTask is AbstractArchiveTask) {
       try {
         depTask.archiveExtension.get().takeIf { it.isNotEmpty() }?.let { extensions.add(it) }
-      } catch (_: Exception) {}
+      } catch (e: Exception) {
+        task.logger.debug("Could not read archiveExtension for ${depTask.path}: ${e.message}")
+      }
     }
     if (depTask is org.gradle.api.tasks.compile.AbstractCompile) {
       extensions.add("class")

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -498,7 +498,7 @@ class ProcessTaskUtilsTest {
   inner class InferExtensionsFromInputPropertiesTests {
 
     @Test
-    fun `inferExtensionsFromInputProperties detects class extension from CompileClasspath`() {
+    fun `compile task infers class from itself and jar from archive dependents`() {
       val kotlinProject = ProjectBuilder.builder().withName("kotlinInferTest").build()
       kotlinProject.plugins.apply("org.jetbrains.kotlin.jvm")
 
@@ -507,13 +507,24 @@ class ProcessTaskUtilsTest {
 
       val extensions = inferExtensionsFromInputProperties(compileTestKotlin, dependsOnTasks)
 
-      assertTrue(
-          extensions.contains("class"),
-          "Expected 'class' extension from CompileClasspath, got $extensions")
+      assertTrue(extensions.contains("class"), "Expected 'class' extension, got $extensions")
     }
 
     @Test
-    fun `inferExtensionsFromInputProperties detects jar extension from archive tasks`() {
+    fun `compile task without archive dependents does not infer jar`() {
+      val project = ProjectBuilder.builder().withName("compileOnly").build()
+      project.plugins.apply("java")
+
+      val compileJava = project.tasks.getByName("compileJava")
+
+      val extensions = inferExtensionsFromInputProperties(compileJava, emptySet())
+
+      assertTrue(extensions.contains("class"), "Expected 'class' extension, got $extensions")
+      assertFalse(extensions.contains("jar"), "Compile task alone should not infer 'jar', got $extensions")
+    }
+
+    @Test
+    fun `archive dependent tasks infer their archive extension`() {
       val kotlinProject = ProjectBuilder.builder().withName("kotlinJarTest").build()
       kotlinProject.plugins.apply("org.jetbrains.kotlin.jvm")
 
@@ -529,41 +540,13 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
-    fun `inferExtensionsFromInputProperties returns empty for task with no classpath inputs`() {
+    fun `plain tasks infer no extensions`() {
       val project = ProjectBuilder.builder().build()
       val task = project.tasks.register("plainTask").get()
 
       val extensions = inferExtensionsFromInputProperties(task, emptySet())
 
       assertTrue(extensions.isEmpty(), "Expected empty extensions for plain task, got $extensions")
-    }
-  }
-
-  @Nested
-  inner class CleanBuildInputDetectionTests {
-
-    @Test
-    fun `getInputsForTask produces dependentTasksOutputFiles on clean build with kotlin plugin`() {
-      val kotlinProject = ProjectBuilder.builder().withName("cleanBuildTest").build()
-      kotlinProject.plugins.apply("org.jetbrains.kotlin.jvm")
-
-      val compileTestKotlin = kotlinProject.tasks.getByName("compileTestKotlin")
-      val workspaceRoot = kotlinProject.rootDir.path
-      val projectRoot = kotlinProject.projectDir.path
-
-      val dependsOnTasks = getDependsOnTask(compileTestKotlin)
-
-      // Verify inferExtensionsFromInputProperties works directly
-      val inferredExtensions = inferExtensionsFromInputProperties(compileTestKotlin, dependsOnTasks)
-      assertTrue(
-          inferredExtensions.contains("class"),
-          "inferExtensionsFromInputProperties should detect 'class', got $inferredExtensions")
-
-      // Verify that the extensions get added even when getInputsForTask encounters issues
-      // with task.inputs.files resolution in ProjectBuilder (it may throw on Kotlin plugin tasks).
-      // The key assertion is that inferExtensionsFromInputProperties works correctly above.
-      // In a real Gradle build, getInputsForTask will use the inferred extensions to populate
-      // dependentTasksOutputFiles entries.
     }
   }
 

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -498,7 +498,7 @@ class ProcessTaskUtilsTest {
   inner class InferExtensionsFromInputPropertiesTests {
 
     @Test
-    fun `compile task infers class from itself and jar from archive dependents`() {
+    fun `compile task infers class and jar with archive dependents`() {
       val kotlinProject = ProjectBuilder.builder().withName("kotlinInferTest").build()
       kotlinProject.plugins.apply("org.jetbrains.kotlin.jvm")
 
@@ -508,6 +508,7 @@ class ProcessTaskUtilsTest {
       val extensions = inferExtensionsFromInputProperties(compileTestKotlin, dependsOnTasks)
 
       assertTrue(extensions.contains("class"), "Expected 'class' extension, got $extensions")
+      assertTrue(extensions.contains("jar"), "Expected 'jar' extension from archive dependents, got $extensions")
     }
 
     @Test
@@ -538,6 +539,18 @@ class ProcessTaskUtilsTest {
       assertTrue(
           extensions.contains("jar"),
           "Expected 'jar' extension from archive task dependency, got $extensions")
+    }
+
+    @Test
+    fun `test task infers class and jar regardless of dependents`() {
+      val kotlinProject = ProjectBuilder.builder().withName("kotlinTestTask").build()
+      kotlinProject.plugins.apply("org.jetbrains.kotlin.jvm")
+
+      val testTask = kotlinProject.tasks.getByName("test")
+      val extensions = inferExtensionsFromInputProperties(testTask, emptySet())
+
+      assertTrue(extensions.contains("class"), "Expected 'class' extension for Test task, got $extensions")
+      assertTrue(extensions.contains("jar"), "Expected 'jar' extension for Test task, got $extensions")
     }
 
     @Test

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -520,7 +520,8 @@ class ProcessTaskUtilsTest {
       val extensions = inferExtensionsFromInputProperties(compileJava, emptySet())
 
       assertTrue(extensions.contains("class"), "Expected 'class' extension, got $extensions")
-      assertFalse(extensions.contains("jar"), "Compile task alone should not infer 'jar', got $extensions")
+      assertFalse(
+          extensions.contains("jar"), "Compile task alone should not infer 'jar', got $extensions")
     }
 
     @Test

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -508,7 +508,9 @@ class ProcessTaskUtilsTest {
       val extensions = inferExtensionsFromInputProperties(compileTestKotlin, dependsOnTasks)
 
       assertTrue(extensions.contains("class"), "Expected 'class' extension, got $extensions")
-      assertTrue(extensions.contains("jar"), "Expected 'jar' extension from archive dependents, got $extensions")
+      assertTrue(
+          extensions.contains("jar"),
+          "Expected 'jar' extension from archive dependents, got $extensions")
     }
 
     @Test
@@ -549,8 +551,10 @@ class ProcessTaskUtilsTest {
       val testTask = kotlinProject.tasks.getByName("test")
       val extensions = inferExtensionsFromInputProperties(testTask, emptySet())
 
-      assertTrue(extensions.contains("class"), "Expected 'class' extension for Test task, got $extensions")
-      assertTrue(extensions.contains("jar"), "Expected 'jar' extension for Test task, got $extensions")
+      assertTrue(
+          extensions.contains("class"), "Expected 'class' extension for Test task, got $extensions")
+      assertTrue(
+          extensions.contains("jar"), "Expected 'jar' extension for Test task, got $extensions")
     }
 
     @Test

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -495,6 +495,79 @@ class ProcessTaskUtilsTest {
   }
 
   @Nested
+  inner class InferExtensionsFromInputPropertiesTests {
+
+    @Test
+    fun `inferExtensionsFromInputProperties detects class extension from CompileClasspath`() {
+      val kotlinProject = ProjectBuilder.builder().withName("kotlinInferTest").build()
+      kotlinProject.plugins.apply("org.jetbrains.kotlin.jvm")
+
+      val compileTestKotlin = kotlinProject.tasks.getByName("compileTestKotlin")
+      val dependsOnTasks = getDependsOnTask(compileTestKotlin)
+
+      val extensions = inferExtensionsFromInputProperties(compileTestKotlin, dependsOnTasks)
+
+      assertTrue(
+          extensions.contains("class"),
+          "Expected 'class' extension from CompileClasspath, got $extensions")
+    }
+
+    @Test
+    fun `inferExtensionsFromInputProperties detects jar extension from archive tasks`() {
+      val kotlinProject = ProjectBuilder.builder().withName("kotlinJarTest").build()
+      kotlinProject.plugins.apply("org.jetbrains.kotlin.jvm")
+
+      val jarTask = kotlinProject.tasks.getByName("jar")
+      val dependentTasks = setOf(jarTask)
+
+      val extensions =
+          inferExtensionsFromInputProperties(kotlinProject.tasks.getByName("build"), dependentTasks)
+
+      assertTrue(
+          extensions.contains("jar"),
+          "Expected 'jar' extension from archive task dependency, got $extensions")
+    }
+
+    @Test
+    fun `inferExtensionsFromInputProperties returns empty for task with no classpath inputs`() {
+      val project = ProjectBuilder.builder().build()
+      val task = project.tasks.register("plainTask").get()
+
+      val extensions = inferExtensionsFromInputProperties(task, emptySet())
+
+      assertTrue(extensions.isEmpty(), "Expected empty extensions for plain task, got $extensions")
+    }
+  }
+
+  @Nested
+  inner class CleanBuildInputDetectionTests {
+
+    @Test
+    fun `getInputsForTask produces dependentTasksOutputFiles on clean build with kotlin plugin`() {
+      val kotlinProject = ProjectBuilder.builder().withName("cleanBuildTest").build()
+      kotlinProject.plugins.apply("org.jetbrains.kotlin.jvm")
+
+      val compileTestKotlin = kotlinProject.tasks.getByName("compileTestKotlin")
+      val workspaceRoot = kotlinProject.rootDir.path
+      val projectRoot = kotlinProject.projectDir.path
+
+      val dependsOnTasks = getDependsOnTask(compileTestKotlin)
+
+      // Verify inferExtensionsFromInputProperties works directly
+      val inferredExtensions = inferExtensionsFromInputProperties(compileTestKotlin, dependsOnTasks)
+      assertTrue(
+          inferredExtensions.contains("class"),
+          "inferExtensionsFromInputProperties should detect 'class', got $inferredExtensions")
+
+      // Verify that the extensions get added even when getInputsForTask encounters issues
+      // with task.inputs.files resolution in ProjectBuilder (it may throw on Kotlin plugin tasks).
+      // The key assertion is that inferExtensionsFromInputProperties works correctly above.
+      // In a real Gradle build, getInputsForTask will use the inferred extensions to populate
+      // dependentTasksOutputFiles entries.
+    }
+  }
+
+  @Nested
   inner class ProviderBasedDependenciesTests {
     @Test
     fun `compileTestKotlin from kotlin plugin has correct provider dependencies`() {


### PR DESCRIPTION
## Current Behavior

When output directories are empty (e.g. on a clean build), the plugin cannot discover file extensions from actual files on disk. This means `dependentTasksOutputFiles` glob patterns are missing for extensions like `.class` and `.jar`, leading to incomplete cache inputs.

## Expected Behavior

Add `inferExtensionsFromInputProperties` to supplement file-based extension discovery using task type checks:
- `Test` tasks → `class` + `jar` (they consume compiled code and library jars on the test classpath)
- `AbstractCompile` tasks → `class` only (they produce/consume compiled classes, not jars)
- `AbstractArchiveTask` dependents → their declared archive extension (jar, war, zip, etc.)

This works at configuration time without requiring files to exist on disk.

## Related Issue(s)

Closes Q-331