### PR TITLE
fix(linter): infer extended tsconfig files as task inputs

### DIFF
--- a/packages/eslint/src/plugins/plugin.spec.ts
+++ b/packages/eslint/src/plugins/plugin.spec.ts
@@ -935,6 +935,174 @@ describe('@nx/eslint/plugin', () => {
     });
   });
 
+  describe('tsconfig extends chain inputs', () => {
+    it('should not add tsconfig inputs when the project has no tsconfig.json', async () => {
+      createFiles({
+        '.eslintrc.json': `{}`,
+        'apps/my-app/project.json': `{}`,
+        'apps/my-app/index.ts': `console.log('hello world')`,
+      });
+      const result = await invokeCreateNodesOnMatchingFiles(context, {
+        targetName: 'lint',
+      });
+      const inputs = result.projects['apps/my-app'].targets.lint.inputs;
+      expect(inputs).not.toContainEqual(expect.stringMatching(/tsconfig/i));
+    });
+
+    it('should not add tsconfig inputs when tsconfig.json has no extends', async () => {
+      createFiles({
+        '.eslintrc.json': `{}`,
+        'apps/my-app/project.json': `{}`,
+        'apps/my-app/index.ts': `console.log('hello world')`,
+        'apps/my-app/tsconfig.json': `{}`,
+      });
+      const result = await invokeCreateNodesOnMatchingFiles(context, {
+        targetName: 'lint',
+      });
+      const inputs = result.projects['apps/my-app'].targets.lint.inputs;
+      expect(inputs).not.toContainEqual(expect.stringContaining('tsconfig'));
+    });
+
+    it('should not add tsconfig inputs when extends points inside the project root', async () => {
+      createFiles({
+        '.eslintrc.json': `{}`,
+        'apps/my-app/project.json': `{}`,
+        'apps/my-app/index.ts': `console.log('hello world')`,
+        'apps/my-app/tsconfig.json': JSON.stringify({
+          extends: './tsconfig.lib.json',
+        }),
+        'apps/my-app/tsconfig.lib.json': `{}`,
+      });
+      const result = await invokeCreateNodesOnMatchingFiles(context, {
+        targetName: 'lint',
+      });
+      const inputs = result.projects['apps/my-app'].targets.lint.inputs;
+      expect(inputs).not.toContainEqual(expect.stringContaining('tsconfig'));
+    });
+
+    it('should exclude the root tsconfig from inputs since it is handled by the native selective hasher', async () => {
+      createFiles({
+        '.eslintrc.json': `{}`,
+        'tsconfig.base.json': `{}`,
+        'apps/my-app/project.json': `{}`,
+        'apps/my-app/index.ts': `console.log('hello world')`,
+        'apps/my-app/tsconfig.json': JSON.stringify({
+          extends: '../../tsconfig.base.json',
+        }),
+      });
+      const result = await invokeCreateNodesOnMatchingFiles(context, {
+        targetName: 'lint',
+      });
+      const inputs = result.projects['apps/my-app'].targets.lint.inputs;
+      expect(inputs).not.toContain('{workspaceRoot}/tsconfig.base.json');
+    });
+
+    it('should add the tsconfig file to inputs when extends points outside the project root', async () => {
+      createFiles({
+        '.eslintrc.json': `{}`,
+        'tsconfig.shared.json': `{}`,
+        'apps/my-app/project.json': `{}`,
+        'apps/my-app/index.ts': `console.log('hello world')`,
+        'apps/my-app/tsconfig.json': JSON.stringify({
+          extends: '../../tsconfig.shared.json',
+        }),
+      });
+      const result = await invokeCreateNodesOnMatchingFiles(context, {
+        targetName: 'lint',
+      });
+      const inputs = result.projects['apps/my-app'].targets.lint.inputs;
+      expect(inputs).toContain('{workspaceRoot}/tsconfig.shared.json');
+    });
+
+    it('should add every file in a transitive extends chain that lives outside the project root except the root tsconfig', async () => {
+      createFiles({
+        '.eslintrc.json': `{}`,
+        'tsconfig.root.json': `{}`,
+        'tsconfig.base.json': JSON.stringify({
+          extends: './tsconfig.root.json',
+        }),
+        'apps/my-app/project.json': `{}`,
+        'apps/my-app/index.ts': `console.log('hello world')`,
+        'apps/my-app/tsconfig.json': JSON.stringify({
+          extends: '../../tsconfig.base.json',
+        }),
+      });
+      const result = await invokeCreateNodesOnMatchingFiles(context, {
+        targetName: 'lint',
+      });
+      const inputs = result.projects['apps/my-app'].targets.lint.inputs;
+      expect(inputs).not.toContain('{workspaceRoot}/tsconfig.base.json');
+      expect(inputs).toContain('{workspaceRoot}/tsconfig.root.json');
+    });
+
+    it('should add every file when extends is an array', async () => {
+      createFiles({
+        '.eslintrc.json': `{}`,
+        'tsconfig.a.json': `{}`,
+        'tsconfig.b.json': `{}`,
+        'apps/my-app/project.json': `{}`,
+        'apps/my-app/index.ts': `console.log('hello world')`,
+        'apps/my-app/tsconfig.json': JSON.stringify({
+          extends: ['../../tsconfig.a.json', '../../tsconfig.b.json'],
+        }),
+      });
+      const result = await invokeCreateNodesOnMatchingFiles(context, {
+        targetName: 'lint',
+      });
+      const inputs = result.projects['apps/my-app'].targets.lint.inputs;
+      expect(inputs).toContain('{workspaceRoot}/tsconfig.a.json');
+      expect(inputs).toContain('{workspaceRoot}/tsconfig.b.json');
+    });
+
+    it('should drop shareable tsconfig packages resolved from node_modules', async () => {
+      createFiles({
+        '.eslintrc.json': `{}`,
+        'node_modules/@some/preset/package.json': JSON.stringify({
+          name: '@some/preset',
+        }),
+        'node_modules/@some/preset/tsconfig.json': `{}`,
+        'apps/my-app/project.json': `{}`,
+        'apps/my-app/index.ts': `console.log('hello world')`,
+        'apps/my-app/tsconfig.json': JSON.stringify({
+          extends: '@some/preset/tsconfig.json',
+        }),
+      });
+      const result = await invokeCreateNodesOnMatchingFiles(context, {
+        targetName: 'lint',
+      });
+      const inputs = result.projects['apps/my-app'].targets.lint.inputs;
+      expect(inputs).not.toContainEqual(
+        expect.stringContaining('node_modules')
+      );
+      expect(inputs).not.toContainEqual(
+        expect.stringContaining('@some/preset')
+      );
+    });
+
+    it('should not crash on a self-referential extends cycle', async () => {
+      createFiles({
+        '.eslintrc.json': `{}`,
+        'tsconfig.a.json': JSON.stringify({
+          extends: './tsconfig.b.json',
+        }),
+        'tsconfig.b.json': JSON.stringify({
+          extends: './tsconfig.a.json',
+        }),
+        'apps/my-app/project.json': `{}`,
+        'apps/my-app/index.ts': `console.log('hello world')`,
+        'apps/my-app/tsconfig.json': JSON.stringify({
+          extends: '../../tsconfig.a.json',
+        }),
+      });
+      const result = await invokeCreateNodesOnMatchingFiles(context, {
+        targetName: 'lint',
+      });
+      const inputs = result.projects['apps/my-app'].targets.lint.inputs;
+      expect(inputs).toContain('{workspaceRoot}/tsconfig.a.json');
+      expect(inputs).toContain('{workspaceRoot}/tsconfig.b.json');
+    });
+  });
+
   function createFiles(fileSys: Record<string, string>) {
     tempFs.createFilesSync(fileSys);
     configFiles = getMatchingFiles(Object.keys(fileSys));

--- a/packages/eslint/src/plugins/plugin.ts
+++ b/packages/eslint/src/plugins/plugin.ts
@@ -10,9 +10,14 @@ import {
   writeJsonFile,
 } from '@nx/devkit';
 import { calculateHashesForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
-import { getLockFileName } from '@nx/js';
+import { getLockFileName, getRootTsConfigFileName } from '@nx/js';
+import {
+  walkTsconfigExtendsChain,
+  type RawTsconfigJsonCache,
+} from '@nx/js/src/internal';
 import type { ESLint as ESLintType } from 'eslint';
 import { existsSync } from 'node:fs';
+import { relative as nativeRelative, sep as nativeSep } from 'node:path';
 import { basename, dirname, join, normalize, sep } from 'node:path/posix';
 import { hashObject } from 'nx/src/hasher/file-hasher';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
@@ -72,6 +77,7 @@ const internalCreateNodesV2 = async (
   context: CreateNodesContextV2,
   projectRootsByEslintRoots: Map<string, string[]>,
   lintableFilesPerProjectRoot: Map<string, string[]>,
+  tsconfigChainsByProjectRoot: Map<string, string[]>,
   projectsCache: Record<string, CreateNodesResult['projects']>,
   hashByRoot: Map<string, string>,
   pmc: ReturnType<typeof getPackageManagerCommand>
@@ -128,7 +134,8 @@ const internalCreateNodesV2 = async (
         eslintVersion,
         options,
         context,
-        pmc
+        pmc,
+        tsconfigChainsByProjectRoot.get(projectRoot) ?? []
       );
 
       if (project) {
@@ -168,6 +175,10 @@ export const createNodes: CreateNodesV2<EslintPluginOptions> = [
       options,
       context
     );
+    const tsconfigChainsByProjectRoot = collectTsconfigChainsByProjectRoot(
+      projectRoots,
+      context.workspaceRoot
+    );
     const lockFilePattern = getLockFileName(
       detectPackageManager(context.workspaceRoot)
     );
@@ -179,7 +190,12 @@ export const createNodes: CreateNodesV2<EslintPluginOptions> = [
         const parentConfigs = eslintConfigFiles.filter((eslintConfig) =>
           isSubDir(root, dirname(eslintConfig))
         );
-        return [...parentConfigs, join(root, '.eslintignore'), lockFilePattern];
+        return [
+          ...parentConfigs,
+          join(root, '.eslintignore'),
+          lockFilePattern,
+          ...(tsconfigChainsByProjectRoot.get(root) ?? []),
+        ];
       })
     );
     const hashByRoot = new Map<string, string>(
@@ -209,6 +225,7 @@ export const createNodes: CreateNodesV2<EslintPluginOptions> = [
             context,
             projectRootsByEslintRoots,
             lintableFilesPerProjectRoot,
+            tsconfigChainsByProjectRoot,
             targetsCache,
             hashByRoot,
             pmc
@@ -276,6 +293,72 @@ function groupProjectRootsByEslintRoots(
   return projectRootsByEslintRoots;
 }
 
+/**
+ * For each project root that has a `tsconfig.json`, resolves its `extends`
+ * chain and returns the workspace-relative paths of every reachable file
+ * that lives OUTSIDE the project root. Files inside the project root are
+ * already covered by `default` (`{projectRoot}/**\/*`); files resolved
+ * inside `node_modules` are invalidated via the lockfile; files that
+ * escape the workspace cannot be expressed as `{workspaceRoot}/...`.
+ *
+ * Root projects (`.`) are skipped — everything reachable from a root
+ * project's tsconfig is inside the project root by definition.
+ */
+function collectTsconfigChainsByProjectRoot(
+  projectRoots: string[],
+  workspaceRoot: string
+): Map<string, string[]> {
+  const jsonCache: RawTsconfigJsonCache = new Map();
+  const result = new Map<string, string[]>();
+
+  // The root tsconfig (tsconfig.base.json or tsconfig.json) is already
+  // handled by the native selective hasher (TsConfiguration hash
+  // instruction) which only hashes the path aliases relevant to each
+  // project.  Adding it as an explicit file input would bypass that
+  // optimization and cause every project to be affected on any change.
+  const rootTsConfigName = getRootTsConfigFileName();
+
+  for (const projectRoot of projectRoots) {
+    if (projectRoot === '.') continue;
+    const tsconfigPath = join(projectRoot, 'tsconfig.json');
+    if (!existsSync(join(workspaceRoot, tsconfigPath))) continue;
+
+    const outside: string[] = [];
+    const projectPrefix = `${projectRoot}/`;
+    walkTsconfigExtendsChain(
+      join(workspaceRoot, tsconfigPath),
+      (absolutePath) => {
+        const wsRelative = nativeRelative(workspaceRoot, absolutePath)
+          .split(nativeSep)
+          .join('/');
+        if (wsRelative.startsWith('../') || wsRelative === '..') {
+          return 'continue'; // escapes workspace
+        }
+        if (
+          wsRelative.startsWith('node_modules/') ||
+          wsRelative.includes('/node_modules/')
+        ) {
+          return 'continue'; // external package, lockfile invalidates
+        }
+        if (
+          wsRelative === projectRoot ||
+          wsRelative.startsWith(projectPrefix)
+        ) {
+          return 'continue'; // inside project root, covered by `default`
+        }
+        if (wsRelative === rootTsConfigName) {
+          return 'continue'; // handled by native selective hasher
+        }
+        outside.push(wsRelative);
+        return 'continue';
+      },
+      { jsonCache }
+    );
+    result.set(projectRoot, outside);
+  }
+  return result;
+}
+
 async function collectLintableFilesByProjectRoot(
   projectRoots: string[],
   options: EslintPluginOptions,
@@ -326,7 +409,8 @@ function getProjectUsingESLintConfig(
   eslintVersion: string,
   options: EslintPluginOptions,
   context: CreateNodesContextV2,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  tsconfigChainOutsideProjectRoot: string[]
 ): CreateNodesResult['projects'][string] | null {
   const rootEslintConfig = [
     baseEsLintConfigFile,
@@ -364,7 +448,8 @@ function getProjectUsingESLintConfig(
       context.workspaceRoot,
       options,
       pmc,
-      standaloneSrcPath
+      standaloneSrcPath,
+      tsconfigChainOutsideProjectRoot
     ),
   };
 }
@@ -376,7 +461,8 @@ function buildEslintTargets(
   workspaceRoot: string,
   options: EslintPluginOptions,
   pmc: ReturnType<typeof getPackageManagerCommand>,
-  standaloneSrcPath?: string
+  standaloneSrcPath?: string,
+  tsconfigChainOutsideProjectRoot: string[] = []
 ) {
   const isRootProject = projectRoot === '.';
   const targets: Record<string, TargetConfiguration> = {};
@@ -397,6 +483,11 @@ function buildEslintTargets(
       ...(existsSync(join(workspaceRoot, projectRoot, '.eslintignore'))
         ? [join('{workspaceRoot}', projectRoot, '.eslintignore')]
         : []),
+      // Tsconfig files reached via `extends` that live outside the project
+      // root — declared so the cache invalidates on upstream changes.
+      ...tsconfigChainOutsideProjectRoot.map(
+        (file) => `{workspaceRoot}/${file}`
+      ),
       '{workspaceRoot}/tools/eslint-rules/**/*',
       { externalDependencies: ['eslint'] },
     ],

--- a/packages/js/src/internal.ts
+++ b/packages/js/src/internal.ts
@@ -1,4 +1,8 @@
 export { resolveModuleByImport } from './utils/typescript/ast-utils';
+export {
+  walkTsconfigExtendsChain,
+  type RawTsconfigJsonCache,
+} from './utils/typescript/raw-tsconfig';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export {
   registerTsProject,

--- a/packages/js/src/utils/typescript/raw-tsconfig.ts
+++ b/packages/js/src/utils/typescript/raw-tsconfig.ts
@@ -1,0 +1,107 @@
+import { readJsonFile } from '@nx/devkit';
+import { dirname } from 'node:path';
+
+/**
+ * Lightweight tsconfig extends walker that does NOT load the `typescript`
+ * package. For full TypeScript-aware parsing (compilerOptions resolution,
+ * file lists, project references, etc.) see the `@nx/js/typescript` plugin,
+ * which uses `ts.parseJsonConfigFileContent` and a persistent cache.
+ */
+
+/**
+ * Cache of raw parsed tsconfig JSON contents, keyed by absolute file path.
+ * `null` indicates a file that doesn't exist or failed to parse.
+ *
+ * Instantiate with `new Map()` and reuse across `walkTsconfigExtendsChain`
+ * calls within one `createNodes` invocation to dedupe file reads when many
+ * starting points share parent tsconfigs.
+ */
+export type RawTsconfigJsonCache = Map<string, unknown | null>;
+
+/**
+ * Walks the `extends` chain of a tsconfig, invoking `visit` for each unique
+ * reachable file (entry first, then recursively). Cycle-safe. Files that
+ * don't exist or fail to parse are silently skipped.
+ *
+ * When a tsconfig has multiple `extends` entries they are visited in
+ * REVERSE order, so visitors looking for the effective value of an
+ * inherited option see the highest-precedence entries first and can
+ * return `'stop'` to abort the traversal. Visitors that want to collect
+ * every reachable file should always return `'continue'`.
+ *
+ * @param entryAbsolutePath Absolute, canonical path of the tsconfig to
+ *   start from. Pass through `path.resolve()` if unsure.
+ * @param visit Invoked once per unique reachable tsconfig.
+ * @param options.jsonCache Optional shared cache of parsed tsconfig
+ *   contents. When omitted, the walker uses a fresh internal cache.
+ */
+export function walkTsconfigExtendsChain(
+  entryAbsolutePath: string,
+  visit: (absolutePath: string, rawJson: unknown) => 'continue' | 'stop',
+  options?: { jsonCache?: RawTsconfigJsonCache }
+): void {
+  const jsonCache: RawTsconfigJsonCache = options?.jsonCache ?? new Map();
+  walk(entryAbsolutePath, visit, jsonCache, new Set());
+}
+
+function walk(
+  absolutePath: string,
+  visit: (absolutePath: string, rawJson: unknown) => 'continue' | 'stop',
+  jsonCache: RawTsconfigJsonCache,
+  visited: Set<string>
+): 'continue' | 'stop' {
+  if (visited.has(absolutePath)) return 'continue';
+  visited.add(absolutePath);
+
+  const json = readCachedJson(absolutePath, jsonCache);
+  if (json === null) return 'continue';
+
+  if (visit(absolutePath, json) === 'stop') return 'stop';
+
+  const extendsField = (json as { extends?: unknown }).extends;
+  if (!extendsField) return 'continue';
+  const extendsList = Array.isArray(extendsField)
+    ? extendsField
+    : [extendsField];
+
+  // Last entry wins per TypeScript precedence; walk in reverse so
+  // precedence-aware visitors see the highest-precedence entries first.
+  const fromDir = dirname(absolutePath);
+  for (let i = extendsList.length - 1; i >= 0; i--) {
+    const ext = extendsList[i];
+    if (typeof ext !== 'string' || !ext) continue;
+    const childPath = resolveExtendsPath(ext, fromDir);
+    if (childPath === null) continue;
+    if (walk(childPath, visit, jsonCache, visited) === 'stop') return 'stop';
+  }
+
+  return 'continue';
+}
+
+function readCachedJson(
+  absolutePath: string,
+  cache: RawTsconfigJsonCache
+): unknown | null {
+  if (cache.has(absolutePath)) {
+    return cache.get(absolutePath) ?? null;
+  }
+  let parsed: unknown | null;
+  try {
+    parsed = readJsonFile(absolutePath);
+  } catch {
+    parsed = null;
+  }
+  cache.set(absolutePath, parsed);
+  return parsed;
+}
+
+function resolveExtendsPath(
+  extendsValue: string,
+  fromDir: string
+): string | null {
+  try {
+    return require.resolve(extendsValue, { paths: [fromDir] });
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Current Behavior

The `@nx/eslint` plugin does not infer extended tsconfig files as inputs for the inferred lint target. Projects whose `tsconfig.json` extends a file outside the project root (e.g. `../../tsconfig.base.json`) omit that upstream file from the lint task's inputs. Tools that walk the tsconfig chain during linting — the typescript-eslint parser in type-aware mode, `@nx/enforce-module-boundaries`, Angular template parsers, and similar — read these files, so sandboxing reports them as undeclared reads and changes to upstream tsconfigs don't invalidate the lint cache.

## Expected Behavior

The inferred lint target declares every tsconfig file reached via the `extends` chain of the project's `tsconfig.json` as an input, when those files live outside the project root. Files inside the project root are already covered by `default` (`{projectRoot}/**/*`); shareable configs resolved from `node_modules` are invalidated via the lockfile; paths that escape the workspace cannot be declared as `{workspaceRoot}/...` inputs.

A new lightweight `walkTsconfigExtendsChain` helper is introduced in `@nx/js/src/internal` so other plugins that need to inspect a tsconfig extends chain can reuse it. It reads tsconfigs as JSONC without loading the `typescript` package, walks `extends` arrays in reverse precedence (matching TypeScript semantics), and accepts a visitor that can short-circuit for precedence-aware lookups or walk exhaustively for input collection. The helper is cycle-safe and accepts a caller-supplied JSON cache to dedupe reads across overlapping chains.