### PR TITLE
chore(repo): add diagnose-sandbox-report skill

### DIFF
--- a/.claude/skills/diagnose-sandbox-report/SKILL.md
+++ b/.claude/skills/diagnose-sandbox-report/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: diagnose-sandbox-report
+description: >
+  Diagnose Nx sandbox violations from a sandbox report. Use when asked to
+  "diagnose sandbox", "analyze sandbox report", "investigate sandbox violations",
+  "check violations", when given a sandbox report JSON file or URL to investigate,
+  or when the user pastes a staging.nx.app sandbox-report URL. Also trigger when
+  discussing unexpected reads/writes in Nx task execution. Guides structured
+  investigation of why tasks read/write undeclared files, determines root causes,
+  and recommends fixes.
+argument-hint: '<sandbox-report.json or URL> [--filter <file|pattern|list>]'
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# Diagnose Sandbox Report
+
+## Overview
+
+Sandbox violations occur when an Nx task reads files not declared as inputs or writes files not declared as outputs.
+
+**Unexpected reads** are one of:
+
+1. **Missing input** (most likely) — the process legitimately needs this file. Understand what the process does and why the access makes sense, then declare it as an input.
+2. **Potential sandboxing gap** (last resort) — the access is irrelevant to correctness and should be filtered/ignored by the sandbox. Only conclude this after exhausting every possibility for it being a missing input.
+
+**Unexpected writes** follow the same logic:
+
+1. **Missing output** (most likely) — the process legitimately produces this file.
+2. **Potential sandboxing gap** (last resort) — same as above.
+
+The default assumption is that an unexpected access IS a missing declaration. The investigation's job is to understand WHY the process accesses the file — not to find reasons it shouldn't.
+
+## Critical Rules
+
+1. **NEVER read the sandbox report JSON directly** — these files are too large for the Read tool (50K+ tokens). Do NOT use `Read`, `cat`, `head`, `python3`, or `jq` on the raw report. All report parsing is handled by the script.
+2. **ALWAYS run the context-gathering script as the very first step** — no manual parsing, no ad-hoc python/jq on the report file. The script does everything deterministically.
+3. If the script fails, **report the error and stop**. Do not attempt manual parsing as a fallback.
+4. **Identify the inferring plugin BEFORE proposing any fix** — check `inference.plugin` in the script output or run `jq '.targets.<target>.metadata' <detail-file>`. Fixing the wrong plugin wastes entire investigation rounds.
+5. **Verify hypotheses empirically before committing to them** — see Principle 4 and the Phase 2 instrumentation guidance.
+
+## Workflow
+
+### Phase 0: Input
+
+User provides one of:
+
+- Path to a sandbox report JSON file
+- A URL to a sandbox report — pass it directly to the script, it handles downloading
+- A task ID + CIPE URL (fetch report via MCP if available)
+- Inline violation data
+
+If a task ID is provided but no report, ask the user for the report file.
+
+**Filtering**: Most invocations will focus on specific files, not the entire report. The user may specify:
+
+- A single file: `e2e.log`
+- A comma-separated list: `apps/nx-cloud/e2e.log,apps/nx-cloud/build/client/assets/main.js`
+- A glob pattern: `*.tsbuildinfo`, `apps/nx-cloud/build/**`
+- A directory prefix: `apps/nx-cloud/build/client/assets`
+
+When the user specifies files to focus on, pass them via `--filter` to the script. When they don't specify a filter and the report has many violations, summarize the groupings (by directory, extension) and ask which group(s) to investigate first rather than trying to investigate everything at once.
+
+### Phase 1: Deterministic Pre-Processing
+
+Run the context-gathering script **immediately** — this is the first tool call after reading the user's input.
+
+Call it exactly as shown — do NOT append `2>&1` or `2>/dev/null` (the script manages its own stderr internally). Run in the **foreground** (no `run_in_background`) with a **3-minute timeout** — reports can be large and the script runs the task + multiple nx commands:
+
+```bash
+npx tsx ${CLAUDE_SKILL_DIR}/scripts/gather-sandbox-context.ts <report.json or URL> [--filter <pattern>] [--workspace <path>]
+```
+
+Pass `--filter` when the user wants to focus on specific files or patterns. The script filters violations before all downstream processing (grouping, validation, classification), so the output only contains relevant data.
+
+The script produces two outputs:
+
+**stdout** (~3-5KB compact brief) — everything needed to start investigating:
+
+- `summary`: violation counts (total, filtered, confirmed vs undeclared)
+- `undeclaredFiles`: the actual file paths that are true violations
+- `grouping`: violations grouped by directory and extension
+- `commands`: processes with violations (pid, cmd, executable, arguments, counts) — no full file lists
+- `classificationSummary`: counts per category (cross-project, build artifacts, config files, etc.)
+- `crossProjectDependencyCheck`: whether cross-project file owners are in the task's dependency chain
+- `staleDeclarations`: grouped analysis of expectedInputsNotRead / expectedOutputsNotWritten
+- `dependentTasksOutputFiles`: extracted from target inputs config and named inputs — shows what dep output globs are declared (critical for cross-project violations)
+- `executorInfo`: executor name and resolved source path in `node_modules` — read this file to understand how the tool is invoked
+- `checkSample`: results of `--check` on up to 5 undeclared files (catches false positives early)
+- `inference` + `pluginRegistration`: plugin metadata
+- `verificationCommands`: pre-built `--check` commands with the correct task ref
+- `detailFile`: path to the full detail JSON
+
+**detail file** (`/tmp/sandbox-diagnosis-detail-<project>-<target>.json`) — full data for drill-down. Structure:
+
+- `processTree.processTree`: array of `{pid, cmd, parentPid}` entries
+- `processTree.processPidToCmd`: `{ "pid": "command string" }` map
+- `processTree.readsByPid`: `{ "pid": ["file1", "file2"] }` — violated reads grouped by PID
+- `processTree.writesByPid`: `{ "pid": ["file1", "file2"] }` — violated writes grouped by PID
+- `targetConfig`: full target configuration (executor, options, inputs, outputs, dependsOn)
+- `projectConfig`: full project configuration
+- `resolvedInputs`: `{ files: [...], depOutputs: [...], runtime: [...], environment: [...] }`
+- `resolvedOutputs`: `{ outputPaths: [...], expandedOutputs: [...] }`
+- `validation`: `{ reads: { confirmed: [...], undeclared: [...] }, writes: { ... } }`
+- `classification`: `{ reads: { crossProject, buildArtifacts, configFiles, ... }, writes: { ... } }`
+
+Read the brief output — it has everything to start. Use `jq` on the detail file only when you need to drill into specific sections. When querying the detail file, use the structure above — do not guess the schema. Do NOT use Python, ad-hoc scripts, or the Read tool on the detail file — only `jq`.
+
+For reports with many violations, use `--filter` to narrow scope. When investigating without a filter, use the `grouping` data to identify patterns and prioritize — don't try to trace every file individually.
+
+If `summary.undeclaredReads` and `summary.undeclaredWrites` are both 0, all violations were resolved by the script's validation against resolved inputs/outputs. Report this to the user — no further investigation needed.
+
+The `commands` array pre-parses each process — use `executable` and `arguments` to identify the tool without re-parsing `cmd`. When many files share the same root cause, group them under one finding using a glob pattern or count (e.g., "88 `.d.ts` files matching `packages/nx/dist/**/*.d.ts`").
+
+### Phase 2: Command Analysis — the core investigation
+
+**This is the most important phase.** The goal is to determine with 100% certainty why each process reads or writes each violated file. Do not classify violations from file names or paths alone — trace the actual causal chain from command → config → file access.
+
+#### Step 1: Understand the command
+
+The brief's `commands` array pre-parses each process. Use the `executable` and `arguments` fields directly — don't re-parse `cmd`. Identify:
+
+- The tool (from `executable`)
+- The arguments (target files/dirs, config flags, extensions — from `arguments`)
+- The working directory (from executor options or project root)
+
+#### Step 2: Trace why the command accesses each violated file
+
+For each violated file, establish the **exact causal chain** that leads the command to read or write it. The approach is the same regardless of tool:
+
+1. Identify the tool's config file (usually in the project root or workspace root)
+2. Read the config and trace file references: `includes`, `extends`, `presets`, entry points, plugins
+3. Follow the reference chain until you can explain exactly why the violated file is accessed
+
+Common causal patterns:
+
+- **Config chain walk-up**: tool reads config, config extends another, chain reaches the violated file (e.g., tsconfig `extends`, eslint config chain, jest preset chain)
+- **Directory traversal**: tool scans a directory for matching files and reads everything, including files it won't process (e.g., jest-haste-map scanning `.next/`, eslint reading `.d.ts` alongside `.ts`)
+- **Dependency resolution**: tool resolves imports/requires and follows the dependency graph to files outside the project (e.g., esbuild/vite/webpack resolving workspace packages to their dist outputs)
+- **Plugin/transformer loading**: tool loads plugins or transformers that read additional files (e.g., ts-jest loading tsconfig for TypeScript compilation)
+
+For any tool, read its source code in `node_modules` to understand its file discovery behavior. Don't assume — trace the actual code.
+
+**You must be able to explain the full path:** e.g., "eslint loads `.eslintrc.json` → configures `@typescript-eslint/parser` → parser resolves `parserOptions.project` → walks up to find `tsconfig.json` → reads it." If you can't trace the full path, keep investigating — do not guess.
+
+**When theoretical analysis is inconclusive, verify empirically.** For difficult cases, instrument `node_modules` with interceptors to capture real stack traces. For example, patch `fs.readFileSync` in the tool's entry point to log stack traces when the violated file is accessed. A confirmed stack trace is worth more than multiple rounds of code reading.
+
+#### Step 3: Confirm the violation with `--check`
+
+**This step is mandatory — do not skip it.** The script already runs `--check` on a sample of up to 5 undeclared files (see `checkSample` in the brief). Review those results first — if the sample files are confirmed as inputs/outputs, the corresponding violations are false positives.
+
+For files not in the sample, use the pre-generated commands from `verificationCommands` in the brief:
+
+```bash
+npx nx show target inputs <project>:<target> --check <violated-read-files>
+npx nx show target outputs <project>:<target> --check <violated-write-files>
+```
+
+If the commands fail because output files don't exist (e.g., the script's task run timed out), run the task first with `verificationCommands.runTask`.
+
+If `--check` shows the file IS already an input/output, the violation is a false positive from the script's static analysis. If it confirms the file is NOT an input/output, proceed to classification.
+
+#### Step 4: Classify
+
+With the causal chain established and the violation confirmed, classify into one of these categories:
+
+1. **Missing input/output** (most common) — the process legitimately needs this file. Understand why:
+   - **Direct dependency** — the tool needs this file to do its job (e.g., tsc reads referenced tsconfigs, eslint loads config chain)
+   - **Transitive dependency** — a config file references another file that references this one (e.g., jest preset → resolver → module). Trace the full chain.
+   - **Directory traversal side effect** — the tool reads all files in a directory even if it only processes some (e.g., eslint reads `.d.ts` files while linting `.ts`). Still a legitimate access from the tool's perspective.
+
+2. **Bad tool configuration** — the tool accesses a file it shouldn't because its scope is too broad. The fix is fixing the tool's config, NOT adding an input. Investigate:
+   - Is the command targeting too broad a directory? (e.g., `eslint .` instead of `eslint src/`)
+   - Is a config file missing ignore/exclude rules? (e.g., eslint processing a file type it should skip)
+   - Is a plugin inferring a target for a project that doesn't match? (e.g., eslint target on a non-JS project)
+   - Is an env var causing the tool to behave differently?
+
+3. **Potential sandboxing gap** (last resort) — the access is genuinely irrelevant to correctness (PID files, temp sockets, dev server logs that no task consumes). Only conclude this after exhausting categories 1 and 2.
+
+### Phase 3: Deep Investigation
+
+For violations that aren't immediately obvious, investigate further:
+
+#### If the target is inferred by a plugin
+
+1. Identify which plugin from `inference.plugin` in the brief output, or `nx show project --json` metadata
+2. Read the plugin's `createNodesV2` implementation to understand inference logic
+3. Determine if this project should have this target at all
+4. Check if the plugin has `include`/`exclude` patterns in `nx.json` that should filter this project
+5. **Check for input override layers** — `project.json`, `package.json`, or `nx.json` `targetDefaults` may override plugin-inferred inputs, rendering plugin-level fixes invisible. Check all three before concluding a plugin fix is sufficient.
+
+#### If violations come from a subprocess
+
+1. Trace the process tree: which parent spawned the subprocess?
+2. Why does the subprocess exist? (dev server for e2e, worker thread, build tool subprocess)
+3. What environment does the subprocess inherit? (env vars, cwd)
+4. Does the subprocess access files in a different project's directory?
+
+#### If violations involve config file reference chains
+
+1. Read the config file (jest.config, tsconfig, .eslintrc)
+2. Trace all file references: `preset`, `extends`, `references`, `setupFiles`, `resolver`, `moduleNameMapper`, `transform`, etc.
+3. Recursively resolve references (preset → preset → files)
+4. Determine which referenced files are not declared as task inputs
+
+#### If violations involve dependency task outputs
+
+1. Check `dependsOn` to understand task dependency chain
+2. Check `dependentTasksOutputFiles` glob pattern — is it too narrow?
+3. Compare the glob against actual file types the tool reads from dependencies (e.g., `**/*.d.ts` missing `.tsbuildinfo`)
+
+#### Generalizability analysis
+
+After diagnosing the root cause, determine scope:
+
+1. Is this violation specific to this project, or does it affect all projects using this tool/plugin?
+2. What conditions trigger it? (specific config, specific tool version, specific project structure)
+3. Should the fix be per-project (declarative input) or systemic (plugin improvement)?
+4. If the plugin can be made smarter to infer the correct inputs, that's preferable to manual declarations.
+
+### Phase 4: Output
+
+**You MUST present findings using the structured format below before proceeding to any implementation discussion.** Do not use free-form narrative — the structure ensures completeness and makes findings reviewable.
+
+Present findings grouped by category:
+
+```
+=== Sandbox Violation Diagnosis: {project}:{target} ===
+
+## Summary
+Unexpected reads:  N total → M validated as declared → K true violations
+Unexpected writes: N total → M validated as declared → K true violations
+
+## Findings
+
+### [MISSING INPUT] {short description}
+Files: {file list or pattern}
+Process: PID {pid} — {command}
+Why: {why the process legitimately needs this file}
+Scope: {project-specific or affects all projects using this tool/plugin}
+Fix: {where/how to add the input declaration — consider both declarative (add input) and systemic (improve plugin inference) options}
+
+### [MISSING OUTPUT] {short description}
+Files: {file list or pattern}
+Process: PID {pid} — {command}
+Why: {why the process produces this file}
+Scope: {project-specific or affects all projects using this tool/plugin}
+Fix: {where/how to add the output declaration}
+
+### [BAD TOOL CONFIG] {short description}
+Files: {file list or pattern}
+Process: PID {pid} — {command}
+Why: {why the tool accesses files it shouldn't — config too broad, missing ignore, etc.}
+Fix: {specific tool config change}
+
+### [POTENTIAL SANDBOXING GAP] {short description}
+Files: {file list or pattern}
+Process: PID {pid} — {command}
+Why: {why this access is irrelevant to correctness}
+Evidence: {proof that categories 1-2 were exhausted}
+
+### [INVESTIGATE] {short description}
+Files: {file list or pattern}
+Notes: {what's known, what needs more info}
+Question: {what to ask the user or team}
+
+## Stale Declarations
+expectedInputsNotRead: {count and details if relevant}
+expectedOutputsNotWritten: {count and details if relevant}
+
+## Verification Plan
+For each fix, provide the exact commands to verify:
+1. Run the task so output files exist on disk: `npx nx <target> <project> --skip-nx-cache`
+2. Check each violation file is now an input: `npx nx show target <project>:<target> inputs --check <space-separated files>`
+3. For plugin-level fixes: build the plugin, patch node_modules, then verify with steps 1-2
+```
+
+## Principles
+
+1. **Missing declaration is the default.** Most unexpected accesses are legitimate — the process needs the file, it just wasn't declared. Start from this assumption and investigate to understand WHY the access happens.
+2. **The command is the unit of analysis.** Don't classify files in isolation. Understand what the command does and whether each file access makes sense given that command's purpose.
+3. **Trace the full chain.** Plugin inference → target config → executor → command → file access. The root cause is often several layers removed from the symptom.
+4. **Empirical over theoretical.** When code analysis produces a hypothesis, verify it before acting. Instrument `node_modules`, capture stack traces, run with debug flags. Wrong theories waste entire investigation rounds.
+5. **Be thorough.** Read plugin source code, config files, executor implementations. Don't guess based on file names alone.
+6. **Potential sandboxing gaps are last resort.** Only conclude this after exhausting missing declaration and bad tool config. The access must be genuinely irrelevant to correctness.
+7. **Verify claims about Nx behavior in source code.** Any assertion about how Nx works must be traced to the actual implementation. Do not reason from theory or assumptions.
+8. **Prefer systemic fixes over per-project declarations.** If a plugin can be improved to infer correct inputs for all projects, that's better than adding manual input declarations to each project.
+
+## Delegating to Subagents
+
+When the investigation is complex and requires parallel research, you can delegate to subagents. Follow this pattern:
+
+1. **Run the context-gathering script yourself first.** The brief output (~3-5KB) is the shared context all subagents need.
+2. **Include the brief output in each subagent prompt** along with the specific question to investigate. Subagents should NOT run the script again or try to parse the raw report.
+3. **Give subagents the detail file path** so they can `jq` specific sections (process tree, resolved inputs, etc.) without re-running the script.
+4. **Each subagent should answer one focused question**, e.g., "Why does PID 12345 (eslint) read `tsconfig.base.json`? Trace the full causal chain from the eslint config."
+5. **Subagents must still follow the skill principles** — trace full causal chains, verify empirically, use `--check`, don't guess from file names. Include these instructions in the subagent prompt.
+6. **Synthesize subagent results yourself** using the structured Phase 4 output format. Do not delegate the final classification.
+
+## Reference
+
+For the sandbox report data model and field definitions, see `references/data-model.md`.

