### PR TITLE
fix(core): normalize spawned run-commands output

### DIFF
--- a/packages/nx/src/executors/run-commands/running-tasks.ts
+++ b/packages/nx/src/executors/run-commands/running-tasks.ts
@@ -404,6 +404,8 @@ class RunningNodeProcess implements RunningTask {
       cwd,
       windowsHide: true,
     });
+    this.childProcess.stdout?.setEncoding('utf8');
+    this.childProcess.stderr?.setEncoding('utf8');
 
     // Register process for metrics collection
     // Skip registration if we're in a forked executor - the fork wrapper already registered


### PR DESCRIPTION
## Current Behavior

Direct `nx:run-commands` tasks on the non-PTY path can forward `Buffer` chunks into the TUI lifecycle after the recent `exec()` to `spawn()` change. When native progressive output handling receives that value, task execution can fail with `StringExpected` instead of surfacing the underlying command output.

## Expected Behavior

Spawned `run-commands` output is decoded to UTF-8 strings before it reaches progressive output consumers, so TUI rendering can continue streaming command output without crashing.