### PR TITLE
chore(repo): revert tsgo compiler for nx package

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -164,21 +164,7 @@
     { "plugin": "@nx/vite/plugin", "include": ["astro-docs/**"] },
     {
       "plugin": "@nx/js/typescript",
-      "include": ["packages/nx/**"],
-      "options": {
-        "typecheck": true,
-        "build": { "targetName": "build-base" },
-        "compiler": "tsgo"
-      }
-    },
-    {
-      "plugin": "@nx/js/typescript",
-      "exclude": [
-        "examples/angular-rspack/**/*",
-        "nx-dev/**/*",
-        "e2e/**/*",
-        "packages/nx/**"
-      ],
+      "exclude": ["examples/angular-rspack/**/*", "nx-dev/**/*", "e2e/**/*"],
       "options": { "typecheck": true, "build": { "targetName": "build-base" } }
     },
     {

--- a/package.json
+++ b/package.json
@@ -166,7 +166,6 @@
     "@typescript-eslint/rule-tester": "^8.40.0",
     "@typescript-eslint/type-utils": "^8.40.0",
     "@typescript-eslint/utils": "^8.40.0",
-    "@typescript/native-preview": "7.0.0-dev.20260327.2",
     "@vitejs/plugin-react": "^6.0.0",
     "@webcontainer/api": "1.5.1",
     "@xstate/immer": "0.3.1",

--- a/packages/nx/tsconfig.lib.json
+++ b/packages/nx/tsconfig.lib.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": null,
     "outDir": "dist",
     "rootDir": ".",
     "declarationDir": "dist",
@@ -12,8 +11,7 @@
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": false
+    "allowSyntheticDefaultImports": true
   },
   "exclude": [
     "node_modules",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -851,9 +851,6 @@ importers:
       '@typescript-eslint/utils':
         specifier: ^8.40.0
         version: 8.40.0(eslint@8.57.0)(typescript@5.9.2)
-      '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260327.2
-        version: 7.0.0-dev.20260327.2
       '@vitejs/plugin-react':
         specifier: ^6.0.0
         version: 6.0.1(vite@8.0.0(@types/node@20.19.19)(esbuild@0.25.0)(jiti@2.6.1)(less@4.5.1)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.8.0))
@@ -13553,45 +13550,6 @@ packages:
   '@typescript-eslint/visitor-keys@8.40.0':
     resolution: {integrity: sha512-8CZ47QwalyRjsypfwnbI3hKy5gJDPmrkLjkgMxhi0+DZZ2QNx2naS6/hWoVYUHU7LU2zleF68V9miaVZvhFfTA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260327.2':
-    resolution: {integrity: sha512-lEcUWwu2DLY0NjoB3x7Fivz63zd57D1fD6PD8ByQqa0/xO8+EC5GHr5YniJlHSpF05cn2sgl7SPS92qVs0Xhlw==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260327.2':
-    resolution: {integrity: sha512-IvUv0dCaVNKbA9Oq/GEEhtBPF9PP3E5MfW4pla4NpDsZh+6/nL5p0WXvlocV0fe1rT9fqmCQfk3oH+XrN1I8Qw==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260327.2':
-    resolution: {integrity: sha512-k98Q20XAC8bM9L915GFIfjo/ii/sYIaEzIDH3l6MwhiJMDPucARQpfbReUdXl8N3TsdCNwk8xay0pNIK0DOkvg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260327.2':
-    resolution: {integrity: sha512-7ATSft1YojnRp/VG70i97CxFe+umhTHYA/jJwQBPrjdopAFa5IvFDr4kNajjy1uypbz/x6pfvCnTdOd1/lM3FQ==}
-    cpu: [arm]
-    os: [linux]
-
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260327.2':
-    resolution: {integrity: sha512-XTe5M1sTwjlxHS1NaNci4vf2nR7bAEwPB70SbhbSTS9ka+75mTP7cv8jHbGhKXEPxDLURBPSyvionog4+5NXmA==}
-    cpu: [x64]
-    os: [linux]
-
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260327.2':
-    resolution: {integrity: sha512-1F86Pmf1QcHv0IENBJJ7nWWVSWjR1nn4jokuSbWiPkKGD57rkJWiHY7xtpt4ql8ZG4bIWxdHonLaepBfjIkaug==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260327.2':
-    resolution: {integrity: sha512-zMI8AIWRr98hOgTC5DCe3GD/MGHfusX/E/Dz64Xcf+re4EUVS/pXP5fAUb3dQr8ndi9mHbM0DEmNb4ctSxsxew==}
-    cpu: [x64]
-    os: [win32]
-
-  '@typescript/native-preview@7.0.0-dev.20260327.2':
-    resolution: {integrity: sha512-npU/LrswTK7gawemSkI2BufIgNgoOHA1OwwIC5EUh++oWLDuWZSvSAcH6mfn28NOt5A196zrHQd3SK7f5XCVAw==}
-    hasBin: true
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -40777,37 +40735,6 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.40.0
       eslint-visitor-keys: 4.2.1
-
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260327.2':
-    optional: true
-
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260327.2':
-    optional: true
-
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260327.2':
-    optional: true
-
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260327.2':
-    optional: true
-
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260327.2':
-    optional: true
-
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260327.2':
-    optional: true
-
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260327.2':
-    optional: true
-
-  '@typescript/native-preview@7.0.0-dev.20260327.2':
-    optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260327.2
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260327.2
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260327.2
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260327.2
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260327.2
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260327.2
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260327.2
 
   '@ungap/structured-clone@1.3.0': {}
 


### PR DESCRIPTION
## Current Behavior

The `packages/nx` project uses `tsgo` (Go-based TypeScript compiler) via a dedicated `@nx/js/typescript` plugin entry with `compiler: "tsgo"`. All other packages use `tsc`.

When a downstream package (e.g., `node:build-base`) runs `tsc --build` with project references to `nx`, `tsc` detects the `.tsbuildinfo` was produced by a different compiler version (`7.0.0-dev` vs `5.9.2`) and recompiles `nx` entirely. This cascades through the reference chain — every project referencing `nx` is then considered out of date, triggering rebuilds across devkit, js, workspace, eslint, jest, docker, and the originating project.

Verified locally with `tsc --build --verbose`:
```
Project '../nx/tsconfig.lib.json' is out of date because output for it
was generated with version '7.0.0-dev.20260327.2' that differs with
current version '5.9.2'
```

## Expected Behavior

All packages use `tsc`, eliminating the compiler version mismatch. `tsc --build` finds all referenced projects up to date and skips recompilation.

> **Note:** We'll switch all packages to `tsgo` once they're all migrated to `nodenext` and prepared for it, so we use a single compiler across the workspace at a time.