### PR TITLE
fix(linter): add missing inputs to eslint executor target defaults

### DIFF
--- a/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
+++ b/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
@@ -103,9 +103,11 @@ exports[`workspace move to nx layout should create nx.json 1`] = `
       "cache": true,
       "inputs": [
         "default",
+        "^default",
         "{workspaceRoot}/.eslintrc.json",
         "{workspaceRoot}/.eslintignore",
         "{workspaceRoot}/eslint.config.mjs",
+        "{workspaceRoot}/tools/eslint-rules/**/*",
       ],
     },
     "build": {

--- a/packages/eslint/migrations.json
+++ b/packages/eslint/migrations.json
@@ -9,6 +9,11 @@
       "version": "20.3.0-beta.1",
       "description": "Update ESLint flat config to include .cjs, .mjs, .cts, and .mts files in overrides (if needed)",
       "implementation": "./src/migrations/update-20-3-0/add-file-extensions-to-overrides"
+    },
+    "update-executor-lint-inputs": {
+      "version": "22.7.0-beta.12",
+      "description": "Add missing inputs to @nx/eslint:lint executor target defaults",
+      "implementation": "./src/migrations/update-21-6-0/update-executor-lint-inputs"
     }
   },
   "packageJsonUpdates": {

--- a/packages/eslint/src/generators/init/init.spec.ts
+++ b/packages/eslint/src/generators/init/init.spec.ts
@@ -116,9 +116,11 @@ describe('@nx/eslint:init', () => {
           cache: true,
           inputs: [
             'default',
+            '^default',
             '{workspaceRoot}/.eslintrc.json',
             '{workspaceRoot}/.eslintignore',
             '{workspaceRoot}/eslint.config.cjs',
+            '{workspaceRoot}/tools/eslint-rules/**/*',
           ],
         });
       });
@@ -144,9 +146,11 @@ describe('@nx/eslint:init', () => {
           cache: true,
           inputs: [
             'default',
+            '^default',
             '{workspaceRoot}/.eslintrc.json',
             '{workspaceRoot}/.eslintignore',
             '{workspaceRoot}/eslint.config.cjs',
+            '{workspaceRoot}/tools/eslint-rules/**/*',
           ],
         });
       });
@@ -166,9 +170,11 @@ describe('@nx/eslint:init', () => {
           cache: true,
           inputs: [
             'default',
+            '^default',
             '{workspaceRoot}/.eslintrc.json',
             '{workspaceRoot}/.eslintignore',
             '{workspaceRoot}/eslint.config.mjs',
+            '{workspaceRoot}/tools/eslint-rules/**/*',
           ],
         });
       });
@@ -194,9 +200,11 @@ describe('@nx/eslint:init', () => {
           cache: true,
           inputs: [
             'default',
+            '^default',
             '{workspaceRoot}/.eslintrc.json',
             '{workspaceRoot}/.eslintignore',
             '{workspaceRoot}/eslint.config.mjs',
+            '{workspaceRoot}/tools/eslint-rules/**/*',
           ],
         });
       });

--- a/packages/eslint/src/generators/init/init.ts
+++ b/packages/eslint/src/generators/init/init.ts
@@ -49,9 +49,11 @@ function addTargetDefaults(tree: Tree, format: 'mjs' | 'cjs') {
   nxJson.targetDefaults['@nx/eslint:lint'].cache ??= true;
   nxJson.targetDefaults['@nx/eslint:lint'].inputs ??= [
     'default',
+    '^default',
     `{workspaceRoot}/.eslintrc.json`,
     `{workspaceRoot}/.eslintignore`,
     `{workspaceRoot}/eslint.config.${format}`,
+    '{workspaceRoot}/tools/eslint-rules/**/*',
   ];
   updateNxJson(tree, nxJson);
 }

--- a/packages/eslint/src/migrations/update-21-6-0/update-executor-lint-inputs.spec.ts
+++ b/packages/eslint/src/migrations/update-21-6-0/update-executor-lint-inputs.spec.ts
@@ -1,0 +1,111 @@
+import { type Tree, readNxJson, updateNxJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './update-executor-lint-inputs';
+
+describe('update-executor-lint-inputs', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should add ^default and tools/eslint-rules glob to existing inputs', async () => {
+    const nxJson = readNxJson(tree);
+    nxJson.targetDefaults = {
+      '@nx/eslint:lint': {
+        cache: true,
+        inputs: [
+          'default',
+          '{workspaceRoot}/.eslintrc.json',
+          '{workspaceRoot}/.eslintignore',
+          '{workspaceRoot}/eslint.config.mjs',
+        ],
+      },
+    };
+    updateNxJson(tree, nxJson);
+
+    await migration(tree);
+
+    const updated = readNxJson(tree);
+    expect(updated.targetDefaults['@nx/eslint:lint'].inputs).toEqual([
+      'default',
+      '^default',
+      '{workspaceRoot}/.eslintrc.json',
+      '{workspaceRoot}/.eslintignore',
+      '{workspaceRoot}/eslint.config.mjs',
+      '{workspaceRoot}/tools/eslint-rules/**/*',
+    ]);
+  });
+
+  it('should not duplicate inputs if already present', async () => {
+    const nxJson = readNxJson(tree);
+    nxJson.targetDefaults = {
+      '@nx/eslint:lint': {
+        cache: true,
+        inputs: [
+          'default',
+          '^default',
+          '{workspaceRoot}/.eslintrc.json',
+          '{workspaceRoot}/tools/eslint-rules/**/*',
+        ],
+      },
+    };
+    updateNxJson(tree, nxJson);
+
+    await migration(tree);
+
+    const updated = readNxJson(tree);
+    expect(updated.targetDefaults['@nx/eslint:lint'].inputs).toEqual([
+      'default',
+      '^default',
+      '{workspaceRoot}/.eslintrc.json',
+      '{workspaceRoot}/tools/eslint-rules/**/*',
+    ]);
+  });
+
+  it('should do nothing if no executor target defaults exist', async () => {
+    const nxJson = readNxJson(tree);
+    nxJson.targetDefaults = {};
+    updateNxJson(tree, nxJson);
+
+    await migration(tree);
+
+    const updated = readNxJson(tree);
+    expect(updated.targetDefaults['@nx/eslint:lint']).toBeUndefined();
+  });
+
+  it('should do nothing if no inputs are configured', async () => {
+    const nxJson = readNxJson(tree);
+    nxJson.targetDefaults = {
+      '@nx/eslint:lint': {
+        cache: true,
+      },
+    };
+    updateNxJson(tree, nxJson);
+
+    await migration(tree);
+
+    const updated = readNxJson(tree);
+    expect(updated.targetDefaults['@nx/eslint:lint'].inputs).toBeUndefined();
+  });
+
+  it('should add ^default at beginning if default is not in the list', async () => {
+    const nxJson = readNxJson(tree);
+    nxJson.targetDefaults = {
+      '@nx/eslint:lint': {
+        cache: true,
+        inputs: ['{workspaceRoot}/.eslintrc.json'],
+      },
+    };
+    updateNxJson(tree, nxJson);
+
+    await migration(tree);
+
+    const updated = readNxJson(tree);
+    expect(updated.targetDefaults['@nx/eslint:lint'].inputs).toEqual([
+      '^default',
+      '{workspaceRoot}/.eslintrc.json',
+      '{workspaceRoot}/tools/eslint-rules/**/*',
+    ]);
+  });
+});

--- a/packages/eslint/src/migrations/update-21-6-0/update-executor-lint-inputs.ts
+++ b/packages/eslint/src/migrations/update-21-6-0/update-executor-lint-inputs.ts
@@ -1,0 +1,29 @@
+import { type Tree, formatFiles, readNxJson, updateNxJson } from '@nx/devkit';
+
+export default async function (tree: Tree) {
+  const nxJson = readNxJson(tree);
+  const executor = '@nx/eslint:lint';
+
+  if (!nxJson.targetDefaults?.[executor]?.inputs) {
+    return;
+  }
+
+  const inputs = nxJson.targetDefaults[executor].inputs;
+
+  if (!inputs.includes('^default')) {
+    // Add after 'default' if present, otherwise at the beginning
+    const defaultIndex = inputs.indexOf('default');
+    if (defaultIndex !== -1) {
+      inputs.splice(defaultIndex + 1, 0, '^default');
+    } else {
+      inputs.unshift('^default');
+    }
+  }
+
+  if (!inputs.includes('{workspaceRoot}/tools/eslint-rules/**/*')) {
+    inputs.push('{workspaceRoot}/tools/eslint-rules/**/*');
+  }
+
+  updateNxJson(tree, nxJson);
+  await formatFiles(tree);
+}


### PR DESCRIPTION
## Current Behavior

After the custom eslint hasher was removed in d64aeef5df, the `@nx/eslint:lint` executor target defaults are missing `^default` and `{workspaceRoot}/tools/eslint-rules/**/*` from their inputs. The old custom hasher was compensating for this by manually handling dependency hashing, but now that it's gone, the inputs need to be self-sufficient.

This means:
- Changes in dependencies don't invalidate the lint cache (problematic for type-aware rules that inspect imported types)
- Changes to custom workspace eslint rules don't trigger re-linting

The inferred/plugin path (`plugin.ts`) already includes these inputs correctly.

## Expected Behavior

The executor target defaults should include `^default` (dependency file changes) and `{workspaceRoot}/tools/eslint-rules/**/*` (custom workspace rules) to match what the eslint plugin already sets for inferred targets.

## Related Issue(s)

Follows up on d64aeef5df (remove custom eslint hasher).