### PR TITLE
fix(linter): properly support bulk suppressions in lint executor

### DIFF
--- a/packages/eslint/src/executors/lint/lint.impl.spec.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.spec.ts
@@ -65,10 +65,10 @@ jest.mock('./utility/eslint-utils', () => {
   return {
     resolveAndInstantiateESLint: (...args: any[]) =>
       mockResolveAndInstantiateESLint(...args),
-    applySuppressions: (...args: any[]) =>
-      mockApplySuppressions(...args),
+    applySuppressions: (...args: any[]) => mockApplySuppressions(...args),
     getSuppressionsFilePath: (...args: any[]) =>
       mockGetSuppressionsFilePath(...args),
+    validateSuppressionOptions: jest.fn(),
   };
 });
 import lintExecutor from './lint.impl';
@@ -1082,7 +1082,9 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
     it('should call applySuppressions for ESLint v9.x when suppressions file exists', async () => {
       setupMocks();
       MockESLint.version = '9.24.0';
-      mockGetSuppressionsFilePath.mockReturnValue('/tmp/eslint-suppressions.json');
+      mockGetSuppressionsFilePath.mockReturnValue(
+        '/tmp/eslint-suppressions.json'
+      );
       (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
         if (p === '/tmp/eslint-suppressions.json') return true;
         return realFs.existsSync(p);
@@ -1120,7 +1122,9 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
     it('should call applySuppressions with suppressAll when suppressAll is true', async () => {
       setupMocks();
       MockESLint.version = '9.24.0';
-      mockGetSuppressionsFilePath.mockReturnValue('/tmp/eslint-suppressions.json');
+      mockGetSuppressionsFilePath.mockReturnValue(
+        '/tmp/eslint-suppressions.json'
+      );
       (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
         if (p === '/tmp/eslint-suppressions.json') return true;
         return realFs.existsSync(p);
@@ -1150,7 +1154,9 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
     it('should call applySuppressions with pruneSuppressions when pruneSuppressions is true', async () => {
       setupMocks();
       MockESLint.version = '9.24.0';
-      mockGetSuppressionsFilePath.mockReturnValue('/tmp/eslint-suppressions.json');
+      mockGetSuppressionsFilePath.mockReturnValue(
+        '/tmp/eslint-suppressions.json'
+      );
       (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
         if (p === '/tmp/eslint-suppressions.json') return true;
         return realFs.existsSync(p);
@@ -1180,7 +1186,9 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
     it('should fail when passOnUnprunedSuppressions is true and there are unused suppressions', async () => {
       setupMocks();
       MockESLint.version = '9.24.0';
-      mockGetSuppressionsFilePath.mockReturnValue('/tmp/eslint-suppressions.json');
+      mockGetSuppressionsFilePath.mockReturnValue(
+        '/tmp/eslint-suppressions.json'
+      );
       (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
         if (p === '/tmp/eslint-suppressions.json') return true;
         return realFs.existsSync(p);
@@ -1212,7 +1220,9 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
           isEslintV10: true,
         })
       );
-      mockGetSuppressionsFilePath.mockReturnValue('/tmp/eslint-suppressions.json');
+      mockGetSuppressionsFilePath.mockReturnValue(
+        '/tmp/eslint-suppressions.json'
+      );
       (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
         if (p === '/tmp/eslint-suppressions.json') return true;
         return realFs.existsSync(p);
@@ -1240,7 +1250,9 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
           isEslintV10: true,
         })
       );
-      mockGetSuppressionsFilePath.mockReturnValue('/tmp/eslint-suppressions.json');
+      mockGetSuppressionsFilePath.mockReturnValue(
+        '/tmp/eslint-suppressions.json'
+      );
       (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
         if (p === '/tmp/eslint-suppressions.json') return true;
         return realFs.existsSync(p);

--- a/packages/eslint/src/executors/lint/lint.impl.spec.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.spec.ts
@@ -1054,12 +1054,12 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
     it('should throw error when using suppression options with ESLint < 9.24.0', async () => {
       setupMocks();
       MockESLint.version = '9.23.0';
-
-      // Mock the resolveAndInstantiateESLint to throw the error
-      mockResolveAndInstantiateESLint.mockRejectedValueOnce(
-        new Error(
-          'Bulk suppression options (suppressAll, suppressRule, suppressionsLocation) require ESLint v9.24.0 or higher. Current version: 9.23.0'
-        )
+      mockResolveAndInstantiateESLint.mockReturnValue(
+        Promise.resolve({
+          ESLint: MockESLint,
+          eslint: new MockESLint(),
+          isEslintV10: false,
+        })
       );
 
       await expect(
@@ -1070,7 +1070,7 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
           mockContext
         )
       ).rejects.toThrow(
-        'Bulk suppression options (suppressAll, suppressRule, suppressionsLocation) require ESLint v9.24.0 or higher. Current version: 9.23.0'
+        'Bulk suppression options (suppressAll, suppressRule, suppressionsLocation, pruneSuppressions) require ESLint v9.24.0 or higher. Current version: 9.23.0'
       );
     });
 
@@ -1307,6 +1307,54 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
           isEslintV10: true,
         })
       );
+    });
+
+    it('should return success when v10 suppressAll suppresses all errors', async () => {
+      setupMocks();
+      MockESLint.version = '10.0.0';
+      mockResolveAndInstantiateESLint.mockReturnValue(
+        Promise.resolve({
+          ESLint: MockESLint,
+          eslint: new MockESLint(),
+          isEslintV10: true,
+        })
+      );
+      mockReports = [
+        {
+          errorCount: 3,
+          warningCount: 0,
+          results: [],
+          usedDeprecatedRules: [],
+        },
+      ];
+      mockGetSuppressionsFilePath.mockReturnValue(
+        '/tmp/eslint-suppressions.json'
+      );
+      (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
+        if (p === '/tmp/eslint-suppressions.json') return true;
+        return realFs.existsSync(p);
+      });
+      mockApplySuppressions.mockResolvedValue({
+        results: [
+          {
+            errorCount: 0,
+            warningCount: 0,
+            results: [],
+            usedDeprecatedRules: [],
+          },
+        ],
+        unusedSuppressions: {},
+      });
+
+      const result = await lintExecutor(
+        createValidRunBuilderOptions({
+          suppressAll: true,
+          lintFilePatterns: ['includedFile1'],
+        }),
+        mockContext
+      );
+
+      expect(result.success).toBe(true);
     });
 
     it('should throw when passOnUnprunedSuppressions is used without pruneSuppressions', async () => {

--- a/packages/eslint/src/executors/lint/lint.impl.spec.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.spec.ts
@@ -50,13 +50,25 @@ const mockResolveAndInstantiateESLint = jest.fn().mockReturnValue(
   Promise.resolve({
     ESLint: MockESLint,
     eslint: new MockESLint(),
+    isEslintV10: false,
   })
 );
 
+const mockApplySuppressions = jest.fn().mockResolvedValue({
+  results: [],
+  unusedSuppressions: {},
+});
+
+const mockGetSuppressionsFilePath = jest.fn().mockReturnValue(null);
+
 jest.mock('./utility/eslint-utils', () => {
   return {
-    resolveAndInstantiateESLint: (...args) =>
+    resolveAndInstantiateESLint: (...args: any[]) =>
       mockResolveAndInstantiateESLint(...args),
+    applySuppressions: (...args: any[]) =>
+      mockApplySuppressions(...args),
+    getSuppressionsFilePath: (...args: any[]) =>
+      mockGetSuppressionsFilePath(...args),
   };
 });
 import lintExecutor from './lint.impl';
@@ -89,6 +101,8 @@ function createValidRunBuilderOptions(
     errorOnUnmatchedPattern: true,
     suppressAll: false,
     suppressRule: [],
+    pruneSuppressions: false,
+    passOnUnprunedSuppressions: false,
     ...additionalOptions,
   };
 }
@@ -108,6 +122,18 @@ function setupMocks() {
     (path: fs.PathLike, options?: any) => realFs.mkdirSync(path, options)
   );
   jest.spyOn(process, 'chdir').mockImplementation(mockChdir);
+  mockApplySuppressions.mockResolvedValue({
+    results: [],
+    unusedSuppressions: {},
+  });
+  mockGetSuppressionsFilePath.mockReturnValue(null);
+  mockResolveAndInstantiateESLint.mockReturnValue(
+    Promise.resolve({
+      ESLint: MockESLint,
+      eslint: new MockESLint(),
+      isEslintV10: false,
+    })
+  );
   console.warn = jest.fn();
   console.error = jest.fn();
   console.info = jest.fn();
@@ -223,6 +249,8 @@ describe('Linter Builder', () => {
         reportUnusedDisableDirectives: null,
         suppressAll: false,
         suppressRule: [],
+        pruneSuppressions: false,
+        passOnUnprunedSuppressions: false,
       },
       false
     );
@@ -967,6 +995,8 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
         reportUnusedDisableDirectives: null,
         suppressAll: false,
         suppressRule: [],
+        pruneSuppressions: false,
+        passOnUnprunedSuppressions: false,
       },
       true
     );
@@ -1046,6 +1076,194 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
           suppressRule: [],
         }),
         expect.any(Boolean)
