### PR TITLE
docs(misc): add troubleshooting guide for Nx in Claude Code sandbox

### DIFF
--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -578,6 +578,10 @@ const knowledgeBaseGroups: SidebarItems = [
             link: 'troubleshooting/troubleshoot-nx-install-issues',
           },
           {
+            label: 'Nx fails in Claude Code sandbox',
+            link: 'troubleshooting/nx-sandbox-unix-sockets',
+          },
+          {
             label: 'Resolve circular dependencies',
             link: 'troubleshooting/resolve-circular-dependencies',
           },

--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -578,7 +578,7 @@ const knowledgeBaseGroups: SidebarItems = [
             link: 'troubleshooting/troubleshoot-nx-install-issues',
           },
           {
-            label: 'Nx fails in Claude Code sandbox',
+            label: 'Fix Nx in Claude Code sandbox',
             link: 'troubleshooting/nx-sandbox-unix-sockets',
           },
           {

--- a/astro-docs/src/content/docs/features/enhance-AI.mdoc
+++ b/astro-docs/src/content/docs/features/enhance-AI.mdoc
@@ -79,12 +79,9 @@ Your AI agent can:
 
 This approach is faster, produces consistent code across projects, and reduces hallucinations.
 
-## Troubleshooting
-
-If you're using Claude Code with sandbox mode enabled and Nx commands are failing, you may need to allow Unix socket access. See [Nx Fails in Claude Code Sandbox](/docs/troubleshooting/nx-sandbox-unix-sockets).
-
 ## Learn more
 
 - [Autonomous AI Agents at Scale](https://nx.dev/blog/ai-agents-and-continuity): Infrastructure requirements for AI agent workflows
 - [Why Nx and AI Work So Well Together](https://nx.dev/blog/nx-and-ai-why-they-work-together): The foundation for AI-powered development
 - [Nx MCP Server Reference](/docs/reference/nx-mcp): Complete tool reference and setup instructions
+- [Configure Claude Code sandboxes for Nx](/docs/troubleshooting/nx-sandbox-unix-sockets): Allow Unix socket access for daemon and plugin communication

--- a/astro-docs/src/content/docs/features/enhance-AI.mdoc
+++ b/astro-docs/src/content/docs/features/enhance-AI.mdoc
@@ -79,6 +79,10 @@ Your AI agent can:
 
 This approach is faster, produces consistent code across projects, and reduces hallucinations.
 
+## Troubleshooting
+
+If you're using Claude Code with sandbox mode enabled and Nx commands are failing, you may need to allow Unix socket access. See [Nx Fails in Claude Code Sandbox](/docs/troubleshooting/nx-sandbox-unix-sockets).
+
 ## Learn more
 
 - [Autonomous AI Agents at Scale](https://nx.dev/blog/ai-agents-and-continuity): Infrastructure requirements for AI agent workflows

--- a/astro-docs/src/content/docs/getting-started/ai-setup.mdoc
+++ b/astro-docs/src/content/docs/getting-started/ai-setup.mdoc
@@ -68,6 +68,10 @@ Nx also integrates AI directly into your CI runs to automatically detect failed 
 
 Read more on the [Self-Healing CI](/docs/features/ci-features/self-healing-ci) docs page.
 
+## Troubleshooting
+
+If you're using Claude Code with sandbox mode enabled and Nx commands are failing, see [Nx Fails in Claude Code Sandbox](/docs/troubleshooting/nx-sandbox-unix-sockets) to configure Unix socket access.
+
 ## Learn more about Nx and AI
 
 - [Autonomous AI Agents at Scale](https://nx.dev/blog/ai-agents-and-continuity) - Infrastructure requirements for scaling AI agent workflows

--- a/astro-docs/src/content/docs/getting-started/ai-setup.mdoc
+++ b/astro-docs/src/content/docs/getting-started/ai-setup.mdoc
@@ -68,11 +68,8 @@ Nx also integrates AI directly into your CI runs to automatically detect failed 
 
 Read more on the [Self-Healing CI](/docs/features/ci-features/self-healing-ci) docs page.
 
-## Troubleshooting
-
-If you're using Claude Code with sandbox mode enabled and Nx commands are failing, see [Nx Fails in Claude Code Sandbox](/docs/troubleshooting/nx-sandbox-unix-sockets) to configure Unix socket access.
-
 ## Learn more about Nx and AI
 
 - [Autonomous AI Agents at Scale](https://nx.dev/blog/ai-agents-and-continuity) - Infrastructure requirements for scaling AI agent workflows
 - [Why Nx and AI Work So Well Together](https://nx.dev/blog/nx-and-ai-why-they-work-together)
+- [Configure Claude Code sandboxes for Nx](/docs/troubleshooting/nx-sandbox-unix-sockets): Allow Unix socket access for daemon and plugin communication

--- a/astro-docs/src/content/docs/reference/nx-mcp.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-mcp.mdoc
@@ -70,8 +70,8 @@ If you're using Cursor or VS Code, install the [Nx Console extension](/docs/gett
 
 ### Claude code
 
-{% aside type="tip" title="Using sandbox mode?" %}
-If Claude Code's sandbox is blocking Nx commands, you need to allow Unix socket access. See [Nx Fails in Claude Code Sandbox](/docs/troubleshooting/nx-sandbox-unix-sockets) for the fix.
+{% aside type="tip" title="Using Claude Code sandboxes?" %}
+With Claude Code sandboxes, you need to allow Unix socket access. See [Nx Fails in Claude Code Sandbox](/docs/troubleshooting/nx-sandbox-unix-sockets) for more information.
 {% /aside %}
 
 {% tabs syncKey="nx-version" %}

--- a/astro-docs/src/content/docs/reference/nx-mcp.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-mcp.mdoc
@@ -70,6 +70,10 @@ If you're using Cursor or VS Code, install the [Nx Console extension](/docs/gett
 
 ### Claude code
 
+{% aside type="tip" title="Using sandbox mode?" %}
+If Claude Code's sandbox is blocking Nx commands, you need to allow Unix socket access. See [Nx Fails in Claude Code Sandbox](/docs/troubleshooting/nx-sandbox-unix-sockets) for the fix.
+{% /aside %}
+
 {% tabs syncKey="nx-version" %}
 {% tabitem label="Nx >= 21.4" %}
 

--- a/astro-docs/src/content/docs/troubleshooting/nx-sandbox-unix-sockets.mdoc
+++ b/astro-docs/src/content/docs/troubleshooting/nx-sandbox-unix-sockets.mdoc
@@ -10,7 +10,8 @@ When running Nx commands inside [Claude Code](https://docs.anthropic.com/en/docs
 
 Add `allowAllUnixSockets: true` to your Claude Code sandbox permissions. You can set this at the project level (`.claude/settings.local.json`) or user level (`~/.claude/settings.json`):
 
-```json {% fileName=".claude/settings.local.json" %}
+```json
+// .claude/settings.local.json
 {
   "permissions": {
     "allowAllUnixSockets": true

--- a/astro-docs/src/content/docs/troubleshooting/nx-sandbox-unix-sockets.mdoc
+++ b/astro-docs/src/content/docs/troubleshooting/nx-sandbox-unix-sockets.mdoc
@@ -1,0 +1,61 @@
+---
+title: Nx Fails in Claude Code Sandbox
+description: Fix Nx commands failing inside Claude Code's sandbox by allowing Unix socket access for daemon and plugin communication.
+filter: 'type:References'
+---
+
+When running Nx commands inside [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview)'s sandbox mode, you may see errors related to the Nx daemon, plugin isolation, or forked processes failing to communicate. This happens because Claude Code's sandbox (Seatbelt on macOS, bubblewrap on Linux) blocks Unix socket access by default, and Nx relies on Unix sockets for inter-process communication.
+
+## The fix
+
+Add `allowAllUnixSockets: true` to your Claude Code sandbox permissions. You can set this at the project level (`.claude/settings.local.json`) or user level (`~/.claude/settings.json`):
+
+```json {% fileName=".claude/settings.local.json" %}
+{
+  "permissions": {
+    "allowAllUnixSockets": true
+  }
+}
+```
+
+This grants Nx the ability to create and connect to Unix sockets, which it needs for daemon communication, plugin isolation, and forked task execution.
+
+## Why `allowAllUnixSockets` instead of specific paths
+
+Claude Code's `allowUnixSockets` setting accepts specific socket paths, but Nx generates socket paths dynamically using `process.pid`, a counter, and `performance.now()`. These paths change on every run and can't be predicted ahead of time. Allowlisting individual paths isn't feasible, so `allowAllUnixSockets: true` is the recommended approach.
+
+## Alternative workarounds
+
+If you prefer not to enable blanket Unix socket access, you can disable the Nx features that require sockets. These workarounds come with tradeoffs:
+
+### Disable the Nx daemon
+
+```shell
+NX_DAEMON=false nx <command>
+```
+
+The [Nx daemon](/docs/concepts/nx-daemon) keeps a persistent process running to speed up repeated operations. Disabling it means Nx starts fresh on every invocation, resulting in slower cold starts (especially in large workspaces).
+
+### Disable plugin isolation
+
+```shell
+NX_ISOLATE_PLUGINS=false nx <command>
+```
+
+[Plugin isolation](/docs/concepts/inferred-tasks) runs each plugin in a separate forked process to prevent conflicts between multiple TypeScript compilers, module-level caches, and global state. Disabling it runs all plugins in the main process, which can cause issues in workspaces with plugins that have conflicting dependencies.
+
+{% aside type="caution" title="Workarounds are not recommended for regular use" %}
+Both environment variables work around the symptom rather than fixing the root cause. The `allowAllUnixSockets` setting is the proper fix and doesn't sacrifice any Nx functionality.
+{% /aside %}
+
+## Socket path environment variables
+
+For advanced use cases, Nx provides environment variables to override where socket files are created:
+
+| Variable                         | Description                                                        |
+| -------------------------------- | ------------------------------------------------------------------ |
+| `NX_SOCKET_DIR`                  | Overrides the directory for both daemon and forked process sockets |
+| `NX_DAEMON_SOCKET_DIR`           | Overrides the daemon socket directory specifically                 |
+| `NX_NATIVE_FILE_CACHE_DIRECTORY` | Overrides the native file cache path                               |
+
+These are primarily useful for environments with restricted temp directory access (e.g., certain Docker or CI setups). For Claude Code's sandbox, `allowAllUnixSockets: true` is simpler and more reliable.

--- a/astro-docs/src/content/docs/troubleshooting/nx-sandbox-unix-sockets.mdoc
+++ b/astro-docs/src/content/docs/troubleshooting/nx-sandbox-unix-sockets.mdoc
@@ -1,6 +1,17 @@
 ---
-title: Nx Fails in Claude Code Sandbox
-description: Fix Nx commands failing inside Claude Code's sandbox by allowing Unix socket access for daemon and plugin communication.
+title: Fix Nx Commands Failing in Claude Code Sandbox
+description: Nx commands fail inside Claude Code sandbox because Unix sockets are blocked. Set allowAllUnixSockets to fix daemon, plugin isolation, and forked process errors.
+keywords:
+  [
+    Claude Code,
+    sandbox,
+    Unix sockets,
+    Nx daemon,
+    allowAllUnixSockets,
+    Seatbelt,
+    bubblewrap,
+    plugin isolation,
+  ]
 filter: 'type:References'
 ---
 


### PR DESCRIPTION
add a kb article explaining using nx w/ claude code sandboxes w/ the recommended fix (`allowAllUnixSockets: true`) and alternative workarounds with their tradeoffs. 

added some cross-linking to this article so users can discover it in ai specific pages


Fixes DOC-456