### PR TITLE
fix(testing): enable Nx daemon for e2e tests

### DIFF
--- a/e2e/utils/get-env-info.ts
+++ b/e2e/utils/get-env-info.ts
@@ -141,7 +141,7 @@ export {
 } from './ensure-browser-installation';
 
 export function getStrippedEnvironmentVariables() {
-  return Object.fromEntries(
+  const stripped = Object.fromEntries(
     Object.entries(process.env).filter(([key]) => {
       if (key.startsWith('NX_E2E_')) {
         return true;
@@ -189,4 +189,5 @@ export function getStrippedEnvironmentVariables() {
       return true;
     })
   );
+  return { ...stripped, NX_DAEMON: 'true' };
 }


### PR DESCRIPTION
## Current Behavior

`getStrippedEnvironmentVariables()` strips `NX_DAEMON` from the environment passed to e2e test commands. This means every `nx generate` (and other nx commands) in e2e tests rebuilds the project graph from scratch, even though CI sets `NX_DAEMON=true`. Each generator call takes ~20-25s due to repeated project graph computation.

## Expected Behavior

The Nx daemon is always enabled during e2e tests. After the first command starts the daemon and computes the project graph, subsequent commands reuse the cached graph, significantly reducing execution time for tests that run multiple nx commands.

## Related Issue(s)

N/A — performance improvement for e2e test suite