### PR TITLE
fix(core): exclude populate-local-registry-storage from sandbox I/O checks

### DIFF
--- a/.nx/workflows/sandboxing-config.yaml
+++ b/.nx/workflows/sandboxing-config.yaml
@@ -9,3 +9,13 @@ task-exclusions:
   - target: lint
     exclude-reads:
       - '**/dist/**/*.json'
+  # TODO: populate-local-registry-storage is doing too much — it reads all build
+  # outputs and writes version-bumped packages across the entire workspace during
+  # nx-release. We're reworking this task to have more focused I/O and will fix
+  # the inputs/outputs properly after that.
+  - project: '@nx/nx-source'
+    target: populate-local-registry-storage
+    exclude-reads:
+      - '**'
+    exclude-writes:
+      - '**'


### PR DESCRIPTION
## Current Behavior

The `populate-local-registry-storage` target has massive I/O violations in sandbox reports (~8k unexpected reads, ~7.6k unexpected writes) because it runs `nx-release --local` which reads all build outputs and writes version-bumped packages across the entire workspace.

## Expected Behavior

Exclude this target from sandbox I/O validation until it is reworked to have more focused I/O boundaries. The task is doing too much in a single step to have meaningful input/output declarations.

## Related Issue(s)

Sandbox violation report: https://staging.nx.app/runs/ffYkwp6x9i/task/%40nx%2Fnx-source%3Apopulate-local-registry-storage/sandbox-report-raw?sandboxReportId=59a38b85-b0f4-40cc-a914-5383abe98adf&workspaceId=62d013ea0852fe0a2df74438