### PR TITLE
fix(node): split package-manager exec command for VS Code launch.json

### DIFF
--- a/packages/node/src/utils/vscode-debug-config.ts
+++ b/packages/node/src/utils/vscode-debug-config.ts
@@ -45,7 +45,15 @@ export function addVSCodeDebugConfiguration(
   tree: Tree,
   options: VSCodeDebugConfigOptions
 ): void {
-  const pmCommand = getPackageManagerCommand().exec;
+  // `getPackageManagerCommand().exec` returns the full subcommand string,
+  // e.g. `pnpm exec` for pnpm or `npm exec --` for npm. VS Code's
+  // `runtimeExecutable` expects an actual executable path, not a string
+  // with embedded arguments — passing `"pnpm exec"` fails on Windows with
+  // `Can't find Node.js binary "pnpm exec": path does not exist`. Split
+  // the command and prepend any extra tokens to runtimeArgs. (#35276)
+  const pmCommandTokens = getPackageManagerCommand().exec.split(' ');
+  const runtimeExecutable = pmCommandTokens[0];
+  const extraExecArgs = pmCommandTokens.slice(1);
 
   // Determine the output path based on project configuration
   let outputPath: string;
@@ -69,8 +77,8 @@ export function addVSCodeDebugConfiguration(
     type: 'node',
     request: 'launch',
     name: `Debug ${options.projectName} with Nx`,
-    runtimeExecutable: pmCommand,
-    runtimeArgs: ['nx', 'serve', options.projectName],
+    runtimeExecutable,
+    runtimeArgs: [...extraExecArgs, 'nx', 'serve', options.projectName],
     env: {
       NODE_OPTIONS: `--inspect=${debugPort}`,
     },


### PR DESCRIPTION
## Current Behavior

When generating a `@nx/node:application` from a pnpm workspace, the generated `launch.json` sets `runtimeExecutable` to the full `getPackageManagerCommand().exec` string (e.g. `"pnpm exec"`). On Windows, VS Code rejects this:

```
Can't find Node.js binary "pnpm exec": path does not exist.
Make sure Node.js is installed and in your PATH, or set the
"runtimeExecutable" in your launch.json.
```

The same issue affects npm (`npm exec --`) and yarn (`yarn exec`).

## Expected Behavior

`runtimeExecutable` should be a real binary path (`pnpm`, `npm`, `yarn`), and the `exec` / `exec --` tokens should live in `runtimeArgs`.

## Fix

Split `getPackageManagerCommand().exec` on whitespace, feed the first token into `runtimeExecutable`, and prepend the remaining tokens to `runtimeArgs`. Bun (`bunx`) is unaffected because it has no space.

## Related Issue(s)

Fixes #35276