### PR TITLE
fix(js): include npm overrides in generated lockfile

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/npm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/npm-parser.spec.ts
@@ -87,6 +87,52 @@ describe('NPM lock file utility', () => {
       expect(Object.keys(graph.externalNodes).length).toEqual(1285);
     });
 
+    it('should include overrides in stringified lock file', async () => {
+      const appPackageJson = {
+        name: 'test',
+        version: '0.0.0',
+        dependencies: {
+          next: rootLockFile.packages['node_modules/next'].version,
+        },
+        overrides: {
+          minimatch: '10.2.1',
+        },
+      };
+
+      const prunedGraph = pruneProjectGraph(graph, appPackageJson);
+      const result = stringifyNpmLockfile(
+        prunedGraph,
+        JSON.stringify(rootLockFile),
+        appPackageJson
+      );
+      const parsed = JSON.parse(result);
+
+      // overrides should be at the top level
+      expect(parsed.overrides).toEqual({ minimatch: '10.2.1' });
+      // overrides should also be in the root packages entry
+      expect(parsed.packages[''].overrides).toEqual({ minimatch: '10.2.1' });
+    });
+
+    it('should not include overrides when not present', async () => {
+      const appPackageJson = {
+        name: 'test',
+        version: '0.0.0',
+        dependencies: {
+          next: rootLockFile.packages['node_modules/next'].version,
+        },
+      };
+
+      const prunedGraph = pruneProjectGraph(graph, appPackageJson);
+      const result = stringifyNpmLockfile(
+        prunedGraph,
+        JSON.stringify(rootLockFile),
+        appPackageJson
+      );
+      const parsed = JSON.parse(result);
+
+      expect(parsed.overrides).toBeUndefined();
+    });
+
     it('should prune lock file', async () => {
       const appPackageJson = loadJsonFixture(
         joinPathFragments(

--- a/packages/nx/src/plugins/js/lock-file/npm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/npm-parser.ts
@@ -53,6 +53,7 @@ type NpmLockFile = {
   version?: string;
   lockfileVersion: number;
   requires?: boolean;
+  overrides?: NormalizedPackageJson['overrides'];
   packages?: Record<string, NpmDependencyV3>;
   dependencies?: Record<string, NpmDependencyV1>;
 };
@@ -302,7 +303,12 @@ function findTarget(
   sourcePath: string,
   keyMap: Map<string, ProjectGraphExternalNode>,
   targetName: string,
-  versionRange: string
+  versionRange: string,
+  // When a package is found at a path but its version doesn't satisfy the
+  // range (e.g. due to npm overrides), we keep it as a fallback. npm already
+  // resolved this dependency to that location, so it is the correct target
+  // even though the semver check fails.
+  fallback?: ProjectGraphExternalNode
 ): ProjectGraphExternalNode {
   if (sourcePath && !sourcePath.endsWith('/')) {
     sourcePath = `${sourcePath}/`;
@@ -329,16 +335,21 @@ function findTarget(
     ) {
       return child;
     }
+    // Version mismatch — save as fallback (could be an npm override)
+    if (!fallback) {
+      fallback = child;
+    }
   }
   // the hoisted package did not match, this dependency is missing
   if (!sourcePath) {
-    return;
+    return fallback;
   }
   return findTarget(
     sourcePath.split('node_modules/').slice(0, -1).join('node_modules/'),
     keyMap,
     targetName,
-    versionRange
+    versionRange,
+    fallback
   );
 }
 
@@ -417,6 +428,9 @@ export function stringifyNpmLockfile(
   };
   if (rootLockFile.requires) {
     output.requires = rootLockFile.requires;
+  }
+  if (packageJson.overrides && Object.keys(packageJson.overrides).length > 0) {
+    output.overrides = packageJson.overrides;
   }
   if (lockfileVersion > 1) {
     const packages = mapV3Snapshots(mappedPackages, packageJson);

--- a/packages/nx/src/plugins/js/lock-file/utils/package-json.ts
+++ b/packages/nx/src/plugins/js/lock-file/utils/package-json.ts
@@ -27,6 +27,8 @@ export type NormalizedPackageJson = Pick<
   | 'optionalDependencies'
   | 'packageManager'
   | 'resolutions'
+  | 'overrides'
+  | 'pnpm'
 >;
 
 /**
@@ -46,6 +48,8 @@ export function normalizePackageJson(
     optionalDependencies,
     packageManager,
     resolutions,
+    overrides,
+    pnpm,
   } = packageJson;
 
   return {
@@ -59,5 +63,7 @@ export function normalizePackageJson(
     optionalDependencies,
     packageManager,
     resolutions,
+    overrides,
+    pnpm,
   };
 }


### PR DESCRIPTION
## Current Behavior

When using `generateLockfile: true` (e.g. with `@nx/next:build`), the generated `package-lock.json` is missing overridden packages for two reasons:

1. `normalizePackageJson()` strips the `overrides` field, so the generated lockfile lacks overrides both at the top level and in `packages[""]`.

2. `findTarget()` uses semver satisfaction to match dependency edges, but npm overrides can force versions outside the declared range (e.g. `minimatch@^9.0.4` overridden to `10.2.1`). This causes overridden packages and their transitive deps to be dropped from the pruned graph entirely.

Running `npm ci` in the output directory fails:
```
npm error Missing: minimatch@10.2.1 from lock file
```

Note: yarn (`resolutions`) and pnpm (`pnpm.overrides`) were already working correctly.

## Expected Behavior

The generated `package-lock.json` includes `overrides` and all overridden packages. `npm ci` succeeds.

This is tested in the original issue repro repo, where with the applied patch `npm ci` works from dist.

<img width="1272" height="362" alt="image" src="https://github.com/user-attachments/assets/2cdbb266-71f8-45c8-8ee0-cec6dcd12705" />

The missing parts are both `overrides` in `package.json`, but also the lockfile must include the pacakges in the overrides. In this example it is like this in `package-lock.json`:

```
    "node_modules/minimatch": {
      "version": "10.2.1",
      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
      "license": "BlueOak-1.0.0",
      "dependencies": {
        "brace-expansion": "^5.0.2"
      },
      "engines": {
        "node": "20 || >=22"
      },
      "funding": {
        "url": "https://github.com/sponsors/isaacs"
      }
    },
```

## Related Issue(s)

Fixes #34529