### PR TITLE
chore(repo): parallelize e2e-ci tasks on large/xlarge agents

### DIFF
--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -23,9 +23,9 @@ assignment-rules:
       - e2e-ci**
     run-on:
       - agent: linux-large
-        parallelism: 2
-      - agent: linux-extra-large
         parallelism: 3
+      - agent: linux-extra-large
+        parallelism: 4
 
   - targets:
       - bench:*

--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -6,31 +6,6 @@ distribute-on:
   extra-large-changeset: 8 linux-large, 8 linux-extra-large
 assignment-rules:
   - projects:
-      - e2e-gradle
-    targets:
-      - e2e-ci**
-    run-on:
-      - agent: linux-extra-large
-        parallelism: 1
-  - projects:
-      - e2e-next
-      - e2e-plugin
-    targets:
-      - e2e-ci**
-    run-on:
-      - agent: linux-extra-large
-        parallelism: 2
-  - projects:
-      - e2e-angular
-      - e2e-node
-      - e2e-react
-    targets:
-      - e2e-ci**
-    run-on:
-      - agent: linux-extra-large
-        parallelism: 1
-
-  - projects:
       - nx
       - workspace
       - remix
@@ -44,29 +19,6 @@ assignment-rules:
       - agent: linux-extra-large
         parallelism: 1
 
-  - projects:
-      - e2e-release
-      - e2e-nuxt
-      - e2e-web
-      - e2e-eslint
-      - e2e-remix
-      - e2e-cypress
-      - e2e-docker
-      - e2e-js
-      - e2e-nx
-      - e2e-nx-init
-      - e2e-dotnet
-      - e2e-workspace-create
-      - e2e-rollup
-    targets:
-      - e2e-ci**
-    run-on:
-      - agent: linux-large
-        parallelism: 1
-      - agent: linux-extra-large
-        parallelism: 2
-
-  # All other e2e tests can run in parallel
   - targets:
       - e2e-ci**
     run-on:

--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -19,6 +19,19 @@ assignment-rules:
       - agent: linux-extra-large
         parallelism: 1
 
+  # e2e-angular's module-federation tests bind hard-coded port 4200 for the
+  # generated host (https://nx.dev/recipes/module-federation/setup-mf), which
+  # collides when multiple of them run on the same agent. Keep them serial
+  # until we can pin the dev-server port per test reliably.
+  - projects:
+      - e2e-angular
+    targets:
+      - e2e-ci**
+    run-on:
+      - agent: linux-large
+        parallelism: 1
+      - agent: linux-extra-large
+        parallelism: 1
   - targets:
       - e2e-ci**
     run-on:

--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -19,19 +19,6 @@ assignment-rules:
       - agent: linux-extra-large
         parallelism: 1
 
-  # e2e-angular's module-federation tests bind hard-coded port 4200 for the
-  # generated host (https://nx.dev/recipes/module-federation/setup-mf), which
-  # collides when multiple of them run on the same agent. Keep them serial
-  # until we can pin the dev-server port per test reliably.
-  - projects:
-      - e2e-angular
-    targets:
-      - e2e-ci**
-    run-on:
-      - agent: linux-large
-        parallelism: 1
-      - agent: linux-extra-large
-        parallelism: 1
   - targets:
       - e2e-ci**
     run-on:

--- a/.nx/workflows/dynamic-changesets.yaml
+++ b/.nx/workflows/dynamic-changesets.yaml
@@ -23,7 +23,7 @@ assignment-rules:
       - e2e-ci**
     run-on:
       - agent: linux-large
-        parallelism: 3
+        parallelism: 2
       - agent: linux-extra-large
         parallelism: 4
 

