### PR TITLE
feat(core): allow generate command to skip project graph creation

### DIFF
--- a/packages/nx/src/command-line/generate/generate.ts
+++ b/packages/nx/src/command-line/generate/generate.ts
@@ -4,11 +4,13 @@ import { relative } from 'path';
 
 import { readNxJson } from '../../config/configuration';
 import { ProjectsConfigurations } from '../../config/workspace-json-project-json';
+import { ProjectGraph } from '../../config/project-graph';
 import { FileChange, flushChanges, FsTree } from '../../generators/tree';
 import {
   createProjectGraphAsync,
   readProjectsConfigurationFromProjectGraph,
 } from '../../project-graph/project-graph';
+import { retrieveProjectConfigurationsWithoutPluginInference } from '../../project-graph/utils/retrieve-workspace-files';
 import { logger, NX_PREFIX } from '../../utils/logger';
 import {
   combineOptionsForGenerator,
@@ -306,9 +308,22 @@ export function printGenHelp(
 export async function generate(args: { [k: string]: any }) {
   return handleErrors(args.verbose, async () => {
     const nxJsonConfiguration = readNxJson();
-    const projectGraph = await createProjectGraphAsync();
-    const projectsConfigurations =
-      readProjectsConfigurationFromProjectGraph(projectGraph);
+
+    let projectGraph: ProjectGraph | undefined;
+    let projectsConfigurations: ProjectsConfigurations;
+
+    if (args.skipProjectGraph) {
+      const projects =
+        await retrieveProjectConfigurationsWithoutPluginInference(
+          workspaceRoot
+        );
+      projectsConfigurations = { version: 2, projects };
+    } else {
+      projectGraph = await createProjectGraphAsync();
+      projectsConfigurations =
+        readProjectsConfigurationFromProjectGraph(projectGraph);
+    }
+
     const opts = await convertToGenerateOptions(
       args,
       'generate',
@@ -413,6 +428,11 @@ export async function generate(args: { [k: string]: any }) {
         logger.warn(`\nNOTE: The "dryRun" flag means no changes were made.`);
       }
     } else {
+      if (!projectGraph) {
+        throw new Error(
+          `Cannot run non-Nx generators with --skipProjectGraph. Remove the flag or use an Nx generator.`
+        );
+      }
       require('../../adapter/compat');
       return (
         await handleImport('../../adapter/ngcli-adapter.js', __dirname)


### PR DESCRIPTION
When `skipProjectGraph` is passed to the `generate()` function, use `retrieveProjectConfigurationsWithoutPluginInference` instead of `createProjectGraphAsync`. This loads only default plugins (js, package-json, project-json) and skips dependency edge computation, making generation faster while still supporting local plugins.

This is a private API — callers must import the `generate` function directly and pass `skipProjectGraph: true`.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
