### PR TITLE
fix(js): resolve build output dir from globbed outputs in node executor

### DIFF
--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -453,7 +453,13 @@ function getFileToRun(
         projectRoot: project.data.root,
         workspaceRoot: context.root,
       });
-      return path.join(outputFilePath, 'main.js');
+      // `outputs` are cache patterns and may contain globs (e.g. the inferred
+      // `@nx/js/typescript` build target scopes its output to
+      // `{projectRoot}/dist/**/*.{js,...}` to avoid caching non-tsc files).
+      // Strip the glob portion back to the last path separator before it to
+      // recover the base output directory.
+      const outputDir = stripGlobToBaseDir(outputFilePath);
+      return path.join(outputDir, 'main.js');
     }
     const fallbackFile = path.join('dist', project.data.root, 'main.js');
 
@@ -483,6 +489,16 @@ function getFileToRun(
   }
 
   return join(context.root, buildOptions.outputPath, outputFileName);
+}
+
+function stripGlobToBaseDir(pathWithGlob: string): string {
+  const globIdx = pathWithGlob.search(/[*?[{(]/);
+  if (globIdx === -1) {
+    return pathWithGlob.replace(/[\\/]+$/, '');
+  }
+  const prefix = pathWithGlob.slice(0, globIdx);
+  const lastSep = Math.max(prefix.lastIndexOf('/'), prefix.lastIndexOf('\\'));
+  return lastSep === -1 ? '' : prefix.slice(0, lastSep);
 }
 
 function fileToRunCorrectPath(fileToRun: string): string {

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -405,7 +405,11 @@ function calculateResolveMappings(
   );
   return dependencies.reduce((m, c) => {
     if (c.node.type !== 'npm' && c.outputs[0] != null) {
-      m[c.name] = joinPathFragments(context.root, c.outputs[0]);
+      // `outputs` are cache patterns and may contain globs (e.g. from the
+      // inferred `@nx/js/typescript` build target). Strip the glob portion
+      // so the runtime require overrides resolve to the actual output dir.
+      const outputDir = stripGlobToBaseDir(c.outputs[0]);
+      m[c.name] = joinPathFragments(context.root, outputDir);
     }
     return m;
   }, {});


### PR DESCRIPTION
## Current Behavior

The `@nx/js:node` executor fails when combined with the inferred `@nx/js/typescript` build target — in two distinct ways:

1. **Script-to-run resolution**: fails with `Could not find <project>/dist/**/*.{js,cjs,mjs,jsx,d.ts,d.cts,d.mts}{,.map}/main.js. Make sure your build succeeded.` — the executor's `getFileToRun` was appending `main.js` onto the glob output pattern.
2. **Buildable-dep import resolution**: when the node app imports a buildable lib that also uses the inferred build target, `require('@scope/my-lib')` throws `MODULE_NOT_FOUND` because `calculateResolveMappings` passes the literal glob into `NX_MAPPINGS`, which the CJS require override / ESM loader then tries to resolve.

Both regressed after #35041 narrowed the inferred build target's `outputs[0]` from `{projectRoot}/dist` to `{projectRoot}/dist/**/*.{js,...}{,.map}` (to prevent cross-OS cache pollution).

## Expected Behavior

`outputs` entries are cache patterns and may legitimately contain globs. The node executor now strips the glob portion back to the last path separator before using the value as a directory, in both `getFileToRun` and `calculateResolveMappings`. Handles `**`, `*`, `?`, character classes, brace expansion, extglob, and Windows/POSIX separators.

## Related Issue(s)

Fixes #35198
Fixes #35301