### PR TITLE
fix(core): await queued processTask promises before cache.getBatch

### DIFF
--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -851,6 +851,10 @@ export class TaskOrchestrator {
     );
     if (cacheableTasks.length === 0) return [];
 
+    // Wait for any queued processTask promises to settle so task.hash is
+    // populated before cache.getBatch maps it into a Rust String.
+    await Promise.all(cacheableTasks.map((t) => this.processedTasks.get(t.id)));
+
     const cacheHits = await this.fetchCacheHits(cacheableTasks);
     if (cacheHits.length === 0) return [];
 

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -265,7 +265,7 @@ export class TaskOrchestrator {
                 this.completedTasks.has(depId)
               )
           );
-        if (unhashed.length > 1) {
+        if (unhashed.length > 0) {
           const perTaskEnvs: Record<string, NodeJS.ProcessEnv> = {};
           for (const task of unhashed) {
             perTaskEnvs[task.id] = getTaskSpecificEnv(task, this.projectGraph);


### PR DESCRIPTION
## Current Behavior

Nx Cloud agents crash on warm-cache runs with:

```
Error: Failed to convert JavaScript value `Null` into rust type `String`
    at DbCache.getBatch (.../cache.js:115:41)
    at TaskOrchestrator.fetchCacheHits (.../task-orchestrator.js:270:47)
    at TaskOrchestrator.resolveCachedTasks (.../task-orchestrator.js:564:38)
    at runDiscreteTasks (.../init-tasks-runner.js:133:42)
  code: 'StringExpected'
```

Regression introduced by #35172 (warm-cache perf optimization). Cloud agents call `runDiscreteTasks` with `task.hash = null` (they intentionally null hashes — see `ocean/.../execute-tasks-v3.ts`). `init-tasks-runner.ts::createOrchestrator` queues `processTask` promises via fire-and-forget `processAllScheduledTasks()`, but `runDiscreteTasks` immediately calls `resolveCachedTasks` which doesn't await them. `cache.getBatch(tasks.map(t => t.hash))` then receives nulls and the napi binding rejects them.

## Expected Behavior

`resolveCachedTasks` awaits the queued `processTask` promises (which set `task.hash` via `hashTask`) before passing hashes into `cache.getBatch`.

The single-task `runTaskDirectly` path already awaits `this.processedTasks.get(task.id)` for the same reason — this fix mirrors that pattern in the bulk path.

Bonus: a second tiny commit changes coordinator step 1's pre-hash guard from `unhashed.length > 1` to `> 0`. The `> 1` micro-optimization silently skipped cache lookup for single-task cycles, because `resolveCachedTasksBulk` filters candidates by `task.hash &&` — a length-1 unhashed task got dropped and ran without a cache check. Cost more in lost cache hits than it saved in batch setup.

## Related Issue(s)

Surfaced internally; no GitHub issue.
