### PR TITLE
docs(misc): update sidebar to expand tutorials and collapse concepts

### DIFF
--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -37,8 +37,7 @@ const learnGroups: SidebarItems = [
       { label: 'Editor setup', link: 'getting-started/editor-setup' },
       {
         label: 'Tutorials',
-        badge: 'New',
-        collapsed: true,
+        collapsed: false,
         items: [
           {
             label: 'Crafting your workspace',
@@ -83,7 +82,7 @@ const learnGroups: SidebarItems = [
 
   {
     label: 'How Nx works',
-    collapsed: false,
+    collapsed: true,
     items: [
       { label: 'Mental model', link: 'concepts/mental-model' },
       { label: 'How caching works', link: 'concepts/how-caching-works' },
@@ -118,7 +117,7 @@ const learnGroups: SidebarItems = [
   },
   {
     label: 'Platform features',
-    collapsed: false,
+    collapsed: true,
     items: [
       { label: 'Run tasks', link: 'features/run-tasks' },
       {


### PR DESCRIPTION
## Current Behavior

- The **Tutorials** sidebar section is collapsed by default with a "New" badge
- **How Nx Works** (Concepts) and **Platform Features** sections are expanded by default
- Only ~10% of traffic reaches the CI tutorial, suggesting tutorials are not discoverable enough

## Expected Behavior

- **Tutorials** section is expanded by default (no badge) to increase discoverability
- **How Nx Works** and **Platform Features** sections are collapsed by default to reduce noise and draw attention to tutorials
- This should drive higher engagement with the tutorial flow including CI setup

<img width="502" height="735" alt="image" src="https://github.com/user-attachments/assets/76a63a36-ab5d-4459-aab6-dc04282e3779" />


## Related Issue(s)

Fixes DOC-474