### PR TITLE
chore(nx-dev): exclude .next from jest haste-map crawl

### DIFF
--- a/nx-dev/nx-dev/jest.config.cts
+++ b/nx-dev/nx-dev/jest.config.cts
@@ -6,6 +6,7 @@ const { default: nxPreset } = require('@nx/jest/preset');
 module.exports = {
   ...nxPreset,
   displayName: 'nx-dev',
+  modulePathIgnorePatterns: ['<rootDir>/.next'],
   transform: {
     '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
     '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/next/babel'] }],


### PR DESCRIPTION
## Current Behavior

The `nx-dev:test` task reads 124 `.js`/`.ts` files from the `.next/` build output directory. These reads come from jest-haste-map's filesystem crawl — it scans all files under the project root matching `moduleFileExtensions` to build its module index and compute SHA-1 hashes, and `.next/` is not excluded.

## Expected Behavior

Jest should not scan the `.next/` build output directory during its haste-map crawl, as these files are not needed for test discovery or execution.

## Fix

Add `modulePathIgnorePatterns: ['<rootDir>/.next']` to the nx-dev jest config. This tells jest-haste-map to skip the `.next/` directory entirely during its initial filesystem crawl, eliminating all 124 unexpected file reads.