### PR TITLE
fix(linter): handle variable references in replaceOverride (#34026)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ kotlinx-coroutines = "1.7.3"
 slf4j = "1.7.10"
 gradle-tooling-api = "8.13"
 shadow = "8.1.1"
-ktfmt = "0.52.0"
+ktfmt = "0.25.0"
 nx-project-graph = "0.1.7"
 gradle-plugin-publish = "1.2.1"
 
@@ -27,6 +27,6 @@ gradle-tooling-api = { module = "org.gradle:gradle-tooling-api", version.ref = "
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }
-ktfmt = { id = "com.ncorti.ktfmt.gradle", version = "+" }
+ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 nx-project-graph = { id = "dev.nx.gradle.project-graph", version.ref = "nx-project-graph" }
 gradle-plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "gradle-plugin-publish" }

--- a/packages/eslint/src/generators/utils/flat-config/ast-utils.spec.ts
+++ b/packages/eslint/src/generators/utils/flat-config/ast-utils.spec.ts
@@ -681,22 +681,22 @@ export default [
 
         export default [
             {
-              "files": [
-                "my-lib/**/*.ts",
-                "my-lib/**/*.tsx"
-              ],
-              "rules": {
-                "my-rule": "error"
-              }
+                files: [
+                    "my-lib/**/*.ts",
+                    "my-lib/**/*.tsx"
+                ],
+                rules: {
+              "my-rule": "error"
+            }
             },
             {
-              "files": [
-                "my-lib/**/*.ts",
-                "my-lib/**/*.js"
-              ],
-              "rules": {
-                "my-rule": "error"
-              }
+                files: [
+                    "my-lib/**/*.ts",
+                    "my-lib/**/*.js"
+                ],
+                rules: {
+              "my-rule": "error"
+            }
             },
             {
                 files: [
@@ -752,14 +752,14 @@ export default [
 
         export default [
             {
-              "files": [
-                "my-lib/**/*.ts",
-                "my-lib/**/*.tsx"
-              ],
-              "rules": {
-                "my-ts-rule": "error",
-                "my-new-rule": "error"
-              }
+                files: [
+                    "my-lib/**/*.ts",
+                    "my-lib/**/*.tsx"
+                ],
+                rules: {
+              "my-ts-rule": "error",
+              "my-new-rule": "error"
+            }
             },
             {
                 files: [
@@ -808,15 +808,129 @@ export default [
         export default [
             ...compat.config({ extends: ["plugin:@nx/typescript"] }).map(config => ({
             ...config,
-              "files": [
+            files: [
                 "my-lib/**/*.ts",
                 "my-lib/**/*.tsx"
-              ],
-              "rules": {
-                "my-ts-rule": "error",
-                "my-new-rule": "error"
-              }
+            ],
+            rules: {
+              "my-ts-rule": "error",
+              "my-new-rule": "error"
+            }
           }),
+        ];"
+      `);
+    });
+
+    it('should update files while preserving variable references (ESM)', () => {
+      const content = `
+import pluginPackageJson from "eslint-plugin-package-json";
+import jsoncParser from "jsonc-eslint-parser";
+
+export default [
+    {
+        files: ["package.json"],
+        plugins: { "package-json": pluginPackageJson },
+        languageOptions: {
+            parser: jsoncParser,
+        },
+        rules: {
+            '@nx/nx-plugin-checks': 'error'
+        }
+    }
+];`;
+
+      const result = replaceOverride(
+        content,
+        '',
+        (o) =>
+          Object.keys(o.rules ?? {}).includes('@nx/nx-plugin-checks') ||
+          Object.keys(o.rules ?? {}).includes('@nrwl/nx/nx-plugin-checks'),
+        (o) => {
+          const files = Array.isArray(o.files) ? o.files : [o.files];
+          return {
+            ...o,
+            files: [...files, './migrations.json'],
+          };
+        }
+      );
+
+      // Property-level AST update: only files is modified, plugins with variable refs is preserved
+      expect(result).toMatchInlineSnapshot(`
+        "
+        import pluginPackageJson from "eslint-plugin-package-json";
+        import jsoncParser from "jsonc-eslint-parser";
+
+        export default [
+            {
+                files: [
+              "package.json",
+              "./migrations.json"
+            ],
+                plugins: { "package-json": pluginPackageJson },
+                languageOptions: {
+                    parser: jsoncParser,
+                },
+                rules: {
+                    '@nx/nx-plugin-checks': 'error'
+                }
+            }
+        ];"
+      `);
+    });
+
+    it('should update files while preserving variable references (CJS)', () => {
+      const content = `
+const pluginPackageJson = require("eslint-plugin-package-json");
+const jsoncParser = require("jsonc-eslint-parser");
+
+module.exports = [
+    {
+        files: ["package.json"],
+        plugins: { "package-json": pluginPackageJson },
+        languageOptions: {
+            parser: jsoncParser,
+        },
+        rules: {
+            '@nx/nx-plugin-checks': 'error'
+        }
+    }
+];`;
+
+      const result = replaceOverride(
+        content,
+        '',
+        (o) =>
+          Object.keys(o.rules ?? {}).includes('@nx/nx-plugin-checks') ||
+          Object.keys(o.rules ?? {}).includes('@nrwl/nx/nx-plugin-checks'),
+        (o) => {
+          const files = Array.isArray(o.files) ? o.files : [o.files];
+          return {
+            ...o,
+            files: [...files, './migrations.json'],
+          };
+        }
+      );
+
+      // Property-level AST update: only files is modified, plugins with variable refs is preserved
+      expect(result).toMatchInlineSnapshot(`
+        "
+        const pluginPackageJson = require("eslint-plugin-package-json");
+        const jsoncParser = require("jsonc-eslint-parser");
+
+        module.exports = [
+            {
+                files: [
+              "package.json",
+              "./migrations.json"
+            ],
+                plugins: { "package-json": pluginPackageJson },
+                languageOptions: {
+                    parser: jsoncParser,
+                },
+                rules: {
+                    '@nx/nx-plugin-checks': 'error'
+                }
+            }
         ];"
       `);
     });

--- a/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
+++ b/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
@@ -187,19 +187,21 @@ export function hasOverride(
   }
   for (const node of exportsArray) {
     if (isOverride(node)) {
-      let objSource;
+      let data: Partial<Linter.ConfigOverride<Linter.RulesRecord>>;
+
       if (ts.isObjectLiteralExpression(node)) {
-        objSource = node.getFullText();
-        // strip any spread elements
-        objSource = objSource.replace(SPREAD_ELEMENTS_REGEXP, '');
+        data = extractPropertiesFromObjectLiteral(node);
       } else {
-        const fullNodeText =
-          node['expression'].arguments[0].body.expression.getFullText();
-        // strip any spread elements
-        objSource = fullNodeText.replace(SPREAD_ELEMENTS_REGEXP, '');
+        // Handle compat.config(...).map(...) pattern
+        const arrowBody = node['expression'].arguments[0].body.expression;
+        if (ts.isObjectLiteralExpression(arrowBody)) {
+          data = extractPropertiesFromObjectLiteral(arrowBody);
+        } else {
+          continue;
+        }
       }
-      const data = parseTextToJson(objSource);
-      if (lookup(data)) {
+
+      if (lookup(data as Linter.ConfigOverride<Linter.RulesRecord>)) {
         return true;
       }
     }
@@ -217,6 +219,79 @@ function parseTextToJson(text: string): any {
       .replace(/require\(['"]([^'"]+)['"]\)/g, '"$1"')
       .replace(/\(?await import\(['"]([^'"]+)['"]\)\)?/g, '"$1"')
   );
+}
+
+/**
+ * Extracts literal values from AST nodes.
+ * Returns undefined for complex expressions that can't be statically evaluated.
+ */
+function extractLiteralValue(node: ts.Node): unknown {
+  if (ts.isStringLiteral(node)) {
+    return node.text;
+  }
+  if (ts.isNumericLiteral(node)) {
+    return Number(node.text);
+  }
+  if (node.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (node.kind === ts.SyntaxKind.FalseKeyword) return false;
+  if (node.kind === ts.SyntaxKind.NullKeyword) return null;
+
+  if (ts.isArrayLiteralExpression(node)) {
+    const arr: unknown[] = [];
+    for (const element of node.elements) {
+      const value = extractLiteralValue(element);
+      if (value === undefined) return undefined;
+      arr.push(value);
+    }
+    return arr;
+  }
+
+  if (ts.isObjectLiteralExpression(node)) {
+    const obj: Record<string, unknown> = {};
+    for (const prop of node.properties) {
+      if (ts.isPropertyAssignment(prop)) {
+        const name = prop.name.getText().replace(/['"]/g, '');
+        const value = extractLiteralValue(prop.initializer);
+        if (value === undefined) {
+          // Skip properties with non-extractable values (like variable references)
+          continue;
+        }
+        obj[name] = value;
+      } else if (ts.isSpreadAssignment(prop)) {
+        // Cannot extract spread assignments statically, skip them
+        continue;
+      } else {
+        // Skip other property types (shorthand, method, etc.)
+        continue;
+      }
+    }
+    return obj;
+  }
+
+  // For complex expressions (identifiers, function calls, etc.), return undefined
+  return undefined;
+}
+
+/**
+ * Extracts property values from an ObjectLiteralExpression using AST.
+ * Only extracts properties that have simple literal values.
+ * Returns a partial object suitable for the lookup function.
+ */
+function extractPropertiesFromObjectLiteral(
+  node: ts.ObjectLiteralExpression
+): Partial<Linter.ConfigOverride<Linter.RulesRecord>> {
+  const result: Record<string, unknown> = {};
+  for (const prop of node.properties) {
+    if (ts.isPropertyAssignment(prop)) {
+      const name = prop.name.getText().replace(/['"]/g, '');
+      const value = extractLiteralValue(prop.initializer);
+      if (value !== undefined) {
+        result[name] = value;
+      }
+    }
+  }
+
+  return result as Partial<Linter.ConfigOverride<Linter.RulesRecord>>;
 }
 
 /**

--- a/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
+++ b/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
@@ -187,7 +187,7 @@ export function hasOverride(
   }
   for (const node of exportsArray) {
     if (isOverride(node)) {
-      let data: Partial<Linter.ConfigOverride<Linter.RulesRecord>>;
+      let data: Partial<Record<string, unknown>>;
 
       if (ts.isObjectLiteralExpression(node)) {
         data = extractPropertiesFromObjectLiteral(node);
@@ -201,7 +201,9 @@ export function hasOverride(
         }
       }
 
-      if (lookup(data as Linter.ConfigOverride<Linter.RulesRecord>)) {
+      if (
+        lookup(data as unknown as Linter.ConfigOverride<Linter.RulesRecord>)
+      ) {
         return true;
       }
     }
@@ -279,7 +281,7 @@ function extractLiteralValue(node: ts.Node): unknown {
  */
 function extractPropertiesFromObjectLiteral(
   node: ts.ObjectLiteralExpression
-): Partial<Linter.ConfigOverride<Linter.RulesRecord>> {
+): Partial<Record<string, unknown>> {
   const result: Record<string, unknown> = {};
   for (const prop of node.properties) {
     if (ts.isPropertyAssignment(prop)) {
@@ -291,7 +293,7 @@ function extractPropertiesFromObjectLiteral(
     }
   }
 
-  return result as Partial<Linter.ConfigOverride<Linter.RulesRecord>>;
+  return result as Partial<Record<string, unknown>>;
 }
 
 /**
@@ -398,11 +400,13 @@ export function replaceOverride(
 
     // Use AST-based extraction to handle variable references (e.g., plugins: { 'abc': abc })
     const data = extractPropertiesFromObjectLiteral(objectLiteralNode);
-    if (lookup(data as Linter.ConfigOverride<Linter.RulesRecord>)) {
+    if (lookup(data as unknown as Linter.ConfigOverride<Linter.RulesRecord>)) {
       // Deep clone before update (update functions may mutate nested objects)
       const originalData = structuredClone(data);
 
-      let updatedData = update?.(data);
+      let updatedData = update?.(
+        data as Partial<Linter.ConfigOverride<Linter.RulesRecord>>
+      );
       if (updatedData) {
         updatedData = mapFilePaths(updatedData);
 
@@ -448,7 +452,10 @@ export function replaceOverride(
             changes.push({
               type: ChangeType.Insert,
               index: insertPos,
-              text: `${needsComma}\n    "${propName}": ${serializeValue(updatedValue, format)}`,
+              text: `${needsComma}\n    "${propName}": ${serializeValue(
+                updatedValue,
+                format
+              )}`,
             });
           }
         }
@@ -1892,9 +1899,7 @@ export function generateAst<T>(
 ): T {
   if (Array.isArray(input)) {
     return ts.factory.createArrayLiteralExpression(
-      input.map((item) =>
-        generateAst<ts.Expression>(item, propertyAssignmentReplacer)
-      ),
+      input.map((item) => generateAst(item, propertyAssignmentReplacer)),
       true // Always treat as multiline, using item.length does not work in all cases
     ) as T;
   }
@@ -1945,7 +1950,7 @@ function generatePropertyAssignmentsFromObjectEntries(
     .map(([key, value]) => {
       const original = ts.factory.createPropertyAssignment(
         isValidKey(key) ? key : ts.factory.createStringLiteral(key),
-        generateAst<ts.Expression>(value, propertyAssignmentReplacer)
+        generateAst(value, propertyAssignmentReplacer)
       );
       if (
         propertyAssignmentReplacer &&


### PR DESCRIPTION
…#32881)

This PR fixes an issue with new docs where graph or PDV tag with inner
JSON content will cause formatting issues with other code blocks on the
page.

Rather than using `<slot/>` to render the inner code fence, which seems
to not play well with the rest of the page, we instead skip rendering
the inner content altogether, and pass the data as `astroRawData` to the
underlying React component. This removes the need to handle
HTML/attribute parsing, so it is much cleaner in addition to resolving
conflicts.

Note: Also fixed some of the previous JSON content as they were invalid.<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
Flat config overrides util may fail when it isn't a plain JS object.
This PR makes the `hasOverrides` function more robust against these
cases.

Fixes #31796

(cherry picked from commit 05bd3a4)