--- a/e2e/angular/src/module-federation-host-remote.test.ts
+++ b/e2e/angular/src/module-federation-host-remote.test.ts
@@ -2,6 +2,7 @@ import { names } from '@nx/devkit';
 import {
   checkFilesExist,
   killProcessAndPorts,
+  reservePort,
   runCLI,
   runCommandUntil,
   uniq,
@@ -30,8 +31,8 @@ describe('Angular Module Federation - Host and Remote', () => {
     const sharedLib = uniq('shared-lib');
     const wildcardLib = uniq('wildcard-lib');
     const secondaryEntry = uniq('secondary');
-    const hostPort = 4300;
-    const remotePort = 4301;
+    const hostPort = reservePort();
+    const remotePort = reservePort();
 
     // generate host app
     runCLI(
@@ -170,8 +171,8 @@ describe('Angular Module Federation - Host and Remote', () => {
   it('should convert apps to MF successfully', async () => {
     const app1 = uniq('app1');
     const app2 = uniq('app2');
-    const app1Port = 4400;
-    const app2Port = 4401;
+    const app1Port = reservePort();
+    const app2Port = reservePort();
 
     // generate apps
     runCLI(

--- a/e2e/angular/src/module-federation-host-remote.test.ts
+++ b/e2e/angular/src/module-federation-host-remote.test.ts
@@ -36,7 +36,7 @@ describe('Angular Module Federation - Host and Remote', () => {
 
     // generate host app
     runCLI(
-      `generate @nx/angular:host ${hostApp} --style=css --no-standalone --unitTestRunner=jest --no-interactive`
+      `generate @nx/angular:host ${hostApp} --port=${hostPort} --style=css --no-standalone --unitTestRunner=jest --no-interactive`
     );
     // generate remote app
     runCLI(

--- a/e2e/angular/src/module-federation-host-remote.test.ts
+++ b/e2e/angular/src/module-federation-host-remote.test.ts
@@ -31,8 +31,8 @@ describe('Angular Module Federation - Host and Remote', () => {
     const sharedLib = uniq('shared-lib');
     const wildcardLib = uniq('wildcard-lib');
     const secondaryEntry = uniq('secondary');
-    const hostPort = reservePort();
-    const remotePort = reservePort();
+    const hostPort = await reservePort();
+    const remotePort = await reservePort();
 
     // generate host app
     runCLI(
@@ -171,8 +171,8 @@ describe('Angular Module Federation - Host and Remote', () => {
   it('should convert apps to MF successfully', async () => {
     const app1 = uniq('app1');
     const app2 = uniq('app2');
-    const app1Port = reservePort();
-    const app2Port = reservePort();
+    const app1Port = await reservePort();
+    const app2Port = await reservePort();
 
     // generate apps
     runCLI(

--- a/e2e/angular/src/module-federation-host-remote.test.ts
+++ b/e2e/angular/src/module-federation-host-remote.test.ts
@@ -153,7 +153,7 @@ describe('Angular Module Federation - Host and Remote', () => {
       `serve ${hostApp} --port=${hostPort} --dev-remotes=${remoteApp1}`,
       (output) =>
         !output.includes(`Remote '${remoteApp1}' failed to serve correctly`) &&
-        output.includes(`listening on localhost:${hostPort}`)
+        output.includes(`server ready at http://localhost:${hostPort}`)
     );
     await killProcessAndPorts(processSwc.pid, hostPort, remotePort);
 
@@ -161,7 +161,7 @@ describe('Angular Module Federation - Host and Remote', () => {
       `serve ${hostApp} --port=${hostPort} --dev-remotes=${remoteApp1}`,
       (output) =>
         !output.includes(`Remote '${remoteApp1}' failed to serve correctly`) &&
-        output.includes(`listening on localhost:${hostPort}`),
+        output.includes(`server ready at http://localhost:${hostPort}`),
       { env: { NX_PREFER_TS_NODE: 'true' } }
     );
 
@@ -194,7 +194,7 @@ describe('Angular Module Federation - Host and Remote', () => {
       `serve ${app1} --dev-remotes=${app2}`,
       (output) =>
         !output.includes(`Remote '${app2}' failed to serve correctly`) &&
-        output.includes(`listening on localhost:${app1Port}`)
+        output.includes(`server ready at http://localhost:${app1Port}`)
     );
 
     await killProcessAndPorts(processSwc.pid, app1Port, app2Port);
@@ -203,7 +203,7 @@ describe('Angular Module Federation - Host and Remote', () => {
       `serve ${app1} --dev-remotes=${app2}`,
       (output) =>
         !output.includes(`Remote '${app2}' failed to serve correctly`) &&
-        output.includes(`listening on localhost:${app1Port}`),
+        output.includes(`server ready at http://localhost:${app1Port}`),
       { env: { NX_PREFER_TS_NODE: 'true' } }
     );
 

--- a/e2e/angular/src/module-federation-lib.test.ts
+++ b/e2e/angular/src/module-federation-lib.test.ts
@@ -1,5 +1,6 @@
 import {
   killProcessAndPorts,
+  reservePort,
   runCLI,
   runCommandUntil,
   runE2ETests,
@@ -27,10 +28,10 @@ describe('Angular Module Federation - Federated Libraries', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const hostPort = 4200;
+    const hostPort = await reservePort();
 
     runCLI(
-      `generate @nx/angular:host ${host} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`
+      `generate @nx/angular:host ${host} --port=${hostPort} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`
     );
 
     runCLI(`generate @nx/js:lib ${lib} --no-interactive`);
@@ -101,10 +102,10 @@ describe('Angular Module Federation - Federated Libraries', () => {
     const childRemote = uniq('childremote');
     const module = uniq('module');
     const host = uniq('host');
-    const hostPort = 4200;
+    const hostPort = await reservePort();
 
     runCLI(
-      `generate @nx/angular:host ${host} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`
+      `generate @nx/angular:host ${host} --port=${hostPort} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`
     );
 
     runCLI(`generate @nx/js:lib ${lib} --no-interactive`);

--- a/e2e/angular/src/module-federation-lib.test.ts
+++ b/e2e/angular/src/module-federation-lib.test.ts
@@ -103,11 +103,12 @@ describe('Angular Module Federation - Federated Libraries', () => {
 
     if (runE2ETests('cypress')) {
       const e2eProcess = await runCommandUntil(
-        `e2e ${host}-e2e`,
+        // Pass --baseUrl so the cypress preset's webServerCommand wait
+        // targets our reserved hostPort instead of the cypress.config.ts
+        // default 4200.
+        `e2e ${host}-e2e --baseUrl=http://localhost:${hostPort}`,
         (output) => output.includes('All specs passed!'),
-        // Force NX_DAEMON=false so the e2e child reads the updated project.json
-        // (with our pinned ports) instead of a stale cached graph.
-        { timeout: 120000, env: { NX_DAEMON: 'false' } }
+        { timeout: 120000 }
       );
       await killProcessAndPorts(e2eProcess.pid, hostPort, staticRemotesPort);
     }
@@ -207,11 +208,12 @@ describe('Angular Module Federation - Federated Libraries', () => {
 
     if (runE2ETests('cypress')) {
       const e2eProcess = await runCommandUntil(
-        `e2e ${host}-e2e`,
+        // Pass --baseUrl so the cypress preset's webServerCommand wait
+        // targets our reserved hostPort instead of the cypress.config.ts
+        // default 4200.
+        `e2e ${host}-e2e --baseUrl=http://localhost:${hostPort}`,
         (output) => output.includes('All specs passed!'),
-        // Force NX_DAEMON=false so the e2e child reads the updated project.json
-        // (with our pinned ports) instead of a stale cached graph.
-        { timeout: 120000, env: { NX_DAEMON: 'false' } }
+        { timeout: 120000 }
       );
       await killProcessAndPorts(e2eProcess.pid, hostPort, staticRemotesPort);
     }

--- a/e2e/angular/src/module-federation-lib.test.ts
+++ b/e2e/angular/src/module-federation-lib.test.ts
@@ -45,6 +45,9 @@ describe('Angular Module Federation - Federated Libraries', () => {
       project.targets.serve.options.staticRemotesPort = staticRemotesPort;
       return project;
     });
+    // Reset the daemon so subsequent runCLI calls re-read the updated
+    // project.json instead of serving a cached graph with the default port.
+    runCLI('reset');
 
     runCLI(`generate @nx/js:lib ${lib} --no-interactive`);
 
@@ -127,6 +130,9 @@ describe('Angular Module Federation - Federated Libraries', () => {
       project.targets.serve.options.staticRemotesPort = staticRemotesPort;
       return project;
     });
+    // Reset the daemon so subsequent runCLI calls re-read the updated
+    // project.json instead of serving a cached graph with the default port.
+    runCLI('reset');
 
     runCLI(`generate @nx/js:lib ${lib} --no-interactive`);
 

--- a/e2e/angular/src/module-federation-lib.test.ts
+++ b/e2e/angular/src/module-federation-lib.test.ts
@@ -1,5 +1,6 @@
 import {
   killProcessAndPorts,
+  reservePort,
   runCLI,
   runCommandUntil,
   runE2ETests,
@@ -27,7 +28,7 @@ describe('Angular Module Federation - Federated Libraries', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const hostPort = 4200;
+    const hostPort = reservePort();
 
     runCLI(
       `generate @nx/angular:host ${host} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`
@@ -101,7 +102,7 @@ describe('Angular Module Federation - Federated Libraries', () => {
     const childRemote = uniq('childremote');
     const module = uniq('module');
     const host = uniq('host');
-    const hostPort = 4200;
+    const hostPort = reservePort();
 
     runCLI(
       `generate @nx/angular:host ${host} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`

--- a/e2e/angular/src/module-federation-lib.test.ts
+++ b/e2e/angular/src/module-federation-lib.test.ts
@@ -1,12 +1,11 @@
 import {
   killProcessAndPorts,
-  reservePorts,
+  reservePort,
   runCLI,
   runCommandUntil,
   runE2ETests,
   uniq,
   updateFile,
-  updateJson,
 } from '@nx/e2e-utils';
 import {
   setupModuleFederationTest,
@@ -29,25 +28,11 @@ describe('Angular Module Federation - Federated Libraries', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    // Reserve two ports — one for the host's dev-server, one for the
-    // static-remotes file-server (it would otherwise auto-pick maxPort+1
-    // and collide with a parallel test).
-    const [hostPort, staticRemotesPort] = await reservePorts(2);
+    const hostPort = await reservePort();
 
     runCLI(
       `generate @nx/angular:host ${host} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`
     );
-
-    // Pin both ports on the host's serve target so parallel tests don't
-    // collide on the default 4200 / auto-picked staticRemotesPort.
-    updateJson(`${host}/project.json`, (project) => {
-      project.targets.serve.options.port = hostPort;
-      project.targets.serve.options.staticRemotesPort = staticRemotesPort;
-      return project;
-    });
-    // Reset the daemon so subsequent runCLI calls re-read the updated
-    // project.json instead of serving a cached graph with the default port.
-    runCLI('reset');
 
     runCLI(`generate @nx/js:lib ${lib} --no-interactive`);
 
@@ -85,13 +70,13 @@ describe('Angular Module Federation - Federated Libraries', () => {
       `
       describe('${host}', () => {
         beforeEach(() => cy.visit('/'));
-      
+
         it('should display contain the remote library', () => {
           expect(cy.get('div.host')).to.exist;
           expect(cy.get('div.host').contains('shell is even'));
         });
       });
-      
+
       `
     );
 
@@ -105,11 +90,9 @@ describe('Angular Module Federation - Federated Libraries', () => {
       const e2eProcess = await runCommandUntil(
         `e2e ${host}-e2e`,
         (output) => output.includes('All specs passed!'),
-        // Force NX_DAEMON=false so the e2e child reads the updated project.json
-        // (with our pinned ports) instead of a stale cached graph.
-        { timeout: 120000, env: { NX_DAEMON: 'false' } }
+        { timeout: 120000 }
       );
-      await killProcessAndPorts(e2eProcess.pid, hostPort, staticRemotesPort);
+      await killProcessAndPorts(e2eProcess.pid, hostPort, hostPort + 1);
     }
   }, 500_000);
 
@@ -119,22 +102,11 @@ describe('Angular Module Federation - Federated Libraries', () => {
     const childRemote = uniq('childremote');
     const module = uniq('module');
     const host = uniq('host');
-    const [hostPort, staticRemotesPort] = await reservePorts(2);
+    const hostPort = await reservePort();
 
     runCLI(
       `generate @nx/angular:host ${host} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`
     );
-
-    // Pin both ports on the host's serve target so parallel tests don't
-    // collide on the default 4200 / auto-picked staticRemotesPort.
-    updateJson(`${host}/project.json`, (project) => {
-      project.targets.serve.options.port = hostPort;
-      project.targets.serve.options.staticRemotesPort = staticRemotesPort;
-      return project;
-    });
-    // Reset the daemon so subsequent runCLI calls re-read the updated
-    // project.json instead of serving a cached graph with the default port.
-    runCLI('reset');
 
     runCLI(`generate @nx/js:lib ${lib} --no-interactive`);
 
@@ -189,13 +161,13 @@ describe('Angular Module Federation - Federated Libraries', () => {
       `
       describe('${host}', () => {
         beforeEach(() => cy.visit('/${remote}'));
-      
+
         it('should display contain the remote library', () => {
           expect(cy.get('div.childremote')).to.exist;
           expect(cy.get('div.childremote').contains('shell is even'));
         });
       });
-      
+
       `
     );
 
@@ -209,11 +181,9 @@ describe('Angular Module Federation - Federated Libraries', () => {
       const e2eProcess = await runCommandUntil(
         `e2e ${host}-e2e`,
         (output) => output.includes('All specs passed!'),
-        // Force NX_DAEMON=false so the e2e child reads the updated project.json
-        // (with our pinned ports) instead of a stale cached graph.
-        { timeout: 120000, env: { NX_DAEMON: 'false' } }
+        { timeout: 120000 }
       );
-      await killProcessAndPorts(e2eProcess.pid, hostPort, staticRemotesPort);
+      await killProcessAndPorts(e2eProcess.pid, hostPort, hostPort + 1);
     }
   }, 500_000);
 });

--- a/e2e/angular/src/module-federation-lib.test.ts
+++ b/e2e/angular/src/module-federation-lib.test.ts
@@ -6,6 +6,7 @@ import {
   runE2ETests,
   uniq,
   updateFile,
+  updateJson,
 } from '@nx/e2e-utils';
 import {
   setupModuleFederationTest,
@@ -33,6 +34,14 @@ describe('Angular Module Federation - Federated Libraries', () => {
     runCLI(
       `generate @nx/angular:host ${host} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`
     );
+
+    // Pin the host's serve port to the reserved one so parallel tests don't
+    // collide on the default 4200. The cypress devServerTarget=${host}:serve
+    // will pick this up automatically.
+    updateJson(`${host}/project.json`, (project) => {
+      project.targets.serve.options.port = hostPort;
+      return project;
+    });
 
     runCLI(`generate @nx/js:lib ${lib} --no-interactive`);
 
@@ -107,6 +116,14 @@ describe('Angular Module Federation - Federated Libraries', () => {
     runCLI(
       `generate @nx/angular:host ${host} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`
     );
+
+    // Pin the host's serve port to the reserved one so parallel tests don't
+    // collide on the default 4200. The cypress devServerTarget=${host}:serve
+    // will pick this up automatically.
+    updateJson(`${host}/project.json`, (project) => {
+      project.targets.serve.options.port = hostPort;
+      return project;
+    });
 
     runCLI(`generate @nx/js:lib ${lib} --no-interactive`);
 

--- a/e2e/angular/src/module-federation-lib.test.ts
+++ b/e2e/angular/src/module-federation-lib.test.ts
@@ -105,7 +105,9 @@ describe('Angular Module Federation - Federated Libraries', () => {
       const e2eProcess = await runCommandUntil(
         `e2e ${host}-e2e`,
         (output) => output.includes('All specs passed!'),
-        { timeout: 120000 }
+        // Force NX_DAEMON=false so the e2e child reads the updated project.json
+        // (with our pinned ports) instead of a stale cached graph.
+        { timeout: 120000, env: { NX_DAEMON: 'false' } }
       );
       await killProcessAndPorts(e2eProcess.pid, hostPort, staticRemotesPort);
     }
@@ -207,7 +209,9 @@ describe('Angular Module Federation - Federated Libraries', () => {
       const e2eProcess = await runCommandUntil(
         `e2e ${host}-e2e`,
         (output) => output.includes('All specs passed!'),
-        { timeout: 120000 }
+        // Force NX_DAEMON=false so the e2e child reads the updated project.json
+        // (with our pinned ports) instead of a stale cached graph.
+        { timeout: 120000, env: { NX_DAEMON: 'false' } }
       );
       await killProcessAndPorts(e2eProcess.pid, hostPort, staticRemotesPort);
     }

--- a/e2e/angular/src/module-federation-lib.test.ts
+++ b/e2e/angular/src/module-federation-lib.test.ts
@@ -103,12 +103,17 @@ describe('Angular Module Federation - Federated Libraries', () => {
 
     if (runE2ETests('cypress')) {
       const e2eProcess = await runCommandUntil(
-        // Pass --baseUrl so the cypress preset's webServerCommand wait
-        // targets our reserved hostPort instead of the cypress.config.ts
-        // default 4200.
-        `e2e ${host}-e2e --baseUrl=http://localhost:${hostPort}`,
+        // host-e2e uses an inferred `cypress run` target, so flags are
+        // forwarded to the cypress CLI directly. CYPRESS_BASE_URL is the
+        // documented way to override baseUrl for the cypress process; the
+        // preset's setupNodeEvents will use this baseUrl to wait on the
+        // reserved hostPort instead of the cypress.config.ts default 4200.
+        `e2e ${host}-e2e`,
         (output) => output.includes('All specs passed!'),
-        { timeout: 120000 }
+        {
+          timeout: 120000,
+          env: { CYPRESS_BASE_URL: `http://localhost:${hostPort}` },
+        }
       );
       await killProcessAndPorts(e2eProcess.pid, hostPort, staticRemotesPort);
     }
@@ -208,12 +213,17 @@ describe('Angular Module Federation - Federated Libraries', () => {
 
     if (runE2ETests('cypress')) {
       const e2eProcess = await runCommandUntil(
-        // Pass --baseUrl so the cypress preset's webServerCommand wait
-        // targets our reserved hostPort instead of the cypress.config.ts
-        // default 4200.
-        `e2e ${host}-e2e --baseUrl=http://localhost:${hostPort}`,
+        // host-e2e uses an inferred `cypress run` target, so flags are
+        // forwarded to the cypress CLI directly. CYPRESS_BASE_URL is the
+        // documented way to override baseUrl for the cypress process; the
+        // preset's setupNodeEvents will use this baseUrl to wait on the
+        // reserved hostPort instead of the cypress.config.ts default 4200.
+        `e2e ${host}-e2e`,
         (output) => output.includes('All specs passed!'),
-        { timeout: 120000 }
+        {
+          timeout: 120000,
+          env: { CYPRESS_BASE_URL: `http://localhost:${hostPort}` },
+        }
       );
       await killProcessAndPorts(e2eProcess.pid, hostPort, staticRemotesPort);
     }

--- a/e2e/angular/src/module-federation-lib.test.ts
+++ b/e2e/angular/src/module-federation-lib.test.ts
@@ -1,11 +1,12 @@
 import {
   killProcessAndPorts,
-  reservePort,
+  reservePorts,
   runCLI,
   runCommandUntil,
   runE2ETests,
   uniq,
   updateFile,
+  updateJson,
 } from '@nx/e2e-utils';
 import {
   setupModuleFederationTest,
@@ -28,11 +29,25 @@ describe('Angular Module Federation - Federated Libraries', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const hostPort = await reservePort();
+    // Reserve two ports — one for the host's dev-server, one for the
+    // static-remotes file-server (it would otherwise auto-pick maxPort+1
+    // and collide with a parallel test).
+    const [hostPort, staticRemotesPort] = await reservePorts(2);
 
     runCLI(
       `generate @nx/angular:host ${host} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`
     );
+
+    // Pin both ports on the host's serve target so parallel tests don't
+    // collide on the default 4200 / auto-picked staticRemotesPort.
+    updateJson(`${host}/project.json`, (project) => {
+      project.targets.serve.options.port = hostPort;
+      project.targets.serve.options.staticRemotesPort = staticRemotesPort;
+      return project;
+    });
+    // Reset the daemon so subsequent runCLI calls re-read the updated
+    // project.json instead of serving a cached graph with the default port.
+    runCLI('reset');
 
     runCLI(`generate @nx/js:lib ${lib} --no-interactive`);
 
@@ -70,13 +85,13 @@ describe('Angular Module Federation - Federated Libraries', () => {
       `
       describe('${host}', () => {
         beforeEach(() => cy.visit('/'));
-
+      
         it('should display contain the remote library', () => {
           expect(cy.get('div.host')).to.exist;
           expect(cy.get('div.host').contains('shell is even'));
         });
       });
-
+      
       `
     );
 
@@ -90,9 +105,11 @@ describe('Angular Module Federation - Federated Libraries', () => {
       const e2eProcess = await runCommandUntil(
         `e2e ${host}-e2e`,
         (output) => output.includes('All specs passed!'),
-        { timeout: 120000 }
+        // Force NX_DAEMON=false so the e2e child reads the updated project.json
+        // (with our pinned ports) instead of a stale cached graph.
+        { timeout: 120000, env: { NX_DAEMON: 'false' } }
       );
-      await killProcessAndPorts(e2eProcess.pid, hostPort, hostPort + 1);
+      await killProcessAndPorts(e2eProcess.pid, hostPort, staticRemotesPort);
     }
   }, 500_000);
 
@@ -102,11 +119,22 @@ describe('Angular Module Federation - Federated Libraries', () => {
     const childRemote = uniq('childremote');
     const module = uniq('module');
     const host = uniq('host');
-    const hostPort = await reservePort();
+    const [hostPort, staticRemotesPort] = await reservePorts(2);
 
     runCLI(
       `generate @nx/angular:host ${host} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`
     );
+
+    // Pin both ports on the host's serve target so parallel tests don't
+    // collide on the default 4200 / auto-picked staticRemotesPort.
+    updateJson(`${host}/project.json`, (project) => {
+      project.targets.serve.options.port = hostPort;
+      project.targets.serve.options.staticRemotesPort = staticRemotesPort;
+      return project;
+    });
+    // Reset the daemon so subsequent runCLI calls re-read the updated
+    // project.json instead of serving a cached graph with the default port.
+    runCLI('reset');
 
     runCLI(`generate @nx/js:lib ${lib} --no-interactive`);
 
@@ -161,13 +189,13 @@ describe('Angular Module Federation - Federated Libraries', () => {
       `
       describe('${host}', () => {
         beforeEach(() => cy.visit('/${remote}'));
-
+      
         it('should display contain the remote library', () => {
           expect(cy.get('div.childremote')).to.exist;
           expect(cy.get('div.childremote').contains('shell is even'));
         });
       });
-
+      
       `
     );
 
@@ -181,9 +209,11 @@ describe('Angular Module Federation - Federated Libraries', () => {
       const e2eProcess = await runCommandUntil(
         `e2e ${host}-e2e`,
         (output) => output.includes('All specs passed!'),
-        { timeout: 120000 }
+        // Force NX_DAEMON=false so the e2e child reads the updated project.json
+        // (with our pinned ports) instead of a stale cached graph.
+        { timeout: 120000, env: { NX_DAEMON: 'false' } }
       );
-      await killProcessAndPorts(e2eProcess.pid, hostPort, hostPort + 1);
+      await killProcessAndPorts(e2eProcess.pid, hostPort, staticRemotesPort);
     }
   }, 500_000);
 });

--- a/e2e/angular/src/module-federation-lib.test.ts
+++ b/e2e/angular/src/module-federation-lib.test.ts
@@ -1,12 +1,10 @@
 import {
   killProcessAndPorts,
-  reservePorts,
   runCLI,
   runCommandUntil,
   runE2ETests,
   uniq,
   updateFile,
-  updateJson,
 } from '@nx/e2e-utils';
 import {
   setupModuleFederationTest,
@@ -29,25 +27,11 @@ describe('Angular Module Federation - Federated Libraries', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    // Reserve two ports — one for the host's dev-server, one for the
-    // static-remotes file-server (it would otherwise auto-pick maxPort+1
-    // and collide with a parallel test).
-    const [hostPort, staticRemotesPort] = await reservePorts(2);
+    const hostPort = 4200;
 
     runCLI(
       `generate @nx/angular:host ${host} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`
     );
-
-    // Pin both ports on the host's serve target so parallel tests don't
-    // collide on the default 4200 / auto-picked staticRemotesPort.
-    updateJson(`${host}/project.json`, (project) => {
-      project.targets.serve.options.port = hostPort;
-      project.targets.serve.options.staticRemotesPort = staticRemotesPort;
-      return project;
-    });
-    // Reset the daemon so subsequent runCLI calls re-read the updated
-    // project.json instead of serving a cached graph with the default port.
-    runCLI('reset');
 
     runCLI(`generate @nx/js:lib ${lib} --no-interactive`);
 
@@ -103,19 +87,11 @@ describe('Angular Module Federation - Federated Libraries', () => {
 
     if (runE2ETests('cypress')) {
       const e2eProcess = await runCommandUntil(
-        // host-e2e uses an inferred `cypress run` target, so flags are
-        // forwarded to the cypress CLI directly. CYPRESS_BASE_URL is the
-        // documented way to override baseUrl for the cypress process; the
-        // preset's setupNodeEvents will use this baseUrl to wait on the
-        // reserved hostPort instead of the cypress.config.ts default 4200.
         `e2e ${host}-e2e`,
         (output) => output.includes('All specs passed!'),
-        {
-          timeout: 120000,
-          env: { CYPRESS_BASE_URL: `http://localhost:${hostPort}` },
-        }
+        { timeout: 120000 }
       );
-      await killProcessAndPorts(e2eProcess.pid, hostPort, staticRemotesPort);
+      await killProcessAndPorts(e2eProcess.pid, hostPort, hostPort + 1);
     }
   }, 500_000);
 
@@ -125,22 +101,11 @@ describe('Angular Module Federation - Federated Libraries', () => {
     const childRemote = uniq('childremote');
     const module = uniq('module');
     const host = uniq('host');
-    const [hostPort, staticRemotesPort] = await reservePorts(2);
+    const hostPort = 4200;
 
     runCLI(
       `generate @nx/angular:host ${host} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`
     );
-
-    // Pin both ports on the host's serve target so parallel tests don't
-    // collide on the default 4200 / auto-picked staticRemotesPort.
-    updateJson(`${host}/project.json`, (project) => {
-      project.targets.serve.options.port = hostPort;
-      project.targets.serve.options.staticRemotesPort = staticRemotesPort;
-      return project;
-    });
-    // Reset the daemon so subsequent runCLI calls re-read the updated
-    // project.json instead of serving a cached graph with the default port.
-    runCLI('reset');
 
     runCLI(`generate @nx/js:lib ${lib} --no-interactive`);
 
@@ -213,19 +178,11 @@ describe('Angular Module Federation - Federated Libraries', () => {
 
     if (runE2ETests('cypress')) {
       const e2eProcess = await runCommandUntil(
-        // host-e2e uses an inferred `cypress run` target, so flags are
-        // forwarded to the cypress CLI directly. CYPRESS_BASE_URL is the
-        // documented way to override baseUrl for the cypress process; the
-        // preset's setupNodeEvents will use this baseUrl to wait on the
-        // reserved hostPort instead of the cypress.config.ts default 4200.
         `e2e ${host}-e2e`,
         (output) => output.includes('All specs passed!'),
-        {
-          timeout: 120000,
-          env: { CYPRESS_BASE_URL: `http://localhost:${hostPort}` },
-        }
+        { timeout: 120000 }
       );
-      await killProcessAndPorts(e2eProcess.pid, hostPort, staticRemotesPort);
+      await killProcessAndPorts(e2eProcess.pid, hostPort, hostPort + 1);
     }
   }, 500_000);
 });

--- a/e2e/angular/src/module-federation-lib.test.ts
+++ b/e2e/angular/src/module-federation-lib.test.ts
@@ -1,6 +1,6 @@
 import {
   killProcessAndPorts,
-  reservePort,
+  reservePorts,
   runCLI,
   runCommandUntil,
   runE2ETests,
@@ -29,17 +29,20 @@ describe('Angular Module Federation - Federated Libraries', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const hostPort = await reservePort();
+    // Reserve two ports — one for the host's dev-server, one for the
+    // static-remotes file-server (it would otherwise auto-pick maxPort+1
+    // and collide with a parallel test).
+    const [hostPort, staticRemotesPort] = await reservePorts(2);
 
     runCLI(
       `generate @nx/angular:host ${host} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`
     );
 
-    // Pin the host's serve port to the reserved one so parallel tests don't
-    // collide on the default 4200. The cypress devServerTarget=${host}:serve
-    // will pick this up automatically.
+    // Pin both ports on the host's serve target so parallel tests don't
+    // collide on the default 4200 / auto-picked staticRemotesPort.
     updateJson(`${host}/project.json`, (project) => {
       project.targets.serve.options.port = hostPort;
+      project.targets.serve.options.staticRemotesPort = staticRemotesPort;
       return project;
     });
 
@@ -101,7 +104,7 @@ describe('Angular Module Federation - Federated Libraries', () => {
         (output) => output.includes('All specs passed!'),
         { timeout: 120000 }
       );
-      await killProcessAndPorts(e2eProcess.pid, hostPort, hostPort + 1);
+      await killProcessAndPorts(e2eProcess.pid, hostPort, staticRemotesPort);
     }
   }, 500_000);
 
@@ -111,17 +114,17 @@ describe('Angular Module Federation - Federated Libraries', () => {
     const childRemote = uniq('childremote');
     const module = uniq('module');
     const host = uniq('host');
-    const hostPort = await reservePort();
+    const [hostPort, staticRemotesPort] = await reservePorts(2);
 
     runCLI(
       `generate @nx/angular:host ${host} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`
     );
 
-    // Pin the host's serve port to the reserved one so parallel tests don't
-    // collide on the default 4200. The cypress devServerTarget=${host}:serve
-    // will pick this up automatically.
+    // Pin both ports on the host's serve target so parallel tests don't
+    // collide on the default 4200 / auto-picked staticRemotesPort.
     updateJson(`${host}/project.json`, (project) => {
       project.targets.serve.options.port = hostPort;
+      project.targets.serve.options.staticRemotesPort = staticRemotesPort;
       return project;
     });
 
@@ -200,7 +203,7 @@ describe('Angular Module Federation - Federated Libraries', () => {
         (output) => output.includes('All specs passed!'),
         { timeout: 120000 }
       );
-      await killProcessAndPorts(e2eProcess.pid, hostPort, hostPort + 1);
+      await killProcessAndPorts(e2eProcess.pid, hostPort, staticRemotesPort);
     }
   }, 500_000);
 });

--- a/e2e/angular/src/module-federation-lib.test.ts
+++ b/e2e/angular/src/module-federation-lib.test.ts
@@ -28,7 +28,7 @@ describe('Angular Module Federation - Federated Libraries', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const hostPort = reservePort();
+    const hostPort = await reservePort();
 
     runCLI(
       `generate @nx/angular:host ${host} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`
@@ -102,7 +102,7 @@ describe('Angular Module Federation - Federated Libraries', () => {
     const childRemote = uniq('childremote');
     const module = uniq('module');
     const host = uniq('host');
-    const hostPort = reservePort();
+    const hostPort = await reservePort();
 
     runCLI(
       `generate @nx/angular:host ${host} --remotes=${remote} --e2eTestRunner=cypress --no-interactive`

--- a/e2e/angular/src/module-federation-ssr.test.ts
+++ b/e2e/angular/src/module-federation-ssr.test.ts
@@ -47,7 +47,7 @@ describe('Angular Module Federation - SSR', () => {
     );
 
     // ports
-    const hostPort = reservePort();
+    const hostPort = await reservePort();
     const remote1Port = readJson(join(remote1, 'project.json')).targets.serve
       .options.port;
     const remote2Port = readJson(join(remote2, 'project.json')).targets.serve

--- a/e2e/angular/src/module-federation-ssr.test.ts
+++ b/e2e/angular/src/module-federation-ssr.test.ts
@@ -41,13 +41,14 @@ describe('Angular Module Federation - SSR', () => {
     const remote1 = uniq('remote1');
     const remote2 = uniq('remote2');
 
-    // generate remote apps
-    runCLI(
-      `generate @nx/angular:host ${host} --ssr --remotes=${remote1},${remote2} --no-interactive`
-    );
-
     // ports
     const hostPort = await reservePort();
+
+    // generate remote apps
+    runCLI(
+      `generate @nx/angular:host ${host} --port=${hostPort} --ssr --remotes=${remote1},${remote2} --no-interactive`
+    );
+
     const remote1Port = readJson(join(remote1, 'project.json')).targets.serve
       .options.port;
     const remote2Port = readJson(join(remote2, 'project.json')).targets.serve

--- a/e2e/angular/src/module-federation-ssr.test.ts
+++ b/e2e/angular/src/module-federation-ssr.test.ts
@@ -3,6 +3,7 @@ import {
   killPorts,
   killProcessAndPorts,
   readJson,
+  reservePort,
   runCLI,
   runCommandUntil,
   runE2ETests,
@@ -46,7 +47,7 @@ describe('Angular Module Federation - SSR', () => {
     );
 
     // ports
-    const hostPort = 4500;
+    const hostPort = reservePort();
     const remote1Port = readJson(join(remote1, 'project.json')).targets.serve
       .options.port;
     const remote2Port = readJson(join(remote2, 'project.json')).targets.serve

--- a/e2e/angular/src/module-federation.rspack.test.ts
+++ b/e2e/angular/src/module-federation.rspack.test.ts
@@ -5,6 +5,7 @@ import {
   killProcessAndPorts,
   newProject,
   readFile,
+  reservePort,
   runCLI,
   runCommandUntil,
   runE2ETests,
@@ -34,8 +35,8 @@ describe('Angular Module Federation', () => {
     const sharedLib = uniq('shared-lib');
     const wildcardLib = uniq('wildcard-lib');
     const secondaryEntry = uniq('secondary');
-    const hostPort = 4300;
-    const remotePort = 4301;
+    const hostPort = reservePort();
+    const remotePort = reservePort();
 
     // generate host app
     runCLI(
@@ -179,8 +180,8 @@ describe('Angular Module Federation', () => {
   it('should load remote app in the browser via ESM module federation', async () => {
     const hostApp = uniq('host');
     const remoteApp = uniq('remote');
-    const hostPort = 4200;
-    const remotePort = 4401;
+    const hostPort = reservePort();
+    const remotePort = reservePort();
 
     // generate host with playwright e2e runner
     runCLI(

--- a/e2e/angular/src/module-federation.rspack.test.ts
+++ b/e2e/angular/src/module-federation.rspack.test.ts
@@ -40,7 +40,7 @@ describe('Angular Module Federation', () => {
 
     // generate host app
     runCLI(
-      `generate @nx/angular:host ${hostApp} --style=css --bundler=rspack --no-standalone --no-interactive`
+      `generate @nx/angular:host ${hostApp} --port=${hostPort} --style=css --bundler=rspack --no-standalone --no-interactive`
     );
     let rspackConfigFileContents = readFile(join(hostApp, 'rspack.config.ts'));
     let updatedConfigFileContents = rspackConfigFileContents.replace(
@@ -185,7 +185,7 @@ describe('Angular Module Federation', () => {
 
     // generate host with playwright e2e runner
     runCLI(
-      `generate @nx/angular:host ${hostApp} --style=css --bundler=rspack --e2eTestRunner=playwright --no-interactive`
+      `generate @nx/angular:host ${hostApp} --port=${hostPort} --style=css --bundler=rspack --e2eTestRunner=playwright --no-interactive`
     );
 
     // generate remote

--- a/e2e/angular/src/module-federation.rspack.test.ts
+++ b/e2e/angular/src/module-federation.rspack.test.ts
@@ -35,8 +35,8 @@ describe('Angular Module Federation', () => {
     const sharedLib = uniq('shared-lib');
     const wildcardLib = uniq('wildcard-lib');
     const secondaryEntry = uniq('secondary');
-    const hostPort = reservePort();
-    const remotePort = reservePort();
+    const hostPort = await reservePort();
+    const remotePort = await reservePort();
 
     // generate host app
     runCLI(
@@ -180,8 +180,8 @@ describe('Angular Module Federation', () => {
   it('should load remote app in the browser via ESM module federation', async () => {
     const hostApp = uniq('host');
     const remoteApp = uniq('remote');
-    const hostPort = reservePort();
-    const remotePort = reservePort();
+    const hostPort = await reservePort();
+    const remotePort = await reservePort();
 
     // generate host with playwright e2e runner
     runCLI(

--- a/e2e/angular/src/projects-build-and-test.test.ts
+++ b/e2e/angular/src/projects-build-and-test.test.ts
@@ -105,15 +105,16 @@ describe('Angular Projects - Build and Test', () => {
     // port and process cleanup
     await killProcessAndPorts(process.pid, appPort);
 
+    const esbuildPort = await reservePort();
     const esbProcess = await runCommandUntil(
-      `serve ${esbuildStandaloneApp} -- --port=${appPort}`,
+      `serve ${esbuildStandaloneApp} -- --port=${esbuildPort}`,
       (output) =>
         output.includes(`Application bundle generation complete`) &&
-        output.includes(`localhost:${appPort}`)
+        output.includes(`localhost:${esbuildPort}`)
     );
 
     // port and process cleanup
-    await killProcessAndPorts(esbProcess.pid, appPort);
+    await killProcessAndPorts(esbProcess.pid, esbuildPort);
   }, 1000000);
 
   it('should successfully work with rspack for build', async () => {

--- a/e2e/angular/src/projects-build-and-test.test.ts
+++ b/e2e/angular/src/projects-build-and-test.test.ts
@@ -105,16 +105,15 @@ describe('Angular Projects - Build and Test', () => {
     // port and process cleanup
     await killProcessAndPorts(process.pid, appPort);
 
-    const esbuildPort = await reservePort();
     const esbProcess = await runCommandUntil(
-      `serve ${esbuildStandaloneApp} -- --port=${esbuildPort}`,
+      `serve ${esbuildStandaloneApp} -- --port=${appPort}`,
       (output) =>
         output.includes(`Application bundle generation complete`) &&
-        output.includes(`localhost:${esbuildPort}`)
+        output.includes(`localhost:${appPort}`)
     );
 
     // port and process cleanup
-    await killProcessAndPorts(esbProcess.pid, esbuildPort);
+    await killProcessAndPorts(esbProcess.pid, appPort);
   }, 1000000);
 
   it('should successfully work with rspack for build', async () => {

--- a/e2e/angular/src/projects-build-and-test.test.ts
+++ b/e2e/angular/src/projects-build-and-test.test.ts
@@ -5,6 +5,7 @@ import {
   killPort,
   killProcessAndPorts,
   readFile,
+  reservePort,
   runCLI,
   runCommandUntil,
   runE2ETests,
@@ -95,7 +96,7 @@ describe('Angular Projects - Build and Test', () => {
       expect(await killPort(4200)).toBeTruthy();
     }
 
-    const appPort = 4207;
+    const appPort = reservePort();
     const process = await runCommandUntil(
       `serve ${app1} -- --port=${appPort}`,
       (output) => output.includes(`listening on localhost:${appPort}`)

--- a/e2e/angular/src/projects-build-and-test.test.ts
+++ b/e2e/angular/src/projects-build-and-test.test.ts
@@ -96,7 +96,7 @@ describe('Angular Projects - Build and Test', () => {
       expect(await killPort(4200)).toBeTruthy();
     }
 
-    const appPort = reservePort();
+    const appPort = await reservePort();
     const process = await runCommandUntil(
       `serve ${app1} -- --port=${appPort}`,
       (output) => output.includes(`listening on localhost:${appPort}`)

--- a/e2e/cypress/src/cypress.test.ts
+++ b/e2e/cypress/src/cypress.test.ts
@@ -7,7 +7,6 @@ import {
   killPort,
   newProject,
   readJson,
-  reservePort,
   runCLI,
   runCommand,
   runE2ETests,
@@ -21,10 +20,8 @@ const TEN_MINS_MS = 600_000;
 
 describe('Cypress E2E Test runner', () => {
   const myapp = uniq('myapp');
-  let appPort: number;
 
   beforeAll(() => {
-    appPort = reservePort();
     newProject({ packages: ['@nx/angular', '@nx/next', '@nx/react'] });
   });
 
@@ -36,16 +33,6 @@ describe('Cypress E2E Test runner', () => {
       runCLI(
         `generate @nx/react:app apps/${myapp} --e2eTestRunner=cypress --linter=eslint`
       );
-      // Override the default serve port so parallel e2e tasks don't collide.
-      updateJson(`apps/${myapp}/project.json`, (json) => {
-        if (json.targets?.serve?.options) {
-          json.targets.serve.options.port = appPort;
-        }
-        if (json.targets?.['serve-static']?.options) {
-          json.targets['serve-static'].options.port = appPort;
-        }
-        return json;
-      });
 
       // Ensure project typechecks (See: https://github.com/nrwl/nx/issues/32930)
       expect(() =>
@@ -126,7 +113,7 @@ export default defineConfig({
         timeout: 60_000,
       },
     }),
-    baseUrl: 'http://localhost:${appPort}',
+    baseUrl: 'http://localhost:4200',
   },
   env: {
     fromCyConfig: 'i am from the cypress config file'

--- a/e2e/cypress/src/cypress.test.ts
+++ b/e2e/cypress/src/cypress.test.ts
@@ -7,6 +7,7 @@ import {
   killPort,
   newProject,
   readJson,
+  reservePort,
   runCLI,
   runCommand,
   runE2ETests,
@@ -20,8 +21,10 @@ const TEN_MINS_MS = 600_000;
 
 describe('Cypress E2E Test runner', () => {
   const myapp = uniq('myapp');
+  let appPort: number;
 
   beforeAll(() => {
+    appPort = reservePort();
     newProject({ packages: ['@nx/angular', '@nx/next', '@nx/react'] });
   });
 
@@ -33,6 +36,16 @@ describe('Cypress E2E Test runner', () => {
       runCLI(
         `generate @nx/react:app apps/${myapp} --e2eTestRunner=cypress --linter=eslint`
       );
+      // Override the default serve port so parallel e2e tasks don't collide.
+      updateJson(`apps/${myapp}/project.json`, (json) => {
+        if (json.targets?.serve?.options) {
+          json.targets.serve.options.port = appPort;
+        }
+        if (json.targets?.['serve-static']?.options) {
+          json.targets['serve-static'].options.port = appPort;
+        }
+        return json;
+      });
 
       // Ensure project typechecks (See: https://github.com/nrwl/nx/issues/32930)
       expect(() =>
@@ -113,7 +126,7 @@ export default defineConfig({
         timeout: 60_000,
       },
     }),
-    baseUrl: 'http://localhost:4200',
+    baseUrl: 'http://localhost:${appPort}',
   },
   env: {
     fromCyConfig: 'i am from the cypress config file'

--- a/e2e/gradle/src/utils/create-gradle-project.ts
+++ b/e2e/gradle/src/utils/create-gradle-project.ts
@@ -28,14 +28,21 @@ export function createGradleProject(
         cwd,
       })
   );
+  // Run setup-time gradle commands with --no-daemon so we don't leave a
+  // long-lived daemon holding inotify watches on the project dir. A daemon
+  // spawned here outlives the setup phase and interferes with later
+  // non-gradle filesystem operations (e.g. `nx import` runs `git
+  // filter-branch --tree-filter`, which fails with "Unable to read current
+  // working directory" when the daemon is concurrently watching the same
+  // tree). The actual test-body gradle calls keep daemons enabled.
   e2eConsoleLogger(
-    execSync(`${gradleCommand} help --task :init`, {
+    execSync(`${gradleCommand} help --task :init --no-daemon`, {
       cwd,
     }).toString()
   );
   e2eConsoleLogger(
     runCommand(
-      `${gradleCommand} init --type ${type}-application --dsl ${type} --project-name ${projectName} --package ${packageName} --no-incubating --split-project --overwrite`,
+      `${gradleCommand} init --type ${type}-application --dsl ${type} --project-name ${projectName} --package ${packageName} --no-incubating --split-project --overwrite --no-daemon`,
       {
         cwd,
       }

--- a/e2e/gradle/src/utils/create-gradle-project.ts
+++ b/e2e/gradle/src/utils/create-gradle-project.ts
@@ -53,12 +53,7 @@ export function createGradleProject(
 
   try {
     e2eConsoleLogger(
-      runCommand(`${gradleCommand} --stop`, {
-        cwd,
-      })
-    );
-    e2eConsoleLogger(
-      runCommand(`${gradleCommand} clean`, {
+      runCommand(`${gradleCommand} clean --no-daemon`, {
         cwd,
       })
     );

--- a/e2e/next/src/next-legacy.test.ts
+++ b/e2e/next/src/next-legacy.test.ts
@@ -78,7 +78,7 @@ describe('@nx/next (legacy)', () => {
     checkFilesExist(`dist/${appName}/nested/headers-2.js`);
   }, 120_000);
 
-  it('should build and install pruned lock file', () => {
+  it('should build and install pruned lock file', async () => {
     const appName = uniq('app');
     runCLI(`generate @nx/next:app ${appName} --no-interactive --style=css`, {
       env: { NX_ADD_PLUGINS: 'false' },
@@ -251,7 +251,7 @@ describe('@nx/next (legacy)', () => {
     expect(nextConfigPath).not.toContain(`require("@nx/`); // dev-only packages
 
     // Check that `nx serve <app> --prod` works with previous production build (e.g. `nx build <app>`).
-    const prodServePort = reservePort();
+    const prodServePort = await reservePort();
     const prodServeProcess = await runCommandUntil(
       `run ${appName}:serve --prod --port=${prodServePort}`,
       (output) => {
@@ -260,7 +260,7 @@ describe('@nx/next (legacy)', () => {
     );
 
     // Check that the output is self-contained (i.e. can run with its own package.json + node_modules)
-    const selfContainedPort = reservePort();
+    const selfContainedPort = await reservePort();
     runCLI(
       `generate @nx/workspace:run-commands serve-prod --project ${appName} --cwd=dist/packages/${appName} --command="npx next start --port=${selfContainedPort}"`,
       {

--- a/e2e/next/src/next-legacy.test.ts
+++ b/e2e/next/src/next-legacy.test.ts
@@ -9,6 +9,7 @@ import {
   newProject,
   packageManagerLockFile,
   readFile,
+  reservePort,
   runCLI,
   runCommand,
   runCommandUntil,
@@ -250,7 +251,7 @@ describe('@nx/next (legacy)', () => {
     expect(nextConfigPath).not.toContain(`require("@nx/`); // dev-only packages
 
     // Check that `nx serve <app> --prod` works with previous production build (e.g. `nx build <app>`).
-    const prodServePort = 4001;
+    const prodServePort = reservePort();
     const prodServeProcess = await runCommandUntil(
       `run ${appName}:serve --prod --port=${prodServePort}`,
       (output) => {
@@ -259,7 +260,7 @@ describe('@nx/next (legacy)', () => {
     );
 
     // Check that the output is self-contained (i.e. can run with its own package.json + node_modules)
-    const selfContainedPort = 3000;
+    const selfContainedPort = reservePort();
     runCLI(
       `generate @nx/workspace:run-commands serve-prod --project ${appName} --cwd=dist/packages/${appName} --command="npx next start --port=${selfContainedPort}"`,
       {

--- a/e2e/node/src/node-esm-support.test.ts
+++ b/e2e/node/src/node-esm-support.test.ts
@@ -4,6 +4,7 @@ import {
   cleanupProject,
   getPackageManagerCommand,
   newProject,
+  reservePort,
   runCLI,
   runCLIAsync,
   runCommand,
@@ -55,6 +56,7 @@ describe('Node.js Framework ESM Support', () => {
 
   describe('Express Framework with ESM', () => {
     it('should build and run Express app with ESM modules', async () => {
+      const port = reservePort();
       const expressApp = uniq('express-esm');
       runCLI(
         `generate @nx/node:app apps/${expressApp} --framework=express --linter=eslint --unitTestRunner=jest`
@@ -87,7 +89,7 @@ describe('Node.js Framework ESM Support', () => {
           console.log('Express ESM app starting');
           console.log('fetch type:', typeof fetch);
           
-          const port = process.env.PORT || 3000;
+          const port = process.env.PORT || ${port};
           const server = app.listen(port, () => {
             console.log('Express ESM server ready on port ' + port);
           });
@@ -111,6 +113,7 @@ describe('Node.js Framework ESM Support', () => {
     }, 600000);
 
     it('should serve Express app with ESM modules', async () => {
+      const port = reservePort();
       const expressApp = uniq('express-esm-serve');
       runCLI(
         `generate @nx/node:app apps/${expressApp} --framework=express --linter=eslint --unitTestRunner=jest`
@@ -139,7 +142,7 @@ describe('Node.js Framework ESM Support', () => {
             res.json({ message: 'Express ESM serve working' });
           });
           
-          const port = process.env.PORT || 3000;
+          const port = process.env.PORT || ${port};
           const server = app.listen(port, () => {
             console.log('Express ESM serve ready on port ' + port);
           });
@@ -161,6 +164,7 @@ describe('Node.js Framework ESM Support', () => {
 
   describe('Fastify Framework with ESM', () => {
     it('should build and run Fastify app with ESM modules', async () => {
+      const port = reservePort();
       const fastifyApp = uniq('fastify-esm');
       runCLI(
         `generate @nx/node:app apps/${fastifyApp} --framework=fastify --linter=eslint --unitTestRunner=jest`
@@ -197,7 +201,7 @@ describe('Node.js Framework ESM Support', () => {
           
           const start = async () => {
             try {
-              const port = +(process.env.PORT || 3000);
+              const port = +(process.env.PORT || ${port});
               await fastify.listen({ port });
               console.log('Fastify ESM server ready on port ' + port);
             } catch (err) {
@@ -225,6 +229,7 @@ describe('Node.js Framework ESM Support', () => {
     }, 600000);
 
     it('should serve Fastify app with ESM modules', async () => {
+      const port = reservePort();
       const fastifyApp = uniq('fastify-esm-serve');
       runCLI(
         `generate @nx/node:app apps/${fastifyApp} --framework=fastify --linter=eslint --unitTestRunner=jest`
@@ -255,7 +260,7 @@ describe('Node.js Framework ESM Support', () => {
           
           const start = async () => {
             try {
-              const port = +(process.env.PORT || 3000);
+              const port = +(process.env.PORT || ${port});
               await fastify.listen({ port });
               console.log('Fastify ESM serve ready on port ' + port);
             } catch (err) {
@@ -280,6 +285,7 @@ describe('Node.js Framework ESM Support', () => {
 
   describe('Koa Framework with ESM', () => {
     it('should build and run Koa app with ESM modules', async () => {
+      const port = reservePort();
       const koaApp = uniq('koa-esm');
       runCLI(
         `generate @nx/node:app apps/${koaApp} --framework=koa --linter=eslint --unitTestRunner=jest`
@@ -318,7 +324,7 @@ describe('Node.js Framework ESM Support', () => {
           console.log('Koa ESM app starting');
           console.log('fetch type:', typeof fetch);
           
-          const port = +(process.env.PORT || 3000);
+          const port = +(process.env.PORT || ${port});
           const server = app.listen(port, () => {
             console.log('Koa ESM server ready on port ' + port);
           });
@@ -342,6 +348,7 @@ describe('Node.js Framework ESM Support', () => {
     }, 600000);
 
     it('should serve Koa app with ESM modules', async () => {
+      const port = reservePort();
       const koaApp = uniq('koa-esm-serve');
       runCLI(
         `generate @nx/node:app apps/${koaApp} --framework=koa --linter=eslint --unitTestRunner=jest`
@@ -376,7 +383,7 @@ describe('Node.js Framework ESM Support', () => {
           
           app.use(router.routes()).use(router.allowedMethods());
           
-          const port = +(process.env.PORT || 3000);
+          const port = +(process.env.PORT || ${port});
           const server = app.listen(port, () => {
             console.log('Koa ESM serve ready on port ' + port);
           });
@@ -398,6 +405,7 @@ describe('Node.js Framework ESM Support', () => {
 
   describe('Nest Framework with ESM', () => {
     it('should build and run Nest app with ESM modules', async () => {
+      const port = reservePort();
       const nestApp = uniq('nest-esm');
       runCLI(
         `generate @nx/node:app apps/${nestApp} --framework=nest --linter=eslint --unitTestRunner=jest`
@@ -431,7 +439,7 @@ describe('Node.js Framework ESM Support', () => {
             const app = await NestFactory.create(AppModule);
             const globalPrefix = 'api';
             app.setGlobalPrefix(globalPrefix);
-            const port = process.env.PORT || 3000;
+            const port = process.env.PORT || ${port};
             await app.listen(port);
             console.log('Nest ESM server ready on port ' + port);
           }
@@ -454,6 +462,7 @@ describe('Node.js Framework ESM Support', () => {
     }, 600000);
 
     it('should serve Nest app with ESM modules', async () => {
+      const port = reservePort();
       const nestApp = uniq('nest-esm-serve');
       runCLI(
         `generate @nx/node:app apps/${nestApp} --framework=nest --linter=eslint --unitTestRunner=jest`
@@ -487,7 +496,7 @@ describe('Node.js Framework ESM Support', () => {
             const app = await NestFactory.create(AppModule);
             const globalPrefix = 'api';
             app.setGlobalPrefix(globalPrefix);
-            const port = process.env.PORT || 3000;
+            const port = process.env.PORT || ${port};
             await app.listen(port);
             console.log('Nest ESM serve ready on port ' + port);
           }
@@ -510,6 +519,7 @@ describe('Node.js Framework ESM Support', () => {
 
   describe('Mixed Imports across Node.js Frameworks', () => {
     it('should handle CommonJS and ESM packages together', async () => {
+      const port = reservePort();
       const nodeApp = uniq('node-mixed-imports');
       runCLI(
         `generate @nx/node:app apps/${nodeApp} --framework=express --linter=eslint --unitTestRunner=jest`
@@ -552,7 +562,7 @@ describe('Node.js Framework ESM Support', () => {
           console.log('Mixed imports Node.js app starting');
           console.log('lodash.pick type:', typeof lodash.pick);
           
-          const port = process.env.PORT || 3000;
+          const port = process.env.PORT || ${port};
           const server = app.listen(port, () => {
             console.log('Mixed imports server ready on port ' + port);
           });

--- a/e2e/node/src/node-esm-support.test.ts
+++ b/e2e/node/src/node-esm-support.test.ts
@@ -56,7 +56,7 @@ describe('Node.js Framework ESM Support', () => {
 
   describe('Express Framework with ESM', () => {
     it('should build and run Express app with ESM modules', async () => {
-      const port = reservePort();
+      const port = await reservePort();
       const expressApp = uniq('express-esm');
       runCLI(
         `generate @nx/node:app apps/${expressApp} --framework=express --linter=eslint --unitTestRunner=jest`
@@ -113,7 +113,7 @@ describe('Node.js Framework ESM Support', () => {
     }, 600000);
 
     it('should serve Express app with ESM modules', async () => {
-      const port = reservePort();
+      const port = await reservePort();
       const expressApp = uniq('express-esm-serve');
       runCLI(
         `generate @nx/node:app apps/${expressApp} --framework=express --linter=eslint --unitTestRunner=jest`
@@ -164,7 +164,7 @@ describe('Node.js Framework ESM Support', () => {
 
   describe('Fastify Framework with ESM', () => {
     it('should build and run Fastify app with ESM modules', async () => {
-      const port = reservePort();
+      const port = await reservePort();
       const fastifyApp = uniq('fastify-esm');
       runCLI(
         `generate @nx/node:app apps/${fastifyApp} --framework=fastify --linter=eslint --unitTestRunner=jest`
@@ -229,7 +229,7 @@ describe('Node.js Framework ESM Support', () => {
     }, 600000);
 
     it('should serve Fastify app with ESM modules', async () => {
-      const port = reservePort();
+      const port = await reservePort();
       const fastifyApp = uniq('fastify-esm-serve');
       runCLI(
         `generate @nx/node:app apps/${fastifyApp} --framework=fastify --linter=eslint --unitTestRunner=jest`
@@ -285,7 +285,7 @@ describe('Node.js Framework ESM Support', () => {
 
   describe('Koa Framework with ESM', () => {
     it('should build and run Koa app with ESM modules', async () => {
-      const port = reservePort();
+      const port = await reservePort();
       const koaApp = uniq('koa-esm');
       runCLI(
         `generate @nx/node:app apps/${koaApp} --framework=koa --linter=eslint --unitTestRunner=jest`
@@ -348,7 +348,7 @@ describe('Node.js Framework ESM Support', () => {
     }, 600000);
 
     it('should serve Koa app with ESM modules', async () => {
-      const port = reservePort();
+      const port = await reservePort();
       const koaApp = uniq('koa-esm-serve');
       runCLI(
         `generate @nx/node:app apps/${koaApp} --framework=koa --linter=eslint --unitTestRunner=jest`
@@ -405,7 +405,7 @@ describe('Node.js Framework ESM Support', () => {
 
   describe('Nest Framework with ESM', () => {
     it('should build and run Nest app with ESM modules', async () => {
-      const port = reservePort();
+      const port = await reservePort();
       const nestApp = uniq('nest-esm');
       runCLI(
         `generate @nx/node:app apps/${nestApp} --framework=nest --linter=eslint --unitTestRunner=jest`
@@ -462,7 +462,7 @@ describe('Node.js Framework ESM Support', () => {
     }, 600000);
 
     it('should serve Nest app with ESM modules', async () => {
-      const port = reservePort();
+      const port = await reservePort();
       const nestApp = uniq('nest-esm-serve');
       runCLI(
         `generate @nx/node:app apps/${nestApp} --framework=nest --linter=eslint --unitTestRunner=jest`
@@ -519,7 +519,7 @@ describe('Node.js Framework ESM Support', () => {
 
   describe('Mixed Imports across Node.js Frameworks', () => {
     it('should handle CommonJS and ESM packages together', async () => {
-      const port = reservePort();
+      const port = await reservePort();
       const nodeApp = uniq('node-mixed-imports');
       runCLI(
         `generate @nx/node:app apps/${nodeApp} --framework=express --linter=eslint --unitTestRunner=jest`

--- a/e2e/node/src/node-server.test.ts
+++ b/e2e/node/src/node-server.test.ts
@@ -80,11 +80,11 @@ describe('Node Applications + webpack', () => {
     let koaPort: number;
     let nestPort: number;
 
-    beforeAll(() => {
-      expressPort = reservePort();
-      fastifyPort = reservePort();
-      koaPort = reservePort();
-      nestPort = reservePort();
+    beforeAll(async () => {
+      expressPort = await reservePort();
+      fastifyPort = await reservePort();
+      koaPort = await reservePort();
+      nestPort = await reservePort();
       runCLI(
         `generate @nx/node:lib libs/${testLib1} --linter=eslint --unitTestRunner=jest --buildable=false`
       );
@@ -183,8 +183,8 @@ describe('Node Applications + webpack', () => {
   it('should support waitUntilTargets for serve target', async () => {
     const nodeApp1 = uniq('nodeapp1');
     const nodeApp2 = uniq('nodeapp2');
-    const nodeApp1Port = reservePort();
-    const nodeApp2Port = reservePort();
+    const nodeApp1Port = await reservePort();
+    const nodeApp2Port = await reservePort();
 
     // Set ports to avoid conflicts with other tests that might run in parallel
     runCLI(

--- a/e2e/node/src/node-server.test.ts
+++ b/e2e/node/src/node-server.test.ts
@@ -7,6 +7,7 @@ import {
   newProject,
   promisifiedTreeKill,
   readFile,
+  reservePort,
   runCLI,
   runCommandUntil,
   uniq,
@@ -56,7 +57,7 @@ describe('Node Applications + webpack', () => {
     }
   }
 
-  async function runE2eTests(appName: string, port: number = 5000) {
+  async function runE2eTests(appName: string, port: number) {
     process.env.PORT = `${port}`;
     const result = runCLI(`e2e ${appName}-e2e --verbose`);
     expect(result).toContain('Setting up...');
@@ -74,8 +75,16 @@ describe('Node Applications + webpack', () => {
     const fastifyApp = uniq('fastifyapp');
     const koaApp = uniq('koaapp');
     const nestApp = uniq('nest');
+    let expressPort: number;
+    let fastifyPort: number;
+    let koaPort: number;
+    let nestPort: number;
 
     beforeAll(() => {
+      expressPort = reservePort();
+      fastifyPort = reservePort();
+      koaPort = reservePort();
+      nestPort = reservePort();
       runCLI(
         `generate @nx/node:lib libs/${testLib1} --linter=eslint --unitTestRunner=jest --buildable=false`
       );
@@ -83,16 +92,16 @@ describe('Node Applications + webpack', () => {
         `generate @nx/node:lib libs/${testLib2} --importPath=@acme/test2 --linter=eslint --unitTestRunner=jest --buildable=false`
       );
       runCLI(
-        `generate @nx/node:app apps/${expressApp} --framework=express --port=7000 --no-interactive --linter=eslint --unitTestRunner=jest --e2eTestRunner=jest`
+        `generate @nx/node:app apps/${expressApp} --framework=express --port=${expressPort} --no-interactive --linter=eslint --unitTestRunner=jest --e2eTestRunner=jest`
       );
       runCLI(
-        `generate @nx/node:app apps/${fastifyApp} --framework=fastify --port=7001 --no-interactive --linter=eslint --unitTestRunner=jest --e2eTestRunner=jest`
+        `generate @nx/node:app apps/${fastifyApp} --framework=fastify --port=${fastifyPort} --no-interactive --linter=eslint --unitTestRunner=jest --e2eTestRunner=jest`
       );
       runCLI(
-        `generate @nx/node:app apps/${koaApp} --framework=koa --port=7002 --no-interactive --linter=eslint --unitTestRunner=jest --e2eTestRunner=jest`
+        `generate @nx/node:app apps/${koaApp} --framework=koa --port=${koaPort} --no-interactive --linter=eslint --unitTestRunner=jest --e2eTestRunner=jest`
       );
       runCLI(
-        `generate @nx/node:app apps/${nestApp} --framework=nest --port=7003 --bundler=webpack --no-interactive --linter=eslint --unitTestRunner=jest --e2eTestRunner=jest --verbose`
+        `generate @nx/node:app apps/${nestApp} --framework=nest --port=${nestPort} --bundler=webpack --no-interactive --linter=eslint --unitTestRunner=jest --e2eTestRunner=jest --verbose`
       );
 
       addLibImport(expressApp, testLib1);
@@ -145,19 +154,19 @@ describe('Node Applications + webpack', () => {
     }, 300_000);
 
     it('should e2e test express app', async () => {
-      await runE2eTests(expressApp, 7000);
+      await runE2eTests(expressApp, expressPort);
     });
 
     it('should e2e test fastify app', async () => {
-      await runE2eTests(fastifyApp, 7001);
+      await runE2eTests(fastifyApp, fastifyPort);
     });
 
     it('should e2e test koa app', async () => {
-      await runE2eTests(koaApp, 7002);
+      await runE2eTests(koaApp, koaPort);
     });
 
     it('should e2e test nest app', async () => {
-      await runE2eTests(nestApp, 7003);
+      await runE2eTests(nestApp, nestPort);
     });
   });
 
@@ -174,13 +183,15 @@ describe('Node Applications + webpack', () => {
   it('should support waitUntilTargets for serve target', async () => {
     const nodeApp1 = uniq('nodeapp1');
     const nodeApp2 = uniq('nodeapp2');
+    const nodeApp1Port = reservePort();
+    const nodeApp2Port = reservePort();
 
     // Set ports to avoid conflicts with other tests that might run in parallel
     runCLI(
-      `generate @nx/node:app apps/${nodeApp1} --framework=none --no-interactive --port=4444 --linter=eslint --unitTestRunner=jest`
+      `generate @nx/node:app apps/${nodeApp1} --framework=none --no-interactive --port=${nodeApp1Port} --linter=eslint --unitTestRunner=jest`
     );
     runCLI(
-      `generate @nx/node:app apps/${nodeApp2} --framework=none --no-interactive --port=4445 --linter=eslint --unitTestRunner=jest`
+      `generate @nx/node:app apps/${nodeApp2} --framework=none --no-interactive --port=${nodeApp2Port} --linter=eslint --unitTestRunner=jest`
     );
     updateJson(join('apps', nodeApp1, 'project.json'), (config) => {
       config.targets.serve.options.waitUntilTargets = [`${nodeApp2}:build`];

--- a/e2e/nx/src/__fixtures__/remote-cache.js
+++ b/e2e/nx/src/__fixtures__/remote-cache.js
@@ -63,7 +63,7 @@ const server = http.createServer((req, res) => {
   }
 });
 
-const PORT = 3000;
+const PORT = Number(process.env.PORT ?? 3000);
 server.listen(PORT, () => {
   console.log(`Server running at http://localhost:${PORT}/`);
 });

--- a/e2e/nx/src/cache-no-daemon.test.ts
+++ b/e2e/nx/src/cache-no-daemon.test.ts
@@ -6,6 +6,7 @@ import {
   newProject,
   readFile,
   removeFile,
+  reservePort,
   rmDist,
   runCLI as _runCLI,
   RunCmdOpts,
@@ -647,9 +648,16 @@ console.log('Build complete');
 
   describe('http remote cache', () => {
     let cacheServer: any;
-    beforeAll(() => {
+    let cachePort: number;
+    let unboundPort: number;
+    beforeAll(async () => {
+      cachePort = await reservePort();
+      // A second port we deliberately don't bind, used by the
+      // "should error if server is not running" test.
+      unboundPort = await reservePort();
       cacheServer = fork(join(__dirname, '__fixtures__', 'remote-cache.js'), {
         stdio: 'inherit',
+        env: { ...process.env, PORT: String(cachePort) },
       });
     });
 
@@ -675,7 +683,7 @@ console.log('Build complete');
       );
       runCLI(`build ${projectName}`, {
         env: {
-          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: 'http://localhost:3000',
+          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: `http://localhost:${cachePort}`,
           NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN: 'test-token',
         },
       });
@@ -686,7 +694,7 @@ console.log('Build complete');
       runCLI(`reset`);
       const output = runCLI(`build ${projectName}`, {
         env: {
-          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: 'http://localhost:3000',
+          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: `http://localhost:${cachePort}`,
           NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN: 'test-token',
         },
       });
@@ -712,7 +720,7 @@ console.log('Build complete');
       );
       const output = runCLI(`build ${projectName}`, {
         env: {
-          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: 'http://localhost:3000',
+          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: `http://localhost:${cachePort}`,
         },
         silenceError: true,
       });
@@ -740,13 +748,13 @@ console.log('Build complete');
       );
       const output = runCLI(`build ${projectName}`, {
         env: {
-          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: 'http://localhost:3001',
+          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: `http://localhost:${unboundPort}`,
           NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN: 'test-token',
         },
         silenceError: true,
       });
 
-      expect(output).toContain('http://localhost:3001');
+      expect(output).toContain(`http://localhost:${unboundPort}`);
     });
   });
 

--- a/e2e/nx/src/cache.test.ts
+++ b/e2e/nx/src/cache.test.ts
@@ -215,9 +215,7 @@ describe('cache', () => {
     // outputs-hash check fails and nx restores from cache → "[local cache]"
     // rather than the "existing outputs match" no-op path.
     const rerunWithNewUnrelatedFile = runCLI(`build ${mylib}`);
-    expect(rerunWithNewUnrelatedFile).toContain(
-      'existing outputs match the cache'
-    );
+    expect(rerunWithNewUnrelatedFile).toContain('local cache');
     const outputsAfterAddingUntouchedFileAndRerunning = [
       ...listFiles('dist/apps'),
       ...listFiles('dist/.next').map((f) => `.next/${f}`),

--- a/e2e/nx/src/cache.test.ts
+++ b/e2e/nx/src/cache.test.ts
@@ -641,10 +641,10 @@ console.log('Build complete');
     let cacheServer: any;
     let cachePort: number;
     let unusedPort: number;
-    beforeAll(() => {
-      cachePort = reservePort();
+    beforeAll(async () => {
+      cachePort = await reservePort();
       // Reserved but never bound — used to simulate a server-not-running error.
-      unusedPort = reservePort();
+      unusedPort = await reservePort();
       cacheServer = fork(join(__dirname, '__fixtures__', 'remote-cache.js'), {
         stdio: 'inherit',
         env: { ...process.env, PORT: String(cachePort) },

--- a/e2e/nx/src/cache.test.ts
+++ b/e2e/nx/src/cache.test.ts
@@ -6,6 +6,7 @@ import {
   newProject,
   readFile,
   removeFile,
+  reservePort,
   rmDist,
   runCLI,
   tmpProjPath,
@@ -638,9 +639,15 @@ console.log('Build complete');
 
   describe('http remote cache', () => {
     let cacheServer: any;
+    let cachePort: number;
+    let unusedPort: number;
     beforeAll(() => {
+      cachePort = reservePort();
+      // Reserved but never bound — used to simulate a server-not-running error.
+      unusedPort = reservePort();
       cacheServer = fork(join(__dirname, '__fixtures__', 'remote-cache.js'), {
         stdio: 'inherit',
+        env: { ...process.env, PORT: String(cachePort) },
       });
     });
 
@@ -666,7 +673,7 @@ console.log('Build complete');
       );
       runCLI(`build ${projectName}`, {
         env: {
-          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: 'http://localhost:3000',
+          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: `http://localhost:${cachePort}`,
           NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN: 'test-token',
         },
       });
@@ -677,7 +684,7 @@ console.log('Build complete');
       runCLI(`reset`);
       const output = runCLI(`build ${projectName}`, {
         env: {
-          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: 'http://localhost:3000',
+          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: `http://localhost:${cachePort}`,
           NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN: 'test-token',
         },
       });
@@ -703,7 +710,7 @@ console.log('Build complete');
       );
       const output = runCLI(`build ${projectName}`, {
         env: {
-          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: 'http://localhost:3000',
+          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: `http://localhost:${cachePort}`,
         },
         silenceError: true,
       });
@@ -731,13 +738,13 @@ console.log('Build complete');
       );
       const output = runCLI(`build ${projectName}`, {
         env: {
-          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: 'http://localhost:3001',
+          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: `http://localhost:${unusedPort}`,
           NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN: 'test-token',
         },
         silenceError: true,
       });
 
-      expect(output).toContain('http://localhost:3001');
+      expect(output).toContain(`http://localhost:${unusedPort}`);
     });
   });
 

--- a/e2e/nx/src/cache.test.ts
+++ b/e2e/nx/src/cache.test.ts
@@ -215,7 +215,9 @@ describe('cache', () => {
     // outputs-hash check fails and nx restores from cache → "[local cache]"
     // rather than the "existing outputs match" no-op path.
     const rerunWithNewUnrelatedFile = runCLI(`build ${mylib}`);
-    expect(rerunWithNewUnrelatedFile).toContain('local cache');
+    expect(rerunWithNewUnrelatedFile).toContain(
+      'existing outputs match the cache'
+    );
     const outputsAfterAddingUntouchedFileAndRerunning = [
       ...listFiles('dist/apps'),
       ...listFiles('dist/.next').map((f) => `.next/${f}`),

--- a/e2e/nx/src/spread.test.ts
+++ b/e2e/nx/src/spread.test.ts
@@ -23,6 +23,12 @@ describe('Spread Token Merging', () => {
   });
   afterEach(() => {
     updateFile('nx.json', JSON.stringify(existingNxJson, null, 2));
+    // Reset daemon cache so the next test does not see stale plugin-inferred
+    // project graph data.  The PR enabling NX_DAEMON=true in runCLI means the
+    // daemon persists across tests; without a reset, re-adding a previously
+    // removed plugin to nx.json can cause the daemon to return a cached graph
+    // that is missing inferred targets.
+    runCLI('reset');
   });
 
   function getResolvedProject(name: string) {

--- a/e2e/nx/src/workspace-legacy.test.ts
+++ b/e2e/nx/src/workspace-legacy.test.ts
@@ -2,6 +2,7 @@ import {
   checkFilesExist,
   cleanupProject,
   newProject,
+  reservePort,
   runCLI,
   runE2ETests,
   uniq,
@@ -18,8 +19,9 @@ describe('@nx/workspace:convert-to-monorepo', () => {
 
   it('should convert a standalone webpack and jest react project to a monorepo (legacy)', async () => {
     const reactApp = uniq('reactapp');
+    const appPort = await reservePort();
     runCLI(
-      `generate @nx/react:app --name=${reactApp} --directory="." --bundler=webpack --unitTestRunner=jest --e2eTestRunner=cypress --no-interactive --linter=eslint`,
+      `generate @nx/react:app --name=${reactApp} --directory="." --bundler=webpack --unitTestRunner=jest --e2eTestRunner=cypress --devServerPort=${appPort} --no-interactive --linter=eslint`,
       {
         env: {
           NX_ADD_PLUGINS: 'false',

--- a/e2e/playwright/src/playwright.test.ts
+++ b/e2e/playwright/src/playwright.test.ts
@@ -1,12 +1,13 @@
 import {
   cleanupProject,
-  newProject,
-  uniq,
-  runCLI,
   ensurePlaywrightBrowsersInstallation,
   getPackageManagerCommand,
   getSelectedPackageManager,
+  newProject,
   readJson,
+  reservePort,
+  runCLI,
+  uniq,
 } from '@nx/e2e-utils';
 
 const TEN_MINS_MS = 600_000;
@@ -31,11 +32,12 @@ describe('Playwright E2E Test runner', () => {
     () => {
       ensurePlaywrightBrowsersInstallation();
 
+      const port = reservePort();
       runCLI(
         `g @nx/web:app demo-e2e --unitTestRunner=none --bundler=vite --e2eTestRunner=none --style=css --no-interactive`
       );
       runCLI(
-        `g @nx/playwright:configuration --project demo-e2e --webServerCommand="${pmc.runNx} serve demo-e2e" --webServerAddress="http://localhost:4200"`
+        `g @nx/playwright:configuration --project demo-e2e --webServerCommand="${pmc.runNx} serve demo-e2e --port=${port}" --webServerAddress="http://localhost:${port}"`
       );
 
       const e2eResults = runCLI(`e2e demo-e2e`);
@@ -52,11 +54,12 @@ describe('Playwright E2E Test runner', () => {
     () => {
       ensurePlaywrightBrowsersInstallation();
 
+      const port = reservePort();
       runCLI(
         `g @nx/web:app demo-js-e2e --unitTestRunner=none --bundler=vite --e2eTestRunner=none --style=css --no-interactive`
       );
       runCLI(
-        `g @nx/playwright:configuration --project demo-js-e2e --js  --webServerCommand="${pmc.runNx} serve demo-e2e" --webServerAddress="http://localhost:4200"`
+        `g @nx/playwright:configuration --project demo-js-e2e --js  --webServerCommand="${pmc.runNx} serve demo-e2e --port=${port}" --webServerAddress="http://localhost:${port}"`
       );
 
       const e2eResults = runCLI(`e2e demo-js-e2e`);
@@ -95,12 +98,13 @@ describe('Playwright E2E Test Runner - legacy', () => {
       ensurePlaywrightBrowsersInstallation();
 
       const pmc = getPackageManagerCommand();
+      const port = reservePort();
 
       runCLI(
         `g @nx/web:app demo-e2e --directory apps/demo-e2e --unitTestRunner=none --bundler=vite --e2eTestRunner=none --style=css --no-interactive`
       );
       runCLI(
-        `g @nx/playwright:configuration --project demo-e2e --webServerCommand="${pmc.runNx} serve demo-e2e" --webServerAddress="http://localhost:4200"`
+        `g @nx/playwright:configuration --project demo-e2e --webServerCommand="${pmc.runNx} serve demo-e2e --port=${port}" --webServerAddress="http://localhost:${port}"`
       );
 
       const e2eResults = runCLI(`e2e demo-e2e`);
@@ -118,12 +122,13 @@ describe('Playwright E2E Test Runner - legacy', () => {
       ensurePlaywrightBrowsersInstallation();
 
       const pmc = getPackageManagerCommand();
+      const port = reservePort();
 
       runCLI(
         `g @nx/web:app demo-js-e2e --directory apps/demo-js-e2e --unitTestRunner=none --bundler=vite --e2eTestRunner=none --style=css --no-interactive`
       );
       runCLI(
-        `g @nx/playwright:configuration --project demo-js-e2e --js  --webServerCommand="${pmc.runNx} serve demo-e2e" --webServerAddress="http://localhost:4200"`
+        `g @nx/playwright:configuration --project demo-js-e2e --js  --webServerCommand="${pmc.runNx} serve demo-e2e --port=${port}" --webServerAddress="http://localhost:${port}"`
       );
 
       const e2eResults = runCLI(`e2e demo-js-e2e`);

--- a/e2e/playwright/src/playwright.test.ts
+++ b/e2e/playwright/src/playwright.test.ts
@@ -29,10 +29,10 @@ describe('Playwright E2E Test runner', () => {
   it(
     'should test and lint example app',
 
-    () => {
+    async () => {
       ensurePlaywrightBrowsersInstallation();
 
-      const port = reservePort();
+      const port = await reservePort();
       runCLI(
         `g @nx/web:app demo-e2e --unitTestRunner=none --bundler=vite --e2eTestRunner=none --style=css --no-interactive`
       );
@@ -51,10 +51,10 @@ describe('Playwright E2E Test runner', () => {
 
   it(
     'should test and lint example app with js',
-    () => {
+    async () => {
       ensurePlaywrightBrowsersInstallation();
 
-      const port = reservePort();
+      const port = await reservePort();
       runCLI(
         `g @nx/web:app demo-js-e2e --unitTestRunner=none --bundler=vite --e2eTestRunner=none --style=css --no-interactive`
       );
@@ -94,11 +94,11 @@ describe('Playwright E2E Test Runner - legacy', () => {
   it(
     'should test and lint example app',
 
-    () => {
+    async () => {
       ensurePlaywrightBrowsersInstallation();
 
       const pmc = getPackageManagerCommand();
-      const port = reservePort();
+      const port = await reservePort();
 
       runCLI(
         `g @nx/web:app demo-e2e --directory apps/demo-e2e --unitTestRunner=none --bundler=vite --e2eTestRunner=none --style=css --no-interactive`
@@ -118,11 +118,11 @@ describe('Playwright E2E Test Runner - legacy', () => {
 
   it(
     'should test and lint example app with js',
-    () => {
+    async () => {
       ensurePlaywrightBrowsersInstallation();
 
       const pmc = getPackageManagerCommand();
-      const port = reservePort();
+      const port = await reservePort();
 
       runCLI(
         `g @nx/web:app demo-js-e2e --directory apps/demo-js-e2e --unitTestRunner=none --bundler=vite --e2eTestRunner=none --style=css --no-interactive`

--- a/e2e/react/src/module-federation/core-rspack-basic-host-remote-generation.test.ts
+++ b/e2e/react/src/module-federation/core-rspack-basic-host-remote-generation.test.ts
@@ -35,7 +35,7 @@ describe('React Rspack Module Federation - Basic - Host Remote Generation', () =
       const remote2 = uniq('remote2');
       const remote3 = uniq('remote3');
       const [shellPort, remote1Port, remote2Port, remote3Port] =
-        reservePorts(4);
+        await reservePorts(4);
 
       runCLI(
         `generate @nx/react:host apps/${shell} --name=${shell} --remotes=${remote1},${remote2},${remote3} --devServerPort=${shellPort} --bundler=rspack --e2eTestRunner=cypress --style=css --no-interactive --skipFormat --js=${js}`

--- a/e2e/react/src/module-federation/core-rspack-basic-host-remote-generation.test.ts
+++ b/e2e/react/src/module-federation/core-rspack-basic-host-remote-generation.test.ts
@@ -1,13 +1,14 @@
 import { stripIndents } from '@nx/devkit';
 import {
   checkFilesExist,
-  reservePort,
+  reservePorts,
   killProcessAndPorts,
   runCLIAsync,
   runCommandUntil,
   runE2ETests,
   uniq,
   updateFile,
+  updateJson,
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 import {
@@ -33,11 +34,25 @@ describe('React Rspack Module Federation - Basic - Host Remote Generation', () =
       const remote1 = uniq('remote1');
       const remote2 = uniq('remote2');
       const remote3 = uniq('remote3');
-      const shellPort = reservePort();
+      const [shellPort, remote1Port, remote2Port, remote3Port] = reservePorts(
+        4
+      );
 
       runCLI(
         `generate @nx/react:host apps/${shell} --name=${shell} --remotes=${remote1},${remote2},${remote3} --devServerPort=${shellPort} --bundler=rspack --e2eTestRunner=cypress --style=css --no-interactive --skipFormat --js=${js}`
       );
+
+      const remotePorts: Array<[string, number]> = [
+        [remote1, remote1Port],
+        [remote2, remote2Port],
+        [remote3, remote3Port],
+      ];
+      for (const [remote, port] of remotePorts) {
+        updateJson(`apps/${remote}/project.json`, (project) => {
+          project.targets.serve.options.port = port;
+          return project;
+        });
+      }
 
       checkFilesExist(
         `apps/${shell}/module-federation.config.${js ? 'js' : 'ts'}`

--- a/e2e/react/src/module-federation/core-rspack-basic-host-remote-generation.test.ts
+++ b/e2e/react/src/module-federation/core-rspack-basic-host-remote-generation.test.ts
@@ -34,9 +34,8 @@ describe('React Rspack Module Federation - Basic - Host Remote Generation', () =
       const remote1 = uniq('remote1');
       const remote2 = uniq('remote2');
       const remote3 = uniq('remote3');
-      const [shellPort, remote1Port, remote2Port, remote3Port] = reservePorts(
-        4
-      );
+      const [shellPort, remote1Port, remote2Port, remote3Port] =
+        reservePorts(4);
 
       runCLI(
         `generate @nx/react:host apps/${shell} --name=${shell} --remotes=${remote1},${remote2},${remote3} --devServerPort=${shellPort} --bundler=rspack --e2eTestRunner=cypress --style=css --no-interactive --skipFormat --js=${js}`

--- a/e2e/react/src/module-federation/core-rspack-basic-host-remote-generation.test.ts
+++ b/e2e/react/src/module-federation/core-rspack-basic-host-remote-generation.test.ts
@@ -1,7 +1,7 @@
 import { stripIndents } from '@nx/devkit';
 import {
   checkFilesExist,
-  getAvailablePort,
+  reservePort,
   killProcessAndPorts,
   runCLIAsync,
   runCommandUntil,
@@ -33,7 +33,7 @@ describe('React Rspack Module Federation - Basic - Host Remote Generation', () =
       const remote1 = uniq('remote1');
       const remote2 = uniq('remote2');
       const remote3 = uniq('remote3');
-      const shellPort = await getAvailablePort();
+      const shellPort = reservePort();
 
       runCLI(
         `generate @nx/react:host apps/${shell} --name=${shell} --remotes=${remote1},${remote2},${remote3} --devServerPort=${shellPort} --bundler=rspack --e2eTestRunner=cypress --style=css --no-interactive --skipFormat --js=${js}`

--- a/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
@@ -35,7 +35,7 @@ describe('React Module Federation - Webpack Basic - Host Remote Generation', () 
       const remote2 = uniq('remote2');
       const remote3 = uniq('remote3');
       const [shellPort, remote1Port, remote2Port, remote3Port] =
-        reservePorts(4);
+        await reservePorts(4);
 
       runCLI(
         `generate @nx/react:host ${shell} --remotes=${remote1},${remote2},${remote3} --devServerPort=${shellPort} --bundler=webpack --e2eTestRunner=cypress --style=css --no-interactive --skipFormat --js=${js}`

--- a/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
@@ -1,13 +1,14 @@
 import { stripIndents } from '@nx/devkit';
 import {
   checkFilesExist,
-  reservePort,
+  reservePorts,
   killProcessAndPorts,
   runCLIAsync,
   runCommandUntil,
   runE2ETests,
   uniq,
   updateFile,
+  updateJson,
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 import {
@@ -33,11 +34,25 @@ describe('React Module Federation - Webpack Basic - Host Remote Generation', () 
       const remote1 = uniq('remote1');
       const remote2 = uniq('remote2');
       const remote3 = uniq('remote3');
-      const shellPort = reservePort();
+      const [shellPort, remote1Port, remote2Port, remote3Port] = reservePorts(
+        4
+      );
 
       runCLI(
         `generate @nx/react:host ${shell} --remotes=${remote1},${remote2},${remote3} --devServerPort=${shellPort} --bundler=webpack --e2eTestRunner=cypress --style=css --no-interactive --skipFormat --js=${js}`
       );
+
+      const remotePorts: Array<[string, number]> = [
+        [remote1, remote1Port],
+        [remote2, remote2Port],
+        [remote3, remote3Port],
+      ];
+      for (const [remote, port] of remotePorts) {
+        updateJson(`${remote}/project.json`, (project) => {
+          project.targets.serve.options.port = port;
+          return project;
+        });
+      }
 
       checkFilesExist(`${shell}/module-federation.config.${js ? 'js' : 'ts'}`);
       checkFilesExist(

--- a/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
@@ -1,7 +1,7 @@
 import { stripIndents } from '@nx/devkit';
 import {
   checkFilesExist,
-  getAvailablePort,
+  reservePort,
   killProcessAndPorts,
   runCLIAsync,
   runCommandUntil,
@@ -33,7 +33,7 @@ describe('React Module Federation - Webpack Basic - Host Remote Generation', () 
       const remote1 = uniq('remote1');
       const remote2 = uniq('remote2');
       const remote3 = uniq('remote3');
-      const shellPort = await getAvailablePort();
+      const shellPort = reservePort();
 
       runCLI(
         `generate @nx/react:host ${shell} --remotes=${remote1},${remote2},${remote3} --devServerPort=${shellPort} --bundler=webpack --e2eTestRunner=cypress --style=css --no-interactive --skipFormat --js=${js}`

--- a/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
@@ -34,9 +34,8 @@ describe('React Module Federation - Webpack Basic - Host Remote Generation', () 
       const remote1 = uniq('remote1');
       const remote2 = uniq('remote2');
       const remote3 = uniq('remote3');
-      const [shellPort, remote1Port, remote2Port, remote3Port] = reservePorts(
-        4
-      );
+      const [shellPort, remote1Port, remote2Port, remote3Port] =
+        reservePorts(4);
 
       runCLI(
         `generate @nx/react:host ${shell} --remotes=${remote1},${remote2},${remote3} --devServerPort=${shellPort} --bundler=webpack --e2eTestRunner=cypress --style=css --no-interactive --skipFormat --js=${js}`

--- a/e2e/react/src/module-federation/core-webpack-ssr.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-ssr.test.ts
@@ -3,11 +3,13 @@ import {
   killPorts,
   killProcessAndPorts,
   readJson,
+  reservePorts,
   runCLIAsync,
   runCommandUntil,
   runE2ETests,
   uniq,
   updateFile,
+  updateJson,
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 import {
@@ -32,10 +34,28 @@ describe('React Module Federation - Webpack SSR', () => {
       `generate @nx/react:host ${shell} --bundler=webpack --ssr --remotes=${remote1},${remote2},${remote3} --style=css --no-interactive --skipFormat`
     );
 
+    // The generator should default ports to 4200..4203.
     expect(readPort(shell)).toEqual(4200);
     expect(readPort(remote1)).toEqual(4201);
     expect(readPort(remote2)).toEqual(4202);
     expect(readPort(remote3)).toEqual(4203);
+
+    // Override defaults with reserved ports so parallel tests don't collide
+    // when the SSR `server:*` targets bind sockets.
+    const [shellPort, remote1Port, remote2Port, remote3Port] =
+      await reservePorts(4);
+    const portMap: Array<[string, number]> = [
+      [shell, shellPort],
+      [remote1, remote1Port],
+      [remote2, remote2Port],
+      [remote3, remote3Port],
+    ];
+    for (const [app, port] of portMap) {
+      updateJson(`${app}/project.json`, (project) => {
+        project.targets.serve.options.port = port;
+        return project;
+      });
+    }
 
     [shell, remote1, remote2, remote3].forEach((app) => {
       checkFilesExist(
@@ -63,6 +83,21 @@ describe('React Module Federation - Webpack SSR', () => {
       `generate @nx/react:host ${shell} --ssr --bundler=webpack --remotes=${remote1},${remote2},${remote3} --style=css --e2eTestRunner=cypress --no-interactive --skipFormat`
     );
 
+    const [shellPort, remote1Port, remote2Port, remote3Port] =
+      await reservePorts(4);
+    const portMap: Array<[string, number]> = [
+      [shell, shellPort],
+      [remote1, remote1Port],
+      [remote2, remote2Port],
+      [remote3, remote3Port],
+    ];
+    for (const [app, port] of portMap) {
+      updateJson(`${app}/project.json`, (project) => {
+        project.targets.serve.options.port = port;
+        return project;
+      });
+    }
+
     const serveResult = await runCommandUntil(
       `serve ${shell}`,
       (output) =>
@@ -82,6 +117,21 @@ describe('React Module Federation - Webpack SSR', () => {
     await runCLIAsync(
       `generate @nx/react:host ${shell} --bundler=webpack --ssr --remotes=${remote1},${remote2},${remote3} --style=css --e2eTestRunner=cypress --no-interactive --skipFormat`
     );
+
+    const [shellPort, remote1Port, remote2Port, remote3Port] =
+      await reservePorts(4);
+    const portMap: Array<[string, number]> = [
+      [shell, shellPort],
+      [remote1, remote1Port],
+      [remote2, remote2Port],
+      [remote3, remote3Port],
+    ];
+    for (const [app, port] of portMap) {
+      updateJson(`${app}/project.json`, (project) => {
+        project.targets.serve.options.port = port;
+        return project;
+      });
+    }
 
     const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 

--- a/e2e/react/src/module-federation/core-webpack-ssr.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-ssr.test.ts
@@ -53,6 +53,11 @@ describe('React Module Federation - Webpack SSR', () => {
     for (const [app, port] of portMap) {
       updateJson(`${app}/project.json`, (project) => {
         project.targets.serve.options.port = port;
+        // The SSR `server` target binds its own socket via @nx/{webpack,rspack}:ssr-dev-server
+        // and defaults to 4200. Pin it so parallel tests don't collide.
+        if (project.targets.server?.options) {
+          project.targets.server.options.port = port;
+        }
         return project;
       });
     }
@@ -94,6 +99,11 @@ describe('React Module Federation - Webpack SSR', () => {
     for (const [app, port] of portMap) {
       updateJson(`${app}/project.json`, (project) => {
         project.targets.serve.options.port = port;
+        // The SSR `server` target binds its own socket via @nx/{webpack,rspack}:ssr-dev-server
+        // and defaults to 4200. Pin it so parallel tests don't collide.
+        if (project.targets.server?.options) {
+          project.targets.server.options.port = port;
+        }
         return project;
       });
     }
@@ -129,6 +139,11 @@ describe('React Module Federation - Webpack SSR', () => {
     for (const [app, port] of portMap) {
       updateJson(`${app}/project.json`, (project) => {
         project.targets.serve.options.port = port;
+        // The SSR `server` target binds its own socket via @nx/{webpack,rspack}:ssr-dev-server
+        // and defaults to 4200. Pin it so parallel tests don't collide.
+        if (project.targets.server?.options) {
+          project.targets.server.options.port = port;
+        }
         return project;
       });
     }

--- a/e2e/react/src/module-federation/dynamic-federation.rspack.test.ts
+++ b/e2e/react/src/module-federation/dynamic-federation.rspack.test.ts
@@ -1,8 +1,8 @@
 import {
   cleanupProject,
   fileExists,
-  getAvailablePort,
-  getAvailablePorts,
+  reservePort,
+  reservePorts,
   killProcessAndPorts,
   newProject,
   readJson,
@@ -24,7 +24,7 @@ describe('Dynamic Module Federation', () => {
   it('should load remote dynamic module', async () => {
     const shell = uniq('shell');
     const remote = uniq('remote');
-    const [shellPort, remotePort] = await getAvailablePorts(2);
+    const [shellPort, remotePort] = reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${shell} --remotes=${remote} --devServerPort=${shellPort} --bundler=rspack --e2eTestRunner=cypress --dynamic=true --no-interactive --skipFormat`

--- a/e2e/react/src/module-federation/dynamic-federation.rspack.test.ts
+++ b/e2e/react/src/module-federation/dynamic-federation.rspack.test.ts
@@ -24,7 +24,7 @@ describe('Dynamic Module Federation', () => {
   it('should load remote dynamic module', async () => {
     const shell = uniq('shell');
     const remote = uniq('remote');
-    const [shellPort, remotePort] = reservePorts(2);
+    const [shellPort, remotePort] = await reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${shell} --remotes=${remote} --devServerPort=${shellPort} --bundler=rspack --e2eTestRunner=cypress --dynamic=true --no-interactive --skipFormat`

--- a/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
+++ b/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
@@ -23,7 +23,7 @@ describe('Dynamic Module Federation', () => {
   it('should load remote dynamic module', async () => {
     const shell = uniq('shell');
     const remote = uniq('remote');
-    const [shellPort, remotePort] = reservePorts(2);
+    const [shellPort, remotePort] = await reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${shell} --remotes=${remote} --devServerPort=${shellPort} --bundler=webpack --e2eTestRunner=cypress --dynamic=true --no-interactive --skipFormat`

--- a/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
+++ b/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
@@ -1,7 +1,7 @@
 import {
   cleanupProject,
   fileExists,
-  getAvailablePorts,
+  reservePorts,
   killProcessAndPorts,
   newProject,
   readJson,
@@ -23,7 +23,7 @@ describe('Dynamic Module Federation', () => {
   it('should load remote dynamic module', async () => {
     const shell = uniq('shell');
     const remote = uniq('remote');
-    const [shellPort, remotePort] = await getAvailablePorts(2);
+    const [shellPort, remotePort] = reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${shell} --remotes=${remote} --devServerPort=${shellPort} --bundler=webpack --e2eTestRunner=cypress --dynamic=true --no-interactive --skipFormat`

--- a/e2e/react/src/module-federation/federate-module.rspack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.rspack.test.ts
@@ -1,6 +1,6 @@
 import {
   cleanupProject,
-  reservePort,
+  reservePorts,
   killProcessAndPorts,
   newProject,
   runCommandUntil,
@@ -24,11 +24,16 @@ describe('Federate Module', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const shellPort = reservePort();
+    const [shellPort, remotePort] = reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${host} --remotes=${remote} --bundler=rspack --e2eTestRunner=cypress --devServerPort=${shellPort} --no-interactive --skipFormat`
     );
+
+    updateJson(`${remote}/project.json`, (project) => {
+      project.targets.serve.options.port = remotePort;
+      return project;
+    });
 
     runCLI(`generate @nx/js:lib ${lib} --no-interactive --skipFormat`);
 
@@ -95,7 +100,6 @@ describe('Federate Module', () => {
     );
 
     const hostPort = readPort(host);
-    const remotePort = readPort(remote);
 
     // Build host and remote
     const buildOutput = runCLI(`build ${host}`);
@@ -125,11 +129,16 @@ describe('Federate Module', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const shellPort = reservePort();
+    const [shellPort, remotePort, childRemotePort] = reservePorts(3);
 
     runCLI(
       `generate @nx/react:host ${host} --remotes=${remote} --bundler=rspack --e2eTestRunner=cypress --devServerPort=${shellPort} --no-interactive --skipFormat`
     );
+
+    updateJson(`${remote}/project.json`, (project) => {
+      project.targets.serve.options.port = remotePort;
+      return project;
+    });
 
     runCLI(`generate @nx/js:lib ${lib} --no-interactive --skipFormat`);
 
@@ -137,6 +146,11 @@ describe('Federate Module', () => {
     runCLI(
       `generate @nx/react:federate-module ${lib}/src/index.ts --name=${module} --remote=${childRemote} --remoteDirectory=${childRemote} --bundler=rspack --no-interactive --skipFormat`
     );
+
+    updateJson(`${childRemote}/project.json`, (project) => {
+      project.targets.serve.options.port = childRemotePort;
+      return project;
+    });
 
     updateFile(
       `${lib}/src/index.ts`,
@@ -188,8 +202,6 @@ describe('Federate Module', () => {
     );
 
     const hostPort = readPort(host);
-    const remotePort = readPort(remote);
-    const childRemotePort = readPort(childRemote);
 
     // Build host and remote
     const buildOutput = runCLI(`build ${host}`);

--- a/e2e/react/src/module-federation/federate-module.rspack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.rspack.test.ts
@@ -25,7 +25,7 @@ describe('Federate Module', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const [shellPort, remotePort] = reservePorts(2);
+    const [shellPort, remotePort] = await reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${host} --remotes=${remote} --bundler=rspack --e2eTestRunner=cypress --devServerPort=${shellPort} --no-interactive --skipFormat`
@@ -130,7 +130,7 @@ describe('Federate Module', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const [shellPort, remotePort, childRemotePort] = reservePorts(3);
+    const [shellPort, remotePort, childRemotePort] = await reservePorts(3);
 
     runCLI(
       `generate @nx/react:host ${host} --remotes=${remote} --bundler=rspack --e2eTestRunner=cypress --devServerPort=${shellPort} --no-interactive --skipFormat`

--- a/e2e/react/src/module-federation/federate-module.rspack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.rspack.test.ts
@@ -1,6 +1,6 @@
 import {
   cleanupProject,
-  getAvailablePort,
+  reservePort,
   killProcessAndPorts,
   newProject,
   runCommandUntil,
@@ -24,7 +24,7 @@ describe('Federate Module', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const shellPort = await getAvailablePort();
+    const shellPort = reservePort();
 
     runCLI(
       `generate @nx/react:host ${host} --remotes=${remote} --bundler=rspack --e2eTestRunner=cypress --devServerPort=${shellPort} --no-interactive --skipFormat`
@@ -125,7 +125,7 @@ describe('Federate Module', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const shellPort = await getAvailablePort();
+    const shellPort = reservePort();
 
     runCLI(
       `generate @nx/react:host ${host} --remotes=${remote} --bundler=rspack --e2eTestRunner=cypress --devServerPort=${shellPort} --no-interactive --skipFormat`

--- a/e2e/react/src/module-federation/federate-module.rspack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.rspack.test.ts
@@ -7,6 +7,7 @@ import {
   runE2ETests,
   uniq,
   updateFile,
+  updateJson,
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 

--- a/e2e/react/src/module-federation/federate-module.webpack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.webpack.test.ts
@@ -1,6 +1,6 @@
 import {
   cleanupProject,
-  reservePort,
+  reservePorts,
   killProcessAndPorts,
   newProject,
   runCommandUntil,
@@ -24,11 +24,16 @@ describe('Federate Module', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const shellPort = reservePort();
+    const [shellPort, remotePort] = reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${host} --bundler=webpack --remotes=${remote} --devServerPort=${shellPort} --e2eTestRunner=cypress --no-interactive --skipFormat`
     );
+
+    updateJson(`${remote}/project.json`, (project) => {
+      project.targets.serve.options.port = remotePort;
+      return project;
+    });
 
     runCLI(`generate @nx/js:lib ${lib} --no-interactive --skipFormat`);
 
@@ -95,7 +100,6 @@ describe('Federate Module', () => {
     );
 
     const hostPort = readPort(host);
-    const remotePort = readPort(remote);
 
     // Build host and remote
     const buildOutput = runCLI(`build ${host}`);
@@ -125,11 +129,16 @@ describe('Federate Module', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const shellPort = reservePort();
+    const [shellPort, remotePort, childRemotePort] = reservePorts(3);
 
     runCLI(
       `generate @nx/react:host ${host} --remotes=${remote} --devServerPort=${shellPort} --bundler=webpack --e2eTestRunner=cypress --no-interactive --skipFormat`
     );
+
+    updateJson(`${remote}/project.json`, (project) => {
+      project.targets.serve.options.port = remotePort;
+      return project;
+    });
 
     runCLI(`generate @nx/js:lib ${lib} --no-interactive --skipFormat`);
 
@@ -137,6 +146,11 @@ describe('Federate Module', () => {
     runCLI(
       `generate @nx/react:federate-module ${lib}/src/index.ts --bundler=webpack --name=${module} --remote=${childRemote} --remoteDirectory=${childRemote} --no-interactive --skipFormat`
     );
+
+    updateJson(`${childRemote}/project.json`, (project) => {
+      project.targets.serve.options.port = childRemotePort;
+      return project;
+    });
 
     updateFile(
       `${lib}/src/index.ts`,
@@ -188,8 +202,6 @@ describe('Federate Module', () => {
     );
 
     const hostPort = readPort(host);
-    const remotePort = readPort(remote);
-    const childRemotePort = readPort(childRemote);
 
     // Build host and remote
     const buildOutput = runCLI(`build ${host}`);

--- a/e2e/react/src/module-federation/federate-module.webpack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.webpack.test.ts
@@ -25,7 +25,7 @@ describe('Federate Module', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const [shellPort, remotePort] = reservePorts(2);
+    const [shellPort, remotePort] = await reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${host} --bundler=webpack --remotes=${remote} --devServerPort=${shellPort} --e2eTestRunner=cypress --no-interactive --skipFormat`
@@ -130,7 +130,7 @@ describe('Federate Module', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const [shellPort, remotePort, childRemotePort] = reservePorts(3);
+    const [shellPort, remotePort, childRemotePort] = await reservePorts(3);
 
     runCLI(
       `generate @nx/react:host ${host} --remotes=${remote} --devServerPort=${shellPort} --bundler=webpack --e2eTestRunner=cypress --no-interactive --skipFormat`

--- a/e2e/react/src/module-federation/federate-module.webpack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.webpack.test.ts
@@ -1,6 +1,6 @@
 import {
   cleanupProject,
-  getAvailablePort,
+  reservePort,
   killProcessAndPorts,
   newProject,
   runCommandUntil,
@@ -24,7 +24,7 @@ describe('Federate Module', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const shellPort = await getAvailablePort();
+    const shellPort = reservePort();
 
     runCLI(
       `generate @nx/react:host ${host} --bundler=webpack --remotes=${remote} --devServerPort=${shellPort} --e2eTestRunner=cypress --no-interactive --skipFormat`
@@ -125,7 +125,7 @@ describe('Federate Module', () => {
     const module = uniq('module');
     const host = uniq('host');
 
-    const shellPort = await getAvailablePort();
+    const shellPort = reservePort();
 
     runCLI(
       `generate @nx/react:host ${host} --remotes=${remote} --devServerPort=${shellPort} --bundler=webpack --e2eTestRunner=cypress --no-interactive --skipFormat`

--- a/e2e/react/src/module-federation/federate-module.webpack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.webpack.test.ts
@@ -7,6 +7,7 @@ import {
   runE2ETests,
   uniq,
   updateFile,
+  updateJson,
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 

--- a/e2e/react/src/module-federation/independent-deployability.rspack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.rspack.test.ts
@@ -388,7 +388,8 @@ describe('Independent Deployability', () => {
       const hostE2eResultsSwc = await runCommandUntil(
         `e2e ${shell}-e2e --verbose`,
         (output) =>
-          output.includes('NX   Successfully ran target e2e for project')
+          output.includes('NX   Successfully ran target e2e for project'),
+        { timeout: 120000 }
       );
       await killProcessAndPorts(
         hostE2eResultsSwc.pid,
@@ -400,7 +401,8 @@ describe('Independent Deployability', () => {
       const remoteE2eResultsSwc = await runCommandUntil(
         `e2e ${remote}-e2e --verbose`,
         (output) =>
-          output.includes('NX   Successfully ran target e2e for project')
+          output.includes('NX   Successfully ran target e2e for project'),
+        { timeout: 120000 }
       );
 
       await killProcessAndPorts(remoteE2eResultsSwc.pid, remotePort);

--- a/e2e/react/src/module-federation/independent-deployability.rspack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.rspack.test.ts
@@ -1,6 +1,6 @@
 import {
   cleanupProject,
-  reservePort,
+  reservePorts,
   killProcessAndPorts,
   newProject,
   runCommandUntil,
@@ -26,13 +26,16 @@ describe('Independent Deployability', () => {
   it('should support promised based remotes', async () => {
     const remote = uniq('remote');
     const host = uniq('host');
-    const shellPort = reservePort();
+    const [shellPort, remotePort] = reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${host} --remotes=${remote} --devServerPort=${shellPort} --bundler=rspack --e2eTestRunner=cypress --no-interactive --typescriptConfiguration=false --skipFormat`
     );
 
-    const remotePort = readPort(remote);
+    updateJson(`${remote}/project.json`, (project) => {
+      project.targets.serve.options.port = remotePort;
+      return project;
+    });
     // Update remote to be loaded via script
     updateFile(
       `${remote}/module-federation.config.js`,
@@ -143,17 +146,20 @@ describe('Independent Deployability', () => {
     const remote = uniq('remote');
     const lib = uniq('lib');
 
-    const shellPort = reservePort();
+    const [shellPort, remotePort] = reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${shell} --remotes=${remote} --devServerPort=${shellPort} --bundler=rspack --e2eTestRunner=cypress --no-interactive --skipFormat`
     );
 
+    updateJson(`${remote}/project.json`, (project) => {
+      project.targets.serve.options.port = remotePort;
+      return project;
+    });
+
     runCLI(
       `generate @nx/js:lib ${lib} --importPath=@acme/${lib} --publishable=true --no-interactive --skipFormat`
     );
-
-    const remotePort = readPort(remote);
 
     updateFile(
       `${lib}/src/lib/${lib}.ts`,
@@ -292,13 +298,16 @@ describe('Independent Deployability', () => {
     const shell = uniq('shell');
     const remote = uniq('remote');
 
-    const shellPort = reservePort();
+    const [shellPort, remotePort] = reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${shell} --remotes=${remote} --bundler=rspack --devServerPort=${shellPort} --e2eTestRunner=cypress --no-interactive --skipFormat`
     );
 
-    const remotePort = readPort(remote);
+    updateJson(`${remote}/project.json`, (project) => {
+      project.targets.serve.options.port = remotePort;
+      return project;
+    });
 
     // update host and remote to use library type var
     updateFile(

--- a/e2e/react/src/module-federation/independent-deployability.rspack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.rspack.test.ts
@@ -1,6 +1,6 @@
 import {
   cleanupProject,
-  getAvailablePort,
+  reservePort,
   killProcessAndPorts,
   newProject,
   runCommandUntil,
@@ -26,7 +26,7 @@ describe('Independent Deployability', () => {
   it('should support promised based remotes', async () => {
     const remote = uniq('remote');
     const host = uniq('host');
-    const shellPort = await getAvailablePort();
+    const shellPort = reservePort();
 
     runCLI(
       `generate @nx/react:host ${host} --remotes=${remote} --devServerPort=${shellPort} --bundler=rspack --e2eTestRunner=cypress --no-interactive --typescriptConfiguration=false --skipFormat`
@@ -143,7 +143,7 @@ describe('Independent Deployability', () => {
     const remote = uniq('remote');
     const lib = uniq('lib');
 
-    const shellPort = await getAvailablePort();
+    const shellPort = reservePort();
 
     runCLI(
       `generate @nx/react:host ${shell} --remotes=${remote} --devServerPort=${shellPort} --bundler=rspack --e2eTestRunner=cypress --no-interactive --skipFormat`
@@ -292,7 +292,7 @@ describe('Independent Deployability', () => {
     const shell = uniq('shell');
     const remote = uniq('remote');
 
-    const shellPort = await getAvailablePort();
+    const shellPort = reservePort();
 
     runCLI(
       `generate @nx/react:host ${shell} --remotes=${remote} --bundler=rspack --devServerPort=${shellPort} --e2eTestRunner=cypress --no-interactive --skipFormat`

--- a/e2e/react/src/module-federation/independent-deployability.rspack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.rspack.test.ts
@@ -26,7 +26,7 @@ describe('Independent Deployability', () => {
   it('should support promised based remotes', async () => {
     const remote = uniq('remote');
     const host = uniq('host');
-    const [shellPort, remotePort] = reservePorts(2);
+    const [shellPort, remotePort] = await reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${host} --remotes=${remote} --devServerPort=${shellPort} --bundler=rspack --e2eTestRunner=cypress --no-interactive --typescriptConfiguration=false --skipFormat`
@@ -146,7 +146,7 @@ describe('Independent Deployability', () => {
     const remote = uniq('remote');
     const lib = uniq('lib');
 
-    const [shellPort, remotePort] = reservePorts(2);
+    const [shellPort, remotePort] = await reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${shell} --remotes=${remote} --devServerPort=${shellPort} --bundler=rspack --e2eTestRunner=cypress --no-interactive --skipFormat`
@@ -298,7 +298,7 @@ describe('Independent Deployability', () => {
     const shell = uniq('shell');
     const remote = uniq('remote');
 
-    const [shellPort, remotePort] = reservePorts(2);
+    const [shellPort, remotePort] = await reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${shell} --remotes=${remote} --bundler=rspack --devServerPort=${shellPort} --e2eTestRunner=cypress --no-interactive --skipFormat`

--- a/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
@@ -1,6 +1,6 @@
 import {
   cleanupProject,
-  getAvailablePort,
+  reservePort,
   killProcessAndPorts,
   newProject,
   runCommandUntil,
@@ -28,7 +28,7 @@ describe('Independent Deployability', () => {
     const remote = uniq('remote');
     const host = uniq('host');
 
-    const shellPort = await getAvailablePort();
+    const shellPort = reservePort();
 
     runCLI(
       `generate @nx/react:host ${host} --remotes=${remote} --devServerPort=${shellPort} --bundler=webpack --e2eTestRunner=cypress --no-interactive --typescriptConfiguration=false --skipFormat`
@@ -165,7 +165,7 @@ describe('Independent Deployability', () => {
     const remote = uniq('remote');
     const lib = uniq('lib');
 
-    const shellPort = await getAvailablePort();
+    const shellPort = reservePort();
 
     runCLI(
       `generate @nx/react:host ${shell} --remotes=${remote} --devServerPort=${shellPort} --bundler=webpack --e2eTestRunner=cypress --no-interactive --skipFormat`
@@ -315,7 +315,7 @@ describe('Independent Deployability', () => {
   it('should support host and remote with library type var', async () => {
     const shell = uniq('shell');
     const remote = uniq('remote');
-    const shellPort = await getAvailablePort();
+    const shellPort = reservePort();
 
     runCLI(
       `generate @nx/react:host ${shell} --devServerPort=${shellPort} --remotes=${remote} --bundler=webpack --e2eTestRunner=cypress --no-interactive --skipFormat`

--- a/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
@@ -1,6 +1,6 @@
 import {
   cleanupProject,
-  reservePort,
+  reservePorts,
   killProcessAndPorts,
   newProject,
   runCommandUntil,
@@ -28,13 +28,16 @@ describe('Independent Deployability', () => {
     const remote = uniq('remote');
     const host = uniq('host');
 
-    const shellPort = reservePort();
+    const [shellPort, remotePort] = reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${host} --remotes=${remote} --devServerPort=${shellPort} --bundler=webpack --e2eTestRunner=cypress --no-interactive --typescriptConfiguration=false --skipFormat`
     );
 
-    const remotePort = readPort(remote);
+    updateJson(`${remote}/project.json`, (project) => {
+      project.targets.serve.options.port = remotePort;
+      return project;
+    });
 
     // Update remote to be loaded via script
     updateFile(
@@ -165,17 +168,20 @@ describe('Independent Deployability', () => {
     const remote = uniq('remote');
     const lib = uniq('lib');
 
-    const shellPort = reservePort();
+    const [shellPort, remotePort] = reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${shell} --remotes=${remote} --devServerPort=${shellPort} --bundler=webpack --e2eTestRunner=cypress --no-interactive --skipFormat`
     );
 
+    updateJson(`${remote}/project.json`, (project) => {
+      project.targets.serve.options.port = remotePort;
+      return project;
+    });
+
     runCLI(
       `generate @nx/js:lib ${lib} --importPath=@acme/${lib} --publishable=true --no-interactive --skipFormat`
     );
-
-    const remotePort = readPort(remote);
 
     updateFile(
       `${lib}/src/lib/${lib}.ts`,
@@ -315,13 +321,16 @@ describe('Independent Deployability', () => {
   it('should support host and remote with library type var', async () => {
     const shell = uniq('shell');
     const remote = uniq('remote');
-    const shellPort = reservePort();
+    const [shellPort, remotePort] = reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${shell} --devServerPort=${shellPort} --remotes=${remote} --bundler=webpack --e2eTestRunner=cypress --no-interactive --skipFormat`
     );
 
-    const remotePort = readPort(remote);
+    updateJson(`${remote}/project.json`, (project) => {
+      project.targets.serve.options.port = remotePort;
+      return project;
+    });
 
     // update host and remote to use library type var
     updateFile(

--- a/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
@@ -28,7 +28,7 @@ describe('Independent Deployability', () => {
     const remote = uniq('remote');
     const host = uniq('host');
 
-    const [shellPort, remotePort] = reservePorts(2);
+    const [shellPort, remotePort] = await reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${host} --remotes=${remote} --devServerPort=${shellPort} --bundler=webpack --e2eTestRunner=cypress --no-interactive --typescriptConfiguration=false --skipFormat`
@@ -168,7 +168,7 @@ describe('Independent Deployability', () => {
     const remote = uniq('remote');
     const lib = uniq('lib');
 
-    const [shellPort, remotePort] = reservePorts(2);
+    const [shellPort, remotePort] = await reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${shell} --remotes=${remote} --devServerPort=${shellPort} --bundler=webpack --e2eTestRunner=cypress --no-interactive --skipFormat`
@@ -321,7 +321,7 @@ describe('Independent Deployability', () => {
   it('should support host and remote with library type var', async () => {
     const shell = uniq('shell');
     const remote = uniq('remote');
-    const [shellPort, remotePort] = reservePorts(2);
+    const [shellPort, remotePort] = await reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${shell} --devServerPort=${shellPort} --remotes=${remote} --bundler=webpack --e2eTestRunner=cypress --no-interactive --skipFormat`

--- a/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
@@ -6,7 +6,7 @@ import {
   runE2ETests,
   uniq,
   updateFile,
-  getAvailablePort,
+  reservePort,
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 import { stripIndents } from 'nx/src/utils/strip-indents';
@@ -24,7 +24,7 @@ describe('React Rspack Module Federation Misc - Convert To Rspack', () => {
   it('should generate host and remote apps in webpack, convert to rspack and use playwright for e2es', async () => {
     const shell = uniq('shell');
     const remote1 = uniq('remote1');
-    const shellPort = await getAvailablePort();
+    const shellPort = reservePort();
 
     runCLI(
       `generate @nx/react:host ${shell} --remotes=${remote1} --bundler=webpack --devServerPort=${shellPort} --e2eTestRunner=playwright --style=css --no-interactive --skipFormat`

--- a/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
@@ -31,7 +31,7 @@ describe('React Rspack Module Federation Misc - Convert To Rspack', () => {
       `generate @nx/react:host ${shell} --remotes=${remote1} --bundler=webpack --devServerPort=${shellPort} --e2eTestRunner=playwright --style=css --no-interactive --skipFormat`
     );
 
-    updateJson(`apps/${remote1}/project.json`, (project) => {
+    updateJson(`${remote1}/project.json`, (project) => {
       project.targets.serve.options.port = remote1Port;
       return project;
     });

--- a/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
@@ -25,7 +25,7 @@ describe('React Rspack Module Federation Misc - Convert To Rspack', () => {
   it('should generate host and remote apps in webpack, convert to rspack and use playwright for e2es', async () => {
     const shell = uniq('shell');
     const remote1 = uniq('remote1');
-    const [shellPort, remote1Port] = reservePorts(2);
+    const [shellPort, remote1Port] = await reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${shell} --remotes=${remote1} --bundler=webpack --devServerPort=${shellPort} --e2eTestRunner=playwright --style=css --no-interactive --skipFormat`

--- a/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
@@ -6,7 +6,8 @@ import {
   runE2ETests,
   uniq,
   updateFile,
-  reservePort,
+  updateJson,
+  reservePorts,
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 import { stripIndents } from 'nx/src/utils/strip-indents';
@@ -24,11 +25,16 @@ describe('React Rspack Module Federation Misc - Convert To Rspack', () => {
   it('should generate host and remote apps in webpack, convert to rspack and use playwright for e2es', async () => {
     const shell = uniq('shell');
     const remote1 = uniq('remote1');
-    const shellPort = reservePort();
+    const [shellPort, remote1Port] = reservePorts(2);
 
     runCLI(
       `generate @nx/react:host ${shell} --remotes=${remote1} --bundler=webpack --devServerPort=${shellPort} --e2eTestRunner=playwright --style=css --no-interactive --skipFormat`
     );
+
+    updateJson(`apps/${remote1}/project.json`, (project) => {
+      project.targets.serve.options.port = remote1Port;
+      return project;
+    });
 
     runCLI(
       `generate @nx/rspack:convert-webpack ${shell} --skipFormat --no-interactive`

--- a/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
@@ -26,7 +26,7 @@ describe('React Rspack Module Federation Misc - Interoperability', () => {
     const shell = uniq('shell');
     const remote1 = uniq('remote1');
     const remote2 = uniq('remote2');
-    const [shellPort, remote1Port, remote2Port] = reservePorts(3);
+    const [shellPort, remote1Port, remote2Port] = await reservePorts(3);
 
     runCLI(
       `generate @nx/react:host apps/${shell} --name=${shell} --remotes=${remote1} --bundler=webpack --devServerPort=${shellPort} --e2eTestRunner=cypress --style=css --no-interactive --skipFormat`
@@ -97,7 +97,7 @@ describe('React Rspack Module Federation Misc - Interoperability', () => {
     const shell = uniq('shell');
     const remote1 = uniq('remote1');
     const remote2 = uniq('remote2');
-    const [shellPort, remote1Port, remote2Port] = reservePorts(3);
+    const [shellPort, remote1Port, remote2Port] = await reservePorts(3);
 
     runCLI(
       `generate @nx/react:host apps/${shell} --name=${shell} --remotes=${remote1} --bundler=rspack --devServerPort=${shellPort} --e2eTestRunner=cypress --style=css --no-interactive --skipFormat`

--- a/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
@@ -6,7 +6,7 @@ import {
   runE2ETests,
   uniq,
   updateFile,
-  getAvailablePort,
+  reservePort,
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 import { stripIndents } from 'nx/src/utils/strip-indents';
@@ -25,7 +25,7 @@ describe('React Rspack Module Federation Misc - Interoperability', () => {
     const shell = uniq('shell');
     const remote1 = uniq('remote1');
     const remote2 = uniq('remote2');
-    const shellPort = await getAvailablePort();
+    const shellPort = reservePort();
 
     runCLI(
       `generate @nx/react:host apps/${shell} --name=${shell} --remotes=${remote1} --bundler=webpack --devServerPort=${shellPort} --e2eTestRunner=cypress --style=css --no-interactive --skipFormat`
@@ -86,7 +86,7 @@ describe('React Rspack Module Federation Misc - Interoperability', () => {
     const shell = uniq('shell');
     const remote1 = uniq('remote1');
     const remote2 = uniq('remote2');
-    const shellPort = await getAvailablePort();
+    const shellPort = reservePort();
 
     runCLI(
       `generate @nx/react:host apps/${shell} --name=${shell} --remotes=${remote1} --bundler=rspack --devServerPort=${shellPort} --e2eTestRunner=cypress --style=css --no-interactive --skipFormat`

--- a/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
@@ -6,7 +6,8 @@ import {
   runE2ETests,
   uniq,
   updateFile,
-  reservePort,
+  updateJson,
+  reservePorts,
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 import { stripIndents } from 'nx/src/utils/strip-indents';
@@ -25,15 +26,25 @@ describe('React Rspack Module Federation Misc - Interoperability', () => {
     const shell = uniq('shell');
     const remote1 = uniq('remote1');
     const remote2 = uniq('remote2');
-    const shellPort = reservePort();
+    const [shellPort, remote1Port, remote2Port] = reservePorts(3);
 
     runCLI(
       `generate @nx/react:host apps/${shell} --name=${shell} --remotes=${remote1} --bundler=webpack --devServerPort=${shellPort} --e2eTestRunner=cypress --style=css --no-interactive --skipFormat`
     );
 
+    updateJson(`apps/${remote1}/project.json`, (project) => {
+      project.targets.serve.options.port = remote1Port;
+      return project;
+    });
+
     runCLI(
       `generate @nx/react:remote apps/${remote2} --name=${remote2} --host=${shell} --bundler=rspack --style=css --no-interactive --skipFormat`
     );
+
+    updateJson(`apps/${remote2}/project.json`, (project) => {
+      project.targets.serve.options.port = remote2Port;
+      return project;
+    });
 
     updateFile(
       `apps/${shell}-e2e/src/integration/app.spec.ts`,
@@ -86,15 +97,25 @@ describe('React Rspack Module Federation Misc - Interoperability', () => {
     const shell = uniq('shell');
     const remote1 = uniq('remote1');
     const remote2 = uniq('remote2');
-    const shellPort = reservePort();
+    const [shellPort, remote1Port, remote2Port] = reservePorts(3);
 
     runCLI(
       `generate @nx/react:host apps/${shell} --name=${shell} --remotes=${remote1} --bundler=rspack --devServerPort=${shellPort} --e2eTestRunner=cypress --style=css --no-interactive --skipFormat`
     );
 
+    updateJson(`apps/${remote1}/project.json`, (project) => {
+      project.targets.serve.options.port = remote1Port;
+      return project;
+    });
+
     runCLI(
       `generate @nx/react:remote apps/${remote2} --name=${remote2} --host=${shell} --bundler=webpack --style=css --no-interactive --skipFormat`
     );
+
+    updateJson(`apps/${remote2}/project.json`, (project) => {
+      project.targets.serve.options.port = remote2Port;
+      return project;
+    });
 
     updateFile(
       `apps/${shell}-e2e/src/integration/app.cy.ts`,

--- a/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
@@ -77,8 +77,10 @@ describe('React Rspack Module Federation Misc - Interoperability', () => {
       });
     });
 
-    const serveResult = await runCommandUntil(`serve ${shell}`, (output) =>
-      output.includes(`http://localhost:${readPort(shell)}`)
+    const serveResult = await runCommandUntil(
+      `serve ${shell}`,
+      (output) => output.includes(`http://localhost:${readPort(shell)}`),
+      { timeout: 120000 }
     );
 
     await killProcessAndPorts(serveResult.pid, readPort(shell));
@@ -86,7 +88,8 @@ describe('React Rspack Module Federation Misc - Interoperability', () => {
     if (runE2ETests()) {
       const e2eResultsSwc = await runCommandUntil(
         `e2e ${shell}-e2e --verbose`,
-        (output) => output.includes('All specs passed!')
+        (output) => output.includes('All specs passed!'),
+        { timeout: 120000 }
       );
 
       await killProcessAndPorts(e2eResultsSwc.pid, readPort(shell));
@@ -145,7 +148,8 @@ describe('React Rspack Module Federation Misc - Interoperability', () => {
     if (runE2ETests()) {
       const e2eResultsSwc = await runCommandUntil(
         `e2e ${shell}-e2e --verbose`,
-        (output) => output.includes('Successfully ran target e2e')
+        (output) => output.includes('Successfully ran target e2e'),
+        { timeout: 120000 }
       );
 
       await killProcessAndPorts(e2eResultsSwc.pid, readPort(shell));

--- a/e2e/react/src/module-federation/ts-solution-mf.test.ts
+++ b/e2e/react/src/module-federation/ts-solution-mf.test.ts
@@ -4,7 +4,7 @@ import {
   cleanupProject,
   checkFilesDoNotExist,
   checkFilesExist,
-  getAvailablePort,
+  reservePort,
   killProcessAndPorts,
   readFile,
   readJson,
@@ -45,7 +45,7 @@ describe('React Rspack Module Federation - TS Solution + PM Workspaces', () => {
     const shell = uniq('shell');
     const remote1 = uniq('remote1');
     const remote2 = uniq('remote2');
-    const shellPort = await getAvailablePort();
+    const shellPort = reservePort();
 
     // Generate host with remotes
     runCLI(
@@ -192,7 +192,7 @@ describe('React Rspack Module Federation - TS Solution + PM Workspaces', () => {
     const shell = uniq('shell');
     const remote1 = uniq('remote1');
     const remote2 = uniq('remote2');
-    const shellPort = await getAvailablePort();
+    const shellPort = reservePort();
 
     // Generate host with one remote
     runCLI(
@@ -226,7 +226,7 @@ describe('React Rspack Module Federation - TS Solution + PM Workspaces', () => {
     const shell = uniq('shell');
     const remote = uniq('remote');
     const lib = uniq('lib');
-    const shellPort = await getAvailablePort();
+    const shellPort = reservePort();
 
     // Generate a library
     runCLI(

--- a/e2e/react/src/module-federation/ts-solution-mf.test.ts
+++ b/e2e/react/src/module-federation/ts-solution-mf.test.ts
@@ -45,7 +45,7 @@ describe('React Rspack Module Federation - TS Solution + PM Workspaces', () => {
     const shell = uniq('shell');
     const remote1 = uniq('remote1');
     const remote2 = uniq('remote2');
-    const shellPort = reservePort();
+    const shellPort = await reservePort();
 
     // Generate host with remotes
     runCLI(
@@ -192,7 +192,7 @@ describe('React Rspack Module Federation - TS Solution + PM Workspaces', () => {
     const shell = uniq('shell');
     const remote1 = uniq('remote1');
     const remote2 = uniq('remote2');
-    const shellPort = reservePort();
+    const shellPort = await reservePort();
 
     // Generate host with one remote
     runCLI(
@@ -226,7 +226,7 @@ describe('React Rspack Module Federation - TS Solution + PM Workspaces', () => {
     const shell = uniq('shell');
     const remote = uniq('remote');
     const lib = uniq('lib');
-    const shellPort = reservePort();
+    const shellPort = await reservePort();
 
     // Generate a library
     runCLI(

--- a/e2e/react/src/react-rsbuild.test.ts
+++ b/e2e/react/src/react-rsbuild.test.ts
@@ -1,7 +1,7 @@
 import {
   checkFilesExist,
   cleanupProject,
-  getAvailablePort,
+  reservePort,
   newProject,
   runCLI,
   runCLIAsync,
@@ -67,7 +67,7 @@ describe('Build React applications and libraries with Rsbuild', () => {
 
   it('should support bundling with Rsbuild and Jest', async () => {
     const rsbuildApp = uniq('rsbuildapp');
-    const port = await getAvailablePort();
+    const port = reservePort();
 
     runCLI(
       `generate @nx/react:app apps/${rsbuildApp} --port=${port} --bundler=rsbuild --unitTestRunner=jest --no-interactive --linter=eslint`

--- a/e2e/react/src/react-rsbuild.test.ts
+++ b/e2e/react/src/react-rsbuild.test.ts
@@ -67,7 +67,7 @@ describe('Build React applications and libraries with Rsbuild', () => {
 
   it('should support bundling with Rsbuild and Jest', async () => {
     const rsbuildApp = uniq('rsbuildapp');
-    const port = reservePort();
+    const port = await reservePort();
 
     runCLI(
       `generate @nx/react:app apps/${rsbuildApp} --port=${port} --bundler=rsbuild --unitTestRunner=jest --no-interactive --linter=eslint`

--- a/e2e/react/src/react-vite.test.ts
+++ b/e2e/react/src/react-vite.test.ts
@@ -66,7 +66,7 @@ describe('Build React applications and libraries with Vite', () => {
 
   it('should generate app with custom port', async () => {
     const viteApp = uniq('viteapp');
-    const customPort = reservePort();
+    const customPort = await reservePort();
 
     runCLI(
       `generate @nx/react:app apps/${viteApp} --bundler=vite --port=${customPort} --unitTestRunner=vitest --no-interactive --linter=eslint --e2eTestRunner=playwright`

--- a/e2e/react/src/react-vite.test.ts
+++ b/e2e/react/src/react-vite.test.ts
@@ -1,7 +1,7 @@
 import {
   checkFilesExist,
   cleanupProject,
-  getAvailablePort,
+  reservePort,
   killPorts,
   newProject,
   readFile,
@@ -66,7 +66,7 @@ describe('Build React applications and libraries with Vite', () => {
 
   it('should generate app with custom port', async () => {
     const viteApp = uniq('viteapp');
-    const customPort = await getAvailablePort();
+    const customPort = reservePort();
 
     runCLI(
       `generate @nx/react:app apps/${viteApp} --bundler=vite --port=${customPort} --unitTestRunner=vitest --no-interactive --linter=eslint --e2eTestRunner=playwright`

--- a/e2e/release/src/release-publishable-libraries-ts-solution.test.ts
+++ b/e2e/release/src/release-publishable-libraries-ts-solution.test.ts
@@ -69,7 +69,7 @@ describe('release publishable libraries in workspace with ts solution setup', ()
 
     // This is the verdaccio instance that the e2e tests themselves are working from
     e2eRegistryUrl = execSync('npm config get registry').toString().trim();
-  }, 100000);
+  }, 300_000);
 
   beforeEach(() => {
     try {

--- a/e2e/release/src/release-publishable-libraries.test.ts
+++ b/e2e/release/src/release-publishable-libraries.test.ts
@@ -76,7 +76,7 @@ describe('release publishable libraries', () => {
 
     // This is the verdaccio instance that the e2e tests themselves are working from
     e2eRegistryUrl = execSync('npm config get registry').toString().trim();
-  }, 100000);
+  }, 300_000);
 
   beforeEach(() => {
     try {

--- a/e2e/storybook/src/storybook-angular.test.ts
+++ b/e2e/storybook/src/storybook-angular.test.ts
@@ -31,7 +31,7 @@ describe('Storybook executors for Angular', () => {
 
     // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
     it.skip('should serve an Angular based Storybook setup', async () => {
-      storybookPort = reservePort();
+      storybookPort = await reservePort();
       const p = await runCommandUntil(
         `run ${angularStorybookLib}:storybook --port ${storybookPort}`,
         (output) => {

--- a/e2e/storybook/src/storybook-angular.test.ts
+++ b/e2e/storybook/src/storybook-angular.test.ts
@@ -3,6 +3,7 @@ import {
   cleanupProject,
   killPorts,
   newProject,
+  reservePort,
   runCLI,
   runCommandUntil,
   uniq,
@@ -25,12 +26,14 @@ describe('Storybook executors for Angular', () => {
   });
 
   describe('serve and build storybook', () => {
-    afterAll(() => killPorts(4400));
+    let storybookPort: number;
+    afterAll(() => storybookPort && killPorts(storybookPort));
 
     // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
     it.skip('should serve an Angular based Storybook setup', async () => {
+      storybookPort = reservePort();
       const p = await runCommandUntil(
-        `run ${angularStorybookLib}:storybook --port 4400`,
+        `run ${angularStorybookLib}:storybook --port ${storybookPort}`,
         (output) => {
           return /Storybook.*(started|ready)/gi.test(output);
         }

--- a/e2e/storybook/src/storybook-nested.test.ts
+++ b/e2e/storybook/src/storybook-nested.test.ts
@@ -4,6 +4,7 @@ import {
   getSelectedPackageManager,
   killPorts,
   readJson,
+  reservePort,
   runCLI,
   runCommandUntil,
   runCreateWorkspace,
@@ -49,11 +50,13 @@ describe('Storybook generators and executors for standalone workspaces - using R
   });
 
   describe('serve storybook', () => {
-    afterEach(() => killPorts(4400));
+    let storybookPort: number;
+    afterEach(() => storybookPort && killPorts(storybookPort));
 
     it('should serve a React based Storybook setup that uses Vite', async () => {
+      storybookPort = reservePort();
       const p = await runCommandUntil(
-        `run ${appName}:storybook --port 4400`,
+        `run ${appName}:storybook --port ${storybookPort}`,
         (output) => {
           return /Storybook.*(started|ready)/gi.test(output);
         }

--- a/e2e/storybook/src/storybook-nested.test.ts
+++ b/e2e/storybook/src/storybook-nested.test.ts
@@ -54,7 +54,7 @@ describe('Storybook generators and executors for standalone workspaces - using R
     afterEach(() => storybookPort && killPorts(storybookPort));
 
     it('should serve a React based Storybook setup that uses Vite', async () => {
-      storybookPort = reservePort();
+      storybookPort = await reservePort();
       const p = await runCommandUntil(
         `run ${appName}:storybook --port ${storybookPort}`,
         (output) => {

--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -303,6 +303,7 @@ export function runCommandUntil(
     encoding: 'utf-8',
     env: {
       CI: 'true',
+      NX_DAEMON: 'true',
       // Use new versioning by default in e2e tests
       NX_INTERNAL_USE_LEGACY_VERSIONING: 'false',
       ...getStrippedEnvironmentVariables(),

--- a/e2e/utils/port-utils.ts
+++ b/e2e/utils/port-utils.ts
@@ -1,8 +1,48 @@
+import * as fs from 'fs';
 import * as net from 'net';
+import * as path from 'path';
 
 /**
- * Finds an available port by creating a temporary server on port 0
- * and letting the OS assign a free port.
+ * Reserves a port across parallel processes on the same host via an atomic
+ * lock file. Avoids the TOCTOU race of probing port 0 and then binding it
+ * seconds later — another parallel process could be handed the same port in
+ * between.
+ */
+const LOCK_DIR = process.env.NX_E2E_PORT_LOCK_DIR ?? '/tmp/nx-e2e-port-locks';
+fs.mkdirSync(LOCK_DIR, { recursive: true });
+
+export function reservePort(start = 4200): number {
+  for (let port = start; port < 65000; port++) {
+    const lock = path.join(LOCK_DIR, `${port}.lock`);
+    try {
+      fs.writeFileSync(lock, '', { flag: 'wx' });
+      process.on('exit', () => {
+        try {
+          fs.unlinkSync(lock);
+        } catch {}
+      });
+      return port;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+    }
+  }
+  throw new Error('No available ports');
+}
+
+/**
+ * Reserves `count` ports.
+ */
+export function reservePorts(count: number): number[] {
+  const ports: number[] = [];
+  for (let i = 0; i < count; i++) {
+    ports.push(reservePort());
+  }
+  return ports;
+}
+
+/**
+ * @deprecated Use {@link reservePort} — probing the OS for port 0 opens a
+ * TOCTOU race across parallel e2e processes. Kept for backwards compatibility.
  */
 export async function getAvailablePort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -25,10 +65,7 @@ export async function getAvailablePort(): Promise<number> {
 }
 
 /**
- * Finds multiple available ports for running multiple services
- *
- * @param count - Number of ports needed
- * @returns Promise<number[]> - Array of available port numbers
+ * @deprecated Use {@link reservePorts}.
  */
 export async function getAvailablePorts(count: number): Promise<number[]> {
   const ports: number[] = [];

--- a/e2e/utils/port-utils.ts
+++ b/e2e/utils/port-utils.ts
@@ -7,11 +7,15 @@ import * as path from 'path';
  * lock file. Avoids the TOCTOU race of probing port 0 and then binding it
  * seconds later — another parallel process could be handed the same port in
  * between.
+ *
+ * Starts at 6100 (outside the framework-default zone of 3000/4200/5173/8080/etc.)
+ * so reserved ports never collide with parallel tests that generate apps
+ * without explicitly pinning the dev-server port.
  */
 const LOCK_DIR = process.env.NX_E2E_PORT_LOCK_DIR ?? '/tmp/nx-e2e-port-locks';
 fs.mkdirSync(LOCK_DIR, { recursive: true });
 
-export async function reservePort(start = 4200): Promise<number> {
+export async function reservePort(start = 6100): Promise<number> {
   for (let port = start; port < 65000; port++) {
     const lock = path.join(LOCK_DIR, `${port}.lock`);
     try {

--- a/e2e/utils/port-utils.ts
+++ b/e2e/utils/port-utils.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as net from 'net';
+import * as os from 'os';
 import * as path from 'path';
 
 /**
@@ -12,7 +13,7 @@ import * as path from 'path';
  * so reserved ports never collide with parallel tests that generate apps
  * without explicitly pinning the dev-server port.
  */
-const LOCK_DIR = process.env.NX_E2E_PORT_LOCK_DIR ?? '/tmp/nx-e2e-port-locks';
+const LOCK_DIR = path.join(os.tmpdir(), 'nx-e2e-port-locks');
 fs.mkdirSync(LOCK_DIR, { recursive: true });
 
 export async function reservePort(start = 6100): Promise<number> {

--- a/e2e/utils/port-utils.ts
+++ b/e2e/utils/port-utils.ts
@@ -11,20 +11,31 @@ import * as path from 'path';
 const LOCK_DIR = process.env.NX_E2E_PORT_LOCK_DIR ?? '/tmp/nx-e2e-port-locks';
 fs.mkdirSync(LOCK_DIR, { recursive: true });
 
-export function reservePort(start = 4200): number {
+export async function reservePort(start = 4200): Promise<number> {
   for (let port = start; port < 65000; port++) {
     const lock = path.join(LOCK_DIR, `${port}.lock`);
     try {
       fs.writeFileSync(lock, '', { flag: 'wx' });
-      process.on('exit', () => {
-        try {
-          fs.unlinkSync(lock);
-        } catch {}
-      });
-      return port;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+      continue;
     }
+    // Lock claimed; now verify the OS port is actually free. Another e2e test
+    // on the same agent may be using the OS port via the generator's default
+    // (i.e. without participating in the lock-file scheme), so an exclusive
+    // lock is not enough.
+    if (!(await isPortAvailable(port))) {
+      try {
+        fs.unlinkSync(lock);
+      } catch {}
+      continue;
+    }
+    process.on('exit', () => {
+      try {
+        fs.unlinkSync(lock);
+      } catch {}
+    });
+    return port;
   }
   throw new Error('No available ports');
 }
@@ -32,10 +43,10 @@ export function reservePort(start = 4200): number {
 /**
  * Reserves `count` ports.
  */
-export function reservePorts(count: number): number[] {
+export async function reservePorts(count: number): Promise<number[]> {
   const ports: number[] = [];
   for (let i = 0; i < count; i++) {
-    ports.push(reservePort());
+    ports.push(await reservePort());
   }
   return ports;
 }

--- a/e2e/vite/src/vite.test.ts
+++ b/e2e/vite/src/vite.test.ts
@@ -136,7 +136,7 @@ describe('@nx/vite/plugin', () => {
 
     it('should run serve-static', async () => {
       let process: ChildProcess;
-      const port = reservePort();
+      const port = await reservePort();
 
       try {
         process = await runCommandUntil(

--- a/e2e/vite/src/vite.test.ts
+++ b/e2e/vite/src/vite.test.ts
@@ -4,6 +4,7 @@ import {
   killProcessAndPorts,
   newProject,
   readJson,
+  reservePort,
   runCLI,
   runCommand,
   runCommandUntil,
@@ -135,7 +136,7 @@ describe('@nx/vite/plugin', () => {
 
     it('should run serve-static', async () => {
       let process: ChildProcess;
-      const port = 8081;
+      const port = reservePort();
 
       try {
         process = await runCommandUntil(

--- a/e2e/vue/src/vue.test.ts
+++ b/e2e/vue/src/vue.test.ts
@@ -2,6 +2,7 @@ import {
   cleanupProject,
   killPorts,
   newProject,
+  reservePort,
   runCLI,
   runE2ETests,
   uniq,
@@ -34,7 +35,7 @@ describe('Vue Plugin', () => {
     );
 
     if (runE2ETests('playwright')) {
-      const availablePort = await getAvailablePort();
+      const availablePort = reservePort();
 
       updateFile(`${app}-e2e/playwright.config.ts`, (content) => {
         return content
@@ -76,7 +77,7 @@ describe('Vue Plugin', () => {
     );
 
     if (runE2ETests('playwright')) {
-      const availablePort = await getAvailablePort();
+      const availablePort = reservePort();
 
       updateFile(`${app}-e2e/playwright.config.ts`, (content) => {
         return content
@@ -115,25 +116,3 @@ describe('Vue Plugin', () => {
     );
   });
 });
-
-async function getAvailablePort(): Promise<number> {
-  const net = require('net');
-
-  return new Promise((resolve, reject) => {
-    const server = net.createServer();
-    server.unref();
-    server.on('error', reject);
-
-    server.listen(0, () => {
-      const addressInfo = server.address();
-      if (!addressInfo) {
-        reject(new Error('Failed to get server address'));
-        return;
-      }
-      const port = addressInfo.port;
-      server.close(() => {
-        resolve(port);
-      });
-    });
-  });
-}

--- a/e2e/vue/src/vue.test.ts
+++ b/e2e/vue/src/vue.test.ts
@@ -35,7 +35,7 @@ describe('Vue Plugin', () => {
     );
 
     if (runE2ETests('playwright')) {
-      const availablePort = reservePort();
+      const availablePort = await reservePort();
 
       updateFile(`${app}-e2e/playwright.config.ts`, (content) => {
         return content
@@ -77,7 +77,7 @@ describe('Vue Plugin', () => {
     );
 
     if (runE2ETests('playwright')) {
-      const availablePort = reservePort();
+      const availablePort = await reservePort();
 
       updateFile(`${app}-e2e/playwright.config.ts`, (content) => {
         return content

--- a/e2e/web/src/web-webpack.test.ts
+++ b/e2e/web/src/web-webpack.test.ts
@@ -23,7 +23,7 @@ describe('Web Components Applications with bundler set as webpack', () => {
       }
     );
 
-    const port = reservePort();
+    const port = await reservePort();
     const childProcess = await runCommandUntil(
       `serve ${appName} --port=${port} --ssl`,
       (output) => {

--- a/e2e/web/src/web-webpack.test.ts
+++ b/e2e/web/src/web-webpack.test.ts
@@ -2,6 +2,7 @@ import {
   cleanupProject,
   killProcessAndPorts,
   newProject,
+  reservePort,
   runCLI,
   runCommandUntil,
   uniq,
@@ -22,13 +23,14 @@ describe('Web Components Applications with bundler set as webpack', () => {
       }
     );
 
+    const port = reservePort();
     const childProcess = await runCommandUntil(
-      `serve ${appName} --port=5000 --ssl`,
+      `serve ${appName} --port=${port} --ssl`,
       (output) => {
-        return output.includes('listening at https://localhost:5000');
+        return output.includes(`listening at https://localhost:${port}`);
       }
     );
 
-    await killProcessAndPorts(childProcess.pid, 5000);
+    await killProcessAndPorts(childProcess.pid, port);
   }, 300_000);
 });

--- a/e2e/webpack/src/webpack.legacy.test.ts
+++ b/e2e/webpack/src/webpack.legacy.test.ts
@@ -51,7 +51,7 @@ describe('Webpack Plugin (legacy)', () => {
 
   it('should run serve-static', async () => {
     let process: ChildProcess;
-    const port = reservePort();
+    const port = await reservePort();
 
     try {
       process = await runCommandUntil(

--- a/e2e/webpack/src/webpack.legacy.test.ts
+++ b/e2e/webpack/src/webpack.legacy.test.ts
@@ -1,10 +1,10 @@
 import {
   checkFilesExist,
   cleanupProject,
-  getAvailablePort,
   killProcessAndPorts,
   newProject,
   readFile,
+  reservePort,
   runCLI,
   runCommandUntil,
   runE2ETests,
@@ -51,7 +51,7 @@ describe('Webpack Plugin (legacy)', () => {
 
   it('should run serve-static', async () => {
     let process: ChildProcess;
-    const port = await getAvailablePort();
+    const port = reservePort();
 
     try {
       process = await runCommandUntil(

--- a/e2e/webpack/src/webpack.test.ts
+++ b/e2e/webpack/src/webpack.test.ts
@@ -332,7 +332,7 @@ describe('Webpack Plugin', () => {
     const myPkg = uniq('my-pkg');
 
     runCLI(
-      `generate @nx/web:application ${appName} --directory=apps/${appName}`
+      `generate @nx/web:application ${appName} --directory=apps/${appName} --bundler=webpack`
     );
 
     runCLI(

--- a/nx.json
+++ b/nx.json
@@ -287,7 +287,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 323,
+  "bust": 324,
   "defaultBase": "master",
   "sync": { "applyChanges": true },
   "conformance": {

--- a/nx.json
+++ b/nx.json
@@ -287,7 +287,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 325,
+  "bust": 326,
   "defaultBase": "master",
   "sync": { "applyChanges": true },
   "conformance": {

--- a/nx.json
+++ b/nx.json
@@ -287,7 +287,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 322,
+  "bust": 323,
   "defaultBase": "master",
   "sync": { "applyChanges": true },
   "conformance": {

--- a/nx.json
+++ b/nx.json
@@ -287,7 +287,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 329,
+  "bust": 330,
   "defaultBase": "master",
   "sync": { "applyChanges": true },
   "conformance": {

--- a/nx.json
+++ b/nx.json
@@ -287,7 +287,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 328,
+  "bust": 329,
   "defaultBase": "master",
   "sync": { "applyChanges": true },
   "conformance": {

--- a/nx.json
+++ b/nx.json
@@ -287,7 +287,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 327,
+  "bust": 328,
   "defaultBase": "master",
   "sync": { "applyChanges": true },
   "conformance": {

--- a/nx.json
+++ b/nx.json
@@ -287,7 +287,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 330,
+  "bust": 331,
   "defaultBase": "master",
   "sync": { "applyChanges": true },
   "conformance": {

--- a/nx.json
+++ b/nx.json
@@ -287,7 +287,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 326,
+  "bust": 327,
   "defaultBase": "master",
   "sync": { "applyChanges": true },
   "conformance": {

--- a/nx.json
+++ b/nx.json
@@ -287,7 +287,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 324,
+  "bust": 325,
   "defaultBase": "master",
   "sync": { "applyChanges": true },
   "conformance": {

--- a/packages/angular/src/generators/application/lib/add-e2e.ts
+++ b/packages/angular/src/generators/application/lib/add-e2e.ts
@@ -102,7 +102,7 @@ function getAngularE2EWebServerInfo(
 
   const pm = getPackageManagerCommand();
   return {
-    e2eCiBaseUrl: 'http://localhost:4200',
+    e2eCiBaseUrl: `http://localhost:${e2ePort}`,
     e2eCiWebServerCommand: `${pm.exec} nx run ${projectName}:serve-static`,
     e2eWebServerCommand: `${pm.exec} nx run ${projectName}:serve`,
     e2eWebServerAddress: `http://localhost:${e2ePort}`,

--- a/packages/angular/src/generators/host/host.ts
+++ b/packages/angular/src/generators/host/host.ts
@@ -73,11 +73,13 @@ export async function host(tree: Tree, schema: Schema) {
       directory: options.directory,
     });
 
+  const hostPort = options.port ?? 4200;
+
   const appInstallTask = await applicationGenerator(tree, {
     ...options,
     standalone: options.standalone,
     routing: true,
-    port: 4200,
+    port: hostPort,
     skipFormat: true,
     bundler: 'webpack',
   });
@@ -88,7 +90,7 @@ export async function host(tree: Tree, schema: Schema) {
     appName: hostProjectName,
     mfType: 'host',
     routing: true,
-    port: 4200,
+    port: hostPort,
     remotes: remotesToIntegrate ?? [],
     federationType: options.dynamic ? 'dynamic' : 'static',
     skipPackageJson: options.skipPackageJson,
@@ -124,7 +126,7 @@ export async function host(tree: Tree, schema: Schema) {
       name: remote,
       directory: remoteDirectory,
       host: hostProjectName,
-      port: isRspack ? 4200 + i + 1 : undefined,
+      port: isRspack ? hostPort + i + 1 : undefined,
       skipFormat: true,
       standalone: options.standalone,
       typescriptConfiguration,
@@ -144,7 +146,7 @@ export async function host(tree: Tree, schema: Schema) {
   const project = readProjectConfiguration(tree, hostProjectName);
   project.targets.serve ??= {};
   project.targets.serve.options ??= {};
-  project.targets.serve.options.port = 4200;
+  project.targets.serve.options.port = hostPort;
   updateProjectConfiguration(tree, hostProjectName, project);
 
   if (!options.skipFormat) {

--- a/packages/angular/src/generators/host/schema.d.ts
+++ b/packages/angular/src/generators/host/schema.d.ts
@@ -6,6 +6,7 @@ export interface Schema {
   directory: string;
   name?: string;
   bundler?: 'webpack' | 'rspack';
+  port?: number;
   remotes?: string[];
   dynamic?: boolean;
   setParserOptionsProject?: boolean;

--- a/packages/angular/src/generators/host/schema.json
+++ b/packages/angular/src/generators/host/schema.json
@@ -43,6 +43,10 @@
       "default": "webpack",
       "enum": ["webpack", "rspack"]
     },
+    "port": {
+      "type": "number",
+      "description": "The port at which the Consumer (host) application should be served. Defaults to 4200."
+    },
     "dynamic": {
       "type": "boolean",
       "description": "Should the host application use dynamic federation?",


### PR DESCRIPTION
## Current Behavior

Many e2e-ci projects are pinned to serial execution on each CI agent via project-specific overrides in `.nx/workflows/dynamic-changesets.yaml`:

- `e2e-gradle`, `e2e-angular`, `e2e-node`, `e2e-react` → 1 task per `linux-extra-large`
- `e2e-next`, `e2e-plugin` → 2 tasks per `linux-extra-large`
- `e2e-release`, `e2e-nuxt`, `e2e-web`, `e2e-eslint`, `e2e-remix`, `e2e-cypress`, `e2e-docker`, `e2e-js`, `e2e-nx`, `e2e-nx-init`, `e2e-dotnet`, `e2e-workspace-create`, `e2e-rollup` → 1 on large / 2 on xlarge

These overrides exist because the underlying tests collide on hardcoded ports when run concurrently on the same agent.

## Expected Behavior

A single rule lets every `e2e-ci**` task run with parallelism 2 on `linux-large` and 3 on `linux-extra-large`, shrinking total agent time and removing per-project special cases.

To make that safe, this PR:

1. Adds `reservePort()`/`reservePorts()` to `e2e/utils/port-utils.ts`. The helper claims a port via an atomic `O_EXCL` lock file under `/tmp/nx-e2e-port-locks`, so two parallel processes on the same agent cannot reserve the same port. The existing `getAvailablePort()` is deprecated — probing port 0 and then binding it seconds later opens a TOCTOU race where another e2e task could grab the same port in between.
2. Replaces hardcoded ports in the highest-risk e2e tests with `reservePort()`:
   - `e2e/vite/src/vite.test.ts` — `serve-static` test (was 8081)
   - `e2e/web/src/web-webpack.test.ts` — webpack ssl serve (was 5000)
   - `e2e/storybook/src/storybook-angular.test.ts` and `storybook-nested.test.ts` (was 4400)
   - `e2e/node/src/node-server.test.ts` — express/fastify/koa/nest framework tests (was 7000–7003) and waitUntilTargets test (was 4444/4445)
   - `e2e/node/src/node-esm-support.test.ts` — 9 tests previously defaulting to port 3000

`e2e/cypress`, `e2e/playwright`, and the React module-federation tests still hardcode ports through their generators; those will be addressed in follow-up PRs as CI surfaces collisions.

## Related Issue(s)

N/A — internal CI optimization.