### PR TITLE
fix(core): add run-native-target script input to dotnet build-analyzer

### DIFF
--- a/packages/dotnet/project.json
+++ b/packages/dotnet/project.json
@@ -21,7 +21,11 @@
       "command": "node ./scripts/run-native-target.js _build-analyzer dotnet",
       "cache": true,
       "outputs": ["{workspaceRoot}/dist/msbuild-analyzer"],
-      "inputs": ["{projectRoot}/analyzer/**", { "env": "SKIP_ANALYZER_BUILD" }]
+      "inputs": [
+        "{projectRoot}/analyzer/**",
+        "{workspaceRoot}/scripts/run-native-target.js",
+        { "env": "SKIP_ANALYZER_BUILD" }
+      ]
     },
     "_build-analyzer": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
## Current Behavior

The `dotnet:build-analyzer` target runs `node ./scripts/run-native-target.js _build-analyzer dotnet` but does not include the `run-native-target.js` script itself in its `inputs` array. This means changes to the script won't invalidate the Nx cache, potentially leading to stale cached results.

## Expected Behavior

The `run-native-target.js` script is included as an input to the `build-analyzer` target, ensuring cache correctness when the script changes.

## Related Issue(s)

Fixes NXC-4219