### PR TITLE
chore(nx-plugin): add optional peer dep on vitest

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -34,6 +34,14 @@
     "@nx/js": "workspace:*",
     "@nx/eslint": "workspace:*"
   },
+  "peerDependencies": {
+    "@nx/vitest": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@nx/vitest": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "nx": "workspace:*"
   },


### PR DESCRIPTION
Sm fix for sandboxing inputs / graph consistency

This pull request adds a new optional peer dependency to the `packages/plugin/package.json` file, allowing consumers to optionally use `@nx/vitest` without requiring it by default.

Dependency management:

* Added `@nx/vitest` as an optional peer dependency under `peerDependencies` and configured it as optional in `peerDependenciesMeta`.