### PR TITLE
chore(repo): fix inputs for nx:test-native

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -89,7 +89,7 @@
       "cache": true
     },
     "test-native": {
-      "inputs": ["native"],
+      "inputs": ["native", "{projectRoot}/**/*.snap"],
       "executor": "@monodon/rust:test",
       "options": {},
       "cache": true


### PR DESCRIPTION
## Current Behavior
Snapshots are not an input for test:native

## Expected Behavior
Snapshots are an input for test:native

