### PR TITLE
fix(nx-dev): seo improvements for nx.dev/docs

### DIFF
--- a/astro-docs/astro.config.mjs
+++ b/astro-docs/astro.config.mjs
@@ -81,6 +81,7 @@ export default defineConfig({
         './src/plugins/github-stars.middleware.ts',
         './src/plugins/raw-content.middleware.ts',
         './src/plugins/canonical.middleware.ts',
+        './src/plugins/schema.middleware.ts',
       ],
       markdown: {
         headingLinks: true,

--- a/astro-docs/astro.config.mjs
+++ b/astro-docs/astro.config.mjs
@@ -5,6 +5,7 @@ import netlify from '@astrojs/netlify';
 import react from '@astrojs/react';
 import markdoc from '@astrojs/markdoc';
 import tailwindcss from '@tailwindcss/vite';
+import sitemap from '@astrojs/sitemap';
 import { sidebar } from './sidebar.mts';
 import rehypeTableOptionLinks from './src/plugins/utils/rehype-table-option-links.ts';
 import { resolveNxDevUrl } from './src/utils/resolve-nx-dev-url.ts';
@@ -57,6 +58,7 @@ export default defineConfig({
         replacesTitle: true,
       },
       disable404Route: true,
+      lastUpdated: true,
       head: [
         {
           tag: 'script',
@@ -141,5 +143,8 @@ export default defineConfig({
       },
     }),
     react(),
+    sitemap({
+      lastmod: new Date(),
+    }),
   ],
 });

--- a/astro-docs/netlify.toml
+++ b/astro-docs/netlify.toml
@@ -3,6 +3,8 @@
   [headers.values]
     X-Frame-Options = "DENY"
     Content-Security-Policy = "frame-ancestors 'none'"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=()"
 
 # Disable gradle and maven plugins on Netlify
 # (Netlify only supports Java 8 but these plugins require Java 17)

--- a/astro-docs/package.json
+++ b/astro-docs/package.json
@@ -7,6 +7,7 @@
     "@astrojs/markdoc": "^0.15.0",
     "@astrojs/netlify": "^6.4.0",
     "@astrojs/react": "^4.3.0",
+    "@astrojs/sitemap": "^3.3.0",
     "@astrojs/starlight": "0.34.6",
     "@astrojs/starlight-markdoc": "^0.4.0",
     "@astrojs/starlight-tailwind": "^4.0.1",

--- a/astro-docs/src/components/layout/Header.astro
+++ b/astro-docs/src/components/layout/Header.astro
@@ -31,8 +31,8 @@ const currentVersion = versions.find((v) => v.current);
 <div class="flex items-center justify-between h-full gap-4">
   <div class="flex items-center gap-2 flex-shrink-0">
     <a href={import.meta.env.SITE} class="flex items-center no-underline">
-      <Image src={nxLogoDark} alt="Nx" class="h-12 w-auto dark:hidden" />
-      <Image src={nxLogoLight} alt="Nx" class="h-12 w-auto hidden dark:block" />
+      <Image src={nxLogoDark} alt="Nx" class="h-12 w-auto dark:hidden" loading="eager" />
+      <Image src={nxLogoLight} alt="Nx" class="h-12 w-auto hidden dark:block" loading="eager" />
     </a>
     <a
       id="header-docs-home-link"

--- a/astro-docs/src/content/docs/getting-started/intro.mdoc
+++ b/astro-docs/src/content/docs/getting-started/intro.mdoc
@@ -1,6 +1,6 @@
 ---
-title: What is Nx?
-description: 'Nx is a build system with smart caching and task orchestration for monorepos. Ship faster without breaking things.'
+title: 'What is Nx? Smart Monorepo Build System & CI'
+description: 'Nx is a build system with smart caching and task orchestration for monorepos and polyrepos. Ship faster and keep CI fast as your codebase scales.'
 sidebar:
   order: 1
   label: Introduction

--- a/astro-docs/src/plugins/og.middleware.ts
+++ b/astro-docs/src/plugins/og.middleware.ts
@@ -37,6 +37,13 @@ export const onRequest = defineRouteMiddleware(async (context) => {
   }
 
   const { head } = context.locals.starlightRoute;
+  const title =
+    context.locals.starlightRoute.entry.data.title || 'Nx Documentation';
+  const description =
+    (
+      context.locals.starlightRoute.entry.data as Record<string, unknown>
+    ).description?.toString() || '';
+
   head.push(
     {
       tag: 'meta',
@@ -49,6 +56,22 @@ export const onRequest = defineRouteMiddleware(async (context) => {
     {
       tag: 'meta',
       attrs: { property: 'og:image:height', content: '630' },
-    }
+    },
+    {
+      tag: 'meta',
+      attrs: { name: 'twitter:image', content: ogImageUrl.href },
+    },
+    {
+      tag: 'meta',
+      attrs: { name: 'twitter:title', content: title },
+    },
+    ...(description
+      ? [
+          {
+            tag: 'meta' as const,
+            attrs: { name: 'twitter:description', content: description },
+          },
+        ]
+      : [])
   );
 });

--- a/astro-docs/src/plugins/schema.middleware.ts
+++ b/astro-docs/src/plugins/schema.middleware.ts
@@ -1,0 +1,133 @@
+import { defineRouteMiddleware } from '@astrojs/starlight/route-data';
+
+const CANONICAL_DOMAIN = 'https://nx.dev';
+
+interface SidebarEntry {
+  type: 'link' | 'group';
+  label: string;
+  href?: string;
+  isCurrent?: boolean;
+  entries?: SidebarEntry[];
+}
+
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+/**
+ * Walk the sidebar tree to find the breadcrumb path to the current page.
+ */
+function findBreadcrumbPath(
+  entries: SidebarEntry[],
+  path: BreadcrumbItem[] = []
+): BreadcrumbItem[] | null {
+  for (const entry of entries) {
+    if (entry.type === 'link' && entry.isCurrent) {
+      return [...path, { label: entry.label, href: entry.href }];
+    }
+    if (entry.type === 'group' && entry.entries) {
+      const result = findBreadcrumbPath(entry.entries, [
+        ...path,
+        { label: entry.label },
+      ]);
+      if (result) return result;
+    }
+  }
+  return null;
+}
+
+/**
+ * Build BreadcrumbList JSON-LD from the sidebar-derived breadcrumb path.
+ */
+function buildBreadcrumbList(
+  crumbs: BreadcrumbItem[],
+  currentPath: string
+): object {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Nx',
+        item: CANONICAL_DOMAIN,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Docs',
+        item: `${CANONICAL_DOMAIN}/docs/getting-started/intro`,
+      },
+      ...crumbs.map((crumb, i) => ({
+        '@type': 'ListItem',
+        position: i + 3,
+        name: crumb.label,
+        ...(crumb.href
+          ? { item: `${CANONICAL_DOMAIN}${crumb.href}` }
+          : { item: `${CANONICAL_DOMAIN}${currentPath}` }),
+      })),
+    ],
+  };
+}
+
+/**
+ * Build TechArticle JSON-LD for the current documentation page.
+ */
+function buildTechArticle(
+  title: string,
+  description: string,
+  currentPath: string
+): object {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: title,
+    description,
+    url: `${CANONICAL_DOMAIN}${currentPath}`,
+    publisher: {
+      '@type': 'Organization',
+      name: 'Nx',
+      url: CANONICAL_DOMAIN,
+      logo: {
+        '@type': 'ImageObject',
+        url: `${CANONICAL_DOMAIN}/docs/nx-media.png`,
+      },
+    },
+    isPartOf: {
+      '@type': 'WebSite',
+      name: 'Nx',
+      url: CANONICAL_DOMAIN,
+    },
+  };
+}
+
+export const onRequest = defineRouteMiddleware((context) => {
+  const route = context.locals.starlightRoute;
+  const { head, sidebar, entry } = route;
+  const currentPath = context.url.pathname;
+  const title = entry.data.title || 'Nx Documentation';
+  const description =
+    (entry.data as Record<string, unknown>).description?.toString() || '';
+
+  const schemas: object[] = [];
+
+  // BreadcrumbList from sidebar hierarchy
+  const crumbs = findBreadcrumbPath(sidebar as SidebarEntry[]);
+  if (crumbs && crumbs.length > 0) {
+    schemas.push(buildBreadcrumbList(crumbs, currentPath));
+  }
+
+  // TechArticle for the current page
+  schemas.push(buildTechArticle(title, description, currentPath));
+
+  // Inject each schema as a separate script tag
+  for (const schema of schemas) {
+    head.push({
+      tag: 'script',
+      attrs: { type: 'application/ld+json' },
+      content: JSON.stringify(schema),
+    });
+  }
+});

