### PR TITLE
chore(vue): add optional peer dependencies

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -46,5 +46,24 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {}
+  "peerDependencies": {
+    "@nx/cypress": "workspace:*",
+    "@nx/playwright": "workspace:*",
+    "@nx/rsbuild": "workspace:*",
+    "@nx/storybook": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@nx/cypress": {
+      "optional": true
+    },
+    "@nx/playwright": {
+      "optional": true
+    },
+    "@nx/rsbuild": {
+      "optional": true
+    },
+    "@nx/storybook": {
+      "optional": true
+    }
+  }
 }


### PR DESCRIPTION
## Current Behavior

The `@nx/vue` plugin uses `ensurePackage` for `@nx/cypress`, `@nx/playwright`, `@nx/rsbuild`, and `@nx/storybook` but doesn't declare them as optional peer dependencies.

## Expected Behavior

These 4 packages are listed as optional peer dependencies via `peerDependencies` + `peerDependenciesMeta`.