+      );
+    });
+
+    it('should call applySuppressions for ESLint v9.x when suppressions file exists', async () => {
+      setupMocks();
+      MockESLint.version = '9.24.0';
+      mockGetSuppressionsFilePath.mockReturnValue('/tmp/eslint-suppressions.json');
+      (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
+        if (p === '/tmp/eslint-suppressions.json') return true;
+        return realFs.existsSync(p);
+      });
+      const suppressedResults = [
+        {
+          errorCount: 0,
+          warningCount: 0,
+          results: [],
+          usedDeprecatedRules: [],
+        },
+      ];
+      mockApplySuppressions.mockResolvedValue({
+        results: suppressedResults,
+        unusedSuppressions: {},
+      });
+
+      await lintExecutor(
+        createValidRunBuilderOptions({
+          lintFilePatterns: ['includedFile1'],
+        }),
+        mockContext
+      );
+
+      expect(mockApplySuppressions).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({
+          suppressAll: false,
+          pruneSuppressions: false,
+          cwd: mockContext.root,
+        })
+      );
+    });
+
+    it('should call applySuppressions with suppressAll when suppressAll is true', async () => {
+      setupMocks();
+      MockESLint.version = '9.24.0';
+      mockGetSuppressionsFilePath.mockReturnValue('/tmp/eslint-suppressions.json');
+      (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
+        if (p === '/tmp/eslint-suppressions.json') return true;
+        return realFs.existsSync(p);
+      });
+      mockApplySuppressions.mockResolvedValue({
+        results: [],
+        unusedSuppressions: {},
+      });
+
+      await lintExecutor(
+        createValidRunBuilderOptions({
+          suppressAll: true,
+          lintFilePatterns: ['includedFile1'],
+        }),
+        mockContext
+      );
+
+      expect(mockApplySuppressions).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({
+          suppressAll: true,
+          pruneSuppressions: false,
+        })
+      );
+    });
+
+    it('should call applySuppressions with pruneSuppressions when pruneSuppressions is true', async () => {
+      setupMocks();
+      MockESLint.version = '9.24.0';
+      mockGetSuppressionsFilePath.mockReturnValue('/tmp/eslint-suppressions.json');
+      (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
+        if (p === '/tmp/eslint-suppressions.json') return true;
+        return realFs.existsSync(p);
+      });
+      mockApplySuppressions.mockResolvedValue({
+        results: [],
+        unusedSuppressions: {},
+      });
+
+      await lintExecutor(
+        createValidRunBuilderOptions({
+          pruneSuppressions: true,
+          lintFilePatterns: ['includedFile1'],
+        }),
+        mockContext
+      );
+
+      expect(mockApplySuppressions).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({
+          pruneSuppressions: true,
+          suppressAll: false,
+        })
+      );
+    });
+
+    it('should fail when passOnUnprunedSuppressions is true and there are unused suppressions', async () => {
+      setupMocks();
+      MockESLint.version = '9.24.0';
+      mockGetSuppressionsFilePath.mockReturnValue('/tmp/eslint-suppressions.json');
+      (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
+        if (p === '/tmp/eslint-suppressions.json') return true;
+        return realFs.existsSync(p);
+      });
+      mockApplySuppressions.mockResolvedValue({
+        results: [],
+        unusedSuppressions: { 'some-file.js': { 'some-rule': { count: 1 } } },
+      });
+
+      const result = await lintExecutor(
+        createValidRunBuilderOptions({
+          pruneSuppressions: true,
+          passOnUnprunedSuppressions: true,
+          lintFilePatterns: ['includedFile1'],
+        }),
+        mockContext
+      );
+
+      expect(result.success).toBe(false);
+    });
+
+    it('should not call applySuppressions for ESLint v10 when no write/prune options are set', async () => {
+      setupMocks();
+      MockESLint.version = '10.0.0';
+      mockResolveAndInstantiateESLint.mockReturnValue(
+        Promise.resolve({
+          ESLint: MockESLint,
+          eslint: new MockESLint(),
+          isEslintV10: true,
+        })
+      );
+      mockGetSuppressionsFilePath.mockReturnValue('/tmp/eslint-suppressions.json');
+      (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
+        if (p === '/tmp/eslint-suppressions.json') return true;
+        return realFs.existsSync(p);
+      });
+
+      await lintExecutor(
+        createValidRunBuilderOptions({
+          lintFilePatterns: ['includedFile1'],
+        }),
+        mockContext
+      );
+
+      // For v10 with no write/prune options, applySuppressions should not be called
+      // because v10 handles it internally via applySuppressions: true
+      expect(mockApplySuppressions).not.toHaveBeenCalled();
+    });
+
+    it('should still call applySuppressions for ESLint v10 when suppressAll is true', async () => {
+      setupMocks();
+      MockESLint.version = '10.0.0';
+      mockResolveAndInstantiateESLint.mockReturnValue(
+        Promise.resolve({
+          ESLint: MockESLint,
+          eslint: new MockESLint(),
+          isEslintV10: true,
+        })
+      );
+      mockGetSuppressionsFilePath.mockReturnValue('/tmp/eslint-suppressions.json');
+      (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
+        if (p === '/tmp/eslint-suppressions.json') return true;
+        return realFs.existsSync(p);
+      });
+      mockApplySuppressions.mockResolvedValue({
+        results: [],
+        unusedSuppressions: {},
+      });
+
+      await lintExecutor(
+        createValidRunBuilderOptions({
+          suppressAll: true,
+          lintFilePatterns: ['includedFile1'],
+        }),
+        mockContext
+      );
+
+      // Even for v10, we need to call applySuppressions for writing new suppressions
+      expect(mockApplySuppressions).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({
+          suppressAll: true,
+        })
       );
     });
   });

--- a/packages/eslint/src/executors/lint/lint.impl.spec.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.spec.ts
@@ -1129,6 +1129,30 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
       );
     });
 
+    it('should not call applySuppressions for ESLint v9.x when no suppression options and no suppressions file', async () => {
+      setupMocks();
+      MockESLint.version = '9.24.0';
+      mockGetSuppressionsFilePath.mockReturnValue(
+        '/tmp/eslint-suppressions.json'
+      );
+      (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
+        if (p === '/tmp/eslint-suppressions.json') return false;
+        return realFs.existsSync(p);
+      });
+
+      await lintExecutor(
+        createValidRunBuilderOptions({
+          lintFilePatterns: ['includedFile1'],
+        }),
+        mockContext
+      );
+
+      // v9.24.0 supports suppressions, but no file exists and no options set,
+      // so getSuppressionsFilePath is called but applySuppressions is not.
+      expect(mockGetSuppressionsFilePath).toHaveBeenCalled();
+      expect(mockApplySuppressions).not.toHaveBeenCalled();
+    });
+
     it('should call applySuppressions with suppressAll when suppressAll is true', async () => {
       setupMocks();
       MockESLint.version = '9.24.0';
@@ -1220,7 +1244,7 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
       expect(result.success).toBe(false);
     });
 
-    it('should not call applySuppressions for ESLint v10 when no write/prune options are set', async () => {
+    it('should not call applySuppressions or getSuppressionsFilePath for ESLint v10 when no write/prune options are set', async () => {
       setupMocks();
       MockESLint.version = '10.0.0';
       mockResolveAndInstantiateESLint.mockReturnValue(
@@ -1230,13 +1254,6 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
           isEslintV10: true,
         })
       );
-      mockGetSuppressionsFilePath.mockReturnValue(
-        '/tmp/eslint-suppressions.json'
-      );
-      (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
-        if (p === '/tmp/eslint-suppressions.json') return true;
-        return realFs.existsSync(p);
-      });
 
       await lintExecutor(
         createValidRunBuilderOptions({
@@ -1245,8 +1262,11 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
         mockContext
       );
 
-      // For v10 with no write/prune options, applySuppressions should not be called
-      // because v10 handles it internally via applySuppressions: true
+      // For v10 with no write/prune options, getSuppressionsFilePath should not
+      // be called because v10 handles suppression application internally via
+      // applySuppressions: true in the constructor, and the post-lint path is
+      // only entered when the user explicitly sets suppression options.
+      expect(mockGetSuppressionsFilePath).not.toHaveBeenCalled();
       expect(mockApplySuppressions).not.toHaveBeenCalled();
     });
 

--- a/packages/eslint/src/executors/lint/lint.impl.spec.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.spec.ts
@@ -29,7 +29,7 @@ const mockLoadFormatter = jest.fn().mockReturnValue(mockFormatter);
 const mockIsPathIgnored = jest.fn().mockReturnValue(Promise.resolve(false));
 const mockOutputFixes = jest.fn();
 
-const VALID_ESLINT_VERSION = '8.0';
+const VALID_ESLINT_VERSION = '8.0.0';
 
 let mockReports: any[] = [{ results: [], usedDeprecatedRules: [] }];
 const mockLintFiles = jest.fn().mockImplementation(() => mockReports);
@@ -61,6 +61,12 @@ const mockApplySuppressions = jest.fn().mockResolvedValue({
 
 const mockGetSuppressionsFilePath = jest.fn().mockReturnValue(null);
 
+const mockValidateSuppressionOptions = jest
+  .fn()
+  .mockImplementation(
+    jest.requireActual('./utility/eslint-utils').validateSuppressionOptions
+  );
+
 jest.mock('./utility/eslint-utils', () => {
   return {
     resolveAndInstantiateESLint: (...args: any[]) =>
@@ -68,7 +74,8 @@ jest.mock('./utility/eslint-utils', () => {
     applySuppressions: (...args: any[]) => mockApplySuppressions(...args),
     getSuppressionsFilePath: (...args: any[]) =>
       mockGetSuppressionsFilePath(...args),
-    validateSuppressionOptions: jest.fn(),
+    validateSuppressionOptions: (...args: any[]) =>
+      mockValidateSuppressionOptions(...args),
   };
 });
 import lintExecutor from './lint.impl';
@@ -127,6 +134,9 @@ function setupMocks() {
     unusedSuppressions: {},
   });
   mockGetSuppressionsFilePath.mockReturnValue(null);
+  mockValidateSuppressionOptions.mockImplementation(
+    jest.requireActual('./utility/eslint-utils').validateSuppressionOptions
+  );
   mockResolveAndInstantiateESLint.mockReturnValue(
     Promise.resolve({
       ESLint: MockESLint,
@@ -1270,13 +1280,104 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
         mockContext
       );
 
-      // Even for v10, we need to call applySuppressions for writing new suppressions
       expect(mockApplySuppressions).toHaveBeenCalledWith(
         expect.any(Array),
         expect.objectContaining({
           suppressAll: true,
+          isEslintV10: true,
         })
       );
+    });
+
+    it('should throw when passOnUnprunedSuppressions is used without pruneSuppressions', async () => {
+      setupMocks();
+      MockESLint.version = '9.24.0';
+
+      await expect(
+        lintExecutor(
+          createValidRunBuilderOptions({
+            passOnUnprunedSuppressions: true,
+            pruneSuppressions: false,
+            lintFilePatterns: ['includedFile1'],
+          }),
+          mockContext
+        )
+      ).rejects.toThrow(
+        'The passOnUnprunedSuppressions option requires pruneSuppressions to be enabled.'
+      );
+    });
+
+    it('should call applySuppressions for ESLint v10 when pruneSuppressions is true', async () => {
+      setupMocks();
+      MockESLint.version = '10.0.0';
+      mockResolveAndInstantiateESLint.mockReturnValue(
+        Promise.resolve({
+          ESLint: MockESLint,
+          eslint: new MockESLint(),
+          isEslintV10: true,
+        })
+      );
+      mockGetSuppressionsFilePath.mockReturnValue(
+        '/tmp/eslint-suppressions.json'
+      );
+      (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
+        if (p === '/tmp/eslint-suppressions.json') return true;
+        return realFs.existsSync(p);
+      });
+      mockApplySuppressions.mockResolvedValue({
+        results: [],
+        unusedSuppressions: {},
+      });
+
+      await lintExecutor(
+        createValidRunBuilderOptions({
+          pruneSuppressions: true,
+          lintFilePatterns: ['includedFile1'],
+        }),
+        mockContext
+      );
+
+      expect(mockApplySuppressions).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({
+          pruneSuppressions: true,
+          isEslintV10: true,
+        })
+      );
+    });
+
+    it('should fail for ESLint v10 when passOnUnprunedSuppressions is true and there are unused suppressions', async () => {
+      setupMocks();
+      MockESLint.version = '10.0.0';
+      mockResolveAndInstantiateESLint.mockReturnValue(
+        Promise.resolve({
+          ESLint: MockESLint,
+          eslint: new MockESLint(),
+          isEslintV10: true,
+        })
+      );
+      mockGetSuppressionsFilePath.mockReturnValue(
+        '/tmp/eslint-suppressions.json'
+      );
+      (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
+        if (p === '/tmp/eslint-suppressions.json') return true;
+        return realFs.existsSync(p);
+      });
+      mockApplySuppressions.mockResolvedValue({
+        results: [],
+        unusedSuppressions: { 'some-file.js': { 'some-rule': { count: 1 } } },
+      });
+
+      const result = await lintExecutor(
+        createValidRunBuilderOptions({
+          pruneSuppressions: true,
+          passOnUnprunedSuppressions: true,
+          lintFilePatterns: ['includedFile1'],
+        }),
+        mockContext
+      );
+
+      expect(result.success).toBe(false);
     });
   });
 });

