### PR TITLE
feat(core): add json input type for selective JSON field hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,6 +1684,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonc-parser"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2e5dea04f54739ca5694ee06e4448ffda065a55b3427d2b131bd5ea697ea2c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "jsonrpsee"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,6 +2218,7 @@ dependencies = [
  "insta",
  "interprocess",
  "itertools 0.10.5",
+ "jsonc-parser",
  "jsonrpsee",
  "machine-uid",
  "mio",

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -33,6 +33,7 @@ globset = "0.4.10"
 hashbrown = { version = "0.14.5", features = ["rayon", "rkyv"] }
 ignore = '0.4'
 itertools = "0.10.5"
+jsonc-parser = { version = "0.32.3", features = ["serde"] }
 once_cell = "1.18.0"
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 napi = { version = "3.8.3", default-features = false, features = [

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -772,6 +772,31 @@
             },
             "required": ["dependentTasksOutputFiles"],
             "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "json": {
+                "type": "string",
+                "description": "Path to a JSON file. Must start with {workspaceRoot} or {projectRoot}. Supports globs."
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Allowlist of fields to include in the hash. Supports dot notation for nested paths (e.g. 'compilerOptions.target')."
+              },
+              "excludeFields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Denylist of fields to exclude from the hash. Supports dot notation for nested paths."
+              }
+            },
+            "required": ["json"],
+            "additionalProperties": false
           }
         ]
       }

--- a/packages/nx/schemas/project-schema.json
+++ b/packages/nx/schemas/project-schema.json
@@ -322,6 +322,31 @@
             },
             "required": ["dependentTasksOutputFiles"],
             "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "json": {
+                "type": "string",
+                "description": "Path to a JSON file. Must start with {workspaceRoot} or {projectRoot}. Supports globs."
+              },
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Allowlist of fields to include in the hash. Supports dot notation for nested paths (e.g. 'compilerOptions.target')."
+              },
+              "excludeFields": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Denylist of fields to exclude from the hash. Supports dot notation for nested paths."
+              }
+            },
+            "required": ["json"],
+            "additionalProperties": false
           }
         ]
       }

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -213,7 +213,8 @@ export type InputDefinition =
   | { externalDependencies: string[] }
   | { dependentTasksOutputFiles: string; transitive?: boolean }
   | { env: string }
-  | { workingDirectory: 'relative' | 'absolute' };
+  | { workingDirectory: 'relative' | 'absolute' }
+  | { json: string; fields?: string[]; excludeFields?: string[] };
 
 /**
  * Target's configuration

--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -1,3 +1,4 @@
+import type { JsonInput } from '../native';
 import type { PackageJson } from '../utils/package-json';
 import type {
   NxJsonConfiguration,
@@ -203,6 +204,10 @@ export interface TargetDependencyConfig {
   options?: 'ignore' | 'forward';
 }
 
+// TODO: import the remaining variants from '../native' so the TS types stay
+// in sync with the Rust/napi-generated shapes. Some variants (fileset/input
+// discrimination, workingDirectory literal union) carry richer TS semantics
+// than their native counterparts and will need a layered type to preserve.
 export type InputDefinition =
   | { input: string; projects: string | string[] }
   | { input: string; dependencies: true }
@@ -214,7 +219,7 @@ export type InputDefinition =
   | { dependentTasksOutputFiles: string; transitive?: boolean }
   | { env: string }
   | { workingDirectory: 'relative' | 'absolute' }
-  | { json: string; fields?: string[]; excludeFields?: string[] };
+  | JsonInput;
 
 /**
  * Target's configuration

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -418,6 +418,12 @@ export declare function isAiAgent(): boolean
 
 export declare function isEditorInstalled(editor: SupportedEditor): Promise<boolean>
 
+export interface JsonInput {
+  json: string
+  fields?: Array<string>
+  excludeFields?: Array<string>
+}
+
 export declare function logDebug(message: string): void
 
 /** Combined metadata for groups and processes */

--- a/packages/nx/src/native/tasks/hash_plan_inspector.rs
+++ b/packages/nx/src/native/tasks/hash_plan_inspector.rs
@@ -1,6 +1,6 @@
 use crate::native::tasks::hashers::{
-    ProjectFileSetCache, hash_project_files_with_inputs_cached, hash_workspace_files_with_inputs,
-    resolve_task_output_files,
+    ProjectFileSetCache, collect_json_input_files, hash_project_files_with_inputs_cached,
+    hash_workspace_files_with_inputs, resolve_task_output_files,
 };
 use crate::native::tasks::task_hasher::{HashInputs, HashInputsBuilder};
 use crate::native::tasks::types::HashInstruction;
@@ -82,7 +82,9 @@ impl HashPlanInspector {
     /// Like `inspect()` but returns structured `HashInputs` objects instead of flat strings.
     /// Each `HashInstruction` is categorized into the appropriate bucket (files, runtime,
     /// environment, depOutputs, external). TsConfiguration is resolved to the root tsconfig
-    /// file path. ProjectConfiguration is skipped for now. Cwd is skipped as it's ambient.
+    /// file path. JsonFileSet is resolved to the matched JSON file paths (field/excludeField
+    /// filters only affect hashing, not which files are reported as inputs).
+    /// ProjectConfiguration is skipped for now. Cwd is skipped as it's ambient.
     #[napi(ts_return_type = "Record<string, HashInputs>")]
     pub fn inspect_inputs(
         &self,
@@ -155,6 +157,26 @@ impl HashPlanInspector {
                         .unwrap_or_else(|_| dep_outputs.iter().cloned().collect());
                 Ok(HashInputsBuilder {
                     dep_outputs: dep_output_files,
+                    ..Default::default()
+                })
+            }
+            HashInstruction::JsonFileSet {
+                project_name,
+                json_path,
+                ..
+            } => {
+                // Resolve the file paths the JsonFileSet would hash, without
+                // reading or parsing any JSON. Field/excludeField filters are
+                // irrelevant here — the reported inputs are still the files.
+                let matched = collect_json_input_files(
+                    json_path,
+                    project_name.as_deref(),
+                    &self.project_file_map,
+                    &self.all_workspace_files,
+                )?;
+                let files: HashSet<String> = matched.into_iter().map(String::from).collect();
+                Ok(HashInputsBuilder {
+                    files,
                     ..Default::default()
                 })
             }

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -450,6 +450,23 @@ impl HashPlanner {
                 };
                 Some(HashInstruction::Cwd(cwd_mode))
             }
+            Input::Json {
+                json,
+                fields,
+                exclude_fields,
+            } => {
+                let proj_name = if json.starts_with("{projectRoot}") {
+                    Some(project_name.to_string())
+                } else {
+                    None
+                };
+                Some(HashInstruction::JsonFileSet {
+                    project_name: proj_name,
+                    json_path: resolve_tokens(json, project_root, project_name),
+                    fields: fields.map(|f| f.to_vec()),
+                    exclude_fields: exclude_fields.map(|f| f.to_vec()),
+                })
+            }
             _ => None,
         });
 

--- a/packages/nx/src/native/tasks/hashers.rs
+++ b/packages/nx/src/native/tasks/hashers.rs
@@ -1,6 +1,7 @@
 mod hash_cwd;
 mod hash_env;
 mod hash_external;
+mod hash_json;
 mod hash_project_config;
 mod hash_project_files;
 mod hash_runtime;
@@ -11,6 +12,7 @@ mod hash_workspace_files;
 pub use hash_cwd::*;
 pub use hash_env::*;
 pub use hash_external::*;
+pub use hash_json::*;
 pub use hash_project_config::*;
 pub(crate) use hash_project_files::{ProjectFileSetCache, hash_project_files_with_inputs_cached};
 pub use hash_project_files::{

--- a/packages/nx/src/native/tasks/hashers/hash_json.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_json.rs
@@ -94,14 +94,20 @@ pub fn hash_json_files(
                 continue;
             };
 
-            let filtered = filter_json_value(&parsed, fields, exclude_fields);
-
-            // Stream canonical (sorted-key) JSON bytes straight into the hasher.
-            // The byte sequence is deterministic and defines the cache key, so it
-            // MUST NOT change once released — do not reformat without a migration.
+            // Stream the JSON bytes (object keys sorted at every level) straight
+            // into the hasher. The byte sequence is deterministic and defines the
+            // cache key, so it MUST NOT change once released — do not reformat
+            // without a migration.
             debug!("Adding {} to hash", file_path);
             hasher.update(file_path.as_bytes());
-            hash_canonical_json(&mut hasher, &filtered);
+            // When no filters are set, skip the filter step to avoid cloning the
+            // parsed tree just to return it unchanged.
+            if fields.is_none() && exclude_fields.is_none() {
+                hash_sorted_json(&mut hasher, &parsed);
+            } else {
+                let filtered = filter_json_value(&parsed, fields, exclude_fields);
+                hash_sorted_json(&mut hasher, &filtered);
+            }
             result_files.push(file_path.to_string());
             trace!("hash_json {}: {:?}", file_path, file_start.elapsed());
         }
