### PR TITLE
fix(core): resolve native binary crash on aarch64 linux with 16K/64K page kernels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -238,6 +238,10 @@ jobs:
               # Help clang find GCC runtime (crtbeginS.o, libgcc) and use lld for jemalloc build
               export CFLAGS="${CFLAGS} -fuse-ld=lld --gcc-toolchain=/usr/aarch64-unknown-linux-gnu"
 
+              # Build jemalloc with 64 KiB allocator page so the binary works on aarch64
+              # Linux kernels with 4K/16K/64K pages (Asahi, Ampere, Graviton, etc.).
+              export JEMALLOC_SYS_WITH_LG_PAGE=16
+
               npm i -g pnpm@${PNPM_VERSION} --force
               pnpm --version
 
@@ -291,6 +295,10 @@ jobs:
                 # Help clang find GCC runtime (crtbeginS.o, libgcc) and use lld for jemalloc build
                 GCC_DIR=\$(dirname \$(find /aarch64-linux-musl-cross/lib/gcc -name crtbeginS.o | head -1))
                 export CFLAGS=\"\${CFLAGS} -fuse-ld=lld --gcc-install-dir=\${GCC_DIR}\"
+
+                # Build jemalloc with 64 KiB allocator page so the binary works on aarch64
+                # Linux kernels with 4K/16K/64K pages (Asahi, Ampere, Graviton, etc.).
+                export JEMALLOC_SYS_WITH_LG_PAGE=16
 
                 # Install deps and run native build
                 pnpm install --frozen-lockfile


### PR DESCRIPTION
## Current Behavior

On aarch64 Linux kernels with page sizes larger than 4 KiB — 16 KiB on Asahi Linux / Apple Silicon, 64 KiB on some Ampere/Fedora server configs — every Nx command (including `nx --version`) aborts immediately:

```
<jemalloc>: Unsupported system page size
<jemalloc>: arena_new: allocation failed
memory allocation of 576 bytes failed
Aborted (core dumped)
```

The cause: jemalloc is compiled with `--with-lg-page=12` (4 KiB allocator page) by default, and refuses to operate when the system page size exceeds the compiled-in value.

## Expected Behavior

Nx native binaries run correctly on every shipping aarch64 Linux kernel (4 KiB, 16 KiB, 64 KiB pages), without losing the performance benefits of jemalloc on the common 4 KiB-page configurations (Graviton, cloud ARM, Raspberry Pi OS, Debian/Ubuntu ARM).

The fix: build `@nx/nx-linux-arm64-gnu` and `@nx/nx-linux-arm64-musl` with `JEMALLOC_SYS_WITH_LG_PAGE=16` (64 KiB allocator page). jemalloc's documented contract is `allocator_page_size ≥ system_page_size`, so a binary built this way runs on any aarch64 Linux kernel with page size ≤ 64 KiB — which covers all known configurations.

## Prior art

The same `JEMALLOC_SYS_WITH_LG_PAGE=16` approach is used by:

- **rustc** — [rust-lang/rust#145353](https://github.com/rust-lang/rust/pull/145353): `cargo.env("JEMALLOC_SYS_WITH_LG_PAGE", "16")` for aarch64 targets in `src/bootstrap/src/core/build_steps/tool.rs`
- **swc** — [swc-project/swc#6541](https://github.com/swc-project/swc/pull/6541): `export JEMALLOC_SYS_WITH_LG_PAGE=16` in the publish workflow for both aarch64 gnu and musl rows
- **fd** — [sharkdp/fd#1547](https://github.com/sharkdp/fd/pull/1547) and follow-up [#1549](https://github.com/sharkdp/fd/pull/1549) moving the env var into `Cross.toml` via `passthrough`
- **Homebrew** — [`Library/Homebrew/extend/os/linux/extend/ENV/super.rb`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/extend/os/linux/extend/ENV/super.rb): `self["JEMALLOC_SYS_WITH_LG_PAGE"] = "16"` (applied globally to Homebrew Linux aarch64 builds)
- **Arch Linux ARM** — [`extra/fd/PKGBUILD`](https://github.com/archlinuxarm/PKGBUILDs/blob/master/extra/fd/PKGBUILD): `[[ $CARCH == "aarch64" ]] && export JEMALLOC_SYS_WITH_LG_PAGE=16`

## Related Issue(s)

Fixes #35345
