### PR TITLE
fix(js): avoid full source scan in readTsConfigPaths

### DIFF
--- a/packages/js/src/utils/typescript/ts-config.spec.ts
+++ b/packages/js/src/utils/typescript/ts-config.spec.ts
@@ -1,5 +1,5 @@
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
-import { resolvePathsBaseUrl } from './ts-config';
+import { readTsConfigPaths, resolvePathsBaseUrl } from './ts-config';
 import { join } from 'path';
 
 describe('resolvePathsBaseUrl', () => {
@@ -221,5 +221,66 @@ describe('resolvePathsBaseUrl', () => {
     expect(resolvePathsBaseUrl(join(tempFs.tempDir, 'nonexistent.json'))).toBe(
       tempFs.tempDir
     );
+  });
+});
+
+describe('readTsConfigPaths', () => {
+  let tempFs: TempFs;
+
+  beforeEach(() => {
+    tempFs = new TempFs('read-ts-config-paths', false);
+  });
+
+  afterEach(() => {
+    tempFs.cleanup();
+  });
+
+  it('should return paths defined in the tsconfig', () => {
+    tempFs.createFileSync(
+      'tsconfig.base.json',
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: { '@app/*': ['libs/app/src/*'] },
+        },
+      })
+    );
+
+    const paths = readTsConfigPaths(join(tempFs.tempDir, 'tsconfig.base.json'));
+
+    expect(paths).toEqual({
+      '@app/*': ['libs/app/src/*'],
+    });
+  });
+
+  it('should return paths inherited via extends', () => {
+    tempFs.createFileSync(
+      'tsconfig.base.json',
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: { '@lib/*': ['libs/*/src/index.ts'] },
+        },
+      })
+    );
+    tempFs.createFileSync(
+      'tsconfig.json',
+      JSON.stringify({ extends: './tsconfig.base.json' })
+    );
+
+    const paths = readTsConfigPaths(join(tempFs.tempDir, 'tsconfig.json'));
+
+    expect(paths).toEqual({
+      '@lib/*': ['libs/*/src/index.ts'],
+    });
+  });
+
+  it('should return null when paths are not defined', () => {
+    tempFs.createFileSync(
+      'tsconfig.json',
+      JSON.stringify({ compilerOptions: {} })
+    );
+
+    expect(readTsConfigPaths(join(tempFs.tempDir, 'tsconfig.json'))).toBeNull();
   });
 });

--- a/packages/js/src/utils/typescript/ts-config.ts
+++ b/packages/js/src/utils/typescript/ts-config.ts
@@ -205,30 +205,31 @@ function resolveExtendsPath(ext: string, fromDir: string): string | null {
 export function readTsConfigPaths(tsConfig?: string | ts.ParsedCommandLine) {
   tsConfig ??= getRootTsConfigPath();
   try {
-    if (!tsModule) {
-      tsModule = ensureTypescript();
-    }
-
     let config: ts.ParsedCommandLine;
 
     if (typeof tsConfig === 'string') {
+      if (!tsModule) {
+        tsModule = ensureTypescript();
+      }
+
       const configFile = tsModule.readConfigFile(
         tsConfig,
         tsModule.sys.readFile
       );
+      // Stub `readDirectory` to skip the source-file scan — only `paths` is consumed.
+      const parseConfigHost: ts.ParseConfigHost = {
+        ...tsModule.sys,
+        readDirectory: () => [],
+      };
       config = tsModule.parseJsonConfigFileContent(
         configFile.config,
-        tsModule.sys,
+        parseConfigHost,
         dirname(tsConfig)
       );
     } else {
       config = tsConfig;
     }
-    if (config.options?.paths) {
-      return config.options.paths;
-    } else {
-      return null;
-    }
+    return config.options?.paths ?? null;
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
## Current Behavior

In large monorepos where the root tsconfig lacks `files`/`include`, `@nx/next:server` (and other executors that rely on `readTsConfigPaths()` via `withNx`) can hang for minutes and fail with `ECONNREFUSED` as the Next.js server never gets a chance to start.

## Expected Behavior

`readTsConfigPaths()` returns the configured path mappings quickly regardless of workspace size, so the Next.js dev server starts normally.

## Technical Details

`readTsConfigPaths()` only needs `compilerOptions.paths`, but TypeScript's default `ParseConfigHost` enumerates every `.ts` file under the tsconfig directory when `files`/`include` are absent. Stubbing `readDirectory` on the host skips the source-file scan while preserving `extends` resolution.