### PR TITLE
docs(misc): add back Cloud CNW CTA in the CI tutorial

### DIFF
--- a/astro-docs/src/content/docs/getting-started/Tutorials/self-healing-ci-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/self-healing-ci-tutorial.mdoc
@@ -31,11 +31,21 @@ Connect your workspace to Nx Cloud, generate a CI workflow, and enable remote ca
 
 {% /aside %}
 
-This tutorial assumes you have an existing Nx workspace (see [Crafting Your Workspace](/docs/getting-started/tutorials/crafting-your-workspace) or the [Gradle tutorial](/docs/getting-started/tutorials/gradle-tutorial)), a [GitHub account](https://github.com) with a repository for your workspace, and [Node.js](https://nodejs.org) v20.19 or later.
+This tutorial assumes you have a [GitHub account](https://github.com) and [Node.js](https://nodejs.org) v20.19 or later.
 
 ## Connect to Nx Cloud
 
-Connect your workspace to Nx Cloud to enable remote caching and CI features:
+### Don't have a workspace yet?
+
+Create a workspace, GitHub repository, and Nx Cloud connection in one step:
+
+{% call_to_action variant="default" title="Create a new Nx workspace" url="https://cloud.nx.app/create-nx-workspace?utm_source=nx-dev&utm_medium=ci-tutorial&utm_campaign=try-nx-cloud" description="Setup takes less than 2 minutes" /%}
+
+This also generates a CI workflow, so you can skip ahead to [Remote caching](#remote-caching).
+
+### Connect an existing workspace
+
+If you already have an Nx workspace, connect it to Nx Cloud:
 
 {% aside type="note" title="Prerequisites for nx connect" %}
 Your workspace must be pushed to a Git provider (GitHub, GitLab, Bitbucket, or Azure DevOps) before running `nx connect`. After connecting, Nx Cloud opens a PR that adds `nxCloudId` to `nx.json`. Merge this PR before proceeding so CI runs appear on the Nx Cloud dashboard.
@@ -51,7 +61,9 @@ The access token is stored in `nx.json` and should be committed to your reposito
 
 ## Generate a CI workflow
 
-Generate a CI workflow configuration for GitHub Actions:
+If your workspace already has a CI workflow (e.g., `.github/workflows/ci.yml`), skip to [Remote caching](#remote-caching).
+
+Generate a CI workflow for GitHub Actions:
 
 ```shell
 nx add @nx/workspace


### PR DESCRIPTION
Add the CTA back as an option for users to quickly get a repo up and running to try the CI tutorial.

Preview: https://deploy-preview-35257--nx-docs.netlify.app/docs/getting-started/tutorials/self-healing-ci-tutorial