### PR TITLE
fix: sort object keys before JSON.stringify in transformProjectGraphForRust

### DIFF
--- a/packages/nx/src/native/tests/transform-objects.spec.ts
+++ b/packages/nx/src/native/tests/transform-objects.spec.ts
@@ -1,0 +1,117 @@
+import { transformProjectGraphForRust } from '../transform-objects';
+import { ProjectGraph } from '../../config/project-graph';
+
+/**
+ * `transformProjectGraphForRust` feeds the Rust hasher. Any difference in the
+ * shape it returns — including key insertion order inside JSON-stringified
+ * fields — produces a different ProjectConfiguration hash, which causes
+ * spurious cache misses across CI runs that built the same logical graph in
+ * different key orders (e.g. plugins iterating Map vs. Object, or async
+ * resolution races).
+ *
+ * These tests assert that the transform is invariant to key insertion order
+ * for every field that ends up in the hash input.
+ */
+describe('transformProjectGraphForRust', () => {
+  function reverseKeys<T>(value: T): T {
+    if (Array.isArray(value)) {
+      return value.map(reverseKeys) as unknown as T;
+    }
+    if (value && typeof value === 'object') {
+      const out: Record<string, unknown> = {};
+      for (const key of Object.keys(value).reverse()) {
+        out[key] = reverseKeys((value as Record<string, unknown>)[key]);
+      }
+      return out as unknown as T;
+    }
+    return value;
+  }
+
+  function makeGraph(transform: <T>(v: T) => T = (v) => v): ProjectGraph {
+    const inputs = [
+      'default',
+      { runtime: 'node -v' },
+      { env: 'CI' },
+      { externalDependencies: ['typescript', 'react'] },
+    ];
+    const outputs = ['{workspaceRoot}/dist', '{projectRoot}/coverage'];
+    const options = {
+      foo: 1,
+      bar: 2,
+      baz: { x: 1, y: 2, z: 3 },
+    };
+    const configurations = {
+      development: { mode: 'dev', flag: true },
+      production: { mode: 'prod', flag: false },
+    };
+    const namedInputs = {
+      default: ['{projectRoot}/**/*'],
+      production: [
+        'default',
+        '!{projectRoot}/**/*.spec.ts',
+        { externalDependencies: ['react', 'typescript'] },
+      ],
+    };
+
+    return {
+      nodes: {
+        foo: {
+          name: 'foo',
+          type: 'lib',
+          data: {
+            root: 'libs/foo',
+            namedInputs: transform(namedInputs),
+            tags: ['scope:shared'],
+            targets: {
+              build: {
+                executor: 'nx:run-commands',
+                inputs: transform(inputs),
+                outputs: transform(outputs),
+                options: transform(options),
+                configurations: transform(configurations),
+                parallelism: false,
+              },
+            },
+          },
+        },
+      },
+      dependencies: { foo: [] },
+      externalNodes: {},
+    } as unknown as ProjectGraph;
+  }
+
+  it('produces an identical Rust input for two graphs that only differ in key insertion order', () => {
+    const a = transformProjectGraphForRust(makeGraph());
+    const b = transformProjectGraphForRust(makeGraph(reverseKeys));
+
+    expect(JSON.stringify(b)).toEqual(JSON.stringify(a));
+  });
+
+  it('normalises target.options key order (covers the original PR case)', () => {
+    const fwd = transformProjectGraphForRust(makeGraph());
+    const rev = transformProjectGraphForRust(makeGraph(reverseKeys));
+
+    expect(rev.nodes.foo.targets.build.options).toEqual(
+      fwd.nodes.foo.targets.build.options
+    );
+  });
+
+  it('normalises target.inputs / outputs (objects inside the array)', () => {
+    const fwd = transformProjectGraphForRust(makeGraph());
+    const rev = transformProjectGraphForRust(makeGraph(reverseKeys));
+
+    expect(rev.nodes.foo.targets.build.inputs).toEqual(
+      fwd.nodes.foo.targets.build.inputs
+    );
+    expect(rev.nodes.foo.targets.build.outputs).toEqual(
+      fwd.nodes.foo.targets.build.outputs
+    );
+  });
+
+  it('normalises namedInputs (top-level keys + nested objects)', () => {
+    const fwd = transformProjectGraphForRust(makeGraph());
+    const rev = transformProjectGraphForRust(makeGraph(reverseKeys));
+
+    expect(rev.nodes.foo.namedInputs).toEqual(fwd.nodes.foo.namedInputs);
+  });
+});

