### PR TITLE
chore(repo): remove blanket apt-get update from ci install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
           sudo apt-get install -y ca-certificates lsof libvips-dev libglib2.0-dev libgirepository1.0-dev
 
       - name: Install Chrome

--- a/nx.json
+++ b/nx.json
@@ -270,7 +270,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 3,
+  "bust": 4,
   "defaultBase": "master",
   "sync": { "applyChanges": true },
   "conformance": {


### PR DESCRIPTION
## Current Behavior

The `Install dependencies` step in `.github/workflows/ci.yml` runs `sudo apt-get update` before installing `ca-certificates lsof libvips-dev libglib2.0-dev libgirepository1.0-dev`. This refreshes the entire Debian package index on every CI run, even though none of these are browser packages and none need the latest upstream versions.

Chrome is installed via the `browser-actions/setup-chrome` action. Playwright's browser (chromium only, per `astro-docs/playwright.config.ts` and `nx-dev/nx-dev-e2e/playwright.config.ts`) and its system libs come from `pnpm playwright install --with-deps`, which runs its own targeted `apt-get update` + install for browser dependencies. So the blanket refresh in this step was doing no browser work -- just updating build deps that are already cached on the runner image.

## Expected Behavior

`apt-get install` runs directly against the apt cache shipped with the `ubuntu-latest` runner image. Browser tooling is unchanged: `setup-chrome` handles Chrome and `playwright install --with-deps` handles Playwright's browser deps. The `bust` key in `nx.json` is also bumped in a separate commit to force a cold CI run so we can validate the install still succeeds without the index refresh.

## Related Issue(s)

N/A -- cleanup of CI install step.