### PR TITLE
fix(angular-rspack): normalize Windows path separators for i18n

### DIFF
--- a/packages/angular-rspack/src/lib/utils/find-project-for-path.spec.ts
+++ b/packages/angular-rspack/src/lib/utils/find-project-for-path.spec.ts
@@ -1,0 +1,53 @@
+import {
+  createProjectRootMappings,
+  findProjectForPath,
+} from './find-project-for-path';
+
+describe('findProjectForPath', () => {
+  const nodes = {
+    'demo-app': {
+      name: 'demo-app',
+      type: 'app' as const,
+      data: {
+        root: 'apps/demo-app',
+      },
+    },
+    ui: {
+      name: 'ui',
+      type: 'lib' as const,
+      data: {
+        root: 'libs/ui',
+      },
+    },
+  };
+
+  let projectRootMappings: Map<string, string>;
+
+  beforeEach(() => {
+    projectRootMappings = createProjectRootMappings(nodes as any);
+  });
+
+  it('should find the project given a POSIX-style path', () => {
+    expect(
+      findProjectForPath('apps/demo-app/src/main.ts', projectRootMappings)
+    ).toEqual('demo-app');
+  });
+
+  it('should find the project given a Windows-style backslash path', () => {
+    expect(
+      findProjectForPath('apps\\demo-app\\src\\main.ts', projectRootMappings)
+    ).toEqual('demo-app');
+  });
+
+  it('should find the project given a mixed separator path', () => {
+    expect(
+      findProjectForPath('apps\\demo-app/src\\main.ts', projectRootMappings)
+    ).toEqual('demo-app');
+  });
+
+  it('should return undefined for a path not in any project', () => {
+    expect(
+      findProjectForPath('other\\path\\file.ts', projectRootMappings)
+    ).toBeUndefined();
+  });
+});

--- a/packages/angular-rspack/src/lib/utils/find-project-for-path.spec.ts
+++ b/packages/angular-rspack/src/lib/utils/find-project-for-path.spec.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from 'vitest';
 import {
   createProjectRootMappings,
   findProjectForPath,

--- a/packages/angular-rspack/src/lib/utils/find-project-for-path.ts
+++ b/packages/angular-rspack/src/lib/utils/find-project-for-path.ts
@@ -34,7 +34,7 @@ export function findProjectForPath(
    * Windows may pass Win-style file paths
    * Ensure filePath is in UNIX-style
    */
-  let currentPath = posix.normalize(filePath);
+  let currentPath = posix.normalize(filePath.replaceAll('\\', '/'));
   for (
     ;
     currentPath != posix.dirname(currentPath);


### PR DESCRIPTION
## Current Behavior
On Windows, `nx serve project --configuration=some-i18n-configuration` fails with "cannot find project in graph.nodes" because `posix.normalize()` does not convert backslashes to forward slashes. Windows-style paths from `path.relative()` produce backslash-separated strings that never match the forward-slash keys in the project root map.

## Expected Behavior
i18n configurations should resolve correctly on Windows. The path lookup in `findProjectForPath` should succeed regardless of whether the input path uses backslashes (Windows) or forward slashes (POSIX).

## Related Issue(s)
Fixes #32864