### PR TITLE
fix(core): add prettier config inputs to astro-docs format target

### DIFF
--- a/astro-docs/project.json
+++ b/astro-docs/project.json
@@ -152,7 +152,12 @@
     "format": {
       "cache": true,
       "//": "nx format doesn't respect overrides, so we manually run prettier for mdoc files",
-      "command": "prettier **/*.mdoc --check"
+      "command": "prettier **/*.mdoc --check",
+      "inputs": [
+        "{projectRoot}/**/*.mdoc",
+        "{workspaceRoot}/.prettierrc",
+        "{workspaceRoot}/.prettierignore"
+      ]
     },
     "format:write": {
       "command": "prettier **/*.mdoc --write"


### PR DESCRIPTION
## Current Behavior

The `astro-docs:format` target is cached but has no explicit `inputs`, so it uses the default named input which only tracks `{projectRoot}/**/*`. Changes to workspace-root prettier configuration files (`.prettierrc`, `.prettierignore`) don't invalidate the cache, potentially returning stale format check results.

## Expected Behavior

The `format` target explicitly lists its inputs: the `.mdoc` files it formats and the prettier config files that control formatting behavior. This ensures the cache invalidates correctly when prettier configuration changes.

## Related Issue(s)

Fixes NXC-4217