### PR TITLE
fix(gradle): patch 0.1.19 to beta.11

### DIFF
--- a/packages/gradle/migrations.json
+++ b/packages/gradle/migrations.json
@@ -121,7 +121,7 @@
       "factory": "./src/migrations/22-7-0/change-plugin-version-0-1-18"
     },
     "change-plugin-version-0-1-19": {
-      "version": "22.7.0-beta.10",
+      "version": "22.7.0-beta.11",
       "cli": "nx",
       "description": "Change dev.nx.gradle.project-graph to version 0.1.19 in build file",
       "factory": "./src/migrations/22-7-0/change-plugin-version-0-1-19"


### PR DESCRIPTION
## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Gradle project graph plugin 0.1.19 should be tied to Nx `22.7.0.beta.11`
