### PR TITLE
fix(repo): resolve FreeBSD build OOM and disk exhaustion

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -513,6 +513,18 @@ jobs:
 
             if [ "$BUILD_EXIT" -ne 0 ]; then
               echo "Build failed with exit code $BUILD_EXIT"
+              echo "=== Disk usage by top-level directories ==="
+              du -sh /* 2>/dev/null | sort -rh | head -20
+              echo "=== Disk usage in home directory ==="
+              du -sh ~/* 2>/dev/null | sort -rh | head -20
+              echo "=== Disk usage in workspace ==="
+              du -sh /home/runner/work/nx/nx/* 2>/dev/null | sort -rh | head -20
+              echo "=== Disk usage in .nx ==="
+              du -sh /home/runner/work/nx/nx/.nx/* 2>/dev/null | sort -rh | head -20
+              echo "=== Disk usage in cargo/rustup ==="
+              du -sh ~/.cargo/* ~/.rustup/* 2>/dev/null | sort -rh | head -20
+              echo "=== Core dumps ==="
+              find / -name "*.core" -o -name "core.*" -o -name "core" 2>/dev/null | head -10
               exit $BUILD_EXIT
             fi
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -504,6 +504,9 @@ jobs:
             echo "Checking disk space after cleanup"
             df -h
             
+            # Disable core dumps - OOM'd Node processes write multi-GB core files that fill the disk
+            ulimit -c 0
+
             echo "Building FreeBSD bindings"
             BUILD_EXIT=0
             pnpm nx run-many --verbose --outputStyle stream --target=build-native -- --target=x86_64-unknown-freebsd || BUILD_EXIT=$?

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -427,11 +427,12 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: 0
           NODE_VERSION: 22.16.0
           NX_GRADLE_DISABLE: 'true'
+          NODE_OPTIONS: '--max-old-space-size=4096'
         with:
           operating_system: freebsd
           version: '14.0'
           architecture: x86-64
-          environment_variables: DEBUG RUSTUP_IO_THREADS CI NX_PREFER_TS_NODE PLAYWRIGHT_BROWSERS_PATH NODE_VERSION NX_GRADLE_DISABLE
+          environment_variables: DEBUG RUSTUP_IO_THREADS CI NX_PREFER_TS_NODE PLAYWRIGHT_BROWSERS_PATH NODE_VERSION NX_GRADLE_DISABLE NODE_OPTIONS
           shell: bash
           run: |
             env

--- a/package.json
+++ b/package.json
@@ -413,10 +413,6 @@
     "overrides": {
       "handlebars": "4.7.9",
       "underscore": "^1.13.8"
-    },
-    "patchedDependencies": {
-      "@astrojs/starlight": "patches/@astrojs__starlight.patch",
-      "@nx/jest@22.7.0-beta.12": "patches/@nx__jest@22.7.0-beta.12.patch"
     }
   },
   "nx": {

--- a/package.json
+++ b/package.json
@@ -415,7 +415,6 @@
       "underscore": "^1.13.8"
     },
     "patchedDependencies": {
-      "@astrojs/starlight": "patches/@astrojs__starlight.patch",
       "@nx/jest@22.7.0-beta.12": "patches/@nx__jest@22.7.0-beta.12.patch"
     }
   },

--- a/package.json
+++ b/package.json
@@ -415,6 +415,7 @@
       "underscore": "^1.13.8"
     },
     "patchedDependencies": {
+      "@astrojs/starlight": "patches/@astrojs__starlight.patch",
       "@nx/jest@22.7.0-beta.12": "patches/@nx__jest@22.7.0-beta.12.patch"
     }
   },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@jest/reporters": "catalog:jest",
     "@jest/test-result": "catalog:jest",
     "@jest/types": "catalog:jest",
-    "smol-toml": "1.6.1",
     "@module-federation/enhanced": "2.1.0",
     "@module-federation/sdk": "^2.1.0",
     "@monodon/rust": "2.3.0",
@@ -302,6 +301,7 @@
     "sass-loader": "16.0.5",
     "semver": "catalog:",
     "shiki": "^4.0.2",
+    "smol-toml": "1.6.1",
     "source-map-loader": "^5.0.0",
     "source-map-support": "0.5.19",
     "storybook": "10.1.0",
@@ -413,6 +413,10 @@
     "overrides": {
       "handlebars": "4.7.9",
       "underscore": "^1.13.8"
+    },
+    "patchedDependencies": {
+      "@astrojs/starlight": "patches/@astrojs__starlight.patch",
+      "@nx/jest@22.7.0-beta.12": "patches/@nx__jest@22.7.0-beta.12.patch"
     }
   },
   "nx": {

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -143,56 +143,54 @@ export const createNodes: CreateNodesV2<JestPluginOptions> = [
 
     const lockFilePattern = getLockFileName(packageManager);
 
-    // Collect external file references (tsconfig chains) and needsDtsInputs
-    // WITHOUT loading jest configs via require(). This avoids holding all
-    // config module trees in memory simultaneously, which caused OOM on
-    // constrained environments (e.g. FreeBSD VM with 8GB RAM, 21 workers).
-    // We optimistically assume any project might use ts-jest and always walk
-    // the tsconfig extends chain.
-    const absWorkspaceRoot = resolve(context.workspaceRoot);
-    const configMetadata: Array<{
-      externalFiles: string[];
-      needsDtsInputs: boolean;
-    }> = [];
-    for (let i = 0; i < validConfigFiles.length; i++) {
-      const projectRoot = projectRoots[i];
-      const absoluteProjectRoot = resolve(absWorkspaceRoot, projectRoot);
-      const externalFiles = new Set<string>();
-
-      const tsconfigAbsPath = findNearestTsconfig(
-        absoluteProjectRoot,
-        absWorkspaceRoot,
-        tsconfigExistsCache
-      );
-
-      let needsDtsInputs = !tsconfigAbsPath;
-      if (tsconfigAbsPath) {
-        const { value: isolatedValue, visitedFiles } = resolveIsolatedModules(
-          tsconfigAbsPath,
-          tsconfigJsonCache,
-          isolatedModulesCache
+    // Load configs in parallel. `loadConfigFile` calls `registerTsProject`,
+    // whose transpiler dedup is refcounted: serial register/unregister cycles
+    // drop refCount to 0 between iterations and recreate a fresh ts-node
+    // service each time (ts-node has no cleanup — see
+    // packages/nx/src/plugins/js/utils/register.js), stacking N services in
+    // `require.extensions` and OOM'ing under NX_PREFER_TS_NODE. Parallel
+    // loads keep all registrations alive concurrently so the dedup holds and
+    // a single transpiler instance is shared.
+    let requireCacheCleared = false;
+    const loadedConfigs = await Promise.all(
+      validConfigFiles.map(async (configFilePath, i) => {
+        const projectRoot = projectRoots[i];
+        const absConfigFilePath = resolve(
+          context.workspaceRoot,
+          configFilePath
         );
-        if (isolatedValue !== true) needsDtsInputs = true;
-        for (const visitedFile of visitedFiles) {
-          collectExternalFile(
-            visitedFile,
-            absWorkspaceRoot,
-            absoluteProjectRoot,
-            externalFiles
-          );
+        if (!requireCacheCleared && require.cache[absConfigFilePath]) {
+          clearRequireCache();
+          requireCacheCleared = true;
         }
-      }
-      configMetadata.push({
-        externalFiles: [...externalFiles],
-        needsDtsInputs,
-      });
-    }
+        const rawConfig = await loadConfigFile(absConfigFilePath, [
+          'tsconfig.spec.json',
+          'tsconfig.test.json',
+          'tsconfig.jest.json',
+          'tsconfig.json',
+        ]);
+        const { externalFiles, needsDtsInputs } =
+          await collectExternalFileReferences(
+            rawConfig,
+            absConfigFilePath,
+            projectRoot,
+            context.workspaceRoot,
+            {
+              presetCache,
+              tsconfigJsonCache,
+              tsconfigExistsCache,
+              isolatedModulesCache,
+            }
+          );
+        return { rawConfig, externalFiles, needsDtsInputs };
+      })
+    );
 
     const hashes = await calculateHashesForCreateNodes(
       projectRoots,
       options,
       context,
-      configMetadata.map(({ externalFiles }) => [
+      loadedConfigs.map(({ externalFiles }) => [
         lockFilePattern,
         ...externalFiles,
       ])
@@ -203,10 +201,10 @@ export const createNodes: CreateNodesV2<JestPluginOptions> = [
         async (configFilePath, options, context, idx) => {
           const projectRoot = projectRoots[idx];
           const hash = hashes[idx];
-          const { needsDtsInputs } = configMetadata[idx];
+          const { rawConfig, needsDtsInputs } = loadedConfigs[idx];
 
           targetsCache[hash] ??= await buildJestTargets(
-            await loadJestConfig(context.workspaceRoot, configFilePath),
+            rawConfig,
             needsDtsInputs,
             configFilePath,
             projectRoot,
@@ -1033,43 +1031,6 @@ async function getTestPaths(
 }
 
 /**
- * Adds a file to the external files set if it is inside the workspace but
- * outside the project root (and not in node_modules).
- */
-function collectExternalFile(
-  absolutePath: string | null,
-  absWorkspaceRoot: string,
-  absoluteProjectRoot: string,
-  externalFiles: Set<string>
-): void {
-  if (!absolutePath) return;
-  const rel = normalizePath(relative(absWorkspaceRoot, absolutePath));
-  if (rel.startsWith('..') || isAbsolute(rel)) return;
-  if (rel.includes('node_modules/')) return;
-  const relToProject = normalizePath(
-    relative(absoluteProjectRoot, absolutePath)
-  );
-  if (!relToProject.startsWith('..') && !isAbsolute(relToProject)) return;
-  externalFiles.add(rel);
-}
-
-async function loadJestConfig(
-  workspaceRoot: string,
-  configFilePath: string
-): Promise<any> {
-  const absConfigFilePath = resolve(workspaceRoot, configFilePath);
-  if (require.cache[absConfigFilePath]) {
-    clearRequireCache();
-  }
-  return loadConfigFile(absConfigFilePath, [
-    'tsconfig.spec.json',
-    'tsconfig.test.json',
-    'tsconfig.jest.json',
-    'tsconfig.json',
-  ]);
-}
-
-/**
  * Collects workspace-relative paths to files whose CONTENT the plugin reads
  * when computing inferred targets and that live OUTSIDE the project root.
  *
@@ -1109,17 +1070,23 @@ async function collectExternalFileReferences(
   const absoluteProjectRoot = resolve(absWorkspaceRoot, projectRoot);
 
   const externalFiles = new Set<string>();
+  const addIfExternal = (absolutePath: string | null) => {
+    if (!absolutePath) return;
+    const rel = normalizePath(relative(absWorkspaceRoot, absolutePath));
+    if (rel.startsWith('..') || isAbsolute(rel)) return; // outside workspace
+    if (rel.includes('node_modules/')) return; // covered by lockfile
+    const relToProject = normalizePath(
+      relative(absoluteProjectRoot, absolutePath)
+    );
+    if (!relToProject.startsWith('..') && !isAbsolute(relToProject)) return; // inside project root
+    externalFiles.add(rel);
+  };
 
   // Preset path (content is loaded by the plugin to merge with rawConfig)
   if (typeof rawConfig.preset === 'string') {
     const replaced = replaceRootDirInPath(rootDir, rawConfig.preset);
     if (replaced.startsWith('.') || isAbsolute(replaced)) {
-      collectExternalFile(
-        resolve(rootDir, replaced),
-        absWorkspaceRoot,
-        absoluteProjectRoot,
-        externalFiles
-      );
+      addIfExternal(resolve(rootDir, replaced));
     }
   }
 
@@ -1166,12 +1133,7 @@ async function collectExternalFileReferences(
       isolatedModulesCache
     );
     for (const visitedFile of visitedFiles) {
-      collectExternalFile(
-        visitedFile,
-        absWorkspaceRoot,
-        absoluteProjectRoot,
-        externalFiles
-      );
+      addIfExternal(visitedFile);
     }
     if (isolatedValue !== true) needsDtsInputs = true;
   }

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -143,47 +143,56 @@ export const createNodes: CreateNodesV2<JestPluginOptions> = [
 
     const lockFilePattern = getLockFileName(packageManager);
 
-    let requireCacheCleared = false;
-    const loadedConfigs: Array<{
-      rawConfig: any;
+    // Collect external file references (tsconfig chains) and needsDtsInputs
+    // WITHOUT loading jest configs via require(). This avoids holding all
+    // config module trees in memory simultaneously, which caused OOM on
+    // constrained environments (e.g. FreeBSD VM with 8GB RAM, 21 workers).
+    // We optimistically assume any project might use ts-jest and always walk
+    // the tsconfig extends chain.
+    const absWorkspaceRoot = resolve(context.workspaceRoot);
+    const configMetadata: Array<{
       externalFiles: string[];
       needsDtsInputs: boolean;
     }> = [];
     for (let i = 0; i < validConfigFiles.length; i++) {
-      const configFilePath = validConfigFiles[i];
       const projectRoot = projectRoots[i];
-      const absConfigFilePath = resolve(context.workspaceRoot, configFilePath);
-      if (!requireCacheCleared && require.cache[absConfigFilePath]) {
-        clearRequireCache();
-        requireCacheCleared = true;
-      }
-      const rawConfig = await loadConfigFile(absConfigFilePath, [
-        'tsconfig.spec.json',
-        'tsconfig.test.json',
-        'tsconfig.jest.json',
-        'tsconfig.json',
-      ]);
-      const { externalFiles, needsDtsInputs } =
-        await collectExternalFileReferences(
-          rawConfig,
-          absConfigFilePath,
-          projectRoot,
-          context.workspaceRoot,
-          {
-            presetCache,
-            tsconfigJsonCache,
-            tsconfigExistsCache,
-            isolatedModulesCache,
-          }
+      const absoluteProjectRoot = resolve(absWorkspaceRoot, projectRoot);
+      const externalFiles = new Set<string>();
+
+      const tsconfigAbsPath = findNearestTsconfig(
+        absoluteProjectRoot,
+        absWorkspaceRoot,
+        tsconfigExistsCache
+      );
+
+      let needsDtsInputs = !tsconfigAbsPath;
+      if (tsconfigAbsPath) {
+        const { value: isolatedValue, visitedFiles } = resolveIsolatedModules(
+          tsconfigAbsPath,
+          tsconfigJsonCache,
+          isolatedModulesCache
         );
-      loadedConfigs.push({ rawConfig, externalFiles, needsDtsInputs });
+        if (isolatedValue !== true) needsDtsInputs = true;
+        for (const visitedFile of visitedFiles) {
+          collectExternalFile(
+            visitedFile,
+            absWorkspaceRoot,
+            absoluteProjectRoot,
+            externalFiles
+          );
+        }
+      }
+      configMetadata.push({
+        externalFiles: [...externalFiles],
+        needsDtsInputs,
+      });
     }
 
     const hashes = await calculateHashesForCreateNodes(
       projectRoots,
       options,
       context,
-      loadedConfigs.map(({ externalFiles }) => [
+      configMetadata.map(({ externalFiles }) => [
         lockFilePattern,
         ...externalFiles,
       ])
@@ -194,10 +203,10 @@ export const createNodes: CreateNodesV2<JestPluginOptions> = [
         async (configFilePath, options, context, idx) => {
           const projectRoot = projectRoots[idx];
           const hash = hashes[idx];
-          const { rawConfig, needsDtsInputs } = loadedConfigs[idx];
+          const { needsDtsInputs } = configMetadata[idx];
 
           targetsCache[hash] ??= await buildJestTargets(
-            rawConfig,
+            await loadJestConfig(context.workspaceRoot, configFilePath),
             needsDtsInputs,
             configFilePath,
             projectRoot,
@@ -1024,6 +1033,43 @@ async function getTestPaths(
 }
 
 /**
+ * Adds a file to the external files set if it is inside the workspace but
+ * outside the project root (and not in node_modules).
+ */
+function collectExternalFile(
+  absolutePath: string | null,
+  absWorkspaceRoot: string,
+  absoluteProjectRoot: string,
+  externalFiles: Set<string>
+): void {
+  if (!absolutePath) return;
+  const rel = normalizePath(relative(absWorkspaceRoot, absolutePath));
+  if (rel.startsWith('..') || isAbsolute(rel)) return;
+  if (rel.includes('node_modules/')) return;
+  const relToProject = normalizePath(
+    relative(absoluteProjectRoot, absolutePath)
+  );
+  if (!relToProject.startsWith('..') && !isAbsolute(relToProject)) return;
+  externalFiles.add(rel);
+}
+
+async function loadJestConfig(
+  workspaceRoot: string,
+  configFilePath: string
+): Promise<any> {
+  const absConfigFilePath = resolve(workspaceRoot, configFilePath);
+  if (require.cache[absConfigFilePath]) {
+    clearRequireCache();
+  }
+  return loadConfigFile(absConfigFilePath, [
+    'tsconfig.spec.json',
+    'tsconfig.test.json',
+    'tsconfig.jest.json',
+    'tsconfig.json',
+  ]);
+}
+
+/**
  * Collects workspace-relative paths to files whose CONTENT the plugin reads
  * when computing inferred targets and that live OUTSIDE the project root.
  *
@@ -1063,23 +1109,17 @@ async function collectExternalFileReferences(
   const absoluteProjectRoot = resolve(absWorkspaceRoot, projectRoot);
 
   const externalFiles = new Set<string>();
-  const addIfExternal = (absolutePath: string | null) => {
-    if (!absolutePath) return;
-    const rel = normalizePath(relative(absWorkspaceRoot, absolutePath));
-    if (rel.startsWith('..') || isAbsolute(rel)) return; // outside workspace
-    if (rel.includes('node_modules/')) return; // covered by lockfile
-    const relToProject = normalizePath(
-      relative(absoluteProjectRoot, absolutePath)
-    );
-    if (!relToProject.startsWith('..') && !isAbsolute(relToProject)) return; // inside project root
-    externalFiles.add(rel);
-  };
 
   // Preset path (content is loaded by the plugin to merge with rawConfig)
   if (typeof rawConfig.preset === 'string') {
     const replaced = replaceRootDirInPath(rootDir, rawConfig.preset);
     if (replaced.startsWith('.') || isAbsolute(replaced)) {
-      addIfExternal(resolve(rootDir, replaced));
+      collectExternalFile(
+        resolve(rootDir, replaced),
+        absWorkspaceRoot,
+        absoluteProjectRoot,
+        externalFiles
+      );
     }
   }
 
@@ -1126,7 +1166,12 @@ async function collectExternalFileReferences(
       isolatedModulesCache
     );
     for (const visitedFile of visitedFiles) {
-      addIfExternal(visitedFile);
+      collectExternalFile(
+        visitedFile,
+        absWorkspaceRoot,
+        absoluteProjectRoot,
+        externalFiles
+      );
     }
     if (isolatedValue !== true) needsDtsInputs = true;
   }

--- a/patches/@nx__jest@22.7.0-beta.12.patch
+++ b/patches/@nx__jest@22.7.0-beta.12.patch
@@ -1,92 +1,35 @@
 diff --git a/src/plugins/plugin.js b/src/plugins/plugin.js
-index b275f0648406163b0a37b870a2bc83b3a212f370..98bebb7b8c8d2771b0c83835f4e97edebd79540d 100644
+index b275f0648406163b0a37b870a2bc83b3a212f370..b0517fe43273a783d8f231d5b44f4a1cbae90607 100644
 --- a/src/plugins/plugin.js
 +++ b/src/plugins/plugin.js
-@@ -57,31 +57,38 @@ exports.createNodes = [
+@@ -57,10 +57,16 @@ exports.createNodes = [
              configFiles: [],
          });
          const lockFilePattern = (0, js_1.getLockFileName)(packageManager);
--        let requireCacheCleared = false;
++        // Load configs in parallel. `loadConfigFile` calls `registerTsProject`,
++        // whose transpiler dedup is refcounted: serial register/unregister cycles
++        // drop refCount to 0 between iterations and recreate a fresh ts-node
++        // service each time (ts-node has no cleanup — see
++        // packages/nx/src/plugins/js/utils/register.js), stacking N services in
++        // `require.extensions` and OOM'ing under NX_PREFER_TS_NODE. Parallel
++        // loads keep all registrations alive concurrently so the dedup holds and
++        // a single transpiler instance is shared.
+         let requireCacheCleared = false;
 -        const loadedConfigs = [];
-+        // Collect external file references (tsconfig chains) WITHOUT loading
-+        // jest configs. Instead of require()'ing each config to check if it uses
-+        // ts-jest, we optimistically assume any project might use ts-jest and
-+        // always walk the tsconfig extends chain. This avoids holding all config
-+        // module trees in memory simultaneously, which caused OOM on constrained
-+        // environments (FreeBSD VM with 8GB RAM).
-+        const absWorkspaceRoot = (0, node_path_1.resolve)(context.workspaceRoot);
-+        const configExternalFiles = [];
-         for (let i = 0; i < validConfigFiles.length; i++) {
+-        for (let i = 0; i < validConfigFiles.length; i++) {
 -            const configFilePath = validConfigFiles[i];
++        const loadedConfigs = await Promise.all(validConfigFiles.map(async (configFilePath, i) => {
              const projectRoot = projectRoots[i];
--            const absConfigFilePath = (0, node_path_1.resolve)(context.workspaceRoot, configFilePath);
--            if (!requireCacheCleared && require.cache[absConfigFilePath]) {
--                (0, config_utils_1.clearRequireCache)();
--                requireCacheCleared = true;
-+            const absoluteProjectRoot = (0, node_path_1.resolve)(absWorkspaceRoot, projectRoot);
-+            const externalFiles = new Set();
-+            const addIfExternal = (absolutePath) => {
-+                if (!absolutePath) return;
-+                const rel = (0, devkit_1.normalizePath)((0, node_path_1.relative)(absWorkspaceRoot, absolutePath));
-+                if (rel.startsWith('..') || (0, node_path_1.isAbsolute)(rel)) return;
-+                if (rel.includes('node_modules/')) return;
-+                const relToProject = (0, devkit_1.normalizePath)((0, node_path_1.relative)(absoluteProjectRoot, absolutePath));
-+                if (!relToProject.startsWith('..') && !(0, node_path_1.isAbsolute)(relToProject)) return;
-+                externalFiles.add(rel);
-+            };
-+            // Always walk tsconfig chain — assume ts-jest might be in use
-+            const tsconfigAbsPath = findNearestTsconfig(absoluteProjectRoot, absWorkspaceRoot, tsconfigExistsCache);
-+            if (tsconfigAbsPath) {
-+                const { visitedFiles } = resolveIsolatedModules(tsconfigAbsPath, tsconfigJsonCache, isolatedModulesCache);
-+                for (const visitedFile of visitedFiles) {
-+                    addIfExternal(visitedFile);
-+                }
-             }
--            const rawConfig = await (0, config_utils_1.loadConfigFile)(absConfigFilePath, [
--                'tsconfig.spec.json',
--                'tsconfig.test.json',
--                'tsconfig.jest.json',
--                'tsconfig.json',
--            ]);
--            const { externalFiles, needsDtsInputs } = await collectExternalFileReferences(rawConfig, absConfigFilePath, projectRoot, context.workspaceRoot, {
--                presetCache,
--                tsconfigJsonCache,
--                tsconfigExistsCache,
--                isolatedModulesCache,
--            });
+             const absConfigFilePath = (0, node_path_1.resolve)(context.workspaceRoot, configFilePath);
+             if (!requireCacheCleared && require.cache[absConfigFilePath]) {
+@@ -79,8 +85,8 @@ exports.createNodes = [
+                 tsconfigExistsCache,
+                 isolatedModulesCache,
+             });
 -            loadedConfigs.push({ rawConfig, externalFiles, needsDtsInputs });
-+            configExternalFiles.push([...externalFiles]);
-         }
--        const hashes = await (0, calculate_hash_for_create_nodes_1.calculateHashesForCreateNodes)(projectRoots, options, context, loadedConfigs.map(({ externalFiles }) => [
-+        const hashes = await (0, calculate_hash_for_create_nodes_1.calculateHashesForCreateNodes)(projectRoots, options, context, configExternalFiles.map((externalFiles) => [
+-        }
++            return { rawConfig, externalFiles, needsDtsInputs };
++        }));
+         const hashes = await (0, calculate_hash_for_create_nodes_1.calculateHashesForCreateNodes)(projectRoots, options, context, loadedConfigs.map(({ externalFiles }) => [
              lockFilePattern,
              ...externalFiles,
-         ]));
-@@ -89,8 +96,25 @@ exports.createNodes = [
-             return await (0, devkit_1.createNodesFromFiles)(async (configFilePath, options, context, idx) => {
-                 const projectRoot = projectRoots[idx];
-                 const hash = hashes[idx];
--                const { rawConfig, needsDtsInputs } = loadedConfigs[idx];
--                targetsCache[hash] ??= await buildJestTargets(rawConfig, needsDtsInputs, configFilePath, projectRoot, options, context, presetCache, pmc);
-+                if (!targetsCache[hash]) {
-+                    const absConfigFilePath = (0, node_path_1.resolve)(context.workspaceRoot, configFilePath);
-+                    if (require.cache[absConfigFilePath]) {
-+                        (0, config_utils_1.clearRequireCache)();
-+                    }
-+                    const rawConfig = await (0, config_utils_1.loadConfigFile)(absConfigFilePath, [
-+                        'tsconfig.spec.json',
-+                        'tsconfig.test.json',
-+                        'tsconfig.jest.json',
-+                        'tsconfig.json',
-+                    ]);
-+                    const { needsDtsInputs } = await collectExternalFileReferences(rawConfig, absConfigFilePath, projectRoot, context.workspaceRoot, {
-+                        presetCache,
-+                        tsconfigJsonCache,
-+                        tsconfigExistsCache,
-+                        isolatedModulesCache,
-+                    });
-+                    targetsCache[hash] = await buildJestTargets(rawConfig, needsDtsInputs, configFilePath, projectRoot, options, context, presetCache, pmc);
-+                }
-                 const { targets, metadata } = targetsCache[hash];
-                 return {
-                     projects: {

--- a/patches/@nx__jest@22.7.0-beta.12.patch
+++ b/patches/@nx__jest@22.7.0-beta.12.patch
@@ -1,0 +1,92 @@
+diff --git a/src/plugins/plugin.js b/src/plugins/plugin.js
+index b275f0648406163b0a37b870a2bc83b3a212f370..98bebb7b8c8d2771b0c83835f4e97edebd79540d 100644
+--- a/src/plugins/plugin.js
++++ b/src/plugins/plugin.js
+@@ -57,31 +57,38 @@ exports.createNodes = [
+             configFiles: [],
+         });
+         const lockFilePattern = (0, js_1.getLockFileName)(packageManager);
+-        let requireCacheCleared = false;
+-        const loadedConfigs = [];
++        // Collect external file references (tsconfig chains) WITHOUT loading
++        // jest configs. Instead of require()'ing each config to check if it uses
++        // ts-jest, we optimistically assume any project might use ts-jest and
++        // always walk the tsconfig extends chain. This avoids holding all config
++        // module trees in memory simultaneously, which caused OOM on constrained
++        // environments (FreeBSD VM with 8GB RAM).
++        const absWorkspaceRoot = (0, node_path_1.resolve)(context.workspaceRoot);
++        const configExternalFiles = [];
+         for (let i = 0; i < validConfigFiles.length; i++) {
+-            const configFilePath = validConfigFiles[i];
+             const projectRoot = projectRoots[i];
+-            const absConfigFilePath = (0, node_path_1.resolve)(context.workspaceRoot, configFilePath);
+-            if (!requireCacheCleared && require.cache[absConfigFilePath]) {
+-                (0, config_utils_1.clearRequireCache)();
+-                requireCacheCleared = true;
++            const absoluteProjectRoot = (0, node_path_1.resolve)(absWorkspaceRoot, projectRoot);
++            const externalFiles = new Set();
++            const addIfExternal = (absolutePath) => {
++                if (!absolutePath) return;
++                const rel = (0, devkit_1.normalizePath)((0, node_path_1.relative)(absWorkspaceRoot, absolutePath));
++                if (rel.startsWith('..') || (0, node_path_1.isAbsolute)(rel)) return;
++                if (rel.includes('node_modules/')) return;
++                const relToProject = (0, devkit_1.normalizePath)((0, node_path_1.relative)(absoluteProjectRoot, absolutePath));
++                if (!relToProject.startsWith('..') && !(0, node_path_1.isAbsolute)(relToProject)) return;
++                externalFiles.add(rel);
++            };
++            // Always walk tsconfig chain — assume ts-jest might be in use
++            const tsconfigAbsPath = findNearestTsconfig(absoluteProjectRoot, absWorkspaceRoot, tsconfigExistsCache);
++            if (tsconfigAbsPath) {
++                const { visitedFiles } = resolveIsolatedModules(tsconfigAbsPath, tsconfigJsonCache, isolatedModulesCache);
++                for (const visitedFile of visitedFiles) {
++                    addIfExternal(visitedFile);
++                }
+             }
+-            const rawConfig = await (0, config_utils_1.loadConfigFile)(absConfigFilePath, [
+-                'tsconfig.spec.json',
+-                'tsconfig.test.json',
+-                'tsconfig.jest.json',
+-                'tsconfig.json',
+-            ]);
+-            const { externalFiles, needsDtsInputs } = await collectExternalFileReferences(rawConfig, absConfigFilePath, projectRoot, context.workspaceRoot, {
+-                presetCache,
+-                tsconfigJsonCache,
+-                tsconfigExistsCache,
+-                isolatedModulesCache,
+-            });
+-            loadedConfigs.push({ rawConfig, externalFiles, needsDtsInputs });
++            configExternalFiles.push([...externalFiles]);
+         }
+-        const hashes = await (0, calculate_hash_for_create_nodes_1.calculateHashesForCreateNodes)(projectRoots, options, context, loadedConfigs.map(({ externalFiles }) => [
++        const hashes = await (0, calculate_hash_for_create_nodes_1.calculateHashesForCreateNodes)(projectRoots, options, context, configExternalFiles.map((externalFiles) => [
+             lockFilePattern,
+             ...externalFiles,
+         ]));
+@@ -89,8 +96,25 @@ exports.createNodes = [
+             return await (0, devkit_1.createNodesFromFiles)(async (configFilePath, options, context, idx) => {
+                 const projectRoot = projectRoots[idx];
+                 const hash = hashes[idx];
+-                const { rawConfig, needsDtsInputs } = loadedConfigs[idx];
+-                targetsCache[hash] ??= await buildJestTargets(rawConfig, needsDtsInputs, configFilePath, projectRoot, options, context, presetCache, pmc);
++                if (!targetsCache[hash]) {
++                    const absConfigFilePath = (0, node_path_1.resolve)(context.workspaceRoot, configFilePath);
++                    if (require.cache[absConfigFilePath]) {
++                        (0, config_utils_1.clearRequireCache)();
++                    }
++                    const rawConfig = await (0, config_utils_1.loadConfigFile)(absConfigFilePath, [
++                        'tsconfig.spec.json',
++                        'tsconfig.test.json',
++                        'tsconfig.jest.json',
++                        'tsconfig.json',
++                    ]);
++                    const { needsDtsInputs } = await collectExternalFileReferences(rawConfig, absConfigFilePath, projectRoot, context.workspaceRoot, {
++                        presetCache,
++                        tsconfigJsonCache,
++                        tsconfigExistsCache,
++                        isolatedModulesCache,
++                    });
++                    targetsCache[hash] = await buildJestTargets(rawConfig, needsDtsInputs, configFilePath, projectRoot, options, context, presetCache, pmc);
++                }
+                 const { targets, metadata } = targetsCache[hash];
+                 return {
+                     projects: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,7 +267,7 @@ patchedDependencies:
     hash: 228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235
     path: patches/@astrojs__starlight.patch
   '@nx/jest@22.7.0-beta.12':
-    hash: 62d1d035d26f63090f9b5c9c1c8adff30ba214b0d023fbbab90430f80f169b3b
+    hash: 393101d17cde75c811fcef5a3488f3a602c0016eb1fb3d875af0bf2e3fd015d1
     path: patches/@nx__jest@22.7.0-beta.12.patch
 
 importers:
@@ -634,7 +634,7 @@ importers:
         version: 22.7.0-beta.12(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
       '@nx/jest':
         specifier: 22.7.0-beta.12
-        version: 22.7.0-beta.12(patch_hash=62d1d035d26f63090f9b5c9c1c8adff30ba214b0d023fbbab90430f80f169b3b)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+        version: 22.7.0-beta.12(patch_hash=393101d17cde75c811fcef5a3488f3a602c0016eb1fb3d875af0bf2e3fd015d1)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/js':
         specifier: 22.7.0-beta.12
         version: 22.7.0-beta.12(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
@@ -36360,7 +36360,7 @@ snapshots:
       react-copy-to-clipboard: 5.1.0(react@18.3.1)
       tailwind-merge: 2.6.0
 
-  '@nx/jest@22.7.0-beta.12(patch_hash=62d1d035d26f63090f9b5c9c1c8adff30ba214b0d023fbbab90430f80f169b3b)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/jest@22.7.0-beta.12(patch_hash=393101d17cde75c811fcef5a3488f3a602c0016eb1fb3d875af0bf2e3fd015d1)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@jest/reporters': 30.0.2
       '@jest/test-result': 30.0.2
@@ -36740,7 +36740,7 @@ snapshots:
     dependencies:
       '@nx/devkit': 22.7.0-beta.12(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
       '@nx/eslint': 22.7.0-beta.12(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/jest': 22.7.0-beta.12(patch_hash=62d1d035d26f63090f9b5c9c1c8adff30ba214b0d023fbbab90430f80f169b3b)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/jest': 22.7.0-beta.12(patch_hash=393101d17cde75c811fcef5a3488f3a602c0016eb1fb3d875af0bf2e3fd015d1)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/js': 22.7.0-beta.12(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       tslib: 2.8.1
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,9 +263,6 @@ overrides:
   underscore: ^1.13.8
 
 patchedDependencies:
-  '@astrojs/starlight':
-    hash: 228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235
-    path: patches/@astrojs__starlight.patch
   '@nx/jest@22.7.0-beta.12':
     hash: 393101d17cde75c811fcef5a3488f3a602c0016eb1fb3d875af0bf2e3fd015d1
     path: patches/@nx__jest@22.7.0-beta.12.patch
@@ -426,7 +423,7 @@ importers:
         version: 0.33.5
       starlight-typedoc:
         specifier: ^0.21.3
-        version: 0.21.3(@astrojs/starlight@0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0)))(typedoc-plugin-markdown@3.17.1(typedoc@0.25.12(typescript@5.9.2)))(typedoc@0.25.12(typescript@5.9.2))
+        version: 0.21.3(@astrojs/starlight@0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0)))(typedoc-plugin-markdown@3.17.1(typedoc@0.25.12(typescript@5.9.2)))(typedoc@0.25.12(typescript@5.9.2))
       string-width:
         specifier: ^4.2.3
         version: 4.2.3
@@ -1387,13 +1384,13 @@ importers:
         version: 3.4.1
       '@astrojs/starlight':
         specifier: 0.34.6
-        version: 0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))
+        version: 0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))
       '@astrojs/starlight-markdoc':
         specifier: ^0.4.0
-        version: 0.4.0(@astrojs/markdoc@0.15.1(@types/react@18.3.1)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))(react@18.3.1))(@astrojs/starlight@0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)))
+        version: 0.4.0(@astrojs/markdoc@0.15.1(@types/react@18.3.1)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))(react@18.3.1))(@astrojs/starlight@0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)))
       '@astrojs/starlight-tailwind':
         specifier: ^4.0.1
-        version: 4.0.1(@astrojs/starlight@0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)))(tailwindcss@4.1.11)
+        version: 4.0.1(@astrojs/starlight@0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)))(tailwindcss@4.1.11)
       '@nx/nx-dev-feature-analytics':
         specifier: workspace:*
         version: link:../nx-dev/feature-analytics
@@ -28799,17 +28796,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.25.76
 
-  '@astrojs/starlight-markdoc@0.4.0(@astrojs/markdoc@0.15.1(@types/react@18.3.1)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))(react@18.3.1))(@astrojs/starlight@0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)))':
+  '@astrojs/starlight-markdoc@0.4.0(@astrojs/markdoc@0.15.1(@types/react@18.3.1)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))(react@18.3.1))(@astrojs/starlight@0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)))':
     dependencies:
       '@astrojs/markdoc': 0.15.1(@types/react@18.3.1)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))(react@18.3.1)
-      '@astrojs/starlight': 0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))
+      '@astrojs/starlight': 0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))
 
-  '@astrojs/starlight-tailwind@4.0.1(@astrojs/starlight@0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)))(tailwindcss@4.1.11)':
+  '@astrojs/starlight-tailwind@4.0.1(@astrojs/starlight@0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)))(tailwindcss@4.1.11)':
     dependencies:
-      '@astrojs/starlight': 0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))
+      '@astrojs/starlight': 0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))
       tailwindcss: 4.1.11
 
-  '@astrojs/starlight@0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0))':
+  '@astrojs/starlight@0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.3
       '@astrojs/mdx': 4.3.1(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0))
@@ -28842,7 +28839,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/starlight@0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))':
+  '@astrojs/starlight@0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.3
       '@astrojs/mdx': 4.3.1(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))
@@ -56191,9 +56188,9 @@ snapshots:
 
   standard-as-callback@2.1.0: {}
 
-  starlight-typedoc@0.21.3(@astrojs/starlight@0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0)))(typedoc-plugin-markdown@3.17.1(typedoc@0.25.12(typescript@5.9.2)))(typedoc@0.25.12(typescript@5.9.2)):
+  starlight-typedoc@0.21.3(@astrojs/starlight@0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0)))(typedoc-plugin-markdown@3.17.1(typedoc@0.25.12(typescript@5.9.2)))(typedoc@0.25.12(typescript@5.9.2)):
     dependencies:
-      '@astrojs/starlight': 0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0))
+      '@astrojs/starlight': 0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0))
       github-slugger: 2.0.0
       typedoc: 0.25.12(typescript@5.9.2)
       typedoc-plugin-markdown: 3.17.1(typedoc@0.25.12(typescript@5.9.2))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,9 @@ overrides:
   underscore: ^1.13.8
 
 patchedDependencies:
+  '@astrojs/starlight':
+    hash: 228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235
+    path: patches/@astrojs__starlight.patch
   '@nx/jest@22.7.0-beta.12':
     hash: 393101d17cde75c811fcef5a3488f3a602c0016eb1fb3d875af0bf2e3fd015d1
     path: patches/@nx__jest@22.7.0-beta.12.patch
@@ -423,7 +426,7 @@ importers:
         version: 0.33.5
       starlight-typedoc:
         specifier: ^0.21.3
-        version: 0.21.3(@astrojs/starlight@0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0)))(typedoc-plugin-markdown@3.17.1(typedoc@0.25.12(typescript@5.9.2)))(typedoc@0.25.12(typescript@5.9.2))
+        version: 0.21.3(@astrojs/starlight@0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0)))(typedoc-plugin-markdown@3.17.1(typedoc@0.25.12(typescript@5.9.2)))(typedoc@0.25.12(typescript@5.9.2))
       string-width:
         specifier: ^4.2.3
         version: 4.2.3
@@ -1384,13 +1387,13 @@ importers:
         version: 3.4.1
       '@astrojs/starlight':
         specifier: 0.34.6
-        version: 0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))
+        version: 0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))
       '@astrojs/starlight-markdoc':
         specifier: ^0.4.0
-        version: 0.4.0(@astrojs/markdoc@0.15.1(@types/react@18.3.1)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))(react@18.3.1))(@astrojs/starlight@0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)))
+        version: 0.4.0(@astrojs/markdoc@0.15.1(@types/react@18.3.1)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))(react@18.3.1))(@astrojs/starlight@0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)))
       '@astrojs/starlight-tailwind':
         specifier: ^4.0.1
-        version: 4.0.1(@astrojs/starlight@0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)))(tailwindcss@4.1.11)
+        version: 4.0.1(@astrojs/starlight@0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)))(tailwindcss@4.1.11)
       '@nx/nx-dev-feature-analytics':
         specifier: workspace:*
         version: link:../nx-dev/feature-analytics
@@ -28796,17 +28799,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.25.76
 
-  '@astrojs/starlight-markdoc@0.4.0(@astrojs/markdoc@0.15.1(@types/react@18.3.1)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))(react@18.3.1))(@astrojs/starlight@0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)))':
+  '@astrojs/starlight-markdoc@0.4.0(@astrojs/markdoc@0.15.1(@types/react@18.3.1)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))(react@18.3.1))(@astrojs/starlight@0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)))':
     dependencies:
       '@astrojs/markdoc': 0.15.1(@types/react@18.3.1)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))(react@18.3.1)
-      '@astrojs/starlight': 0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))
+      '@astrojs/starlight': 0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))
 
-  '@astrojs/starlight-tailwind@4.0.1(@astrojs/starlight@0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)))(tailwindcss@4.1.11)':
+  '@astrojs/starlight-tailwind@4.0.1(@astrojs/starlight@0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2)))(tailwindcss@4.1.11)':
     dependencies:
-      '@astrojs/starlight': 0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))
+      '@astrojs/starlight': 0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))
       tailwindcss: 4.1.11
 
-  '@astrojs/starlight@0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0))':
+  '@astrojs/starlight@0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.3
       '@astrojs/mdx': 4.3.1(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0))
@@ -28839,7 +28842,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/starlight@0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))':
+  '@astrojs/starlight@0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.3
       '@astrojs/mdx': 4.3.1(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@24.2.0)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.59.0)(sass-embedded@1.85.1)(sass@1.97.3)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.2))
@@ -56188,9 +56191,9 @@ snapshots:
 
   standard-as-callback@2.1.0: {}
 
-  starlight-typedoc@0.21.3(@astrojs/starlight@0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0)))(typedoc-plugin-markdown@3.17.1(typedoc@0.25.12(typescript@5.9.2)))(typedoc@0.25.12(typescript@5.9.2)):
+  starlight-typedoc@0.21.3(@astrojs/starlight@0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0)))(typedoc-plugin-markdown@3.17.1(typedoc@0.25.12(typescript@5.9.2)))(typedoc@0.25.12(typescript@5.9.2)):
     dependencies:
-      '@astrojs/starlight': 0.34.6(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0))
+      '@astrojs/starlight': 0.34.6(patch_hash=228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235)(astro@5.12.3(@netlify/blobs@10.0.7)(@types/node@20.19.19)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.10.0)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(rollup@4.44.2)(sass-embedded@1.85.1)(sass@1.55.0)(stylus@0.64.0)(terser@5.46.0)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.0))
       github-slugger: 2.0.0
       typedoc: 0.25.12(typescript@5.9.2)
       typedoc-plugin-markdown: 3.17.1(typedoc@0.25.12(typescript@5.9.2))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,9 @@ patchedDependencies:
   '@astrojs/starlight':
     hash: 228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235
     path: patches/@astrojs__starlight.patch
+  '@nx/jest@22.7.0-beta.12':
+    hash: 62d1d035d26f63090f9b5c9c1c8adff30ba214b0d023fbbab90430f80f169b3b
+    path: patches/@nx__jest@22.7.0-beta.12.patch
 
 importers:
 
@@ -631,7 +634,7 @@ importers:
         version: 22.7.0-beta.12(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
       '@nx/jest':
         specifier: 22.7.0-beta.12
-        version: 22.7.0-beta.12(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+        version: 22.7.0-beta.12(patch_hash=62d1d035d26f63090f9b5c9c1c8adff30ba214b0d023fbbab90430f80f169b3b)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/js':
         specifier: 22.7.0-beta.12
         version: 22.7.0-beta.12(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
@@ -36357,7 +36360,7 @@ snapshots:
       react-copy-to-clipboard: 5.1.0(react@18.3.1)
       tailwind-merge: 2.6.0
 
-  '@nx/jest@22.7.0-beta.12(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/jest@22.7.0-beta.12(patch_hash=62d1d035d26f63090f9b5c9c1c8adff30ba214b0d023fbbab90430f80f169b3b)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@jest/reporters': 30.0.2
       '@jest/test-result': 30.0.2
@@ -36737,7 +36740,7 @@ snapshots:
     dependencies:
       '@nx/devkit': 22.7.0-beta.12(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
       '@nx/eslint': 22.7.0-beta.12(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/jest': 22.7.0-beta.12(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/jest': 22.7.0-beta.12(patch_hash=62d1d035d26f63090f9b5c9c1c8adff30ba214b0d023fbbab90430f80f169b3b)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@20.19.19)(typescript@5.9.2))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/js': 22.7.0-beta.12(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))(nx@22.7.0-beta.12(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       tslib: 2.8.1
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ onlyBuiltDependencies:
   - 'nx'
 patchedDependencies:
   '@astrojs/starlight': 'patches/@astrojs__starlight.patch'
+allowNonAppliedPatches: true
 catalog:
   '@zkochan/js-yaml': '0.0.7'
   chalk: '^4.1.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,7 @@ onlyBuiltDependencies:
   - 'nx'
 patchedDependencies:
   '@astrojs/starlight': 'patches/@astrojs__starlight.patch'
+  '@nx/jest@22.7.0-beta.12': 'patches/@nx__jest@22.7.0-beta.12.patch'
 allowNonAppliedPatches: true
 catalog:
   '@zkochan/js-yaml': '0.0.7'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ onlyBuiltDependencies:
 patchedDependencies:
   '@astrojs/starlight': 'patches/@astrojs__starlight.patch'
   '@nx/jest@22.7.0-beta.12': 'patches/@nx__jest@22.7.0-beta.12.patch'
-allowNonAppliedPatches: true
+allowUnusedPatches: true
 catalog:
   '@zkochan/js-yaml': '0.0.7'
   chalk: '^4.1.0'


### PR DESCRIPTION
## Current Behavior

The FreeBSD native build in the publish workflow fails with "filesystem full" or OOM. Two issues:

1. **Jest plugin OOM**: PR #35231 changed `createNodes` to load all jest configs upfront in a sequential `for` loop before hash computation. Each `loadConfigFile` registers a ts-node transpiler via `registerTsProject` (`packages/nx/src/plugins/js/utils/register.js`), whose dedup is refcounted. Serial register/unregister cycles drive refCount to 0 between iterations and delete the Map entry — but ts-node's `transpilerCleanup` is a no-op, so the service stays alive in `require.extensions`. The next iteration creates a fresh ts-node service. Across 96 TS jest configs under `NX_PREFER_TS_NODE=true` (set for the FreeBSD build), 96 ts-node services stack and OOM at V8's ~2GB heap limit.

2. **Core dump fills disk**: When the jest plugin OOMs, FreeBSD writes a 2.3GB `node.core` file to the workspace root, filling the remaining 4GB of free disk space before cargo can run.

### Failing runs

- [beta.13 publish (Apr 15)](https://github.com/nrwl/nx/actions/runs/24480325293/job/71547815608) — `filesystem full` during project graph, cargo never ran
- [Canary after beta.12 (Apr 10)](https://github.com/nrwl/nx/actions/runs/24260184601/job/70841801347) — jest plugin OOM at 2GB heap, `node.core` filled disk
- [Diagnostics run](https://github.com/nrwl/nx/actions/runs/24490680528/job/71574929552) — confirmed 2.3GB `node.core` file in workspace root

### Passing run (with pnpm patch)

- [Fix validation run (Apr 16)](https://github.com/nrwl/nx/actions/runs/24508325992/job/71632565433) — jest plugin no longer OOMs, cargo compiles successfully (validated an earlier lazy-load form of the patch; the current form uses parallel load but is equivalent for FreeBSD's resource envelope)

## Expected Behavior

The FreeBSD build completes successfully. The jest plugin loads configs in parallel so the ts-node transpiler dedup holds across all registrations and only one service is created.

### Changes

**Jest plugin memory fix** (`packages/jest/src/plugins/plugin.ts`):
- Convert the upfront config-loading `for` loop to `Promise.all(validConfigFiles.map(async ...))`. Keeps all `registerTsProject` registrations alive concurrently so refCount goes `0→1→2→…→N→N-1→…→0` and only one ts-node service is ever created.
- Preserves #35231's hash correctness: preset path and tsconfig extends chain remain inputs to `calculateHashesForCreateNodes`; `needsDtsInputs` is still derived from the real jest config + ts-jest transform inspection.

**pnpm patch** (`patches/@nx__jest@22.7.0-beta.12.patch`):
- Same fix applied to the installed `@nx/jest@22.7.0-beta.12` so the FreeBSD build (which uses the published package, not source) gets the fix immediately. Generated via `pnpm patch` from the built source output — installed `plugin.js` is byte-identical to `dist/packages/jest/src/plugins/plugin.js`.

**Workflow hardening** (`.github/workflows/publish.yml`):
- `ulimit -c 0` to disable core dumps (prevents 2.3GB files from filling disk)
- `NODE_OPTIONS='--max-old-space-size=4096'` as a safety net
- Disk usage diagnostics on build failure for future debugging

### Local verification

Cold cache (`npx nx reset` before each run), `NX_PREFER_TS_NODE=true NX_CACHE_PROJECT_GRAPH=false NX_DAEMON=false`, 96 TS jest configs:

- **Pre-fix (serial for-loop)**: per-iteration heap grows `40 → 60 → 160 → 756 MB` at iter 1/10/20/30, then OOM at iter ~33 with `--max-old-space-size=4096`.
- **Post-fix (parallel)**: heap flat at **272 MB from load 1 through 96**. `require.cache` constant at 599 entries. No accumulation.
- Real `nx show projects` end-to-end: 600 MB RSS, 5 s.

### Follow-up (separate PR)

`packages/nx/src/plugins/js/utils/register.js` has a latent leak: when the transpiler has no real cleanup (ts-node always, swc sometimes), `registered.delete(registrationKey)` on refCount==0 allows the next registration with the same key to stack a fresh service. Any Nx plugin that loads configs serially hits this. Worth gating `registered.delete` on whether the transpiler is actually disposable, analogous to the existing `isTsEsmLoaderRegistered` flag. Not in scope for this PR.

## Related Issue(s)

Fixes the FreeBSD build failure in the publish workflow.
