### PR TITLE
fix(core): replace exec() with spawn() to prevent maxBuffer crash on large command output

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -2,10 +2,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import { env } from 'npm-run-path';
 import { relative } from 'path';
 import { dirSync, fileSync } from 'tmp';
-import runCommands, {
-  interpolateArgsIntoCommand,
-  LARGE_BUFFER,
-} from './run-commands.impl';
+import runCommands, { interpolateArgsIntoCommand } from './run-commands.impl';
 
 function normalize(p: string) {
   return p.startsWith('/private') ? p.substring(8) : p;
@@ -685,7 +682,7 @@ describe('Run Commands', () => {
 
   describe('--color', () => {
     it('should not set FORCE_COLOR=true', async () => {
-      const exec = jest.spyOn(require('child_process'), 'exec');
+      const spawn = jest.spyOn(require('child_process'), 'spawn');
       await runCommands(
         {
           commands: [`echo 'Hello World'`, `echo 'Hello Universe'`],
@@ -695,17 +692,17 @@ describe('Run Commands', () => {
         context
       );
 
-      expect(exec).toHaveBeenCalledTimes(2);
-      expect(exec).toHaveBeenNthCalledWith(1, `echo 'Hello World'`, {
-        maxBuffer: LARGE_BUFFER,
+      expect(spawn).toHaveBeenCalledTimes(2);
+      expect(spawn).toHaveBeenNthCalledWith(1, `echo 'Hello World'`, [], {
+        shell: true,
         env: {
           ...process.env,
           ...env(),
         },
         windowsHide: true,
       });
-      expect(exec).toHaveBeenNthCalledWith(2, `echo 'Hello Universe'`, {
-        maxBuffer: LARGE_BUFFER,
+      expect(spawn).toHaveBeenNthCalledWith(2, `echo 'Hello Universe'`, [], {
+        shell: true,
         env: {
           ...process.env,
           ...env(),
@@ -715,7 +712,7 @@ describe('Run Commands', () => {
     });
 
     it('should not set FORCE_COLOR=true when --no-color is passed', async () => {
-      const exec = jest.spyOn(require('child_process'), 'exec');
+      const spawn = jest.spyOn(require('child_process'), 'spawn');
       await runCommands(
         {
           commands: [`echo 'Hello World'`, `echo 'Hello Universe'`],
@@ -726,17 +723,17 @@ describe('Run Commands', () => {
         context
       );
 
-      expect(exec).toHaveBeenCalledTimes(2);
-      expect(exec).toHaveBeenNthCalledWith(1, `echo 'Hello World'`, {
-        maxBuffer: LARGE_BUFFER,
+      expect(spawn).toHaveBeenCalledTimes(2);
+      expect(spawn).toHaveBeenNthCalledWith(1, `echo 'Hello World'`, [], {
+        shell: true,
         env: {
           ...process.env,
           ...env(),
         },
         windowsHide: true,
       });
-      expect(exec).toHaveBeenNthCalledWith(2, `echo 'Hello Universe'`, {
-        maxBuffer: LARGE_BUFFER,
+      expect(spawn).toHaveBeenNthCalledWith(2, `echo 'Hello Universe'`, [], {
+        shell: true,
         env: {
           ...process.env,
           ...env(),
@@ -746,7 +743,7 @@ describe('Run Commands', () => {
     });
 
     it('should set FORCE_COLOR=true when running with --color', async () => {
-      const exec = jest.spyOn(require('child_process'), 'exec');
+      const spawn = jest.spyOn(require('child_process'), 'spawn');
       await runCommands(
         {
           commands: [`echo 'Hello World'`, `echo 'Hello Universe'`],
@@ -757,14 +754,14 @@ describe('Run Commands', () => {
         context
       );
 
-      expect(exec).toHaveBeenCalledTimes(2);
-      expect(exec).toHaveBeenNthCalledWith(1, `echo 'Hello World'`, {
-        maxBuffer: LARGE_BUFFER,
+      expect(spawn).toHaveBeenCalledTimes(2);
+      expect(spawn).toHaveBeenNthCalledWith(1, `echo 'Hello World'`, [], {
+        shell: true,
         env: { ...process.env, FORCE_COLOR: `true`, ...env() },
         windowsHide: true,
       });
-      expect(exec).toHaveBeenNthCalledWith(2, `echo 'Hello Universe'`, {
-        maxBuffer: LARGE_BUFFER,
+      expect(spawn).toHaveBeenNthCalledWith(2, `echo 'Hello Universe'`, [], {
+        shell: true,
         env: { ...process.env, FORCE_COLOR: `true`, ...env() },
         windowsHide: true,
       });
@@ -1151,6 +1148,57 @@ describe('Run Commands', () => {
       const duration = Date.now() - startTime;
       // Should complete quickly after failure and cleanup
       expect(duration).toBeLessThan(500);
+    });
+  });
+
+  describe('large output handling', () => {
+    it('should handle output that exceeds default maxBuffer without crashing', async () => {
+      // Node.js default maxBuffer for exec() is 1MB (1024 * 1024).
+      // This command generates ~2MB of output, which would crash exec()
+      // unless LARGE_BUFFER was set. With spawn(), there is no maxBuffer
+      // limit at all — output streams through data events.
+      const result = await runCommands(
+        {
+          commands: [
+            {
+              // Generate ~2MB of output (each line is ~80 chars, 25000 lines ≈ 2MB)
+              command: `node -e "for(let i=0;i<25000;i++){console.log('x'.repeat(80))}"`,
+            },
+          ],
+          parallel: false,
+          __unparsed__: [],
+        },
+        context
+      );
+
+      expect(result).toEqual(expect.objectContaining({ success: true }));
+    });
+
+    it('exec() with small maxBuffer crashes on large output, spawn() does not', async () => {
+      const { exec, spawn } = require('child_process');
+      const cmd = `node -e "for(let i=0;i<1000;i++){console.log('x'.repeat(200))}"`;
+
+      // Prove exec() crashes when output exceeds maxBuffer
+      const execResult = await new Promise<{ error: Error | null }>((res) => {
+        exec(cmd, { maxBuffer: 1024 * 50 }, (error) => res({ error }));
+      });
+      expect(execResult.error).toBeTruthy();
+      expect(execResult.error.message).toContain('maxBuffer');
+
+      // Prove spawn() handles the same output without any crash
+      const spawnResult = await new Promise<{
+        code: number;
+        totalBytes: number;
+      }>((res) => {
+        let totalBytes = 0;
+        const child = spawn(cmd, [], { shell: true });
+        child.stdout.on('data', (chunk) => {
+          totalBytes += chunk.length;
+        });
+        child.on('exit', (code) => res({ code, totalBytes }));
+      });
+      expect(spawnResult.code).toBe(0);
+      expect(spawnResult.totalBytes).toBeGreaterThan(1024 * 50); // well over 50KB
     });
   });
 });

--- a/packages/nx/src/executors/run-commands/running-tasks.ts
+++ b/packages/nx/src/executors/run-commands/running-tasks.ts
@@ -1,5 +1,5 @@
 import * as pc from 'picocolors';
-import { ChildProcess, exec, Serializable } from 'child_process';
+import { ChildProcess, spawn, Serializable } from 'child_process';
 import { env as appendLocalEnv } from 'npm-run-path';
 import { isAbsolute, join } from 'path';
 import treeKill from 'tree-kill';
@@ -17,7 +17,6 @@ import {
 import { registerTaskProcessStart } from '../../tasks-runner/task-io-service';
 import { signalToCode } from '../../utils/exit-codes';
 import {
-  LARGE_BUFFER,
   NormalizedRunCommandsOptions,
   RunCommandsCommandOptions,
 } from './run-commands.impl';
@@ -399,8 +398,8 @@ class RunningNodeProcess implements RunningTask {
     if (streamOutput) {
       process.stdout.write(header);
     }
-    this.childProcess = exec(commandConfig.command, {
-      maxBuffer: LARGE_BUFFER,
+    this.childProcess = spawn(commandConfig.command, [], {
+      shell: true,
       env,
       cwd,
       windowsHide: true,

--- a/packages/nx/src/executors/run-script/run-script.impl.ts
+++ b/packages/nx/src/executors/run-script/run-script.impl.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { spawn } from 'child_process';
 import * as path from 'path';
 import treeKill from 'tree-kill';
 import type { ExecutorContext } from '../../config/misc-interfaces';
@@ -7,8 +7,6 @@ import {
   PseudoTerminal,
 } from '../../tasks-runner/pseudo-terminal';
 import { getPackageManagerCommand } from '../../utils/package-manager';
-
-const LARGE_BUFFER = 1024 * 1000000;
 
 export interface RunScriptOptions {
   script: string;
@@ -54,21 +52,28 @@ function nodeProcess(
   env: Record<string, string>
 ): Promise<void> {
   return new Promise<void>((res, rej) => {
-    let cp = exec(
-      command,
-      { cwd, env, maxBuffer: LARGE_BUFFER, windowsHide: true },
-      (error) => {
-        if (error) {
-          rej(error);
-        } else {
-          res();
-        }
-      }
-    );
+    let cp = spawn(command, [], {
+      shell: true,
+      cwd,
+      env,
+      windowsHide: true,
+    });
 
     // Forward stdout/stderr to parent process
     cp.stdout.pipe(process.stdout);
     cp.stderr.pipe(process.stderr);
+
+    cp.on('error', (error) => {
+      rej(error);
+    });
+
+    cp.on('exit', (code) => {
+      if (code === 0) {
+        res();
+      } else {
+        rej(new Error(`Command "${command}" exited with non-zero status code`));
+      }
+    });
 
     const exitHandler = (signal: NodeJS.Signals) => {
       if (cp && cp.pid && !cp.killed) {


### PR DESCRIPTION
## Current Behavior

The `run-commands` and `run-script` executors use Node.js `child_process.exec()` to run shell commands. `exec()` internally buffers **all** stdout/stderr into memory and compares the total against a `maxBuffer` limit (set to ~1GB via `LARGE_BUFFER`). When a command produces output exceeding this limit, Node.js kills the child process and throws `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`:

```
NX   stdout maxBuffer length exceeded
Pass --verbose to see the stacktrace.
```

This is the **default code path on CI**, because `PseudoTerminal.isSupported()` checks `process.stdout.isTTY`, which is `false` when stdout is piped (as it is on all CI runners). So while local development typically uses the Rust PTY path (which streams output with no buffer limit), every `run-commands` task on CI goes through the `exec()` fallback.

The reason this hasn't been hit more often is that the 1GB `LARGE_BUFFER` is large enough for most commands. But commands that produce very large output quickly (e.g., deploying a site with thousands of files) can exceed it.

## Expected Behavior

Commands that produce arbitrarily large output should complete successfully without crashing Nx. Output should stream through data events with no internal buffering limit.

This PR replaces `exec()` with `spawn()` + `{ shell: true }` in both the `run-commands` and `run-script` executors. `spawn()` provides identical shell-based command execution but uses streaming I/O — there is no `maxBuffer` at all. Since both executors already consumed output via stream event listeners (`stdout.on('data')`) rather than the `exec()` callback, this is a safe swap with no behavioral change.

The PR also includes a test that directly demonstrates the issue: the same command that crashes `exec()` with a maxBuffer error completes successfully under `spawn()`.

## Related Issue(s)

N/A — encountered during a deploy task producing large stdout.