### PR TITLE
fix(js): suppress false swc-node/ts-node warning on Node 22.18+

### DIFF
--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -49,6 +49,15 @@ const isInvokedByTsx: boolean = (() => {
 })();
 
 /**
+ * Whether the current Node.js version supports native TypeScript execution
+ * via type stripping (Node 22.6+).
+ *
+ * process.features.typescript is 'strip' | 'transform' | false in Node 22.6+
+ */
+const nodeSupportsNativeTypescript: boolean =
+  (process as any).features?.typescript === 'strip';
+
+/**
  * When process.features.typescript is truthy and the user has opted in via
  * NX_PREFER_NODE_STRIP_TYPES=true, we can skip registering swc-node or ts-node
  * transpilers since Node.js will handle TypeScript natively.
@@ -62,8 +71,7 @@ const preferNodeStripTypes: boolean = (() => {
   if (process.env.NX_PREFER_NODE_STRIP_TYPES !== 'true') {
     return false;
   }
-  // process.features.typescript is 'strip' | 'transform' | false in Node 22.6+
-  return !!(process as any).features?.typescript;
+  return nodeSupportsNativeTypescript;
 })();
 
 /**
@@ -362,7 +370,9 @@ export function registerTranspiler(
   // Function to register transpiler that returns cleanup function
   const transpiler = getTranspiler(compilerOptions, tsConfigRaw);
 
-  if (!transpiler) {
+  // If Node.js natively supports TypeScript (22.6+), no transpiler is needed.
+  // Don't warn — Node will handle .ts files via type stripping.
+  if (!transpiler && !nodeSupportsNativeTypescript) {
     warnNoTranspiler();
     return () => {};
   }

--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -370,10 +370,12 @@ export function registerTranspiler(
   // Function to register transpiler that returns cleanup function
   const transpiler = getTranspiler(compilerOptions, tsConfigRaw);
 
-  // If Node.js natively supports TypeScript (22.6+), no transpiler is needed.
-  // Don't warn — Node will handle .ts files via type stripping.
-  if (!transpiler && !nodeSupportsNativeTypescript) {
-    warnNoTranspiler();
+  if (!transpiler) {
+    // If Node.js natively supports TypeScript (22.6+), no transpiler is needed.
+    // Don't warn — Node will handle .ts files via type stripping.
+    if (!nodeSupportsNativeTypescript) {
+      warnNoTranspiler();
+    }
     return () => {};
   }
 

--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -54,8 +54,9 @@ const isInvokedByTsx: boolean = (() => {
  *
  * process.features.typescript is 'strip' | 'transform' | false in Node 22.6+
  */
-const nodeSupportsNativeTypescript: boolean =
-  (process as any).features?.typescript === 'strip';
+
+const nodeSupportsNativeTypescript: boolean = !!(process as any).features
+  ?.typescript;
 
 /**
  * When process.features.typescript is truthy and the user has opted in via


### PR DESCRIPTION
On Node 22.18+ (which supports native TypeScript execution via type stripping), Nx incorrectly warns "Unable to locate swc-node or ts-node. Nx will be unable to run local ts files without transpiling." even though Node can handle .ts files natively without any transpiler.

The warning should only appear on Node versions that cannot natively execute TypeScript files. On Node 22.6+ (where process.features.typescript is truthy), no warning should be emitted when swc-node and ts-node are absent.

Fixes #32567
