### PR TITLE
fix(webpack): disable symlink resolution for ts-solution workspaces

### DIFF
--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -443,6 +443,12 @@ function applyNxDependentConfig(
       ) ?? {}),
     },
     mainFields: config.resolve?.mainFields ?? mainFields,
+    // In ts-solution setups, workspace libraries are linked via pnpm symlinks
+    // in node_modules. Webpack resolves symlinks to real paths by default,
+    // which causes loaders' exclude patterns (e.g. /node_modules/) to miss
+    // these resolved paths, leading to errors like ts-loader trying to
+    // recompile pre-built .js files from library dist directories.
+    symlinks: config.resolve?.symlinks ?? (isUsingTsSolution ? false : true),
   };
 
   config.externals = externals;


### PR DESCRIPTION
## Current Behavior

In pnpm ts-solution workspaces, webpack builds fail when an app imports a workspace library. The error is:

```
ERROR in ../../packages/nodelib/dist/index.js
[tsl] ERROR
    Root file specified for compilation
```

This happens because:
1. pnpm creates symlinks in `node_modules` pointing to workspace packages
2. Webpack resolves these symlinks to real paths by default (`resolve.symlinks: true`)
3. The resolved real path (e.g. `../../packages/nodelib/dist/index.js`) no longer matches the loader `exclude: /node_modules/` pattern
4. ts-loader attempts to recompile the library's pre-built `.js` files and fails

This causes the `e2e-node:e2e-ci--src/node-ts-solution.test.ts` CI test to fail on master.

## Expected Behavior

Webpack builds succeed when importing workspace libraries in ts-solution setups. The `resolve.symlinks` option is set to `false` for ts-solution workspaces, preserving the `node_modules/` paths so that loader exclude patterns work correctly.

## Related Issue(s)

Fixes failing `e2e-node:e2e-ci--src/node-ts-solution.test.ts` on master CI.