### PR TITLE
fix(vitest): infer ancestor tsconfig files as test task inputs

### DIFF
--- a/packages/vite/src/plugins/plugin.spec.ts
+++ b/packages/vite/src/plugins/plugin.spec.ts
@@ -320,6 +320,114 @@ describe('@nx/vite/plugin', () => {
     });
   });
 
+  it('should add ancestor tsconfig.json to test inputs when it exists outside the project root', async () => {
+    const tempFs = new TempFs('vite-tsconfig-ancestor');
+    context = {
+      nxJsonConfiguration: {
+        namedInputs: {
+          default: ['{projectRoot}/**/*'],
+          production: ['!{projectRoot}/**/*.spec.ts'],
+        },
+      },
+      workspaceRoot: tempFs.tempDir,
+    };
+    tempFs.createFileSync('tsconfig.json', JSON.stringify({}));
+    tempFs.createFileSync('apps/my-app/tsconfig.json', JSON.stringify({}));
+    tempFs.createFileSync(
+      'apps/my-app/project.json',
+      JSON.stringify({ name: 'my-app' })
+    );
+    tempFs.createFileSync('apps/my-app/vitest.config.ts', '');
+    tempFs.createFileSync('package-lock.json', '{}');
+
+    const nodes = await createNodesFunction(
+      ['apps/my-app/vitest.config.ts'],
+      { testTargetName: 'test' },
+      context
+    );
+
+    const inputs = nodes[0][1].projects['apps/my-app'].targets.test.inputs;
+    expect(inputs).toContainEqual({
+      json: '{workspaceRoot}/tsconfig.json',
+      fields: ['compilerOptions'],
+    });
+    tempFs.cleanup();
+  });
+
+  it('should add tsconfig files from the extends chain outside the project root', async () => {
+    const tempFs = new TempFs('vite-tsconfig-extends');
+    context = {
+      nxJsonConfiguration: {
+        namedInputs: {
+          default: ['{projectRoot}/**/*'],
+          production: ['!{projectRoot}/**/*.spec.ts'],
+        },
+      },
+      workspaceRoot: tempFs.tempDir,
+    };
+    tempFs.createFileSync('tsconfig.shared.json', JSON.stringify({}));
+    tempFs.createFileSync(
+      'apps/my-app/tsconfig.json',
+      JSON.stringify({ extends: '../../tsconfig.shared.json' })
+    );
+    tempFs.createFileSync(
+      'apps/my-app/project.json',
+      JSON.stringify({ name: 'my-app' })
+    );
+    tempFs.createFileSync('apps/my-app/vitest.config.ts', '');
+    tempFs.createFileSync('package-lock.json', '{}');
+
+    const nodes = await createNodesFunction(
+      ['apps/my-app/vitest.config.ts'],
+      { testTargetName: 'test' },
+      context
+    );
+
+    const inputs = nodes[0][1].projects['apps/my-app'].targets.test.inputs;
+    expect(inputs).toContainEqual({
+      json: '{workspaceRoot}/tsconfig.shared.json',
+      fields: ['compilerOptions'],
+    });
+    tempFs.cleanup();
+  });
+
+  it('should not add the root tsconfig handled by the native TsConfiguration hasher', async () => {
+    const tempFs = new TempFs('vite-tsconfig-root-skip');
+    context = {
+      nxJsonConfiguration: {
+        namedInputs: {
+          default: ['{projectRoot}/**/*'],
+          production: ['!{projectRoot}/**/*.spec.ts'],
+        },
+      },
+      workspaceRoot: tempFs.tempDir,
+    };
+    tempFs.createFileSync('tsconfig.base.json', JSON.stringify({}));
+    tempFs.createFileSync(
+      'apps/my-app/tsconfig.json',
+      JSON.stringify({ extends: '../../tsconfig.base.json' })
+    );
+    tempFs.createFileSync(
+      'apps/my-app/project.json',
+      JSON.stringify({ name: 'my-app' })
+    );
+    tempFs.createFileSync('apps/my-app/vitest.config.ts', '');
+    tempFs.createFileSync('package-lock.json', '{}');
+
+    const nodes = await createNodesFunction(
+      ['apps/my-app/vitest.config.ts'],
+      { testTargetName: 'test' },
+      context
+    );
+
+    const inputs = nodes[0][1].projects['apps/my-app'].targets.test.inputs;
+    expect(inputs).not.toContainEqual({
+      json: '{workspaceRoot}/tsconfig.base.json',
+      fields: ['compilerOptions'],
+    });
+    tempFs.cleanup();
+  });
+
   describe('Library mode', () => {
     it('should exclude serve and preview targets when vite.config.ts is in library mode', async () => {
       const tempFs = new TempFs('test');

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -14,11 +14,15 @@ import {
 } from '@nx/devkit';
 import { calculateHashesForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
-import { getLockFileName } from '@nx/js';
+import { getLockFileName, getRootTsConfigFileName } from '@nx/js';
+import {
+  walkTsconfigExtendsChain,
+  type RawTsconfigJsonCache,
+} from '@nx/js/src/internal';
 import { addBuildAndWatchDepsTargets } from '@nx/js/src/plugins/typescript/util';
 import { isUsingTsSolutionSetup as _isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { existsSync, readdirSync } from 'node:fs';
-import { dirname, isAbsolute, join, relative } from 'node:path';
+import { dirname, isAbsolute, join, relative, sep } from 'node:path';
 import { hashObject } from 'nx/src/hasher/file-hasher';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { deriveGroupNameFromTarget } from 'nx/src/utils/plugins';
@@ -105,11 +109,18 @@ export const createNodes: CreateNodesV2<VitePluginOptions> = [
     const detectedPackageManager = detectPackageManager(context.workspaceRoot);
     const pmc = getPackageManagerCommand(detectedPackageManager);
     const lockfile = getLockFileName(detectedPackageManager);
+    const tsconfigChainsByProjectRoot = collectTsconfigInputsByProjectRoot(
+      projectRoots,
+      context.workspaceRoot
+    );
     const hashes = await calculateHashesForCreateNodes(
       projectRoots,
       { ...normalizedOptions, isUsingTsSolutionSetup },
       context,
-      projectRoots.map((r) => [lockfile])
+      projectRoots.map((root) => [
+        lockfile,
+        ...(tsconfigChainsByProjectRoot.get(root) ?? []),
+      ])
     );
 
     try {
@@ -149,7 +160,8 @@ export const createNodes: CreateNodesV2<VitePluginOptions> = [
               hasReactRouterConfig,
               isUsingTsSolutionSetup,
               context,
-              pmc
+              pmc,
+              tsconfigChainsByProjectRoot.get(projectRoot) ?? []
             ));
 
           const project: ProjectConfiguration = {
@@ -190,7 +202,8 @@ async function buildViteTargets(
   hasReactRouterConfig: boolean,
   isUsingTsSolutionSetup: boolean,
   context: CreateNodesContextV2,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  tsconfigInputs: string[]
 ): Promise<ViteTargets> {
   const absoluteConfigFilePath = joinPathFragments(
     context.workspaceRoot,
@@ -256,7 +269,8 @@ async function buildViteTargets(
       testOutputs,
       projectRoot,
       pmc,
-      isTypecheckEnabled
+      isTypecheckEnabled,
+      tsconfigInputs
     );
 
     if (options.ciTargetName) {
@@ -575,7 +589,8 @@ async function testTarget(
   outputs: string[],
   projectRoot: string,
   pmc: ReturnType<typeof getPackageManagerCommand>,
-  isTypecheckEnabled: boolean
+  isTypecheckEnabled: boolean,
+  tsconfigInputs: string[]
 ) {
   const depOutputsGlob = isTypecheckEnabled ? '**/*.{js,d.ts}' : '**/*.js';
   return {
@@ -586,6 +601,10 @@ async function testTarget(
       ...('production' in namedInputs
         ? ['default', '^production']
         : ['default', '^default']),
+      ...tsconfigInputs.map((f) => ({
+        json: `{workspaceRoot}/${f}`,
+        fields: ['compilerOptions'],
+      })),
       {
         externalDependencies: ['vitest'],
       },
@@ -714,6 +733,105 @@ function normalizeOptions(options: VitePluginOptions): VitePluginOptions {
   options.serveStaticTargetName ??= 'serve-static';
   options.typecheckTargetName ??= 'typecheck';
   return options;
+}
+
+/**
+ * Collects tsconfig files that Vite's esbuild-based config bundler reads
+ * but are outside the project root (and thus not covered by `default`).
+ *
+ * Vite < 8 uses esbuild's Build API to bundle config files. esbuild walks
+ * UP from the entry point, reading and parsing every `tsconfig.json` in
+ * every ancestor directory plus their `extends` chains. Vite >= 8 uses
+ * rolldown with `tsconfig: false`, but pnpm can resolve different Vite
+ * versions per project, so we always collect — the walk is cheap (cached
+ * JSON reads) and over-declaring inputs for Vite 8 projects is harmless.
+ */
+function collectTsconfigInputsByProjectRoot(
+  projectRoots: string[],
+  workspaceRoot: string
+): Map<string, string[]> {
+  const jsonCache: RawTsconfigJsonCache = new Map();
+  const result = new Map<string, string[]>();
+
+  const rootTsConfigName = getRootTsConfigFileName();
+
+  for (const projectRoot of projectRoots) {
+    if (projectRoot === '.') continue;
+
+    const outside: string[] = [];
+    const seen = new Set<string>();
+    const projectPrefix = `${projectRoot}/`;
+
+    const collect = (absolutePath: string) => {
+      const wsRelative = relative(workspaceRoot, absolutePath)
+        .split(sep)
+        .join('/');
+      if (seen.has(wsRelative)) return;
+      seen.add(wsRelative);
+      if (wsRelative.startsWith('../') || wsRelative === '..') return;
+      if (
+        wsRelative.startsWith('node_modules/') ||
+        wsRelative.includes('/node_modules/')
+      )
+        return;
+      if (wsRelative === projectRoot || wsRelative.startsWith(projectPrefix))
+        return;
+      if (wsRelative === rootTsConfigName) return;
+      outside.push(wsRelative);
+    };
+
+    // Walk the project tsconfig's extends chain
+    const projectTsconfig = join(workspaceRoot, projectRoot, 'tsconfig.json');
+    if (existsSync(projectTsconfig)) {
+      walkTsconfigExtendsChain(
+        projectTsconfig,
+        (absPath) => {
+          collect(absPath);
+          return 'continue';
+        },
+        { jsonCache }
+      );
+    }
+
+    // Walk UP ancestor directories — esbuild reads every tsconfig.json
+    // between the entry point and the filesystem root.
+    let dir = dirname(projectRoot);
+    while (dir && dir !== '.') {
+      const ancestorTsconfig = join(workspaceRoot, dir, 'tsconfig.json');
+      if (existsSync(ancestorTsconfig)) {
+        walkTsconfigExtendsChain(
+          ancestorTsconfig,
+          (absPath) => {
+            collect(absPath);
+            return 'continue';
+          },
+          { jsonCache }
+        );
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+
+    // Check the workspace root itself (dirname loop above stops at '.')
+    const rootTsconfig = join(workspaceRoot, 'tsconfig.json');
+    if (existsSync(rootTsconfig)) {
+      walkTsconfigExtendsChain(
+        rootTsconfig,
+        (absPath) => {
+          collect(absPath);
+          return 'continue';
+        },
+        { jsonCache }
+      );
+    }
+
+    if (outside.length > 0) {
+      result.set(projectRoot, outside);
+    }
+  }
+
+  return result;
 }
 
 function checkIfConfigFileShouldBeProject(

--- a/packages/vitest/src/plugins/plugin.ts
+++ b/packages/vitest/src/plugins/plugin.ts
@@ -14,9 +14,13 @@ import {
 } from '@nx/devkit';
 import { calculateHashesForCreateNodes } from '@nx/devkit/src/utils/calculate-hash-for-create-nodes';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
-import { getLockFileName } from '@nx/js';
+import { getLockFileName, getRootTsConfigFileName } from '@nx/js';
+import {
+  walkTsconfigExtendsChain,
+  type RawTsconfigJsonCache,
+} from '@nx/js/src/internal';
 import { existsSync, readdirSync } from 'node:fs';
-import { dirname, isAbsolute, join, relative } from 'node:path';
+import { dirname, isAbsolute, join, relative, sep } from 'node:path';
 import { hashObject } from 'nx/src/hasher/file-hasher';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { deriveGroupNameFromTarget } from 'nx/src/utils/plugins';
@@ -103,11 +107,18 @@ export const createNodes: CreateNodesV2<VitestPluginOptions> = [
     const lockfile = getLockFileName(
       detectPackageManager(context.workspaceRoot)
     );
+    const tsconfigChainsByProjectRoot = collectTsconfigInputsByProjectRoot(
+      projectRoots,
+      context.workspaceRoot
+    );
     const hashes = await calculateHashesForCreateNodes(
       projectRoots,
       normalizedOptions,
       context,
-      projectRoots.map((r) => [lockfile])
+      projectRoots.map((root) => [
+        lockfile,
+        ...(tsconfigChainsByProjectRoot.get(root) ?? []),
+      ])
     );
 
     try {
@@ -126,7 +137,8 @@ export const createNodes: CreateNodesV2<VitestPluginOptions> = [
               projectRoot,
               normalizedOptions,
               context,
-              pmc
+              pmc,
+              tsconfigChainsByProjectRoot.get(projectRoot) ?? []
             ));
 
           const project: ProjectConfiguration = {
@@ -159,7 +171,8 @@ async function buildVitestTargets(
   projectRoot: string,
   options: VitestPluginOptions,
   context: CreateNodesContextV2,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  tsconfigInputs: string[]
 ): Promise<VitestTargets> {
   const absoluteConfigFilePath = joinPathFragments(
     context.workspaceRoot,
@@ -244,7 +257,8 @@ async function buildVitestTargets(
       projectRoot,
       options.testMode,
       pmc,
-      isTypecheckEnabled
+      isTypecheckEnabled,
+      tsconfigInputs
     );
 
     if (options.ciTargetName) {
@@ -346,7 +360,8 @@ async function testTarget(
   projectRoot: string,
   testMode: 'watch' | 'run' = 'watch',
   pmc: ReturnType<typeof getPackageManagerCommand>,
-  isTypecheckEnabled: boolean
+  isTypecheckEnabled: boolean,
+  tsconfigInputs: string[]
 ) {
   const command = testMode === 'run' ? 'vitest run' : 'vitest';
   const depOutputsGlob = isTypecheckEnabled ? '**/*.{js,d.ts}' : '**/*.js';
@@ -358,6 +373,10 @@ async function testTarget(
       ...('production' in namedInputs
         ? ['default', '^production']
         : ['default', '^default']),
+      ...tsconfigInputs.map((f) => ({
+        json: `{workspaceRoot}/${f}`,
+        fields: ['compilerOptions'],
+      })),
       {
         externalDependencies: ['vitest'],
       },
@@ -434,6 +453,112 @@ function normalizeOptions(options: VitestPluginOptions): VitestPluginOptions {
   options.testTargetName ??= 'test';
   options.testMode ??= 'watch';
   return options;
+}
+
+/**
+ * Collects tsconfig files that Vite's esbuild-based config bundler reads
+ * but are outside the project root (and thus not covered by `default`).
+ *
+ * Vite < 8 uses esbuild's Build API to bundle config files. esbuild walks
+ * UP from the entry point, reading and parsing every `tsconfig.json` in
+ * every ancestor directory plus their `extends` chains. Vite >= 8 uses
+ * rolldown with `tsconfig: false`, but pnpm can resolve different Vite
+ * versions per project, so we always collect — the walk is cheap (cached
+ * JSON reads) and over-declaring inputs for Vite 8 projects is harmless.
+ *
+ * Files already handled elsewhere are excluded:
+ * - Inside the project root → covered by `default` (`{projectRoot}/**\/*`)
+ * - The root tsconfig (tsconfig.base.json or tsconfig.json) → covered by
+ *   the native TsConfiguration hash instruction
+ * - Inside node_modules → invalidated via lockfile
+ * - Outside the workspace → cannot be expressed as inputs
+ */
+function collectTsconfigInputsByProjectRoot(
+  projectRoots: string[],
+  workspaceRoot: string
+): Map<string, string[]> {
+  const jsonCache: RawTsconfigJsonCache = new Map();
+  const result = new Map<string, string[]>();
+
+  const rootTsConfigName = getRootTsConfigFileName();
+
+  for (const projectRoot of projectRoots) {
+    if (projectRoot === '.') continue;
+
+    const outside: string[] = [];
+    const seen = new Set<string>();
+    const projectPrefix = `${projectRoot}/`;
+
+    const collect = (absolutePath: string) => {
+      const wsRelative = relative(workspaceRoot, absolutePath)
+        .split(sep)
+        .join('/');
+      if (seen.has(wsRelative)) return;
+      seen.add(wsRelative);
+      if (wsRelative.startsWith('../') || wsRelative === '..') return;
+      if (
+        wsRelative.startsWith('node_modules/') ||
+        wsRelative.includes('/node_modules/')
+      )
+        return;
+      if (wsRelative === projectRoot || wsRelative.startsWith(projectPrefix))
+        return;
+      if (wsRelative === rootTsConfigName) return;
+      outside.push(wsRelative);
+    };
+
+    // 1. Walk the project tsconfig's extends chain
+    const projectTsconfig = join(workspaceRoot, projectRoot, 'tsconfig.json');
+    if (existsSync(projectTsconfig)) {
+      walkTsconfigExtendsChain(
+        projectTsconfig,
+        (absPath) => {
+          collect(absPath);
+          return 'continue';
+        },
+        { jsonCache }
+      );
+    }
+
+    // 2. Walk UP ancestor directories (esbuild reads every tsconfig.json
+    //    between the entry point and the filesystem root)
+    let dir = dirname(projectRoot);
+    while (dir && dir !== '.') {
+      const ancestorTsconfig = join(workspaceRoot, dir, 'tsconfig.json');
+      if (existsSync(ancestorTsconfig)) {
+        walkTsconfigExtendsChain(
+          ancestorTsconfig,
+          (absPath) => {
+            collect(absPath);
+            return 'continue';
+          },
+          { jsonCache }
+        );
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+
+    // 3. Check the workspace root itself (dirname loop above stops at '.')
+    const rootTsconfig = join(workspaceRoot, 'tsconfig.json');
+    if (existsSync(rootTsconfig)) {
+      walkTsconfigExtendsChain(
+        rootTsconfig,
+        (absPath) => {
+          collect(absPath);
+          return 'continue';
+        },
+        { jsonCache }
+      );
+    }
+
+    if (outside.length > 0) {
+      result.set(projectRoot, outside);
+    }
+  }
+
+  return result;
 }
 
 function checkIfConfigFileShouldBeProject(


### PR DESCRIPTION
## Current Behavior

Vite <8 uses esbuild to bundle config files (`vitest.config.mts`). esbuild walks up from the entry point and reads every `tsconfig.json` in ancestor directories plus their `extends` chains. These files are not declared as task inputs, so changes to them don't invalidate the test cache.

Sandbox violation: https://staging.nx.app/runs/B5EjkJA6p1/task/angular-rspack-compiler%3Atest?batchId=7f8749c3-4e9a-4a93-b8f4-56efa69f14ab

## Expected Behavior

The `@nx/vite` and `@nx/vitest` plugins walk ancestor directories and `extends` chains, declaring discovered tsconfig files as selective JSON inputs that only hash `compilerOptions`. This avoids cache invalidation from irrelevant tsconfig changes (`include`, `exclude`, `references`, etc.) while correctly invalidating when compilation-affecting settings change.

Files already covered elsewhere are excluded:
- Inside the project root (covered by `default`)
- The root tsconfig handled by the native `TsConfiguration` hasher
- Inside `node_modules` (invalidated via lockfile)
- Outside the workspace