### PR TITLE
docs(nx-dev): add agent-readiness signals for link headers and robots.txt

### DIFF
--- a/astro-docs/netlify.toml
+++ b/astro-docs/netlify.toml
@@ -5,6 +5,9 @@
     Content-Security-Policy = "frame-ancestors 'none'"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=()"
+    # Agent discovery via RFC 8288 Link headers (see https://isitagentready.com/.well-known/agent-skills/link-headers/SKILL.md)
+    # Points AI agents/crawlers at machine-readable entry points hosted on nx.dev.
+    Link = '''</llms.txt>; rel="describedby"; type="text/plain", </llms-full.txt>; rel="service-doc"; type="text/plain", </sitemap-index.xml>; rel="sitemap"; type="application/xml"'''
 
 # Disable gradle and maven plugins on Netlify
 # (Netlify only supports Java 8 but these plugins require Java 17)

--- a/astro-docs/netlify.toml
+++ b/astro-docs/netlify.toml
@@ -7,7 +7,9 @@
     Permissions-Policy = "camera=(), microphone=(), geolocation=()"
     # Agent discovery via RFC 8288 Link headers (see https://isitagentready.com/.well-known/agent-skills/link-headers/SKILL.md)
     # Points AI agents/crawlers at machine-readable entry points hosted on nx.dev.
-    Link = '''</llms.txt>; rel="describedby"; type="text/plain", </llms-full.txt>; rel="service-doc"; type="text/plain", </sitemap-index.xml>; rel="sitemap"; type="application/xml"'''
+
+    Link = '''</llms.txt>; rel="describedby"; type="text/plain", </llms-full.txt>; rel="service-doc"; type="text/plain", </sitemap.xml>; rel="sitemap"; type="application/xml"'''
+
 
 # Disable gradle and maven plugins on Netlify
 # (Netlify only supports Java 8 but these plugins require Java 17)

--- a/astro-docs/src/pages/robots.txt.ts
+++ b/astro-docs/src/pages/robots.txt.ts
@@ -15,7 +15,7 @@ Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Host: https://nx.dev
 
 # Sitemaps
-Sitemap: https://nx.dev/sitemap-index.xml
+Sitemap: https://nx.dev/sitemap.xml
 `;
 
 // Block all crawling on non-production domains (canary, versioned, etc.)

--- a/astro-docs/src/pages/robots.txt.ts
+++ b/astro-docs/src/pages/robots.txt.ts
@@ -6,6 +6,10 @@ const isProductionDomain = siteUrl === 'https://nx.dev';
 const productionRobotsTxt = `# https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Allow: /
+# Content usage preferences — https://contentsignals.org/
+# nx.dev is public documentation for the Nx open-source CLI; we actively
+# want AI assistants to consume, reference, and train on these docs.
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 
 # Host
 Host: https://nx.dev

--- a/netlify/edge-functions/rewrite-framer-urls.ts
+++ b/netlify/edge-functions/rewrite-framer-urls.ts
@@ -223,6 +223,11 @@ export default async function handler(
 
   const newHeaders = new Headers(response.headers);
   newHeaders.set('x-nx-edge-function', 'framer-proxy');
+  // Agent discovery (RFC 8288) — point AI agents at nx.dev's machine-readable entry points.
+  newHeaders.set(
+    'Link',
+    '</llms.txt>; rel="describedby"; type="text/plain", </llms-full.txt>; rel="service-doc"; type="text/plain", </sitemap.xml>; rel="sitemap"; type="application/xml"'
+  );
   newHeaders.set('Cache-Control', 'public, max-age=3600, must-revalidate');
   // Edge CDN cache — stale-while-revalidate serves instantly while revalidating in background
   newHeaders.set(

--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -93,10 +93,6 @@ module.exports = withNx({
         destination: `${astroDocsUrl}/.netlify/:path*`,
       },
       {
-        source: '/robots.txt',
-        destination: `${astroDocsUrl}/docs/robots.txt`,
-      },
-      {
         source: '/llms.txt',
         destination: `${astroDocsUrl}/docs/llms.txt`,
       },
@@ -113,7 +109,18 @@ module.exports = withNx({
       });
     }
 
-    return entries;
+    return {
+      // beforeFiles runs before Next.js checks public/ — needed so this rewrite
+      // wins over the generated public/robots.txt (gitignored, built from Framer).
+      beforeFiles: [
+        {
+          source: '/robots.txt',
+          destination: `${astroDocsUrl}/docs/robots.txt`,
+        },
+      ],
+      afterFiles: entries,
+      fallback: [],
+    };
   },
   transpilePackages: [
     '@nx/nx-dev-data-access-courses',

--- a/nx-dev/nx-dev/next.config.js
+++ b/nx-dev/nx-dev/next.config.js
@@ -93,6 +93,10 @@ module.exports = withNx({
         destination: `${astroDocsUrl}/.netlify/:path*`,
       },
       {
+        source: '/robots.txt',
+        destination: `${astroDocsUrl}/docs/robots.txt`,
+      },
+      {
         source: '/llms.txt',
         destination: `${astroDocsUrl}/docs/llms.txt`,
       },


### PR DESCRIPTION

## Current Behavior

[isitagentready.com](isitagentready.com) scan flagged two gaps on nx.dev: no agent-useful Link relation types in response headers, and no Content-Signal directives in robots.txt.

## Expected Behavior

- Netlify serves Link response headers pointing agents at /llms.txt (describedby), /llms-full.txt (service-doc), and /sitemap-index.xml (sitemap).
- Production robots.txt declares permissive Content-Signal preferences (search=yes, ai-input=yes, ai-train=yes) so AI crawlers know the docs are intentionally open.



<img width="873" height="1269" alt="image" src="https://github.com/user-attachments/assets/70fbcbee-04df-4f5c-b274-c360f420060d" />

Note: robots.txt won't work until we go to prod, so I'll re-run benchmarks again once deployed.

## Related Issue(s)

DOC-479