### PR TITLE
fix(vitest): add dependent task output files as inputs for vitest test targets

### DIFF
--- a/packages/angular-rspack-compiler/package.json
+++ b/packages/angular-rspack-compiler/package.json
@@ -79,11 +79,6 @@
         "dependsOn": [
           "^build-native"
         ],
-        "inputs": [
-          "default",
-          "^production",
-          "{projectRoot}/vitest.config.mts"
-        ],
         "options": {
           "args": [
             "--passWithNoTests"

--- a/packages/angular-rspack/package.json
+++ b/packages/angular-rspack/package.json
@@ -128,11 +128,6 @@
           "^build-native",
           "angular-rspack-compiler:build"
         ],
-        "inputs": [
-          "default",
-          "^production",
-          "{projectRoot}/vitest.config.mts"
-        ],
         "options": {
           "args": [
             "--passWithNoTests"

--- a/packages/vite/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
@@ -29,6 +29,10 @@ exports[`@nx/vite/plugin root project should create nodes 1`] = `
                 {
                   "env": "CI",
                 },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
+                },
               ],
               "metadata": {
                 "description": "Run Vite tests",
@@ -138,6 +142,10 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name 1`
                 {
                   "env": "CI",
                 },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
+                },
               ],
               "metadata": {
                 "description": "Run Vitest Tests in CI",
@@ -171,6 +179,10 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name 1`
                 },
                 {
                   "env": "CI",
+                },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
                 },
               ],
               "metadata": {
@@ -209,6 +221,10 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name 1`
                 {
                   "env": "CI",
                 },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
+                },
               ],
               "metadata": {
                 "description": "Run Vitest Tests in src/test-2.ts",
@@ -245,6 +261,10 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name 1`
                 },
                 {
                   "env": "CI",
+                },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
                 },
               ],
               "metadata": {
@@ -355,6 +375,10 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name an
                 {
                   "env": "CI",
                 },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
+                },
               ],
               "metadata": {
                 "description": "Run Vitest Tests in CI",
@@ -388,6 +412,10 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name an
                 },
                 {
                   "env": "CI",
+                },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
                 },
               ],
               "metadata": {
@@ -426,6 +454,10 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name an
                 {
                   "env": "CI",
                 },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
+                },
               ],
               "metadata": {
                 "description": "Run Vitest Tests in src/test-2.ts",
@@ -462,6 +494,10 @@ exports[`@nx/vite/plugin root project should create nodes with ci target name an
                 },
                 {
                   "env": "CI",
+                },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
                 },
               ],
               "metadata": {

--- a/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin-with-test.spec.ts.snap
@@ -29,6 +29,10 @@ exports[`@nx/vite/plugin with test node root project should create nodes - with 
                 {
                   "env": "CI",
                 },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
+                },
               ],
               "metadata": {
                 "description": "Run Vite tests",

--- a/packages/vite/src/plugins/plugin-vitest.spec.ts
+++ b/packages/vite/src/plugins/plugin-vitest.spec.ts
@@ -1,6 +1,7 @@
 import * as devkit from '@nx/devkit';
 import { CreateNodesContextV2 } from '@nx/devkit';
 import { createNodesV2 } from './plugin';
+import { loadViteDynamicImport } from '../utils/executor-utils';
 
 // Mock fs to provide stable test environment
 jest.mock('node:fs', () => ({
@@ -127,6 +128,70 @@ describe('@nx/vite/plugin', () => {
       );
 
       expect(nodes).toMatchSnapshot();
+    });
+  });
+
+  describe('typecheck enabled', () => {
+    beforeEach(async () => {
+      context = {
+        nxJsonConfiguration: {
+          targetDefaults: {},
+          namedInputs: {
+            default: ['{projectRoot}/**/*'],
+            production: ['!{projectRoot}/**/*.spec.ts'],
+          },
+        },
+        workspaceRoot: '',
+      };
+    });
+
+    afterEach(() => {
+      jest.resetModules();
+    });
+
+    it('should include d.ts in dependentTasksOutputFiles when typecheck is enabled', async () => {
+      (loadViteDynamicImport as jest.Mock).mockResolvedValueOnce({
+        resolveConfig: jest.fn().mockResolvedValue({
+          path: 'vitest.config.ts',
+          config: {},
+          dependencies: [],
+          test: {
+            typecheck: {
+              enabled: true,
+            },
+          },
+        }),
+      });
+
+      const nodes = await createNodesFunction(
+        ['vitest.config.ts'],
+        {
+          testTargetName: 'test',
+        },
+        context
+      );
+
+      const testTarget = nodes[0][1].projects['.'].targets['test'];
+      expect(testTarget.inputs).toContainEqual({
+        dependentTasksOutputFiles: '**/*.{js,d.ts}',
+        transitive: true,
+      });
+    });
+
+    it('should only include js in dependentTasksOutputFiles when typecheck is not enabled', async () => {
+      const nodes = await createNodesFunction(
+        ['vitest.config.ts'],
+        {
+          testTargetName: 'test',
+        },
+        context
+      );
+
+      const testTarget = nodes[0][1].projects['.'].targets['test'];
+      expect(testTarget.inputs).toContainEqual({
+        dependentTasksOutputFiles: '**/*.js',
+        transitive: true,
+      });
     });
   });
 });

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -249,11 +249,14 @@ async function buildViteTargets(
 
   // if file is vitest.config or vite.config has definition for test, create targets for test and/or atomized tests
   if (configFilePath.includes('vitest.config') || hasTest) {
+    const isTypecheckEnabled = !!(viteBuildConfig as any)?.test?.typecheck
+      ?.enabled;
     targets[options.testTargetName] = await testTarget(
       namedInputs,
       testOutputs,
       projectRoot,
-      pmc
+      pmc,
+      isTypecheckEnabled
     );
 
     if (options.ciTargetName) {
@@ -571,8 +574,10 @@ async function testTarget(
   },
   outputs: string[],
   projectRoot: string,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  isTypecheckEnabled: boolean
 ) {
+  const depOutputsGlob = isTypecheckEnabled ? '**/*.{js,d.ts}' : '**/*.js';
   return {
     command: `vitest`,
     options: { cwd: joinPathFragments(projectRoot) },
@@ -585,6 +590,7 @@ async function testTarget(
         externalDependencies: ['vitest'],
       },
       { env: 'CI' },
+      { dependentTasksOutputFiles: depOutputsGlob, transitive: true },
     ],
     outputs,
     metadata: {

--- a/packages/vitest/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
+++ b/packages/vitest/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
@@ -25,6 +25,10 @@ exports[`@nx/vitest root project should create nodes 1`] = `
                 {
                   "env": "CI",
                 },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
+                },
               ],
               "metadata": {
                 "description": "Run Vitest tests",
@@ -93,6 +97,10 @@ exports[`@nx/vitest root project should create nodes with ci target name 1`] = `
                 {
                   "env": "CI",
                 },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
+                },
               ],
               "metadata": {
                 "description": "Run Vitest Tests in CI",
@@ -126,6 +134,10 @@ exports[`@nx/vitest root project should create nodes with ci target name 1`] = `
                 },
                 {
                   "env": "CI",
+                },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
                 },
               ],
               "metadata": {
@@ -164,6 +176,10 @@ exports[`@nx/vitest root project should create nodes with ci target name 1`] = `
                 {
                   "env": "CI",
                 },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
+                },
               ],
               "metadata": {
                 "description": "Run Vitest Tests in src/test-2.ts",
@@ -200,6 +216,10 @@ exports[`@nx/vitest root project should create nodes with ci target name 1`] = `
                 },
                 {
                   "env": "CI",
+                },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
                 },
               ],
               "metadata": {
@@ -269,6 +289,10 @@ exports[`@nx/vitest root project should create nodes with ci target name and ci 
                 {
                   "env": "CI",
                 },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
+                },
               ],
               "metadata": {
                 "description": "Run Vitest Tests in CI",
@@ -302,6 +326,10 @@ exports[`@nx/vitest root project should create nodes with ci target name and ci 
                 },
                 {
                   "env": "CI",
+                },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
                 },
               ],
               "metadata": {
@@ -340,6 +368,10 @@ exports[`@nx/vitest root project should create nodes with ci target name and ci 
                 {
                   "env": "CI",
                 },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
+                },
               ],
               "metadata": {
                 "description": "Run Vitest Tests in src/test-2.ts",
@@ -376,6 +408,10 @@ exports[`@nx/vitest root project should create nodes with ci target name and ci 
                 },
                 {
                   "env": "CI",
+                },
+                {
+                  "dependentTasksOutputFiles": "**/*.js",
+                  "transitive": true,
                 },
               ],
               "metadata": {

--- a/packages/vitest/src/plugins/plugin-vitest.spec.ts
+++ b/packages/vitest/src/plugins/plugin-vitest.spec.ts
@@ -130,6 +130,70 @@ describe('@nx/vitest', () => {
     });
   });
 