@@ -122,7 +128,6 @@ fn filter_json_value(
     fields: Option<&[String]>,
     exclude_fields: Option<&[String]>,
 ) -> Value {
-    // If no filtering specified, return the whole value
     if fields.is_none() && exclude_fields.is_none() {
         return value.clone();
     }
@@ -132,39 +137,40 @@ fn filter_json_value(
     };
 
     let mut result = if let Some(fields) = fields {
-        // Allowlist: only include specified fields
         let mut filtered = serde_json::Map::new();
         for field_path in fields {
-            let parts: Vec<&str> = field_path.splitn(2, '.').collect();
-            let key = parts[0];
-            if let Some(val) = obj.get(key) {
-                if parts.len() > 1 {
-                    // Nested path: extract nested field
-                    let nested = extract_nested_field(val, parts[1]);
-                    if let Some(nested_val) = nested {
-                        // Merge into existing key if already present
-                        if let Some(existing) = filtered.get(key) {
-                            if let (Some(existing_obj), Some(nested_obj)) =
-                                (existing.as_object(), nested_val.as_object())
-                            {
-                                let mut merged = existing_obj.clone();
-                                for (k, v) in nested_obj {
-                                    merged.insert(k.clone(), v.clone());
-                                }
-                                filtered.insert(key.to_string(), Value::Object(merged));
-                            }
-                        } else {
-                            filtered.insert(key.to_string(), nested_val);
-                        }
+            let (key, rest) = match field_path.split_once('.') {
+                Some((k, r)) => (k, Some(r)),
+                None => (field_path.as_str(), None),
+            };
+            let Some(val) = obj.get(key) else {
+                continue;
+            };
+            let Some(rest) = rest else {
+                filtered.insert(key.to_string(), val.clone());
+                continue;
+            };
+            let Some(nested_val) = extract_nested_field(val, rest) else {
+                continue;
+            };
+            // Merge into existing key if already present so sibling paths like
+            // ["a.b", "a.c"] produce a single {"a": {"b", "c"}} entry.
+            if let Some(existing) = filtered.get(key) {
+                if let (Some(existing_obj), Some(nested_obj)) =
+                    (existing.as_object(), nested_val.as_object())
+                {
+                    let mut merged = existing_obj.clone();
+                    for (k, v) in nested_obj {
+                        merged.insert(k.clone(), v.clone());
                     }
-                } else {
-                    filtered.insert(key.to_string(), val.clone());
+                    filtered.insert(key.to_string(), Value::Object(merged));
                 }
+            } else {
+                filtered.insert(key.to_string(), nested_val);
             }
         }
         filtered
     } else {
-        // No allowlist — start with everything
         obj.clone()
     };
 
@@ -180,57 +186,53 @@ fn filter_json_value(
 
 /// Extracts a nested field from a JSON value using dot-notation path.
 /// Returns the value wrapped in its parent structure.
-/// e.g., for path "target" on {"target": "ES2021", "paths": {...}},
-/// returns {"target": "ES2021"}
-fn extract_nested_field(value: &Value, remaining_path: &str) -> Option<Value> {
-    let parts: Vec<&str> = remaining_path.splitn(2, '.').collect();
-    let key = parts[0];
-
-    match value.as_object() {
-        Some(obj) => {
-            if let Some(val) = obj.get(key) {
-                if parts.len() > 1 {
-                    // More nesting
-                    extract_nested_field(val, parts[1]).map(|nested| {
-                        let mut wrapper = serde_json::Map::new();
-                        wrapper.insert(key.to_string(), nested);
-                        Value::Object(wrapper)
-                    })
-                } else {
-                    let mut wrapper = serde_json::Map::new();
-                    wrapper.insert(key.to_string(), val.clone());
-                    Some(Value::Object(wrapper))
-                }
-            } else {
-                None
-            }
-        }
-        None => None,
-    }
+/// e.g., for path "target" on `{"target": "ES2021", "paths": {...}}`,
+/// returns `{"target": "ES2021"}`.
+fn extract_nested_field(value: &Value, path: &str) -> Option<Value> {
+    let (key, rest) = match path.split_once('.') {
+        Some((k, r)) => (k, Some(r)),
+        None => (path, None),
+    };
+    let val = value.as_object()?.get(key)?;
+    let inner = match rest {
+        Some(rest) => extract_nested_field(val, rest)?,
+        None => val.clone(),
+    };
+    let mut wrapper = serde_json::Map::new();
+    wrapper.insert(key.to_string(), inner);
+    Some(Value::Object(wrapper))
 }
 
 /// Removes a field from a JSON object using dot-notation path.
 fn remove_nested_field(obj: &mut serde_json::Map<String, Value>, path: &str) {
-    let parts: Vec<&str> = path.splitn(2, '.').collect();
-    let key = parts[0];
-
-    if parts.len() > 1 {
-        // Recurse into nested object
-        if let Some(Value::Object(nested)) = obj.get_mut(key) {
-            remove_nested_field(nested, parts[1]);
+    match path.split_once('.') {
+        Some((key, rest)) => {
+            if let Some(Value::Object(nested)) = obj.get_mut(key) {
+                remove_nested_field(nested, rest);
+            }
         }
-    } else {
-        obj.remove(key);
+        None => {
+            obj.remove(path);
+        }
     }
 }
 
-/// Feeds a canonical (deterministic) JSON encoding of `value` directly into
-/// `hasher`. Object keys are sorted at every level; arrays preserve their
-/// order. Matches `{"a":1,"b":{...}}`-style compact JSON without whitespace.
+/// Feeds a deterministic byte encoding of `value` into `hasher` so that two
+/// JSON objects with the same contents but different key insertion order
+/// produce the same hash.
+///
+/// The encoding is compact JSON (no whitespace) with object keys sorted at
+/// every level. Arrays preserve their order. Leaf values are serialized by
+/// `serde_json` so strings, numbers, bools, and null match standard JSON.
+///
+/// This is **not** RFC 8785 / JCS-compliant canonical JSON — it only sorts
+/// keys. Number normalization, Unicode escape canonicalization, etc. are not
+/// performed. The goal here is cache-key stability within this codebase, not
+/// cross-implementation interoperability.
 ///
 /// The produced byte sequence defines the cache key and MUST NOT change once
 /// released — do not reformat without a migration.
-fn hash_canonical_json(hasher: &mut Xxh3, value: &Value) {
+fn hash_sorted_json(hasher: &mut Xxh3, value: &Value) {
     match value {
         Value::Object(map) => {
             let mut sorted: Vec<(&String, &Value)> = map.iter().collect();
@@ -244,7 +246,7 @@ fn hash_canonical_json(hasher: &mut Xxh3, value: &Value) {
                 let key_json = serde_json::to_string(k).unwrap();
                 hasher.update(key_json.as_bytes());
                 hasher.update(b":");
-                hash_canonical_json(hasher, v);
+                hash_sorted_json(hasher, v);
             }
             hasher.update(b"}");
         }
@@ -254,7 +256,7 @@ fn hash_canonical_json(hasher: &mut Xxh3, value: &Value) {
                 if i > 0 {
                     hasher.update(b",");
                 }
-                hash_canonical_json(hasher, v);
+                hash_sorted_json(hasher, v);
             }
             hasher.update(b"]");
         }
@@ -311,6 +313,25 @@ mod tests {
     }
 
     #[test]
+    fn test_filter_merges_sibling_fields() {
+        // Sibling paths under the same parent must merge, not overwrite each other
+        let json: Value = serde_json::from_str(
+            r#"{"compilerOptions": {"target": "ES2021", "module": "commonjs", "strict": true}}"#,
+        )
+        .unwrap();
+        let fields = vec![
+            "compilerOptions.target".to_string(),
+            "compilerOptions.module".to_string(),
+        ];
+        let result = filter_json_value(&json, Some(&fields), None);
+        let expected: Value = serde_json::from_str(
+            r#"{"compilerOptions": {"target": "ES2021", "module": "commonjs"}}"#,
+        )
+        .unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn test_filter_exclude_nested() {
         let json: Value = serde_json::from_str(
             r#"{"compilerOptions": {"target": "ES2021", "paths": {"@foo": ["libs/foo"]}}}"#,
@@ -326,12 +347,12 @@ mod tests {
 
     fn hash_of(value: &Value) -> String {
         let mut hasher = Xxh3::new();
-        hash_canonical_json(&mut hasher, value);
+        hash_sorted_json(&mut hasher, value);
         hasher.digest().to_string()
     }
 
     #[test]
-    fn test_hash_canonical_sorts_keys() {
+    fn test_hash_sorted_json_sorts_keys() {
         // Different insertion order, same content → identical hash
         let a: Value = serde_json::from_str(r#"{"z": 1, "a": 2, "m": 3}"#).unwrap();
         let b: Value = serde_json::from_str(r#"{"a": 2, "m": 3, "z": 1}"#).unwrap();
@@ -339,14 +360,14 @@ mod tests {
     }
 
     #[test]
-    fn test_hash_canonical_nested_deterministic() {
+    fn test_hash_sorted_json_nested_deterministic() {
         let a: Value = serde_json::from_str(r#"{"b": {"z": 1, "a": 2}, "a": 3}"#).unwrap();
         let b: Value = serde_json::from_str(r#"{"a": 3, "b": {"a": 2, "z": 1}}"#).unwrap();
         assert_eq!(hash_of(&a), hash_of(&b));
     }
 
     #[test]
-    fn test_hash_canonical_distinguishes_array_order() {
+    fn test_hash_sorted_json_distinguishes_array_order() {
         // Arrays are order-sensitive, unlike objects
         let a: Value = serde_json::from_str(r#"[1, 2, 3]"#).unwrap();
         let b: Value = serde_json::from_str(r#"[3, 2, 1]"#).unwrap();

--- a/packages/nx/src/native/tasks/hashers/hash_json.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_json.rs
@@ -1,0 +1,438 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::Result;
+use serde_json::Value;
+use tracing::trace;
+
+use crate::native::glob::build_glob_set;
+use crate::native::hasher::hash;
+use crate::native::tasks::hashers::hash_workspace_files::globs_from_workspace_globs;
+use crate::native::types::FileData;
+
+pub struct JsonHashResult {
+    pub hash: String,
+    pub files: Vec<String>,
+}
+
+/// Hashes JSON files, optionally filtering to specific fields.
+///
+/// Token resolution (`{projectRoot}`, `{projectName}`) is handled upstream by the
+/// `HashPlanner`, so `json_path` arrives here already resolved. `project_name` is
+/// `Some` when the original pattern started with `{projectRoot}` (match against
+/// `project_file_map`) and `None` for `{workspaceRoot}` patterns (match against
+/// `all_workspace_files` after stripping the prefix).
+///
+/// Reads matching files from disk, parses JSON, filters by fields/excludeFields,
+/// and hashes the result deterministically.
+pub fn hash_json_files(
+    workspace_root: &str,
+    json_path: &str,
+    project_name: Option<&str>,
+    fields: Option<&[String]>,
+    exclude_fields: Option<&[String]>,
+    project_file_map: &HashMap<String, Vec<FileData>>,
+    all_workspace_files: &[FileData],
+) -> Result<JsonHashResult> {
+    // Resolve file paths matching the glob
+    let matched_files: Vec<&str> = if let Some(project_name) = project_name {
+        // Project-root path: already resolved by the planner (e.g. "libs/my-lib/package.json")
+        let glob_set = build_glob_set(&[json_path.to_string()])?;
+        project_file_map
+            .get(project_name)
+            .map(|files| {
+                files
+                    .iter()
+                    .filter(|f| glob_set.is_match(&f.file))
+                    .map(|f| f.file.as_str())
+                    .collect()
+            })
+            .unwrap_or_default()
+    } else {
+        // Workspace-root path: still carries the `{workspaceRoot}/` prefix
+        let globs = globs_from_workspace_globs(&[json_path.to_string()]);
+        if globs.is_empty() {
+            vec![]
+        } else {
+            let glob_set = build_glob_set(&globs)?;
+            all_workspace_files
+                .iter()
+                .filter(|f| glob_set.is_match(&f.file))
+                .map(|f| f.file.as_str())
+                .collect()
+        }
+    };
+
+    if matched_files.is_empty() {
+        return Ok(JsonHashResult {
+            hash: hash(b""),
+            files: vec![],
+        });
+    }
+
+    let mut hasher = xxhash_rust::xxh3::Xxh3::new();
+    let mut result_files = Vec::with_capacity(matched_files.len());
+
+    for file_path in &matched_files {
+        let abs_path = Path::new(workspace_root).join(file_path);
+        let content = match std::fs::read_to_string(&abs_path) {
+            Ok(c) => c,
+            Err(e) => {
+                trace!("Failed to read JSON file {:?}: {}", abs_path, e);
+                continue;
+            }
+        };
+
+        let parsed: Value = match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                trace!("Failed to parse JSON file {:?}: {}", abs_path, e);
+                // If we can't parse it as JSON, hash the raw content
+                hasher.update(file_path.as_bytes());
+                hasher.update(content.as_bytes());
+                result_files.push(file_path.to_string());
+                continue;
+            }
+        };
+
+        let filtered = filter_json_value(&parsed, fields, exclude_fields);
+
+        // Serialize deterministically (serde_json sorts keys for Value::Object when using BTreeMap internally)
+        let serialized = canonical_json_string(&filtered);
+        trace!("JSON hash input for {}: {}", file_path, serialized);
+
+        hasher.update(file_path.as_bytes());
+        hasher.update(serialized.as_bytes());
+        result_files.push(file_path.to_string());
+    }
+
+    Ok(JsonHashResult {
+        hash: hasher.digest().to_string(),
+        files: result_files,
+    })
+}
+
+/// Filters a JSON value based on field allowlist and denylist.
+/// Fields use dot notation for nested access (e.g., "compilerOptions.target").
+fn filter_json_value(
+    value: &Value,
+    fields: Option<&[String]>,
+    exclude_fields: Option<&[String]>,
+) -> Value {
+    // If no filtering specified, return the whole value
+    if fields.is_none() && exclude_fields.is_none() {
+        return value.clone();
+    }
+
+    let Some(obj) = value.as_object() else {
+        return value.clone();
+    };
+
+    let mut result = if let Some(fields) = fields {
+        // Allowlist: only include specified fields
+        let mut filtered = serde_json::Map::new();
+        for field_path in fields {
+            let parts: Vec<&str> = field_path.splitn(2, '.').collect();
+            let key = parts[0];
+            if let Some(val) = obj.get(key) {
+                if parts.len() > 1 {
+                    // Nested path: extract nested field
+                    let nested = extract_nested_field(val, parts[1]);
+                    if let Some(nested_val) = nested {
+                        // Merge into existing key if already present
+                        if let Some(existing) = filtered.get(key) {
+                            if let (Some(existing_obj), Some(nested_obj)) =
+                                (existing.as_object(), nested_val.as_object())
+                            {
+                                let mut merged = existing_obj.clone();
+                                for (k, v) in nested_obj {
+                                    merged.insert(k.clone(), v.clone());
+                                }
+                                filtered.insert(key.to_string(), Value::Object(merged));
+                            }
+                        } else {
+                            filtered.insert(key.to_string(), nested_val);
+                        }
+                    }
+                } else {
+                    filtered.insert(key.to_string(), val.clone());
+                }
+            }
+        }
+        filtered
+    } else {
+        // No allowlist — start with everything
+        obj.clone()
+    };
+
+    // Apply denylist
+    if let Some(exclude_fields) = exclude_fields {
+        for field_path in exclude_fields {
+            remove_nested_field(&mut result, field_path);
+        }
+    }
+
+    Value::Object(result)
+}
+
+/// Extracts a nested field from a JSON value using dot-notation path.
+/// Returns the value wrapped in its parent structure.
+/// e.g., for path "target" on {"target": "ES2021", "paths": {...}},
+/// returns {"target": "ES2021"}
+fn extract_nested_field(value: &Value, remaining_path: &str) -> Option<Value> {
+    let parts: Vec<&str> = remaining_path.splitn(2, '.').collect();
+    let key = parts[0];
+
+    match value.as_object() {
+        Some(obj) => {
+            if let Some(val) = obj.get(key) {
+                if parts.len() > 1 {
+                    // More nesting
+                    extract_nested_field(val, parts[1]).map(|nested| {
+                        let mut wrapper = serde_json::Map::new();
+                        wrapper.insert(key.to_string(), nested);
+                        Value::Object(wrapper)
+                    })
+                } else {
+                    let mut wrapper = serde_json::Map::new();
+                    wrapper.insert(key.to_string(), val.clone());
+                    Some(Value::Object(wrapper))
+                }
+            } else {
+                None
+            }
+        }
+        None => None,
+    }
+}
+
+/// Removes a field from a JSON object using dot-notation path.
+fn remove_nested_field(obj: &mut serde_json::Map<String, Value>, path: &str) {
+    let parts: Vec<&str> = path.splitn(2, '.').collect();
+    let key = parts[0];
+
+    if parts.len() > 1 {
+        // Recurse into nested object
+        if let Some(Value::Object(nested)) = obj.get_mut(key) {
+            remove_nested_field(nested, parts[1]);
+        }
+    } else {
+        obj.remove(key);
+    }
+}
+
+/// Produces a canonical (deterministic) JSON string by sorting object keys.
+fn canonical_json_string(value: &Value) -> String {
+    match value {
+        Value::Object(map) => {
+            let mut sorted: Vec<(&String, &Value)> = map.iter().collect();
+            sorted.sort_by_key(|(k, _)| *k);
+            let entries: Vec<String> = sorted
+                .into_iter()
+                .map(|(k, v)| {
+                    format!(
+                        "{}:{}",
+                        serde_json::to_string(k).unwrap(),
+                        canonical_json_string(v)
+                    )
+                })
+                .collect();
+            format!("{{{}}}", entries.join(","))
+        }
+        Value::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(|v| canonical_json_string(v)).collect();
+            format!("[{}]", items.join(","))
+        }
+        _ => serde_json::to_string(value).unwrap_or_default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_filter_no_filters() {
+        let json: Value = serde_json::from_str(r#"{"a": 1, "b": 2, "c": 3}"#).unwrap();
+        let result = filter_json_value(&json, None, None);
+        assert_eq!(result, json);
+    }
+
+    #[test]
+    fn test_filter_with_fields_allowlist() {
+        let json: Value =
+            serde_json::from_str(r#"{"engines": "v18", "name": "foo", "version": "1.0"}"#).unwrap();
+        let fields = vec!["engines".to_string()];
+        let result = filter_json_value(&json, Some(&fields), None);
+        let expected: Value = serde_json::from_str(r#"{"engines": "v18"}"#).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_filter_with_exclude_fields() {
+        let json: Value = serde_json::from_str(r#"{"a": 1, "b": 2, "c": 3}"#).unwrap();
+        let exclude = vec!["b".to_string()];
+        let result = filter_json_value(&json, None, Some(&exclude));
+        let expected: Value = serde_json::from_str(r#"{"a": 1, "c": 3}"#).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_filter_nested_dot_notation() {
+        let json: Value = serde_json::from_str(
+            r#"{"compilerOptions": {"target": "ES2021", "paths": {"@foo": ["libs/foo"]}, "module": "commonjs"}}"#,
+        )
+        .unwrap();
+        let fields = vec!["compilerOptions.target".to_string()];
+        let result = filter_json_value(&json, Some(&fields), None);
+        let expected: Value =
+            serde_json::from_str(r#"{"compilerOptions": {"target": "ES2021"}}"#).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_filter_exclude_nested() {
+        let json: Value = serde_json::from_str(
+            r#"{"compilerOptions": {"target": "ES2021", "paths": {"@foo": ["libs/foo"]}}}"#,
+        )
+        .unwrap();
+        let fields = vec!["compilerOptions".to_string()];
+        let exclude = vec!["compilerOptions.paths".to_string()];
+        let result = filter_json_value(&json, Some(&fields), Some(&exclude));
+        let expected: Value =
+            serde_json::from_str(r#"{"compilerOptions": {"target": "ES2021"}}"#).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_canonical_json_string_sorts_keys() {
+        let json: Value = serde_json::from_str(r#"{"z": 1, "a": 2, "m": 3}"#).unwrap();
+        let result = canonical_json_string(&json);
+        assert_eq!(result, r#"{"a":2,"m":3,"z":1}"#);
+    }
+
+    #[test]
+    fn test_canonical_json_nested() {
+        let json: Value = serde_json::from_str(r#"{"b": {"z": 1, "a": 2}, "a": 3}"#).unwrap();
+        let result = canonical_json_string(&json);
+        assert_eq!(result, r#"{"a":3,"b":{"a":2,"z":1}}"#);
+    }
+
+    #[test]
+    fn test_hash_json_files_workspace_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws_root = dir.path().to_str().unwrap();
+
+        // Create a JSON file
+        let json_content = r#"{"engines": "v18", "name": "test", "version": "1.0"}"#;
+        std::fs::write(dir.path().join("package.json"), json_content).unwrap();
+
+        let all_workspace_files = vec![FileData {
+            file: "package.json".into(),
+            hash: "abc123".into(),
+        }];
+
+        let project_file_map: HashMap<String, Vec<FileData>> = HashMap::new();
+
+        let result = hash_json_files(
+            ws_root,
+            "{workspaceRoot}/package.json",
+            None,
+            Some(&["engines".to_string()]),
+            None,
+            &project_file_map,
+            &all_workspace_files,
+        )
+        .unwrap();
+
+        assert!(!result.hash.is_empty());
+        assert_eq!(result.files, vec!["package.json"]);
+
+        // Hash should be deterministic
+        let result2 = hash_json_files(
+            ws_root,
+            "{workspaceRoot}/package.json",
+            None,
+            Some(&["engines".to_string()]),
+            None,
+            &project_file_map,
+            &all_workspace_files,
+        )
+        .unwrap();
+        assert_eq!(result.hash, result2.hash);
+    }
+
+    #[test]
+    fn test_hash_json_different_fields_different_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws_root = dir.path().to_str().unwrap();
+
+        let json_content = r#"{"engines": "v18", "name": "test", "version": "1.0"}"#;
+        std::fs::write(dir.path().join("package.json"), json_content).unwrap();
+
+        let all_workspace_files = vec![FileData {
+            file: "package.json".into(),
+            hash: "abc123".into(),
+        }];
+        let project_file_map: HashMap<String, Vec<FileData>> = HashMap::new();
+
+        let hash_engines = hash_json_files(
+            ws_root,
+            "{workspaceRoot}/package.json",
+            None,
+            Some(&["engines".to_string()]),
+            None,
+            &project_file_map,
+            &all_workspace_files,
+        )
+        .unwrap();
+
+        let hash_name = hash_json_files(
+            ws_root,
+            "{workspaceRoot}/package.json",
+            None,
+            Some(&["name".to_string()]),
+            None,
+            &project_file_map,
+            &all_workspace_files,
+        )
+        .unwrap();
+
+        assert_ne!(hash_engines.hash, hash_name.hash);
+    }
+
+    #[test]
+    fn test_hash_json_project_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let ws_root = dir.path().to_str().unwrap();
+
+        let proj_dir = dir.path().join("libs").join("my-lib");
+        std::fs::create_dir_all(&proj_dir).unwrap();
+        let json_content = r#"{"name": "@scope/my-lib", "version": "1.0.0"}"#;
+        std::fs::write(proj_dir.join("package.json"), json_content).unwrap();
+
+        let project_file_map: HashMap<String, Vec<FileData>> = HashMap::from([(
+            "my-lib".to_string(),
+            vec![FileData {
+                file: "libs/my-lib/package.json".into(),
+                hash: "def456".into(),
+            }],
+        )]);
+
+        // Planner pre-resolves `{projectRoot}` before the hasher sees it
+        let result = hash_json_files(
+            ws_root,
+            "libs/my-lib/package.json",
+            Some("my-lib"),
+            Some(&["name".to_string()]),
+            None,
+            &project_file_map,
+            &[],
+        )
+        .unwrap();
+
+        assert!(!result.hash.is_empty());
+        assert_eq!(result.files, vec!["libs/my-lib/package.json"]);
+    }
+}

--- a/packages/nx/src/native/tasks/hashers/hash_json.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_json.rs
@@ -72,10 +72,10 @@ fn parse_json_or_jsonc(bytes: &[u8]) -> Option<Value> {
     if let Ok(v) = serde_json::from_slice::<Value>(bytes) {
         return Some(v);
     }
-    // serde_json rejected it — might be JSONC. Retry with the JSONC parser.
-    // Requires valid UTF-8; jsonc_parser takes &str.
     let text = std::str::from_utf8(bytes).ok()?;
-    jsonc_parser::parse_to_serde_value(text, &Default::default()).ok()?
+    jsonc_parser::parse_to_serde_value(text, &Default::default())
+        .inspect_err(|e| trace!("jsonc parse failed: {}", e))
+        .ok()?
 }
 
 /// Hashes JSON files, optionally filtering to specific fields.

--- a/packages/nx/src/native/tasks/hashers/hash_json.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_json.rs
@@ -180,7 +180,7 @@ fn filter_json_value(
     };
 
     let mut result = if let Some(fields) = fields {
-        let mut filtered = serde_json::Map::new();
+        let mut filtered: serde_json::Map<String, Value> = serde_json::Map::new();
         for field_path in fields {
             let (key, rest) = match field_path.split_once('.') {
                 Some((k, r)) => (k, Some(r)),
@@ -189,27 +189,26 @@ fn filter_json_value(
             let Some(val) = obj.get(key) else {
                 continue;
             };
-            let Some(rest) = rest else {
-                filtered.insert(key.to_string(), val.clone());
-                continue;
-            };
-            let Some(nested_val) = extract_nested_field(val, rest) else {
-                continue;
-            };
-            // Merge into existing key if already present so sibling paths like
-            // ["a.b", "a.c"] produce a single {"a": {"b", "c"}} entry.
-            if let Some(existing) = filtered.get(key) {
-                if let (Some(existing_obj), Some(nested_obj)) =
-                    (existing.as_object(), nested_val.as_object())
-                {
-                    let mut merged = existing_obj.clone();
-                    for (k, v) in nested_obj {
-                        merged.insert(k.clone(), v.clone());
-                    }
-                    filtered.insert(key.to_string(), Value::Object(merged));
+            // Build this field's contribution under `key`: either the full
+            // value (no sub-path) or a wrapper containing just the nested
+            // slice. `deep_merge_value` then unions it into any prior entry
+            // at `key` — recursing through nested objects so sibling paths
+            // at arbitrary depth (e.g. ["a.b.c", "a.b.d"]) accumulate
+            // instead of overwriting each other.
+            let contribution = match rest {
+                None => val.clone(),
+                Some(rest) => {
+                    let Some(nested_val) = extract_nested_field(val, rest) else {
+                        continue;
+                    };
+                    nested_val
                 }
-            } else {
-                filtered.insert(key.to_string(), nested_val);
+            };
+            match filtered.get_mut(key) {
+                Some(existing) => deep_merge_value(existing, contribution),
+                None => {
+                    filtered.insert(key.to_string(), contribution);
+                }
             }
         }
         filtered
@@ -225,6 +224,30 @@ fn filter_json_value(
     }
 
     Value::Object(result)
+}
+
+/// Recursively merges `source` into `target`.
+///
+/// When both sides are objects, keys are unioned and colliding values are
+/// deep-merged. When the two sides are not both objects (one is a primitive
+/// or array, or their types differ), `source` wins — matching the "more
+/// specific path wins" semantics so that a broader path like `["a"]` coming
+/// after a narrower path like `["a.b"]` ends with the full `a` value, and
+/// a re-specified primitive overwrites rather than silently being dropped.
+fn deep_merge_value(target: &mut Value, source: Value) {
+    match (target, source) {
+        (Value::Object(target_map), Value::Object(source_map)) => {
+            for (k, v) in source_map {
+                match target_map.get_mut(&k) {
+                    Some(existing) => deep_merge_value(existing, v),
+                    None => {
+                        target_map.insert(k, v);
+                    }
+                }
+            }
+        }
+        (target, source) => *target = source,
+    }
 }
 
 /// Extracts a nested field from a JSON value using dot-notation path.
@@ -371,6 +394,33 @@ mod tests {
             r#"{"compilerOptions": {"target": "ES2021", "module": "commonjs"}}"#,
         )
         .unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_filter_deep_sibling_merge_preserves_all_branches() {
+        // Regression: the prior shallow merge would overwrite at depth 2.
+        // Paths ["a.b.c", "a.b.d"] against a nested source must keep BOTH
+        // `c` and `d`, not just the last one processed.
+        let json: Value =
+            serde_json::from_str(r#"{"a": {"b": {"c": 1, "d": 2, "e": 3}}}"#).unwrap();
+        let fields = vec!["a.b.c".to_string(), "a.b.d".to_string()];
+        let result = filter_json_value(&json, Some(&fields), None);
+        let expected: Value = serde_json::from_str(r#"{"a": {"b": {"c": 1, "d": 2}}}"#).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_filter_broader_path_subsumes_narrower() {
+        // When a narrower path comes first and a broader path comes second,
+        // the broader path wins at the shared key — the user effectively
+        // asked for everything under `a`, so sibling keys like `x` that
+        // weren't mentioned by the narrower path should still appear.
+        let json: Value =
+            serde_json::from_str(r#"{"a": {"b": {"c": 1}, "x": 99}, "other": 7}"#).unwrap();
+        let fields = vec!["a.b".to_string(), "a".to_string()];
+        let result = filter_json_value(&json, Some(&fields), None);
+        let expected: Value = serde_json::from_str(r#"{"a": {"b": {"c": 1}, "x": 99}}"#).unwrap();
         assert_eq!(result, expected);
     }
 

--- a/packages/nx/src/native/tasks/hashers/hash_json.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_json.rs
@@ -11,9 +11,71 @@ use crate::native::hasher::hash;
 use crate::native::tasks::hashers::hash_workspace_files::globs_from_workspace_globs;
 use crate::native::types::FileData;
 
+#[derive(Clone)]
 pub struct JsonHashResult {
     pub hash: String,
     pub files: Vec<String>,
+}
+
+/// Returns the file paths that a JsonFileSet instruction would read, without
+/// any disk I/O or hashing. Used by both `hash_json_files` (to know which
+/// files to open) and by `HashPlanInspector` (to report inputs without side
+/// effects).
+///
+/// `project_name` is `Some` for `{projectRoot}` inputs (match against
+/// `project_file_map`) and `None` for `{workspaceRoot}` inputs (match against
+/// `all_workspace_files` after stripping the prefix). Token resolution has
+/// already been performed upstream by the `HashPlanner`.
+pub fn collect_json_input_files<'a>(
+    json_path: &str,
+    project_name: Option<&str>,
+    project_file_map: &'a HashMap<String, Vec<FileData>>,
+    all_workspace_files: &'a [FileData],
+) -> Result<Vec<&'a str>> {
+    if let Some(project_name) = project_name {
+        // Project-root path: already resolved by the planner (e.g. "libs/my-lib/package.json")
+        let glob_set = build_glob_set(&[json_path.to_string()])?;
+        Ok(project_file_map
+            .get(project_name)
+            .map(|files| {
+                files
+                    .iter()
+                    .filter(|f| glob_set.is_match(&f.file))
+                    .map(|f| f.file.as_str())
+                    .collect()
+            })
+            .unwrap_or_default())
+    } else {
+        // Workspace-root path: still carries the `{workspaceRoot}/` prefix
+        let globs = globs_from_workspace_globs(&[json_path.to_string()]);
+        if globs.is_empty() {
+            return Ok(vec![]);
+        }
+        let glob_set = build_glob_set(&globs)?;
+        Ok(all_workspace_files
+            .iter()
+            .filter(|f| glob_set.is_match(&f.file))
+            .map(|f| f.file.as_str())
+            .collect())
+    }
+}
+
+/// Parses `bytes` as JSON, falling back to JSONC on strict-parse failure so
+/// `tsconfig.json` (with `//` comments or trailing commas) works with field
+/// filters. The fast path is `serde_json` since the overwhelming majority of
+/// JSON inputs (`package.json`, `project.json`, lockfiles) are strict JSON and
+/// we don't want to pay JSONC parsing overhead on every file.
+///
+/// Returns `None` when neither parser accepts the bytes — callers should fall
+/// back to hashing the raw bytes in that case.
+fn parse_json_or_jsonc(bytes: &[u8]) -> Option<Value> {
+    if let Ok(v) = serde_json::from_slice::<Value>(bytes) {
+        return Some(v);
+    }
+    // serde_json rejected it — might be JSONC. Retry with the JSONC parser.
+    // Requires valid UTF-8; jsonc_parser takes &str.
+    let text = std::str::from_utf8(bytes).ok()?;
+    jsonc_parser::parse_to_serde_value(text, &Default::default()).ok()?
 }
 
 /// Hashes JSON files, optionally filtering to specific fields.
@@ -24,8 +86,9 @@ pub struct JsonHashResult {
 /// `project_file_map`) and `None` for `{workspaceRoot}` patterns (match against
 /// `all_workspace_files` after stripping the prefix).
 ///
-/// Reads matching files from disk, parses JSON, filters by fields/excludeFields,
-/// and hashes the result deterministically.
+/// Reads matching files from disk, parses JSON (falling back to JSONC for files
+/// like `tsconfig.json` that may carry `//` comments or trailing commas),
+/// filters by fields/excludeFields, and hashes the result deterministically.
 pub fn hash_json_files(
     workspace_root: &str,
     json_path: &str,
@@ -35,34 +98,12 @@ pub fn hash_json_files(
     project_file_map: &HashMap<String, Vec<FileData>>,
     all_workspace_files: &[FileData],
 ) -> Result<JsonHashResult> {
-    // Resolve file paths matching the glob
-    let matched_files: Vec<&str> = if let Some(project_name) = project_name {
-        // Project-root path: already resolved by the planner (e.g. "libs/my-lib/package.json")
-        let glob_set = build_glob_set(&[json_path.to_string()])?;
-        project_file_map
-            .get(project_name)
-            .map(|files| {
-                files
-                    .iter()
-                    .filter(|f| glob_set.is_match(&f.file))
-                    .map(|f| f.file.as_str())
-                    .collect()
-            })
-            .unwrap_or_default()
-    } else {
-        // Workspace-root path: still carries the `{workspaceRoot}/` prefix
-        let globs = globs_from_workspace_globs(&[json_path.to_string()]);
-        if globs.is_empty() {
-            vec![]
-        } else {
-            let glob_set = build_glob_set(&globs)?;
-            all_workspace_files
-                .iter()
-                .filter(|f| glob_set.is_match(&f.file))
-                .map(|f| f.file.as_str())
-                .collect()
-        }
-    };
+    let matched_files = collect_json_input_files(
+        json_path,
+        project_name,
+        project_file_map,
+        all_workspace_files,
+    )?;
 
     if matched_files.is_empty() {
         return Ok(JsonHashResult {
@@ -84,10 +125,12 @@ pub fn hash_json_files(
                 continue;
             };
 
-            let Ok(parsed) = serde_json::from_slice::<Value>(&bytes)
-                .inspect_err(|e| trace!("Failed to parse JSON file {:?}: {}", abs_path, e))
-            else {
-                // If we can't parse it as JSON, hash the raw bytes
+            let Some(parsed) = parse_json_or_jsonc(&bytes) else {
+                // Neither strict JSON nor JSONC accepted the bytes. Fall back
+                // to hashing the raw file contents so the input is still
+                // covered by the cache key — but field filters are necessarily
+                // ignored in this branch since we have no parsed tree.
+                trace!("Failed to parse JSON/JSONC file {:?}", abs_path);
                 hasher.update(file_path.as_bytes());
                 hasher.update(&bytes);
                 result_files.push(file_path.to_string());
@@ -489,5 +532,68 @@ mod tests {
 
         assert!(!result.hash.is_empty());
         assert_eq!(result.files, vec!["libs/my-lib/package.json"]);
+    }
+
+    #[test]
+    fn test_hash_json_jsonc_fallback_respects_field_filter() {
+        // A `tsconfig.json` written as JSONC (with `//` comments and a
+        // trailing comma) must still go through the field filter — the
+        // hash should match a strict-JSON equivalent with the same filtered
+        // fields, proving we parsed it rather than falling back to raw bytes.
+        let dir = tempfile::tempdir().unwrap();
+        let ws_root = dir.path().to_str().unwrap();
+
+        let jsonc = r#"{
+            // compiler settings
+            "compilerOptions": {
+                "target": "ES2021",
+                "module": "commonjs", /* module system */
+                "strict": true,
+            },
+            "exclude": ["node_modules"],
+        }"#;
+        std::fs::write(dir.path().join("tsconfig.json"), jsonc).unwrap();
+
+        let all_workspace_files = vec![FileData {
+            file: "tsconfig.json".into(),
+            hash: "abc".into(),
+        }];
+        let project_file_map: HashMap<String, Vec<FileData>> = HashMap::new();
+
+        let jsonc_result = hash_json_files(
+            ws_root,
+            "{workspaceRoot}/tsconfig.json",
+            None,
+            Some(&["compilerOptions.target".to_string()]),
+            None,
+            &project_file_map,
+            &all_workspace_files,
+        )
+        .unwrap();
+
+        // Now write a strict-JSON file with the same semantic content but
+        // different whitespace and key order — filtered hash must match.
+        let dir2 = tempfile::tempdir().unwrap();
+        let ws_root2 = dir2.path().to_str().unwrap();
+        let strict = r#"{"exclude":["node_modules"],"compilerOptions":{"strict":true,"module":"commonjs","target":"ES2021"}}"#;
+        std::fs::write(dir2.path().join("tsconfig.json"), strict).unwrap();
+
+        let strict_result = hash_json_files(
+            ws_root2,
+            "{workspaceRoot}/tsconfig.json",
+            None,
+            Some(&["compilerOptions.target".to_string()]),
+            None,
+            &project_file_map,
+            &all_workspace_files,
+        )
+        .unwrap();
+
+        assert_eq!(
+            jsonc_result.hash, strict_result.hash,
+            "JSONC file with comments/trailing commas should produce the \
+             same filtered hash as strict JSON — if this fails, the JSONC \
+             fallback is not being hit and we're hashing raw bytes"
+        );
     }
 }

--- a/packages/nx/src/native/tasks/hashers/hash_json.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_json.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 
 use anyhow::Result;
 use serde_json::Value;
-use tracing::trace;
+use tracing::{debug, debug_span, trace};
+use xxhash_rust::xxh3::Xxh3;
 
 use crate::native::glob::build_glob_set;
 use crate::native::hasher::hash;
@@ -70,45 +71,51 @@ pub fn hash_json_files(
         });
     }
 
-    let mut hasher = xxhash_rust::xxh3::Xxh3::new();
+    let mut hasher = Xxh3::new();
     let mut result_files = Vec::with_capacity(matched_files.len());
 
-    for file_path in &matched_files {
-        let abs_path = Path::new(workspace_root).join(file_path);
-        let content = match std::fs::read_to_string(&abs_path) {
-            Ok(c) => c,
-            Err(e) => {
-                trace!("Failed to read JSON file {:?}: {}", abs_path, e);
-                continue;
-            }
-        };
+    debug_span!("Hashing JSON fileset with inputs").in_scope(|| {
+        for file_path in &matched_files {
+            let file_start = std::time::Instant::now();
+            let abs_path = Path::new(workspace_root).join(file_path);
+            let content = match std::fs::read_to_string(&abs_path) {
+                Ok(c) => c,
+                Err(e) => {
+                    trace!("Failed to read JSON file {:?}: {}", abs_path, e);
+                    continue;
+                }
+            };
 
-        let parsed: Value = match serde_json::from_str(&content) {
-            Ok(v) => v,
-            Err(e) => {
-                trace!("Failed to parse JSON file {:?}: {}", abs_path, e);
-                // If we can't parse it as JSON, hash the raw content
-                hasher.update(file_path.as_bytes());
-                hasher.update(content.as_bytes());
-                result_files.push(file_path.to_string());
-                continue;
-            }
-        };
+            let parsed: Value = match serde_json::from_str(&content) {
+                Ok(v) => v,
+                Err(e) => {
+                    trace!("Failed to parse JSON file {:?}: {}", abs_path, e);
+                    // If we can't parse it as JSON, hash the raw content
+                    hasher.update(file_path.as_bytes());
+                    hasher.update(content.as_bytes());
+                    result_files.push(file_path.to_string());
+                    continue;
+                }
+            };
 
-        let filtered = filter_json_value(&parsed, fields, exclude_fields);
+            let filtered = filter_json_value(&parsed, fields, exclude_fields);
 
-        // Serialize deterministically (serde_json sorts keys for Value::Object when using BTreeMap internally)
-        let serialized = canonical_json_string(&filtered);
-        trace!("JSON hash input for {}: {}", file_path, serialized);
+            // Stream canonical (sorted-key) JSON bytes straight into the hasher.
+            // The byte sequence is deterministic and defines the cache key, so it
+            // MUST NOT change once released — do not reformat without a migration.
+            debug!("Adding {} to hash", file_path);
+            hasher.update(file_path.as_bytes());
+            hash_canonical_json(&mut hasher, &filtered);
+            result_files.push(file_path.to_string());
+            trace!("hash_json {}: {:?}", file_path, file_start.elapsed());
+        }
+        let hashed_value = hasher.digest().to_string();
+        debug!("Hash Value: {}", hashed_value);
 
-        hasher.update(file_path.as_bytes());
-        hasher.update(serialized.as_bytes());
-        result_files.push(file_path.to_string());
-    }
-
-    Ok(JsonHashResult {
-        hash: hasher.digest().to_string(),
-        files: result_files,
+        Ok(JsonHashResult {
+            hash: hashed_value,
+            files: result_files,
+        })
     })
 }
 
@@ -221,29 +228,45 @@ fn remove_nested_field(obj: &mut serde_json::Map<String, Value>, path: &str) {
     }
 }
 
-/// Produces a canonical (deterministic) JSON string by sorting object keys.
-fn canonical_json_string(value: &Value) -> String {
+/// Feeds a canonical (deterministic) JSON encoding of `value` directly into
+/// `hasher`. Object keys are sorted at every level; arrays preserve their
+/// order. Matches `{"a":1,"b":{...}}`-style compact JSON without whitespace.
+///
+/// The produced byte sequence defines the cache key and MUST NOT change once
+/// released — do not reformat without a migration.
+fn hash_canonical_json(hasher: &mut Xxh3, value: &Value) {
     match value {
         Value::Object(map) => {
             let mut sorted: Vec<(&String, &Value)> = map.iter().collect();
-            sorted.sort_by_key(|(k, _)| *k);
-            let entries: Vec<String> = sorted
-                .into_iter()
-                .map(|(k, v)| {
-                    format!(
-                        "{}:{}",
-                        serde_json::to_string(k).unwrap(),
-                        canonical_json_string(v)
-                    )
-                })
-                .collect();
-            format!("{{{}}}", entries.join(","))
+            sorted.sort_by_key(|(k, _)| k.as_str());
+            hasher.update(b"{");
+            for (i, (k, v)) in sorted.iter().enumerate() {
+                if i > 0 {
+                    hasher.update(b",");
+                }
+                // Keys go through serde_json so escaping matches JSON rules
+                let key_json = serde_json::to_string(k).unwrap();
+                hasher.update(key_json.as_bytes());
+                hasher.update(b":");
+                hash_canonical_json(hasher, v);
+            }
+            hasher.update(b"}");
         }
         Value::Array(arr) => {
-            let items: Vec<String> = arr.iter().map(|v| canonical_json_string(v)).collect();
-            format!("[{}]", items.join(","))
+            hasher.update(b"[");
+            for (i, v) in arr.iter().enumerate() {
+                if i > 0 {
+                    hasher.update(b",");
+                }
+                hash_canonical_json(hasher, v);
+            }
+            hasher.update(b"]");
         }
-        _ => serde_json::to_string(value).unwrap_or_default(),
+        // Leaves: numbers, strings, bools, null — serde_json handles escaping/formatting
+        _ => {
+            let leaf = serde_json::to_string(value).unwrap_or_default();
+            hasher.update(leaf.as_bytes());
+        }
     }
 }
 
@@ -305,18 +328,33 @@ mod tests {
         assert_eq!(result, expected);
     }
 
-    #[test]
-    fn test_canonical_json_string_sorts_keys() {
-        let json: Value = serde_json::from_str(r#"{"z": 1, "a": 2, "m": 3}"#).unwrap();
-        let result = canonical_json_string(&json);
-        assert_eq!(result, r#"{"a":2,"m":3,"z":1}"#);
+    fn hash_of(value: &Value) -> String {
+        let mut hasher = Xxh3::new();
+        hash_canonical_json(&mut hasher, value);
+        hasher.digest().to_string()
     }
 
     #[test]
-    fn test_canonical_json_nested() {
-        let json: Value = serde_json::from_str(r#"{"b": {"z": 1, "a": 2}, "a": 3}"#).unwrap();
-        let result = canonical_json_string(&json);
-        assert_eq!(result, r#"{"a":3,"b":{"a":2,"z":1}}"#);
+    fn test_hash_canonical_sorts_keys() {
+        // Different insertion order, same content → identical hash
+        let a: Value = serde_json::from_str(r#"{"z": 1, "a": 2, "m": 3}"#).unwrap();
+        let b: Value = serde_json::from_str(r#"{"a": 2, "m": 3, "z": 1}"#).unwrap();
+        assert_eq!(hash_of(&a), hash_of(&b));
+    }
+
+    #[test]
+    fn test_hash_canonical_nested_deterministic() {
+        let a: Value = serde_json::from_str(r#"{"b": {"z": 1, "a": 2}, "a": 3}"#).unwrap();
+        let b: Value = serde_json::from_str(r#"{"a": 3, "b": {"a": 2, "z": 1}}"#).unwrap();
+        assert_eq!(hash_of(&a), hash_of(&b));
+    }
+
+    #[test]
+    fn test_hash_canonical_distinguishes_array_order() {
+        // Arrays are order-sensitive, unlike objects
+        let a: Value = serde_json::from_str(r#"[1, 2, 3]"#).unwrap();
+        let b: Value = serde_json::from_str(r#"[3, 2, 1]"#).unwrap();
+        assert_ne!(hash_of(&a), hash_of(&b));
     }
 
     #[test]

--- a/packages/nx/src/native/tasks/hashers/hash_json.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_json.rs
@@ -78,24 +78,20 @@ pub fn hash_json_files(
         for file_path in &matched_files {
             let file_start = std::time::Instant::now();
             let abs_path = Path::new(workspace_root).join(file_path);
-            let content = match std::fs::read_to_string(&abs_path) {
-                Ok(c) => c,
-                Err(e) => {
-                    trace!("Failed to read JSON file {:?}: {}", abs_path, e);
-                    continue;
-                }
+            let Ok(bytes) = std::fs::read(&abs_path)
+                .inspect_err(|e| trace!("Failed to read JSON file {:?}: {}", abs_path, e))
+            else {
+                continue;
             };
 
-            let parsed: Value = match serde_json::from_str(&content) {
-                Ok(v) => v,
-                Err(e) => {
-                    trace!("Failed to parse JSON file {:?}: {}", abs_path, e);
-                    // If we can't parse it as JSON, hash the raw content
-                    hasher.update(file_path.as_bytes());
-                    hasher.update(content.as_bytes());
-                    result_files.push(file_path.to_string());
-                    continue;
-                }
+            let Ok(parsed) = serde_json::from_slice::<Value>(&bytes)
+                .inspect_err(|e| trace!("Failed to parse JSON file {:?}: {}", abs_path, e))
+            else {
+                // If we can't parse it as JSON, hash the raw bytes
+                hasher.update(file_path.as_bytes());
+                hasher.update(&bytes);
+                result_files.push(file_path.to_string());
+                continue;
             };
 
             let filtered = filter_json_value(&parsed, fields, exclude_fields);

--- a/packages/nx/src/native/tasks/inputs.rs
+++ b/packages/nx/src/native/tasks/inputs.rs
@@ -139,7 +139,8 @@ fn split_inputs_into_self_and_deps<'a>(
                 | Input::Environment(_)
                 | Input::DepsOutputs { .. }
                 | Input::ExternalDependency(_)
-                | Input::WorkingDirectory(_) => {
+                | Input::WorkingDirectory(_)
+                | Input::Json { .. } => {
                     acc.1.push(input);
                 }
                 Input::Projects { .. } => {
@@ -215,6 +216,18 @@ pub(super) fn expand_single_project_inputs<'a>(
                 dependent_tasks_output_files,
             }),
             Input::WorkingDirectory(mode) => expanded.push(Input::WorkingDirectory(mode)),
+            Input::Json {
+                json,
+                fields,
+                exclude_fields,
+            } => {
+                validate_file_set(json)?;
+                expanded.push(Input::Json {
+                    json,
+                    fields: *fields,
+                    exclude_fields: *exclude_fields,
+                });
+            }
             Input::Projects { .. }
             | Input::Inputs {
                 dependencies: true, ..

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -16,9 +16,9 @@ use crate::native::{
 };
 use crate::native::{
     tasks::hashers::{
-        CachedTaskOutput, ProjectFileSetCache, hash_all_externals, hash_external, hash_json_files,
-        hash_project_config, hash_project_files_with_inputs_cached, hash_task_output,
-        hash_tsconfig_selectively, hash_workspace_files_with_inputs,
+        CachedTaskOutput, JsonHashResult, ProjectFileSetCache, hash_all_externals, hash_external,
+        hash_json_files, hash_project_config, hash_project_files_with_inputs_cached,
+        hash_task_output, hash_tsconfig_selectively, hash_workspace_files_with_inputs,
     },
     types::FileData,
     workspace::types::ProjectFiles,
@@ -205,6 +205,7 @@ impl TaskHasher {
         let runtime_cache: DashMap<String, String> = DashMap::new();
         let project_file_set_cache = ProjectFileSetCache::new();
         let workspace_file_set_cache: DashMap<String, CachedFileSetHash> = DashMap::new();
+        let json_file_set_cache: DashMap<String, JsonHashResult> = DashMap::new();
         let should_collect_inputs = collect_task_inputs.unwrap_or(false);
 
         let function_start = std::time::Instant::now();
@@ -263,6 +264,7 @@ impl TaskHasher {
                         runtime_cache: &runtime_cache,
                         project_file_set_cache: &project_file_set_cache,
                         workspace_file_set_cache: &workspace_file_set_cache,
+                        json_file_set_cache: &json_file_set_cache,
                         cwd: cwd_path,
                         collect_inputs: should_collect_inputs,
                     },
@@ -340,6 +342,7 @@ impl TaskHasher {
             runtime_cache,
             project_file_set_cache,
             workspace_file_set_cache,
+            json_file_set_cache,
             cwd,
             collect_inputs,
         }: HashInstructionArgs,
@@ -529,23 +532,39 @@ impl TaskHasher {
                 fields,
                 exclude_fields,
             } => {
-                let result = hash_json_files(
-                    &self.workspace_root,
-                    json_path,
-                    project_name.as_deref(),
-                    fields.as_deref(),
-                    exclude_fields.as_deref(),
-                    &self.project_file_map,
-                    &self.all_workspace_files,
-                )?;
+                // Cache is keyed on the full instruction string so
+                // different fields/excludeFields against the same file
+                // remain distinct. `instruction.to_string()` already
+                // encodes (project_name, json_path, fields, exclude_fields)
+                // via the Display impl — see types.rs.
+                let cache_key = instruction.to_string();
+                // Clone the cached entry and drop the Ref before any
+                // subsequent insert to avoid deadlocking DashMap.
+                let cached_entry = if let Some(entry) = json_file_set_cache.get(&cache_key) {
+                    entry.clone()
+                } else {
+                    let result = hash_json_files(
+                        &self.workspace_root,
+                        json_path,
+                        project_name.as_deref(),
+                        fields.as_deref(),
+                        exclude_fields.as_deref(),
+                        &self.project_file_map,
+                        &self.all_workspace_files,
+                    )?;
+                    json_file_set_cache.insert(cache_key, result.clone());
+                    result
+                };
                 trace!(parent: &span, "hash_json: {:?}", now.elapsed());
-                (
-                    result.hash,
+                let inputs = if collect_inputs {
                     HashInputsBuilder {
-                        files: result.files.into_iter().collect(),
+                        files: cached_entry.files.into_iter().collect(),
                         ..Default::default()
-                    },
-                )
+                    }
+                } else {
+                    empty
+                };
+                (cached_entry.hash, inputs)
             }
         };
         Ok((instruction.to_string(), hash, inputs))
@@ -562,6 +581,7 @@ struct HashInstructionArgs<'a> {
     runtime_cache: &'a DashMap<String, String>,
     project_file_set_cache: &'a ProjectFileSetCache,
     workspace_file_set_cache: &'a DashMap<String, CachedFileSetHash>,
+    json_file_set_cache: &'a DashMap<String, JsonHashResult>,
     cwd: &'a std::path::Path,
     collect_inputs: bool,
 }

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -16,7 +16,7 @@ use crate::native::{
 };
 use crate::native::{
     tasks::hashers::{
-        CachedTaskOutput, ProjectFileSetCache, hash_all_externals, hash_external,
+        CachedTaskOutput, ProjectFileSetCache, hash_all_externals, hash_external, hash_json_files,
         hash_project_config, hash_project_files_with_inputs_cached, hash_task_output,
         hash_tsconfig_selectively, hash_workspace_files_with_inputs,
     },
@@ -522,6 +522,30 @@ impl TaskHasher {
                     empty
                 };
                 (hashed_all_externals, inputs)
+            }
+            HashInstruction::JsonFileSet {
+                project_name,
+                json_path,
+                fields,
+                exclude_fields,
+            } => {
+                let result = hash_json_files(
+                    &self.workspace_root,
+                    json_path,
+                    project_name.as_deref(),
+                    fields.as_deref(),
+                    exclude_fields.as_deref(),
+                    &self.project_file_map,
+                    &self.all_workspace_files,
+                )?;
+                trace!(parent: &span, "hash_json: {:?}", now.elapsed());
+                (
+                    result.hash,
+                    HashInputsBuilder {
+                        files: result.files.into_iter().collect(),
+                        ..Default::default()
+                    },
+                )
             }
         };
         Ok((instruction.to_string(), hash, inputs))

--- a/packages/nx/src/native/tasks/types.rs
+++ b/packages/nx/src/native/tasks/types.rs
@@ -61,6 +61,12 @@ pub enum HashInstruction {
     TaskOutput(String, Vec<String>),
     External(String),
     AllExternalDependencies,
+    JsonFileSet {
+        project_name: Option<String>,
+        json_path: String,
+        fields: Option<Vec<String>>,
+        exclude_fields: Option<Vec<String>>,
+    },
 }
 
 impl ToNapiValue for HashInstruction {
@@ -122,6 +128,26 @@ impl fmt::Display for HashInstruction {
                 }
                 HashInstruction::TsConfiguration(project_name) => {
                     format!("{project_name}:TsConfig")
+                }
+                HashInstruction::JsonFileSet {
+                    project_name,
+                    json_path,
+                    fields,
+                    exclude_fields,
+                } => {
+                    let prefix = project_name
+                        .as_deref()
+                        .map(|p| format!("{p}:"))
+                        .unwrap_or_default();
+                    let fields_str = fields
+                        .as_ref()
+                        .map(|f| format!("[{}]", f.join(",")))
+                        .unwrap_or_default();
+                    let exclude_str = exclude_fields
+                        .as_ref()
+                        .map(|f| format!("![{}]", f.join(",")))
+                        .unwrap_or_default();
+                    format!("{prefix}json:{json_path}{fields_str}{exclude_str}")
                 }
             }
         )


### PR DESCRIPTION
## Current Behavior

When configuring task inputs for cache hashing, Nx hashes entire files. For JSON config files like `tsconfig.json` or `package.json`, changing any field invalidates the cache — even fields irrelevant to the task (e.g., changing `description` in package.json invalidates a build task).

The only special case is tsconfig, which has hardcoded selective hashing in the native hasher.

## Expected Behavior

A new `json` input type allows users and plugins to specify exactly which fields from a JSON file should be included in the hash. This enables more granular cache invalidation.

```jsonc
// Only hash the "engines" field from package.json
{ "json": "{projectRoot}/package.json", "fields": ["engines"] }

// Hash all of compilerOptions except paths
{ "json": "{workspaceRoot}/tsconfig.json", "fields": ["compilerOptions"], "excludeFields": ["compilerOptions.paths"] }
```

### Features
- **`{workspaceRoot}` and `{projectRoot}` tokens** — same syntax as `fileset` inputs
- **Glob support** — e.g. `{projectRoot}/tsconfig*.json`
- **Dot notation** — nested field paths like `compilerOptions.target`
- **Allowlist (`fields`) and denylist (`excludeFields`)** — can be used together
- **Deterministic hashing** — canonical JSON serialization with sorted keys

### Files changed
- **TypeScript**: `InputDefinition` type + JSON schemas for IDE support
- **Rust NAPI bridge**: `JsonInput` struct, `Either8` → `Either9`, `Input::Json` variant
- **Rust hash planning**: `HashInstruction::JsonFileSet`, planner emits it from `gather_self_inputs`
- **Rust hasher**: new `hash_json.rs` with field filtering, canonical serialization, and 10 unit tests

## Related Issue(s)

<!-- Link related issues here -->