### PR TITLE
fix(core): preserve FORCE_COLOR=0 intent for forked child tasks

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -537,7 +537,8 @@
             "NX_PREFIX_OUTPUT",
             "NX_INFER_ALL_PACKAGE_JSONS",
             "NX_AI_FILES_USE_LOCAL",
-            "NX_WINDOWS_PTY_SUPPORT"
+            "NX_WINDOWS_PTY_SUPPORT",
+            "NX_ORIGINAL_FORCE_COLOR"
           ]
         }
       }

--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -4,6 +4,7 @@
 // See: https://github.com/alexeyraspopov/picocolors/issues/100
 
 if (process.env.FORCE_COLOR === '0') {
+  process.env.NX_ORIGINAL_FORCE_COLOR = '0';
   process.env.NO_COLOR = '1';
   delete process.env.FORCE_COLOR;
 }

--- a/packages/nx/src/tasks-runner/task-env.spec.ts
+++ b/packages/nx/src/tasks-runner/task-env.spec.ts
@@ -6,6 +6,7 @@ import { Task } from '../config/task-graph';
 import {
   getEnvFilesForTask,
   getEnvVariablesForTask,
+  getForceColorForChild,
   loadAndExpandDotEnvFile,
 } from './task-env';
 
@@ -269,5 +270,37 @@ describe('getEnvFilesForTask', () => {
     } as any as ProjectGraph;
     const envFiles = getEnvFilesForTask(task, graph);
     expect(envFiles).toMatchSnapshot();
+  });
+});
+
+describe('getForceColorForChild', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('should return FORCE_COLOR when it is explicitly set', () => {
+    process.env.FORCE_COLOR = '1';
+    delete process.env.NX_ORIGINAL_FORCE_COLOR;
+    expect(getForceColorForChild()).toBe('1');
+  });
+
+  it('should return "0" when NX_ORIGINAL_FORCE_COLOR is "0" and FORCE_COLOR was deleted', () => {
+    delete process.env.FORCE_COLOR;
+    process.env.NX_ORIGINAL_FORCE_COLOR = '0';
+    expect(getForceColorForChild()).toBe('0');
+  });
+
+  it('should default to "true" when neither FORCE_COLOR nor NX_ORIGINAL_FORCE_COLOR is set', () => {
+    delete process.env.FORCE_COLOR;
+    delete process.env.NX_ORIGINAL_FORCE_COLOR;
+    expect(getForceColorForChild()).toBe('true');
+  });
+
+  it('should prefer FORCE_COLOR over NX_ORIGINAL_FORCE_COLOR when both are set', () => {
+    process.env.FORCE_COLOR = '3';
+    process.env.NX_ORIGINAL_FORCE_COLOR = '0';
+    expect(getForceColorForChild()).toBe('3');
   });
 });

--- a/packages/nx/src/tasks-runner/task-env.ts
+++ b/packages/nx/src/tasks-runner/task-env.ts
@@ -6,20 +6,41 @@ import { Task } from '../config/task-graph';
 import { workspaceRoot } from '../utils/workspace-root';
 import { getEnvPathsForTask } from './task-env-paths';
 
+/**
+ * Resolves the FORCE_COLOR value for forked child processes.
+ *
+ * When the user sets FORCE_COLOR=0, bin/nx.ts deletes it from process.env
+ * (workaround for picocolors treating "0" as truthy) and saves the original
+ * value in NX_ORIGINAL_FORCE_COLOR. Without this check, the undefined
+ * FORCE_COLOR would default to 'true', re-enabling colors in all children.
+ */
+export function getForceColorForChild(): string {
+  if (process.env.FORCE_COLOR !== undefined) {
+    return process.env.FORCE_COLOR;
+  }
+  if (process.env.NX_ORIGINAL_FORCE_COLOR === '0') {
+    return '0';
+  }
+  return 'true';
+}
+
 export function getEnvVariablesForBatchProcess(
   skipNxCache: boolean,
   captureStderr: boolean
 ): NodeJS.ProcessEnv {
-  return {
+  const res = {
     // User Process Env Variables override Dotenv Variables
     ...process.env,
     // Nx Env Variables overrides everything
     ...getNxEnvVariablesForForkedProcess(
-      process.env.FORCE_COLOR === undefined ? 'true' : process.env.FORCE_COLOR,
+      getForceColorForChild(),
       skipNxCache,
       captureStderr
     ),
   };
+  // NX_ORIGINAL_FORCE_COLOR is an internal signal and should not leak into child processes
+  delete res.NX_ORIGINAL_FORCE_COLOR;
+  return res;
 }
 
 // The orchestrator now calls this eagerly during the coordinator pre-hash
@@ -80,6 +101,9 @@ export function getEnvVariablesForTask(
   }
   // we don't reset NX_BASE or NX_HEAD because those are set by the user and should be preserved
   delete res.NX_SET_CLI;
+  // NX_ORIGINAL_FORCE_COLOR is an internal signal used by getForceColorForChild()
+  // and should not leak into child processes
+  delete res.NX_ORIGINAL_FORCE_COLOR;
   return res;
 }
 

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -49,6 +49,7 @@ import { SharedRunningTask } from './running-tasks/shared-running-task';
 import {
   getEnvVariablesForBatchProcess,
   getEnvVariablesForTask,
+  getForceColorForChild,
   getTaskSpecificEnv,
 } from './task-env';
 import { TaskStatus } from './tasks-runner';