--- a/astro-docs/src/styles/global.css
+++ b/astro-docs/src/styles/global.css
@@ -4,7 +4,9 @@
 @import 'tailwindcss/theme.css' layer(theme);
 @import 'tailwindcss/utilities.css' layer(utilities);
 
-@source '../../node_modules/@nx/nx-dev-*';
+@source '../../node_modules/@nx/nx-dev-feature-analytics';
+@source '../../node_modules/@nx/nx-dev-ui-markdoc';
+@source '../../node_modules/@nx/nx-dev-ui-common';
 
 /* Custom styles for Nx documentation */
 

--- a/netlify/edge-functions/rewrite-framer-urls.ts
+++ b/netlify/edge-functions/rewrite-framer-urls.ts
@@ -192,6 +192,12 @@ export const config = {
   // Only process HTML requests to save on compute
   accept: ['text/html'],
   excludedPath: [
+    // SEO-critical files — must bypass Framer so Next.js serves them
+    '/robots.txt',
+    '/sitemap.xml',
+    '/sitemap-0.xml',
+    '/llms.txt',
+    '/llms-full.txt',
     '/docs',
     '/docs/*',
     '/api/*',

--- a/nx-dev/nx-dev/next-sitemap.config.js
+++ b/nx-dev/nx-dev/next-sitemap.config.js
@@ -20,9 +20,17 @@ module.exports = {
         policies: [{ userAgent: '*', disallow: '/' }],
       }
     : {
-        additionalSitemaps: [
-          `${siteUrl}/sitemap-1.xml`,
-          `${siteUrl}/docs/sitemap-index.xml`,
+        policies: [
+          { userAgent: '*', allow: '/' },
+          { userAgent: 'GPTBot', allow: '/' },
+          { userAgent: 'ClaudeBot', allow: '/' },
+          { userAgent: 'Google-Extended', allow: '/' },
+          { userAgent: 'PerplexityBot', allow: '/' },
+          { userAgent: 'OAI-SearchBot', allow: '/' },
+          { userAgent: 'Applebot-Extended', allow: '/' },
+          { userAgent: 'Meta-ExternalAgent', allow: '/' },
         ],
+        // Additional sitemaps are added to the sitemap index by
+        // scripts/patch-sitemap-index.mjs to avoid duplicate entries.
       },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1379,6 +1379,9 @@ importers:
       '@astrojs/react':
         specifier: ^4.3.0
         version: 4.3.0(@types/node@24.2.0)(@types/react-dom@18.3.1)(@types/react@18.3.1)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.8.2)
+      '@astrojs/sitemap':
+        specifier: ^3.3.0
+        version: 3.4.1
       '@astrojs/starlight':
         specifier: 0.34.6
         version: 0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))