+  describe('typecheck enabled', () => {
+    beforeEach(async () => {
+      context = {
+        nxJsonConfiguration: {
+          targetDefaults: {},
+          namedInputs: {
+            default: ['{projectRoot}/**/*'],
+            production: ['!{projectRoot}/**/*.spec.ts'],
+          },
+        },
+        workspaceRoot: '',
+      };
+    });
+
+    afterEach(() => {
+      jest.resetModules();
+    });
+
+    it('should include d.ts in dependentTasksOutputFiles when typecheck is enabled', async () => {
+      (loadViteDynamicImport as jest.Mock).mockResolvedValueOnce({
+        resolveConfig: jest.fn().mockResolvedValue({
+          path: 'vitest.config.ts',
+          config: {},
+          dependencies: [],
+          test: {
+            typecheck: {
+              enabled: true,
+            },
+          },
+        }),
+      });
+
+      const nodes = await createNodesFunction(
+        ['vitest.config.ts'],
+        {
+          testTargetName: 'test',
+        },
+        context
+      );
+
+      const testTarget = nodes[0][1].projects['.'].targets['test'];
+      expect(testTarget.inputs).toContainEqual({
+        dependentTasksOutputFiles: '**/*.{js,d.ts}',
+        transitive: true,
+      });
+    });
+
+    it('should only include js in dependentTasksOutputFiles when typecheck is not enabled', async () => {
+      const nodes = await createNodesFunction(
+        ['vitest.config.ts'],
+        {
+          testTargetName: 'test',
+        },
+        context
+      );
+
+      const testTarget = nodes[0][1].projects['.'].targets['test'];
+      expect(testTarget.inputs).toContainEqual({
+        dependentTasksOutputFiles: '**/*.js',
+        transitive: true,
+      });
+    });
+  });
+
   describe('workspace config with projects', () => {
     beforeEach(async () => {
       context = {

--- a/packages/vitest/src/plugins/plugin.ts
+++ b/packages/vitest/src/plugins/plugin.ts
@@ -236,12 +236,15 @@ async function buildVitestTargets(
 
   // if file is vitest.config or vite.config has definition for test, create targets for test and/or atomized tests
   if (configFilePath.includes('vitest.config') || hasTest) {
+    const isTypecheckEnabled = !!(viteBuildConfig as any)?.test?.typecheck
+      ?.enabled;
     targets[options.testTargetName] = await testTarget(
       namedInputs,
       testOutputs,
       projectRoot,
       options.testMode,
-      pmc
+      pmc,
+      isTypecheckEnabled
     );
 
     if (options.ciTargetName) {
@@ -342,9 +345,11 @@ async function testTarget(
   outputs: string[],
   projectRoot: string,
   testMode: 'watch' | 'run' = 'watch',
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  isTypecheckEnabled: boolean
 ) {
   const command = testMode === 'run' ? 'vitest run' : 'vitest';
+  const depOutputsGlob = isTypecheckEnabled ? '**/*.{js,d.ts}' : '**/*.js';
   return {
     command,
     options: { cwd: joinPathFragments(projectRoot) },
@@ -357,6 +362,7 @@ async function testTarget(
         externalDependencies: ['vitest'],
       },
       { env: 'CI' },
+      { dependentTasksOutputFiles: depOutputsGlob, transitive: true },
     ],
     outputs,
     metadata: {


### PR DESCRIPTION
## Current Behavior

Vitest test targets can resolve workspace dependency imports to build artifacts (e.g., `dist/*.js`). These build outputs aren't declared as task inputs, causing sandbox I/O violations (unexpected reads from dependency `dist/` directories).

## Expected Behavior

The vite and vitest plugins include `dependentTasksOutputFiles` in the inferred test target inputs. This declares dependency build outputs as inputs when a test target depends on build tasks via `dependsOn`. The input is a no-op when there are no build task dependencies. When `typecheck.enabled` is configured, `.d.ts` files are also included since `tsc --noEmit` reads type declarations from dependencies.

Also removes redundant explicit `inputs` overrides from `angular-rspack` and `angular-rspack-compiler` test targets — the plugin-inferred defaults are now more complete.