### PR TITLE
fix(angular-rspack): speed up watch-mode rebuilds

### DIFF
--- a/packages/angular-rspack-compiler/src/compilation/build-and-analyze.ts
+++ b/packages/angular-rspack-compiler/src/compilation/build-and-analyze.ts
@@ -4,6 +4,13 @@ import { AngularCompilation } from '../models';
 
 const JS_TS_FILE_PATTERN = /\.[cm]?[jt]sx?$/;
 
+/**
+ * Raw JS/TS content emitted by the Angular compilation, keyed by normalized
+ * filename. The Rspack loader transforms entries on demand so only files the
+ * bundler actually requests pay the JavaScript transformation cost.
+ */
+export const rawEmitCache = new Map<string, string>();
+
 export async function buildAndAnalyze(
   angularCompilation: AngularCompilation,
   typescriptFileCache: Map<string, string | Uint8Array>,
@@ -15,24 +22,23 @@ export async function buildAndAnalyze(
   } of await angularCompilation.emitAffectedFiles()) {
     const normalizedFilename = normalize(filename.replace(/^[A-Z]:/, ''));
 
-    // Skip JavaScript transformation for non-JS/TS files (JSON, CSS, etc.)
-    // Let Rspack handle these through its native module rules
+    const text =
+      typeof contents === 'string'
+        ? contents
+        : Buffer.from(contents).toString();
+
     if (!JS_TS_FILE_PATTERN.test(normalizedFilename)) {
-      const text =
-        typeof contents === 'string'
-          ? contents
-          : Buffer.from(contents).toString();
       typescriptFileCache.set(normalizedFilename, text);
       continue;
     }
 
-    await javascriptTransformer
-      .transformData(normalizedFilename, contents, true, false)
-      .then((contents) => {
-        typescriptFileCache.set(
-          normalizedFilename,
-          Buffer.from(contents).toString()
-        );
-      });
+    // Drop the previous transformed output when the raw emit changes so the
+    // loader produces a fresh transform on next access.
+    const previousRaw = rawEmitCache.get(normalizedFilename);
+    rawEmitCache.set(normalizedFilename, text);
+
+    if (previousRaw !== text) {
+      typescriptFileCache.delete(normalizedFilename);
+    }
   }
 }

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -27,6 +27,7 @@ export interface SetupCompilationOptions {
   hasServer?: boolean;
   includePaths?: string[];
   sass?: Sass;
+  watch?: boolean;
 }
 
 export const DEFAULT_NG_COMPILER_OPTIONS: ts.CompilerOptions = {
@@ -113,7 +114,7 @@ export async function setupCompilation(
       tailwindConfiguration,
     },
     options.inlineStyleLanguage,
-    false
+    !!options.watch
   );
 
   return {

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
@@ -25,6 +25,14 @@ export async function setupCompilationWithAngularCompilation(
     options.hasServer,
     false
   );
+
+  // Drop the bundler's cached results for files the watcher reported as
+  // modified so dependent stylesheets get rebuilt; skipped on the initial
+  // build when there's nothing to invalidate.
+  if (modifiedFiles) {
+    componentStylesheetBundler.invalidate(modifiedFiles);
+  }
+
   modifiedFiles ??= new Set(rootNames);
 
   const fileReplacements: Record<string, string> =

--- a/packages/angular-rspack/src/lib/models/augmented-compilation.ts
+++ b/packages/angular-rspack/src/lib/models/augmented-compilation.ts
@@ -10,6 +10,7 @@ export const NG_RSPACK_SYMBOL_NAME = 'NG_RSPACK_BUILD';
 export type NG_RSPACK_COMPILATION_STATE = {
   javascriptTransformer: JavaScriptTransformer;
   typescriptFileCache: SourceFileCache['typeScriptFileCache'];
+  rawEmitCache: Map<string, string>;
   i18n?: I18nOptions;
 };
 export type NgRspackCompilation = Compilation & {

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -6,6 +6,7 @@ import {
 } from '@angular/build/private';
 import {
   buildAndAnalyze,
+  rawEmitCache,
   DiagnosticModes,
   JavaScriptTransformer,
   SourceFileCache,
@@ -127,7 +128,8 @@ export class AngularRspackPlugin implements RspackPluginInstance {
                 compiler.options.resolve.tsConfig,
                 watchingModifiedFiles.size > 0
                   ? watchingModifiedFiles
-                  : undefined
+                  : undefined,
+                true
               );
 
               await buildAndAnalyze(
@@ -266,6 +268,13 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         }
       }
 
+      callback();
+    });
+
+    // Tear down the JavaScriptTransformer worker pool only when the compiler
+    // shuts down. Doing it per-build would respawn workers on every rebuild
+    // and discard their warm in-memory state.
+    compiler.hooks.shutdown.tapAsync(PLUGIN_NAME, async (callback) => {
       await this.#javascriptTransformer.close();
       callback();
     });
@@ -358,6 +367,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         javascriptTransformer: this
           .#javascriptTransformer as unknown as JavaScriptTransformer,
         typescriptFileCache: this.#sourceFileCache.typeScriptFileCache,
+        rawEmitCache,
         i18n: this.#i18n,
       });
     });