--- a/packages/eslint/src/executors/lint/lint.impl.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.ts
@@ -7,7 +7,7 @@ import type { ESLint } from 'eslint';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { interpolate } from 'nx/src/tasks-runner/utils';
 import { dirname, posix, relative, resolve } from 'path';
-import { major } from 'semver';
+import { gte, major } from 'semver';
 import { findFlatConfigFile, findOldConfigFile } from '../../utils/config-file';
 import {
   warnEslintExecutorDeprecation,
@@ -221,12 +221,21 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
   // - ESLint v10+: applySuppressions is set on the constructor, so lintFiles() already applied suppressions.
   //   We only need post-lint handling for writing (suppressAll/suppressRule) and pruning.
   // - ESLint v9.x: The programmatic API silently ignores suppression options, so we handle everything post-lint.
+  const eslintVersion = ESLint.version;
+  let supportsSuppressions = false;
+  try {
+    supportsSuppressions =
+      !isEslintV10 && !!eslintVersion && gte(eslintVersion, '9.24.0');
+  } catch {
+    // Invalid semver (e.g., test mocks) - suppressions not supported
+  }
+
   const needsPostLintSuppressions =
     normalizedOptions.suppressAll ||
     (normalizedOptions.suppressRule &&
       normalizedOptions.suppressRule.length > 0) ||
     normalizedOptions.pruneSuppressions ||
-    !isEslintV10; // v9.x always needs post-lint handling to apply suppressions from the file
+    supportsSuppressions; // Only apply file-based suppressions for v9.x (v10 handles it internally)
 
   if (needsPostLintSuppressions) {
     const suppressionsFilePath = getSuppressionsFilePath(

--- a/packages/eslint/src/executors/lint/lint.impl.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.ts
@@ -7,7 +7,7 @@ import type { ESLint } from 'eslint';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { interpolate } from 'nx/src/tasks-runner/utils';
 import { dirname, posix, relative, resolve } from 'path';
-import { gte, major } from 'semver';
+import { gte, major, valid } from 'semver';
 import { findFlatConfigFile, findOldConfigFile } from '../../utils/config-file';
 import {
   warnEslintExecutorDeprecation,
@@ -60,13 +60,16 @@ export default async function run(
     normalizedOptions.suppressAll ||
     (normalizedOptions.suppressRule &&
       normalizedOptions.suppressRule.length > 0) ||
-    normalizedOptions.pruneSuppressions
+    normalizedOptions.pruneSuppressions ||
+    normalizedOptions.passOnUnprunedSuppressions
   ) {
     validateSuppressionOptions({
       suppressAll: !!normalizedOptions.suppressAll,
       suppressRule: normalizedOptions.suppressRule,
       suppressionsLocation: normalizedOptions.suppressionsLocation,
       pruneSuppressions: !!normalizedOptions.pruneSuppressions,
+      passOnUnprunedSuppressions:
+        !!normalizedOptions.passOnUnprunedSuppressions,
       cwd: systemRoot,
     });
   }
@@ -222,20 +225,18 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
   //   We only need post-lint handling for writing (suppressAll/suppressRule) and pruning.
   // - ESLint v9.x: The programmatic API silently ignores suppression options, so we handle everything post-lint.
   const eslintVersion = ESLint.version;
-  let supportsSuppressions = false;
-  try {
-    supportsSuppressions =
-      !isEslintV10 && !!eslintVersion && gte(eslintVersion, '9.24.0');
-  } catch {
-    // Invalid semver (e.g., test mocks) - suppressions not supported
-  }
+  const supportsSuppressions =
+    !isEslintV10 &&
+    !!eslintVersion &&
+    !!valid(eslintVersion) &&
+    gte(eslintVersion, '9.24.0');
 
   const needsPostLintSuppressions =
     normalizedOptions.suppressAll ||
     (normalizedOptions.suppressRule &&
       normalizedOptions.suppressRule.length > 0) ||
     normalizedOptions.pruneSuppressions ||
-    supportsSuppressions; // Only apply file-based suppressions for v9.x (v10 handles it internally)
+    supportsSuppressions;
 
   if (needsPostLintSuppressions) {
     const suppressionsFilePath = getSuppressionsFilePath(
@@ -258,7 +259,10 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
           suppressRule: normalizedOptions.suppressRule,
           suppressionsLocation: normalizedOptions.suppressionsLocation,
           pruneSuppressions: !!normalizedOptions.pruneSuppressions,
+          passOnUnprunedSuppressions:
+            !!normalizedOptions.passOnUnprunedSuppressions,
           cwd: systemRoot,
+          isEslintV10,
         });
       lintResults = suppressedResults;
 

--- a/packages/eslint/src/executors/lint/lint.impl.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.ts
@@ -4,7 +4,7 @@ import {
   getInstalledPackageVersion,
 } from '@nx/devkit/internal';
 import type { ESLint } from 'eslint';
-import { mkdirSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { interpolate } from 'nx/src/tasks-runner/utils';
 import { dirname, posix, relative, resolve } from 'path';
 import { major } from 'semver';
@@ -15,7 +15,11 @@ import {
 } from '../../utils/deprecation';
 import { minSupportedEslintVersion } from '../../utils/versions';
 import type { Schema } from './schema';
-import { resolveAndInstantiateESLint } from './utility/eslint-utils';
+import {
+  resolveAndInstantiateESLint,
+  applySuppressions,
+  getSuppressionsFilePath,
+} from './utility/eslint-utils';
 
 export default async function run(
   options: Schema,
@@ -68,7 +72,7 @@ export default async function run(
     ? resolve(systemRoot, normalizedOptions.eslintConfig)
     : undefined;
 
-  const { eslint, ESLint } = await resolveAndInstantiateESLint(
+  const { eslint, ESLint, isEslintV10 } = await resolveAndInstantiateESLint(
     eslintConfigPath,
     normalizedOptions,
     hasFlatConfig
@@ -194,6 +198,50 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
 
   // output fixes to disk, if applicable based on the options
   await ESLint.outputFixes(lintResults);
+
+  // Handle suppressions:
+  // - ESLint v10+: applySuppressions is set on the constructor, so lintFiles() already applied suppressions.
+  //   We only need post-lint handling for writing (suppressAll/suppressRule) and pruning.
+  // - ESLint v9.x: The programmatic API silently ignores suppression options, so we handle everything post-lint.
+  const needsPostLintSuppressions =
+    normalizedOptions.suppressAll ||
+    (normalizedOptions.suppressRule && normalizedOptions.suppressRule.length > 0) ||
+    normalizedOptions.pruneSuppressions ||
+    !isEslintV10; // v9.x always needs post-lint handling to apply suppressions from the file
+
+  if (needsPostLintSuppressions) {
+    const suppressionsFilePath = getSuppressionsFilePath(
+      normalizedOptions.suppressionsLocation,
+      systemRoot
+    );
+    const suppressionsFileExists = suppressionsFilePath
+      ? existsSync(suppressionsFilePath)
+      : false;
+
+    const shouldWrite = !!normalizedOptions.suppressAll ||
+      (normalizedOptions.suppressRule && normalizedOptions.suppressRule.length > 0);
+    const shouldPrune = !!normalizedOptions.pruneSuppressions;
+
+    // Only process if we need to write/prune OR a suppressions file exists
+    if (shouldWrite || shouldPrune || suppressionsFileExists) {
+      const { results: suppressedResults, unusedSuppressions } = await applySuppressions(lintResults, {
+        suppressAll: !!normalizedOptions.suppressAll,
+        suppressRule: normalizedOptions.suppressRule,
+        suppressionsLocation: normalizedOptions.suppressionsLocation,
+        pruneSuppressions: !!normalizedOptions.pruneSuppressions,
+        cwd: systemRoot,
+      });
+      lintResults = suppressedResults;
+
+      if (
+        Object.keys(unusedSuppressions).length > 0 &&
+        normalizedOptions.passOnUnprunedSuppressions &&
+        !normalizedOptions.force
+      ) {
+        return { success: false };
+      }
+    }
+  }
 
   // if quiet, only show errors
   if (normalizedOptions.quiet) {

--- a/packages/eslint/src/executors/lint/lint.impl.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.ts
@@ -19,6 +19,7 @@ import {
   resolveAndInstantiateESLint,
   applySuppressions,
   getSuppressionsFilePath,
+  validateSuppressionOptions,
 } from './utility/eslint-utils';
 
 export default async function run(
@@ -52,6 +53,23 @@ export default async function run(
 
   const { printConfig, errorOnUnmatchedPattern, ...normalizedOptions } =
     options;
+
+  // Validate mutually exclusive suppression options early, before any ESLint work.
+  // This provides clear error messages instead of failing deep in the utility layer.
+  if (
+    normalizedOptions.suppressAll ||
+    (normalizedOptions.suppressRule &&
+      normalizedOptions.suppressRule.length > 0) ||
+    normalizedOptions.pruneSuppressions
+  ) {
+    validateSuppressionOptions({
+      suppressAll: !!normalizedOptions.suppressAll,
+      suppressRule: normalizedOptions.suppressRule,
+      suppressionsLocation: normalizedOptions.suppressionsLocation,
+      pruneSuppressions: !!normalizedOptions.pruneSuppressions,
+      cwd: systemRoot,
+    });
+  }
 
   // locate the flat config file if it exists starting from the project root
   const flatConfigFilePath = findFlatConfigFile(projectRoot, context.root);
@@ -205,7 +223,8 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
   // - ESLint v9.x: The programmatic API silently ignores suppression options, so we handle everything post-lint.
   const needsPostLintSuppressions =
     normalizedOptions.suppressAll ||
-    (normalizedOptions.suppressRule && normalizedOptions.suppressRule.length > 0) ||
+    (normalizedOptions.suppressRule &&
+      normalizedOptions.suppressRule.length > 0) ||
     normalizedOptions.pruneSuppressions ||
     !isEslintV10; // v9.x always needs post-lint handling to apply suppressions from the file
 
@@ -214,23 +233,24 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
       normalizedOptions.suppressionsLocation,
       systemRoot
     );
-    const suppressionsFileExists = suppressionsFilePath
-      ? existsSync(suppressionsFilePath)
-      : false;
+    const suppressionsFileExists = existsSync(suppressionsFilePath);
 
-    const shouldWrite = !!normalizedOptions.suppressAll ||
-      (normalizedOptions.suppressRule && normalizedOptions.suppressRule.length > 0);
+    const shouldWrite =
+      !!normalizedOptions.suppressAll ||
+      (normalizedOptions.suppressRule &&
+        normalizedOptions.suppressRule.length > 0);
     const shouldPrune = !!normalizedOptions.pruneSuppressions;
 
     // Only process if we need to write/prune OR a suppressions file exists
     if (shouldWrite || shouldPrune || suppressionsFileExists) {
-      const { results: suppressedResults, unusedSuppressions } = await applySuppressions(lintResults, {
-        suppressAll: !!normalizedOptions.suppressAll,
-        suppressRule: normalizedOptions.suppressRule,
-        suppressionsLocation: normalizedOptions.suppressionsLocation,
-        pruneSuppressions: !!normalizedOptions.pruneSuppressions,
-        cwd: systemRoot,
-      });
+      const { results: suppressedResults, unusedSuppressions } =
+        await applySuppressions(lintResults, {
+          suppressAll: !!normalizedOptions.suppressAll,
+          suppressRule: normalizedOptions.suppressRule,
+          suppressionsLocation: normalizedOptions.suppressionsLocation,
+          pruneSuppressions: !!normalizedOptions.pruneSuppressions,
+          cwd: systemRoot,
+        });
       lintResults = suppressedResults;
 
       if (

--- a/packages/eslint/src/executors/lint/lint.impl.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.ts
@@ -224,6 +224,15 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
   // - ESLint v10+: applySuppressions is set on the constructor, so lintFiles() already applied suppressions.
   //   We only need post-lint handling for writing (suppressAll/suppressRule) and pruning.
   // - ESLint v9.x: The programmatic API silently ignores suppression options, so we handle everything post-lint.
+  const hasUserSuppressionOptions =
+    !!normalizedOptions.suppressAll ||
+    (normalizedOptions.suppressRule &&
+      normalizedOptions.suppressRule.length > 0) ||
+    !!normalizedOptions.pruneSuppressions;
+
+  // For v9.x, check if there's an existing suppressions file to apply.
+  // For v10+, suppressions are already applied by lintFiles() — we only need
+  // post-lint handling for write/prune operations.
   const eslintVersion = ESLint.version;
   const supportsSuppressions =
     !isEslintV10 &&
@@ -231,48 +240,40 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
     !!valid(eslintVersion) &&
     gte(eslintVersion, '9.24.0');
 
-  const needsPostLintSuppressions =
-    normalizedOptions.suppressAll ||
-    (normalizedOptions.suppressRule &&
-      normalizedOptions.suppressRule.length > 0) ||
-    normalizedOptions.pruneSuppressions ||
-    supportsSuppressions;
+  let suppressionsFileExists = false;
+  let suppressionsFilePath: string | undefined;
 
-  if (needsPostLintSuppressions) {
-    const suppressionsFilePath = getSuppressionsFilePath(
+  if (hasUserSuppressionOptions || supportsSuppressions) {
+    suppressionsFilePath = getSuppressionsFilePath(
       normalizedOptions.suppressionsLocation,
       systemRoot
     );
-    const suppressionsFileExists = existsSync(suppressionsFilePath);
+    suppressionsFileExists = existsSync(suppressionsFilePath);
+  }
 
-    const shouldWrite =
-      !!normalizedOptions.suppressAll ||
-      (normalizedOptions.suppressRule &&
-        normalizedOptions.suppressRule.length > 0);
-    const shouldPrune = !!normalizedOptions.pruneSuppressions;
+  if (hasUserSuppressionOptions || suppressionsFileExists) {
+    const { results: suppressedResults, unusedSuppressions } =
+      await applySuppressions(lintResults, {
+        suppressAll: !!normalizedOptions.suppressAll,
+        suppressRule: normalizedOptions.suppressRule,
+        suppressionsLocation: normalizedOptions.suppressionsLocation,
+        pruneSuppressions: !!normalizedOptions.pruneSuppressions,
+        passOnUnprunedSuppressions:
+          !!normalizedOptions.passOnUnprunedSuppressions,
+        cwd: systemRoot,
+        isEslintV10,
+      });
+    lintResults = suppressedResults;
 
-    // Only process if we need to write/prune OR a suppressions file exists
-    if (shouldWrite || shouldPrune || suppressionsFileExists) {
-      const { results: suppressedResults, unusedSuppressions } =
-        await applySuppressions(lintResults, {
-          suppressAll: !!normalizedOptions.suppressAll,
-          suppressRule: normalizedOptions.suppressRule,
-          suppressionsLocation: normalizedOptions.suppressionsLocation,
-          pruneSuppressions: !!normalizedOptions.pruneSuppressions,
-          passOnUnprunedSuppressions:
-            !!normalizedOptions.passOnUnprunedSuppressions,
-          cwd: systemRoot,
-          isEslintV10,
-        });
-      lintResults = suppressedResults;
-
-      if (
-        Object.keys(unusedSuppressions).length > 0 &&
-        normalizedOptions.passOnUnprunedSuppressions &&
-        !normalizedOptions.force
-      ) {
-        return { success: false };
-      }
+    // When passOnUnprunedSuppressions is set, unused suppressions cause a failure
+    // unless force is also set (matching ESLint's --force behavior where force
+    // overrides strict failure modes).
+    if (
+      Object.keys(unusedSuppressions).length > 0 &&
+      normalizedOptions.passOnUnprunedSuppressions &&
+      !normalizedOptions.force
+    ) {
+      return { success: false };
     }
   }
 

--- a/packages/eslint/src/executors/lint/lint.impl.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.ts
@@ -56,13 +56,16 @@ export default async function run(
 
   // Validate mutually exclusive suppression options early, before any ESLint work.
   // This provides clear error messages instead of failing deep in the utility layer.
-  if (
-    normalizedOptions.suppressAll ||
-    (normalizedOptions.suppressRule &&
-      normalizedOptions.suppressRule.length > 0) ||
-    normalizedOptions.pruneSuppressions ||
-    normalizedOptions.passOnUnprunedSuppressions
-  ) {
+  const hasUserSuppressionOptions =
+    !!normalizedOptions.suppressAll ||
+    !!(
+      normalizedOptions.suppressRule &&
+      normalizedOptions.suppressRule.length > 0
+    ) ||
+    !!normalizedOptions.pruneSuppressions ||
+    !!normalizedOptions.passOnUnprunedSuppressions;
+
+  if (hasUserSuppressionOptions) {
     validateSuppressionOptions({
       suppressAll: !!normalizedOptions.suppressAll,
       suppressRule: normalizedOptions.suppressRule,
@@ -104,6 +107,16 @@ export default async function run(
   const installedEslintVersion = getInstalledPackageVersion('eslint');
   if (installedEslintVersion && major(installedEslintVersion) === 8) {
     warnEslintV8Deprecation();
+  }
+
+  if (hasUserSuppressionOptions) {
+    const eslintVersion = ESLint.version;
+    if (!eslintVersion || !gte(eslintVersion, '9.24.0')) {
+      throw new Error(
+        'Bulk suppression options (suppressAll, suppressRule, suppressionsLocation, pruneSuppressions) require ESLint v9.24.0 or higher. Current version: ' +
+          (eslintVersion || 'unknown')
+      );
+    }
   }
 
   if (printConfig) {
@@ -224,10 +237,12 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
   // - ESLint v10+: applySuppressions is set on the constructor, so lintFiles() already applied suppressions.
   //   We only need post-lint handling for writing (suppressAll/suppressRule) and pruning.
   // - ESLint v9.x: The programmatic API silently ignores suppression options, so we handle everything post-lint.
-  const hasUserSuppressionOptions =
+  const hasWriteOrPruneOptions =
     !!normalizedOptions.suppressAll ||
-    (normalizedOptions.suppressRule &&
-      normalizedOptions.suppressRule.length > 0) ||
+    !!(
+      normalizedOptions.suppressRule &&
+      normalizedOptions.suppressRule.length > 0
+    ) ||
     !!normalizedOptions.pruneSuppressions;
 
   // For v9.x, check if there's an existing suppressions file to apply.
@@ -243,7 +258,7 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
   let suppressionsFileExists = false;
   let suppressionsFilePath: string | undefined;
 
-  if (hasUserSuppressionOptions || supportsSuppressions) {
+  if (hasWriteOrPruneOptions || supportsSuppressions) {
     suppressionsFilePath = getSuppressionsFilePath(
       normalizedOptions.suppressionsLocation,
       systemRoot
@@ -251,7 +266,7 @@ Please see https://nx.dev/recipes/tips-n-tricks/eslint for full guidance on how 
     suppressionsFileExists = existsSync(suppressionsFilePath);
   }
 
-  if (hasUserSuppressionOptions || suppressionsFileExists) {
+  if (hasWriteOrPruneOptions || suppressionsFileExists) {
     const { results: suppressedResults, unusedSuppressions } =
       await applySuppressions(lintResults, {
         suppressAll: !!normalizedOptions.suppressAll,

--- a/packages/eslint/src/executors/lint/schema.d.ts
+++ b/packages/eslint/src/executors/lint/schema.d.ts
@@ -27,6 +27,8 @@ export interface Schema extends JsonObject {
   suppressAll?: boolean;
   suppressRule?: string[];
   suppressionsLocation?: string;
+  pruneSuppressions?: boolean;
+  passOnUnprunedSuppressions?: boolean;
 }
 
 type Formatter =

--- a/packages/eslint/src/executors/lint/schema.json
+++ b/packages/eslint/src/executors/lint/schema.json
@@ -170,7 +170,7 @@
     },
     "passOnUnprunedSuppressions": {
       "type": "boolean",
-      "description": "When set to true, causes the task to fail if there are unused suppression entries. This is equivalent to the `--pass-on-unpruned-suppressions` flag on the ESLint CLI. Requires ESLint v9.24.0 or higher.",
+      "description": "When set to true, causes the task to fail if there are unused suppression entries. Must be used together with pruneSuppressions. This is equivalent to the `--pass-on-unpruned-suppressions` flag on the ESLint CLI. Requires ESLint v9.24.0 or higher.",
       "default": false
     }
   },

--- a/packages/eslint/src/executors/lint/schema.json
+++ b/packages/eslint/src/executors/lint/schema.json
@@ -162,6 +162,16 @@
       "type": "string",
       "description": "Specify the location of the suppressions file. This is equivalent to the `--suppressions-location` flag on the ESLint CLI. Defaults to 'eslint-suppressions.json' in the project root. Requires ESLint v9.24.0 or higher.",
       "x-completion-type": "file"
+    },
+    "pruneSuppressions": {
+      "type": "boolean",
+      "description": "Remove unused suppression entries. This is equivalent to the `--prune-suppressions` flag on the ESLint CLI. Cannot be used together with suppressAll or suppressRule. Requires ESLint v9.24.0 or higher.",
+      "default": false
+    },
+    "passOnUnprunedSuppressions": {
+      "type": "boolean",
+      "description": "When set to true, causes the task to fail if there are unused suppression entries. This is equivalent to the `--pass-on-unpruned-suppressions` flag on the ESLint CLI. Requires ESLint v9.24.0 or higher.",
+      "default": false
     }
   },
   "examplesFile": "../../../docs/eslint-examples.md"

--- a/packages/eslint/src/executors/lint/utility/eslint-utils.spec.ts
+++ b/packages/eslint/src/executors/lint/utility/eslint-utils.spec.ts
@@ -7,8 +7,13 @@ jest.mock('eslint/use-at-your-own-risk', () => ({
 }));
 
 const { LegacyESLint } = require('eslint/use-at-your-own-risk');
-import { resolveAndInstantiateESLint } from './eslint-utils';
+import {
+  resolveAndInstantiateESLint,
+  getSuppressionsFilePath,
+  validateSuppressionOptions,
+} from './eslint-utils';
 import * as resolveEslintClassModule from '../../../utils/resolve-eslint-class';
+import type { SuppressionsContext } from './eslint-utils';
 
 describe('eslint-utils', () => {
   beforeEach(() => {
@@ -277,6 +282,106 @@ describe('eslint-utils', () => {
         ruleFilter: expect.any(Function),
       });
       expect(LegacyESLint).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validateSuppressionOptions', () => {
+    function createContext(
+      overrides: Partial<SuppressionsContext> = {}
+    ): SuppressionsContext {
+      return {
+        suppressAll: false,
+        suppressRule: undefined,
+        suppressionsLocation: undefined,
+        pruneSuppressions: false,
+        cwd: '/root',
+        ...overrides,
+      };
+    }
+
+    it('should not throw when no suppression options are set', () => {
+      expect(() => validateSuppressionOptions(createContext())).not.toThrow();
+    });
+
+    it('should not throw when only suppressAll is set', () => {
+      expect(() =>
+        validateSuppressionOptions(createContext({ suppressAll: true }))
+      ).not.toThrow();
+    });
+
+    it('should not throw when only suppressRule is set', () => {
+      expect(() =>
+        validateSuppressionOptions(
+          createContext({ suppressRule: ['no-console'] })
+        )
+      ).not.toThrow();
+    });
+
+    it('should not throw when only pruneSuppressions is set', () => {
+      expect(() =>
+        validateSuppressionOptions(createContext({ pruneSuppressions: true }))
+      ).not.toThrow();
+    });
+
+    it('should throw when suppressAll and suppressRule are used together', () => {
+      expect(() =>
+        validateSuppressionOptions(
+          createContext({
+            suppressAll: true,
+            suppressRule: ['no-console'],
+          })
+        )
+      ).toThrow(
+        'The suppressAll option and the suppressRule option cannot be used together.'
+      );
+    });
+
+    it('should throw when suppressAll and pruneSuppressions are used together', () => {
+      expect(() =>
+        validateSuppressionOptions(
+          createContext({
+            suppressAll: true,
+            pruneSuppressions: true,
+          })
+        )
+      ).toThrow(
+        'The suppressAll option and the pruneSuppressions option cannot be used together.'
+      );
+    });
+
+    it('should throw when suppressRule and pruneSuppressions are used together', () => {
+      expect(() =>
+        validateSuppressionOptions(
+          createContext({
+            suppressRule: ['no-console'],
+            pruneSuppressions: true,
+          })
+        )
+      ).toThrow(
+        'The suppressRule option and the pruneSuppressions option cannot be used together.'
+      );
+    });
+  });
+
+  describe('getSuppressionsFilePath', () => {
+    it('should return a resolved path ending with the provided custom location', () => {
+      const result = getSuppressionsFilePath(
+        'custom-suppressions.json',
+        '/project'
+      );
+      expect(result).toBe('/project/custom-suppressions.json');
+    });
+
+    it('should return a path ending with a fallback filename when no location is provided and SuppressionsService is unavailable', () => {
+      const result = getSuppressionsFilePath(undefined, '/project');
+      expect(result).toContain('/project/');
+      expect(result).toContain('eslint-suppressions.json');
+    });
+
+    it('should always return a string, never null', () => {
+      const result = getSuppressionsFilePath(undefined, '/project');
+      expect(typeof result).toBe('string');
+      expect(result.length).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/eslint/src/executors/lint/utility/eslint-utils.spec.ts
+++ b/packages/eslint/src/executors/lint/utility/eslint-utils.spec.ts
@@ -294,6 +294,7 @@ describe('eslint-utils', () => {
         suppressRule: undefined,
         suppressionsLocation: undefined,
         pruneSuppressions: false,
+        passOnUnprunedSuppressions: false,
         cwd: '/root',
         ...overrides,
       };
@@ -360,6 +361,30 @@ describe('eslint-utils', () => {
       ).toThrow(
         'The suppressRule option and the pruneSuppressions option cannot be used together.'
       );
+    });
+
+    it('should throw when passOnUnprunedSuppressions is true but pruneSuppressions is false', () => {
+      expect(() =>
+        validateSuppressionOptions(
+          createContext({
+            passOnUnprunedSuppressions: true,
+            pruneSuppressions: false,
+          })
+        )
+      ).toThrow(
+        'The passOnUnprunedSuppressions option requires pruneSuppressions to be enabled.'
+      );
+    });
+
+    it('should not throw when passOnUnprunedSuppressions and pruneSuppressions are both true', () => {
+      expect(() =>
+        validateSuppressionOptions(
+          createContext({
+            passOnUnprunedSuppressions: true,
+            pruneSuppressions: true,
+          })
+        )
+      ).not.toThrow();
     });
   });
 

--- a/packages/eslint/src/executors/lint/utility/eslint-utils.ts
+++ b/packages/eslint/src/executors/lint/utility/eslint-utils.ts
@@ -18,6 +18,18 @@ export interface SuppressionsResult {
   unusedSuppressions: Record<string, any>;
 }
 
+/**
+ * Resolve the ESLint class, validate version requirements for suppression features,
+ * and instantiate an ESLint instance with the appropriate options.
+ *
+ * Version handling:
+ * - ESLint v9.24.0+: supports suppressAll, suppressRule, suppressionsLocation via constructor.
+ *   However, the v9 programmatic API silently ignores these options, so suppression
+ *   application must be handled post-lint via SuppressionsService (see applySuppressions below).
+ * - ESLint v10.0.0+: supports applySuppressions via constructor, which causes lintFiles()
+ *   to automatically apply suppressions from the suppressions file during linting.
+ *   Writing new suppressions (suppressAll/suppressRule) and pruning still happen post-lint.
+ */
 export async function resolveAndInstantiateESLint(
   eslintConfigPath: string | undefined,
   options: Schema,
@@ -32,20 +44,27 @@ export async function resolveAndInstantiateESLint(
     useFlatConfigOverrideVal: useFlatConfig,
   });
 
+  // Validate version requirements early, before doing any other work.
+  // Fail early with a clear error message if the user is using suppression features
+  // with an ESLint version that doesn't support them.
   const hasSuppressionOptions =
     options.suppressAll ||
     (options.suppressRule && options.suppressRule.length > 0) ||
     options.suppressionsLocation ||
     options.pruneSuppressions;
 
-  if (hasSuppressionOptions && ESLint.version && !gte(ESLint.version, '9.24.0')) {
+  if (
+    hasSuppressionOptions &&
+    ESLint.version &&
+    !gte(ESLint.version, '9.24.0')
+  ) {
     throw new Error(
       'Bulk suppression options (suppressAll, suppressRule, suppressionsLocation, pruneSuppressions) require ESLint v9.24.0 or higher. Current version: ' +
         (ESLint.version || 'unknown')
     );
   }
 
-  const eslintVersion = ESLint.version;
+  const eslintVersion = ESLint?.version;
   const isEslintV10 = eslintVersion && gte(eslintVersion, '10.0.0');
 
   // Use the broader legacy options shape so the v8 (legacy-only) fields assigned
@@ -63,6 +82,16 @@ export async function resolveAndInstantiateESLint(
     cache: !!options.cache,
     cacheLocation: options.cacheLocation || undefined,
     cacheStrategy: options.cacheStrategy || undefined,
+    /**
+     * Default is `true` and if not overridden the eslint.lintFiles() method will throw an error
+     * when no target files are found.
+     *
+     * We don't want ESLint to throw an error if a user has only just created
+     * a project and therefore doesn't necessarily have matching files, for example.
+     *
+     * Also, the angular generator creates a lint pattern for `html` files, but there may
+     * not be any html files in the project, so keeping it true would break linting every time.
+     */
     errorOnUnmatchedPattern: false,
   };
 
@@ -92,17 +121,23 @@ export async function resolveAndInstantiateESLint(
     eslintOptions.resolvePluginsRelativeTo =
       options.resolvePluginsRelativeTo || undefined;
     eslintOptions.ignorePath = options.ignorePath || undefined;
+    /**
+     * If "noEslintrc" is set to `true` (and therefore here "useEslintrc" will be `false`), then ESLint will not
+     * merge the provided config with others it finds automatically.
+     */
     eslintOptions.useEslintrc = !options.noEslintrc;
     eslintOptions.reportUnusedDisableDirectives =
       options.reportUnusedDisableDirectives || undefined;
   }
 
+  // pass --quiet to ESLint 9+ directly: filter to only errors
   if (options.quiet && gte(ESLint.version, '9.0.0')) {
     eslintOptions.ruleFilter = (rule) => rule.severity === 2;
   }
 
-  // For ESLint v10+, pass applySuppressions so the programmatic API handles suppression.
-  // suppressAll/suppressRule (writing suppressions) remain post-lint for all versions.
+  // For ESLint v10+, pass applySuppressions so the programmatic API handles suppression
+  // automatically during lintFiles(). Writing new suppressions (suppressAll/suppressRule)
+  // and pruning remain post-lint operations for all versions.
   if (isEslintV10) {
     eslintOptions.applySuppressions = true;
     if (options.suppressionsLocation) {
@@ -122,61 +157,66 @@ export async function resolveAndInstantiateESLint(
   };
 }
 
+/**
+ * Resolve the path to the suppressions file.
+ *
+ * Tries to read the default filename from ESLint's SuppressionsService to stay
+ * in sync with ESLint's own default. Falls back to 'eslint-suppressions.json' if
+ * SuppressionsService cannot be resolved (e.g., ESLint < 9.24.0).
+ *
+ * NOTE: This reaches into ESLint internals (eslint/lib/services/suppressions-service).
+ * The internal path could change between ESLint versions without notice.
+ */
 export function getSuppressionsFilePath(
   suppressionsLocation: string | undefined,
   cwd: string
-): string | null {
+): string {
+  const path = require('path') as typeof import('path');
+
+  // If the user explicitly provided a location, use it directly
+  if (suppressionsLocation) {
+    return path.resolve(cwd, suppressionsLocation);
+  }
+
+  // Otherwise, try to read the default filename from ESLint's SuppressionsService
+  // to stay in sync with ESLint's own default.
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { SuppressionsService } = require('eslint/lib/services/suppressions-service') as {
-      SuppressionsService: { DEFAULT_SUPPRESSIONS_FILENAME: string };
-    };
+    const { SuppressionsService } =
+      require('eslint/lib/services/suppressions-service') as {
+        SuppressionsService: { DEFAULT_SUPPRESSIONS_FILENAME: string };
+      };
     const defaultName = SuppressionsService.DEFAULT_SUPPRESSIONS_FILENAME;
-    // Use the provided location or default filename
-    const location = suppressionsLocation || defaultName;
-    return require('path').resolve(cwd, location);
+    return path.resolve(cwd, defaultName);
   } catch {
-    return require('path').resolve(cwd, 'eslint-suppressions.json');
+    return path.resolve(cwd, 'eslint-suppressions.json');
   }
 }
 
+/**
+ * Apply bulk suppressions to lint results using ESLint's SuppressionsService.
+ *
+ * This is needed because:
+ * - ESLint v9.x: the programmatic API (new ESLint({ suppressAll: true })) silently
+ *   ignores suppression options. We must call SuppressionsService directly to
+ *   write suppressions, prune unused entries, and apply existing suppressions to results.
+ * - ESLint v10.x: lintFiles() applies suppressions automatically when `applySuppressions: true`
+ *   is passed to the constructor, but writing (suppressAll/suppressRule) and pruning still
+ *   need to be done post-lint via this function.
+ *
+ * NOTE: This uses ESLint's internal SuppressionsService API
+ * (eslint/lib/services/suppressions-service). The methods suppress(), prune(), load(),
+ * and applySuppressions() are not part of ESLint's public API and could change.
+ */
 export async function applySuppressions(
   results: ESLint.LintResult[],
   context: SuppressionsContext
 ): Promise<SuppressionsResult> {
   const path = await import('path');
 
-  // Mutually exclusive validation
-  if (context.suppressAll && context.suppressRule && context.suppressRule.length > 0) {
-    throw new Error('The suppressAll option and the suppressRule option cannot be used together.');
-  }
-  if (context.suppressAll && context.pruneSuppressions) {
-    throw new Error('The suppressAll option and the pruneSuppressions option cannot be used together.');
-  }
-  if (context.suppressRule && context.suppressRule.length > 0 && context.pruneSuppressions) {
-    throw new Error('The suppressRule option and the pruneSuppressions option cannot be used together.');
-  }
+  validateSuppressionOptions(context);
 
-  let SuppressionsService: any;
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    SuppressionsService = (require('eslint/lib/services/suppressions-service') as {
-      SuppressionsService: any;
-    }).SuppressionsService;
-  } catch {
-    // Fallback: try to resolve from the ESLint package location
-    try {
-      const eslintPath = require.resolve('eslint');
-      const eslintDir = path.dirname(eslintPath);
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      SuppressionsService = require(path.join(eslintDir, 'services', 'suppressions-service')).SuppressionsService;
-    } catch {
-      throw new Error(
-        'Could not resolve SuppressionsService from the installed ESLint package. ' +
-        'Ensure ESLint v9.24.0 or higher is installed.'
-      );
-    }
-  }
+  const SuppressionsService = resolveSuppressionsService(path);
 
   const suppressionsFilePath = getSuppressionsFilePath(
     context.suppressionsLocation,
@@ -228,4 +268,65 @@ export async function applySuppressions(
     results: suppressionResults.results,
     unusedSuppressions: suppressionResults.unused,
   };
+}
+
+/**
+ * Validate that mutually exclusive suppression options are not used together.
+ * These constraints mirror ESLint's CLI behavior.
+ */
+export function validateSuppressionOptions(context: SuppressionsContext): void {
+  if (
+    context.suppressAll &&
+    context.suppressRule &&
+    context.suppressRule.length > 0
+  ) {
+    throw new Error(
+      'The suppressAll option and the suppressRule option cannot be used together.'
+    );
+  }
+  if (context.suppressAll && context.pruneSuppressions) {
+    throw new Error(
+      'The suppressAll option and the pruneSuppressions option cannot be used together.'
+    );
+  }
+  if (
+    context.suppressRule &&
+    context.suppressRule.length > 0 &&
+    context.pruneSuppressions
+  ) {
+    throw new Error(
+      'The suppressRule option and the pruneSuppressions option cannot be used together.'
+    );
+  }
+}
+
+/**
+ * Resolve ESLint's internal SuppressionsService class.
+ *
+ * Tries the direct internal path first, then falls back to resolving from
+ * the ESLint package location. Throws a clear error if neither works.
+ */
+export function resolveSuppressionsService(path: typeof import('path')): any {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return (
+      require('eslint/lib/services/suppressions-service') as {
+        SuppressionsService: any;
+      }
+    ).SuppressionsService;
+  } catch {
+    // Fallback: try to resolve from the ESLint package location
+    try {
+      const eslintPath = require.resolve('eslint');
+      const eslintDir = path.dirname(eslintPath);
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      return require(path.join(eslintDir, 'services', 'suppressions-service'))
+        .SuppressionsService;
+    } catch {
+      throw new Error(
+        'Could not resolve SuppressionsService from the installed ESLint package. ' +
+          'Ensure ESLint v9.24.0 or higher is installed.'
+      );
+    }
+  }
 }

--- a/packages/eslint/src/executors/lint/utility/eslint-utils.ts
+++ b/packages/eslint/src/executors/lint/utility/eslint-utils.ts
@@ -243,11 +243,11 @@ export async function applySuppressions(
     await suppressions.prune(results);
   }
 
-  if (context.isEslintV10) {
+  const loaded = await suppressions.load();
+
+  if (context.isEslintV10 && !shouldWriteSuppressions) {
     // v10 already applied suppressions during lintFiles(), so we only need the
     // unused suppressions data for the passOnUnprunedSuppressions check.
-    // We discard suppressionResults.results and keep the original results.
-    const loaded = await suppressions.load();
     if (Object.keys(loaded).length > 0) {
       const { unused } = suppressions.applySuppressions(results, loaded);
       return { results, unusedSuppressions: unused };

--- a/packages/eslint/src/executors/lint/utility/eslint-utils.ts
+++ b/packages/eslint/src/executors/lint/utility/eslint-utils.ts
@@ -1,8 +1,22 @@
+import { existsSync } from 'fs';
 import type { ESLint } from 'eslint';
 import { gte } from 'semver';
 import { isFlatConfig } from '../../../utils/config-file';
 import { resolveESLintClass } from '../../../utils/resolve-eslint-class';
 import type { Schema } from '../schema';
+
+export interface SuppressionsContext {
+  suppressAll: boolean;
+  suppressRule: string[] | undefined;
+  suppressionsLocation: string | undefined;
+  pruneSuppressions: boolean;
+  cwd: string;
+}
+
+export interface SuppressionsResult {
+  results: ESLint.LintResult[];
+  unusedSuppressions: Record<string, any>;
+}
 
 export async function resolveAndInstantiateESLint(
   eslintConfigPath: string | undefined,
@@ -18,13 +32,28 @@ export async function resolveAndInstantiateESLint(
     useFlatConfigOverrideVal: useFlatConfig,
   });
 
+  const hasSuppressionOptions =
+    options.suppressAll ||
+    (options.suppressRule && options.suppressRule.length > 0) ||
+    options.suppressionsLocation ||
+    options.pruneSuppressions;
+
+  if (hasSuppressionOptions && ESLint.version && !gte(ESLint.version, '9.24.0')) {
+    throw new Error(
+      'Bulk suppression options (suppressAll, suppressRule, suppressionsLocation, pruneSuppressions) require ESLint v9.24.0 or higher. Current version: ' +
+        (ESLint.version || 'unknown')
+    );
+  }
+
+  const eslintVersion = ESLint.version;
+  const isEslintV10 = eslintVersion && gte(eslintVersion, '10.0.0');
+
   // Use the broader legacy options shape so the v8 (legacy-only) fields assigned
   // below type-check. Flat-only fields (ruleFilter, suppress*) are intersected
   // in; they're ignored at runtime by legacy ESLint and are version-gated below.
   const eslintOptions: ESLint.LegacyOptions & {
     ruleFilter?: Function;
-    suppressAll?: boolean;
-    suppressRule?: string[];
+    applySuppressions?: boolean;
     suppressionsLocation?: string;
   } = {
     overrideConfigFile: eslintConfigPath,
@@ -34,16 +63,6 @@ export async function resolveAndInstantiateESLint(
     cache: !!options.cache,
     cacheLocation: options.cacheLocation || undefined,
     cacheStrategy: options.cacheStrategy || undefined,
-    /**
-     * Default is `true` and if not overridden the eslint.lintFiles() method will throw an error
-     * when no target files are found.
-     *
-     * We don't want ESLint to throw an error if a user has only just created
-     * a project and therefore doesn't necessarily have matching files, for example.
-     *
-     * Also, the angular generator creates a lint pattern for `html` files, but there may
-     * not be any html files in the project, so keeping it true would break linting every time
-     */
     errorOnUnmatchedPattern: false,
   };
 
@@ -73,53 +92,21 @@ export async function resolveAndInstantiateESLint(
     eslintOptions.resolvePluginsRelativeTo =
       options.resolvePluginsRelativeTo || undefined;
     eslintOptions.ignorePath = options.ignorePath || undefined;
-    /**
-     * If "noEslintrc" is set to `true` (and therefore here "useEslintrc" will be `false`), then ESLint will not
-     * merge the provided config with others it finds automatically.
-     */
     eslintOptions.useEslintrc = !options.noEslintrc;
     eslintOptions.reportUnusedDisableDirectives =
       options.reportUnusedDisableDirectives || undefined;
   }
 
-  // pass --quiet to eslint 9+ directly: filter only errors
   if (options.quiet && gte(ESLint.version, '9.0.0')) {
     eslintOptions.ruleFilter = (rule) => rule.severity === 2;
   }
 
-  // Handle bulk suppression options (ESLint v9.24.0+)
-  try {
-    if (ESLint.version && gte(ESLint.version, '9.24.0')) {
-      if (options.suppressAll) {
-        eslintOptions.suppressAll = true;
-      }
-      if (options.suppressRule && options.suppressRule.length > 0) {
-        eslintOptions.suppressRule = options.suppressRule;
-      }
-      if (options.suppressionsLocation) {
-        eslintOptions.suppressionsLocation = options.suppressionsLocation;
-      }
-    } else if (
-      options.suppressAll ||
-      (options.suppressRule && options.suppressRule.length > 0) ||
-      options.suppressionsLocation
-    ) {
-      throw new Error(
-        'Bulk suppression options (suppressAll, suppressRule, suppressionsLocation) require ESLint v9.24.0 or higher. Current version: ' +
-          (ESLint.version || 'unknown')
-      );
-    }
-  } catch (error) {
-    // If version checking fails (e.g., in tests), skip suppression options
-    if (
-      options.suppressAll ||
-      (options.suppressRule && options.suppressRule.length > 0) ||
-      options.suppressionsLocation
-    ) {
-      // In test environment, just skip the suppression options
-      console.warn(
-        'Bulk suppression options skipped due to version check failure'
-      );
+  // For ESLint v10+, pass applySuppressions so the programmatic API handles suppression.
+  // suppressAll/suppressRule (writing suppressions) remain post-lint for all versions.
+  if (isEslintV10) {
+    eslintOptions.applySuppressions = true;
+    if (options.suppressionsLocation) {
+      eslintOptions.suppressionsLocation = options.suppressionsLocation;
     }
   }
 
@@ -131,5 +118,114 @@ export async function resolveAndInstantiateESLint(
   return {
     ESLint,
     eslint,
+    isEslintV10: !!isEslintV10,
+  };
+}
+
+export function getSuppressionsFilePath(
+  suppressionsLocation: string | undefined,
+  cwd: string
+): string | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { SuppressionsService } = require('eslint/lib/services/suppressions-service') as {
+      SuppressionsService: { DEFAULT_SUPPRESSIONS_FILENAME: string };
+    };
+    const defaultName = SuppressionsService.DEFAULT_SUPPRESSIONS_FILENAME;
+    // Use the provided location or default filename
+    const location = suppressionsLocation || defaultName;
+    return require('path').resolve(cwd, location);
+  } catch {
+    return require('path').resolve(cwd, 'eslint-suppressions.json');
+  }
+}
+
+export async function applySuppressions(
+  results: ESLint.LintResult[],
+  context: SuppressionsContext
+): Promise<SuppressionsResult> {
+  const path = await import('path');
+
+  // Mutually exclusive validation
+  if (context.suppressAll && context.suppressRule && context.suppressRule.length > 0) {
+    throw new Error('The suppressAll option and the suppressRule option cannot be used together.');
+  }
+  if (context.suppressAll && context.pruneSuppressions) {
+    throw new Error('The suppressAll option and the pruneSuppressions option cannot be used together.');
+  }
+  if (context.suppressRule && context.suppressRule.length > 0 && context.pruneSuppressions) {
+    throw new Error('The suppressRule option and the pruneSuppressions option cannot be used together.');
+  }
+
+  let SuppressionsService: any;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    SuppressionsService = (require('eslint/lib/services/suppressions-service') as {
+      SuppressionsService: any;
+    }).SuppressionsService;
+  } catch {
+    // Fallback: try to resolve from the ESLint package location
+    try {
+      const eslintPath = require.resolve('eslint');
+      const eslintDir = path.dirname(eslintPath);
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      SuppressionsService = require(path.join(eslintDir, 'services', 'suppressions-service')).SuppressionsService;
+    } catch {
+      throw new Error(
+        'Could not resolve SuppressionsService from the installed ESLint package. ' +
+        'Ensure ESLint v9.24.0 or higher is installed.'
+      );
+    }
+  }
+
+  const suppressionsFilePath = getSuppressionsFilePath(
+    context.suppressionsLocation,
+    context.cwd
+  );
+
+  if (
+    context.suppressionsLocation &&
+    !existsSync(suppressionsFilePath) &&
+    !context.suppressAll &&
+    !(context.suppressRule && context.suppressRule.length > 0)
+  ) {
+    throw new Error(
+      'The suppressions file does not exist. Please run the command with `suppressAll` or `suppressRule` to create it.'
+    );
+  }
+
+  const shouldWriteSuppressions =
+    context.suppressAll ||
+    (context.suppressRule && context.suppressRule.length > 0);
+
+  const shouldPrune = context.pruneSuppressions;
+
+  const hasSuppressionsFile = existsSync(suppressionsFilePath);
+
+  if (!shouldWriteSuppressions && !shouldPrune && !hasSuppressionsFile) {
+    return { results, unusedSuppressions: {} };
+  }
+
+  const suppressions = new SuppressionsService({
+    filePath: suppressionsFilePath,
+    cwd: context.cwd,
+  });
+
+  if (shouldWriteSuppressions) {
+    await suppressions.suppress(results, context.suppressRule);
+  }
+
+  if (shouldPrune) {
+    await suppressions.prune(results);
+  }
+
+  const suppressionResults = suppressions.applySuppressions(
+    results,
+    await suppressions.load()
+  );
+
+  return {
+    results: suppressionResults.results,
+    unusedSuppressions: suppressionResults.unused,
   };
 }

--- a/packages/eslint/src/executors/lint/utility/eslint-utils.ts
+++ b/packages/eslint/src/executors/lint/utility/eslint-utils.ts
@@ -252,7 +252,11 @@ export async function applySuppressions(
   });
 
   if (shouldWriteSuppressions) {
-    await suppressions.suppress(results, context.suppressRule);
+    const rulesToSuppress =
+      context.suppressRule && context.suppressRule.length > 0
+        ? context.suppressRule
+        : undefined;
+    await suppressions.suppress(results, rulesToSuppress);
   }
 
   if (shouldPrune) {

--- a/packages/eslint/src/executors/lint/utility/eslint-utils.ts
+++ b/packages/eslint/src/executors/lint/utility/eslint-utils.ts
@@ -255,10 +255,7 @@ export async function applySuppressions(
     return { results, unusedSuppressions: {} };
   }
 
-  const suppressionResults = suppressions.applySuppressions(
-    results,
-    await suppressions.load()
-  );
+  const suppressionResults = suppressions.applySuppressions(results, loaded);
 
   return {
     results: suppressionResults.results,

--- a/packages/eslint/src/executors/lint/utility/eslint-utils.ts
+++ b/packages/eslint/src/executors/lint/utility/eslint-utils.ts
@@ -10,7 +10,9 @@ export interface SuppressionsContext {
   suppressRule: string[] | undefined;
   suppressionsLocation: string | undefined;
   pruneSuppressions: boolean;
+  passOnUnprunedSuppressions: boolean;
   cwd: string;
+  isEslintV10?: boolean;
 }
 
 export interface SuppressionsResult {
@@ -214,8 +216,6 @@ export async function applySuppressions(
 ): Promise<SuppressionsResult> {
   const path = await import('path');
 
-  validateSuppressionOptions(context);
-
   const SuppressionsService = resolveSuppressionsService(path);
 
   const suppressionsFilePath = getSuppressionsFilePath(
@@ -263,6 +263,18 @@ export async function applySuppressions(
     await suppressions.prune(results);
   }
 
+  if (context.isEslintV10) {
+    // v10 already applied suppressions during lintFiles(), so we only need the
+    // unused suppressions data for the passOnUnprunedSuppressions check.
+    // We discard suppressionResults.results and keep the original results.
+    const loaded = await suppressions.load();
+    if (Object.keys(loaded).length > 0) {
+      const { unused } = suppressions.applySuppressions(results, loaded);
+      return { results, unusedSuppressions: unused };
+    }
+    return { results, unusedSuppressions: {} };
+  }
+
   const suppressionResults = suppressions.applySuppressions(
     results,
     await suppressions.load()
@@ -300,6 +312,11 @@ export function validateSuppressionOptions(context: SuppressionsContext): void {
   ) {
     throw new Error(
       'The suppressRule option and the pruneSuppressions option cannot be used together.'
+    );
+  }
+  if (context.passOnUnprunedSuppressions && !context.pruneSuppressions) {
+    throw new Error(
+      'The passOnUnprunedSuppressions option requires pruneSuppressions to be enabled.'
     );
   }
 }

--- a/packages/eslint/src/executors/lint/utility/eslint-utils.ts
+++ b/packages/eslint/src/executors/lint/utility/eslint-utils.ts
@@ -46,26 +46,6 @@ export async function resolveAndInstantiateESLint(
     useFlatConfigOverrideVal: useFlatConfig,
   });
 
-  // Validate version requirements early, before doing any other work.
-  // Fail early with a clear error message if the user is using suppression features
-  // with an ESLint version that doesn't support them.
-  const hasSuppressionOptions =
-    options.suppressAll ||
-    (options.suppressRule && options.suppressRule.length > 0) ||
-    options.suppressionsLocation ||
-    options.pruneSuppressions;
-
-  if (
-    hasSuppressionOptions &&
-    ESLint.version &&
-    !gte(ESLint.version, '9.24.0')
-  ) {
-    throw new Error(
-      'Bulk suppression options (suppressAll, suppressRule, suppressionsLocation, pruneSuppressions) require ESLint v9.24.0 or higher. Current version: ' +
-        (ESLint.version || 'unknown')
-    );
-  }
-
   const eslintVersion = ESLint?.version;
   const isEslintV10 = eslintVersion && gte(eslintVersion, '10.0.0');
 


### PR DESCRIPTION
## Summary

Fixes #35284

The `@nx/eslint:lint` executor accepts `suppressAll`, `suppressRule`, and `suppressionsLocation` options but they have no effect at runtime because ESLint's programmatic API silently ignores them.

## Changes

### `eslint-utils.ts`
- For ESLint v10+: Set `applySuppressions: true` on the ESLint constructor, enabling programmatic suppression support
- Add `applySuppressions()` helper that integrates `SuppressionsService` post-lint (for writing, pruning, and applying suppressions)
- Add `getSuppressionsFilePath()` helper for resolving the suppressions file path
- Return `isEslintV10` flag from `resolveAndInstantiateESLint()`
- **Extract `validateSuppressionOptions()`** and **`resolveSuppressionsService()`** into named functions for testability and reuse
- **Restore deleted JSDoc comments**: `errorOnUnmatchedPattern`, `noEslintrc`/`useEslintrc`, quiet filter, and type cleanup comments — these explain *why* the code exists and prevent future regressions
- **Fix `ESLint?.version` null access crash** when the ESLint class cannot be resolved (e.g., in certain test environments)
- **Fix `getSuppressionsFilePath` bug**: custom `suppressionsLocation` was silently ignored when `SuppressionsService` couldn't be required, falling back to the default filename instead
- **Fix `getSuppressionsFilePath` return type**: changed from `string | null` to `string` (it never actually returned null)
- **Fix `suppress()` empty array bug**: `SuppressionsService.suppress(results, [])` suppresses nothing; normalize empty `suppressRule` to `undefined` when `suppressAll` is true
- **Add JSDoc architectural comments** on `resolveAndInstantiateESLint`, `getSuppressionsFilePath`, and `applySuppressions` explaining the v9/v10 suppression handling split and why ESLint internals are used

### `lint.impl.ts`
- Add post-lint suppression handling after `eslint.lintFiles()`:
  - **ESLint v9.x**: Always apply suppressions from the file if it exists (since v9's programmatic API doesn't support it)
  - **All versions**: Handle `suppressAll`/`suppressRule` (writing) and `pruneSuppressions` (pruning) post-lint
  - Support `passOnUnprunedSuppressions` to fail on unused suppressions
- **Add early validation** of mutually exclusive suppression options before any ESLint work, providing clear error messages at the executor level instead of deep in the utility layer
- **Guard post-lint suppressions behind ESLint >=9.24.0 check** (review feedback: `!isEslintV10` was true for v8 too, which would crash)

### `schema.json` / `schema.d.ts`
- Add `pruneSuppressions` option (equivalent to `--prune-suppressions` CLI flag)
- Add `passOnUnprunedSuppressions` option (equivalent to `--pass-on-unpruned-suppressions` CLI flag)

### Tests
- Update existing test mocks to include new schema fields and exports
- Add 7 new tests in `lint.impl.spec.ts` covering suppression behavior for v9.x and v10
- Add 8 new unit tests in `eslint-utils.spec.ts`:
  - `validateSuppressionOptions`: 5 tests for all mutual exclusivity combinations
  - `getSuppressionsFilePath`: 3 tests for custom location, fallback, and null-safety

## Version handling design

The suppression handling differs between ESLint versions:

- **ESLint v9.24.0+**: The programmatic API (`new ESLint({ suppressAll: true })`) silently ignores suppression options. We must call `SuppressionsService` directly post-lint to write suppressions, prune unused entries, and apply existing suppressions to results.
- **ESLint v10.0.0+**: Supports `applySuppressions: true` on the constructor, which causes `lintFiles()` to automatically apply suppressions during linting. Writing (suppressAll/suppressRule) and pruning still happen post-lint.

**Note**: Both paths use ESLint's internal `SuppressionsService` (`eslint/lib/services/suppressions-service`). The methods `suppress()`, `prune()`, `load()`, and `applySuppressions()` are not part of ESLint's public API and could change between versions.

## Manual Test Results

Tested with ESLint v9.39.4 and v10.3.0:

| # | Scenario | v9 (9.39.4) | v10 (10.3.0) |
|---|----------|-------------|--------------|
| 1 | Baseline lint (1 error) | PASS | PASS |
| 2 | `suppressAll` creates file, exits 0 | PASS | PASS |
| 3 | Re-run with existing suppressions (auto-apply) | PASS | PASS |
| 5 | `suppressRule` for specific rule | PASS | PASS |
| 6 | Custom `suppressionsLocation` | PASS | PASS |
| 7 | `pruneSuppressions` removes stale entries | PASS | PASS |
| 8 | `passOnUnprunedSuppressions` fails on unused | PASS | PASS |
| 9 | `suppressAll` + `suppressRule` mutual exclusivity error | PASS | PASS |
| 10 | `suppressAll` + `pruneSuppressions` mutual exclusivity error | PASS | PASS |
| 11 | `suppressRule` + `pruneSuppressions` mutual exclusivity error | PASS | PASS |

### Bug found during testing

`SuppressionsService.suppress(results, [])` with an empty `suppressRule` array suppresses nothing — it must be `undefined` for "suppress all". Fixed by normalizing empty arrays to `undefined`.

---

*This PR description was generated and updated with the assistance of AI (GLM-5.1 via z.ai Coding Plan).*