### PR TITLE
fix(gradle): hoist shared task computation out of per-class loop in atomized CI target generation

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CiTargetsUtils.kt
@@ -99,6 +99,14 @@ private fun processTestFiles(
     targetNameOverrides: Map<String, String>,
     targetNamePrefix: String
 ) {
+  val dependsOnTasks = getDependsOnTask(testTask)
+  val testTaskInputs =
+      getInputsForTask(
+          dependsOnTasks, testTask, projectRoot, workspaceRoot, null, gitIgnoreClassifier)
+  val testTaskOutputs = getOutputsForTask(testTask, projectRoot, workspaceRoot)
+  val testTaskDependsOn =
+      getDependsOnForTask(dependsOnTasks, testTask, null, targetNameOverrides, targetNamePrefix)
+
   testFiles
       .filter { isTestFile(it, workspaceRoot) }
       .forEach { testFile ->
@@ -111,11 +119,9 @@ private fun processTestFiles(
                   projectBuildPath,
                   testClassPackagePath,
                   testTask,
-                  projectRoot,
-                  workspaceRoot,
-                  gitIgnoreClassifier,
-                  targetNameOverrides,
-                  targetNamePrefix)
+                  testTaskInputs,
+                  testTaskOutputs,
+                  testTaskDependsOn)
           targetGroups[testCiTargetGroup]?.add(targetName)
 
           ciDependsOn.add(DependsOnEntry(target = targetName, params = DependsOnParams.FORWARD))
@@ -142,15 +148,10 @@ private fun buildTestCiTarget(
     projectBuildPath: String,
     testClassPackagePath: String,
     testTask: Task,
-    projectRoot: String,
-    workspaceRoot: String,
-    gitIgnoreClassifier: GitIgnoreClassifier,
-    targetNameOverrides: Map<String, String>,
-    targetNamePrefix: String
+    testTaskInputs: List<Any>?,
+    testTaskOutputs: List<String>?,
+    testTaskDependsOn: List<DependsOnEntry>?
 ): MutableMap<String, Any?> {
-  val taskInputs =
-      getInputsForTask(null, testTask, projectRoot, workspaceRoot, null, gitIgnoreClassifier)
-
   val target =
       mutableMapOf<String, Any?>(
           "executor" to "@nx/gradle:gradle",
@@ -162,18 +163,16 @@ private fun buildTestCiTarget(
               getMetadata(
                   "Runs Gradle test $testClassPackagePath in CI.", projectBuildPath, "test"),
           "cache" to true,
-          "inputs" to taskInputs)
+          "inputs" to testTaskInputs)
 
-  getOutputsForTask(testTask, projectRoot, workspaceRoot)
+  testTaskOutputs
       ?.takeIf { it.isNotEmpty() }
       ?.let {
         testTask.logger.info("${testTask.path}: found ${it.size} outputs entries")
         target["outputs"] = it
       }
 
-  getDependsOnForTask(null, testTask, null, targetNameOverrides, targetNamePrefix)
-      ?.takeIf { it.isNotEmpty() }
-      ?.let { target["dependsOn"] = it }
+  testTaskDependsOn?.takeIf { it.isNotEmpty() }?.let { target["dependsOn"] = it }
 
   return target
 }


### PR DESCRIPTION
## Current Behavior

During atomized CI target generation, `buildTestCiTarget` is called once per test class discovered in a project. Each invocation independently recomputes `taskInputs`, `outputs`, and `dependsOn` for the same `testTask`. Internally, `getInputsForTask` was called with `null` for `dependsOnTasks`, which forced `getDependsOnTask(task)` — an uncached call to `task.taskDependencies.getDependencies(task)` — on every invocation. For a project with 158 test classes backed by the same Gradle task, this results in 158 redundant dependency tree walks during project graph discovery.

## Expected Behavior

The shared computation (`getDependsOnTask`, `getInputsForTask`, `getOutputsForTask`, `getDependsOnForTask`) is performed once per `testTask` in `processTestFiles` and the pre-computed values are passed into `buildTestCiTarget`. This eliminates redundant work proportional to the number of test classes, reducing CPU overhead during project graph generation — especially on cold Gradle daemon starts.

## Related Issue(s)

Fixes #