### PR TITLE
fix(core): add missing inputs and sandbox exclusions for native tasks

### DIFF
--- a/.nx/workflows/sandboxing-config.yaml
+++ b/.nx/workflows/sandboxing-config.yaml
@@ -1,7 +1,9 @@
 exclude-reads:
   - packages/nx/src/native/*.node
+  - 'dist/target/**'
 exclude-writes:
   - '**/.swc/**'
+  - 'dist/target/**'
 
 task-exclusions:
   - target: lint

--- a/nx.json
+++ b/nx.json
@@ -28,6 +28,10 @@
     "native": [
       "{projectRoot}/**/*.rs",
       "{projectRoot}/**/Cargo.*",
+      "{workspaceRoot}/Cargo.toml",
+      "{workspaceRoot}/Cargo.lock",
+      "{workspaceRoot}/clippy.toml",
+      "{workspaceRoot}/.cargo/config.toml",
       { "runtime": "node -p '`${process.platform}_${process.arch}`'" },
       { "runtime": "rustc --version" },
       { "externalDependencies": ["npm:@monodon/rust", "npm:@napi-rs/cli"] }


### PR DESCRIPTION
## Current Behavior

The `native` named input in `nx.json` only includes `{projectRoot}/**/Cargo.*`, which misses workspace-root files that Cargo/Clippy read: `Cargo.toml` (workspace manifest), `Cargo.lock`, `clippy.toml`, and `.cargo/config.toml`. This means changes to these files don't invalidate the cache for native tasks.

Additionally, Cargo writes intermediate build artifacts to `dist/target/` which causes sandbox violations in Nx Cloud CI.

## Expected Behavior

Native task cache is correctly invalidated when workspace-root Cargo/Clippy config files change. Sandbox no longer flags `dist/target/` reads/writes as violations.

## Related Issue(s)

N/A
