### PR TITLE
fix(node): fix node e2e tests for TS solution workspaces

### DIFF
--- a/e2e/node/src/node-ts-solution.test.ts
+++ b/e2e/node/src/node-ts-solution.test.ts
@@ -60,8 +60,7 @@ describe('Node Applications', () => {
     await killPorts(port);
   }, 300_000);
 
-  // TODO(jack): fix and re-enable
-  xit('should be able to generate an express application', async () => {
+  it('should be able to generate an express application', async () => {
     const nodeapp = uniq('nodeapp');
     const nodelib = uniq('nodelib');
     const port = getRandomPort();
@@ -181,8 +180,7 @@ describe('Node Applications', () => {
     }
   }, 300_000);
 
-  // TODO(jack): fix and re-enable
-  xit('should be able to import a lib into a nest application', async () => {
+  it('should be able to import a lib into a nest application', async () => {
     const nestApp = uniq('nestapp');
     const nestLib = uniq('nestlib');
 

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -25,6 +25,7 @@ import { fileExists } from 'nx/src/utils/fileutils';
 import { getRelativeDirectoryToProjectRoot } from '../../utils/get-main-file-dir';
 import { interpolate } from 'nx/src/tasks-runner/utils';
 import { detectModuleFormat } from './lib/detect-module-format';
+import { isUsingTsSolutionSetup } from '../../utils/typescript/ts-solution-setup';
 
 interface ActiveTask {
   id: string;
@@ -394,6 +395,12 @@ function calculateResolveMappings(
   context: ExecutorContext,
   options: NodeExecutorOptions
 ) {
+  // In TS solution workspaces, dependencies are resolved via workspace
+  // protocol and node_modules symlinks, so no custom mappings are needed.
+  if (isUsingTsSolutionSetup()) {
+    return {};
+  }
+
   const parsed = parseTargetString(options.buildTarget, context);
   const { dependencies } = calculateProjectBuildableDependencies(
     context.taskGraph,

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/compiler-loaders.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/compiler-loaders.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import { readTsConfig } from '@nx/js';
+import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
 import { NormalizedNxAppWebpackPluginOptions } from '../nx-app-webpack-plugin-options';
 
@@ -44,6 +45,11 @@ export function createLoaderFromCompiler(
           transpileOnly: !hasPlugin,
           // https://github.com/TypeStrong/ts-loader/pull/685
           experimentalWatchApi: true,
+          // In TS solution workspaces, non-buildable workspace libs are
+          // bundled by webpack but their source files live outside the
+          // app's rootDir, causing TS6059. Suppress this since type
+          // checking is handled by the separate typecheck target.
+          ...(isUsingTsSolutionSetup() && { ignoreDiagnostics: [6059] }),
           getCustomTransformers: (program) => ({
             before: compilerPluginHooks.beforeHooks.map((hook) =>
               hook(program)


### PR DESCRIPTION
## Current Behavior

Two issues cause `e2e-node` test failures in TS solution workspaces:

1. **NX_MAPPINGS glob pattern** (regression from #35041): The node executor's `calculateResolveMappings` uses `outputs[0]` from dependency targets as require path overrides. Since #35041 narrowed tsc build-base outputs to glob patterns, these glob strings are treated as literal file paths at runtime, causing `Cannot find module` errors when serving node/express apps that import workspace libraries.

2. **TS6059 rootDir error** (long-standing): When webpack builds a nest app that imports a non-buildable workspace lib, ts-loader processes the lib's source files which are outside the app's `rootDir`, causing TS6059 errors. This check is already handled by the separate `typecheck` target so safe to skip.

## Expected Behavior

1. In TS solution workspaces, dependencies are resolved natively via workspace protocol and node_modules symlinks. Skip `NX_MAPPINGS` overrides entirely.

2. Suppress TS6059 in ts-loader for TS solution workspaces since rootDir validation during webpack bundling is unnecessary. Only for TS solution setup, so legacy workspaces continue to do typechecks with webpack if they choose to.

## Related Issue(s)

Fixes failing `e2e-node` tests: `should be able to generate an express application` and `should be able to import a lib into a nest application` in `node-ts-solution.test.ts`.