### PR TITLE
fix(release): respect preid for cross-releaseGroup bumps

### DIFF
--- a/packages/nx/src/command-line/release/version/release-group-processor.spec.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.spec.ts
@@ -1424,6 +1424,73 @@ describe('ReleaseGroupProcessor', () => {
       `);
     });
 
+    it('should use prepatch instead of patch when preid is set and a dependent project is bumped across release groups', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          group1 ({ "projectsRelationship": "fixed" }):
+            - projectA@1.0.0 [js]
+              -> depends on projectB
+            - projectC@1.0.0 [js]
+          group2 ({ "projectsRelationship": "independent" }):
+            - projectB@2.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+              updateDependents: 'always',
+            },
+          },
+          mockResolveCurrentVersion
+        );
+
+      processor = await createTestReleaseGroupProcessor(
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters,
+        { preid: 'alpha' }
+      );
+
+      mockDeriveSpecifierFromConventionalCommits.mockImplementation(
+        (_, __, ___, ____, { name: projectName }) => {
+          // Only projectB in group2 has changes; deriveSpecifierFromConventionalCommits converts
+          // 'minor' -> 'preminor' itself when preid is set, so mock the already-converted value
+          if (projectName === 'projectB') return 'preminor';
+          return 'none';
+        }
+      );
+      await processor.processGroups();
+
+      // projectB in group2 is bumped based on its own specifier (preminor + preid)
+      expect(readJson(tree, 'projectB/package.json')).toMatchInlineSnapshot(`
+        {
+          "name": "projectB",
+          "version": "2.1.0-alpha.0",
+        }
+      `);
+
+      // projectA in group1 is bumped via DEPENDENCY_WAS_BUMPED: should be prepatch, not patch
+      expect(readJson(tree, 'projectA/package.json')).toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "projectB": "2.1.0-alpha.0",
+          },
+          "name": "projectA",
+          "version": "1.0.1-alpha.0",
+        }
+      `);
+
+      // projectC in group1 is bumped via OTHER_PROJECT_IN_FIXED_GROUP_WAS_BUMPED_DUE_TO_DEPENDENCY: should be prepatch, not patch
+      expect(readJson(tree, 'projectC/package.json')).toMatchInlineSnapshot(`
+        {
+          "name": "projectC",
+          "version": "1.0.1-alpha.0",
+        }
+      `);
+    });
+
     it('should bump projects across different release groups when updateDependents is explicitly set to "always"', async () => {
       const { nxReleaseConfig, projectGraph, filters } =
         await createNxReleaseConfigAndPopulateWorkspace(

--- a/packages/nx/src/command-line/release/version/release-group-processor.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.ts
@@ -406,7 +406,7 @@ export class ReleaseGroupProcessor {
           if (!this.bumpedProjects.has(project)) {
             await this.bumpVersionForProject(
               project,
-              'patch',
+              this.options.preid ? 'prepatch' : 'patch',
               'OTHER_PROJECT_IN_FIXED_GROUP_WAS_BUMPED_DUE_TO_DEPENDENCY',
               {}
             );
@@ -894,7 +894,7 @@ export class ReleaseGroupProcessor {
         if (!this.bumpedProjects.has(dependent)) {
           await this.bumpVersionForProject(
             dependent,
-            'patch',
+            this.options.preid ? 'prepatch' : 'patch',
             'DEPENDENCY_WAS_BUMPED',
             {}
           );
@@ -955,12 +955,11 @@ export class ReleaseGroupProcessor {
       .newVersionInput;
   }
 
-  // TODO: Support influencing the side effect bump in a future version, always patch for now like in legacy versioning
   private determineSideEffectBump(
     releaseGroup: ReleaseGroupWithName,
     dependencyBumpType: SemverBumpType
   ): SemverBumpType {
-    const sideEffectBump = 'patch';
+    const sideEffectBump = this.options.preid ? 'prepatch' : 'patch';
     return sideEffectBump as SemverBumpType;
   }
 


### PR DESCRIPTION
## Summary

- When `--preid` is passed to `nx release`, transitive version bumps that previously always used `patch` now use `prepatch` so dependent release groups stay on the prerelease line (e.g. `1.0.1-alpha.0` instead of `1.0.1`).
- Covers `DEPENDENCY_WAS_BUMPED`, `OTHER_PROJECT_IN_FIXED_GROUP_WAS_BUMPED_DUE_TO_DEPENDENCY`, and `determineSideEffectBump` (`DEPENDENCY_ACROSS_GROUPS_WAS_BUMPED`).

## Context

Fixes https://github.com/nrwl/nx/issues/35080 (repro: only the downstream release group gets a prerelease bump today; dependents get a plain patch).

This matches the approach in https://github.com/nrwl/nx/pull/35077 from @mpsanchis; this PR was opened from a separate fork for visibility while that PR is pending review.

## Test plan

- [ ] `nx test nx` (or targeted `release-group-processor` specs) — not run here: local `nx` project graph fails in this environment because `@nx/gradle` cannot download Gradle (SSL PKIX).

Made with [Cursor](https://cursor.com)