### PR TITLE
fix(misc): remove process exit handlers when child process exits

### DIFF
--- a/packages/nx/src/executors/run-commands/running-tasks.ts
+++ b/packages/nx/src/executors/run-commands/running-tasks.ts
@@ -502,14 +502,41 @@ class RunningNodeProcess implements RunningTask {
       }
       const terminalOutput = this.terminalOutputChunks.join('');
       this.terminalOutputChunks = [];
+      removeProcessListeners();
       for (const cb of this.exitCallbacks) {
         cb(1, terminalOutput);
       }
     });
+
+    // Store signal/exit handlers so they can be removed when the child exits.
+    // Without cleanup, each RunningNodeProcess leaks 4 process listeners.
+    // In a large monorepo (2600+ run-commands tasks), these accumulate and
+    // cause a multi-minute synchronous hang at process.exit() as each handler
+    // calls treeKill on an already-dead PID.
+    const onExit = () => {
+      this.kill();
+    };
+    const onSigInt = () => {
+      this.kill('SIGTERM');
+    };
+    const onSigTerm = () => {
+      this.kill('SIGTERM');
+    };
+    const onSigHup = () => {
+      this.kill('SIGTERM');
+    };
+    const removeProcessListeners = () => {
+      process.removeListener('exit', onExit);
+      process.removeListener('SIGINT', onSigInt);
+      process.removeListener('SIGTERM', onSigTerm);
+      process.removeListener('SIGHUP', onSigHup);
+    };
+
     this.childProcess.on('exit', (code, signal) => {
       if (code === null) {
         code = signalToCode(signal);
       }
+      removeProcessListeners();
       if (!this.readyWhenStatus.length || isReady(this.readyWhenStatus)) {
         const terminalOutput = this.terminalOutputChunks.join('');
         this.terminalOutputChunks = [];
@@ -518,23 +545,12 @@ class RunningNodeProcess implements RunningTask {
         }
       }
     });
+
     // Terminate any task processes on exit
-    process.on('exit', () => {
-      this.kill();
-    });
-    process.on('SIGINT', () => {
-      this.kill('SIGTERM');
-    });
-    process.on('SIGTERM', () => {
-      this.kill('SIGTERM');
-      // no exit here because we expect child processes to terminate which
-      // will store results to the cache and will terminate this process
-    });
-    process.on('SIGHUP', () => {
-      this.kill('SIGTERM');
-      // no exit here because we expect child processes to terminate which
-      // will store results to the cache and will terminate this process
-    });
+    process.on('exit', onExit);
+    process.on('SIGINT', onSigInt);
+    process.on('SIGTERM', onSigTerm);
+    process.on('SIGHUP', onSigHup);
   }
 }
 


### PR DESCRIPTION
## Current Behavior

I noticed this while investigating a 6-minute hang in our ~2600-project monorepo for any target that uses `run_command` (in our case, a `check-types` target that runs `tsc --noEmit`). The hang happens after Nx appears to have run all the tasks, as seen in github actions log with the "timestamps" setting enabled:

<img width="1258" height="336" alt="image" src="https://github.com/user-attachments/assets/14a66362-3253-4649-b750-a69d9baf7c1d" />

We've patched our Nx instance locally (`pnpm patch`) with the changes in this PR and the hang is now gone for us. Offering this PR upstream in case anyone else is affected.

What seems to be happening is that each `RunningNodeProcess` registers 4 process-level event handlers (`exit`, `SIGINT`, `SIGTERM`, `SIGHUP`) in `addListeners()` but never removes them after the child process exits. This causes two problems:

1. **`MaxListenersExceededWarning`** when more than ~10 `run-commands` tasks execute in parallel
2. **Multi-minute synchronous hang at process exit** — when `process.exit()` is called, Node.js runs every leaked `exit` handler sequentially. Each one calls `treeKill()` on an already-dead PID, which takes ~143ms. With thousands of tasks, this adds minutes of dead time at the end of every CI run.

### Reproduction

Run any target using `nx:run-commands` on a monorepo with 1000+ projects. After "Successfully ran target..." prints, the process hangs for several minutes before exiting.

### Measured impact

On our 2610-project monorepo:
- **2610 leaked exit handlers** × **~143ms each** = **~6.2 minutes** of synchronous blocking after every `check-types` CI run
- Identified via `process.on('exit')` instrumentation showing each handler calling `treeKill` on dead PIDs from `RunningNodeProcess.addListeners` at `running-tasks.ts:522`

## Expected Behavior

Process exit handlers registered by `RunningNodeProcess` are cleaned up when the child process exits. The Node.js process exits promptly after task completion with no leaked listeners.

## Fix

Store the 4 signal/exit handlers as named references and remove them via `process.removeListener()` when the child process exits or errors. This is a minimal, targeted change — no new dependencies, no behavioral changes to signal handling during task execution.
