### PR TITLE
fix(core): hash tasks before cache lookup to prevent null-hash crash on Cloud agents

### DIFF
--- a/packages/nx/src/tasks-runner/init-tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/init-tasks-runner.ts
@@ -175,6 +175,14 @@ export async function runDiscreteTasks(
     lifeCycle
   );
 
+  // Kick off hashing + scheduleTask lifecycle for every task immediately so
+  // they overlap with the batch dispatch loop below. Both helpers are
+  // idempotent (hashTasks filters !task.hash; lifecycle dedupes via Set), so
+  // the per-task defensive calls in runTaskDirectly stay cheap no-ops.
+  const prepared = orchestrator
+    .ensureHashes(tasks)
+    .then(() => orchestrator.fireScheduleLifecycle(tasks));
+
   let groupId = 0;
   let nextBatch = orchestrator.nextBatch();
   const batchResults: Array<Promise<TaskResult[]>> = [];
@@ -195,6 +203,10 @@ export async function runDiscreteTasks(
   }
 
   const discreteTasks = tasks.filter((task) => !batchTasks.has(task.id));
+
+  // Wait for the bulk prepare before any cache lookup. resolveCachedTasks
+  // would also self-hash, but waiting here means it hits a no-op filter.
+  await prepared;
 
   // Bulk-resolve every discrete task's cache state in one shot —
   // single SQL call plus parallel remote retrievals. Batches kicked
@@ -231,6 +243,13 @@ export async function runContinuousTasks(
     nxJson,
     lifeCycle
   );
