### PR TITLE
fix(gradle): resolve sandbox violations in e2e-gradle tests

### DIFF
--- a/astro-docs/project.json
+++ b/astro-docs/project.json
@@ -98,7 +98,7 @@
       "command": "playwright show-report dist/astro-docs/playwright-report"
     },
     "validate-links": {
-      "dependsOn": ["build"],
+      "dependsOn": ["build", "nx-dev:build"],
       "cache": true,
       "inputs": [
         "{projectRoot}/validate-links.ts",

--- a/astro-docs/project.json
+++ b/astro-docs/project.json
@@ -102,6 +102,7 @@
       "cache": true,
       "inputs": [
         "{projectRoot}/validate-links.ts",
+        { "dependentTasksOutputFiles": "**/*.html" },
         { "dependentTasksOutputFiles": "**/sitemap*.xml" },
         "{projectRoot}/src/**/*",
         "{projectRoot}/astro.config.mjs",

--- a/astro-docs/validate-links.ts
+++ b/astro-docs/validate-links.ts
@@ -16,6 +16,13 @@ const filesToIgnore = [
 const distDir = path.join(workspaceRoot, 'astro-docs', 'dist');
 const sitemapIndexPath = path.join(distDir, 'sitemap-index.xml');
 const sitemapFallbackPath = path.join(distDir, 'sitemap-0.xml');
+const nxDevSitemapPath = path.join(
+  workspaceRoot,
+  'nx-dev',
+  'nx-dev',
+  'public',
+  'sitemap-0.xml'
+);
 
 if (!fs.existsSync(distDir)) {
   console.error(
@@ -147,6 +154,22 @@ function loadAllSitemapRoutes(): Set<string> {
     for (const route of parseSitemap(sitemapContent)) {
       allRoutes.add(route);
     }
+  }
+
+  // Load nx-dev (Next.js) sitemap routes for cross-site validation
+  if (fs.existsSync(nxDevSitemapPath)) {
+    const nxDevSitemapContent = fs.readFileSync(nxDevSitemapPath, 'utf-8');
+    const nxDevRoutes = parseSitemap(nxDevSitemapContent);
+    console.log(
+      `Found ${nxDevRoutes.size} routes in nx-dev sitemap (${nxDevSitemapPath})`
+    );
+    for (const route of nxDevRoutes) {
+      allRoutes.add(route);
+    }
+  } else {
+    console.warn(
+      `nx-dev sitemap not found at ${nxDevSitemapPath}. Run "nx build nx-dev" to enable cross-site link validation against nx-dev routes.`
+    );
   }
 
   return allRoutes;

--- a/astro-docs/validate-links.ts
+++ b/astro-docs/validate-links.ts
@@ -16,13 +16,6 @@ const filesToIgnore = [
 const distDir = path.join(workspaceRoot, 'astro-docs', 'dist');
 const sitemapIndexPath = path.join(distDir, 'sitemap-index.xml');
 const sitemapFallbackPath = path.join(distDir, 'sitemap-0.xml');
-const nxDevSitemapPath = path.join(
-  workspaceRoot,
-  'nx-dev',
-  'nx-dev',
-  'public',
-  'sitemap-0.xml'
-);
 
 if (!fs.existsSync(distDir)) {
   console.error(
@@ -154,22 +147,6 @@ function loadAllSitemapRoutes(): Set<string> {
     for (const route of parseSitemap(sitemapContent)) {
       allRoutes.add(route);
     }
-  }
-
-  // Load nx-dev (Next.js) sitemap routes for cross-site validation
-  if (fs.existsSync(nxDevSitemapPath)) {
-    const nxDevSitemapContent = fs.readFileSync(nxDevSitemapPath, 'utf-8');
-    const nxDevRoutes = parseSitemap(nxDevSitemapContent);
-    console.log(
-      `Found ${nxDevRoutes.size} routes in nx-dev sitemap (${nxDevSitemapPath})`
-    );
-    for (const route of nxDevRoutes) {
-      allRoutes.add(route);
-    }
-  } else {
-    console.warn(
-      `nx-dev sitemap not found at ${nxDevSitemapPath}. Run "nx build nx-dev" to enable cross-site link validation against nx-dev routes.`
-    );
   }
 
   return allRoutes;

--- a/e2e/gradle/project.json
+++ b/e2e/gradle/project.json
@@ -11,6 +11,13 @@
   "// targets": "to see all targets run: nx show project e2e-gradle --web",
   "targets": {
     "e2e-local": {
+      "inputs": [
+        "e2eInputs",
+        "^production",
+        "{workspaceRoot}/gradle/wrapper/gradle-wrapper.jar",
+        "{workspaceRoot}/gradle/wrapper/gradle-wrapper.properties",
+        "{workspaceRoot}/gradle.properties"
+      ],
       "dependsOn": [
         "@nx/nx-source:populate-local-registry-storage",
         "@nx/nx-source:local-registry",
@@ -18,6 +25,13 @@
       ]
     },
     "e2e-ci--**/**": {
+      "inputs": [
+        "e2eInputs",
+        "^production",
+        "{workspaceRoot}/gradle/wrapper/gradle-wrapper.jar",
+        "{workspaceRoot}/gradle/wrapper/gradle-wrapper.properties",
+        "{workspaceRoot}/gradle.properties"
+      ],
       "dependsOn": [
         "@nx/nx-source:populate-local-registry-storage",
         "@nx/nx-source:local-registry",

--- a/e2e/gradle/project.json
+++ b/e2e/gradle/project.json
@@ -9,5 +9,20 @@
     ":gradle-batch-runner"
   ],
   "// targets": "to see all targets run: nx show project e2e-gradle --web",
-  "targets": {}
+  "targets": {
+    "e2e-local": {
+      "dependsOn": [
+        "@nx/nx-source:populate-local-registry-storage",
+        "@nx/nx-source:local-registry",
+        ":gradle-project-graph:gradle:publishToMavenLocal"
+      ]
+    },
+    "e2e-ci--**/**": {
+      "dependsOn": [
+        "@nx/nx-source:populate-local-registry-storage",
+        "@nx/nx-source:local-registry",
+        ":gradle-project-graph:gradle:publishToMavenLocal"
+      ]
+    }
+  }
 }

--- a/e2e/gradle/src/utils/create-gradle-project.ts
+++ b/e2e/gradle/src/utils/create-gradle-project.ts
@@ -88,15 +88,6 @@ export function createGradleProject(
   addSpringBootPlugin(
     join(cwd, `app/build.gradle${type === 'kotlin' ? '.kts' : ''}`)
   );
-
-  e2eConsoleLogger(
-    execSync(
-      `${gradleCommand} :gradle-project-graph:publishToMavenLocal -PskipSign=true`,
-      {
-        cwd: `${__dirname}/../../../..`,
-      }
-    ).toString()
-  );
 }
 
 function addLocalPluginManagement(filePath: string) {

--- a/nx.json
+++ b/nx.json
@@ -49,7 +49,11 @@
       { "env": "NX_E2E_CI_CACHE_KEY" },
       { "env": "CI" },
       { "env": "NX_E2E_RUN_E2E" },
-      { "dependentTasksOutputFiles": "**/*.d.ts", "transitive": true }
+      { "dependentTasksOutputFiles": "**/*.d.ts", "transitive": true },
+      {
+        "json": "{workspaceRoot}/tsconfig.json",
+        "fields": ["compilerOptions", "extends", "files", "include"]
+      }
     ]
   },
   "release": {

--- a/packages/gradle/project-graph/build.gradle.kts
+++ b/packages/gradle/project-graph/build.gradle.kts
@@ -121,16 +121,15 @@ afterEvaluate {
     }
   }
 
-  val skipSign = project.findProperty("skipSign") == "true"
-  if (!skipSign) {
-    signing {
-      sign(publishing.publications["pluginMaven"])
-      sign(publishing.publications["nxProjectGraphPluginPluginMarkerMaven"])
-    }
+  signing {
+    // Only required when actually publishing to Maven Central (via the
+    // `publish` lifecycle task). publishToMavenLocal targets ~/.m2 and
+    // doesn't need signatures — when no keys are configured, signing
+    // silently no-ops instead of failing the build.
+    setRequired({ gradle.taskGraph.hasTask(":gradle-project-graph:publish") })
+    sign(publishing.publications["pluginMaven"])
+    sign(publishing.publications["nxProjectGraphPluginPluginMarkerMaven"])
   }
-
-  // Even if signing plugin was applied, we can prevent the sign tasks from running
-  tasks.withType<Sign>().configureEach { onlyIf { !skipSign } }
 }
 
 tasks.test { useJUnitPlatform() }

--- a/packages/gradle/project-graph/project.json
+++ b/packages/gradle/project-graph/project.json
@@ -2,6 +2,9 @@
   "name": ":gradle-project-graph",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "targets": {
+    "gradle:publishToMavenLocal": {
+      "cache": false
+    },
     "publish-staging": {
       "command": "./gradlew :gradle-project-graph:publish",
       "cache": true,


### PR DESCRIPTION
## Current Behavior

The `e2e-gradle:e2e-ci--**/*.test.ts` tasks produce hundreds of sandbox violations: ~163 unexpected reads + ~160 unexpected writes under `packages/gradle/project-graph/build/**`, plus reads of workspace-root gradle config files.

The root cause is `e2e/gradle/src/utils/create-gradle-project.ts` invoking `./gradlew :gradle-project-graph:publishToMavenLocal -PskipSign=true` inline via `execSync` during test setup, which compiles Kotlin sources inside the sandboxed task and produces all those file accesses.

## Expected Behavior

The `publishToMavenLocal` step runs as a proper Nx task dependency before the e2e test, outside the sandbox. Its outputs are declared by the `@nx/gradle`-inferred target.

### Changes

- **Move publishing out of the test** — delete the inline `execSync(gradlew :gradle-project-graph:publishToMavenLocal)` in `create-gradle-project.ts`; make the `e2e-local` and `e2e-ci--**/**` targets on `e2e-gradle` depend on `:gradle-project-graph:gradle:publishToMavenLocal`.
- **Fix signing** — the inferred `publishToMavenLocal` target doesn't pass `-PskipSign=true`, so replace the `skipSign` flag in `packages/gradle/project-graph/build.gradle.kts` with `setRequired({ gradle.taskGraph.hasTask(":gradle-project-graph:publish") })`. Signing is required for the Maven Central path (`publish` lifecycle task) but silently no-ops for `publishToMavenLocal` when no GPG keys are provisioned.
- **Declare workspace wrapper inputs** — the bootstrap `gradle init` call must use the workspace wrapper, so add `gradle/wrapper/gradle-wrapper.jar`, `gradle/wrapper/gradle-wrapper.properties`, and `gradle.properties` as inputs on the e2e targets, matching the `@nx/gradle` plugin's inferred gradle-task input set.
- **Disable cache on the publish task** — `publishToMavenLocal` writes to `~/.m2/repository/` (outside the workspace, can't be declared as an Nx output). A remote cache hit would skip launching gradle, leaving `~/.m2/` empty on the agent and breaking plugin resolution. Override `cache: false` on `:gradle-project-graph:gradle:publishToMavenLocal`.
- **Narrow `e2eInputs` tsconfig input** — use `{ json, fields }` in `nx.json` to hash only the fields that affect compilation (same pattern as `@nx/playwright`).
- **Tighten `astro-docs:validate-links` inputs** — swap the `**/sitemap*.xml` dep-task-outputs glob for `**/*.html` + `**/sitemap*.xml` (the actual files the script reads) and drop the dead `nx-dev/public/sitemap-0.xml` branch since #35315 removed `next-sitemap` from nx-dev.

## Related Issue(s)

NXC-3981
