### PR TITLE
fix(testing): add dependent .d.ts inputs for ts-jest without isolatedModules

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -1,5 +1,13 @@
 // Ensure that the preset loads from node_modules rather than our local typescript source
 const nxPreset = require('./node_modules/@nx/jest/preset').default;
+const path = require('path');
+
+// SWC resolves bare plugin names by walking node_modules upward from cwd.
+// Tests that chdir into temp dirs would fail resolution since the temp dir
+// has no node_modules. Pre-resolving to an absolute path bypasses this.
+const mutCjsExportsPlugin = path.dirname(
+  require.resolve('@swc-contrib/mut-cjs-exports/package.json')
+);
 
 module.exports = {
   ...nxPreset,
@@ -16,7 +24,7 @@ module.exports = {
             useDefineForClassFields: false,
           },
           experimental: {
-            plugins: [['@swc-contrib/mut-cjs-exports', {}]],
+            plugins: [[mutCjsExportsPlugin, {}]],
           },
         },
         module: { type: 'commonjs' },

--- a/nx.json
+++ b/nx.json
@@ -48,7 +48,8 @@
       { "env": "SELECTED_PM" },
       { "env": "NX_E2E_CI_CACHE_KEY" },
       { "env": "CI" },
-      { "env": "NX_E2E_RUN_E2E" }
+      { "env": "NX_E2E_RUN_E2E" },
+      { "dependentTasksOutputFiles": "**/*.d.ts", "transitive": true }
     ]
   },
   "release": {

--- a/packages/jest/.eslintrc.json
+++ b/packages/jest/.eslintrc.json
@@ -42,6 +42,8 @@
               "jest",
               "@jest/types",
               "jest-runtime",
+              // require'd dynamically only when ts-jest is the configured transformer
+              "ts-jest",
               // require.resolve is used for these packages
               "identity-obj-proxy"
             ]

--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -1413,6 +1413,211 @@ describe('@nx/jest/plugin config file inputs', () => {
     expect(extDeps).not.toContain('@my-org/jest-preset');
   });
 
