### PR TITLE
fix(js): fix prune-lockfile transitive workspace dep specifier mismatch for pnpm

### DIFF
--- a/packages/js/src/executors/copy-workspace-modules/copy-workspace-modules.ts
+++ b/packages/js/src/executors/copy-workspace-modules/copy-workspace-modules.ts
@@ -19,6 +19,8 @@ import { dirname, join, relative, sep } from 'path';
 import { lstatSync } from 'fs';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { getWorkspacePackagesFromGraph } from 'nx/src/plugins/js/utils/get-workspace-packages-from-graph';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { getCatalogManager } from 'nx/src/utils/catalog';
 
 export default async function copyWorkspaceModules(
   schema: CopyWorkspaceModulesOptions,
@@ -47,6 +49,7 @@ function handleWorkspaceModules(
   const workspaceModules = getWorkspacePackagesFromGraph(projectGraph);
   const processedModules = new Set<string>();
   const workspaceModulesDir = join(outputDirectory, 'workspace_modules');
+  const catalogManager = getCatalogManager(workspaceRoot);
 
   function calculateRelativePath(
     fromPkgName: string,
@@ -89,7 +92,11 @@ function handleWorkspaceModules(
 
     // Read the copied module's package.json to process its dependencies
     const copiedPackageJsonPath = join(newWorkspaceModulePath, 'package.json');
-    let copiedPackageJson: { dependencies?: Record<string, string> };
+    let copiedPackageJson: {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+      [key: string]: unknown;
+    };
     try {
       copiedPackageJson = JSON.parse(
         readFileSync(copiedPackageJsonPath, 'utf-8')
@@ -99,30 +106,51 @@ function handleWorkspaceModules(
       return;
     }
 
+    // Strip devDependencies — they are not needed at deployment runtime and
+    // their specifiers (especially catalog: references) can cause
+    // ERR_PNPM_OUTDATED_LOCKFILE mismatches against the pruned lockfile.
+    let packageJsonModified = 'devDependencies' in copiedPackageJson;
+    delete copiedPackageJson.devDependencies;
+
     // Process and update dependencies
     if (copiedPackageJson.dependencies) {
-      let packageJsonModified = false;
-
       for (const [depName, depVersion] of Object.entries(
         copiedPackageJson.dependencies
       )) {
-        if (workspaceModules.has(depName)) {
+        if (
+          workspaceModules.has(depName) &&
+          depVersion.startsWith('workspace:')
+        ) {
           const relativePath = calculateRelativePath(pkgName, depName);
           copiedPackageJson.dependencies[depName] = `file:${relativePath}`;
           packageJsonModified = true;
           processModule(depName);
+        } else if (
+          catalogManager?.isCatalogReference(depVersion)
+        ) {
+          // Resolve catalog: references so the deployed workspace_modules packages
+          // are self-contained and don't require catalog resolution at install time.
+          const resolved = catalogManager.resolveCatalogReference(
+            workspaceRoot,
+            depName,
+            depVersion
+          );
+          if (resolved) {
+            copiedPackageJson.dependencies[depName] = resolved;
+            packageJsonModified = true;
+          }
         }
       }
+    }
 
-      if (packageJsonModified) {
-        writeFileSync(
-          copiedPackageJsonPath,
-          JSON.stringify(copiedPackageJson, null, 2)
-        );
-        logger.verbose(
-          `Updated package.json for ${pkgName} with relative workspace module paths.`
-        );
-      }
+    if (packageJsonModified) {
+      writeFileSync(
+        copiedPackageJsonPath,
+        JSON.stringify(copiedPackageJson, null, 2)
+      );
+      logger.verbose(
+        `Updated package.json for ${pkgName} with relative workspace module paths.`
+      );
     }
   }
 

--- a/packages/js/src/executors/prune-lockfile/prune-lockfile.ts
+++ b/packages/js/src/executors/prune-lockfile/prune-lockfile.ts
@@ -42,9 +42,15 @@ export default async function pruneLockfileExecutor(
     );
     const lockfileOutputPath = join(outputDirectory, lockfileName);
     writeFileSync(lockfileOutputPath, lockFile);
+    // Strip devDependencies and peerDependencies from the deployed package.json —
+    // workspace: references in those fields cause ERR_PNPM_WORKSPACE_PKG_NOT_FOUND
+    // if those packages are not present in the pruned workspace.
+    const deployPackageJson = { ...packageJson };
+    delete deployPackageJson.devDependencies;
+    delete deployPackageJson.peerDependencies;
     writeFileSync(
       join(outputDirectory, 'package.json'),
-      JSON.stringify(packageJson, null, 2)
+      JSON.stringify(deployPackageJson, null, 2)
     );
     logger.log(`Lockfile pruned: ${lockfileOutputPath}`);
   }

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -28,7 +28,7 @@ import { hashArray } from '../../../hasher/file-hasher';
 import { CreateDependenciesContext } from '../../../project-graph/plugins';
 import { getCatalogManager } from '../../../utils/catalog';
 import { findNodeMatchingVersion } from './project-graph-pruning';
-import { join } from 'path';
+import { join, relative, sep } from 'path';
 import { getWorkspacePackagesFromGraph } from '../utils/get-workspace-packages-from-graph';
 import { satisfies, validRange } from 'semver';
 let currentLockFileHash: string;
@@ -589,12 +589,77 @@ export function stringifyPnpmLockfile(
     +lockfileVersion
   );
 
+  const workspaceModules = getWorkspacePackagesFromGraph(graph);
+
+  // Collect ALL workspace modules needed — direct deps from requiredImporters plus
+  // their transitive workspace deps — so every copied package has an importer block.
+  const allRequiredImporters: Record<string, string> = { ...requiredImporters };
+  function collectTransitiveWorkspaceDeps(importerPath: string): void {
+    const imp = importers[importerPath];
+    if (!imp) return;
+    for (const depType of [
+      'dependencies',
+      'optionalDependencies',
+    ] as const) {
+      const deps = imp[depType];
+      if (!deps) continue;
+      for (const [depName, depVersion] of Object.entries(deps)) {
+        if (
+          workspaceModules.has(depName) &&
+          !allRequiredImporters[depName]
+        ) {
+          // Find the importer path for this transitive workspace dep
+          const wsMod = workspaceModules.get(depName);
+          if (wsMod) {
+            const transitivePath = wsMod.data.root;
+            allRequiredImporters[depName] = transitivePath;
+            collectTransitiveWorkspaceDeps(transitivePath);
+          }
+        }
+      }
+    }
+  }
+  for (const importerPath of Object.values(requiredImporters)) {
+    collectTransitiveWorkspaceDeps(importerPath);
+  }
+
   const workspaceDependencyImporters: Record<string, ProjectSnapshot> = {};
-  for (const [packageName, importerPath] of Object.entries(requiredImporters)) {
+  for (const [packageName, importerPath] of Object.entries(
+    allRequiredImporters
+  )) {
     const baseImporter = importers[importerPath];
     if (baseImporter) {
+      // Deep-clone to avoid mutating the parsed lockfile data.
+      const importer: ProjectSnapshot = JSON.parse(
+        JSON.stringify(baseImporter)
+      );
+
+      // Rewrite workspace:* specifiers to file: relative paths so they match
+      // what @nx/js:copy-workspace-modules writes to package.json files.
+      // Without this, `pnpm install --frozen-lockfile` fails with
+      // ERR_PNPM_OUTDATED_LOCKFILE because the specifier in the lockfile
+      // ("workspace:*") doesn't match the package.json dep ("file:../lib-b").
+      for (const depType of ['dependencies', 'optionalDependencies'] as const) {
+        const deps = importer[depType] as Record<string, string> | undefined;
+        if (!deps) continue;
+        for (const depName of Object.keys(deps)) {
+          if (workspaceModules.has(depName)) {
+            // All modules are flattened under workspace_modules/. The relative
+            // path from workspace_modules/<packageName> to
+            // workspace_modules/<depName> equals relative(packageName, depName).
+            const rel = relative(packageName, depName)
+              .split(sep)
+              .join('/');
+            // specifier must match what copy-workspace-modules writes to package.json (file:)
+            importer.specifiers[depName] = `file:${rel}`;
+            // version stays as link: (pnpm's internal representation for local deps)
+            (deps as Record<string, string>)[depName] = `link:${rel}`;
+          }
+        }
+      }
+
       workspaceDependencyImporters[`workspace_modules/${packageName}`] =
-        baseImporter;
+        importer;
     }
   }
 

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -634,11 +634,57 @@ export function stringifyPnpmLockfile(
         JSON.stringify(baseImporter)
       );
 
+      // Add any peerDependency specifiers from the package.json that are absent
+      // from the original lockfile importer. Some packages declare peer deps
+      // that pnpm doesn't record in the workspace lockfile (e.g. if they were
+      // never installed), but the package.json still expects them — pnpm will
+      // report them as "added" without this reconciliation.
+      const wsMod = workspaceModules.get(packageName);
+      if (wsMod) {
+        const pkgJsonPath = join(workspaceRoot, wsMod.data.root, 'package.json');
+        const { existsSync: fsExists, readFileSync: fsRead } = require('fs');
+        if (fsExists(pkgJsonPath)) {
+          const srcPkgJson = JSON.parse(fsRead(pkgJsonPath, 'utf-8'));
+          for (const [depName, depVersion] of Object.entries(
+            srcPkgJson.peerDependencies ?? {}
+          ) as [string, string][]) {
+            if (!(importer.specifiers ?? {})[depName]) {
+              let specifier = depVersion;
+              const mgr = getCatalogManager(workspaceRoot);
+              if (mgr?.isCatalogReference(specifier)) {
+                specifier =
+                  mgr.resolveCatalogReference(workspaceRoot, depName, specifier) ??
+                  specifier;
+              }
+              importer.specifiers = importer.specifiers ?? {};
+              importer.specifiers[depName] = specifier;
+            }
+          }
+        }
+      }
+
+      // Strip devDependencies — copy-workspace-modules removes them from
+      // package.json files, so the lockfile must match.
+      delete importer.devDependencies;
+      if (importer.specifiers) {
+        const keepDepNames = new Set([
+          ...Object.keys(importer.dependencies ?? {}),
+          ...Object.keys(importer.optionalDependencies ?? {}),
+          ...Object.keys(importer.peerDependencies ?? {}),
+        ]);
+        for (const key of Object.keys(importer.specifiers)) {
+          if (!keepDepNames.has(key)) {
+            delete importer.specifiers[key];
+          }
+        }
+      }
+
       // Rewrite workspace:* specifiers to file: relative paths so they match
       // what @nx/js:copy-workspace-modules writes to package.json files.
       // Without this, `pnpm install --frozen-lockfile` fails with
       // ERR_PNPM_OUTDATED_LOCKFILE because the specifier in the lockfile
       // ("workspace:*") doesn't match the package.json dep ("file:../lib-b").
+      const catalogMgr = getCatalogManager(workspaceRoot);
       for (const depType of ['dependencies', 'optionalDependencies'] as const) {
         const deps = importer[depType] as Record<string, string> | undefined;
         if (!deps) continue;
@@ -654,6 +700,17 @@ export function stringifyPnpmLockfile(
             importer.specifiers[depName] = `file:${rel}`;
             // version stays as link: (pnpm's internal representation for local deps)
             (deps as Record<string, string>)[depName] = `link:${rel}`;
+          } else if (catalogMgr?.isCatalogReference(importer.specifiers[depName])) {
+            // Resolve catalog: specifiers so they match the resolved versions
+            // that copy-workspace-modules writes to package.json.
+            const resolved = catalogMgr.resolveCatalogReference(
+              workspaceRoot,
+              depName,
+              importer.specifiers[depName]
+            );
+            if (resolved) {
+              importer.specifiers[depName] = resolved;
+            }
           }
         }
       }

--- a/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
+++ b/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
@@ -188,12 +188,25 @@ function traverseNode(
 function traverseWorkspaceNode(
   graph: ProjectGraph,
   builder: ProjectGraphBuilder,
-  node: ProjectGraphProjectNode
+  node: ProjectGraphProjectNode,
+  visited: Set<string> = new Set()
 ) {
+  if (visited.has(node.name)) {
+    return;
+  }
+  visited.add(node.name);
+
   graph.dependencies[node.name]?.forEach((dep) => {
-    const depNode = graph.externalNodes[dep.target];
-    if (depNode) {
-      traverseNode(graph, builder, depNode);
+    const externalDepNode = graph.externalNodes[dep.target];
+    if (externalDepNode) {
+      traverseNode(graph, builder, externalDepNode);
+    } else {
+      // Recursively follow workspace → workspace dependencies so that
+      // transitive workspace deps' npm packages are included in the pruned graph.
+      const workspaceDepNode = graph.nodes[dep.target];
+      if (workspaceDepNode) {
+        traverseWorkspaceNode(graph, builder, workspaceDepNode, visited);
+      }
     }
   });
 }


### PR DESCRIPTION
## Current Behavior

When an app depends on workspace lib-a, which depends on workspace lib-b, running `nx run app:prune-lockfile` + `nx run app:copy-workspace-modules` produces a broken deployment:

1. **Missing transitive importer blocks** — `workspace_modules/@myorg/lib-b` has no importer block in the pruned lockfile even though `copy-workspace-modules` copies it to disk
2. **Missing transitive npm packages** — `lodash` (lib-b's npm dep) is absent from the `packages:` section  
3. **Specifier mismatch** — `workspace_modules/@myorg/lib-a` importer has `specifier: workspace:*` for lib-b, but `copy-workspace-modules` rewrites `lib-a/package.json` to `"@myorg/lib-b": "file:../lib-b"`. pnpm --frozen-lockfile fails:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date
  - @myorg/lib-b (lockfile: workspace:*, manifest: file:../lib-b)
```

## Expected Behavior

`pnpm install --frozen-lockfile` succeeds in the pruned output directory.

## Changes

**`project-graph-pruning.ts` — `traverseWorkspaceNode`**

Added recursive traversal of workspace→workspace dependencies. Previously only external (npm) deps of a workspace node were traversed, so lodash (a transitive npm dep via lib-b) was never added to the pruned graph or lockfile `packages:` section.

**`pnpm-parser.ts` — `stringifyPnpmLockfile`**

1. After `mapRootSnapshot` returns `requiredImporters` (only direct workspace deps), recursively collect transitive workspace deps so every module copied by `copy-workspace-modules` has an importer block.

2. For each workspace importer block, rewrite `workspace:*` specifiers to `file:<relative>` (matching what `copy-workspace-modules` writes to package.json) while keeping the version field as `link:<relative>` (pnpm's internal representation for local deps).

## Repro

https://github.com/estevaolucas/nx-34655-repro

Run `./repro.sh` to see the failure, then apply this fix and verify `pnpm install --frozen-lockfile` passes.

Fixes #34655