### PR TITLE
fix(linter): improve convert-to-flat-config output fidelity

### DIFF
--- a/packages/eslint/src/generators/convert-to-flat-config/__snapshots__/generator.spec.ts.snap
+++ b/packages/eslint/src/generators/convert-to-flat-config/__snapshots__/generator.spec.ts.snap
@@ -5,9 +5,6 @@ exports[`convert-to-flat-config generator CJS should add env configuration 1`] =
 const globals = require('globals');
 
 module.exports = [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   { languageOptions: { globals: { ...globals.browser, ...globals.node } } },
   {
@@ -39,9 +36,6 @@ exports[`convert-to-flat-config generator CJS should add global and env configur
 const globals = require('globals');
 
 module.exports = [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   {
     languageOptions: {
@@ -76,9 +70,6 @@ exports[`convert-to-flat-config generator CJS should add global configuration 1`
 "const nx = require('@nx/eslint-plugin');
 
 module.exports = [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   { languageOptions: { globals: { myCustomGlobal: 'readonly' } } },
   {
@@ -109,9 +100,6 @@ exports[`convert-to-flat-config generator CJS should add global eslintignores 1`
 "const nx = require('@nx/eslint-plugin');
 
 module.exports = [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -145,9 +133,6 @@ exports[`convert-to-flat-config generator CJS should add parser 1`] = `
 const typescriptEslintParser = require('@typescript-eslint/parser');
 
 module.exports = [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   { languageOptions: { parser: typescriptEslintParser } },
   {
@@ -182,9 +167,6 @@ const justScopeEslintPlugin = require('@just-scope/eslint-plugin');
 const nx = require('@nx/eslint-plugin');
 
 module.exports = [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   {
     plugins: {
       'eslint-plugin-import': eslintPluginImport,
@@ -221,9 +203,6 @@ exports[`convert-to-flat-config generator CJS should add settings 1`] = `
 "const nx = require('@nx/eslint-plugin');
 
 module.exports = [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   {
     settings: {
@@ -258,9 +237,6 @@ exports[`convert-to-flat-config generator CJS should convert json successfully 1
 "const nx = require('@nx/eslint-plugin');
 
 module.exports = [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -290,9 +266,6 @@ exports[`convert-to-flat-config generator CJS should convert json successfully 2
 "const baseConfig = require('../../eslint.config.cjs');
 
 module.exports = [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...baseConfig,
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -317,9 +290,6 @@ exports[`convert-to-flat-config generator CJS should convert yaml successfully 1
 "const nx = require('@nx/eslint-plugin');
 
 module.exports = [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -349,9 +319,6 @@ exports[`convert-to-flat-config generator CJS should convert yaml successfully 2
 "const baseConfig = require('../../eslint.config.cjs');
 
 module.exports = [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...baseConfig,
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -376,9 +343,6 @@ exports[`convert-to-flat-config generator CJS should convert yml successfully 1`
 "const nx = require('@nx/eslint-plugin');
 
 module.exports = [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -408,9 +372,6 @@ exports[`convert-to-flat-config generator CJS should convert yml successfully 2`
 "const baseConfig = require('../../eslint.config.cjs');
 
 module.exports = [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...baseConfig,
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -435,9 +396,6 @@ exports[`convert-to-flat-config generator CJS should handle custom eslintignores
 "const baseConfig = require('../../eslint.config.cjs');
 
 module.exports = [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...baseConfig,
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -469,9 +427,6 @@ exports[`convert-to-flat-config generator MJS should add env configuration 1`] =
 import globals from 'globals';
 
 export default [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   { languageOptions: { globals: { ...globals.browser, ...globals.node } } },
   {
@@ -503,9 +458,6 @@ exports[`convert-to-flat-config generator MJS should add global and env configur
 import globals from 'globals';
 
 export default [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   {
     languageOptions: {
@@ -540,9 +492,6 @@ exports[`convert-to-flat-config generator MJS should add global configuration 1`
 "import nx from '@nx/eslint-plugin';
 
 export default [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   { languageOptions: { globals: { myCustomGlobal: 'readonly' } } },
   {
@@ -573,9 +522,6 @@ exports[`convert-to-flat-config generator MJS should add global eslintignores 1`
 "import nx from '@nx/eslint-plugin';
 
 export default [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -609,9 +555,6 @@ exports[`convert-to-flat-config generator MJS should add parser 1`] = `
 import typescriptEslintParser from '@typescript-eslint/parser';
 
 export default [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   { languageOptions: { parser: typescriptEslintParser } },
   {
@@ -646,9 +589,6 @@ import justScopeEslintPlugin from '@just-scope/eslint-plugin';
 import nx from '@nx/eslint-plugin';
 
 export default [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   {
     plugins: {
       'eslint-plugin-import': eslintPluginImport,
@@ -685,9 +625,6 @@ exports[`convert-to-flat-config generator MJS should add settings 1`] = `
 "import nx from '@nx/eslint-plugin';
 
 export default [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   {
     settings: {
@@ -722,9 +659,6 @@ exports[`convert-to-flat-config generator MJS should convert json successfully 1
 "import nx from '@nx/eslint-plugin';
 
 export default [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -754,9 +688,6 @@ exports[`convert-to-flat-config generator MJS should convert json successfully 2
 "import baseConfig from '../../eslint.config.mjs';
 
 export default [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...baseConfig,
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -781,9 +712,6 @@ exports[`convert-to-flat-config generator MJS should convert yaml successfully 1
 "import nx from '@nx/eslint-plugin';
 
 export default [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -813,9 +741,6 @@ exports[`convert-to-flat-config generator MJS should convert yaml successfully 2
 "import baseConfig from '../../eslint.config.mjs';
 
 export default [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...baseConfig,
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -840,9 +765,6 @@ exports[`convert-to-flat-config generator MJS should convert yml successfully 1`
 "import nx from '@nx/eslint-plugin';
 
 export default [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...nx.configs['flat/base'],
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -872,9 +794,6 @@ exports[`convert-to-flat-config generator MJS should convert yml successfully 2`
 "import baseConfig from '../../eslint.config.mjs';
 
 export default [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...baseConfig,
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -899,9 +818,6 @@ exports[`convert-to-flat-config generator MJS should handle custom eslintignores
 "import baseConfig from '../../eslint.config.mjs';
 
 export default [
-  {
-    ignores: ['**/dist', '**/out-tsc'],
-  },
   ...baseConfig,
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.spec.ts
@@ -332,6 +332,58 @@ describe('convertEslintJsonToFlatConfig', () => {
       `);
     });
 
+    it('should preserve non-sentinel negated ignorePatterns', async () => {
+      tree.write(
+        '.eslintrc.json',
+        JSON.stringify({
+          root: true,
+          ignorePatterns: [
+            '**/*',
+            'dist/**',
+            '!dist/keep.js',
+            '.next/**/*',
+          ],
+          plugins: ['@nx'],
+        })
+      );
+
+      const { content } = convertEslintJsonToFlatConfig(
+        tree,
+        '',
+        readJson(tree, '.eslintrc.json'),
+        [],
+        'mjs'
+      );
+
+      expect(content).toContain('"dist/**"');
+      expect(content).toContain('"!dist/keep.js"');
+      expect(content).toContain('".next/**/*"');
+    });
+
+    it('should rewrite extends pointing at extensionless .eslintrc', async () => {
+      tree.write(
+        'mylib/.eslintrc.json',
+        JSON.stringify({
+          extends: ['../../.eslintrc'],
+          rules: {},
+        })
+      );
+
+      const { content } = convertEslintJsonToFlatConfig(
+        tree,
+        'mylib',
+        readJson(tree, 'mylib/.eslintrc.json'),
+        [],
+        'mjs'
+      );
+
+      expect(content).toContain(
+        'import baseConfig from "../../eslint.config.mjs"'
+      );
+      expect(content).toContain('...baseConfig');
+      expect(content).not.toContain('compat.extends');
+    });
+
     it('should handle overrides with mixed Nx and non-Nx extends', async () => {
       tree.write(
         '.eslintrc.json',

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.spec.ts
@@ -332,17 +332,12 @@ describe('convertEslintJsonToFlatConfig', () => {
       `);
     });
 
-    it('should preserve non-sentinel negated ignorePatterns', async () => {
+    it('should preserve negated ignorePatterns paired with broader ignores', async () => {
       tree.write(
         '.eslintrc.json',
         JSON.stringify({
           root: true,
-          ignorePatterns: [
-            '**/*',
-            'dist/**',
-            '!dist/keep.js',
-            '.next/**/*',
-          ],
+          ignorePatterns: ['**/*', 'dist/**', '!dist/keep.js', '.next/**/*'],
           plugins: ['@nx'],
         })
       );

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.spec.ts
@@ -88,12 +88,6 @@ describe('convertEslintJsonToFlatConfig', () => {
 
 
         export default [
-            {
-                ignores: [
-                    "**/dist",
-                    "**/out-tsc"
-                ]
-            },
             ...nx.configs["flat/base"],
             {
                 files: [
@@ -217,6 +211,7 @@ describe('convertEslintJsonToFlatConfig', () => {
         import baseConfig from "../../eslint.config.mjs";
         import nx from "@nx/eslint-plugin";
         import globals from "globals";
+        import jsoncEslintParser from "jsonc-eslint-parser";
 
         const compat = new FlatCompat({
           baseDirectory: dirname(fileURLToPath(import.meta.url)),
@@ -225,12 +220,6 @@ describe('convertEslintJsonToFlatConfig', () => {
 
 
         export default [
-            {
-                ignores: [
-                    "**/dist",
-                    "**/out-tsc"
-                ]
-            },
             ...baseConfig,
             ...nx.configs["flat/react-typescript"],
             ...compat.extends("next", "next/core-web-vitals"),
@@ -278,7 +267,7 @@ describe('convertEslintJsonToFlatConfig', () => {
                     "@nx/dependency-checks": "error"
                 },
                 languageOptions: {
-                    parser: await import("jsonc-eslint-parser")
+                    parser: jsoncEslintParser
                 }
             },
             {
@@ -327,12 +316,6 @@ describe('convertEslintJsonToFlatConfig', () => {
         "import nx from "@nx/eslint-plugin";
 
         export default [
-            {
-                ignores: [
-                    "**/dist",
-                    "**/out-tsc"
-                ]
-            },
             ...nx.configs["flat/base"],
             ...nx.configs["flat/typescript"],
             {
@@ -394,12 +377,6 @@ describe('convertEslintJsonToFlatConfig', () => {
 
 
         export default [
-            {
-                ignores: [
-                    "**/dist",
-                    "**/out-tsc"
-                ]
-            },
             ...nx.configs["flat/base"],
             ...nx.configs["flat/typescript"],
             ...compat.config({
@@ -498,12 +475,6 @@ describe('convertEslintJsonToFlatConfig', () => {
         });
 
         module.exports = [
-            {
-                ignores: [
-                    "**/dist",
-                    "**/out-tsc"
-                ]
-            },
             ...nx.configs["flat/base"],
             {
                 files: [
@@ -632,12 +603,6 @@ describe('convertEslintJsonToFlatConfig', () => {
         });
 
         module.exports = [
-            {
-                ignores: [
-                    "**/dist",
-                    "**/out-tsc"
-                ]
-            },
             ...baseConfig,
             ...nx.configs["flat/react-typescript"],
             ...compat.extends("next", "next/core-web-vitals"),

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
@@ -14,13 +14,16 @@ import {
 import { getPluginImport } from '../../utils/eslint-file';
 import { mapFilePath } from '../../utils/flat-config/path-utils';
 
-// Rewrites legacy `.eslintrc[.base].json` filenames to their flat-config counterparts.
-// Used both for `extends` local paths and for rule option values that embed these filenames.
-function renameLegacyEslintrcFile(path: string, format: 'mjs' | 'cjs'): string {
-  return path.replace(
-    /(^|.*?)\.eslintrc(\.base)?\.json$/,
-    `$1eslint$2.config.${format}`
-  );
+// Rewrites legacy `.eslintrc[.base].json` / `.eslintignore` filenames to their flat-config
+// counterparts. Used for `extends` local paths, rule option values that embed these filenames,
+// and nx.json / project.json input globs that referenced the deleted files.
+export function renameLegacyEslintrcFile(
+  path: string,
+  format: 'mjs' | 'cjs'
+): string {
+  return path
+    .replace(/(^|.*?)\.eslintrc(\.base)?\.json$/, `$1eslint$2.config.${format}`)
+    .replace(/(^|.*?)\.eslintignore$/, `$1eslint.config.${format}`);
 }
 
 // In flat config, `@nx/workspace/<rule>` is parsed as plugin `@nx/workspace`, rule `<rule>`.

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
@@ -50,7 +50,10 @@ function renameLegacyWorkspaceRules(
 // inside rule option values (e.g. `@nx/dependency-checks`'s `ignoredFiles`) to point at the
 // generated flat-config files instead. Without this, rule options keep pointing at files that
 // no longer exist after the conversion.
-function rewriteStaleEslintrcRefs(value: unknown, format: 'mjs' | 'cjs'): unknown {
+function rewriteStaleEslintrcRefs(
+  value: unknown,
+  format: 'mjs' | 'cjs'
+): unknown {
   if (typeof value === 'string') {
     return renameLegacyEslintrcFile(value, format);
   }
@@ -305,9 +308,11 @@ export function convertEslintJsonToFlatConfig(
         : [config.ignorePatterns]
     ).filter(
       (pattern) =>
-        // Drop sentinels that are meaningless in flat config. Real negations
-        // (e.g. `['dist/**', '!dist/keep.js']`) are preserved — flat config
-        // still supports un-ignoring within a broader ignores block.
+        // Drop patterns that are meaningless in flat config. `'**/*'` and
+        // `'!**/*'` were eslintrc cascading toggles; `node_modules` is already
+        // ignored by default. Real negations like `['dist/**', '!dist/keep.js']`
+        // are preserved — flat config still supports un-ignoring within a
+        // broader ignores block.
         !['**/*', '!**/*', 'node_modules'].includes(pattern)
     );
     if (patterns.length > 0) {

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
@@ -42,9 +42,10 @@ function renameLegacyWorkspaceRules(
   return renamed;
 }
 
-// Rewrites references to the legacy `.eslintrc[.base].json` that may appear inside rule option
-// values (e.g. `@nx/dependency-checks`'s `ignoredFiles`) to point at the generated flat-config
-// files instead. Without this, rule options keep pointing at files that no longer exist.
+// Rewrites references to the legacy `.eslintrc[.base].json` / `.eslintignore` that may appear
+// inside rule option values (e.g. `@nx/dependency-checks`'s `ignoredFiles`) to point at the
+// generated flat-config files instead. Without this, rule options keep pointing at files that
+// no longer exist after the conversion.
 function rewriteStaleEslintrcRefs(value: unknown, format: 'mjs' | 'cjs'): unknown {
   if (typeof value === 'string') {
     return renameLegacyEslintrcFile(value, format);

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
@@ -14,6 +14,54 @@ import {
 import { getPluginImport } from '../../utils/eslint-file';
 import { mapFilePath } from '../../utils/flat-config/path-utils';
 
+// In flat config, `@nx/workspace/<rule>` is parsed as plugin `@nx/workspace`, rule `<rule>`.
+// The `@nx` plugin already exposes workspace rules under both `workspace/<rule>` and `workspace-<rule>` keys.
+// Rewriting to `@nx/workspace-<rule>` makes ESLint resolve them via the already-registered `@nx` plugin.
+function renameLegacyWorkspaceRules(
+  rules: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!rules || typeof rules !== 'object') {
+    return rules;
+  }
+  const renamed: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(rules)) {
+    const newKey = key.startsWith('@nx/workspace/')
+      ? '@nx/workspace-' + key.slice('@nx/workspace/'.length)
+      : key;
+    renamed[newKey] = value;
+  }
+  return renamed;
+}
+
+// Rewrites references to the legacy `.eslintrc.json` / `.eslintrc.base.json` that may appear
+// inside rule option values (e.g. `@nx/dependency-checks`'s `ignoredFiles`) to point at the
+// generated flat-config files instead. Without this, rule options keep pointing at files that
+// no longer exist after the conversion.
+function rewriteStaleEslintrcRefs<T>(value: T, format: 'mjs' | 'cjs'): T {
+  if (typeof value === 'string') {
+    return value
+      .replace(/\.eslintrc\.base\.json$/, `eslint.base.config.${format}`)
+      .replace(/\.eslintrc\.json$/, `eslint.config.${format}`) as unknown as T;
+  }
+  if (Array.isArray(value)) {
+    const mapped = value.map((v) => rewriteStaleEslintrcRefs(v, format));
+    // Rewriting may collapse distinct strings (e.g. `.eslintrc.json` and
+    // `.eslintrc.base.json`) into identical entries; dedupe string arrays.
+    if (mapped.every((v) => typeof v === 'string')) {
+      return Array.from(new Set(mapped as string[])) as unknown as T;
+    }
+    return mapped as unknown as T;
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = rewriteStaleEslintrcRefs(v, format);
+    }
+    return out as unknown as T;
+  }
+  return value;
+}
+
 /**
  * Converts an ESLint JSON config to a flat config.
  * Deletes the original file along with .eslintignore if it exists.
@@ -32,12 +80,27 @@ export function convertEslintJsonToFlatConfig(
   let combinedConfig: ts.PropertyAssignment[] = [];
   let languageOptions: ts.PropertyAssignment[] = [];
 
-  // exclude dist and eslint config from being linted, which matches the default for new workspaces
-  exportElements.push(
-    generateAst({
-      ignores: ['**/dist', '**/out-tsc'],
-    })
-  );
+  if (config.rules) {
+    config.rules = renameLegacyWorkspaceRules(
+      config.rules as Record<string, unknown>
+    ) as ESLint.ConfigData['rules'];
+    config.rules = rewriteStaleEslintrcRefs(config.rules, format);
+  }
+  if (config.overrides) {
+    config.overrides = config.overrides.map((override) =>
+      override.rules
+        ? {
+            ...override,
+            rules: rewriteStaleEslintrcRefs(
+              renameLegacyWorkspaceRules(
+                override.rules as Record<string, unknown>
+              ) as ESLint.ConfigData['rules'],
+              format
+            ),
+          }
+        : override
+    );
+  }
 
   if (config.extends) {
     const extendsResult = addExtends(
@@ -197,28 +260,22 @@ export function convertEslintJsonToFlatConfig(
             if (
               remainingOverride.env ||
               remainingOverride.extends ||
-              remainingOverride.plugins ||
-              remainingOverride.parser
+              remainingOverride.plugins
             ) {
               isFlatCompatNeeded = true;
             }
             exportElements.push(
-              generateFlatOverride(remainingOverride, format)
+              generateFlatOverride(remainingOverride, format, importsMap)
             );
           }
           return;
         }
       }
 
-      if (
-        override.env ||
-        override.extends ||
-        override.plugins ||
-        override.parser
-      ) {
+      if (override.env || override.extends || override.plugins) {
         isFlatCompatNeeded = true;
       }
-      exportElements.push(generateFlatOverride(override, format));
+      exportElements.push(generateFlatOverride(override, format, importsMap));
     });
   }
 
@@ -227,7 +284,9 @@ export function convertEslintJsonToFlatConfig(
       Array.isArray(config.ignorePatterns)
         ? config.ignorePatterns
         : [config.ignorePatterns]
-    ).filter((pattern) => !['**/*', '!**/*', 'node_modules'].includes(pattern)); // these are useless in a flat config
+    )
+      .filter((pattern) => !['**/*', '!**/*', 'node_modules'].includes(pattern)) // these are useless in a flat config
+      .filter((pattern) => !pattern.startsWith('!')); // negated patterns rely on eslintrc cascading and have no meaning in flat config
     if (patterns.length > 0) {
       exportElements.push(
         generateAst({

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
@@ -14,15 +14,19 @@ import {
 import { getPluginImport } from '../../utils/eslint-file';
 import { mapFilePath } from '../../utils/flat-config/path-utils';
 
-// Rewrites legacy `.eslintrc[.base].json` / `.eslintignore` filenames to their flat-config
+// Rewrites legacy `.eslintrc[.base][.json]` / `.eslintignore` filenames to their flat-config
 // counterparts. Used for `extends` local paths, rule option values that embed these filenames,
-// and nx.json / project.json input globs that referenced the deleted files.
+// and nx.json / project.json input globs that referenced the deleted files. Accepts
+// extensionless `.eslintrc` since ESLint treats that as JSON by convention.
 export function renameLegacyEslintrcFile(
   path: string,
   format: 'mjs' | 'cjs'
 ): string {
   return path
-    .replace(/(^|.*?)\.eslintrc(\.base)?\.json$/, `$1eslint$2.config.${format}`)
+    .replace(
+      /(^|.*?)\.eslintrc(\.base)?(\.json)?$/,
+      `$1eslint$2.config.${format}`
+    )
     .replace(/(^|.*?)\.eslintignore$/, `$1eslint.config.${format}`);
 }
 
@@ -301,9 +305,10 @@ export function convertEslintJsonToFlatConfig(
         : [config.ignorePatterns]
     ).filter(
       (pattern) =>
-        // Drop patterns that are useless in flat config: universal selectors and
-        // negated entries (un-ignores relied on eslintrc cascading, which flat config lacks).
-        !['**/*', 'node_modules'].includes(pattern) && !pattern.startsWith('!')
+        // Drop sentinels that are meaningless in flat config. Real negations
+        // (e.g. `['dist/**', '!dist/keep.js']`) are preserved — flat config
+        // still supports un-ignoring within a broader ignores block.
+        !['**/*', '!**/*', 'node_modules'].includes(pattern)
     );
     if (patterns.length > 0) {
       exportElements.push(
@@ -360,7 +365,7 @@ function addExtends(
   extendsConfig
     .filter((imp) => imp.match(/^\.?(\.\/)/))
     .forEach((imp, index) => {
-      if (imp.match(/\.eslintrc(\.base)?\.json$/)) {
+      if (imp.match(/\.eslintrc(\.base)?(\.json)?$/)) {
         const localName = index ? `baseConfig${index}` : 'baseConfig';
         configBlocks.push(generateSpreadElement(localName));
         importsMap.set(renameLegacyEslintrcFile(imp, format), localName);

--- a/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/converters/json-converter.ts
@@ -14,15 +14,21 @@ import {
 import { getPluginImport } from '../../utils/eslint-file';
 import { mapFilePath } from '../../utils/flat-config/path-utils';
 
+// Rewrites legacy `.eslintrc[.base].json` filenames to their flat-config counterparts.
+// Used both for `extends` local paths and for rule option values that embed these filenames.
+function renameLegacyEslintrcFile(path: string, format: 'mjs' | 'cjs'): string {
+  return path.replace(
+    /(^|.*?)\.eslintrc(\.base)?\.json$/,
+    `$1eslint$2.config.${format}`
+  );
+}
+
 // In flat config, `@nx/workspace/<rule>` is parsed as plugin `@nx/workspace`, rule `<rule>`.
 // The `@nx` plugin already exposes workspace rules under both `workspace/<rule>` and `workspace-<rule>` keys.
 // Rewriting to `@nx/workspace-<rule>` makes ESLint resolve them via the already-registered `@nx` plugin.
 function renameLegacyWorkspaceRules(
-  rules: Record<string, unknown> | undefined
-): Record<string, unknown> | undefined {
-  if (!rules || typeof rules !== 'object') {
-    return rules;
-  }
+  rules: Record<string, unknown>
+): Record<string, unknown> {
   const renamed: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(rules)) {
     const newKey = key.startsWith('@nx/workspace/')
@@ -33,33 +39,40 @@ function renameLegacyWorkspaceRules(
   return renamed;
 }
 
-// Rewrites references to the legacy `.eslintrc.json` / `.eslintrc.base.json` that may appear
-// inside rule option values (e.g. `@nx/dependency-checks`'s `ignoredFiles`) to point at the
-// generated flat-config files instead. Without this, rule options keep pointing at files that
-// no longer exist after the conversion.
-function rewriteStaleEslintrcRefs<T>(value: T, format: 'mjs' | 'cjs'): T {
+// Rewrites references to the legacy `.eslintrc[.base].json` that may appear inside rule option
+// values (e.g. `@nx/dependency-checks`'s `ignoredFiles`) to point at the generated flat-config
+// files instead. Without this, rule options keep pointing at files that no longer exist.
+function rewriteStaleEslintrcRefs(value: unknown, format: 'mjs' | 'cjs'): unknown {
   if (typeof value === 'string') {
-    return value
-      .replace(/\.eslintrc\.base\.json$/, `eslint.base.config.${format}`)
-      .replace(/\.eslintrc\.json$/, `eslint.config.${format}`) as unknown as T;
+    return renameLegacyEslintrcFile(value, format);
   }
   if (Array.isArray(value)) {
     const mapped = value.map((v) => rewriteStaleEslintrcRefs(v, format));
     // Rewriting may collapse distinct strings (e.g. `.eslintrc.json` and
     // `.eslintrc.base.json`) into identical entries; dedupe string arrays.
     if (mapped.every((v) => typeof v === 'string')) {
-      return Array.from(new Set(mapped as string[])) as unknown as T;
+      return Array.from(new Set(mapped as string[]));
     }
-    return mapped as unknown as T;
+    return mapped;
   }
   if (value && typeof value === 'object') {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
       out[k] = rewriteStaleEslintrcRefs(v, format);
     }
-    return out as unknown as T;
+    return out;
   }
   return value;
+}
+
+function preprocessRules(
+  rules: Record<string, unknown>,
+  format: 'mjs' | 'cjs'
+): ESLint.ConfigData['rules'] {
+  return rewriteStaleEslintrcRefs(
+    renameLegacyWorkspaceRules(rules),
+    format
+  ) as ESLint.ConfigData['rules'];
 }
 
 /**
@@ -81,20 +94,18 @@ export function convertEslintJsonToFlatConfig(
   let languageOptions: ts.PropertyAssignment[] = [];
 
   if (config.rules) {
-    config.rules = renameLegacyWorkspaceRules(
-      config.rules as Record<string, unknown>
-    ) as ESLint.ConfigData['rules'];
-    config.rules = rewriteStaleEslintrcRefs(config.rules, format);
+    config.rules = preprocessRules(
+      config.rules as Record<string, unknown>,
+      format
+    );
   }
   if (config.overrides) {
     config.overrides = config.overrides.map((override) =>
       override.rules
         ? {
             ...override,
-            rules: rewriteStaleEslintrcRefs(
-              renameLegacyWorkspaceRules(
-                override.rules as Record<string, unknown>
-              ) as ESLint.ConfigData['rules'],
+            rules: preprocessRules(
+              override.rules as Record<string, unknown>,
               format
             ),
           }
@@ -284,9 +295,12 @@ export function convertEslintJsonToFlatConfig(
       Array.isArray(config.ignorePatterns)
         ? config.ignorePatterns
         : [config.ignorePatterns]
-    )
-      .filter((pattern) => !['**/*', '!**/*', 'node_modules'].includes(pattern)) // these are useless in a flat config
-      .filter((pattern) => !pattern.startsWith('!')); // negated patterns rely on eslintrc cascading and have no meaning in flat config
+    ).filter(
+      (pattern) =>
+        // Drop patterns that are useless in flat config: universal selectors and
+        // negated entries (un-ignores relied on eslintrc cascading, which flat config lacks).
+        !['**/*', 'node_modules'].includes(pattern) && !pattern.startsWith('!')
+    );
     if (patterns.length > 0) {
       exportElements.push(
         generateAst({
@@ -342,14 +356,10 @@ function addExtends(
   extendsConfig
     .filter((imp) => imp.match(/^\.?(\.\/)/))
     .forEach((imp, index) => {
-      if (imp.match(/\.eslintrc(.base)?\.json$/)) {
+      if (imp.match(/\.eslintrc(\.base)?\.json$/)) {
         const localName = index ? `baseConfig${index}` : 'baseConfig';
         configBlocks.push(generateSpreadElement(localName));
-        const newImport = imp.replace(
-          /^(.*)\.eslintrc(.base)?\.json$/,
-          `$1eslint$2.config.${format}`
-        );
-        importsMap.set(newImport, localName);
+        importsMap.set(renameLegacyEslintrcFile(imp, format), localName);
       } else {
         eslintrcConfigs.push(imp);
       }

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
@@ -191,9 +191,6 @@ describe('convert-to-flat-config generator', () => {
         });
 
         module.exports = [
-          {
-            ignores: ['**/dist', '**/out-tsc'],
-          },
           ...compat.extends('plugin:storybook/recommended'),
           ...nx.configs['flat/base'],
           {
@@ -224,9 +221,6 @@ describe('convert-to-flat-config generator', () => {
         "const baseConfig = require('../../eslint.config.cjs');
 
         module.exports = [
-          {
-            ignores: ['**/dist', '**/out-tsc'],
-          },
           ...baseConfig,
           {
             files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -434,9 +428,6 @@ describe('convert-to-flat-config generator', () => {
         "const nx = require('@nx/eslint-plugin');
 
         module.exports = [
-          {
-            ignores: ['**/dist', '**/out-tsc'],
-          },
           ...nx.configs['flat/base'],
           {
             linterOptions: {
@@ -611,9 +602,6 @@ describe('convert-to-flat-config generator', () => {
         "const baseConfig = require('../../eslint.config.cjs');
 
         module.exports = [
-          {
-            ignores: ['**/dist', '**/out-tsc'],
-          },
           ...baseConfig,
           {
             files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -793,9 +781,6 @@ describe('convert-to-flat-config generator', () => {
         });
 
         export default [
-          {
-            ignores: ['**/dist', '**/out-tsc'],
-          },
           ...compat.extends('plugin:storybook/recommended'),
           ...nx.configs['flat/base'],
           {
@@ -826,9 +811,6 @@ describe('convert-to-flat-config generator', () => {
         "import baseConfig from '../../eslint.config.mjs';
 
         export default [
-          {
-            ignores: ['**/dist', '**/out-tsc'],
-          },
           ...baseConfig,
           {
             files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
@@ -1036,9 +1018,6 @@ describe('convert-to-flat-config generator', () => {
         "import nx from '@nx/eslint-plugin';
 
         export default [
-          {
-            ignores: ['**/dist', '**/out-tsc'],
-          },
           ...nx.configs['flat/base'],
           {
             linterOptions: {
@@ -1180,9 +1159,6 @@ describe('convert-to-flat-config generator', () => {
         "import baseConfig from '../../eslint.config.mjs';
 
         export default [
-          {
-            ignores: ['**/dist', '**/out-tsc'],
-          },
           ...baseConfig,
           {
             files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
@@ -8,7 +8,9 @@ import {
   addProjectConfiguration,
   logger,
   readJson,
+  readProjectConfiguration,
   updateJson,
+  updateProjectConfiguration,
 } from '@nx/devkit';
 
 import { convertToFlatConfigGenerator } from './generator';
@@ -1186,6 +1188,107 @@ describe('convert-to-flat-config generator', () => {
         ];
         "
       `);
+    });
+
+    it('should rewrite stale eslintrc/eslintignore references in nx.json and project.json inputs', async () => {
+      await lintProjectGenerator(tree, {
+        skipFormat: false,
+        linter: 'eslint',
+        project: 'test-lib',
+        setParserOptionsProject: false,
+        eslintConfigFormat: 'mjs',
+      });
+      updateJson(tree, 'nx.json', (json: NxJsonConfiguration) => {
+        json.targetDefaults = {
+          ...json.targetDefaults,
+          lint: {
+            inputs: [
+              'default',
+              '{workspaceRoot}/.eslintrc.json',
+              '{workspaceRoot}/.eslintignore',
+            ],
+          },
+          build: {
+            inputs: [
+              'production',
+              '^production',
+              '{projectRoot}/.eslintrc.json',
+              { runtime: 'node --version' },
+            ],
+          },
+        };
+        json.namedInputs = {
+          ...json.namedInputs,
+          production: [
+            'default',
+            '!{projectRoot}/.eslintrc.json',
+            '!{projectRoot}/.eslintignore',
+          ],
+          customNamedInput: [
+            '{projectRoot}/.eslintrc.base.json',
+            '{projectRoot}/src/**/*',
+          ],
+        };
+        return json;
+      });
+      updateProjectConfiguration(tree, 'test-lib', {
+        ...readProjectConfiguration(tree, 'test-lib'),
+        root: 'libs/test-lib',
+        targets: {
+          lint: {
+            executor: '@nx/eslint:lint',
+            inputs: [
+              'default',
+              '{projectRoot}/.eslintrc.json',
+              '{projectRoot}/.eslintignore',
+            ],
+            options: {},
+          },
+        },
+        namedInputs: {
+          projectNamed: [
+            '{projectRoot}/.eslintrc.json',
+            '{projectRoot}/src/**/*',
+          ],
+        },
+      });
+
+      await convertToFlatConfigGenerator(tree, {
+        skipFormat: false,
+        eslintConfigFormat: 'mjs',
+      });
+
+      const nxJson = readJson(tree, 'nx.json');
+      // legacy refs rewritten and dedup'd against the newly ensured entry
+      expect(nxJson.targetDefaults.lint.inputs).toEqual([
+        'default',
+        '{workspaceRoot}/eslint.config.mjs',
+      ]);
+      // non-lint targets: legacy refs still rewritten, non-string inputs preserved
+      expect(nxJson.targetDefaults.build.inputs).toEqual([
+        'production',
+        '^production',
+        '{projectRoot}/eslint.config.mjs',
+        { runtime: 'node --version' },
+      ]);
+      expect(nxJson.namedInputs.production).toEqual([
+        'default',
+        '!{projectRoot}/eslint.config.mjs',
+      ]);
+      expect(nxJson.namedInputs.customNamedInput).toEqual([
+        '{projectRoot}/eslint.base.config.mjs',
+        '{projectRoot}/src/**/*',
+      ]);
+
+      const projectJson = readProjectConfiguration(tree, 'test-lib');
+      expect(projectJson.targets.lint.inputs).toEqual([
+        'default',
+        '{projectRoot}/eslint.config.mjs',
+      ]);
+      expect(projectJson.namedInputs.projectNamed).toEqual([
+        '{projectRoot}/eslint.config.mjs',
+        '{projectRoot}/src/**/*',
+      ]);
     });
   });
 });

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.ts
@@ -200,7 +200,12 @@ function rewriteLegacyInputs(
       seenStrings.add(rewritten);
       result.push(rewritten);
     } else if ('fileset' in entry) {
-      result.push({ ...entry, fileset: renameLegacyEslintrcFile(entry.fileset, format) });
+      const rewritten = renameLegacyEslintrcFile(entry.fileset, format);
+      // Preserve the original reference when nothing changed so downstream identity
+      // checks (e.g. `inputsEqual`) don't see a spurious mutation.
+      result.push(
+        rewritten === entry.fileset ? entry : { ...entry, fileset: rewritten }
+      );
     } else {
       result.push(entry);
     }

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.ts
@@ -14,6 +14,7 @@ import {
   updateJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
+import type { InputDefinition } from 'nx/src/config/workspace-json-project-json';
 import { ConvertToFlatConfigGeneratorSchema } from './schema';
 import { findEslintFile } from '../utils/eslint-file';
 import { hasEslintPlugin } from '../utils/plugin';
@@ -26,7 +27,10 @@ import {
   eslintVersion,
 } from '../../utils/versions';
 import { ESLint } from 'eslint';
-import { convertEslintJsonToFlatConfig } from './converters/json-converter';
+import {
+  convertEslintJsonToFlatConfig,
+  renameLegacyEslintrcFile,
+} from './converters/json-converter';
 
 export async function convertToFlatConfigGenerator(
   tree: Tree,
@@ -67,8 +71,9 @@ export async function convertToFlatConfigGenerator(
     tree.delete(ignoreFile);
   }
 
-  // replace references in nx.json
+  // replace references in nx.json and project.json files
   updateNxJsonConfig(tree, options.eslintConfigFormat);
+  updateProjectConfigsInputs(tree, options.eslintConfigFormat);
   // install missing packages
 
   if (!options.skipFormat) {
@@ -178,29 +183,119 @@ function convertProjectToFlatConfig(
   }
 }
 
-// update names of eslint files in nx.json
-// and remove eslintignore
-function updateNxJsonConfig(tree: Tree, format: 'cjs' | 'mjs') {
-  if (tree.exists('nx.json')) {
-    updateJson(tree, 'nx.json', (json: NxJsonConfiguration) => {
-      if (json.targetDefaults?.lint?.inputs) {
-        const inputSet = new Set(json.targetDefaults.lint.inputs);
-        inputSet.add(`{workspaceRoot}/eslint.config.${format}`);
-        json.targetDefaults.lint.inputs = Array.from(inputSet);
-      }
-      if (json.targetDefaults?.['@nx/eslint:lint']?.inputs) {
-        const inputSet = new Set(json.targetDefaults['@nx/eslint:lint'].inputs);
-        inputSet.add(`{workspaceRoot}/eslint.config.${format}`);
-        json.targetDefaults['@nx/eslint:lint'].inputs = Array.from(inputSet);
-      }
-      if (json.namedInputs?.production) {
-        const inputSet = new Set(json.namedInputs.production);
-        inputSet.add(`!{projectRoot}/eslint.config.${format}`);
-        json.namedInputs.production = Array.from(inputSet);
-      }
-      return json;
-    });
+// Rewrites input entries that reference legacy `.eslintrc[.base].json` / `.eslintignore`
+// files to their flat-config counterparts, then dedupes so the rewrite doesn't produce
+// duplicates of entries that already pointed at the flat config. Leaves non-string /
+// non-fileset inputs (runtime/env/dependentTasksOutputFiles/etc.) untouched.
+function rewriteLegacyInputs(
+  inputs: Array<string | InputDefinition>,
+  format: 'cjs' | 'mjs'
+): Array<string | InputDefinition> {
+  const seenStrings = new Set<string>();
+  const result: Array<string | InputDefinition> = [];
+  for (const entry of inputs) {
+    if (typeof entry === 'string') {
+      const rewritten = renameLegacyEslintrcFile(entry, format);
+      if (seenStrings.has(rewritten)) continue;
+      seenStrings.add(rewritten);
+      result.push(rewritten);
+    } else if ('fileset' in entry) {
+      result.push({ ...entry, fileset: renameLegacyEslintrcFile(entry.fileset, format) });
+    } else {
+      result.push(entry);
+    }
   }
+  return result;
+}
+
+// Adds `value` to `inputs` (after rewriting) when the rewritten set doesn't already contain it.
+function ensureInputPresent(
+  inputs: Array<string | InputDefinition>,
+  value: string,
+  format: 'cjs' | 'mjs'
+): Array<string | InputDefinition> {
+  const rewritten = rewriteLegacyInputs(inputs, format);
+  if (!rewritten.some((entry) => entry === value)) {
+    rewritten.push(value);
+  }
+  return rewritten;
+}
+
+// Updates nx.json: rewrites stale eslintrc/eslintignore references across all targetDefaults
+// inputs and namedInputs, and ensures lint targets include the new flat config file as an input
+// (and `production` excludes it).
+function updateNxJsonConfig(tree: Tree, format: 'cjs' | 'mjs') {
+  if (!tree.exists('nx.json')) {
+    return;
+  }
+  updateJson(tree, 'nx.json', (json: NxJsonConfiguration) => {
+    if (json.targetDefaults) {
+      for (const [name, target] of Object.entries(json.targetDefaults)) {
+        if (!target.inputs) continue;
+        const isLintTarget = name === 'lint' || name === ESLINT_LINT_EXECUTOR;
+        target.inputs = isLintTarget
+          ? ensureInputPresent(
+              target.inputs,
+              `{workspaceRoot}/eslint.config.${format}`,
+              format
+            )
+          : rewriteLegacyInputs(target.inputs, format);
+      }
+    }
+    if (json.namedInputs) {
+      for (const [name, inputs] of Object.entries(json.namedInputs)) {
+        json.namedInputs[name] =
+          name === 'production'
+            ? ensureInputPresent(
+                inputs,
+                `!{projectRoot}/eslint.config.${format}`,
+                format
+              )
+            : rewriteLegacyInputs(inputs, format);
+      }
+    }
+    return json;
+  });
+}
+
+// Walks every project's `targets.*.inputs` and `namedInputs.*`, rewriting stale references.
+function updateProjectConfigsInputs(tree: Tree, format: 'cjs' | 'mjs') {
+  for (const [project, projectConfig] of getProjects(tree)) {
+    let changed = false;
+    if (projectConfig.targets) {
+      for (const target of Object.values(projectConfig.targets)) {
+        if (!target.inputs) continue;
+        const rewritten = rewriteLegacyInputs(target.inputs, format);
+        if (!inputsEqual(target.inputs, rewritten)) {
+          target.inputs = rewritten;
+          changed = true;
+        }
+      }
+    }
+    if (projectConfig.namedInputs) {
+      for (const [name, inputs] of Object.entries(projectConfig.namedInputs)) {
+        const rewritten = rewriteLegacyInputs(inputs, format);
+        if (!inputsEqual(inputs, rewritten)) {
+          projectConfig.namedInputs[name] = rewritten;
+          changed = true;
+        }
+      }
+    }
+    if (changed) {
+      updateProjectConfiguration(tree, project, projectConfig);
+    }
+  }
+}
+
+function inputsEqual(
+  a: ReadonlyArray<string | InputDefinition>,
+  b: ReadonlyArray<string | InputDefinition>
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
 }
 
 function convertConfigToFlatConfig(

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.ts
@@ -17,7 +17,7 @@ import {
 import { ConvertToFlatConfigGeneratorSchema } from './schema';
 import { findEslintFile } from '../utils/eslint-file';
 import { hasEslintPlugin } from '../utils/plugin';
-import { join } from 'path';
+import { basename, join } from 'path';
 import {
   eslint9__eslintVersion,
   eslint9__typescriptESLintVersion,
@@ -215,7 +215,8 @@ function convertConfigToFlatConfig(
     ? [ignorePath, `${root}/.eslintignore`]
     : [`${root}/.eslintignore`];
 
-  if (source.endsWith('.json') || /(^|\/)\.eslintrc$/.test(source)) {
+  // `.eslintrc` (no extension) is JSON by convention.
+  if (source.endsWith('.json') || basename(source) === '.eslintrc') {
     const config: ESLint.ConfigData = readJson(tree, `${root}/${source}`);
     const conversionResult = convertEslintJsonToFlatConfig(
       tree,

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.ts
@@ -296,11 +296,7 @@ function inputsEqual(
   a: ReadonlyArray<string | InputDefinition>,
   b: ReadonlyArray<string | InputDefinition>
 ): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
+  return a.length === b.length && a.every((entry, i) => entry === b[i]);
 }
 
 function convertConfigToFlatConfig(

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.ts
@@ -215,7 +215,7 @@ function convertConfigToFlatConfig(
     ? [ignorePath, `${root}/.eslintignore`]
     : [`${root}/.eslintignore`];
 
-  if (source.endsWith('.json')) {
+  if (source.endsWith('.json') || /(^|\/)\.eslintrc$/.test(source)) {
     const config: ESLint.ConfigData = readJson(tree, `${root}/${source}`);
     const conversionResult = convertEslintJsonToFlatConfig(
       tree,

--- a/packages/eslint/src/generators/convert-to-flat-config/schema.json
+++ b/packages/eslint/src/generators/convert-to-flat-config/schema.json
@@ -10,6 +10,13 @@
       "description": "Skip formatting files.",
       "default": false,
       "x-priority": "internal"
+    },
+    "eslintConfigFormat": {
+      "type": "string",
+      "description": "The format of the generated ESLint flat config files.",
+      "enum": ["mjs", "cjs"],
+      "default": "mjs",
+      "x-priority": "internal"
     }
   },
   "additionalProperties": false,

--- a/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
+++ b/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
@@ -1,6 +1,7 @@
 import {
   applyChangesToString,
   ChangeType,
+  names,
   parseJson,
   StringChange,
 } from '@nx/devkit';
@@ -1648,7 +1649,8 @@ export function generateFlatOverride(
   _override: Partial<Linter.ConfigOverride<Linter.RulesRecord>> & {
     ignores?: Linter.FlatConfig['ignores'];
   },
-  format: 'mjs' | 'cjs'
+  format: 'mjs' | 'cjs',
+  importsMap?: Map<string, string>
 ): ts.ObjectLiteralExpression | ts.SpreadElement {
   const override = mapFilePaths(_override);
 
@@ -1727,7 +1729,7 @@ export function generateFlatOverride(
         } else {
           // Change parser to import statement.
           return format === 'mjs'
-            ? generateESMParserImport(override)
+            ? generateESMParserImport(override, importsMap)
             : generateCJSParserImport(override);
         }
       },
@@ -1839,21 +1841,31 @@ export function generateFlatOverride(
 function generateESMParserImport(
   override: Partial<Linter.ConfigOverride<Linter.RulesRecord>> & {
     ignores?: Linter.FlatConfig['ignores'];
-  }
+  },
+  importsMap?: Map<string, string>
 ): ts.PropertyAssignment {
+  const parser =
+    override['languageOptions']?.['parserOptions']?.parser ??
+    override['languageOptions']?.parser ??
+    override.parser;
+  // Dynamic `await import()` doesn't expose top-level CJS exports (e.g. `parseForESLint`)
+  // because those are nested under `.default`. Use a hoisted static import instead so the
+  // resolved binding matches the parser's module.exports shape.
+  if (importsMap) {
+    const parserName = importsMap.get(parser) ?? names(parser).propertyName;
+    importsMap.set(parser, parserName);
+    return ts.factory.createPropertyAssignment(
+      'parser',
+      ts.factory.createIdentifier(parserName)
+    );
+  }
   return ts.factory.createPropertyAssignment(
     'parser',
     ts.factory.createAwaitExpression(
       ts.factory.createCallExpression(
         ts.factory.createIdentifier('import'),
         undefined,
-        [
-          ts.factory.createStringLiteral(
-            override['languageOptions']?.['parserOptions']?.parser ??
-              override['languageOptions']?.parser ??
-              override.parser
-          ),
-        ]
+        [ts.factory.createStringLiteral(parser)]
       )
     )
   );
@@ -1906,14 +1918,17 @@ export function mapFilePaths<
     override.files = Array.isArray(override.files)
       ? override.files
       : [override.files];
-    override.files = override.files.map((file) => mapFilePath(file));
+    // Dedupe after mapping — both source-side duplicates and map collisions collapse.
+    override.files = Array.from(
+      new Set(override.files.map((file) => mapFilePath(file)))
+    );
   }
   if (override.excludedFiles) {
     override.excludedFiles = Array.isArray(override.excludedFiles)
       ? override.excludedFiles
       : [override.excludedFiles];
-    override.excludedFiles = override.excludedFiles.map((file) =>
-      mapFilePath(file)
+    override.excludedFiles = Array.from(
+      new Set(override.excludedFiles.map((file) => mapFilePath(file)))
     );
   }
   return override;

--- a/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
+++ b/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
@@ -1914,22 +1914,16 @@ export function mapFilePaths<
   const override: T = {
     ..._override,
   };
-  if (override.files) {
-    override.files = Array.isArray(override.files)
-      ? override.files
-      : [override.files];
-    // Dedupe after mapping — both source-side duplicates and map collisions collapse.
-    override.files = Array.from(
-      new Set(override.files.map((file) => mapFilePath(file)))
+  // Dedupe after mapping — both source-side duplicates and glob-mapping collisions collapse.
+  const normalize = (value: string | string[]): string[] =>
+    Array.from(
+      new Set((Array.isArray(value) ? value : [value]).map(mapFilePath))
     );
+  if (override.files) {
+    override.files = normalize(override.files);
   }
   if (override.excludedFiles) {
-    override.excludedFiles = Array.isArray(override.excludedFiles)
-      ? override.excludedFiles
-      : [override.excludedFiles];
-    override.excludedFiles = Array.from(
-      new Set(override.excludedFiles.map((file) => mapFilePath(file)))
-    );
+    override.excludedFiles = normalize(override.excludedFiles);
   }
   return override;
 }


### PR DESCRIPTION
## Current Behavior

Running `@nx/eslint:convert-to-flat-config` against a workspace with legacy `.eslintrc` configs produces flat configs that don't faithfully reflect the source, and leaves stale references to the deleted files behind:

- Every converted config — root and leaves — gets an unconditional `{ ignores: ['**/dist', '**/out-tsc'] }` block prepended, even when the legacy config never ignored those paths.
- Leaves whose only compat-looking field was a custom `parser` (e.g. `jsonc-eslint-parser` for `package.json`) get a full `@eslint/eslintrc` FlatCompat scaffold — `FlatCompat` import, `dirname`, `fileURLToPath`, `js`, the `const compat = new FlatCompat({...})` block — that's never referenced.
- Rule option values that embedded legacy filenames (most notably `@nx/dependency-checks`'s `ignoredFiles`) keep pointing at `.eslintrc.json` / `.eslintrc.base.json` / `.eslintignore` after those files are deleted.
- `nx.json` gets the new `eslint.config.<fmt>` entry added to the lint target and `production` named input, but legacy `.eslintrc.json` / `.eslintignore` entries stay in place. Other `targetDefaults` inputs and `namedInputs` are never rewritten.
- `project.json` files aren't touched at all — every `targets[*].inputs` or `namedInputs[*]` that referenced the deleted files stays stale.
- Configs with `extends: '../../.eslintrc'` (extensionless — ESLint's JSON-by-convention form) aren't supported: the source file isn't converted, and if a leaf extends one that was converted elsewhere the leaf ends up with `...compat.extends('../../.eslintrc')` pointing at nothing.
- Legacy `ignorePatterns` entries that started with `!` were being dropped wholesale, destroying real un-ignores like `['dist/**', '!dist/keep.js']` that flat config still honors.
- `files` / `excludedFiles` arrays with source-side duplicates (e.g. `package.json`, `./generators.json`, `./executors.json` repeated in the same override) are emitted with the duplicates intact.

## Expected Behavior

Conversion preserves the semantics and intent of the legacy config, rewrites everything that referred to the deleted files, and drops noise that serves no purpose in flat config:

- The implicit `**/dist` / `**/out-tsc` ignore block is no longer added. If the legacy config didn't ignore those paths, the converted one doesn't either — migration stays faithful to the source. (`lint-project` still adds them for fresh scaffolding, where there's no source intent to preserve.)
- Parser-only overrides emit a clean flat entry with a hoisted static parser import and no unused FlatCompat scaffold. Leaf configs shed the dead boilerplate.
- Rule option values that embed `.eslintrc[.base].json` or `.eslintignore` are rewritten to the flat-config equivalent. Accidentally collapsed duplicates inside string arrays are deduped.
- `nx.json` is swept generically — every `targetDefaults[*].inputs` and `namedInputs[*]` gets legacy filenames rewritten, with dedup so the rewrite doesn't collide with freshly-added entries. `{ fileset }` shapes are handled; non-path shapes (`runtime`, `env`, `externalDependencies`, `dependentTasksOutputFiles`, named-input refs) are left untouched.
- Every project's `project.json` receives the same sweep across `targets[*].inputs` and `namedInputs[*]`.
- Extensionless `.eslintrc` is now a convertible source, and `extends` paths that point at `../../.eslintrc` (or `.eslintrc.base`) are rewritten to the generated base config and imported as `baseConfig`.
- Real negated `ignorePatterns` like `!dist/keep.js` survive the conversion; only the legacy `**/*` / `!**/*` / `node_modules` catch-alls are dropped.
- `files` / `excludedFiles` arrays are deduped after glob mapping, so source-side duplicates and glob-normalization collisions collapse.