--- a/.claude/skills/diagnose-sandbox-report/references/data-model.md
+++ b/.claude/skills/diagnose-sandbox-report/references/data-model.md
@@ -1,0 +1,92 @@
+# Sandbox Report Data Model
+
+## Raw Report Structure (JSON)
+
+```typescript
+interface SandboxReport {
+  taskId: string; // "project:target" or "project:target:configuration"
+  sandboxReportId: string;
+  inputs: string[]; // declared input patterns (globs or paths)
+  outputs: string[]; // declared output patterns
+  filesRead: FileAccessEntry[]; // all files actually read
+  filesWritten: FileAccessEntry[]; // all files actually written
+  unexpectedReads?: FileAccessEntry[]; // reads not matching any input pattern
+  unexpectedWrites?: FileAccessEntry[]; // writes not matching any output pattern
+  expectedInputsNotRead?: string[]; // declared inputs never accessed
+  expectedOutputsNotWritten?: string[]; // declared outputs never written
+  processTree?: ProcessTreeEntry[]; // process hierarchy with commands
+}
+
+interface FileAccessEntry {
+  path: string; // workspace-relative file path
+  pid: number; // process ID that accessed the file
+}
+
+interface ProcessTreeEntry {
+  pid: number;
+  cmd: string; // full command string
+  parentPid?: number; // parent process (absent for root)
+}
+```
+
+## Violation Computation
+
+Violations are computed by `findUnexpectedFiles()` using `minimatch`:
+
+- A file is "unexpected" if it does NOT match any declared pattern
+- Patterns without wildcards also match as directory prefixes (`pattern + '/'`)
+- If `unexpectedReads`/`unexpectedWrites` are pre-computed in the report, those are used directly
+
+## Nx CLI Commands for Context
+
+### `nx show target <project:target> --json`
+
+Returns: executor, command, options (merged with configuration), inputs (configured, not resolved), outputs, dependsOn, cache, parallelism, configurations, metadata.
+
+### `nx show target inputs <project:target> --json`
+
+Returns resolved input files (requires files to exist on disk — task must have run):
+
+```json
+{
+  "files": ["workspace-relative paths..."],
+  "runtime": ["node version checks..."],
+  "environment": ["ENV_VAR_NAMES..."],
+  "depOutputs": ["dependency output paths..."],
+  "external": ["external package names..."]
+}
+```
+
+### `nx show target inputs <project:target> --check <files...>`
+
+Validates specific files against declared inputs. Exit code 0 = match, 1 = no match.
+Categories: `files`, `environment`, `runtime`, `external`, `depOutputs`.
+Also detects directory matches (directory containing N input files).
+
+### `nx show target outputs <project:target> --json`
+
+Returns:
+
+```json
+{
+  "outputPaths": ["configured output paths..."],
+  "expandedOutputs": ["glob-expanded actual paths..."],
+  "unresolvedOutputs": ["{options.key} patterns that couldn't resolve..."]
+}
+```
+
+### `nx show target outputs <project:target> --check <files...>`
+
+Validates specific files against declared outputs. Same exit code behavior as inputs.
+
+### `nx show project <project> --json`
+
+Returns full project config. Key fields for sandbox analysis:
+
+- `targets[name].metadata.plugin` — which plugin inferred the target
+- `targets[name].metadata.technologies` — what tech the target uses
+- `root` — project root directory
+
+### `nx graph --view=tasks --targets=<target> --focus=<project> --print --file=stdout`
+
+Returns task dependency graph with task IDs, dependencies, and roots.

