### PR TITLE
fix(core): add vale-changed.mjs script to vale target inputs

### DIFF
--- a/astro-docs/project.json
+++ b/astro-docs/project.json
@@ -133,7 +133,8 @@
         "{projectRoot}/src/content/docs/**/*.mdx",
         "{projectRoot}/src/content/docs/**/*.md",
         "{projectRoot}/.vale.ini",
-        "{projectRoot}/.vale/styles/**/*"
+        "{projectRoot}/.vale/styles/**/*",
+        "{projectRoot}/scripts/vale-changed.mjs"
       ]
     },
     "vale:all": {
@@ -146,7 +147,8 @@
         "{projectRoot}/src/content/docs/**/*.mdx",
         "{projectRoot}/src/content/docs/**/*.md",
         "{projectRoot}/.vale.ini",
-        "{projectRoot}/.vale/styles/**/*"
+        "{projectRoot}/.vale/styles/**/*",
+        "{projectRoot}/scripts/vale-changed.mjs"
       ]
     },
     "format": {


### PR DESCRIPTION
## Current Behavior

The `vale` and `vale:all` targets in `astro-docs/project.json` execute `node scripts/vale-changed.mjs` but do not include the script itself in their `inputs`. This means changes to `vale-changed.mjs` won't invalidate the Nx cache, potentially serving stale results.

## Expected Behavior

The `vale-changed.mjs` script is declared as an input for both `vale` and `vale:all` targets, so any changes to the script correctly bust the cache.

## Related Issue(s)

Fixes NXC-4218