### PR TITLE
fix(nx-dev): restore sitemap generation 

### DIFF
--- a/nx-dev/nx-dev/next-sitemap.config.js
+++ b/nx-dev/nx-dev/next-sitemap.config.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+const siteUrl = process.env.NX_DEV_URL || 'https://nx.dev';
+const noIndex = process.env.NEXT_PUBLIC_NO_INDEX === 'true';
+
+const buildOutputDir = path.resolve(__dirname, '.next');
+const publicOutputDir = path.resolve(__dirname, 'public');
+
+/**
+ * @type {import('next-sitemap').IConfig}
+ **/
+module.exports = {
+  siteUrl,
+  // robots.txt is served via Next.js rewrite to astro-docs (next.config.js
+  // beforeFiles). Leaving this false avoids clobbering that with a static file.
+  generateRobotsTxt: false,
+  // /ai-chat is the root redirect target and /api/* is not indexable.
+  exclude: noIndex ? ['/*'] : ['/ai-chat', '/api/*'],
+  sourceDir: buildOutputDir,
+  outDir: publicOutputDir,
+  // Additional sitemaps are added to the sitemap index by
+  // scripts/patch-sitemap-index.mjs to avoid duplicate entries.
+};

--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -16,7 +16,25 @@
         { "externalDependencies": ["next"] },
         { "dependentTasksOutputFiles": "**/*.d.ts", "transitive": true }
       ],
-      "outputs": ["{workspaceRoot}/nx-dev/nx-dev/.next"]
+      "outputs": [
+        "{workspaceRoot}/nx-dev/nx-dev/.next",
+        "{workspaceRoot}/nx-dev/nx-dev/public/sitemap*.xml"
+      ]
+    },
+    "sitemap": {
+      "dependsOn": ["nx-dev:next:build"],
+      "inputs": [
+        "production",
+        "{projectRoot}/next-sitemap.config.js",
+        "{projectRoot}/scripts/patch-sitemap-index.mjs",
+        { "env": "NX_DEV_URL" },
+        { "env": "NEXT_PUBLIC_NO_INDEX" }
+      ],
+      "outputs": ["{workspaceRoot}/nx-dev/nx-dev/public/sitemap*.xml"],
+      "command": "pnpm next-sitemap --config ./next-sitemap.config.js && node ./scripts/patch-sitemap-index.mjs",
+      "options": {
+        "cwd": "nx-dev/nx-dev"
+      }
     },
     "copy-redirects": {
       "dependsOn": ["next:build"],
@@ -25,7 +43,7 @@
       "command": "cp nx-dev/nx-dev/_redirects nx-dev/nx-dev/.next/_redirects"
     },
     "build": {
-      "dependsOn": ["next:build", "copy-redirects"],
+      "dependsOn": ["sitemap", "copy-redirects"],
       "outputs": ["{projectRoot}/.next"]
     },
     "deploy-build": {

--- a/nx-dev/nx-dev/scripts/patch-sitemap-index.mjs
+++ b/nx-dev/nx-dev/scripts/patch-sitemap-index.mjs
@@ -1,0 +1,29 @@
+/**
+ * Patches the generated sitemap.xml index to include additional sitemaps
+ * that next-sitemap doesn't natively support adding to the index.
+ */
+import { readFileSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+
+const siteUrl = process.env.NX_DEV_URL || 'https://nx.dev';
+const outDir = resolve(import.meta.dirname, '../public');
+
+const sitemapPath = resolve(outDir, 'sitemap.xml');
+
+const additionalSitemaps = [
+  `${siteUrl}/sitemap-1.xml`,
+  `${siteUrl}/docs/sitemap-index.xml`,
+];
+
+const xml = readFileSync(sitemapPath, 'utf-8');
+
+const entries = additionalSitemaps
+  .map((url) => `<sitemap><loc>${url}</loc></sitemap>`)
+  .join('');
+
+const patched = xml.replace('</sitemapindex>', `${entries}</sitemapindex>`);
+
+writeFileSync(sitemapPath, patched);
+console.log(
+  `Patched sitemap.xml with ${additionalSitemaps.length} additional sitemaps`
+);


### PR DESCRIPTION
The previous clean-up was overly zealous and removed both `sitemap.xml` and `sitemap-0.xml` because I assumed there was nothing from Next.js app. This restores both.

A follow-up will be to move these out of Next.js, but for now the root one will point to both Framer and Next.js routes, and the latter has `/courses/*` which we use still.