### PR TITLE
fix(release): surface swallowed publish errors when stdout is not valid JSON

### DIFF
--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -456,7 +456,18 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
         };
       }
 
-      const stdoutData = JSON.parse(err.stdout?.toString() || '{}');
+      // stdout is not guaranteed to be JSON (e.g. lifecycle script failures).
+      // If parsing fails, print raw stderr/stdout so the underlying error is visible to the user.
+      let stdoutData;
+      try {
+        stdoutData = JSON.parse(err.stdout?.toString() || '{}');
+      } catch {
+        console.error(err.stderr?.toString() || '');
+        console.error(err.stdout?.toString() || '');
+        return {
+          success: false,
+        };
+      }
 
       console.error(`${pm} publish error:`);
       // npm returns error.summary and error.detail


### PR DESCRIPTION
## Current Behavior
<!-- This is the behavior we have today -->
When `npm publish` or `pnpm publish` fails, the executor assumes `err.stdout` (always) contains valid JSON. If a lifecycle script (e.g. `prepublishOnly`) fails, it writes plaintext to stdout instead. This causes `JSON.parse` to throw and the actual error to be swallowed by the outer catch, printing only a generic "something unexpected went wrong" message.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Wrap `JSON.parse(err.stdout...)` in a try/catch block. If parsing fails, fall back to logging raw stderr/stdout directly and return early, so lifecycle script failures and other non-JSON errors are always visible to the user.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #34497
