### PR TITLE
fix(core): recognize json inputs in TS task hasher fallback

### DIFF
--- a/packages/nx/src/hasher/task-hasher.spec.ts
+++ b/packages/nx/src/hasher/task-hasher.spec.ts
@@ -2,6 +2,7 @@
 
 import {
   expandNamedInput,
+  expandSingleProjectInputs,
   filterUsingGlobPatterns,
   splitInputsIntoSelfAndDependencies,
 } from './task-hasher';
@@ -224,6 +225,26 @@ describe('TaskHasher', () => {
         b: ['c'],
       });
       expect(expanded).toEqual([{ fileset: 'c' }]);
+    });
+  });
+
+  describe('expandSingleProjectInputs', () => {
+    it('should pass through json inputs unchanged', () => {
+      const jsonInput = {
+        json: '{workspaceRoot}/tsconfig.base.json',
+        fields: ['compilerOptions', 'extends', 'files', 'include'],
+      };
+      const expanded = expandSingleProjectInputs([jsonInput], {});
+      expect(expanded).toEqual([jsonInput]);
+    });
+
+    it('should pass through json inputs with excludeFields unchanged', () => {
+      const jsonInput = {
+        json: '{projectRoot}/package.json',
+        excludeFields: ['scripts', 'description'],
+      };
+      const expanded = expandSingleProjectInputs([jsonInput as any], {});
+      expect(expanded).toEqual([jsonInput]);
     });
   });
 

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -463,7 +463,8 @@ export function expandSingleProjectInputs(
         (d as any).runtime ||
         (d as any).externalDependencies ||
         (d as any).dependentTasksOutputFiles ||
-        (d as any).workingDirectory
+        (d as any).workingDirectory ||
+        (d as any).json
       ) {
         expanded.push(d);
       } else {


### PR DESCRIPTION
## Current Behavior

PR #35248 added a new `json` input type for selective JSON field hashing (landed between 22.7.0-beta.12 and 22.7.0-beta.14). It updated the Rust hasher (`packages/nx/src/native/tasks/inputs.rs`, `types/inputs.rs`), but the TypeScript twin — `expandSingleProjectInputs` in `packages/nx/src/hasher/task-hasher.ts` — was not updated.

That function duck-types inputs against a fixed allowlist of shapes (`fileset`, `env`, `runtime`, `externalDependencies`, `dependentTasksOutputFiles`, `workingDirectory`). A `{ json, fields }` object fails every check and falls into the `else` branch, which calls `expandNamedInput(d.input, ...)`. Since `d.input` is `undefined`, it throws:

```
 NX   Input 'undefined' is not defined
```

This only surfaces on code paths that use the TS hasher (e.g. Nx Cloud DTE) — the native Rust hasher handles `json` inputs correctly, which is why local `nx run` / `nx affected` runs succeed while CI runs fail.

Reproduced in CI when the playwright, vite, and vitest plugins emit `{ json: '{workspaceRoot}/tsconfig.base.json', fields: [...] }` inputs for selective tsconfig hashing.

## Expected Behavior

`expandSingleProjectInputs` recognizes `json` as a known input shape and passes it through unchanged, matching the Rust hasher's behavior.

## Related Issue(s)

<!-- Link related issues here -->