### PR TITLE
fix(repo): switch agent apt mirror to azure to avoid canonical sync races

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -36,7 +36,16 @@ common-init-steps: &common-init-steps
 
   - name: Install system deps
     script: |
-      sudo apt-get update
+      # archive.ubuntu.com periodically serves a Packages.gz that doesn't
+      # match its own InRelease metadata while the canonical mirror is
+      # mid-sync, breaking apt-get update across all agents at once.
+      # Switch to Azure's mirror — better SLA and historically stable.
+      sudo sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g; s|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+      for i in 1 2 3 4 5; do
+        sudo apt-get -o Acquire::Retries=3 update && break
+        echo "apt-get update failed (attempt $i/5), retrying in 30s..."
+        sleep 30
+      done
       sudo apt-get install -y ca-certificates lsof libvips-dev libglib2.0-dev libgirepository1.0-dev zip unzip
 
   - name: Pnpm Install from lockfile

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -39,13 +39,9 @@ common-init-steps: &common-init-steps
       # archive.ubuntu.com periodically serves a Packages.gz that doesn't
       # match its own InRelease metadata while the canonical mirror is
       # mid-sync, breaking apt-get update across all agents at once.
-      # Switch to Azure's mirror — better SLA and historically stable.
+      # Azure's mirror has a better SLA and is what GitHub Actions runners use.
       sudo sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g; s|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
-      for i in 1 2 3 4 5; do
-        sudo apt-get -o Acquire::Retries=3 update && break
-        echo "apt-get update failed (attempt $i/5), retrying in 30s..."
-        sleep 30
-      done
+      sudo apt-get update
       sudo apt-get install -y ca-certificates lsof libvips-dev libglib2.0-dev libgirepository1.0-dev zip unzip
 
   - name: Pnpm Install from lockfile


### PR DESCRIPTION
## Current Behavior

CI agents launched by `.nx/workflows/agents.yaml` are failing during the `Install system deps` step on a majority of agents:

```
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/jammy-updates/main/binary-amd64/Packages.gz
File has unexpected size (4263778 != 4263737). Mirror sync in progress? [IP: 91.189.92.22 80]
```

`archive.ubuntu.com` is serving a `Packages.gz` whose size/hash doesn't match its own `InRelease` metadata while the canonical mirror is mid-sync. Apt detects the mismatch and refuses to use the index. Without that index, `apt-get install` fails to find packages and the agent dies before any task runs. Every agent hits the same mirror, so every agent fails simultaneously — taking down distributed CI runs.

This is currently affecting both PR CI and master CI on staging (confirmed via `gh run` and Nx Cloud CIPE status).

## Expected Behavior

`apt-get update` succeeds reliably on agent provisioning, regardless of canonical-mirror sync races.

Switch the agent's apt sources from `archive.ubuntu.com` / `security.ubuntu.com` to `azure.archive.ubuntu.com` via a one-line `sed` on `/etc/apt/sources.list`. Azure's mirror is what GitHub Actions runners use by default — historically much more stable than canonical for the "many concurrent CI agents hammering one mirror" workload that triggers the sync race.

## Related Issue(s)

No GitHub issue — surfaced today via the linked CI failures.