@@ -1036,9 +1037,7 @@ export class TaskOrchestrator {
       ? getEnvVariablesForTask(
           task,
           taskSpecificEnv,
-          process.env.FORCE_COLOR === undefined
-            ? 'true'
-            : process.env.FORCE_COLOR,
+          getForceColorForChild(),
           this.options.skipNxCache,
           this.options.captureStderr,
           null,
@@ -1347,9 +1346,7 @@ export class TaskOrchestrator {
       ? getEnvVariablesForTask(
           task,
           taskSpecificEnv,
-          process.env.FORCE_COLOR === undefined
-            ? 'true'
-            : process.env.FORCE_COLOR,
+          getForceColorForChild(),
           this.options.skipNxCache,
           this.options.captureStderr,
           null,


### PR DESCRIPTION
> **Note:** An alternative to this PR is to wait for the upstream [picocolors#100](https://github.com/alexeyraspopov/picocolors/issues/100) fix and then remove the `FORCE_COLOR=0` workaround in `bin/nx.ts` entirely. However, picocolors has not had a release or meaningful activity in over two years and appears to be unmaintained, so this fix ensures correct behavior in the meantime.

## Current Behavior

When `FORCE_COLOR=0` is set (common in CI to suppress ANSI codes), `bin/nx.ts` deletes it from `process.env` as a workaround for [picocolors#100](https://github.com/alexeyraspopov/picocolors/issues/100). However, `task-env.ts` and `task-orchestrator.ts` then default the undefined `FORCE_COLOR` to `'true'` for all forked child tasks, re-enabling ANSI colors in every child process.

```
User sets FORCE_COLOR=0
  → bin/nx.ts deletes FORCE_COLOR, sets NO_COLOR=1
  → task-env.ts sees FORCE_COLOR === undefined → defaults to 'true'
  → child processes receive FORCE_COLOR=true (overrides NO_COLOR)
  → ANSI escape codes in ESLint, TypeScript, Vitest output
```

## Expected Behavior

`FORCE_COLOR=0` should propagate to child tasks, resulting in no ANSI escape codes.

## Solution

1. **`bin/nx.ts`**: Save the original value in `NX_ORIGINAL_FORCE_COLOR` before deleting
2. **`task-env.ts`**: Extract a `getForceColorForChild()` helper that checks `NX_ORIGINAL_FORCE_COLOR` when `FORCE_COLOR` is undefined
3. **`task-orchestrator.ts`**: Use the shared helper at both call sites

## Impact

This affects any CI environment that sets `FORCE_COLOR=0`. In our case, ANSI escape codes in ESLint output broke downstream log parsers that use regex to extract lint errors (the `✖ N problems` summary line contains invisible ANSI bytes that prevent matching).

## Tests

Added 4 unit tests for `getForceColorForChild()` covering:
- Explicit `FORCE_COLOR` passthrough
- `FORCE_COLOR=0` → deleted → restored via `NX_ORIGINAL_FORCE_COLOR`
- Default to `'true'` when neither is set
- `FORCE_COLOR` takes precedence over `NX_ORIGINAL_FORCE_COLOR`

Fixes #35292

🤖 _This PR was drafted with the help of AI_