### PR TITLE
chore(repo): remove unused browser installs and system deps from main-linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,6 @@ jobs:
       - name: Start CI Run
         run: npx nx-cloud@next start-ci-run --distribute-on="./.nx/workflows/dynamic-changesets.yaml" --stop-agents-after="e2e"
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ca-certificates lsof libvips-dev libglib2.0-dev libgirepository1.0-dev
-
       - name: Install Chrome
         uses: browser-actions/setup-chrome@2dbff04819ebbfd5c974947148805a825b8a07fd # v2.1.0
 
@@ -88,9 +83,6 @@ jobs:
 
       - name: Install project dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Install Playwright
-        run: pnpm playwright install --with-deps
 
       - name: Nx Report
         run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,6 @@ jobs:
       - name: Start CI Run
         run: npx nx-cloud@next start-ci-run --distribute-on="./.nx/workflows/dynamic-changesets.yaml" --stop-agents-after="e2e"
 
-      - name: Install Chrome
-        uses: browser-actions/setup-chrome@2dbff04819ebbfd5c974947148805a825b8a07fd # v2.1.0
-
       - name: Setup dev tools with mise
         uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
 


### PR DESCRIPTION
## Current Behavior

The `main-linux` orchestrator job in `.github/workflows/ci.yml` installs several system packages, Chrome, and Playwright browsers on every run:

```yaml
- name: Install dependencies
  run: |
    sudo apt-get update
    sudo apt-get install -y ca-certificates lsof libvips-dev libglib2.0-dev libgirepository1.0-dev

- name: Install Chrome
  uses: browser-actions/setup-chrome@...

- name: Install Playwright
  run: pnpm playwright install --with-deps
```

None of these are actually used by tasks the orchestrator executes. The orchestrator runs `format:check`, `sync:check`, `conformance:check`, `check-imports`, `check-lock-files`, `check-codeowners`, and kicks off `nx affected` -- which distributes all `lint`/`test`/`build`/`e2e`/`e2e-ci` tasks to Nx agents per `.nx/workflows/dynamic-changesets.yaml`.

Historically these steps were copy-pasted during the CircleCI to GHA migration (5b9d43f9) without evaluating whether the orchestrator actually needed them. Tracing each back to its origin:

- **`lsof`** (added in c9cd67ea) -- only used by `kill-port` in e2e tests (`e2e/next`, `e2e/storybook`, etc.), which run on agents.
- **`libvips-dev` / `libglib2.0-dev` / `libgirepository1.0-dev`** (added in cfcedb48 for storybook/Next.js image tests) -- only needed if `sharp` falls back to a source build. Sharp ships prebuilt binaries for linux-x64 and is only reached via `astro-docs`/Next.js builds, which run on agents.
- **`ca-certificates`** -- already present on `ubuntu-latest`.
- **`browser-actions/setup-chrome`** -- no orchestrator-local task uses Chrome. No Karma/Puppeteer tests run here. Browser-driven tests run on agents, which get Chromium via Playwright.
- **`pnpm playwright install --with-deps`** -- only needed by browser tests, which run on agents (agents install Playwright themselves, see `.nx/workflows/agents.yaml` lines 51-54).

## Expected Behavior

The `main-linux` orchestrator skips the unnecessary install steps, saving ~30-60s per CI run with no functional change. Nx agents continue to install these packages themselves when they need them.

The macOS React Native job (`main-macos`) keeps its Playwright install because those e2e tests run directly on the macOS runner, not on agents.

## Related Issue(s)

N/A -- cleanup.