### PR TITLE
fix(nx-dev): improve search ranking for reference pages

### DIFF
--- a/astro-docs/astro.config.mjs
+++ b/astro-docs/astro.config.mjs
@@ -122,10 +122,10 @@ export default defineConfig({
           // frequency of the term relative to document length
           // versus weighted term count.
           // default is 1.0
-          termFrequency: 0.75,
+          termFrequency: 0.65,
           // pageLength changes the way ranking compares page lengths with the average page lengths on your site.
           // default 0.75
-          pageLength: 0.5,
+          pageLength: 0.3,
           // termSaturation controls how quickly a term “saturates” on a page.
           // Once a term has appeared on a page many times,
           // further appearances have a reduced impact on the page rank.

--- a/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-monorepo.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-monorepo.mdoc
@@ -2,7 +2,7 @@
 title: Adding Nx to NPM/Yarn/PNPM Workspace
 description: Learn how to integrate Nx into an existing NPM, Yarn, or PNPM workspace monorepo to gain task scheduling, caching, and improved CI performance.
 filter: 'type:Guides'
-weight: 6.4
+weight: 2
 sidebar:
   label: NPM/Yarn/PNPM workspaces
 ---

--- a/astro-docs/src/content/docs/technologies/angular/angular-rsbuild/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/angular-rsbuild/introduction.mdoc
@@ -3,7 +3,7 @@ title: 'Angular Rsbuild Plugin for Nx'
 description: 'Use Rsbuild as the build tool for Angular applications in your Nx workspace with the @nx/angular-rsbuild plugin.'
 sidebar:
   label: 'Introduction'
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/angular/angular-rspack-compiler/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/angular-rspack-compiler/introduction.mdoc
@@ -3,7 +3,7 @@ title: 'Angular Rspack Compiler'
 description: 'Compilation utilities for Angular with Rspack and Rsbuild.'
 sidebar:
   label: 'Introduction'
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/angular/angular-rspack/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/angular-rspack/introduction.mdoc
@@ -3,7 +3,7 @@ title: 'Angular Rspack Plugin for Nx'
 description: 'Learn how Rspack can help you speed up your Angular applications.'
 sidebar:
   label: 'Introduction'
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/angular/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/introduction.mdoc
@@ -5,7 +5,7 @@ keywords: [angular]
 sidebar:
   label: Introduction
   order: 1
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/build-tools/docker/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/docker/introduction.mdoc
@@ -4,7 +4,7 @@ description: The Nx Plugin for Docker contains executors and utilities for build
 keywords: [docker]
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/build-tools/esbuild/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/esbuild/introduction.mdoc
@@ -3,7 +3,7 @@ title: esbuild Plugin for Nx
 description: The Nx Plugin for esbuild contains executors and generators that support building applications using esbuild, including setup and configuration for your Nx workspace.
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/build-tools/rollup/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rollup/introduction.mdoc
@@ -3,7 +3,7 @@ title: Rollup Plugin for Nx
 description: The Nx Plugin for Rollup contains executors and generators that support building applications using Rollup.
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/build-tools/rsbuild/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rsbuild/introduction.mdoc
@@ -3,7 +3,7 @@ title: Rsbuild Plugin for Nx
 description: The Nx Plugin for Rsbuild contains executors and generators that support building applications using Rsbuild.
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/build-tools/rspack/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rspack/introduction.mdoc
@@ -3,7 +3,7 @@ title: Rspack Plugin for Nx
 description: The Nx Plugin for Rspack contains executors, generators, and utilities for managing Rspack projects in an Nx Workspace.
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/build-tools/vite/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/vite/introduction.mdoc
@@ -3,7 +3,7 @@ title: Vite Plugin for Nx
 description: Use Vite with Nx for inferred dev/build tasks, generators, and CI-friendly workflows.
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/build-tools/webpack/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/webpack/introduction.mdoc
@@ -3,7 +3,7 @@ title: Webpack Plugin for Nx
 description: The Nx Plugin for Webpack contains executors and generators that support building applications using Webpack.
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
@@ -3,7 +3,7 @@ title: .NET Plugin for Nx
 description: This plugin allows .NET projects to be run through Nx.
 sidebar:
   label: 'Introduction'
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/eslint/eslint-plugin/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/eslint/eslint-plugin/introduction.mdoc
@@ -3,7 +3,7 @@ title: ESLint Plugin
 sidebar:
   hidden: true
 description: Nx ESLint plugin features
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/eslint/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/eslint/introduction.mdoc
@@ -3,7 +3,7 @@ title: ESLint Plugin for Nx
 description: Learn how to set up and use the @nx/eslint plugin to integrate ESLint with Nx, enabling caching and providing code generators for ESLint configuration.
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
@@ -3,7 +3,7 @@ title: Gradle Plugin for Nx
 description: Run Gradle tasks through Nx with caching, graph insights, and CI optimization.
 sidebar:
   label: 'Introduction'
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/java/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/introduction.mdoc
@@ -3,7 +3,7 @@ title: Java with Nx
 description: Build scalable Java applications with Nx
 sidebar:
   label: 'Introduction'
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/java/maven/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/maven/introduction.mdoc
@@ -3,7 +3,7 @@ title: Maven Plugin for Nx
 description: This plugin allows Maven tasks to be run through Nx.
 sidebar:
   label: 'Introduction'
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/module-federation/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/module-federation/introduction.mdoc
@@ -3,7 +3,7 @@ title: Module Federation Plugin for Nx
 description: Details about the NxModuleFederationPlugin
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/node/express/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/express/introduction.mdoc
@@ -3,7 +3,7 @@ title: Express Plugin for Nx
 description: Learn how to use the @nx/express plugin to create and manage Express applications in your Nx workspace, including setup and common guides.
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/node/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/introduction.mdoc
@@ -3,7 +3,7 @@ title: Node.js Plugin for Nx
 description: Learn how to use the @nx/node plugin to create and manage Node.js applications and libraries in your Nx workspace, including setup, building, and testing.
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/node/nest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/nest/introduction.mdoc
@@ -4,7 +4,7 @@ description: Learn how to use the @nx/nest plugin to create and manage Nest.js a
 keywords: [nest, nestjs]
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/react/expo/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/expo/introduction.mdoc
@@ -3,7 +3,7 @@ title: Expo Plugin for Nx
 description: Learn how to use the @nx/expo plugin to manage Expo applications and libraries within an Nx workspace, including setup, configuration, and task inference.
 sidebar:
   label: 'Introduction'
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/react/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/introduction.mdoc
@@ -5,7 +5,7 @@ keywords: [react]
 sidebar:
   label: 'Introduction'
   order: 1
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/react/next/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/next/introduction.mdoc
@@ -5,7 +5,7 @@ keywords: [nextjs, next, react]
 sidebar:
   label: 'Introduction'
   order: 1
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/react/react-native/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/react-native/introduction.mdoc
@@ -3,7 +3,7 @@ title: React Native Plugin for Nx
 description: The Nx Plugin for React Native contains generators for managing React Native applications and libraries within an Nx workspace, including setup and configuration.
 sidebar:
   label: 'Introduction'
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/react/remix/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/remix/introduction.mdoc
@@ -5,7 +5,7 @@ keywords: [remix, react]
 sidebar:
   label: 'Introduction'
   order: 1
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/test-tools/cypress/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/cypress/introduction.mdoc
@@ -3,7 +3,7 @@ title: Cypress Plugin for Nx
 description: The Nx Plugin for Cypress contains executors and generators that support e2e testing with Cypress, including setup and configuration for your Nx workspace.
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/test-tools/detox/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/detox/introduction.mdoc
@@ -3,7 +3,7 @@ title: Detox Plugin for Nx
 description: Learn how to set up and use Detox for end-to-end testing of mobile applications in your Nx workspace, including environment setup and configuration options.
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/test-tools/jest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/jest/introduction.mdoc
@@ -3,7 +3,7 @@ title: Jest Plugin for Nx
 description: The Nx Plugin for Jest contains executors and generators that support testing projects using Jest, including setup and configuration for your Nx workspace.
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -3,7 +3,7 @@ title: Playwright Plugin for Nx
 description: The Nx Plugin for Playwright contains executors and generators that support e2e testing with Playwright, including setup and configuration for your Nx workspace.
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/test-tools/storybook/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/storybook/introduction.mdoc
@@ -3,7 +3,7 @@ title: Storybook Plugin for Nx
 description: This is an overview page for the Storybook plugin in Nx. It explains what Storybook is and how to set it up in your Nx workspace.
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
@@ -3,7 +3,7 @@ title: Vitest Plugin for Nx
 description: The Nx Plugin for Vitest contains executors and generators that support testing projects using Vitest, including setup and configuration for your Nx workspace.
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/typescript/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/typescript/introduction.mdoc
@@ -5,7 +5,7 @@ keywords: [typescript, javascript, js, ts]
 sidebar:
   label: Introduction
   order: 1
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/vue/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/vue/introduction.mdoc
@@ -3,7 +3,7 @@ title: Vue Plugin for Nx
 description: The Nx Plugin for Vue contains generators for managing Vue applications and libraries within an Nx workspace, including setup and configuration.
 sidebar:
   label: 'Introduction'
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 

--- a/astro-docs/src/content/docs/technologies/vue/nuxt/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/vue/nuxt/introduction.mdoc
@@ -3,7 +3,7 @@ title: Nuxt Plugin for Nx
 description: The Nx Plugin for Nuxt contains generators for managing Nuxt applications within an Nx workspace, including setup and configuration.
 sidebar:
   label: Introduction
-weight: 5
+weight: 2
 filter: 'type:References'
 ---
 


### PR DESCRIPTION
## Current Behavior

Searching for `nx.json` on nx.dev/docs does not surface the actual nx.json reference page in the top results. The `.NET Plugin for Nx` and other technology introduction pages rank higher because they have `weight: 5` in frontmatter, which inflates their body text scoring via Pagefind's `data-pagefind-weight` attribute (~25x impact via quadratic scaling). The same issue affects `project.json`, `inputs`, and other reference pages.

## Expected Behavior

Reference pages whose title exactly matches the search query should rank first or near the top. Technology introduction pages should still be discoverable for their framework name but should not outrank reference pages for terms they merely mention in body text.

**After this change:**
- `nx.json` → "nx.json Reference" is `#1` (was `#7+`)
- `project.json` → "Project Configuration" is `#1`
- `angular` → "Angular Plugin for Nx" is `#1` (preserved)
- `nest` → "Nest.js Plugin for Nx" is `#1` (preserved)
- `react` → "React Plugin for Nx" is `#2` (React Native `#1` — valid match)

**Changes:**
- Reduce `weight` on 35 technology introduction pages from `5` → `2` to reduce body text inflation while keeping a modest boost
- Reduce `weight` on adding-to-monorepo guide from `6.4` → `2`
- Adjust Pagefind ranking params: `termFrequency: 0.75 → 0.65`, `pageLength: 0.5 → 0.3` to reduce the penalty on long reference pages

## Related Issue(s)

Fixes DOC-475