### PR TITLE
fix(gradle): recognize Kotlin compile tasks in inferred input extensions

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -18,6 +18,17 @@ import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.testing.Test as GradleTest
 
+private val kotlinCompileToolClass: Class<*>? by lazy {
+  try {
+    Class.forName("org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompileTool")
+  } catch (e: Throwable) {
+    null
+  }
+}
+
+private fun isKotlinCompileTask(task: Task): Boolean =
+    kotlinCompileToolClass?.isInstance(task) == true
+
 /**
  * Process a task and convert it into target Going to populate:
  * - cache
@@ -161,12 +172,12 @@ fun getGradleFilesInputs(workspaceRoot: String): List<String> {
 fun inferExtensionsFromInputProperties(task: Task, dependentTasks: Set<Task>): Set<String> {
   val extensions = mutableSetOf<String>()
 
-  when (task) {
-    is GradleTest -> {
+  when {
+    task is GradleTest -> {
       extensions.add("class")
       extensions.add("jar")
     }
-    is AbstractCompile -> extensions.add("class")
+    task is AbstractCompile || isKotlinCompileTask(task) -> extensions.add("class")
   }
 
   dependentTasks.forEach { depTask ->
@@ -177,7 +188,7 @@ fun inferExtensionsFromInputProperties(task: Task, dependentTasks: Set<Task>): S
         task.logger.debug("Could not read archiveExtension for ${depTask.path}: ${e.message}")
       }
     }
-    if (depTask is AbstractCompile) {
+    if (depTask is AbstractCompile || isKotlinCompileTask(depTask)) {
       extensions.add("class")
     }
   }

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -514,6 +514,38 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
+    fun `kotlin compile task alone infers class via primary branch`() {
+      val kotlinProject = ProjectBuilder.builder().withName("kotlinPrimaryBranch").build()
+      kotlinProject.plugins.apply("org.jetbrains.kotlin.jvm")
+
+      val compileKotlin = kotlinProject.tasks.getByName("compileKotlin")
+
+      val extensions = inferExtensionsFromInputProperties(compileKotlin, emptySet())
+
+      assertTrue(
+          extensions.contains("class"),
+          "Expected 'class' extension from primary branch for KotlinCompile task, got $extensions")
+      assertFalse(
+          extensions.contains("jar"),
+          "Expected no 'jar' extension with empty dependents, got $extensions")
+    }
+
+    @Test
+    fun `kotlin compile dependent contributes class extension`() {
+      val kotlinProject = ProjectBuilder.builder().withName("kotlinDepBranch").build()
+      kotlinProject.plugins.apply("org.jetbrains.kotlin.jvm")
+
+      val compileKotlin = kotlinProject.tasks.getByName("compileKotlin")
+      val plain = kotlinProject.tasks.register("plain").get()
+
+      val extensions = inferExtensionsFromInputProperties(plain, setOf(compileKotlin))
+
+      assertTrue(
+          extensions.contains("class"),
+          "Expected 'class' from KotlinCompile dependent, got $extensions")
+    }
+
+    @Test
     fun `compile task without archive dependents does not infer jar`() {
       val project = ProjectBuilder.builder().withName("compileOnly").build()
       project.plugins.apply("java")


### PR DESCRIPTION
## Current Behavior

`inferExtensionsFromInputProperties` uses `is AbstractCompile` to determine when to add `.class` as an inferred input extension. As a result, Kotlin compile tasks are silently excluded from the `.class` branch, producing incomplete inferred inputs in the Nx project graph for Kotlin projects.

## Expected Behavior

All Kotlin compile tasks should be recognized alongside `AbstractCompile` tasks and produce `.class` as an inferred input extension, regardless of which Gradle plugin hierarchy they belong to. Java-only projects are unaffected.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #