### PR TITLE
fix(core): kill discrete tasks and use tree-kill for batch cleanup on SIGINT

### DIFF
--- a/e2e/nx/src/run.test.ts
+++ b/e2e/nx/src/run.test.ts
@@ -2,6 +2,7 @@ import {
   checkFilesExist,
   cleanupProject,
   fileExists,
+  getStrippedEnvironmentVariables,
   isWindows,
   newProject,
   readJson,
@@ -14,6 +15,7 @@ import {
   updateFile,
   updateJson,
 } from '@nx/e2e-utils';
+import { execSync } from 'child_process';
 import { PackageJson } from 'nx/src/utils/package-json';
 import * as path from 'path';
 
@@ -773,6 +775,301 @@ describe('Nx Running Tests', () => {
     });
   });
 
+  describe('SIGINT process cleanup', () => {
+    if (isWindows()) {
+      it('skipped on windows', () => {});
+    } else {
+      it('should kill executor-based (discrete) task processes on SIGINT', async () => {
+        const lib = uniq('sigint-lib');
+        runCLI(`generate @nx/js:lib libs/${lib}`);
+
+        const pidFile = path.join(tmpProjPath(), `libs/${lib}/build.pid`);
+        const scriptBody = writePidScript('build.pid');
+
+        updateFile(`libs/${lib}/slow-build.js`, scriptBody);
+
+        // nx:run-script executor goes through the discrete/forked process path
+        updateJson(`libs/${lib}/project.json`, (config) => {
+          config.targets = {
+            build: {
+              executor: 'nx:run-script',
+              options: { script: 'build' },
+            },
+          };
+          return config;
+        });
+
+        updateJson(`libs/${lib}/package.json`, (pkg) => {
+          pkg.scripts = { build: 'node slow-build.js' };
+          return pkg;
+        });
+
+        const pids = await runNxAndSigint(
+          ['build', lib, '--skip-nx-cache'],
+          pidFile
+        );
+
+        for (const pid of pids) {
+          expect(isProcessAlive(pid)).toBe(false);
+        }
+      }, 60_000);
+
+      it('should kill run-commands task processes on SIGINT', async () => {
+        const lib = uniq('sigint-rc');
+        runCLI(`generate @nx/js:lib libs/${lib}`);
+
+        const pidFile = path.join(tmpProjPath(), `libs/${lib}/build.pid`);
+
+        updateFile(`libs/${lib}/slow-build.js`, writePidScript('build.pid'));
+
+        updateJson(`libs/${lib}/project.json`, (config) => {
+          config.targets = {
+            build: {
+              command: 'node slow-build.js',
+              options: { cwd: `libs/${lib}` },
+            },
+          };
+          return config;
+        });
+
+        const pids = await runNxAndSigint(
+          ['build', lib, '--skip-nx-cache'],
+          pidFile
+        );
+
+        for (const pid of pids) {
+          expect(isProcessAlive(pid)).toBe(false);
+        }
+      }, 60_000);
+
+      it('should kill continuous task processes on SIGINT', async () => {
+        const lib = uniq('sigint-cont');
+        runCLI(`generate @nx/js:lib libs/${lib}`);
+
+        const pidFile = path.join(tmpProjPath(), `libs/${lib}/serve.pid`);
+
+        updateFile(`libs/${lib}/serve.js`, writePidScript('serve.pid'));
+
+        updateJson(`libs/${lib}/project.json`, (config) => {
+          config.targets = {
+            serve: {
+              command: 'node serve.js',
+              options: { cwd: `libs/${lib}` },
+              continuous: true,
+            },
+          };
+          return config;
+        });
+
+        const pids = await runNxAndSigint(
+          ['serve', lib, '--skip-nx-cache'],
+          pidFile
+        );
+
+        for (const pid of pids) {
+          expect(isProcessAlive(pid)).toBe(false);
+        }
+      }, 60_000);
+
+      it('should kill executor-based (discrete) task processes on SIGINT (TUI mode)', async () => {
+        const lib = uniq('sigint-tui');
+        runCLI(`generate @nx/js:lib libs/${lib}`);
+
+        const pidFile = path.join(tmpProjPath(), `libs/${lib}/build.pid`);
+
+        updateFile(`libs/${lib}/slow-build.js`, writePidScript('build.pid'));
+
+        updateJson(`libs/${lib}/project.json`, (config) => {
+          config.targets = {
+            build: {
+              executor: 'nx:run-script',
+              options: { script: 'build' },
+            },
+          };
+          return config;
+        });
+
+        updateJson(`libs/${lib}/package.json`, (pkg) => {
+          pkg.scripts = { build: 'node slow-build.js' };
+          return pkg;
+        });
+
+        const pids = await runNxAndSigint(
+          ['build', lib, '--skip-nx-cache'],
+          pidFile,
+          { useTui: true }
+        );
+
+        for (const pid of pids) {
+          expect(isProcessAlive(pid)).toBe(false);
+        }
+      }, 60_000);
+
+      it('should kill run-commands task processes on SIGINT (TUI mode)', async () => {
+        const lib = uniq('sigint-tui-rc');
+        runCLI(`generate @nx/js:lib libs/${lib}`);
+
+        const pidFile = path.join(tmpProjPath(), `libs/${lib}/build.pid`);
+
+        updateFile(`libs/${lib}/slow-build.js`, writePidScript('build.pid'));
+
+        updateJson(`libs/${lib}/project.json`, (config) => {
+          config.targets = {
+            build: {
+              command: 'node slow-build.js',
+              options: { cwd: `libs/${lib}` },
+            },
+          };
+          return config;
+        });
+
+        const pids = await runNxAndSigint(
+          ['build', lib, '--skip-nx-cache'],
+          pidFile,
+          { useTui: true }
+        );
+
+        for (const pid of pids) {
+          expect(isProcessAlive(pid)).toBe(false);
+        }
+      }, 60_000);
+
+      it('should kill continuous task processes on SIGINT (TUI mode)', async () => {
+        const lib = uniq('sigint-tui-cont');
+        runCLI(`generate @nx/js:lib libs/${lib}`);
+
+        const pidFile = path.join(tmpProjPath(), `libs/${lib}/serve.pid`);
+
+        updateFile(`libs/${lib}/serve.js`, writePidScript('serve.pid'));
+
+        updateJson(`libs/${lib}/project.json`, (config) => {
+          config.targets = {
+            serve: {
+              command: 'node serve.js',
+              options: { cwd: `libs/${lib}` },
+              continuous: true,
+            },
+          };
+          return config;
+        });
+
+        const pids = await runNxAndSigint(
+          ['serve', lib, '--skip-nx-cache'],
+          pidFile,
+          { useTui: true }
+        );
+
+        for (const pid of pids) {
+          expect(isProcessAlive(pid)).toBe(false);
+        }
+      }, 60_000);
+    }
+
+    /** Script that writes its PID to a file and keeps running. */
+    function writePidScript(filename: string): string {
+      return `
+        const fs = require('fs');
+        const path = require('path');
+        fs.writeFileSync(path.join(__dirname, '${filename}'), String(process.pid));
+        setInterval(() => {}, 1000);
+      `;
+    }
+
+    /**
+     * Runs nx inside a real pseudo-terminal, polls for a PID file,
+     * sends SIGINT (identical to Ctrl+C), and asserts nx exits
+     * promptly with all processes in the tree dead.
+     */
+    async function runNxAndSigint(
+      args: string[],
+      pidFile: string,
+      { useTui }: { useTui?: boolean } = {}
+    ): Promise<number[]> {
+      const { existsSync, readFileSync, unlinkSync } = require('fs');
+      const { RustPseudoTerminal } = require('nx/src/native');
+
+      try {
+        unlinkSync(pidFile);
+      } catch {}
+
+      const nxBin = path.join(tmpProjPath(), 'node_modules', '.bin', 'nx');
+      const command = `${nxBin} ${args.join(' ')}`;
+
+      const pty = new RustPseudoTerminal();
+      const childProcess = pty.runCommand(command, tmpProjPath(), {
+        ...getStrippedEnvironmentVariables(),
+        CI: 'true',
+        FORCE_COLOR: 'false',
+        NX_DAEMON: 'false',
+        NX_TUI: useTui ? 'true' : 'false',
+        ...(useTui ? { NX_TUI_SKIP_CAPABILITY_CHECK: 'true' } : {}),
+      });
+
+      const nxPid = childProcess.getPid();
+      console.log(`[sigint-test] started PID=${nxPid}, useTui=${!!useTui}`);
+
+      // Track exit immediately so we don't miss it
+      let exited = false;
+      let exitResolve: (clean: boolean) => void;
+      const exitPromise = new Promise<boolean>((r) => (exitResolve = r));
+      childProcess.onExit((msg) => {
+        console.log(`[sigint-test] onExit: ${msg}`);
+        exited = true;
+        exitResolve(true);
+      });
+
+      // Poll for PID file written by the task script
+      let taskPid: number | undefined;
+      const startTime = Date.now();
+      while (Date.now() - startTime < 30_000 && !exited) {
+        if (existsSync(pidFile)) {
+          taskPid = parseInt(readFileSync(pidFile, 'utf-8').trim(), 10);
+          if (taskPid && !isNaN(taskPid)) break;
+        }
+        await new Promise((r) => setTimeout(r, 200));
+      }
+
+      if (!taskPid) {
+        childProcess.kill('SIGKILL');
+        throw new Error(
+          exited
+            ? 'nx exited before task script wrote PID file'
+            : 'Timed out waiting for PID file from task'
+        );
+      }
+
+      expect(isProcessAlive(taskPid)).toBe(true);
+
+      // Capture entire process tree before sending SIGINT
+      const processTree = getProcessTree(nxPid);
+
+      console.log(
+        `[sigint-test] taskPid=${taskPid} alive=${isProcessAlive(taskPid)}, tree=${JSON.stringify(processTree)}`
+      );
+
+      // Send SIGINT — identical to Ctrl+C in a real terminal
+      console.log(`[sigint-test] sending SIGINT`);
+      childProcess.kill('SIGINT');
+
+      // Nx should exit promptly. Without the fix, cleanup hangs
+      // waiting for unkilled discrete tasks.
+      const exitTimeout = setTimeout(() => {
+        console.log(`[sigint-test] TIMEOUT — sending SIGKILL`);
+        childProcess.kill('SIGKILL');
+        exitResolve(false);
+      }, 10_000);
+      const exitedCleanly = await exitPromise;
+      clearTimeout(exitTimeout);
+
+      console.log(`[sigint-test] exitedCleanly=${exitedCleanly}`);
+      expect(exitedCleanly).toBe(true);
+
+      await new Promise((r) => setTimeout(r, 2000));
+
+      return processTree;
+    }
+  });
+
   describe('exec', () => {
     let pkg: string;
     let pkg2: string;
@@ -945,3 +1242,46 @@ describe('Nx Running Tests', () => {
     });
   });
 });
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get all descendant PIDs of a process (recursive).
+ * Uses `pgrep -P` on macOS/Linux.
+ */
+function getProcessTree(rootPid: number): number[] {
+  const pids: number[] = [rootPid];
+  try {
+    const children = execSync(`pgrep -P ${rootPid}`, { encoding: 'utf-8' })
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map(Number);
+    for (const child of children) {
+      pids.push(...getProcessTree(child));
+    }
+  } catch {
+    // No children or process already exited
+  }
+  return pids;
+}
+
+/**
+ * Kill an entire process tree by walking descendants.
+ * Used as a fallback when cleanup times out.
+ */
+function killProcessTree(pid: number) {
+  const pids = getProcessTree(pid);
+  for (const p of pids) {
+    try {
+      process.kill(p, 'SIGKILL');
+    } catch {}
+  }
+}

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
@@ -99,6 +99,14 @@ private fun processTestFiles(
     targetNameOverrides: Map<String, String>,
     targetNamePrefix: String
 ) {
+  val dependsOnTasks = getDependsOnTask(testTask)
+  val testTaskInputs =
+      getInputsForTask(
+          dependsOnTasks, testTask, projectRoot, workspaceRoot, null, gitIgnoreClassifier)
+  val testTaskOutputs = getOutputsForTask(testTask, projectRoot, workspaceRoot)
+  val testTaskDependsOn =
+      getDependsOnForTask(dependsOnTasks, testTask, null, targetNameOverrides, targetNamePrefix)
+
   testFiles
       .filter { isTestFile(it, workspaceRoot) }
       .forEach { testFile ->
@@ -111,11 +119,9 @@ private fun processTestFiles(
                   projectBuildPath,
                   testClassPackagePath,
                   testTask,
-                  projectRoot,
-                  workspaceRoot,
-                  gitIgnoreClassifier,
-                  targetNameOverrides,
-                  targetNamePrefix)
+                  testTaskInputs,
+                  testTaskOutputs,
+                  testTaskDependsOn)
           targetGroups[testCiTargetGroup]?.add(targetName)
 
           ciDependsOn.add(DependsOnEntry(target = targetName, params = DependsOnParams.FORWARD))
@@ -142,15 +148,10 @@ private fun buildTestCiTarget(
     projectBuildPath: String,
     testClassPackagePath: String,
     testTask: Task,
-    projectRoot: String,
-    workspaceRoot: String,
-    gitIgnoreClassifier: GitIgnoreClassifier,
-    targetNameOverrides: Map<String, String>,
-    targetNamePrefix: String
+    testTaskInputs: List<Any>?,
+    testTaskOutputs: List<String>?,
+    testTaskDependsOn: List<DependsOnEntry>?
 ): MutableMap<String, Any?> {
-  val taskInputs =
-      getInputsForTask(null, testTask, projectRoot, workspaceRoot, null, gitIgnoreClassifier)
-
   val target =
       mutableMapOf<String, Any?>(
           "executor" to "@nx/gradle:gradle",
@@ -162,18 +163,16 @@ private fun buildTestCiTarget(
               getMetadata(
                   "Runs Gradle test $testClassPackagePath in CI.", projectBuildPath, "test"),
           "cache" to true,
-          "inputs" to taskInputs)
+          "inputs" to testTaskInputs)
 
-  getOutputsForTask(testTask, projectRoot, workspaceRoot)
+  testTaskOutputs
       ?.takeIf { it.isNotEmpty() }
       ?.let {
         testTask.logger.info("${testTask.path}: found ${it.size} outputs entries")
         target["outputs"] = it
       }
 
-  getDependsOnForTask(null, testTask, null, targetNameOverrides, targetNamePrefix)
-      ?.takeIf { it.isNotEmpty() }
-      ?.let { target["dependsOn"] = it }
+  testTaskDependsOn?.takeIf { it.isNotEmpty() }?.let { target["dependsOn"] = it }
 
   return target
 }

--- a/packages/gradle/src/executors/gradle/gradle-batch.impl.ts
+++ b/packages/gradle/src/executors/gradle/gradle-batch.impl.ts
@@ -17,7 +17,7 @@ import {
   getCustomGradleExecutableDirectoryFromPlugin,
 } from '../../utils/exec-gradle';
 import { dirname, join } from 'path';
-import { execSync } from 'child_process';
+import { spawn } from 'child_process';
 import {
   getAllDependsOn,
   getExcludeTasks,
@@ -192,26 +192,43 @@ async function runTasksInBatch(
 ): Promise<BatchResults> {
   const gradlewBatchStart = performance.mark(`gradlew-batch:start`);
 
-  const debugOptions = ' ' + (process.env.NX_GRADLE_BATCH_DEBUG ?? '');
-  const command = `java${debugOptions} -jar ${batchRunnerPath} --tasks='${JSON.stringify(
-    gradlewTasksToRun
-  )}' --workspaceRoot=${root} --args='${args
-    .join(' ')
-    .replaceAll("'", '"')}' --excludeTasks='${Array.from(excludeTasks).join(
-    ','
-  )}' --excludeTestTasks='${Array.from(excludeTestTasks).join(',')}' ${
-    process.env.NX_VERBOSE_LOGGING === 'true' ? '' : '--quiet'
-  }`;
+  const debugOptions = (process.env.NX_GRADLE_BATCH_DEBUG ?? '').trim();
+  const spawnArgs = [
+    ...(debugOptions ? debugOptions.split(/\s+/) : []),
+    '-jar',
+    batchRunnerPath,
+    `--tasks=${JSON.stringify(gradlewTasksToRun)}`,
+    `--workspaceRoot=${root}`,
+    `--args=${args.join(' ').replaceAll("'", '"')}`,
+    `--excludeTasks=${Array.from(excludeTasks).join(',')}`,
+    `--excludeTestTasks=${Array.from(excludeTestTasks).join(',')}`,
+    ...(process.env.NX_VERBOSE_LOGGING === 'true' ? [] : ['--quiet']),
+  ];
+
   // Use 'inherit' for stderr so Gradle output (tee'd to System.err
   // by TeeOutputStream) flows to the terminal in real-time.
   // stdout is piped to capture the JSON batch results.
-  const batchResults = execSync(command, {
-    cwd: workspaceRoot,
-    windowsHide: true,
-    env: process.env,
-    stdio: ['pipe', 'pipe', 'inherit'],
-    maxBuffer: LARGE_BUFFER,
-  }).toString();
+  const batchResults = await new Promise<string>((resolve, reject) => {
+    const cp = spawn('java', spawnArgs, {
+      cwd: workspaceRoot,
+      windowsHide: true,
+      env: process.env,
+      stdio: ['pipe', 'pipe', 'inherit'],
+    });
+
+    const chunks: Buffer[] = [];
+    cp.stdout.on('data', (chunk) => chunks.push(chunk));
+
+    cp.on('error', reject);
+    cp.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`Gradle batch runner exited with code ${code}`));
+      } else {
+        resolve(Buffer.concat(chunks).toString());
+      }
+    });
+  });
+
   const gradlewBatchEnd = performance.mark(`gradlew-batch:end`);
   performance.measure(
     `gradlew-batch`,

--- a/packages/nx/src/native/pseudo_terminal/process_killer/unix.rs
+++ b/packages/nx/src/native/pseudo_terminal/process_killer/unix.rs
@@ -20,7 +20,7 @@ impl ProcessKiller {
     pub fn kill(&self, signal: Option<&str>) -> anyhow::Result<()> {
         let signal = signal.unwrap_or("SIGINT");
         debug!("Killing process {} with {}", &self.pid, signal);
-        let pid = Pid::from_raw(self.pid);
+        let pid = Pid::from_raw(-self.pid);
         match kill(
             pid,
             NixSignal::from(Signal::try_from(signal).map_err(|e| anyhow::anyhow!(e))?),

--- a/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/batch-process.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess, Serializable } from 'child_process';
+import treeKill from 'tree-kill';
 import type { TaskResult } from '../../config/misc-interfaces';
 import { signalToCode } from '../../utils/exit-codes';
 import {
@@ -126,8 +127,10 @@ export class BatchProcess {
   }
 
   kill(signal?: NodeJS.Signals): void {
-    if (this.childProcess.connected) {
-      this.childProcess.kill(signal);
+    if (this.childProcess?.pid) {
+      treeKill(this.childProcess.pid, signal, () => {
+        // Ignore errors - process may have already exited
+      });
     }
   }
 }

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -1417,6 +1417,15 @@ export class TaskOrchestrator {
           console.error(`Unable to terminate ${taskId}\nError:`, e);
         }
       }),
+      ...Array.from(this.runningDiscreteTasks).map(
+        async ([taskId, { runningTask }]) => {
+          try {
+            await runningTask.kill();
+          } catch (e) {
+            console.error(`Unable to terminate ${taskId}\nError:`, e);
+          }
+        }
+      ),
       ...Array.from(this.runningRunCommandsTasks).map(async ([taskId, t]) => {
         try {
           await t.kill();


### PR DESCRIPTION
## Current Behavior

When Nx receives SIGINT (Ctrl+C), `performCleanup()` in the task orchestrator kills continuous tasks and run-commands tasks, but **not discrete tasks** (executor-based builds like `@nx/js:tsc`, `nx:run-script`, etc.). In TUI mode, fork workers run in separate PTY process groups and don't receive SIGINT directly, so cleanup hangs waiting for tasks that are never terminated.

Additionally, `BatchProcess.kill()` only sends a signal to the immediate child process, leaving grandchild processes (e.g. Java JVM, Gradle daemon, Gradle workers) alive.

The Gradle batch executor also uses `execSync`, which blocks the Node event loop and prevents the worker from responding to signals.

## Expected Behavior

All task types — discrete, continuous, and run-commands — should be explicitly killed during SIGINT cleanup. Batch processes should use `tree-kill` to terminate the entire process tree. The Gradle batch executor should use async `spawn` instead of blocking `execSync`.

## Related Issue(s)

Closes NXC-4194