### PR TITLE
fix(core): add missing build inputs for angular-rspack examples

### DIFF
--- a/examples/angular-rspack/appshell-css/package.json
+++ b/examples/angular-rspack/appshell-css/package.json
@@ -13,6 +13,21 @@
   "nx": {
     "targets": {
       "build": {
+        "inputs": [
+          "production",
+          "^production",
+          {
+            "dependentTasksOutputFiles": "**/*.js",
+            "transitive": true
+          },
+          "{workspaceRoot}/examples/angular-rspack/patch-devkit-request-path.js",
+          "{workspaceRoot}/examples/angular-rspack/tsconfig.base.json",
+          "{workspaceRoot}/LICENSE",
+          "{workspaceRoot}/tsconfig.json"
+        ],
+        "outputs": [
+          "{projectRoot}/dist"
+        ],
         "dependsOn": [
           "^build"
         ]

--- a/examples/angular-rspack/csr-css-assets/package.json
+++ b/examples/angular-rspack/csr-css-assets/package.json
@@ -26,6 +26,22 @@
         ]
       },
       "build": {
+        "inputs": [
+          "production",
+          "^production",
+          {
+            "dependentTasksOutputFiles": "**/*.js",
+            "transitive": true
+          },
+          "{workspaceRoot}/examples/angular-rspack/patch-devkit-request-path.js",
+          "{workspaceRoot}/examples/angular-rspack/tsconfig.base.json",
+          "{workspaceRoot}/LICENSE",
+          "{workspaceRoot}/tsconfig.json",
+          "{workspaceRoot}/examples/angular-rspack/shared/**/*"
+        ],
+        "outputs": [
+          "{projectRoot}/dist"
+        ],
         "dependsOn": [
           "^build"
         ]

--- a/examples/angular-rspack/csr-css/package.json
+++ b/examples/angular-rspack/csr-css/package.json
@@ -26,6 +26,22 @@
         ]
       },
       "build": {
+        "inputs": [
+          "production",
+          "^production",
+          {
+            "dependentTasksOutputFiles": "**/*.js",
+            "transitive": true
+          },
+          "{workspaceRoot}/examples/angular-rspack/patch-devkit-request-path.js",
+          "{workspaceRoot}/examples/angular-rspack/tsconfig.base.json",
+          "{workspaceRoot}/LICENSE",
+          "{workspaceRoot}/tsconfig.json",
+          "{workspaceRoot}/examples/angular-rspack/shared/**/*"
+        ],
+        "outputs": [
+          "{projectRoot}/dist"
+        ],
         "dependsOn": [
           "^build"
         ]

--- a/examples/angular-rspack/csr-i18n/package.json
+++ b/examples/angular-rspack/csr-i18n/package.json
@@ -25,6 +25,21 @@
     },
     "targets": {
       "build": {
+        "inputs": [
+          "production",
+          "^production",
+          {
+            "dependentTasksOutputFiles": "**/*.js",
+            "transitive": true
+          },
+          "{workspaceRoot}/examples/angular-rspack/patch-devkit-request-path.js",
+          "{workspaceRoot}/examples/angular-rspack/tsconfig.base.json",
+          "{workspaceRoot}/LICENSE",
+          "{workspaceRoot}/tsconfig.json"
+        ],
+        "outputs": [
+          "{projectRoot}/dist"
+        ],
         "dependsOn": [
           "^build"
         ]

--- a/examples/angular-rspack/csr-scss/package.json
+++ b/examples/angular-rspack/csr-scss/package.json
@@ -14,9 +14,23 @@
     "targets": {
       "build": {
         "inputs": [
+          "production",
+          "^production",
           {
             "env": "NGRS_CONFIG"
-          }
+          },
+          {
+            "dependentTasksOutputFiles": "**/*.js",
+            "transitive": true
+          },
+          "{workspaceRoot}/examples/angular-rspack/patch-devkit-request-path.js",
+          "{workspaceRoot}/examples/angular-rspack/tsconfig.base.json",
+          "{workspaceRoot}/LICENSE",
+          "{workspaceRoot}/tsconfig.json",
+          "{workspaceRoot}/examples/angular-rspack/shared/**/*"
+        ],
+        "outputs": [
+          "{projectRoot}/dist"
         ],
         "dependsOn": [
           "^build"

--- a/examples/angular-rspack/csr-tailwind/package.json
+++ b/examples/angular-rspack/csr-tailwind/package.json
@@ -14,6 +14,21 @@
   "nx": {
     "targets": {
       "build": {
+        "inputs": [
+          "production",
+          "^production",
+          {
+            "dependentTasksOutputFiles": "**/*.js",
+            "transitive": true
+          },
+          "{workspaceRoot}/examples/angular-rspack/patch-devkit-request-path.js",
+          "{workspaceRoot}/examples/angular-rspack/tsconfig.base.json",
+          "{workspaceRoot}/LICENSE",
+          "{workspaceRoot}/tsconfig.json"
+        ],
+        "outputs": [
+          "{projectRoot}/dist"
+        ],
         "dependsOn": [
           "^build"
         ]

--- a/examples/angular-rspack/module-federation/host/package.json
+++ b/examples/angular-rspack/module-federation/host/package.json
@@ -19,6 +19,21 @@
         ]
       },
       "build": {
+        "inputs": [
+          "production",
+          "^production",
+          {
+            "dependentTasksOutputFiles": "**/*.js",
+            "transitive": true
+          },
+          "{workspaceRoot}/examples/angular-rspack/patch-devkit-request-path.js",
+          "{workspaceRoot}/examples/angular-rspack/tsconfig.base.json",
+          "{workspaceRoot}/LICENSE",
+          "{workspaceRoot}/tsconfig.json"
+        ],
+        "outputs": [
+          "{projectRoot}/dist"
+        ],
         "dependsOn": [
           "^build"
         ]

--- a/examples/angular-rspack/module-federation/remote/package.json
+++ b/examples/angular-rspack/module-federation/remote/package.json
@@ -28,8 +28,20 @@
         }
       },
       "build": {
+        "inputs": [
+          "production",
+          "^production",
+          {
+            "dependentTasksOutputFiles": "**/*.js",
+            "transitive": true
+          },
+          "{workspaceRoot}/examples/angular-rspack/patch-devkit-request-path.js",
+          "{workspaceRoot}/examples/angular-rspack/tsconfig.base.json",
+          "{workspaceRoot}/LICENSE",
+          "{workspaceRoot}/tsconfig.json"
+        ],
         "outputs": [
-          "{projectRoot}/dist/browser"
+          "{projectRoot}/dist"
         ],
         "dependsOn": [
           "^build"

--- a/examples/angular-rspack/ssg-css/package.json
+++ b/examples/angular-rspack/ssg-css/package.json
@@ -13,6 +13,21 @@
   "nx": {
     "targets": {
       "build": {
+        "inputs": [
+          "production",
+          "^production",
+          {
+            "dependentTasksOutputFiles": "**/*.js",
+            "transitive": true
+          },
+          "{workspaceRoot}/examples/angular-rspack/patch-devkit-request-path.js",
+          "{workspaceRoot}/examples/angular-rspack/tsconfig.base.json",
+          "{workspaceRoot}/LICENSE",
+          "{workspaceRoot}/tsconfig.json"
+        ],
+        "outputs": [
+          "{projectRoot}/dist"
+        ],
         "dependsOn": [
           "^build"
         ]

--- a/examples/angular-rspack/ssr-css/package.json
+++ b/examples/angular-rspack/ssr-css/package.json
@@ -13,6 +13,21 @@
   "nx": {
     "targets": {
       "build": {
+        "inputs": [
+          "production",
+          "^production",
+          {
+            "dependentTasksOutputFiles": "**/*.js",
+            "transitive": true
+          },
+          "{workspaceRoot}/examples/angular-rspack/patch-devkit-request-path.js",
+          "{workspaceRoot}/examples/angular-rspack/tsconfig.base.json",
+          "{workspaceRoot}/LICENSE",
+          "{workspaceRoot}/tsconfig.json"
+        ],
+        "outputs": [
+          "{projectRoot}/dist"
+        ],
         "dependsOn": [
           "^build"
         ]

--- a/examples/angular-rspack/zoneless-csr-css/package.json
+++ b/examples/angular-rspack/zoneless-csr-css/package.json
@@ -26,6 +26,22 @@
         ]
       },
       "build": {
+        "inputs": [
+          "production",
+          "^production",
+          {
+            "dependentTasksOutputFiles": "**/*.js",
+            "transitive": true
+          },
+          "{workspaceRoot}/examples/angular-rspack/patch-devkit-request-path.js",
+          "{workspaceRoot}/examples/angular-rspack/tsconfig.base.json",
+          "{workspaceRoot}/LICENSE",
+          "{workspaceRoot}/tsconfig.json",
+          "{workspaceRoot}/examples/angular-rspack/shared/**/*"
+        ],
+        "outputs": [
+          "{projectRoot}/dist"
+        ],
         "dependsOn": [
           "^build"
         ]

--- a/examples/angular-rspack/zoneless-csr-i18n/package.json
+++ b/examples/angular-rspack/zoneless-csr-i18n/package.json
@@ -25,6 +25,21 @@
     },
     "targets": {
       "build": {
+        "inputs": [
+          "production",
+          "^production",
+          {
+            "dependentTasksOutputFiles": "**/*.js",
+            "transitive": true
+          },
+          "{workspaceRoot}/examples/angular-rspack/patch-devkit-request-path.js",
+          "{workspaceRoot}/examples/angular-rspack/tsconfig.base.json",
+          "{workspaceRoot}/LICENSE",
+          "{workspaceRoot}/tsconfig.json"
+        ],
+        "outputs": [
+          "{projectRoot}/dist"
+        ],
         "dependsOn": [
           "^build"
         ]

--- a/examples/angular-rspack/zoneless-ssg-css/package.json
+++ b/examples/angular-rspack/zoneless-ssg-css/package.json
@@ -13,6 +13,21 @@
   "nx": {
     "targets": {
       "build": {
+        "inputs": [
+          "production",
+          "^production",
+          {
+            "dependentTasksOutputFiles": "**/*.js",
+            "transitive": true
+          },
+          "{workspaceRoot}/examples/angular-rspack/patch-devkit-request-path.js",
+          "{workspaceRoot}/examples/angular-rspack/tsconfig.base.json",
+          "{workspaceRoot}/LICENSE",
+          "{workspaceRoot}/tsconfig.json"
+        ],
+        "outputs": [
+          "{projectRoot}/dist"
+        ],
         "dependsOn": [
           "^build"
         ]

--- a/examples/angular-rspack/zoneless-ssr-css/package.json
+++ b/examples/angular-rspack/zoneless-ssr-css/package.json
@@ -13,6 +13,21 @@
   "nx": {
     "targets": {
       "build": {
+        "inputs": [
+          "production",
+          "^production",
+          {
+            "dependentTasksOutputFiles": "**/*.js",
+            "transitive": true
+          },
+          "{workspaceRoot}/examples/angular-rspack/patch-devkit-request-path.js",
+          "{workspaceRoot}/examples/angular-rspack/tsconfig.base.json",
+          "{workspaceRoot}/LICENSE",
+          "{workspaceRoot}/tsconfig.json"
+        ],
+        "outputs": [
+          "{projectRoot}/dist"
+        ],
         "dependsOn": [
           "^build"
         ]


### PR DESCRIPTION
## Current Behavior

The 14 angular-rspack example projects have build targets that read files not declared as inputs:

- **Dependent task outputs**: `dist/packages/devkit/**/*.js`, `packages/angular-rspack/dist/**/*.js`, and `packages/angular-rspack-compiler/dist/**/*.js` — loaded at runtime via the `patch-devkit-request-path.js` monkey-patch
- **Shared workspace files**: `examples/angular-rspack/patch-devkit-request-path.js` and `examples/angular-rspack/tsconfig.base.json`

This causes sandbox violations during task sandboxing runs (see [sandboxing report](https://staging.nx.app/runs/B5EjkJA6p1/task/angular-rspack-compiler%3Abuild?batchId=e0e77df9-807f-49f5-b7ea-b97d91d207d1)).

## Expected Behavior

All example build targets declare:
- `dependentTasksOutputFiles: "**/*.js"` with `transitive: true` to include JS outputs from the full dependency chain (devkit → angular-rspack-compiler → angular-rspack)
- Explicit inputs for the shared `patch-devkit-request-path.js` and `tsconfig.base.json` files

## Related Issue(s)

Fixes NXC-4222