### PR TITLE
chore(misc): update docs version script

### DIFF
--- a/astro-docs/README.md
+++ b/astro-docs/README.md
@@ -194,8 +194,8 @@ Example:
 
 ```markdown
 ---
-title: "My New Guide"
-description: "Learn how to use this feature"
+title: 'My New Guide'
+description: 'Learn how to use this feature'
 ---
 
 # Introduction

--- a/astro-docs/README.md
+++ b/astro-docs/README.md
@@ -194,8 +194,8 @@ Example:
 
 ```markdown
 ---
-title: 'My New Guide'
-description: 'Learn how to use this feature'
+title: "My New Guide"
+description: "Learn how to use this feature"
 ---
 
 # Introduction
@@ -325,31 +325,44 @@ The Framer page should render JSON inside a `<pre>` tag:
 
 ## Versioned Docs
 
-When a new major Nx version is released (or about to be released), create a versioned snapshot of the docs site so the previous version remains accessible at `v{major}.nx.dev` (e.g. `v22.nx.dev`).
+When a new major Nx version is released (or about to be released), create a versioned snapshot of the docs site so the previous version remains accessible at `{major}.nx.dev` (e.g. `22.nx.dev`).
 
 ### Creating a Version Snapshot
 
 ```bash
-node ./scripts/create-versioned-docs.mts v22
+node ./scripts/create-versioned-docs.mts 22
 ```
 
 This will:
 
 1. Fetch tags from origin, find the latest stable release for that major (e.g. `22.6.4`)
-2. Checkout that tag, install deps, and build astro-docs
-3. Create an orphan git branch `v22` containing only the pre-built static site
+2. Checkout that tag, install deps, and build the docs site
+3. Create an orphan git branch `22` containing only the pre-built static site plus minimal scaffolding (root `package.json`, `nx.json`, `pnpm-lock.yaml`, `netlify.toml`, and a no-op `nx-dev` project) so Netlify's configured build command succeeds instantly
 4. Return to your original branch
 
 If no stable tags exist for that major version, it builds from the current branch.
 
-The branch contains a no-op `project.json` build target so Netlify's existing build command (`pnpm nx build astro-docs --force`) succeeds instantly without rebuilding.
+For Nx 21+, the script builds `astro-docs` (Astro/Starlight). For legacy Nx 18–20, it builds `nx-dev` (Next.js with static export) — this path will be removed once those versions are no longer maintained.
+
+#### Flags
+
+- `--force` — overwrite an existing local/remote `{major}` branch
+- `--redirect-to-prod` — skip the build and produce a branch that 301s every path to `https://nx.dev/docs`. Used to retire an old versioned subdomain (e.g. `16.nx.dev`) without maintaining its docs
+
+```bash
+# Retire an old versioned site
+node ./scripts/create-versioned-docs.mts 16 --redirect-to-prod
+```
 
 ### Pushing the Branch
 
 ```bash
-git push -f origin v22
+git push -f origin 22
 ```
 
-### Netlify Setup
+### Deployment Setup
 
