### PR TITLE
chore(misc): declare .editorconfig as input for astro-docs:format

### DIFF
--- a/astro-docs/project.json
+++ b/astro-docs/project.json
@@ -152,7 +152,8 @@
       "inputs": [
         "{projectRoot}/**/*.mdoc",
         "{workspaceRoot}/.prettierrc",
-        "{workspaceRoot}/.prettierignore"
+        "{workspaceRoot}/.prettierignore",
+        "{workspaceRoot}/.editorconfig"
       ]
     },
     "format:write": {


### PR DESCRIPTION
## Current Behavior

The `astro-docs:format` target runs `prettier **/*.mdoc --check`. Prettier has `--editorconfig` enabled by default and walks up from each source file to read `.editorconfig`, deriving options like `endOfLine`, `tabWidth`, `useTabs`, and `printWidth` from it. The target's declared inputs do not include `.editorconfig`, so the task sandbox flags it as an unexpected read and changes to `.editorconfig` do not invalidate the cache even though they can change `--check` results.

## Expected Behavior

`.editorconfig` is declared as an input of the `astro-docs:format` target so the sandbox recognizes the read and the cache key reflects changes to the file.