### PR TITLE
docs(misc): review remote cache docs and fix powerpack redirect

### DIFF
--- a/astro-docs/src/content/docs/guides/Tasks & Caching/self-hosted-caching.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/self-hosted-caching.mdoc
@@ -1,10 +1,11 @@
 ---
 title: 'Remote Cache'
-description: 'Learn how to set up remote cache.'
+description: 'Learn how to set up remote cache with Nx Cloud or a self-hosted solution.'
 filter: 'type:Guides'
 ---
 
-There are several ways to set up remote caching with Nx.
+Remote caching shares build results across your team and CI so you don't repeat work.
+You can use Nx Cloud for a fully managed solution or self-host with one of the available plugins.
 
 {% aside type="note" title="Nx Cloud: Managed Remote Cache" %}
 
@@ -50,14 +51,22 @@ All packages below (along with other bucket-based remote cache implementations) 
 
 {% /aside %}
 
-All packages are free but require an activation key. Getting a key is a fully automated, self-service process that happens during package installation.
+All packages are free but require an activation key. Getting a key is a fully automated, self-service process that happens during package installation. Install any of the following with `nx add`:
 
-The following remote cache adapters are available:
+| Package                                                                                | Storage                      | Install command              |
+| -------------------------------------------------------------------------------------- | ---------------------------- | ---------------------------- |
+| [`@nx/s3-cache`](/docs/reference/remote-cache-plugins/s3-cache/overview)               | Amazon S3 bucket             | `nx add @nx/s3-cache`        |
+| [`@nx/gcs-cache`](/docs/reference/remote-cache-plugins/gcs-cache/overview)             | Google Cloud Storage         | `nx add @nx/gcs-cache`       |
+| [`@nx/azure-cache`](/docs/reference/remote-cache-plugins/azure-cache/overview)         | Azure Blob Storage           | `nx add @nx/azure-cache`     |
+| [`@nx/shared-fs-cache`](/docs/reference/remote-cache-plugins/shared-fs-cache/overview) | Shared file system directory | `nx add @nx/shared-fs-cache` |
 
-- [@nx/s3-cache](/docs/reference/remote-cache-plugins/s3-cache/overview): Cache is self-hosted on an Amazon S3 bucket
-- [@nx/gcs-cache](/docs/reference/remote-cache-plugins/gcs-cache/overview): Cache is self-hosted on Google Cloud storage
-- [@nx/azure-cache](/docs/reference/remote-cache-plugins/azure-cache/overview): Cache is self-hosted on Azure
-- [@nx/shared-fs-cache](/docs/reference/remote-cache-plugins/shared-fs-cache/overview): Cache is self-hosted on a shared file system location
+The `nx add` command installs the package, configures your workspace, and walks you through generating an activation key.
+The key is saved to `.nx/key/key.ini` and should be committed to your repository.
+In CI or public repositories, set the `NX_KEY` environment variable instead.
+
+If you don't have a key yet, run `nx register` to generate one.
+If your existing key is expired or invalid, delete `.nx/key/key.ini` and run `nx register` again.
+In CI, verify that the `NX_KEY` environment variable is set and matches the key in `.nx/key/key.ini`.
 
 > Why require an activation key? It simply helps us know and support our users. If you prefer not to provide this information, you can also [build your own cache server](#build-your-own-caching-server).
 
@@ -227,3 +236,10 @@ You might have used Nx now-deprecated custom task runners API in these scenarios
 - To inject custom behavior before and after running tasks: use our new API with dedicated pre and post hooks
 
 To learn more about migrating from custom task runners, [please refer to this detailed guide](/docs/reference/deprecated/custom-tasks-runner).
+
+## Looking for conformance or code owners?
+
+If you previously used Nx Powerpack for conformance rules or code ownership, those features are now part of [Nx Enterprise](/docs/enterprise). See:
+
+- [Conformance](/docs/enterprise/conformance) — write and enforce language-agnostic rules across your workspace
+- [Owners](/docs/enterprise/owners) — define code ownership at the project level and auto-generate CODEOWNERS files

--- a/nx-dev/nx-dev/_redirects
+++ b/nx-dev/nx-dev/_redirects
@@ -536,9 +536,14 @@
 /nx-api/powerpack-s3-cache /docs/reference/remote-cache-plugins/s3-cache 301
 /nx-api/powerpack-gcs-cache /docs/reference/remote-cache-plugins/gcs-cache 301
 
+# --- remoteCacheShortUrl ---
+/remote-cache /docs/guides/tasks--caching/self-hosted-caching 301
+
 # --- powerpackRedirects ---
-/powerpack /enterprise 301
-/powerpack/* /enterprise 301
+/powerpack /docs/guides/tasks--caching/self-hosted-caching 301
+/powerpack/conformance /docs/enterprise/conformance 301
+/powerpack/owners /docs/enterprise/owners 301
+/powerpack/* /docs/enterprise 301
 /nx-enterprise/powerpack/custom-caching /docs/guides/tasks--caching/self-hosted-caching 301
 /nx-enterprise/powerpack/free-licenses-and-trials /docs/enterprise 301
 /nx-api/powerpack-owners /nx-api/owners 301


### PR DESCRIPTION
## Current Behavior

- `/powerpack` redirects to the `/enterprise` marketing page, which doesn't help users who have an expired or missing activation key for shared cache plugins (`@nx/s3-cache`, `@nx/gcs-cache`, etc.)
- The self-hosted caching guide lists available packages but requires clicking through to individual reference pages to find install commands and key setup instructions
- No short, stable URL exists for CLI error messages to link to

## Expected Behavior

- `/powerpack` redirects to the self-hosted caching guide (`/docs/guides/tasks--caching/self-hosted-caching`), which is the right landing page for cache plugin users
- `/powerpack/conformance` and `/powerpack/owners` redirect to their respective enterprise docs pages
- A new `/remote-cache` short URL points to the self-hosted caching guide for use in CLI error messages (e.g., the `nx-key` hardcoded link in ocean)
- The self-hosted caching page includes a table with install commands (`nx add @nx/...`), key setup instructions (`.nx/key/key.ini`, `NX_KEY` env var, `nx register`), and a section pointing former Powerpack users to conformance/owners enterprise docs

Preview: https://deploy-preview-35240--nx-docs.netlify.app/docs/guides/tasks--caching/self-hosted-caching

## Related Issue(s)

Fixes DOC-477

**Follow-up:** The `nx-key` hardcoded link in the ocean repo (`libs/nx-packages/nx-key/src/consts.rs` L1) should be updated to `nx.dev/remote-cache` in a separate PR.