### PR TITLE
fix(core): overwrite inferred script target when nx prop defines executor or command

### DIFF
--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -76,6 +76,16 @@ describe('installPackageToTmp', () => {
 });
 
 describe('readTargetsFromPackageJson', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(pacakgeManager, 'getPackageManagerCommand')
+      .mockReturnValue({ run: (script) => `npm run ${script}` } as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   const packageJson: PackageJson = {
     name: 'my-app',
     version: '0.0.0',
@@ -315,6 +325,33 @@ describe('readTargetsFromPackageJson', () => {
             "echo 2",
           ],
         },
+      }
+    `);
+  });
+
+  it('should override script target when nx target uses command shorthand', () => {
+    const result = readTargetsFromPackageJson(
+      {
+        name: 'my-other-app',
+        version: '',
+        scripts: {
+          build: 'echo 1',
+        },
+        nx: {
+          targets: {
+            build: {
+              command: 'echo 2',
+            },
+          },
+        },
+      },
+      {},
+      workspaceRoot,
+      '/root'
+    );
+    expect(result.build).toMatchInlineSnapshot(`
+      {
+        "command": "echo 2",
       }
     `);
   });

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -235,10 +235,15 @@ export function readTargetsFromPackageJson(
     res[script] = buildTargetFromScript(script, scripts, packageManagerCommand);
   }
   for (const targetName in nx?.targets) {
-    res[targetName] = mergeTargetConfigurations(
-      nx?.targets[targetName],
-      res[targetName]
-    );
+    const nxTarget = nx.targets[targetName];
+    // If the nx target specifies how to run (via executor or command shorthand),
+    // it's incompatible with the inferred nx:run-script target from scripts,
+    // so overwrite instead of merge.
+    if (res[targetName] && (nxTarget.executor || nxTarget.command)) {
+      res[targetName] = nxTarget;
+    } else {
+      res[targetName] = mergeTargetConfigurations(nxTarget, res[targetName]);
+    }
   }
 
   /**


### PR DESCRIPTION
## Current Behavior

When a `package.json` has both a script entry and an `nx.targets` entry for the same target name, and the `nx.targets` entry uses command shorthand (`command: "tsc"`) or an explicit executor, the two targets are merged together. This produces an invalid hybrid target that has both `executor: "nx:run-script"` (from the inferred script target) and the `command` property (from the nx prop), causing the node to fail to merge into the project graph.

## Expected Behavior

When the `nx.targets` entry specifies how to run (via `executor` or `command`), it should completely overwrite the inferred script target instead of merging with it. Targets without `executor` or `command` (e.g., just adding `outputs` or `dependsOn`) should continue to merge as before.

## Related Issue(s)

Fixes NXC-3923