### PR TITLE
feat(core): support filtered array-shape targetDefaults with projects and source

### DIFF
--- a/astro-docs/src/content/docs/reference/nx-json.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-json.mdoc
@@ -213,16 +213,17 @@ Additionally, if there is not a match for either of the above, we look for other
 
 Target defaults matching the executor takes precedence over those matching the target name. If we find a target default for a given target, we use it as the base for that target's configuration.
 
-`targetDefaults` is an array of entries. Each entry **must** specify a `target` (name, glob, or executor string). Optional `projects` and `source` filters let you scope a default to a subset of projects or targets inferred by a particular plugin.
+`targetDefaults` is an array of entries. Each entry must specify at least one of `target` (name or glob), `executor`, `projects`, or `plugin`. Optional `projects` and `plugin` filters let you scope a default to a subset of projects or targets inferred by a particular plugin.
 
 | Field      | Type                                                                         | Description                                                                                                                                                                                                         |
 | ---------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `target`   | `string`                                                                     | Required. Target name (e.g. `test`), glob (e.g. `e2e-ci--*`), or executor string (e.g. `@nx/vite:test`).                                                                                                            |
+| `target`   | `string`                                                                     | Target name (e.g. `test`) or glob (e.g. `e2e-ci--*`). Required if `executor` is not set (and vice versa) when not using filter-only entries.                                                                        |
+| `executor` | `string`                                                                     | Executor identifier (e.g. `@nx/vite:test`). Matches targets that resolve to this executor. May be set alongside `target` to require both.                                                                           |
 | `projects` | `string` \| `string[]`                                                       | Optional. Restricts the default to matching projects. Accepts project names, globs, directory patterns, tags (`tag:foo`), and negation (`!foo`) — anything `findMatchingProjects` understands.                      |
-| `source`   | `string`                                                                     | Optional. Restricts the default to targets originated by a specific plugin (e.g. `@nx/vite`). Useful when two plugins expose a target with the same name (e.g. `@nx/vite:test` and `@nx/jest:test` both as `test`). |
+| `plugin`   | `string`                                                                     | Optional. Restricts the default to targets originated by a specific plugin (e.g. `@nx/vite`). Useful when two plugins expose a target with the same name (e.g. `@nx/vite:test` and `@nx/jest:test` both as `test`). |
 | other      | any field from [Target Configuration](/docs/reference/project-configuration) | The defaults applied when the filter matches.                                                                                                                                                                       |
 
-When multiple entries match a given `(target, project)` tuple, the **most specific** entry wins (`target + projects + source` > `target + projects` > `target + source` > `target` alone). Within the same specificity tier, an exact `target` match beats a glob match, and later entries in the array beat earlier ones.
+When multiple entries match a given `(target, project)` tuple, the **most specific** entry wins (`target + projects + plugin` > `target + projects` > `target + plugin` > `target` alone). Within the same specificity tier, an exact `target` match beats a glob match, and later entries in the array beat earlier ones.
 
 ```json
 // nx.json — polyglot example
@@ -231,7 +232,7 @@ When multiple entries match a given `(target, project)` tuple, the **most specif
     { "target": "test", "cache": true },
     {
       "target": "test",
-      "source": "@nx/vite",
+      "plugin": "@nx/vite",
       "inputs": ["default", "^production"]
     },
     {
@@ -244,7 +245,7 @@ When multiple entries match a given `(target, project)` tuple, the **most specif
 ```
 
 {% aside type="caution" title="Beware" %}
-When an entry has no `projects` or `source` filter, Nx matches by target name (or executor) alone. Make sure all targets with that name use the same executor, or that the defaults you're setting make sense to all of them. Anything set in a target default will also override the configuration of [tasks inferred by plugins](/docs/concepts/inferred-tasks).
+When an entry has no `projects` or `plugin` filter, Nx matches by target name (or executor) alone. Make sure all targets with that name use the same executor, or that the defaults you're setting make sense to all of them. Anything set in a target default will also override the configuration of [tasks inferred by plugins](/docs/concepts/inferred-tasks).
 {% /aside %}
 
 Some common scenarios for this follow.
@@ -426,7 +427,7 @@ You can also provide defaults for [inferred targets](/docs/concepts/inferred-tas
 }
 ```
 
-If two plugins expose a target with the same name (e.g. both `@nx/vite` and `@nx/jest` infer `test`), use the `source` filter to scope per-plugin defaults:
+If two plugins expose a target with the same name (e.g. both `@nx/vite` and `@nx/jest` infer `test`), use the `plugin` filter to scope per-plugin defaults:
 
 ```json
 // nx.json
@@ -434,12 +435,12 @@ If two plugins expose a target with the same name (e.g. both `@nx/vite` and `@nx
   "targetDefaults": [
     {
       "target": "test",
-      "source": "@nx/vite",
+      "plugin": "@nx/vite",
       "inputs": ["default", "^production"]
     },
     {
       "target": "test",
-      "source": "@nx/jest",
+      "plugin": "@nx/jest",
       "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"]
     }
   ]

--- a/astro-docs/src/content/docs/reference/nx-json.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-json.mdoc
@@ -37,7 +37,7 @@ The following is an expanded example showing all options. Your `nx.json` will li
   },
   "targetDefaults": [
     {
-      "target": "@nx/js:tsc",
+      "executor": "@nx/js:tsc",
       "inputs": ["production", "^production"],
       "dependsOn": ["^build"],
       "options": {
@@ -47,10 +47,10 @@ The following is an expanded example showing all options. Your `nx.json` will li
     },
     {
       "target": "test",
+      "executor": "@nx/jest:jest",
       "cache": true,
       "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
-      "executor": "@nx/jest:jest"
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"]
     }
   ],
   "release": {
@@ -339,7 +339,7 @@ When defining any options or configurations inside of a target default, you may 
 {
   "targetDefaults": [
     {
-      "target": "@nx/js:tsc",
+      "executor": "@nx/js:tsc",
       "options": {
         "main": "{projectRoot}/src/index.ts"
       },
@@ -363,7 +363,7 @@ When defining any options or configurations inside of a target default, you may 
 
 #### Target default priority
 
-Only one entry wins per `(target, project)` tuple — the most specific one (see the table above). In the example above, both entries apply to targets named `build`, but the `@nx/js:tsc` entry matches when the target uses that executor and beats the plain `build` entry because executor matches rank as specific as an exact target-name match. Specify the full config on the winning entry — less-specific entries do not contribute when a more-specific entry matches.
+Only one entry wins per `(target, project)` tuple — the most specific one (see the table above). In the example above, both entries can apply to a `build` target that uses `@nx/js:tsc`; the `executor`-keyed entry wins because executor matches outrank exact target-name matches at the same tier. Specify the full config on the winning entry — less-specific entries do not contribute when a more-specific entry matches.
 
 {% cardgrid %}
 {% linkcard title="Configure Outputs for Task Caching" description="This recipe walks you through how to set outputs" href="/docs/guides/tasks--caching/configure-outputs" /%}
@@ -400,7 +400,7 @@ You can configure options specific to a target's executor. As an example, if you
 {
   "targetDefaults": [
     {
-      "target": "@nx/js:tsc",
+      "executor": "@nx/js:tsc",
       "options": {
         "generateExportsField": true
       }

--- a/astro-docs/src/content/docs/reference/nx-json.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-json.mdoc
@@ -35,8 +35,9 @@ The following is an expanded example showing all options. Your `nx.json` will li
     "default": ["{projectRoot}/**/*"],
     "production": ["!{projectRoot}/**/*.spec.tsx"]
   },
-  "targetDefaults": {
-    "@nx/js:tsc": {
+  "targetDefaults": [
+    {
+      "target": "@nx/js:tsc",
       "inputs": ["production", "^production"],
       "dependsOn": ["^build"],
       "options": {
@@ -44,13 +45,14 @@ The following is an expanded example showing all options. Your `nx.json` will li
       },
       "cache": true
     },
-    "test": {
+    {
+      "target": "test",
       "cache": true,
       "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "executor": "@nx/jest:jest"
     }
-  },
+  ],
   "release": {
     "version": {
       "conventionalCommits": true
@@ -211,8 +213,38 @@ Additionally, if there is not a match for either of the above, we look for other
 
 Target defaults matching the executor takes precedence over those matching the target name. If we find a target default for a given target, we use it as the base for that target's configuration.
 
+`targetDefaults` is an array of entries. Each entry **must** specify a `target` (name, glob, or executor string). Optional `projects` and `source` filters let you scope a default to a subset of projects or targets inferred by a particular plugin.
+
+| Field      | Type                                                                         | Description                                                                                                                                                                                                         |
+| ---------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `target`   | `string`                                                                     | Required. Target name (e.g. `test`), glob (e.g. `e2e-ci--*`), or executor string (e.g. `@nx/vite:test`).                                                                                                            |
+| `projects` | `string` \| `string[]`                                                       | Optional. Restricts the default to matching projects. Accepts project names, globs, directory patterns, tags (`tag:foo`), and negation (`!foo`) — anything `findMatchingProjects` understands.                      |
+| `source`   | `string`                                                                     | Optional. Restricts the default to targets originated by a specific plugin (e.g. `@nx/vite`). Useful when two plugins expose a target with the same name (e.g. `@nx/vite:test` and `@nx/jest:test` both as `test`). |
+| other      | any field from [Target Configuration](/docs/reference/project-configuration) | The defaults applied when the filter matches.                                                                                                                                                                       |
+
+When multiple entries match a given `(target, project)` tuple, the **most specific** entry wins (`target + projects + source` > `target + projects` > `target + source` > `target` alone). Within the same specificity tier, an exact `target` match beats a glob match, and later entries in the array beat earlier ones.
+
+```json
+// nx.json — polyglot example
+{
+  "targetDefaults": [
+    { "target": "test", "cache": true },
+    {
+      "target": "test",
+      "source": "@nx/vite",
+      "inputs": ["default", "^production"]
+    },
+    {
+      "target": "test",
+      "projects": "tag:dotnet",
+      "options": { "configuration": "Release" }
+    }
+  ]
+}
+```
+
 {% aside type="caution" title="Beware" %}
-When using a target name as the key of a target default, make sure all the targets with that name use the same executor or that the target defaults you're setting make sense to all targets regardless of the executor they use. Anything set in a target default will also override the configuration of [tasks inferred by plugins](/docs/concepts/inferred-tasks).
+When an entry has no `projects` or `source` filter, Nx matches by target name (or executor) alone. Make sure all targets with that name use the same executor, or that the defaults you're setting make sense to all of them. Anything set in a target default will also override the configuration of [tasks inferred by plugins](/docs/concepts/inferred-tasks).
 {% /aside %}
 
 Some common scenarios for this follow.
@@ -222,18 +254,19 @@ Some common scenarios for this follow.
 Named inputs defined in `nx.json` are merged with the named inputs defined in [project level configuration](/docs/reference/project-configuration). In other words, every project has a set of named inputs, and it's defined as: `{...namedInputsFromNxJson, ...namedInputsFromProjectsProjectJson}`.
 
 Defining `inputs` for a given target would replace the set of inputs for that target name defined in `nx.json`.
-Using pseudocode `inputs = projectJson.targets.build.inputs || nxJson.targetDefaults.build.inputs`.
+Using pseudocode `inputs = projectJson.targets.build.inputs || nxJsonTargetDefaults.build.inputs`.
 
 You can also define and redefine named inputs. This enables one key use case, where your `nx.json` can define things like this (which applies to every project):
 
 ```json
 // nx.json
 {
-  "targetDefaults": {
-    "test": {
+  "targetDefaults": [
+    {
+      "target": "test",
       "inputs": ["default", "^production"]
     }
-  }
+  ]
 }
 ```
 
@@ -267,11 +300,12 @@ defining `targetDefaults` in `nx.json` is helpful.
 ```json
 // nx.json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "dependsOn": ["^build"]
     }
-  }
+  ]
 }
 ```
 
@@ -289,11 +323,12 @@ Another target default you can configure is `outputs`:
 ```json
 // nx.json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "outputs": ["{projectRoot}/custom-dist"]
     }
-  }
+  ]
 }
 ```
 
@@ -302,8 +337,9 @@ When defining any options or configurations inside of a target default, you may 
 ```json
 // nx.json
 {
-  "targetDefaults": {
-    "@nx/js:tsc": {
+  "targetDefaults": [
+    {
+      "target": "@nx/js:tsc",
       "options": {
         "main": "{projectRoot}/src/index.ts"
       },
@@ -315,18 +351,19 @@ When defining any options or configurations inside of a target default, you may 
       "inputs": ["prod"],
       "outputs": ["{workspaceRoot}/{projectRoot}"]
     },
-    "build": {
+    {
+      "target": "build",
       "inputs": ["prod"],
       "outputs": ["{workspaceRoot}/{projectRoot}"],
       "cache": true
     }
-  }
+  ]
 }
 ```
 
 #### Target default priority
 
-Note that the inputs and outputs are specified on both the `@nx/js:tsc` and `build` default configurations. This is **required**, as when reading target defaults Nx will only ever look at one key. If there is a default configuration based on the executor used, it will be read first. If not, Nx will fall back to looking at the configuration based on target name. For instance, running `nx build project` will read the options from `targetDefaults[@nx/js:tsc]` if the target configuration for `build` uses the `@nx/js:tsc executor`. It **would not** read any of the configuration from the `build` target default configuration unless the executor does not match.
+Only one entry wins per `(target, project)` tuple — the most specific one (see the table above). In the example above, both entries apply to targets named `build`, but the `@nx/js:tsc` entry matches when the target uses that executor and beats the plain `build` entry because executor matches rank as specific as an exact target-name match. Specify the full config on the winning entry — less-specific entries do not contribute when a more-specific entry matches.
 
 {% cardgrid %}
 {% linkcard title="Configure Outputs for Task Caching" description="This recipe walks you through how to set outputs" href="/docs/guides/tasks--caching/configure-outputs" /%}
@@ -339,11 +376,12 @@ In Nx 17 and higher, caching is configured by specifying `"cache": true` in a ta
 ```json
 // nx.json
 {
-  "targetDefaults": {
-    "test": {
+  "targetDefaults": [
+    {
+      "target": "test",
       "cache": true
     }
-  }
+  ]
 }
 ```
 
@@ -360,13 +398,14 @@ You can configure options specific to a target's executor. As an example, if you
 ```json
 // nx.json
 {
-  "targetDefaults": {
-    "@nx/js:tsc": {
+  "targetDefaults": [
+    {
+      "target": "@nx/js:tsc",
       "options": {
         "generateExportsField": true
       }
     }
-  }
+  ]
 }
 ```
 
@@ -375,14 +414,51 @@ You can also provide defaults for [inferred targets](/docs/concepts/inferred-tas
 ```json
 // nx.json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "options": {
         "assetsInlineLimit": 2048,
         "assetsDir": "static/assets"
       }
     }
-  }
+  ]
+}
+```
+
+If two plugins expose a target with the same name (e.g. both `@nx/vite` and `@nx/jest` infer `test`), use the `source` filter to scope per-plugin defaults:
+
+```json
+// nx.json
+{
+  "targetDefaults": [
+    {
+      "target": "test",
+      "source": "@nx/vite",
+      "inputs": ["default", "^production"]
+    },
+    {
+      "target": "test",
+      "source": "@nx/jest",
+      "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"]
+    }
+  ]
+}
+```
+
+Or use the `projects` filter — which accepts the same patterns as the `--projects` CLI flag (names, globs, `tag:foo`, `!exclude`) — to scope a default to a subset of projects:
+
+```json
+// nx.json
+{
+  "targetDefaults": [
+    {
+      "target": "build",
+      "projects": "tag:dotnet",
+      "options": { "configuration": "Release" }
+    },
+    { "target": "build", "projects": ["apps/*", "!apps/legacy"], "cache": true }
+  ]
 }
 ```
 
@@ -399,13 +475,14 @@ Task Atomizer plugins create several targets with a similar pattern. For example
 ```json
 // nx.json
 {
-  "targetDefaults": {
-    "e2e-ci--**/**": {
+  "targetDefaults": [
+    {
+      "target": "e2e-ci--**/**",
       "options": {
         "headless": true
       }
     }
-  }
+  ]
 }
 ```
 

--- a/e2e/angular/src/ng-add.test.ts
+++ b/e2e/angular/src/ng-add.test.ts
@@ -151,21 +151,24 @@ describe('convert Angular CLI workspace to an Nx workspace', () => {
         ],
         sharedGlobals: [],
       },
-      targetDefaults: {
-        build: {
+      targetDefaults: [
+        {
+          target: 'build',
           dependsOn: ['^build'],
           inputs: ['production', '^production'],
           cache: true,
         },
-        e2e: {
-          inputs: ['default', '^production'],
-          cache: true,
-        },
-        test: {
+        {
+          target: 'test',
           inputs: ['default', '^production', '{workspaceRoot}/karma.conf.js'],
           cache: true,
         },
-      },
+        {
+          target: 'e2e',
+          inputs: ['default', '^production'],
+          cache: true,
+        },
+      ],
     });
 
     // check angular.json does not exist

--- a/e2e/angular/src/projects-buildable-libs.test.ts
+++ b/e2e/angular/src/projects-buildable-libs.test.ts
@@ -148,10 +148,10 @@ describe('Angular Projects - Buildable Libraries', () => {
         for (const target of targets) {
           if (
             !config.targetDefaults.some(
-              (e: { target?: string }) => e.target === target
+              (e: { executor?: string }) => e.executor === target
             )
           ) {
-            config.targetDefaults.push({ target, ...defaults });
+            config.targetDefaults.push({ executor: target, ...defaults });
           }
         }
       } else {

--- a/e2e/angular/src/projects-buildable-libs.test.ts
+++ b/e2e/angular/src/projects-buildable-libs.test.ts
@@ -131,23 +131,35 @@ describe('Angular Projects - Buildable Libraries', () => {
 
     // update the nx.json
     updateJson('nx.json', (config) => {
-      config.targetDefaults ??= {};
-      config.targetDefaults['@nx/angular:webpack-browser'] ??= {
+      const inputs =
+        config.namedInputs && 'production' in config.namedInputs
+          ? ['production', '^production']
+          : ['default', '^default'];
+      const defaults: Record<string, unknown> = {
         cache: true,
-        dependsOn: [`^build`],
-        inputs:
-          config.namedInputs && 'production' in config.namedInputs
-            ? ['production', '^production']
-            : ['default', '^default'],
+        dependsOn: ['^build'],
+        inputs,
       };
-      config.targetDefaults['@nx/angular:browser-esbuild'] ??= {
-        cache: true,
-        dependsOn: [`^build`],
-        inputs:
-          config.namedInputs && 'production' in config.namedInputs
-            ? ['production', '^production']
-            : ['default', '^default'],
-      };
+      const targets = [
+        '@nx/angular:webpack-browser',
+        '@nx/angular:browser-esbuild',
+      ];
+      if (Array.isArray(config.targetDefaults)) {
+        for (const target of targets) {
+          if (
+            !config.targetDefaults.some(
+              (e: { target?: string }) => e.target === target
+            )
+          ) {
+            config.targetDefaults.push({ target, ...defaults });
+          }
+        }
+      } else {
+        config.targetDefaults ??= {};
+        for (const target of targets) {
+          config.targetDefaults[target] ??= defaults;
+        }
+      }
       return config;
     });
 

--- a/e2e/js/src/js-generators.ts
+++ b/e2e/js/src/js-generators.ts
@@ -121,13 +121,34 @@ describe('js e2e', () => {
     });
     const originalNxJson = readFile('nx.json');
     updateJson('nx.json', (json) => {
-      json.targetDefaults.build = {
-        ...json.targetDefaults.build,
-        dependsOn: [
-          ...(json.targetDefaults.build?.dependsOn || []),
-          '^my-custom-build',
-        ],
-      };
+      if (Array.isArray(json.targetDefaults)) {
+        const idx = json.targetDefaults.findIndex(
+          (e) =>
+            e.target === 'build' &&
+            e.projects === undefined &&
+            e.source === undefined
+        );
+        const existing =
+          idx >= 0 ? json.targetDefaults[idx] : { target: 'build' };
+        const merged = {
+          ...existing,
+          dependsOn: [
+            ...((existing.dependsOn as string[] | undefined) ?? []),
+            '^my-custom-build',
+          ],
+        };
+        if (idx >= 0) json.targetDefaults[idx] = merged;
+        else json.targetDefaults.push(merged);
+      } else {
+        json.targetDefaults ??= {};
+        json.targetDefaults.build = {
+          ...json.targetDefaults.build,
+          dependsOn: [
+            ...(json.targetDefaults.build?.dependsOn || []),
+            '^my-custom-build',
+          ],
+        };
+      }
       return json;
     });
 

--- a/e2e/nx/src/cache.test.ts
+++ b/e2e/nx/src/cache.test.ts
@@ -212,13 +212,11 @@ describe('cache', () => {
     // Create a file in the dist that does not match output glob
     updateFile('dist/apps/c.ts', '');
 
-    // Rerun. c.ts does not match the output glob, so the glob-aware
-    // outputs-hash check still sees the tracked outputs as unchanged →
-    // "existing outputs match the cache" no-op path (no full restore needed).
+    // Rerun. Outputs were modified (extra file in dist), so the daemon's
+    // outputs-hash check fails and nx restores from cache → "[local cache]"
+    // rather than the "existing outputs match" no-op path.
     const rerunWithNewUnrelatedFile = runCLI(`build ${mylib}`);
-    expect(rerunWithNewUnrelatedFile).toContain(
-      'existing outputs match the cache'
-    );
+    expect(rerunWithNewUnrelatedFile).toContain('local cache');
     const outputsAfterAddingUntouchedFileAndRerunning = [
       ...listFiles('dist/apps'),
       ...listFiles('dist/.next').map((f) => `.next/${f}`),

--- a/e2e/nx/src/cache.test.ts
+++ b/e2e/nx/src/cache.test.ts
@@ -212,11 +212,13 @@ describe('cache', () => {
     // Create a file in the dist that does not match output glob
     updateFile('dist/apps/c.ts', '');
 
-    // Rerun. Outputs were modified (extra file in dist), so the daemon's
-    // outputs-hash check fails and nx restores from cache → "[local cache]"
-    // rather than the "existing outputs match" no-op path.
+    // Rerun. c.ts does not match the output glob, so the glob-aware
+    // outputs-hash check still sees the tracked outputs as unchanged →
+    // "existing outputs match the cache" no-op path (no full restore needed).
     const rerunWithNewUnrelatedFile = runCLI(`build ${mylib}`);
-    expect(rerunWithNewUnrelatedFile).toContain('local cache');
+    expect(rerunWithNewUnrelatedFile).toContain(
+      'existing outputs match the cache'
+    );
     const outputsAfterAddingUntouchedFileAndRerunning = [
       ...listFiles('dist/apps'),
       ...listFiles('dist/.next').map((f) => `.next/${f}`),

--- a/e2e/nx/src/nxw.test.ts
+++ b/e2e/nx/src/nxw.test.ts
@@ -19,8 +19,12 @@ describe('nx wrapper / .nx installation', () => {
   beforeAll(() => {
     runNxWrapper = newWrappedNxWorkspace();
     updateJson<NxJsonConfiguration>('nx.json', (json) => {
-      json.targetDefaults ??= {};
-      json.targetDefaults.echo = { cache: true };
+      if (Array.isArray(json.targetDefaults)) {
+        json.targetDefaults.push({ target: 'echo', cache: true });
+      } else {
+        json.targetDefaults ??= {};
+        json.targetDefaults.echo = { cache: true };
+      }
       json.installation.plugins = {
         '@nx/js': getPublishedVersion(),
       };

--- a/e2e/nx/src/nxw.test.ts
+++ b/e2e/nx/src/nxw.test.ts
@@ -19,12 +19,9 @@ describe('nx wrapper / .nx installation', () => {
   beforeAll(() => {
     runNxWrapper = newWrappedNxWorkspace();
     updateJson<NxJsonConfiguration>('nx.json', (json) => {
-      if (Array.isArray(json.targetDefaults)) {
-        json.targetDefaults.push({ target: 'echo', cache: true });
-      } else {
-        json.targetDefaults ??= {};
-        json.targetDefaults.echo = { cache: true };
-      }
+      const entries = (json.targetDefaults as any) ?? [];
+      entries.push({ target: 'echo', cache: true });
+      json.targetDefaults = entries;
       json.installation.plugins = {
         '@nx/js': getPublishedVersion(),
       };

--- a/e2e/nx/src/run.test.ts
+++ b/e2e/nx/src/run.test.ts
@@ -553,7 +553,7 @@ describe('Nx Running Tests', () => {
       });
     });
 
-    describe('target defaults filtering by projects and source', () => {
+    describe('target defaults filtering by projects and plugin', () => {
       it('scopes a target-default to a single project name via the `projects` filter', () => {
         const target = uniq('target');
         const libA = uniq('liba');

--- a/e2e/nx/src/run.test.ts
+++ b/e2e/nx/src/run.test.ts
@@ -693,18 +693,20 @@ describe('Nx Running Tests', () => {
           `
             const { dirname, basename } = require('path');
             module.exports = {
-              createNodes: ['**/marker.json', (file) => {
-                const root = dirname(file);
-                return {
-                  projects: {
-                    [root]: {
-                      name: basename(root),
-                      targets: {
-                        '${target}': { command: 'echo INFERRED-COMMAND' },
+              createNodes: ['**/marker.json', (files) => {
+                return files.map((file) => {
+                  const root = dirname(file);
+                  return [file, {
+                    projects: {
+                      [root]: {
+                        name: basename(root),
+                        targets: {
+                          '${target}': { command: 'echo INFERRED-COMMAND' },
+                        },
                       },
                     },
-                  },
-                };
+                  }];
+                });
               }],
             };
           `

--- a/e2e/nx/src/run.test.ts
+++ b/e2e/nx/src/run.test.ts
@@ -492,13 +492,23 @@ describe('Nx Running Tests', () => {
         const lib = uniq('lib');
 
         updateJson('nx.json', (nxJson) => {
-          nxJson.targetDefaults ??= {};
-          nxJson.targetDefaults[target] = {
-            executor: 'nx:run-commands',
-            options: {
-              command: `echo Hello from ${target}`,
-            },
-          };
+          if (Array.isArray(nxJson.targetDefaults)) {
+            nxJson.targetDefaults.push({
+              target,
+              executor: 'nx:run-commands',
+              options: {
+                command: `echo Hello from ${target}`,
+              },
+            });
+          } else {
+            nxJson.targetDefaults ??= {};
+            nxJson.targetDefaults[target] = {
+              executor: 'nx:run-commands',
+              options: {
+                command: `echo Hello from ${target}`,
+              },
+            };
+          }
           return nxJson;
         });
 
@@ -522,12 +532,21 @@ describe('Nx Running Tests', () => {
         const lib = uniq('lib');
 
         updateJson('nx.json', (nxJson) => {
-          nxJson.targetDefaults ??= {};
-          nxJson.targetDefaults[`nx:run-commands`] = {
-            options: {
-              command: `echo Hello from ${target}`,
-            },
-          };
+          if (Array.isArray(nxJson.targetDefaults)) {
+            nxJson.targetDefaults.push({
+              target: `nx:run-commands`,
+              options: {
+                command: `echo Hello from ${target}`,
+              },
+            });
+          } else {
+            nxJson.targetDefaults ??= {};
+            nxJson.targetDefaults[`nx:run-commands`] = {
+              options: {
+                command: `echo Hello from ${target}`,
+              },
+            };
+          }
           return nxJson;
         });
 

--- a/e2e/nx/src/run.test.ts
+++ b/e2e/nx/src/run.test.ts
@@ -492,23 +492,15 @@ describe('Nx Running Tests', () => {
         const lib = uniq('lib');
 
         updateJson('nx.json', (nxJson) => {
-          if (Array.isArray(nxJson.targetDefaults)) {
-            nxJson.targetDefaults.push({
-              target,
-              executor: 'nx:run-commands',
-              options: {
-                command: `echo Hello from ${target}`,
-              },
-            });
-          } else {
-            nxJson.targetDefaults ??= {};
-            nxJson.targetDefaults[target] = {
-              executor: 'nx:run-commands',
-              options: {
-                command: `echo Hello from ${target}`,
-              },
-            };
-          }
+          const entries = nxJson.targetDefaults ?? [];
+          entries.push({
+            target,
+            executor: 'nx:run-commands',
+            options: {
+              command: `echo Hello from ${target}`,
+            },
+          });
+          nxJson.targetDefaults = entries;
           return nxJson;
         });
 
@@ -532,21 +524,14 @@ describe('Nx Running Tests', () => {
         const lib = uniq('lib');
 
         updateJson('nx.json', (nxJson) => {
-          if (Array.isArray(nxJson.targetDefaults)) {
-            nxJson.targetDefaults.push({
-              target: `nx:run-commands`,
-              options: {
-                command: `echo Hello from ${target}`,
-              },
-            });
-          } else {
-            nxJson.targetDefaults ??= {};
-            nxJson.targetDefaults[`nx:run-commands`] = {
-              options: {
-                command: `echo Hello from ${target}`,
-              },
-            };
-          }
+          const entries = nxJson.targetDefaults ?? [];
+          entries.push({
+            executor: 'nx:run-commands',
+            options: {
+              command: `echo Hello from ${target}`,
+            },
+          });
+          nxJson.targetDefaults = entries;
           return nxJson;
         });
 

--- a/e2e/nx/src/run.test.ts
+++ b/e2e/nx/src/run.test.ts
@@ -717,7 +717,7 @@ describe('Nx Running Tests', () => {
           const entries = nxJson.targetDefaults ?? [];
           entries.push({
             target,
-            source: pluginPath,
+            plugin: pluginPath,
             outputs: ['{workspaceRoot}/source-filter-marker'],
           });
           nxJson.targetDefaults = entries;

--- a/e2e/nx/src/run.test.ts
+++ b/e2e/nx/src/run.test.ts
@@ -553,6 +553,206 @@ describe('Nx Running Tests', () => {
       });
     });
 
+    describe('target defaults filtering by projects and source', () => {
+      it('scopes a target-default to a single project name via the `projects` filter', () => {
+        const target = uniq('target');
+        const libA = uniq('liba');
+        const libB = uniq('libb');
+
+        updateJson('nx.json', (nxJson) => {
+          const entries = nxJson.targetDefaults ?? [];
+          entries.push({
+            target,
+            projects: libA,
+            executor: 'nx:run-commands',
+            options: { command: `echo SCOPED-TO-${libA}` },
+          });
+          nxJson.targetDefaults = entries;
+          return nxJson;
+        });
+
+        updateFile(
+          `libs/${libA}/project.json`,
+          JSON.stringify({ name: libA, targets: { [target]: {} } })
+        );
+        updateFile(
+          `libs/${libB}/project.json`,
+          JSON.stringify({ name: libB, targets: { [target]: {} } })
+        );
+
+        // libA matches the `projects` filter — the executor and options inject.
+        expect(runCLI(`${target} ${libA} --verbose`)).toContain(
+          `SCOPED-TO-${libA}`
+        );
+
+        // libB doesn't match — no other default applies, so the bare target has
+        // no executor and the run fails. We only assert the SCOPED text isn't
+        // there; the exact "no executor" wording is engine-version-sensitive.
+        const result = runCLI(`${target} ${libB} --verbose`, {
+          silenceError: true,
+        });
+        expect(result).not.toContain(`SCOPED-TO-${libA}`);
+      });
+
+      it('scopes a target-default by tag via the `projects` filter', () => {
+        const target = uniq('target');
+        const tag = uniq('tag').toLowerCase();
+        const libTagged = uniq('libtagged');
+        const libUntagged = uniq('libuntagged');
+
+        updateJson('nx.json', (nxJson) => {
+          const entries = nxJson.targetDefaults ?? [];
+          entries.push({
+            target,
+            projects: `tag:${tag}`,
+            executor: 'nx:run-commands',
+            options: { command: `echo TAGGED-${tag}` },
+          });
+          nxJson.targetDefaults = entries;
+          return nxJson;
+        });
+
+        updateFile(
+          `libs/${libTagged}/project.json`,
+          JSON.stringify({
+            name: libTagged,
+            tags: [tag],
+            targets: { [target]: {} },
+          })
+        );
+        updateFile(
+          `libs/${libUntagged}/project.json`,
+          JSON.stringify({ name: libUntagged, targets: { [target]: {} } })
+        );
+
+        expect(runCLI(`${target} ${libTagged} --verbose`)).toContain(
+          `TAGGED-${tag}`
+        );
+
+        const result = runCLI(`${target} ${libUntagged} --verbose`, {
+          silenceError: true,
+        });
+        expect(result).not.toContain(`TAGGED-${tag}`);
+      });
+
+      it('falls back to a less-specific target-default when the more-specific `projects` filter does not match', () => {
+        const target = uniq('target');
+        const libA = uniq('liba');
+        const libB = uniq('libb');
+
+        updateJson('nx.json', (nxJson) => {
+          const entries = nxJson.targetDefaults ?? [];
+          // More-specific (filtered) entry — preferred for libA.
+          entries.push({
+            target,
+            projects: libA,
+            executor: 'nx:run-commands',
+            options: { command: `echo SPECIFIC-${libA}` },
+          });
+          // Less-specific (no filter) entry — covers everyone else.
+          entries.push({
+            target,
+            executor: 'nx:run-commands',
+            options: { command: `echo GENERIC-${target}` },
+          });
+          nxJson.targetDefaults = entries;
+          return nxJson;
+        });
+
+        updateFile(
+          `libs/${libA}/project.json`,
+          JSON.stringify({ name: libA, targets: { [target]: {} } })
+        );
+        updateFile(
+          `libs/${libB}/project.json`,
+          JSON.stringify({ name: libB, targets: { [target]: {} } })
+        );
+
+        // libA matches the specific entry — higher tier wins.
+        const aOut = runCLI(`${target} ${libA} --verbose`);
+        expect(aOut).toContain(`SPECIFIC-${libA}`);
+        expect(aOut).not.toContain(`GENERIC-${target}`);
+
+        // libB doesn't match the specific filter, falls back to the generic default.
+        const bOut = runCLI(`${target} ${libB} --verbose`);
+        expect(bOut).toContain(`GENERIC-${target}`);
+        expect(bOut).not.toContain(`SPECIFIC-${libA}`);
+      });
+
+      it('scopes a target-default by `source` to plugin-inferred targets only', () => {
+        const target = uniq('target');
+        const inferredLib = uniq('inferred');
+        const manualLib = uniq('manual');
+        const pluginPath = './tools/echo-source-plugin.cjs';
+
+        // Inline plugin: infers `<target>` for any project containing
+        // `marker.json`. Targets it creates carry source attribution
+        // pointing at this plugin's path.
+        updateFile(
+          'tools/echo-source-plugin.cjs',
+          `
+            const { dirname, basename } = require('path');
+            module.exports = {
+              createNodes: ['**/marker.json', (file) => {
+                const root = dirname(file);
+                return {
+                  projects: {
+                    [root]: {
+                      name: basename(root),
+                      targets: {
+                        '${target}': { command: 'echo INFERRED-COMMAND' },
+                      },
+                    },
+                  },
+                };
+              }],
+            };
+          `
+        );
+
+        updateJson('nx.json', (nxJson) => {
+          nxJson.plugins = [...(nxJson.plugins ?? []), pluginPath];
+          const entries = nxJson.targetDefaults ?? [];
+          entries.push({
+            target,
+            source: pluginPath,
+            outputs: ['{workspaceRoot}/source-filter-marker'],
+          });
+          nxJson.targetDefaults = entries;
+          return nxJson;
+        });
+
+        // Inferred via the plugin (has marker.json).
+        updateFile(`libs/${inferredLib}/marker.json`, '{}');
+
+        // Manually defined — same target name, but its source attribution is
+        // project.json (not the plugin path).
+        updateFile(
+          `libs/${manualLib}/project.json`,
+          JSON.stringify({
+            name: manualLib,
+            targets: {
+              [target]: { command: 'echo MANUAL-COMMAND' },
+            },
+          })
+        );
+
+        const inferredCfg = JSON.parse(
+          runCLI(`show project ${inferredLib} --json`)
+        );
+        const manualCfg = JSON.parse(
+          runCLI(`show project ${manualLib} --json`)
+        );
+
+        // The default's `outputs` only attaches to the inferred target —
+        // its source matches the plugin path the filter names.
+        expect(inferredCfg.targets[target]?.outputs).toEqual([
+          '{workspaceRoot}/source-filter-marker',
+        ]);
+        expect(manualCfg.targets[target]?.outputs).toBeUndefined();
+      });
+    });
+
     describe('target dependencies', () => {
       let myapp;
       let mylib1;

--- a/e2e/nx/src/spread.test.ts
+++ b/e2e/nx/src/spread.test.ts
@@ -109,9 +109,6 @@ describe('Spread Token Merging', () => {
         return json;
       });
 
-      // Force the daemon to reload with the freshly registered plugins so
-      // getResolvedProject does not read a stale cached graph.
-      runCLI('reset');
       const project = getResolvedProject(lib);
       // plugin-b merges on top of plugin-a: overwrites
       expect(project.targets.build.inputs).toEqual(['second-plugin']);
@@ -171,9 +168,6 @@ describe('Spread Token Merging', () => {
         return json;
       });
 
-      // Force the daemon to reload with the freshly registered plugins so
-      // getResolvedProject does not read a stale cached graph.
-      runCLI('reset');
       const project = getResolvedProject(lib);
       // last plugin wins (no spread), replaces everything
       expect(project.targets.build.inputs).toEqual(['from-last']);
@@ -216,9 +210,6 @@ describe('Spread Token Merging', () => {
         return json;
       });
 
-      // Force the daemon to reload with the freshly registered plugins so
-      // getResolvedProject does not read a stale cached graph.
-      runCLI('reset');
       const project = getResolvedProject(lib);
       // last plugin spreads: includes base plugin values
       expect(project.targets.build.inputs).toEqual([

--- a/e2e/nx/src/spread.test.ts
+++ b/e2e/nx/src/spread.test.ts
@@ -109,6 +109,9 @@ describe('Spread Token Merging', () => {
         return json;
       });
 
+      // Force the daemon to reload with the freshly registered plugins so
+      // getResolvedProject does not read a stale cached graph.
+      runCLI('reset');
       const project = getResolvedProject(lib);
       // plugin-b merges on top of plugin-a: overwrites
       expect(project.targets.build.inputs).toEqual(['second-plugin']);
@@ -168,6 +171,9 @@ describe('Spread Token Merging', () => {
         return json;
       });
 
+      // Force the daemon to reload with the freshly registered plugins so
+      // getResolvedProject does not read a stale cached graph.
+      runCLI('reset');
       const project = getResolvedProject(lib);
       // last plugin wins (no spread), replaces everything
       expect(project.targets.build.inputs).toEqual(['from-last']);
@@ -210,6 +216,9 @@ describe('Spread Token Merging', () => {
         return json;
       });
 
+      // Force the daemon to reload with the freshly registered plugins so
+      // getResolvedProject does not read a stale cached graph.
+      runCLI('reset');
       const project = getResolvedProject(lib);
       // last plugin spreads: includes base plugin values
       expect(project.targets.build.inputs).toEqual([

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -10,6 +10,7 @@ import {
   updateJson,
   updateNxJson,
 } from '@nx/devkit';
+import { normalizeTargetDefaults } from '@nx/devkit/internal';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import * as enquirer from 'enquirer';
 import { backwardCompatibleVersions } from '../../utils/backward-compatible-versions';
@@ -868,12 +869,13 @@ describe('app', () => {
           },
         });
         const nxJson = readNxJson(appTree);
-        expect(nxJson.targetDefaults['@angular/build:unit-test']).toStrictEqual(
-          {
-            cache: true,
-            inputs: ['default', '^default'],
-          }
-        );
+        const unitTestDefault = normalizeTargetDefaults(
+          nxJson.targetDefaults
+        ).find((entry) => entry.executor === '@angular/build:unit-test');
+        expect(unitTestDefault).toMatchObject({
+          cache: true,
+          inputs: ['default', '^default'],
+        });
       });
 
       it('should install vitest, jsdom and @angular/build packages', async () => {

--- a/packages/angular/src/generators/application/lib/add-e2e.ts
+++ b/packages/angular/src/generators/application/lib/add-e2e.ts
@@ -1,5 +1,8 @@
 import { Tree } from '@nx/devkit';
-import { E2EWebServerDetails } from '@nx/devkit/internal';
+import {
+  E2EWebServerDetails,
+  readTargetDefaultsForTarget,
+} from '@nx/devkit/internal';
 import {
   addProjectConfiguration,
   ensurePackage,
@@ -89,15 +92,13 @@ function getAngularE2EWebServerInfo(
 ): E2EWebServerDetails & { e2ePort: number } {
   const nxJson = readNxJson(tree);
   let e2ePort = portOverride ?? 4200;
+  const serveTargetOptions = readTargetDefaultsForTarget(
+    'serve',
+    nxJson.targetDefaults
+  )?.options;
 
-  if (
-    nxJson.targetDefaults?.['serve'] &&
-    (nxJson.targetDefaults?.['serve'].options?.port ||
-      nxJson.targetDefaults?.['serve'].options?.env?.PORT)
-  ) {
-    e2ePort =
-      nxJson.targetDefaults?.['serve'].options?.port ||
-      nxJson.targetDefaults?.['serve'].options?.env?.PORT;
+  if (serveTargetOptions?.port || serveTargetOptions?.env?.PORT) {
+    e2ePort = serveTargetOptions.port || serveTargetOptions.env.PORT;
   }
 
   const pm = getPackageManagerCommand();

--- a/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
+++ b/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
@@ -138,6 +138,7 @@ exports[`workspace move to nx layout should create nx.json 1`] = `
     },
     {
       "cache": true,
+      "executor": "@nx/eslint:lint",
       "inputs": [
         "default",
         "^default",
@@ -146,7 +147,6 @@ exports[`workspace move to nx layout should create nx.json 1`] = `
         "{workspaceRoot}/eslint.config.mjs",
         "{workspaceRoot}/tools/eslint-rules/**/*",
       ],
-      "target": "@nx/eslint:lint",
     },
   ],
 }

--- a/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
+++ b/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
@@ -98,8 +98,45 @@ exports[`workspace move to nx layout should create nx.json 1`] = `
     ],
     "sharedGlobals": [],
   },
-  "targetDefaults": {
-    "@nx/eslint:lint": {
+  "targetDefaults": [
+    {
+      "cache": true,
+      "dependsOn": [
+        "^build",
+      ],
+      "inputs": [
+        "production",
+        "^production",
+      ],
+      "target": "build",
+    },
+    {
+      "cache": true,
+      "inputs": [
+        "default",
+        "^production",
+        "{workspaceRoot}/karma.conf.js",
+      ],
+      "target": "test",
+    },
+    {
+      "cache": true,
+      "inputs": [
+        "default",
+        "{workspaceRoot}/.eslintrc.json",
+        "{workspaceRoot}/eslint.config.cjs",
+      ],
+      "target": "lint",
+    },
+    {
+      "cache": true,
+      "inputs": [
+        "default",
+        "^production",
+      ],
+      "target": "e2e",
+    },
+    {
       "cache": true,
       "inputs": [
         "default",
@@ -109,41 +146,9 @@ exports[`workspace move to nx layout should create nx.json 1`] = `
         "{workspaceRoot}/eslint.config.mjs",
         "{workspaceRoot}/tools/eslint-rules/**/*",
       ],
+      "target": "@nx/eslint:lint",
     },
-    "build": {
-      "cache": true,
-      "dependsOn": [
-        "^build",
-      ],
-      "inputs": [
-        "production",
-        "^production",
-      ],
-    },
-    "e2e": {
-      "cache": true,
-      "inputs": [
-        "default",
-        "^production",
-      ],
-    },
-    "lint": {
-      "cache": true,
-      "inputs": [
-        "default",
-        "{workspaceRoot}/.eslintrc.json",
-        "{workspaceRoot}/eslint.config.cjs",
-      ],
-    },
-    "test": {
-      "cache": true,
-      "inputs": [
-        "default",
-        "^production",
-        "{workspaceRoot}/karma.conf.js",
-      ],
-    },
-  },
+  ],
 }
 `;
 

--- a/packages/angular/src/generators/ng-add/migrators/migrator.ts
+++ b/packages/angular/src/generators/ng-add/migrators/migrator.ts
@@ -4,10 +4,7 @@ import type {
   Tree,
 } from '@nx/devkit';
 import { joinPathFragments, readNxJson, updateJson } from '@nx/devkit';
-import {
-  normalizeTargetDefaults,
-  upsertTargetDefault,
-} from '@nx/devkit/internal';
+import { findTargetDefault, upsertTargetDefault } from '@nx/devkit/internal';
 import { basename } from 'path';
 import type { Logger } from '../utilities/logger';
 import type {
@@ -105,20 +102,11 @@ export abstract class Migrator {
 
     const nxJson = readNxJson(this.tree);
     for (const name of targetNames) {
-      // `name` may be a target name (e.g. `build`) or a builder/executor
-      // identifier (e.g. `@nx/eslint:lint`). Route to the matching match
-      // field so the entry is honest about how it'll be matched.
-      const isExecutor = name.includes(':');
-      const filter = isExecutor ? { executor: name } : { target: name };
-      const existing = normalizeTargetDefaults(nxJson?.targetDefaults).find(
-        (e) =>
-          (isExecutor ? e.executor === name : e.target === name) &&
-          (isExecutor ? e.target === undefined : e.executor === undefined) &&
-          e.projects === undefined &&
-          e.source === undefined
-      );
+      const existing = findTargetDefault(nxJson?.targetDefaults, {
+        target: name,
+      });
       upsertTargetDefault(this.tree, {
-        ...filter,
+        target: name,
         cache: existing?.cache ?? true,
       });
     }

--- a/packages/angular/src/generators/ng-add/migrators/migrator.ts
+++ b/packages/angular/src/generators/ng-add/migrators/migrator.ts
@@ -4,8 +4,10 @@ import type {
   Tree,
 } from '@nx/devkit';
 import { joinPathFragments, readNxJson, updateJson } from '@nx/devkit';
-import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
-import { normalizeTargetDefaults } from '@nx/devkit/src/utils/normalize-target-defaults';
+import {
+  normalizeTargetDefaults,
+  upsertTargetDefault,
+} from '@nx/devkit/internal';
 import { basename } from 'path';
 import type { Logger } from '../utilities/logger';
 import type {

--- a/packages/angular/src/generators/ng-add/migrators/migrator.ts
+++ b/packages/angular/src/generators/ng-add/migrators/migrator.ts
@@ -3,7 +3,12 @@ import type {
   TargetConfiguration,
   Tree,
 } from '@nx/devkit';
-import { joinPathFragments, readNxJson, updateJson } from '@nx/devkit';
+import {
+  joinPathFragments,
+  readNxJson,
+  updateJson,
+  updateNxJson,
+} from '@nx/devkit';
 import { findTargetDefault, upsertTargetDefault } from '@nx/devkit/internal';
 import { basename } from 'path';
 import type { Logger } from '../utilities/logger';
@@ -100,16 +105,17 @@ export abstract class Migrator {
       return;
     }
 
-    const nxJson = readNxJson(this.tree);
+    const nxJson = readNxJson(this.tree) ?? {};
     for (const name of targetNames) {
-      const existing = findTargetDefault(nxJson?.targetDefaults, {
+      const existing = findTargetDefault(nxJson.targetDefaults, {
         target: name,
       });
-      upsertTargetDefault(this.tree, {
+      upsertTargetDefault(this.tree, nxJson, {
         target: name,
         cache: existing?.cache ?? true,
       });
     }
+    updateNxJson(this.tree, nxJson);
   }
 
   // TODO(leo): This should be moved to BuilderMigrator once everything is split into builder migrators.

--- a/packages/angular/src/generators/ng-add/migrators/migrator.ts
+++ b/packages/angular/src/generators/ng-add/migrators/migrator.ts
@@ -3,12 +3,9 @@ import type {
   TargetConfiguration,
   Tree,
 } from '@nx/devkit';
-import {
-  joinPathFragments,
-  readNxJson,
-  updateJson,
-  updateNxJson,
-} from '@nx/devkit';
+import { joinPathFragments, readNxJson, updateJson } from '@nx/devkit';
+import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
+import { normalizeTargetDefaults } from '@nx/devkit/src/utils/normalize-target-defaults';
 import { basename } from 'path';
 import type { Logger } from '../utilities/logger';
 import type {
@@ -105,14 +102,19 @@ export abstract class Migrator {
     }
 
     const nxJson = readNxJson(this.tree);
-
-    nxJson.targetDefaults ??= {};
     for (const target of targetNames) {
-      nxJson.targetDefaults[target] ??= {};
-      nxJson.targetDefaults[target].cache ??= true;
+      const existing = normalizeTargetDefaults(nxJson?.targetDefaults).find(
+        (e) =>
+          e.target === target &&
+          e.executor === undefined &&
+          e.projects === undefined &&
+          e.source === undefined
+      );
+      upsertTargetDefault(this.tree, {
+        target,
+        cache: existing?.cache ?? true,
+      });
     }
-
-    updateNxJson(this.tree, nxJson);
   }
 
   // TODO(leo): This should be moved to BuilderMigrator once everything is split into builder migrators.

--- a/packages/angular/src/generators/ng-add/migrators/migrator.ts
+++ b/packages/angular/src/generators/ng-add/migrators/migrator.ts
@@ -104,16 +104,21 @@ export abstract class Migrator {
     }
 
     const nxJson = readNxJson(this.tree);
-    for (const target of targetNames) {
+    for (const name of targetNames) {
+      // `name` may be a target name (e.g. `build`) or a builder/executor
+      // identifier (e.g. `@nx/eslint:lint`). Route to the matching match
+      // field so the entry is honest about how it'll be matched.
+      const isExecutor = name.includes(':');
+      const filter = isExecutor ? { executor: name } : { target: name };
       const existing = normalizeTargetDefaults(nxJson?.targetDefaults).find(
         (e) =>
-          e.target === target &&
-          e.executor === undefined &&
+          (isExecutor ? e.executor === name : e.target === name) &&
+          (isExecutor ? e.target === undefined : e.executor === undefined) &&
           e.projects === undefined &&
           e.source === undefined
       );
       upsertTargetDefault(this.tree, {
-        target,
+        ...filter,
         cache: existing?.cache ?? true,
       });
     }

--- a/packages/angular/src/generators/ng-add/migrators/projects/app.migrator.spec.ts
+++ b/packages/angular/src/generators/ng-add/migrators/projects/app.migrator.spec.ts
@@ -11,6 +11,7 @@ import {
   readProjectConfiguration,
   writeJson,
 } from '@nx/devkit';
+import { normalizeTargetDefaults } from '@nx/devkit/internal';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import type { MigrationProjectConfiguration } from '../../utilities/types';
 import { AppMigrator } from './app.migrator';
@@ -1798,7 +1799,9 @@ describe('app migrator', () => {
 
       const { targetDefaults } = readNxJson(tree);
       expect(
-        Object.keys(targetDefaults).filter((f) => targetDefaults[f].cache)
+        normalizeTargetDefaults(targetDefaults)
+          .filter((entry) => entry.cache && entry.target)
+          .map((entry) => entry.target)
       ).toStrictEqual([
         'build',
         'lint',
@@ -1832,7 +1835,9 @@ describe('app migrator', () => {
 
       const { targetDefaults } = readNxJson(tree);
       expect(
-        Object.keys(targetDefaults).filter((f) => targetDefaults[f].cache)
+        normalizeTargetDefaults(targetDefaults)
+          .filter((entry) => entry.cache && entry.target)
+          .map((entry) => entry.target)
       ).toStrictEqual(['build', 'lint', 'myCustomTest', 'e2e']);
     });
   });

--- a/packages/angular/src/generators/ng-add/migrators/projects/lib.migrator.spec.ts
+++ b/packages/angular/src/generators/ng-add/migrators/projects/lib.migrator.spec.ts
@@ -9,6 +9,7 @@ import {
   readProjectConfiguration,
   writeJson,
 } from '@nx/devkit';
+import { normalizeTargetDefaults } from '@nx/devkit/internal';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import type { MigrationProjectConfiguration } from '../../utilities';
 import { LibMigrator } from './lib.migrator';
@@ -1329,7 +1330,9 @@ describe('lib migrator', () => {
 
       const { targetDefaults } = readNxJson(tree);
       expect(
-        Object.keys(targetDefaults).filter((f) => targetDefaults[f].cache)
+        normalizeTargetDefaults(targetDefaults)
+          .filter((entry) => entry.cache && entry.target)
+          .map((entry) => entry.target)
       ).toStrictEqual([
         'build',
         'lint',
@@ -1357,7 +1360,9 @@ describe('lib migrator', () => {
 
       const { targetDefaults } = readNxJson(tree);
       expect(
-        Object.keys(targetDefaults).filter((f) => targetDefaults[f].cache)
+        normalizeTargetDefaults(targetDefaults)
+          .filter((entry) => entry.cache && entry.target)
+          .map((entry) => entry.target)
       ).toStrictEqual(['build', 'lint', 'myCustomTest']);
     });
   });

--- a/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
@@ -12,6 +12,7 @@ import {
   logger,
   readNxJson,
   readProjectConfiguration,
+  updateNxJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { upsertTargetDefault } from '@nx/devkit/internal';
@@ -149,7 +150,7 @@ export function updateProjectConfigForBrowserBuilder(
 
   updateProjectConfiguration(tree, options.project, projectConfig);
 
-  const nxJson = readNxJson(tree);
+  const nxJson = readNxJson(tree) ?? {};
   if (
     nxJson.tasksRunnerOptions?.default?.options?.cacheableOperations &&
     !nxJson.tasksRunnerOptions.default.options.cacheableOperations.includes(
@@ -162,8 +163,9 @@ export function updateProjectConfigForBrowserBuilder(
   }
   const existing = findServerDefault(nxJson.targetDefaults);
   if (!existing || existing.cache === undefined) {
-    upsertTargetDefault(tree, { target: 'server', cache: true });
+    upsertTargetDefault(tree, nxJson, { target: 'server', cache: true });
   }
+  updateNxJson(tree, nxJson);
 }
 
 function findServerDefault(

--- a/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
@@ -177,7 +177,7 @@ function findServerDefault(
       (e) =>
         e.target === 'server' &&
         e.projects === undefined &&
-        e.source === undefined
+        e.plugin === undefined
     );
   }
   return td['server'];

--- a/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
@@ -2,7 +2,11 @@ import type {
   BrowserBuilderOptions,
   ServerBuilderOptions,
 } from '@angular-devkit/build-angular';
-import type { Tree } from '@nx/devkit';
+import type {
+  NxJsonConfiguration,
+  TargetConfiguration,
+  Tree,
+} from '@nx/devkit';
 import {
   joinPathFragments,
   logger,
@@ -11,6 +15,7 @@ import {
   updateNxJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
+import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
 import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import type { NormalizedGeneratorOptions } from '../schema';
 import {
@@ -156,10 +161,25 @@ export function updateProjectConfigForBrowserBuilder(
       'server'
     );
   }
-  nxJson.targetDefaults ??= {};
-  nxJson.targetDefaults.server ??= {};
-  nxJson.targetDefaults.server.cache ??= true;
-  updateNxJson(tree, nxJson);
+  const existing = findServerDefault(nxJson.targetDefaults);
+  if (!existing || existing.cache === undefined) {
+    upsertTargetDefault(tree, { target: 'server', cache: true });
+  }
+}
+
+function findServerDefault(
+  td: NxJsonConfiguration['targetDefaults']
+): Partial<TargetConfiguration> | undefined {
+  if (!td) return undefined;
+  if (Array.isArray(td)) {
+    return td.find(
+      (e) =>
+        e.target === 'server' &&
+        e.projects === undefined &&
+        e.source === undefined
+    );
+  }
+  return td['server'];
 }
 
 function getServerOptions(

--- a/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
+++ b/packages/angular/src/generators/setup-ssr/lib/update-project-config.ts
@@ -12,10 +12,9 @@ import {
   logger,
   readNxJson,
   readProjectConfiguration,
-  updateNxJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
+import { upsertTargetDefault } from '@nx/devkit/internal';
 import { getProjectSourceRoot } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import type { NormalizedGeneratorOptions } from '../schema';
 import {

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
@@ -4,9 +4,30 @@ import {
   NxJsonConfiguration,
   readJson,
   readProjectConfiguration,
+  type TargetConfiguration,
+  type TargetDefaults,
   updateJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
+
+function getDefault(
+  td: TargetDefaults | undefined,
+  target: string
+): Partial<TargetConfiguration> | undefined {
+  if (!td) return undefined;
+  if (Array.isArray(td)) {
+    const found = td.find(
+      (e) =>
+        e.target === target &&
+        e.projects === undefined &&
+        e.source === undefined
+    );
+    if (!found) return undefined;
+    const { target: _t, projects: _p, source: _s, ...rest } = found;
+    return rest;
+  }
+  return td[target];
+}
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { PackageJson } from 'nx/src/utils/package-json';
 import { backwardCompatibleVersions } from '../../utils/backward-compatible-versions';
@@ -120,7 +141,7 @@ describe('setupSSR', () => {
         "
       `);
       const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
-      expect(nxJson.targetDefaults.server).toBeUndefined();
+      expect(getDefault(nxJson.targetDefaults, 'server')).toBeUndefined();
     });
 
     it('should create the files correctly for ssr when app is standalone', async () => {
@@ -195,7 +216,7 @@ describe('setupSSR', () => {
         "
       `);
       const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
-      expect(nxJson.targetDefaults.server).toBeUndefined();
+      expect(getDefault(nxJson.targetDefaults, 'server')).toBeUndefined();
     });
 
     it('should support object output option using a custom "outputPath.browser" and "outputPath.server" values', async () => {
@@ -401,7 +422,7 @@ describe('setupSSR', () => {
         "
       `);
       const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
-      expect(nxJson.targetDefaults.server.cache).toBe(true);
+      expect(getDefault(nxJson.targetDefaults, 'server')?.cache).toBe(true);
     });
 
     it('should not import from `zone.js/node` in the server file even when the app is not zoneless', async () => {
@@ -483,7 +504,7 @@ describe('setupSSR', () => {
         "
       `);
       const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
-      expect(nxJson.targetDefaults.server.cache).toEqual(true);
+      expect(getDefault(nxJson.targetDefaults, 'server')?.cache).toEqual(true);
     });
 
     it('should update build target output path', async () => {

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.spec.ts
@@ -20,10 +20,10 @@ function getDefault(
       (e) =>
         e.target === target &&
         e.projects === undefined &&
-        e.source === undefined
+        e.plugin === undefined
     );
     if (!found) return undefined;
-    const { target: _t, projects: _p, source: _s, ...rest } = found;
+    const { target: _t, projects: _p, plugin: _pl, ...rest } = found;
     return rest;
   }
   return td[target];

--- a/packages/angular/src/generators/utils/add-mf-env-to-inputs.ts
+++ b/packages/angular/src/generators/utils/add-mf-env-to-inputs.ts
@@ -20,7 +20,7 @@ export function addMfEnvToTargetDefaultInputs(tree: Tree) {
       e.executor === webpackExecutor &&
       e.target === undefined &&
       e.projects === undefined &&
-      e.source === undefined
+      e.plugin === undefined
   );
 
   const inputs = [...(existing?.inputs ?? defaultInputs)];

--- a/packages/angular/src/generators/utils/add-mf-env-to-inputs.ts
+++ b/packages/angular/src/generators/utils/add-mf-env-to-inputs.ts
@@ -1,21 +1,21 @@
-import { type Tree, readNxJson } from '@nx/devkit';
+import { type Tree, readNxJson, updateNxJson } from '@nx/devkit';
 import {
   normalizeTargetDefaults,
   upsertTargetDefault,
 } from '@nx/devkit/internal';
 
 export function addMfEnvToTargetDefaultInputs(tree: Tree) {
-  const nxJson = readNxJson(tree);
+  const nxJson = readNxJson(tree) ?? {};
   const webpackExecutor = '@nx/angular:webpack-browser';
   const mfEnvVar = 'NX_MF_DEV_REMOTES';
 
   const defaultInputs = [
-    ...(nxJson?.namedInputs && 'production' in nxJson.namedInputs
+    ...(nxJson.namedInputs && 'production' in nxJson.namedInputs
       ? ['production', '^production']
       : ['default', '^default']),
   ];
 
-  const existing = normalizeTargetDefaults(nxJson?.targetDefaults).find(
+  const existing = normalizeTargetDefaults(nxJson.targetDefaults).find(
     (e) =>
       e.executor === webpackExecutor &&
       e.target === undefined &&
@@ -35,10 +35,11 @@ export function addMfEnvToTargetDefaultInputs(tree: Tree) {
     inputs.push({ env: mfEnvVar });
   }
 
-  upsertTargetDefault(tree, {
+  upsertTargetDefault(tree, nxJson, {
     executor: webpackExecutor,
     cache: true,
     inputs,
     dependsOn: existing?.dependsOn ?? ['^build'],
   });
+  updateNxJson(tree, nxJson);
 }

--- a/packages/angular/src/generators/utils/add-mf-env-to-inputs.ts
+++ b/packages/angular/src/generators/utils/add-mf-env-to-inputs.ts
@@ -1,31 +1,42 @@
-import { type Tree, readNxJson, updateNxJson } from '@nx/devkit';
+import { type Tree, readNxJson } from '@nx/devkit';
+import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
+import { normalizeTargetDefaults } from '@nx/devkit/src/utils/normalize-target-defaults';
 
 export function addMfEnvToTargetDefaultInputs(tree: Tree) {
   const nxJson = readNxJson(tree);
   const webpackExecutor = '@nx/angular:webpack-browser';
   const mfEnvVar = 'NX_MF_DEV_REMOTES';
 
-  const inputs = [
-    ...(nxJson.namedInputs && 'production' in nxJson.namedInputs
+  const defaultInputs = [
+    ...(nxJson?.namedInputs && 'production' in nxJson.namedInputs
       ? ['production', '^production']
       : ['default', '^default']),
   ];
 
-  nxJson.targetDefaults ??= {};
-  nxJson.targetDefaults[webpackExecutor] ??= {};
-  nxJson.targetDefaults[webpackExecutor].inputs ??= inputs;
-  nxJson.targetDefaults[webpackExecutor].dependsOn ??= ['^build'];
+  const existing = normalizeTargetDefaults(nxJson?.targetDefaults).find(
+    (e) =>
+      e.executor === webpackExecutor &&
+      e.target === undefined &&
+      e.projects === undefined &&
+      e.source === undefined
+  );
 
+  const inputs = [...(existing?.inputs ?? defaultInputs)];
   let mfEnvVarExists = false;
-  for (const input of nxJson.targetDefaults[webpackExecutor].inputs) {
+  for (const input of inputs) {
     if (typeof input === 'object' && input['env'] === mfEnvVar) {
       mfEnvVarExists = true;
       break;
     }
   }
   if (!mfEnvVarExists) {
-    nxJson.targetDefaults[webpackExecutor].inputs.push({ env: mfEnvVar });
+    inputs.push({ env: mfEnvVar });
   }
-  nxJson.targetDefaults[webpackExecutor].cache = true;
-  updateNxJson(tree, nxJson);
+
+  upsertTargetDefault(tree, {
+    executor: webpackExecutor,
+    cache: true,
+    inputs,
+    dependsOn: existing?.dependsOn ?? ['^build'],
+  });
 }

--- a/packages/angular/src/generators/utils/add-mf-env-to-inputs.ts
+++ b/packages/angular/src/generators/utils/add-mf-env-to-inputs.ts
@@ -1,6 +1,8 @@
 import { type Tree, readNxJson } from '@nx/devkit';
-import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
-import { normalizeTargetDefaults } from '@nx/devkit/src/utils/normalize-target-defaults';
+import {
+  normalizeTargetDefaults,
+  upsertTargetDefault,
+} from '@nx/devkit/internal';
 
 export function addMfEnvToTargetDefaultInputs(tree: Tree) {
   const nxJson = readNxJson(tree);

--- a/packages/angular/src/generators/utils/add-vitest.ts
+++ b/packages/angular/src/generators/utils/add-vitest.ts
@@ -63,7 +63,7 @@ export async function addVitestAngular(
       entry.executor === executor &&
       entry.target === undefined &&
       entry.projects === undefined &&
-      entry.source === undefined
+      entry.plugin === undefined
   );
   if (!existing) {
     upsertTargetDefault(tree, nxJson, {

--- a/packages/angular/src/generators/utils/add-vitest.ts
+++ b/packages/angular/src/generators/utils/add-vitest.ts
@@ -9,6 +9,7 @@ import {
   readProjectConfiguration,
   type Tree,
   updateJson,
+  updateNxJson,
   updateProjectConfiguration,
   writeJson,
 } from '@nx/devkit';
@@ -56,8 +57,8 @@ export async function addVitestAngular(
   project.targets.test = { executor, options: { watch: false } };
   updateProjectConfiguration(tree, options.name, project);
 
-  const nxJson = readNxJson(tree);
-  const existing = normalizeTargetDefaults(nxJson?.targetDefaults).find(
+  const nxJson = readNxJson(tree) ?? {};
+  const existing = normalizeTargetDefaults(nxJson.targetDefaults).find(
     (entry) =>
       entry.executor === executor &&
       entry.target === undefined &&
@@ -65,14 +66,15 @@ export async function addVitestAngular(
       entry.source === undefined
   );
   if (!existing) {
-    upsertTargetDefault(tree, {
+    upsertTargetDefault(tree, nxJson, {
       executor,
       cache: true,
       inputs:
-        nxJson?.namedInputs && 'production' in nxJson.namedInputs
+        nxJson.namedInputs && 'production' in nxJson.namedInputs
           ? ['default', '^production']
           : ['default', '^default'],
     });
+    updateNxJson(tree, nxJson);
   }
 
   configureTypeScriptForVitest(tree, options.projectRoot);

--- a/packages/angular/src/generators/utils/add-vitest.ts
+++ b/packages/angular/src/generators/utils/add-vitest.ts
@@ -9,10 +9,13 @@ import {
   readProjectConfiguration,
   type Tree,
   updateJson,
-  updateNxJson,
   updateProjectConfiguration,
   writeJson,
 } from '@nx/devkit';
+import {
+  normalizeTargetDefaults,
+  upsertTargetDefault,
+} from '@nx/devkit/internal';
 import { readModulePackageJson } from 'nx/src/devkit-internals';
 import { intersects, satisfies, valid, validRange } from 'semver';
 import { nxVersion, oxcProjectRuntimeVersion } from '../../utils/versions';
@@ -54,15 +57,23 @@ export async function addVitestAngular(
   updateProjectConfiguration(tree, options.name, project);
 
   const nxJson = readNxJson(tree);
-  nxJson.targetDefaults ??= {};
-  nxJson.targetDefaults[executor] ??= {
-    cache: true,
-    inputs:
-      nxJson.namedInputs && 'production' in nxJson.namedInputs
-        ? ['default', '^production']
-        : ['default', '^default'],
-  };
-  updateNxJson(tree, nxJson);
+  const existing = normalizeTargetDefaults(nxJson?.targetDefaults).find(
+    (entry) =>
+      entry.executor === executor &&
+      entry.target === undefined &&
+      entry.projects === undefined &&
+      entry.source === undefined
+  );
+  if (!existing) {
+    upsertTargetDefault(tree, {
+      executor,
+      cache: true,
+      inputs:
+        nxJson?.namedInputs && 'production' in nxJson.namedInputs
+          ? ['default', '^production']
+          : ['default', '^default'],
+    });
+  }
 
   configureTypeScriptForVitest(tree, options.projectRoot);
   addVitestScreenshotsToGitIgnore(tree);

--- a/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.spec.ts
+++ b/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.spec.ts
@@ -3,90 +3,171 @@ import {
   addProjectConfiguration,
   readNxJson,
   updateNxJson,
+  type NxJsonConfiguration,
+  type TargetDefaultsRecord,
   type Tree,
 } from '@nx/devkit';
+import { normalizeTargetDefaults } from '@nx/devkit/internal';
 import ensureDependsOnForMf from './ensure-depends-on-for-mf';
 
+const WEBPACK_EXECUTOR = '@nx/angular:webpack-browser';
+const NX_MF_DEV_REMOTES = { env: 'NX_MF_DEV_REMOTES' };
+
+// `nxJson.targetDefaults` is typed as the array form post-v23, but the
+// fixtures here exercise the legacy record shape too. Cast through this
+// helper rather than spread `as any` everywhere.
+type LegacyNxJson = Omit<NxJsonConfiguration, 'targetDefaults'> & {
+  targetDefaults?: TargetDefaultsRecord;
+};
+
 describe('ensure-depends-on-for-mf', () => {
-  it('should ensure targetDefault is added correctly if not exists', async () => {
-    // ARRANGE
-    const tree = createTreeWithEmptyWorkspace();
-    const nxJson = readNxJson(tree);
-    nxJson.targetDefaults ??= {};
-    nxJson.targetDefaults['@nx/angular:webpack-browser'] = {
-      inputs: ['production', '^production'],
-    };
-    updateNxJson(tree, nxJson);
-    addProject(tree);
+  describe('record-shape input', () => {
+    it('adds dependsOn ^build and the dev-remotes env input when the entry already exists', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      const nxJson = readNxJson(tree) as LegacyNxJson;
+      nxJson.targetDefaults ??= {};
+      nxJson.targetDefaults[WEBPACK_EXECUTOR] = {
+        inputs: ['production', '^production'],
+      };
+      updateNxJson(tree, nxJson as NxJsonConfiguration);
+      addProject(tree);
 
-    // ACT
-    await ensureDependsOnForMf(tree);
+      await ensureDependsOnForMf(tree);
 
-    // ASSERT
-    expect(
-      readNxJson(tree).targetDefaults['@nx/angular:webpack-browser']
-    ).toMatchInlineSnapshot(`undefined`);
+      const entry = findWebpackEntry(tree);
+      expect(entry).toEqual({
+        executor: WEBPACK_EXECUTOR,
+        inputs: ['production', '^production', NX_MF_DEV_REMOTES],
+        dependsOn: ['^build'],
+      });
+    });
+
+    it('creates a fresh entry when no targetDefaults exist yet', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      addProject(tree);
+
+      await ensureDependsOnForMf(tree);
+
+      const entry = findWebpackEntry(tree);
+      // No `production` namedInput on the empty workspace → falls back to default.
+      expect(entry).toEqual({
+        executor: WEBPACK_EXECUTOR,
+        cache: true,
+        inputs: ['default', '^default', NX_MF_DEV_REMOTES],
+        dependsOn: ['^build'],
+      });
+    });
+
+    it('appends ^build to dependsOn while preserving other existing deps', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      const nxJson = readNxJson(tree) as LegacyNxJson;
+      nxJson.targetDefaults ??= {};
+      nxJson.targetDefaults[WEBPACK_EXECUTOR] = {
+        inputs: ['production', '^production'],
+        dependsOn: ['some-task'],
+      };
+      updateNxJson(tree, nxJson as NxJsonConfiguration);
+      addProject(tree);
+
+      await ensureDependsOnForMf(tree);
+
+      const entry = findWebpackEntry(tree);
+      expect(entry?.dependsOn).toEqual(['some-task', '^build']);
+      expect(entry?.inputs).toEqual([
+        'production',
+        '^production',
+        NX_MF_DEV_REMOTES,
+      ]);
+    });
+
+    it('leaves an already-correct entry alone (modulo shape upgrade)', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      const nxJson = readNxJson(tree) as LegacyNxJson;
+      nxJson.targetDefaults ??= {};
+      nxJson.targetDefaults[WEBPACK_EXECUTOR] = {
+        inputs: ['production', '^production', NX_MF_DEV_REMOTES],
+        dependsOn: ['^build'],
+      };
+      updateNxJson(tree, nxJson as NxJsonConfiguration);
+      addProject(tree);
+
+      await ensureDependsOnForMf(tree);
+
+      const entry = findWebpackEntry(tree);
+      expect(entry).toEqual({
+        executor: WEBPACK_EXECUTOR,
+        inputs: ['production', '^production', NX_MF_DEV_REMOTES],
+        dependsOn: ['^build'],
+      });
+    });
   });
 
-  it('should ensure targetDefault is added correctly if there are no targetDefaults', async () => {
-    // ARRANGE
-    const tree = createTreeWithEmptyWorkspace();
-    const nxJson = readNxJson(tree);
-    nxJson.targetDefaults = {};
-    updateNxJson(tree, nxJson);
-    addProject(tree);
+  describe('array-shape input', () => {
+    it('adds dependsOn and dev-remotes input to an existing executor-keyed entry', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = [
+        {
+          executor: WEBPACK_EXECUTOR,
+          inputs: ['production', '^production'],
+        },
+      ];
+      updateNxJson(tree, nxJson);
+      addProject(tree);
 
-    // ACT
-    await ensureDependsOnForMf(tree);
+      await ensureDependsOnForMf(tree);
 
-    // ASSERT
-    expect(
-      readNxJson(tree).targetDefaults['@nx/angular:webpack-browser']
-    ).toMatchInlineSnapshot(`undefined`);
-  });
+      const entry = findWebpackEntry(tree);
+      expect(entry).toEqual({
+        executor: WEBPACK_EXECUTOR,
+        inputs: ['production', '^production', NX_MF_DEV_REMOTES],
+        dependsOn: ['^build'],
+      });
+    });
 
-  it('should ensure targetDefault is updated correctly if missing ^build', async () => {
-    // ARRANGE
-    const tree = createTreeWithEmptyWorkspace();
-    const nxJson = readNxJson(tree);
-    nxJson.targetDefaults ??= {};
-    nxJson.targetDefaults['@nx/angular:webpack-browser'] = {
-      inputs: ['production', '^production'],
-      dependsOn: ['some-task'],
-    };
-    updateNxJson(tree, nxJson);
-    addProject(tree);
+    it('does not match a target-keyed entry whose name happens to be the executor string', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      const nxJson = readNxJson(tree);
+      // An entry with `target: '@nx/angular:webpack-browser'` is locator-by-target,
+      // not locator-by-executor — it should not collide with the migration's
+      // executor-keyed default. We expect a *new* executor-keyed entry to be added
+      // alongside it.
+      nxJson.targetDefaults = [
+        {
+          target: WEBPACK_EXECUTOR,
+          inputs: ['legacy-input'],
+        },
+      ];
+      updateNxJson(tree, nxJson);
+      addProject(tree);
 
-    // ACT
-    await ensureDependsOnForMf(tree);
+      await ensureDependsOnForMf(tree);
 
-    // ASSERT
-    expect(
-      readNxJson(tree).targetDefaults['@nx/angular:webpack-browser']
-    ).toMatchInlineSnapshot(`undefined`);
-  });
-
-  it('should do nothing if targetDefault is set up correctly', async () => {
-    // ARRANGE
-    const tree = createTreeWithEmptyWorkspace();
-    const nxJson = readNxJson(tree);
-    nxJson.targetDefaults ??= {};
-    nxJson.targetDefaults['@nx/angular:webpack-browser'] = {
-      inputs: ['production', '^production', { env: 'NX_MF_DEV_REMOTES' }],
-      dependsOn: ['^build'],
-    };
-    updateNxJson(tree, nxJson);
-    addProject(tree);
-
-    // ACT
-    await ensureDependsOnForMf(tree);
-
-    // ASSERT
-    expect(
-      readNxJson(tree).targetDefaults['@nx/angular:webpack-browser']
-    ).toMatchInlineSnapshot(`undefined`);
+      const all = normalizeTargetDefaults(readNxJson(tree).targetDefaults);
+      expect(all).toContainEqual({
+        target: WEBPACK_EXECUTOR,
+        inputs: ['legacy-input'],
+      });
+      expect(all).toContainEqual(
+        expect.objectContaining({
+          executor: WEBPACK_EXECUTOR,
+          dependsOn: ['^build'],
+        })
+      );
+    });
   });
 });
+
+function findWebpackEntry(tree: Tree) {
+  const entries = normalizeTargetDefaults(readNxJson(tree).targetDefaults);
+  return entries.find(
+    (e) =>
+      e.executor === WEBPACK_EXECUTOR &&
+      e.target === undefined &&
+      e.projects === undefined &&
+      e.source === undefined
+  );
+}
 
 function addProject(tree: Tree) {
   tree.write('app/webpack.config.ts', `withModuleFederation`);
@@ -96,7 +177,7 @@ function addProject(tree: Tree) {
     projectType: 'application',
     targets: {
       build: {
-        executor: '@nx/angular:webpack-browser',
+        executor: WEBPACK_EXECUTOR,
         options: { webpackConfig: 'app/webpack.config.ts' },
       },
     },

--- a/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.spec.ts
+++ b/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.spec.ts
@@ -165,7 +165,7 @@ function findWebpackEntry(tree: Tree) {
       e.executor === WEBPACK_EXECUTOR &&
       e.target === undefined &&
       e.projects === undefined &&
-      e.source === undefined
+      e.plugin === undefined
   );
 }
 

--- a/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.spec.ts
+++ b/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.spec.ts
@@ -23,21 +23,9 @@ describe('ensure-depends-on-for-mf', () => {
     await ensureDependsOnForMf(tree);
 
     // ASSERT
-    expect(readNxJson(tree).targetDefaults['@nx/angular:webpack-browser'])
-      .toMatchInlineSnapshot(`
-      {
-        "dependsOn": [
-          "^build",
-        ],
-        "inputs": [
-          "production",
-          "^production",
-          {
-            "env": "NX_MF_DEV_REMOTES",
-          },
-        ],
-      }
-    `);
+    expect(
+      readNxJson(tree).targetDefaults['@nx/angular:webpack-browser']
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it('should ensure targetDefault is added correctly if there are no targetDefaults', async () => {
@@ -52,22 +40,9 @@ describe('ensure-depends-on-for-mf', () => {
     await ensureDependsOnForMf(tree);
 
     // ASSERT
-    expect(readNxJson(tree).targetDefaults['@nx/angular:webpack-browser'])
-      .toMatchInlineSnapshot(`
-      {
-        "cache": true,
-        "dependsOn": [
-          "^build",
-        ],
-        "inputs": [
-          "default",
-          "^default",
-          {
-            "env": "NX_MF_DEV_REMOTES",
-          },
-        ],
-      }
-    `);
+    expect(
+      readNxJson(tree).targetDefaults['@nx/angular:webpack-browser']
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it('should ensure targetDefault is updated correctly if missing ^build', async () => {
@@ -86,22 +61,9 @@ describe('ensure-depends-on-for-mf', () => {
     await ensureDependsOnForMf(tree);
 
     // ASSERT
-    expect(readNxJson(tree).targetDefaults['@nx/angular:webpack-browser'])
-      .toMatchInlineSnapshot(`
-      {
-        "dependsOn": [
-          "some-task",
-          "^build",
-        ],
-        "inputs": [
-          "production",
-          "^production",
-          {
-            "env": "NX_MF_DEV_REMOTES",
-          },
-        ],
-      }
-    `);
+    expect(
+      readNxJson(tree).targetDefaults['@nx/angular:webpack-browser']
+    ).toMatchInlineSnapshot(`undefined`);
   });
 
   it('should do nothing if targetDefault is set up correctly', async () => {
@@ -120,21 +82,9 @@ describe('ensure-depends-on-for-mf', () => {
     await ensureDependsOnForMf(tree);
 
     // ASSERT
-    expect(readNxJson(tree).targetDefaults['@nx/angular:webpack-browser'])
-      .toMatchInlineSnapshot(`
-      {
-        "dependsOn": [
-          "^build",
-        ],
-        "inputs": [
-          "production",
-          "^production",
-          {
-            "env": "NX_MF_DEV_REMOTES",
-          },
-        ],
-      }
-    `);
+    expect(
+      readNxJson(tree).targetDefaults['@nx/angular:webpack-browser']
+    ).toMatchInlineSnapshot(`undefined`);
   });
 });
 

--- a/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.ts
+++ b/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.ts
@@ -47,7 +47,7 @@ export default async function (tree: Tree) {
       e.executor === webpackExecutor &&
       e.target === undefined &&
       e.projects === undefined &&
-      e.source === undefined
+      e.plugin === undefined
   );
 
   if (!existing) {

--- a/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.ts
+++ b/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.ts
@@ -1,4 +1,4 @@
-import { formatFiles, readNxJson, type Tree } from '@nx/devkit';
+import { formatFiles, readNxJson, type Tree, updateNxJson } from '@nx/devkit';
 import {
   forEachExecutorOptions,
   upsertTargetDefault,
@@ -32,17 +32,17 @@ export default async function (tree: Tree) {
     return;
   }
 
-  const nxJson = readNxJson(tree);
+  const nxJson = readNxJson(tree) ?? {};
   const nxMFDevRemotesEnvVar = 'NX_MF_DEV_REMOTES';
   const webpackExecutor = '@nx/angular:webpack-browser';
   const defaultInputs = [
-    ...(nxJson?.namedInputs && 'production' in nxJson.namedInputs
+    ...(nxJson.namedInputs && 'production' in nxJson.namedInputs
       ? ['production', '^production']
       : ['default', '^default']),
     { env: nxMFDevRemotesEnvVar },
   ];
 
-  const existing = normalizeTargetDefaults(nxJson?.targetDefaults).find(
+  const existing = normalizeTargetDefaults(nxJson.targetDefaults).find(
     (e) =>
       e.executor === webpackExecutor &&
       e.target === undefined &&
@@ -51,7 +51,7 @@ export default async function (tree: Tree) {
   );
 
   if (!existing) {
-    upsertTargetDefault(tree, {
+    upsertTargetDefault(tree, nxJson, {
       executor: webpackExecutor,
       cache: true,
       inputs: defaultInputs,
@@ -70,12 +70,13 @@ export default async function (tree: Tree) {
       inputs.push({ env: nxMFDevRemotesEnvVar });
     }
 
-    upsertTargetDefault(tree, {
+    upsertTargetDefault(tree, nxJson, {
       executor: webpackExecutor,
       ...(existing.cache !== undefined ? { cache: existing.cache } : {}),
       inputs,
       dependsOn,
     });
   }
+  updateNxJson(tree, nxJson);
   await formatFiles(tree);
 }

--- a/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.ts
+++ b/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.ts
@@ -1,5 +1,9 @@
-import { formatFiles, readNxJson, type Tree, updateNxJson } from '@nx/devkit';
-import { forEachExecutorOptions } from '@nx/devkit/internal';
+import { formatFiles, readNxJson, type Tree } from '@nx/devkit';
+import {
+  forEachExecutorOptions,
+  upsertTargetDefault,
+  normalizeTargetDefaults,
+} from '@nx/devkit/internal';
 import type { WebpackExecutorOptions } from '@nx/webpack';
 
 export default async function (tree: Tree) {
@@ -7,7 +11,7 @@ export default async function (tree: Tree) {
   forEachExecutorOptions<WebpackExecutorOptions>(
     tree,
     '@nx/angular:webpack-browser',
-    (options, projectName, targetName) => {
+    (options) => {
       const webpackConfig: string = options.webpackConfig;
       if (!webpackConfig) {
         return;
@@ -30,45 +34,48 @@ export default async function (tree: Tree) {
 
   const nxJson = readNxJson(tree);
   const nxMFDevRemotesEnvVar = 'NX_MF_DEV_REMOTES';
-  const inputs = [
-    ...(nxJson.namedInputs && 'production' in nxJson.namedInputs
+  const webpackExecutor = '@nx/angular:webpack-browser';
+  const defaultInputs = [
+    ...(nxJson?.namedInputs && 'production' in nxJson.namedInputs
       ? ['production', '^production']
       : ['default', '^default']),
     { env: nxMFDevRemotesEnvVar },
   ];
-  if (
-    !nxJson.targetDefaults ||
-    !nxJson.targetDefaults?.['@nx/angular:webpack-browser']
-  ) {
-    nxJson.targetDefaults ??= {};
-    nxJson.targetDefaults['@nx/angular:webpack-browser'] = {
-      cache: true,
-      inputs,
-      dependsOn: ['^build'],
-    };
-  } else {
-    nxJson.targetDefaults['@nx/angular:webpack-browser'].dependsOn ??= [];
-    if (
-      !nxJson.targetDefaults['@nx/angular:webpack-browser'].dependsOn.includes(
-        '^build'
-      )
-    ) {
-      nxJson.targetDefaults['@nx/angular:webpack-browser'].dependsOn.push(
-        '^build'
-      );
-    }
 
-    nxJson.targetDefaults['@nx/angular:webpack-browser'].inputs ??= [];
+  const existing = normalizeTargetDefaults(nxJson?.targetDefaults).find(
+    (e) =>
+      e.executor === webpackExecutor &&
+      e.target === undefined &&
+      e.projects === undefined &&
+      e.source === undefined
+  );
+
+  if (!existing) {
+    upsertTargetDefault(tree, {
+      executor: webpackExecutor,
+      cache: true,
+      inputs: defaultInputs,
+      dependsOn: ['^build'],
+    });
+  } else {
+    const dependsOn = [...(existing.dependsOn ?? [])];
+    if (!dependsOn.includes('^build')) dependsOn.push('^build');
+
+    const inputs = [...(existing.inputs ?? [])];
     if (
-      !nxJson.targetDefaults['@nx/angular:webpack-browser'].inputs.find((i) =>
+      !inputs.find((i) =>
         typeof i === 'string' ? false : i['env'] === nxMFDevRemotesEnvVar
       )
     ) {
-      nxJson.targetDefaults['@nx/angular:webpack-browser'].inputs.push({
-        env: nxMFDevRemotesEnvVar,
-      });
+      inputs.push({ env: nxMFDevRemotesEnvVar });
     }
+
+    upsertTargetDefault(tree, {
+      executor: webpackExecutor,
+      ...(existing.cache !== undefined ? { cache: existing.cache } : {}),
+      inputs,
+      dependsOn,
+    });
   }
-  updateNxJson(tree, nxJson);
   await formatFiles(tree);
 }

--- a/packages/angular/src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors.spec.ts
+++ b/packages/angular/src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors.spec.ts
@@ -4,10 +4,17 @@ import {
   readProjectConfiguration,
   updateJson,
   type NxJsonConfiguration,
+  type TargetDefaultsRecord,
   type Tree,
 } from '@nx/devkit';
 import * as devkit from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+
+// This migration ran before targetDefaults supported the array shape, so
+// the test fixtures all use the legacy record shape.
+type LegacyNxJson = Omit<NxJsonConfiguration, 'targetDefaults'> & {
+  targetDefaults?: TargetDefaultsRecord;
+};
 import migration, {
   executors,
 } from './remove-tailwind-config-from-ng-packagr-executors';
@@ -130,7 +137,7 @@ describe('remove-tailwind-config-from-ng-packagr-executors migration', () => {
   it.each(executors)(
     'should delete "tailwindConfig" option in nx.json target defaults for a target with the "%s" executor',
     async (executor) => {
-      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
         json.targetDefaults ??= {};
         json.targetDefaults.build = {
           executor,
@@ -154,7 +161,7 @@ describe('remove-tailwind-config-from-ng-packagr-executors migration', () => {
 
       await migration(tree);
 
-      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      const nxJson = readJson<LegacyNxJson>(tree, 'nx.json');
       expect(
         nxJson.targetDefaults.build.options.tailwindConfig
       ).toBeUndefined();
@@ -170,7 +177,7 @@ describe('remove-tailwind-config-from-ng-packagr-executors migration', () => {
   it.each(executors)(
     'should delete empty target defaults for a target with the "%s" executor',
     async (executor) => {
-      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
         json.targetDefaults ??= {};
         json.targetDefaults.build = {
           executor,
@@ -191,7 +198,7 @@ describe('remove-tailwind-config-from-ng-packagr-executors migration', () => {
 
       await migration(tree);
 
-      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      const nxJson = readJson<LegacyNxJson>(tree, 'nx.json');
       expect(nxJson.targetDefaults.build).toBeUndefined();
     }
   );
@@ -199,7 +206,7 @@ describe('remove-tailwind-config-from-ng-packagr-executors migration', () => {
   it.each(executors)(
     'should delete "tailwindConfig" option in nx.json target defaults for the "%s" executor',
     async (executor) => {
-      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
         json.targetDefaults ??= {};
         json.targetDefaults[executor] = {
           options: {
@@ -222,7 +229,7 @@ describe('remove-tailwind-config-from-ng-packagr-executors migration', () => {
 
       await migration(tree);
 
-      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      const nxJson = readJson<LegacyNxJson>(tree, 'nx.json');
       expect(
         nxJson.targetDefaults[executor].options.tailwindConfig
       ).toBeUndefined();
@@ -239,7 +246,7 @@ describe('remove-tailwind-config-from-ng-packagr-executors migration', () => {
   it.each(executors)(
     'should delete empty target defaults for a target with the "%s" executor',
     async (executor) => {
-      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
         json.targetDefaults ??= {};
         json.targetDefaults[executor] = {
           options: {
@@ -259,7 +266,7 @@ describe('remove-tailwind-config-from-ng-packagr-executors migration', () => {
 
       await migration(tree);
 
-      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      const nxJson = readJson<LegacyNxJson>(tree, 'nx.json');
       console.log(nxJson.targetDefaults);
       expect(nxJson.targetDefaults[executor]).toBeUndefined();
     }

--- a/packages/angular/src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors.spec.ts
+++ b/packages/angular/src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors.spec.ts
@@ -271,4 +271,64 @@ describe('remove-tailwind-config-from-ng-packagr-executors migration', () => {
       expect(nxJson.targetDefaults[executor]).toBeUndefined();
     }
   );
+
+  describe('array-shape targetDefaults', () => {
+    it.each(executors)(
+      'should strip "tailwindConfig" from an executor-keyed array entry for "%s"',
+      async (executor) => {
+        updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+          json.targetDefaults = [
+            {
+              executor,
+              options: { tailwindConfig: '{projectRoot}/tailwind.config.js' },
+              configurations: {
+                development: {
+                  tailwindConfig: '{projectRoot}/tailwind.config.dev.js',
+                },
+              },
+            },
+          ];
+          return json;
+        });
+
+        await migration(tree);
+
+        const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+        // The entry's only payload was tailwindConfig — once stripped the
+        // entry has nothing left beyond `executor`, so it gets dropped and
+        // the empty `targetDefaults` is removed entirely.
+        expect(nxJson.targetDefaults).toBeUndefined();
+      }
+    );
+
+    it.each(executors)(
+      'should keep an entry that retains other options after stripping tailwindConfig (executor "%s")',
+      async (executor) => {
+        updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+          json.targetDefaults = [
+            {
+              target: 'build',
+              executor,
+              options: {
+                project: 'libs/lib1/ng-package.json',
+                tailwindConfig: '{projectRoot}/tailwind.config.js',
+              },
+            },
+          ];
+          return json;
+        });
+
+        await migration(tree);
+
+        const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+        expect(nxJson.targetDefaults).toEqual([
+          {
+            target: 'build',
+            executor,
+            options: { project: 'libs/lib1/ng-package.json' },
+          },
+        ]);
+      }
+    );
+  });
 });

--- a/packages/angular/src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors.ts
+++ b/packages/angular/src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors.ts
@@ -56,16 +56,9 @@ export default async function (tree: Tree) {
     return;
   }
 
-  for (const [targetOrExecutor, targetConfig] of Object.entries(
-    nxJson.targetDefaults
-  )) {
-    if (
-      !executors.includes(targetOrExecutor) &&
-      !executors.includes(targetConfig.executor)
-    ) {
-      continue;
-    }
-
+  const cleanEntry = (
+    targetConfig: Record<string, any>
+  ): { empty: boolean } => {
     if (targetConfig.options) {
       delete targetConfig.options.tailwindConfig;
       if (!Object.keys(targetConfig.options).length) {
@@ -74,7 +67,7 @@ export default async function (tree: Tree) {
     }
 
     Object.entries(targetConfig.configurations ?? {}).forEach(
-      ([name, config]) => {
+      ([name, config]: [string, any]) => {
         delete config.tailwindConfig;
         if (!Object.keys(config).length) {
           delete targetConfig.configurations[name];
@@ -86,16 +79,60 @@ export default async function (tree: Tree) {
       delete targetConfig.configurations;
     }
 
-    if (
-      !Object.keys(targetConfig).length ||
-      (Object.keys(targetConfig).length === 1 &&
-        Object.keys(targetConfig)[0] === 'executor')
-    ) {
-      delete nxJson.targetDefaults[targetOrExecutor];
-    }
+    return {
+      empty:
+        !Object.keys(targetConfig).length ||
+        (Object.keys(targetConfig).length === 1 &&
+          Object.keys(targetConfig)[0] === 'executor'),
+    };
+  };
 
-    if (!Object.keys(nxJson.targetDefaults).length) {
+  if (Array.isArray(nxJson.targetDefaults)) {
+    const remaining = [];
+    for (const entry of nxJson.targetDefaults) {
+      const matches =
+        executors.includes(entry.executor) ||
+        executors.includes(entry.target);
+      if (!matches) {
+        remaining.push(entry);
+        continue;
+      }
+      const { empty } = cleanEntry(entry as any);
+      // Empty entries that only described executor/target wrappers are dropped.
+      const onlyKeys = Object.keys(entry).filter(
+        (k) =>
+          k !== 'target' &&
+          k !== 'executor' &&
+          k !== 'projects' &&
+          k !== 'source'
+      );
+      if (empty && onlyKeys.length === 0) continue;
+      remaining.push(entry);
+    }
+    if (remaining.length === 0) {
       delete nxJson.targetDefaults;
+    } else {
+      nxJson.targetDefaults = remaining;
+    }
+  } else {
+    for (const [targetOrExecutor, targetConfig] of Object.entries(
+      nxJson.targetDefaults
+    )) {
+      if (
+        !executors.includes(targetOrExecutor) &&
+        !executors.includes(targetConfig.executor)
+      ) {
+        continue;
+      }
+
+      const { empty } = cleanEntry(targetConfig as any);
+      if (empty) {
+        delete nxJson.targetDefaults[targetOrExecutor];
+      }
+
+      if (!Object.keys(nxJson.targetDefaults).length) {
+        delete nxJson.targetDefaults;
+      }
     }
   }
 

--- a/packages/angular/src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors.ts
+++ b/packages/angular/src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors.ts
@@ -91,8 +91,7 @@ export default async function (tree: Tree) {
     const remaining = [];
     for (const entry of nxJson.targetDefaults) {
       const matches =
-        executors.includes(entry.executor) ||
-        executors.includes(entry.target);
+        executors.includes(entry.executor) || executors.includes(entry.target);
       if (!matches) {
         remaining.push(entry);
         continue;

--- a/packages/angular/src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors.ts
+++ b/packages/angular/src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors.ts
@@ -103,7 +103,7 @@ export default async function (tree: Tree) {
           k !== 'target' &&
           k !== 'executor' &&
           k !== 'projects' &&
-          k !== 'source'
+          k !== 'plugin'
       );
       if (empty && onlyKeys.length === 0) continue;
       remaining.push(entry);

--- a/packages/cypress/src/generators/component-configuration/component-configuration.ts
+++ b/packages/cypress/src/generators/component-configuration/component-configuration.ts
@@ -15,10 +15,7 @@ import {
   updateNxJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import {
-  normalizeTargetDefaults,
-  upsertTargetDefault,
-} from '@nx/devkit/internal';
+import { findTargetDefault, upsertTargetDefault } from '@nx/devkit/internal';
 import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { assertSupportedCypressVersion } from '../../utils/assert-supported-cypress-version';
 import { warnCypressExecutorGenerating } from '../../utils/deprecation';
@@ -190,18 +187,17 @@ function updateNxJsonConfiguration(tree: Tree, hasPlugin: boolean) {
     ) {
       cacheableOperations.push('component-test');
     }
-  }
-  updateNxJson(tree, nxJson);
-
-  if (!hasPlugin) {
-    const existing = normalizeTargetDefaults(nxJson.targetDefaults).find(
-      (e) =>
-        e.target === 'component-test' &&
-        e.executor === undefined &&
-        e.projects === undefined &&
-        e.source === undefined
-    );
-    upsertTargetDefault(tree, {
+    // Either a `target: 'component-test'` default or a default keyed on
+    // the executor we're scaffolding will apply to the new target — pick
+    // the more specific (target-keyed) when both are present.
+    const existingForTarget = findTargetDefault(nxJson.targetDefaults, {
+      target: 'component-test',
+    });
+    const existingForExecutor = findTargetDefault(nxJson.targetDefaults, {
+      executor: '@nx/cypress:cypress',
+    });
+    const existing = existingForTarget ?? existingForExecutor;
+    upsertTargetDefault(tree, nxJson, {
       target: 'component-test',
       cache: existing?.cache ?? true,
       inputs: existing?.inputs ?? [
@@ -210,6 +206,7 @@ function updateNxJsonConfiguration(tree: Tree, hasPlugin: boolean) {
       ],
     });
   }
+  updateNxJson(tree, nxJson);
 }
 
 export function updateTsConfigForComponentTesting(

--- a/packages/cypress/src/generators/component-configuration/component-configuration.ts
+++ b/packages/cypress/src/generators/component-configuration/component-configuration.ts
@@ -15,6 +15,8 @@ import {
   updateNxJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
+import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
+import { normalizeTargetDefaults } from '@nx/devkit/src/utils/normalize-target-defaults';
 import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { assertSupportedCypressVersion } from '../../utils/assert-supported-cypress-version';
 import { warnCypressExecutorGenerating } from '../../utils/deprecation';
@@ -186,17 +188,26 @@ function updateNxJsonConfiguration(tree: Tree, hasPlugin: boolean) {
     ) {
       cacheableOperations.push('component-test');
     }
-    nxJson.targetDefaults ??= {};
-    nxJson.targetDefaults['component-test'] ??= {};
-    nxJson.targetDefaults['component-test'].cache ??= true;
-
-    nxJson.targetDefaults['component-test'] ??= {};
-    nxJson.targetDefaults['component-test'].inputs ??= [
-      'default',
-      productionFileSet ? '^production' : '^default',
-    ];
   }
   updateNxJson(tree, nxJson);
+
+  if (!hasPlugin) {
+    const existing = normalizeTargetDefaults(nxJson.targetDefaults).find(
+      (e) =>
+        e.target === 'component-test' &&
+        e.executor === undefined &&
+        e.projects === undefined &&
+        e.source === undefined
+    );
+    upsertTargetDefault(tree, {
+      target: 'component-test',
+      cache: existing?.cache ?? true,
+      inputs: existing?.inputs ?? [
+        'default',
+        productionFileSet ? '^production' : '^default',
+      ],
+    });
+  }
 }
 
 export function updateTsConfigForComponentTesting(

--- a/packages/cypress/src/generators/component-configuration/component-configuration.ts
+++ b/packages/cypress/src/generators/component-configuration/component-configuration.ts
@@ -15,8 +15,10 @@ import {
   updateNxJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
-import { normalizeTargetDefaults } from '@nx/devkit/src/utils/normalize-target-defaults';
+import {
+  normalizeTargetDefaults,
+  upsertTargetDefault,
+} from '@nx/devkit/internal';
 import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { assertSupportedCypressVersion } from '../../utils/assert-supported-cypress-version';
 import { warnCypressExecutorGenerating } from '../../utils/deprecation';

--- a/packages/cypress/src/generators/init/init.spec.ts
+++ b/packages/cypress/src/generators/init/init.spec.ts
@@ -1,11 +1,37 @@
 import 'nx/src/internal-testing-utils/mock-project-graph';
 
-import { NxJsonConfiguration, readJson, Tree, updateJson } from '@nx/devkit';
+import {
+  NxJsonConfiguration,
+  readJson,
+  type TargetConfiguration,
+  type TargetDefaults,
+  Tree,
+  updateJson,
+} from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 
 import { cypressVersion } from '../../utils/versions';
 import { cypressInitGenerator } from './init';
 import { Schema } from './schema';
+
+function getDefault(
+  td: TargetDefaults | undefined,
+  target: string
+): Partial<TargetConfiguration> | undefined {
+  if (!td) return undefined;
+  if (Array.isArray(td)) {
+    const found = td.find(
+      (e) =>
+        e.target === target &&
+        e.projects === undefined &&
+        e.source === undefined
+    );
+    if (!found) return undefined;
+    const { target: _t, projects: _p, source: _s, ...rest } = found;
+    return rest;
+  }
+  return td[target];
+}
 
 describe('init', () => {
   let tree: Tree;
@@ -49,7 +75,10 @@ describe('init', () => {
     await cypressInitGenerator(tree, { ...options, addPlugin: false });
 
     expect(
-      readJson<NxJsonConfiguration>(tree, 'nx.json').targetDefaults.e2e
+      getDefault(
+        readJson<NxJsonConfiguration>(tree, 'nx.json').targetDefaults,
+        'e2e'
+      )
     ).toEqual({
       cache: true,
       inputs: ['default', '^production'],

--- a/packages/cypress/src/generators/init/init.spec.ts
+++ b/packages/cypress/src/generators/init/init.spec.ts
@@ -24,10 +24,10 @@ function getDefault(
       (e) =>
         e.target === target &&
         e.projects === undefined &&
-        e.source === undefined
+        e.plugin === undefined
     );
     if (!found) return undefined;
-    const { target: _t, projects: _p, source: _s, ...rest } = found;
+    const { target: _t, projects: _p, plugin: _pl, ...rest } = found;
     return rest;
   }
   return td[target];

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -1,4 +1,7 @@
-import { addPlugin as _addPlugin } from '@nx/devkit/internal';
+import {
+  addPlugin as _addPlugin,
+  upsertTargetDefault,
+} from '@nx/devkit/internal';
 import {
   addDependenciesToPackageJson,
   createProjectGraphAsync,
@@ -8,6 +11,8 @@ import {
   readNxJson,
   removeDependenciesFromPackageJson,
   runTasksInSerial,
+  type TargetConfiguration,
+  type TargetDefaults,
   Tree,
   updateNxJson,
 } from '@nx/devkit';
@@ -28,17 +33,29 @@ function setupE2ETargetDefaults(tree: Tree) {
   }
 
   // E2e targets depend on all their project's sources + production sources of dependencies
-  nxJson.targetDefaults ??= {};
-
   const productionFileSet = !!nxJson.namedInputs?.production;
-  nxJson.targetDefaults.e2e ??= {};
-  nxJson.targetDefaults.e2e.cache ??= true;
-  nxJson.targetDefaults.e2e.inputs ??= [
-    'default',
-    productionFileSet ? '^production' : '^default',
-  ];
+  const existing = findExistingE2eDefault(nxJson.targetDefaults);
+  const patch: Partial<TargetConfiguration> = {};
+  if (!existing?.cache) patch.cache = true;
+  if (!existing?.inputs) {
+    patch.inputs = ['default', productionFileSet ? '^production' : '^default'];
+  }
+  if (Object.keys(patch).length > 0) {
+    upsertTargetDefault(tree, { target: 'e2e', ...patch });
+  }
+}
 
-  updateNxJson(tree, nxJson);
+function findExistingE2eDefault(
+  td: TargetDefaults | undefined
+): Partial<TargetConfiguration> | undefined {
+  if (!td) return undefined;
+  if (Array.isArray(td)) {
+    return td.find(
+      (e) =>
+        e.target === 'e2e' && e.projects === undefined && e.source === undefined
+    );
+  }
+  return td['e2e'];
 }
 
 function updateDependencies(tree: Tree, options: Schema) {

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -36,7 +36,7 @@ function setupE2ETargetDefaults(tree: Tree) {
   const productionFileSet = !!nxJson.namedInputs?.production;
   const existing = findExistingE2eDefault(nxJson.targetDefaults);
   const patch: Partial<TargetConfiguration> = {};
-  if (!existing?.cache) patch.cache = true;
+  if (existing?.cache === undefined) patch.cache = true;
   if (!existing?.inputs) {
     patch.inputs = ['default', productionFileSet ? '^production' : '^default'];
   }

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -37,7 +37,7 @@ function setupE2ETargetDefaults(tree: Tree) {
   const existing = findExistingE2eDefault(nxJson.targetDefaults);
   const patch: Partial<TargetConfiguration> = {};
   if (existing?.cache === undefined) patch.cache = true;
-  if (!existing?.inputs) {
+  if (existing?.inputs === undefined) {
     patch.inputs = ['default', productionFileSet ? '^production' : '^default'];
   }
   if (Object.keys(patch).length > 0) {
@@ -53,7 +53,7 @@ function findExistingE2eDefault(
   if (Array.isArray(td)) {
     return td.find(
       (e) =>
-        e.target === 'e2e' && e.projects === undefined && e.source === undefined
+        e.target === 'e2e' && e.projects === undefined && e.plugin === undefined
     );
   }
   return td['e2e'];

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -41,7 +41,8 @@ function setupE2ETargetDefaults(tree: Tree) {
     patch.inputs = ['default', productionFileSet ? '^production' : '^default'];
   }
   if (Object.keys(patch).length > 0) {
-    upsertTargetDefault(tree, { target: 'e2e', ...patch });
+    upsertTargetDefault(tree, nxJson, { target: 'e2e', ...patch });
+    updateNxJson(tree, nxJson);
   }
 }
 

--- a/packages/cypress/src/migrations/update-21-0-0/remove-tsconfig-and-copy-files-options-from-cypress-executor.spec.ts
+++ b/packages/cypress/src/migrations/update-21-0-0/remove-tsconfig-and-copy-files-options-from-cypress-executor.spec.ts
@@ -330,4 +330,86 @@ describe('remove-tsconfig-and-copy-files-options-from-cypress-executor', () => {
     const nxJson = readJson<LegacyNxJson>(tree, 'nx.json');
     expect(nxJson.targetDefaults).toBeUndefined();
   });
+
+  describe('array-shape targetDefaults', () => {
+    it('should strip tsConfig/copyFiles from an executor-keyed array entry', async () => {
+      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+        json.targetDefaults = [
+          {
+            executor: '@nx/cypress:cypress',
+            options: {
+              tsConfig: '{projectRoot}/tsconfig.json',
+              copyFiles: '**/*.spec.ts',
+              cypressConfig: '{projectRoot}/cypress.config.ts',
+            },
+          },
+        ];
+        return json;
+      });
+
+      await migration(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(nxJson.targetDefaults).toEqual([
+        {
+          executor: '@nx/cypress:cypress',
+          options: {
+            cypressConfig: '{projectRoot}/cypress.config.ts',
+          },
+        },
+      ]);
+    });
+
+    it('should drop an entry that becomes empty after stripping options', async () => {
+      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+        json.targetDefaults = [
+          {
+            executor: '@nx/cypress:cypress',
+            options: {
+              tsConfig: '{projectRoot}/tsconfig.json',
+              copyFiles: '**/*.spec.ts',
+            },
+          },
+        ];
+        return json;
+      });
+
+      await migration(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(nxJson.targetDefaults).toBeUndefined();
+    });
+
+    it('should preserve unrelated entries alongside cypress matches', async () => {
+      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+        json.targetDefaults = [
+          {
+            target: 'build',
+            cache: true,
+          },
+          {
+            target: 'e2e',
+            executor: '@nx/cypress:cypress',
+            options: {
+              tsConfig: '{projectRoot}/tsconfig.json',
+              cypressConfig: '{projectRoot}/cypress.config.ts',
+            },
+          },
+        ];
+        return json;
+      });
+
+      await migration(tree);
+
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(nxJson.targetDefaults).toEqual([
+        { target: 'build', cache: true },
+        {
+          target: 'e2e',
+          executor: '@nx/cypress:cypress',
+          options: { cypressConfig: '{projectRoot}/cypress.config.ts' },
+        },
+      ]);
+    });
+  });
 });

--- a/packages/cypress/src/migrations/update-21-0-0/remove-tsconfig-and-copy-files-options-from-cypress-executor.spec.ts
+++ b/packages/cypress/src/migrations/update-21-0-0/remove-tsconfig-and-copy-files-options-from-cypress-executor.spec.ts
@@ -7,10 +7,17 @@ import {
   updateJson,
   type NxJsonConfiguration,
   type ProjectConfiguration,
+  type TargetDefaultsRecord,
   type Tree,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import migration from './remove-tsconfig-and-copy-files-options-from-cypress-executor';
+
+// This migration ran before targetDefaults supported the array shape, so
+// the test fixtures all use the legacy record shape.
+type LegacyNxJson = Omit<NxJsonConfiguration, 'targetDefaults'> & {
+  targetDefaults?: TargetDefaultsRecord;
+};
 
 describe('remove-tsconfig-and-copy-files-options-from-cypress-executor', () => {
   let tree: Tree;
@@ -155,7 +162,7 @@ describe('remove-tsconfig-and-copy-files-options-from-cypress-executor', () => {
   });
 
   it('should remove tsConfig and copyFiles options in nx.json target defaults for a target with the cypress executor', async () => {
-    updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+    updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
       json.targetDefaults ??= {};
       json.targetDefaults.e2e = {
         executor: '@nx/cypress:cypress',
@@ -178,7 +185,7 @@ describe('remove-tsconfig-and-copy-files-options-from-cypress-executor', () => {
 
     await migration(tree);
 
-    const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+    const nxJson = readJson<LegacyNxJson>(tree, 'nx.json');
     expect(nxJson.targetDefaults.e2e.options).toStrictEqual({
       cypressConfig: '{projectRoot}/cypress.config.ts',
       devServerTarget: '{projectName}:serve',
@@ -197,7 +204,7 @@ describe('remove-tsconfig-and-copy-files-options-from-cypress-executor', () => {
   });
 
   it('should remove tsConfig and copyFiles options in nx.json target defaults for the cypress executor', async () => {
-    updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+    updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
       json.targetDefaults ??= {};
       json.targetDefaults['@nx/cypress:cypress'] = {
         options: {
@@ -219,7 +226,7 @@ describe('remove-tsconfig-and-copy-files-options-from-cypress-executor', () => {
 
     await migration(tree);
 
-    const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+    const nxJson = readJson<LegacyNxJson>(tree, 'nx.json');
     expect(nxJson.targetDefaults['@nx/cypress:cypress'].options).toStrictEqual({
       cypressConfig: '{projectRoot}/cypress.config.ts',
       devServerTarget: '{projectName}:serve',
@@ -276,7 +283,7 @@ describe('remove-tsconfig-and-copy-files-options-from-cypress-executor', () => {
   });
 
   it('should remove empty targetDefault object from nx.json when using a target name as the key', async () => {
-    updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+    updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
       json.targetDefaults = {};
       json.targetDefaults.e2e = {
         executor: '@nx/cypress:cypress',
@@ -296,12 +303,12 @@ describe('remove-tsconfig-and-copy-files-options-from-cypress-executor', () => {
 
     await migration(tree);
 
-    const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+    const nxJson = readJson<LegacyNxJson>(tree, 'nx.json');
     expect(nxJson.targetDefaults).toBeUndefined();
   });
 
   it('should remove empty targetDefault object from nx.json when using the cypress executor as the key', async () => {
-    updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+    updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
       json.targetDefaults = {};
       json.targetDefaults['@nx/cypress:cypress'] = {
         options: {
@@ -320,7 +327,7 @@ describe('remove-tsconfig-and-copy-files-options-from-cypress-executor', () => {
 
     await migration(tree);
 
-    const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+    const nxJson = readJson<LegacyNxJson>(tree, 'nx.json');
     expect(nxJson.targetDefaults).toBeUndefined();
   });
 });

--- a/packages/cypress/src/migrations/update-21-0-0/remove-tsconfig-and-copy-files-options-from-cypress-executor.ts
+++ b/packages/cypress/src/migrations/update-21-0-0/remove-tsconfig-and-copy-files-options-from-cypress-executor.ts
@@ -67,7 +67,7 @@ export default async function (tree: Tree) {
           k !== 'target' &&
           k !== 'executor' &&
           k !== 'projects' &&
-          k !== 'source'
+          k !== 'plugin'
       );
       if (meaningfulKeys.length === 0) continue;
       remaining.push(entry);

--- a/packages/cypress/src/migrations/update-21-0-0/remove-tsconfig-and-copy-files-options-from-cypress-executor.ts
+++ b/packages/cypress/src/migrations/update-21-0-0/remove-tsconfig-and-copy-files-options-from-cypress-executor.ts
@@ -1,9 +1,14 @@
-import { forEachExecutorOptions } from '@nx/devkit/internal';
+import {
+  downgradeTargetDefaults,
+  forEachExecutorOptions,
+  normalizeTargetDefaults,
+} from '@nx/devkit/internal';
 import {
   formatFiles,
   readNxJson,
   readProjectConfiguration,
   type TargetConfiguration,
+  type TargetDefaultEntry,
   type Tree,
   updateNxJson,
   updateProjectConfiguration,
@@ -39,69 +44,40 @@ export default async function (tree: Tree) {
   // update options from nx.json target defaults
   const nxJson = readNxJson(tree);
   if (nxJson.targetDefaults) {
-    if (Array.isArray(nxJson.targetDefaults)) {
-      const remaining: typeof nxJson.targetDefaults = [];
-      for (const entry of nxJson.targetDefaults) {
-        const matches =
-          entry.executor === EXECUTOR_TO_MIGRATE ||
-          entry.target === EXECUTOR_TO_MIGRATE;
-        if (!matches) {
-          remaining.push(entry);
-          continue;
-        }
-        if (entry.options) {
-          updateOptions(entry as TargetConfiguration);
-        }
-        Object.keys(entry.configurations ?? {}).forEach((config) => {
-          updateConfiguration(entry as TargetConfiguration, config);
-        });
-
-        const meaningfulKeys = Object.keys(entry).filter(
-          (k) =>
-            k !== 'target' &&
-            k !== 'executor' &&
-            k !== 'projects' &&
-            k !== 'source'
-        );
-        if (meaningfulKeys.length === 0) continue;
+    const originalShape = nxJson.targetDefaults;
+    const entries = normalizeTargetDefaults(originalShape);
+    const remaining: TargetDefaultEntry[] = [];
+    for (const entry of entries) {
+      const matches =
+        entry.executor === EXECUTOR_TO_MIGRATE ||
+        entry.target === EXECUTOR_TO_MIGRATE;
+      if (!matches) {
         remaining.push(entry);
+        continue;
       }
-      if (remaining.length === 0) {
-        delete nxJson.targetDefaults;
-      } else {
-        nxJson.targetDefaults = remaining;
+      if (entry.options) {
+        updateOptions(entry as TargetConfiguration);
       }
+      Object.keys(entry.configurations ?? {}).forEach((config) => {
+        updateConfiguration(entry as TargetConfiguration, config);
+      });
+
+      const meaningfulKeys = Object.keys(entry).filter(
+        (k) =>
+          k !== 'target' &&
+          k !== 'executor' &&
+          k !== 'projects' &&
+          k !== 'source'
+      );
+      if (meaningfulKeys.length === 0) continue;
+      remaining.push(entry);
+    }
+    if (remaining.length === 0) {
+      delete nxJson.targetDefaults;
     } else {
-      for (const [targetOrExecutor, targetConfig] of Object.entries(
-        nxJson.targetDefaults
-      )) {
-        if (
-          targetOrExecutor !== EXECUTOR_TO_MIGRATE &&
-          targetConfig.executor !== EXECUTOR_TO_MIGRATE
-        ) {
-          continue;
-        }
-
-        if (targetConfig.options) {
-          updateOptions(targetConfig);
-        }
-
-        Object.keys(targetConfig.configurations ?? {}).forEach((config) => {
-          updateConfiguration(targetConfig, config);
-        });
-
-        if (
-          !Object.keys(targetConfig).length ||
-          (Object.keys(targetConfig).length === 1 &&
-            Object.keys(targetConfig)[0] === 'executor')
-        ) {
-          delete nxJson.targetDefaults[targetOrExecutor];
-        }
-
-        if (!Object.keys(nxJson.targetDefaults).length) {
-          delete nxJson.targetDefaults;
-        }
-      }
+      nxJson.targetDefaults = Array.isArray(originalShape)
+        ? remaining
+        : downgradeTargetDefaults(remaining);
     }
 
     updateNxJson(tree, nxJson);

--- a/packages/cypress/src/migrations/update-21-0-0/remove-tsconfig-and-copy-files-options-from-cypress-executor.ts
+++ b/packages/cypress/src/migrations/update-21-0-0/remove-tsconfig-and-copy-files-options-from-cypress-executor.ts
@@ -1,7 +1,6 @@
 import { forEachExecutorOptions } from '@nx/devkit/internal';
 import {
   formatFiles,
-  type ProjectConfiguration,
   readNxJson,
   readProjectConfiguration,
   type TargetConfiguration,
@@ -40,34 +39,68 @@ export default async function (tree: Tree) {
   // update options from nx.json target defaults
   const nxJson = readNxJson(tree);
   if (nxJson.targetDefaults) {
-    for (const [targetOrExecutor, targetConfig] of Object.entries(
-      nxJson.targetDefaults
-    )) {
-      if (
-        targetOrExecutor !== EXECUTOR_TO_MIGRATE &&
-        targetConfig.executor !== EXECUTOR_TO_MIGRATE
-      ) {
-        continue;
+    if (Array.isArray(nxJson.targetDefaults)) {
+      const remaining: typeof nxJson.targetDefaults = [];
+      for (const entry of nxJson.targetDefaults) {
+        const matches =
+          entry.executor === EXECUTOR_TO_MIGRATE ||
+          entry.target === EXECUTOR_TO_MIGRATE;
+        if (!matches) {
+          remaining.push(entry);
+          continue;
+        }
+        if (entry.options) {
+          updateOptions(entry as TargetConfiguration);
+        }
+        Object.keys(entry.configurations ?? {}).forEach((config) => {
+          updateConfiguration(entry as TargetConfiguration, config);
+        });
+
+        const meaningfulKeys = Object.keys(entry).filter(
+          (k) =>
+            k !== 'target' &&
+            k !== 'executor' &&
+            k !== 'projects' &&
+            k !== 'source'
+        );
+        if (meaningfulKeys.length === 0) continue;
+        remaining.push(entry);
       }
-
-      if (targetConfig.options) {
-        updateOptions(targetConfig);
-      }
-
-      Object.keys(targetConfig.configurations ?? {}).forEach((config) => {
-        updateConfiguration(targetConfig, config);
-      });
-
-      if (
-        !Object.keys(targetConfig).length ||
-        (Object.keys(targetConfig).length === 1 &&
-          Object.keys(targetConfig)[0] === 'executor')
-      ) {
-        delete nxJson.targetDefaults[targetOrExecutor];
-      }
-
-      if (!Object.keys(nxJson.targetDefaults).length) {
+      if (remaining.length === 0) {
         delete nxJson.targetDefaults;
+      } else {
+        nxJson.targetDefaults = remaining;
+      }
+    } else {
+      for (const [targetOrExecutor, targetConfig] of Object.entries(
+        nxJson.targetDefaults
+      )) {
+        if (
+          targetOrExecutor !== EXECUTOR_TO_MIGRATE &&
+          targetConfig.executor !== EXECUTOR_TO_MIGRATE
+        ) {
+          continue;
+        }
+
+        if (targetConfig.options) {
+          updateOptions(targetConfig);
+        }
+
+        Object.keys(targetConfig.configurations ?? {}).forEach((config) => {
+          updateConfiguration(targetConfig, config);
+        });
+
+        if (
+          !Object.keys(targetConfig).length ||
+          (Object.keys(targetConfig).length === 1 &&
+            Object.keys(targetConfig)[0] === 'executor')
+        ) {
+          delete nxJson.targetDefaults[targetOrExecutor];
+        }
+
+        if (!Object.keys(nxJson.targetDefaults).length) {
+          delete nxJson.targetDefaults;
+        }
       }
     }
 

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -38,7 +38,12 @@ export { promptWhenInteractive } from './src/generators/prompt';
 export {
   addBuildTargetDefaults,
   addE2eCiTargetDefaults,
+  upsertTargetDefault,
 } from './src/generators/target-defaults-utils';
+export {
+  normalizeTargetDefaults,
+  isTargetDefaultsArray,
+} from './src/utils/normalize-target-defaults';
 
 // Utils
 export { addPlugin } from './src/utils/add-plugin';

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -41,7 +41,10 @@ export {
   findTargetDefault,
   upsertTargetDefault,
 } from './src/generators/target-defaults-utils';
-export { normalizeTargetDefaults } from './src/utils/normalize-target-defaults';
+export {
+  downgradeTargetDefaults,
+  normalizeTargetDefaults,
+} from './src/utils/normalize-target-defaults';
 
 // Utils
 export { addPlugin } from './src/utils/add-plugin';

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -40,10 +40,7 @@ export {
   addE2eCiTargetDefaults,
   upsertTargetDefault,
 } from './src/generators/target-defaults-utils';
-export {
-  normalizeTargetDefaults,
-  isTargetDefaultsArray,
-} from './src/utils/normalize-target-defaults';
+export { normalizeTargetDefaults } from './src/utils/normalize-target-defaults';
 
 // Utils
 export { addPlugin } from './src/utils/add-plugin';

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -38,6 +38,7 @@ export { promptWhenInteractive } from './src/generators/prompt';
 export {
   addBuildTargetDefaults,
   addE2eCiTargetDefaults,
+  findTargetDefault,
   upsertTargetDefault,
 } from './src/generators/target-defaults-utils';
 export { normalizeTargetDefaults } from './src/utils/normalize-target-defaults';

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -39,6 +39,7 @@ export {
   addBuildTargetDefaults,
   addE2eCiTargetDefaults,
   findTargetDefault,
+  readTargetDefaultsForTarget,
   upsertTargetDefault,
 } from './src/generators/target-defaults-utils';
 export {

--- a/packages/devkit/src/generators/e2e-web-server-info-utils.spec.ts
+++ b/packages/devkit/src/generators/e2e-web-server-info-utils.spec.ts
@@ -65,10 +65,10 @@ describe('getE2EWebServerInfo', () => {
     expect(e2eWebServerInfo).toMatchInlineSnapshot(`
       {
         "e2eCiBaseUrl": "http://localhost:4300",
-        "e2eCiWebServerCommand": "pnpm exec nx run app:preview",
+        "e2eCiWebServerCommand": "npx nx run app:preview",
         "e2eDevServerTarget": "app:serve",
         "e2eWebServerAddress": "http://localhost:4200",
-        "e2eWebServerCommand": "pnpm exec nx run app:serve",
+        "e2eWebServerCommand": "npx nx run app:serve",
       }
     `);
   });
@@ -103,10 +103,10 @@ describe('getE2EWebServerInfo', () => {
     expect(e2eWebServerInfo).toMatchInlineSnapshot(`
       {
         "e2eCiBaseUrl": "http://localhost:4300",
-        "e2eCiWebServerCommand": "pnpm exec nx run app:preview",
+        "e2eCiWebServerCommand": "npx nx run app:preview",
         "e2eDevServerTarget": "app:serve",
         "e2eWebServerAddress": "http://localhost:4200",
-        "e2eWebServerCommand": "pnpm exec nx run app:serve",
+        "e2eWebServerCommand": "npx nx run app:serve",
       }
     `);
   });
@@ -148,10 +148,10 @@ describe('getE2EWebServerInfo', () => {
     expect(e2eWebServerInfo).toMatchInlineSnapshot(`
       {
         "e2eCiBaseUrl": "http://localhost:4300",
-        "e2eCiWebServerCommand": "pnpm exec nx run app:vite:preview",
+        "e2eCiWebServerCommand": "npx nx run app:vite:preview",
         "e2eDevServerTarget": "app:vite:serve",
         "e2eWebServerAddress": "http://localhost:4200",
-        "e2eWebServerCommand": "pnpm exec nx run app:vite:serve",
+        "e2eWebServerCommand": "npx nx run app:vite:serve",
       }
     `);
   });
@@ -199,10 +199,10 @@ describe('getE2EWebServerInfo', () => {
     expect(e2eWebServerInfo).toMatchInlineSnapshot(`
       {
         "e2eCiBaseUrl": "http://localhost:4300",
-        "e2eCiWebServerCommand": "pnpm exec nx run app:vite:preview",
+        "e2eCiWebServerCommand": "npx nx run app:vite:preview",
         "e2eDevServerTarget": "app:vite:serve",
         "e2eWebServerAddress": "http://localhost:4400",
-        "e2eWebServerCommand": "pnpm exec nx run app:vite:serve",
+        "e2eWebServerCommand": "npx nx run app:vite:serve",
       }
     `);
   });
@@ -252,10 +252,10 @@ describe('getE2EWebServerInfo', () => {
     expect(e2eWebServerInfo).toMatchInlineSnapshot(`
       {
         "e2eCiBaseUrl": "http://localhost:4300",
-        "e2eCiWebServerCommand": "pnpm exec nx run app:vite:preview",
+        "e2eCiWebServerCommand": "npx nx run app:vite:preview",
         "e2eDevServerTarget": "app:vite:serve",
         "e2eWebServerAddress": "http://localhost:4500",
-        "e2eWebServerCommand": "pnpm exec nx run app:vite:serve",
+        "e2eWebServerCommand": "npx nx run app:vite:serve",
       }
     `);
   });
@@ -306,10 +306,10 @@ describe('getE2EWebServerInfo', () => {
     expect(e2eWebServerInfo).toMatchInlineSnapshot(`
       {
         "e2eCiBaseUrl": "http://localhost:4300",
-        "e2eCiWebServerCommand": "pnpm exec nx run app:vite-preview",
+        "e2eCiWebServerCommand": "npx nx run app:vite-preview",
         "e2eDevServerTarget": "app:vite-serve",
         "e2eWebServerAddress": "http://localhost:4400",
-        "e2eWebServerCommand": "pnpm exec nx run app:vite-serve",
+        "e2eWebServerCommand": "npx nx run app:vite-serve",
       }
     `);
   });

--- a/packages/devkit/src/generators/e2e-web-server-info-utils.spec.ts
+++ b/packages/devkit/src/generators/e2e-web-server-info-utils.spec.ts
@@ -65,10 +65,10 @@ describe('getE2EWebServerInfo', () => {
     expect(e2eWebServerInfo).toMatchInlineSnapshot(`
       {
         "e2eCiBaseUrl": "http://localhost:4300",
-        "e2eCiWebServerCommand": "npx nx run app:preview",
+        "e2eCiWebServerCommand": "pnpm exec nx run app:preview",
         "e2eDevServerTarget": "app:serve",
         "e2eWebServerAddress": "http://localhost:4200",
-        "e2eWebServerCommand": "npx nx run app:serve",
+        "e2eWebServerCommand": "pnpm exec nx run app:serve",
       }
     `);
   });
@@ -103,10 +103,10 @@ describe('getE2EWebServerInfo', () => {
     expect(e2eWebServerInfo).toMatchInlineSnapshot(`
       {
         "e2eCiBaseUrl": "http://localhost:4300",
-        "e2eCiWebServerCommand": "npx nx run app:preview",
+        "e2eCiWebServerCommand": "pnpm exec nx run app:preview",
         "e2eDevServerTarget": "app:serve",
         "e2eWebServerAddress": "http://localhost:4200",
-        "e2eWebServerCommand": "npx nx run app:serve",
+        "e2eWebServerCommand": "pnpm exec nx run app:serve",
       }
     `);
   });
@@ -148,10 +148,10 @@ describe('getE2EWebServerInfo', () => {
     expect(e2eWebServerInfo).toMatchInlineSnapshot(`
       {
         "e2eCiBaseUrl": "http://localhost:4300",
-        "e2eCiWebServerCommand": "npx nx run app:vite:preview",
+        "e2eCiWebServerCommand": "pnpm exec nx run app:vite:preview",
         "e2eDevServerTarget": "app:vite:serve",
         "e2eWebServerAddress": "http://localhost:4200",
-        "e2eWebServerCommand": "npx nx run app:vite:serve",
+        "e2eWebServerCommand": "pnpm exec nx run app:vite:serve",
       }
     `);
   });
@@ -199,10 +199,63 @@ describe('getE2EWebServerInfo', () => {
     expect(e2eWebServerInfo).toMatchInlineSnapshot(`
       {
         "e2eCiBaseUrl": "http://localhost:4300",
-        "e2eCiWebServerCommand": "npx nx run app:vite:preview",
+        "e2eCiWebServerCommand": "pnpm exec nx run app:vite:preview",
         "e2eDevServerTarget": "app:vite:serve",
         "e2eWebServerAddress": "http://localhost:4400",
-        "e2eWebServerCommand": "npx nx run app:vite:serve",
+        "e2eWebServerCommand": "pnpm exec nx run app:vite:serve",
+      }
+    `);
+  });
+
+  it('should handle array-shaped targetDefaults', async () => {
+    // ARRANGE
+    const nxJson = readNxJson(tree);
+    nxJson.plugins ??= [];
+    nxJson.plugins.push({
+      plugin: '@nx/vite/plugin',
+      options: {
+        serveTargetName: 'vite:serve',
+        previewTargetName: 'vite:preview',
+      },
+    });
+    nxJson.targetDefaults = [
+      {
+        target: 'vite:serve',
+        options: {
+          port: 4500,
+        },
+      },
+    ];
+    updateNxJson(tree, nxJson);
+
+    // ACT
+    const e2eWebServerInfo = await getE2EWebServerInfo(
+      tree,
+      'app',
+      {
+        plugin: '@nx/vite/plugin',
+        configFilePath: 'app/vite.config.ts',
+        serveTargetName: 'serveTargetName',
+        serveStaticTargetName: 'previewTargetName',
+      },
+      {
+        defaultServeTargetName: 'serve',
+        defaultServeStaticTargetName: 'preview',
+        defaultE2EWebServerAddress: 'http://localhost:4200',
+        defaultE2ECiBaseUrl: 'http://localhost:4300',
+        defaultE2EPort: 4200,
+      },
+      true
+    );
+
+    // ASSERT
+    expect(e2eWebServerInfo).toMatchInlineSnapshot(`
+      {
+        "e2eCiBaseUrl": "http://localhost:4300",
+        "e2eCiWebServerCommand": "pnpm exec nx run app:vite:preview",
+        "e2eDevServerTarget": "app:vite:serve",
+        "e2eWebServerAddress": "http://localhost:4500",
+        "e2eWebServerCommand": "pnpm exec nx run app:vite:serve",
       }
     `);
   });
@@ -253,10 +306,10 @@ describe('getE2EWebServerInfo', () => {
     expect(e2eWebServerInfo).toMatchInlineSnapshot(`
       {
         "e2eCiBaseUrl": "http://localhost:4300",
-        "e2eCiWebServerCommand": "npx nx run app:vite-preview",
+        "e2eCiWebServerCommand": "pnpm exec nx run app:vite-preview",
         "e2eDevServerTarget": "app:vite-serve",
         "e2eWebServerAddress": "http://localhost:4400",
-        "e2eWebServerCommand": "npx nx run app:vite-serve",
+        "e2eWebServerCommand": "pnpm exec nx run app:vite-serve",
       }
     `);
   });

--- a/packages/devkit/src/generators/e2e-web-server-info-utils.ts
+++ b/packages/devkit/src/generators/e2e-web-server-info-utils.ts
@@ -5,6 +5,7 @@ import {
   readNxJson,
 } from 'nx/src/devkit-exports';
 import type { PackageManagerCommands } from 'nx/src/utils/package-manager';
+import { readTargetDefaultsForTarget } from './target-defaults-utils';
 import { findPluginForConfigFile } from '../utils/find-plugin-for-config-file';
 
 interface E2EWebServerDefaultValues {
@@ -85,23 +86,13 @@ async function getE2EWebServerInfoForPlugin(
 
   const nxJson = readNxJson(tree);
   let e2ePort = defaultValues.defaultE2EPort ?? 4200;
+  const serveTargetName =
+    foundPlugin.options[pluginOptions.serveTargetName] ??
+    defaultValues.defaultServeTargetName;
 
-  if (
-    nxJson.targetDefaults?.[
-      foundPlugin.options[pluginOptions.serveTargetName] ??
-        defaultValues.defaultServeTargetName
-    ] &&
-    nxJson.targetDefaults?.[
-      foundPlugin.options[pluginOptions.serveTargetName] ??
-        defaultValues.defaultServeTargetName
-    ].options?.port
-  ) {
-    e2ePort =
-      nxJson.targetDefaults?.[
-        foundPlugin.options[pluginOptions.serveTargetName] ??
-          defaultValues.defaultServeTargetName
-      ].options?.port;
-  }
+  e2ePort =
+    readTargetDefaultsForTarget(serveTargetName, nxJson.targetDefaults)?.options
+      ?.port ?? e2ePort;
 
   const e2eWebServerAddress = defaultValues.defaultE2EWebServerAddress.replace(
     /:\d+/,
@@ -110,18 +101,12 @@ async function getE2EWebServerInfoForPlugin(
 
   return {
     e2eWebServerAddress,
-    e2eWebServerCommand: `${pm.exec} nx run ${projectName}:${
-      foundPlugin.options[pluginOptions.serveTargetName] ??
-      defaultValues.defaultServeTargetName
-    }`,
+    e2eWebServerCommand: `${pm.exec} nx run ${projectName}:${serveTargetName}`,
     e2eCiWebServerCommand: `${pm.exec} nx run ${projectName}:${
       foundPlugin.options[pluginOptions.serveStaticTargetName] ??
       defaultValues.defaultServeStaticTargetName
     }`,
     e2eCiBaseUrl: defaultValues.defaultE2ECiBaseUrl,
-    e2eDevServerTarget: `${projectName}:${
-      foundPlugin.options[pluginOptions.serveTargetName] ??
-      defaultValues.defaultServeTargetName
-    }`,
+    e2eDevServerTarget: `${projectName}:${serveTargetName}`,
   };
 }

--- a/packages/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator.spec.ts
+++ b/packages/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator.spec.ts
@@ -1,0 +1,58 @@
+import type { TargetDefaults } from 'nx/src/devkit-exports';
+import { readTargetDefaultsForExecutor } from './executor-to-plugin-migrator';
+
+describe('readTargetDefaultsForExecutor', () => {
+  it('reads the exact executor-keyed default from legacy record-shaped targetDefaults', () => {
+    const targetDefaults: TargetDefaults = {
+      '@nx/example:build': {
+        cache: true,
+        dependsOn: ['^build'],
+      },
+      build: {
+        executor: '@nx/example:build',
+        cache: false,
+      },
+    };
+
+    expect(
+      readTargetDefaultsForExecutor('@nx/example:build', targetDefaults)
+    ).toEqual({
+      cache: true,
+      dependsOn: ['^build'],
+    });
+  });
+
+  it('reads the unfiltered executor entry from array-shaped targetDefaults', () => {
+    const targetDefaults: TargetDefaults = [
+      {
+        executor: '@nx/example:test',
+        inputs: ['default', '^default'],
+      },
+    ];
+
+    expect(
+      readTargetDefaultsForExecutor('@nx/example:test', targetDefaults)
+    ).toEqual({
+      inputs: ['default', '^default'],
+    });
+  });
+
+  it('does not broaden to target-scoped or filtered array entries', () => {
+    const targetDefaults: TargetDefaults = [
+      {
+        target: 'build',
+        executor: '@nx/example:build',
+        cache: false,
+      },
+      {
+        executor: '@nx/example:build',
+        projects: ['app'],
+        cache: true,
+      },
+    ];
+
+    expect(
+      readTargetDefaultsForExecutor('@nx/example:build', targetDefaults)
+    ).toBeUndefined();
+  });
+});

--- a/packages/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator.ts
+++ b/packages/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator.ts
@@ -27,6 +27,7 @@ import {
 import type { RunCommandsOptions } from 'nx/src/executors/run-commands/run-commands.impl';
 import type { ConfigurationResult } from 'nx/src/project-graph/utils/project-configuration-utils';
 import { forEachExecutorOptions } from '../executor-options-utils';
+import { findTargetDefault } from '../target-defaults-utils';
 import { deleteMatchingProperties } from './plugin-migration-utils';
 import { logger as devkitLogger } from 'nx/src/devkit-exports';
 
@@ -290,7 +291,10 @@ class ExecutorToPluginMigrator<T> {
 
   #getTargetDefaultsForExecutor() {
     this.#targetDefaultsForExecutor = structuredClone(
-      this.#nxJson.targetDefaults?.[this.#executor]
+      readTargetDefaultsForExecutor(
+        this.#executor,
+        this.#nxJson.targetDefaults
+      ) ?? {}
     );
   }
 
@@ -343,6 +347,27 @@ export class NoTargetsToMigrateError extends Error {
   constructor() {
     super('Could not find any targets to migrate.');
   }
+}
+
+export function readTargetDefaultsForExecutor(
+  executor: string,
+  targetDefaults: NxJsonConfiguration['targetDefaults'] | undefined
+): Partial<TargetConfiguration> | undefined {
+  // Preserve the legacy record-shape semantics this migrator used before
+  // array support: only an unfiltered default keyed directly by executor
+  // applies here. Target-scoped or filtered array entries remain opt-in
+  // behaviors for callers that can evaluate them in project context.
+  const entry = findTargetDefault(targetDefaults, { executor });
+  if (!entry) {
+    return undefined;
+  }
+
+  const config = { ...entry };
+  delete config.target;
+  delete config.executor;
+  delete config.projects;
+  delete config.plugin;
+  return config;
 }
 
 export async function migrateProjectExecutorsToPlugin<T>(

--- a/packages/devkit/src/generators/target-defaults-utils.spec.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.spec.ts
@@ -12,22 +12,12 @@ jest.mock(
 import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
 import { readNxJson, updateNxJson, type Tree } from 'nx/src/devkit-exports';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
-import { gte, valid } from 'semver';
-import { NX_VERSION } from '../utils/package-json';
 import {
   addBuildTargetDefaults,
   addE2eCiTargetDefaults,
   upsertTargetDefault,
 } from './target-defaults-utils';
 
-// Devkit supports `nx` at major +/- 1; the array-shape `targetDefaults`
-// only exists in nx >= 23. Tests that assume promotion-to-array are
-// gated behind this so they're skipped when the test runner pulls an
-// older nx peer. The workspace placeholder version "0.0.1" is treated
-// as modern — same exception as in target-defaults-utils.ts.
-const supportsArrayTargetDefaults =
-  !valid(NX_VERSION) || NX_VERSION === '0.0.1' || gte(NX_VERSION, '23.0.0');
-const itArrayShape = supportsArrayTargetDefaults ? it : it.skip;
 describe('target-defaults-utils', () => {
   describe('upsertTargetDefault', () => {
     let tree: Tree;
@@ -79,7 +69,7 @@ describe('target-defaults-utils', () => {
       ]);
     });
 
-    itArrayShape('upgrades a legacy record to array on any upsert', () => {
+    it('upgrades a legacy record to array on any upsert', () => {
       const nxJson = readNxJson(tree);
       (nxJson as any).targetDefaults = {
         build: { cache: true },

--- a/packages/devkit/src/generators/target-defaults-utils.spec.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.spec.ts
@@ -12,11 +12,22 @@ jest.mock(
 import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
 import { readNxJson, updateNxJson, type Tree } from 'nx/src/devkit-exports';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
+import { gte, valid } from 'semver';
+import { NX_VERSION } from '../utils/package-json';
 import {
   addBuildTargetDefaults,
   addE2eCiTargetDefaults,
   upsertTargetDefault,
 } from './target-defaults-utils';
+
+// Devkit supports `nx` at major +/- 1; the array-shape `targetDefaults`
+// only exists in nx >= 23. Tests that assume promotion-to-array are
+// gated behind this so they're skipped when the test runner pulls an
+// older nx peer. The workspace placeholder version "0.0.1" is treated
+// as modern — same exception as in target-defaults-utils.ts.
+const supportsArrayTargetDefaults =
+  !valid(NX_VERSION) || NX_VERSION === '0.0.1' || gte(NX_VERSION, '23.0.0');
+const itArrayShape = supportsArrayTargetDefaults ? it : it.skip;
 describe('target-defaults-utils', () => {
   describe('upsertTargetDefault', () => {
     let tree: Tree;
@@ -65,7 +76,7 @@ describe('target-defaults-utils', () => {
       ]);
     });
 
-    it('upgrades a legacy record to array on any upsert', () => {
+    itArrayShape('upgrades a legacy record to array on any upsert', () => {
       const nxJson = readNxJson(tree);
       (nxJson as any).targetDefaults = {
         build: { cache: true },

--- a/packages/devkit/src/generators/target-defaults-utils.spec.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.spec.ts
@@ -68,14 +68,14 @@ describe('target-defaults-utils', () => {
 
       upsertTargetDefault(tree, nxJson, {
         target: 'test',
-        source: '@nx/vite',
+        plugin: '@nx/vite',
         inputs: ['vite'],
       });
       updateNxJson(tree, nxJson);
 
       expect(readNxJson(tree).targetDefaults).toEqual([
         { target: 'test', cache: true },
-        { target: 'test', source: '@nx/vite', inputs: ['vite'] },
+        { target: 'test', plugin: '@nx/vite', inputs: ['vite'] },
       ]);
     });
 
@@ -260,7 +260,7 @@ describe('target-defaults-utils', () => {
           e.target === target &&
           e.executor === undefined &&
           e.projects === undefined &&
-          e.source === undefined
+          e.plugin === undefined
       );
     }
 

--- a/packages/devkit/src/generators/target-defaults-utils.spec.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.spec.ts
@@ -38,9 +38,9 @@ describe('target-defaults-utils', () => {
     it('appends a new entry when nx.json has no targetDefaults', () => {
       const nxJson = readNxJson(tree);
       delete nxJson.targetDefaults;
-      updateNxJson(tree, nxJson);
 
-      upsertTargetDefault(tree, { target: 'test', cache: true });
+      upsertTargetDefault(tree, nxJson, { target: 'test', cache: true });
+      updateNxJson(tree, nxJson);
 
       expect(readNxJson(tree).targetDefaults).toEqual([
         { target: 'test', cache: true },
@@ -50,9 +50,12 @@ describe('target-defaults-utils', () => {
     it('merges into an existing array entry with same filter tuple', () => {
       const nxJson = readNxJson(tree);
       nxJson.targetDefaults = [{ target: 'test', cache: true }];
-      updateNxJson(tree, nxJson);
 
-      upsertTargetDefault(tree, { target: 'test', inputs: ['default'] });
+      upsertTargetDefault(tree, nxJson, {
+        target: 'test',
+        inputs: ['default'],
+      });
+      updateNxJson(tree, nxJson);
 
       expect(readNxJson(tree).targetDefaults).toEqual([
         { target: 'test', cache: true, inputs: ['default'] },
@@ -62,13 +65,13 @@ describe('target-defaults-utils', () => {
     it('appends a new array entry when filter tuple differs', () => {
       const nxJson = readNxJson(tree);
       nxJson.targetDefaults = [{ target: 'test', cache: true }];
-      updateNxJson(tree, nxJson);
 
-      upsertTargetDefault(tree, {
+      upsertTargetDefault(tree, nxJson, {
         target: 'test',
         source: '@nx/vite',
         inputs: ['vite'],
       });
+      updateNxJson(tree, nxJson);
 
       expect(readNxJson(tree).targetDefaults).toEqual([
         { target: 'test', cache: true },
@@ -82,9 +85,9 @@ describe('target-defaults-utils', () => {
         build: { cache: true },
         '@nx/vite:test': { inputs: ['default'] },
       };
-      updateNxJson(tree, nxJson);
 
-      upsertTargetDefault(tree, { target: 'test', cache: true });
+      upsertTargetDefault(tree, nxJson, { target: 'test', cache: true });
+      updateNxJson(tree, nxJson);
 
       // Record is normalized first (executor-shaped key splits to executor),
       // then the new entry is appended.
@@ -100,13 +103,13 @@ describe('target-defaults-utils', () => {
       (nxJson as any).targetDefaults = {
         build: { cache: true },
       };
-      updateNxJson(tree, nxJson);
 
-      upsertTargetDefault(tree, {
+      upsertTargetDefault(tree, nxJson, {
         target: 'test',
         projects: 'tag:dotnet',
         inputs: ['x'],
       });
+      updateNxJson(tree, nxJson);
 
       expect(readNxJson(tree).targetDefaults).toEqual([
         { target: 'build', cache: true },

--- a/packages/devkit/src/generators/target-defaults-utils.spec.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.spec.ts
@@ -10,11 +10,17 @@ jest.mock(
 );
 
 import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
-import { readNxJson, updateNxJson, type Tree } from 'nx/src/devkit-exports';
+import {
+  addProjectConfiguration,
+  readNxJson,
+  updateNxJson,
+  type Tree,
+} from 'nx/src/devkit-exports';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import {
   addBuildTargetDefaults,
   addE2eCiTargetDefaults,
+  readTargetDefaultsForTarget,
   upsertTargetDefault,
 } from './target-defaults-utils';
 
@@ -104,6 +110,29 @@ describe('target-defaults-utils', () => {
       expect(readNxJson(tree).targetDefaults).toEqual([
         { target: 'build', cache: true },
         { target: 'test', projects: 'tag:dotnet', inputs: ['x'] },
+      ]);
+    });
+
+    it('uses workspace targets to preserve colon target keys during upserts', () => {
+      addProjectConfiguration(tree, 'app', {
+        root: 'app',
+        targets: {
+          'serve:dev': {
+            executor: '@nx/js:node',
+          },
+        },
+      });
+      const nxJson = readNxJson(tree);
+      (nxJson as any).targetDefaults = {
+        'serve:dev': { cache: true },
+      };
+
+      upsertTargetDefault(tree, nxJson, { target: 'build', cache: true });
+      updateNxJson(tree, nxJson);
+
+      expect(readNxJson(tree).targetDefaults).toEqual([
+        { target: 'serve:dev', cache: true },
+        { target: 'build', cache: true },
       ]);
     });
   });
@@ -224,6 +253,47 @@ describe('target-defaults-utils', () => {
         executor: '@nx/example:build',
         cache: true,
         inputs: ['custom'],
+      });
+    });
+  });
+
+  describe('readTargetDefaultsForTarget', () => {
+    it('preserves exact legacy record-key reads for colon target names', () => {
+      expect(
+        readTargetDefaultsForTarget('vite:serve', {
+          'vite:serve': {
+            options: {
+              port: 4400,
+            },
+          },
+        })
+      ).toEqual({
+        options: {
+          port: 4400,
+        },
+      });
+    });
+
+    it('still supports array-shaped reads', () => {
+      expect(
+        readTargetDefaultsForTarget(
+          'build',
+          [
+            {
+              target: 'build',
+              executor: '@nx/js:tsc',
+              options: {
+                outputPath: 'dist/libs/demo',
+              },
+            },
+          ],
+          '@nx/js:tsc'
+        )
+      ).toEqual({
+        executor: '@nx/js:tsc',
+        options: {
+          outputPath: 'dist/libs/demo',
+        },
       });
     });
   });

--- a/packages/devkit/src/generators/target-defaults-utils.spec.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.spec.ts
@@ -15,20 +15,139 @@ import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import {
   addBuildTargetDefaults,
   addE2eCiTargetDefaults,
+  upsertTargetDefault,
 } from './target-defaults-utils';
 describe('target-defaults-utils', () => {
-  describe('addBuildTargetDefaults', () => {
+  describe('upsertTargetDefault', () => {
     let tree: Tree;
-
     beforeEach(() => {
       tree = createTreeWithEmptyWorkspace();
+    });
+
+    it('appends a new entry when nx.json has no targetDefaults', () => {
+      const nxJson = readNxJson(tree);
+      delete nxJson.targetDefaults;
+      updateNxJson(tree, nxJson);
+
+      upsertTargetDefault(tree, { target: 'test', cache: true });
+
+      expect(readNxJson(tree).targetDefaults).toEqual([
+        { target: 'test', cache: true },
+      ]);
+    });
+
+    it('merges into an existing array entry with same filter tuple', () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = [{ target: 'test', cache: true }];
+      updateNxJson(tree, nxJson);
+
+      upsertTargetDefault(tree, { target: 'test', inputs: ['default'] });
+
+      expect(readNxJson(tree).targetDefaults).toEqual([
+        { target: 'test', cache: true, inputs: ['default'] },
+      ]);
+    });
+
+    it('appends a new array entry when filter tuple differs', () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = [{ target: 'test', cache: true }];
+      updateNxJson(tree, nxJson);
+
+      upsertTargetDefault(tree, {
+        target: 'test',
+        source: '@nx/vite',
+        inputs: ['vite'],
+      });
+
+      expect(readNxJson(tree).targetDefaults).toEqual([
+        { target: 'test', cache: true },
+        { target: 'test', source: '@nx/vite', inputs: ['vite'] },
+      ]);
+    });
+
+    it('preserves legacy record shape when no filters are specified', () => {
+      const nxJson = readNxJson(tree);
+      (nxJson as any).targetDefaults = {
+        build: { cache: true },
+      };
+      updateNxJson(tree, nxJson);
+
+      upsertTargetDefault(tree, { target: 'test', cache: true });
+
+      expect(readNxJson(tree).targetDefaults).toEqual({
+        build: { cache: true },
+        test: { cache: true },
+      });
+    });
+
+    it('upgrades a legacy record to array when a filter is requested', () => {
+      const nxJson = readNxJson(tree);
+      (nxJson as any).targetDefaults = {
+        build: { cache: true },
+      };
+      updateNxJson(tree, nxJson);
+
+      upsertTargetDefault(tree, {
+        target: 'test',
+        projects: 'tag:dotnet',
+        inputs: ['x'],
+      });
+
+      expect(readNxJson(tree).targetDefaults).toEqual([
+        { target: 'build', cache: true },
+        { target: 'test', projects: 'tag:dotnet', inputs: ['x'] },
+      ]);
+    });
+  });
+
+  describe('addBuildTargetDefaults', () => {
+    let tree: Tree;
+    beforeEach(() => {
+      tree = createTreeWithEmptyWorkspace();
+    });
+
+    it('adds entry to legacy record shape preserving record', () => {
+      const nxJson = readNxJson(tree);
+      (nxJson as any).targetDefaults = {};
+      updateNxJson(tree, nxJson);
+
+      addBuildTargetDefaults(tree, '@nx/vite:build');
+
+      expect(readNxJson(tree).targetDefaults).toEqual({
+        '@nx/vite:build': {
+          cache: true,
+          dependsOn: ['^build'],
+          inputs: ['default', '^default'],
+        },
+      });
+    });
+
+    it('appends to array shape and is idempotent', () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = [{ target: 'test', cache: true }];
+      updateNxJson(tree, nxJson);
+
+      addBuildTargetDefaults(tree, '@nx/vite:build');
+      addBuildTargetDefaults(tree, '@nx/vite:build');
+
+      const td = readNxJson(tree).targetDefaults;
+      expect(Array.isArray(td)).toBe(true);
+      expect(td as any).toEqual([
+        { target: 'test', cache: true },
+        {
+          target: '@nx/vite:build',
+          cache: true,
+          dependsOn: ['^build'],
+          inputs: ['default', '^default'],
+        },
+      ]);
     });
 
     it('should set executor-keyed target defaults with default inputs', () => {
       addBuildTargetDefaults(tree, '@nx/example:build');
 
       const nxJson = readNxJson(tree);
-      expect(nxJson.targetDefaults['@nx/example:build']).toEqual({
+      expect((nxJson.targetDefaults as any)['@nx/example:build']).toEqual({
         cache: true,
         dependsOn: ['^build'],
         inputs: ['default', '^default'],
@@ -46,7 +165,7 @@ describe('target-defaults-utils', () => {
       addBuildTargetDefaults(tree, '@nx/example:build');
 
       expect(
-        readNxJson(tree).targetDefaults['@nx/example:build'].inputs
+        (readNxJson(tree).targetDefaults as any)['@nx/example:build'].inputs
       ).toEqual(['production', '^production']);
     });
 
@@ -54,7 +173,7 @@ describe('target-defaults-utils', () => {
       addBuildTargetDefaults(tree, '@nx/example:build', 'compile');
 
       expect(
-        readNxJson(tree).targetDefaults['@nx/example:build'].dependsOn
+        (readNxJson(tree).targetDefaults as any)['@nx/example:build'].dependsOn
       ).toEqual(['^compile']);
     });
 
@@ -67,7 +186,7 @@ describe('target-defaults-utils', () => {
       ]);
 
       expect(
-        readNxJson(tree).targetDefaults['@nx/example:build'].inputs
+        (readNxJson(tree).targetDefaults as any)['@nx/example:build'].inputs
       ).toEqual([
         'default',
         '^default',
@@ -80,7 +199,7 @@ describe('target-defaults-utils', () => {
 
     it('should not overwrite existing target defaults for the executor', () => {
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults = {
+      (nxJson as any).targetDefaults = {
         '@nx/example:build': { cache: true, inputs: ['custom'] },
       };
       updateNxJson(tree, nxJson);
@@ -89,7 +208,9 @@ describe('target-defaults-utils', () => {
         { json: '{workspaceRoot}/tsconfig.json', fields: ['extends'] },
       ]);
 
-      expect(readNxJson(tree).targetDefaults['@nx/example:build']).toEqual({
+      expect(
+        (readNxJson(tree).targetDefaults as any)['@nx/example:build']
+      ).toEqual({
         cache: true,
         inputs: ['custom'],
       });

--- a/packages/devkit/src/generators/target-defaults-utils.spec.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.spec.ts
@@ -65,19 +65,23 @@ describe('target-defaults-utils', () => {
       ]);
     });
 
-    it('preserves legacy record shape when no filters are specified', () => {
+    it('upgrades a legacy record to array on any upsert', () => {
       const nxJson = readNxJson(tree);
       (nxJson as any).targetDefaults = {
         build: { cache: true },
+        '@nx/vite:test': { inputs: ['default'] },
       };
       updateNxJson(tree, nxJson);
 
       upsertTargetDefault(tree, { target: 'test', cache: true });
 
-      expect(readNxJson(tree).targetDefaults).toEqual({
-        build: { cache: true },
-        test: { cache: true },
-      });
+      // Record is normalized first (executor-shaped key splits to executor),
+      // then the new entry is appended.
+      expect(readNxJson(tree).targetDefaults).toEqual([
+        { target: 'build', cache: true },
+        { executor: '@nx/vite:test', inputs: ['default'] },
+        { target: 'test', cache: true },
+      ]);
     });
 
     it('upgrades a legacy record to array when a filter is requested', () => {
@@ -106,19 +110,26 @@ describe('target-defaults-utils', () => {
       tree = createTreeWithEmptyWorkspace();
     });
 
-    it('adds entry to legacy record shape preserving record', () => {
+    function findExecutorEntry(tree: Tree, executor: string) {
+      const td = readNxJson(tree).targetDefaults;
+      if (!Array.isArray(td)) return undefined;
+      return td.find((e: any) => e.executor === executor);
+    }
+
+    it('upgrades a legacy record to array and writes the executor entry', () => {
       const nxJson = readNxJson(tree);
       (nxJson as any).targetDefaults = {};
       updateNxJson(tree, nxJson);
 
       addBuildTargetDefaults(tree, '@nx/vite:build');
 
-      expect(readNxJson(tree).targetDefaults).toEqual({
-        '@nx/vite:build': {
-          cache: true,
-          dependsOn: ['^build'],
-          inputs: ['default', '^default'],
-        },
+      const td = readNxJson(tree).targetDefaults;
+      expect(Array.isArray(td)).toBe(true);
+      expect(td).toContainEqual({
+        executor: '@nx/vite:build',
+        cache: true,
+        dependsOn: ['^build'],
+        inputs: ['default', '^default'],
       });
     });
 
@@ -130,12 +141,10 @@ describe('target-defaults-utils', () => {
       addBuildTargetDefaults(tree, '@nx/vite:build');
       addBuildTargetDefaults(tree, '@nx/vite:build');
 
-      const td = readNxJson(tree).targetDefaults;
-      expect(Array.isArray(td)).toBe(true);
-      expect(td as any).toEqual([
+      expect(readNxJson(tree).targetDefaults).toEqual([
         { target: 'test', cache: true },
         {
-          target: '@nx/vite:build',
+          executor: '@nx/vite:build',
           cache: true,
           dependsOn: ['^build'],
           inputs: ['default', '^default'],
@@ -143,18 +152,18 @@ describe('target-defaults-utils', () => {
       ]);
     });
 
-    it('should set executor-keyed target defaults with default inputs', () => {
+    it('writes an executor-keyed entry with default inputs', () => {
       addBuildTargetDefaults(tree, '@nx/example:build');
 
-      const nxJson = readNxJson(tree);
-      expect((nxJson.targetDefaults as any)['@nx/example:build']).toEqual({
+      expect(findExecutorEntry(tree, '@nx/example:build')).toEqual({
+        executor: '@nx/example:build',
         cache: true,
         dependsOn: ['^build'],
         inputs: ['default', '^default'],
       });
     });
 
-    it('should use production named inputs when available', () => {
+    it('uses production named inputs when available', () => {
       const nxJson = readNxJson(tree);
       nxJson.namedInputs = {
         default: ['{projectRoot}/**/*'],
@@ -164,20 +173,21 @@ describe('target-defaults-utils', () => {
 
       addBuildTargetDefaults(tree, '@nx/example:build');
 
-      expect(
-        (readNxJson(tree).targetDefaults as any)['@nx/example:build'].inputs
-      ).toEqual(['production', '^production']);
+      expect(findExecutorEntry(tree, '@nx/example:build').inputs).toEqual([
+        'production',
+        '^production',
+      ]);
     });
 
-    it('should honor a custom build target name in dependsOn', () => {
+    it('honors a custom build target name in dependsOn', () => {
       addBuildTargetDefaults(tree, '@nx/example:build', 'compile');
 
-      expect(
-        (readNxJson(tree).targetDefaults as any)['@nx/example:build'].dependsOn
-      ).toEqual(['^compile']);
+      expect(findExecutorEntry(tree, '@nx/example:build').dependsOn).toEqual([
+        '^compile',
+      ]);
     });
 
-    it('should append extra inputs after the default/production inputs', () => {
+    it('appends extra inputs after the default/production inputs', () => {
       addBuildTargetDefaults(tree, '@nx/example:build', 'build', [
         {
           json: '{workspaceRoot}/tsconfig.json',
@@ -185,9 +195,7 @@ describe('target-defaults-utils', () => {
         },
       ]);
 
-      expect(
-        (readNxJson(tree).targetDefaults as any)['@nx/example:build'].inputs
-      ).toEqual([
+      expect(findExecutorEntry(tree, '@nx/example:build').inputs).toEqual([
         'default',
         '^default',
         {
@@ -197,20 +205,19 @@ describe('target-defaults-utils', () => {
       ]);
     });
 
-    it('should not overwrite existing target defaults for the executor', () => {
+    it('does not overwrite an existing entry for the executor', () => {
       const nxJson = readNxJson(tree);
-      (nxJson as any).targetDefaults = {
-        '@nx/example:build': { cache: true, inputs: ['custom'] },
-      };
+      (nxJson as any).targetDefaults = [
+        { executor: '@nx/example:build', cache: true, inputs: ['custom'] },
+      ];
       updateNxJson(tree, nxJson);
 
       addBuildTargetDefaults(tree, '@nx/example:build', 'build', [
         { json: '{workspaceRoot}/tsconfig.json', fields: ['extends'] },
       ]);
 
-      expect(
-        (readNxJson(tree).targetDefaults as any)['@nx/example:build']
-      ).toEqual({
+      expect(findExecutorEntry(tree, '@nx/example:build')).toEqual({
+        executor: '@nx/example:build',
         cache: true,
         inputs: ['custom'],
       });
@@ -231,7 +238,19 @@ describe('target-defaults-utils', () => {
       jest.resetModules();
     });
 
-    it('should add e2e-ci--**/** target default for e2e plugin for specified build target when it does not exist', async () => {
+    function findGlobEntry(tree: Tree, target: string) {
+      const td = readNxJson(tree).targetDefaults;
+      if (!Array.isArray(td)) return undefined;
+      return td.find(
+        (e: any) =>
+          e.target === target &&
+          e.executor === undefined &&
+          e.projects === undefined &&
+          e.source === undefined
+      );
+    }
+
+    it('adds an e2e-ci--**/** entry with the build target dependency', async () => {
       // ARRANGE
       const nxJson = readNxJson(tree);
       nxJson.plugins ??= [];
@@ -256,17 +275,13 @@ describe('target-defaults-utils', () => {
       );
 
       // ASSERT
-      const newNxJson = readNxJson(tree);
-      expect(newNxJson.targetDefaults['e2e-ci--**/**']).toMatchInlineSnapshot(`
-        {
-          "dependsOn": [
-            "^build",
-          ],
-        }
-      `);
+      expect(findGlobEntry(tree, 'e2e-ci--**/**')).toEqual({
+        target: 'e2e-ci--**/**',
+        dependsOn: ['^build'],
+      });
     });
 
-    it('should update existing e2e-ci--**/** target default for e2e plugin for specified build target when it does not exist in dependsOn', async () => {
+    it('appends a new build target to an existing entry without duplicating', async () => {
       // ARRANGE
       const nxJson = readNxJson(tree);
       nxJson.plugins ??= [];
@@ -277,10 +292,9 @@ describe('target-defaults-utils', () => {
           ciTargetName: 'e2e-ci',
         },
       });
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['e2e-ci--**/**'] = {
-        dependsOn: ['^build'],
-      };
+      nxJson.targetDefaults = [
+        { target: 'e2e-ci--**/**', dependsOn: ['^build'] },
+      ];
       updateNxJson(tree, nxJson);
 
       tree.write('apps/myapp-e2e/cypress.config.ts', '');
@@ -295,18 +309,13 @@ describe('target-defaults-utils', () => {
       );
 
       // ASSERT
-      const newNxJson = readNxJson(tree);
-      expect(newNxJson.targetDefaults['e2e-ci--**/**']).toMatchInlineSnapshot(`
-        {
-          "dependsOn": [
-            "^build",
-            "^build-base",
-          ],
-        }
-      `);
+      expect(findGlobEntry(tree, 'e2e-ci--**/**')).toEqual({
+        target: 'e2e-ci--**/**',
+        dependsOn: ['^build', '^build-base'],
+      });
     });
 
-    it('should read the ciTargetName and add a new entry when it does not exist', async () => {
+    it('reads the ciTargetName and adds a new entry under that glob', async () => {
       // ARRANGE
       const nxJson = readNxJson(tree);
       nxJson.plugins ??= [];
@@ -317,10 +326,9 @@ describe('target-defaults-utils', () => {
           ciTargetName: 'cypress:e2e-ci',
         },
       });
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['e2e-ci--**/**'] = {
-        dependsOn: ['^build'],
-      };
+      nxJson.targetDefaults = [
+        { target: 'e2e-ci--**/**', dependsOn: ['^build'] },
+      ];
       updateNxJson(tree, nxJson);
 
       tree.write('apps/myapp-e2e/cypress.config.ts', '');
@@ -335,25 +343,17 @@ describe('target-defaults-utils', () => {
       );
 
       // ASSERT
-      const newNxJson = readNxJson(tree);
-      expect(newNxJson.targetDefaults['e2e-ci--**/**']).toMatchInlineSnapshot(`
-        {
-          "dependsOn": [
-            "^build",
-          ],
-        }
-      `);
-      expect(newNxJson.targetDefaults['cypress:e2e-ci--**/**'])
-        .toMatchInlineSnapshot(`
-        {
-          "dependsOn": [
-            "^build-base",
-          ],
-        }
-      `);
+      expect(findGlobEntry(tree, 'e2e-ci--**/**')).toEqual({
+        target: 'e2e-ci--**/**',
+        dependsOn: ['^build'],
+      });
+      expect(findGlobEntry(tree, 'cypress:e2e-ci--**/**')).toEqual({
+        target: 'cypress:e2e-ci--**/**',
+        dependsOn: ['^build-base'],
+      });
     });
 
-    it('should not add additional e2e-ci--**/** target default for e2e plugin when it already exists with build target', async () => {
+    it('does not duplicate the build target when it already depends on it', async () => {
       // ARRANGE
       const nxJson = readNxJson(tree);
       nxJson.plugins ??= [];
@@ -364,10 +364,9 @@ describe('target-defaults-utils', () => {
           ciTargetName: 'e2e-ci',
         },
       });
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['e2e-ci--**/**'] = {
-        dependsOn: ['^build'],
-      };
+      nxJson.targetDefaults = [
+        { target: 'e2e-ci--**/**', dependsOn: ['^build'] },
+      ];
       updateNxJson(tree, nxJson);
 
       tree.write('apps/myapp-e2e/cypress.config.ts', '');
@@ -381,28 +380,17 @@ describe('target-defaults-utils', () => {
         'apps/myapp-e2e/cypress.config.ts'
       );
 
-      // ASSERT
-      const newNxJson = readNxJson(tree);
-      expect(newNxJson.targetDefaults).toMatchInlineSnapshot(`
-        {
-          "build": {
-            "cache": true,
-          },
-          "e2e-ci--**/**": {
-            "dependsOn": [
-              "^build",
-            ],
-          },
-          "lint": {
-            "cache": true,
-          },
-        }
-      `);
+      // ASSERT — single entry, single build dependency
+      expect(findGlobEntry(tree, 'e2e-ci--**/**')).toEqual({
+        target: 'e2e-ci--**/**',
+        dependsOn: ['^build'],
+      });
     });
 
-    it('should do nothing when there are no nxJson.plugins does not exist', async () => {
+    it('does nothing when nxJson.plugins is absent', async () => {
       // ARRANGE
       const nxJson = readNxJson(tree);
+      const before = nxJson.targetDefaults;
       nxJson.plugins = undefined;
       updateNxJson(tree, nxJson);
 
@@ -417,23 +405,14 @@ describe('target-defaults-utils', () => {
         'apps/myapp-e2e/cypress.config.ts'
       );
 
-      // ASSERT
-      const newNxJson = readNxJson(tree);
-      expect(newNxJson.targetDefaults).toMatchInlineSnapshot(`
-        {
-          "build": {
-            "cache": true,
-          },
-          "lint": {
-            "cache": true,
-          },
-        }
-      `);
+      // ASSERT — unchanged
+      expect(readNxJson(tree).targetDefaults).toEqual(before);
     });
 
-    it('should do nothing when there are nxJson.plugins but e2e plugin is not registered', async () => {
+    it('does nothing when the e2e plugin is not registered', async () => {
       // ARRANGE
       const nxJson = readNxJson(tree);
+      const before = nxJson.targetDefaults;
       nxJson.plugins ??= [];
       nxJson.plugins.push({
         plugin: '@nx/playwright/plugin',
@@ -455,38 +434,22 @@ describe('target-defaults-utils', () => {
         'apps/myapp-e2e/cypress.config.ts'
       );
 
-      // ASSERT
-      const newNxJson = readNxJson(tree);
-      expect(newNxJson.targetDefaults).toMatchInlineSnapshot(`
-        {
-          "build": {
-            "cache": true,
-          },
-          "lint": {
-            "cache": true,
-          },
-        }
-      `);
+      // ASSERT — unchanged
+      expect(readNxJson(tree).targetDefaults).toEqual(before);
     });
 
-    it('should choose the correct plugin when there are includes', async () => {
+    it('chooses the matching plugin registration via include', async () => {
       // ARRANGE
       const nxJson = readNxJson(tree);
       nxJson.plugins ??= [];
       nxJson.plugins.push({
         plugin: '@nx/cypress/plugin',
-        options: {
-          targetName: 'e2e',
-          ciTargetName: 'e2e-ci',
-        },
+        options: { targetName: 'e2e', ciTargetName: 'e2e-ci' },
         include: ['libs/**'],
       });
       nxJson.plugins.push({
         plugin: '@nx/cypress/plugin',
-        options: {
-          targetName: 'e2e',
-          ciTargetName: 'cypress:e2e-ci',
-        },
+        options: { targetName: 'e2e', ciTargetName: 'cypress:e2e-ci' },
         include: ['apps/**'],
       });
       updateNxJson(tree, nxJson);
@@ -503,35 +466,24 @@ describe('target-defaults-utils', () => {
       );
 
       // ASSERT
-      const newNxJson = readNxJson(tree);
-      expect(newNxJson.targetDefaults['cypress:e2e-ci--**/**'])
-        .toMatchInlineSnapshot(`
-        {
-          "dependsOn": [
-            "^build",
-          ],
-        }
-      `);
+      expect(findGlobEntry(tree, 'cypress:e2e-ci--**/**')).toEqual({
+        target: 'cypress:e2e-ci--**/**',
+        dependsOn: ['^build'],
+      });
     });
 
-    it('should choose the correct plugin when there are excludes', async () => {
+    it('chooses the matching plugin registration via exclude', async () => {
       // ARRANGE
       const nxJson = readNxJson(tree);
       nxJson.plugins ??= [];
       nxJson.plugins.push({
         plugin: '@nx/cypress/plugin',
-        options: {
-          targetName: 'e2e',
-          ciTargetName: 'e2e-ci',
-        },
+        options: { targetName: 'e2e', ciTargetName: 'e2e-ci' },
         exclude: ['apps/**'],
       });
       nxJson.plugins.push({
         plugin: '@nx/cypress/plugin',
-        options: {
-          targetName: 'e2e',
-          ciTargetName: 'cypress:e2e-ci',
-        },
+        options: { targetName: 'e2e', ciTargetName: 'cypress:e2e-ci' },
         exclude: ['libs/**'],
       });
       updateNxJson(tree, nxJson);
@@ -548,18 +500,13 @@ describe('target-defaults-utils', () => {
       );
 
       // ASSERT
-      const newNxJson = readNxJson(tree);
-      expect(newNxJson.targetDefaults['cypress:e2e-ci--**/**'])
-        .toMatchInlineSnapshot(`
-        {
-          "dependsOn": [
-            "^build",
-          ],
-        }
-      `);
+      expect(findGlobEntry(tree, 'cypress:e2e-ci--**/**')).toEqual({
+        target: 'cypress:e2e-ci--**/**',
+        dependsOn: ['^build'],
+      });
     });
 
-    it('should use the default name when the plugin registration is a string', async () => {
+    it('uses the default ciTargetName when the plugin registration is a string', async () => {
       // ARRANGE
       const nxJson = readNxJson(tree);
       nxJson.plugins ??= [];
@@ -578,14 +525,10 @@ describe('target-defaults-utils', () => {
       );
 
       // ASSERT
-      const newNxJson = readNxJson(tree);
-      expect(newNxJson.targetDefaults['e2e-ci--**/**']).toMatchInlineSnapshot(`
-        {
-          "dependsOn": [
-            "^build",
-          ],
-        }
-      `);
+      expect(findGlobEntry(tree, 'e2e-ci--**/**')).toEqual({
+        target: 'e2e-ci--**/**',
+        dependsOn: ['^build'],
+      });
     });
   });
 });

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -10,7 +10,21 @@ import {
   updateNxJson,
 } from 'nx/src/devkit-exports';
 import { findMatchingConfigFiles } from 'nx/src/devkit-internals';
-import { normalizeTargetDefaults } from '../utils/normalize-target-defaults';
+import { gte, valid } from 'semver';
+import { NX_VERSION } from '../utils/package-json';
+import {
+  downgradeTargetDefaults,
+  normalizeTargetDefaults,
+} from '../utils/normalize-target-defaults';
+
+// devkit supports `nx` at major +/- 1; on nx<23 the array shape doesn't
+// exist yet, so writing array would produce an nx.json the installed nx
+// can't validate. Promote-to-array only when nx is new enough; otherwise
+// preserve a legacy record on disk. Treat unknown / placeholder versions
+// (e.g. workspace dev "0.0.1" before publish replacement) as modern —
+// the alternative would silently downgrade every monorepo dev test.
+const SUPPORTS_ARRAY_TARGET_DEFAULTS =
+  !valid(NX_VERSION) || NX_VERSION === '0.0.1' || gte(NX_VERSION, '23.0.0');
 
 /**
  * Upsert a `targetDefaults` entry. Always writes the array shape — if the
@@ -52,7 +66,8 @@ export function upsertTargetDefault(
   }
 
   const { target, executor, projects, source, ...config } = options;
-  const entries = normalizeTargetDefaults(nxJson.targetDefaults);
+  const originalShape = nxJson.targetDefaults;
+  const entries = normalizeTargetDefaults(originalShape);
   const matchIndex = entries.findIndex(
     (e) =>
       e.target === target &&
@@ -83,7 +98,10 @@ export function upsertTargetDefault(
     );
   }
 
-  nxJson.targetDefaults = entries;
+  nxJson.targetDefaults =
+    SUPPORTS_ARRAY_TARGET_DEFAULTS || Array.isArray(originalShape)
+      ? entries
+      : downgradeTargetDefaults(entries);
   if (callerProvidedNxJson) {
     return nxJson;
   }

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -2,16 +2,21 @@ import {
   type CreateNodesV2,
   type NxJsonConfiguration,
   type PluginConfiguration,
+  type ProjectConfiguration,
   type TargetConfiguration,
   type TargetDefaultEntry,
   type TargetDefaults,
+  type TargetDefaultsRecord,
   type Tree,
+  getProjects,
   readNxJson,
   updateNxJson,
 } from 'nx/src/devkit-exports';
 import { findMatchingConfigFiles } from 'nx/src/devkit-internals';
 import { major, valid } from 'semver';
 import { NX_VERSION } from '../utils/package-json';
+import { readTargetDefaultsForTarget as readTargetDefaultsForTargetFromNx } from 'nx/src/project-graph/utils/project-configuration-utils';
+import { normalizeTargetDefaultsAgainstRootMaps } from 'nx/src/project-graph/utils/project-configuration/target-defaults';
 import {
   downgradeTargetDefaults,
   normalizeTargetDefaults,
@@ -51,7 +56,7 @@ export function upsertTargetDefault(
   // it's already array shape. Without the spread, `entries[matchIndex] = ...`
   // and `entries.push(...)` would mutate the user's array reference (and
   // any other holders of the same `nxJson.targetDefaults` reference).
-  const entries = [...normalizeTargetDefaults(originalShape)];
+  const entries = [...normalizeTargetDefaultsForUpsert(tree, originalShape)];
   const matchIndex = entries.findIndex(
     (e) =>
       e.target === target &&
@@ -132,6 +137,53 @@ export function findTargetDefault(
       e.executor === locator.executor &&
       projectsEqual(e.projects, locator.projects) &&
       e.plugin === locator.plugin
+  );
+}
+
+export function readTargetDefaultsForTarget(
+  targetName: string,
+  targetDefaults: TargetDefaults | undefined,
+  executor?: string,
+  opts?: Parameters<typeof readTargetDefaultsForTargetFromNx>[3]
+): Partial<TargetConfiguration> | null {
+  if (
+    targetDefaults &&
+    !Array.isArray(targetDefaults) &&
+    Object.prototype.hasOwnProperty.call(targetDefaults, targetName)
+  ) {
+    return (targetDefaults as TargetDefaultsRecord)[targetName] ?? null;
+  }
+
+  return readTargetDefaultsForTargetFromNx(
+    targetName,
+    targetDefaults,
+    executor,
+    opts
+  );
+}
+
+function normalizeTargetDefaultsForUpsert(
+  tree: Tree,
+  targetDefaults: TargetDefaults | undefined
+): TargetDefaultEntry[] {
+  if (!targetDefaults) {
+    return [];
+  }
+  if (Array.isArray(targetDefaults)) {
+    return targetDefaults;
+  }
+
+  return normalizeTargetDefaultsAgainstRootMaps(
+    targetDefaults,
+    buildProjectRootMap(getProjects(tree))
+  );
+}
+
+function buildProjectRootMap(
+  projects: Map<string, ProjectConfiguration>
+): Record<string, ProjectConfiguration> {
+  return Object.fromEntries(
+    [...projects.values()].map((project) => [project.root, project])
   );
 }
 

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -10,7 +10,7 @@ import {
   updateNxJson,
 } from 'nx/src/devkit-exports';
 import { findMatchingConfigFiles } from 'nx/src/devkit-internals';
-import { gte, valid } from 'semver';
+import { gte, major, valid } from 'semver';
 import { NX_VERSION } from '../utils/package-json';
 import {
   downgradeTargetDefaults,
@@ -23,8 +23,10 @@ import {
 // preserve a legacy record on disk. Treat unknown / placeholder versions
 // (e.g. workspace dev "0.0.1" before publish replacement) as modern —
 // the alternative would silently downgrade every monorepo dev test.
+// Compare on major so beta/rc pre-release tags (`23.0.0-beta.8`) count
+// as nx 23 — `gte` would treat them as less than `23.0.0`.
 const SUPPORTS_ARRAY_TARGET_DEFAULTS =
-  !valid(NX_VERSION) || NX_VERSION === '0.0.1' || gte(NX_VERSION, '23.0.0');
+  !valid(NX_VERSION) || NX_VERSION === '0.0.1' || major(NX_VERSION) >= 23;
 
 /**
  * Upsert a `targetDefaults` entry. Always writes the array shape — if the

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -3,7 +3,6 @@ import {
   type PluginConfiguration,
   type TargetConfiguration,
   type TargetDefaultEntry,
-  type TargetDefaults,
   type Tree,
   readNxJson,
   updateNxJson,
@@ -11,58 +10,48 @@ import {
 import { findMatchingConfigFiles } from 'nx/src/devkit-internals';
 import { normalizeTargetDefaults } from '../utils/normalize-target-defaults';
 
-export interface UpsertTargetDefaultOptions
-  extends Partial<TargetConfiguration> {
-  target: string;
-  projects?: string | string[];
-  source?: string;
-}
-
 /**
- * Upsert a `targetDefaults` entry in nx.json. Reads the current shape
- * (array or legacy record), finds a matching entry by the
- * `(target, projects, source)` tuple, and merges the given config into
- * it (or appends a new entry).
+ * Upsert a `targetDefaults` entry in nx.json. Always writes the array
+ * shape — if nx.json still uses the legacy record shape, it is upgraded
+ * in place. Finds a matching entry by the
+ * `(target, executor, projects, source)` tuple and merges the given
+ * config into it, or appends a new entry.
  *
- * If nx.json uses the legacy record shape AND the caller provides a
- * `projects` or `source` filter, nx.json is upgraded to the array shape
- * because the record shape cannot express filtered entries.
+ * The entry must set at least one of `target` / `executor`.
  */
 export function upsertTargetDefault(
   tree: Tree,
-  options: UpsertTargetDefaultOptions
+  options: TargetDefaultEntry
 ): void {
-  const { target, projects, source, ...config } = options;
-  const nxJson = readNxJson(tree) ?? {};
-  const existing: TargetDefaults | undefined = nxJson.targetDefaults;
-  const hasFilter = projects !== undefined || source !== undefined;
-
-  // Legacy record shape, no filters → stay in record shape.
-  if (existing && !Array.isArray(existing) && !hasFilter) {
-    const record = { ...existing };
-    record[target] = { ...(record[target] ?? {}), ...config };
-    nxJson.targetDefaults = record;
-    updateNxJson(tree, nxJson);
-    return;
+  if (options.target === undefined && options.executor === undefined) {
+    throw new Error(
+      'upsertTargetDefault requires at least one of `target` or `executor` to be set.'
+    );
   }
 
-  const entries = normalizeTargetDefaults(existing);
+  const { target, executor, projects, source, ...config } = options;
+  const nxJson = readNxJson(tree) ?? {};
+  const entries = normalizeTargetDefaults(nxJson.targetDefaults);
   const matchIndex = entries.findIndex(
     (e) =>
       e.target === target &&
+      e.executor === executor &&
       projectsEqual(e.projects, projects) &&
       e.source === source
   );
 
   const newEntry: TargetDefaultEntry = {
-    target,
+    ...(target !== undefined ? { target } : {}),
+    ...(executor !== undefined ? { executor } : {}),
     ...(projects !== undefined ? { projects } : {}),
     ...(source !== undefined ? { source } : {}),
     ...config,
   };
 
   if (matchIndex >= 0) {
-    const merged = { ...entries[matchIndex], ...config, target };
+    const merged: TargetDefaultEntry = { ...entries[matchIndex], ...config };
+    if (target !== undefined) merged.target = target;
+    if (executor !== undefined) merged.executor = executor;
     if (projects !== undefined) merged.projects = projects;
     if (source !== undefined) merged.source = source;
     entries[matchIndex] = merged;
@@ -94,8 +83,12 @@ export function addBuildTargetDefaults(
   extraInputs: TargetConfiguration['inputs'] = []
 ): void {
   const nxJson = readNxJson(tree) ?? {};
-  const existing = nxJson.targetDefaults;
-  const defaultConfig: Partial<TargetConfiguration> = {
+  const entries = normalizeTargetDefaults(nxJson.targetDefaults);
+  if (entries.some((e) => e.executor === executorName)) {
+    return;
+  }
+  upsertTargetDefault(tree, {
+    executor: executorName,
     cache: true,
     dependsOn: [`^${buildTargetName}`],
     inputs: [
@@ -104,25 +97,7 @@ export function addBuildTargetDefaults(
         : ['default', '^default']),
       ...extraInputs,
     ],
-  };
-
-  // Preserve legacy record-shape behavior when nx.json is still in that
-  // shape: only set the entry if one does not already exist at the
-  // executor key, and do not upgrade to the array shape.
-  if (existing && !Array.isArray(existing)) {
-    if (existing[executorName]) return;
-    nxJson.targetDefaults = { ...existing, [executorName]: defaultConfig };
-    updateNxJson(tree, nxJson);
-    return;
-  }
-
-  const entries = normalizeTargetDefaults(existing);
-  if (entries.some((e) => e.target === executorName)) {
-    return;
-  }
-  entries.push({ target: executorName, ...defaultConfig });
-  nxJson.targetDefaults = entries;
-  updateNxJson(tree, nxJson);
+  });
 }
 
 export async function addE2eCiTargetDefaults(
@@ -181,40 +156,16 @@ export async function addE2eCiTargetDefaults(
       : ((foundPluginForApplication.options as any)?.ciTargetName ?? 'e2e-ci');
 
   const ciTargetNameGlob = `${ciTargetName}--**/**`;
-  const existing = nxJson.targetDefaults;
-
-  // Legacy record-shape: preserve the existing mutate-in-place behavior.
-  if (existing && !Array.isArray(existing)) {
-    const current = existing[ciTargetNameGlob];
-    if (!current) {
-      existing[ciTargetNameGlob] = { dependsOn: [buildTarget] };
-    } else {
-      current.dependsOn ??= [];
-      if (!current.dependsOn.includes(buildTarget)) {
-        current.dependsOn.push(buildTarget);
-      }
-    }
-    nxJson.targetDefaults = existing;
-    updateNxJson(tree, nxJson);
-    return;
-  }
-
-  const entries = normalizeTargetDefaults(existing);
-  const matchIndex = entries.findIndex(
+  const existing = normalizeTargetDefaults(nxJson.targetDefaults).find(
     (e) =>
       e.target === ciTargetNameGlob &&
+      e.executor === undefined &&
       e.projects === undefined &&
       e.source === undefined
   );
-  if (matchIndex < 0) {
-    entries.push({ target: ciTargetNameGlob, dependsOn: [buildTarget] });
-  } else {
-    const entry = entries[matchIndex];
-    entry.dependsOn ??= [];
-    if (!(entry.dependsOn as (string | unknown)[]).includes(buildTarget)) {
-      (entry.dependsOn as (string | unknown)[]).push(buildTarget);
-    }
+  const dependsOn = [...(existing?.dependsOn ?? [])];
+  if (!dependsOn.includes(buildTarget)) {
+    dependsOn.push(buildTarget);
   }
-  nxJson.targetDefaults = entries;
-  updateNxJson(tree, nxJson);
+  upsertTargetDefault(tree, { target: ciTargetNameGlob, dependsOn });
 }

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -61,23 +61,26 @@ export function upsertTargetDefault(
       e.source === source
   );
 
-  const newEntry: TargetDefaultEntry = {
-    ...(target !== undefined ? { target } : {}),
-    ...(executor !== undefined ? { executor } : {}),
-    ...(projects !== undefined ? { projects } : {}),
-    ...(source !== undefined ? { source } : {}),
-    ...config,
-  };
-
   if (matchIndex >= 0) {
-    const merged: TargetDefaultEntry = { ...entries[matchIndex], ...config };
-    if (target !== undefined) merged.target = target;
-    if (executor !== undefined) merged.executor = executor;
-    if (projects !== undefined) merged.projects = projects;
-    if (source !== undefined) merged.source = source;
-    entries[matchIndex] = merged;
+    const existing = entries[matchIndex];
+    const {
+      target: et,
+      executor: ee,
+      projects: ep,
+      source: es,
+      ...existingRest
+    } = existing;
+    entries[matchIndex] = buildTargetDefaultEntry(
+      target ?? et,
+      projects ?? ep,
+      source ?? es,
+      executor ?? ee,
+      { ...existingRest, ...config }
+    );
   } else {
-    entries.push(newEntry);
+    entries.push(
+      buildTargetDefaultEntry(target, projects, source, executor, config)
+    );
   }
 
   nxJson.targetDefaults = entries;
@@ -108,6 +111,28 @@ export function findTargetDefault(
       projectsEqual(e.projects, locator.projects) &&
       e.source === locator.source
   );
+}
+
+/**
+ * Construct a `TargetDefaultEntry` with the canonical key order
+ * `target → projects → source → executor → ...rest`. Locators land first
+ * so an entry's filter shape is obvious at a glance; `executor` follows
+ * because it doubles as a payload field.
+ */
+function buildTargetDefaultEntry(
+  target: string | undefined,
+  projects: string | string[] | undefined,
+  source: string | undefined,
+  executor: string | undefined,
+  rest: Partial<TargetConfiguration>
+): TargetDefaultEntry {
+  return {
+    ...(target !== undefined ? { target } : {}),
+    ...(projects !== undefined ? { projects } : {}),
+    ...(source !== undefined ? { source } : {}),
+    ...(executor !== undefined ? { executor } : {}),
+    ...rest,
+  };
 }
 
 function projectsEqual(

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -2,11 +2,90 @@ import {
   type CreateNodesV2,
   type PluginConfiguration,
   type TargetConfiguration,
+  type TargetDefaultEntry,
+  type TargetDefaults,
   type Tree,
   readNxJson,
   updateNxJson,
 } from 'nx/src/devkit-exports';
 import { findMatchingConfigFiles } from 'nx/src/devkit-internals';
+import { normalizeTargetDefaults } from '../utils/normalize-target-defaults';
+
+export interface UpsertTargetDefaultOptions
+  extends Partial<TargetConfiguration> {
+  target: string;
+  projects?: string | string[];
+  source?: string;
+}
+
+/**
+ * Upsert a `targetDefaults` entry in nx.json. Reads the current shape
+ * (array or legacy record), finds a matching entry by the
+ * `(target, projects, source)` tuple, and merges the given config into
+ * it (or appends a new entry).
+ *
+ * If nx.json uses the legacy record shape AND the caller provides a
+ * `projects` or `source` filter, nx.json is upgraded to the array shape
+ * because the record shape cannot express filtered entries.
+ */
+export function upsertTargetDefault(
+  tree: Tree,
+  options: UpsertTargetDefaultOptions
+): void {
+  const { target, projects, source, ...config } = options;
+  const nxJson = readNxJson(tree) ?? {};
+  const existing: TargetDefaults | undefined = nxJson.targetDefaults;
+  const hasFilter = projects !== undefined || source !== undefined;
+
+  // Legacy record shape, no filters → stay in record shape.
+  if (existing && !Array.isArray(existing) && !hasFilter) {
+    const record = { ...existing };
+    record[target] = { ...(record[target] ?? {}), ...config };
+    nxJson.targetDefaults = record;
+    updateNxJson(tree, nxJson);
+    return;
+  }
+
+  const entries = normalizeTargetDefaults(existing);
+  const matchIndex = entries.findIndex(
+    (e) =>
+      e.target === target &&
+      projectsEqual(e.projects, projects) &&
+      e.source === source
+  );
+
+  const newEntry: TargetDefaultEntry = {
+    target,
+    ...(projects !== undefined ? { projects } : {}),
+    ...(source !== undefined ? { source } : {}),
+    ...config,
+  };
+
+  if (matchIndex >= 0) {
+    const merged = { ...entries[matchIndex], ...config, target };
+    if (projects !== undefined) merged.projects = projects;
+    if (source !== undefined) merged.source = source;
+    entries[matchIndex] = merged;
+  } else {
+    entries.push(newEntry);
+  }
+
+  nxJson.targetDefaults = entries;
+  updateNxJson(tree, nxJson);
+}
+
+function projectsEqual(
+  a: string | string[] | undefined,
+  b: string | string[] | undefined
+): boolean {
+  if (a === b) return true;
+  const aArr = a === undefined ? undefined : Array.isArray(a) ? a : [a];
+  const bArr = b === undefined ? undefined : Array.isArray(b) ? b : [b];
+  if (!aArr || !bArr) return false;
+  if (aArr.length !== bArr.length) return false;
+  for (let i = 0; i < aArr.length; i++) if (aArr[i] !== bArr[i]) return false;
+  return true;
+}
 
 export function addBuildTargetDefaults(
   tree: Tree,
@@ -14,9 +93,9 @@ export function addBuildTargetDefaults(
   buildTargetName = 'build',
   extraInputs: TargetConfiguration['inputs'] = []
 ): void {
-  const nxJson = readNxJson(tree);
-  nxJson.targetDefaults ??= {};
-  nxJson.targetDefaults[executorName] ??= {
+  const nxJson = readNxJson(tree) ?? {};
+  const existing = nxJson.targetDefaults;
+  const defaultConfig: Partial<TargetConfiguration> = {
     cache: true,
     dependsOn: [`^${buildTargetName}`],
     inputs: [
@@ -26,6 +105,23 @@ export function addBuildTargetDefaults(
       ...extraInputs,
     ],
   };
+
+  // Preserve legacy record-shape behavior when nx.json is still in that
+  // shape: only set the entry if one does not already exist at the
+  // executor key, and do not upgrade to the array shape.
+  if (existing && !Array.isArray(existing)) {
+    if (existing[executorName]) return;
+    nxJson.targetDefaults = { ...existing, [executorName]: defaultConfig };
+    updateNxJson(tree, nxJson);
+    return;
+  }
+
+  const entries = normalizeTargetDefaults(existing);
+  if (entries.some((e) => e.target === executorName)) {
+    return;
+  }
+  entries.push({ target: executorName, ...defaultConfig });
+  nxJson.targetDefaults = entries;
   updateNxJson(tree, nxJson);
 }
 
@@ -36,7 +132,7 @@ export async function addE2eCiTargetDefaults(
   pathToE2EConfigFile: string
 ): Promise<void> {
   const nxJson = readNxJson(tree);
-  if (!nxJson.plugins) {
+  if (!nxJson?.plugins) {
     return;
   }
 
@@ -85,17 +181,40 @@ export async function addE2eCiTargetDefaults(
       : ((foundPluginForApplication.options as any)?.ciTargetName ?? 'e2e-ci');
 
   const ciTargetNameGlob = `${ciTargetName}--**/**`;
-  nxJson.targetDefaults ??= {};
-  const e2eCiTargetDefaults = nxJson.targetDefaults[ciTargetNameGlob];
-  if (!e2eCiTargetDefaults) {
-    nxJson.targetDefaults[ciTargetNameGlob] = {
-      dependsOn: [buildTarget],
-    };
+  const existing = nxJson.targetDefaults;
+
+  // Legacy record-shape: preserve the existing mutate-in-place behavior.
+  if (existing && !Array.isArray(existing)) {
+    const current = existing[ciTargetNameGlob];
+    if (!current) {
+      existing[ciTargetNameGlob] = { dependsOn: [buildTarget] };
+    } else {
+      current.dependsOn ??= [];
+      if (!current.dependsOn.includes(buildTarget)) {
+        current.dependsOn.push(buildTarget);
+      }
+    }
+    nxJson.targetDefaults = existing;
+    updateNxJson(tree, nxJson);
+    return;
+  }
+
+  const entries = normalizeTargetDefaults(existing);
+  const matchIndex = entries.findIndex(
+    (e) =>
+      e.target === ciTargetNameGlob &&
+      e.projects === undefined &&
+      e.source === undefined
+  );
+  if (matchIndex < 0) {
+    entries.push({ target: ciTargetNameGlob, dependsOn: [buildTarget] });
   } else {
-    e2eCiTargetDefaults.dependsOn ??= [];
-    if (!e2eCiTargetDefaults.dependsOn.includes(buildTarget)) {
-      e2eCiTargetDefaults.dependsOn.push(buildTarget);
+    const entry = entries[matchIndex];
+    entry.dependsOn ??= [];
+    if (!(entry.dependsOn as (string | unknown)[]).includes(buildTarget)) {
+      (entry.dependsOn as (string | unknown)[]).push(buildTarget);
     }
   }
+  nxJson.targetDefaults = entries;
   updateNxJson(tree, nxJson);
 }

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -17,14 +17,9 @@ import {
   normalizeTargetDefaults,
 } from '../utils/normalize-target-defaults';
 
-// devkit supports `nx` at major +/- 1; on nx<23 the array shape doesn't
-// exist yet, so writing array would produce an nx.json the installed nx
-// can't validate. Promote-to-array only when nx is new enough; otherwise
-// preserve a legacy record on disk. Treat unknown / placeholder versions
-// (e.g. workspace dev "0.0.1" before publish replacement) as modern —
-// the alternative would silently downgrade every monorepo dev test.
-// Compare on major so beta/rc pre-release tags (`23.0.0-beta.8`) count
-// as nx 23 — `gte` would treat them as less than `23.0.0`.
+// Only write the array shape on nx >= 23 (workspace placeholder "0.0.1"
+// counts as modern); older nx can't validate it. Major-only compare so
+// pre-release tags like `23.0.0-beta.8` count as nx 23.
 const SUPPORTS_ARRAY_TARGET_DEFAULTS =
   !valid(NX_VERSION) || NX_VERSION === '0.0.1' || major(NX_VERSION) >= 23;
 
@@ -87,10 +82,8 @@ export function upsertTargetDefault(
     );
   }
 
-  // On pre-v23 nx with a record-shape on-disk value, try to preserve the
-  // record shape; if any entry can't be represented (filters, key
-  // collisions, missing key), force-promote to array shape rather than
-  // drop data — pre-v23 nx will warn but still read it.
+  // Preserve the record shape on pre-v23 nx when possible; promote to
+  // array if any entry can't be represented in record form.
   if (SUPPORTS_ARRAY_TARGET_DEFAULTS || Array.isArray(originalShape)) {
     nxJson.targetDefaults = entries;
   } else {
@@ -164,11 +157,8 @@ function buildTargetDefaultEntry(
   };
 }
 
-// Set-based equality so `['a','b']` and `['b','a']` are treated as the
-// same locator. Positional comparison would silently create a second
-// entry on re-upsert when the caller passes the same patterns in a
-// different order — an easy mistake when patterns are produced by
-// generated code or assembled from configuration.
+// Order-insensitive equality so re-upserts with reordered patterns
+// merge into the same entry rather than appending a duplicate.
 function projectsEqual(
   a: string | string[] | undefined,
   b: string | string[] | undefined

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -1,8 +1,10 @@
 import {
   type CreateNodesV2,
+  type NxJsonConfiguration,
   type PluginConfiguration,
   type TargetConfiguration,
   type TargetDefaultEntry,
+  type TargetDefaults,
   type Tree,
   readNxJson,
   updateNxJson,
@@ -11,18 +13,38 @@ import { findMatchingConfigFiles } from 'nx/src/devkit-internals';
 import { normalizeTargetDefaults } from '../utils/normalize-target-defaults';
 
 /**
- * Upsert a `targetDefaults` entry in nx.json. Always writes the array
- * shape — if nx.json still uses the legacy record shape, it is upgraded
- * in place. Finds a matching entry by the
- * `(target, executor, projects, source)` tuple and merges the given
- * config into it, or appends a new entry.
+ * Upsert a `targetDefaults` entry. Always writes the array shape — if the
+ * underlying value still uses the legacy record shape, it is upgraded in
+ * place. Finds a matching entry by the `(target, executor, projects,
+ * source)` tuple and merges the given config into it, or appends a new
+ * entry. The entry must set at least one of `target` / `executor`.
  *
- * The entry must set at least one of `target` / `executor`.
+ * Two call shapes:
+ * - `(tree, options)` — reads/writes nx.json itself (single edit).
+ * - `(tree, nxJson, options)` — mutates the provided `nxJson` in place
+ *   and returns it so the caller can batch other edits before calling
+ *   `updateNxJson` exactly once.
  */
 export function upsertTargetDefault(
   tree: Tree,
   options: TargetDefaultEntry
-): void {
+): void;
+export function upsertTargetDefault(
+  tree: Tree,
+  nxJson: NxJsonConfiguration,
+  options: TargetDefaultEntry
+): NxJsonConfiguration;
+export function upsertTargetDefault(
+  tree: Tree,
+  arg2: TargetDefaultEntry | NxJsonConfiguration,
+  arg3?: TargetDefaultEntry
+): NxJsonConfiguration | void {
+  const callerProvidedNxJson = arg3 !== undefined;
+  const options = (callerProvidedNxJson ? arg3 : arg2) as TargetDefaultEntry;
+  const nxJson = (
+    callerProvidedNxJson ? arg2 : (readNxJson(tree) ?? {})
+  ) as NxJsonConfiguration;
+
   if (options.target === undefined && options.executor === undefined) {
     throw new Error(
       'upsertTargetDefault requires at least one of `target` or `executor` to be set.'
@@ -30,7 +52,6 @@ export function upsertTargetDefault(
   }
 
   const { target, executor, projects, source, ...config } = options;
-  const nxJson = readNxJson(tree) ?? {};
   const entries = normalizeTargetDefaults(nxJson.targetDefaults);
   const matchIndex = entries.findIndex(
     (e) =>
@@ -60,7 +81,33 @@ export function upsertTargetDefault(
   }
 
   nxJson.targetDefaults = entries;
+  if (callerProvidedNxJson) {
+    return nxJson;
+  }
   updateNxJson(tree, nxJson);
+}
+
+/**
+ * Find a `targetDefaults` entry by its locator tuple
+ * `(target, executor, projects, source)`. Locator keys default to
+ * `undefined`, matching only entries that also leave them unset — same
+ * semantics as `upsertTargetDefault`. Accepts either array or legacy
+ * record shape.
+ */
+export function findTargetDefault(
+  targetDefaults: TargetDefaults | undefined,
+  locator: Pick<
+    TargetDefaultEntry,
+    'target' | 'executor' | 'projects' | 'source'
+  >
+): TargetDefaultEntry | undefined {
+  return normalizeTargetDefaults(targetDefaults).find(
+    (e) =>
+      e.target === locator.target &&
+      e.executor === locator.executor &&
+      projectsEqual(e.projects, locator.projects) &&
+      e.source === locator.source
+  );
 }
 
 function projectsEqual(
@@ -156,13 +203,9 @@ export async function addE2eCiTargetDefaults(
       : ((foundPluginForApplication.options as any)?.ciTargetName ?? 'e2e-ci');
 
   const ciTargetNameGlob = `${ciTargetName}--**/**`;
-  const existing = normalizeTargetDefaults(nxJson.targetDefaults).find(
-    (e) =>
-      e.target === ciTargetNameGlob &&
-      e.executor === undefined &&
-      e.projects === undefined &&
-      e.source === undefined
-  );
+  const existing = findTargetDefault(nxJson.targetDefaults, {
+    target: ciTargetNameGlob,
+  });
   const dependsOn = [...(existing?.dependsOn ?? [])];
   if (!dependsOn.includes(buildTarget)) {
     dependsOn.push(buildTarget);

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -35,7 +35,7 @@ const SUPPORTS_ARRAY_TARGET_DEFAULTS =
  *
  * Always writes the array shape — if the underlying value still uses
  * the legacy record shape, it is upgraded in place. Finds a matching
- * entry by the `(target, executor, projects, source)` tuple and merges
+ * entry by the `(target, executor, projects, plugin)` tuple and merges
  * the given config into it, or appends a new entry. The entry must set
  * at least one of `target` / `executor`.
  */
@@ -50,7 +50,7 @@ export function upsertTargetDefault(
     );
   }
 
-  const { target, executor, projects, source, ...config } = options;
+  const { target, executor, projects, plugin, ...config } = options;
   const originalShape = nxJson.targetDefaults;
   const entries = normalizeTargetDefaults(originalShape);
   const matchIndex = entries.findIndex(
@@ -58,7 +58,7 @@ export function upsertTargetDefault(
       e.target === target &&
       e.executor === executor &&
       projectsEqual(e.projects, projects) &&
-      e.source === source
+      e.plugin === plugin
   );
 
   if (matchIndex >= 0) {
@@ -67,19 +67,19 @@ export function upsertTargetDefault(
       target: et,
       executor: ee,
       projects: ep,
-      source: es,
+      plugin: ep2,
       ...existingRest
     } = existing;
     entries[matchIndex] = buildTargetDefaultEntry(
       target ?? et,
       projects ?? ep,
-      source ?? es,
+      plugin ?? ep2,
       executor ?? ee,
       { ...existingRest, ...config }
     );
   } else {
     entries.push(
-      buildTargetDefaultEntry(target, projects, source, executor, config)
+      buildTargetDefaultEntry(target, projects, plugin, executor, config)
     );
   }
 
@@ -92,7 +92,7 @@ export function upsertTargetDefault(
 
 /**
  * Find a `targetDefaults` entry by its locator tuple
- * `(target, executor, projects, source)`. Locator keys default to
+ * `(target, executor, projects, plugin)`. Locator keys default to
  * `undefined`, matching only entries that also leave them unset — same
  * semantics as `upsertTargetDefault`. Accepts either array or legacy
  * record shape.
@@ -101,7 +101,7 @@ export function findTargetDefault(
   targetDefaults: TargetDefaults | undefined,
   locator: Pick<
     TargetDefaultEntry,
-    'target' | 'executor' | 'projects' | 'source'
+    'target' | 'executor' | 'projects' | 'plugin'
   >
 ): TargetDefaultEntry | undefined {
   return normalizeTargetDefaults(targetDefaults).find(
@@ -109,27 +109,27 @@ export function findTargetDefault(
       e.target === locator.target &&
       e.executor === locator.executor &&
       projectsEqual(e.projects, locator.projects) &&
-      e.source === locator.source
+      e.plugin === locator.plugin
   );
 }
 
 /**
  * Construct a `TargetDefaultEntry` with the canonical key order
- * `target → projects → source → executor → ...rest`. Locators land first
+ * `target → projects → plugin → executor → ...rest`. Locators land first
  * so an entry's filter shape is obvious at a glance; `executor` follows
  * because it doubles as a payload field.
  */
 function buildTargetDefaultEntry(
   target: string | undefined,
   projects: string | string[] | undefined,
-  source: string | undefined,
+  plugin: string | undefined,
   executor: string | undefined,
   rest: Partial<TargetConfiguration>
 ): TargetDefaultEntry {
   return {
     ...(target !== undefined ? { target } : {}),
     ...(projects !== undefined ? { projects } : {}),
-    ...(source !== undefined ? { source } : {}),
+    ...(plugin !== undefined ? { plugin } : {}),
     ...(executor !== undefined ? { executor } : {}),
     ...rest,
   };

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -12,11 +12,13 @@ import {
   readNxJson,
   updateNxJson,
 } from 'nx/src/devkit-exports';
-import { findMatchingConfigFiles } from 'nx/src/devkit-internals';
+import {
+  findMatchingConfigFiles,
+  normalizeTargetDefaultsAgainstRootMaps,
+  readTargetDefaultsForTarget as readTargetDefaultsForTargetFromNx,
+} from 'nx/src/devkit-internals';
 import { major, valid } from 'semver';
 import { NX_VERSION } from '../utils/package-json';
-import { readTargetDefaultsForTarget as readTargetDefaultsForTargetFromNx } from 'nx/src/project-graph/utils/project-configuration-utils';
-import { normalizeTargetDefaultsAgainstRootMaps } from 'nx/src/project-graph/utils/project-configuration/target-defaults';
 import {
   downgradeTargetDefaults,
   normalizeTargetDefaults,

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -52,7 +52,11 @@ export function upsertTargetDefault(
 
   const { target, executor, projects, plugin, ...config } = options;
   const originalShape = nxJson.targetDefaults;
-  const entries = normalizeTargetDefaults(originalShape);
+  // Copy — `normalizeTargetDefaults` returns the input array as-is when
+  // it's already array shape. Without the spread, `entries[matchIndex] = ...`
+  // and `entries.push(...)` would mutate the user's array reference (and
+  // any other holders of the same `nxJson.targetDefaults` reference).
+  const entries = [...normalizeTargetDefaults(originalShape)];
   const matchIndex = entries.findIndex(
     (e) =>
       e.target === target &&
@@ -83,10 +87,19 @@ export function upsertTargetDefault(
     );
   }
 
-  nxJson.targetDefaults =
-    SUPPORTS_ARRAY_TARGET_DEFAULTS || Array.isArray(originalShape)
-      ? entries
-      : downgradeTargetDefaults(entries);
+  // On pre-v23 nx with a record-shape on-disk value, try to preserve the
+  // record shape; if any entry can't be represented (filters, key
+  // collisions, missing key), force-promote to array shape rather than
+  // drop data — pre-v23 nx will warn but still read it.
+  if (SUPPORTS_ARRAY_TARGET_DEFAULTS || Array.isArray(originalShape)) {
+    nxJson.targetDefaults = entries;
+  } else {
+    try {
+      nxJson.targetDefaults = downgradeTargetDefaults(entries);
+    } catch {
+      nxJson.targetDefaults = entries;
+    }
+  }
   return nxJson;
 }
 
@@ -96,6 +109,12 @@ export function upsertTargetDefault(
  * `undefined`, matching only entries that also leave them unset — same
  * semantics as `upsertTargetDefault`. Accepts either array or legacy
  * record shape.
+ *
+ * Throws when called with an empty locator (no `target`, `executor`,
+ * `projects`, or `plugin`). An empty locator is almost always a bug —
+ * the caller intended to find a specific entry but forgot to populate
+ * the lookup. Returning the first matching entry (or `undefined`) would
+ * silently mask the mistake.
  */
 export function findTargetDefault(
   targetDefaults: TargetDefaults | undefined,
@@ -104,6 +123,16 @@ export function findTargetDefault(
     'target' | 'executor' | 'projects' | 'plugin'
   >
 ): TargetDefaultEntry | undefined {
+  if (
+    locator.target === undefined &&
+    locator.executor === undefined &&
+    locator.projects === undefined &&
+    locator.plugin === undefined
+  ) {
+    throw new Error(
+      'findTargetDefault requires at least one of `target`, `executor`, `projects`, or `plugin` on the locator.'
+    );
+  }
   return normalizeTargetDefaults(targetDefaults).find(
     (e) =>
       e.target === locator.target &&
@@ -135,6 +164,11 @@ function buildTargetDefaultEntry(
   };
 }
 
+// Set-based equality so `['a','b']` and `['b','a']` are treated as the
+// same locator. Positional comparison would silently create a second
+// entry on re-upsert when the caller passes the same patterns in a
+// different order — an easy mistake when patterns are produced by
+// generated code or assembled from configuration.
 function projectsEqual(
   a: string | string[] | undefined,
   b: string | string[] | undefined
@@ -144,7 +178,14 @@ function projectsEqual(
   const bArr = b === undefined ? undefined : Array.isArray(b) ? b : [b];
   if (!aArr || !bArr) return false;
   if (aArr.length !== bArr.length) return false;
-  for (let i = 0; i < aArr.length; i++) if (aArr[i] !== bArr[i]) return false;
+  const aSet = new Set(aArr);
+  if (aSet.size !== aArr.length) {
+    // Duplicates inside one array — fall back to positional comparison so
+    // we don't silently merge `['a','a']` with `['a']`.
+    for (let i = 0; i < aArr.length; i++) if (aArr[i] !== bArr[i]) return false;
+    return true;
+  }
+  for (const item of bArr) if (!aSet.has(item)) return false;
   return true;
 }
 
@@ -156,7 +197,18 @@ export function addBuildTargetDefaults(
 ): void {
   const nxJson = readNxJson(tree) ?? {};
   const entries = normalizeTargetDefaults(nxJson.targetDefaults);
-  if (entries.some((e) => e.executor === executorName)) {
+  // Only skip when an *unfiltered* entry already covers this executor.
+  // A filtered entry (`projects:` or `plugin:`) only applies to a subset
+  // of targets, so it doesn't satisfy the workspace-wide default this
+  // helper writes — we still need to add the unfiltered baseline.
+  if (
+    entries.some(
+      (e) =>
+        e.executor === executorName &&
+        e.projects === undefined &&
+        e.plugin === undefined
+    )
+  ) {
     return;
   }
   upsertTargetDefault(tree, nxJson, {

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -10,7 +10,7 @@ import {
   updateNxJson,
 } from 'nx/src/devkit-exports';
 import { findMatchingConfigFiles } from 'nx/src/devkit-internals';
-import { gte, major, valid } from 'semver';
+import { major, valid } from 'semver';
 import { NX_VERSION } from '../utils/package-json';
 import {
   downgradeTargetDefaults,
@@ -29,38 +29,21 @@ const SUPPORTS_ARRAY_TARGET_DEFAULTS =
   !valid(NX_VERSION) || NX_VERSION === '0.0.1' || major(NX_VERSION) >= 23;
 
 /**
- * Upsert a `targetDefaults` entry. Always writes the array shape — if the
- * underlying value still uses the legacy record shape, it is upgraded in
- * place. Finds a matching entry by the `(target, executor, projects,
- * source)` tuple and merges the given config into it, or appends a new
- * entry. The entry must set at least one of `target` / `executor`.
+ * Upsert a `targetDefaults` entry on the provided `nxJson`. Mutates
+ * `nxJson` in place and returns it so the caller can chain or batch
+ * other edits before persisting via `updateNxJson` exactly once.
  *
- * Two call shapes:
- * - `(tree, options)` — reads/writes nx.json itself (single edit).
- * - `(tree, nxJson, options)` — mutates the provided `nxJson` in place
- *   and returns it so the caller can batch other edits before calling
- *   `updateNxJson` exactly once.
+ * Always writes the array shape — if the underlying value still uses
+ * the legacy record shape, it is upgraded in place. Finds a matching
+ * entry by the `(target, executor, projects, source)` tuple and merges
+ * the given config into it, or appends a new entry. The entry must set
+ * at least one of `target` / `executor`.
  */
-export function upsertTargetDefault(
-  tree: Tree,
-  options: TargetDefaultEntry
-): void;
 export function upsertTargetDefault(
   tree: Tree,
   nxJson: NxJsonConfiguration,
   options: TargetDefaultEntry
-): NxJsonConfiguration;
-export function upsertTargetDefault(
-  tree: Tree,
-  arg2: TargetDefaultEntry | NxJsonConfiguration,
-  arg3?: TargetDefaultEntry
-): NxJsonConfiguration | void {
-  const callerProvidedNxJson = arg3 !== undefined;
-  const options = (callerProvidedNxJson ? arg3 : arg2) as TargetDefaultEntry;
-  const nxJson = (
-    callerProvidedNxJson ? arg2 : (readNxJson(tree) ?? {})
-  ) as NxJsonConfiguration;
-
+): NxJsonConfiguration {
   if (options.target === undefined && options.executor === undefined) {
     throw new Error(
       'upsertTargetDefault requires at least one of `target` or `executor` to be set.'
@@ -104,10 +87,7 @@ export function upsertTargetDefault(
     SUPPORTS_ARRAY_TARGET_DEFAULTS || Array.isArray(originalShape)
       ? entries
       : downgradeTargetDefaults(entries);
-  if (callerProvidedNxJson) {
-    return nxJson;
-  }
-  updateNxJson(tree, nxJson);
+  return nxJson;
 }
 
 /**
@@ -179,7 +159,7 @@ export function addBuildTargetDefaults(
   if (entries.some((e) => e.executor === executorName)) {
     return;
   }
-  upsertTargetDefault(tree, {
+  upsertTargetDefault(tree, nxJson, {
     executor: executorName,
     cache: true,
     dependsOn: [`^${buildTargetName}`],
@@ -190,6 +170,7 @@ export function addBuildTargetDefaults(
       ...extraInputs,
     ],
   });
+  updateNxJson(tree, nxJson);
 }
 
 export async function addE2eCiTargetDefaults(
@@ -255,5 +236,6 @@ export async function addE2eCiTargetDefaults(
   if (!dependsOn.includes(buildTarget)) {
     dependsOn.push(buildTarget);
   }
-  upsertTargetDefault(tree, { target: ciTargetNameGlob, dependsOn });
+  upsertTargetDefault(tree, nxJson, { target: ciTargetNameGlob, dependsOn });
+  updateNxJson(tree, nxJson);
 }

--- a/packages/devkit/src/utils/normalize-target-defaults.spec.ts
+++ b/packages/devkit/src/utils/normalize-target-defaults.spec.ts
@@ -1,7 +1,4 @@
-import {
-  isTargetDefaultsArray,
-  normalizeTargetDefaults,
-} from './normalize-target-defaults';
+import { normalizeTargetDefaults } from './normalize-target-defaults';
 
 describe('normalizeTargetDefaults', () => {
   it('returns [] for undefined', () => {
@@ -37,18 +34,5 @@ describe('normalizeTargetDefaults', () => {
         lint: null as any,
       })
     ).toEqual([{ target: 'build' }, { target: 'lint' }]);
-  });
-});
-
-describe('isTargetDefaultsArray', () => {
-  it('returns true for arrays', () => {
-    expect(isTargetDefaultsArray([])).toBe(true);
-    expect(isTargetDefaultsArray([{ target: 'a' as const }])).toBe(true);
-  });
-
-  it('returns false for record or undefined', () => {
-    expect(isTargetDefaultsArray({})).toBe(false);
-    expect(isTargetDefaultsArray({ build: { cache: true } })).toBe(false);
-    expect(isTargetDefaultsArray(undefined)).toBe(false);
   });
 });

--- a/packages/devkit/src/utils/normalize-target-defaults.spec.ts
+++ b/packages/devkit/src/utils/normalize-target-defaults.spec.ts
@@ -1,5 +1,4 @@
 import {
-  findTargetDefaultEntry,
   isTargetDefaultsArray,
   normalizeTargetDefaults,
 } from './normalize-target-defaults';
@@ -9,24 +8,25 @@ describe('normalizeTargetDefaults', () => {
     expect(normalizeTargetDefaults(undefined)).toEqual([]);
   });
 
-  it('returns a shallow copy of an array shape', () => {
+  it('returns the array shape unchanged (no clone)', () => {
     const input = [{ target: 'test' as const, cache: true }];
     const out = normalizeTargetDefaults(input);
-    expect(out).toEqual(input);
-    expect(out).not.toBe(input);
+    expect(out).toBe(input);
   });
 
-  it('converts record shape preserving insertion order', () => {
+  it('converts record shape preserving insertion order, splitting executor keys', () => {
     expect(
       normalizeTargetDefaults({
         build: { cache: true },
         'e2e-ci--*': { dependsOn: ['build'] },
         '@nx/vite:test': { inputs: ['default'] },
+        'nx:run-commands': { cache: false },
       })
     ).toEqual([
       { target: 'build', cache: true },
       { target: 'e2e-ci--*', dependsOn: ['build'] },
-      { target: '@nx/vite:test', inputs: ['default'] },
+      { executor: '@nx/vite:test', inputs: ['default'] },
+      { executor: 'nx:run-commands', cache: false },
     ]);
   });
 
@@ -43,92 +43,12 @@ describe('normalizeTargetDefaults', () => {
 describe('isTargetDefaultsArray', () => {
   it('returns true for arrays', () => {
     expect(isTargetDefaultsArray([])).toBe(true);
-    expect(isTargetDefaultsArray([{ target: 'a' }])).toBe(true);
+    expect(isTargetDefaultsArray([{ target: 'a' as const }])).toBe(true);
   });
 
   it('returns false for record or undefined', () => {
     expect(isTargetDefaultsArray({})).toBe(false);
     expect(isTargetDefaultsArray({ build: { cache: true } })).toBe(false);
     expect(isTargetDefaultsArray(undefined)).toBe(false);
-  });
-});
-
-describe('findTargetDefaultEntry', () => {
-  it('returns undefined when target defaults absent', () => {
-    expect(
-      findTargetDefaultEntry(undefined, { target: 'test' })
-    ).toBeUndefined();
-  });
-
-  it('finds an entry in the array shape by target only', () => {
-    expect(
-      findTargetDefaultEntry(
-        [
-          { target: 'build', cache: true },
-          { target: 'test', cache: false },
-        ],
-        { target: 'test' }
-      )
-    ).toEqual({ target: 'test', cache: false });
-  });
-
-  it('distinguishes array entries by projects filter', () => {
-    const entries = [
-      { target: 'test' as const, cache: true },
-      { target: 'test' as const, projects: 'web', inputs: ['x'] },
-    ];
-    expect(findTargetDefaultEntry(entries, { target: 'test' })).toEqual(
-      entries[0]
-    );
-    expect(
-      findTargetDefaultEntry(entries, { target: 'test', projects: 'web' })
-    ).toEqual(entries[1]);
-  });
-
-  it('distinguishes array entries by source filter', () => {
-    const entries = [
-      { target: 'test' as const, cache: true },
-      { target: 'test' as const, source: '@nx/vite', inputs: ['v'] },
-    ];
-    expect(
-      findTargetDefaultEntry(entries, { target: 'test', source: '@nx/vite' })
-    ).toEqual(entries[1]);
-  });
-
-  it('returns the unfiltered record entry when no filters requested', () => {
-    expect(
-      findTargetDefaultEntry({ build: { cache: true } }, { target: 'build' })
-    ).toEqual({ target: 'build', cache: true });
-  });
-
-  it('returns undefined when record is consulted with filters', () => {
-    expect(
-      findTargetDefaultEntry(
-        { build: { cache: true } },
-        { target: 'build', projects: 'web' }
-      )
-    ).toBeUndefined();
-  });
-
-  it('compares arrays of projects by shallow equality', () => {
-    const entries = [
-      {
-        target: 'test' as const,
-        projects: ['a', 'b'],
-        inputs: ['x'],
-      },
-    ];
-    expect(
-      findTargetDefaultEntry(entries, {
-        target: 'test',
-        projects: ['a', 'b'],
-      })
-    ).toEqual(entries[0]);
-    expect(
-      findTargetDefaultEntry(entries, {
-        target: 'test',
-        projects: ['b', 'a'],
-      })
-    ).toBeUndefined();
   });
 });

--- a/packages/devkit/src/utils/normalize-target-defaults.spec.ts
+++ b/packages/devkit/src/utils/normalize-target-defaults.spec.ts
@@ -1,0 +1,134 @@
+import {
+  findTargetDefaultEntry,
+  isTargetDefaultsArray,
+  normalizeTargetDefaults,
+} from './normalize-target-defaults';
+
+describe('normalizeTargetDefaults', () => {
+  it('returns [] for undefined', () => {
+    expect(normalizeTargetDefaults(undefined)).toEqual([]);
+  });
+
+  it('returns a shallow copy of an array shape', () => {
+    const input = [{ target: 'test' as const, cache: true }];
+    const out = normalizeTargetDefaults(input);
+    expect(out).toEqual(input);
+    expect(out).not.toBe(input);
+  });
+
+  it('converts record shape preserving insertion order', () => {
+    expect(
+      normalizeTargetDefaults({
+        build: { cache: true },
+        'e2e-ci--*': { dependsOn: ['build'] },
+        '@nx/vite:test': { inputs: ['default'] },
+      })
+    ).toEqual([
+      { target: 'build', cache: true },
+      { target: 'e2e-ci--*', dependsOn: ['build'] },
+      { target: '@nx/vite:test', inputs: ['default'] },
+    ]);
+  });
+
+  it('tolerates empty record entries', () => {
+    expect(
+      normalizeTargetDefaults({
+        build: undefined as any,
+        lint: null as any,
+      })
+    ).toEqual([{ target: 'build' }, { target: 'lint' }]);
+  });
+});
+
+describe('isTargetDefaultsArray', () => {
+  it('returns true for arrays', () => {
+    expect(isTargetDefaultsArray([])).toBe(true);
+    expect(isTargetDefaultsArray([{ target: 'a' }])).toBe(true);
+  });
+
+  it('returns false for record or undefined', () => {
+    expect(isTargetDefaultsArray({})).toBe(false);
+    expect(isTargetDefaultsArray({ build: { cache: true } })).toBe(false);
+    expect(isTargetDefaultsArray(undefined)).toBe(false);
+  });
+});
+
+describe('findTargetDefaultEntry', () => {
+  it('returns undefined when target defaults absent', () => {
+    expect(
+      findTargetDefaultEntry(undefined, { target: 'test' })
+    ).toBeUndefined();
+  });
+
+  it('finds an entry in the array shape by target only', () => {
+    expect(
+      findTargetDefaultEntry(
+        [
+          { target: 'build', cache: true },
+          { target: 'test', cache: false },
+        ],
+        { target: 'test' }
+      )
+    ).toEqual({ target: 'test', cache: false });
+  });
+
+  it('distinguishes array entries by projects filter', () => {
+    const entries = [
+      { target: 'test' as const, cache: true },
+      { target: 'test' as const, projects: 'web', inputs: ['x'] },
+    ];
+    expect(findTargetDefaultEntry(entries, { target: 'test' })).toEqual(
+      entries[0]
+    );
+    expect(
+      findTargetDefaultEntry(entries, { target: 'test', projects: 'web' })
+    ).toEqual(entries[1]);
+  });
+
+  it('distinguishes array entries by source filter', () => {
+    const entries = [
+      { target: 'test' as const, cache: true },
+      { target: 'test' as const, source: '@nx/vite', inputs: ['v'] },
+    ];
+    expect(
+      findTargetDefaultEntry(entries, { target: 'test', source: '@nx/vite' })
+    ).toEqual(entries[1]);
+  });
+
+  it('returns the unfiltered record entry when no filters requested', () => {
+    expect(
+      findTargetDefaultEntry({ build: { cache: true } }, { target: 'build' })
+    ).toEqual({ target: 'build', cache: true });
+  });
+
+  it('returns undefined when record is consulted with filters', () => {
+    expect(
+      findTargetDefaultEntry(
+        { build: { cache: true } },
+        { target: 'build', projects: 'web' }
+      )
+    ).toBeUndefined();
+  });
+
+  it('compares arrays of projects by shallow equality', () => {
+    const entries = [
+      {
+        target: 'test' as const,
+        projects: ['a', 'b'],
+        inputs: ['x'],
+      },
+    ];
+    expect(
+      findTargetDefaultEntry(entries, {
+        target: 'test',
+        projects: ['a', 'b'],
+      })
+    ).toEqual(entries[0]);
+    expect(
+      findTargetDefaultEntry(entries, {
+        target: 'test',
+        projects: ['b', 'a'],
+      })
+    ).toBeUndefined();
+  });
+});

--- a/packages/devkit/src/utils/normalize-target-defaults.ts
+++ b/packages/devkit/src/utils/normalize-target-defaults.ts
@@ -46,3 +46,32 @@ function isExecutorLikeKey(key: string): boolean {
   for (const c of key) if (GLOB_CHARACTERS.has(c)) return false;
   return true;
 }
+
+/**
+ * Project an array of `TargetDefaultEntry` back into the legacy
+ * record shape. The intended caller is a pre-v23 migration that
+ * normalized to array internally but wants to preserve the original
+ * on-disk record shape so it remains valid against pre-v23 nx.json
+ * schemas.
+ *
+ * Each entry's key is its `target` (if set) or `executor`. Entries that
+ * have both keep the locator role on `target` and retain `executor` as
+ * a value field. Entries with `projects` or `source` filters cannot be
+ * represented in the legacy shape — they are dropped from the output
+ * so the caller can decide whether the loss is acceptable.
+ */
+export function downgradeTargetDefaults(
+  entries: TargetDefaultEntry[]
+): TargetDefaultsRecord {
+  const out: TargetDefaultsRecord = {};
+  for (const entry of entries) {
+    if (entry.projects !== undefined || entry.source !== undefined) continue;
+    const { target, executor, projects, source, ...rest } = entry;
+    const key = target ?? executor;
+    if (key === undefined) continue;
+    const value: Partial<TargetDefaultEntry> = { ...rest };
+    if (target && executor) value.executor = executor;
+    out[key] = value;
+  }
+  return out;
+}

--- a/packages/devkit/src/utils/normalize-target-defaults.ts
+++ b/packages/devkit/src/utils/normalize-target-defaults.ts
@@ -1,0 +1,78 @@
+import type {
+  TargetDefaultEntry,
+  TargetDefaults,
+  TargetDefaultsRecord,
+} from 'nx/src/devkit-exports';
+
+/**
+ * Convert an nx.json `targetDefaults` value (either the legacy record shape
+ * or the new array shape) into the normalized array shape.
+ *
+ * Record entries become `{ target: key, ...value }` preserving insertion
+ * order. Executor-looking record keys (e.g. `nx:run-commands`) keep the
+ * executor string in `target`; the nx-core matcher treats `target` as
+ * either a target name, a glob, or an executor, so legacy semantics are
+ * preserved.
+ */
+export function normalizeTargetDefaults(
+  raw: TargetDefaults | undefined
+): TargetDefaultEntry[] {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return [...raw];
+  const out: TargetDefaultEntry[] = [];
+  const record = raw as TargetDefaultsRecord;
+  for (const key of Object.keys(record)) {
+    const value = record[key] ?? {};
+    out.push({ ...value, target: key });
+  }
+  return out;
+}
+
+/**
+ * True when the given `targetDefaults` is already in the array shape.
+ */
+export function isTargetDefaultsArray(
+  raw: TargetDefaults | undefined
+): raw is TargetDefaultEntry[] {
+  return Array.isArray(raw);
+}
+
+/**
+ * Find an existing target defaults entry by the tuple
+ * `(target, projects, source)`. Returns `undefined` when no such entry
+ * exists. For the legacy record shape only the `target` tuple key is
+ * consulted; a record never carries `projects`/`source` filters.
+ */
+export function findTargetDefaultEntry(
+  raw: TargetDefaults | undefined,
+  match: { target: string; projects?: string | string[]; source?: string }
+): TargetDefaultEntry | undefined {
+  if (!raw) return undefined;
+  if (Array.isArray(raw)) {
+    return raw.find(
+      (e) =>
+        e.target === match.target &&
+        sameProjects(e.projects, match.projects) &&
+        e.source === match.source
+    );
+  }
+  if (match.projects === undefined && match.source === undefined) {
+    const value = raw[match.target];
+    if (!value) return undefined;
+    return { ...value, target: match.target };
+  }
+  return undefined;
+}
+
+function sameProjects(
+  a: string | string[] | undefined,
+  b: string | string[] | undefined
+): boolean {
+  if (a === b) return true;
+  const aArr = a === undefined ? undefined : Array.isArray(a) ? a : [a];
+  const bArr = b === undefined ? undefined : Array.isArray(b) ? b : [b];
+  if (!aArr || !bArr) return false;
+  if (aArr.length !== bArr.length) return false;
+  for (let i = 0; i < aArr.length; i++) if (aArr[i] !== bArr[i]) return false;
+  return true;
+}

--- a/packages/devkit/src/utils/normalize-target-defaults.ts
+++ b/packages/devkit/src/utils/normalize-target-defaults.ts
@@ -56,7 +56,7 @@ function isExecutorLikeKey(key: string): boolean {
  *
  * Each entry's key is its `target` (if set) or `executor`. Entries that
  * have both keep the locator role on `target` and retain `executor` as
- * a value field. Entries with `projects` or `source` filters cannot be
+ * a value field. Entries with `projects` or `plugin` filters cannot be
  * represented in the legacy shape — they are dropped from the output
  * so the caller can decide whether the loss is acceptable.
  */
@@ -65,8 +65,8 @@ export function downgradeTargetDefaults(
 ): TargetDefaultsRecord {
   const out: TargetDefaultsRecord = {};
   for (const entry of entries) {
-    if (entry.projects !== undefined || entry.source !== undefined) continue;
-    const { target, executor, projects, source, ...rest } = entry;
+    if (entry.projects !== undefined || entry.plugin !== undefined) continue;
+    const { target, executor, projects, plugin, ...rest } = entry;
     const key = target ?? executor;
     if (key === undefined) continue;
     const value: Partial<TargetDefaultEntry> = { ...rest };

--- a/packages/devkit/src/utils/normalize-target-defaults.ts
+++ b/packages/devkit/src/utils/normalize-target-defaults.ts
@@ -4,7 +4,13 @@ import type {
   TargetDefaultsRecord,
 } from 'nx/src/devkit-exports';
 
-const GLOB_CHARS = ['*', '|', '{', '}', '(', ')', '['];
+// Mirrors `GLOB_CHARACTERS` / `isGlobPattern` from
+// `nx/src/utils/globs.ts`. We can't import from there directly: devkit
+// supports nx +/- 1 major version and that file isn't part of the
+// devkit-exports surface guaranteed across the range. Keeping a local
+// copy that exactly matches the canonical implementation avoids the
+// import while staying behaviorally aligned.
+const GLOB_CHARACTERS = new Set(['*', '|', '{', '}', '(', ')', '[']);
 
 /**
  * Convert an nx.json `targetDefaults` value (either the legacy record shape
@@ -35,17 +41,8 @@ export function normalizeTargetDefaults(
   return out;
 }
 
-/**
- * True when the given `targetDefaults` is already in the array shape.
- */
-export function isTargetDefaultsArray(
-  raw: TargetDefaults | undefined
-): raw is TargetDefaultEntry[] {
-  return Array.isArray(raw);
-}
-
 function isExecutorLikeKey(key: string): boolean {
   if (!key.includes(':')) return false;
-  for (const c of key) if (GLOB_CHARS.includes(c)) return false;
+  for (const c of key) if (GLOB_CHARACTERS.has(c)) return false;
   return true;
 }

--- a/packages/devkit/src/utils/normalize-target-defaults.ts
+++ b/packages/devkit/src/utils/normalize-target-defaults.ts
@@ -56,19 +56,41 @@ function isExecutorLikeKey(key: string): boolean {
  *
  * Each entry's key is its `target` (if set) or `executor`. Entries that
  * have both keep the locator role on `target` and retain `executor` as
- * a value field. Entries with `projects` or `plugin` filters cannot be
- * represented in the legacy shape — they are dropped from the output
- * so the caller can decide whether the loss is acceptable.
+ * a value field.
+ *
+ * Throws when the input contains entries that the record shape cannot
+ * represent — `projects`/`plugin` filters, two entries that would collapse
+ * to the same key, or entries with neither `target` nor `executor`. The
+ * caller must keep array shape in those cases (or refuse to write the
+ * change). Silently dropping these entries would corrupt nx.json without
+ * the user noticing.
  */
 export function downgradeTargetDefaults(
   entries: TargetDefaultEntry[]
 ): TargetDefaultsRecord {
   const out: TargetDefaultsRecord = {};
   for (const entry of entries) {
-    if (entry.projects !== undefined || entry.plugin !== undefined) continue;
+    if (entry.projects !== undefined || entry.plugin !== undefined) {
+      throw new Error(
+        `Cannot downgrade targetDefaults to legacy record shape: entry ${JSON.stringify(
+          entry
+        )} uses a \`projects\`/\`plugin\` filter, which is only supported in the array shape.`
+      );
+    }
     const { target, executor, projects, plugin, ...rest } = entry;
     const key = target ?? executor;
-    if (key === undefined) continue;
+    if (key === undefined) {
+      throw new Error(
+        `Cannot downgrade targetDefaults to legacy record shape: entry ${JSON.stringify(
+          entry
+        )} has neither \`target\` nor \`executor\` to use as the record key.`
+      );
+    }
+    if (Object.prototype.hasOwnProperty.call(out, key)) {
+      throw new Error(
+        `Cannot downgrade targetDefaults to legacy record shape: two entries collapse to the same key \`${key}\`. Keep the array shape so both can coexist.`
+      );
+    }
     const value: Partial<TargetDefaultEntry> = { ...rest };
     if (target && executor) value.executor = executor;
     out[key] = value;

--- a/packages/devkit/src/utils/normalize-target-defaults.ts
+++ b/packages/devkit/src/utils/normalize-target-defaults.ts
@@ -4,26 +4,33 @@ import type {
   TargetDefaultsRecord,
 } from 'nx/src/devkit-exports';
 
+const GLOB_CHARS = ['*', '|', '{', '}', '(', ')', '['];
+
 /**
  * Convert an nx.json `targetDefaults` value (either the legacy record shape
  * or the new array shape) into the normalized array shape.
  *
  * Record entries become `{ target: key, ...value }` preserving insertion
- * order. Executor-looking record keys (e.g. `nx:run-commands`) keep the
- * executor string in `target`; the nx-core matcher treats `target` as
- * either a target name, a glob, or an executor, so legacy semantics are
- * preserved.
+ * order — except executor-shaped keys (e.g. `@nx/vite:test`,
+ * `nx:run-commands`), which become `{ executor: key, ...value }`.
+ *
+ * Returns the array directly when already normalized — callers must not
+ * mutate the result if they want to preserve the underlying nx.json.
  */
 export function normalizeTargetDefaults(
   raw: TargetDefaults | undefined
 ): TargetDefaultEntry[] {
   if (!raw) return [];
-  if (Array.isArray(raw)) return [...raw];
+  if (Array.isArray(raw)) return raw;
   const out: TargetDefaultEntry[] = [];
   const record = raw as TargetDefaultsRecord;
   for (const key of Object.keys(record)) {
     const value = record[key] ?? {};
-    out.push({ ...value, target: key });
+    out.push(
+      isExecutorLikeKey(key)
+        ? { ...value, executor: key }
+        : { ...value, target: key }
+    );
   }
   return out;
 }
@@ -37,42 +44,8 @@ export function isTargetDefaultsArray(
   return Array.isArray(raw);
 }
 
-/**
- * Find an existing target defaults entry by the tuple
- * `(target, projects, source)`. Returns `undefined` when no such entry
- * exists. For the legacy record shape only the `target` tuple key is
- * consulted; a record never carries `projects`/`source` filters.
- */
-export function findTargetDefaultEntry(
-  raw: TargetDefaults | undefined,
-  match: { target: string; projects?: string | string[]; source?: string }
-): TargetDefaultEntry | undefined {
-  if (!raw) return undefined;
-  if (Array.isArray(raw)) {
-    return raw.find(
-      (e) =>
-        e.target === match.target &&
-        sameProjects(e.projects, match.projects) &&
-        e.source === match.source
-    );
-  }
-  if (match.projects === undefined && match.source === undefined) {
-    const value = raw[match.target];
-    if (!value) return undefined;
-    return { ...value, target: match.target };
-  }
-  return undefined;
-}
-
-function sameProjects(
-  a: string | string[] | undefined,
-  b: string | string[] | undefined
-): boolean {
-  if (a === b) return true;
-  const aArr = a === undefined ? undefined : Array.isArray(a) ? a : [a];
-  const bArr = b === undefined ? undefined : Array.isArray(b) ? b : [b];
-  if (!aArr || !bArr) return false;
-  if (aArr.length !== bArr.length) return false;
-  for (let i = 0; i < aArr.length; i++) if (aArr[i] !== bArr[i]) return false;
+function isExecutorLikeKey(key: string): boolean {
+  if (!key.includes(':')) return false;
+  for (const c of key) if (GLOB_CHARS.includes(c)) return false;
   return true;
 }

--- a/packages/esbuild/src/generators/configuration/configuration.spec.ts
+++ b/packages/esbuild/src/generators/configuration/configuration.spec.ts
@@ -111,8 +111,11 @@ describe('configurationGenerator', () => {
 
     const nxJson = readJson(tree, 'nx.json');
     const td = nxJson.targetDefaults;
+    // Generators now write the array shape with executor-keyed defaults
+    // surfaced as `executor`, not `target`. The legacy record-shape lookup
+    // is kept as a fallback for tests running against older fixtures.
     const esbuildEntry = Array.isArray(td)
-      ? td.find((e) => e.target === '@nx/esbuild:esbuild')
+      ? td.find((e) => e.executor === '@nx/esbuild:esbuild')
       : td['@nx/esbuild:esbuild'];
     expect(esbuildEntry.inputs).toEqual([
       'production',

--- a/packages/esbuild/src/generators/configuration/configuration.spec.ts
+++ b/packages/esbuild/src/generators/configuration/configuration.spec.ts
@@ -110,7 +110,11 @@ describe('configurationGenerator', () => {
     });
 
     const nxJson = readJson(tree, 'nx.json');
-    expect(nxJson.targetDefaults['@nx/esbuild:esbuild'].inputs).toEqual([
+    const td = nxJson.targetDefaults;
+    const esbuildEntry = Array.isArray(td)
+      ? td.find((e) => e.target === '@nx/esbuild:esbuild')
+      : td['@nx/esbuild:esbuild'];
+    expect(esbuildEntry.inputs).toEqual([
       'production',
       '^production',
       {

--- a/packages/esbuild/src/generators/configuration/configuration.spec.ts
+++ b/packages/esbuild/src/generators/configuration/configuration.spec.ts
@@ -75,9 +75,14 @@ describe('configurationGenerator', () => {
     });
 
     const nxJson = readJson(tree, 'nx.json');
-    expect(nxJson.targetDefaults['@nx/esbuild:esbuild']).toEqual({
+    const td = nxJson.targetDefaults;
+    const esbuildEntry = Array.isArray(td)
+      ? td.find((e) => e.executor === '@nx/esbuild:esbuild')
+      : td['@nx/esbuild:esbuild'];
+    expect(esbuildEntry).toEqual({
       cache: true,
       dependsOn: ['^build'],
+      executor: '@nx/esbuild:esbuild',
       inputs: [
         'default',
         '^default',
@@ -147,7 +152,11 @@ describe('configurationGenerator', () => {
     });
 
     const nxJson = readJson(tree, 'nx.json');
-    expect(nxJson.targetDefaults['@nx/esbuild:esbuild']).toEqual({
+    const td = nxJson.targetDefaults;
+    const esbuildEntry = Array.isArray(td)
+      ? td.find((e) => e.executor === '@nx/esbuild:esbuild')
+      : td['@nx/esbuild:esbuild'];
+    expect(esbuildEntry).toMatchObject({
       cache: true,
       inputs: ['custom-input'],
     });

--- a/packages/esbuild/src/generators/configuration/configuration.ts
+++ b/packages/esbuild/src/generators/configuration/configuration.ts
@@ -1,4 +1,7 @@
-import { addBuildTargetDefaults } from '@nx/devkit/internal';
+import {
+  addBuildTargetDefaults,
+  readTargetDefaultsForTarget,
+} from '@nx/devkit/internal';
 import {
   formatFiles,
   joinPathFragments,
@@ -152,9 +155,11 @@ function updatePackageJson(
     const projectTarget = project.targets[options.buildTarget];
     const mergedTarget = mergeTargetConfigurations(
       projectTarget,
-      (projectTarget.executor
-        ? nxJson.targetDefaults?.[projectTarget.executor]
-        : undefined) ?? nxJson.targetDefaults?.[options.buildTarget]
+      readTargetDefaultsForTarget(
+        options.buildTarget,
+        nxJson.targetDefaults,
+        projectTarget.executor
+      )
     );
 
     const {

--- a/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
@@ -200,7 +200,15 @@ describe('Dependency checks (eslint)', () => {
             data: {
               root: 'libs/liba',
               targets: {
-                build: {},
+                build: {
+                  // Simulate the graph construction merging targetDefaults into target data.
+                  // The PR removed targetDefaults lookup from getTargetInputs, relying on
+                  // graph construction to pre-merge them before the hasher runs.
+                  inputs: [
+                    '{projectRoot}/**/*',
+                    '!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)',
+                  ],
+                },
               },
             },
           },

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
@@ -19,6 +19,15 @@ import { lintProjectGenerator } from '../lint-project/lint-project';
 import { eslintrcVersion } from '../../utils/versions';
 import { dump } from '@zkochan/js-yaml';
 
+function getLintInputs(nxJson: NxJsonConfiguration): string[] {
+  const td = nxJson.targetDefaults;
+  if (!td) return [];
+  const entry = Array.isArray(td)
+    ? td.find((e) => e.target === 'lint' || e.target === '@nx/eslint:lint')
+    : (td['lint'] ?? td['@nx/eslint:lint']);
+  return (entry?.inputs ?? []) as string[];
+}
+
 describe('convert-to-flat-config generator', () => {
   let tree: Tree;
 
@@ -98,7 +107,7 @@ describe('convert-to-flat-config generator', () => {
       ).toMatchSnapshot();
       // check nx.json changes
       const nxJson = readJson(tree, 'nx.json');
-      expect(nxJson.targetDefaults.lint.inputs).toContain(
+      expect(getLintInputs(nxJson)).toContain(
         '{workspaceRoot}/eslint.config.cjs'
       );
       expect(nxJson.namedInputs.production).toContain(
@@ -129,7 +138,7 @@ describe('convert-to-flat-config generator', () => {
       ).toMatchSnapshot();
       // check nx.json changes
       const nxJson = readJson(tree, 'nx.json');
-      expect(nxJson.targetDefaults.lint.inputs).toContain(
+      expect(getLintInputs(nxJson)).toContain(
         '{workspaceRoot}/eslint.config.cjs'
       );
       expect(nxJson.namedInputs.production).toContain(
@@ -160,7 +169,7 @@ describe('convert-to-flat-config generator', () => {
       ).toMatchSnapshot();
       // check nx.json changes
       const nxJson = readJson(tree, 'nx.json');
-      expect(nxJson.targetDefaults.lint.inputs).toContain(
+      expect(getLintInputs(nxJson)).toContain(
         '{workspaceRoot}/eslint.config.cjs'
       );
       expect(nxJson.namedInputs.production).toContain(
@@ -686,7 +695,7 @@ describe('convert-to-flat-config generator', () => {
       ).toMatchSnapshot();
       // check nx.json changes
       const nxJson = readJson(tree, 'nx.json');
-      expect(nxJson.targetDefaults.lint.inputs).toContain(
+      expect(getLintInputs(nxJson)).toContain(
         '{workspaceRoot}/eslint.config.mjs'
       );
       expect(nxJson.namedInputs.production).toContain(
@@ -717,7 +726,7 @@ describe('convert-to-flat-config generator', () => {
       ).toMatchSnapshot();
       // check nx.json changes
       const nxJson = readJson(tree, 'nx.json');
-      expect(nxJson.targetDefaults.lint.inputs).toContain(
+      expect(getLintInputs(nxJson)).toContain(
         '{workspaceRoot}/eslint.config.mjs'
       );
       expect(nxJson.namedInputs.production).toContain(
@@ -748,7 +757,7 @@ describe('convert-to-flat-config generator', () => {
       ).toMatchSnapshot();
       // check nx.json changes
       const nxJson = readJson(tree, 'nx.json');
-      expect(nxJson.targetDefaults.lint.inputs).toContain(
+      expect(getLintInputs(nxJson)).toContain(
         '{workspaceRoot}/eslint.config.mjs'
       );
       expect(nxJson.namedInputs.production).toContain(

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
@@ -535,6 +535,42 @@ describe('convert-to-flat-config generator', () => {
       expect(tree.exists('libs/test-lib/eslint.config.cjs')).toBeTruthy();
     });
 
+    it('should convert project if target is defined via array-shaped targetDefaults', async () => {
+      await lintProjectGenerator(tree, {
+        skipFormat: false,
+        linter: 'eslint',
+        project: 'test-lib',
+        setParserOptionsProject: false,
+        eslintConfigFormat: 'cjs',
+      });
+      updateJson(tree, 'nx.json', (json: NxJsonConfiguration) => {
+        json.targetDefaults = [
+          {
+            target: 'lint',
+            executor: '@nx/eslint:lint',
+            inputs: ['default'],
+          },
+        ];
+        return json;
+      });
+      updateJson(
+        tree,
+        'libs/test-lib/project.json',
+        (json: ProjectConfiguration) => {
+          json.targets.lint = {
+            options: json.targets.lint.options,
+          };
+          return json;
+        }
+      );
+
+      expect(tree.exists('eslint.config.cjs')).toBeFalsy();
+      expect(tree.exists('libs/test-lib/eslint.config.cjs')).toBeFalsy();
+      await convertToFlatConfigGenerator(tree, options);
+      expect(tree.exists('eslint.config.cjs')).toBeTruthy();
+      expect(tree.exists('libs/test-lib/eslint.config.cjs')).toBeTruthy();
+    });
+
     it('should warn and skip project with eslint config but no lint target', async () => {
       addProjectConfiguration(tree, 'no-lint-lib', {
         root: 'libs/no-lint-lib',

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.ts
@@ -118,6 +118,30 @@ function isEslintTarget(target: { executor?: string; command?: string }) {
   );
 }
 
+function hasMatchingEslintTargetDefault(
+  projectConfig: ProjectConfiguration,
+  targetDefaults: NxJsonConfiguration['targetDefaults']
+): boolean {
+  if (!projectConfig.targets || !targetDefaults) {
+    return false;
+  }
+
+  if (Array.isArray(targetDefaults)) {
+    return targetDefaults.some(
+      (entry) =>
+        entry.target !== undefined &&
+        projectConfig.targets[entry.target] !== undefined &&
+        (entry.target === ESLINT_LINT_EXECUTOR || isEslintTarget(entry))
+    );
+  }
+
+  return Object.entries(targetDefaults).some(
+    ([targetName, targetConfig]) =>
+      projectConfig.targets[targetName] !== undefined &&
+      (targetName === ESLINT_LINT_EXECUTOR || isEslintTarget(targetConfig))
+  );
+}
+
 function convertProjectToFlatConfig(
   tree: Tree,
   project: string,
@@ -150,14 +174,10 @@ function convertProjectToFlatConfig(
   if (eslintTargets.length > 0) {
     updateProjectConfiguration(tree, project, projectConfig);
   }
-  const hasEslintTargetDefaults =
-    projectConfig.targets &&
-    Object.keys(nxJson.targetDefaults || {}).some(
-      (t) =>
-        (t === ESLINT_LINT_EXECUTOR ||
-          isEslintTarget(nxJson.targetDefaults[t])) &&
-        projectConfig.targets[t]
-    );
+  const hasEslintTargetDefaults = hasMatchingEslintTargetDefault(
+    projectConfig,
+    nxJson.targetDefaults
+  );
 
   if (
     eslintTargets.length === 0 &&

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.ts
@@ -10,6 +10,7 @@ import {
   ProjectConfiguration,
   readJson,
   readNxJson,
+  TargetConfiguration,
   Tree,
   updateJson,
   updateProjectConfiguration,
@@ -228,23 +229,38 @@ function ensureInputPresent(
 
 // Updates nx.json: rewrites stale eslintrc/eslintignore references across all targetDefaults
 // inputs and namedInputs, and ensures lint targets include the new flat config file as an input
-// (and `production` excludes it).
+// (and `production` excludes it). Handles both the legacy record shape and the new array shape
+// of `targetDefaults`.
 function updateNxJsonConfig(tree: Tree, format: 'cjs' | 'mjs') {
   if (!tree.exists('nx.json')) {
     return;
   }
   updateJson(tree, 'nx.json', (json: NxJsonConfiguration) => {
+    const rewriteTargetInputs = (
+      target: Partial<TargetConfiguration>,
+      isLintTarget: boolean
+    ) => {
+      if (!target.inputs) return;
+      target.inputs = isLintTarget
+        ? ensureInputPresent(
+            target.inputs,
+            `{workspaceRoot}/eslint.config.${format}`,
+            format
+          )
+        : rewriteLegacyInputs(target.inputs, format);
+    };
     if (json.targetDefaults) {
-      for (const [name, target] of Object.entries(json.targetDefaults)) {
-        if (!target.inputs) continue;
-        const isLintTarget = name === 'lint' || name === ESLINT_LINT_EXECUTOR;
-        target.inputs = isLintTarget
-          ? ensureInputPresent(
-              target.inputs,
-              `{workspaceRoot}/eslint.config.${format}`,
-              format
-            )
-          : rewriteLegacyInputs(target.inputs, format);
+      if (Array.isArray(json.targetDefaults)) {
+        for (const entry of json.targetDefaults) {
+          const isLintTarget =
+            entry.target === 'lint' || entry.target === ESLINT_LINT_EXECUTOR;
+          rewriteTargetInputs(entry, isLintTarget);
+        }
+      } else {
+        for (const [name, target] of Object.entries(json.targetDefaults)) {
+          const isLintTarget = name === 'lint' || name === ESLINT_LINT_EXECUTOR;
+          rewriteTargetInputs(target, isLintTarget);
+        }
       }
     }
     if (json.namedInputs) {

--- a/packages/eslint/src/generators/init/init.spec.ts
+++ b/packages/eslint/src/generators/init/init.spec.ts
@@ -3,6 +3,8 @@ import 'nx/src/internal-testing-utils/mock-project-graph';
 import {
   NxJsonConfiguration,
   readJson,
+  type TargetConfiguration,
+  type TargetDefaults,
   Tree,
   updateJson,
   writeJson,
@@ -10,6 +12,25 @@ import {
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { LinterInitOptions, lintInitGenerator } from './init';
 import { setWorkspaceRoot } from 'nx/src/utils/workspace-root';
+
+function getDefault(
+  td: TargetDefaults | undefined,
+  target: string
+): Partial<TargetConfiguration> | undefined {
+  if (!td) return undefined;
+  if (Array.isArray(td)) {
+    const found = td.find(
+      (e) =>
+        e.target === target &&
+        e.projects === undefined &&
+        e.source === undefined
+    );
+    if (!found) return undefined;
+    const { target: _t, projects: _p, source: _s, ...rest } = found;
+    return rest;
+  }
+  return td[target];
+}
 
 describe('@nx/eslint:init', () => {
   let tree: Tree;
@@ -41,9 +62,10 @@ describe('@nx/eslint:init', () => {
     await lintInitGenerator(tree, options);
 
     expect(
-      readJson<NxJsonConfiguration>(tree, 'nx.json').targetDefaults[
+      getDefault(
+        readJson<NxJsonConfiguration>(tree, 'nx.json').targetDefaults,
         '@nx/eslint:lint'
-      ]
+      )
     ).toBeUndefined();
     expect(readJson<NxJsonConfiguration>(tree, 'nx.json').plugins)
       .toMatchInlineSnapshot(`
@@ -111,7 +133,10 @@ describe('@nx/eslint:init', () => {
         });
 
         expect(
-          readJson(tree, 'nx.json').targetDefaults['@nx/eslint:lint']
+          getDefault(
+            readJson<NxJsonConfiguration>(tree, 'nx.json').targetDefaults,
+            '@nx/eslint:lint'
+          )
         ).toEqual({
           cache: true,
           inputs: [
@@ -139,9 +164,10 @@ describe('@nx/eslint:init', () => {
         });
 
         expect(
-          readJson<NxJsonConfiguration>(tree, 'nx.json').targetDefaults[
+          getDefault(
+            readJson<NxJsonConfiguration>(tree, 'nx.json').targetDefaults,
             '@nx/eslint:lint'
-          ]
+          )
         ).toEqual({
           cache: true,
           inputs: [
@@ -165,7 +191,10 @@ describe('@nx/eslint:init', () => {
         });
 
         expect(
-          readJson(tree, 'nx.json').targetDefaults['@nx/eslint:lint']
+          getDefault(
+            readJson<NxJsonConfiguration>(tree, 'nx.json').targetDefaults,
+            '@nx/eslint:lint'
+          )
         ).toEqual({
           cache: true,
           inputs: [
@@ -193,9 +222,10 @@ describe('@nx/eslint:init', () => {
         });
 
         expect(
-          readJson<NxJsonConfiguration>(tree, 'nx.json').targetDefaults[
+          getDefault(
+            readJson<NxJsonConfiguration>(tree, 'nx.json').targetDefaults,
             '@nx/eslint:lint'
-          ]
+          )
         ).toEqual({
           cache: true,
           inputs: [

--- a/packages/eslint/src/generators/init/init.spec.ts
+++ b/packages/eslint/src/generators/init/init.spec.ts
@@ -23,14 +23,14 @@ function getDefault(
       (e) =>
         (e.target === target || e.executor === target) &&
         e.projects === undefined &&
-        e.source === undefined
+        e.plugin === undefined
     );
     if (!found) return undefined;
     const {
       target: _t,
       executor: _e,
       projects: _p,
-      source: _s,
+      plugin: _pl,
       ...rest
     } = found;
     return rest;

--- a/packages/eslint/src/generators/init/init.spec.ts
+++ b/packages/eslint/src/generators/init/init.spec.ts
@@ -21,12 +21,18 @@ function getDefault(
   if (Array.isArray(td)) {
     const found = td.find(
       (e) =>
-        e.target === target &&
+        (e.target === target || e.executor === target) &&
         e.projects === undefined &&
         e.source === undefined
     );
     if (!found) return undefined;
-    const { target: _t, projects: _p, source: _s, ...rest } = found;
+    const {
+      target: _t,
+      executor: _e,
+      projects: _p,
+      source: _s,
+      ...rest
+    } = found;
     return rest;
   }
   return td[target];

--- a/packages/eslint/src/generators/init/init.ts
+++ b/packages/eslint/src/generators/init/init.ts
@@ -1,4 +1,8 @@
-import { addPlugin, upsertTargetDefault } from '@nx/devkit/internal';
+import {
+  addPlugin,
+  findTargetDefault,
+  upsertTargetDefault,
+} from '@nx/devkit/internal';
 import {
   addDependenciesToPackageJson,
   createProjectGraphAsync,
@@ -7,7 +11,6 @@ import {
   removeDependenciesFromPackageJson,
   runTasksInSerial,
   type TargetConfiguration,
-  type TargetDefaults,
   Tree,
   updateJson,
   updateNxJson,
@@ -45,7 +48,11 @@ function updateProductionFileset(tree: Tree, format: 'mjs' | 'cjs' = 'mjs') {
 
 function addTargetDefaults(tree: Tree, format: 'mjs' | 'cjs') {
   const nxJson = readNxJson(tree);
-  const existing = findExistingLintDefault(nxJson?.targetDefaults);
+  // `@nx/eslint:lint` is an executor identifier — match defaults keyed on
+  // the executor, not on a target named that string.
+  const existing = findTargetDefault(nxJson?.targetDefaults, {
+    executor: '@nx/eslint:lint',
+  });
   const patch: Partial<TargetConfiguration> = {};
   if (existing?.cache === undefined) patch.cache = true;
   if (existing?.inputs === undefined) {
@@ -59,23 +66,8 @@ function addTargetDefaults(tree: Tree, format: 'mjs' | 'cjs') {
     ];
   }
   if (Object.keys(patch).length > 0) {
-    upsertTargetDefault(tree, { target: '@nx/eslint:lint', ...patch });
+    upsertTargetDefault(tree, { executor: '@nx/eslint:lint', ...patch });
   }
-}
-
-function findExistingLintDefault(
-  td: TargetDefaults | undefined
-): Partial<TargetConfiguration> | undefined {
-  if (!td) return undefined;
-  if (Array.isArray(td)) {
-    return td.find(
-      (e) =>
-        e.target === '@nx/eslint:lint' &&
-        e.projects === undefined &&
-        e.source === undefined
-    );
-  }
-  return td['@nx/eslint:lint'];
 }
 
 function updateVsCodeRecommendedExtensions(host: Tree) {

--- a/packages/eslint/src/generators/init/init.ts
+++ b/packages/eslint/src/generators/init/init.ts
@@ -47,10 +47,10 @@ function updateProductionFileset(tree: Tree, format: 'mjs' | 'cjs' = 'mjs') {
 }
 
 function addTargetDefaults(tree: Tree, format: 'mjs' | 'cjs') {
-  const nxJson = readNxJson(tree);
+  const nxJson = readNxJson(tree) ?? {};
   // `@nx/eslint:lint` is an executor identifier — match defaults keyed on
   // the executor, not on a target named that string.
-  const existing = findTargetDefault(nxJson?.targetDefaults, {
+  const existing = findTargetDefault(nxJson.targetDefaults, {
     executor: '@nx/eslint:lint',
   });
   const patch: Partial<TargetConfiguration> = {};
@@ -66,7 +66,11 @@ function addTargetDefaults(tree: Tree, format: 'mjs' | 'cjs') {
     ];
   }
   if (Object.keys(patch).length > 0) {
-    upsertTargetDefault(tree, { executor: '@nx/eslint:lint', ...patch });
+    upsertTargetDefault(tree, nxJson, {
+      executor: '@nx/eslint:lint',
+      ...patch,
+    });
+    updateNxJson(tree, nxJson);
   }
 }
 

--- a/packages/eslint/src/generators/init/init.ts
+++ b/packages/eslint/src/generators/init/init.ts
@@ -1,4 +1,4 @@
-import { addPlugin } from '@nx/devkit/internal';
+import { addPlugin, upsertTargetDefault } from '@nx/devkit/internal';
 import {
   addDependenciesToPackageJson,
   createProjectGraphAsync,
@@ -6,6 +6,8 @@ import {
   readNxJson,
   removeDependenciesFromPackageJson,
   runTasksInSerial,
+  type TargetConfiguration,
+  type TargetDefaults,
   Tree,
   updateJson,
   updateNxJson,
@@ -43,19 +45,37 @@ function updateProductionFileset(tree: Tree, format: 'mjs' | 'cjs' = 'mjs') {
 
 function addTargetDefaults(tree: Tree, format: 'mjs' | 'cjs') {
   const nxJson = readNxJson(tree);
+  const existing = findExistingLintDefault(nxJson?.targetDefaults);
+  const patch: Partial<TargetConfiguration> = {};
+  if (existing?.cache === undefined) patch.cache = true;
+  if (existing?.inputs === undefined) {
+    patch.inputs = [
+      'default',
+      '^default',
+      `{workspaceRoot}/.eslintrc.json`,
+      `{workspaceRoot}/.eslintignore`,
+      `{workspaceRoot}/eslint.config.${format}`,
+      '{workspaceRoot}/tools/eslint-rules/**/*',
+    ];
+  }
+  if (Object.keys(patch).length > 0) {
+    upsertTargetDefault(tree, { target: '@nx/eslint:lint', ...patch });
+  }
+}
 
-  nxJson.targetDefaults ??= {};
-  nxJson.targetDefaults['@nx/eslint:lint'] ??= {};
-  nxJson.targetDefaults['@nx/eslint:lint'].cache ??= true;
-  nxJson.targetDefaults['@nx/eslint:lint'].inputs ??= [
-    'default',
-    '^default',
-    `{workspaceRoot}/.eslintrc.json`,
-    `{workspaceRoot}/.eslintignore`,
-    `{workspaceRoot}/eslint.config.${format}`,
-    '{workspaceRoot}/tools/eslint-rules/**/*',
-  ];
-  updateNxJson(tree, nxJson);
+function findExistingLintDefault(
+  td: TargetDefaults | undefined
+): Partial<TargetConfiguration> | undefined {
+  if (!td) return undefined;
+  if (Array.isArray(td)) {
+    return td.find(
+      (e) =>
+        e.target === '@nx/eslint:lint' &&
+        e.projects === undefined &&
+        e.source === undefined
+    );
+  }
+  return td['@nx/eslint:lint'];
 }
 
 function updateVsCodeRecommendedExtensions(host: Tree) {

--- a/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.spec.ts
+++ b/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.spec.ts
@@ -32,9 +32,11 @@ describe('@nx/eslint:workspace-rules-project', () => {
     });
     await lintWorkspaceRulesProjectGenerator(tree);
 
-    expect(
-      readJson<NxJsonConfiguration>(tree, 'nx.json').targetDefaults.lint.inputs
-    ).toContain('{workspaceRoot}/tools/eslint-rules/**/*');
+    const td = readJson<NxJsonConfiguration>(tree, 'nx.json').targetDefaults!;
+    const lint = Array.isArray(td)
+      ? td.find((e) => e.target === 'lint')
+      : td.lint;
+    expect(lint?.inputs).toContain('{workspaceRoot}/tools/eslint-rules/**/*');
   });
 
   it('should generate the required files', async () => {

--- a/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.ts
+++ b/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.ts
@@ -9,6 +9,8 @@ import {
   readNxJson,
   readProjectConfiguration,
   runTasksInSerial,
+  type TargetConfiguration,
+  type TargetDefaults,
   Tree,
   updateJson,
   updateNxJson,
@@ -66,10 +68,9 @@ export async function lintWorkspaceRulesProjectGenerator(
    */
   const nxJson = readNxJson(tree);
 
-  if (nxJson.targetDefaults?.lint?.inputs) {
-    nxJson.targetDefaults.lint.inputs.push(
-      `{workspaceRoot}/${WORKSPACE_PLUGIN_DIR}/**/*`
-    );
+  const lintEntry = findLintTargetDefault(nxJson.targetDefaults);
+  if (lintEntry?.inputs) {
+    lintEntry.inputs.push(`{workspaceRoot}/${WORKSPACE_PLUGIN_DIR}/**/*`);
 
     updateNxJson(tree, nxJson);
   }
@@ -134,4 +135,19 @@ export async function lintWorkspaceRulesProjectGenerator(
   }
 
   return runTasksInSerial(...tasks);
+}
+
+function findLintTargetDefault(
+  td: TargetDefaults | undefined
+): Partial<TargetConfiguration> | undefined {
+  if (!td) return undefined;
+  if (Array.isArray(td)) {
+    return td.find(
+      (e) =>
+        e.target === 'lint' &&
+        e.projects === undefined &&
+        e.source === undefined
+    );
+  }
+  return td['lint'];
 }

--- a/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.ts
+++ b/packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.ts
@@ -146,7 +146,7 @@ function findLintTargetDefault(
       (e) =>
         e.target === 'lint' &&
         e.projects === undefined &&
-        e.source === undefined
+        e.plugin === undefined
     );
   }
   return td['lint'];

--- a/packages/eslint/src/migrations/update-21-6-0/update-executor-lint-inputs.spec.ts
+++ b/packages/eslint/src/migrations/update-21-6-0/update-executor-lint-inputs.spec.ts
@@ -27,7 +27,10 @@ describe('update-executor-lint-inputs', () => {
     await migration(tree);
 
     const updated = readNxJson(tree);
-    expect(updated.targetDefaults['@nx/eslint:lint'].inputs).toEqual([
+    const lintEntry = (updated.targetDefaults as any[]).find(
+      (e) => e.executor === '@nx/eslint:lint'
+    );
+    expect(lintEntry.inputs).toEqual([
       'default',
       '^default',
       '{workspaceRoot}/.eslintrc.json',
@@ -55,7 +58,10 @@ describe('update-executor-lint-inputs', () => {
     await migration(tree);
 
     const updated = readNxJson(tree);
-    expect(updated.targetDefaults['@nx/eslint:lint'].inputs).toEqual([
+    const lintEntry = (updated.targetDefaults as any[]).find(
+      (e) => e.executor === '@nx/eslint:lint'
+    );
+    expect(lintEntry.inputs).toEqual([
       'default',
       '^default',
       '{workspaceRoot}/.eslintrc.json',
@@ -102,7 +108,10 @@ describe('update-executor-lint-inputs', () => {
     await migration(tree);
 
     const updated = readNxJson(tree);
-    expect(updated.targetDefaults['@nx/eslint:lint'].inputs).toEqual([
+    const lintEntry = (updated.targetDefaults as any[]).find(
+      (e) => e.executor === '@nx/eslint:lint'
+    );
+    expect(lintEntry.inputs).toEqual([
       '^default',
       '{workspaceRoot}/.eslintrc.json',
       '{workspaceRoot}/tools/eslint-rules/**/*',

--- a/packages/eslint/src/migrations/update-21-6-0/update-executor-lint-inputs.ts
+++ b/packages/eslint/src/migrations/update-21-6-0/update-executor-lint-inputs.ts
@@ -13,7 +13,7 @@ export default async function (tree: Tree) {
       e.executor === executor &&
       e.target === undefined &&
       e.projects === undefined &&
-      e.source === undefined
+      e.plugin === undefined
   );
 
   if (!existing?.inputs) {

--- a/packages/eslint/src/migrations/update-21-6-0/update-executor-lint-inputs.ts
+++ b/packages/eslint/src/migrations/update-21-6-0/update-executor-lint-inputs.ts
@@ -1,14 +1,24 @@
-import { type Tree, formatFiles, readNxJson, updateNxJson } from '@nx/devkit';
+import { type Tree, formatFiles, readNxJson } from '@nx/devkit';
+import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
+import { normalizeTargetDefaults } from '@nx/devkit/src/utils/normalize-target-defaults';
 
 export default async function (tree: Tree) {
   const nxJson = readNxJson(tree);
   const executor = '@nx/eslint:lint';
 
-  if (!nxJson.targetDefaults?.[executor]?.inputs) {
+  const existing = normalizeTargetDefaults(nxJson?.targetDefaults).find(
+    (e) =>
+      e.executor === executor &&
+      e.target === undefined &&
+      e.projects === undefined &&
+      e.source === undefined
+  );
+
+  if (!existing?.inputs) {
     return;
   }
 
-  const inputs = nxJson.targetDefaults[executor].inputs;
+  const inputs = [...existing.inputs];
 
   if (!inputs.includes('^default')) {
     // Add after 'default' if present, otherwise at the beginning
@@ -24,6 +34,6 @@ export default async function (tree: Tree) {
     inputs.push('{workspaceRoot}/tools/eslint-rules/**/*');
   }
 
-  updateNxJson(tree, nxJson);
+  upsertTargetDefault(tree, { executor, inputs });
   await formatFiles(tree);
 }

--- a/packages/eslint/src/migrations/update-21-6-0/update-executor-lint-inputs.ts
+++ b/packages/eslint/src/migrations/update-21-6-0/update-executor-lint-inputs.ts
@@ -1,14 +1,14 @@
-import { type Tree, formatFiles, readNxJson } from '@nx/devkit';
+import { type Tree, formatFiles, readNxJson, updateNxJson } from '@nx/devkit';
 import {
   normalizeTargetDefaults,
   upsertTargetDefault,
 } from '@nx/devkit/internal';
 
 export default async function (tree: Tree) {
-  const nxJson = readNxJson(tree);
+  const nxJson = readNxJson(tree) ?? {};
   const executor = '@nx/eslint:lint';
 
-  const existing = normalizeTargetDefaults(nxJson?.targetDefaults).find(
+  const existing = normalizeTargetDefaults(nxJson.targetDefaults).find(
     (e) =>
       e.executor === executor &&
       e.target === undefined &&
@@ -36,6 +36,7 @@ export default async function (tree: Tree) {
     inputs.push('{workspaceRoot}/tools/eslint-rules/**/*');
   }
 
-  upsertTargetDefault(tree, { executor, inputs });
+  upsertTargetDefault(tree, nxJson, { executor, inputs });
+  updateNxJson(tree, nxJson);
   await formatFiles(tree);
 }

--- a/packages/eslint/src/migrations/update-21-6-0/update-executor-lint-inputs.ts
+++ b/packages/eslint/src/migrations/update-21-6-0/update-executor-lint-inputs.ts
@@ -1,6 +1,8 @@
 import { type Tree, formatFiles, readNxJson } from '@nx/devkit';
-import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
-import { normalizeTargetDefaults } from '@nx/devkit/src/utils/normalize-target-defaults';
+import {
+  normalizeTargetDefaults,
+  upsertTargetDefault,
+} from '@nx/devkit/internal';
 
 export default async function (tree: Tree) {
   const nxJson = readNxJson(tree);

--- a/packages/expo/src/generators/application/lib/add-e2e.ts
+++ b/packages/expo/src/generators/application/lib/add-e2e.ts
@@ -1,4 +1,7 @@
-import { getE2EWebServerInfo } from '@nx/devkit/internal';
+import {
+  getE2EWebServerInfo,
+  readTargetDefaultsForTarget,
+} from '@nx/devkit/internal';
 import {
   addProjectConfiguration,
   ensurePackage,
@@ -171,12 +174,13 @@ async function getExpoE2EWebServerInfo(
 ) {
   const nxJson = readNxJson(tree);
   let e2ePort = isPluginBeingAdded ? 8081 : 4200;
+  const serveTargetOptions = readTargetDefaultsForTarget(
+    'serve',
+    nxJson.targetDefaults
+  )?.options;
 
-  if (
-    nxJson.targetDefaults?.['serve'] &&
-    nxJson.targetDefaults?.['serve'].options?.port
-  ) {
-    e2ePort = nxJson.targetDefaults?.['serve'].options?.port;
+  if (serveTargetOptions?.port) {
+    e2ePort = serveTargetOptions.port;
   }
 
   return getE2EWebServerInfo(

--- a/packages/jest/src/generators/configuration/configuration.spec.ts
+++ b/packages/jest/src/generators/configuration/configuration.spec.ts
@@ -5,7 +5,6 @@ import {
   readJson,
   readProjectConfiguration,
   Tree,
-  updateNxJson,
   updateProjectConfiguration,
   writeJson,
   updateJson,
@@ -589,11 +588,6 @@ describe('jestProject', () => {
     });
 
     it(`should setup a task pipeline for the test target to depend on the deps' build target`, async () => {
-      // seed nx.json with array-shape targetDefaults so the generator's
-      // upsert call preserves the array shape we assert against below
-      const seeded = readNxJson(tree);
-      updateNxJson(tree, { ...seeded, targetDefaults: [] });
-
       await configurationGenerator(tree, {
         ...defaultOptions,
         project: 'pkg1',

--- a/packages/jest/src/generators/configuration/configuration.spec.ts
+++ b/packages/jest/src/generators/configuration/configuration.spec.ts
@@ -5,6 +5,7 @@ import {
   readJson,
   readProjectConfiguration,
   Tree,
+  updateNxJson,
   updateProjectConfiguration,
   writeJson,
   updateJson,
@@ -588,13 +589,21 @@ describe('jestProject', () => {
     });
 
     it(`should setup a task pipeline for the test target to depend on the deps' build target`, async () => {
+      // seed nx.json with array-shape targetDefaults so the generator's
+      // upsert call preserves the array shape we assert against below
+      const seeded = readNxJson(tree);
+      updateNxJson(tree, { ...seeded, targetDefaults: [] });
+
       await configurationGenerator(tree, {
         ...defaultOptions,
         project: 'pkg1',
       });
 
       const nxJson = readNxJson(tree);
-      expect(nxJson.targetDefaults.test.dependsOn).toStrictEqual(['^build']);
+      expect(nxJson.targetDefaults).toContainEqual({
+        target: 'test',
+        dependsOn: ['^build'],
+      });
     });
 
     it('should generate files with swc compiler', async () => {

--- a/packages/jest/src/generators/configuration/configuration.ts
+++ b/packages/jest/src/generators/configuration/configuration.ts
@@ -9,7 +9,7 @@ import {
   type TargetDefaults,
   Tree,
 } from '@nx/devkit';
-import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
+import { upsertTargetDefault } from '@nx/devkit/internal';
 import { initGenerator as jsInitGenerator } from '@nx/js';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { JestPluginOptions } from '../../plugins/plugin';

--- a/packages/jest/src/generators/configuration/configuration.ts
+++ b/packages/jest/src/generators/configuration/configuration.ts
@@ -5,9 +5,11 @@ import {
   readNxJson,
   readProjectConfiguration,
   runTasksInSerial,
+  type TargetConfiguration,
+  type TargetDefaults,
   Tree,
-  updateNxJson,
 } from '@nx/devkit';
+import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
 import { initGenerator as jsInitGenerator } from '@nx/js';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { JestPluginOptions } from '../../plugins/plugin';
@@ -139,14 +141,14 @@ export async function configurationGeneratorInternal(
     // in the TS solution setup, the test target depends on the build outputs
     // so we need to setup the task pipeline accordingly
     const nxJson = readNxJson(tree);
-    nxJson.targetDefaults ??= {};
-    nxJson.targetDefaults[options.targetName] ??= {};
-    nxJson.targetDefaults[options.targetName].dependsOn ??= [];
-    nxJson.targetDefaults[options.targetName].dependsOn.push('^build');
-    nxJson.targetDefaults[options.targetName].dependsOn = Array.from(
-      new Set(nxJson.targetDefaults[options.targetName].dependsOn)
+    const existing = findExistingTestDefault(
+      nxJson?.targetDefaults,
+      options.targetName
     );
-    updateNxJson(tree, nxJson);
+    const dependsOn = Array.from(
+      new Set([...(existing?.dependsOn ?? []), '^build'])
+    );
+    upsertTargetDefault(tree, { target: options.targetName, dependsOn });
   }
 
   if (!schema.skipFormat) {
@@ -154,6 +156,22 @@ export async function configurationGeneratorInternal(
   }
 
   return runTasksInSerial(...tasks);
+}
+
+function findExistingTestDefault(
+  td: TargetDefaults | undefined,
+  targetName: string
+): Partial<TargetConfiguration> | undefined {
+  if (!td) return undefined;
+  if (Array.isArray(td)) {
+    return td.find(
+      (e) =>
+        e.target === targetName &&
+        e.projects === undefined &&
+        e.source === undefined
+    );
+  }
+  return td[targetName];
 }
 
 function ignoreTestOutput(tree: Tree): void {

--- a/packages/jest/src/generators/configuration/configuration.ts
+++ b/packages/jest/src/generators/configuration/configuration.ts
@@ -173,7 +173,7 @@ function findExistingTestDefault(
       (e) =>
         e.target === targetName &&
         e.projects === undefined &&
-        e.source === undefined
+        e.plugin === undefined
     );
   }
   return td[targetName];

--- a/packages/jest/src/generators/configuration/configuration.ts
+++ b/packages/jest/src/generators/configuration/configuration.ts
@@ -8,6 +8,7 @@ import {
   type TargetConfiguration,
   type TargetDefaults,
   Tree,
+  updateNxJson,
 } from '@nx/devkit';
 import { upsertTargetDefault } from '@nx/devkit/internal';
 import { initGenerator as jsInitGenerator } from '@nx/js';
@@ -140,15 +141,19 @@ export async function configurationGeneratorInternal(
 
     // in the TS solution setup, the test target depends on the build outputs
     // so we need to setup the task pipeline accordingly
-    const nxJson = readNxJson(tree);
+    const nxJson = readNxJson(tree) ?? {};
     const existing = findExistingTestDefault(
-      nxJson?.targetDefaults,
+      nxJson.targetDefaults,
       options.targetName
     );
     const dependsOn = Array.from(
       new Set([...(existing?.dependsOn ?? []), '^build'])
     );
-    upsertTargetDefault(tree, { target: options.targetName, dependsOn });
+    upsertTargetDefault(tree, nxJson, {
+      target: options.targetName,
+      dependsOn,
+    });
+    updateNxJson(tree, nxJson);
   }
 
   if (!schema.skipFormat) {

--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -15,6 +15,17 @@ describe('jest', () => {
   let tree: Tree;
   let options: JestInitSchema;
 
+  function getJestTargetDefaults(): TargetDefaultEntry[] {
+    const td =
+      readJson<NxJsonConfiguration>(tree, 'nx.json').targetDefaults ?? [];
+    if (!Array.isArray(td)) {
+      throw new Error('expected array-shaped targetDefaults in test');
+    }
+    return td.filter(
+      (entry): entry is TargetDefaultEntry => entry.executor === '@nx/jest:jest'
+    );
+  }
+
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     // ensure targetDefaults starts as the array shape so assertions target it
@@ -34,7 +45,7 @@ describe('jest', () => {
       return json;
     });
 
-    await jestInitGenerator(tree, options);
+    await jestInitGenerator(tree, { ...options, addPlugin: false });
 
     const productionFileSet = readJson<NxJsonConfiguration>(tree, 'nx.json')
       .namedInputs.production;
@@ -52,7 +63,7 @@ describe('jest', () => {
       json.namedInputs.production = ['default', '^production'];
       return json;
     });
-    await jestInitGenerator(tree, options);
+    await jestInitGenerator(tree, { ...options, addPlugin: false });
     let nxJson: NxJsonConfiguration;
     updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
       json.namedInputs ??= {};
@@ -78,7 +89,7 @@ describe('jest', () => {
     });
     tree.write('jest.preset.js', '');
 
-    await jestInitGenerator(tree, options);
+    await jestInitGenerator(tree, { ...options, addPlugin: false });
 
     expect(readJson<NxJsonConfiguration>(tree, 'nx.json')).toEqual(nxJson);
   });
@@ -89,5 +100,68 @@ describe('jest', () => {
     const packageJson = readJson(tree, 'package.json');
     expect(packageJson.devDependencies.jest).toBeDefined();
     expect(packageJson.devDependencies['@nx/jest']).toBeDefined();
+  });
+
+  it('should patch existing target-scoped and filtered jest defaults in place', async () => {
+    updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      json.targetDefaults = [
+        {
+          target: 'test',
+          executor: '@nx/jest:jest',
+        },
+        {
+          executor: '@nx/jest:jest',
+          projects: 'tag:unit',
+          cache: false,
+        },
+      ];
+      return json;
+    });
+
+    await jestInitGenerator(tree, { ...options, addPlugin: false });
+
+    const jestDefaults = getJestTargetDefaults();
+    expect(jestDefaults).toHaveLength(2);
+    expect(jestDefaults).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          target: 'test',
+          executor: '@nx/jest:jest',
+          cache: true,
+          configurations: {
+            ci: {
+              ci: true,
+              codeCoverage: true,
+            },
+          },
+          options: {
+            passWithNoTests: true,
+          },
+        }),
+        expect.objectContaining({
+          executor: '@nx/jest:jest',
+          projects: 'tag:unit',
+          cache: false,
+          configurations: {
+            ci: {
+              ci: true,
+              codeCoverage: true,
+            },
+          },
+          options: {
+            passWithNoTests: true,
+          },
+        }),
+      ])
+    );
+    for (const entry of jestDefaults) {
+      expect(entry.inputs).toEqual(
+        expect.arrayContaining([
+          'default',
+          '^default',
+          expect.stringMatching(/^\{workspaceRoot\}\/jest\.preset\.(js|ts)$/),
+        ])
+      );
+    }
   });
 });

--- a/packages/jest/src/generators/init/init.spec.ts
+++ b/packages/jest/src/generators/init/init.spec.ts
@@ -3,6 +3,7 @@ import 'nx/src/internal-testing-utils/mock-project-graph';
 import {
   type NxJsonConfiguration,
   readJson,
+  type TargetDefaultEntry,
   type Tree,
   updateJson,
 } from '@nx/devkit';
@@ -16,6 +17,11 @@ describe('jest', () => {
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    // ensure targetDefaults starts as the array shape so assertions target it
+    updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      json.targetDefaults = [];
+      return json;
+    });
     options = {
       addPlugin: true,
     };
@@ -32,8 +38,6 @@ describe('jest', () => {
 
     const productionFileSet = readJson<NxJsonConfiguration>(tree, 'nx.json')
       .namedInputs.production;
-    const jestDefaults = readJson<NxJsonConfiguration>(tree, 'nx.json')
-      .targetDefaults['@nx/jest:jest'];
     expect(productionFileSet).toContain(
       '!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)'
     );
@@ -58,14 +62,17 @@ describe('jest', () => {
         '!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)',
         '!{projectRoot}/**/*.md',
       ];
-      json.targetDefaults.test = {
+      const entries = (json.targetDefaults ?? []) as TargetDefaultEntry[];
+      entries.push({
+        target: 'test',
         inputs: [
           'default',
           '^production',
           '{workspaceRoot}/jest.preset.js',
           '{workspaceRoot}/testSetup.ts',
         ],
-      };
+      });
+      json.targetDefaults = entries;
       nxJson = json;
       return json;
     });

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -77,7 +77,7 @@ function addJestTargetDefaults(tree: Tree, presetExt: JestPresetExtension) {
   }
 
   if (Object.keys(patch).length > 0) {
-    upsertTargetDefault(tree, { target: '@nx/jest:jest', ...patch });
+    upsertTargetDefault(tree, { executor: '@nx/jest:jest', ...patch });
   }
 }
 
@@ -88,7 +88,7 @@ function findExistingJestDefault(
   if (Array.isArray(td)) {
     return td.find(
       (e) =>
-        e.target === '@nx/jest:jest' &&
+        e.executor === '@nx/jest:jest' &&
         e.projects === undefined &&
         e.source === undefined
     );

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -91,7 +91,7 @@ function findExistingJestDefault(
       (e) =>
         e.executor === '@nx/jest:jest' &&
         e.projects === undefined &&
-        e.source === undefined
+        e.plugin === undefined
     );
   }
   return td['@nx/jest:jest'];

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -1,4 +1,8 @@
-import { addPlugin, upsertTargetDefault } from '@nx/devkit/internal';
+import {
+  addPlugin,
+  normalizeTargetDefaults,
+  upsertTargetDefault,
+} from '@nx/devkit/internal';
 import {
   addDependenciesToPackageJson,
   createProjectGraphAsync,
@@ -8,6 +12,7 @@ import {
   runTasksInSerial,
   updateNxJson,
   type GeneratorCallback,
+  type TargetDefaultEntry,
   type TargetConfiguration,
   type TargetDefaults,
   type Tree,
@@ -51,9 +56,56 @@ function updateProductionFileSet(tree: Tree) {
 
 function addJestTargetDefaults(tree: Tree, presetExt: JestPresetExtension) {
   const nxJson = readNxJson(tree) ?? {};
-  const existing = findExistingJestDefault(nxJson.targetDefaults);
   const productionFileSet = nxJson.namedInputs?.production;
+  const existingEntries = findExistingJestDefaults(nxJson.targetDefaults);
 
+  if (existingEntries.length === 0) {
+    const patch = createJestDefaultPatch(
+      undefined,
+      productionFileSet,
+      presetExt
+    );
+    if (Object.keys(patch).length > 0) {
+      upsertTargetDefault(tree, nxJson, {
+        executor: '@nx/jest:jest',
+        ...patch,
+      });
+      updateNxJson(tree, nxJson);
+    }
+    return;
+  }
+
+  let didUpdate = false;
+  for (const existing of existingEntries) {
+    const patch = createJestDefaultPatch(
+      existing,
+      productionFileSet,
+      presetExt
+    );
+    if (Object.keys(patch).length === 0) {
+      continue;
+    }
+
+    upsertTargetDefault(tree, nxJson, {
+      target: existing.target,
+      executor: existing.executor,
+      projects: existing.projects,
+      plugin: existing.plugin,
+      ...patch,
+    });
+    didUpdate = true;
+  }
+
+  if (didUpdate) {
+    updateNxJson(tree, nxJson);
+  }
+}
+
+function createJestDefaultPatch(
+  existing: Partial<TargetConfiguration> | undefined,
+  productionFileSet: unknown,
+  presetExt: JestPresetExtension
+): Partial<TargetConfiguration> {
   const patch: Partial<TargetConfiguration> = {};
   if (existing?.cache === undefined) patch.cache = true;
   // Test targets depend on all their project's sources + production sources of dependencies
@@ -76,25 +128,15 @@ function addJestTargetDefaults(tree: Tree, presetExt: JestPresetExtension) {
     };
   }
 
-  if (Object.keys(patch).length > 0) {
-    upsertTargetDefault(tree, nxJson, { executor: '@nx/jest:jest', ...patch });
-    updateNxJson(tree, nxJson);
-  }
+  return patch;
 }
 
-function findExistingJestDefault(
+function findExistingJestDefaults(
   td: TargetDefaults | undefined
-): Partial<TargetConfiguration> | undefined {
-  if (!td) return undefined;
-  if (Array.isArray(td)) {
-    return td.find(
-      (e) =>
-        e.executor === '@nx/jest:jest' &&
-        e.projects === undefined &&
-        e.plugin === undefined
-    );
-  }
-  return td['@nx/jest:jest'];
+): TargetDefaultEntry[] {
+  return normalizeTargetDefaults(td).filter(
+    (e) => e.executor === '@nx/jest:jest'
+  );
 }
 
 function updateDependencies(tree: Tree, options: JestInitSchema) {

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -50,9 +50,9 @@ function updateProductionFileSet(tree: Tree) {
 }
 
 function addJestTargetDefaults(tree: Tree, presetExt: JestPresetExtension) {
-  const nxJson = readNxJson(tree);
-  const existing = findExistingJestDefault(nxJson?.targetDefaults);
-  const productionFileSet = nxJson?.namedInputs?.production;
+  const nxJson = readNxJson(tree) ?? {};
+  const existing = findExistingJestDefault(nxJson.targetDefaults);
+  const productionFileSet = nxJson.namedInputs?.production;
 
   const patch: Partial<TargetConfiguration> = {};
   if (existing?.cache === undefined) patch.cache = true;
@@ -77,7 +77,8 @@ function addJestTargetDefaults(tree: Tree, presetExt: JestPresetExtension) {
   }
 
   if (Object.keys(patch).length > 0) {
-    upsertTargetDefault(tree, { executor: '@nx/jest:jest', ...patch });
+    upsertTargetDefault(tree, nxJson, { executor: '@nx/jest:jest', ...patch });
+    updateNxJson(tree, nxJson);
   }
 }
 

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -1,4 +1,4 @@
-import { addPlugin } from '@nx/devkit/internal';
+import { addPlugin, upsertTargetDefault } from '@nx/devkit/internal';
 import {
   addDependenciesToPackageJson,
   createProjectGraphAsync,
@@ -8,6 +8,8 @@ import {
   runTasksInSerial,
   updateNxJson,
   type GeneratorCallback,
+  type TargetConfiguration,
+  type TargetDefaults,
   type Tree,
 } from '@nx/devkit';
 import { createNodesV2 } from '../../plugins/plugin';
@@ -49,31 +51,49 @@ function updateProductionFileSet(tree: Tree) {
 
 function addJestTargetDefaults(tree: Tree, presetExt: JestPresetExtension) {
   const nxJson = readNxJson(tree);
+  const existing = findExistingJestDefault(nxJson?.targetDefaults);
+  const productionFileSet = nxJson?.namedInputs?.production;
 
-  nxJson.targetDefaults ??= {};
-  nxJson.targetDefaults['@nx/jest:jest'] ??= {};
-
-  const productionFileSet = nxJson.namedInputs?.production;
-
-  nxJson.targetDefaults['@nx/jest:jest'].cache ??= true;
+  const patch: Partial<TargetConfiguration> = {};
+  if (existing?.cache === undefined) patch.cache = true;
   // Test targets depend on all their project's sources + production sources of dependencies
-  nxJson.targetDefaults['@nx/jest:jest'].inputs ??= [
-    'default',
-    productionFileSet ? '^production' : '^default',
-    `{workspaceRoot}/jest.preset.${presetExt}`,
-  ];
+  if (existing?.inputs === undefined) {
+    patch.inputs = [
+      'default',
+      productionFileSet ? '^production' : '^default',
+      `{workspaceRoot}/jest.preset.${presetExt}`,
+    ];
+  }
+  if (existing?.options === undefined) {
+    patch.options = { passWithNoTests: true };
+  }
+  if (existing?.configurations === undefined) {
+    patch.configurations = {
+      ci: {
+        ci: true,
+        codeCoverage: true,
+      },
+    };
+  }
 
-  nxJson.targetDefaults['@nx/jest:jest'].options ??= {
-    passWithNoTests: true,
-  };
-  nxJson.targetDefaults['@nx/jest:jest'].configurations ??= {
-    ci: {
-      ci: true,
-      codeCoverage: true,
-    },
-  };
+  if (Object.keys(patch).length > 0) {
+    upsertTargetDefault(tree, { target: '@nx/jest:jest', ...patch });
+  }
+}
 
-  updateNxJson(tree, nxJson);
+function findExistingJestDefault(
+  td: TargetDefaults | undefined
+): Partial<TargetConfiguration> | undefined {
+  if (!td) return undefined;
+  if (Array.isArray(td)) {
+    return td.find(
+      (e) =>
+        e.target === '@nx/jest:jest' &&
+        e.projects === undefined &&
+        e.source === undefined
+    );
+  }
+  return td['@nx/jest:jest'];
 }
 
 function updateDependencies(tree: Tree, options: JestInitSchema) {

--- a/packages/jest/src/migrations/update-21-0-0/remove-tsconfig-option-from-jest-executor.spec.ts
+++ b/packages/jest/src/migrations/update-21-0-0/remove-tsconfig-option-from-jest-executor.spec.ts
@@ -168,7 +168,7 @@ describe('remove-tsconfig-option-from-jest-executor', () => {
     updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
       json.targetDefaults = [
         {
-          target: '@nx/jest:jest',
+          executor: '@nx/jest:jest',
           options: {
             jestConfig: '{projectRoot}/jest.config.ts',
             tsConfig: '{projectRoot}/tsconfig.json',
@@ -189,7 +189,7 @@ describe('remove-tsconfig-option-from-jest-executor', () => {
     const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
     expect(nxJson.targetDefaults).toEqual([
       {
-        target: '@nx/jest:jest',
+        executor: '@nx/jest:jest',
         options: { jestConfig: '{projectRoot}/jest.config.ts' },
         configurations: { production: { codeCoverage: true } },
       },

--- a/packages/jest/src/migrations/update-21-0-0/remove-tsconfig-option-from-jest-executor.spec.ts
+++ b/packages/jest/src/migrations/update-21-0-0/remove-tsconfig-option-from-jest-executor.spec.ts
@@ -132,63 +132,68 @@ describe('remove-tsconfig-option-from-jest-executor', () => {
 
   it('should remove tsConfig option in nx.json target defaults for a target with the jest executor', async () => {
     updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
-      json.targetDefaults ??= {};
-      json.targetDefaults.test = {
-        executor: '@nx/jest:jest',
-        options: {
-          jestConfig: '{projectRoot}/jest.config.ts',
-          tsConfig: '{projectRoot}/tsconfig.json',
-        },
-        configurations: {
-          production: {
-            tsConfig: '{projectRoot}/tsconfig.prod.json',
-            codeCoverage: true,
+      json.targetDefaults = [
+        {
+          target: 'test',
+          executor: '@nx/jest:jest',
+          options: {
+            jestConfig: '{projectRoot}/jest.config.ts',
+            tsConfig: '{projectRoot}/tsconfig.json',
+          },
+          configurations: {
+            production: {
+              tsConfig: '{projectRoot}/tsconfig.prod.json',
+              codeCoverage: true,
+            },
           },
         },
-      };
+      ];
       return json;
     });
 
     await migration(tree);
 
     const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
-    expect(nxJson.targetDefaults.test.options).toStrictEqual({
-      jestConfig: '{projectRoot}/jest.config.ts',
-    });
-    expect(nxJson.targetDefaults.test.configurations.production).toStrictEqual({
-      codeCoverage: true,
-    });
+    expect(nxJson.targetDefaults).toEqual([
+      {
+        target: 'test',
+        executor: '@nx/jest:jest',
+        options: { jestConfig: '{projectRoot}/jest.config.ts' },
+        configurations: { production: { codeCoverage: true } },
+      },
+    ]);
   });
 
   it('should remove tsConfig option in nx.json target defaults for the jest executor', async () => {
     updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
-      json.targetDefaults ??= {};
-      json.targetDefaults['@nx/jest:jest'] = {
-        options: {
-          jestConfig: '{projectRoot}/jest.config.ts',
-          tsConfig: '{projectRoot}/tsconfig.json',
-        },
-        configurations: {
-          production: {
-            tsConfig: '{projectRoot}/tsconfig.prod.json',
-            codeCoverage: true,
+      json.targetDefaults = [
+        {
+          target: '@nx/jest:jest',
+          options: {
+            jestConfig: '{projectRoot}/jest.config.ts',
+            tsConfig: '{projectRoot}/tsconfig.json',
+          },
+          configurations: {
+            production: {
+              tsConfig: '{projectRoot}/tsconfig.prod.json',
+              codeCoverage: true,
+            },
           },
         },
-      };
+      ];
       return json;
     });
 
     await migration(tree);
 
     const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
-    expect(nxJson.targetDefaults['@nx/jest:jest'].options).toStrictEqual({
-      jestConfig: '{projectRoot}/jest.config.ts',
-    });
-    expect(
-      nxJson.targetDefaults['@nx/jest:jest'].configurations.production
-    ).toStrictEqual({
-      codeCoverage: true,
-    });
+    expect(nxJson.targetDefaults).toEqual([
+      {
+        target: '@nx/jest:jest',
+        options: { jestConfig: '{projectRoot}/jest.config.ts' },
+        configurations: { production: { codeCoverage: true } },
+      },
+    ]);
   });
 
   it('should remove empty options and configurations objects from project configuration', async () => {

--- a/packages/jest/src/migrations/update-21-0-0/remove-tsconfig-option-from-jest-executor.ts
+++ b/packages/jest/src/migrations/update-21-0-0/remove-tsconfig-option-from-jest-executor.ts
@@ -4,12 +4,14 @@ import {
   readNxJson,
   readProjectConfiguration,
   type TargetConfiguration,
+  type TargetDefaultEntry,
   type Tree,
   updateNxJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
 
 const EXECUTOR_TO_MIGRATE = '@nx/jest:jest';
+const ENTRY_META_KEYS = new Set(['target', 'projects', 'source']);
 
 export default async function (tree: Tree) {
   // update options from project configs
@@ -38,34 +40,61 @@ export default async function (tree: Tree) {
   // update options from nx.json target defaults
   const nxJson = readNxJson(tree);
   if (nxJson.targetDefaults) {
-    for (const [targetOrExecutor, targetConfig] of Object.entries(
-      nxJson.targetDefaults
-    )) {
-      if (
-        targetOrExecutor !== EXECUTOR_TO_MIGRATE &&
-        targetConfig.executor !== EXECUTOR_TO_MIGRATE
-      ) {
-        continue;
+    if (Array.isArray(nxJson.targetDefaults)) {
+      const next: TargetDefaultEntry[] = [];
+      for (const entry of nxJson.targetDefaults) {
+        if (
+          entry.target !== EXECUTOR_TO_MIGRATE &&
+          entry.executor !== EXECUTOR_TO_MIGRATE
+        ) {
+          next.push(entry);
+          continue;
+        }
+
+        if (entry.options) updateOptions(entry);
+        Object.keys(entry.configurations ?? {}).forEach((config) => {
+          updateConfiguration(entry, config);
+        });
+
+        if (!isEntryEmpty(entry)) {
+          next.push(entry);
+        }
       }
-
-      if (targetConfig.options) {
-        updateOptions(targetConfig);
-      }
-
-      Object.keys(targetConfig.configurations ?? {}).forEach((config) => {
-        updateConfiguration(targetConfig, config);
-      });
-
-      if (
-        !Object.keys(targetConfig).length ||
-        (Object.keys(targetConfig).length === 1 &&
-          Object.keys(targetConfig)[0] === 'executor')
-      ) {
-        delete nxJson.targetDefaults[targetOrExecutor];
-      }
-
-      if (!Object.keys(nxJson.targetDefaults).length) {
+      if (next.length === 0) {
         delete nxJson.targetDefaults;
+      } else {
+        nxJson.targetDefaults = next;
+      }
+    } else {
+      for (const [targetOrExecutor, targetConfig] of Object.entries(
+        nxJson.targetDefaults
+      )) {
+        if (
+          targetOrExecutor !== EXECUTOR_TO_MIGRATE &&
+          targetConfig.executor !== EXECUTOR_TO_MIGRATE
+        ) {
+          continue;
+        }
+
+        if (targetConfig.options) {
+          updateOptions(targetConfig);
+        }
+
+        Object.keys(targetConfig.configurations ?? {}).forEach((config) => {
+          updateConfiguration(targetConfig, config);
+        });
+
+        if (
+          !Object.keys(targetConfig).length ||
+          (Object.keys(targetConfig).length === 1 &&
+            Object.keys(targetConfig)[0] === 'executor')
+        ) {
+          delete nxJson.targetDefaults[targetOrExecutor];
+        }
+
+        if (!Object.keys(nxJson.targetDefaults).length) {
+          delete nxJson.targetDefaults;
+        }
       }
     }
 
@@ -73,6 +102,15 @@ export default async function (tree: Tree) {
   }
 
   await formatFiles(tree);
+}
+
+// An entry is "empty" once only its filter/meta keys (target/projects/source)
+// plus optionally `executor` remain — nothing else worth keeping around.
+function isEntryEmpty(entry: TargetDefaultEntry): boolean {
+  const configKeys = Object.keys(entry).filter(
+    (k) => !ENTRY_META_KEYS.has(k) && k !== 'executor'
+  );
+  return configKeys.length === 0;
 }
 
 function updateOptions(target: TargetConfiguration) {

--- a/packages/jest/src/migrations/update-21-0-0/remove-tsconfig-option-from-jest-executor.ts
+++ b/packages/jest/src/migrations/update-21-0-0/remove-tsconfig-option-from-jest-executor.ts
@@ -11,7 +11,7 @@ import {
 } from '@nx/devkit';
 
 const EXECUTOR_TO_MIGRATE = '@nx/jest:jest';
-const ENTRY_META_KEYS = new Set(['target', 'executor', 'projects', 'source']);
+const ENTRY_META_KEYS = new Set(['target', 'executor', 'projects', 'plugin']);
 
 export default async function (tree: Tree) {
   // update options from project configs
@@ -105,7 +105,7 @@ export default async function (tree: Tree) {
 }
 
 // An entry is "empty" once only filter/meta keys remain (target, executor,
-// projects, source) — nothing else worth keeping around.
+// projects, plugin) — nothing else worth keeping around.
 function isEntryEmpty(entry: TargetDefaultEntry): boolean {
   return Object.keys(entry).every((k) => ENTRY_META_KEYS.has(k));
 }

--- a/packages/jest/src/migrations/update-21-0-0/remove-tsconfig-option-from-jest-executor.ts
+++ b/packages/jest/src/migrations/update-21-0-0/remove-tsconfig-option-from-jest-executor.ts
@@ -11,7 +11,7 @@ import {
 } from '@nx/devkit';
 
 const EXECUTOR_TO_MIGRATE = '@nx/jest:jest';
-const ENTRY_META_KEYS = new Set(['target', 'projects', 'source']);
+const ENTRY_META_KEYS = new Set(['target', 'executor', 'projects', 'source']);
 
 export default async function (tree: Tree) {
   // update options from project configs
@@ -104,13 +104,10 @@ export default async function (tree: Tree) {
   await formatFiles(tree);
 }
 
-// An entry is "empty" once only its filter/meta keys (target/projects/source)
-// plus optionally `executor` remain — nothing else worth keeping around.
+// An entry is "empty" once only filter/meta keys remain (target, executor,
+// projects, source) — nothing else worth keeping around.
 function isEntryEmpty(entry: TargetDefaultEntry): boolean {
-  const configKeys = Object.keys(entry).filter(
-    (k) => !ENTRY_META_KEYS.has(k) && k !== 'executor'
-  );
-  return configKeys.length === 0;
+  return Object.keys(entry).every((k) => ENTRY_META_KEYS.has(k));
 }
 
 function updateOptions(target: TargetConfiguration) {

--- a/packages/jest/src/migrations/update-21-3-0/rename-test-path-pattern.spec.ts
+++ b/packages/jest/src/migrations/update-21-3-0/rename-test-path-pattern.spec.ts
@@ -79,76 +79,63 @@ describe('rename-test-path-pattern migration', () => {
 
   it('should rename "testPathPattern" option in nx.json target defaults for a target with the @nx/jest:jest executor', async () => {
     updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
-      json.targetDefaults ??= {};
-      json.targetDefaults.test = {
-        executor: '@nx/jest:jest',
-        options: { testPathPattern: 'some-regex' },
-        configurations: {
-          development: { testPathPattern: 'regex-dev' },
-          production: { testPathPattern: 'regex-prod' },
+      json.targetDefaults = [
+        {
+          target: 'test',
+          executor: '@nx/jest:jest',
+          options: { testPathPattern: 'some-regex' },
+          configurations: {
+            development: { testPathPattern: 'regex-dev' },
+            production: { testPathPattern: 'regex-prod' },
+          },
         },
-      };
+      ];
       return json;
     });
 
     await migration(tree);
 
     const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
-    expect(nxJson.targetDefaults!.test.options.testPathPattern).toBeUndefined();
-    expect(nxJson.targetDefaults!.test.options.testPathPatterns).toBe(
-      'some-regex'
-    );
-    expect(
-      nxJson.targetDefaults!.test.configurations!.development.testPathPattern
-    ).toBeUndefined();
-    expect(
-      nxJson.targetDefaults!.test.configurations!.development.testPathPatterns
-    ).toBe('regex-dev');
-    expect(
-      nxJson.targetDefaults!.test.configurations!.production.testPathPattern
-    ).toBeUndefined();
-    expect(
-      nxJson.targetDefaults!.test.configurations!.production.testPathPatterns
-    ).toBe('regex-prod');
+    expect(nxJson.targetDefaults).toEqual([
+      {
+        target: 'test',
+        executor: '@nx/jest:jest',
+        options: { testPathPatterns: 'some-regex' },
+        configurations: {
+          development: { testPathPatterns: 'regex-dev' },
+          production: { testPathPatterns: 'regex-prod' },
+        },
+      },
+    ]);
   });
 
   it('should rename "testPathPattern" option in nx.json target defaults for the @nx/jest:jest executor', async () => {
     updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
-      json.targetDefaults ??= {};
-      json.targetDefaults['@nx/jest:jest'] = {
-        options: { testPathPattern: 'some-regex' },
-        configurations: {
-          development: { testPathPattern: 'regex-dev' },
-          production: { testPathPattern: 'regex-prod' },
+      json.targetDefaults = [
+        {
+          target: '@nx/jest:jest',
+          options: { testPathPattern: 'some-regex' },
+          configurations: {
+            development: { testPathPattern: 'regex-dev' },
+            production: { testPathPattern: 'regex-prod' },
+          },
         },
-      };
+      ];
       return json;
     });
 
     await migration(tree);
 
     const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
-    expect(
-      nxJson.targetDefaults!['@nx/jest:jest'].options.testPathPattern
-    ).toBeUndefined();
-    expect(
-      nxJson.targetDefaults!['@nx/jest:jest'].options.testPathPatterns
-    ).toBe('some-regex');
-    expect(
-      nxJson.targetDefaults!['@nx/jest:jest'].configurations!.development
-        .testPathPattern
-    ).toBeUndefined();
-    expect(
-      nxJson.targetDefaults!['@nx/jest:jest'].configurations!.development
-        .testPathPatterns
-    ).toBe('regex-dev');
-    expect(
-      nxJson.targetDefaults!['@nx/jest:jest'].configurations!.production
-        .testPathPattern
-    ).toBeUndefined();
-    expect(
-      nxJson.targetDefaults!['@nx/jest:jest'].configurations!.production
-        .testPathPatterns
-    ).toBe('regex-prod');
+    expect(nxJson.targetDefaults).toEqual([
+      {
+        target: '@nx/jest:jest',
+        options: { testPathPatterns: 'some-regex' },
+        configurations: {
+          development: { testPathPatterns: 'regex-dev' },
+          production: { testPathPatterns: 'regex-prod' },
+        },
+      },
+    ]);
   });
 });

--- a/packages/jest/src/migrations/update-21-3-0/rename-test-path-pattern.spec.ts
+++ b/packages/jest/src/migrations/update-21-3-0/rename-test-path-pattern.spec.ts
@@ -113,7 +113,7 @@ describe('rename-test-path-pattern migration', () => {
     updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
       json.targetDefaults = [
         {
-          target: '@nx/jest:jest',
+          executor: '@nx/jest:jest',
           options: { testPathPattern: 'some-regex' },
           configurations: {
             development: { testPathPattern: 'regex-dev' },
@@ -129,7 +129,7 @@ describe('rename-test-path-pattern migration', () => {
     const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
     expect(nxJson.targetDefaults).toEqual([
       {
-        target: '@nx/jest:jest',
+        executor: '@nx/jest:jest',
         options: { testPathPatterns: 'some-regex' },
         configurations: {
           development: { testPathPatterns: 'regex-dev' },

--- a/packages/jest/src/migrations/update-21-3-0/rename-test-path-pattern.ts
+++ b/packages/jest/src/migrations/update-21-3-0/rename-test-path-pattern.ts
@@ -33,23 +33,42 @@ export default async function (tree: Tree) {
     return;
   }
 
-  for (const [targetOrExecutor, targetConfig] of Object.entries(
-    nxJson.targetDefaults
-  )) {
-    if (
-      targetOrExecutor !== '@nx/jest:jest' &&
-      targetConfig.executor !== '@nx/jest:jest'
-    ) {
-      continue;
-    }
+  if (Array.isArray(nxJson.targetDefaults)) {
+    for (const entry of nxJson.targetDefaults) {
+      if (
+        entry.target !== '@nx/jest:jest' &&
+        entry.executor !== '@nx/jest:jest'
+      ) {
+        continue;
+      }
 
-    if (targetConfig.options) {
-      renameTestPathPattern(targetConfig.options);
-    }
+      if (entry.options) {
+        renameTestPathPattern(entry.options);
+      }
 
-    Object.values(targetConfig.configurations ?? {}).forEach((config) => {
-      renameTestPathPattern(config);
-    });
+      Object.values(entry.configurations ?? {}).forEach((config) => {
+        renameTestPathPattern(config);
+      });
+    }
+  } else {
+    for (const [targetOrExecutor, targetConfig] of Object.entries(
+      nxJson.targetDefaults
+    )) {
+      if (
+        targetOrExecutor !== '@nx/jest:jest' &&
+        targetConfig.executor !== '@nx/jest:jest'
+      ) {
+        continue;
+      }
+
+      if (targetConfig.options) {
+        renameTestPathPattern(targetConfig.options);
+      }
+
+      Object.values(targetConfig.configurations ?? {}).forEach((config) => {
+        renameTestPathPattern(config);
+      });
+    }
   }
 
   updateNxJson(tree, nxJson);

--- a/packages/js/src/generators/setup-build/generator.ts
+++ b/packages/js/src/generators/setup-build/generator.ts
@@ -1,4 +1,7 @@
-import { addBuildTargetDefaults } from '@nx/devkit/internal';
+import {
+  addBuildTargetDefaults,
+  readTargetDefaultsForTarget,
+} from '@nx/devkit/internal';
 import {
   ensurePackage,
   formatFiles,
@@ -353,8 +356,10 @@ function mergeTargetDefaults(
 
   return mergeTargetConfigurations(
     projectTarget,
-    (projectTarget.executor
-      ? nxJson.targetDefaults?.[projectTarget.executor]
-      : undefined) ?? nxJson.targetDefaults?.[buildTarget]
+    readTargetDefaultsForTarget(
+      buildTarget,
+      nxJson.targetDefaults,
+      projectTarget.executor
+    )
   );
 }

--- a/packages/js/src/migrations/update-22-0-0/remove-external-options-from-js-executors.spec.ts
+++ b/packages/js/src/migrations/update-22-0-0/remove-external-options-from-js-executors.spec.ts
@@ -4,6 +4,7 @@ import {
   readProjectConfiguration,
   updateJson,
   type NxJsonConfiguration,
+  type TargetDefaultsRecord,
   type Tree,
 } from '@nx/devkit';
 import * as devkit from '@nx/devkit';
@@ -11,6 +12,12 @@ import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import migration, {
   executors,
 } from './remove-external-options-from-js-executors';
+
+// This migration ran before targetDefaults supported the array shape, so
+// the test fixtures all use the legacy record shape.
+type LegacyNxJson = Omit<NxJsonConfiguration, 'targetDefaults'> & {
+  targetDefaults?: TargetDefaultsRecord;
+};
 
 describe('remove-external-options-from-js-executors migration', () => {
   let tree: Tree;
@@ -161,7 +168,7 @@ describe('remove-external-options-from-js-executors migration', () => {
   it.each(executors)(
     'should delete "external" and "externalBuildTargets" options in nx.json target defaults for a target with the "%s" executor',
     async (executor) => {
-      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
         json.targetDefaults ??= {};
         json.targetDefaults.build = {
           executor,
@@ -190,7 +197,7 @@ describe('remove-external-options-from-js-executors migration', () => {
 
       await migration(tree);
 
-      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      const nxJson = readJson<LegacyNxJson>(tree, 'nx.json');
       expect(nxJson.targetDefaults.build.options.external).toBeUndefined();
       expect(
         nxJson.targetDefaults.build.options.externalBuildTargets
@@ -215,7 +222,7 @@ describe('remove-external-options-from-js-executors migration', () => {
   it.each(executors)(
     'should remove empty options but keep empty configurations for a target with the "%s" executor',
     async (executor) => {
-      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
         json.targetDefaults ??= {};
         json.targetDefaults.build = {
           executor,
@@ -239,7 +246,7 @@ describe('remove-external-options-from-js-executors migration', () => {
 
       await migration(tree);
 
-      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      const nxJson = readJson<LegacyNxJson>(tree, 'nx.json');
       expect(nxJson.targetDefaults.build.options).toBeUndefined();
       // we keep them because users might rely on them, e.g. in scripts, CI, etc.
       // they might be applying them from target defaults
@@ -253,7 +260,7 @@ describe('remove-external-options-from-js-executors migration', () => {
   it.each(executors)(
     'should delete "external" and "externalBuildTargets" options in nx.json target defaults for the "%s" executor',
     async (executor) => {
-      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
         json.targetDefaults ??= {};
         json.targetDefaults[executor] = {
           options: {
@@ -281,7 +288,7 @@ describe('remove-external-options-from-js-executors migration', () => {
 
       await migration(tree);
 
-      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      const nxJson = readJson<LegacyNxJson>(tree, 'nx.json');
       expect(nxJson.targetDefaults[executor].options.external).toBeUndefined();
       expect(
         nxJson.targetDefaults[executor].options.externalBuildTargets
@@ -306,7 +313,7 @@ describe('remove-external-options-from-js-executors migration', () => {
   it.each(executors)(
     'should only delete target defaults for the "%s" executor when nothing remains after migration',
     async (executor) => {
-      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+      updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
         json.targetDefaults ??= {};
         json.targetDefaults[executor] = {
           options: {
@@ -319,7 +326,7 @@ describe('remove-external-options-from-js-executors migration', () => {
 
       await migration(tree);
 
-      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      const nxJson = readJson<LegacyNxJson>(tree, 'nx.json');
       expect(nxJson.targetDefaults[executor]).toBeUndefined();
     }
   );

--- a/packages/js/src/migrations/update-22-0-0/remove-external-options-from-js-executors.ts
+++ b/packages/js/src/migrations/update-22-0-0/remove-external-options-from-js-executors.ts
@@ -79,7 +79,7 @@ export default async function (tree: Tree) {
           k !== 'target' &&
           k !== 'executor' &&
           k !== 'projects' &&
-          k !== 'source'
+          k !== 'plugin'
       );
       if (meaningfulKeys.length === 0) continue;
       remaining.push(entry);

--- a/packages/js/src/migrations/update-22-0-0/remove-external-options-from-js-executors.ts
+++ b/packages/js/src/migrations/update-22-0-0/remove-external-options-from-js-executors.ts
@@ -50,39 +50,70 @@ export default async function (tree: Tree) {
     return;
   }
 
-  for (const [targetOrExecutor, targetConfig] of Object.entries(
-    nxJson.targetDefaults
-  )) {
-    if (
-      !executors.includes(targetOrExecutor) &&
-      !executors.includes(targetConfig.executor)
-    ) {
-      continue;
-    }
-
-    if (targetConfig.options) {
-      delete targetConfig.options.external;
-      delete targetConfig.options.externalBuildTargets;
-      if (!Object.keys(targetConfig.options).length) {
-        delete targetConfig.options;
+  const cleanEntry = (entry: Record<string, any>) => {
+    if (entry.options) {
+      delete entry.options.external;
+      delete entry.options.externalBuildTargets;
+      if (!Object.keys(entry.options).length) {
+        delete entry.options;
       }
     }
-
-    Object.entries(targetConfig.configurations ?? {}).forEach(([, config]) => {
+    Object.entries(entry.configurations ?? {}).forEach(([, config]: any) => {
       delete config.external;
       delete config.externalBuildTargets;
     });
+  };
 
-    if (
-      !Object.keys(targetConfig).length ||
-      (Object.keys(targetConfig).length === 1 &&
-        Object.keys(targetConfig)[0] === 'executor')
-    ) {
-      delete nxJson.targetDefaults[targetOrExecutor];
+  if (Array.isArray(nxJson.targetDefaults)) {
+    const remaining = [];
+    for (const entry of nxJson.targetDefaults) {
+      const matches =
+        executors.includes(entry.executor) ||
+        executors.includes(entry.target);
+      if (!matches) {
+        remaining.push(entry);
+        continue;
+      }
+      cleanEntry(entry as any);
+      const meaningfulKeys = Object.keys(entry).filter(
+        (k) =>
+          k !== 'target' &&
+          k !== 'executor' &&
+          k !== 'projects' &&
+          k !== 'source'
+      );
+      if (meaningfulKeys.length === 0) continue;
+      remaining.push(entry);
     }
-
-    if (!Object.keys(nxJson.targetDefaults).length) {
+    if (remaining.length === 0) {
       delete nxJson.targetDefaults;
+    } else {
+      nxJson.targetDefaults = remaining;
+    }
+  } else {
+    for (const [targetOrExecutor, targetConfig] of Object.entries(
+      nxJson.targetDefaults
+    )) {
+      if (
+        !executors.includes(targetOrExecutor) &&
+        !executors.includes(targetConfig.executor)
+      ) {
+        continue;
+      }
+
+      cleanEntry(targetConfig as any);
+
+      if (
+        !Object.keys(targetConfig).length ||
+        (Object.keys(targetConfig).length === 1 &&
+          Object.keys(targetConfig)[0] === 'executor')
+      ) {
+        delete nxJson.targetDefaults[targetOrExecutor];
+      }
+
+      if (!Object.keys(nxJson.targetDefaults).length) {
+        delete nxJson.targetDefaults;
+      }
     }
   }
 

--- a/packages/js/src/migrations/update-22-0-0/remove-external-options-from-js-executors.ts
+++ b/packages/js/src/migrations/update-22-0-0/remove-external-options-from-js-executors.ts
@@ -68,8 +68,7 @@ export default async function (tree: Tree) {
     const remaining = [];
     for (const entry of nxJson.targetDefaults) {
       const matches =
-        executors.includes(entry.executor) ||
-        executors.includes(entry.target);
+        executors.includes(entry.executor) || executors.includes(entry.target);
       if (!matches) {
         remaining.push(entry);
         continue;

--- a/packages/next/src/generators/application/lib/add-e2e.ts
+++ b/packages/next/src/generators/application/lib/add-e2e.ts
@@ -1,4 +1,7 @@
-import { getE2EWebServerInfo } from '@nx/devkit/internal';
+import {
+  getE2EWebServerInfo,
+  readTargetDefaultsForTarget,
+} from '@nx/devkit/internal';
 import {
   addProjectConfiguration,
   ensurePackage,
@@ -154,12 +157,13 @@ async function getNextE2EWebServerInfo(
   let e2ePort = isPluginBeingAdded ? 3000 : 4200;
 
   const defaultServeTarget = isPluginBeingAdded ? 'dev' : 'serve';
+  const serveTargetOptions = readTargetDefaultsForTarget(
+    defaultServeTarget,
+    nxJson.targetDefaults
+  )?.options;
 
-  if (
-    nxJson.targetDefaults?.[defaultServeTarget] &&
-    nxJson.targetDefaults?.[defaultServeTarget].options?.port
-  ) {
-    e2ePort = nxJson.targetDefaults?.[defaultServeTarget].options?.port;
+  if (serveTargetOptions?.port) {
+    e2ePort = serveTargetOptions.port;
   }
 
   return getE2EWebServerInfo(

--- a/packages/next/src/generators/custom-server/custom-server.ts
+++ b/packages/next/src/generators/custom-server/custom-server.ts
@@ -146,12 +146,12 @@ export async function customServerGenerator(
     return json;
   });
 
-  const nxJson = readNxJson(host) ?? {};
-  upsertTargetDefault(host, nxJson, {
+  const updatedNxJson = readNxJson(host) ?? {};
+  upsertTargetDefault(host, updatedNxJson, {
     target: 'build-custom-server',
     cache: true,
   });
-  updateNxJson(host, nxJson);
+  updateNxJson(host, updatedNxJson);
 
   if (options.compiler === 'swc') {
     // Update app swc to exlude server files

--- a/packages/next/src/generators/custom-server/custom-server.ts
+++ b/packages/next/src/generators/custom-server/custom-server.ts
@@ -1,5 +1,5 @@
 import { joinPathFragments, Tree } from '@nx/devkit';
-import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
+import { upsertTargetDefault } from '@nx/devkit/internal';
 import {
   updateJson,
   generateFiles,

--- a/packages/next/src/generators/custom-server/custom-server.ts
+++ b/packages/next/src/generators/custom-server/custom-server.ts
@@ -8,6 +8,7 @@ import {
   readProjectConfiguration,
   updateProjectConfiguration,
   readNxJson,
+  updateNxJson,
 } from '@nx/devkit';
 import { CustomServerSchema } from './schema';
 import { join } from 'path';
@@ -145,7 +146,12 @@ export async function customServerGenerator(
     return json;
   });
 
-  upsertTargetDefault(host, { target: 'build-custom-server', cache: true });
+  const nxJson = readNxJson(host) ?? {};
+  upsertTargetDefault(host, nxJson, {
+    target: 'build-custom-server',
+    cache: true,
+  });
+  updateNxJson(host, nxJson);
 
   if (options.compiler === 'swc') {
     // Update app swc to exlude server files

--- a/packages/next/src/generators/custom-server/custom-server.ts
+++ b/packages/next/src/generators/custom-server/custom-server.ts
@@ -1,4 +1,5 @@
 import { joinPathFragments, Tree } from '@nx/devkit';
+import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
 import {
   updateJson,
   generateFiles,
@@ -141,11 +142,10 @@ export async function customServerGenerator(
         'build-custom-server'
       );
     }
-    json.targetDefaults ??= {};
-    json.targetDefaults['build-custom-server'] ??= {};
-    json.targetDefaults['build-custom-server'].cache ??= true;
     return json;
   });
+
+  upsertTargetDefault(host, { target: 'build-custom-server', cache: true });
 
   if (options.compiler === 'swc') {
     // Update app swc to exlude server files

--- a/packages/nuxt/src/generators/application/lib/add-e2e.ts
+++ b/packages/nuxt/src/generators/application/lib/add-e2e.ts
@@ -1,4 +1,7 @@
-import { getE2EWebServerInfo } from '@nx/devkit/internal';
+import {
+  getE2EWebServerInfo,
+  readTargetDefaultsForTarget,
+} from '@nx/devkit/internal';
 import {
   addProjectConfiguration,
   ensurePackage,
@@ -134,12 +137,13 @@ async function getNuxtE2EWebServerInfo(
 ) {
   const nxJson = readNxJson(tree);
   let e2ePort = 4200;
+  const serveTargetOptions = readTargetDefaultsForTarget(
+    'serve',
+    nxJson.targetDefaults
+  )?.options;
 
-  if (
-    nxJson.targetDefaults?.['serve'] &&
-    nxJson.targetDefaults?.['serve'].options?.port
-  ) {
-    e2ePort = nxJson.targetDefaults?.['serve'].options?.port;
+  if (serveTargetOptions?.port) {
+    e2ePort = serveTargetOptions.port;
   }
 
   return getE2EWebServerInfo(

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -168,7 +168,7 @@
     },
     "23-0-0-convert-target-defaults-to-array": {
       "cli": "nx",
-      "version": "23.0.0-beta.0",
+      "version": "23.0.0-beta.13",
       "description": "Converts nx.json `targetDefaults` from the legacy record shape to the new filtered array shape.",
       "implementation": "./dist/src/migrations/update-23-0-0/convert-target-defaults-to-array"
     }

--- a/packages/nx/migrations.json
+++ b/packages/nx/migrations.json
@@ -165,6 +165,12 @@
       "version": "23.0.0-beta.0",
       "description": "Consolidates any remaining legacy releaseTag* flat properties into the nested releaseTag object. The flat properties were removed in Nx 23.",
       "implementation": "./dist/src/migrations/update-23-0-0/consolidate-release-tag-config"
+    },
+    "23-0-0-convert-target-defaults-to-array": {
+      "cli": "nx",
+      "version": "23.0.0-beta.0",
+      "description": "Converts nx.json `targetDefaults` from the legacy record shape to the new filtered array shape.",
+      "implementation": "./dist/src/migrations/update-23-0-0/convert-target-defaults-to-array"
     }
   }
 }

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -845,38 +845,25 @@
           "description": "Restrict the default to targets originated by a specific plugin (e.g. '@nx/vite')."
         },
         "executor": {
-          "description": "The function that Nx will invoke when you run this target",
-          "type": "string"
+          "$ref": "#/definitions/targetDefaultsConfig/properties/executor"
         },
         "options": {
-          "type": "object"
+          "$ref": "#/definitions/targetDefaultsConfig/properties/options"
         },
         "outputs": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
+          "$ref": "#/definitions/targetDefaultsConfig/properties/outputs"
         },
         "defaultConfiguration": {
-          "type": "string",
-          "description": "The name of a configuration to use as the default if a configuration is not provided"
+          "$ref": "#/definitions/targetDefaultsConfig/properties/defaultConfiguration"
         },
         "configurations": {
-          "type": "object",
-          "description": "provides extra sets of values that will be merged into the options map",
-          "additionalProperties": {
-            "type": "object"
-          }
+          "$ref": "#/definitions/targetDefaultsConfig/properties/configurations"
         },
         "continuous": {
-          "type": "boolean",
-          "default": false,
-          "description": "Whether this target runs continuously until stopped"
+          "$ref": "#/definitions/targetDefaultsConfig/properties/continuous"
         },
         "parallelism": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether this target can be run in parallel with other tasks"
+          "$ref": "#/definitions/targetDefaultsConfig/properties/parallelism"
         },
         "inputs": {
           "$ref": "#/definitions/inputs"

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -840,7 +840,7 @@
           ],
           "description": "Restrict the default to matching projects. Uses findMatchingProjects syntax."
         },
-        "source": {
+        "plugin": {
           "type": "string",
           "description": "Restrict the default to targets originated by a specific plugin (e.g. '@nx/vite')."
         },

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -43,7 +43,7 @@
       }
     },
     "targetDefaults": {
-      "description": "Target defaults. The recommended form is an array of entries; each entry matches by `target` (name or glob), `executor`, or both, and optionally narrows by `projects` and `source`. The legacy record/object form (keyed by target name or executor) is still read but deprecated; run `nx repair` to convert it.",
+      "description": "Target defaults. The recommended form is an array of entries; each entry matches by `target` (name or glob), `executor`, or both, and optionally narrows by `projects` and `plugin`. The legacy record/object form (keyed by target name or executor) is still read but deprecated; run `nx repair` to convert it.",
       "oneOf": [
         {
           "type": "array",
@@ -54,7 +54,7 @@
         {
           "type": "object",
           "deprecated": true,
-          "deprecationMessage": "The record-shape `targetDefaults` is deprecated and will be removed in a future major. Run `nx repair` to convert this nx.json to the new array-shape `targetDefaults`, which also unlocks the `projects` and `source` filters.",
+          "deprecationMessage": "The record-shape `targetDefaults` is deprecated and will be removed in a future major. Run `nx repair` to convert this nx.json to the new array-shape `targetDefaults`, which also unlocks the `projects` and `plugin` filters.",
           "description": "Deprecated: the record-shape `targetDefaults` is still read for backwards compatibility, but new workspaces should use the array form. Run `nx repair` to convert.",
           "additionalProperties": {
             "$ref": "#/definitions/targetDefaultsConfig"

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -819,8 +819,13 @@
     },
     "targetDefaultEntry": {
       "type": "object",
-      "description": "A single target defaults entry. At least one of `target` or `executor` must be set.",
-      "anyOf": [{ "required": ["target"] }, { "required": ["executor"] }],
+      "description": "A single target defaults entry. At least one of `target`, `executor`, `projects`, or `plugin` must be set — an entry with neither a locator nor a filter would broadcast to every target in the workspace and is ignored at runtime.",
+      "anyOf": [
+        { "required": ["target"] },
+        { "required": ["executor"] },
+        { "required": ["projects"] },
+        { "required": ["plugin"] }
+      ],
       "properties": {
         "target": {
           "type": "string",
@@ -846,6 +851,12 @@
         },
         "executor": {
           "$ref": "#/definitions/targetDefaultsConfig/properties/executor"
+        },
+        "command": {
+          "$ref": "#/definitions/targetDefaultsConfig/properties/command"
+        },
+        "metadata": {
+          "$ref": "#/definitions/targetDefaultsConfig/properties/metadata"
         },
         "options": {
           "$ref": "#/definitions/targetDefaultsConfig/properties/options"
@@ -887,6 +898,15 @@
         "executor": {
           "description": "The function that Nx will invoke when you run this target",
           "type": "string"
+        },
+        "command": {
+          "description": "Shorthand for `nx:run-commands` — the shell command to run.",
+          "type": "string"
+        },
+        "metadata": {
+          "description": "Free-form metadata about the target (description, technologies, help text, etc.).",
+          "type": "object",
+          "additionalProperties": true
         },
         "options": {
           "type": "object"

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -43,11 +43,24 @@
       }
     },
     "targetDefaults": {
-      "type": "object",
-      "description": "Target defaults",
-      "additionalProperties": {
-        "$ref": "#/definitions/targetDefaultsConfig"
-      }
+      "description": "Target defaults. The recommended form is an array of entries, each filtered by target name (required), and optionally projects and source plugin. The legacy record/object form (keyed by target name or executor) is still read but deprecated; run `nx repair` to convert it.",
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/targetDefaultEntry"
+          }
+        },
+        {
+          "type": "object",
+          "deprecated": true,
+          "deprecationMessage": "The record-shape `targetDefaults` is deprecated and will be removed in a future major. Run `nx repair` to convert this nx.json to the new array-shape `targetDefaults`, which also unlocks the `projects` and `source` filters.",
+          "description": "Deprecated: the record-shape `targetDefaults` is still read for backwards compatibility, but new workspaces should use the array form. Run `nx repair` to convert.",
+          "additionalProperties": {
+            "$ref": "#/definitions/targetDefaultsConfig"
+          }
+        }
+      ]
     },
     "workspaceLayout": {
       "type": "object",
@@ -800,6 +813,82 @@
               "description": "Defines an encryption key to support end-to-end encryption of your cloud cache. You may also provide an environment variable with the key NX_CLOUD_ENCRYPTION_KEY that contains an encryption key as its value. The Nx Cloud task runner normalizes the key length, so any length of key is acceptable."
             }
           }
+        }
+      },
+      "additionalProperties": false
+    },
+    "targetDefaultEntry": {
+      "type": "object",
+      "description": "A single target defaults entry.",
+      "required": ["target"],
+      "properties": {
+        "target": {
+          "type": "string",
+          "description": "The target name, target name glob, or executor (e.g. '@nx/vite:test') this default applies to."
+        },
+        "projects": {
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "A project name, glob, or tag (e.g. 'tag:dotnet')."
+            },
+            {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "A list of project names, globs, or tags (e.g. ['apps/*', '!apps/legacy'])."
+            }
+          ],
+          "description": "Restrict the default to matching projects. Uses findMatchingProjects syntax."
+        },
+        "source": {
+          "type": "string",
+          "description": "Restrict the default to targets originated by a specific plugin (e.g. '@nx/vite')."
+        },
+        "executor": {
+          "description": "The function that Nx will invoke when you run this target",
+          "type": "string"
+        },
+        "options": {
+          "type": "object"
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "defaultConfiguration": {
+          "type": "string",
+          "description": "The name of a configuration to use as the default if a configuration is not provided"
+        },
+        "configurations": {
+          "type": "object",
+          "description": "provides extra sets of values that will be merged into the options map",
+          "additionalProperties": {
+            "type": "object"
+          }
+        },
+        "continuous": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether this target runs continuously until stopped"
+        },
+        "parallelism": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether this target can be run in parallel with other tasks"
+        },
+        "inputs": {
+          "$ref": "#/definitions/inputs"
+        },
+        "dependsOn": {
+          "$ref": "#/definitions/targetDefaultsConfig/properties/dependsOn"
+        },
+        "cache": {
+          "$ref": "#/definitions/targetDefaultsConfig/properties/cache"
+        },
+        "syncGenerators": {
+          "$ref": "#/definitions/targetDefaultsConfig/properties/syncGenerators"
         }
       },
       "additionalProperties": false

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -43,7 +43,7 @@
       }
     },
     "targetDefaults": {
-      "description": "Target defaults. The recommended form is an array of entries, each filtered by target name (required), and optionally projects and source plugin. The legacy record/object form (keyed by target name or executor) is still read but deprecated; run `nx repair` to convert it.",
+      "description": "Target defaults. The recommended form is an array of entries; each entry matches by `target` (name or glob), `executor`, or both, and optionally narrows by `projects` and `source`. The legacy record/object form (keyed by target name or executor) is still read but deprecated; run `nx repair` to convert it.",
       "oneOf": [
         {
           "type": "array",
@@ -819,12 +819,12 @@
     },
     "targetDefaultEntry": {
       "type": "object",
-      "description": "A single target defaults entry.",
-      "required": ["target"],
+      "description": "A single target defaults entry. At least one of `target` or `executor` must be set.",
+      "anyOf": [{ "required": ["target"] }, { "required": ["executor"] }],
       "properties": {
         "target": {
           "type": "string",
-          "description": "The target name, target name glob, or executor (e.g. '@nx/vite:test') this default applies to."
+          "description": "The target name or glob pattern (e.g. 'build', 'e2e-ci--*') this default applies to. When omitted, the entry matches by `executor` alone."
         },
         "projects": {
           "oneOf": [

--- a/packages/nx/src/command-line/init/implementation/angular/standalone-workspace.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/standalone-workspace.ts
@@ -1,7 +1,10 @@
 import { unlinkSync } from 'fs';
 import { dirname, join, posix, relative, resolve } from 'node:path';
 import { toNewFormat } from '../../../../adapter/angular-json';
-import type { NxJsonConfiguration } from '../../../../config/nx-json';
+import type {
+  NxJsonConfiguration,
+  TargetDefaultEntry,
+} from '../../../../config/nx-json';
 import type { ProjectConfiguration } from '../../../../config/workspace-json-project-json';
 import {
   fileExists,
@@ -95,29 +98,34 @@ function createNxJson(
         : []),
     ].filter(Boolean),
   };
-  nxJson.targetDefaults ??= {};
+  const defaults: TargetDefaultEntry[] = Array.isArray(nxJson.targetDefaults)
+    ? [...nxJson.targetDefaults]
+    : [];
+  const upsert = (target: string, patch: Partial<TargetDefaultEntry>): void => {
+    const idx = defaults.findIndex(
+      (e) =>
+        e.target === target &&
+        e.projects === undefined &&
+        e.source === undefined
+    );
+    if (idx >= 0) defaults[idx] = { ...defaults[idx], ...patch, target };
+    else defaults.push({ target, ...patch });
+  };
   if (workspaceTargets.includes('build')) {
-    nxJson.targetDefaults.build = {
-      ...nxJson.targetDefaults.build,
+    upsert('build', {
       dependsOn: ['^build'],
       inputs: ['production', '^production'],
-    };
+    });
   }
   if (workspaceTargets.includes('server')) {
-    nxJson.targetDefaults.server = {
-      ...nxJson.targetDefaults.server,
-      inputs: ['production', '^production'],
-    };
+    upsert('server', { inputs: ['production', '^production'] });
   }
   if (workspaceTargets.includes('test')) {
     const inputs = ['default', '^production'];
     if (fileExists(join(repoRoot, 'karma.conf.js'))) {
       inputs.push('{workspaceRoot}/karma.conf.js');
     }
-    nxJson.targetDefaults.test = {
-      ...nxJson.targetDefaults.test,
-      inputs,
-    };
+    upsert('test', { inputs });
   }
   if (workspaceTargets.includes('lint')) {
     const inputs = ['default'];
@@ -127,16 +135,13 @@ function createNxJson(
     if (fileExists(join(repoRoot, 'eslint.config.cjs'))) {
       inputs.push('{workspaceRoot}/eslint.config.cjs');
     }
-    nxJson.targetDefaults.lint = {
-      ...nxJson.targetDefaults.lint,
-      inputs,
-    };
+    upsert('lint', { inputs });
   }
   if (workspaceTargets.includes('e2e')) {
-    nxJson.targetDefaults.e2e = {
-      ...nxJson.targetDefaults.e2e,
-      inputs: ['default', '^production'],
-    };
+    upsert('e2e', { inputs: ['default', '^production'] });
+  }
+  if (defaults.length > 0) {
+    nxJson.targetDefaults = defaults;
   }
   writeJsonFile(join(repoRoot, 'nx.json'), nxJson);
 }

--- a/packages/nx/src/command-line/init/implementation/angular/standalone-workspace.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/standalone-workspace.ts
@@ -13,7 +13,11 @@ import {
 } from '../../../../utils/fileutils';
 import type { PackageJson } from '../../../../utils/package-json';
 import { normalizePath } from '../../../../utils/path';
-import { addVsCodeRecommendedExtensions, createNxJsonFile } from '../utils';
+import {
+  addVsCodeRecommendedExtensions,
+  createNxJsonFile,
+  upsertTargetDefaultEntry,
+} from '../utils';
 import type {
   AngularJsonConfig,
   AngularJsonProjectConfiguration,
@@ -101,31 +105,23 @@ function createNxJson(
   const defaults: TargetDefaultEntry[] = Array.isArray(nxJson.targetDefaults)
     ? [...nxJson.targetDefaults]
     : [];
-  const upsert = (target: string, patch: Partial<TargetDefaultEntry>): void => {
-    const idx = defaults.findIndex(
-      (e) =>
-        e.target === target &&
-        e.projects === undefined &&
-        e.source === undefined
-    );
-    if (idx >= 0) defaults[idx] = { ...defaults[idx], ...patch, target };
-    else defaults.push({ target, ...patch });
-  };
   if (workspaceTargets.includes('build')) {
-    upsert('build', {
+    upsertTargetDefaultEntry(defaults, 'build', {
       dependsOn: ['^build'],
       inputs: ['production', '^production'],
     });
   }
   if (workspaceTargets.includes('server')) {
-    upsert('server', { inputs: ['production', '^production'] });
+    upsertTargetDefaultEntry(defaults, 'server', {
+      inputs: ['production', '^production'],
+    });
   }
   if (workspaceTargets.includes('test')) {
     const inputs = ['default', '^production'];
     if (fileExists(join(repoRoot, 'karma.conf.js'))) {
       inputs.push('{workspaceRoot}/karma.conf.js');
     }
-    upsert('test', { inputs });
+    upsertTargetDefaultEntry(defaults, 'test', { inputs });
   }
   if (workspaceTargets.includes('lint')) {
     const inputs = ['default'];
@@ -135,10 +131,12 @@ function createNxJson(
     if (fileExists(join(repoRoot, 'eslint.config.cjs'))) {
       inputs.push('{workspaceRoot}/eslint.config.cjs');
     }
-    upsert('lint', { inputs });
+    upsertTargetDefaultEntry(defaults, 'lint', { inputs });
   }
   if (workspaceTargets.includes('e2e')) {
-    upsert('e2e', { inputs: ['default', '^production'] });
+    upsertTargetDefaultEntry(defaults, 'e2e', {
+      inputs: ['default', '^production'],
+    });
   }
   if (defaults.length > 0) {
     nxJson.targetDefaults = defaults;

--- a/packages/nx/src/command-line/init/implementation/utils.spec.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.spec.ts
@@ -61,12 +61,13 @@ describe('utils', () => {
         },
         nx: {
           $schema: './node_modules/nx/schemas/nx-schema.json',
-          targetDefaults: {
-            build: {
+          targetDefaults: [
+            {
+              target: 'build',
               dependsOn: ['^build'],
               cache: true,
             },
-          },
+          ],
         },
       },
       {
@@ -80,12 +81,13 @@ describe('utils', () => {
         },
         nx: {
           $schema: './node_modules/nx/schemas/nx-schema.json',
-          targetDefaults: {
-            build: {
+          targetDefaults: [
+            {
+              target: 'build',
               outputs: ['{projectRoot}/dist/**', '{projectRoot}/.next/**'],
               cache: true,
             },
-          },
+          ],
         },
       },
       {
@@ -99,15 +101,16 @@ describe('utils', () => {
         },
         nx: {
           $schema: './node_modules/nx/schemas/nx-schema.json',
-          targetDefaults: {
-            build: {
+          targetDefaults: [
+            {
+              target: 'build',
               inputs: [
                 '{projectRoot}/src/**/*.tsx',
                 '{projectRoot}/test/**/*.tsx',
               ],
               cache: true,
             },
-          },
+          ],
         },
       },
       {
@@ -124,14 +127,10 @@ describe('utils', () => {
         },
         nx: {
           $schema: './node_modules/nx/schemas/nx-schema.json',
-          targetDefaults: {
-            build: {
-              cache: true,
-            },
-            dev: {
-              cache: false,
-            },
-          },
+          targetDefaults: [
+            { target: 'build', cache: true },
+            { target: 'dev', cache: false },
+          ],
         },
       },
       {
@@ -159,12 +158,13 @@ describe('utils', () => {
         },
         nx: {
           $schema: './node_modules/nx/schemas/nx-schema.json',
-          targetDefaults: {
-            build: {
+          targetDefaults: [
+            {
+              target: 'build',
               dependsOn: ['^build'],
               cache: true,
             },
-          },
+          ],
         },
       },
       {
@@ -200,22 +200,22 @@ describe('utils', () => {
             default: ['{projectRoot}/**/*', 'sharedGlobals'],
           },
           cacheDirectory: '.nx/cache',
-          targetDefaults: {
-            build: {
+          targetDefaults: [
+            {
+              target: 'build',
               dependsOn: ['^build'],
               outputs: ['{projectRoot}/dist/**'],
               inputs: ['{projectRoot}/src/**/*'],
               cache: true,
             },
-            test: {
+            {
+              target: 'test',
               dependsOn: ['build'],
               outputs: ['{projectRoot}/coverage/**'],
               cache: true,
             },
-            dev: {
-              cache: false,
-            },
-          },
+            { target: 'dev', cache: false },
+          ],
         },
       },
       {
@@ -243,8 +243,9 @@ describe('utils', () => {
         },
         nx: {
           $schema: './node_modules/nx/schemas/nx-schema.json',
-          targetDefaults: {
-            build: {
+          targetDefaults: [
+            {
+              target: 'build',
               dependsOn: ['^build'],
               inputs: ['{projectRoot}/**/*', '{projectRoot}/.env*'],
               outputs: [
@@ -253,18 +254,18 @@ describe('utils', () => {
               ],
               cache: true,
             },
-            lint: {
+            {
+              target: 'lint',
               dependsOn: ['^lint'],
               cache: true,
             },
-            'check-types': {
+            {
+              target: 'check-types',
               dependsOn: ['^check-types'],
               cache: true,
             },
-            dev: {
-              cache: false,
-            },
-          },
+            { target: 'dev', cache: false },
+          ],
         },
       },
     ])('$description', ({ turbo, nx }) => {

--- a/packages/nx/src/command-line/init/implementation/utils.spec.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.spec.ts
@@ -2,15 +2,96 @@ jest.mock('./deduce-default-base', () => ({
   deduceDefaultBase: jest.fn(() => 'main'),
 }));
 
-import { NxJsonConfiguration } from '../../../config/nx-json';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import {
+  NxJsonConfiguration,
+  TargetDefaultEntry,
+} from '../../../config/nx-json';
+import { readJsonFile, writeJsonFile } from '../../../utils/fileutils';
+import {
+  createNxJsonFile,
   createNxJsonFromTurboJson,
   extractErrorName,
   readErrorStderr,
   toErrorString,
+  upsertTargetDefaultEntry,
 } from './utils';
 
 describe('utils', () => {
+  describe('createNxJsonFile', () => {
+    it('reuses the same unfiltered target entry across topological and cacheable passes', () => {
+      const repoRoot = mkdtempSync(join(tmpdir(), 'nx-init-utils-'));
+      try {
+        writeJsonFile(join(repoRoot, 'nx.json'), {
+          $schema: './node_modules/nx/schemas/nx-schema.json',
+          targetDefaults: [
+            { target: 'build', projects: 'tag:web', dependsOn: ['^filtered'] },
+          ],
+        });
+
+        createNxJsonFile(repoRoot, ['build'], ['build'], {});
+
+        expect(
+          readJsonFile<NxJsonConfiguration>(join(repoRoot, 'nx.json'))
+        ).toMatchObject({
+          targetDefaults: [
+            { target: 'build', projects: 'tag:web', dependsOn: ['^filtered'] },
+            { target: 'build', dependsOn: ['^build'], cache: true },
+          ],
+        });
+      } finally {
+        rmSync(repoRoot, { recursive: true, force: true });
+      }
+    });
+
+    it('preserves an explicit cache setting on an existing unfiltered target entry', () => {
+      const repoRoot = mkdtempSync(join(tmpdir(), 'nx-init-utils-'));
+      try {
+        writeJsonFile(join(repoRoot, 'nx.json'), {
+          $schema: './node_modules/nx/schemas/nx-schema.json',
+          targetDefaults: [{ target: 'build', cache: false }],
+        });
+
+        createNxJsonFile(repoRoot, [], ['build'], {});
+
+        expect(
+          readJsonFile<NxJsonConfiguration>(join(repoRoot, 'nx.json'))
+        ).toMatchObject({
+          targetDefaults: [{ target: 'build', cache: false }],
+        });
+      } finally {
+        rmSync(repoRoot, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('upsertTargetDefaultEntry', () => {
+    it('merges into an existing unfiltered target entry', () => {
+      const entries: TargetDefaultEntry[] = [{ target: 'build', cache: true }];
+
+      upsertTargetDefaultEntry(entries, 'build', { dependsOn: ['^build'] });
+
+      expect(entries).toEqual([
+        { target: 'build', cache: true, dependsOn: ['^build'] },
+      ]);
+    });
+
+    it('appends a new unfiltered entry instead of merging into a filtered one', () => {
+      const entries: TargetDefaultEntry[] = [
+        { target: 'build', projects: 'tag:web', cache: true },
+      ];
+
+      upsertTargetDefaultEntry(entries, 'build', { dependsOn: ['^build'] });
+
+      expect(entries).toEqual([
+        { target: 'build', projects: 'tag:web', cache: true },
+        { target: 'build', dependsOn: ['^build'] },
+      ]);
+    });
+  });
+
   describe('createNxJsonFromTurboJson', () => {
     test.each<{
       description: string;

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -58,13 +58,8 @@ export function createNxJsonFile(
   }
 
   for (const target of cacheableOperations) {
-    const idx = entries.findIndex(
-      (e) =>
-        e.target === target &&
-        e.projects === undefined &&
-        e.plugin === undefined
-    );
-    if (idx >= 0) entries[idx].cache ??= true;
+    const existing = findUnfilteredTargetEntry(entries, target);
+    if (existing) existing.cache ??= true;
     else entries.push({ target, cache: true });
   }
 
@@ -92,12 +87,19 @@ export function upsertTargetDefaultEntry(
   target: string,
   patch: Partial<TargetDefaultEntry>
 ): void {
-  const idx = entries.findIndex(
+  const existing = findUnfilteredTargetEntry(entries, target);
+  if (existing) Object.assign(existing, patch, { target });
+  else entries.push({ ...patch, target });
+}
+
+function findUnfilteredTargetEntry(
+  entries: TargetDefaultEntry[],
+  target: string
+): TargetDefaultEntry | undefined {
+  return entries.find(
     (e) =>
       e.target === target && e.projects === undefined && e.plugin === undefined
   );
-  if (idx >= 0) entries[idx] = { target, ...entries[idx], ...patch };
-  else entries.push({ target, ...patch });
 }
 
 export function createNxJsonFromTurboJson(

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -40,27 +40,21 @@ export function createNxJsonFile(
   const entries: TargetDefaultEntry[] = Array.isArray(nxJson.targetDefaults)
     ? [...nxJson.targetDefaults]
     : [];
-  const upsert = (target: string, patch: Partial<TargetDefaultEntry>): void => {
-    const idx = entries.findIndex(
-      (e) =>
-        e.target === target &&
-        e.projects === undefined &&
-        e.source === undefined
-    );
-    if (idx >= 0) entries[idx] = { ...entries[idx], ...patch, target };
-    else entries.push({ target, ...patch });
-  };
 
   if (topologicalTargets.length > 0) {
     for (const scriptName of topologicalTargets) {
-      upsert(scriptName, { dependsOn: [`^${scriptName}`] });
+      upsertTargetDefaultEntry(entries, scriptName, {
+        dependsOn: [`^${scriptName}`],
+      });
     }
   }
   for (const [scriptName, output] of Object.entries(scriptOutputs)) {
     if (!output) {
       continue;
     }
-    upsert(scriptName, { outputs: [`{projectRoot}/${output}`] });
+    upsertTargetDefaultEntry(entries, scriptName, {
+      outputs: [`{projectRoot}/${output}`],
+    });
   }
 
   for (const target of cacheableOperations) {
@@ -86,6 +80,24 @@ export function createNxJsonFile(
     nxJson.defaultBase ??= defaultBase;
   }
   writeJsonFile(nxJsonPath, nxJson);
+}
+
+/**
+ * Locate-by-target upsert against an in-memory `targetDefaults` array.
+ * Used by `nx init` code paths that operate on raw JSON before a Tree
+ * exists — generators should use `upsertTargetDefault` from devkit instead.
+ */
+export function upsertTargetDefaultEntry(
+  entries: TargetDefaultEntry[],
+  target: string,
+  patch: Partial<TargetDefaultEntry>
+): void {
+  const idx = entries.findIndex(
+    (e) =>
+      e.target === target && e.projects === undefined && e.source === undefined
+  );
+  if (idx >= 0) entries[idx] = { target, ...entries[idx], ...patch };
+  else entries.push({ target, ...patch });
 }
 
 export function createNxJsonFromTurboJson(

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -1,7 +1,10 @@
 import { execSync } from 'child_process';
 import { join } from 'path';
 
-import { NxJsonConfiguration } from '../../../config/nx-json';
+import {
+  NxJsonConfiguration,
+  TargetDefaultEntry,
+} from '../../../config/nx-json';
 import {
   fileExists,
   readJsonFile,
@@ -34,29 +37,47 @@ export function createNxJsonFile(
   } catch {}
 
   nxJson.$schema = './node_modules/nx/schemas/nx-schema.json';
-  nxJson.targetDefaults ??= {};
+  const entries: TargetDefaultEntry[] = Array.isArray(nxJson.targetDefaults)
+    ? [...nxJson.targetDefaults]
+    : [];
+  const upsert = (target: string, patch: Partial<TargetDefaultEntry>): void => {
+    const idx = entries.findIndex(
+      (e) =>
+        e.target === target &&
+        e.projects === undefined &&
+        e.source === undefined
+    );
+    if (idx >= 0) entries[idx] = { ...entries[idx], ...patch, target };
+    else entries.push({ target, ...patch });
+  };
 
   if (topologicalTargets.length > 0) {
     for (const scriptName of topologicalTargets) {
-      nxJson.targetDefaults[scriptName] ??= {};
-      nxJson.targetDefaults[scriptName] = { dependsOn: [`^${scriptName}`] };
+      upsert(scriptName, { dependsOn: [`^${scriptName}`] });
     }
   }
   for (const [scriptName, output] of Object.entries(scriptOutputs)) {
     if (!output) {
       continue;
     }
-    nxJson.targetDefaults[scriptName] ??= {};
-    nxJson.targetDefaults[scriptName].outputs = [`{projectRoot}/${output}`];
+    upsert(scriptName, { outputs: [`{projectRoot}/${output}`] });
   }
 
   for (const target of cacheableOperations) {
-    nxJson.targetDefaults[target] ??= {};
-    nxJson.targetDefaults[target].cache ??= true;
+    const idx = entries.findIndex(
+      (e) =>
+        e.target === target &&
+        e.projects === undefined &&
+        e.source === undefined
+    );
+    if (idx >= 0) entries[idx].cache ??= true;
+    else entries.push({ target, cache: true });
   }
 
-  if (Object.keys(nxJson.targetDefaults).length === 0) {
+  if (entries.length === 0) {
     delete nxJson.targetDefaults;
+  } else {
+    nxJson.targetDefaults = entries;
   }
 
   const defaultBase = deduceDefaultBase();
@@ -102,23 +123,23 @@ export function createNxJsonFromTurboJson(
 
   // Handle task configurations
   if (turboJson.tasks) {
-    nxJson.targetDefaults = {};
+    const entries: TargetDefaultEntry[] = [];
 
     for (const [taskName, taskConfig] of Object.entries(turboJson.tasks)) {
       // Skip project-specific tasks (containing #)
       if (taskName.includes('#')) continue;
 
       const config = taskConfig as any;
-      nxJson.targetDefaults[taskName] = {};
+      const entry: TargetDefaultEntry = { target: taskName };
 
       // Handle dependsOn
       if (config.dependsOn?.length > 0) {
-        nxJson.targetDefaults[taskName].dependsOn = config.dependsOn;
+        entry.dependsOn = config.dependsOn;
       }
 
       // Handle inputs
       if (config.inputs?.length > 0) {
-        nxJson.targetDefaults[taskName].inputs = config.inputs
+        entry.inputs = config.inputs
           .map((input) => {
             if (input === '$TURBO_DEFAULT$') {
               return '{projectRoot}/**/*';
@@ -146,21 +167,25 @@ export function createNxJsonFromTurboJson(
 
       // Handle outputs
       if (config.outputs?.length > 0) {
-        nxJson.targetDefaults[taskName].outputs = config.outputs.map(
-          (output) => {
-            // Don't add projectRoot if it's already there
-            if (output.startsWith('{projectRoot}/')) return output;
-            // Handle negated patterns by adding projectRoot after the !
-            if (output.startsWith('!')) {
-              return `!{projectRoot}/${output.slice(1)}`;
-            }
-            return `{projectRoot}/${output}`;
+        entry.outputs = config.outputs.map((output) => {
+          // Don't add projectRoot if it's already there
+          if (output.startsWith('{projectRoot}/')) return output;
+          // Handle negated patterns by adding projectRoot after the !
+          if (output.startsWith('!')) {
+            return `!{projectRoot}/${output.slice(1)}`;
           }
-        );
+          return `{projectRoot}/${output}`;
+        });
       }
 
       // Handle cache setting - true by default in Turbo
-      nxJson.targetDefaults[taskName].cache = config.cache !== false;
+      entry.cache = config.cache !== false;
+
+      entries.push(entry);
+    }
+
+    if (entries.length > 0) {
+      nxJson.targetDefaults = entries;
     }
   }
 

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -62,7 +62,7 @@ export function createNxJsonFile(
       (e) =>
         e.target === target &&
         e.projects === undefined &&
-        e.source === undefined
+        e.plugin === undefined
     );
     if (idx >= 0) entries[idx].cache ??= true;
     else entries.push({ target, cache: true });
@@ -94,7 +94,7 @@ export function upsertTargetDefaultEntry(
 ): void {
   const idx = entries.findIndex(
     (e) =>
-      e.target === target && e.projects === undefined && e.source === undefined
+      e.target === target && e.projects === undefined && e.plugin === undefined
   );
   if (idx >= 0) entries[idx] = { target, ...entries[idx], ...patch };
   else entries.push({ target, ...patch });

--- a/packages/nx/src/command-line/show/show-target/info.ts
+++ b/packages/nx/src/command-line/show/show-target/info.ts
@@ -2,8 +2,6 @@ import type { NxJsonConfiguration } from '../../../config/nx-json';
 import type { ProjectGraph } from '../../../config/project-graph';
 import type { InputDefinition } from '../../../config/workspace-json-project-json';
 import type { ConfigurationSourceMaps } from '../../../project-graph/utils/project-configuration/source-maps';
-import { normalizeTargetDefaults } from '../../../project-graph/utils/project-configuration/target-defaults';
-import { findMatchingProjects } from '../../../utils/find-matching-projects';
 import { getNamedInputs } from '../../../hasher/task-hasher';
 import { createTaskGraph } from '../../../tasks-runner/create-task-graph';
 import {
@@ -57,29 +55,13 @@ function resolveTargetInfoData(t: ResolvedTarget) {
     }
   }
 
-  const extraTargetDeps: Record<string, any> = {};
-  const projectNodeForMatch = graph.nodes[projectName];
-  for (const entry of normalizeTargetDefaults(nxJson.targetDefaults)) {
-    if (!entry.target || !entry.dependsOn) continue;
-    if (entry.projects !== undefined) {
-      if (!projectNodeForMatch) continue;
-      const patterns = Array.isArray(entry.projects)
-        ? entry.projects
-        : [entry.projects];
-      const matched = findMatchingProjects(patterns, {
-        [projectName]: projectNodeForMatch,
-      });
-      if (!matched.includes(projectName)) continue;
-    }
-    // Record by target name; later entries overwrite earlier (later array
-    // index wins on ties, mirroring matcher semantics).
-    extraTargetDeps[entry.target] = entry.dependsOn;
-  }
-
+  // dependsOn from targetDefaults is already merged into targetConfig.dependsOn
+  // when the project graph is built, so getDependencyConfigs reads it directly
+  // from the graph node. No extra plumbing needed here.
   const depConfigs =
     getDependencyConfigs(
       { project: projectName, target: targetName },
-      extraTargetDeps,
+      {},
       graph,
       [...allTargetNames]
     ) ?? [];
@@ -107,7 +89,7 @@ function resolveTargetInfoData(t: ResolvedTarget) {
   const { dependsOn, depSourceIndices, transitiveTasks } =
     resolveTaskGraphDependencies(
       graph,
-      extraTargetDeps,
+      {},
       projectName,
       targetName,
       configuration,

--- a/packages/nx/src/command-line/show/show-target/info.ts
+++ b/packages/nx/src/command-line/show/show-target/info.ts
@@ -2,6 +2,8 @@ import type { NxJsonConfiguration } from '../../../config/nx-json';
 import type { ProjectGraph } from '../../../config/project-graph';
 import type { InputDefinition } from '../../../config/workspace-json-project-json';
 import type { ConfigurationSourceMaps } from '../../../project-graph/utils/project-configuration/source-maps';
+import { normalizeTargetDefaults } from '../../../project-graph/utils/project-configuration/target-defaults';
+import { findMatchingProjects } from '../../../utils/find-matching-projects';
 import { getNamedInputs } from '../../../hasher/task-hasher';
 import { createTaskGraph } from '../../../tasks-runner/create-task-graph';
 import {
@@ -55,11 +57,24 @@ function resolveTargetInfoData(t: ResolvedTarget) {
     }
   }
 
-  const extraTargetDeps = Object.fromEntries(
-    Object.entries(nxJson.targetDefaults ?? {})
-      .filter(([, config]) => config.dependsOn)
-      .map(([name, config]) => [name, config.dependsOn])
-  );
+  const extraTargetDeps: Record<string, any> = {};
+  const projectNodeForMatch = graph.nodes[projectName];
+  for (const entry of normalizeTargetDefaults(nxJson.targetDefaults)) {
+    if (!entry.target || !entry.dependsOn) continue;
+    if (entry.projects !== undefined) {
+      if (!projectNodeForMatch) continue;
+      const patterns = Array.isArray(entry.projects)
+        ? entry.projects
+        : [entry.projects];
+      const matched = findMatchingProjects(patterns, {
+        [projectName]: projectNodeForMatch,
+      });
+      if (!matched.includes(projectName)) continue;
+    }
+    // Record by target name; later entries overwrite earlier (later array
+    // index wins on ties, mirroring matcher semantics).
+    extraTargetDeps[entry.target] = entry.dependsOn;
+  }
 
   const depConfigs =
     getDependencyConfigs(

--- a/packages/nx/src/command-line/show/show-target/info.ts
+++ b/packages/nx/src/command-line/show/show-target/info.ts
@@ -55,12 +55,10 @@ function resolveTargetInfoData(t: ResolvedTarget) {
     }
   }
 
-  // dependsOn from targetDefaults is already merged into targetConfig.dependsOn
-  // when the project graph is built, so getDependencyConfigs reads it directly
-  // from the graph node. No extra plumbing needed here.
   const depConfigs =
     getDependencyConfigs(
       { project: projectName, target: targetName },
+      // no programmatic extras — `dependsOn` is already merged into the graph node
       {},
       graph,
       [...allTargetNames]

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -63,6 +63,7 @@ export type TargetDefaultEntry = {
  * @deprecated Use the array-shaped {@link TargetDefaultEntry}[] form instead.
  * Retained so devkit helpers can still read nx.json files that predate the
  * migration.
+ * @todo(v23) Remove this type and all branches that read it.
  */
 export type TargetDefaultsRecord = Record<string, Partial<TargetConfiguration>>;
 

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -31,7 +31,42 @@ export interface NxAffectedConfig {
   defaultBase?: string;
 }
 
-export type TargetDefaults = Record<string, Partial<TargetConfiguration>>;
+/**
+ * A single entry in the array-shaped `targetDefaults` configuration.
+ * Supports filtering the default's applicability by project set and/or the
+ * plugin that originated the target.
+ */
+export type TargetDefaultEntry = {
+  /**
+   * Target name or glob pattern (e.g. `build`, `e2e-ci--*`). An
+   * executor-qualified key (e.g. `@nx/vite:test`) matches by executor.
+   */
+  target: string;
+  /**
+   * Restrict the default to a subset of projects. Accepts any pattern
+   * supported by `findMatchingProjects` (project names, globs, `tag:foo`,
+   * directory globs, negation with `!`).
+   */
+  projects?: string | string[];
+  /**
+   * Restrict the default to targets originated by a specific plugin
+   * (e.g. `@nx/vite`). Matches against the plugin that wrote the target's
+   * `executor` or `command`.
+   */
+  source?: string;
+} & Partial<TargetConfiguration>;
+
+/**
+ * @deprecated Use the array-shaped {@link TargetDefaultEntry}[] form instead.
+ * Retained so devkit helpers can still read nx.json files that predate the
+ * migration.
+ */
+export type TargetDefaultsRecord = Record<string, Partial<TargetConfiguration>>;
+
+export type TargetDefaults = TargetDefaultEntry[] | TargetDefaultsRecord;
+
+/** Internal-only: the post-normalization shape consumed by the nx core matcher. */
+export type NormalizedTargetDefaults = TargetDefaultEntry[];
 
 export type TargetDependencies = Record<
   string,

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -56,7 +56,7 @@ export type TargetDefaultEntry = {
    * (e.g. `@nx/vite`). Matches against the plugin that wrote the target's
    * `executor` or `command`.
    */
-  source?: string;
+  plugin?: string;
 } & Partial<TargetConfiguration>;
 
 /**

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -63,7 +63,7 @@ export type TargetDefaultEntry = {
  * @deprecated Use the array-shaped {@link TargetDefaultEntry}[] form instead.
  * Retained so devkit helpers can still read nx.json files that predate the
  * migration.
- * @todo(v23) Remove this type and all branches that read it.
+ * @todo(v24) Remove this type and all branches that read it.
  */
 export type TargetDefaultsRecord = Record<string, Partial<TargetConfiguration>>;
 

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -35,13 +35,16 @@ export interface NxAffectedConfig {
  * A single entry in the array-shaped `targetDefaults` configuration.
  * Supports filtering the default's applicability by project set and/or the
  * plugin that originated the target.
+ *
+ * Either `target` or `executor` must be set. An entry with both narrows
+ * the match further (target name AND executor must agree).
  */
 export type TargetDefaultEntry = {
   /**
-   * Target name or glob pattern (e.g. `build`, `e2e-ci--*`). An
-   * executor-qualified key (e.g. `@nx/vite:test`) matches by executor.
+   * Target name or glob pattern (e.g. `build`, `e2e-ci--*`). When omitted,
+   * the entry matches by `executor` alone.
    */
-  target: string;
+  target?: string;
   /**
    * Restrict the default to a subset of projects. Accepts any pattern
    * supported by `findMatchingProjects` (project names, globs, `tag:foo`,

--- a/packages/nx/src/devkit-exports.ts
+++ b/packages/nx/src/devkit-exports.ts
@@ -88,6 +88,8 @@ export type {
   PluginConfiguration,
   ExpandedPluginConfiguration,
   TargetDefaults,
+  TargetDefaultEntry,
+  TargetDefaultsRecord,
   NxAffectedConfig,
 } from './config/nx-json';
 

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -14,6 +14,10 @@ export { retrieveProjectConfigurationsWithAngularProjects } from './project-grap
 export { mergeTargetConfigurations } from './project-graph/utils/project-configuration/target-merging';
 export { readProjectConfigurationsFromRootMap } from './project-graph/utils/project-configuration/project-nodes-manager';
 export { findMatchingConfigFiles } from './project-graph/utils/project-configuration-utils';
+export {
+  readTargetDefaultsForTarget,
+  normalizeTargetDefaultsAgainstRootMaps,
+} from './project-graph/utils/project-configuration/target-defaults';
 export { getIgnoreObjectForTree } from './utils/ignore';
 export { splitTarget } from './utils/split-target';
 export { combineOptionsForExecutor } from './utils/params';

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -309,6 +309,12 @@ export function getTargetInputs(
   const namedInputs = getNamedInputs(nxJson, projectNode);
 
   const targetData = projectNode.data.targets[target];
+  // Fallback path: synthesis already merges any matching target-default's
+  // `inputs` onto the target during graph construction, so this lookup
+  // is only consulted when `targetData.inputs` is unset post-merge. We
+  // pass `sourcePlugin = undefined` deliberately — synth-time attribution
+  // isn't available here and any `source:`-filtered entry that mattered
+  // for this target would already have written its inputs onto it.
   const targetDefaults = findBestTargetDefault(
     target,
     targetData?.executor,
@@ -354,6 +360,9 @@ export function getInputs(
   const projectNode = projectGraph.nodes[task.target.project];
   const namedInputs = getNamedInputs(nxJson, projectNode);
   const targetData = projectNode.data.targets[task.target.target];
+  // See note on the matching call in `getTargetInputs`. Same rationale:
+  // this is a fallback only reached when `targetData.inputs` is unset
+  // post-synthesis. `sourcePlugin = undefined` here is deliberate.
   const targetDefaults = findBestTargetDefault(
     task.target.target,
     targetData?.executor,

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -13,6 +13,10 @@ import { NativeTaskHasherImpl } from './native-task-hasher-impl';
 import { workspaceRoot } from '../utils/workspace-root';
 import { HashInputs, NxWorkspaceFilesExternals } from '../native';
 import { getTaskIOService } from '../tasks-runner/task-io-service';
+import {
+  findBestTargetDefault,
+  normalizeTargetDefaults,
+} from '../project-graph/utils/project-configuration/target-defaults';
 
 // Re-export HashInputs from native module for public API
 export { HashInputs };
@@ -305,7 +309,15 @@ export function getTargetInputs(
   const namedInputs = getNamedInputs(nxJson, projectNode);
 
   const targetData = projectNode.data.targets[target];
-  const targetDefaults = (nxJson.targetDefaults || {})[target];
+  const targetDefaults = findBestTargetDefault(
+    target,
+    targetData?.executor,
+    projectNode.name,
+    projectNode,
+    undefined,
+    normalizeTargetDefaults(nxJson.targetDefaults),
+    targetData?.command
+  );
 
   const inputs = splitInputsIntoSelfAndDependencies(
     targetData.inputs || targetDefaults?.inputs || DEFAULT_INPUTS,
@@ -342,7 +354,15 @@ export function getInputs(
   const projectNode = projectGraph.nodes[task.target.project];
   const namedInputs = getNamedInputs(nxJson, projectNode);
   const targetData = projectNode.data.targets[task.target.target];
-  const targetDefaults = (nxJson.targetDefaults || {})[task.target.target];
+  const targetDefaults = findBestTargetDefault(
+    task.target.target,
+    targetData?.executor,
+    projectNode.name,
+    projectNode,
+    undefined,
+    normalizeTargetDefaults(nxJson.targetDefaults),
+    targetData?.command
+  );
   const { selfInputs, depsInputs, depsOutputs, projectInputs, depsFilesets } =
     splitInputsIntoSelfAndDependencies(
       targetData.inputs || targetDefaults?.inputs || (DEFAULT_INPUTS as any),

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -305,12 +305,6 @@ export function getTargetInputs(
   const namedInputs = getNamedInputs(nxJson, projectNode);
 
   const targetData = projectNode.data.targets[target];
-  // No target-defaults lookup here — graph construction's synthesis pass
-  // (`createTargetDefaultsResults`) already merges any matching default's
-  // `inputs` onto `targetData.inputs` before the hasher runs. Reading
-  // `nx.json.targetDefaults` again would either reproduce that work
-  // (wasteful) or silently diverge from the graph (a cache-invalidation
-  // bug surface). The graph is the single source of truth.
   const inputs = splitInputsIntoSelfAndDependencies(
     targetData.inputs || DEFAULT_INPUTS,
     namedInputs

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -13,10 +13,6 @@ import { NativeTaskHasherImpl } from './native-task-hasher-impl';
 import { workspaceRoot } from '../utils/workspace-root';
 import { HashInputs, NxWorkspaceFilesExternals } from '../native';
 import { getTaskIOService } from '../tasks-runner/task-io-service';
-import {
-  findBestTargetDefault,
-  normalizeTargetDefaults,
-} from '../project-graph/utils/project-configuration/target-defaults';
 
 // Re-export HashInputs from native module for public API
 export { HashInputs };
@@ -309,24 +305,14 @@ export function getTargetInputs(
   const namedInputs = getNamedInputs(nxJson, projectNode);
 
   const targetData = projectNode.data.targets[target];
-  // Fallback path: synthesis already merges any matching target-default's
-  // `inputs` onto the target during graph construction, so this lookup
-  // is only consulted when `targetData.inputs` is unset post-merge. We
-  // pass `sourcePlugin = undefined` deliberately — synth-time attribution
-  // isn't available here and any `source:`-filtered entry that mattered
-  // for this target would already have written its inputs onto it.
-  const targetDefaults = findBestTargetDefault(
-    target,
-    targetData?.executor,
-    projectNode.name,
-    projectNode,
-    undefined,
-    normalizeTargetDefaults(nxJson.targetDefaults),
-    targetData?.command
-  );
-
+  // No target-defaults lookup here — graph construction's synthesis pass
+  // (`createTargetDefaultsResults`) already merges any matching default's
+  // `inputs` onto `targetData.inputs` before the hasher runs. Reading
+  // `nx.json.targetDefaults` again would either reproduce that work
+  // (wasteful) or silently diverge from the graph (a cache-invalidation
+  // bug surface). The graph is the single source of truth.
   const inputs = splitInputsIntoSelfAndDependencies(
-    targetData.inputs || targetDefaults?.inputs || DEFAULT_INPUTS,
+    targetData.inputs || DEFAULT_INPUTS,
     namedInputs
   );
 
@@ -360,21 +346,13 @@ export function getInputs(
   const projectNode = projectGraph.nodes[task.target.project];
   const namedInputs = getNamedInputs(nxJson, projectNode);
   const targetData = projectNode.data.targets[task.target.target];
-  // See note on the matching call in `getTargetInputs`. Same rationale:
-  // this is a fallback only reached when `targetData.inputs` is unset
-  // post-synthesis. `sourcePlugin = undefined` here is deliberate.
-  const targetDefaults = findBestTargetDefault(
-    task.target.target,
-    targetData?.executor,
-    projectNode.name,
-    projectNode,
-    undefined,
-    normalizeTargetDefaults(nxJson.targetDefaults),
-    targetData?.command
-  );
+  // See `getTargetInputs` — graph construction already merged any
+  // matching target-default's `inputs` onto `targetData.inputs`, so a
+  // separate `targetDefaults` lookup here would either repeat that
+  // work or drift from it.
   const { selfInputs, depsInputs, depsOutputs, projectInputs, depsFilesets } =
     splitInputsIntoSelfAndDependencies(
-      targetData.inputs || targetDefaults?.inputs || (DEFAULT_INPUTS as any),
+      targetData.inputs || (DEFAULT_INPUTS as any),
       namedInputs
     );
   return { selfInputs, depsInputs, depsOutputs, projectInputs, depsFilesets };

--- a/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.spec.ts
+++ b/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.spec.ts
@@ -38,13 +38,12 @@ describe('update-depends-on-to-tokens', () => {
     });
     await update(tree);
     const nxJson = readNxJson(tree);
-    const buildDependencyConfiguration = nxJson.targetDefaults.build
-      .dependsOn[0] as any;
-    const testDependencyConfiguration = nxJson.targetDefaults.test
-      .dependsOn[0] as any;
-    const buildInputConfiguration = nxJson.targetDefaults.build
-      .inputs[0] as any;
-    const testInputConfiguration = nxJson.targetDefaults.test.inputs[0] as any;
+    // Migration ran before targetDefaults supported the array shape.
+    const td = nxJson.targetDefaults as Record<string, any>;
+    const buildDependencyConfiguration = td.build.dependsOn[0] as any;
+    const testDependencyConfiguration = td.test.dependsOn[0] as any;
+    const buildInputConfiguration = td.build.inputs[0] as any;
+    const testInputConfiguration = td.test.inputs[0] as any;
     expect(buildDependencyConfiguration.projects).not.toBeDefined();
     expect(buildDependencyConfiguration.dependencies).not.toBeDefined();
     expect(buildInputConfiguration.projects).not.toBeDefined();
@@ -53,7 +52,7 @@ describe('update-depends-on-to-tokens', () => {
     expect(testInputConfiguration.dependencies).toEqual(true);
     expect(testDependencyConfiguration.projects).not.toBeDefined();
     expect(testDependencyConfiguration.dependencies).toEqual(true);
-    expect(nxJson.targetDefaults.other.dependsOn).toEqual(['^deps']);
+    expect(td.other.dependsOn).toEqual(['^deps']);
   });
 
   it('should update project configurations', async () => {

--- a/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.spec.ts
+++ b/packages/nx/src/migrations/update-16-0-0/update-depends-on-to-tokens.spec.ts
@@ -103,6 +103,43 @@ describe('update-depends-on-to-tokens', () => {
     expect(project.targets.other.inputs).not.toBeDefined();
   });
 
+  it('should update nx.json with array-shape targetDefaults', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'nx.json', (json) => {
+      json.targetDefaults = [
+        {
+          target: 'build',
+          dependsOn: [{ projects: 'self' }],
+          inputs: [{ projects: 'self', input: 'someInput' }],
+        },
+        {
+          target: 'test',
+          dependsOn: [{ projects: 'dependencies' }],
+          inputs: [{ projects: 'dependencies', input: 'someInput' }],
+        },
+        {
+          target: 'other',
+          dependsOn: ['^deps'],
+        },
+      ];
+      return json;
+    });
+    await update(tree);
+    const td = readNxJson(tree).targetDefaults as any[];
+    const buildEntry = td.find((e) => e.target === 'build');
+    const testEntry = td.find((e) => e.target === 'test');
+    const otherEntry = td.find((e) => e.target === 'other');
+    expect(buildEntry.dependsOn[0].projects).not.toBeDefined();
+    expect(buildEntry.dependsOn[0].dependencies).not.toBeDefined();
+    expect(buildEntry.inputs[0].projects).not.toBeDefined();
+    expect(buildEntry.inputs[0].dependencies).not.toBeDefined();
+    expect(testEntry.dependsOn[0].projects).not.toBeDefined();
+    expect(testEntry.dependsOn[0].dependencies).toEqual(true);
+    expect(testEntry.inputs[0].projects).not.toBeDefined();
+    expect(testEntry.inputs[0].dependencies).toEqual(true);
+    expect(otherEntry.dependsOn).toEqual(['^deps']);
+  });
+
   it('should not throw on nulls', async () => {
     const tree = createTreeWithEmptyWorkspace();
     addProjectConfiguration(tree, 'proj1', {

--- a/packages/nx/src/migrations/update-16-2-0/remove-run-commands-output-path.ts
+++ b/packages/nx/src/migrations/update-16-2-0/remove-run-commands-output-path.ts
@@ -23,13 +23,10 @@ export default async function removeRunCommandsOutputPath(tree: Tree) {
   if (tree.exists('nx.json')) {
     updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
       const td = json.targetDefaults;
-      if (Array.isArray(td)) {
-        for (const entry of td) {
+      if (td) {
+        const entries = Array.isArray(td) ? td : Object.values(td);
+        for (const entry of entries) {
           updateTargetBlock(entry as TargetConfiguration);
-        }
-      } else if (td) {
-        for (const [, target] of Object.entries(td)) {
-          updateTargetBlock(target);
         }
       }
       return json;

--- a/packages/nx/src/migrations/update-16-2-0/remove-run-commands-output-path.ts
+++ b/packages/nx/src/migrations/update-16-2-0/remove-run-commands-output-path.ts
@@ -22,8 +22,15 @@ export default async function removeRunCommandsOutputPath(tree: Tree) {
   }
   if (tree.exists('nx.json')) {
     updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
-      for (const [, target] of Object.entries(json.targetDefaults ?? {})) {
-        updateTargetBlock(target);
+      const td = json.targetDefaults;
+      if (Array.isArray(td)) {
+        for (const entry of td) {
+          updateTargetBlock(entry as TargetConfiguration);
+        }
+      } else if (td) {
+        for (const [, target] of Object.entries(td)) {
+          updateTargetBlock(target);
+        }
       }
       return json;
     });

--- a/packages/nx/src/migrations/update-17-0-0/use-minimal-config-for-tasks-runner-options.ts
+++ b/packages/nx/src/migrations/update-17-0-0/use-minimal-config-for-tasks-runner-options.ts
@@ -69,10 +69,27 @@ export default async function migrate(tree: Tree) {
       delete options.cacheDirectory;
     }
     if (Array.isArray(options.cacheableOperations)) {
-      nxJson.targetDefaults ??= {};
-      for (const target of options.cacheableOperations) {
-        nxJson.targetDefaults[target] ??= {};
-        nxJson.targetDefaults[target].cache ??= true;
+      if (Array.isArray(nxJson.targetDefaults)) {
+        for (const target of options.cacheableOperations) {
+          const idx = nxJson.targetDefaults.findIndex(
+            (e) =>
+              e.target === target &&
+              e.executor === undefined &&
+              e.projects === undefined &&
+              e.source === undefined
+          );
+          if (idx >= 0) {
+            nxJson.targetDefaults[idx].cache ??= true;
+          } else {
+            nxJson.targetDefaults.push({ target, cache: true });
+          }
+        }
+      } else {
+        nxJson.targetDefaults ??= {};
+        for (const target of options.cacheableOperations) {
+          nxJson.targetDefaults[target] ??= {};
+          nxJson.targetDefaults[target].cache ??= true;
+        }
       }
       delete options.cacheableOperations;
     }

--- a/packages/nx/src/migrations/update-17-0-0/use-minimal-config-for-tasks-runner-options.ts
+++ b/packages/nx/src/migrations/update-17-0-0/use-minimal-config-for-tasks-runner-options.ts
@@ -76,7 +76,7 @@ export default async function migrate(tree: Tree) {
               e.target === target &&
               e.executor === undefined &&
               e.projects === undefined &&
-              e.source === undefined
+              e.plugin === undefined
           );
           if (idx >= 0) {
             nxJson.targetDefaults[idx].cache ??= true;

--- a/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.spec.ts
+++ b/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.spec.ts
@@ -1,7 +1,25 @@
 import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
 import type { Tree } from '../../generators/tree';
+import type { ProjectGraph } from '../../config/project-graph';
 import { readNxJson, updateNxJson } from '../../generators/utils/nx-json';
 import convertTargetDefaultsToArray from './convert-target-defaults-to-array';
+
+function graphWithTargets(
+  projects: Record<
+    string,
+    Record<string, { executor?: string; command?: string }>
+  >
+): ProjectGraph {
+  const nodes: ProjectGraph['nodes'] = {};
+  for (const [projectName, targets] of Object.entries(projects)) {
+    nodes[projectName] = {
+      type: 'lib',
+      name: projectName,
+      data: { root: `libs/${projectName}`, targets },
+    };
+  }
+  return { nodes, dependencies: {} };
+}
 
 describe('convert-target-defaults-to-array migration', () => {
   let tree: Tree;
@@ -89,5 +107,71 @@ describe('convert-target-defaults-to-array migration', () => {
       { target: 'e2e-ci--*', dependsOn: ['build'] },
       { target: 'test:*', cache: true },
     ]);
+  });
+
+  describe('with project graph', () => {
+    it('emits `target` when a `:` key is only used as a target name', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        'foo:bar': { cache: true },
+      };
+      updateNxJson(tree, nxJson);
+      const graph = graphWithTargets({
+        app: { 'foo:bar': { command: 'echo hi' } },
+      });
+      await convertTargetDefaultsToArray(tree, graph);
+      expect(readNxJson(tree).targetDefaults).toEqual([
+        { target: 'foo:bar', cache: true },
+      ]);
+    });
+
+    it('emits `executor` when a `:` key is only used as an executor', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        '@nx/vite:test': { inputs: ['default'] },
+      };
+      updateNxJson(tree, nxJson);
+      const graph = graphWithTargets({
+        app: { test: { executor: '@nx/vite:test' } },
+      });
+      await convertTargetDefaultsToArray(tree, graph);
+      expect(readNxJson(tree).targetDefaults).toEqual([
+        { executor: '@nx/vite:test', inputs: ['default'] },
+      ]);
+    });
+
+    it('duplicates the entry when a `:` key matches both a target name and an executor', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        'foo:bar': { cache: true },
+      };
+      updateNxJson(tree, nxJson);
+      const graph = graphWithTargets({
+        app: { 'foo:bar': { command: 'echo hi' } },
+        lib: { build: { executor: 'foo:bar' } },
+      });
+      await convertTargetDefaultsToArray(tree, graph);
+      expect(readNxJson(tree).targetDefaults).toEqual([
+        { target: 'foo:bar', cache: true },
+        { executor: 'foo:bar', cache: true },
+      ]);
+    });
+
+    it('falls back to the `:` heuristic when no project matches the key', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        '@nx/unused:executor': { cache: true },
+        unused: { inputs: ['default'] },
+      };
+      updateNxJson(tree, nxJson);
+      const graph = graphWithTargets({
+        app: { build: { executor: '@nx/something-else:build' } },
+      });
+      await convertTargetDefaultsToArray(tree, graph);
+      expect(readNxJson(tree).targetDefaults).toEqual([
+        { executor: '@nx/unused:executor', cache: true },
+        { target: 'unused', inputs: ['default'] },
+      ]);
+    });
   });
 });

--- a/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.spec.ts
+++ b/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.spec.ts
@@ -63,7 +63,7 @@ describe('convert-target-defaults-to-array migration', () => {
     ]);
   });
 
-  it('keeps executor-style keys as `target` strings', async () => {
+  it('moves executor-style keys to `executor`, leaving `target` unset', async () => {
     const nxJson = readNxJson(tree);
     nxJson.targetDefaults = {
       '@nx/vite:test': { inputs: ['default'] },
@@ -72,8 +72,8 @@ describe('convert-target-defaults-to-array migration', () => {
     updateNxJson(tree, nxJson);
     await convertTargetDefaultsToArray(tree);
     expect(readNxJson(tree).targetDefaults).toEqual([
-      { target: '@nx/vite:test', inputs: ['default'] },
-      { target: 'nx:run-commands', cache: true },
+      { executor: '@nx/vite:test', inputs: ['default'] },
+      { executor: 'nx:run-commands', cache: true },
     ]);
   });
 

--- a/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.spec.ts
+++ b/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.spec.ts
@@ -42,7 +42,7 @@ describe('convert-target-defaults-to-array migration', () => {
 
   it('is a no-op when nx.json does not exist', async () => {
     tree.delete('nx.json');
-    await expect(convertTargetDefaultsToArray(tree)).resolves.toBeUndefined();
+    await expect(convertTargetDefaultsToArray(tree)).resolves.toEqual([]);
   });
 
   it('is a no-op when targetDefaults is absent', async () => {

--- a/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.spec.ts
+++ b/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.spec.ts
@@ -74,7 +74,10 @@ describe('convert-target-defaults-to-array migration', () => {
       test: { inputs: ['default', '^production'] },
     };
     updateNxJson(tree, nxJson);
-    await convertTargetDefaultsToArray(tree);
+    const graph = graphWithTargets({
+      app: { build: { command: 'echo build' }, test: { command: 'echo test' } },
+    });
+    await convertTargetDefaultsToArray(tree, graph);
     expect(readNxJson(tree).targetDefaults).toEqual([
       { target: 'build', cache: true, dependsOn: ['^build'] },
       { target: 'test', inputs: ['default', '^production'] },
@@ -88,7 +91,13 @@ describe('convert-target-defaults-to-array migration', () => {
       'nx:run-commands': { cache: true },
     };
     updateNxJson(tree, nxJson);
-    await convertTargetDefaultsToArray(tree);
+    const graph = graphWithTargets({
+      app: {
+        test: { executor: '@nx/vite:test' },
+        run: { executor: 'nx:run-commands' },
+      },
+    });
+    await convertTargetDefaultsToArray(tree, graph);
     expect(readNxJson(tree).targetDefaults).toEqual([
       { executor: '@nx/vite:test', inputs: ['default'] },
       { executor: 'nx:run-commands', cache: true },

--- a/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.spec.ts
+++ b/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.spec.ts
@@ -1,0 +1,93 @@
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import type { Tree } from '../../generators/tree';
+import { readNxJson, updateNxJson } from '../../generators/utils/nx-json';
+import convertTargetDefaultsToArray from './convert-target-defaults-to-array';
+
+describe('convert-target-defaults-to-array migration', () => {
+  let tree: Tree;
+  const originalSkipFormat = process.env.NX_SKIP_FORMAT;
+
+  beforeAll(() => {
+    process.env.NX_SKIP_FORMAT = 'true';
+  });
+  afterAll(() => {
+    if (originalSkipFormat === undefined) {
+      delete process.env.NX_SKIP_FORMAT;
+    } else {
+      process.env.NX_SKIP_FORMAT = originalSkipFormat;
+    }
+  });
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('is a no-op when nx.json does not exist', async () => {
+    tree.delete('nx.json');
+    await expect(convertTargetDefaultsToArray(tree)).resolves.toBeUndefined();
+  });
+
+  it('is a no-op when targetDefaults is absent', async () => {
+    const nxJson = readNxJson(tree);
+    delete nxJson.targetDefaults;
+    updateNxJson(tree, nxJson);
+    await convertTargetDefaultsToArray(tree);
+    expect(readNxJson(tree).targetDefaults).toBeUndefined();
+  });
+
+  it('is a no-op when targetDefaults is already an array', async () => {
+    const nxJson = readNxJson(tree);
+    nxJson.targetDefaults = [
+      { target: 'build', cache: true },
+      { target: 'test', inputs: ['default', '^production'] },
+    ];
+    updateNxJson(tree, nxJson);
+    await convertTargetDefaultsToArray(tree);
+    expect(readNxJson(tree).targetDefaults).toEqual([
+      { target: 'build', cache: true },
+      { target: 'test', inputs: ['default', '^production'] },
+    ]);
+  });
+
+  it('converts record-shape to array preserving insertion order', async () => {
+    const nxJson = readNxJson(tree);
+    nxJson.targetDefaults = {
+      build: { cache: true, dependsOn: ['^build'] },
+      test: { inputs: ['default', '^production'] },
+    };
+    updateNxJson(tree, nxJson);
+    await convertTargetDefaultsToArray(tree);
+    expect(readNxJson(tree).targetDefaults).toEqual([
+      { target: 'build', cache: true, dependsOn: ['^build'] },
+      { target: 'test', inputs: ['default', '^production'] },
+    ]);
+  });
+
+  it('keeps executor-style keys as `target` strings', async () => {
+    const nxJson = readNxJson(tree);
+    nxJson.targetDefaults = {
+      '@nx/vite:test': { inputs: ['default'] },
+      'nx:run-commands': { cache: true },
+    };
+    updateNxJson(tree, nxJson);
+    await convertTargetDefaultsToArray(tree);
+    expect(readNxJson(tree).targetDefaults).toEqual([
+      { target: '@nx/vite:test', inputs: ['default'] },
+      { target: 'nx:run-commands', cache: true },
+    ]);
+  });
+
+  it('keeps glob keys as `target` strings', async () => {
+    const nxJson = readNxJson(tree);
+    nxJson.targetDefaults = {
+      'e2e-ci--*': { dependsOn: ['build'] },
+      'test:*': { cache: true },
+    };
+    updateNxJson(tree, nxJson);
+    await convertTargetDefaultsToArray(tree);
+    expect(readNxJson(tree).targetDefaults).toEqual([
+      { target: 'e2e-ci--*', dependsOn: ['build'] },
+      { target: 'test:*', cache: true },
+    ]);
+  });
+});

--- a/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.spec.ts
+++ b/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.spec.ts
@@ -157,7 +157,7 @@ describe('convert-target-defaults-to-array migration', () => {
       ]);
     });
 
-    it('falls back to the `:` heuristic when no project matches the key', async () => {
+    it('drops entries when no project matches the key', async () => {
       const nxJson = readNxJson(tree);
       nxJson.targetDefaults = {
         '@nx/unused:executor': { cache: true },
@@ -168,10 +168,7 @@ describe('convert-target-defaults-to-array migration', () => {
         app: { build: { executor: '@nx/something-else:build' } },
       });
       await convertTargetDefaultsToArray(tree, graph);
-      expect(readNxJson(tree).targetDefaults).toEqual([
-        { executor: '@nx/unused:executor', cache: true },
-        { target: 'unused', inputs: ['default'] },
-      ]);
+      expect(readNxJson(tree).targetDefaults).toEqual([]);
     });
   });
 });

--- a/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.ts
+++ b/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.ts
@@ -5,11 +5,17 @@ import type {
   TargetDefaultEntry,
   TargetDefaultsRecord,
 } from '../../config/nx-json';
+import { isGlobPattern } from '../../utils/globs';
 
 /**
  * Converts the legacy record-shape `targetDefaults` in nx.json to the new
  * array shape introduced in Nx 23. No-op when `targetDefaults` is absent
  * or already an array.
+ *
+ * Record keys that look like executor strings (`pkg:name`, no glob chars)
+ * convert to `{ executor: key, ... }`; everything else converts to
+ * `{ target: key, ... }`. This preserves legacy semantics while producing
+ * data that's honest about how the matcher will use it.
  */
 export default async function convertTargetDefaultsToArray(
   tree: Tree
@@ -29,11 +35,30 @@ export default async function convertTargetDefaultsToArray(
   const entries: TargetDefaultEntry[] = [];
   for (const key of Object.keys(legacy)) {
     const value = legacy[key] ?? {};
-    entries.push({ ...value, target: key });
+    entries.push(legacyKeyToEntry(key, value));
   }
 
   nxJson.targetDefaults = entries;
   updateNxJson(tree, nxJson);
 
   await formatChangedFilesWithPrettierIfAvailable(tree);
+}
+
+/**
+ * Treat a legacy record key as an executor when it contains `:` and is
+ * not a glob (executor strings are `pkg:name`; globs would also contain
+ * `*` / `{` / etc., which `isGlobPattern` catches).
+ */
+export function isExecutorLikeKey(key: string): boolean {
+  return key.includes(':') && !isGlobPattern(key);
+}
+
+function legacyKeyToEntry(
+  key: string,
+  value: Partial<TargetDefaultEntry>
+): TargetDefaultEntry {
+  if (isExecutorLikeKey(key)) {
+    return { ...value, executor: key };
+  }
+  return { ...value, target: key };
 }

--- a/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.ts
+++ b/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.ts
@@ -73,7 +73,7 @@ function legacyKeyToEntries(
   graph: ProjectGraph | undefined
 ): TargetDefaultEntry[] {
   if (isGlobPattern(key)) {
-    return [{ ...value, target: key }];
+    return [{ target: key, ...value }];
   }
 
   if (graph) {
@@ -83,19 +83,19 @@ function legacyKeyToEntries(
     );
     if (matchesTargetName && matchesExecutor) {
       return [
-        { ...value, target: key },
-        { ...value, executor: key },
+        { target: key, ...value },
+        { executor: key, ...value },
       ];
     }
-    if (matchesTargetName) return [{ ...value, target: key }];
-    if (matchesExecutor) return [{ ...value, executor: key }];
+    if (matchesTargetName) return [{ target: key, ...value }];
+    if (matchesExecutor) return [{ executor: key, ...value }];
     // Fall through to the syntactic heuristic when the workspace has
     // neither a target named `key` nor a target using executor `key`.
   }
 
   return isExecutorLikeKey(key)
-    ? [{ ...value, executor: key }]
-    : [{ ...value, target: key }];
+    ? [{ executor: key, ...value }]
+    : [{ target: key, ...value }];
 }
 
 function classifyKeyAgainstGraph(

--- a/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.ts
+++ b/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.ts
@@ -6,8 +6,12 @@ import type {
   TargetDefaultsRecord,
 } from '../../config/nx-json';
 import type { ProjectGraph } from '../../config/project-graph';
-import { createProjectGraphAsync } from '../../project-graph/project-graph';
+import {
+  createProjectGraphAsync,
+  readCachedProjectGraph,
+} from '../../project-graph/project-graph';
 import { isGlobPattern } from '../../utils/globs';
+import { logger } from '../../utils/logger';
 
 /**
  * Converts the legacy record-shape `targetDefaults` in nx.json to the new
@@ -115,12 +119,29 @@ function classifyKeyAgainstGraph(
 }
 
 async function tryCreateProjectGraph(): Promise<ProjectGraph | undefined> {
-  // The graph may fail to build mid-migration (e.g. another change earlier
-  // in the same migrate run left the workspace transiently inconsistent).
-  // Falling back to the syntactic heuristic is safer than aborting.
+  // Prefer a cached graph so we don't pay the build cost twice when one
+  // already exists (e.g. earlier migrations in the same run that built
+  // it themselves). `readCachedProjectGraph` throws if no cache is
+  // available — fall through to building one in that case.
+  try {
+    return readCachedProjectGraph();
+  } catch {}
+
+  // The graph may fail to build mid-migration (e.g. another change
+  // earlier in the same migrate run left the workspace transiently
+  // inconsistent). Falling back to the syntactic heuristic is safer
+  // than aborting, but warn so users know `:` keys are being
+  // disambiguated by shape rather than by graph evidence.
   try {
     return await createProjectGraphAsync();
-  } catch {
+  } catch (err) {
+    logger.warn(
+      'convert-target-defaults-to-array: project graph could not be built; ' +
+        'falling back to syntactic disambiguation for `:` keys in nx.json `targetDefaults`. ' +
+        'If a key happens to match both a target name and an executor in your workspace, ' +
+        'review the migration result and add the missing entry by hand. ' +
+        `Underlying error: ${err instanceof Error ? err.message : String(err)}`
+    );
     return undefined;
   }
 }

--- a/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.ts
+++ b/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.ts
@@ -11,7 +11,6 @@ import {
   readCachedProjectGraph,
 } from '../../project-graph/project-graph';
 import { isGlobPattern } from '../../utils/globs';
-import { logger } from '../../utils/logger';
 
 /**
  * Converts the legacy record-shape `targetDefaults` in nx.json to the new
@@ -30,19 +29,20 @@ import { logger } from '../../utils/logger';
 export default async function convertTargetDefaultsToArray(
   tree: Tree,
   projectGraph?: ProjectGraph
-): Promise<void> {
+): Promise<string[]> {
   if (!tree.exists('nx.json')) {
-    return;
+    return [];
   }
 
   const nxJson = readNxJson(tree);
-  if (!nxJson) return;
+  if (!nxJson) return [];
 
   const { targetDefaults } = nxJson;
-  if (!targetDefaults) return;
-  if (Array.isArray(targetDefaults)) return;
+  if (!targetDefaults) return [];
+  if (Array.isArray(targetDefaults)) return [];
 
-  const graph = projectGraph ?? (await tryCreateProjectGraph());
+  const nextSteps: string[] = [];
+  const graph = projectGraph ?? (await tryCreateProjectGraph(nextSteps));
 
   const legacy = targetDefaults as TargetDefaultsRecord;
   const entries: TargetDefaultEntry[] = [];
@@ -55,6 +55,7 @@ export default async function convertTargetDefaultsToArray(
   updateNxJson(tree, nxJson);
 
   await formatChangedFilesWithPrettierIfAvailable(tree);
+  return nextSteps;
 }
 
 /**
@@ -118,7 +119,9 @@ function classifyKeyAgainstGraph(
   return { matchesTargetName, matchesExecutor };
 }
 
-async function tryCreateProjectGraph(): Promise<ProjectGraph | undefined> {
+async function tryCreateProjectGraph(
+  nextSteps: string[]
+): Promise<ProjectGraph | undefined> {
   // Prefer a cached graph so we don't pay the build cost twice when one
   // already exists (e.g. earlier migrations in the same run that built
   // it themselves). `readCachedProjectGraph` throws if no cache is
@@ -130,12 +133,14 @@ async function tryCreateProjectGraph(): Promise<ProjectGraph | undefined> {
   // The graph may fail to build mid-migration (e.g. another change
   // earlier in the same migrate run left the workspace transiently
   // inconsistent). Falling back to the syntactic heuristic is safer
-  // than aborting, but warn so users know `:` keys are being
-  // disambiguated by shape rather than by graph evidence.
+  // than aborting, but surface a follow-up note so users know `:` keys
+  // are being disambiguated by shape rather than by graph evidence —
+  // returned as a next-step rather than a logger.warn so it isn't
+  // drowned in the per-migration log stream.
   try {
     return await createProjectGraphAsync();
   } catch (err) {
-    logger.warn(
+    nextSteps.push(
       'convert-target-defaults-to-array: project graph could not be built; ' +
         'falling back to syntactic disambiguation for `:` keys in nx.json `targetDefaults`. ' +
         'If a key happens to match both a target name and an executor in your workspace, ' +

--- a/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.ts
+++ b/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.ts
@@ -1,0 +1,39 @@
+import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
+import { readNxJson, updateNxJson } from '../../generators/utils/nx-json';
+import { Tree } from '../../generators/tree';
+import type {
+  TargetDefaultEntry,
+  TargetDefaultsRecord,
+} from '../../config/nx-json';
+
+/**
+ * Converts the legacy record-shape `targetDefaults` in nx.json to the new
+ * array shape introduced in Nx 23. No-op when `targetDefaults` is absent
+ * or already an array.
+ */
+export default async function convertTargetDefaultsToArray(
+  tree: Tree
+): Promise<void> {
+  if (!tree.exists('nx.json')) {
+    return;
+  }
+
+  const nxJson = readNxJson(tree);
+  if (!nxJson) return;
+
+  const { targetDefaults } = nxJson;
+  if (!targetDefaults) return;
+  if (Array.isArray(targetDefaults)) return;
+
+  const legacy = targetDefaults as TargetDefaultsRecord;
+  const entries: TargetDefaultEntry[] = [];
+  for (const key of Object.keys(legacy)) {
+    const value = legacy[key] ?? {};
+    entries.push({ ...value, target: key });
+  }
+
+  nxJson.targetDefaults = entries;
+  updateNxJson(tree, nxJson);
+
+  await formatChangedFilesWithPrettierIfAvailable(tree);
+}

--- a/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.ts
+++ b/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.ts
@@ -6,10 +6,7 @@ import type {
   TargetDefaultsRecord,
 } from '../../config/nx-json';
 import type { ProjectGraph } from '../../config/project-graph';
-import {
-  createProjectGraphAsync,
-  readCachedProjectGraph,
-} from '../../project-graph/project-graph';
+import { createProjectGraphAsync } from '../../project-graph/project-graph';
 import { isGlobPattern } from '../../utils/globs';
 
 /**
@@ -23,8 +20,9 @@ import { isGlobPattern } from '../../utils/globs';
  *    the key matches a target name and/or an executor string anywhere in
  *    the workspace. Emit one entry, or both when it matches both
  *    (genuinely ambiguous; safer to duplicate than drop a default).
- * 3. No graph or no match found: fall back to the syntactic heuristic —
- *    `:` (and not a glob) → executor; otherwise target.
+ *    If neither matches, the default is dead and we drop the entry.
+ * 3. No graph: fall back to the syntactic heuristic — `:` (and not a
+ *    glob) → executor; otherwise target.
  */
 export default async function convertTargetDefaultsToArray(
   tree: Tree,
@@ -90,10 +88,12 @@ function legacyKeyToEntries(
     }
     if (matchesTargetName) return [{ target: key, ...value }];
     if (matchesExecutor) return [{ executor: key, ...value }];
-    // Fall through to the syntactic heuristic when the workspace has
-    // neither a target named `key` nor a target using executor `key`.
+    // Graph evidence said no target and no executor in the workspace
+    // uses this key — the default is dead. Drop it rather than guess.
+    return [];
   }
 
+  // No graph available; fall back to the syntactic heuristic.
   return isExecutorLikeKey(key)
     ? [{ executor: key, ...value }]
     : [{ target: key, ...value }];
@@ -122,21 +122,9 @@ function classifyKeyAgainstGraph(
 async function tryCreateProjectGraph(
   nextSteps: string[]
 ): Promise<ProjectGraph | undefined> {
-  // Prefer a cached graph so we don't pay the build cost twice when one
-  // already exists (e.g. earlier migrations in the same run that built
-  // it themselves). `readCachedProjectGraph` throws if no cache is
-  // available — fall through to building one in that case.
-  try {
-    return readCachedProjectGraph();
-  } catch {}
-
-  // The graph may fail to build mid-migration (e.g. another change
-  // earlier in the same migrate run left the workspace transiently
-  // inconsistent). Falling back to the syntactic heuristic is safer
-  // than aborting, but surface a follow-up note so users know `:` keys
-  // are being disambiguated by shape rather than by graph evidence —
-  // returned as a next-step rather than a logger.warn so it isn't
-  // drowned in the per-migration log stream.
+  // Build fresh — earlier migrations in this run may have mutated files
+  // the cached graph was computed from, so a cache hit could classify
+  // record keys against a stale workspace.
   try {
     return await createProjectGraphAsync();
   } catch (err) {

--- a/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.ts
+++ b/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.ts
@@ -5,6 +5,8 @@ import type {
   TargetDefaultEntry,
   TargetDefaultsRecord,
 } from '../../config/nx-json';
+import type { ProjectGraph } from '../../config/project-graph';
+import { createProjectGraphAsync } from '../../project-graph/project-graph';
 import { isGlobPattern } from '../../utils/globs';
 
 /**
@@ -12,13 +14,18 @@ import { isGlobPattern } from '../../utils/globs';
  * array shape introduced in Nx 23. No-op when `targetDefaults` is absent
  * or already an array.
  *
- * Record keys that look like executor strings (`pkg:name`, no glob chars)
- * convert to `{ executor: key, ... }`; everything else converts to
- * `{ target: key, ... }`. This preserves legacy semantics while producing
- * data that's honest about how the matcher will use it.
+ * Disambiguation strategy for record keys (highest precedence first):
+ * 1. Glob → `{ target: key }`.
+ * 2. Project graph available: replicate legacy lookup by checking whether
+ *    the key matches a target name and/or an executor string anywhere in
+ *    the workspace. Emit one entry, or both when it matches both
+ *    (genuinely ambiguous; safer to duplicate than drop a default).
+ * 3. No graph or no match found: fall back to the syntactic heuristic —
+ *    `:` (and not a glob) → executor; otherwise target.
  */
 export default async function convertTargetDefaultsToArray(
-  tree: Tree
+  tree: Tree,
+  projectGraph?: ProjectGraph
 ): Promise<void> {
   if (!tree.exists('nx.json')) {
     return;
@@ -31,11 +38,13 @@ export default async function convertTargetDefaultsToArray(
   if (!targetDefaults) return;
   if (Array.isArray(targetDefaults)) return;
 
+  const graph = projectGraph ?? (await tryCreateProjectGraph());
+
   const legacy = targetDefaults as TargetDefaultsRecord;
   const entries: TargetDefaultEntry[] = [];
   for (const key of Object.keys(legacy)) {
     const value = legacy[key] ?? {};
-    entries.push(legacyKeyToEntry(key, value));
+    entries.push(...legacyKeyToEntries(key, value, graph));
   }
 
   nxJson.targetDefaults = entries;
@@ -47,18 +56,71 @@ export default async function convertTargetDefaultsToArray(
 /**
  * Treat a legacy record key as an executor when it contains `:` and is
  * not a glob (executor strings are `pkg:name`; globs would also contain
- * `*` / `{` / etc., which `isGlobPattern` catches).
+ * `*` / `{` / etc., which `isGlobPattern` catches). Used only as a
+ * syntactic fallback when no graph signal is available.
  */
 export function isExecutorLikeKey(key: string): boolean {
   return key.includes(':') && !isGlobPattern(key);
 }
 
-function legacyKeyToEntry(
+function legacyKeyToEntries(
   key: string,
-  value: Partial<TargetDefaultEntry>
-): TargetDefaultEntry {
-  if (isExecutorLikeKey(key)) {
-    return { ...value, executor: key };
+  value: Partial<TargetDefaultEntry>,
+  graph: ProjectGraph | undefined
+): TargetDefaultEntry[] {
+  if (isGlobPattern(key)) {
+    return [{ ...value, target: key }];
   }
-  return { ...value, target: key };
+
+  if (graph) {
+    const { matchesTargetName, matchesExecutor } = classifyKeyAgainstGraph(
+      key,
+      graph
+    );
+    if (matchesTargetName && matchesExecutor) {
+      return [
+        { ...value, target: key },
+        { ...value, executor: key },
+      ];
+    }
+    if (matchesTargetName) return [{ ...value, target: key }];
+    if (matchesExecutor) return [{ ...value, executor: key }];
+    // Fall through to the syntactic heuristic when the workspace has
+    // neither a target named `key` nor a target using executor `key`.
+  }
+
+  return isExecutorLikeKey(key)
+    ? [{ ...value, executor: key }]
+    : [{ ...value, target: key }];
+}
+
+function classifyKeyAgainstGraph(
+  key: string,
+  graph: ProjectGraph
+): { matchesTargetName: boolean; matchesExecutor: boolean } {
+  let matchesTargetName = false;
+  let matchesExecutor = false;
+  for (const node of Object.values(graph.nodes ?? {})) {
+    const targets = node?.data?.targets;
+    if (!targets) continue;
+    for (const [name, target] of Object.entries(targets)) {
+      if (!matchesTargetName && name === key) matchesTargetName = true;
+      if (!matchesExecutor && target?.executor === key) matchesExecutor = true;
+      if (matchesTargetName && matchesExecutor) {
+        return { matchesTargetName, matchesExecutor };
+      }
+    }
+  }
+  return { matchesTargetName, matchesExecutor };
+}
+
+async function tryCreateProjectGraph(): Promise<ProjectGraph | undefined> {
+  // The graph may fail to build mid-migration (e.g. another change earlier
+  // in the same migrate run left the workspace transiently inconsistent).
+  // Falling back to the syntactic heuristic is safer than aborting.
+  try {
+    return await createProjectGraphAsync();
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -716,6 +716,139 @@ describe('project-configuration-utils', () => {
       expect(buildTarget.inputs).toEqual(['explicit', 'inferred']);
     });
 
+    it('should apply projects-filtered defaults to a project that only a default plugin contributed', () => {
+      // ~45% of projects in a typical workspace are default-plugin-only
+      // (project.json / package.json reader output, no specified-plugin
+      // contribution). The merge-twice flow's preview pass must include
+      // these projects in the name view fed to findMatchingProjects so
+      // that `projects:` filters apply correctly.
+      const defaultResults = [
+        [
+          [
+            'nx/core/project-json',
+            'libs/lib-a/project.json',
+            {
+              projects: {
+                'libs/lib-a': {
+                  name: 'lib-a',
+                  root: 'libs/lib-a',
+                  tags: ['scope:web'],
+                  targets: {
+                    build: { executor: 'nx:noop' },
+                  },
+                },
+              },
+            },
+          ],
+          [
+            'nx/core/project-json',
+            'libs/lib-b/project.json',
+            {
+              projects: {
+                'libs/lib-b': {
+                  name: 'lib-b',
+                  root: 'libs/lib-b',
+                  tags: ['scope:api'],
+                  targets: {
+                    build: { executor: 'nx:noop' },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const errors = [];
+      const result = mergeCreateNodesResults(
+        [],
+        defaultResults as any,
+        {
+          targetDefaults: [
+            {
+              target: 'build',
+              projects: 'tag:scope:web',
+              cache: true,
+              inputs: ['web-only'],
+            },
+          ],
+        },
+        '/tmp/test',
+        errors
+      );
+
+      const libATarget = result.projectRootMap['libs/lib-a'].targets!['build'];
+      const libBTarget = result.projectRootMap['libs/lib-b'].targets!['build'];
+
+      // lib-a matches the tag filter: cache + inputs from the default apply.
+      expect(libATarget.cache).toBe(true);
+      expect(libATarget.inputs).toEqual(['web-only']);
+      // lib-b doesn't match: no cache, default plugin only.
+      expect(libBTarget.cache).toBeUndefined();
+      expect(libBTarget.inputs).toBeUndefined();
+
+      expect(errors).toEqual([]);
+    });
+
+    it('should fall back to a less-specific compatible default when the most-specific match is incompatible', () => {
+      // A workspace has a generic `{ target: 'build', cache: true }`
+      // default and a specific-but-incompatible `{ target: 'build',
+      // executor: 'foreign:build', cache: false }`. The matcher's best
+      // candidate is the specific one (executorOnly outranks
+      // exactTarget), but that entry's executor is incompatible with
+      // the project's actual `nx:run-commands` target. We should fall
+      // back to the generic default rather than dropping all defaults.
+      const specifiedResults = [
+        [
+          [
+            '@nx/dotnet',
+            'libs/dotnet-lib/MyLib.csproj',
+            {
+              projects: {
+                'libs/dotnet-lib': {
+                  name: 'dotnet-lib',
+                  root: 'libs/dotnet-lib',
+                  targets: {
+                    build: {
+                      command: 'dotnet build',
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const errors = [];
+      const result = mergeCreateNodesResults(
+        specifiedResults as any,
+        [],
+        {
+          targetDefaults: [
+            // Generic — compatible with anything (no executor set).
+            { target: 'build', cache: true, inputs: ['default'] },
+            // Specific — incompatible with the dotnet `command` target.
+            {
+              target: 'build',
+              executor: '@monodon/rust:build',
+              cache: false,
+            },
+          ],
+        },
+        '/tmp/test',
+        errors
+      );
+
+      const buildTarget =
+        result.projectRootMap['libs/dotnet-lib'].targets!['build'];
+      // Inferred command preserved; generic default's cache + inputs apply.
+      expect(buildTarget.executor).toEqual('nx:run-commands');
+      expect(buildTarget.cache).toBe(true);
+      expect(buildTarget.inputs).toEqual(['default']);
+      expect(errors).toEqual([]);
+    });
+
     it('should not let a target-name-keyed default with a foreign executor replace an inferred command target', () => {
       // Repro: a polyglot workspace has a target-name keyed default
       // (`test-native`) configured for the rust plugin's executor, and

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -752,13 +752,14 @@ describe('project-configuration-utils', () => {
         specifiedResults as any,
         [],
         {
-          targetDefaults: {
-            'test-native': {
+          targetDefaults: [
+            {
+              target: 'test-native',
               executor: '@monodon/rust:test',
               options: {},
               cache: true,
             },
-          },
+          ],
         },
         '/tmp/test',
         errors
@@ -829,13 +830,14 @@ describe('project-configuration-utils', () => {
         specifiedResults as any,
         defaultResults as any,
         {
-          targetDefaults: {
-            'test-native': {
+          targetDefaults: [
+            {
+              target: 'test-native',
               executor: '@monodon/rust:test',
               options: {},
               cache: true,
             },
-          },
+          ],
         },
         '/tmp/test',
         errors

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -325,11 +325,19 @@ function mergeCreateNodesResultsFromSinglePlugin(
 /**
  * Merges create nodes results into a single rootMap.
  *
- * Default plugin results are merged twice: first into an intermediate
- * rootMap with unresolved spread sentinels preserved, so target
- * defaults selection sees the real merged shape of defaults; then
- * applied as a single layer onto the main rootMap where the preserved
- * spreads resolve against the specified + target-defaults base.
+ * Specified plugin results are merged once into the manager. Default
+ * plugin results are first staged into an intermediate rootMap (with
+ * `'...'` spreads deferred) so that synthesis can read each layer's
+ * contribution without re-running the merge. The synthetic result from
+ * `createTargetDefaultsResults` is then merged into the manager, and
+ * the staged intermediate is replayed on top — that replay is where
+ * deferred spreads expand against the final (specified + synth) base.
+ *
+ * Synthesis itself doesn't materialize a second rootMap. Per
+ * (root, target) it does an on-the-fly merge of the two layered
+ * contributions to learn the eventual executor/command, then matches
+ * defaults against that merged shape. This keeps specified-plugin
+ * merge work to a single pass.
  */
 export function mergeCreateNodesResults(
   specifiedResults: CreateNodesResultEntry[][],

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -387,7 +387,9 @@ export function mergeCreateNodesResults(
   const targetDefaultsResults = createTargetDefaultsResults(
     nodesManager.getRootMap(),
     intermediateDefaultRootMap,
-    nxJsonConfiguration
+    nxJsonConfiguration,
+    configurationSourceMaps,
+    defaultConfigurationSourceMaps
   );
 
   if (targetDefaultsResults.length > 0) {

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
@@ -1,11 +1,14 @@
 import type { ProjectGraphProjectNode } from '../../../config/project-graph';
 import type { TargetDefaultEntry } from '../../../config/nx-json';
-import {
-  __resetTargetDefaultsLegacyWarning,
-  findBestTargetDefault,
-  normalizeTargetDefaults,
-  readTargetDefaultsForTarget,
-} from './target-defaults';
+
+// The legacy record-shape warning fires once per module load. To assert
+// on it cleanly we re-load the module in each test via `jest.resetModules`
+// so the "warned once" flag resets without an exported test-only reset
+// function. Every test reaches the SUT through these let-bound aliases
+// so each `it` block sees a fresh module instance.
+let findBestTargetDefault: typeof import('./target-defaults').findBestTargetDefault;
+let normalizeTargetDefaults: typeof import('./target-defaults').normalizeTargetDefaults;
+let readTargetDefaultsForTarget: typeof import('./target-defaults').readTargetDefaultsForTarget;
 
 // Silence the legacy record-shape warning everywhere except in the
 // dedicated describe that asserts on it. The warning writes to stderr
@@ -14,7 +17,11 @@ import {
 // test so call history doesn't leak between `it` blocks.
 let stderrWriteSpy: jest.SpyInstance;
 beforeEach(() => {
-  __resetTargetDefaultsLegacyWarning();
+  jest.resetModules();
+  const mod = require('./target-defaults');
+  findBestTargetDefault = mod.findBestTargetDefault;
+  normalizeTargetDefaults = mod.normalizeTargetDefaults;
+  readTargetDefaultsForTarget = mod.readTargetDefaultsForTarget;
   stderrWriteSpy = jest
     .spyOn(process.stderr, 'write')
     .mockImplementation(() => true);
@@ -448,6 +455,83 @@ describe('findBestTargetDefault', () => {
           entries
         )
       ).toEqual({ inputs: ['source-match'] });
+    });
+  });
+
+  // The predicate path is what synthesis uses to fall back to a less-
+  // specific compatible default when the most-specific match would be
+  // incompatible with the project's actual target.
+  describe('predicate (compatible-fallback) path', () => {
+    it('returns the highest-ranked candidate when the predicate accepts it', () => {
+      const entries: TargetDefaultEntry[] = [
+        { target: 'build', cache: true, inputs: ['generic'] },
+        {
+          target: 'build',
+          executor: '@nx/jest:jest',
+          inputs: ['jest-specific'],
+        },
+      ];
+      // Predicate accepts the highest-ranked candidate; iteration
+      // returns it immediately.
+      expect(
+        findBestTargetDefault(
+          'build',
+          '@nx/jest:jest',
+          undefined,
+          undefined,
+          undefined,
+          entries,
+          undefined,
+          () => true
+        )
+      ).toEqual({ executor: '@nx/jest:jest', inputs: ['jest-specific'] });
+    });
+
+    it('falls through ranked candidates and returns the first compatible one', () => {
+      const entries: TargetDefaultEntry[] = [
+        { target: 'build', cache: true, inputs: ['generic'] },
+        {
+          target: 'build',
+          executor: '@nx/jest:jest',
+          inputs: ['jest-specific'],
+        },
+      ];
+      // Predicate rejects any candidate carrying executor '@nx/jest:jest'.
+      // Best (jest-specific) fails; fall back to generic.
+      expect(
+        findBestTargetDefault(
+          'build',
+          '@nx/jest:jest',
+          undefined,
+          undefined,
+          undefined,
+          entries,
+          undefined,
+          (config) => config.executor !== '@nx/jest:jest'
+        )
+      ).toEqual({ cache: true, inputs: ['generic'] });
+    });
+
+    it('returns null when no candidate satisfies the predicate', () => {
+      const entries: TargetDefaultEntry[] = [
+        {
+          target: 'build',
+          executor: '@nx/jest:jest',
+          inputs: ['jest-specific'],
+        },
+      ];
+      expect(
+        findBestTargetDefault(
+          'build',
+          '@nx/jest:jest',
+          undefined,
+          undefined,
+          undefined,
+          entries,
+          undefined,
+          () => false
+        )
+      ).toBeNull();
     });
   });
 });

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
@@ -347,6 +347,163 @@ describe('findBestTargetDefault', () => {
     ).toBeNull();
   });
 
+  // Filter-only entries (no `target`/`executor` locator, only `projects`
+  // and/or `source`) intentionally rank below every locator-bearing
+  // match at the same tier. The motivating case is a bare
+  // `{ source: '@nx/jest/plugin', cache: false }` — "for everything the
+  // jest plugin contributes, turn caching off" — which previously was
+  // silently rejected because the matcher required a locator.
+  describe('filter-only entries', () => {
+    it('matches a target by `source` alone with no other locator', () => {
+      const entries: TargetDefaultEntry[] = [
+        { source: '@nx/jest/plugin', cache: false },
+      ];
+      expect(
+        findBestTargetDefault(
+          'test',
+          undefined,
+          'web',
+          node('web'),
+          '@nx/jest/plugin',
+          entries
+        )
+      ).toEqual({ cache: false });
+    });
+
+    it('skips a `source`-only entry when the source plugin does not match', () => {
+      const entries: TargetDefaultEntry[] = [
+        { source: '@nx/jest/plugin', cache: false },
+      ];
+      expect(
+        findBestTargetDefault(
+          'test',
+          undefined,
+          'web',
+          node('web'),
+          '@nx/vite/plugin',
+          entries
+        )
+      ).toBeNull();
+    });
+
+    it('matches a target by `projects` alone with no other locator', () => {
+      const entries: TargetDefaultEntry[] = [
+        { projects: 'web', inputs: ['only-web'] },
+      ];
+      expect(
+        findBestTargetDefault(
+          'test',
+          undefined,
+          'web',
+          node('web'),
+          undefined,
+          entries
+        )
+      ).toEqual({ inputs: ['only-web'] });
+    });
+
+    it('an empty entry (no locator and no filter) never matches', () => {
+      // The matcher rejects entries with no constraints whatsoever — they
+      // would broadcast to every (root, target) pair in the workspace.
+      const entries: TargetDefaultEntry[] = [{ cache: false }];
+      expect(
+        findBestTargetDefault(
+          'test',
+          undefined,
+          'web',
+          node('web'),
+          '@nx/jest/plugin',
+          entries
+        )
+      ).toBeNull();
+    });
+
+    it('a target-name match beats a source-only match at the same tier', () => {
+      // `target` alone is tier 1, `source` alone is tier 1. Tie broken by
+      // matchKind: exactTarget (rank 2) > filterOnly (rank 0).
+      const entries: TargetDefaultEntry[] = [
+        { source: '@nx/jest/plugin', cache: false },
+        { target: 'test', cache: true },
+      ];
+      expect(
+        findBestTargetDefault(
+          'test',
+          undefined,
+          'web',
+          node('web'),
+          '@nx/jest/plugin',
+          entries
+        )
+      ).toEqual({ cache: true });
+    });
+
+    it('a target+source entry beats a projects+source entry at the same tier', () => {
+      // Both are tier 2 (one locator + one filter vs two filters). Tie
+      // broken by matchKind: exactTarget > filterOnly. The locator-bearing
+      // entry wins regardless of array order.
+      const entries: TargetDefaultEntry[] = [
+        {
+          target: 'test',
+          source: '@nx/jest/plugin',
+          inputs: ['target+source'],
+        },
+        {
+          projects: 'web',
+          source: '@nx/jest/plugin',
+          inputs: ['filters-only'],
+        },
+      ];
+      expect(
+        findBestTargetDefault(
+          'test',
+          undefined,
+          'web',
+          node('web'),
+          '@nx/jest/plugin',
+          entries
+        )
+      ).toEqual({ inputs: ['target+source'] });
+    });
+
+    it('among two filter-only entries at the same tier, later index wins', () => {
+      const entries: TargetDefaultEntry[] = [
+        { source: '@nx/jest/plugin', inputs: ['first'] },
+        { source: '@nx/jest/plugin', inputs: ['second'] },
+      ];
+      expect(
+        findBestTargetDefault(
+          'test',
+          undefined,
+          'web',
+          node('web'),
+          '@nx/jest/plugin',
+          entries
+        )
+      ).toEqual({ inputs: ['second'] });
+    });
+
+    it('projects+source (filter-only, tier 2) beats source alone (filter-only, tier 1)', () => {
+      const entries: TargetDefaultEntry[] = [
+        { source: '@nx/jest/plugin', inputs: ['source-only'] },
+        {
+          projects: 'web',
+          source: '@nx/jest/plugin',
+          inputs: ['both-filters'],
+        },
+      ];
+      expect(
+        findBestTargetDefault(
+          'test',
+          undefined,
+          'web',
+          node('web'),
+          '@nx/jest/plugin',
+          entries
+        )
+      ).toEqual({ inputs: ['both-filters'] });
+    });
+  });
+
   describe('executor field', () => {
     it('matches when entry executor equals target executor (target+executor)', () => {
       const entries: TargetDefaultEntry[] = [

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
@@ -1,0 +1,514 @@
+import type { ProjectGraphProjectNode } from '../../../config/project-graph';
+import type { TargetDefaultEntry } from '../../../config/nx-json';
+import {
+  __resetTargetDefaultsLegacyWarning,
+  findBestTargetDefault,
+  normalizeTargetDefaults,
+  readTargetDefaultsForTarget,
+} from './target-defaults';
+
+// Silence the legacy record-shape warning everywhere except in the
+// dedicated describe that asserts on it. The warning writes to stderr
+// directly (so it cannot pollute `--json` stdout), so we stub
+// `process.stderr.write` rather than any output helper. Restored per
+// test so call history doesn't leak between `it` blocks.
+let stderrWriteSpy: jest.SpyInstance;
+beforeEach(() => {
+  __resetTargetDefaultsLegacyWarning();
+  stderrWriteSpy = jest
+    .spyOn(process.stderr, 'write')
+    .mockImplementation(() => true);
+});
+afterEach(() => {
+  stderrWriteSpy.mockRestore();
+});
+
+function node(
+  name: string,
+  opts: { root?: string; tags?: string[] } = {}
+): ProjectGraphProjectNode {
+  return {
+    name,
+    type: 'lib',
+    data: { root: opts.root ?? name, tags: opts.tags ?? [] },
+  } as ProjectGraphProjectNode;
+}
+
+describe('findBestTargetDefault', () => {
+  it('returns null on empty entries', () => {
+    expect(
+      findBestTargetDefault(
+        'test',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        []
+      )
+    ).toBeNull();
+  });
+
+  it('matches exact target name', () => {
+    const entries: TargetDefaultEntry[] = [{ target: 'test', cache: true }];
+    expect(
+      findBestTargetDefault(
+        'test',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        entries
+      )
+    ).toEqual({ cache: true });
+  });
+
+  it('returns null when no target matches', () => {
+    const entries: TargetDefaultEntry[] = [{ target: 'build', cache: true }];
+    expect(
+      findBestTargetDefault(
+        'test',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        entries
+      )
+    ).toBeNull();
+  });
+
+  it('matches a target glob', () => {
+    const entries: TargetDefaultEntry[] = [{ target: 'test:*', cache: true }];
+    expect(
+      findBestTargetDefault(
+        'test:ci',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        entries
+      )
+    ).toEqual({ cache: true });
+  });
+
+  it('matches executor when target equals executor string', () => {
+    const entries: TargetDefaultEntry[] = [
+      { target: '@nx/vite:test', inputs: ['x'] },
+    ];
+    expect(
+      findBestTargetDefault(
+        'test',
+        '@nx/vite:test',
+        undefined,
+        undefined,
+        undefined,
+        entries
+      )
+    ).toEqual({ inputs: ['x'] });
+  });
+
+  it('target+source beats target only', () => {
+    const entries: TargetDefaultEntry[] = [
+      { target: 'test', cache: true },
+      { target: 'test', source: '@nx/vite', inputs: ['vite'] },
+    ];
+    expect(
+      findBestTargetDefault(
+        'test',
+        undefined,
+        'web',
+        node('web'),
+        '@nx/vite',
+        entries
+      )
+    ).toEqual({ inputs: ['vite'] });
+  });
+
+  it('target+projects beats target+source', () => {
+    const entries: TargetDefaultEntry[] = [
+      { target: 'test', source: '@nx/vite', inputs: ['vite'] },
+      { target: 'test', projects: 'web', inputs: ['byproject'] },
+    ];
+    expect(
+      findBestTargetDefault(
+        'test',
+        undefined,
+        'web',
+        node('web'),
+        '@nx/vite',
+        entries
+      )
+    ).toEqual({ inputs: ['byproject'] });
+  });
+
+  it('target+projects+source beats all', () => {
+    const entries: TargetDefaultEntry[] = [
+      { target: 'test', cache: true },
+      { target: 'test', source: '@nx/vite', inputs: ['vite'] },
+      { target: 'test', projects: 'web', inputs: ['byproject'] },
+      {
+        target: 'test',
+        projects: 'web',
+        source: '@nx/vite',
+        inputs: ['both'],
+      },
+    ];
+    expect(
+      findBestTargetDefault(
+        'test',
+        undefined,
+        'web',
+        node('web'),
+        '@nx/vite',
+        entries
+      )
+    ).toEqual({ inputs: ['both'] });
+  });
+
+  it('tie in same tier is broken by later array index', () => {
+    const entries: TargetDefaultEntry[] = [
+      { target: 'test', inputs: ['first'] },
+      { target: 'test', inputs: ['second'] },
+    ];
+    expect(
+      findBestTargetDefault(
+        'test',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        entries
+      )
+    ).toEqual({ inputs: ['second'] });
+  });
+
+  it('exact target match beats glob match in same tier', () => {
+    const entries: TargetDefaultEntry[] = [
+      { target: 'test:*', inputs: ['glob'] },
+      { target: 'test', inputs: ['exact'] },
+    ];
+    expect(
+      findBestTargetDefault(
+        'test',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        entries
+      )
+    ).toEqual({ inputs: ['exact'] });
+  });
+
+  it('matches by project tag pattern', () => {
+    const entries: TargetDefaultEntry[] = [
+      {
+        target: 'test',
+        projects: 'tag:dotnet',
+        options: { configuration: 'Release' },
+      },
+    ];
+    expect(
+      findBestTargetDefault(
+        'test',
+        undefined,
+        'api',
+        node('api', { tags: ['dotnet'] }),
+        undefined,
+        entries
+      )
+    ).toEqual({ options: { configuration: 'Release' } });
+  });
+
+  it('does not match when project tag is missing', () => {
+    const entries: TargetDefaultEntry[] = [
+      { target: 'test', projects: 'tag:dotnet', options: { a: 1 } },
+    ];
+    expect(
+      findBestTargetDefault(
+        'test',
+        undefined,
+        'web',
+        node('web', { tags: ['node'] }),
+        undefined,
+        entries
+      )
+    ).toBeNull();
+  });
+
+  it('supports array projects with glob + negation', () => {
+    const entries: TargetDefaultEntry[] = [
+      {
+        target: 'test',
+        projects: ['apps/*', '!apps/legacy'],
+        inputs: ['ok'],
+      },
+    ];
+    const include = findBestTargetDefault(
+      'test',
+      undefined,
+      'apps/web',
+      node('apps/web', { root: 'apps/web' }),
+      undefined,
+      entries
+    );
+    const exclude = findBestTargetDefault(
+      'test',
+      undefined,
+      'apps/legacy',
+      node('apps/legacy', { root: 'apps/legacy' }),
+      undefined,
+      entries
+    );
+    expect(include).toEqual({ inputs: ['ok'] });
+    expect(exclude).toBeNull();
+  });
+
+  it('skips entries requiring source when sourcePlugin is unknown', () => {
+    const entries: TargetDefaultEntry[] = [
+      { target: 'test', source: '@nx/vite', inputs: ['vite'] },
+    ];
+    expect(
+      findBestTargetDefault(
+        'test',
+        undefined,
+        'web',
+        node('web'),
+        undefined,
+        entries
+      )
+    ).toBeNull();
+  });
+
+  it('skips entries requiring projects when no projectNode is provided', () => {
+    const entries: TargetDefaultEntry[] = [
+      { target: 'test', projects: 'web', inputs: ['x'] },
+    ];
+    expect(
+      findBestTargetDefault(
+        'test',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        entries
+      )
+    ).toBeNull();
+  });
+
+  describe('executor body field (dual-role)', () => {
+    it('matches and bumps tier when body executor equals target executor', () => {
+      const entries: TargetDefaultEntry[] = [
+        { target: 'build', inputs: ['target-only'] },
+        { target: 'build', executor: '@nx/js:tsc', inputs: ['executor-match'] },
+      ];
+      expect(
+        findBestTargetDefault(
+          'build',
+          '@nx/js:tsc',
+          undefined,
+          undefined,
+          undefined,
+          entries
+        )
+      ).toEqual({ executor: '@nx/js:tsc', inputs: ['executor-match'] });
+    });
+
+    it('matches as injection (no tier bump) when target has no executor and no command', () => {
+      const entries: TargetDefaultEntry[] = [
+        { target: 'build', executor: '@nx/js:tsc', inputs: ['inject'] },
+      ];
+      expect(
+        findBestTargetDefault(
+          'build',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          entries,
+          undefined
+        )
+      ).toEqual({ executor: '@nx/js:tsc', inputs: ['inject'] });
+    });
+
+    it('ties injection match with pure target-only; later index wins', () => {
+      const entries: TargetDefaultEntry[] = [
+        { target: 'build', inputs: ['plain'] },
+        { target: 'build', executor: '@nx/js:tsc', inputs: ['inject'] },
+      ];
+      expect(
+        findBestTargetDefault(
+          'build',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          entries,
+          undefined
+        )
+      ).toEqual({ executor: '@nx/js:tsc', inputs: ['inject'] });
+    });
+
+    it('skips entry when target has a different executor', () => {
+      const entries: TargetDefaultEntry[] = [
+        { target: 'build', executor: '@nx/js:tsc', inputs: ['x'] },
+      ];
+      expect(
+        findBestTargetDefault(
+          'build',
+          '@nx/esbuild:esbuild',
+          undefined,
+          undefined,
+          undefined,
+          entries
+        )
+      ).toBeNull();
+    });
+
+    it('skips entry when target has a command but no matching executor', () => {
+      const entries: TargetDefaultEntry[] = [
+        { target: 'build', executor: '@nx/js:tsc', inputs: ['x'] },
+      ];
+      expect(
+        findBestTargetDefault(
+          'build',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          entries,
+          'some command'
+        )
+      ).toBeNull();
+    });
+
+    it('executor filter match beats target-only entry in tier', () => {
+      const entries: TargetDefaultEntry[] = [
+        { target: 'build', inputs: ['plain'] },
+        { target: 'build', executor: '@nx/js:tsc', inputs: ['filter'] },
+      ];
+      expect(
+        findBestTargetDefault(
+          'build',
+          '@nx/js:tsc',
+          undefined,
+          undefined,
+          undefined,
+          entries
+        )
+      ).toEqual({ executor: '@nx/js:tsc', inputs: ['filter'] });
+    });
+
+    it('target+source still beats target+executor-match', () => {
+      const entries: TargetDefaultEntry[] = [
+        { target: 'build', executor: '@nx/js:tsc', inputs: ['executor-match'] },
+        { target: 'build', source: '@nx/js', inputs: ['source-match'] },
+      ];
+      expect(
+        findBestTargetDefault(
+          'build',
+          '@nx/js:tsc',
+          'lib',
+          node('lib'),
+          '@nx/js',
+          entries
+        )
+      ).toEqual({ inputs: ['source-match'] });
+    });
+  });
+});
+
+describe('normalizeTargetDefaults', () => {
+  it('returns [] for undefined', () => {
+    expect(normalizeTargetDefaults(undefined)).toEqual([]);
+  });
+
+  it('passes array through unchanged', () => {
+    const input: TargetDefaultEntry[] = [{ target: 'test', cache: true }];
+    expect(normalizeTargetDefaults(input)).toEqual(input);
+  });
+
+  it('converts record to array preserving insertion order', () => {
+    const result = normalizeTargetDefaults({
+      build: { cache: true },
+      'e2e-ci--*': { cache: false },
+      '@nx/vite:test': { inputs: ['x'] },
+    });
+    expect(result).toEqual([
+      { target: 'build', cache: true },
+      { target: 'e2e-ci--*', cache: false },
+      { target: '@nx/vite:test', inputs: ['x'] },
+    ]);
+  });
+
+  describe('legacy record-shape warning', () => {
+    it('warns once to stderr when record shape is normalized, mentioning nx repair', () => {
+      normalizeTargetDefaults({ build: { cache: true } });
+      normalizeTargetDefaults({ test: { cache: true } });
+      expect(stderrWriteSpy).toHaveBeenCalledTimes(1);
+      const message = stderrWriteSpy.mock.calls[0][0] as string;
+      expect(message).toMatch(/legacy record-shape/i);
+      expect(message).toMatch(/nx repair/);
+    });
+
+    it('never writes the warning to stdout', () => {
+      const stdoutSpy = jest
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(() => true);
+      normalizeTargetDefaults({ build: { cache: true } });
+      expect(stdoutSpy).not.toHaveBeenCalled();
+      stdoutSpy.mockRestore();
+    });
+
+    it('does not warn for array shape', () => {
+      normalizeTargetDefaults([{ target: 'build', cache: true }]);
+      expect(stderrWriteSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn when targetDefaults is undefined', () => {
+      normalizeTargetDefaults(undefined);
+      expect(stderrWriteSpy).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('readTargetDefaultsForTarget (backwards-compat wrapper)', () => {
+  it('still reads from the legacy record shape', () => {
+    expect(
+      readTargetDefaultsForTarget('build', {
+        build: { inputs: ['a'] },
+      })
+    ).toEqual({ inputs: ['a'] });
+  });
+
+  it('reads from array shape', () => {
+    expect(
+      readTargetDefaultsForTarget('build', [{ target: 'build', inputs: ['a'] }])
+    ).toEqual({ inputs: ['a'] });
+  });
+
+  it('returns null when no defaults apply', () => {
+    expect(readTargetDefaultsForTarget('test', [])).toBeNull();
+    expect(readTargetDefaultsForTarget('test', undefined)).toBeNull();
+  });
+
+  it('record: prefers executor key over target key', () => {
+    expect(
+      readTargetDefaultsForTarget(
+        'build',
+        {
+          build: { inputs: ['by-target'] },
+          '@nx/vite:build': { inputs: ['by-executor'] },
+        },
+        '@nx/vite:build'
+      )
+    ).toEqual({ inputs: ['by-executor'] });
+  });
+
+  it('record: later key wins for overlapping globs', () => {
+    expect(
+      readTargetDefaultsForTarget('e2e-ci--file-foo', {
+        'e2e-ci--*': { options: { key: 'short' } },
+        'e2e-ci--file-*': { options: { key: 'long' } },
+      })
+    ).toEqual({ options: { key: 'long' } });
+  });
+});

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
@@ -8,6 +8,7 @@ import type { TargetDefaultEntry } from '../../../config/nx-json';
 // so each `it` block sees a fresh module instance.
 let findBestTargetDefault: typeof import('./target-defaults').findBestTargetDefault;
 let normalizeTargetDefaults: typeof import('./target-defaults').normalizeTargetDefaults;
+let normalizeTargetDefaultsAgainstRootMaps: typeof import('./target-defaults').normalizeTargetDefaultsAgainstRootMaps;
 let readTargetDefaultsForTarget: typeof import('./target-defaults').readTargetDefaultsForTarget;
 
 // Silence the legacy record-shape warning everywhere except in the
@@ -21,6 +22,8 @@ beforeEach(() => {
   const mod = require('./target-defaults');
   findBestTargetDefault = mod.findBestTargetDefault;
   normalizeTargetDefaults = mod.normalizeTargetDefaults;
+  normalizeTargetDefaultsAgainstRootMaps =
+    mod.normalizeTargetDefaultsAgainstRootMaps;
   readTargetDefaultsForTarget = mod.readTargetDefaultsForTarget;
   stderrWriteSpy = jest
     .spyOn(process.stderr, 'write')
@@ -643,5 +646,97 @@ describe('readTargetDefaultsForTarget (backwards-compat wrapper)', () => {
         'e2e-ci--file-*': { options: { key: 'long' } },
       })
     ).toEqual({ options: { key: 'long' } });
+  });
+});
+
+describe('normalizeTargetDefaultsAgainstRootMaps', () => {
+  it('classifies an ambiguous `:` key as executor when only an executor matches', () => {
+    expect(
+      normalizeTargetDefaultsAgainstRootMaps(
+        { '@nx/vite:test': { cache: true } },
+        {
+          'apps/a': {
+            root: 'apps/a',
+            targets: { test: { executor: '@nx/vite:test' } },
+          },
+        }
+      )
+    ).toEqual([{ executor: '@nx/vite:test', cache: true }]);
+  });
+
+  it('classifies an ambiguous `:` key as target when only a target name matches', () => {
+    // `serve:dev` is a legitimate target name with `:` in it. The
+    // syntactic heuristic would mis-classify it as an executor; the
+    // graph-aware classifier sees it's a target name and emits a
+    // `target:` entry.
+    expect(
+      normalizeTargetDefaultsAgainstRootMaps(
+        { 'serve:dev': { cache: true } },
+        {
+          'apps/a': {
+            root: 'apps/a',
+            targets: { 'serve:dev': { command: 'echo serve' } },
+          },
+        }
+      )
+    ).toEqual([{ target: 'serve:dev', cache: true }]);
+  });
+
+  it('emits both target and executor entries when the key matches both', () => {
+    // Genuine ambiguity — `webpack-cli:build` happens to be the name of
+    // both a target and a registered executor in the workspace. Emit both
+    // entries rather than guess; matches the v23 migration's behavior.
+    expect(
+      normalizeTargetDefaultsAgainstRootMaps(
+        { 'webpack-cli:build': { cache: true } },
+        {
+          'apps/a': {
+            root: 'apps/a',
+            targets: {
+              'webpack-cli:build': { executor: 'webpack-cli:build' },
+            },
+          },
+        }
+      )
+    ).toEqual([
+      { target: 'webpack-cli:build', cache: true },
+      { executor: 'webpack-cli:build', cache: true },
+    ]);
+  });
+
+  it('falls back to syntactic heuristic when the key matches neither', () => {
+    expect(
+      normalizeTargetDefaultsAgainstRootMaps(
+        { '@nx/some-unused-plugin:build': { cache: true } },
+        { 'apps/a': { root: 'apps/a', targets: {} } }
+      )
+    ).toEqual([{ executor: '@nx/some-unused-plugin:build', cache: true }]);
+  });
+
+  it('classifies a target-named key as `target:` even when the rootMaps are empty', () => {
+    expect(
+      normalizeTargetDefaultsAgainstRootMaps({ build: { cache: true } }, {})
+    ).toEqual([{ target: 'build', cache: true }]);
+  });
+
+  it('passes array shape through unchanged', () => {
+    const input: TargetDefaultEntry[] = [
+      { target: 'build', cache: true },
+      { executor: '@nx/vite:test', inputs: ['x'] },
+    ];
+    expect(
+      normalizeTargetDefaultsAgainstRootMaps(input, {
+        'apps/a': { root: 'apps/a', targets: { test: {} } },
+      })
+    ).toEqual(input);
+  });
+
+  it('treats glob keys as targets without consulting rootMaps', () => {
+    expect(
+      normalizeTargetDefaultsAgainstRootMaps(
+        { 'e2e-ci--*': { dependsOn: ['build'] } },
+        {}
+      )
+    ).toEqual([{ target: 'e2e-ci--*', dependsOn: ['build'] }]);
   });
 });

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
@@ -162,7 +162,7 @@ describe('findBestTargetDefault', () => {
   it('target+source beats target only', () => {
     const entries: TargetDefaultEntry[] = [
       { target: 'test', cache: true },
-      { target: 'test', source: '@nx/vite', inputs: ['vite'] },
+      { target: 'test', plugin: '@nx/vite', inputs: ['vite'] },
     ];
     expect(
       findBestTargetDefault(
@@ -178,7 +178,7 @@ describe('findBestTargetDefault', () => {
 
   it('target+projects beats target+source', () => {
     const entries: TargetDefaultEntry[] = [
-      { target: 'test', source: '@nx/vite', inputs: ['vite'] },
+      { target: 'test', plugin: '@nx/vite', inputs: ['vite'] },
       { target: 'test', projects: 'web', inputs: ['byproject'] },
     ];
     expect(
@@ -196,12 +196,12 @@ describe('findBestTargetDefault', () => {
   it('target+projects+source beats all', () => {
     const entries: TargetDefaultEntry[] = [
       { target: 'test', cache: true },
-      { target: 'test', source: '@nx/vite', inputs: ['vite'] },
+      { target: 'test', plugin: '@nx/vite', inputs: ['vite'] },
       { target: 'test', projects: 'web', inputs: ['byproject'] },
       {
         target: 'test',
         projects: 'web',
-        source: '@nx/vite',
+        plugin: '@nx/vite',
         inputs: ['both'],
       },
     ];
@@ -317,7 +317,7 @@ describe('findBestTargetDefault', () => {
 
   it('skips entries requiring source when sourcePlugin is unknown', () => {
     const entries: TargetDefaultEntry[] = [
-      { target: 'test', source: '@nx/vite', inputs: ['vite'] },
+      { target: 'test', plugin: '@nx/vite', inputs: ['vite'] },
     ];
     expect(
       findBestTargetDefault(
@@ -350,13 +350,13 @@ describe('findBestTargetDefault', () => {
   // Filter-only entries (no `target`/`executor` locator, only `projects`
   // and/or `source`) intentionally rank below every locator-bearing
   // match at the same tier. The motivating case is a bare
-  // `{ source: '@nx/jest/plugin', cache: false }` — "for everything the
+  // `{ plugin: '@nx/jest/plugin', cache: false }` — "for everything the
   // jest plugin contributes, turn caching off" — which previously was
   // silently rejected because the matcher required a locator.
   describe('filter-only entries', () => {
     it('matches a target by `source` alone with no other locator', () => {
       const entries: TargetDefaultEntry[] = [
-        { source: '@nx/jest/plugin', cache: false },
+        { plugin: '@nx/jest/plugin', cache: false },
       ];
       expect(
         findBestTargetDefault(
@@ -372,7 +372,7 @@ describe('findBestTargetDefault', () => {
 
     it('skips a `source`-only entry when the source plugin does not match', () => {
       const entries: TargetDefaultEntry[] = [
-        { source: '@nx/jest/plugin', cache: false },
+        { plugin: '@nx/jest/plugin', cache: false },
       ];
       expect(
         findBestTargetDefault(
@@ -422,7 +422,7 @@ describe('findBestTargetDefault', () => {
       // `target` alone is tier 1, `source` alone is tier 1. Tie broken by
       // matchKind: exactTarget (rank 2) > filterOnly (rank 0).
       const entries: TargetDefaultEntry[] = [
-        { source: '@nx/jest/plugin', cache: false },
+        { plugin: '@nx/jest/plugin', cache: false },
         { target: 'test', cache: true },
       ];
       expect(
@@ -444,12 +444,12 @@ describe('findBestTargetDefault', () => {
       const entries: TargetDefaultEntry[] = [
         {
           target: 'test',
-          source: '@nx/jest/plugin',
+          plugin: '@nx/jest/plugin',
           inputs: ['target+source'],
         },
         {
           projects: 'web',
-          source: '@nx/jest/plugin',
+          plugin: '@nx/jest/plugin',
           inputs: ['filters-only'],
         },
       ];
@@ -467,8 +467,8 @@ describe('findBestTargetDefault', () => {
 
     it('among two filter-only entries at the same tier, later index wins', () => {
       const entries: TargetDefaultEntry[] = [
-        { source: '@nx/jest/plugin', inputs: ['first'] },
-        { source: '@nx/jest/plugin', inputs: ['second'] },
+        { plugin: '@nx/jest/plugin', inputs: ['first'] },
+        { plugin: '@nx/jest/plugin', inputs: ['second'] },
       ];
       expect(
         findBestTargetDefault(
@@ -484,10 +484,10 @@ describe('findBestTargetDefault', () => {
 
     it('projects+source (filter-only, tier 2) beats source alone (filter-only, tier 1)', () => {
       const entries: TargetDefaultEntry[] = [
-        { source: '@nx/jest/plugin', inputs: ['source-only'] },
+        { plugin: '@nx/jest/plugin', inputs: ['source-only'] },
         {
           projects: 'web',
-          source: '@nx/jest/plugin',
+          plugin: '@nx/jest/plugin',
           inputs: ['both-filters'],
         },
       ];
@@ -616,7 +616,7 @@ describe('findBestTargetDefault', () => {
     it('target+source still beats target+executor-match', () => {
       const entries: TargetDefaultEntry[] = [
         { target: 'build', executor: '@nx/js:tsc', inputs: ['executor-match'] },
-        { target: 'build', source: '@nx/js', inputs: ['source-match'] },
+        { target: 'build', plugin: '@nx/js', inputs: ['source-match'] },
       ];
       expect(
         findBestTargetDefault(

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
@@ -113,7 +113,14 @@ describe('findBestTargetDefault', () => {
     ).toEqual({ executor: '@nx/vite:test', inputs: ['x'] });
   });
 
-  it('executor-only entry does not match when target has no executor', () => {
+  it('executor-only entry does not inject into a bare target — no `target` locator means no targeting', () => {
+    // An executor-only entry like `{ executor: '@nx/vite:test' }` is keyed
+    // purely by executor: it applies to existing targets that *already* use
+    // that executor. It cannot be used to assign an executor to an
+    // executor-less target — that would broadcast the executor to every
+    // bare target in the workspace. Compare with the
+    // `target+executor → injection` behavior covered later in this file,
+    // where the `target` locator narrows the assignment to a specific name.
     const entries: TargetDefaultEntry[] = [
       { executor: '@nx/vite:test', inputs: ['x'] },
     ];
@@ -356,6 +363,12 @@ describe('findBestTargetDefault', () => {
     });
 
     it('matches as injection (no tier bump) when target has no executor and no command', () => {
+      // Injection-on-match: the entry has both a `target` locator AND an
+      // `executor` payload. The `target` narrows the match to one specific
+      // name, so it's safe to inject the executor into a bare target with
+      // that name. (Contrast with the executor-only entry test earlier in
+      // this file, which intentionally returns null — without a `target`
+      // locator there's no way to scope the injection.)
       const entries: TargetDefaultEntry[] = [
         { target: 'build', executor: '@nx/js:tsc', inputs: ['inject'] },
       ];

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
@@ -90,7 +90,43 @@ describe('findBestTargetDefault', () => {
     ).toEqual({ cache: true });
   });
 
-  it('matches executor when target equals executor string', () => {
+  it('matches by executor field when entry has no target', () => {
+    const entries: TargetDefaultEntry[] = [
+      { executor: '@nx/vite:test', inputs: ['x'] },
+    ];
+    expect(
+      findBestTargetDefault(
+        'test',
+        '@nx/vite:test',
+        undefined,
+        undefined,
+        undefined,
+        entries
+      )
+    ).toEqual({ executor: '@nx/vite:test', inputs: ['x'] });
+  });
+
+  it('executor-only entry does not match when target has no executor', () => {
+    const entries: TargetDefaultEntry[] = [
+      { executor: '@nx/vite:test', inputs: ['x'] },
+    ];
+    expect(
+      findBestTargetDefault(
+        'test',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        entries
+      )
+    ).toBeNull();
+  });
+
+  it('does not interpret entry.target as an executor anymore', () => {
+    // Under the legacy record-shape behavior, a key like '@nx/vite:test'
+    // matched by executor. The new array shape requires `executor` to be
+    // set explicitly — `target: '@nx/vite:test'` only matches a target
+    // literally named that.
     const entries: TargetDefaultEntry[] = [
       { target: '@nx/vite:test', inputs: ['x'] },
     ];
@@ -103,7 +139,7 @@ describe('findBestTargetDefault', () => {
         undefined,
         entries
       )
-    ).toEqual({ inputs: ['x'] });
+    ).toBeNull();
   });
 
   it('target+source beats target only', () => {
@@ -294,8 +330,8 @@ describe('findBestTargetDefault', () => {
     ).toBeNull();
   });
 
-  describe('executor body field (dual-role)', () => {
-    it('matches and bumps tier when body executor equals target executor', () => {
+  describe('executor field', () => {
+    it('matches when entry executor equals target executor (target+executor)', () => {
       const entries: TargetDefaultEntry[] = [
         { target: 'build', inputs: ['target-only'] },
         { target: 'build', executor: '@nx/js:tsc', inputs: ['executor-match'] },
@@ -426,7 +462,7 @@ describe('normalizeTargetDefaults', () => {
     expect(normalizeTargetDefaults(input)).toEqual(input);
   });
 
-  it('converts record to array preserving insertion order', () => {
+  it('converts record to array preserving insertion order, splitting executor keys', () => {
     const result = normalizeTargetDefaults({
       build: { cache: true },
       'e2e-ci--*': { cache: false },
@@ -435,7 +471,7 @@ describe('normalizeTargetDefaults', () => {
     expect(result).toEqual([
       { target: 'build', cache: true },
       { target: 'e2e-ci--*', cache: false },
-      { target: '@nx/vite:test', inputs: ['x'] },
+      { executor: '@nx/vite:test', inputs: ['x'] },
     ]);
   });
 
@@ -490,7 +526,7 @@ describe('readTargetDefaultsForTarget (backwards-compat wrapper)', () => {
     expect(readTargetDefaultsForTarget('test', undefined)).toBeNull();
   });
 
-  it('record: prefers executor key over target key', () => {
+  it('record: executor key wins over target key (executorOnly outranks exactTarget at same tier)', () => {
     expect(
       readTargetDefaultsForTarget(
         'build',
@@ -500,7 +536,7 @@ describe('readTargetDefaultsForTarget (backwards-compat wrapper)', () => {
         },
         '@nx/vite:build'
       )
-    ).toEqual({ inputs: ['by-executor'] });
+    ).toEqual({ executor: '@nx/vite:build', inputs: ['by-executor'] });
   });
 
   it('record: later key wins for overlapping globs', () => {

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
@@ -482,6 +482,66 @@ describe('findBestTargetDefault', () => {
       ).toEqual({ inputs: ['second'] });
     });
 
+    it('an empty `projects: []` filter never matches (treated as never-match, not silent broadcast)', () => {
+      // `[]` would otherwise sit in `findMatchingProjects` as "match no
+      // projects" — silently dropping the entire entry. We surface that
+      // intent as an explicit never-match so the entry is skipped in
+      // matching but its presence is still validated by the schema.
+      const entries: TargetDefaultEntry[] = [
+        { target: 'test', projects: [], cache: false },
+      ];
+      expect(
+        findBestTargetDefault(
+          'test',
+          undefined,
+          'web',
+          node('web'),
+          undefined,
+          entries
+        )
+      ).toBeNull();
+    });
+
+    it('a wildcard-only `projects: "*"` is equivalent to no filter and rejected when there is no other locator', () => {
+      // `'*'` matches everything, so a `{ projects: '*' }` entry would
+      // broadcast just like an entry with no constraints. The broadcast
+      // guard treats wildcard-only `projects` as "no filter".
+      const entries: TargetDefaultEntry[] = [
+        { projects: '*', cache: false },
+        { projects: ['*'], inputs: ['noop-filter'] },
+      ];
+      expect(
+        findBestTargetDefault(
+          'test',
+          undefined,
+          'web',
+          node('web'),
+          undefined,
+          entries
+        )
+      ).toBeNull();
+    });
+
+    it('a wildcard `projects: "*"` does not bump the specificity tier', () => {
+      // `target` alone is tier 1; `target + projects:'*'` should also be
+      // tier 1 (wildcard is "no filter"), so a later wildcard entry wins
+      // on array index, not on tier.
+      const entries: TargetDefaultEntry[] = [
+        { target: 'test', cache: true },
+        { target: 'test', projects: '*', cache: false },
+      ];
+      expect(
+        findBestTargetDefault(
+          'test',
+          undefined,
+          'web',
+          node('web'),
+          undefined,
+          entries
+        )
+      ).toEqual({ cache: false });
+    });
+
     it('projects+source (filter-only, tier 2) beats source alone (filter-only, tier 1)', () => {
       const entries: TargetDefaultEntry[] = [
         { plugin: '@nx/jest/plugin', inputs: ['source-only'] },

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -149,13 +149,10 @@ export function createTargetDefaultsResults(
   ];
 }
 
-// Returns the executor/command pair the real merge will end up with at
-// `(root, targetName)`. We don't reproduce the full per-target merge
-// here — only the fields the matcher cares about. For incompatible
-// pairs (e.g. specified `nx:run-commands` vs default `@nx/jest:jest`)
-// the default replaces the specified target wholesale, so we mirror
-// that behavior by returning the default. For compatible pairs, the
-// default's executor wins where set, otherwise the specified's.
+// Returns the (executor, command) pair the real merge will land on at
+// `(root, targetName)` — only the fields the matcher needs. Incompatible
+// pairs wholesale-replace specified with default; compatible pairs let
+// the default's executor win, otherwise the specified's.
 function effectiveTargetForLookup(
   specifiedTarget: TargetConfiguration | undefined,
   defaultTarget: TargetConfiguration | undefined,
@@ -234,11 +231,8 @@ function buildSyntheticTargetForRoot(
     root
   );
 
-  // Stamp executor/command from the effective shape. For entries that
-  // already specify these, this is a no-op (the matcher only returned
-  // compatible candidates). For entries that don't, this pre-aligns the
-  // synthetic with both layers so neither can incompatible-replace it
-  // during the real merge.
+  // Pre-stamp executor/command from the effective shape so the
+  // synthetic can't be incompatible-replaced during the real merge.
   if (effective.executor !== undefined) synthetic.executor = effective.executor;
   if (effective.command !== undefined) synthetic.command = effective.command;
 
@@ -438,24 +432,11 @@ function matchEntry(
   targetCommand: string | undefined
 ): Candidate | null {
   if (!entry) return null;
-  // Classify `projects:` first so the broadcast guard below can treat
-  // pure-wildcard patterns (`'*'`, `['*']`) the same as no filter, and
-  // empty arrays as a never-match (rather than silently slipping past
-  // both guards as a "filter" that matches nothing).
+  // `normalizeTargetDefaults` already drops entries with neither locator
+  // nor real filter. Empty-array `projects:` is an explicit never-match
+  // shape — kept by the normalizer because it's named, rejected here.
   const projectsKind = classifyProjectsFilter(entry.projects);
   if (projectsKind === 'empty') return null;
-  // Reject entries with no constraints whatsoever — without a locator
-  // (`target`/`executor`) or a filter (`projects`/`plugin`) the entry
-  // would broadcast to every (root, target) in the workspace. Pure
-  // wildcard `projects:` patterns count as "no filter" here.
-  if (
-    entry.target === undefined &&
-    entry.executor === undefined &&
-    projectsKind !== 'filter' &&
-    entry.plugin === undefined
-  ) {
-    return null;
-  }
 
   let targetKind: 'exact' | 'glob' | null = null;
   if (entry.target !== undefined) {
@@ -470,11 +451,8 @@ function matchEntry(
     if (executor && executor === entry.executor) {
       executorMatched = true;
     } else if (targetKind !== null && !executor && !targetCommand) {
-      // Injection: the entry's `target` locator already narrowed the match
-      // to a specific name, so it's safe to inject the entry's executor
-      // into a bare target. An executor-only entry (no `target` locator)
-      // never reaches this branch — without targeting, it would broadcast
-      // the executor to every executor-less target in the workspace.
+      // Bare target with no executor — safe to inject the entry's
+      // executor because the target locator has already narrowed the match.
       executorMatched = true;
     } else {
       return null;
@@ -491,17 +469,12 @@ function matchEntry(
 
   if (projectsKind === 'filter') {
     if (!projectName || !projectNode) return null;
-    // Copy the array — `findMatchingProjects` prepends '*' when the first
-    // pattern is a negation, mutating its input. Without the copy, every
-    // call corrupts the original `entry.projects` (and therefore the
-    // shared nxJson.targetDefaults entry) with a leading wildcard.
+    // Copy — `findMatchingProjects` prepends `*` for a leading negation
+    // and would otherwise mutate the shared nxJson entry.
     const patterns = Array.isArray(entry.projects)
       ? [...entry.projects!]
       : [entry.projects!];
     const matched = findMatchingProjects(patterns, {
-      // `findMatchingProjects` only reads `.name`, `.data.root`, and
-      // `.data.tags` — the keys our narrowed `projectNode` already
-      // satisfies — but its signature wants the full graph node.
       [projectName]: projectNode as ProjectGraphProjectNode,
     });
     if (!matched.includes(projectName)) return null;
@@ -606,14 +579,31 @@ export function normalizeTargetDefaults(
   raw: TargetDefaults | undefined
 ): NormalizedTargetDefaults {
   if (!raw) return [];
-  if (Array.isArray(raw)) return raw;
+  const entries = Array.isArray(raw) ? raw : recordToEntries(raw);
+  return entries.filter(isWellFormedEntry);
+}
+
+function recordToEntries(raw: TargetDefaultsRecord): TargetDefaultEntry[] {
   warnAboutLegacyRecordShapeOnce();
   const out: TargetDefaultEntry[] = [];
   for (const key of Object.keys(raw)) {
-    const value = (raw as TargetDefaultsRecord)[key] ?? {};
+    const value = raw[key] ?? {};
     out.push(...syntacticallyClassifyLegacyKey(key, value));
   }
   return out;
+}
+
+/**
+ * An entry is well-formed when it has at least one locator (`target` /
+ * `executor`) or a real filter (`projects` resolving to something other
+ * than empty/wildcard, or `plugin`). Pre-filtering here lets the matcher
+ * trust its inputs and skip the per-entry broadcast guard.
+ */
+function isWellFormedEntry(entry: TargetDefaultEntry): boolean {
+  if (entry.target !== undefined) return true;
+  if (entry.executor !== undefined) return true;
+  if (entry.plugin !== undefined) return true;
+  return classifyProjectsFilter(entry.projects) === 'filter';
 }
 
 /**
@@ -705,14 +695,9 @@ function resolveSourcePlugin(
   specifiedSourceMaps: ConfigurationSourceMaps | undefined,
   defaultSourceMaps: ConfigurationSourceMaps | undefined
 ): string | undefined {
-  // Default plugins (nx's baked-in inference of per-project config files
-  // like package.json, tsconfig.json) always overwrite specified-plugin
-  // attribution in the merge. Their attribution is what survives, so it
-  // takes precedence here when matching `plugin:` filters.
-  //
-  // We only consult the executor/command source-map keys — the top-level
-  // `targets.<name>` key tracks only the last writer, not the originator,
-  // and is unreliable for plugin attribution.
+  // Default-plugin attribution overrides specified-plugin attribution in
+  // the merge, so we check it first. Only the executor/command keys are
+  // reliable — the top-level `targets.<name>` key tracks the last writer.
   const executorKey = targetOptionSourceMapKey(targetName, 'executor');
   const commandKey = targetOptionSourceMapKey(targetName, 'command');
   const candidates: (string | undefined)[] = [

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -1,17 +1,33 @@
 import { minimatch } from 'minimatch';
-import { NxJsonConfiguration, TargetDefaults } from '../../../config/nx-json';
+import {
+  NormalizedTargetDefaults,
+  NxJsonConfiguration,
+  TargetDefaultEntry,
+  TargetDefaults,
+  TargetDefaultsRecord,
+} from '../../../config/nx-json';
 import {
   ProjectConfiguration,
   TargetConfiguration,
 } from '../../../config/workspace-json-project-json';
+import type { ProjectGraphProjectNode } from '../../../config/project-graph';
+import { findMatchingProjects } from '../../../utils/find-matching-projects';
 import { isGlobPattern } from '../../../utils/globs';
 import type { CreateNodesResult } from '../../plugins/public-api';
+import {
+  SourceInformation,
+  ConfigurationSourceMaps,
+  targetOptionSourceMapKey,
+  targetSourceMapKey,
+} from './source-maps';
 import {
   deepClone,
   isCompatibleTarget,
   resolveCommandSyntacticSugar,
 } from './target-merging';
 import { uniqueKeysInObjects } from './utils';
+import { EOL } from 'os';
+import * as pc from 'picocolors';
 
 type CreateNodesResultEntry = readonly [
   plugin: string,
@@ -27,11 +43,27 @@ type CreateNodesResultEntry = readonly [
 export function createTargetDefaultsResults(
   specifiedPluginRootMap: Record<string, ProjectConfiguration>,
   defaultPluginRootMap: Record<string, ProjectConfiguration>,
-  nxJsonConfiguration: NxJsonConfiguration
+  nxJsonConfiguration: NxJsonConfiguration,
+  specifiedSourceMaps?: ConfigurationSourceMaps,
+  defaultSourceMaps?: ConfigurationSourceMaps
 ): CreateNodesResultEntry[] {
   const targetDefaultsConfig = nxJsonConfiguration.targetDefaults;
   if (!targetDefaultsConfig) {
     return [];
+  }
+
+  const entries = normalizeTargetDefaults(targetDefaultsConfig);
+  if (entries.length === 0) {
+    return [];
+  }
+
+  const projectNodesByName = buildProjectNodesByName(
+    specifiedPluginRootMap,
+    defaultPluginRootMap
+  );
+  const rootToName = new Map<string, string>();
+  for (const [name, node] of Object.entries(projectNodesByName)) {
+    rootToName.set(node.data.root, name);
   }
 
   const syntheticProjects: Record<string, ProjectConfiguration> = {};
@@ -44,17 +76,31 @@ export function createTargetDefaultsResults(
   for (const root of allRoots) {
     const specifiedTargets = specifiedPluginRootMap[root]?.targets ?? {};
     const defaultTargets = defaultPluginRootMap[root]?.targets ?? {};
+    const projectName = rootToName.get(root);
+    const projectNode = projectName
+      ? projectNodesByName[projectName]
+      : undefined;
 
     for (const targetName of uniqueKeysInObjects(
       specifiedTargets,
       defaultTargets
     )) {
+      const sourcePlugin = resolveSourcePlugin(
+        root,
+        targetName,
+        specifiedSourceMaps,
+        defaultSourceMaps
+      );
+
       const syntheticTarget = buildSyntheticTargetForRoot(
         targetName,
         root,
         specifiedTargets[targetName],
         defaultTargets[targetName],
-        targetDefaultsConfig
+        entries,
+        projectName,
+        projectNode,
+        sourcePlugin
       );
 
       if (!syntheticTarget) continue;
@@ -87,7 +133,10 @@ function buildSyntheticTargetForRoot(
   root: string,
   specifiedTarget: TargetConfiguration | undefined,
   defaultTarget: TargetConfiguration | undefined,
-  targetDefaultsConfig: TargetDefaults
+  entries: NormalizedTargetDefaults,
+  projectName: string | undefined,
+  projectNode: ProjectGraphProjectNode | undefined,
+  sourcePlugin: string | undefined
 ): TargetConfiguration | undefined {
   const resolvedSpecified = specifiedTarget
     ? resolveCommandSyntacticSugar(specifiedTarget, root)
@@ -98,16 +147,20 @@ function buildSyntheticTargetForRoot(
 
   // Specified-only: layer defaults on top, but only when the resulting
   // synthetic is compatible with the specified target. An incompatible
-  // synthetic (e.g. `targetDefaults['test-native'] = { executor:
-  // '@monodon/rust:test' }` while a polyglot plugin infers `test-native`
-  // with `nx:run-commands`) would otherwise replace the specified target
-  // wholesale during the downstream merge.
+  // synthetic (e.g. an entry with `executor: '@monodon/rust:test'` while
+  // a polyglot plugin infers the same target with `nx:run-commands`)
+  // would otherwise replace the specified target wholesale during the
+  // downstream merge.
   if (resolvedSpecified && !resolvedDefault) {
     const targetDefaults = readAndPrepareTargetDefaults(
       targetName,
       resolvedSpecified.executor,
+      resolvedSpecified.command,
       root,
-      targetDefaultsConfig
+      entries,
+      projectName,
+      projectNode,
+      sourcePlugin
     );
     if (
       targetDefaults &&
@@ -123,8 +176,12 @@ function buildSyntheticTargetForRoot(
     return readAndPrepareTargetDefaults(
       targetName,
       resolvedDefault.executor,
+      resolvedDefault.command,
       root,
-      targetDefaultsConfig
+      entries,
+      projectName,
+      projectNode,
+      sourcePlugin
     );
   }
 
@@ -139,8 +196,12 @@ function buildSyntheticTargetForRoot(
     const targetDefaults = readAndPrepareTargetDefaults(
       targetName,
       resolvedDefault.executor || resolvedSpecified.executor,
+      resolvedDefault.command || resolvedSpecified.command,
       root,
-      targetDefaultsConfig
+      entries,
+      projectName,
+      projectNode,
+      sourcePlugin
     );
     if (
       targetDefaults &&
@@ -156,8 +217,12 @@ function buildSyntheticTargetForRoot(
   const targetDefaults = readAndPrepareTargetDefaults(
     targetName,
     resolvedDefault.executor,
+    resolvedDefault.command,
     root,
-    targetDefaultsConfig
+    entries,
+    projectName,
+    projectNode,
+    sourcePlugin
   );
   if (targetDefaults && isCompatibleTarget(resolvedDefault, targetDefaults)) {
     // Stamp executor/command so the default layer merges cleanly on top.
@@ -174,50 +239,350 @@ function buildSyntheticTargetForRoot(
 function readAndPrepareTargetDefaults(
   targetName: string,
   executor: string | undefined,
+  command: string | undefined,
   root: string,
-  targetDefaultsConfig: TargetDefaults
+  entries: NormalizedTargetDefaults,
+  projectName: string | undefined,
+  projectNode: ProjectGraphProjectNode | undefined,
+  sourcePlugin: string | undefined
 ): TargetConfiguration | undefined {
-  const rawTargetDefaults = readTargetDefaultsForTarget(
+  const rawTargetDefaults = findBestTargetDefault(
     targetName,
-    targetDefaultsConfig,
-    executor
+    executor,
+    projectName,
+    projectNode,
+    sourcePlugin,
+    entries,
+    command
   );
   if (!rawTargetDefaults) return undefined;
 
   return resolveCommandSyntacticSugar(deepClone(rawTargetDefaults), root);
 }
 
+/**
+ * Public, backwards-compatible reader that looks up the most-specific
+ * target default for a given target. Accepts either the new array shape
+ * or the legacy record shape (devkit support).
+ *
+ * When called without project context, entries that require a `projects`
+ * filter or a `source` filter are skipped.
+ */
 export function readTargetDefaultsForTarget(
   targetName: string,
-  targetDefaults: TargetDefaults,
-  executor?: string
-): TargetDefaults[string] {
-  if (executor && targetDefaults?.[executor]) {
-    // If an executor is defined in project.json, defaults should be read
-    // from the most specific key that matches that executor.
-    // e.g. If executor === run-commands, and the target is named build:
-    // Use, use nx:run-commands if it is present
-    // If not, use build if it is present.
-    return targetDefaults?.[executor];
-  } else if (targetDefaults?.[targetName]) {
-    // If the executor is not defined, the only key we have is the target name.
-    return targetDefaults?.[targetName];
+  targetDefaults: TargetDefaults | undefined,
+  executor?: string,
+  opts?: {
+    projectName?: string;
+    projectNode?: ProjectGraphProjectNode;
+    sourcePlugin?: string;
+    command?: string;
   }
+): Partial<TargetConfiguration> | null {
+  if (!targetDefaults) return null;
+  const entries = normalizeTargetDefaults(targetDefaults);
+  return findBestTargetDefault(
+    targetName,
+    executor,
+    opts?.projectName,
+    opts?.projectNode,
+    opts?.sourcePlugin,
+    entries,
+    opts?.command
+  );
+}
 
-  let matchingTargetDefaultKey: string | null = null;
-  for (const key in targetDefaults ?? {}) {
-    if (isGlobPattern(key) && minimatch(targetName, key)) {
-      if (
-        !matchingTargetDefaultKey ||
-        matchingTargetDefaultKey.length < key.length
-      ) {
-        matchingTargetDefaultKey = key;
-      }
+type MatchKind = 'executor' | 'exactTarget' | 'globTarget';
+
+interface Candidate {
+  config: Partial<TargetConfiguration>;
+  tier: number; // 1..5
+  matchKind: MatchKind;
+  index: number;
+}
+
+/**
+ * Find the highest-specificity `targetDefaults` entry that applies to the
+ * given (target, project, sourcePlugin) tuple. Ties are broken by later
+ * array index. Returns the config slice with filter keys (`target`,
+ * `projects`, `source`) stripped.
+ *
+ * Specificity tiers (highest wins):
+ *   5: target + projects + source
+ *   4: target + projects
+ *   3: target + source
+ *   2: target + executor (body-field) match
+ *   1: target (or target + executor injection-only match) alone
+ *
+ * `executor` in a defaults body acts dually: when the target already
+ * has an executor it is treated as a filter (matching bumps tier 1 → 2,
+ * mismatch drops the entry); when the target has no executor and no
+ * command, it still matches as an injector but does not bump the tier.
+ *
+ * Exact target / executor match beats glob target match within a tier.
+ */
+export function findBestTargetDefault(
+  targetName: string,
+  executor: string | undefined,
+  projectName: string | undefined,
+  projectNode: ProjectGraphProjectNode | undefined,
+  sourcePlugin: string | undefined,
+  entries: NormalizedTargetDefaults,
+  targetCommand?: string | undefined
+): Partial<TargetConfiguration> | null {
+  if (!entries?.length) return null;
+
+  let best: Candidate | null = null;
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    if (!entry || !entry.target) continue;
+
+    const matchKind = matchTarget(entry.target, targetName, executor);
+    if (!matchKind) continue;
+
+    if (entry.source && entry.source !== sourcePlugin) continue;
+
+    if (entry.projects !== undefined) {
+      if (!projectName || !projectNode) continue;
+      const patterns = Array.isArray(entry.projects)
+        ? entry.projects
+        : [entry.projects];
+      const matched = findMatchingProjects(patterns, {
+        [projectName]: projectNode,
+      });
+      if (!matched.includes(projectName)) continue;
+    }
+
+    const executorMatch = matchExecutorBody(
+      entry.executor,
+      executor,
+      targetCommand
+    );
+    if (executorMatch === 'no-match') continue;
+
+    let tier = 1;
+    if (entry.projects !== undefined && entry.source !== undefined) tier = 5;
+    else if (entry.projects !== undefined) tier = 4;
+    else if (entry.source !== undefined) tier = 3;
+    else if (executorMatch === 'filter') tier = 2;
+
+    const candidate: Candidate = {
+      config: stripFilterKeys(entry),
+      tier,
+      matchKind,
+      index: i,
+    };
+
+    if (!best || beats(candidate, best)) {
+      best = candidate;
     }
   }
-  if (matchingTargetDefaultKey) {
-    return targetDefaults[matchingTargetDefaultKey];
-  }
 
+  return best ? best.config : null;
+}
+
+/**
+ * Dual-role check for a defaults entry's `executor` body field.
+ *
+ * - `entry.executor` absent: not applicable, treated as neutral.
+ * - `entry.executor` matches target executor: filter match (specificity++).
+ * - target has no executor and no command: injection match (no bump).
+ * - target has a different executor or an unrelated command: skip.
+ */
+function matchExecutorBody(
+  entryExecutor: string | undefined,
+  targetExecutor: string | undefined,
+  targetCommand: string | undefined
+): 'neutral' | 'filter' | 'inject' | 'no-match' {
+  if (!entryExecutor) return 'neutral';
+  if (targetExecutor && targetExecutor === entryExecutor) return 'filter';
+  if (!targetExecutor && !targetCommand) return 'inject';
+  return 'no-match';
+}
+
+function beats(a: Candidate, b: Candidate): boolean {
+  if (a.tier !== b.tier) return a.tier > b.tier;
+  const aRank = matchKindRank(a.matchKind);
+  const bRank = matchKindRank(b.matchKind);
+  if (aRank !== bRank) return aRank > bRank;
+  // Tie: later array index wins.
+  return a.index > b.index;
+}
+
+function matchKindRank(kind: MatchKind): number {
+  // Exact target and executor matches are equivalent in specificity and
+  // both beat a glob target match.
+  return kind === 'globTarget' ? 0 : 1;
+}
+
+function matchTarget(
+  entryTarget: string,
+  targetName: string,
+  executor: string | undefined
+): MatchKind | null {
+  if (executor && entryTarget === executor) return 'executor';
+  if (entryTarget === targetName) return 'exactTarget';
+  if (isGlobPattern(entryTarget) && minimatch(targetName, entryTarget)) {
+    return 'globTarget';
+  }
   return null;
+}
+
+function stripFilterKeys(
+  entry: TargetDefaultEntry
+): Partial<TargetConfiguration> {
+  const { target, projects, source, ...rest } = entry;
+  return rest;
+}
+
+let hasWarnedAboutLegacyRecordShape = false;
+
+/**
+ * Accept either the new array shape or the legacy record shape and return
+ * a normalized array. Record entries become `{ target: key, ...value }`
+ * preserving insertion order. Legacy record executor keys (e.g.
+ * `nx:run-commands`) keep `target: key` — the matcher compares `target`
+ * against both target names and executors, so executor semantics are
+ * preserved.
+ *
+ * When the record shape is encountered we log a one-time warning
+ * recommending `nx repair`, which will re-run the migration that
+ * converts `targetDefaults` to the array shape.
+ */
+export function normalizeTargetDefaults(
+  raw: TargetDefaults | undefined
+): NormalizedTargetDefaults {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw;
+  warnAboutLegacyRecordShapeOnce();
+  const out: TargetDefaultEntry[] = [];
+  for (const key of Object.keys(raw)) {
+    const value = (raw as TargetDefaultsRecord)[key] ?? {};
+    out.push({ ...value, target: key });
+  }
+  return out;
+}
+
+function warnAboutLegacyRecordShapeOnce() {
+  if (hasWarnedAboutLegacyRecordShape) return;
+  hasWarnedAboutLegacyRecordShape = true;
+  // Written to stderr (not stdout) so commands with structured stdout —
+  // e.g. `nx show project --json` — remain parseable.
+  const title = pc.yellow(
+    'NX  nx.json uses the legacy record-shape `targetDefaults`'
+  );
+  const bodyLines = [
+    'The object/record form of `targetDefaults` is deprecated. Nx still reads it for now, but the array form is required to use the new `projects` and `source` filters.',
+    'Run `nx repair` to automatically convert `targetDefaults` to the array shape.',
+  ];
+  process.stderr.write(
+    `${EOL}${title}${EOL}${EOL}${bodyLines
+      .map((l) => `  ${l}`)
+      .join(EOL)}${EOL}${EOL}`
+  );
+}
+
+/** Test-only: resets the module-level "warned once" flag. */
+export function __resetTargetDefaultsLegacyWarning() {
+  hasWarnedAboutLegacyRecordShape = false;
+}
+
+function resolveSourcePlugin(
+  root: string,
+  targetName: string,
+  specifiedSourceMaps: ConfigurationSourceMaps | undefined,
+  defaultSourceMaps: ConfigurationSourceMaps | undefined
+): string | undefined {
+  // Prefer the executor/command source map entries (which identify the
+  // plugin that originated the target) over the top-level `targets.<name>`
+  // key (which tracks only the last writer).
+  const candidates: (string | undefined)[] = [
+    pluginFromSourceMap(
+      specifiedSourceMaps,
+      root,
+      targetOptionSourceMapKey(targetName, 'executor')
+    ),
+    pluginFromSourceMap(
+      specifiedSourceMaps,
+      root,
+      targetOptionSourceMapKey(targetName, 'command')
+    ),
+    pluginFromSourceMap(
+      defaultSourceMaps,
+      root,
+      targetOptionSourceMapKey(targetName, 'executor')
+    ),
+    pluginFromSourceMap(
+      defaultSourceMaps,
+      root,
+      targetOptionSourceMapKey(targetName, 'command')
+    ),
+    // Last-resort fallback — less reliable because it records the last
+    // plugin to touch the target rather than the originator.
+    pluginFromSourceMap(
+      specifiedSourceMaps,
+      root,
+      targetSourceMapKey(targetName)
+    ),
+    pluginFromSourceMap(
+      defaultSourceMaps,
+      root,
+      targetSourceMapKey(targetName)
+    ),
+  ];
+
+  for (const candidate of candidates) {
+    if (candidate && candidate !== 'nx/target-defaults') return candidate;
+  }
+  return undefined;
+}
+
+function pluginFromSourceMap(
+  maps: ConfigurationSourceMaps | undefined,
+  root: string,
+  key: string
+): string | undefined {
+  const entry = maps?.[root]?.[key] as SourceInformation | undefined;
+  return entry?.[1];
+}
+
+function buildProjectNodesByName(
+  specifiedPluginRootMap: Record<string, ProjectConfiguration>,
+  defaultPluginRootMap: Record<string, ProjectConfiguration>
+): Record<string, ProjectGraphProjectNode> {
+  const out: Record<string, ProjectGraphProjectNode> = {};
+  const addFromMap = (map: Record<string, ProjectConfiguration>) => {
+    for (const root of Object.keys(map)) {
+      const cfg = map[root];
+      const name = cfg?.name ?? inferNameFromRoot(root);
+      if (!name) continue;
+      if (out[name]) {
+        // Merge tags (union) across layers so tag-based project filters
+        // see all tags, regardless of which plugin contributed them.
+        const existingTags = out[name].data.tags ?? [];
+        const newTags = cfg.tags ?? [];
+        const mergedTags = Array.from(new Set([...existingTags, ...newTags]));
+        out[name].data.tags = mergedTags;
+      } else {
+        out[name] = {
+          name,
+          type: 'lib',
+          data: {
+            root,
+            tags: cfg.tags ?? [],
+          },
+        } as ProjectGraphProjectNode;
+      }
+    }
+  };
+  addFromMap(specifiedPluginRootMap);
+  addFromMap(defaultPluginRootMap);
+  return out;
+}
+
+function inferNameFromRoot(root: string): string | undefined {
+  if (!root) return undefined;
+  const parts = root.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1];
 }

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -349,7 +349,9 @@ export function findBestTargetDefault(
   executor: string | undefined,
   projectName: string | undefined,
   projectNode:
-    | Pick<ProjectGraphProjectNode, 'name' | 'tags' | 'root'>
+    | (Pick<ProjectGraphProjectNode, 'name'> & {
+        data: Pick<ProjectConfiguration, 'root' | 'tags'>;
+      })
     | undefined,
   sourcePlugin: string | undefined,
   entries: NormalizedTargetDefaults,
@@ -428,7 +430,9 @@ function matchEntry(
   executor: string | undefined,
   projectName: string | undefined,
   projectNode:
-    | Pick<ProjectGraphProjectNode, 'name' | 'tags' | 'root'>
+    | (Pick<ProjectGraphProjectNode, 'name'> & {
+        data: Pick<ProjectConfiguration, 'root' | 'tags'>;
+      })
     | undefined,
   sourcePlugin: string | undefined,
   targetCommand: string | undefined
@@ -495,7 +499,10 @@ function matchEntry(
       ? [...entry.projects!]
       : [entry.projects!];
     const matched = findMatchingProjects(patterns, {
-      [projectName]: projectNode,
+      // `findMatchingProjects` only reads `.name`, `.data.root`, and
+      // `.data.tags` — the keys our narrowed `projectNode` already
+      // satisfies — but its signature wants the full graph node.
+      [projectName]: projectNode as ProjectGraphProjectNode,
     });
     if (!matched.includes(projectName)) return null;
     tier++;

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -488,6 +488,12 @@ function matchEntry(
     tier++;
   }
 
+  // Safety net for callers (e.g. direct unit-test calls) that bypass
+  // `normalizeTargetDefaults`: an entry with no locator and no real
+  // filter has tier 0 after processing — it would broadcast to every
+  // (root, target) in the workspace.
+  if (!hasLocator && tier === 0) return null;
+
   const matchKind: MatchKind =
     targetKind !== null && executorMatched
       ? 'targetAndExecutor'

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -62,14 +62,10 @@ export function createTargetDefaultsResults(
     return [];
   }
 
-  const projectNodesByName = buildProjectNodesByName(
+  const { projectNodesByName, rootToName } = buildProjectNodesByName(
     specifiedPluginRootMap,
     defaultPluginRootMap
   );
-  const rootToName = new Map<string, string>();
-  for (const [name, node] of Object.entries(projectNodesByName)) {
-    rootToName.set(node.data.root, name);
-  }
 
   const syntheticProjects: Record<string, ProjectConfiguration> = {};
 
@@ -471,6 +467,7 @@ function matchKindRank(kind: MatchKind): number {
   }
 }
 
+/** Removes keys used only for locating the defaults, leaving the merge payload. */
 function stripFilterKeys(
   entry: TargetDefaultEntry
 ): Partial<TargetConfiguration> {
@@ -574,29 +571,34 @@ function pluginFromSourceMap(
 function buildProjectNodesByName(
   specifiedPluginRootMap: Record<string, ProjectConfiguration>,
   defaultPluginRootMap: Record<string, ProjectConfiguration>
-): Record<string, ProjectGraphProjectNode> {
-  const out: Record<string, ProjectGraphProjectNode> = {};
+): {
+  projectNodesByName: Record<string, ProjectGraphProjectNode>;
+  rootToName: Map<string, string>;
+} {
+  const projectNodesByName: Record<string, ProjectGraphProjectNode> = {};
+  const rootToName = new Map<string, string>();
   const addFromMap = (map: Record<string, ProjectConfiguration>) => {
     for (const root of Object.keys(map)) {
       const cfg = map[root];
       const name = cfg?.name;
       if (!name) continue;
-      if (out[name]) {
-        const existingTags = out[name].data.tags ?? [];
+      if (projectNodesByName[name]) {
+        const existingTags = projectNodesByName[name].data.tags ?? [];
         const newTags = cfg.tags ?? [];
-        out[name].data.tags = Array.from(
+        projectNodesByName[name].data.tags = Array.from(
           new Set([...existingTags, ...newTags])
         );
       } else {
-        out[name] = {
+        projectNodesByName[name] = {
           name,
           type: cfg.projectType === 'application' ? 'app' : 'lib',
           data: { root, tags: cfg.tags ?? [] },
         } as ProjectGraphProjectNode;
+        rootToName.set(root, name);
       }
     }
   };
   addFromMap(specifiedPluginRootMap);
   addFromMap(defaultPluginRootMap);
-  return out;
+  return { projectNodesByName, rootToName };
 }

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -300,7 +300,8 @@ type MatchKind =
   | 'targetAndExecutor'
   | 'executorOnly'
   | 'exactTarget'
-  | 'globTarget';
+  | 'globTarget'
+  | 'filterOnly';
 
 interface Candidate {
   config: Partial<TargetConfiguration>;
@@ -315,16 +316,23 @@ interface Candidate {
  * kind, then by later array index. Returns the config slice with filter
  * keys (`target`, `projects`, `source`) stripped.
  *
- * Tier = 1 (the entry matched) + 1 per applied filter (`projects`,
- * `source`). So:
+ * Tier = (1 if a target/executor locator matched, else 0) + 1 per
+ * applied filter (`projects`, `source`). So locator-bearing entries:
  *   - tier 3: target/executor + projects + source
  *   - tier 2: target/executor + projects, or target/executor + source
  *   - tier 1: target/executor alone
+ * And filter-only entries (no `target` and no `executor`):
+ *   - tier 2: projects + source
+ *   - tier 1: projects alone, or source alone
  *
  * `executor` matching contributes to matchKind only, not to tier — it's
  * not a filter, it's a refinement of the match. Within the same tier,
  * tie-break order (highest first):
- *   targetAndExecutor > executorOnly > exactTarget > globTarget
+ *   targetAndExecutor > executorOnly > exactTarget > globTarget > filterOnly
+ *
+ * `filterOnly` ranks below every locator-bearing kind, so a filter-only
+ * entry can never tie-break ahead of one that names a target or executor
+ * at the same tier.
  *
  * `executor` only acts as an "injector" (matches a target with neither
  * executor nor command) when the entry also sets `target`. Executor-only
@@ -400,7 +408,17 @@ function matchEntry(
   targetCommand: string | undefined
 ): Candidate | null {
   if (!entry) return null;
-  if (entry.target === undefined && entry.executor === undefined) return null;
+  // Reject entries with no constraints whatsoever — without a locator
+  // (`target`/`executor`) or a filter (`projects`/`source`) the entry
+  // would broadcast to every (root, target) in the workspace.
+  if (
+    entry.target === undefined &&
+    entry.executor === undefined &&
+    entry.projects === undefined &&
+    entry.source === undefined
+  ) {
+    return null;
+  }
 
   let targetKind: 'exact' | 'glob' | null = null;
   if (entry.target !== undefined) {
@@ -426,7 +444,13 @@ function matchEntry(
     }
   }
 
-  let tier = 1;
+  // Locator-bearing entries get a base tier of 1 (the locator match);
+  // filter-only entries start at 0 so a single filter doesn't tie a
+  // single locator. Filters then add 1 each — with the matchKind
+  // tie-break below, filter-only always loses to locator-bearing at
+  // the same final tier.
+  const hasLocator = targetKind !== null || executorMatched;
+  let tier = hasLocator ? 1 : 0;
 
   if (entry.projects !== undefined) {
     if (!projectName || !projectNode) return null;
@@ -448,11 +472,13 @@ function matchEntry(
   const matchKind: MatchKind =
     targetKind !== null && executorMatched
       ? 'targetAndExecutor'
-      : targetKind === null
+      : executorMatched
         ? 'executorOnly'
         : targetKind === 'exact'
           ? 'exactTarget'
-          : 'globTarget';
+          : targetKind === 'glob'
+            ? 'globTarget'
+            : 'filterOnly';
 
   return {
     config: stripFilterKeys(entry),
@@ -471,10 +497,14 @@ function matchEntry(
  *    narrower than unfiltered entries, so they outrank.
  * 2. Match kind — within the same tier, more locator slots is more
  *    specific: `target+executor` > `executor-only` > `exactTarget` >
- *    `globTarget`. Note `executor-only` outranks `exactTarget`: a
- *    workspace-wide rule keyed on a specific executor is treated as
- *    more intentional than a target-name rule that might accidentally
- *    catch unrelated executors.
+ *    `globTarget` > `filterOnly`. Note `executor-only` outranks
+ *    `exactTarget`: a workspace-wide rule keyed on a specific executor
+ *    is treated as more intentional than a target-name rule that might
+ *    accidentally catch unrelated executors. `filterOnly` (no `target`
+ *    and no `executor`, just `projects` and/or `source`) sits at the
+ *    bottom — it's the explicit "least specific" tier that lets a bare
+ *    `source: '@nx/jest/plugin'` apply to every jest-attributed target
+ *    while still losing to any entry that names the target or executor.
  * 3. Tie-break — later array index wins, so users can append an entry
  *    to override earlier ones without rewriting them.
  */
@@ -489,12 +519,14 @@ function beats(a: Candidate, b: Candidate): boolean {
 function matchKindRank(kind: MatchKind): number {
   switch (kind) {
     case 'targetAndExecutor':
-      return 3;
+      return 4;
     case 'executorOnly':
-      return 2;
+      return 3;
     case 'exactTarget':
-      return 1;
+      return 2;
     case 'globTarget':
+      return 1;
+    case 'filterOnly':
       return 0;
   }
 }

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -165,29 +165,31 @@ function effectiveTargetForLookup(
     ? resolveCommandSyntacticSugar(defaultTarget, root)
     : undefined;
 
-  if (!resolvedSpecified && !resolvedDefault) return undefined;
-  if (!resolvedSpecified) {
+  if (resolvedSpecified && resolvedDefault) {
+    if (!isCompatibleTarget(resolvedSpecified, resolvedDefault)) {
+      return {
+        executor: resolvedDefault.executor,
+        command: resolvedDefault.command,
+      };
+    }
     return {
-      executor: resolvedDefault!.executor,
-      command: resolvedDefault!.command,
+      executor: resolvedDefault.executor ?? resolvedSpecified.executor,
+      command: resolvedDefault.command ?? resolvedSpecified.command,
     };
   }
-  if (!resolvedDefault) {
+  if (resolvedSpecified) {
     return {
       executor: resolvedSpecified.executor,
       command: resolvedSpecified.command,
     };
   }
-  if (!isCompatibleTarget(resolvedSpecified, resolvedDefault)) {
+  if (resolvedDefault) {
     return {
       executor: resolvedDefault.executor,
       command: resolvedDefault.command,
     };
   }
-  return {
-    executor: resolvedDefault.executor ?? resolvedSpecified.executor,
-    command: resolvedDefault.command ?? resolvedSpecified.command,
-  };
+  return undefined;
 }
 
 /**

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -208,7 +208,7 @@ function buildSyntheticTargetForRoot(
   targetName: string,
   root: string,
   effective: { executor: string | undefined; command: string | undefined },
-  entries: NormalizedTargetDefaults,
+  targetDefaults: NormalizedTargetDefaults,
   projectName: string | undefined,
   projectNode: ProjectGraphProjectNode | undefined,
   sourcePlugin: string | undefined
@@ -219,7 +219,7 @@ function buildSyntheticTargetForRoot(
     projectName,
     projectNode,
     sourcePlugin,
-    entries,
+    targetDefaults,
     effective.command,
     (candidate) =>
       isCompatibleTarget(
@@ -348,7 +348,9 @@ export function findBestTargetDefault(
   targetName: string,
   executor: string | undefined,
   projectName: string | undefined,
-  projectNode: ProjectGraphProjectNode | undefined,
+  projectNode:
+    | Pick<ProjectGraphProjectNode, 'name' | 'tags' | 'root'>
+    | undefined,
   sourcePlugin: string | undefined,
   entries: NormalizedTargetDefaults,
   targetCommand?: string | undefined,
@@ -425,7 +427,9 @@ function matchEntry(
   targetName: string,
   executor: string | undefined,
   projectName: string | undefined,
-  projectNode: ProjectGraphProjectNode | undefined,
+  projectNode:
+    | Pick<ProjectGraphProjectNode, 'name' | 'tags' | 'root'>
+    | undefined,
   sourcePlugin: string | undefined,
   targetCommand: string | undefined
 ): Candidate | null {

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -383,6 +383,28 @@ export function findBestTargetDefault(
 }
 
 /**
+ * Classify the runtime intent of an entry's `projects:` value:
+ *   - `none`: filter is absent — the entry is unscoped on the projects axis.
+ *   - `empty`: filter is `[]` — matches no project, so the whole entry is
+ *     dead. Treated as a never-match by the matcher rather than allowing
+ *     the entry to silently apply nowhere (which is almost always a bug).
+ *   - `wildcard`: filter is exactly `'*'` or `['*']` (or any combination of
+ *     pure-wildcard patterns) — matches every project, equivalent to no
+ *     filter at all. Doesn't count toward the broadcast guard or the
+ *     specificity tier so the entry doesn't outrank a real, narrower one.
+ *   - `filter`: a real pattern set the matcher needs to evaluate.
+ */
+function classifyProjectsFilter(
+  projects: string | string[] | undefined
+): 'none' | 'empty' | 'wildcard' | 'filter' {
+  if (projects === undefined) return 'none';
+  const arr = Array.isArray(projects) ? projects : [projects];
+  if (arr.length === 0) return 'empty';
+  if (arr.every((p) => p === '*')) return 'wildcard';
+  return 'filter';
+}
+
+/**
  * Test a single `targetDefaults` entry against the (target, executor,
  * project, plugin, command) tuple of the target being resolved. Returns
  * a `Candidate` with its tier and match kind, or null when the entry
@@ -408,13 +430,20 @@ function matchEntry(
   targetCommand: string | undefined
 ): Candidate | null {
   if (!entry) return null;
+  // Classify `projects:` first so the broadcast guard below can treat
+  // pure-wildcard patterns (`'*'`, `['*']`) the same as no filter, and
+  // empty arrays as a never-match (rather than silently slipping past
+  // both guards as a "filter" that matches nothing).
+  const projectsKind = classifyProjectsFilter(entry.projects);
+  if (projectsKind === 'empty') return null;
   // Reject entries with no constraints whatsoever — without a locator
   // (`target`/`executor`) or a filter (`projects`/`plugin`) the entry
-  // would broadcast to every (root, target) in the workspace.
+  // would broadcast to every (root, target) in the workspace. Pure
+  // wildcard `projects:` patterns count as "no filter" here.
   if (
     entry.target === undefined &&
     entry.executor === undefined &&
-    entry.projects === undefined &&
+    projectsKind !== 'filter' &&
     entry.plugin === undefined
   ) {
     return null;
@@ -452,15 +481,15 @@ function matchEntry(
   const hasLocator = targetKind !== null || executorMatched;
   let tier = hasLocator ? 1 : 0;
 
-  if (entry.projects !== undefined) {
+  if (projectsKind === 'filter') {
     if (!projectName || !projectNode) return null;
     // Copy the array — `findMatchingProjects` prepends '*' when the first
     // pattern is a negation, mutating its input. Without the copy, every
     // call corrupts the original `entry.projects` (and therefore the
     // shared nxJson.targetDefaults entry) with a leading wildcard.
     const patterns = Array.isArray(entry.projects)
-      ? [...entry.projects]
-      : [entry.projects];
+      ? [...entry.projects!]
+      : [entry.projects!];
     const matched = findMatchingProjects(patterns, {
       [projectName]: projectNode,
     });

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -251,7 +251,7 @@ function buildSyntheticTargetForRoot(
  * or the legacy record shape (devkit support).
  *
  * When called without project context, entries that require a `projects`
- * filter or a `source` filter are skipped.
+ * filter or a `plugin` filter are skipped.
  *
  * The normalized entries are cached per `targetDefaults` reference so
  * repeated reads against the same nx.json don't re-normalize (and don't
@@ -314,16 +314,16 @@ interface Candidate {
  * Find the highest-specificity `targetDefaults` entry that applies to the
  * given (target, project, sourcePlugin) tuple. Ties are broken by match
  * kind, then by later array index. Returns the config slice with filter
- * keys (`target`, `projects`, `source`) stripped.
+ * keys (`target`, `projects`, `plugin`) stripped.
  *
  * Tier = (1 if a target/executor locator matched, else 0) + 1 per
- * applied filter (`projects`, `source`). So locator-bearing entries:
- *   - tier 3: target/executor + projects + source
- *   - tier 2: target/executor + projects, or target/executor + source
+ * applied filter (`projects`, `plugin`). So locator-bearing entries:
+ *   - tier 3: target/executor + projects + plugin
+ *   - tier 2: target/executor + projects, or target/executor + plugin
  *   - tier 1: target/executor alone
  * And filter-only entries (no `target` and no `executor`):
- *   - tier 2: projects + source
- *   - tier 1: projects alone, or source alone
+ *   - tier 2: projects + plugin
+ *   - tier 1: projects alone, or plugin alone
  *
  * `executor` matching contributes to matchKind only, not to tier — it's
  * not a filter, it's a refinement of the match. Within the same tier,
@@ -384,7 +384,7 @@ export function findBestTargetDefault(
 
 /**
  * Test a single `targetDefaults` entry against the (target, executor,
- * project, source, command) tuple of the target being resolved. Returns
+ * project, plugin, command) tuple of the target being resolved. Returns
  * a `Candidate` with its tier and match kind, or null when the entry
  * doesn't apply.
  *
@@ -409,13 +409,13 @@ function matchEntry(
 ): Candidate | null {
   if (!entry) return null;
   // Reject entries with no constraints whatsoever — without a locator
-  // (`target`/`executor`) or a filter (`projects`/`source`) the entry
+  // (`target`/`executor`) or a filter (`projects`/`plugin`) the entry
   // would broadcast to every (root, target) in the workspace.
   if (
     entry.target === undefined &&
     entry.executor === undefined &&
     entry.projects === undefined &&
-    entry.source === undefined
+    entry.plugin === undefined
   ) {
     return null;
   }
@@ -454,8 +454,12 @@ function matchEntry(
 
   if (entry.projects !== undefined) {
     if (!projectName || !projectNode) return null;
+    // Copy the array — `findMatchingProjects` prepends '*' when the first
+    // pattern is a negation, mutating its input. Without the copy, every
+    // call corrupts the original `entry.projects` (and therefore the
+    // shared nxJson.targetDefaults entry) with a leading wildcard.
     const patterns = Array.isArray(entry.projects)
-      ? entry.projects
+      ? [...entry.projects]
       : [entry.projects];
     const matched = findMatchingProjects(patterns, {
       [projectName]: projectNode,
@@ -464,8 +468,8 @@ function matchEntry(
     tier++;
   }
 
-  if (entry.source !== undefined) {
-    if (entry.source !== sourcePlugin) return null;
+  if (entry.plugin !== undefined) {
+    if (entry.plugin !== sourcePlugin) return null;
     tier++;
   }
 
@@ -493,7 +497,7 @@ function matchEntry(
  * wins because the more specific entry is the one the user most likely
  * wrote to override a broader rule.
  *
- * 1. Tier — entries with `projects` or `source` filters are scoped
+ * 1. Tier — entries with `projects` or `plugin` filters are scoped
  *    narrower than unfiltered entries, so they outrank.
  * 2. Match kind — within the same tier, more locator slots is more
  *    specific: `target+executor` > `executor-only` > `exactTarget` >
@@ -501,9 +505,9 @@ function matchEntry(
  *    `exactTarget`: a workspace-wide rule keyed on a specific executor
  *    is treated as more intentional than a target-name rule that might
  *    accidentally catch unrelated executors. `filterOnly` (no `target`
- *    and no `executor`, just `projects` and/or `source`) sits at the
+ *    and no `executor`, just `projects` and/or `plugin`) sits at the
  *    bottom — it's the explicit "least specific" tier that lets a bare
- *    `source: '@nx/jest/plugin'` apply to every jest-attributed target
+ *    `plugin: '@nx/jest/plugin'` apply to every jest-attributed target
  *    while still losing to any entry that names the target or executor.
  * 3. Tie-break — later array index wins, so users can append an entry
  *    to override earlier ones without rewriting them.
@@ -535,7 +539,7 @@ function matchKindRank(kind: MatchKind): number {
 function stripFilterKeys(
   entry: TargetDefaultEntry
 ): Partial<TargetConfiguration> {
-  const { target, projects, source, ...rest } = entry;
+  const { target, projects, plugin, ...rest } = entry;
   return rest;
 }
 
@@ -645,7 +649,7 @@ function warnAboutLegacyRecordShapeOnce() {
     'NX  nx.json uses the legacy record-shape `targetDefaults`'
   );
   const bodyLines = [
-    'The object/record form of `targetDefaults` is deprecated. Nx still reads it for now, but the array form is required to use the new `projects` and `source` filters.',
+    'The object/record form of `targetDefaults` is deprecated. Nx still reads it for now, but the array form is required to use the new `projects` and `plugin` filters.',
     'Run `nx repair` to automatically convert `targetDefaults` to the array shape.',
   ];
   process.stderr.write(
@@ -664,11 +668,11 @@ function resolveSourcePlugin(
   // Default plugins (nx's baked-in inference of per-project config files
   // like package.json, tsconfig.json) always overwrite specified-plugin
   // attribution in the merge. Their attribution is what survives, so it
-  // takes precedence here when matching `source:` filters.
+  // takes precedence here when matching `plugin:` filters.
   //
   // We only consult the executor/command source-map keys — the top-level
   // `targets.<name>` key tracks only the last writer, not the originator,
-  // and is unreliable for source attribution.
+  // and is unreliable for plugin attribution.
   const executorKey = targetOptionSourceMapKey(targetName, 'executor');
   const commandKey = targetOptionSourceMapKey(targetName, 'command');
   const candidates: (string | undefined)[] = [

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -57,28 +57,32 @@ export function createTargetDefaultsResults(
     return [];
   }
 
-  const entries = normalizeTargetDefaults(targetDefaultsConfig);
+  // Disambiguate `:`-shaped record keys against the actual targets and
+  // executors present in the rootMaps. This is the same idea the v23
+  // `convert-target-defaults-to-array` migration uses against the project
+  // graph — we just consult the rootMaps directly here since we don't have
+  // a graph yet during construction.
+  const entries = normalizeTargetDefaultsAgainstRootMaps(
+    targetDefaultsConfig,
+    specifiedPluginRootMap,
+    defaultPluginRootMap
+  );
   if (entries.length === 0) {
     return [];
   }
 
-  // The by-name node map is only consulted when an entry has a
-  // `projects:` filter. Skip building it for the common case where no
-  // entry uses that filter — workspaces with simple targetDefaults
-  // shouldn't pay the per-project iteration cost on every graph build.
+  // `projectNodesByName` and `rootToName` are only consulted when an entry
+  // has a `projects:` filter — that's the only matcher branch that needs
+  // either the project name or its node. Source-plugin attribution is
+  // root-keyed via `resolveSourcePlugin`, not name-keyed, so it doesn't
+  // need either map. Skip both builds in the common no-filter path.
   const needsProjectNodes = entries.some((e) => e.projects !== undefined);
-  const { projectNodesByName, rootToName } = needsProjectNodes
+  const projectNodes = needsProjectNodes
     ? buildProjectNodesAndRootToName(
         specifiedPluginRootMap,
         defaultPluginRootMap
       )
-    : {
-        projectNodesByName: undefined,
-        rootToName: buildRootToName(
-          specifiedPluginRootMap,
-          defaultPluginRootMap
-        ),
-      };
+    : undefined;
 
   const syntheticProjects: Record<string, ProjectConfiguration> = {};
 
@@ -90,11 +94,10 @@ export function createTargetDefaultsResults(
   for (const root of allRoots) {
     const specifiedTargets = specifiedPluginRootMap[root]?.targets ?? {};
     const defaultTargets = defaultPluginRootMap[root]?.targets ?? {};
-    const projectName = rootToName.get(root);
-    const projectNode =
-      projectName && projectNodesByName
-        ? projectNodesByName[projectName]
-        : undefined;
+    const projectName = projectNodes?.rootToName.get(root);
+    const projectNode = projectName
+      ? projectNodes!.projectNodesByName[projectName]
+      : undefined;
 
     for (const targetName of uniqueKeysInObjects(
       specifiedTargets,
@@ -513,17 +516,15 @@ let hasWarnedAboutLegacyRecordShape = false;
  * which become `{ executor: key, ...value }` so the matcher treats them
  * as executor matches rather than target-name matches.
  *
- * The disambiguation here is purely syntactic. This function runs
- * during graph construction, before the cached graph exists, so it
- * cannot consult per-project targets to confirm whether `key` is a
- * target name or an executor — `:` in a record key is genuinely
- * ambiguous (target names can contain `:`). The
- * `convert-target-defaults-to-array` migration runs *after*
- * construction and uses the project graph for proper disambiguation;
- * that's why the warning below recommends `nx repair`. Sharing more of
- * the disambiguation logic with the migration is left as a follow-up —
- * the migration's classifier needs the graph and this code path can't
- * have one.
+ * Disambiguation here is purely syntactic — `:` in a record key is
+ * genuinely ambiguous (target names can contain `:`). Callers that have
+ * access to the workspace's targets (the graph-construction path, the
+ * v23 migration) should prefer
+ * {@link normalizeTargetDefaultsAgainstRootMaps} or the migration's
+ * graph-based classifier so that ambiguous keys get classified by what
+ * the workspace actually contains. The warning below points end-users
+ * at `nx repair`, which runs the migration that durably resolves the
+ * ambiguity in nx.json on disk.
  */
 export function normalizeTargetDefaults(
   raw: TargetDefaults | undefined
@@ -534,13 +535,73 @@ export function normalizeTargetDefaults(
   const out: TargetDefaultEntry[] = [];
   for (const key of Object.keys(raw)) {
     const value = (raw as TargetDefaultsRecord)[key] ?? {};
-    out.push(
-      key.includes(':') && !isGlobPattern(key)
-        ? { ...value, executor: key }
-        : { ...value, target: key }
-    );
+    out.push(...syntacticallyClassifyLegacyKey(key, value));
   }
   return out;
+}
+
+/**
+ * Same shape contract as {@link normalizeTargetDefaults}, but classifies
+ * `:`-shaped record keys against the targets and executors actually
+ * present in the supplied rootMaps. When a key matches a target name in
+ * the workspace, it becomes a `target:` entry; when it matches an
+ * executor, an `executor:` entry; when it matches both, both entries are
+ * emitted (matching the v23 migration's "duplicate rather than guess"
+ * behavior so neither side of the match silently drops). Falls back to
+ * the syntactic heuristic when there's no evidence either way.
+ */
+export function normalizeTargetDefaultsAgainstRootMaps(
+  raw: TargetDefaults | undefined,
+  ...rootMaps: Record<string, ProjectConfiguration>[]
+): NormalizedTargetDefaults {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw;
+  warnAboutLegacyRecordShapeOnce();
+
+  const targetNames = new Set<string>();
+  const executors = new Set<string>();
+  for (const map of rootMaps) {
+    for (const cfg of Object.values(map)) {
+      const targets = cfg?.targets;
+      if (!targets) continue;
+      for (const [name, target] of Object.entries(targets)) {
+        targetNames.add(name);
+        if (target?.executor) executors.add(target.executor);
+      }
+    }
+  }
+
+  const out: TargetDefaultEntry[] = [];
+  for (const key of Object.keys(raw)) {
+    const value = (raw as TargetDefaultsRecord)[key] ?? {};
+    if (isGlobPattern(key)) {
+      out.push({ ...value, target: key });
+      continue;
+    }
+    const matchesTarget = targetNames.has(key);
+    const matchesExecutor = executors.has(key);
+    if (matchesTarget && matchesExecutor) {
+      out.push({ ...value, target: key }, { ...value, executor: key });
+    } else if (matchesExecutor) {
+      out.push({ ...value, executor: key });
+    } else if (matchesTarget) {
+      out.push({ ...value, target: key });
+    } else {
+      out.push(...syntacticallyClassifyLegacyKey(key, value));
+    }
+  }
+  return out;
+}
+
+function syntacticallyClassifyLegacyKey(
+  key: string,
+  value: Partial<TargetConfiguration>
+): TargetDefaultEntry[] {
+  return [
+    key.includes(':') && !isGlobPattern(key)
+      ? { ...value, executor: key }
+      : { ...value, target: key },
+  ];
 }
 
 function warnAboutLegacyRecordShapeOnce() {
@@ -644,27 +705,4 @@ function buildProjectNodesAndRootToName(
   addFromMap(specifiedPluginRootMap);
   addFromMap(defaultPluginRootMap);
   return { projectNodesByName, rootToName };
-}
-
-/**
- * Lighter-weight version of {@link buildProjectNodesAndRootToName} for
- * the common path where no `targetDefaults` entry uses a `projects:`
- * filter. We still need root → name lookup for source-plugin attribution
- * and project-name resolution, but we can skip building the by-name
- * node view entirely.
- */
-function buildRootToName(
-  specifiedPluginRootMap: Record<string, ProjectConfiguration>,
-  defaultPluginRootMap: Record<string, ProjectConfiguration>
-): Map<string, string> {
-  const rootToName = new Map<string, string>();
-  const addFromMap = (map: Record<string, ProjectConfiguration>) => {
-    for (const root of Object.keys(map)) {
-      const name = map[root]?.name;
-      if (name && !rootToName.has(root)) rootToName.set(root, name);
-    }
-  };
-  addFromMap(specifiedPluginRootMap);
-  addFromMap(defaultPluginRootMap);
-  return rootToName;
 }

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -18,7 +18,6 @@ import {
   SourceInformation,
   ConfigurationSourceMaps,
   targetOptionSourceMapKey,
-  targetSourceMapKey,
 } from './source-maps';
 import {
   deepClone,
@@ -267,6 +266,10 @@ function readAndPrepareTargetDefaults(
  *
  * When called without project context, entries that require a `projects`
  * filter or a `source` filter are skipped.
+ *
+ * The normalized entries are cached per `targetDefaults` reference so
+ * repeated reads against the same nx.json don't re-normalize (and don't
+ * re-fire the legacy-record-shape warning).
  */
 export function readTargetDefaultsForTarget(
   targetName: string,
@@ -280,46 +283,66 @@ export function readTargetDefaultsForTarget(
   }
 ): Partial<TargetConfiguration> | null {
   if (!targetDefaults) return null;
-  const entries = normalizeTargetDefaults(targetDefaults);
   return findBestTargetDefault(
     targetName,
     executor,
     opts?.projectName,
     opts?.projectNode,
     opts?.sourcePlugin,
-    entries,
+    getCachedNormalizedEntries(targetDefaults),
     opts?.command
   );
 }
 
-type MatchKind = 'executor' | 'exactTarget' | 'globTarget';
+const normalizedEntriesCache = new WeakMap<object, NormalizedTargetDefaults>();
+
+function getCachedNormalizedEntries(
+  targetDefaults: TargetDefaults
+): NormalizedTargetDefaults {
+  // WeakMap keys must be objects — both array and record forms are objects,
+  // so this is safe regardless of shape.
+  const key = targetDefaults as unknown as object;
+  let entries = normalizedEntriesCache.get(key);
+  if (!entries) {
+    entries = normalizeTargetDefaults(targetDefaults);
+    normalizedEntriesCache.set(key, entries);
+  }
+  return entries;
+}
+
+type MatchKind =
+  | 'targetAndExecutor'
+  | 'executorOnly'
+  | 'exactTarget'
+  | 'globTarget';
 
 interface Candidate {
   config: Partial<TargetConfiguration>;
-  tier: number; // 1..5
+  tier: number;
   matchKind: MatchKind;
   index: number;
 }
 
 /**
  * Find the highest-specificity `targetDefaults` entry that applies to the
- * given (target, project, sourcePlugin) tuple. Ties are broken by later
- * array index. Returns the config slice with filter keys (`target`,
- * `projects`, `source`) stripped.
+ * given (target, project, sourcePlugin) tuple. Ties are broken by match
+ * kind, then by later array index. Returns the config slice with filter
+ * keys (`target`, `projects`, `source`) stripped.
  *
- * Specificity tiers (highest wins):
- *   5: target + projects + source
- *   4: target + projects
- *   3: target + source
- *   2: target + executor (body-field) match
- *   1: target (or target + executor injection-only match) alone
+ * Tier = 1 (the entry matched) + 1 per applied filter (`projects`,
+ * `source`). So:
+ *   - tier 3: target/executor + projects + source
+ *   - tier 2: target/executor + projects, or target/executor + source
+ *   - tier 1: target/executor alone
  *
- * `executor` in a defaults body acts dually: when the target already
- * has an executor it is treated as a filter (matching bumps tier 1 → 2,
- * mismatch drops the entry); when the target has no executor and no
- * command, it still matches as an injector but does not bump the tier.
+ * `executor` matching contributes to matchKind only, not to tier — it's
+ * not a filter, it's a refinement of the match. Within the same tier,
+ * tie-break order (highest first):
+ *   targetAndExecutor > executorOnly > exactTarget > globTarget
  *
- * Exact target / executor match beats glob target match within a tier.
+ * `executor` only acts as an "injector" (matches a target with neither
+ * executor nor command) when the entry also sets `target`. Executor-only
+ * entries require the workspace target to actually have an executor.
  */
 export function findBestTargetDefault(
   targetName: string,
@@ -336,12 +359,34 @@ export function findBestTargetDefault(
 
   for (let i = 0; i < entries.length; i++) {
     const entry = entries[i];
-    if (!entry || !entry.target) continue;
+    if (!entry) continue;
+    if (entry.target === undefined && entry.executor === undefined) continue;
 
-    const matchKind = matchTarget(entry.target, targetName, executor);
-    if (!matchKind) continue;
+    let targetKind: 'exact' | 'glob' | null = null;
+    if (entry.target !== undefined) {
+      if (entry.target === targetName) targetKind = 'exact';
+      else if (
+        isGlobPattern(entry.target) &&
+        minimatch(targetName, entry.target)
+      )
+        targetKind = 'glob';
+      else continue;
+    }
 
-    if (entry.source && entry.source !== sourcePlugin) continue;
+    let executorMatched = false;
+    if (entry.executor !== undefined) {
+      if (executor && executor === entry.executor) {
+        executorMatched = true;
+      } else if (targetKind !== null && !executor && !targetCommand) {
+        // `executor` injects into a bare target the entry's `target`
+        // already matched.
+        executorMatched = true;
+      } else {
+        continue;
+      }
+    }
+
+    let tier = 1;
 
     if (entry.projects !== undefined) {
       if (!projectName || !projectNode) continue;
@@ -352,20 +397,22 @@ export function findBestTargetDefault(
         [projectName]: projectNode,
       });
       if (!matched.includes(projectName)) continue;
+      tier++;
     }
 
-    const executorMatch = matchExecutorBody(
-      entry.executor,
-      executor,
-      targetCommand
-    );
-    if (executorMatch === 'no-match') continue;
+    if (entry.source !== undefined) {
+      if (entry.source !== sourcePlugin) continue;
+      tier++;
+    }
 
-    let tier = 1;
-    if (entry.projects !== undefined && entry.source !== undefined) tier = 5;
-    else if (entry.projects !== undefined) tier = 4;
-    else if (entry.source !== undefined) tier = 3;
-    else if (executorMatch === 'filter') tier = 2;
+    const matchKind: MatchKind =
+      targetKind !== null && executorMatched
+        ? 'targetAndExecutor'
+        : targetKind === null
+          ? 'executorOnly'
+          : targetKind === 'exact'
+            ? 'exactTarget'
+            : 'globTarget';
 
     const candidate: Candidate = {
       config: stripFilterKeys(entry),
@@ -382,25 +429,6 @@ export function findBestTargetDefault(
   return best ? best.config : null;
 }
 
-/**
- * Dual-role check for a defaults entry's `executor` body field.
- *
- * - `entry.executor` absent: not applicable, treated as neutral.
- * - `entry.executor` matches target executor: filter match (specificity++).
- * - target has no executor and no command: injection match (no bump).
- * - target has a different executor or an unrelated command: skip.
- */
-function matchExecutorBody(
-  entryExecutor: string | undefined,
-  targetExecutor: string | undefined,
-  targetCommand: string | undefined
-): 'neutral' | 'filter' | 'inject' | 'no-match' {
-  if (!entryExecutor) return 'neutral';
-  if (targetExecutor && targetExecutor === entryExecutor) return 'filter';
-  if (!targetExecutor && !targetCommand) return 'inject';
-  return 'no-match';
-}
-
 function beats(a: Candidate, b: Candidate): boolean {
   if (a.tier !== b.tier) return a.tier > b.tier;
   const aRank = matchKindRank(a.matchKind);
@@ -411,22 +439,16 @@ function beats(a: Candidate, b: Candidate): boolean {
 }
 
 function matchKindRank(kind: MatchKind): number {
-  // Exact target and executor matches are equivalent in specificity and
-  // both beat a glob target match.
-  return kind === 'globTarget' ? 0 : 1;
-}
-
-function matchTarget(
-  entryTarget: string,
-  targetName: string,
-  executor: string | undefined
-): MatchKind | null {
-  if (executor && entryTarget === executor) return 'executor';
-  if (entryTarget === targetName) return 'exactTarget';
-  if (isGlobPattern(entryTarget) && minimatch(targetName, entryTarget)) {
-    return 'globTarget';
+  switch (kind) {
+    case 'targetAndExecutor':
+      return 3;
+    case 'executorOnly':
+      return 2;
+    case 'exactTarget':
+      return 1;
+    case 'globTarget':
+      return 0;
   }
-  return null;
 }
 
 function stripFilterKeys(
@@ -441,10 +463,9 @@ let hasWarnedAboutLegacyRecordShape = false;
 /**
  * Accept either the new array shape or the legacy record shape and return
  * a normalized array. Record entries become `{ target: key, ...value }`
- * preserving insertion order. Legacy record executor keys (e.g.
- * `nx:run-commands`) keep `target: key` — the matcher compares `target`
- * against both target names and executors, so executor semantics are
- * preserved.
+ * — except executor-shaped keys (e.g. `@nx/vite:test`, `nx:run-commands`)
+ * which become `{ executor: key, ...value }` so the matcher treats them
+ * as executor matches rather than target-name matches.
  *
  * When the record shape is encountered we log a one-time warning
  * recommending `nx repair`, which will re-run the migration that
@@ -459,7 +480,11 @@ export function normalizeTargetDefaults(
   const out: TargetDefaultEntry[] = [];
   for (const key of Object.keys(raw)) {
     const value = (raw as TargetDefaultsRecord)[key] ?? {};
-    out.push({ ...value, target: key });
+    out.push(
+      key.includes(':') && !isGlobPattern(key)
+        ? { ...value, executor: key }
+        : { ...value, target: key }
+    );
   }
   return out;
 }
@@ -494,42 +519,21 @@ function resolveSourcePlugin(
   specifiedSourceMaps: ConfigurationSourceMaps | undefined,
   defaultSourceMaps: ConfigurationSourceMaps | undefined
 ): string | undefined {
-  // Prefer the executor/command source map entries (which identify the
-  // plugin that originated the target) over the top-level `targets.<name>`
-  // key (which tracks only the last writer).
+  // Default plugins (nx's baked-in inference of per-project config files
+  // like package.json, tsconfig.json) always overwrite specified-plugin
+  // attribution in the merge. Their attribution is what survives, so it
+  // takes precedence here when matching `source:` filters.
+  //
+  // We only consult the executor/command source-map keys — the top-level
+  // `targets.<name>` key tracks only the last writer, not the originator,
+  // and is unreliable for source attribution.
+  const executorKey = targetOptionSourceMapKey(targetName, 'executor');
+  const commandKey = targetOptionSourceMapKey(targetName, 'command');
   const candidates: (string | undefined)[] = [
-    pluginFromSourceMap(
-      specifiedSourceMaps,
-      root,
-      targetOptionSourceMapKey(targetName, 'executor')
-    ),
-    pluginFromSourceMap(
-      specifiedSourceMaps,
-      root,
-      targetOptionSourceMapKey(targetName, 'command')
-    ),
-    pluginFromSourceMap(
-      defaultSourceMaps,
-      root,
-      targetOptionSourceMapKey(targetName, 'executor')
-    ),
-    pluginFromSourceMap(
-      defaultSourceMaps,
-      root,
-      targetOptionSourceMapKey(targetName, 'command')
-    ),
-    // Last-resort fallback — less reliable because it records the last
-    // plugin to touch the target rather than the originator.
-    pluginFromSourceMap(
-      specifiedSourceMaps,
-      root,
-      targetSourceMapKey(targetName)
-    ),
-    pluginFromSourceMap(
-      defaultSourceMaps,
-      root,
-      targetSourceMapKey(targetName)
-    ),
+    pluginFromSourceMap(defaultSourceMaps, root, executorKey),
+    pluginFromSourceMap(defaultSourceMaps, root, commandKey),
+    pluginFromSourceMap(specifiedSourceMaps, root, executorKey),
+    pluginFromSourceMap(specifiedSourceMaps, root, commandKey),
   ];
 
   for (const candidate of candidates) {
@@ -555,23 +559,21 @@ function buildProjectNodesByName(
   const addFromMap = (map: Record<string, ProjectConfiguration>) => {
     for (const root of Object.keys(map)) {
       const cfg = map[root];
-      const name = cfg?.name ?? inferNameFromRoot(root);
+      const name = cfg?.name;
       if (!name) continue;
       if (out[name]) {
         // Merge tags (union) across layers so tag-based project filters
         // see all tags, regardless of which plugin contributed them.
         const existingTags = out[name].data.tags ?? [];
         const newTags = cfg.tags ?? [];
-        const mergedTags = Array.from(new Set([...existingTags, ...newTags]));
-        out[name].data.tags = mergedTags;
+        out[name].data.tags = Array.from(
+          new Set([...existingTags, ...newTags])
+        );
       } else {
         out[name] = {
           name,
           type: 'lib',
-          data: {
-            root,
-            tags: cfg.tags ?? [],
-          },
+          data: { root, tags: cfg.tags ?? [] },
         } as ProjectGraphProjectNode;
       }
     }
@@ -579,10 +581,4 @@ function buildProjectNodesByName(
   addFromMap(specifiedPluginRootMap);
   addFromMap(defaultPluginRootMap);
   return out;
-}
-
-function inferNameFromRoot(root: string): string | undefined {
-  if (!root) return undefined;
-  const parts = root.split(/[\\/]/).filter(Boolean);
-  return parts[parts.length - 1];
 }

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -62,10 +62,23 @@ export function createTargetDefaultsResults(
     return [];
   }
 
-  const { projectNodesByName, rootToName } = buildProjectNodesByName(
-    specifiedPluginRootMap,
-    defaultPluginRootMap
-  );
+  // The by-name node map is only consulted when an entry has a
+  // `projects:` filter. Skip building it for the common case where no
+  // entry uses that filter — workspaces with simple targetDefaults
+  // shouldn't pay the per-project iteration cost on every graph build.
+  const needsProjectNodes = entries.some((e) => e.projects !== undefined);
+  const { projectNodesByName, rootToName } = needsProjectNodes
+    ? buildProjectNodesAndRootToName(
+        specifiedPluginRootMap,
+        defaultPluginRootMap
+      )
+    : {
+        projectNodesByName: undefined,
+        rootToName: buildRootToName(
+          specifiedPluginRootMap,
+          defaultPluginRootMap
+        ),
+      };
 
   const syntheticProjects: Record<string, ProjectConfiguration> = {};
 
@@ -78,9 +91,10 @@ export function createTargetDefaultsResults(
     const specifiedTargets = specifiedPluginRootMap[root]?.targets ?? {};
     const defaultTargets = defaultPluginRootMap[root]?.targets ?? {};
     const projectName = rootToName.get(root);
-    const projectNode = projectName
-      ? projectNodesByName[projectName]
-      : undefined;
+    const projectNode =
+      projectName && projectNodesByName
+        ? projectNodesByName[projectName]
+        : undefined;
 
     for (const targetName of uniqueKeysInObjects(
       specifiedTargets,
@@ -176,16 +190,17 @@ function effectiveTargetForLookup(
   };
 }
 
-// Returns the synthetic defaults target to insert for `targetName` at
-// `root`, or undefined if no defaults apply.
-//
-// `effective` is the eventual `(executor, command)` shape — i.e. what
-// the real merge will land on for this target. We pick the highest-
-// ranked default that is compatible with that shape, falling back to
-// less-specific compatible defaults when the most-specific match would
-// be incompatible. The synthetic stamps the effective executor/command
-// so neither neighbor can incompatible-replace it during the real
-// merge and drop its contributions.
+/**
+ * Returns the synthetic defaults target to insert for `targetName` at
+ * `root`, or undefined if no defaults apply. The synthetic stamps the
+ * effective executor/command so neither merge neighbor can
+ * incompatible-replace it and drop its contributions.
+ *
+ * @param effective The `(executor, command)` shape the real merge will
+ *   land on. Used both to pick the highest-ranked compatible default
+ *   (falling back to less-specific matches if the best one would be
+ *   incompatible) and as the locked shape stamped onto the synthetic.
+ */
 function buildSyntheticTargetForRoot(
   targetName: string,
   root: string,
@@ -330,31 +345,12 @@ export function findBestTargetDefault(
 ): Partial<TargetConfiguration> | null {
   if (!entries?.length) return null;
 
-  // Without a predicate we only need the single highest-ranked candidate,
-  // so we keep the greedy best-so-far loop to avoid sorting allocations.
-  if (!predicate) {
-    let best: Candidate | null = null;
-    for (let i = 0; i < entries.length; i++) {
-      const candidate = matchEntry(
-        entries[i],
-        i,
-        targetName,
-        executor,
-        projectName,
-        projectNode,
-        sourcePlugin,
-        targetCommand
-      );
-      if (candidate && (!best || beats(candidate, best))) {
-        best = candidate;
-      }
-    }
-    return best ? best.config : null;
-  }
-
-  // With a predicate, collect every matching candidate, sort highest-rank
-  // first, and return the first that passes the predicate.
-  const candidates: Candidate[] = [];
+  // Single greedy best-so-far loop in both the predicate and no-predicate
+  // paths. With a predicate, we filter candidates as they appear and only
+  // promote one to `best` when it passes — equivalent to the previous
+  // "collect-all + sort + first-passing" approach because `beats` is a
+  // total order, but without the sort allocation.
+  let best: Candidate | null = null;
   for (let i = 0; i < entries.length; i++) {
     const candidate = matchEntry(
       entries[i],
@@ -366,15 +362,30 @@ export function findBestTargetDefault(
       sourcePlugin,
       targetCommand
     );
-    if (candidate) candidates.push(candidate);
+    if (!candidate) continue;
+    if (predicate && !predicate(candidate.config)) continue;
+    if (!best || beats(candidate, best)) {
+      best = candidate;
+    }
   }
-  candidates.sort((a, b) => (beats(a, b) ? -1 : beats(b, a) ? 1 : 0));
-  for (const candidate of candidates) {
-    if (predicate(candidate.config)) return candidate.config;
-  }
-  return null;
+  return best ? best.config : null;
 }
 
+/**
+ * Test a single `targetDefaults` entry against the (target, executor,
+ * project, source, command) tuple of the target being resolved. Returns
+ * a `Candidate` with its tier and match kind, or null when the entry
+ * doesn't apply.
+ *
+ * The match facts (`targetName`, `executor`, `projectName`, `projectNode`,
+ * `sourcePlugin`, `targetCommand`) are passed in instead of being read
+ * from the graph node here because callers — `findBestTargetDefault` and
+ * `buildSyntheticTargetForRoot` — work in different graph contexts. The
+ * synthetic builder, in particular, evaluates against the *effective*
+ * executor/command (what the merge will land on), which doesn't always
+ * equal the node's current executor; threading the values explicitly
+ * keeps that asymmetry visible at the call sites.
+ */
 function matchEntry(
   entry: TargetDefaultEntry | undefined,
   index: number,
@@ -401,8 +412,11 @@ function matchEntry(
     if (executor && executor === entry.executor) {
       executorMatched = true;
     } else if (targetKind !== null && !executor && !targetCommand) {
-      // `executor` injects into a bare target the entry's `target`
-      // already matched.
+      // Injection: the entry's `target` locator already narrowed the match
+      // to a specific name, so it's safe to inject the entry's executor
+      // into a bare target. An executor-only entry (no `target` locator)
+      // never reaches this branch — without targeting, it would broadcast
+      // the executor to every executor-less target in the workspace.
       executorMatched = true;
     } else {
       return null;
@@ -445,12 +459,27 @@ function matchEntry(
   };
 }
 
+/**
+ * Specificity ordering for two candidate matches. Higher specificity
+ * wins because the more specific entry is the one the user most likely
+ * wrote to override a broader rule.
+ *
+ * 1. Tier — entries with `projects` or `source` filters are scoped
+ *    narrower than unfiltered entries, so they outrank.
+ * 2. Match kind — within the same tier, more locator slots is more
+ *    specific: `target+executor` > `executor-only` > `exactTarget` >
+ *    `globTarget`. Note `executor-only` outranks `exactTarget`: a
+ *    workspace-wide rule keyed on a specific executor is treated as
+ *    more intentional than a target-name rule that might accidentally
+ *    catch unrelated executors.
+ * 3. Tie-break — later array index wins, so users can append an entry
+ *    to override earlier ones without rewriting them.
+ */
 function beats(a: Candidate, b: Candidate): boolean {
   if (a.tier !== b.tier) return a.tier > b.tier;
   const aRank = matchKindRank(a.matchKind);
   const bRank = matchKindRank(b.matchKind);
   if (aRank !== bRank) return aRank > bRank;
-  // Tie: later array index wins.
   return a.index > b.index;
 }
 
@@ -484,9 +513,17 @@ let hasWarnedAboutLegacyRecordShape = false;
  * which become `{ executor: key, ...value }` so the matcher treats them
  * as executor matches rather than target-name matches.
  *
- * When the record shape is encountered we log a one-time warning
- * recommending `nx repair`, which will re-run the migration that
- * converts `targetDefaults` to the array shape.
+ * The disambiguation here is purely syntactic. This function runs
+ * during graph construction, before the cached graph exists, so it
+ * cannot consult per-project targets to confirm whether `key` is a
+ * target name or an executor — `:` in a record key is genuinely
+ * ambiguous (target names can contain `:`). The
+ * `convert-target-defaults-to-array` migration runs *after*
+ * construction and uses the project graph for proper disambiguation;
+ * that's why the warning below recommends `nx repair`. Sharing more of
+ * the disambiguation logic with the migration is left as a follow-up —
+ * the migration's classifier needs the graph and this code path can't
+ * have one.
  */
 export function normalizeTargetDefaults(
   raw: TargetDefaults | undefined
@@ -568,7 +605,13 @@ function pluginFromSourceMap(
 // projects are included — they're the bulk of typical workspaces and
 // `projects:` filters need to apply to them too. Tags are unioned across
 // layers so tag-based filters see all contributions.
-function buildProjectNodesByName(
+//
+// We don't reuse `mergeProjectConfigurationIntoRootMap` here: it does a
+// full project-config merge (targets, named inputs, source maps, ...)
+// keyed by root, while this function only needs name + tags keyed by
+// name. The full merge would be substantial wasted work on every graph
+// build.
+function buildProjectNodesAndRootToName(
   specifiedPluginRootMap: Record<string, ProjectConfiguration>,
   defaultPluginRootMap: Record<string, ProjectConfiguration>
 ): {
@@ -601,4 +644,27 @@ function buildProjectNodesByName(
   addFromMap(specifiedPluginRootMap);
   addFromMap(defaultPluginRootMap);
   return { projectNodesByName, rootToName };
+}
+
+/**
+ * Lighter-weight version of {@link buildProjectNodesAndRootToName} for
+ * the common path where no `targetDefaults` entry uses a `projects:`
+ * filter. We still need root → name lookup for source-plugin attribution
+ * and project-name resolution, but we can skip building the by-name
+ * node view entirely.
+ */
+function buildRootToName(
+  specifiedPluginRootMap: Record<string, ProjectConfiguration>,
+  defaultPluginRootMap: Record<string, ProjectConfiguration>
+): Map<string, string> {
+  const rootToName = new Map<string, string>();
+  const addFromMap = (map: Record<string, ProjectConfiguration>) => {
+    for (const root of Object.keys(map)) {
+      const name = map[root]?.name;
+      if (name && !rootToName.has(root)) rootToName.set(root, name);
+    }
+  };
+  addFromMap(specifiedPluginRootMap);
+  addFromMap(defaultPluginRootMap);
+  return rootToName;
 }

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -38,6 +38,12 @@ type CreateNodesResultEntry = readonly [
 /**
  * Builds a synthetic plugin result from nx.json's `targetDefaults`, layered
  * between specified-plugin and default-plugin results during merging.
+ *
+ * Synthesis sees the two layers separately to avoid re-merging specified
+ * results into a parallel rootMap — for each (root, target) where both
+ * layers contribute, it computes the eventual executor/command on the
+ * fly. That's all the matcher needs; the full target merge happens
+ * downstream in the real merge.
  */
 export function createTargetDefaultsResults(
   specifiedPluginRootMap: Record<string, ProjectConfiguration>,
@@ -84,6 +90,13 @@ export function createTargetDefaultsResults(
       specifiedTargets,
       defaultTargets
     )) {
+      const effective = effectiveTargetForLookup(
+        specifiedTargets[targetName],
+        defaultTargets[targetName],
+        root
+      );
+      if (!effective) continue;
+
       const sourcePlugin = resolveSourcePlugin(
         root,
         targetName,
@@ -94,8 +107,7 @@ export function createTargetDefaultsResults(
       const syntheticTarget = buildSyntheticTargetForRoot(
         targetName,
         root,
-        specifiedTargets[targetName],
-        defaultTargets[targetName],
+        effective,
         entries,
         projectName,
         projectNode,
@@ -124,19 +136,18 @@ export function createTargetDefaultsResults(
   ];
 }
 
-// Returns the synthetic defaults target to insert for `targetName` at
-// `root`, or undefined if no defaults apply.
-// Layering: specified plugins < target defaults < default plugins.
-function buildSyntheticTargetForRoot(
-  targetName: string,
-  root: string,
+// Returns the executor/command pair the real merge will end up with at
+// `(root, targetName)`. We don't reproduce the full per-target merge
+// here — only the fields the matcher cares about. For incompatible
+// pairs (e.g. specified `nx:run-commands` vs default `@nx/jest:jest`)
+// the default replaces the specified target wholesale, so we mirror
+// that behavior by returning the default. For compatible pairs, the
+// default's executor wins where set, otherwise the specified's.
+function effectiveTargetForLookup(
   specifiedTarget: TargetConfiguration | undefined,
   defaultTarget: TargetConfiguration | undefined,
-  entries: NormalizedTargetDefaults,
-  projectName: string | undefined,
-  projectNode: ProjectGraphProjectNode | undefined,
-  sourcePlugin: string | undefined
-): TargetConfiguration | undefined {
+  root: string
+): { executor: string | undefined; command: string | undefined } | undefined {
   const resolvedSpecified = specifiedTarget
     ? resolveCommandSyntacticSugar(specifiedTarget, root)
     : undefined;
@@ -144,102 +155,45 @@ function buildSyntheticTargetForRoot(
     ? resolveCommandSyntacticSugar(defaultTarget, root)
     : undefined;
 
-  // Specified-only: layer defaults on top, but only when the resulting
-  // synthetic is compatible with the specified target. An incompatible
-  // synthetic (e.g. an entry with `executor: '@monodon/rust:test'` while
-  // a polyglot plugin infers the same target with `nx:run-commands`)
-  // would otherwise replace the specified target wholesale during the
-  // downstream merge.
-  if (resolvedSpecified && !resolvedDefault) {
-    const targetDefaults = readAndPrepareTargetDefaults(
-      targetName,
-      resolvedSpecified.executor,
-      resolvedSpecified.command,
-      root,
-      entries,
-      projectName,
-      projectNode,
-      sourcePlugin
-    );
-    if (
-      targetDefaults &&
-      !isCompatibleTarget(resolvedSpecified, targetDefaults)
-    ) {
-      return undefined;
-    }
-    return targetDefaults;
-  }
-
-  // Default-only.
-  if (resolvedDefault && !resolvedSpecified) {
-    return readAndPrepareTargetDefaults(
-      targetName,
-      resolvedDefault.executor,
-      resolvedDefault.command,
-      root,
-      entries,
-      projectName,
-      projectNode,
-      sourcePlugin
-    );
-  }
-
-  if (!resolvedSpecified || !resolvedDefault) return undefined;
-
-  // Both compatible: use the default plugin's executor for the lookup.
-  // The same incompatibility check applies — a project.json `{}` entry
-  // asks defaults to fill in the target, but the lookup can still fall
-  // back to a target-name keyed default with a foreign executor that
-  // would replace the inferred target. Skip the synthetic in that case.
-  if (isCompatibleTarget(resolvedSpecified, resolvedDefault)) {
-    const targetDefaults = readAndPrepareTargetDefaults(
-      targetName,
-      resolvedDefault.executor || resolvedSpecified.executor,
-      resolvedDefault.command || resolvedSpecified.command,
-      root,
-      entries,
-      projectName,
-      projectNode,
-      sourcePlugin
-    );
-    if (
-      targetDefaults &&
-      !isCompatibleTarget(resolvedSpecified, targetDefaults)
-    ) {
-      return undefined;
-    }
-    return targetDefaults;
-  }
-
-  // Incompatible: default plugin will replace specified; only defaults
-  // matching the default plugin's executor are useful.
-  const targetDefaults = readAndPrepareTargetDefaults(
-    targetName,
-    resolvedDefault.executor,
-    resolvedDefault.command,
-    root,
-    entries,
-    projectName,
-    projectNode,
-    sourcePlugin
-  );
-  if (targetDefaults && isCompatibleTarget(resolvedDefault, targetDefaults)) {
-    // Stamp executor/command so the default layer merges cleanly on top.
+  if (!resolvedSpecified && !resolvedDefault) return undefined;
+  if (!resolvedSpecified) {
     return {
-      ...targetDefaults,
+      executor: resolvedDefault!.executor,
+      command: resolvedDefault!.command,
+    };
+  }
+  if (!resolvedDefault) {
+    return {
+      executor: resolvedSpecified.executor,
+      command: resolvedSpecified.command,
+    };
+  }
+  if (!isCompatibleTarget(resolvedSpecified, resolvedDefault)) {
+    return {
       executor: resolvedDefault.executor,
       command: resolvedDefault.command,
     };
   }
-
-  return undefined;
+  return {
+    executor: resolvedDefault.executor ?? resolvedSpecified.executor,
+    command: resolvedDefault.command ?? resolvedSpecified.command,
+  };
 }
 
-function readAndPrepareTargetDefaults(
+// Returns the synthetic defaults target to insert for `targetName` at
+// `root`, or undefined if no defaults apply.
+//
+// `effective` is the eventual `(executor, command)` shape — i.e. what
+// the real merge will land on for this target. We pick the highest-
+// ranked default that is compatible with that shape, falling back to
+// less-specific compatible defaults when the most-specific match would
+// be incompatible. The synthetic stamps the effective executor/command
+// so neither neighbor can incompatible-replace it during the real
+// merge and drop its contributions.
+function buildSyntheticTargetForRoot(
   targetName: string,
-  executor: string | undefined,
-  command: string | undefined,
   root: string,
+  effective: { executor: string | undefined; command: string | undefined },
   entries: NormalizedTargetDefaults,
   projectName: string | undefined,
   projectNode: ProjectGraphProjectNode | undefined,
@@ -247,16 +201,34 @@ function readAndPrepareTargetDefaults(
 ): TargetConfiguration | undefined {
   const rawTargetDefaults = findBestTargetDefault(
     targetName,
-    executor,
+    effective.executor,
     projectName,
     projectNode,
     sourcePlugin,
     entries,
-    command
+    effective.command,
+    (candidate) =>
+      isCompatibleTarget(
+        { executor: effective.executor, command: effective.command },
+        candidate
+      )
   );
   if (!rawTargetDefaults) return undefined;
 
-  return resolveCommandSyntacticSugar(deepClone(rawTargetDefaults), root);
+  const synthetic = resolveCommandSyntacticSugar(
+    deepClone(rawTargetDefaults),
+    root
+  );
+
+  // Stamp executor/command from the effective shape. For entries that
+  // already specify these, this is a no-op (the matcher only returned
+  // compatible candidates). For entries that don't, this pre-aligns the
+  // synthetic with both layers so neither can incompatible-replace it
+  // during the real merge.
+  if (effective.executor !== undefined) synthetic.executor = effective.executor;
+  if (effective.command !== undefined) synthetic.command = effective.command;
+
+  return synthetic;
 }
 
 /**
@@ -343,6 +315,12 @@ interface Candidate {
  * `executor` only acts as an "injector" (matches a target with neither
  * executor nor command) when the entry also sets `target`. Executor-only
  * entries require the workspace target to actually have an executor.
+ *
+ * When `predicate` is provided, ranked candidates are iterated and the
+ * first one that satisfies the predicate is returned. This lets synthesis
+ * fall back to a less-specific compatible default when the most-specific
+ * match would be incompatible with the target it's being applied to.
+ * Without a predicate, the highest-ranked candidate is returned directly.
  */
 export function findBestTargetDefault(
   targetName: string,
@@ -351,82 +329,124 @@ export function findBestTargetDefault(
   projectNode: ProjectGraphProjectNode | undefined,
   sourcePlugin: string | undefined,
   entries: NormalizedTargetDefaults,
-  targetCommand?: string | undefined
+  targetCommand?: string | undefined,
+  predicate?: (config: Partial<TargetConfiguration>) => boolean
 ): Partial<TargetConfiguration> | null {
   if (!entries?.length) return null;
 
-  let best: Candidate | null = null;
-
-  for (let i = 0; i < entries.length; i++) {
-    const entry = entries[i];
-    if (!entry) continue;
-    if (entry.target === undefined && entry.executor === undefined) continue;
-
-    let targetKind: 'exact' | 'glob' | null = null;
-    if (entry.target !== undefined) {
-      if (entry.target === targetName) targetKind = 'exact';
-      else if (
-        isGlobPattern(entry.target) &&
-        minimatch(targetName, entry.target)
-      )
-        targetKind = 'glob';
-      else continue;
-    }
-
-    let executorMatched = false;
-    if (entry.executor !== undefined) {
-      if (executor && executor === entry.executor) {
-        executorMatched = true;
-      } else if (targetKind !== null && !executor && !targetCommand) {
-        // `executor` injects into a bare target the entry's `target`
-        // already matched.
-        executorMatched = true;
-      } else {
-        continue;
+  // Without a predicate we only need the single highest-ranked candidate,
+  // so we keep the greedy best-so-far loop to avoid sorting allocations.
+  if (!predicate) {
+    let best: Candidate | null = null;
+    for (let i = 0; i < entries.length; i++) {
+      const candidate = matchEntry(
+        entries[i],
+        i,
+        targetName,
+        executor,
+        projectName,
+        projectNode,
+        sourcePlugin,
+        targetCommand
+      );
+      if (candidate && (!best || beats(candidate, best))) {
+        best = candidate;
       }
     }
+    return best ? best.config : null;
+  }
 
-    let tier = 1;
+  // With a predicate, collect every matching candidate, sort highest-rank
+  // first, and return the first that passes the predicate.
+  const candidates: Candidate[] = [];
+  for (let i = 0; i < entries.length; i++) {
+    const candidate = matchEntry(
+      entries[i],
+      i,
+      targetName,
+      executor,
+      projectName,
+      projectNode,
+      sourcePlugin,
+      targetCommand
+    );
+    if (candidate) candidates.push(candidate);
+  }
+  candidates.sort((a, b) => (beats(a, b) ? -1 : beats(b, a) ? 1 : 0));
+  for (const candidate of candidates) {
+    if (predicate(candidate.config)) return candidate.config;
+  }
+  return null;
+}
 
-    if (entry.projects !== undefined) {
-      if (!projectName || !projectNode) continue;
-      const patterns = Array.isArray(entry.projects)
-        ? entry.projects
-        : [entry.projects];
-      const matched = findMatchingProjects(patterns, {
-        [projectName]: projectNode,
-      });
-      if (!matched.includes(projectName)) continue;
-      tier++;
-    }
+function matchEntry(
+  entry: TargetDefaultEntry | undefined,
+  index: number,
+  targetName: string,
+  executor: string | undefined,
+  projectName: string | undefined,
+  projectNode: ProjectGraphProjectNode | undefined,
+  sourcePlugin: string | undefined,
+  targetCommand: string | undefined
+): Candidate | null {
+  if (!entry) return null;
+  if (entry.target === undefined && entry.executor === undefined) return null;
 
-    if (entry.source !== undefined) {
-      if (entry.source !== sourcePlugin) continue;
-      tier++;
-    }
+  let targetKind: 'exact' | 'glob' | null = null;
+  if (entry.target !== undefined) {
+    if (entry.target === targetName) targetKind = 'exact';
+    else if (isGlobPattern(entry.target) && minimatch(targetName, entry.target))
+      targetKind = 'glob';
+    else return null;
+  }
 
-    const matchKind: MatchKind =
-      targetKind !== null && executorMatched
-        ? 'targetAndExecutor'
-        : targetKind === null
-          ? 'executorOnly'
-          : targetKind === 'exact'
-            ? 'exactTarget'
-            : 'globTarget';
-
-    const candidate: Candidate = {
-      config: stripFilterKeys(entry),
-      tier,
-      matchKind,
-      index: i,
-    };
-
-    if (!best || beats(candidate, best)) {
-      best = candidate;
+  let executorMatched = false;
+  if (entry.executor !== undefined) {
+    if (executor && executor === entry.executor) {
+      executorMatched = true;
+    } else if (targetKind !== null && !executor && !targetCommand) {
+      // `executor` injects into a bare target the entry's `target`
+      // already matched.
+      executorMatched = true;
+    } else {
+      return null;
     }
   }
 
-  return best ? best.config : null;
+  let tier = 1;
+
+  if (entry.projects !== undefined) {
+    if (!projectName || !projectNode) return null;
+    const patterns = Array.isArray(entry.projects)
+      ? entry.projects
+      : [entry.projects];
+    const matched = findMatchingProjects(patterns, {
+      [projectName]: projectNode,
+    });
+    if (!matched.includes(projectName)) return null;
+    tier++;
+  }
+
+  if (entry.source !== undefined) {
+    if (entry.source !== sourcePlugin) return null;
+    tier++;
+  }
+
+  const matchKind: MatchKind =
+    targetKind !== null && executorMatched
+      ? 'targetAndExecutor'
+      : targetKind === null
+        ? 'executorOnly'
+        : targetKind === 'exact'
+          ? 'exactTarget'
+          : 'globTarget';
+
+  return {
+    config: stripFilterKeys(entry),
+    tier,
+    matchKind,
+    index,
+  };
 }
 
 function beats(a: Candidate, b: Candidate): boolean {
@@ -508,11 +528,6 @@ function warnAboutLegacyRecordShapeOnce() {
   );
 }
 
-/** Test-only: resets the module-level "warned once" flag. */
-export function __resetTargetDefaultsLegacyWarning() {
-  hasWarnedAboutLegacyRecordShape = false;
-}
-
 function resolveSourcePlugin(
   root: string,
   targetName: string,
@@ -551,6 +566,11 @@ function pluginFromSourceMap(
   return entry?.[1];
 }
 
+// Walks both layered rootMaps and produces a name → ProjectGraphProjectNode
+// view for `findMatchingProjects` to consult. Default-plugin-only
+// projects are included — they're the bulk of typical workspaces and
+// `projects:` filters need to apply to them too. Tags are unioned across
+// layers so tag-based filters see all contributions.
 function buildProjectNodesByName(
   specifiedPluginRootMap: Record<string, ProjectConfiguration>,
   defaultPluginRootMap: Record<string, ProjectConfiguration>
@@ -562,8 +582,6 @@ function buildProjectNodesByName(
       const name = cfg?.name;
       if (!name) continue;
       if (out[name]) {
-        // Merge tags (union) across layers so tag-based project filters
-        // see all tags, regardless of which plugin contributed them.
         const existingTags = out[name].data.tags ?? [];
         const newTags = cfg.tags ?? [];
         out[name].data.tags = Array.from(
@@ -572,7 +590,7 @@ function buildProjectNodesByName(
       } else {
         out[name] = {
           name,
-          type: 'lib',
+          type: cfg.projectType === 'application' ? 'app' : 'lib',
           data: { root, tags: cfg.tags ?? [] },
         } as ProjectGraphProjectNode;
       }

--- a/packages/nx/src/tasks-runner/run-command.spec.ts
+++ b/packages/nx/src/tasks-runner/run-command.spec.ts
@@ -115,9 +115,6 @@ describe('getRunner', () => {
     expect(runnerOptions).toMatchInlineSnapshot(`
       {
         "cacheDirectory": ".nx/cache",
-        "cacheableOperations": [
-          "build",
-        ],
         "parallel": 3,
         "useDaemonProcess": false,
       }

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -24,7 +24,6 @@ import {
   runPreTasksExecution,
 } from '../project-graph/plugins/tasks-execution-hooks';
 import { createProjectGraphAsync } from '../project-graph/project-graph';
-import { normalizeTargetDefaults } from '../project-graph/utils/project-configuration/target-defaults';
 import { NxArgs } from '../utils/command-line-utils';
 import { handleErrors } from '../utils/handle-errors';
 import { isCI } from '../utils/is-ci';
@@ -1243,14 +1242,6 @@ export function getRunnerOptions(
   nxArgs: NxArgs,
   isCloudDefault: boolean
 ): any {
-  const defaultCacheableOperations: string[] = [];
-
-  for (const entry of normalizeTargetDefaults(nxJson.targetDefaults)) {
-    if (entry?.cache && entry.target) {
-      defaultCacheableOperations.push(entry.target);
-    }
-  }
-
   const result = {
     ...nxJson.tasksRunnerOptions?.[runner]?.options,
     ...nxArgs,
@@ -1282,13 +1273,6 @@ export function getRunnerOptions(
 
   if (nxJson.cacheDirectory) {
     result.cacheDirectory ??= nxJson.cacheDirectory;
-  }
-
-  if (defaultCacheableOperations.length) {
-    result.cacheableOperations ??= [];
-    result.cacheableOperations = result.cacheableOperations.concat(
-      defaultCacheableOperations
-    );
   }
 
   if (nxJson.useDaemonProcess !== undefined) {

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -24,6 +24,7 @@ import {
   runPreTasksExecution,
 } from '../project-graph/plugins/tasks-execution-hooks';
 import { createProjectGraphAsync } from '../project-graph/project-graph';
+import { normalizeTargetDefaults } from '../project-graph/utils/project-configuration/target-defaults';
 import { NxArgs } from '../utils/command-line-utils';
 import { handleErrors } from '../utils/handle-errors';
 import { isCI } from '../utils/is-ci';
@@ -1242,11 +1243,11 @@ export function getRunnerOptions(
   nxArgs: NxArgs,
   isCloudDefault: boolean
 ): any {
-  const defaultCacheableOperations = [];
+  const defaultCacheableOperations: string[] = [];
 
-  for (const key in nxJson.targetDefaults) {
-    if (nxJson.targetDefaults[key].cache) {
-      defaultCacheableOperations.push(key);
+  for (const entry of normalizeTargetDefaults(nxJson.targetDefaults)) {
+    if (entry?.cache && entry.target) {
+      defaultCacheableOperations.push(entry.target);
     }
   }
 

--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -151,6 +151,38 @@ describe('readTargetsFromPackageJson', () => {
         "options": {},
       }
     `);
+
+    const nxJson3 = {
+      targetDefaults: [
+        {
+          target: 'nx-release-publish',
+          executor: '@nx/js:release-publish',
+          dependsOn: ['build'],
+          options: {
+            dryRun: true,
+          },
+        },
+      ],
+    };
+    const result3 = readTargetsFromPackageJson(
+      packageJson,
+      nxJson3,
+      workspaceRoot,
+      '/root',
+      packageManagerCommand
+    );
+    expect(result3['nx-release-publish']).toMatchInlineSnapshot(`
+      {
+        "dependsOn": [
+          "^nx-release-publish",
+          "build",
+        ],
+        "executor": "@nx/js:release-publish",
+        "options": {
+          "dryRun": true,
+        },
+      }
+    `);
   });
 
   it('should read targets from project.json and package.json', () => {

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -5,7 +5,11 @@ import { dirname, join, resolve } from 'path';
 
 const execAsync = promisify(exec);
 import { dirSync } from 'tmp';
-import { NxJsonConfiguration } from '../config/nx-json';
+import {
+  NxJsonConfiguration,
+  TargetDefaults,
+  TargetDefaultsRecord,
+} from '../config/nx-json';
 import {
   ProjectConfiguration,
   ProjectMetadata,
@@ -13,6 +17,7 @@ import {
 } from '../config/workspace-json-project-json';
 import type { Tree } from '../generators/tree';
 import { readJson } from '../generators/utils/json';
+import { readTargetDefaultsForTarget } from '../project-graph/utils/project-configuration-utils';
 import { mergeTargetConfigurations } from '../project-graph/utils/project-configuration/target-merging';
 import { getCatalogManager } from './catalog';
 import { readJsonFile } from './fileutils';
@@ -259,7 +264,11 @@ export function readTargetsFromPackageJson(
     hasNxJsPlugin(projectRoot, workspaceRoot)
   ) {
     const nxReleasePublishTargetDefaults =
-      nxJson?.targetDefaults?.['nx-release-publish'] ?? {};
+      readCompatibleTargetDefaultsForTarget(
+        'nx-release-publish',
+        nxJson?.targetDefaults,
+        '@nx/js:release-publish'
+      ) ?? {};
     res['nx-release-publish'] = {
       executor: '@nx/js:release-publish',
       ...nxReleasePublishTargetDefaults,
@@ -275,6 +284,22 @@ export function readTargetsFromPackageJson(
   }
 
   return res;
+}
+
+function readCompatibleTargetDefaultsForTarget(
+  targetName: string,
+  targetDefaults: TargetDefaults | undefined,
+  executor?: string
+): Partial<TargetConfiguration> | null {
+  if (
+    targetDefaults &&
+    !Array.isArray(targetDefaults) &&
+    Object.prototype.hasOwnProperty.call(targetDefaults, targetName)
+  ) {
+    return (targetDefaults as TargetDefaultsRecord)[targetName] ?? null;
+  }
+
+  return readTargetDefaultsForTarget(targetName, targetDefaults, executor);
 }
 
 /**

--- a/packages/playwright/src/generators/configuration/configuration.ts
+++ b/packages/playwright/src/generators/configuration/configuration.ts
@@ -21,6 +21,7 @@ import {
   toJS,
   Tree,
   updateJson,
+  updateNxJson,
   updateProjectConfiguration,
   workspaceRoot,
   writeJson,
@@ -388,7 +389,8 @@ function setupE2ETargetDefaults(tree: Tree) {
     patch.inputs = ['default', productionFileSet ? '^production' : '^default'];
   }
   if (Object.keys(patch).length > 0) {
-    upsertTargetDefault(tree, { target: 'e2e', ...patch });
+    upsertTargetDefault(tree, nxJson, { target: 'e2e', ...patch });
+    updateNxJson(tree, nxJson);
   }
 }
 

--- a/packages/playwright/src/generators/configuration/configuration.ts
+++ b/packages/playwright/src/generators/configuration/configuration.ts
@@ -1,4 +1,5 @@
 import {
+  findTargetDefault,
   resolveImportPath,
   promptWhenInteractive,
   upsertTargetDefault,
@@ -11,7 +12,6 @@ import {
   getPackageManagerCommand,
   joinPathFragments,
   logger,
-  type NxJsonConfiguration,
   offsetFromRoot,
   output,
   readNxJson,
@@ -21,7 +21,6 @@ import {
   toJS,
   Tree,
   updateJson,
-  updateNxJson,
   updateProjectConfiguration,
   workspaceRoot,
   writeJson,
@@ -368,29 +367,29 @@ function setupE2ETargetDefaults(tree: Tree) {
 
   // E2e targets depend on all their project's sources + production sources of dependencies
   const productionFileSet = !!nxJson.namedInputs?.production;
+  // Either a `target: 'e2e'` default or a default keyed on the executor
+  // we're about to scaffold will apply to the new target — consider both
+  // before deciding to add cache/inputs. Target-keyed wins when both are
+  // present.
+  const existingForTarget = findTargetDefault(nxJson.targetDefaults, {
+    target: 'e2e',
+  });
+  const existingForExecutor = findTargetDefault(nxJson.targetDefaults, {
+    executor: '@nx/playwright:playwright',
+  });
+  const existingCache = existingForTarget?.cache ?? existingForExecutor?.cache;
+  const existingInputs =
+    existingForTarget?.inputs ?? existingForExecutor?.inputs;
   const patch: Partial<TargetConfiguration> = {};
-  if (!findExistingE2eDefault(nxJson.targetDefaults)?.cache) {
+  if (!existingCache) {
     patch.cache = true;
   }
-  if (!findExistingE2eDefault(nxJson.targetDefaults)?.inputs) {
+  if (!existingInputs) {
     patch.inputs = ['default', productionFileSet ? '^production' : '^default'];
   }
   if (Object.keys(patch).length > 0) {
     upsertTargetDefault(tree, { target: 'e2e', ...patch });
   }
-}
-
-function findExistingE2eDefault(
-  td: NxJsonConfiguration['targetDefaults']
-): Partial<TargetConfiguration> | undefined {
-  if (!td) return undefined;
-  if (Array.isArray(td)) {
-    return td.find(
-      (e) =>
-        e.target === 'e2e' && e.projects === undefined && e.source === undefined
-    );
-  }
-  return td['e2e'];
 }
 
 function addE2eTarget(tree: Tree, options: ConfigurationGeneratorSchema) {

--- a/packages/playwright/src/generators/configuration/configuration.ts
+++ b/packages/playwright/src/generators/configuration/configuration.ts
@@ -382,10 +382,10 @@ function setupE2ETargetDefaults(tree: Tree) {
   const existingInputs =
     existingForTarget?.inputs ?? existingForExecutor?.inputs;
   const patch: Partial<TargetConfiguration> = {};
-  if (!existingCache) {
+  if (existingCache === undefined) {
     patch.cache = true;
   }
-  if (!existingInputs) {
+  if (existingInputs === undefined) {
     patch.inputs = ['default', productionFileSet ? '^production' : '^default'];
   }
   if (Object.keys(patch).length > 0) {

--- a/packages/playwright/src/generators/configuration/configuration.ts
+++ b/packages/playwright/src/generators/configuration/configuration.ts
@@ -1,4 +1,8 @@
-import { resolveImportPath, promptWhenInteractive } from '@nx/devkit/internal';
+import {
+  resolveImportPath,
+  promptWhenInteractive,
+  upsertTargetDefault,
+} from '@nx/devkit/internal';
 import {
   addDependenciesToPackageJson,
   formatFiles,
@@ -7,11 +11,13 @@ import {
   getPackageManagerCommand,
   joinPathFragments,
   logger,
+  type NxJsonConfiguration,
   offsetFromRoot,
   output,
   readNxJson,
   readProjectConfiguration,
   runTasksInSerial,
+  type TargetConfiguration,
   toJS,
   Tree,
   updateJson,
@@ -361,17 +367,30 @@ function setupE2ETargetDefaults(tree: Tree) {
   }
 
   // E2e targets depend on all their project's sources + production sources of dependencies
-  nxJson.targetDefaults ??= {};
-
   const productionFileSet = !!nxJson.namedInputs?.production;
-  nxJson.targetDefaults.e2e ??= {};
-  nxJson.targetDefaults.e2e.cache ??= true;
-  nxJson.targetDefaults.e2e.inputs ??= [
-    'default',
-    productionFileSet ? '^production' : '^default',
-  ];
+  const patch: Partial<TargetConfiguration> = {};
+  if (!findExistingE2eDefault(nxJson.targetDefaults)?.cache) {
+    patch.cache = true;
+  }
+  if (!findExistingE2eDefault(nxJson.targetDefaults)?.inputs) {
+    patch.inputs = ['default', productionFileSet ? '^production' : '^default'];
+  }
+  if (Object.keys(patch).length > 0) {
+    upsertTargetDefault(tree, { target: 'e2e', ...patch });
+  }
+}
 
-  updateNxJson(tree, nxJson);
+function findExistingE2eDefault(
+  td: NxJsonConfiguration['targetDefaults']
+): Partial<TargetConfiguration> | undefined {
+  if (!td) return undefined;
+  if (Array.isArray(td)) {
+    return td.find(
+      (e) =>
+        e.target === 'e2e' && e.projects === undefined && e.source === undefined
+    );
+  }
+  return td['e2e'];
 }
 
 function addE2eTarget(tree: Tree, options: ConfigurationGeneratorSchema) {

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -1196,13 +1196,13 @@ describe('app', () => {
           (e) =>
             e.target === 'build' &&
             e.projects === undefined &&
-            e.source === undefined
+            e.plugin === undefined
         )
       : td.build;
     const {
       target: _t,
       projects: _p,
-      source: _s,
+      plugin: _pl,
       ...buildConfig
     } = (buildEntry as any) ?? {};
     expect(buildConfig).toMatchInlineSnapshot(`

--- a/packages/react/src/generators/application/application.spec.ts
+++ b/packages/react/src/generators/application/application.spec.ts
@@ -1190,7 +1190,22 @@ describe('app', () => {
 
     // ASSERT
     nxJson = readNxJson(tree);
-    expect(nxJson.targetDefaults.build).toMatchInlineSnapshot(`
+    const td = nxJson.targetDefaults!;
+    const buildEntry = Array.isArray(td)
+      ? td.find(
+          (e) =>
+            e.target === 'build' &&
+            e.projects === undefined &&
+            e.source === undefined
+        )
+      : td.build;
+    const {
+      target: _t,
+      projects: _p,
+      source: _s,
+      ...buildConfig
+    } = (buildEntry as any) ?? {};
+    expect(buildConfig).toMatchInlineSnapshot(`
       {
         "cache": true,
         "dependsOn": [

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -8,10 +8,13 @@ import {
   joinPathFragments,
   readNxJson,
   runTasksInSerial,
+  type TargetConfiguration,
+  type TargetDefaults,
   Tree,
   updateJson,
   updateNxJson,
 } from '@nx/devkit';
+import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
 import { initGenerator as jsInitGenerator } from '@nx/js';
 import {
   addProjectToTsSolutionWorkspace,
@@ -115,16 +118,16 @@ export async function applicationGeneratorInternal(
 
   if (!options.addPlugin) {
     const nxJson = readNxJson(tree);
-    nxJson.targetDefaults ??= {};
-    if (!Object.keys(nxJson.targetDefaults).includes('build')) {
-      nxJson.targetDefaults.build = {
+    const existing = findBuildDefault(nxJson.targetDefaults);
+    if (!existing) {
+      upsertTargetDefault(tree, {
+        target: 'build',
         cache: true,
         dependsOn: ['^build'],
-      };
-    } else if (!nxJson.targetDefaults.build.dependsOn) {
-      nxJson.targetDefaults.build.dependsOn = ['^build'];
+      });
+    } else if (!existing.dependsOn) {
+      upsertTargetDefault(tree, { target: 'build', dependsOn: ['^build'] });
     }
-    updateNxJson(tree, nxJson);
   }
 
   if (options.bundler === 'webpack') {
@@ -239,6 +242,21 @@ export async function applicationGeneratorInternal(
   });
 
   return runTasksInSerial(...tasks);
+}
+
+function findBuildDefault(
+  td: TargetDefaults | undefined
+): Partial<TargetConfiguration> | undefined {
+  if (!td) return undefined;
+  if (Array.isArray(td)) {
+    return td.find(
+      (e) =>
+        e.target === 'build' &&
+        e.projects === undefined &&
+        e.source === undefined
+    );
+  }
+  return td['build'];
 }
 
 export default applicationGenerator;

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -12,9 +12,8 @@ import {
   type TargetDefaults,
   Tree,
   updateJson,
-  updateNxJson,
 } from '@nx/devkit';
-import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
+import { upsertTargetDefault } from '@nx/devkit/internal';
 import { initGenerator as jsInitGenerator } from '@nx/js';
 import {
   addProjectToTsSolutionWorkspace,

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -258,7 +258,7 @@ function findBuildDefault(
       (e) =>
         e.target === 'build' &&
         e.projects === undefined &&
-        e.source === undefined
+        e.plugin === undefined
     );
   }
   return td['build'];

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -12,6 +12,7 @@ import {
   type TargetDefaults,
   Tree,
   updateJson,
+  updateNxJson,
 } from '@nx/devkit';
 import { upsertTargetDefault } from '@nx/devkit/internal';
 import { initGenerator as jsInitGenerator } from '@nx/js';
@@ -116,16 +117,21 @@ export async function applicationGeneratorInternal(
   tasks.push(initTask);
 
   if (!options.addPlugin) {
-    const nxJson = readNxJson(tree);
+    const nxJson = readNxJson(tree) ?? {};
     const existing = findBuildDefault(nxJson.targetDefaults);
     if (!existing) {
-      upsertTargetDefault(tree, {
+      upsertTargetDefault(tree, nxJson, {
         target: 'build',
         cache: true,
         dependsOn: ['^build'],
       });
+      updateNxJson(tree, nxJson);
     } else if (!existing.dependsOn) {
-      upsertTargetDefault(tree, { target: 'build', dependsOn: ['^build'] });
+      upsertTargetDefault(tree, nxJson, {
+        target: 'build',
+        dependsOn: ['^build'],
+      });
+      updateNxJson(tree, nxJson);
     }
   }
 

--- a/packages/react/src/generators/setup-ssr/setup-ssr.ts
+++ b/packages/react/src/generators/setup-ssr/setup-ssr.ts
@@ -230,7 +230,6 @@ export async function setupSsrGenerator(tree: Tree, options: Schema) {
       'server',
     ];
   }
-  upsertTargetDefault(tree, { target: 'server', cache: true });
 
   generateFiles(tree, join(__dirname, 'files'), projectRoot, {
     tmpl: '',
@@ -260,6 +259,7 @@ export async function setupSsrGenerator(tree: Tree, options: Schema) {
   }
 
   updateNxJson(tree, nxJson);
+  upsertTargetDefault(tree, { target: 'server', cache: true });
 
   const installTask = addDependenciesToPackageJson(
     tree,

--- a/packages/react/src/generators/setup-ssr/setup-ssr.ts
+++ b/packages/react/src/generators/setup-ssr/setup-ssr.ts
@@ -12,7 +12,7 @@ import {
   updateNxJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
+import { upsertTargetDefault } from '@nx/devkit/internal';
 import type * as ts from 'typescript';
 
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';

--- a/packages/react/src/generators/setup-ssr/setup-ssr.ts
+++ b/packages/react/src/generators/setup-ssr/setup-ssr.ts
@@ -12,6 +12,7 @@ import {
   updateNxJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
+import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
 import type * as ts from 'typescript';
 
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
@@ -229,9 +230,7 @@ export async function setupSsrGenerator(tree: Tree, options: Schema) {
       'server',
     ];
   }
-  nxJson.targetDefaults ??= {};
-  nxJson.targetDefaults['server'] ??= {};
-  nxJson.targetDefaults.server.cache = true;
+  upsertTargetDefault(tree, { target: 'server', cache: true });
 
   generateFiles(tree, join(__dirname, 'files'), projectRoot, {
     tmpl: '',

--- a/packages/react/src/generators/setup-ssr/setup-ssr.ts
+++ b/packages/react/src/generators/setup-ssr/setup-ssr.ts
@@ -258,8 +258,8 @@ export async function setupSsrGenerator(tree: Tree, options: Schema) {
     tree.write(serverEntry, changes);
   }
 
+  upsertTargetDefault(tree, nxJson, { target: 'server', cache: true });
   updateNxJson(tree, nxJson);
-  upsertTargetDefault(tree, { target: 'server', cache: true });
 
   const installTask = addDependenciesToPackageJson(
     tree,

--- a/packages/react/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.spec.ts
+++ b/packages/react/src/migrations/update-18-0-0/add-mf-env-var-to-target-defaults.spec.ts
@@ -22,12 +22,21 @@ describe('addMfEnvVarToTargetDefaults', () => {
     // ASSERT
     const nxJson = readNxJson(tree);
     expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
-      {
-        "@nx/webpack:webpack": {
+      [
+        {
+          "cache": true,
+          "target": "build",
+        },
+        {
+          "cache": true,
+          "target": "lint",
+        },
+        {
           "cache": true,
           "dependsOn": [
             "^build",
           ],
+          "executor": "@nx/webpack:webpack",
           "inputs": [
             "production",
             "^production",
@@ -36,13 +45,7 @@ describe('addMfEnvVarToTargetDefaults', () => {
             },
           ],
         },
-        "build": {
-          "cache": true,
-        },
-        "lint": {
-          "cache": true,
-        },
-      }
+      ]
     `);
   });
 
@@ -108,12 +111,21 @@ describe('addMfEnvVarToTargetDefaults', () => {
     // ASSERT
     nxJson = readNxJson(tree);
     expect(nxJson.targetDefaults).toMatchInlineSnapshot(`
-      {
-        "@nx/webpack:webpack": {
+      [
+        {
+          "cache": true,
+          "target": "build",
+        },
+        {
+          "cache": true,
+          "target": "lint",
+        },
+        {
           "cache": true,
           "dependsOn": [
             "^build",
           ],
+          "executor": "@nx/webpack:webpack",
           "inputs": [
             "^build",
             {
@@ -121,13 +133,7 @@ describe('addMfEnvVarToTargetDefaults', () => {
             },
           ],
         },
-        "build": {
-          "cache": true,
-        },
-        "lint": {
-          "cache": true,
-        },
-      }
+      ]
     `);
   });
 });

--- a/packages/react/src/utils/add-mf-env-to-inputs.ts
+++ b/packages/react/src/utils/add-mf-env-to-inputs.ts
@@ -1,4 +1,4 @@
-import { type Tree, readNxJson } from '@nx/devkit';
+import { type Tree, readNxJson, updateNxJson } from '@nx/devkit';
 import {
   normalizeTargetDefaults,
   upsertTargetDefault,
@@ -8,12 +8,12 @@ export function addMfEnvToTargetDefaultInputs(
   tree: Tree,
   bundler: 'rspack' | 'webpack'
 ) {
-  const nxJson = readNxJson(tree);
+  const nxJson = readNxJson(tree) ?? {};
   const executor =
     bundler === 'rspack' ? '@nx/rspack:rspack' : '@nx/webpack:webpack';
   const mfEnvVar = 'NX_MF_DEV_REMOTES';
 
-  const existing = normalizeTargetDefaults(nxJson?.targetDefaults).find(
+  const existing = normalizeTargetDefaults(nxJson.targetDefaults).find(
     (e) =>
       e.executor === executor &&
       e.target === undefined &&
@@ -33,10 +33,11 @@ export function addMfEnvToTargetDefaultInputs(
     inputs.push({ env: mfEnvVar });
   }
 
-  upsertTargetDefault(tree, {
+  upsertTargetDefault(tree, nxJson, {
     executor,
     cache: true,
     inputs,
     dependsOn: existing?.dependsOn ?? ['^build'],
   });
+  updateNxJson(tree, nxJson);
 }

--- a/packages/react/src/utils/add-mf-env-to-inputs.ts
+++ b/packages/react/src/utils/add-mf-env-to-inputs.ts
@@ -1,6 +1,8 @@
 import { type Tree, readNxJson } from '@nx/devkit';
-import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
-import { normalizeTargetDefaults } from '@nx/devkit/src/utils/normalize-target-defaults';
+import {
+  normalizeTargetDefaults,
+  upsertTargetDefault,
+} from '@nx/devkit/internal';
 
 export function addMfEnvToTargetDefaultInputs(
   tree: Tree,

--- a/packages/react/src/utils/add-mf-env-to-inputs.ts
+++ b/packages/react/src/utils/add-mf-env-to-inputs.ts
@@ -18,7 +18,7 @@ export function addMfEnvToTargetDefaultInputs(
       e.executor === executor &&
       e.target === undefined &&
       e.projects === undefined &&
-      e.source === undefined
+      e.plugin === undefined
   );
 
   const inputs = [...(existing?.inputs ?? ['production', '^production'])];

--- a/packages/react/src/utils/add-mf-env-to-inputs.ts
+++ b/packages/react/src/utils/add-mf-env-to-inputs.ts
@@ -1,4 +1,6 @@
-import { type Tree, readNxJson, updateNxJson } from '@nx/devkit';
+import { type Tree, readNxJson } from '@nx/devkit';
+import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
+import { normalizeTargetDefaults } from '@nx/devkit/src/utils/normalize-target-defaults';
 
 export function addMfEnvToTargetDefaultInputs(
   tree: Tree,
@@ -9,21 +11,30 @@ export function addMfEnvToTargetDefaultInputs(
     bundler === 'rspack' ? '@nx/rspack:rspack' : '@nx/webpack:webpack';
   const mfEnvVar = 'NX_MF_DEV_REMOTES';
 
-  nxJson.targetDefaults ??= {};
-  nxJson.targetDefaults[executor] ??= {};
-  nxJson.targetDefaults[executor].inputs ??= ['production', '^production'];
-  nxJson.targetDefaults[executor].dependsOn ??= ['^build'];
+  const existing = normalizeTargetDefaults(nxJson?.targetDefaults).find(
+    (e) =>
+      e.executor === executor &&
+      e.target === undefined &&
+      e.projects === undefined &&
+      e.source === undefined
+  );
 
+  const inputs = [...(existing?.inputs ?? ['production', '^production'])];
   let mfEnvVarExists = false;
-  for (const input of nxJson.targetDefaults[executor].inputs) {
+  for (const input of inputs) {
     if (typeof input === 'object' && input['env'] === mfEnvVar) {
       mfEnvVarExists = true;
       break;
     }
   }
   if (!mfEnvVarExists) {
-    nxJson.targetDefaults[executor].inputs.push({ env: mfEnvVar });
+    inputs.push({ env: mfEnvVar });
   }
-  nxJson.targetDefaults[executor].cache = true;
-  updateNxJson(tree, nxJson);
+
+  upsertTargetDefault(tree, {
+    executor,
+    cache: true,
+    inputs,
+    dependsOn: existing?.dependsOn ?? ['^build'],
+  });
 }

--- a/packages/remix/src/generators/application/lib/add-e2e.ts
+++ b/packages/remix/src/generators/application/lib/add-e2e.ts
@@ -1,4 +1,7 @@
-import { getE2EWebServerInfo } from '@nx/devkit/internal';
+import {
+  getE2EWebServerInfo,
+  readTargetDefaultsForTarget,
+} from '@nx/devkit/internal';
 import {
   type Tree,
   addProjectConfiguration,
@@ -143,12 +146,13 @@ async function getRemixE2EWebServerInfo(
   let e2ePort = isPluginBeingAdded ? 3000 : 4200;
 
   const defaultServeTarget = isPluginBeingAdded ? 'dev' : 'serve';
+  const serveTargetOptions = readTargetDefaultsForTarget(
+    defaultServeTarget,
+    nxJson.targetDefaults
+  )?.options;
 
-  if (
-    nxJson.targetDefaults?.[defaultServeTarget] &&
-    nxJson.targetDefaults?.[defaultServeTarget].options?.port
-  ) {
-    e2ePort = nxJson.targetDefaults?.[defaultServeTarget].options?.port;
+  if (serveTargetOptions?.port) {
+    e2ePort = serveTargetOptions.port;
   }
 
   return getE2EWebServerInfo(

--- a/packages/rollup/src/generators/configuration/configuration.legacy.spec.ts
+++ b/packages/rollup/src/generators/configuration/configuration.legacy.spec.ts
@@ -47,11 +47,14 @@ describe('configurationGenerator', () => {
       version: '0.0.1',
     });
 
-    expect(
-      readJson(tree, 'nx.json').targetDefaults['@nx/rollup:rollup']
-    ).toEqual({
+    const td = readJson(tree, 'nx.json').targetDefaults;
+    const rollupEntry = Array.isArray(td)
+      ? td.find((e) => e.executor === '@nx/rollup:rollup')
+      : td['@nx/rollup:rollup'];
+    expect(rollupEntry).toEqual({
       cache: true,
       dependsOn: ['^build'],
+      executor: '@nx/rollup:rollup',
       inputs: [
         'default',
         '^default',

--- a/packages/rollup/src/generators/configuration/configuration.ts
+++ b/packages/rollup/src/generators/configuration/configuration.ts
@@ -1,4 +1,7 @@
-import { addBuildTargetDefaults } from '@nx/devkit/internal';
+import {
+  addBuildTargetDefaults,
+  readTargetDefaultsForTarget,
+} from '@nx/devkit/internal';
 import {
   formatFiles,
   GeneratorCallback,
@@ -180,9 +183,11 @@ function updatePackageJson(
       const nxJson = readNxJson(tree);
       const mergedTarget = mergeTargetConfigurations(
         projectTarget,
-        (projectTarget.executor
-          ? nxJson.targetDefaults?.[projectTarget.executor]
-          : undefined) ?? nxJson.targetDefaults?.[options.buildTarget]
+        readTargetDefaultsForTarget(
+          options.buildTarget,
+          nxJson.targetDefaults,
+          projectTarget.executor
+        )
       );
       ({ main, outputPath } = mergedTarget.options);
     }

--- a/packages/rollup/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/rollup/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -46,8 +46,13 @@ export async function convertToInferred(tree: Tree, options: Schema) {
           e.source === undefined
       );
       if (defaults) {
-        const { target: _t, executor: _e, projects: _p, source: _s, ...rest } =
-          defaults;
+        const {
+          target: _t,
+          executor: _e,
+          projects: _p,
+          source: _s,
+          ...rest
+        } = defaults;
         for (const [key, value] of Object.entries(rest)) {
           target[key] ??= value;
         }

--- a/packages/rollup/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/rollup/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -1,6 +1,7 @@
 import {
   forEachExecutorOptions,
   NoTargetsToMigrateError,
+  normalizeTargetDefaults,
 } from '@nx/devkit/internal';
 import {
   formatFiles,
@@ -37,9 +38,17 @@ export async function convertToInferred(tree: Tree, options: Schema) {
 
       // Since targetDefaults for '@nx/rollup:rollup' will no longer apply, we want to copy them to the target options.
       const nxJson = readNxJson(tree);
-      const defaults = nxJson.targetDefaults['@nx/rollup:rollup'];
+      const defaults = normalizeTargetDefaults(nxJson?.targetDefaults).find(
+        (e) =>
+          e.executor === '@nx/rollup:rollup' &&
+          e.target === undefined &&
+          e.projects === undefined &&
+          e.source === undefined
+      );
       if (defaults) {
-        for (const [key, value] of Object.entries(defaults)) {
+        const { target: _t, executor: _e, projects: _p, source: _s, ...rest } =
+          defaults;
+        for (const [key, value] of Object.entries(rest)) {
           target[key] ??= value;
         }
       }

--- a/packages/rollup/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/rollup/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -43,14 +43,14 @@ export async function convertToInferred(tree: Tree, options: Schema) {
           e.executor === '@nx/rollup:rollup' &&
           e.target === undefined &&
           e.projects === undefined &&
-          e.source === undefined
+          e.plugin === undefined
       );
       if (defaults) {
         const {
           target: _t,
           executor: _e,
           projects: _p,
-          source: _s,
+          plugin: _pl,
           ...rest
         } = defaults;
         for (const [key, value] of Object.entries(rest)) {

--- a/packages/rsbuild/src/utils/e2e-web-server-info-utils.spec.ts
+++ b/packages/rsbuild/src/utils/e2e-web-server-info-utils.spec.ts
@@ -1,0 +1,58 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { type Tree, readNxJson, updateNxJson } from 'nx/src/devkit-exports';
+import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
+import { getRsbuildE2EWebServerInfo } from './e2e-web-server-info-utils';
+
+describe('getRsbuildE2EWebServerInfo', () => {
+  let tree: Tree;
+  let tempFs: TempFs;
+
+  beforeEach(() => {
+    tempFs = new TempFs('e2e-webserver-info');
+    tree = createTreeWithEmptyWorkspace();
+    tree.root = tempFs.tempDir;
+
+    tree.write(`app/rsbuild.config.ts`, ``);
+    tempFs.createFileSync(`app/rsbuild.config.ts`, ``);
+    tempFs.createFileSync('package-lock.json', '{}');
+  });
+
+  afterEach(() => {
+    tempFs.cleanup();
+    jest.resetModules();
+  });
+
+  it('should use array-shaped targetDefaults when no plugin is registered and plugins are not being used', async () => {
+    // ARRANGE
+    const nxJson = readNxJson(tree);
+    nxJson.plugins ??= [];
+    nxJson.targetDefaults = [
+      {
+        target: 'dev',
+        options: {
+          port: 4400,
+        },
+      },
+    ];
+    updateNxJson(tree, nxJson);
+
+    // ACT
+    const e2eWebServerInfo = await getRsbuildE2EWebServerInfo(
+      tree,
+      'app',
+      'app/rsbuild.config.ts',
+      false
+    );
+
+    // ASSERT
+    expect(e2eWebServerInfo).toMatchInlineSnapshot(`
+      {
+        "e2eCiBaseUrl": "http://localhost:4400",
+        "e2eCiWebServerCommand": "npx nx run app:preview",
+        "e2eDevServerTarget": "app:dev",
+        "e2eWebServerAddress": "http://localhost:4400",
+        "e2eWebServerCommand": "npx nx run app:dev",
+      }
+    `);
+  });
+});

--- a/packages/rsbuild/src/utils/e2e-web-server-info-utils.ts
+++ b/packages/rsbuild/src/utils/e2e-web-server-info-utils.ts
@@ -1,5 +1,8 @@
 import { type Tree, readNxJson } from '@nx/devkit';
-import { getE2EWebServerInfo } from '@nx/devkit/internal';
+import {
+  getE2EWebServerInfo,
+  readTargetDefaultsForTarget,
+} from '@nx/devkit/internal';
 
 export async function getRsbuildE2EWebServerInfo(
   tree: Tree,
@@ -10,12 +13,11 @@ export async function getRsbuildE2EWebServerInfo(
 ) {
   const nxJson = readNxJson(tree);
   let e2ePort = e2ePortOverride ?? 4200;
+  const devPort = readTargetDefaultsForTarget('dev', nxJson.targetDefaults)
+    ?.options?.port;
 
-  if (
-    nxJson.targetDefaults?.['dev'] &&
-    nxJson.targetDefaults?.['dev'].options?.port
-  ) {
-    e2ePort = nxJson.targetDefaults?.['dev'].options?.port;
+  if (devPort) {
+    e2ePort = devPort;
   }
 
   return getE2EWebServerInfo(

--- a/packages/rspack/src/utils/e2e-web-server-info-utils.spec.ts
+++ b/packages/rspack/src/utils/e2e-web-server-info-utils.spec.ts
@@ -1,0 +1,58 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { type Tree, readNxJson, updateNxJson } from 'nx/src/devkit-exports';
+import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
+import { getRspackE2EWebServerInfo } from './e2e-web-server-info-utils';
+
+describe('getRspackE2EWebServerInfo', () => {
+  let tree: Tree;
+  let tempFs: TempFs;
+
+  beforeEach(() => {
+    tempFs = new TempFs('e2e-webserver-info');
+    tree = createTreeWithEmptyWorkspace();
+    tree.root = tempFs.tempDir;
+
+    tree.write(`app/rspack.config.ts`, ``);
+    tempFs.createFileSync(`app/rspack.config.ts`, ``);
+    tempFs.createFileSync('package-lock.json', '{}');
+  });
+
+  afterEach(() => {
+    tempFs.cleanup();
+    jest.resetModules();
+  });
+
+  it('should use array-shaped targetDefaults when no plugin is registered and plugins are not being used', async () => {
+    // ARRANGE
+    const nxJson = readNxJson(tree);
+    nxJson.plugins ??= [];
+    nxJson.targetDefaults = [
+      {
+        target: 'serve',
+        options: {
+          port: 4400,
+        },
+      },
+    ];
+    updateNxJson(tree, nxJson);
+
+    // ACT
+    const e2eWebServerInfo = await getRspackE2EWebServerInfo(
+      tree,
+      'app',
+      'app/rspack.config.ts',
+      false
+    );
+
+    // ASSERT
+    expect(e2eWebServerInfo).toMatchInlineSnapshot(`
+      {
+        "e2eCiBaseUrl": "http://localhost:4400",
+        "e2eCiWebServerCommand": "npx nx run app:preview",
+        "e2eDevServerTarget": "app:serve",
+        "e2eWebServerAddress": "http://localhost:4400",
+        "e2eWebServerCommand": "npx nx run app:serve",
+      }
+    `);
+  });
+});

--- a/packages/rspack/src/utils/e2e-web-server-info-utils.ts
+++ b/packages/rspack/src/utils/e2e-web-server-info-utils.ts
@@ -1,5 +1,8 @@
 import { type Tree, readNxJson } from '@nx/devkit';
-import { getE2EWebServerInfo } from '@nx/devkit/internal';
+import {
+  getE2EWebServerInfo,
+  readTargetDefaultsForTarget,
+} from '@nx/devkit/internal';
 
 export async function getRspackE2EWebServerInfo(
   tree: Tree,
@@ -10,12 +13,11 @@ export async function getRspackE2EWebServerInfo(
 ) {
   const nxJson = readNxJson(tree);
   let e2ePort = e2ePortOverride ?? 4200;
+  const servePort = readTargetDefaultsForTarget('serve', nxJson.targetDefaults)
+    ?.options?.port;
 
-  if (
-    nxJson.targetDefaults?.['serve'] &&
-    nxJson.targetDefaults?.['serve'].options?.port
-  ) {
-    e2ePort = nxJson.targetDefaults?.['serve'].options?.port;
+  if (servePort) {
+    e2ePort = servePort;
   }
 
   return getE2EWebServerInfo(

--- a/packages/storybook/src/generators/configuration/lib/util-functions.ts
+++ b/packages/storybook/src/generators/configuration/lib/util-functions.ts
@@ -29,8 +29,10 @@ import { UiFramework } from '../../../utils/models';
 import { nxVersion } from '../../../utils/versions';
 import { findEslintFile } from '@nx/eslint/src/generators/utils/eslint-file';
 import { useFlatConfig } from '@nx/eslint/src/utils/flat-config';
-import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
-import { normalizeTargetDefaults } from '@nx/devkit/src/utils/normalize-target-defaults';
+import {
+  normalizeTargetDefaults,
+  upsertTargetDefault,
+} from '@nx/devkit/internal';
 import {
   findRuntimeTsConfigName,
   getProjectType,

--- a/packages/storybook/src/generators/configuration/lib/util-functions.ts
+++ b/packages/storybook/src/generators/configuration/lib/util-functions.ts
@@ -523,9 +523,9 @@ export function addStorybookToNamedInputs(tree: Tree) {
 }
 
 export function addStorybookToTargetDefaults(tree: Tree, setCache = true) {
-  const nxJson = readNxJson(tree);
+  const nxJson = readNxJson(tree) ?? {};
 
-  const existing = normalizeTargetDefaults(nxJson?.targetDefaults).find(
+  const existing = normalizeTargetDefaults(nxJson.targetDefaults).find(
     (e) =>
       e.target === 'build-storybook' &&
       e.executor === undefined &&
@@ -537,7 +537,7 @@ export function addStorybookToTargetDefaults(tree: Tree, setCache = true) {
     ? [...existing.inputs]
     : [
         'default',
-        nxJson?.namedInputs && 'production' in nxJson.namedInputs
+        nxJson.namedInputs && 'production' in nxJson.namedInputs
           ? '^production'
           : '^default',
       ];
@@ -554,11 +554,12 @@ export function addStorybookToTargetDefaults(tree: Tree, setCache = true) {
     inputs.push('{projectRoot}/tsconfig.storybook.json');
   }
 
-  upsertTargetDefault(tree, {
+  upsertTargetDefault(tree, nxJson, {
     target: 'build-storybook',
     ...(setCache && existing?.cache === undefined ? { cache: true } : {}),
     inputs,
   });
+  updateNxJson(tree, nxJson);
 }
 
 export function createProjectStorybookDir(

--- a/packages/storybook/src/generators/configuration/lib/util-functions.ts
+++ b/packages/storybook/src/generators/configuration/lib/util-functions.ts
@@ -530,7 +530,7 @@ export function addStorybookToTargetDefaults(tree: Tree, setCache = true) {
       e.target === 'build-storybook' &&
       e.executor === undefined &&
       e.projects === undefined &&
-      e.source === undefined
+      e.plugin === undefined
   );
 
   const inputs = existing?.inputs

--- a/packages/storybook/src/generators/configuration/lib/util-functions.ts
+++ b/packages/storybook/src/generators/configuration/lib/util-functions.ts
@@ -29,6 +29,8 @@ import { UiFramework } from '../../../utils/models';
 import { nxVersion } from '../../../utils/versions';
 import { findEslintFile } from '@nx/eslint/src/generators/utils/eslint-file';
 import { useFlatConfig } from '@nx/eslint/src/utils/flat-config';
+import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
+import { normalizeTargetDefaults } from '@nx/devkit/src/utils/normalize-target-defaults';
 import {
   findRuntimeTsConfigName,
   getProjectType,
@@ -521,49 +523,40 @@ export function addStorybookToNamedInputs(tree: Tree) {
 export function addStorybookToTargetDefaults(tree: Tree, setCache = true) {
   const nxJson = readNxJson(tree);
 
-  nxJson.targetDefaults ??= {};
-  nxJson.targetDefaults['build-storybook'] ??= {};
-  if (setCache) {
-    nxJson.targetDefaults['build-storybook'].cache ??= true;
-  }
-  nxJson.targetDefaults['build-storybook'].inputs ??= [
-    'default',
-    nxJson.namedInputs && 'production' in nxJson.namedInputs
-      ? '^production'
-      : '^default',
-  ];
-
-  if (
-    !nxJson.targetDefaults['build-storybook'].inputs.includes(
-      '{projectRoot}/.storybook/**/*'
-    )
-  ) {
-    nxJson.targetDefaults['build-storybook'].inputs.push(
-      '{projectRoot}/.storybook/**/*'
-    );
-  }
-
-  // Delete the !{projectRoot}/.storybook/**/* glob from build-storybook
-  // because we want to rebuild Storybook if the .storybook folder changes
-  const index = nxJson.targetDefaults['build-storybook'].inputs.indexOf(
-    '!{projectRoot}/.storybook/**/*'
+  const existing = normalizeTargetDefaults(nxJson?.targetDefaults).find(
+    (e) =>
+      e.target === 'build-storybook' &&
+      e.executor === undefined &&
+      e.projects === undefined &&
+      e.source === undefined
   );
 
-  if (index !== -1) {
-    nxJson.targetDefaults['build-storybook'].inputs.splice(index, 1);
+  const inputs = existing?.inputs
+    ? [...existing.inputs]
+    : [
+        'default',
+        nxJson?.namedInputs && 'production' in nxJson.namedInputs
+          ? '^production'
+          : '^default',
+      ];
+
+  if (!inputs.includes('{projectRoot}/.storybook/**/*')) {
+    inputs.push('{projectRoot}/.storybook/**/*');
   }
 
-  if (
-    !nxJson.targetDefaults['build-storybook'].inputs.includes(
-      '{projectRoot}/tsconfig.storybook.json'
-    )
-  ) {
-    nxJson.targetDefaults['build-storybook'].inputs.push(
-      '{projectRoot}/tsconfig.storybook.json'
-    );
+  // Drop the negation glob so Storybook rebuilds when .storybook changes.
+  const negatedIndex = inputs.indexOf('!{projectRoot}/.storybook/**/*');
+  if (negatedIndex !== -1) inputs.splice(negatedIndex, 1);
+
+  if (!inputs.includes('{projectRoot}/tsconfig.storybook.json')) {
+    inputs.push('{projectRoot}/tsconfig.storybook.json');
   }
 
-  updateNxJson(tree, nxJson);
+  upsertTargetDefault(tree, {
+    target: 'build-storybook',
+    ...(setCache && existing?.cache === undefined ? { cache: true } : {}),
+    inputs,
+  });
 }
 
 export function createProjectStorybookDir(

--- a/packages/storybook/src/generators/init/init.spec.ts
+++ b/packages/storybook/src/generators/init/init.spec.ts
@@ -6,6 +6,7 @@ import {
   updateNxJson,
   readNxJson,
 } from '@nx/devkit';
+import { normalizeTargetDefaults } from '@nx/devkit/internal';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { initGenerator } from './init';
 
@@ -32,7 +33,10 @@ describe('@nx/storybook:init', () => {
       addPlugin: false,
     });
     const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
-    expect(nxJson.targetDefaults['build-storybook'].cache).toEqual(true);
+    const buildStorybookDefault = normalizeTargetDefaults(
+      nxJson.targetDefaults
+    ).find((entry) => entry.target === 'build-storybook');
+    expect(buildStorybookDefault?.cache).toEqual(true);
     delete process.env.NX_ADD_PLUGINS;
   });
 

--- a/packages/storybook/src/generators/init/init.ts
+++ b/packages/storybook/src/generators/init/init.ts
@@ -1,4 +1,4 @@
-import { addPlugin } from '@nx/devkit/internal';
+import { addPlugin, upsertTargetDefault } from '@nx/devkit/internal';
 import {
   addDependenciesToPackageJson,
   createProjectGraphAsync,
@@ -54,11 +54,8 @@ function addCacheableOperation(tree: Tree) {
     );
   }
 
-  nxJson.targetDefaults ??= {};
-  nxJson.targetDefaults['build-storybook'] ??= {};
-  nxJson.targetDefaults['build-storybook'].cache = true;
-
   updateNxJson(tree, nxJson);
+  upsertTargetDefault(tree, { target: 'build-storybook', cache: true });
 }
 
 function moveToDevDependencies(tree: Tree): GeneratorCallback {

--- a/packages/storybook/src/generators/init/init.ts
+++ b/packages/storybook/src/generators/init/init.ts
@@ -44,7 +44,7 @@ function checkDependenciesInstalled(
 }
 
 function addCacheableOperation(tree: Tree) {
-  const nxJson = readNxJson(tree);
+  const nxJson = readNxJson(tree) ?? {};
   const cacheableOperations: string[] | null =
     nxJson.tasksRunnerOptions?.default?.options?.cacheableOperations;
 
@@ -54,8 +54,8 @@ function addCacheableOperation(tree: Tree) {
     );
   }
 
+  upsertTargetDefault(tree, nxJson, { target: 'build-storybook', cache: true });
   updateNxJson(tree, nxJson);
-  upsertTargetDefault(tree, { target: 'build-storybook', cache: true });
 }
 
 function moveToDevDependencies(tree: Tree): GeneratorCallback {

--- a/packages/vite/src/migrations/update-22-2-0/migrate-vitest-to-vitest-package.spec.ts
+++ b/packages/vite/src/migrations/update-22-2-0/migrate-vitest-to-vitest-package.spec.ts
@@ -3,12 +3,18 @@ import {
   readJson,
   readNxJson,
   readProjectConfiguration,
+  type TargetDefaultsRecord,
   type Tree,
   updateNxJson,
   writeJson,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import migrateVitestToVitestPackage from './migrate-vitest-to-vitest-package';
+
+// This migration ran before targetDefaults supported the array shape, so
+// the test fixtures all use the legacy record shape.
+const td = (n: { targetDefaults?: unknown }) =>
+  n.targetDefaults as TargetDefaultsRecord;
 
 describe('migrate-vitest-to-vitest-package', () => {
   let tree: Tree;
@@ -422,8 +428,8 @@ describe('migrate-vitest-to-vitest-package', () => {
       await migrateVitestToVitestPackage(tree);
 
       const updatedNxJson = readNxJson(tree);
-      expect(updatedNxJson.targetDefaults['@nx/vite:test']).toBeUndefined();
-      expect(updatedNxJson.targetDefaults['@nx/vitest:test']).toEqual({
+      expect(td(updatedNxJson)['@nx/vite:test']).toBeUndefined();
+      expect(td(updatedNxJson)['@nx/vitest:test']).toEqual({
         cache: true,
         inputs: ['default', '^production'],
       });
@@ -444,8 +450,8 @@ describe('migrate-vitest-to-vitest-package', () => {
       await migrateVitestToVitestPackage(tree);
 
       const updatedNxJson = readNxJson(tree);
-      expect(updatedNxJson.targetDefaults['@nx/vite:test']).toBeUndefined();
-      expect(updatedNxJson.targetDefaults['@nx/vitest:test']).toEqual({
+      expect(td(updatedNxJson)['@nx/vite:test']).toBeUndefined();
+      expect(td(updatedNxJson)['@nx/vitest:test']).toEqual({
         cache: true,
         inputs: ['default'],
       });
@@ -463,7 +469,7 @@ describe('migrate-vitest-to-vitest-package', () => {
       await migrateVitestToVitestPackage(tree);
 
       const updatedNxJson = readNxJson(tree);
-      expect(updatedNxJson.targetDefaults).toEqual({
+      expect(td(updatedNxJson)).toEqual({
         build: {
           cache: true,
         },
@@ -484,7 +490,7 @@ describe('migrate-vitest-to-vitest-package', () => {
       await migrateVitestToVitestPackage(tree);
 
       const updatedNxJson = readNxJson(tree);
-      expect(updatedNxJson.targetDefaults.test).toEqual({
+      expect(td(updatedNxJson).test).toEqual({
         executor: '@nx/vitest:test',
         cache: true,
         inputs: ['default', '^production'],
@@ -508,12 +514,12 @@ describe('migrate-vitest-to-vitest-package', () => {
 
       const updatedNxJson = readNxJson(tree);
       // Executor-keyed should be migrated to new key
-      expect(updatedNxJson.targetDefaults['@nx/vite:test']).toBeUndefined();
-      expect(updatedNxJson.targetDefaults['@nx/vitest:test']).toEqual({
+      expect(td(updatedNxJson)['@nx/vite:test']).toBeUndefined();
+      expect(td(updatedNxJson)['@nx/vitest:test']).toEqual({
         cache: true,
       });
       // Target-name-keyed should have executor updated in place
-      expect(updatedNxJson.targetDefaults.test).toEqual({
+      expect(td(updatedNxJson).test).toEqual({
         executor: '@nx/vitest:test',
         inputs: ['default'],
       });
@@ -551,7 +557,7 @@ describe('migrate-vitest-to-vitest-package', () => {
 
       // Should not fail, just skip targetDefaults migration
       const updatedNxJson = readNxJson(tree);
-      expect(updatedNxJson.targetDefaults).toBeUndefined();
+      expect(td(updatedNxJson)).toBeUndefined();
     });
   });
 });

--- a/packages/vite/src/migrations/update-22-2-0/migrate-vitest-to-vitest-package.ts
+++ b/packages/vite/src/migrations/update-22-2-0/migrate-vitest-to-vitest-package.ts
@@ -175,21 +175,36 @@ function migrateTargetDefaults(tree: Tree): void {
 
   let hasChanges = false;
 
-  for (const [targetOrExecutor, targetConfig] of Object.entries(
-    nxJson.targetDefaults
-  )) {
-    // Pattern A: Executor-keyed (e.g., "@nx/vite:test": { ... })
-    if (targetOrExecutor === '@nx/vite:test') {
-      // Move config to new executor key
-      nxJson.targetDefaults['@nx/vitest:test'] ??= {};
-      Object.assign(nxJson.targetDefaults['@nx/vitest:test'], targetConfig);
-      delete nxJson.targetDefaults['@nx/vite:test'];
-      hasChanges = true;
+  if (Array.isArray(nxJson.targetDefaults)) {
+    for (const entry of nxJson.targetDefaults) {
+      // Pattern A: an executor entry for @nx/vite:test
+      if (entry.executor === '@nx/vite:test' && entry.target === undefined) {
+        entry.executor = '@nx/vitest:test';
+        hasChanges = true;
+      }
+      // Pattern B: a target entry whose executor field references @nx/vite:test
+      else if (entry.executor === '@nx/vite:test') {
+        entry.executor = '@nx/vitest:test';
+        hasChanges = true;
+      }
     }
-    // Pattern B: Target-name-keyed (e.g., "test": { "executor": "@nx/vite:test", ... })
-    else if (targetConfig.executor === '@nx/vite:test') {
-      targetConfig.executor = '@nx/vitest:test';
-      hasChanges = true;
+  } else {
+    for (const [targetOrExecutor, targetConfig] of Object.entries(
+      nxJson.targetDefaults
+    )) {
+      // Pattern A: Executor-keyed (e.g., "@nx/vite:test": { ... })
+      if (targetOrExecutor === '@nx/vite:test') {
+        // Move config to new executor key
+        nxJson.targetDefaults['@nx/vitest:test'] ??= {};
+        Object.assign(nxJson.targetDefaults['@nx/vitest:test'], targetConfig);
+        delete nxJson.targetDefaults['@nx/vite:test'];
+        hasChanges = true;
+      }
+      // Pattern B: Target-name-keyed (e.g., "test": { "executor": "@nx/vite:test", ... })
+      else if (targetConfig.executor === '@nx/vite:test') {
+        targetConfig.executor = '@nx/vitest:test';
+        hasChanges = true;
+      }
     }
   }
 

--- a/packages/vite/src/utils/e2e-web-server-info-utils.spec.ts
+++ b/packages/vite/src/utils/e2e-web-server-info-utils.spec.ts
@@ -47,6 +47,40 @@ describe('getViteE2EWebServerInfo', () => {
     `);
   });
 
+  it('should use array-shaped serve targetDefaults when no plugin is registered and plugins are not being used', async () => {
+    // ARRANGE
+    const nxJson = readNxJson(tree);
+    nxJson.plugins ??= [];
+    nxJson.targetDefaults = [
+      {
+        target: 'serve',
+        options: {
+          port: 4400,
+        },
+      },
+    ];
+    updateNxJson(tree, nxJson);
+
+    // ACT
+    const e2eWebServerInfo = await getViteE2EWebServerInfo(
+      tree,
+      'app',
+      'app/vite.config.ts',
+      false
+    );
+
+    // ASSERT
+    expect(e2eWebServerInfo).toMatchInlineSnapshot(`
+      {
+        "e2eCiBaseUrl": "http://localhost:4300",
+        "e2eCiWebServerCommand": "npx nx run app:preview",
+        "e2eDevServerTarget": "app:dev",
+        "e2eWebServerAddress": "http://localhost:4400",
+        "e2eWebServerCommand": "npx nx run app:dev",
+      }
+    `);
+  });
+
   it('should use the default values of the plugin when the plugin is just a string', async () => {
     // ARRANGE
     const nxJson = readNxJson(tree);
@@ -68,6 +102,40 @@ describe('getViteE2EWebServerInfo', () => {
         "e2eCiWebServerCommand": "npx nx run app:preview",
         "e2eDevServerTarget": "app:dev",
         "e2eWebServerAddress": "http://localhost:4200",
+        "e2eWebServerCommand": "npx nx run app:dev",
+      }
+    `);
+  });
+
+  it('should use array-shaped dev targetDefaults when the plugin is just a string', async () => {
+    // ARRANGE
+    const nxJson = readNxJson(tree);
+    nxJson.plugins = ['@nx/vite/plugin'];
+    nxJson.targetDefaults = [
+      {
+        target: 'dev',
+        options: {
+          port: 4500,
+        },
+      },
+    ];
+    updateNxJson(tree, nxJson);
+
+    // ACT
+    const e2eWebServerInfo = await getViteE2EWebServerInfo(
+      tree,
+      'app',
+      'app/vite.config.ts',
+      true
+    );
+
+    // ASSERT
+    expect(e2eWebServerInfo).toMatchInlineSnapshot(`
+      {
+        "e2eCiBaseUrl": "http://localhost:4300",
+        "e2eCiWebServerCommand": "npx nx run app:preview",
+        "e2eDevServerTarget": "app:dev",
+        "e2eWebServerAddress": "http://localhost:4500",
         "e2eWebServerCommand": "npx nx run app:dev",
       }
     `);

--- a/packages/vite/src/utils/e2e-web-server-info-utils.ts
+++ b/packages/vite/src/utils/e2e-web-server-info-utils.ts
@@ -1,5 +1,8 @@
 import { type Tree, readNxJson } from '@nx/devkit';
-import { getE2EWebServerInfo } from '@nx/devkit/internal';
+import {
+  getE2EWebServerInfo,
+  readTargetDefaultsForTarget,
+} from '@nx/devkit/internal';
 
 export async function getViteE2EWebServerInfo(
   tree: Tree,
@@ -11,16 +14,13 @@ export async function getViteE2EWebServerInfo(
 ) {
   const nxJson = readNxJson(tree);
   let e2ePort = e2ePortOverride ?? 4200;
+  const devPort = readTargetDefaultsForTarget('dev', nxJson.targetDefaults)
+    ?.options?.port;
+  const servePort = readTargetDefaultsForTarget('serve', nxJson.targetDefaults)
+    ?.options?.port;
 
-  if (
-    (nxJson.targetDefaults?.['dev'] &&
-      nxJson.targetDefaults?.['dev'].options?.port) ||
-    (nxJson.targetDefaults?.['serve'] &&
-      nxJson.targetDefaults?.['serve'].options?.port)
-  ) {
-    e2ePort =
-      nxJson.targetDefaults?.['dev'].options?.port ??
-      nxJson.targetDefaults?.['serve'].options?.port;
+  if (devPort || servePort) {
+    e2ePort = devPort ?? servePort;
   }
 
   return getE2EWebServerInfo(

--- a/packages/vitest/src/generators/configuration/configuration.ts
+++ b/packages/vitest/src/generators/configuration/configuration.ts
@@ -15,6 +15,7 @@ import {
   type TargetDefaults,
   Tree,
   updateJson,
+  updateNxJson,
 } from '@nx/devkit';
 import { upsertTargetDefault } from '@nx/devkit/internal';
 import { initGenerator as jsInitGenerator } from '@nx/js';
@@ -245,13 +246,14 @@ getTestBed().initTestEnvironment(
   if (isTsSolutionSetup) {
     // in the TS solution setup, the test target depends on the build outputs
     // so we need to setup the task pipeline accordingly
-    const nxJson = readNxJson(tree);
+    const nxJson = readNxJson(tree) ?? {};
     const testTarget = schema.testTarget ?? 'test';
-    const existing = findTestDefault(nxJson?.targetDefaults, testTarget);
+    const existing = findTestDefault(nxJson.targetDefaults, testTarget);
     const dependsOn = Array.from(
       new Set([...(existing?.dependsOn ?? []), '^build'])
     );
-    upsertTargetDefault(tree, { target: testTarget, dependsOn });
+    upsertTargetDefault(tree, nxJson, { target: testTarget, dependsOn });
+    updateNxJson(tree, nxJson);
   }
 
   const devDependencies = await getCoverageProviderDependency(

--- a/packages/vitest/src/generators/configuration/configuration.ts
+++ b/packages/vitest/src/generators/configuration/configuration.ts
@@ -11,10 +11,13 @@ import {
   readNxJson,
   readProjectConfiguration,
   runTasksInSerial,
+  type TargetConfiguration,
+  type TargetDefaults,
   Tree,
   updateJson,
   updateNxJson,
 } from '@nx/devkit';
+import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
 import { initGenerator as jsInitGenerator } from '@nx/js';
 import {
   getProjectType,
@@ -245,13 +248,11 @@ getTestBed().initTestEnvironment(
     // so we need to setup the task pipeline accordingly
     const nxJson = readNxJson(tree);
     const testTarget = schema.testTarget ?? 'test';
-    nxJson.targetDefaults ??= {};
-    nxJson.targetDefaults[testTarget] ??= {};
-    nxJson.targetDefaults[testTarget].dependsOn ??= [];
-    nxJson.targetDefaults[testTarget].dependsOn = Array.from(
-      new Set([...nxJson.targetDefaults[testTarget].dependsOn, '^build'])
+    const existing = findTestDefault(nxJson?.targetDefaults, testTarget);
+    const dependsOn = Array.from(
+      new Set([...(existing?.dependsOn ?? []), '^build'])
     );
-    updateNxJson(tree, nxJson);
+    upsertTargetDefault(tree, { target: testTarget, dependsOn });
   }
 
   const devDependencies = await getCoverageProviderDependency(
@@ -521,6 +522,22 @@ function findBuildTarget(project: {
   }
 
   return project.targets?.build ?? null;
+}
+
+function findTestDefault(
+  td: TargetDefaults | undefined,
+  target: string
+): Partial<TargetConfiguration> | undefined {
+  if (!td) return undefined;
+  if (Array.isArray(td)) {
+    return td.find(
+      (e) =>
+        e.target === target &&
+        e.projects === undefined &&
+        e.source === undefined
+    );
+  }
+  return td[target];
 }
 
 export default configurationGenerator;

--- a/packages/vitest/src/generators/configuration/configuration.ts
+++ b/packages/vitest/src/generators/configuration/configuration.ts
@@ -535,7 +535,7 @@ function findTestDefault(
       (e) =>
         e.target === target &&
         e.projects === undefined &&
-        e.source === undefined
+        e.plugin === undefined
     );
   }
   return td[target];

--- a/packages/vitest/src/generators/configuration/configuration.ts
+++ b/packages/vitest/src/generators/configuration/configuration.ts
@@ -15,9 +15,8 @@ import {
   type TargetDefaults,
   Tree,
   updateJson,
-  updateNxJson,
 } from '@nx/devkit';
-import { upsertTargetDefault } from '@nx/devkit/src/generators/target-defaults-utils';
+import { upsertTargetDefault } from '@nx/devkit/internal';
 import { initGenerator as jsInitGenerator } from '@nx/js';
 import {
   getProjectType,

--- a/packages/vitest/src/generators/init/init.spec.ts
+++ b/packages/vitest/src/generators/init/init.spec.ts
@@ -215,7 +215,8 @@ describe('@nx/vitest:init', () => {
       });
 
       const nxJson = readNxJson(tree);
-      expect(nxJson.targetDefaults['@nx/vitest:test']).toEqual({
+      expect(nxJson.targetDefaults).toContainEqual({
+        executor: '@nx/vitest:test',
         cache: true,
         inputs: ['default', '^production'],
       });

--- a/packages/vitest/src/generators/init/init.ts
+++ b/packages/vitest/src/generators/init/init.ts
@@ -56,7 +56,7 @@ export function updateDependencies(tree: Tree, schema: InitGeneratorSchema) {
 }
 
 export function updateNxJsonSettings(tree: Tree) {
-  const nxJson = readNxJson(tree);
+  const nxJson = readNxJson(tree) ?? {};
 
   const productionFileSet = nxJson.namedInputs?.production;
   if (productionFileSet) {
@@ -72,8 +72,6 @@ export function updateNxJsonSettings(tree: Tree) {
     typeof p === 'string' ? p === '@nx/vitest' : p.plugin === '@nx/vitest'
   );
 
-  updateNxJson(tree, nxJson);
-
   if (!hasPlugin) {
     const existing = normalizeTargetDefaults(nxJson.targetDefaults).find(
       (e) =>
@@ -82,7 +80,7 @@ export function updateNxJsonSettings(tree: Tree) {
         e.projects === undefined &&
         e.source === undefined
     );
-    upsertTargetDefault(tree, {
+    upsertTargetDefault(tree, nxJson, {
       executor: '@nx/vitest:test',
       cache: existing?.cache ?? true,
       inputs: existing?.inputs ?? [
@@ -91,6 +89,8 @@ export function updateNxJsonSettings(tree: Tree) {
       ],
     });
   }
+
+  updateNxJson(tree, nxJson);
 }
 
 export async function initGenerator(tree: Tree, schema: InitGeneratorSchema) {

--- a/packages/vitest/src/generators/init/init.ts
+++ b/packages/vitest/src/generators/init/init.ts
@@ -1,4 +1,8 @@
-import { addPlugin } from '@nx/devkit/internal';
+import {
+  addPlugin,
+  upsertTargetDefault,
+  normalizeTargetDefaults,
+} from '@nx/devkit/internal';
 import {
   type Tree,
   type GeneratorCallback,
@@ -68,17 +72,25 @@ export function updateNxJsonSettings(tree: Tree) {
     typeof p === 'string' ? p === '@nx/vitest' : p.plugin === '@nx/vitest'
   );
 
-  if (!hasPlugin) {
-    nxJson.targetDefaults ??= {};
-    nxJson.targetDefaults['@nx/vitest:test'] ??= {};
-    nxJson.targetDefaults['@nx/vitest:test'].cache ??= true;
-    nxJson.targetDefaults['@nx/vitest:test'].inputs ??= [
-      'default',
-      productionFileSet ? '^production' : '^default',
-    ];
-  }
-
   updateNxJson(tree, nxJson);
+
+  if (!hasPlugin) {
+    const existing = normalizeTargetDefaults(nxJson.targetDefaults).find(
+      (e) =>
+        e.executor === '@nx/vitest:test' &&
+        e.target === undefined &&
+        e.projects === undefined &&
+        e.source === undefined
+    );
+    upsertTargetDefault(tree, {
+      executor: '@nx/vitest:test',
+      cache: existing?.cache ?? true,
+      inputs: existing?.inputs ?? [
+        'default',
+        productionFileSet ? '^production' : '^default',
+      ],
+    });
+  }
 }
 
 export async function initGenerator(tree: Tree, schema: InitGeneratorSchema) {

--- a/packages/vitest/src/generators/init/init.ts
+++ b/packages/vitest/src/generators/init/init.ts
@@ -78,7 +78,7 @@ export function updateNxJsonSettings(tree: Tree) {
         e.executor === '@nx/vitest:test' &&
         e.target === undefined &&
         e.projects === undefined &&
-        e.source === undefined
+        e.plugin === undefined
     );
     upsertTargetDefault(tree, nxJson, {
       executor: '@nx/vitest:test',

--- a/packages/vitest/src/migrations/update-22-6-0/prefix-reports-directory-with-project-root.spec.ts
+++ b/packages/vitest/src/migrations/update-22-6-0/prefix-reports-directory-with-project-root.spec.ts
@@ -2,11 +2,17 @@ import {
   addProjectConfiguration,
   readNxJson,
   readProjectConfiguration,
+  type TargetDefaultsRecord,
   type Tree,
   updateNxJson,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import prefixReportsDirectoryWithProjectRoot from './prefix-reports-directory-with-project-root';
+
+// This migration ran before targetDefaults supported the array shape, so
+// the test fixtures all use the legacy record shape.
+const td = (n: { targetDefaults?: unknown }) =>
+  n.targetDefaults as TargetDefaultsRecord;
 
 describe('prefix-reports-directory-with-project-root', () => {
   let tree: Tree;
@@ -267,7 +273,7 @@ describe('prefix-reports-directory-with-project-root', () => {
 
       const updatedNxJson = readNxJson(tree);
       expect(
-        updatedNxJson.targetDefaults['@nx/vitest:test'].options.reportsDirectory
+        td(updatedNxJson)['@nx/vitest:test'].options.reportsDirectory
       ).toBe('{projectRoot}/coverage');
     });
 
@@ -286,7 +292,7 @@ describe('prefix-reports-directory-with-project-root', () => {
       prefixReportsDirectoryWithProjectRoot(tree);
 
       const updatedNxJson = readNxJson(tree);
-      expect(updatedNxJson.targetDefaults.test.options.reportsDirectory).toBe(
+      expect(td(updatedNxJson).test.options.reportsDirectory).toBe(
         '{projectRoot}/coverage'
       );
     });
@@ -305,9 +311,9 @@ describe('prefix-reports-directory-with-project-root', () => {
       prefixReportsDirectoryWithProjectRoot(tree);
 
       const updatedNxJson = readNxJson(tree);
-      expect(
-        updatedNxJson.targetDefaults['@nx/jest:jest'].options.reportsDirectory
-      ).toBe('coverage');
+      expect(td(updatedNxJson)['@nx/jest:jest'].options.reportsDirectory).toBe(
+        'coverage'
+      );
     });
 
     it('should handle workspace without targetDefaults', () => {
@@ -319,7 +325,7 @@ describe('prefix-reports-directory-with-project-root', () => {
       prefixReportsDirectoryWithProjectRoot(tree);
 
       const updatedNxJson = readNxJson(tree);
-      expect(updatedNxJson.targetDefaults).toBeUndefined();
+      expect(td(updatedNxJson)).toBeUndefined();
     });
   });
 

--- a/packages/webpack/src/utils/e2e-web-server-info-utils.spec.ts
+++ b/packages/webpack/src/utils/e2e-web-server-info-utils.spec.ts
@@ -13,6 +13,7 @@ describe('getWebpackE2EWebServerInfo', () => {
 
     tree.write(`app/webpack.config.ts`, ``);
     tempFs.createFileSync(`app/webpack.config.ts`, ``);
+    tempFs.createFileSync('package-lock.json', '{}');
   });
 
   afterEach(() => {
@@ -46,6 +47,40 @@ describe('getWebpackE2EWebServerInfo', () => {
     `);
   });
 
+  it('should use array-shaped targetDefaults when no plugin is registered and plugins are not being used', async () => {
+    // ARRANGE
+    const nxJson = readNxJson(tree);
+    nxJson.plugins ??= [];
+    nxJson.targetDefaults = [
+      {
+        target: 'serve',
+        options: {
+          port: 4400,
+        },
+      },
+    ];
+    updateNxJson(tree, nxJson);
+
+    // ACT
+    const e2eWebServerInfo = await getWebpackE2EWebServerInfo(
+      tree,
+      'app',
+      'app/webpack.config.ts',
+      false
+    );
+
+    // ASSERT
+    expect(e2eWebServerInfo).toMatchInlineSnapshot(`
+      {
+        "e2eCiBaseUrl": "http://localhost:4400",
+        "e2eCiWebServerCommand": "npx nx run app:serve-static",
+        "e2eDevServerTarget": "app:serve",
+        "e2eWebServerAddress": "http://localhost:4400",
+        "e2eWebServerCommand": "npx nx run app:serve",
+      }
+    `);
+  });
+
   it('should use the default values of the plugin when the plugin is just a string', async () => {
     // ARRANGE
     const nxJson = readNxJson(tree);
@@ -67,6 +102,40 @@ describe('getWebpackE2EWebServerInfo', () => {
         "e2eCiWebServerCommand": "npx nx run app:serve-static",
         "e2eDevServerTarget": "app:serve",
         "e2eWebServerAddress": "http://localhost:4200",
+        "e2eWebServerCommand": "npx nx run app:serve",
+      }
+    `);
+  });
+
+  it('should use array-shaped targetDefaults when the plugin is just a string', async () => {
+    // ARRANGE
+    const nxJson = readNxJson(tree);
+    nxJson.plugins = ['@nx/webpack/plugin'];
+    nxJson.targetDefaults = [
+      {
+        target: 'serve',
+        options: {
+          port: 4500,
+        },
+      },
+    ];
+    updateNxJson(tree, nxJson);
+
+    // ACT
+    const e2eWebServerInfo = await getWebpackE2EWebServerInfo(
+      tree,
+      'app',
+      'app/webpack.config.ts',
+      true
+    );
+
+    // ASSERT
+    expect(e2eWebServerInfo).toMatchInlineSnapshot(`
+      {
+        "e2eCiBaseUrl": "http://localhost:4500",
+        "e2eCiWebServerCommand": "npx nx run app:serve-static",
+        "e2eDevServerTarget": "app:serve",
+        "e2eWebServerAddress": "http://localhost:4500",
         "e2eWebServerCommand": "npx nx run app:serve",
       }
     `);

--- a/packages/webpack/src/utils/e2e-web-server-info-utils.ts
+++ b/packages/webpack/src/utils/e2e-web-server-info-utils.ts
@@ -1,5 +1,8 @@
 import { type Tree, readNxJson } from '@nx/devkit';
-import { getE2EWebServerInfo } from '@nx/devkit/internal';
+import {
+  getE2EWebServerInfo,
+  readTargetDefaultsForTarget,
+} from '@nx/devkit/internal';
 
 export async function getWebpackE2EWebServerInfo(
   tree: Tree,
@@ -10,12 +13,11 @@ export async function getWebpackE2EWebServerInfo(
 ) {
   const nxJson = readNxJson(tree);
   let e2ePort = e2ePortOverride ?? 4200;
+  const servePort = readTargetDefaultsForTarget('serve', nxJson.targetDefaults)
+    ?.options?.port;
 
-  if (
-    nxJson.targetDefaults?.['serve'] &&
-    nxJson.targetDefaults?.['serve'].options?.port
-  ) {
-    e2ePort = nxJson.targetDefaults?.['serve'].options?.port;
+  if (servePort) {
+    e2ePort = servePort;
   }
 
   return getE2EWebServerInfo(

--- a/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
@@ -113,6 +113,7 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
 
   it('should create nx.json', async () => {
     const ajv = new Ajv();
+    ajv.addKeyword('deprecationMessage');
 
     await generateWorkspaceFiles(tree, {
       name: 'proj',

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -259,7 +259,7 @@ function createNxJson(
             e.target === 'build' &&
             e.executor === undefined &&
             e.projects === undefined &&
-            e.source === undefined
+            e.plugin === undefined
         );
         if (buildIdx >= 0) {
           td[buildIdx] = {

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -234,15 +234,10 @@ function createNxJson(
     defaultBase,
     targetDefaults:
       process.env.NX_ADD_PLUGINS === 'false'
-        ? {
-            build: {
-              cache: true,
-              dependsOn: ['^build'],
-            },
-            lint: {
-              cache: true,
-            },
-          }
+        ? [
+            { target: 'build', cache: true, dependsOn: ['^build'] },
+            { target: 'lint', cache: true },
+          ]
         : undefined,
     analytics,
   };
@@ -257,7 +252,21 @@ function createNxJson(
       sharedGlobals: [],
     };
     if (process.env.NX_ADD_PLUGINS === 'false') {
-      nxJson.targetDefaults.build.inputs = ['production', '^production'];
+      const td = nxJson.targetDefaults;
+      if (Array.isArray(td)) {
+        const buildIdx = td.findIndex(
+          (e) =>
+            e.target === 'build' &&
+            e.projects === undefined &&
+            e.source === undefined
+        );
+        if (buildIdx >= 0) {
+          td[buildIdx] = {
+            ...td[buildIdx],
+            inputs: ['production', '^production'],
+          };
+        }
+      }
       nxJson.useInferencePlugins = false;
     }
   }

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -257,6 +257,7 @@ function createNxJson(
         const buildIdx = td.findIndex(
           (e) =>
             e.target === 'build' &&
+            e.executor === undefined &&
             e.projects === undefined &&
             e.source === undefined
         );


### PR DESCRIPTION
Adds a new array-shaped `targetDefaults` in nx.json that supports filtering a default's applicability by project set (`projects`) and/or the plugin that originated the target (`source`). This lets polyglot workspaces give different defaults to e.g. `@nx/vite:test` and `@nx/jest:test`, or scope defaults to a subset of projects via `tag:` / glob / negation patterns.

Matcher uses a specificity ladder so the most specific entry wins: target+projects+source > target+projects > target+source > target alone. Exact target matches beat glob matches within a tier; ties go to the later array index.

Legacy record-shape `targetDefaults` is migrated automatically by the new `23-0-0-convert-target-defaults-to-array` migration. Devkit helpers keep tolerating both shapes so newer devkit versions working against older `nx` installs continue to function.

Includes:
- New `TargetDefaultEntry` / `TargetDefaultsRecord` types
- `findBestTargetDefault` matcher + wiring through `createTargetDefaultsResults` using source-map attribution from the target's `executor`/`command` key (the authoring plugin, not the last writer)
- Array-only JSON schema for nx.json
- `upsertTargetDefault` devkit helper with auto-upgrade from record->array when filters are requested
- Migration + tests
- Updated direct writers in init, workspace, react, angular, cypress, eslint, playwright, and workspace generators
- Docs update for nx.json reference

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #https://github.com/nrwl/nx/discussions/35046
