### PR TITLE
fix(js): resolve project tsconfig for inferred tsc run-commands targets in dependency-checks

### DIFF
--- a/packages/js/src/utils/find-npm-dependencies.spec.ts
+++ b/packages/js/src/utils/find-npm-dependencies.spec.ts
@@ -235,6 +235,60 @@ describe('findNpmDependencies', () => {
     }
   );
 
+  it.each`
+    rootImportHelpers | projectImportHelpers | expected
+    ${false}          | ${true}              | ${{ tslib: '2.6.0' }}
+    ${true}           | ${false}             | ${{}}
+  `(
+    'should resolve importHelpers from project tsconfig (root=$rootImportHelpers, project=$projectImportHelpers) for run-commands',
+    ({ rootImportHelpers, projectImportHelpers, expected }) => {
+      vol.fromJSON(
+        {
+          './tsconfig.base.json': JSON.stringify({
+            compilerOptions: { importHelpers: rootImportHelpers },
+          }),
+          './nx.json': JSON.stringify(nxJson),
+          './libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            compilerOptions: { importHelpers: projectImportHelpers },
+          }),
+        },
+        '/root'
+      );
+      const lib = {
+        name: 'my-lib',
+        type: 'lib' as const,
+        data: {
+          root: 'libs/my-lib',
+          targets: {
+            build: {
+              executor: 'nx:run-commands',
+              options: {
+                command: 'tsc --build tsconfig.lib.json',
+                cwd: 'libs/my-lib',
+              },
+            },
+          },
+        },
+      };
+      const projectGraph = {
+        nodes: { 'my-lib': lib },
+        externalNodes: {
+          'npm:tslib': {
+            name: 'npm:tslib' as const,
+            type: 'npm' as const,
+            data: { packageName: 'tslib', version: '2.6.0' },
+          },
+        },
+        dependencies: {},
+      };
+      const projectFileMap = { 'my-lib': [] };
+
+      expect(
+        findNpmDependencies('/root', lib, projectGraph, projectFileMap, 'build')
+      ).toEqual(expected);
+    }
+  );
+
   it('should handle missing ts/swc helper packages from externalNodes', () => {
     vol.fromJSON(
       {

--- a/packages/js/src/utils/find-npm-dependencies.ts
+++ b/packages/js/src/utils/find-npm-dependencies.ts
@@ -1,4 +1,4 @@
-import { join, relative } from 'path';
+import { isAbsolute, join, relative } from 'path';
 import { readNxJson } from 'nx/src/config/configuration';
 import {
   joinPathFragments,
@@ -10,7 +10,7 @@ import {
 } from '@nx/devkit';
 import { fileExists } from 'nx/src/utils/fileutils';
 import { fileDataDepTarget } from 'nx/src/config/project-graph';
-import { getRootTsConfigFileName, readTsConfig } from './typescript/ts-config';
+import { getRootTsConfigPath, readTsConfig } from './typescript/ts-config';
 import {
   filterUsingGlobPatterns,
   getTargetInputs,
@@ -246,9 +246,13 @@ function collectHelperDependencies(
     target.executor === 'nx:run-commands' &&
     /\b(tsc|tsgo)\b/.test(target.options.command)
   ) {
-    const tsConfigFileName = getRootTsConfigFileName();
-    if (tsConfigFileName) {
-      const tsConfig = readTsConfig(join(workspaceRoot, tsConfigFileName));
+    const tsConfigPath = resolveTsConfigForRunCommandsTarget(
+      workspaceRoot,
+      sourceProject,
+      target.options
+    );
+    if (tsConfigPath) {
+      const tsConfig = readTsConfig(tsConfigPath);
       if (
         tsConfig?.options['importHelpers'] &&
         projectGraph.externalNodes['npm:tslib']?.type === 'npm'
@@ -257,4 +261,31 @@ function collectHelperDependencies(
       }
     }
   }
+}
+
+function resolveTsConfigForRunCommandsTarget(
+  workspaceRoot: string,
+  sourceProject: ProjectGraphProjectNode,
+  targetOptions: { command: string; cwd?: string }
+): string | null {
+  const commandTsConfig = extractTsConfigFromCommand(targetOptions.command);
+  if (commandTsConfig) {
+    const cwd = targetOptions.cwd ?? sourceProject.data.root;
+    const cwdAbsolute = isAbsolute(cwd) ? cwd : join(workspaceRoot, cwd);
+    const resolved = isAbsolute(commandTsConfig)
+      ? commandTsConfig
+      : join(cwdAbsolute, commandTsConfig);
+    if (fileExists(resolved)) return resolved;
+  }
+
+  // Preserves prior behavior when the tsconfig can't be determined from the command.
+  return getRootTsConfigPath();
+}
+
+// Matches the `<compiler> --build <configName>` shape emitted by the
+// `@nx/js/typescript` plugin. Other shapes fall through to the workspace root
+// tsconfig in the caller.
+function extractTsConfigFromCommand(command: string): string | null {
+  const match = command.match(/(?:^|\s)--build\s+([^\s-]\S*)/);
+  return match ? match[1] : null;
 }


### PR DESCRIPTION
## Current Behavior

The `@nx/dependency-checks` ESLint rule reads `importHelpers` from the **workspace root** tsconfig when deciding whether `tslib` should be a required dependency for targets with executor `nx:run-commands` that invoke `tsc`/`tsgo` — which is what the `@nx/js/typescript` inferred plugin emits (`tsc --build tsconfig.lib.json`). The project's own tsconfig is ignored.

This produces incorrect results:

- Project sets `importHelpers: true` in `tsconfig.lib.json`, root doesn't → rule doesn't require `tslib`, but `tsc` uses it (false negative).
- Root sets `importHelpers: true`, project overrides to `false` → rule requires `tslib` for every project using the inferred plugin (false positive).

The `@nx/js:tsc` executor branch already resolves `target.options.tsConfig` correctly; the `nx:run-commands` branch is the outlier.

## Expected Behavior

For `nx:run-commands` targets matching the inferred plugin's emit (`<compiler> --build <configName> [--verbose]`), the rule resolves the tsconfig from the command (relative to `target.options.cwd`) and reads `importHelpers` from that file. TypeScript's `parseJsonConfigFileContent` continues to resolve `extends`, so inheritance from a base tsconfig still applies.

For commands whose tsconfig can't be determined (arbitrary hand-written shapes), behavior falls back to the prior workspace-root tsconfig lookup — no regression.

## Related Issue(s)

Fixes #35277