### PR TITLE
fix(misc): preserve package alias keys in generated package.json

### DIFF
--- a/packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
@@ -1330,6 +1330,102 @@ describe('createPackageJson', () => {
       mockReadNxJson.mockRestore();
     });
   });
+
+  describe('package aliases', () => {
+    it('should preserve alias dependency keys when canonical packages also exist in the graph', () => {
+      const mockReadNxJson = jest
+        .spyOn(configModule, 'readNxJson')
+        .mockReturnValue({});
+      const mockGetTargetInputs = jest
+        .spyOn(hashModule, 'getTargetInputs')
+        .mockReturnValue({
+          selfInputs: ['{projectRoot}/**/*'],
+          dependencyInputs: [],
+        });
+      const mockFilterUsingGlobPatterns = jest
+        .spyOn(hashModule, 'filterUsingGlobPatterns')
+        .mockImplementation((_root, files) => files);
+
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+      jest.spyOn(fileutilsModule, 'readJsonFile').mockReturnValue({
+        name: 'root-package',
+        dependencies: {
+          zod: '^3.0.0',
+          zod4: 'npm:zod@^4.1.13',
+        },
+      });
+
+      const graph: ProjectGraph = {
+        nodes: {
+          myapp: {
+            type: 'app',
+            name: 'myapp',
+            data: {
+              targets: { build: {} },
+              root: 'apps/myapp',
+            },
+          },
+        },
+        externalNodes: {
+          'npm:zod': {
+            type: 'npm',
+            name: 'npm:zod',
+            data: { version: '^3.0.0', hash: '', packageName: 'zod' },
+          },
+          'npm:zod@4.1.13': {
+            type: 'npm',
+            name: 'npm:zod@4.1.13',
+            data: { version: '4.1.13', hash: '', packageName: 'zod' },
+          },
+          'npm:zod4': {
+            type: 'npm',
+            name: 'npm:zod4',
+            data: {
+              version: 'npm:zod@4.1.13',
+              hash: '',
+              packageName: 'zod4',
+            },
+          },
+        },
+        dependencies: {
+          myapp: [
+            {
+              source: 'myapp',
+              target: 'npm:zod4',
+              type: DependencyType.static,
+            },
+          ],
+        },
+      };
+
+      const fileMap: ProjectFileMap = {
+        myapp: [
+          createFile('apps/myapp/src/main.ts', [
+            ['apps/myapp/src/main.ts', 'npm:zod4', DependencyType.static],
+          ]),
+        ],
+      };
+
+      const result = createPackageJson(
+        'myapp',
+        graph,
+        {
+          target: 'build',
+          root: '',
+          isProduction: true,
+        },
+        fileMap
+      );
+
+      expect(result.dependencies).toEqual({
+        zod4: 'npm:zod@4.1.13',
+      });
+
+      mockFilterUsingGlobPatterns.mockRestore();
+      mockGetTargetInputs.mockRestore();
+      mockReadNxJson.mockRestore();
+    });
+  });
 });
 
 function createFile(f: string, deps?: FileDataDependency[]): FileData {

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -321,6 +321,14 @@ describe('TargetProjectLocator', () => {
             packageName: 'lodash',
           },
         },
+        'npm:lodash@4.0.0': {
+          name: 'npm:lodash@4.0.0',
+          type: 'npm',
+          data: {
+            version: '4.0.0',
+            packageName: 'lodash',
+          },
+        },
         'npm:lodash-4': {
           name: 'npm:lodash-4',
           type: 'npm',
@@ -588,7 +596,7 @@ describe('TargetProjectLocator', () => {
       expect(proj5).toEqual('proj5');
     });
 
-    it('should be able to resolve packages aliases', () => {
+    it('should prefer alias nodes when canonical package nodes also exist', () => {
       const lodash = targetProjectLocator.findProjectFromImport(
         'lodash',
         'libs/proj/index.ts'

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -241,13 +241,21 @@ export class TargetProjectLocator {
       }
 
       const version = clean(externalPackageJson.version);
-      let matchingExternalNode =
-        this.npmProjects[`npm:${externalPackageJson.name}@${version}`];
+      const isAliasImport = packageName !== externalPackageJson.name;
+      let matchingExternalNode: ProjectGraphExternalNode | null = null;
+
+      if (isAliasImport) {
+        // Prefer the alias node when both the alias import and the resolved package
+        // exist in the graph, otherwise generated package.json files lose the alias key.
+        const aliasNpmProjectKey = `npm:${packageName}@npm:${externalPackageJson.name}@${version}`;
+        matchingExternalNode =
+          this.npmProjects[aliasNpmProjectKey] ??
+          this.npmProjects[`npm:${packageName}`];
+      }
 
       if (!matchingExternalNode) {
-        // check if it's a package alias, where the resolved package key is used as the version
-        const aliasNpmProjectKey = `npm:${packageName}@npm:${externalPackageJson.name}@${version}`;
-        matchingExternalNode = this.npmProjects[aliasNpmProjectKey];
+        matchingExternalNode =
+          this.npmProjects[`npm:${externalPackageJson.name}@${version}`];
       }
 
       if (!matchingExternalNode) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Releated Issues
https://github.com/nrwl/nx/issues/27098
https://github.com/nrwl/nx/issues/35205

Fixes #

When use generatedPackageJson with js project, solve packge alias problem.

can test it with 
```
pnpm exec jest -c packages/nx/jest.config.cts \    
  packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts \
  packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
```