### PR TITLE
fix(angular): preserve specific file paths in tsconfig when adding secondary entry point

### DIFF
--- a/packages/angular/src/generators/library-secondary-entry-point/lib/update-tsconfig-included-files.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/lib/update-tsconfig-included-files.ts
@@ -19,17 +19,27 @@ export function updateTsConfigIncludedFiles(
     return;
   }
 
+  const entryPointPrefix = `${options.name}/`;
+
   updateJson(tree, tsConfigPath, (json) => {
     if (json.include?.length) {
-      json.include = json.include.map((path: string) =>
-        path.replace(/^(?:\.\/)?src\//, '')
-      );
+      const newIncludes: string[] = [];
+      for (const pattern of json.include) {
+        if (pattern.includes('*')) {
+          newIncludes.push(`${entryPointPrefix}${pattern}`);
+        }
+      }
+      json.include = [...json.include, ...newIncludes];
     }
 
     if (json.exclude?.length) {
-      json.exclude = json.exclude.map((path: string) =>
-        path.replace(/^(?:\.\/)?src\//, '')
-      );
+      const newExcludes: string[] = [];
+      for (const pattern of json.exclude) {
+        if (pattern.includes('*')) {
+          newExcludes.push(`${entryPointPrefix}${pattern}`);
+        }
+      }
+      json.exclude = [...json.exclude, ...newExcludes];
     }
 
     return json;

--- a/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.spec.ts
@@ -213,8 +213,58 @@ describe('librarySecondaryEntryPoint generator', () => {
     });
 
     tsConfig = readJson(tree, 'libs/lib1/tsconfig.lib.json');
-    expect(tsConfig.include).toStrictEqual(['**/*.ts']);
-    expect(tsConfig.exclude).toStrictEqual(['**/*.spec.ts', '**/*.test.ts']);
+    expect(tsConfig.include).toStrictEqual([
+      'src/**/*.ts',
+      'testing/src/**/*.ts',
+    ]);
+    expect(tsConfig.exclude).toStrictEqual([
+      'src/**/*.spec.ts',
+      'src/**/*.test.ts',
+      'testing/src/**/*.spec.ts',
+      'testing/src/**/*.test.ts',
+    ]);
+  });
+
+  it('should not modify non-glob exclude paths like "src/test-setup.ts"', async () => {
+    await generateTestLibrary(tree, {
+      name: 'lib1',
+      directory: 'libs/lib1',
+      importPath: '@my-org/lib1',
+      publishable: true,
+      skipFormat: true,
+    });
+    // Simulate jest setup adding src/test-setup.ts to exclude
+    updateJson(tree, 'libs/lib1/tsconfig.lib.json', (json) => {
+      json.exclude = [...(json.exclude ?? []), 'src/test-setup.ts'];
+      return json;
+    });
+    // verify initial state
+    let tsConfig = readJson(tree, 'libs/lib1/tsconfig.lib.json');
+    expect(tsConfig.include).toStrictEqual(['src/**/*.ts']);
+    expect(tsConfig.exclude).toStrictEqual([
+      'src/**/*.spec.ts',
+      'src/**/*.test.ts',
+      'src/test-setup.ts',
+    ]);
+
+    await librarySecondaryEntryPointGenerator(tree, {
+      name: 'testing',
+      library: 'lib1',
+      skipFormat: true,
+    });
+
+    tsConfig = readJson(tree, 'libs/lib1/tsconfig.lib.json');
+    expect(tsConfig.include).toStrictEqual([
+      'src/**/*.ts',
+      'testing/src/**/*.ts',
+    ]);
+    expect(tsConfig.exclude).toStrictEqual([
+      'src/**/*.spec.ts',
+      'src/**/*.test.ts',
+      'src/test-setup.ts',
+      'testing/src/**/*.spec.ts',
+      'testing/src/**/*.test.ts',
+    ]);
   });
 
   describe('--skipFormat', () => {


### PR DESCRIPTION


## Current Behavior
The secondary entry point generator rewrites all tsconfig include/exclude entries by stripping the `src/` prefix (e.g. `src/**/*.ts` → `**/*.ts`). This also strips `src/` from literal file paths like `src/test-setup.ts`, breaking the exclude rule since the file still lives at that path.

## Expected Behavior
The generator should add new include/exclude entries scoped to the secondary entry point directory instead of mutating existing entries. This is additive — existing entries are left untouched and new `<name>/src/**/*.ts` patterns are appended for the secondary entry point.

## Related Issue(s)
Fixes #33051