### PR TITLE
fix(angular): add storybook and playwright as implicit dependencies

### DIFF
--- a/packages/angular/project.json
+++ b/packages/angular/project.json
@@ -21,5 +21,5 @@
       "inputs": ["copyReadme"]
     }
   },
-  "implicitDependencies": ["vite"]
+  "implicitDependencies": ["vite", "storybook", "playwright"]
 }


### PR DESCRIPTION
## Current Behavior

The `angular:test` task sandboxing run shows unexpected file reads from `@nx/storybook` and `@nx/playwright` packages — including `.template` and `__tmpl__` generator files. These packages are loaded dynamically via `ensurePackage()` calls (in `generate-storybook-configuration.ts` and `add-e2e.ts`), so the static dependency analyzer doesn't detect them as dependencies of the angular project. This means their files are not included in the test task's input hash, causing sandbox violations.

Relevant run: [staging.nx.app task run](https://staging.nx.app/runs/B5EjkJA6p1/task/angular%3Atest?batchId=77ad1700-bc33-4663-b344-cbfab899c6c4)

## Expected Behavior

The `storybook` and `playwright` projects are declared as `implicitDependencies` of the angular project (alongside the existing `vite` entry which exists for the same reason). This ensures their files are included in the angular test task's input hash via the `^production` input qualifier, resolving the sandbox failures.

## Related Issue(s)

Fixes NXC-4216