@@ -56974,7 +56977,7 @@ snapshots:
       css-what: 6.2.2
       csso: 5.0.5
       picocolors: 1.1.1
-      sax: 1.4.1
+      sax: 1.6.0
 
   svgo@4.0.1:
     dependencies:
@@ -59848,7 +59851,7 @@ snapshots:
 
   xml-js@1.6.11:
     dependencies:
-      sax: 1.4.1
+      sax: 1.6.0
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
The nx.dev/docs site has several SEO issues a few minor a few larger impacts. 

Changes:

- **robots.txt** is served by Next.js with correct `Sitemap: https://nx.dev/sitemap.xml` and explicit AI crawler policies
    - **AI crawlers** (GPTBot, ClaudeBot, Google-Extended, PerplexityBot, OAI-SearchBot) have explicit Allow rules
- **llms.txt** and **llms-full.txt** are served correctly (Astro-generated, proxied via Next.js)
- **Sitemap index** has no duplicate entries 
- **Every docs page** has BreadcrumbList + TechArticle JSON-LD schema markup
- **Logo images** are eager-loaded (`loading="eager"`), improving mobile LCP
- **Docs sitemap** includes `lastmod` dates (build timestamp)
- **Security headers** (Referrer-Policy, Permissions-Policy) set on Astro docs
- **Page title** expanded to 47 chars with key terms
- **Twitter card** meta tags explicitly set on all docs pages
- **CSS bundle** no longer scans unused @nx/nx-dev-ui-icons and @nx/nx-dev-ui-animations packages

## Related Issue(s)

closes DOC-473