+
+  // Bulk-prepare so each startContinuousTask doesn't serialize on a single-
+  // task hash call. Per-task defensive calls inside startContinuousTask hit
+  // the no-op filter once these resolve.
+  await orchestrator.ensureHashes(tasks);
+  await orchestrator.fireScheduleLifecycle(tasks);
+
   return tasks.reduce(
     (current, task, index) => {
       current[task.id] = orchestrator.startContinuousTask(task, index);

--- a/packages/nx/src/tasks-runner/init-tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/init-tasks-runner.ts
@@ -157,8 +157,6 @@ async function createOrchestrator(
 
   await orchestrator.init();
 
-  orchestrator.processAllScheduledTasks();
-
   return orchestrator;
 }
 

--- a/packages/nx/src/tasks-runner/task-env.ts
+++ b/packages/nx/src/tasks-runner/task-env.ts
@@ -22,10 +22,9 @@ export function getEnvVariablesForBatchProcess(
   };
 }
 
-// The orchestrator now calls this eagerly during the coordinator pre-hash
-// in addition to processTask (and again in hashBatchTasks), so the same
-// task hits this function multiple times per run. Each call reads 3+ .env
-// files from disk — memoize by task.id to skip the repeat work.
+// Each call reads 3+ .env files from disk and the orchestrator hits this
+// function multiple times per task (coordinator pre-hash, hashBatchTasks,
+// per-task env at run time). Memoize by task.id to skip the repeat work.
 //
 // Cache lifetime is the current Nx invocation: the function is only called
 // from CLI/orchestrator code (not the long-lived daemon), so the map is

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -796,7 +796,7 @@ export class TaskOrchestrator {
    * any path; the dedupe Set guarantees at-most-once even when the
    * coordinator and a leaf path both reach the same task.
    */
-  private async fireScheduleLifecycle(tasks: Task[]): Promise<void> {
+  async fireScheduleLifecycle(tasks: Task[]): Promise<void> {
     const newlyScheduled: Task[] = [];
     for (const task of tasks) {
       if (this.scheduledIds.has(task.id)) continue;
@@ -817,7 +817,7 @@ export class TaskOrchestrator {
    * env changes. `hashTasks` filters by `!task.hash` internally, so this
    * is safe to call on already-hashed sets.
    */
-  private async ensureHashes(tasks: Task[]): Promise<void> {
+  async ensureHashes(tasks: Task[]): Promise<void> {
     const unhashed = tasks.filter((t) => !t.hash);
     if (unhashed.length === 0) return;
 

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -9,7 +9,7 @@ import { readProjectsConfigurationFromProjectGraph } from '../project-graph/proj
 import { Task, TaskGraph } from '../config/task-graph';
 import { DaemonClient } from '../daemon/client/client';
 import { runCommands } from '../executors/run-commands/run-commands.impl';
-import { getTaskDetails, hashTask, hashTasks } from '../hasher/hash-task';
+import { getTaskDetails, hashTasks } from '../hasher/hash-task';
 import { walkTaskGraph } from './task-graph-utils';
 import { getInputs, TaskHasher } from '../hasher/task-hasher';
 import {
@@ -100,7 +100,7 @@ export class TaskOrchestrator {
 
   private initializingTaskIds = new Set(this.initiatingTasks.map((t) => t.id));
 
-  private processedTasks = new Map<string, Promise<NodeJS.ProcessEnv>>();
+  private scheduledIds = new Set<string>();
 
   private completedTasks = new Map<string, TaskStatus>();
   private waitingForTasks: Function[] = [];
@@ -236,10 +236,6 @@ export class TaskOrchestrator {
    * happen on this single thread — no races. Cache misses are dispatched
    * as fire-and-forget workers. Workers signal completion via
    * scheduleNextTasksAndReleaseThreads which wakes all waiting loops.
-   *
-   * Safety: the dispatch phase (step 5) is fully synchronous — no
-   * worker can run during it. So all tasks picked up by nextTask()
-   * are guaranteed to be in processedTasks from step 1.
    */
   private async executeCoordinatorLoop(
     doNotSkipCache: boolean,
@@ -248,50 +244,29 @@ export class TaskOrchestrator {
     while (true) {
       if (this.bailed || this.stopRequested) break;
 
-      // 1. Hash BEFORE processAll so processTask sees hashes set, and so
-      //    resolveCachedTasksBulk can look them up in the cache. Each task
-      //    is hashed with its own task-specific env (project/target .env
-      //    files, custom hasher env reads) — the shared batchEnv would
-      //    compute a different cache key than the single-task path and
-      //    risk stale cache reuse after env changes.
-      {
-        const { scheduledTasks } = this.tasksSchedule.getAllScheduledTasks();
-        const unhashed = scheduledTasks
-          .map((id) => this.taskGraph.tasks[id])
-          .filter(
-            (t) =>
-              !t.hash &&
-              this.taskGraph.dependencies[t.id].every((depId) =>
-                this.completedTasks.has(depId)
-              )
-          );
-        if (unhashed.length > 1) {
-          const perTaskEnvs: Record<string, NodeJS.ProcessEnv> = {};
-          for (const task of unhashed) {
-            perTaskEnvs[task.id] = getTaskSpecificEnv(task, this.projectGraph);
-          }
-          await hashTasks(
-            this.hasher,
-            this.projectGraph,
-            this.taskGraphForHashing,
-            perTaskEnvs,
-            this.taskDetails,
-            unhashed
-          );
-        }
-      }
+      // 1. Hash + scheduleTask all dep-ready scheduled tasks before any
+      //    cache check or dispatch. Hashing must happen first so cache
+      //    lookups have keys; scheduleTask must fire before dispatch to
+      //    match the pre-refactor "queued = scheduled" semantics.
+      const ready = this.tasksSchedule
+        .getAllScheduledTasks()
+        .scheduledTasks.map((id) => this.taskGraph.tasks[id])
+        .filter((t) =>
+          this.taskGraph.dependencies[t.id].every((depId) =>
+            this.completedTasks.has(depId)
+          )
+        );
+      await this.ensureHashes(ready);
+      await this.fireScheduleLifecycle(ready);
 
-      // 2. Bulk-resolve cache hits before processTask — avoids N
-      //    lifecycle calls for tasks that will be resolved from cache.
+      // 2. Bulk-resolve cache hits — one SQL call + parallel remote
+      //    retrievals for everything cacheable in this cycle.
       if (doNotSkipCache) {
         const resolved = await this.resolveCachedTasksBulk();
         if (resolved) continue;
       }
 
-      // 3. Process remaining scheduled tasks (cache misses + non-cacheable).
-      this.processAllScheduledTasks();
-
-      // 4. Handle batch executors
+      // 3. Handle batch executors
       const batch = this.nextBatch();
       if (batch) {
         const groupId = this.closeGroup();
@@ -300,7 +275,7 @@ export class TaskOrchestrator {
         continue;
       }
 
-      // 5. Dispatch cache misses as individual workers
+      // 4. Dispatch cache misses as individual workers
       while (this.pendingDiscreteWorkers.size < parallelism) {
         const task = this.tasksSchedule.nextTask((t) => !t.continuous);
         if (!task) break;
@@ -308,7 +283,7 @@ export class TaskOrchestrator {
         this.dispatchDiscreteWorker(doNotSkipCache, task, groupId);
       }
 
-      // 6. Nothing left to dispatch and nothing in flight — done.
+      // 5. Nothing left to dispatch and nothing in flight — done.
       if (
         !this.tasksSchedule.hasTasks() &&
         this.pendingDiscreteWorkers.size === 0
@@ -316,7 +291,7 @@ export class TaskOrchestrator {
         break;
       }
 
-      // 7. Wait for a worker to finish (woken by scheduleNextTasksAndReleaseThreads)
+      // 6. Wait for a worker to finish (woken by scheduleNextTasksAndReleaseThreads)
       await new Promise((res) => this.waitingForTasks.push(res));
     }
   }
@@ -327,8 +302,6 @@ export class TaskOrchestrator {
       if (!this.tasksSchedule.hasTasks() || this.bailed || this.stopRequested) {
         return null;
       }
-
-      this.processAllScheduledTasks();
 
       const task = this.tasksSchedule.nextTask((t) => t.continuous);
       if (task) {
@@ -357,39 +330,6 @@ export class TaskOrchestrator {
       await new Promise((res) => this.waitingForTasks.push(res));
     }
   }
-
-  // region Processing Scheduled Tasks
-  private async processTask(taskId: string): Promise<NodeJS.ProcessEnv> {
-    const task = this.taskGraph.tasks[taskId];
-    const taskSpecificEnv = getTaskSpecificEnv(task, this.projectGraph);
-
-    if (!task.hash) {
-      await hashTask(
-        this.hasher,
-        this.projectGraph,
-        this.taskGraphForHashing,
-        task,
-        taskSpecificEnv,
-        this.taskDetails
-      );
-    }
-
-    await this.options.lifeCycle.scheduleTask(task);
-
-    return taskSpecificEnv;
-  }
-
-  public processAllScheduledTasks() {
-    const { scheduledTasks } = this.tasksSchedule.getAllScheduledTasks();
-    for (const taskId of scheduledTasks) {
-      // Task is already handled or being handled
-      if (!this.processedTasks.has(taskId)) {
-        this.processedTasks.set(taskId, this.processTask(taskId));
-      }
-    }
-  }
-
-  // endregion Processing Scheduled Tasks
 
   // region Applying Cache
 
@@ -585,9 +525,7 @@ export class TaskOrchestrator {
 
         if (cacheResults.length > 0) {
           const cachedTasks = cacheResults.map((r) => r.task);
-          await Promise.all(
-            cachedTasks.map((task) => this.options.lifeCycle.scheduleTask(task))
-          );
+          await this.fireScheduleLifecycle(cachedTasks);
           await this.preRunSteps(cachedTasks, { groupId });
           await this.postRunSteps(cacheResults, doNotSkipCache, { groupId });
         }
@@ -646,9 +584,7 @@ export class TaskOrchestrator {
     const cachedTaskIds = new Set(cachedResults.map((r) => r.task.id));
     const nonCachedTasks = tasks.filter((t) => !cachedTaskIds.has(t.id));
     if (nonCachedTasks.length > 0) {
-      await Promise.all(
-        nonCachedTasks.map((task) => this.options.lifeCycle.scheduleTask(task))
-      );
+      await this.fireScheduleLifecycle(nonCachedTasks);
       await this.preRunSteps(nonCachedTasks, { groupId });
     }
 
@@ -826,15 +762,11 @@ export class TaskOrchestrator {
   // region Single Task
 
   /**
-   * Bulk-resolve cache hits for a set of tasks: fetch cached entries,
-   * copy outputs as needed, fire lifecycle, and return the TaskResults
-   * for the hits. Tasks that aren't in the cache (or aren't cacheable)
-   * are silently omitted from the return value — callers are responsible
-   * for running those via {@link runTaskDirectly}.
-   *
-   * Fires scheduleTask lifecycle for hits that haven't been through
-   * processAllScheduledTasks yet. That's a coordinator gap-filler and
-   * a no-op for callers that pre-process the schedule.
+   * Bulk-resolve cache hits for a set of tasks: hash any unhashed tasks,
+   * fetch cached entries, copy outputs as needed, fire lifecycle, and
+   * return the TaskResults for the hits. Tasks that aren't in the cache
+   * (or aren't cacheable) are silently omitted from the return value —
+   * callers are responsible for running those via {@link runTaskDirectly}.
    *
    * The caller provides `groupId` — cache hits share one slot since they
    * don't actually compete for parallelism.
@@ -851,23 +783,61 @@ export class TaskOrchestrator {
     );
     if (cacheableTasks.length === 0) return [];
 
+    await this.ensureHashes(cacheableTasks);
+    await this.fireScheduleLifecycle(cacheableTasks);
+
     const cacheHits = await this.fetchCacheHits(cacheableTasks);
     if (cacheHits.length === 0) return [];
-
-    // scheduleTask lifecycle for hits the coordinator resolved before
-    // processAllScheduledTasks could fire it. No-op for callers that
-    // already ran processAllScheduledTasks (every hit is in processedTasks).
-    await Promise.all(
-      cacheHits
-        .filter(({ task }) => !this.processedTasks.has(task.id))
-        .map(({ task }) => this.options.lifeCycle.scheduleTask(task))
-    );
 
     const hitTasks = cacheHits.map((h) => h.task);
     await this.preRunSteps(hitTasks, { groupId });
     const results = await this.finalizeCacheHits(cacheHits);
     await this.postRunSteps(results, doNotSkipCache, { groupId });
     return results;
+  }
+
+  /**
+   * Fire `scheduleTask` lifecycle exactly once per task. Safe to call from
+   * any path; the dedupe Set guarantees at-most-once even when the
+   * coordinator and a leaf path both reach the same task.
+   */
+  private async fireScheduleLifecycle(tasks: Task[]): Promise<void> {
+    const newlyScheduled: Task[] = [];
+    for (const task of tasks) {
+      if (this.scheduledIds.has(task.id)) continue;
+      this.scheduledIds.add(task.id);
+      newlyScheduled.push(task);
+    }
+    if (newlyScheduled.length === 0) return;
+    await Promise.all(
+      newlyScheduled.map((t) => this.options.lifeCycle.scheduleTask(t))
+    );
+  }
+
+  /**
+   * Batch-hash any tasks in the set that lack a hash. Each task is hashed
+   * with its own task-specific env (project/target `.env` files, custom
+   * hasher env reads) — the shared batchEnv would compute a different
+   * cache key than the single-task path and risk stale cache reuse after
+   * env changes. `hashTasks` filters by `!task.hash` internally, so this
+   * is safe to call on already-hashed sets.
+   */
+  private async ensureHashes(tasks: Task[]): Promise<void> {
+    const unhashed = tasks.filter((t) => !t.hash);
+    if (unhashed.length === 0) return;
+
+    const perTaskEnvs: Record<string, NodeJS.ProcessEnv> = {};
+    for (const task of unhashed) {
+      perTaskEnvs[task.id] = getTaskSpecificEnv(task, this.projectGraph);
+    }
+    await hashTasks(
+      this.hasher,
+      this.projectGraph,
+      this.taskGraphForHashing,
+      perTaskEnvs,
+      this.taskDetails,
+      unhashed
+    );
   }
 
   /**
@@ -935,8 +905,9 @@ export class TaskOrchestrator {
     task: Task,
     groupId: number
   ): Promise<TaskResult> {
-    // Wait for task to be processed
-    const taskSpecificEnv = await this.processedTasks.get(task.id);
+    await this.ensureHashes([task]);
+    await this.fireScheduleLifecycle([task]);
+    const taskSpecificEnv = getTaskSpecificEnv(task, this.projectGraph);
 
     await this.preRunSteps([task], { groupId });
 
@@ -1209,6 +1180,9 @@ export class TaskOrchestrator {
   }
 
   async startContinuousTask(task: Task, groupId: number) {
+    await this.ensureHashes([task]);
+    await this.fireScheduleLifecycle([task]);
+
     if (
       this.runningTasksService &&
       this.runningTasksService.getRunningTasks([task.id]).length
@@ -1245,7 +1219,7 @@ export class TaskOrchestrator {
       return runningTask;
     }
 
-    const taskSpecificEnv = await this.processedTasks.get(task.id);
+    const taskSpecificEnv = getTaskSpecificEnv(task, this.projectGraph);
     await this.preRunSteps([task], { groupId });
 
     const pipeOutput = await this.pipeOutputCapture(task);

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -244,18 +244,13 @@ export class TaskOrchestrator {
     while (true) {
       if (this.bailed || this.stopRequested) break;
 
-      // 1. Hash + scheduleTask all dep-ready scheduled tasks before any
-      //    cache check or dispatch. Hashing must happen first so cache
-      //    lookups have keys; scheduleTask must fire before dispatch to
-      //    match the pre-refactor "queued = scheduled" semantics.
+      // 1. Hash + scheduleTask everything currently scheduled before any
+      //    cache check or dispatch. tasksSchedule.scheduledTasks only ever
+      //    contains dep-ready tasks (added from the roots of the not-yet-
+      //    scheduled subgraph), so no extra dep filter is needed.
       const ready = this.tasksSchedule
         .getAllScheduledTasks()
-        .scheduledTasks.map((id) => this.taskGraph.tasks[id])
-        .filter((t) =>
-          this.taskGraph.dependencies[t.id].every((depId) =>
-            this.completedTasks.has(depId)
-          )
-        );
+        .scheduledTasks.map((id) => this.taskGraph.tasks[id]);
       await this.ensureHashes(ready);
       await this.fireScheduleLifecycle(ready);
 


### PR DESCRIPTION
## Current Behavior

Nx Cloud agents crash on warm-cache runs with:

```
Error: Failed to convert JavaScript value `Null` into rust type `String`
    at DbCache.getBatch (.../cache.js:115:41)
    at TaskOrchestrator.fetchCacheHits (.../task-orchestrator.js:270:47)
    at TaskOrchestrator.resolveCachedTasks (.../task-orchestrator.js:564:38)
    at runDiscreteTasks (.../init-tasks-runner.js:133:42)
  code: 'StringExpected'
```

Regression introduced by #35172 (warm-cache perf optimization). `init-tasks-runner.ts::createOrchestrator` calls `orchestrator.processAllScheduledTasks()` **without awaiting** — that method only sets up hashing promises in a private `processedTasks` map. `runDiscreteTasks` then immediately calls `resolveCachedTasks`, which hits `cache.getBatch(tasks.map(t => t.hash))`. Hashes are still `null` because the queued `processTask` → `hashTask` promises haven't resolved.

## Expected Behavior

Warm-cache agent runs resolve cached tasks without crashing.

Rather than papering over with another `await`, the underlying state machine is simplified. The `processedTasks: Map<string, Promise<NodeJS.ProcessEnv>>` field bundled three concerns into one shared promise (env memo, hash dedupe, `scheduleTask` lifecycle) and created the timing trap. Investigation showed it was now vestigial:

- `getTaskSpecificEnv` already memoizes internally via `taskSpecificEnvCache` (`task-env.ts:35-50`).
- No `LifeCycle` implementation in the codebase implements `scheduleTask`.
- `task.hash` itself is the natural gate for hash dedupe.

So `processedTasks`, `processTask`, and `processAllScheduledTasks` are deleted. Two single-purpose helpers replace them:

- `ensureHashes(tasks)` — batch-hashes any tasks lacking a hash; idempotent because `hashTasks` filters by `!task.hash` internally.
- `fireScheduleLifecycle(tasks)` — fires `scheduleTask` once per task, deduped by a `scheduledIds: Set<string>`.

Both run in coordinator step 1 (before any cache check or dispatch — preserves the pre-refactor "queued = scheduled" timing) and defensively in `resolveCachedTasks`, `runTaskDirectly`, `startContinuousTask`, and `applyFromCacheOrRunBatch`. Idempotent dedupe means safe-to-call from any path.

Bonus: coordinator step 1's hash guard `unhashed.length > 1` → `> 0`. The `> 1` was a micro-optimization that silently skipped cache lookup for single-task cycles (because `resolveCachedTasksBulk` filters by `task.hash &&`). Cost more in lost cache hits than it saved in batch setup.

Net: **−29 lines** in `task-orchestrator.ts` despite adding two helper docstrings.

## Related Issue(s)

No GitHub issue — surfaced internally on a CI run after upgrading Nx.
