### PR TITLE
fix(core): ensure build tasks use copyReadme named input

### DIFF
--- a/packages/angular-rspack-compiler/package.json
+++ b/packages/angular-rspack-compiler/package.json
@@ -69,9 +69,7 @@
       "build": {
         "command": "node ./scripts/copy-readme.js angular-rspack-compiler packages/angular-rspack-compiler/readme-template.md packages/angular-rspack-compiler/README.md",
         "inputs": [
-          "{projectRoot}/readme-template.md",
-          "{workspaceRoot}/scripts/copy-readme.js",
-          "{workspaceRoot}/scripts/readme-fragments"
+          "copyReadme"
         ],
         "outputs": [
           "{projectRoot}/README.md"

--- a/packages/angular-rspack/package.json
+++ b/packages/angular-rspack/package.json
@@ -116,9 +116,7 @@
       "build": {
         "command": "node ./scripts/copy-readme.js angular-rspack packages/angular-rspack/readme-template.md packages/angular-rspack/README.md",
         "inputs": [
-          "{projectRoot}/readme-template.md",
-          "{workspaceRoot}/scripts/copy-readme.js",
-          "{workspaceRoot}/scripts/readme-fragments"
+          "copyReadme"
         ],
         "outputs": [
           "{projectRoot}/README.md"

--- a/packages/esbuild/project.json
+++ b/packages/esbuild/project.json
@@ -5,6 +5,7 @@
   "projectType": "library",
   "targets": {
     "build": {
+      "inputs": ["copyReadme"],
       "outputs": ["{workspaceRoot}/dist/packages/esbuild/README.md"],
       "commands": ["node ./scripts/copy-readme.js esbuild"]
     }


### PR DESCRIPTION
## Current Behavior

Three packages (`angular-rspack-compiler`, `angular-rspack`, `esbuild`) have build targets that run `copy-readme.js` but don't correctly declare all required inputs:

- `angular-rspack-compiler` and `angular-rspack` manually listed partial inputs (missing `.prettierignore` and using a bare directory path `{workspaceRoot}/scripts/readme-fragments` that doesn't resolve to files)
- `esbuild` had no inputs at all for its build target, falling back to the default `["production", "^production"]`

This means changes to `.prettierignore` or `readme-fragments/*.md` would not invalidate the build cache for these projects.

## Expected Behavior

All three packages use the `copyReadme` named input (defined in `nx.json`), consistent with every other package in the repo. This ensures `.prettierignore`, `readme-fragments/**/*`, `copy-readme.js`, and project README files are all correctly tracked as build inputs.

## Related Issue(s)

Fixes NXC-4214