### PR TITLE
chore(gradle): bump gradle project graph plugin version to 0.1.19

### DIFF
--- a/packages/gradle/migrations.json
+++ b/packages/gradle/migrations.json
@@ -119,6 +119,12 @@
       "cli": "nx",
       "description": "Change dev.nx.gradle.project-graph to version 0.1.18 in build file",
       "factory": "./src/migrations/22-7-0/change-plugin-version-0-1-18"
+    },
+    "change-plugin-version-0-1-19": {
+      "version": "22.7.0-beta.10",
+      "cli": "nx",
+      "description": "Change dev.nx.gradle.project-graph to version 0.1.19 in build file",
+      "factory": "./src/migrations/22-7-0/change-plugin-version-0-1-19"
     }
   },
   "packageJsonUpdates": {}

--- a/packages/gradle/project-graph/build.gradle.kts
+++ b/packages/gradle/project-graph/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 group = "dev.nx.gradle"
 
-version = "0.1.18"
+version = "0.1.19"
 
 repositories { mavenCentral() }
 

--- a/packages/gradle/src/migrations/22-7-0/change-plugin-version-0-1-19.md
+++ b/packages/gradle/src/migrations/22-7-0/change-plugin-version-0-1-19.md
@@ -1,0 +1,21 @@
+#### Change dev.nx.gradle.project-graph to version 0.1.19
+
+Change dev.nx.gradle.project-graph to version 0.1.19 in build file
+
+#### Sample Code Changes
+
+##### Before
+
+```text title="build.gradle"
+plugins {
+id "dev.nx.gradle.project-graph" version "0.1.18"
+}
+```
+
+##### After
+
+```text title="build.gradle"
+plugins {
+id "dev.nx.gradle.project-graph" version "0.1.19"
+}
+```

--- a/packages/gradle/src/migrations/22-7-0/change-plugin-version-0-1-19.ts
+++ b/packages/gradle/src/migrations/22-7-0/change-plugin-version-0-1-19.ts
@@ -1,0 +1,24 @@
+import { Tree, readNxJson } from '@nx/devkit';
+import { hasGradlePlugin } from '../../utils/has-gradle-plugin';
+import { addNxProjectGraphPlugin } from '../../generators/init/gradle-project-graph-plugin-utils';
+import { updateNxPluginVersionInCatalogsAst } from '../../utils/version-catalog-ast-utils';
+
+/* Change the plugin version to 0.1.19
+ */
+export default async function update(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  if (!nxJson) {
+    return;
+  }
+  if (!hasGradlePlugin(tree)) {
+    return;
+  }
+
+  const gradlePluginVersionToUpdate = '0.1.19';
+
+  // Update version in version catalogs using AST-based approach to preserve formatting
+  await updateNxPluginVersionInCatalogsAst(tree, gradlePluginVersionToUpdate);
+
+  // Then update in build.gradle(.kts) files
+  await addNxProjectGraphPlugin(tree, gradlePluginVersionToUpdate);
+}

--- a/packages/gradle/src/utils/versions.ts
+++ b/packages/gradle/src/utils/versions.ts
@@ -1,4 +1,4 @@
 export const nxVersion = require('../../package.json').version;
 
 export const gradleProjectGraphPluginName = 'dev.nx.gradle.project-graph';
-export const gradleProjectGraphVersion = '0.1.18';
+export const gradleProjectGraphVersion = '0.1.19';


### PR DESCRIPTION
## Current Behavior

The Gradle project graph plugin is at version 0.1.18.

## Expected Behavior

The Gradle project graph plugin is bumped to version 0.1.19, with the corresponding migration files created so that users upgrading Nx will automatically get the new plugin version.

## Related Issue(s)

N/A - routine version bump