### PR TITLE
chore(core): update dotenv-expand to 12.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "czg": "^1.4.0",
     "detect-port": "^1.5.1",
     "dotenv": "~16.4.5",
-    "dotenv-expand": "~11.0.6",
+    "dotenv-expand": "~12.0.3",
     "ejs": "5.0.1",
     "emnapi": "^1.2.0",
     "enhanced-resolve": "^5.8.3",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -60,7 +60,7 @@
     "cli-spinners": "2.6.1",
     "cliui": "^8.0.1",
     "dotenv": "~16.4.5",
-    "dotenv-expand": "~11.0.6",
+    "dotenv-expand": "~12.0.3",
     "ejs": "5.0.1",
     "enquirer": "catalog:",
     "figures": "3.2.0",

--- a/packages/nx/src/tasks-runner/task-env.spec.ts
+++ b/packages/nx/src/tasks-runner/task-env.spec.ts
@@ -1,6 +1,71 @@
-import { getEnvFilesForTask } from './task-env';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getEnvFilesForTask, loadAndExpandDotEnvFile } from './task-env';
 import { Task } from '../config/task-graph';
 import { ProjectGraph } from '../config/project-graph';
+
+describe(loadAndExpandDotEnvFile.name, () => {
+  let tempDir: string;
+
+  afterEach(() => {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should support chained variable expansion across multiple env files', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'nx-task-env-'));
+
+    const firstFile = join(tempDir, '.env.local');
+    const secondFile = join(tempDir, '.local.env');
+    const thirdFile = join(tempDir, '.env');
+
+    writeFileSync(firstFile, 'BASE_URL=https://nx.dev\n');
+    writeFileSync(secondFile, 'API_URL=$BASE_URL/api\n');
+    writeFileSync(thirdFile, 'FULL_URL=$API_URL/v1\n');
+
+    const environmentVariables: NodeJS.ProcessEnv = {};
+
+    loadAndExpandDotEnvFile(
+      [firstFile, secondFile, thirdFile],
+      environmentVariables
+    );
+
+    expect(environmentVariables).toMatchObject({
+      BASE_URL: 'https://nx.dev',
+      API_URL: 'https://nx.dev/api',
+      FULL_URL: 'https://nx.dev/api/v1',
+    });
+  });
+
+  it('should support back-referenced chains from third file to second to first', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'nx-task-env-'));
+
+    const firstFile = join(tempDir, '.env.local');
+    const secondFile = join(tempDir, '.local.env');
+    const thirdFile = join(tempDir, '.env');
+
+    writeFileSync(firstFile, 'FULL_URL=$API_URL/v1\n');
+    writeFileSync(secondFile, 'API_URL=$BASE_URL/api\n');
+    writeFileSync(thirdFile, 'BASE_URL=https://nx.dev\n');
+
+    const environmentVariables: NodeJS.ProcessEnv = {};
+
+    // Load in declared priority order while allowing references to values
+    // that are defined in later files.
+    loadAndExpandDotEnvFile(
+      [firstFile, secondFile, thirdFile],
+      environmentVariables
+    );
+
+    expect(environmentVariables).toMatchObject({
+      BASE_URL: 'https://nx.dev',
+      API_URL: 'https://nx.dev/api',
+      FULL_URL: 'https://nx.dev/api/v1',
+    });
+  });
+});
 
 describe('getEnvFilesForTask', () => {
   it('should return the correct env files for a standard task', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -936,8 +936,8 @@ importers:
         specifier: ~16.4.5
         version: 16.4.7
       dotenv-expand:
-        specifier: ~11.0.6
-        version: 11.0.7
+        specifier: ~12.0.3
+        version: 12.0.3
       ejs:
         specifier: 5.0.1
         version: 5.0.1
@@ -3511,8 +3511,8 @@ importers:
         specifier: ~16.4.5
         version: 16.4.7
       dotenv-expand:
-        specifier: ~11.0.6
-        version: 11.0.7
+        specifier: ~12.0.3
+        version: 12.0.3
       ejs:
         specifier: 5.0.1
         version: 5.0.1
@@ -16810,6 +16810,10 @@ packages:
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
+    engines: {node: '>=12'}
+
+  dotenv-expand@12.0.3:
+    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
     engines: {node: '>=12'}
 
   dotenv@16.4.7:
@@ -45221,6 +45225,10 @@ snapshots:
       type-fest: 4.41.0
 
   dotenv-expand@11.0.7:
+    dependencies:
+      dotenv: 16.4.7
+
+  dotenv-expand@12.0.3:
     dependencies:
       dotenv: 16.4.7
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Nx now batches `.env` loading across files, but chained interpolation can still break with the older dotenv-expand behavior when variables depend on values defined in later files in the load order.

A concrete back-reference chain is:

first file defines `FULL_URL` as `$API_URL/v1`
second file defines `API_URL` as `$BASE_URL/api`
third file defines `BASE_URL` as `https://nx.dev`

This scenario should resolve end-to-end, but with the older dependency behavior it can fail to fully interpolate chained references.

## Expected Behavior
Chained cross-file references should resolve completely, including back-referenced chains where earlier files depend on values declared in later files.

For the example above, final values should be:

```env
BASE_URL = https://nx.dev
API_URL = https://nx.dev/api
FULL_URL = https://nx.dev/api/v1
```

## What Changed
Upgraded `dotenv-expand` to `12.0.3` in `packages/nx/package.json` and `package.json` dependencies.
Updated lockfile accordingly by installing dependencies.
Added/updated regression coverage in `task-env.spec.ts` to explicitly verify:
 - chained interpolation across multiple files
 - back-reference chain from first file to second to third file
 
## Validation
Ran focused spec:
```bash
pnpm nx test nx --runTestsByPath src/tasks-runner/task-env.spec.ts --outputStyle=static
```
Result: passed.

## Related Issue(s)
Follow-up to #34956
Related to #34955
