### PR TITLE
feat(core): prompt for setup mode when running nx init in empty git directory

### DIFF
--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -1,9 +1,10 @@
 import { existsSync } from 'fs';
+import { basename } from 'path';
 
 import { prompt } from 'enquirer';
 import { prerelease } from 'semver';
 import { NxJsonConfiguration, readNxJson } from '../../config/nx-json';
-import { readJsonFile } from '../../utils/fileutils';
+import { readJsonFile, writeJsonFile } from '../../utils/fileutils';
 import { getPackageNameFromImportPath } from '../../utils/get-package-name-from-import-path';
 import { output } from '../../utils/output';
 import { PackageJson } from '../../utils/package-json';
@@ -142,6 +143,45 @@ async function initHandlerImpl(options: InitArgs): Promise<void> {
       learnMoreLink: 'https://nx.dev/technologies/angular/migration/angular',
     });
     return;
+  }
+
+  // When in an empty directory (no package.json) and the user hasn't explicitly
+  // chosen a setup method, prompt them to pick between .nx and package.json setup.
+  // Skip the prompt when stdin is not a TTY (e.g. CI, e2e tests) to avoid hangs.
+  if (
+    !existsSync('package.json') &&
+    !options.useDotNxInstallation &&
+    options.interactive &&
+    !aiMode &&
+    process.stdin.isTTY
+  ) {
+    const setupMode = await prompt<{ setupMode: string }>([
+      {
+        type: 'select',
+        name: 'setupMode',
+        message: 'How would you like to set up Nx in this directory?',
+        choices: [
+          {
+            name: '.nx installation (recommended for non-JavaScript projects)',
+          },
+          {
+            name: 'package.json installation (recommended for JavaScript/TypeScript projects)',
+          },
+        ],
+      },
+    ]).then((r) => r.setupMode);
+
+    if (setupMode.startsWith('package.json')) {
+      // Create a minimal package.json so the JS/TS workflow takes over
+      const workspaceName = basename(process.cwd());
+      writeJsonFile('package.json', {
+        name: workspaceName,
+        version: '0.0.0',
+        private: true,
+      });
+    } else {
+      options.useDotNxInstallation = true;
+    }
   }
 
   const _isNonJs = !existsSync('package.json') || options.useDotNxInstallation;


### PR DESCRIPTION
## Current Behavior

When running `nx init` in an empty git directory (no `package.json`), the V2 init handler silently defaults to the `.nx` installation method without prompting the user. This may not be suitable for users who intend to create a JavaScript/TypeScript project and would prefer a `package.json`-based setup.

## Expected Behavior

When running `nx init` in an empty git directory, users are now prompted to choose between two setup methods:

- **`.nx installation`** — recommended for non-JavaScript projects (Gradle, .NET, etc.)
- **`package.json installation`** — recommended for JavaScript/TypeScript projects

The prompt only appears when:
- No `package.json` exists in the directory
- The `--useDotNxInstallation` flag was not explicitly passed
- Running in interactive mode (not AI agent mode)

If the user chooses `package.json`, a minimal `package.json` is created and the existing npm-repo setup flow takes over. If they choose `.nx`, the existing dot-nx setup flow is used. In both cases, the workspace is created in the current directory (not a subfolder).

## Related Issue(s)

Fixes NXC-3983