### PR TITLE
fix(core): use fresh package manager cache for e2e tests

### DIFF
--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -3,6 +3,8 @@ import { existsSync, removeSync } from 'fs-extra';
 import * as isCI from 'is-ci';
 import { exec, execSync } from 'node:child_process';
 import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { registerTsConfigPaths } from '../../packages/nx/src/plugins/js/utils/register';
 import { runLocalRelease } from '../../scripts/local-registry/populate-storage';
 
@@ -48,6 +50,15 @@ export default async function (globalConfig: Config.ConfigGlobals) {
     // yarnv2
     process.env.YARN_NPM_REGISTRY_SERVER = registry;
     process.env.YARN_UNSAFE_HTTP_WHITELIST = listenAddress;
+
+    // Use fresh cache directories to avoid serving stale packages when the
+    // same version is republished to the local registry.
+    const e2eCacheDir = mkdtempSync(join(tmpdir(), 'nx-e2e-cache-'));
+    process.env.npm_config_cache = join(e2eCacheDir, 'npm');
+    // yarnv1
+    process.env.YARN_CACHE_FOLDER = join(e2eCacheDir, 'yarn');
+    // yarnv2
+    process.env.YARN_ENABLE_GLOBAL_CACHE = 'false';
 
     process.env.NX_SKIP_PROVENANCE_CHECK = 'true';
 


### PR DESCRIPTION
## Current Behavior

When e2e tests publish packages to the local Verdaccio registry with the same version number (e.g., `23.0.0`), npm and yarn serve stale cached tarballs from previous test runs instead of fetching the freshly published packages. This causes e2e tests to run against outdated code.

## Expected Behavior

Each e2e test run uses a fresh package manager cache directory, ensuring that npm and yarn always fetch the latest packages from the local registry — even when the version number hasn't changed.

- **npm**: `npm_config_cache` set to a temp directory
- **yarn v1**: `YARN_CACHE_FOLDER` set to a temp directory
- **yarn v2**: `YARN_ENABLE_GLOBAL_CACHE` set to `false`
- **pnpm**: not affected (content-addressed store)
- **bun**: already handled via `--no-cache` flag

## Related Issue(s)

<!-- No specific issue — discovered during local e2e testing -->