-Each versioned branch is deployed as a [Netlify branch deploy](https://docs.netlify.com/site-deploys/overview/#branch-deploy-controls). Configure the branch subdomain in Netlify to point `v22.nx.dev` to the `v22` branch deploy.
+Versioned sites are served via Netlify branch deploys of the main `nx-dev` Netlify site, with custom domains managed in Squarespace.
+
+- **Netlify** — each `{major}` branch is deployed as a [branch deploy](https://docs.netlify.com/site-deploys/overview/#branch-deploy-controls) of the `nx-dev` site. The branch's root `netlify.toml` overrides the UI build settings so Netlify serves the pre-built static files (no rebuild, no `@netlify/plugin-nextjs`). Add the branch to the site's branch deploy allowlist, then add `{major}.nx.dev` as a domain alias pointing at the branch deploy
+- **Squarespace** — DNS for `nx.dev` is managed in Squarespace. Add a CNAME for `{major}` pointing at the Netlify branch deploy hostname

--- a/nx-dev/nx-dev/README.md
+++ b/nx-dev/nx-dev/README.md
@@ -2,6 +2,42 @@
 
 This folder contains the app and libs to power [nx.dev](https://nx.dev).
 
+## Versioned Docs
+
+The previous major's docs are preserved at `{major}.nx.dev` (e.g. `22.nx.dev`) using pre-built static snapshots on orphan branches, deployed via Netlify branch deploys.
+
+**The primary docs site now lives in `astro-docs/`.** This Next.js app is only built into a versioned snapshot for legacy majors (Nx 18–20) and will stop being versioned once those are retired. See [`astro-docs/README.md`](../../astro-docs/README.md#versioned-docs) for the authoritative versioning workflow.
+
+### Creating a Version Snapshot
+
+From the repo root:
+
+```bash
+# Nx 21+ (builds astro-docs)
+node ./scripts/create-versioned-docs.mts 22
+
+# Nx 18–20 (builds this Next.js app with static export) — legacy path
+node ./scripts/create-versioned-docs.mts 20
+
+# Retire an old versioned site (301 everything to nx.dev/docs, no build)
+node ./scripts/create-versioned-docs.mts 16 --redirect-to-prod
+```
+
+The script finds the latest stable tag for that major, checks it out, builds, and creates an orphan branch named `{major}` containing only the pre-built static site plus minimal scaffolding (root `package.json`, `nx.json`, `pnpm-lock.yaml`, `netlify.toml`, and a no-op `nx-dev` project) so Netlify's UI-configured build command succeeds instantly.
+
+Pass `--force` to overwrite an existing local/remote `{major}` branch.
+
+```bash
+git push -f origin 22
+```
+
+### Deployment Setup
+
+Versioned sites are served via Netlify branch deploys of the main `nx-dev` Netlify site, with custom domains managed in Squarespace.
+
+- **Netlify** — each `{major}` branch is deployed as a [branch deploy](https://docs.netlify.com/site-deploys/overview/#branch-deploy-controls). The branch's root `netlify.toml` overrides the UI build settings so Netlify serves the pre-built static files (no rebuild, no `@netlify/plugin-nextjs`). Add the branch to the site's branch deploy allowlist, then add `{major}.nx.dev` as a domain alias pointing at the branch deploy
+- **Squarespace** — DNS for `nx.dev` is managed in Squarespace. Add a CNAME for `{major}` pointing at the Netlify branch deploy hostname
+
 ## Banner Configuration
 
 The floating banner promotes events/webinars. It's fetched at **build time** from a Framer CMS page and stored locally.

--- a/scripts/create-versioned-docs.mts
+++ b/scripts/create-versioned-docs.mts
@@ -4,6 +4,12 @@
  * Usage:
  *   node ./scripts/create-versioned-docs.mts v22
  *   node ./scripts/create-versioned-docs.mts 22
+ *   node ./scripts/create-versioned-docs.mts v16 --redirect-to-prod
+ *
+ * --redirect-to-prod: skip the build and produce a branch that 301s every
+ *   path to https://nx.dev/docs. Used to retire an old versioned subdomain
+ *   (e.g. 16.nx.dev) without maintaining its docs — old paths won't map
+ *   cleanly anymore, so everything goes to the /docs root.
  *
  * What it does:
  *   1. Fetches tags from origin, finds the latest stable release for that major
@@ -177,6 +183,42 @@ ${headersAndRedirects}`
 }
 
 // ---------------------------------------------------------------------------
+// Stage: redirect-to-prod (no build)
+// Produces a dummy publish dir + netlify.toml that 301s everything to nx.dev/docs.
+// Used to retire an old versioned subdomain without maintaining its docs.
+// ---------------------------------------------------------------------------
+function stageRedirectToProd(tmpDir: string): void {
+  const publishDir = resolve(tmpDir, PUBLISH_DIR);
+  mkdirSync(publishDir, { recursive: true });
+
+  writeFileSync(
+    resolve(publishDir, 'index.html'),
+    `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting to nx.dev/docs</title>
+    <meta http-equiv="refresh" content="0; url=https://nx.dev/docs">
+    <link rel="canonical" href="https://nx.dev/docs">
+    <script>window.location.replace("https://nx.dev/docs");</script>
+  </head>
+  <body>
+    Redirecting to <a href="https://nx.dev/docs">https://nx.dev/docs</a>.
+  </body>
+</html>
+`
+  );
+
+  const headersAndRedirects = `[[redirects]]
+  from = "/*"
+  to = "https://nx.dev/docs"
+  status = 301
+  force = true`;
+
+  writeSharedScaffolding(tmpDir, headersAndRedirects);
+}
+
+// ---------------------------------------------------------------------------
 // Build + stage: Astro (v21+)
 // ---------------------------------------------------------------------------
 function buildAndStageAstro(tmpDir: string): void {
@@ -284,12 +326,16 @@ function buildAndStageNextjs(tmpDir: string): void {
 const positionalArgs = process.argv.slice(2).filter((a) => !a.startsWith('-'));
 const flags = new Set(process.argv.slice(2).filter((a) => a.startsWith('-')));
 const force = flags.has('--force');
+const redirectToProd = flags.has('--redirect-to-prod');
 
 if (positionalArgs.length === 0) {
   console.error(
-    'Usage: node ./scripts/create-versioned-docs.mts <version> [--force]'
+    'Usage: node ./scripts/create-versioned-docs.mts <version> [--force] [--redirect-to-prod]'
   );
   console.error('  e.g. node ./scripts/create-versioned-docs.mts v22');
+  console.error(
+    '       node ./scripts/create-versioned-docs.mts v16 --redirect-to-prod'
+  );
   process.exit(1);
 }
 
@@ -329,7 +375,13 @@ if (branchExists && !force) {
 
 console.log(`\nCreating versioned docs branch: ${branchName}`);
 console.log(
-  `Site type: ${isAstro ? 'Astro (v21+)' : 'Next.js (legacy v18-v20)'}\n`
+  `Site type: ${
+    redirectToProd
+      ? 'redirect-to-prod (no build)'
+      : isAstro
+      ? 'Astro (v21+)'
+      : 'Next.js (legacy v18-v20)'
+  }\n`
 );
 
 // Save current ref to return to later
@@ -338,25 +390,34 @@ const currentRef = execSync('git rev-parse --abbrev-ref HEAD', { cwd: ROOT })
   .trim();
 
 // --- Step 0: Find and checkout the latest stable tag ---
-console.log('=== Step 0: Finding latest stable release tag ===\n');
-run('git fetch --tags --force origin');
-
-const latestTag = findLatestStableTag(majorVersion);
+// Skipped in --redirect-to-prod mode: there's nothing to build, so the source
+// ref doesn't matter — stay on the current branch for commit provenance.
 let sourceRef: string;
-
-if (latestTag) {
-  sourceRef = latestTag;
-  console.log(`Found latest stable tag: ${sourceRef}`);
-  run(`git checkout ${sourceRef}`);
-} else {
+if (redirectToProd) {
   sourceRef = currentRef;
   console.log(
-    `No stable tags found for major version ${majorVersion}. Using current branch: ${currentRef}`
+    '=== Step 0: Skipped (redirect-to-prod) ===\n' +
+      `Using current ref: ${sourceRef}\n`
   );
+} else {
+  console.log('=== Step 0: Finding latest stable release tag ===\n');
+  run('git fetch --tags --force origin');
+
+  const latestTag = findLatestStableTag(majorVersion);
+  if (latestTag) {
+    sourceRef = latestTag;
+    console.log(`Found latest stable tag: ${sourceRef}`);
+    run(`git checkout ${sourceRef}`);
+  } else {
+    sourceRef = currentRef;
+    console.log(
+      `No stable tags found for major version ${majorVersion}. Using current branch: ${currentRef}`
+    );
+  }
 }
 
 // --- Resolve GITHUB_TOKEN (needed for GitHub stars in docs build) ---
-if (!process.env.GITHUB_TOKEN) {
+if (!redirectToProd && !process.env.GITHUB_TOKEN) {
   try {
     const token = execSync(
       "op read --account tuskteam 'op://Employee/API Keys/github_token'",
@@ -381,21 +442,23 @@ if (!process.env.GITHUB_TOKEN) {
 // --- Step 1: Install + build ---
 console.log('\n=== Step 1: Building docs site ===\n');
 
-// Legacy Next.js builds need Node 20 — pin via mise so child processes use it
-if (!isAstro) {
-  console.log('Pinning Node 20 via mise for legacy build...');
-  run('mise use node@20');
-  useMise = true;
-}
+if (!redirectToProd) {
+  // Legacy Next.js builds need Node 20 — pin via mise so child processes use it
+  if (!isAstro) {
+    console.log('Pinning Node 20 via mise for legacy build...');
+    run('mise use node@20');
+    useMise = true;
+  }
 
-// Remove node_modules to avoid stale deps from a different version/branch
-const nodeModulesDir = resolve(ROOT, 'node_modules');
-if (existsSync(nodeModulesDir)) {
-  console.log('Removing node_modules for clean install...');
-  rmSync(nodeModulesDir, { recursive: true });
-}
+  // Remove node_modules to avoid stale deps from a different version/branch
+  const nodeModulesDir = resolve(ROOT, 'node_modules');
+  if (existsSync(nodeModulesDir)) {
+    console.log('Removing node_modules for clean install...');
+    rmSync(nodeModulesDir, { recursive: true });
+  }
 
-run('pnpm install --frozen-lockfile');
+  run('pnpm install --frozen-lockfile');
+}
 
 const tmpDir = resolve(ROOT, 'tmp/versioned-docs');
 if (existsSync(tmpDir)) {
@@ -403,7 +466,9 @@ if (existsSync(tmpDir)) {
 }
 mkdirSync(tmpDir, { recursive: true });
 
-if (isAstro) {
+if (redirectToProd) {
+  stageRedirectToProd(tmpDir);
+} else if (isAstro) {
   buildAndStageAstro(tmpDir);
 } else {
   buildAndStageNextjs(tmpDir);

--- a/scripts/create-versioned-docs.mts
+++ b/scripts/create-versioned-docs.mts
@@ -396,8 +396,8 @@ console.log(
     redirectToProd
       ? 'redirect-to-prod (no build)'
       : isAstro
-      ? 'Astro (v21+)'
-      : 'Next.js (legacy v18-v20)'
+        ? 'Astro (v21+)'
+        : 'Next.js (legacy v18-v20)'
   }\n`
 );
 

--- a/scripts/create-versioned-docs.mts
+++ b/scripts/create-versioned-docs.mts
@@ -188,6 +188,8 @@ ${headersAndRedirects}`
 // Used to retire an old versioned subdomain without maintaining its docs.
 // ---------------------------------------------------------------------------
 function stageRedirectToProd(tmpDir: string): void {
+  // Publish dir must match the Netlify UI setting (nx-dev/nx-dev/.next) —
+  // the UI value is authoritative; a toml `publish` override isn't honored.
   const publishDir = resolve(tmpDir, PUBLISH_DIR);
   mkdirSync(publishDir, { recursive: true });
 
@@ -209,13 +211,28 @@ function stageRedirectToProd(tmpDir: string): void {
 `
   );
 
-  const headersAndRedirects = `[[redirects]]
+  // netlify.toml: overrides the UI build command to a no-op and force-301s
+  // every path to nx.dev/docs. Publish dir stays as the UI-configured
+  // ${PUBLISH_DIR}. No package.json / lockfile / nx scaffolding needed.
+  writeFileSync(
+    resolve(tmpDir, 'netlify.toml'),
+    `# Auto-generated for redirect-to-prod versioned branch.
+# Overrides Netlify UI build command so no install/build runs.
+# Publish dir stays as the UI-configured ${PUBLISH_DIR}.
+
+[build]
+  command = "echo 'redirect-only branch — no build'"
+
+[build.environment]
+  NETLIFY_NEXT_PLUGIN_SKIP = "true"
+
+[[redirects]]
   from = "/*"
   to = "https://nx.dev/docs"
   status = 301
-  force = true`;
-
-  writeSharedScaffolding(tmpDir, headersAndRedirects);
+  force = true
+`
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -482,15 +499,23 @@ try {
   run('git rm -rf .');
 
   // Copy staged files into the working tree
-  cpSync(resolve(tmpDir, 'package.json'), resolve(ROOT, 'package.json'));
-  cpSync(resolve(tmpDir, 'nx.json'), resolve(ROOT, 'nx.json'));
-  cpSync(resolve(tmpDir, 'pnpm-lock.yaml'), resolve(ROOT, 'pnpm-lock.yaml'));
-  cpSync(resolve(tmpDir, 'netlify.toml'), resolve(ROOT, 'netlify.toml'));
-  cpSync(resolve(tmpDir, 'nx-dev'), resolve(ROOT, 'nx-dev'), {
-    recursive: true,
-  });
-
-  run('git add package.json nx.json pnpm-lock.yaml netlify.toml nx-dev/');
+  if (redirectToProd) {
+    cpSync(resolve(tmpDir, 'netlify.toml'), resolve(ROOT, 'netlify.toml'));
+    // Publish dir tree lives at nx-dev/nx-dev/.next/ — matches Netlify UI.
+    cpSync(resolve(tmpDir, 'nx-dev'), resolve(ROOT, 'nx-dev'), {
+      recursive: true,
+    });
+    run('git add netlify.toml nx-dev/');
+  } else {
+    cpSync(resolve(tmpDir, 'package.json'), resolve(ROOT, 'package.json'));
+    cpSync(resolve(tmpDir, 'nx.json'), resolve(ROOT, 'nx.json'));
+    cpSync(resolve(tmpDir, 'pnpm-lock.yaml'), resolve(ROOT, 'pnpm-lock.yaml'));
+    cpSync(resolve(tmpDir, 'netlify.toml'), resolve(ROOT, 'netlify.toml'));
+    cpSync(resolve(tmpDir, 'nx-dev'), resolve(ROOT, 'nx-dev'), {
+      recursive: true,
+    });
+    run('git add package.json nx.json pnpm-lock.yaml netlify.toml nx-dev/');
+  }
   run(
     `git commit -m "docs: versioned docs snapshot for ${branchName} (from ${sourceRef})"`
   );


### PR DESCRIPTION
Add support for `--redirect-to-prod` flag for 16, 17, 18 which we do not have versioned docs for. Also update README.md with more details on how Netlify and Squarespace are used to support versions docs.