--- a/packages/nx/src/native/transform-objects.ts
+++ b/packages/nx/src/native/transform-objects.ts
@@ -33,8 +33,8 @@ export function transformProjectGraphForRust(
     )) {
       targets[targetName] = {
         executor: targetConfig.executor,
-        inputs: targetConfig.inputs,
-        outputs: targetConfig.outputs,
+        inputs: sortObjectKeys(targetConfig.inputs) as Target['inputs'],
+        outputs: sortObjectKeys(targetConfig.outputs) as Target['outputs'],
         options: JSON.stringify(sortObjectKeys(targetConfig.options)),
         configurations: JSON.stringify(sortObjectKeys(targetConfig.configurations)),
         parallelism: targetConfig.parallelism,
@@ -42,7 +42,9 @@ export function transformProjectGraphForRust(
     }
     nodes[projectName] = {
       root: projectNode.data.root,
-      namedInputs: projectNode.data.namedInputs,
+      namedInputs: sortObjectKeys(
+        projectNode.data.namedInputs
+      ) as Project['namedInputs'],
       targets,
       tags: projectNode.data.tags,
     };

--- a/packages/nx/src/native/transform-objects.ts
+++ b/packages/nx/src/native/transform-objects.ts
@@ -6,6 +6,20 @@ import {
   ProjectGraph as RustProjectGraph,
 } from './index';
 
+function sortObjectKeys(obj: unknown): unknown {
+  if (obj === null || obj === undefined || typeof obj !== 'object') {
+    return obj;
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(sortObjectKeys);
+  }
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(obj).sort()) {
+    sorted[key] = sortObjectKeys((obj as Record<string, unknown>)[key]);
+  }
+  return sorted;
+}
+
 export function transformProjectGraphForRust(
   graph: ProjectGraph
 ): RustProjectGraph {
@@ -21,8 +35,8 @@ export function transformProjectGraphForRust(
         executor: targetConfig.executor,
         inputs: targetConfig.inputs,
         outputs: targetConfig.outputs,
-        options: JSON.stringify(targetConfig.options),
-        configurations: JSON.stringify(targetConfig.configurations),
+        options: JSON.stringify(sortObjectKeys(targetConfig.options)),
+        configurations: JSON.stringify(sortObjectKeys(targetConfig.configurations)),
         parallelism: targetConfig.parallelism,
       };
     }


### PR DESCRIPTION
## Summary

Fixes #35297

`JSON.stringify()` preserves JavaScript object key insertion order. In `transformProjectGraphForRust`, target `options` and `configurations` are serialized with `JSON.stringify()` and passed to the Rust native hasher, which hashes them as-is for `ProjectConfiguration`.

If any Nx plugin or the target-defaults merge step produces these objects with keys in a different insertion order on different CI runners, the serialized string changes, causing the `ProjectConfiguration` hash to become **non-deterministic**. This leads to:

- Nx Cloud cache invalidation on CI reruns
- Previously succeeded tasks being re-executed unnecessarily
- Wasted CI compute time

## The Fix

Adds a recursive `sortObjectKeys` helper that normalizes key order before serialization, making the `ProjectConfiguration` hash independent of JS object construction order.

Note: The Rust hasher already sorts **target names** before hashing (making the hash independent of target insertion order), but it does not normalize the **content** of the stringified `options`/`configurations`. This fix closes that gap.

## Evidence

Tested locally using the native `HashPlanner` + `TaskHasher` APIs:

### Without fix
| Options string | ProjectConfiguration hash |
|---|---|
| `{"cwd":"...","env":{...},"command":"jest","passWithNoTests":true}` | `10839486168096120338` |
| `{"passWithNoTests":true,"command":"jest","env":{...},"cwd":"..."}` | `14689511571626992510` |

### With fix
Reversed ALL target orders AND ALL options/configurations key orders for ALL projects across the entire project graph:
- **530 `ProjectConfiguration` entries, 0 mismatches**
- **Identical task hashes**

## Related

This is analogous to the fix in commit `db31f30` which sorted keys before hashing for `AllExternalDependencies` via `hashObject`.