### PR TITLE
fix(maven): log analyzer startup under verbose instead of stdout

### DIFF
--- a/packages/maven/src/plugins/maven-analyzer.ts
+++ b/packages/maven/src/plugins/maven-analyzer.ts
@@ -41,12 +41,13 @@ export async function runMavenAnalysis(
   workspaceRoot: string,
   options: MavenPluginOptions
 ): Promise<MavenAnalysisData> {
-  console.log(`[Maven Analyzer] Starting analysis with options:`, options);
-
   const outputFile = join(workspaceDataDirectory, 'nx-maven-projects.json');
   const isVerbose =
     options.verbose || process.env.NX_VERBOSE_LOGGING === 'true';
 
+  logger.verbose(
+    `[Maven Analyzer] Starting analysis with options: ${JSON.stringify(options)}`
+  );
   logger.verbose(`[Maven Analyzer] Output file: ${outputFile}`);
   logger.verbose(`[Maven Analyzer] Verbose mode: ${isVerbose}`);
   logger.verbose(`[Maven Analyzer] Workspace root: ${workspaceRoot}`);


### PR DESCRIPTION
## Current Behavior

The Maven analyzer prints `[Maven Analyzer] Starting analysis with options: { verbose: false }` unconditionally to stdout. This corrupts commands that expect clean stdout output, such as `nx show projects --json`, where consumers end up parsing:

```
[Maven Analyzer] Starting analysis with options: { verbose: false }
["@somnex/krista","@somnex/somnex"]
```

## Expected Behavior

The startup message should only be shown in verbose mode, matching the rest of the analyzer diagnostics in this file that already use `logger.verbose`. Normal `nx show projects --json` output stays clean.

## Related Issue(s)

Fixes NXC-4253