### PR TITLE
fix(angular): fall back to addUndefinedDefaults when addUndefinedObjectDefaults is unavailable

### DIFF
--- a/packages/nx/src/adapter/ngcli-adapter.ts
+++ b/packages/nx/src/adapter/ngcli-adapter.ts
@@ -87,6 +87,16 @@ function getProjectGraph(): Promise<ProjectGraph> {
   }
 }
 
+function getUndefinedDefaultsTransform(isAngularBuild: boolean) {
+  // `addUndefinedObjectDefaults` was introduced in @angular-devkit/core v20.
+  // `@nx/angular` supports Angular >=19, so fall back to `addUndefinedDefaults`
+  // when the object-specific transform is unavailable.
+  if (isAngularBuild && schema.transforms.addUndefinedObjectDefaults) {
+    return schema.transforms.addUndefinedObjectDefaults;
+  }
+  return schema.transforms.addUndefinedDefaults;
+}
+
 export async function createBuilderContext(
   builderInfo: {
     builderName: string;
@@ -119,11 +129,7 @@ export async function createBuilderContext(
     ['@nx/angular:application', '@nx/angular:unit-test'].includes(
       builderInfo.builderName
     );
-  if (isAngularBuild) {
-    registry.addPostTransform(schema.transforms.addUndefinedObjectDefaults);
-  } else {
-    registry.addPostTransform(schema.transforms.addUndefinedDefaults);
-  }
+  registry.addPostTransform(getUndefinedDefaultsTransform(isAngularBuild));
   registry.addSmartDefaultProvider('unparsed', () => {
     // This happens when context.scheduleTarget is used to run a target using nx:run-commands
     return [];
@@ -265,11 +271,7 @@ export async function scheduleTarget(
     ['@nx/angular:application', '@nx/angular:unit-test'].includes(builderName);
 
   const registry = new schema.CoreSchemaRegistry();
-  if (isAngularBuild) {
-    registry.addPostTransform(schema.transforms.addUndefinedObjectDefaults);
-  } else {
-    registry.addPostTransform(schema.transforms.addUndefinedDefaults);
-  }
+  registry.addPostTransform(getUndefinedDefaultsTransform(isAngularBuild));
   registry.addSmartDefaultProvider('unparsed', () => {
     // This happens when context.scheduleTarget is used to run a target using nx:run-commands
     return [];


### PR DESCRIPTION
## Current Behavior

Running a build with `@angular/build:application` on Angular 19 crashes with:

```
NX   visitor is not a function

TypeError: visitor is not a function
    at _visitJsonRecursive (.../@angular-devkit/core/src/json/schema/visitor.js:48:19)
```

`schema.transforms.addUndefinedObjectDefaults` was added in `@angular-devkit/core` v20, but `@nx/angular` still supports Angular 19. On v19 the transform is `undefined`, so `registry.addPostTransform(undefined)` registers a non-callable visitor that later throws.

## Expected Behavior

Nx runs Angular application builders across all supported Angular versions (19–21) without crashing.

## Related Issue(s)

Fixes #35267