@@ -410,7 +420,8 @@ export class AngularRspackPlugin implements RspackPluginInstance {
   private async setupCompilation(
     root: string,
     tsConfig: RspackOptionsNormalized['resolve']['tsConfig'],
-    modifiedFiles?: Set<string>
+    modifiedFiles?: Set<string>,
+    watch = false
   ) {
     const tsconfigPath = tsConfig
       ? typeof tsConfig === 'string'
@@ -433,6 +444,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         hasServer: this.#_options.hasServer,
         includePaths: this.#_options.stylePreprocessorOptions?.includePaths,
         sass: this.#_options.stylePreprocessorOptions?.sass,
+        watch,
       },
       this.#sourceFileCache,
       this.#angularCompilation,

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.spec.ts
@@ -23,9 +23,15 @@ describe('angular-transform.loader', () => {
   const callback = vi.fn();
   const addDependency = vi.fn();
   const typescriptFileCache = new Map<string, string | Buffer>();
+  const rawEmitCache = new Map<string, string>();
+  const javascriptTransformer = {
+    transformData: vi.fn(),
+  };
   const _compilation = {
     [NG_RSPACK_SYMBOL_NAME]: () => ({
       typescriptFileCache,
+      rawEmitCache,
+      javascriptTransformer,
     }),
   } as unknown as NgRspackCompilation;
   const thisValue = {

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
@@ -28,9 +28,9 @@ export default function loader(
   ) {
     callback(null, content);
   } else {
-    const { typescriptFileCache } = (this._compilation as NgRspackCompilation)[
-      NG_RSPACK_SYMBOL_NAME
-    ]();
+    const { typescriptFileCache, javascriptTransformer, rawEmitCache } = (
+      this._compilation as NgRspackCompilation
+    )[NG_RSPACK_SYMBOL_NAME]();
 
     const request = this.resourcePath.replace(/^[A-Z]:/, '');
     const normalizedRequest = normalize(request);
@@ -48,13 +48,32 @@ export default function loader(
       this.addDependency(absoluteFileUrl);
     }
 
-    const contents = typescriptFileCache.get(normalizedRequest);
-    if (contents === undefined) {
-      callback(null, content);
-    } else if (typeof contents === 'string') {
-      callback(null, contents);
-    } else {
-      callback(null, Buffer.from(contents));
+    const cached = typescriptFileCache.get(normalizedRequest);
+    if (cached !== undefined) {
+      if (typeof cached === 'string') {
+        callback(null, cached);
+      } else {
+        callback(null, Buffer.from(cached));
+      }
+      return;
     }
+
+    // No transformed entry yet for this file. If the Angular compilation
+    // produced raw JS/TS for it, transform now and cache the result; subsequent
+    // loader calls hit the fast path above until the raw emit changes again.
+    const raw = rawEmitCache.get(normalizedRequest);
+    if (raw !== undefined) {
+      javascriptTransformer
+        .transformData(normalizedRequest, raw, true, false)
+        .then((transformed: Uint8Array) => {
+          const text = Buffer.from(transformed).toString();
+          typescriptFileCache.set(normalizedRequest, text);
+          callback(null, text);
+        })
+        .catch((err: Error) => callback(err));
+      return;
+    }
+
+    callback(null, content);
   }
 }


### PR DESCRIPTION
## Current Behavior

Watch-mode rebuilds in `@nx/angular-rspack` are significantly slower than expected — often several times slower than the Angular CLI's esbuild-based dev server on the same project. On large apps, a single-file change can take 10+ seconds to rebuild even though only one file changed.

Three root causes:

1. `buildAndAnalyze` eagerly runs `JavaScriptTransformer.transformData()` on **every** file returned by `emitAffectedFiles()`. Due to Angular's `.ngtypecheck.ts` shim version mismatch between the first build (placeholder content) and subsequent rebuilds (real analysis content), TypeScript's incremental builder reports all ~7800 files as affected — so all ~7800 files go through the expensive transform on every rebuild.
2. `ComponentStylesheetBundler` is constructed with `incremental: false`, which disables result caching, selective invalidation, and esbuild's incremental rebuild mode for component styles.
3. `JavaScriptTransformer.close()` is called in the `emit` hook, which fires on every compilation — tearing down and re-spawning the worker thread pool on each rebuild.

## Expected Behavior

Watch-mode rebuilds perform on par with the Angular CLI's esbuild pipeline. A single-file change should only transform the changed file and reuse cached output for everything else.

Changes:

- **Lazy transform** — `buildAndAnalyze` now stores raw emitted content in a `rawEmitCache` and invalidates matching transformed cache entries only when the raw content actually changed. The Angular transform loader runs `transformData()` lazily when Rspack requests a module, mirroring esbuild's `onLoad` pattern. Files Rspack doesn't re-process are never re-transformed.
- **Incremental stylesheet bundler** — `ComponentStylesheetBundler` is now constructed with `incremental: !!options.watch` and `invalidate(modifiedFiles)` is called on rebuilds, matching the Angular CLI's `setup-bundling.js` behavior.
- **Persistent worker pool** — `JavaScriptTransformer.close()` moved from the per-build `emit` hook to the `shutdown` hook so workers live across rebuilds (mirrors esbuild plugin's `onDispose`).

Measured on a benchmark app with ~7800 files (Angular 21.2):

| Pipeline                | Warm rebuild |
| ----------------------- | ------------ |
| rspack (before)         | ~12s         |
| rspack (after)          | ~3.6s        |
| esbuild (Angular CLI)   | ~3.8s        |

## Related Issue(s)

Fixes #34936