--- a/.claude/skills/diagnose-sandbox-report/scripts/gather-sandbox-context.ts
+++ b/.claude/skills/diagnose-sandbox-report/scripts/gather-sandbox-context.ts
@@ -1,0 +1,846 @@
+#!/usr/bin/env npx tsx
+/**
+ * gather-sandbox-context: Parse sandbox report + gather Nx task context
+ * Produces structured JSON for the diagnose-sandbox-report skill
+ *
+ * Usage: npx tsx gather-sandbox-context.ts <report.json or URL> [--filter <pattern>] [--workspace <path>]
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { resolve, basename, extname, dirname } from 'path';
+import { execSync, execFileSync } from 'child_process';
+import { minimatch } from 'minimatch';
+
+// --- CLI argument parsing ---
+
+interface Args {
+  reportFile: string;
+  filter: string | null;
+  workspaceRoot: string;
+}
+
+function parseArgs(): Args {
+  const args = process.argv.slice(2);
+  let reportFile = '';
+  let filter: string | null = null;
+  let workspaceRoot = process.cwd();
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--filter':
+        filter = args[++i];
+        break;
+      case '--workspace':
+        workspaceRoot = args[++i];
+        break;
+      case '--help':
+      case '-h':
+        console.error(
+          'Usage: gather-sandbox-context <report.json or URL> [--filter <pattern>] [--workspace <path>]'
+        );
+        process.exit(1);
+      default:
+        if (args[i].startsWith('-')) {
+          console.error(`Unknown option: ${args[i]}`);
+          process.exit(1);
+        }
+        reportFile = args[i];
+    }
+  }
+
+  if (!reportFile) {
+    console.error(
+      'Usage: gather-sandbox-context <report.json or URL> [--filter <pattern>] [--workspace <path>]'
+    );
+    process.exit(1);
+  }
+
+  return { reportFile, filter, workspaceRoot };
+}
+
+// --- Types ---
+
+interface FileAccessEntry {
+  path: string;
+  pid: number;
+}
+
+interface ProcessTreeEntry {
+  pid: number;
+  cmd: string;
+  parentPid?: number;
+}
+
+interface SandboxReport {
+  taskId: string;
+  unexpectedReads?: FileAccessEntry[];
+  unexpectedWrites?: FileAccessEntry[];
+  expectedInputsNotRead?: string[];
+  expectedOutputsNotWritten?: string[];
+  filesRead?: FileAccessEntry[];
+  filesWritten?: FileAccessEntry[];
+  processTree?: ProcessTreeEntry[];
+}
+
+// --- Helpers ---
+
+function downloadUrl(url: string): string {
+  const tmpPath = `/tmp/sandbox-report-${Date.now()}.json`;
+  try {
+    execFileSync('curl', ['-sL', '-o', tmpPath, url], { stdio: 'pipe' });
+  } catch {
+    console.error(`Error: Failed to download report from URL: ${url}`);
+    process.exit(1);
+  }
+  return tmpPath;
+}
+
+function runNxCommand(
+  args: string[],
+  workspaceRoot: string,
+  timeoutMs = 30000
+): string | null {
+  try {
+    return execFileSync('npx', ['nx', ...args], {
+      cwd: workspaceRoot,
+      timeout: timeoutMs,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+    });
+  } catch {
+    return null;
+  }
+}
+
+function safeJsonParse<T>(str: string | null, fallback: T): T {
+  if (!str) return fallback;
+  try {
+    return JSON.parse(str);
+  } catch {
+    return fallback;
+  }
+}
+
+function filterEntries(
+  entries: FileAccessEntry[],
+  filterStr: string | null
+): FileAccessEntry[] {
+  if (!filterStr) return entries;
+
+  const patterns = filterStr.split(',').map((p) => p.trim());
+  return entries.filter((entry) =>
+    patterns.some((pattern) => {
+      if (
+        pattern.includes('*') ||
+        pattern.includes('?') ||
+        pattern.includes('[')
+      ) {
+        // Glob pattern — if no slashes, match against basename
+        if (!pattern.includes('/')) {
+          return minimatch(basename(entry.path), pattern);
+        }
+        return minimatch(entry.path, pattern);
+      }
+      // Literal: exact match or directory prefix
+      return entry.path === pattern || entry.path.startsWith(pattern + '/');
+    })
+  );
+}
+
+function groupByDirPrefix(
+  paths: string[],
+  depth = 3
+): { prefix: string; count: number }[] {
+  const groups: Record<string, number> = {};
+  for (const p of paths) {
+    const prefix = p.split('/').slice(0, depth).join('/');
+    groups[prefix] = (groups[prefix] || 0) + 1;
+  }
+  return Object.entries(groups)
+    .map(([prefix, count]) => ({ prefix, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+function groupByExtension(paths: string[]): { ext: string; count: number }[] {
+  const groups: Record<string, number> = {};
+  for (const p of paths) {
+    const ext = extname(p) || '(no ext)';
+    groups[ext] = (groups[ext] || 0) + 1;
+  }
+  return Object.entries(groups)
+    .map(([ext, count]) => ({ ext, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+function classifyFiles(
+  undeclared: string[],
+  projectRoot: string,
+  projectRoots: Record<string, string>
+) {
+  const projects = Object.entries(projectRoots).map(([project, root]) => ({
+    project,
+    root,
+  }));
+
+  const isBuildArtifact = (f: string) =>
+    f.startsWith('dist/') ||
+    f.startsWith('build/') ||
+    f.startsWith('out-tsc/') ||
+    f.startsWith('.next/') ||
+    f.includes('/node_modules/.cache/') ||
+    f.endsWith('.tsbuildinfo') ||
+    f.includes('/dist/') ||
+    f.includes('/build/output/');
+
+  const configBasenames = new Set(['nx.json', 'project.json', 'package.json']);
+  const configPrefixes = [
+    'tsconfig',
+    'jest.config',
+    'jest.preset',
+    '.eslintrc',
+    'eslint.config',
+    'playwright.config',
+    'webpack.config',
+    'vite.config',
+    'babel.config',
+    '.babelrc',
+    'rollup.config',
+  ];
+  const isConfigFile = (f: string) => {
+    const b = basename(f);
+    return (
+      configBasenames.has(b) ||
+      configPrefixes.some((prefix) => b.startsWith(prefix))
+    );
+  };
+
+  const isEnvFile = (f: string) => {
+    const b = basename(f);
+    return b === '.env' || b.startsWith('.env.');
+  };
+
+  const classified = undeclared.map((f) => {
+    const inProjectRoot = projectRoot !== '' && f.startsWith(projectRoot + '/');
+    const owner = projects.find((p) => f.startsWith(p.root + '/'));
+    return {
+      path: f,
+      inProjectRoot,
+      ownerProject: owner?.project ?? null,
+      isBuildArtifact: isBuildArtifact(f),
+      isConfigFile: isConfigFile(f),
+      isEnvFile: isEnvFile(f),
+    };
+  });
+
+  return {
+    crossProject: classified
+      .filter((c) => !c.inProjectRoot)
+      .map((c) => ({ path: c.path, owner: c.ownerProject })),
+    buildArtifacts: classified
+      .filter((c) => c.isBuildArtifact)
+      .map((c) => c.path),
+    configFiles: classified.filter((c) => c.isConfigFile).map((c) => c.path),
+    envFiles: classified.filter((c) => c.isEnvFile).map((c) => c.path),
+    inProjectRoot: classified.filter((c) => c.inProjectRoot).map((c) => c.path),
+    outsideProjectRoot: classified
+      .filter((c) => !c.inProjectRoot)
+      .map((c) => c.path),
+    total: undeclared.length,
+  };
+}
+
+function validateViolations(
+  violations: string[],
+  resolvedFiles: Set<string>
+): { confirmed: string[]; undeclared: string[] } {
+  const confirmed: string[] = [];
+  const undeclared: string[] = [];
+  const seen = new Set<string>();
+  for (const f of violations) {
+    if (seen.has(f)) continue;
+    seen.add(f);
+    if (resolvedFiles.has(f)) {
+      confirmed.push(f);
+    } else {
+      undeclared.push(f);
+    }
+  }
+  return { confirmed, undeclared };
+}
+
+function validateOutputViolations(
+  violations: string[],
+  resolvedOutputs: string[]
+): { confirmed: string[]; undeclared: string[] } {
+  const outputSet = new Set(resolvedOutputs);
+  const outputDirs = resolvedOutputs.map((o) => o + '/');
+  const confirmed: string[] = [];
+  const undeclared: string[] = [];
+  const seen = new Set<string>();
+  for (const f of violations) {
+    if (seen.has(f)) continue;
+    seen.add(f);
+    if (outputSet.has(f) || outputDirs.some((d) => f.startsWith(d))) {
+      confirmed.push(f);
+    } else {
+      undeclared.push(f);
+    }
+  }
+  return { confirmed, undeclared };
+}
+
+function extractCommands(
+  processTree: ProcessTreeEntry[],
+  readsByPid: Record<string, string[]>,
+  writesByPid: Record<string, string[]>
+) {
+  const pidToCmd: Record<string, string> = {};
+  for (const entry of processTree) {
+    pidToCmd[String(entry.pid)] = entry.cmd;
+  }
+
+  return processTree
+    .filter(
+      (entry) =>
+        (readsByPid[String(entry.pid)]?.length ?? 0) > 0 ||
+        (writesByPid[String(entry.pid)]?.length ?? 0) > 0
+    )
+    .map((entry) => {
+      const parts = entry.cmd.split(' ');
+      const exe = parts[0].split('/').pop() ?? parts[0];
+      return {
+        pid: entry.pid,
+        cmd: entry.cmd,
+        parentPid: entry.parentPid ?? null,
+        parentCmd: entry.parentPid
+          ? (pidToCmd[String(entry.parentPid)] ?? null)
+          : null,
+        unexpectedReadCount: readsByPid[String(entry.pid)]?.length ?? 0,
+        unexpectedWriteCount: writesByPid[String(entry.pid)]?.length ?? 0,
+        unexpectedReads: readsByPid[String(entry.pid)] ?? [],
+        unexpectedWrites: writesByPid[String(entry.pid)] ?? [],
+        executable: exe,
+        arguments: parts.slice(1).join(' '),
+      };
+    })
+    .sort(
+      (a, b) =>
+        b.unexpectedReadCount +
+        b.unexpectedWriteCount -
+        (a.unexpectedReadCount + a.unexpectedWriteCount)
+    );
+}
+
+function resolveExecutorSource(
+  executor: string | undefined,
+  workspaceRoot: string
+): { executor: string; sourcePath: string } {
+  if (
+    !executor ||
+    executor === 'null' ||
+    executor.includes('nx:run-commands')
+  ) {
+    return { executor: executor ?? '', sourcePath: '' };
+  }
+
+  const lastColon = executor.lastIndexOf(':');
+  const pkg = executor.substring(0, lastColon);
+  const name = executor.substring(lastColon + 1);
+
+  try {
+    const result = execFileSync(
+      'node',
+      [
+        '-e',
+        `
+      try {
+        const pkg = require('${pkg}/package.json');
+        const executors = pkg.executors || pkg.builders;
+        if (executors) {
+          const p = require.resolve('${pkg}/' + executors);
+          const dir = require('path').dirname(p);
+          const json = require(p);
+          const impl = json.executors?.['${name}']?.implementation ||
+                       json.builders?.['${name}']?.implementation;
+          if (impl) console.log(require.resolve(dir + '/' + impl));
+        }
+      } catch(e) {}
+    `,
+      ],
+      {
+        cwd: workspaceRoot,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 10000,
+      }
+    ).trim();
+    return { executor, sourcePath: result };
+  } catch {
+    return { executor, sourcePath: '' };
+  }
+}
+
+function extractDepTaskOutputFiles(
+  targetConfig: any,
+  workspaceRoot: string
+): { dependentTasksOutputFiles: any[]; namedInputs: string[] } {
+  const inputs: any[] = targetConfig?.inputs ?? [];
+  const depOutputs: any[] = [];
+  const namedInputs: string[] = [];
+
+  for (const input of inputs) {
+    if (
+      typeof input === 'object' &&
+      input !== null &&
+      'dependentTasksOutputFiles' in input
+    ) {
+      depOutputs.push({
+        glob: input.dependentTasksOutputFiles,
+        transitive: input.transitive ?? false,
+      });
+    } else if (
+      typeof input === 'string' &&
+      !input.startsWith('{') &&
+      !input.startsWith('^') &&
+      !input.includes('/') &&
+      !input.includes('.')
+    ) {
+      namedInputs.push(input);
+    }
+  }
+
+  // Resolve named inputs from nx.json
+  const nxJsonPath = resolve(workspaceRoot, 'nx.json');
+  if (existsSync(nxJsonPath) && namedInputs.length > 0) {
+    try {
+      const nxJson = JSON.parse(readFileSync(nxJsonPath, 'utf-8'));
+      for (const name of namedInputs) {
+        const namedDef = nxJson.namedInputs?.[name] ?? [];
+        for (const entry of namedDef) {
+          if (
+            typeof entry === 'object' &&
+            entry !== null &&
+            'dependentTasksOutputFiles' in entry
+          ) {
+            depOutputs.push({
+              glob: entry.dependentTasksOutputFiles,
+              transitive: entry.transitive ?? false,
+              fromNamedInput: name,
+            });
+          }
+        }
+      }
+    } catch {
+      // ignore nx.json parse errors
+    }
+  }
+
+  return { dependentTasksOutputFiles: depOutputs, namedInputs };
+}
+
+function analyzeStaleDeclarations(
+  expectedInputsNotRead: string[],
+  expectedOutputsNotWritten: string[]
+) {
+  const classifyPattern = (value: string) => {
+    if (/[*{]/.test(value)) return 'glob';
+    if (value.startsWith('^')) return 'depOutput';
+    return 'file';
+  };
+
+  const groupByType = (items: string[]) => {
+    const groups: Record<string, string[]> = {};
+    for (const item of items) {
+      const type = classifyPattern(item);
+      (groups[type] ??= []).push(item);
+    }
+    return Object.entries(groups).map(([type, values]) => ({
+      type,
+      count: values.length,
+      samples: values.slice(0, 3),
+    }));
+  };
+
+  return {
+    expectedInputsNotRead: expectedInputsNotRead.length,
+    expectedOutputsNotWritten: expectedOutputsNotWritten.length,
+    staleInputsByType: groupByType(expectedInputsNotRead),
+    staleOutputsByType: groupByType(expectedOutputsNotWritten),
+  };
+}
+
+// --- Main ---
+
+async function main() {
+  const args = parseArgs();
+  let reportPath = args.reportFile;
+
+  // Handle URL inputs
+  if (reportPath.startsWith('http')) {
+    reportPath = downloadUrl(reportPath);
+  }
+
+  if (!existsSync(reportPath)) {
+    console.error(`Error: Report file not found: ${reportPath}`);
+    process.exit(1);
+  }
+
+  reportPath = resolve(reportPath);
+  process.chdir(args.workspaceRoot);
+
+  // Phase 1: Parse report (single read)
+  let report: SandboxReport;
+  try {
+    report = JSON.parse(readFileSync(reportPath, 'utf-8'));
+  } catch {
+    console.error(`Error: Report file is not valid JSON: ${reportPath}`);
+    process.exit(1);
+  }
+
+  if (!report.taskId) {
+    console.error('Error: Report file has no .taskId field');
+    process.exit(1);
+  }
+
+  const [project, target, config] = report.taskId.split(':');
+  const taskRef = config
+    ? `${project}:${target}:${config}`
+    : `${project}:${target}`;
+
+  const unexpectedReads = report.unexpectedReads ?? [];
+  const unexpectedWrites = report.unexpectedWrites ?? [];
+
+  // Apply filter
+  const filteredReads = filterEntries(unexpectedReads, args.filter);
+  const filteredWrites = filterEntries(unexpectedWrites, args.filter);
+
+  const readPaths = filteredReads.map((e) => e.path);
+  const writePaths = filteredWrites.map((e) => e.path);
+
+  // Build pid → files maps
+  const readsByPid: Record<string, string[]> = {};
+  const writesByPid: Record<string, string[]> = {};
+  for (const entry of filteredReads) {
+    (readsByPid[String(entry.pid)] ??= []).push(entry.path);
+  }
+  for (const entry of filteredWrites) {
+    (writesByPid[String(entry.pid)] ??= []).push(entry.path);
+  }
+
+  // Phase 2: Gather Nx task context (run task + parallel nx commands)
+  runNxCommand(['run', taskRef], args.workspaceRoot, 120000);
+
+  const [
+    targetConfigStr,
+    projectConfigStr,
+    resolvedInputsStr,
+    resolvedOutputsStr,
+    graphResult,
+  ] = await Promise.all([
+    runNxCommand(['show', 'target', taskRef, '--json'], args.workspaceRoot),
+    runNxCommand(['show', 'project', project, '--json'], args.workspaceRoot),
+    runNxCommand(
+      ['show', 'target', 'inputs', taskRef, '--json'],
+      args.workspaceRoot
+    ),
+    runNxCommand(
+      ['show', 'target', 'outputs', taskRef, '--json'],
+      args.workspaceRoot
+    ),
+    (() => {
+      const graphPath = `/tmp/sandbox-project-graph-${Date.now()}.json`;
+      runNxCommand(['graph', '--file', graphPath], args.workspaceRoot);
+      try {
+        return readFileSync(graphPath, 'utf-8');
+      } catch {
+        return '{"graph":{"nodes":{}}}';
+      }
+    })(),
+  ]);
+
+  const targetConfig = safeJsonParse(targetConfigStr, {} as any);
+  const projectConfig = safeJsonParse(projectConfigStr, {} as any);
+  const resolvedInputs = safeJsonParse(resolvedInputsStr, {} as any);
+  const resolvedOutputs = safeJsonParse(resolvedOutputsStr, {} as any);
+  const projectGraph = safeJsonParse(graphResult, {
+    graph: { nodes: {} },
+  } as any);
+
+  // Phase 3: Validate violations
+  const resolvedInputFiles = new Set([
+    ...(resolvedInputs.files ?? []),
+    ...(resolvedInputs.depOutputs ?? []),
+  ]);
+  const resolvedOutputFiles = [
+    ...(resolvedOutputs.outputPaths ?? []),
+    ...(resolvedOutputs.expandedOutputs ?? []),
+  ];
+
+  const checkInputs = validateViolations(readPaths, resolvedInputFiles);
+  const checkOutputs = validateOutputViolations(
+    writePaths,
+    resolvedOutputFiles
+  );
+
+  // Phase 3.5: Sample --check verification
+  let checkSampleInputs: any = {};
+  let checkSampleOutputs: any = {};
+  const sampleReadFiles = checkInputs.undeclared.slice(0, 5);
+  if (sampleReadFiles.length > 0) {
+    const result = runNxCommand(
+      [
+        'show',
+        'target',
+        'inputs',
+        taskRef,
+        '--check',
+        ...sampleReadFiles,
+        '--json',
+      ],
+      args.workspaceRoot
+    );
+    checkSampleInputs = safeJsonParse(result, {});
+  }
+  const sampleWriteFiles = checkOutputs.undeclared.slice(0, 5);
+  if (sampleWriteFiles.length > 0) {
+    const result = runNxCommand(
+      [
+        'show',
+        'target',
+        'outputs',
+        taskRef,
+        '--check',
+        ...sampleWriteFiles,
+        '--json',
+      ],
+      args.workspaceRoot
+    );
+    checkSampleOutputs = safeJsonParse(result, {});
+  }
+
+  // Phase 4: File classification
+  const projectRoots: Record<string, string> = {};
+  for (const [name, node] of Object.entries(projectGraph.graph?.nodes ?? {})) {
+    projectRoots[name] = (node as any).data?.root ?? name;
+  }
+  const taskProjectRoot = projectRoots[project] ?? '';
+
+  const readClassification = classifyFiles(
+    checkInputs.undeclared,
+    taskProjectRoot,
+    projectRoots
+  );
+  const writeClassification = classifyFiles(
+    checkOutputs.undeclared,
+    taskProjectRoot,
+    projectRoots
+  );
+
+  // Phase 5: Command extraction
+  const processTree = report.processTree ?? [];
+  const commands = extractCommands(processTree, readsByPid, writesByPid);
+
+  // Phase 6: Inference detection
+  const targetMeta = projectConfig.targets?.[target]?.metadata ?? {};
+  const inference = {
+    isInferred: 'plugin' in targetMeta || 'technologies' in targetMeta,
+    plugin: targetMeta.plugin ?? null,
+    technologies: targetMeta.technologies ?? null,
+    description: targetMeta.description ?? null,
+  };
+
+  let pluginRegistration: any = {};
+  const nxJsonPath = resolve(args.workspaceRoot, 'nx.json');
+  if (inference.plugin && existsSync(nxJsonPath)) {
+    try {
+      const nxJson = JSON.parse(readFileSync(nxJsonPath, 'utf-8'));
+      const plugins = (nxJson.plugins ?? []).map((p: any) =>
+        typeof p === 'string' ? { plugin: p, options: {} } : p
+      );
+      pluginRegistration =
+        plugins.find((p: any) => p.plugin === inference.plugin) ?? {};
+    } catch {
+      // ignore
+    }
+  }
+
+  // Phase 6.5: dependentTasksOutputFiles + executor resolution
+  const depTaskOutputs = extractDepTaskOutputFiles(
+    targetConfig,
+    args.workspaceRoot
+  );
+  const executorInfo = resolveExecutorSource(
+    targetConfig.executor ?? targetConfig.command,
+    args.workspaceRoot
+  );
+
+  // Phase 7: Cross-project dependency check
+  const dependsOn = (targetConfig.dependsOn ?? []).map((d: any) =>
+    typeof d === 'string' ? d : (d.target ?? '')
+  );
+  const checkCrossProject = (classification: typeof readClassification) => {
+    const owners = [
+      ...new Set(
+        classification.crossProject
+          .map((c) => c.owner)
+          .filter((o): o is string => o !== null)
+      ),
+    ];
+    return owners.map((owner) => ({
+      project: owner,
+      isDependency: dependsOn.some(
+        (d: string) =>
+          d === owner ||
+          d === `${owner}:build` ||
+          d === `^${owner}:build` ||
+          d.includes(`^${owner}`)
+      ),
+      files: classification.crossProject
+        .filter((c) => c.owner === owner)
+        .map((c) => c.path),
+    }));
+  };
+
+  const crossProjectDeps = {
+    reads: checkCrossProject(readClassification),
+    writes: checkCrossProject(writeClassification),
+  };
+
+  // Phase 8: Stale declarations
+  const staleDeclarations = analyzeStaleDeclarations(
+    report.expectedInputsNotRead ?? [],
+    report.expectedOutputsNotWritten ?? []
+  );
+
+  // Assemble outputs
+  const detailFile = `/tmp/sandbox-diagnosis-detail-${taskRef.replace(/[/:@]/g, '-')}.json`;
+
+  const detail = {
+    processTree: {
+      processTree,
+      processPidToCmd: Object.fromEntries(
+        processTree.map((e) => [String(e.pid), e.cmd])
+      ),
+      readsByPid,
+      writesByPid,
+    },
+    targetConfig,
+    projectConfig,
+    resolvedInputs,
+    resolvedOutputs,
+    validation: { reads: checkInputs, writes: checkOutputs },
+    classification: { reads: readClassification, writes: writeClassification },
+    report: {
+      taskId: report.taskId,
+      totalFilesRead: report.filesRead?.length ?? 0,
+      totalFilesWritten: report.filesWritten?.length ?? 0,
+      totalUnexpectedReads: unexpectedReads.length,
+      totalUnexpectedWrites: unexpectedWrites.length,
+      expectedInputsNotRead: report.expectedInputsNotRead ?? [],
+      expectedOutputsNotWritten: report.expectedOutputsNotWritten ?? [],
+    },
+    commands,
+    crossProjectDependencyCheck: crossProjectDeps,
+    staleDeclarations,
+    inference,
+    pluginRegistration,
+    dependentTasksOutputFiles: depTaskOutputs,
+    executorInfo,
+  };
+  writeFileSync(detailFile, JSON.stringify(detail, null, 2));
+
+  // Brief to stdout
+  const brief = {
+    task: {
+      ref: taskRef,
+      project,
+      target,
+      configuration: config ?? null,
+      projectRoot: taskProjectRoot,
+    },
+    summary: {
+      unexpectedReads: unexpectedReads.length,
+      unexpectedWrites: unexpectedWrites.length,
+      filteredReads: filteredReads.length,
+      filteredWrites: filteredWrites.length,
+      filterApplied: args.filter !== null,
+      filterPattern: args.filter,
+      confirmedReads: checkInputs.confirmed.length,
+      undeclaredReads: checkInputs.undeclared.length,
+      confirmedWrites: checkOutputs.confirmed.length,
+      undeclaredWrites: checkOutputs.undeclared.length,
+    },
+    undeclaredFiles: {
+      reads: checkInputs.undeclared,
+      writes: checkOutputs.undeclared,
+    },
+    grouping: {
+      readsByDirectory: groupByDirPrefix(readPaths),
+      writesByDirectory: groupByDirPrefix(writePaths),
+      byExtension: {
+        readsByExt: groupByExtension(readPaths),
+        writesByExt: groupByExtension(writePaths),
+      },
+    },
+    commands: commands.map(
+      ({
+        pid,
+        cmd,
+        parentCmd,
+        executable,
+        arguments: args,
+        unexpectedReadCount,
+        unexpectedWriteCount,
+      }) => ({
+        pid,
+        cmd,
+        parentCmd,
+        executable,
+        arguments: args,
+        unexpectedReadCount,
+        unexpectedWriteCount,
+      })
+    ),
+    checkSample: {
+      inputs: checkSampleInputs,
+      outputs: checkSampleOutputs,
+    },
+    classificationSummary: {
+      reads: {
+        crossProject: readClassification.crossProject.length,
+        buildArtifacts: readClassification.buildArtifacts.length,
+        configFiles: readClassification.configFiles.length,
+        envFiles: readClassification.envFiles.length,
+        inProjectRoot: readClassification.inProjectRoot.length,
+        outsideProjectRoot: readClassification.outsideProjectRoot.length,
+      },
+      writes: {
+        crossProject: writeClassification.crossProject.length,
+        buildArtifacts: writeClassification.buildArtifacts.length,
+        configFiles: writeClassification.configFiles.length,
+        envFiles: writeClassification.envFiles.length,
+        inProjectRoot: writeClassification.inProjectRoot.length,
+        outsideProjectRoot: writeClassification.outsideProjectRoot.length,
+      },
+    },
+    crossProjectDependencyCheck: crossProjectDeps,
+    staleDeclarations,
+    dependentTasksOutputFiles: depTaskOutputs.dependentTasksOutputFiles,
+    executorInfo,
+    inference,
+    pluginRegistration,
+    verificationCommands: {
+      checkInputs: `npx nx show target inputs ${taskRef} --check <files...>`,
+      checkOutputs: `npx nx show target outputs ${taskRef} --check <files...>`,
+      runTask: `npx nx run ${taskRef} --skip-nx-cache`,
+    },
+    detailFile,
+  };
+
+  console.log(JSON.stringify(brief, null, 2));
+}
+
+main().catch((err) => {
+  console.error(`Script failed: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Current Behavior

No skill for investigating Nx sandbox violations.

## Expected Behavior

The `diagnose-sandbox-report` skill provides a structured workflow for diagnosing sandbox violations, with a TypeScript script that automates report parsing, Nx context gathering, violation validation, and file classification.