+  it('should add dependentTasksOutputFiles when ts-jest is used without isolatedModules', async () => {
+    mockConfig({
+      transform: { '^.+\\.ts$': 'ts-jest' },
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).toContainEqual({
+      dependentTasksOutputFiles: '**/*.d.ts',
+      transitive: true,
+    });
+  });
+
+  it('should add dependentTasksOutputFiles when ts-jest has tsconfig without isolatedModules', async () => {
+    await tempFs.createFiles({
+      'proj/tsconfig.json': JSON.stringify({
+        compilerOptions: { isolatedModules: false },
+      }),
+    });
+    mockConfig({
+      transform: {
+        '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.json' }],
+      },
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).toContainEqual({
+      dependentTasksOutputFiles: '**/*.d.ts',
+      transitive: true,
+    });
+  });
+
+  it('should not add dependentTasksOutputFiles when ts-jest has isolatedModules enabled in tsconfig', async () => {
+    await tempFs.createFiles({
+      'proj/tsconfig.spec.json': JSON.stringify({
+        compilerOptions: { isolatedModules: true },
+      }),
+    });
+    mockConfig({
+      transform: {
+        '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.spec.json' }],
+      },
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).not.toContainEqual(
+      expect.objectContaining({ dependentTasksOutputFiles: '**/*.d.ts' })
+    );
+  });
+
+  it('should not add dependentTasksOutputFiles when using @swc/jest', async () => {
+    mockConfig({
+      transform: { '^.+\\.ts$': '@swc/jest' },
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).not.toContainEqual(
+      expect.objectContaining({ dependentTasksOutputFiles: '**/*.d.ts' })
+    );
+  });
+
+  it('should add dependentTasksOutputFiles when ts-jest is inherited from a preset', async () => {
+    await tempFs.createFiles({
+      'jest.preset.js': `module.exports = { transform: { '^.+\\\\.ts$': 'ts-jest' } };`,
+    });
+    mockConfig({ preset: '../jest.preset.js' });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).toContainEqual({
+      dependentTasksOutputFiles: '**/*.d.ts',
+      transitive: true,
+    });
+  });
+
+  it('should resolve <rootDir> in the ts-jest tsconfig option', async () => {
+    await tempFs.createFiles({
+      'proj/tsconfig.spec.json': JSON.stringify({
+        compilerOptions: { isolatedModules: true },
+      }),
+    });
+    mockConfig({
+      transform: {
+        '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+      },
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).not.toContainEqual(
+      expect.objectContaining({ dependentTasksOutputFiles: '**/*.d.ts' })
+    );
+  });
+
+  it('should follow the tsconfig extends chain to find isolatedModules', async () => {
+    await tempFs.createFiles({
+      'proj/tsconfig.json': JSON.stringify({
+        compilerOptions: { isolatedModules: true },
+      }),
+      'proj/tsconfig.spec.json': JSON.stringify({
+        extends: './tsconfig.json',
+        compilerOptions: { types: ['jest'] },
+      }),
+    });
+    mockConfig({
+      transform: {
+        '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.spec.json' }],
+      },
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).not.toContainEqual(
+      expect.objectContaining({ dependentTasksOutputFiles: '**/*.d.ts' })
+    );
+  });
+
+  it('should treat verbatimModuleSyntax as implying isolatedModules', async () => {
+    await tempFs.createFiles({
+      'proj/tsconfig.json': JSON.stringify({
+        compilerOptions: { verbatimModuleSyntax: true },
+      }),
+    });
+    mockConfig({
+      transform: {
+        '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.json' }],
+      },
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).not.toContainEqual(
+      expect.objectContaining({ dependentTasksOutputFiles: '**/*.d.ts' })
+    );
+  });
+
+  it('should respect last-entry precedence in multi-extends arrays', async () => {
+    await tempFs.createFiles({
+      'proj/tsconfig.isolated.json': JSON.stringify({
+        compilerOptions: { isolatedModules: true },
+      }),
+      'proj/tsconfig.not-isolated.json': JSON.stringify({
+        compilerOptions: { isolatedModules: false },
+      }),
+      'proj/tsconfig.spec.json': JSON.stringify({
+        extends: ['./tsconfig.isolated.json', './tsconfig.not-isolated.json'],
+      }),
+    });
+    mockConfig({
+      transform: {
+        '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.spec.json' }],
+      },
+    });
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).toContainEqual({
+      dependentTasksOutputFiles: '**/*.d.ts',
+      transitive: true,
+    });
+  });
+
+  it('should not add dependentTasksOutputFiles when no transform is specified', async () => {
+    mockConfig({});
+    const results = await createNodesFunction(
+      ['proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime: true },
+      context
+    );
+    const inputs = getTestInputs(results);
+    expect(inputs).not.toContainEqual(
+      expect.objectContaining({ dependentTasksOutputFiles: '**/*.d.ts' })
+    );
+  });
+
   it('should not crash when preset fails to load', async () => {
     mockConfig({
       preset: '../nonexistent-preset.js',

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -35,6 +35,11 @@ import { combineGlobPatterns } from 'nx/src/utils/globs';
 import { getNxRequirePaths } from 'nx/src/utils/installation-directory';
 import { deriveGroupNameFromTarget } from 'nx/src/utils/plugins';
 import { globWithWorkspaceContext } from 'nx/src/utils/workspace-context';
+import { getLockFileName } from '@nx/js';
+import {
+  walkTsconfigExtendsChain,
+  type RawTsconfigJsonCache,
+} from '@nx/js/src/internal';
 import { getInstalledJestMajorVersion } from '../utils/versions';
 
 const REPORTER_BUILTINS = new Set(['default', 'github-actions', 'summary']);
@@ -65,6 +70,11 @@ export interface JestPluginOptions {
   useJestResolver?: boolean;
 }
 
+type IsolatedModulesResult = {
+  value: boolean | undefined;
+  visitedFiles: ReadonlySet<string>;
+};
+
 type JestTargets = Awaited<ReturnType<typeof buildJestTargets>>;
 
 function readTargetsCache(cachePath: string): Record<string, JestTargets> {
@@ -90,6 +100,11 @@ export const createNodes: CreateNodesV2<JestPluginOptions> = [
     const targetsCache = readTargetsCache(cachePath);
     // Cache jest preset(s) to avoid penalties of module load times. Most of jest configs will use the same preset.
     const presetCache: Record<string, unknown> = {};
+    // Cache tsconfig reads + isolatedModules resolution. Many projects share
+    // the same base tsconfig in their extends chain — read each file once.
+    const tsconfigJsonCache: RawTsconfigJsonCache = new Map();
+    const tsconfigExistsCache = new Map<string, boolean>();
+    const isolatedModulesCache = new Map<string, IsolatedModulesResult>();
 
     const isInPackageManagerWorkspaces = buildPackageJsonWorkspacesMatcher(
       context.workspaceRoot
@@ -97,9 +112,8 @@ export const createNodes: CreateNodesV2<JestPluginOptions> = [
 
     options = normalizeOptions(options);
 
-    const pmc = getPackageManagerCommand(
-      detectPackageManager(context.workspaceRoot)
-    );
+    const packageManager = detectPackageManager(context.workspaceRoot);
+    const pmc = getPackageManagerCommand(packageManager);
 
     const { roots: projectRoots, configFiles: validConfigFiles } =
       configFiles.reduce(
@@ -127,10 +141,52 @@ export const createNodes: CreateNodesV2<JestPluginOptions> = [
         }
       );
 
+    const lockFilePattern = getLockFileName(packageManager);
+
+    let requireCacheCleared = false;
+    const loadedConfigs: Array<{
+      rawConfig: any;
+      externalFiles: string[];
+      needsDtsInputs: boolean;
+    }> = [];
+    for (let i = 0; i < validConfigFiles.length; i++) {
+      const configFilePath = validConfigFiles[i];
+      const projectRoot = projectRoots[i];
+      const absConfigFilePath = resolve(context.workspaceRoot, configFilePath);
+      if (!requireCacheCleared && require.cache[absConfigFilePath]) {
+        clearRequireCache();
+        requireCacheCleared = true;
+      }
+      const rawConfig = await loadConfigFile(absConfigFilePath, [
+        'tsconfig.spec.json',
+        'tsconfig.test.json',
+        'tsconfig.jest.json',
+        'tsconfig.json',
+      ]);
+      const { externalFiles, needsDtsInputs } =
+        await collectExternalFileReferences(
+          rawConfig,
+          absConfigFilePath,
+          projectRoot,
+          context.workspaceRoot,
+          {
+            presetCache,
+            tsconfigJsonCache,
+            tsconfigExistsCache,
+            isolatedModulesCache,
+          }
+        );
+      loadedConfigs.push({ rawConfig, externalFiles, needsDtsInputs });
+    }
+
     const hashes = await calculateHashesForCreateNodes(
       projectRoots,
       options,
-      context
+      context,
+      loadedConfigs.map(({ externalFiles }) => [
+        lockFilePattern,
+        ...externalFiles,
+      ])
     );
 
     try {
@@ -138,8 +194,11 @@ export const createNodes: CreateNodesV2<JestPluginOptions> = [
         async (configFilePath, options, context, idx) => {
           const projectRoot = projectRoots[idx];
           const hash = hashes[idx];
+          const { rawConfig, needsDtsInputs } = loadedConfigs[idx];
 
           targetsCache[hash] ??= await buildJestTargets(
+            rawConfig,
+            needsDtsInputs,
             configFilePath,
             projectRoot,
             options,
@@ -226,6 +285,8 @@ function checkIfConfigFileShouldBeProject(
 }
 
 async function buildJestTargets(
+  rawConfig: any,
+  needsDtsInputs: boolean,
   configFilePath: string,
   projectRoot: string,
   options: JestPluginOptions,
@@ -234,18 +295,6 @@ async function buildJestTargets(
   pmc: ReturnType<typeof getPackageManagerCommand>
 ): Promise<Pick<ProjectConfiguration, 'targets' | 'metadata'>> {
   const absConfigFilePath = resolve(context.workspaceRoot, configFilePath);
-
-  if (require.cache[absConfigFilePath]) clearRequireCache();
-  const rawConfig = await loadConfigFile(
-    absConfigFilePath,
-    // lookup for the same files we look for in the resolver and fall back to tsconfig.json
-    [
-      'tsconfig.spec.json',
-      'tsconfig.test.json',
-      'tsconfig.jest.json',
-      'tsconfig.json',
-    ]
-  );
 
   const targets: Record<string, TargetConfiguration> = {};
   const namedInputs = getNamedInputs(projectRoot, context);
@@ -299,6 +348,7 @@ async function buildJestTargets(
     projectRoot,
     context.workspaceRoot,
     presetCache,
+    needsDtsInputs,
     useJestResolver
   ));
 
@@ -466,7 +516,7 @@ async function buildJestTargets(
       ) as typeof import('jest');
       const source = new jest.SearchSource(jestContext);
 
-      const jestVersion = getInstalledJestMajorVersion()!;
+      const jestVersion = getJestMajorVersion()!;
       const specs =
         jestVersion >= 30
           ? await source.getTestPaths(config.globalConfig, config.projectConfig)
@@ -571,6 +621,7 @@ async function getInputs(
   projectRoot: string,
   workspaceRoot: string,
   presetCache: Record<string, unknown>,
+  needsDtsInputs: boolean,
   useJestResolver?: boolean
 ): Promise<TargetConfiguration['inputs']> {
   const inputs: TargetConfiguration['inputs'] = [
@@ -654,6 +705,17 @@ async function getInputs(
   }
 
   inputs.push({ externalDependencies });
+
+  // When ts-jest runs without isolatedModules, it creates a TypeScript
+  // Language Service that reads .d.ts files from dependency projects.
+  // Declare these as dependentTasksOutputFiles so changes to dependency
+  // type declarations correctly invalidate the test cache.
+  if (needsDtsInputs) {
+    inputs.push({
+      dependentTasksOutputFiles: '**/*.d.ts',
+      transitive: true,
+    });
+  }
 
   return inputs;
 }
@@ -961,6 +1023,117 @@ async function getTestPaths(
   return { specs: paths, testMatch };
 }
 
+/**
+ * Collects workspace-relative paths to files whose CONTENT the plugin reads
+ * when computing inferred targets and that live OUTSIDE the project root.
+ *
+ * Only two kinds of files qualify:
+ *  - The jest preset (loaded to read its `transform`, etc.)
+ *  - Tsconfig files in the extends chain referenced by ts-jest (read to
+ *    determine `isolatedModules`); only walked when ts-jest is not already
+ *    known to be in isolated mode.
+ *
+ * Other config references (setup files, custom resolvers, transformers,
+ * etc.) are NOT collected — the plugin only resolves their paths and emits
+ * them as task inputs; their content is not read by the plugin, so changes
+ * to them don't influence inference.
+ */
+async function collectExternalFileReferences(
+  rawConfig: any,
+  absConfigFilePath: string,
+  projectRoot: string,
+  workspaceRoot: string,
+  caches: {
+    presetCache: Record<string, unknown>;
+    tsconfigJsonCache: RawTsconfigJsonCache;
+    tsconfigExistsCache: Map<string, boolean>;
+    isolatedModulesCache: Map<string, IsolatedModulesResult>;
+  }
+): Promise<{ externalFiles: string[]; needsDtsInputs: boolean }> {
+  const {
+    presetCache,
+    tsconfigJsonCache,
+    tsconfigExistsCache,
+    isolatedModulesCache,
+  } = caches;
+  const absWorkspaceRoot = resolve(workspaceRoot);
+  const rootDir = rawConfig.rootDir
+    ? resolve(dirname(absConfigFilePath), rawConfig.rootDir)
+    : resolve(absWorkspaceRoot, projectRoot);
+  const absoluteProjectRoot = resolve(absWorkspaceRoot, projectRoot);
+
+  const externalFiles = new Set<string>();
+  const addIfExternal = (absolutePath: string | null) => {
+    if (!absolutePath) return;
+    const rel = normalizePath(relative(absWorkspaceRoot, absolutePath));
+    if (rel.startsWith('..') || isAbsolute(rel)) return; // outside workspace
+    if (rel.includes('node_modules/')) return; // covered by lockfile
+    const relToProject = normalizePath(
+      relative(absoluteProjectRoot, absolutePath)
+    );
+    if (!relToProject.startsWith('..') && !isAbsolute(relToProject)) return; // inside project root
+    externalFiles.add(rel);
+  };
+
+  // Preset path (content is loaded by the plugin to merge with rawConfig)
+  if (typeof rawConfig.preset === 'string') {
+    const replaced = replaceRootDirInPath(rootDir, rawConfig.preset);
+    if (replaced.startsWith('.') || isAbsolute(replaced)) {
+      addIfExternal(resolve(rootDir, replaced));
+    }
+  }
+
+  // ts-jest tsconfig extends chain — only walked when ts-jest is in
+  // non-isolated mode (otherwise the chain doesn't influence the output).
+  // Loading the preset is required to merge its transform with the raw
+  // config, since presets are the common source of ts-jest configuration.
+  const presetConfig = await loadPresetConfig(rawConfig, rootDir, presetCache);
+  const transform: Record<string, string | [string, unknown]> = {
+    ...(presetConfig?.transform ?? {}),
+    ...(rawConfig.transform ?? {}),
+  };
+  let needsDtsInputs = false;
+  for (const value of Object.values(transform)) {
+    let transformPath: string;
+    let transformOptions: Record<string, any> | undefined;
+    if (Array.isArray(value)) {
+      transformPath = value[0];
+      transformOptions = value[1] as Record<string, any>;
+    } else if (typeof value === 'string') {
+      transformPath = value;
+    } else {
+      continue;
+    }
+    if (!isTsJestTransformer(transformPath)) continue;
+    if (transformOptions?.isolatedModules === true) {
+      const tsJestMajor = getTsJestMajorVersion();
+      if (tsJestMajor !== null && tsJestMajor < 30) continue;
+    }
+    const tsconfigAbsPath = transformOptions?.tsconfig
+      ? resolve(
+          rootDir,
+          replaceRootDirInPath(rootDir, transformOptions.tsconfig)
+        )
+      : findNearestTsconfig(rootDir, absWorkspaceRoot, tsconfigExistsCache);
+    if (!tsconfigAbsPath) {
+      // No tsconfig found — ts-jest defaults to non-isolated mode
+      needsDtsInputs = true;
+      continue;
+    }
+    const { value: isolatedValue, visitedFiles } = resolveIsolatedModules(
+      tsconfigAbsPath,
+      tsconfigJsonCache,
+      isolatedModulesCache
+    );
+    for (const visitedFile of visitedFiles) {
+      addIfExternal(visitedFile);
+    }
+    if (isolatedValue !== true) needsDtsInputs = true;
+  }
+
+  return { externalFiles: [...externalFiles], needsDtsInputs };
+}
+
 async function loadPresetConfig(
   rawConfig: any,
   rootDir: string,
@@ -1113,6 +1286,111 @@ async function getConfigFileInputs(
     fileInputs: [...fileInputs],
     externalDeps: [...externalDeps],
   };
+}
+
+/**
+ * Walks up from `startDir` looking for `tsconfig.json`, stopping at
+ * `stopDir` (inclusive). Mirrors `ts.findConfigFile` but capped at the
+ * workspace root to avoid escaping the monorepo.
+ */
+function findNearestTsconfig(
+  startDir: string,
+  stopDir: string,
+  existsCache: Map<string, boolean>
+): string | null {
+  let dir = startDir;
+  while (true) {
+    const candidate = join(dir, 'tsconfig.json');
+    let exists = existsCache.get(candidate);
+    if (exists === undefined) {
+      exists = existsSync(candidate);
+      existsCache.set(candidate, exists);
+    }
+    if (exists) return candidate;
+    if (dir === stopDir) return null;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function isTsJestTransformer(value: string): boolean {
+  if (value === 'ts-jest' || value.startsWith('ts-jest/')) {
+    return true;
+  }
+
+  // Handle resolved paths (e.g. from require.resolve('ts-jest') in configs)
+  const normalized = normalizePath(value);
+  return (
+    normalized.includes('/node_modules/ts-jest/') ||
+    normalized.endsWith('/node_modules/ts-jest')
+  );
+}
+
+/**
+ * Returns the effective `compilerOptions.isolatedModules` for a tsconfig,
+ * walking the `extends` chain via `walkTsconfigExtendsChain`. Tri-state:
+ * `value` is `undefined` when the option is not set anywhere in the chain.
+ */
+function resolveIsolatedModules(
+  tsconfigPath: string,
+  jsonCache: RawTsconfigJsonCache,
+  resultCache: Map<string, IsolatedModulesResult>
+): IsolatedModulesResult {
+  const cached = resultCache.get(tsconfigPath);
+  if (cached) return cached;
+
+  let value: boolean | undefined;
+  const visitedFiles = new Set<string>();
+
+  walkTsconfigExtendsChain(
+    tsconfigPath,
+    (absPath, rawJson) => {
+      visitedFiles.add(absPath);
+      const opts = (rawJson as any)?.compilerOptions;
+      if (opts?.isolatedModules !== undefined) {
+        value = opts.isolatedModules === true;
+        return 'stop';
+      }
+      // verbatimModuleSyntax: true implies isolatedModules: true (TS 5.0+,
+      // the minimum TS version Nx supports)
+      if (opts?.verbatimModuleSyntax === true) {
+        value = true;
+        return 'stop';
+      }
+      return 'continue';
+    },
+    { jsonCache }
+  );
+
+  const result: IsolatedModulesResult = { value, visitedFiles };
+  resultCache.set(tsconfigPath, result);
+  return result;
+}
+
+// Module-level memoization: package versions don't change during a process
+// lifetime, so it's safe to cache across createNodes invocations.
+let cachedJestMajorVersion: number | null | undefined;
+function getJestMajorVersion(): number | null {
+  if (cachedJestMajorVersion === undefined) {
+    cachedJestMajorVersion = getInstalledJestMajorVersion();
+  }
+  return cachedJestMajorVersion;
+}
+
+let cachedTsJestMajorVersion: number | null | undefined;
+function getTsJestMajorVersion(): number | null {
+  if (cachedTsJestMajorVersion !== undefined) {
+    return cachedTsJestMajorVersion;
+  }
+  try {
+    const { major } = require('semver');
+    const version = require('ts-jest/package.json').version as string;
+    cachedTsJestMajorVersion = major(version) as number;
+  } catch {
+    cachedTsJestMajorVersion = null;
+  }
+  return cachedTsJestMajorVersion;
 }
 
 async function getJestOption<T = any>(

--- a/packages/js/src/internal.ts
+++ b/packages/js/src/internal.ts
@@ -1,4 +1,8 @@
 export { resolveModuleByImport } from './utils/typescript/ast-utils';
+export {
+  walkTsconfigExtendsChain,
+  type RawTsconfigJsonCache,
+} from './utils/typescript/raw-tsconfig';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 export {
   registerTsProject,

--- a/packages/js/src/utils/typescript/raw-tsconfig.ts
+++ b/packages/js/src/utils/typescript/raw-tsconfig.ts
@@ -1,0 +1,107 @@
+import { readJsonFile } from '@nx/devkit';
+import { dirname } from 'node:path';
+
+/**
+ * Lightweight tsconfig extends walker that does NOT load the `typescript`
+ * package. For full TypeScript-aware parsing (compilerOptions resolution,
+ * file lists, project references, etc.) see the `@nx/js/typescript` plugin,
+ * which uses `ts.parseJsonConfigFileContent` and a persistent cache.
+ */
+
+/**
+ * Cache of raw parsed tsconfig JSON contents, keyed by absolute file path.
+ * `null` indicates a file that doesn't exist or failed to parse.
+ *
+ * Instantiate with `new Map()` and reuse across `walkTsconfigExtendsChain`
+ * calls within one `createNodes` invocation to dedupe file reads when many
+ * starting points share parent tsconfigs.
+ */
+export type RawTsconfigJsonCache = Map<string, unknown | null>;
+
+/**
+ * Walks the `extends` chain of a tsconfig, invoking `visit` for each unique
+ * reachable file (entry first, then recursively). Cycle-safe. Files that
+ * don't exist or fail to parse are silently skipped.
+ *
+ * When a tsconfig has multiple `extends` entries they are visited in
+ * REVERSE order, so visitors looking for the effective value of an
+ * inherited option see the highest-precedence entries first and can
+ * return `'stop'` to abort the traversal. Visitors that want to collect
+ * every reachable file should always return `'continue'`.
+ *
+ * @param entryAbsolutePath Absolute, canonical path of the tsconfig to
+ *   start from. Pass through `path.resolve()` if unsure.
+ * @param visit Invoked once per unique reachable tsconfig.
+ * @param options.jsonCache Optional shared cache of parsed tsconfig
+ *   contents. When omitted, the walker uses a fresh internal cache.
+ */
+export function walkTsconfigExtendsChain(
+  entryAbsolutePath: string,
+  visit: (absolutePath: string, rawJson: unknown) => 'continue' | 'stop',
+  options?: { jsonCache?: RawTsconfigJsonCache }
+): void {
+  const jsonCache: RawTsconfigJsonCache = options?.jsonCache ?? new Map();
+  walk(entryAbsolutePath, visit, jsonCache, new Set());
+}
+
+function walk(
+  absolutePath: string,
+  visit: (absolutePath: string, rawJson: unknown) => 'continue' | 'stop',
+  jsonCache: RawTsconfigJsonCache,
+  visited: Set<string>
+): 'continue' | 'stop' {
+  if (visited.has(absolutePath)) return 'continue';
+  visited.add(absolutePath);
+
+  const json = readCachedJson(absolutePath, jsonCache);
+  if (json === null) return 'continue';
+
+  if (visit(absolutePath, json) === 'stop') return 'stop';
+
+  const extendsField = (json as { extends?: unknown }).extends;
+  if (!extendsField) return 'continue';
+  const extendsList = Array.isArray(extendsField)
+    ? extendsField
+    : [extendsField];
+
+  // Last entry wins per TypeScript precedence; walk in reverse so
+  // precedence-aware visitors see the highest-precedence entries first.
+  const fromDir = dirname(absolutePath);
+  for (let i = extendsList.length - 1; i >= 0; i--) {
+    const ext = extendsList[i];
+    if (typeof ext !== 'string' || !ext) continue;
+    const childPath = resolveExtendsPath(ext, fromDir);
+    if (childPath === null) continue;
+    if (walk(childPath, visit, jsonCache, visited) === 'stop') return 'stop';
+  }
+
+  return 'continue';
+}
+
+function readCachedJson(
+  absolutePath: string,
+  cache: RawTsconfigJsonCache
+): unknown | null {
+  if (cache.has(absolutePath)) {
+    return cache.get(absolutePath) ?? null;
+  }
+  let parsed: unknown | null;
+  try {
+    parsed = readJsonFile(absolutePath);
+  } catch {
+    parsed = null;
+  }
+  cache.set(absolutePath, parsed);
+  return parsed;
+}
+
+function resolveExtendsPath(
+  extendsValue: string,
+  fromDir: string
+): string | null {
+  try {
+    return require.resolve(extendsValue, { paths: [fromDir] });
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Current Behavior

When ts-jest runs without `isolatedModules`, it creates a TypeScript Language Service that reads `.d.ts` files from dependency projects. Changes to those `.d.ts` files don't invalidate the test cache, leading to stale test results.

## Expected Behavior

The jest plugin detects ts-jest usage without `isolatedModules` and adds `dependentTasksOutputFiles: '**/*.d.ts'` as a transitive input. This ensures dependency type declaration changes correctly invalidate the test cache.

The plugin:
- Inspects jest config transforms (including presets) for ts-jest
- Walks the tsconfig `extends` chain to resolve the effective `isolatedModules` value, reusing the lightweight walker from `@nx/js` (intentionally avoids loading `typescript` for performance)
- Handles `verbatimModuleSyntax` as implying `isolatedModules`
- Respects ts-jest v29 vs v30 semantics for the deprecated `isolatedModules` transform option
- Mirrors `ts.findConfigFile` upward walk (capped at workspace root) when no explicit tsconfig is configured
- Tracks external file references (presets, tsconfigs outside project root) for correct hash computation

## Additional Changes

- **Plugin hash correctness**: config loading moved before hash computation so external file references (preset files, tsconfig extends chains) are included in the hash. Previously, changes to files outside the project root that the plugin reads during inference (e.g., a shared jest preset or base tsconfig) would not invalidate the cached target configuration. The lockfile is also now included as a hash input.
- **e2eInputs**: added `dependentTasksOutputFiles` to the `e2eInputs` named input in `nx.json` since e2e target defaults override plugin-inferred inputs.
- **Jest preset**: pre-resolve the `@swc-contrib/mut-cjs-exports` SWC plugin to an absolute path. Tests that `chdir` into temp dirs would fail SWC plugin resolution since the temp dir has no `node_modules`.