### PR TITLE
chore(module-federation): disable webpack-incompatible react e2e suites

### DIFF
--- a/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
@@ -15,7 +15,9 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-describe('React Module Federation - Webpack Basic - Host Remote Generation', () => {
+// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
+// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+describe.skip('React Module Federation - Webpack Basic - Host Remote Generation', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
@@ -17,6 +17,7 @@ import {
 
 // TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
 // webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+// eslint-disable-next-line jest/no-disabled-tests
 describe.skip('React Module Federation - Webpack Basic - Host Remote Generation', () => {
   beforeAll(() => {
     setupCoreWebpackTest();

--- a/e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts
@@ -14,7 +14,9 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-describe('React Module Federation - Webpack Basic - Playwright', () => {
+// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
+// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+describe.skip('React Module Federation - Webpack Basic - Playwright', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts
@@ -16,6 +16,7 @@ import {
 
 // TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
 // webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+// eslint-disable-next-line jest/no-disabled-tests
 describe.skip('React Module Federation - Webpack Basic - Playwright', () => {
   beforeAll(() => {
     setupCoreWebpackTest();

--- a/e2e/react/src/module-federation/core-webpack-name-and-root.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-name-and-root.test.ts
@@ -10,7 +10,9 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-describe('React Module Federation - Webpack Name and Root Format', () => {
+// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
+// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+describe.skip('React Module Federation - Webpack Name and Root Format', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/core-webpack-name-and-root.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-name-and-root.test.ts
@@ -12,6 +12,7 @@ import {
 
 // TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
 // webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+// eslint-disable-next-line jest/no-disabled-tests
 describe.skip('React Module Federation - Webpack Name and Root Format', () => {
   beforeAll(() => {
     setupCoreWebpackTest();

--- a/e2e/react/src/module-federation/core-webpack-query-params.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-query-params.test.ts
@@ -7,6 +7,7 @@ import {
 
 // TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
 // webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+// eslint-disable-next-line jest/no-disabled-tests
 describe.skip('React Module Federation - Webpack Query Params', () => {
   beforeAll(() => {
     setupCoreWebpackTest();

--- a/e2e/react/src/module-federation/core-webpack-query-params.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-query-params.test.ts
@@ -5,7 +5,9 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-describe('React Module Federation - Webpack Query Params', () => {
+// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
+// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+describe.skip('React Module Federation - Webpack Query Params', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/core-webpack-ssr.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-ssr.test.ts
@@ -15,7 +15,9 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-describe('React Module Federation - Webpack SSR', () => {
+// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
+// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+describe.skip('React Module Federation - Webpack SSR', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/core-webpack-ssr.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-ssr.test.ts
@@ -17,6 +17,7 @@ import {
 
 // TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
 // webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+// eslint-disable-next-line jest/no-disabled-tests
 describe.skip('React Module Federation - Webpack SSR', () => {
   beforeAll(() => {
     setupCoreWebpackTest();

--- a/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
+++ b/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
@@ -14,7 +14,9 @@ import {
 } from '@nx/e2e-utils';
 import { runCLI } from './utils';
 
-describe('Dynamic Module Federation', () => {
+// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
+// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+describe.skip('Dynamic Module Federation', () => {
   beforeAll(() => {
     newProject({ packages: ['@nx/react'] });
   });

--- a/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
+++ b/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
@@ -16,6 +16,7 @@ import { runCLI } from './utils';
 
 // TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
 // webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+// eslint-disable-next-line jest/no-disabled-tests
 describe.skip('Dynamic Module Federation', () => {
   beforeAll(() => {
     newProject({ packages: ['@nx/react'] });

--- a/e2e/react/src/module-federation/federate-module.webpack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.webpack.test.ts
@@ -12,6 +12,7 @@ import { readPort, runCLI } from './utils';
 
 // TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
 // webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+// eslint-disable-next-line jest/no-disabled-tests
 describe.skip('Federate Module', () => {
   let proj: string;
 

--- a/e2e/react/src/module-federation/federate-module.webpack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.webpack.test.ts
@@ -10,7 +10,9 @@ import {
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 
-describe('Federate Module', () => {
+// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
+// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+describe.skip('Federate Module', () => {
   let proj: string;
 
   beforeAll(() => {

--- a/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
@@ -14,6 +14,7 @@ import { readPort, runCLI } from './utils';
 
 // TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
 // webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+// eslint-disable-next-line jest/no-disabled-tests
 describe.skip('Independent Deployability', () => {
   let proj: string;
   beforeAll(() => {

--- a/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
@@ -12,7 +12,9 @@ import {
 import { stripIndents } from 'nx/src/utils/strip-indents';
 import { readPort, runCLI } from './utils';
 
-describe('Independent Deployability', () => {
+// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
+// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+describe.skip('Independent Deployability', () => {
   let proj: string;
   beforeAll(() => {
     process.env.NX_ADD_PLUGINS = 'false';

--- a/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
@@ -11,7 +11,9 @@ import {
 import { readPort, runCLI } from './utils';
 import { stripIndents } from 'nx/src/utils/strip-indents';
 
-describe('React Rspack Module Federation Misc - Convert To Rspack', () => {
+// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
+// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+describe.skip('React Rspack Module Federation Misc - Convert To Rspack', () => {
   beforeAll(() => {
     process.env.NX_ADD_PLUGINS = 'false';
     newProject({ packages: ['@nx/react', '@nx/rspack'] });

--- a/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
@@ -13,6 +13,7 @@ import { stripIndents } from 'nx/src/utils/strip-indents';
 
 // TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
 // webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+// eslint-disable-next-line jest/no-disabled-tests
 describe.skip('React Rspack Module Federation Misc - Convert To Rspack', () => {
   beforeAll(() => {
     process.env.NX_ADD_PLUGINS = 'false';

--- a/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
@@ -11,7 +11,9 @@ import {
 import { readPort, runCLI } from './utils';
 import { stripIndents } from 'nx/src/utils/strip-indents';
 
-describe('React Rspack Module Federation Misc - Interoperability', () => {
+// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
+// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+describe.skip('React Rspack Module Federation Misc - Interoperability', () => {
   beforeEach(() => {
     process.env.NX_ADD_PLUGINS = 'false';
     newProject({ packages: ['@nx/react'] });

--- a/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
@@ -13,6 +13,7 @@ import { stripIndents } from 'nx/src/utils/strip-indents';
 
 // TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
 // webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
+// eslint-disable-next-line jest/no-disabled-tests
 describe.skip('React Rspack Module Federation Misc - Interoperability', () => {
   beforeEach(() => {
     process.env.NX_ADD_PLUGINS = 'false';


### PR DESCRIPTION
## Current Behavior

React module federation e2e suites that exercise webpack generation paths are failing because webpack 5.106.0 removed `lib/util/create-schema-validation.js`, which `@module-federation/enhanced@2.3.1` still depends on.

## Expected Behavior

These known-broken suites should be skipped until the upstream module federation dependency is compatible with webpack 5.106.0+ so they do not keep failing CI.

## Related Issue(s)

N/A

## Summary

This PR temporarily disables the affected React module federation e2e suites by switching their top-level test groups to `describe.skip(...)` and adding a short note about the webpack / `@module-federation/enhanced` incompatibility.

It covers the webpack-specific suites as well as the mixed Rspack interoperability/convert flows that still generate webpack-based module federation apps.

## Validation

- `npx prettier --write` on the modified test files
- `git push -u origin fix/disable-mf-webpack-tests`
- repository pre-push hook passed during push (`nx` prepush checks)
