### PR TITLE
feat(core): show target uses task graph + filter broken dependsOn during normalization

### DIFF
--- a/packages/nx/src/command-line/show/show-target/info.spec.ts
+++ b/packages/nx/src/command-line/show/show-target/info.spec.ts
@@ -183,6 +183,181 @@ describe('show target info', () => {
     expect(parsed.dependsOn.sort()).toEqual(['lib-a:build', 'lib-b:build']);
   });
 
+  it('should expose transitive task deps and group them by target', async () => {
+    setGraph(
+      new GraphBuilder()
+        .addProjectConfiguration(
+          {
+            root: 'apps/my-app',
+            name: 'my-app',
+            targets: {
+              build: { executor: '@nx/web:build', dependsOn: ['^build'] },
+            },
+          },
+          'app'
+        )
+        .addProjectConfiguration(
+          {
+            root: 'libs/lib-a',
+            name: 'lib-a',
+            targets: {
+              build: { executor: '@nx/js:tsc', dependsOn: ['^build'] },
+            },
+          },
+          'lib'
+        )
+        .addProjectConfiguration(
+          {
+            root: 'libs/lib-b',
+            name: 'lib-b',
+            targets: { build: { executor: '@nx/js:tsc' } },
+          },
+          'lib'
+        )
+        .addDependency('my-app', 'lib-a')
+        .addDependency('lib-a', 'lib-b')
+        .build()
+    );
+
+    await showTargetInfoHandler({ target: 'my-app:build', json: true });
+
+    const parsed = JSON.parse((console.log as jest.Mock).mock.calls[0][0]);
+    expect(parsed.dependsOn).toEqual(['lib-a:build']);
+    expect(parsed.transitiveTasks).toEqual(['lib-b:build']);
+  });
+
+  it('should render a transitive-task summary line in text output', async () => {
+    setGraph(
+      new GraphBuilder()
+        .addProjectConfiguration(
+          {
+            root: 'apps/my-app',
+            name: 'my-app',
+            targets: {
+              build: { executor: '@nx/web:build', dependsOn: ['^build'] },
+            },
+          },
+          'app'
+        )
+        .addProjectConfiguration(
+          {
+            root: 'libs/lib-a',
+            name: 'lib-a',
+            targets: {
+              build: { executor: '@nx/js:tsc', dependsOn: ['^compile'] },
+            },
+          },
+          'lib'
+        )
+        .addProjectConfiguration(
+          {
+            root: 'libs/lib-b',
+            name: 'lib-b',
+            targets: { compile: { executor: '@nx/js:tsc' } },
+          },
+          'lib'
+        )
+        .addDependency('my-app', 'lib-a')
+        .addDependency('lib-a', 'lib-b')
+        .build()
+    );
+
+    await showTargetInfoHandler({ target: 'my-app:build', json: false });
+
+    const allLogged = (console.log as jest.Mock).mock.calls
+      .map((c) => c[0])
+      .join('\n');
+    // With ≤3 unique transitive target names, list them.
+    expect(allLogged).toMatch(/and 1 compile transitive task/m);
+  });
+
+  it('should collapse the transitive-task summary to just a count when there are more than 3 unique target names', async () => {
+    const builder = new GraphBuilder().addProjectConfiguration(
+      {
+        root: 'apps/my-app',
+        name: 'my-app',
+        targets: {
+          build: { executor: '@nx/web:build', dependsOn: ['^build'] },
+        },
+      },
+      'app'
+    );
+
+    // direct: lib-0:build. transient fans out into 4 distinct target names
+    // (build, compile, lint, test) so the summary should collapse.
+    builder.addProjectConfiguration(
+      {
+        root: 'libs/lib-0',
+        name: 'lib-0',
+        targets: {
+          build: {
+            executor: '@nx/js:tsc',
+            dependsOn: ['^build', 'compile', 'lint', 'test'],
+          },
+          compile: { executor: '@nx/js:tsc' },
+          lint: { executor: '@nx/eslint:lint' },
+          test: { executor: '@nx/jest:jest' },
+        },
+      },
+      'lib'
+    );
+    builder.addProjectConfiguration(
+      {
+        root: 'libs/lib-1',
+        name: 'lib-1',
+        targets: { build: { executor: '@nx/js:tsc' } },
+      },
+      'lib'
+    );
+    builder.addDependency('my-app', 'lib-0');
+    builder.addDependency('lib-0', 'lib-1');
+    setGraph(builder.build());
+
+    await showTargetInfoHandler({ target: 'my-app:build', json: false });
+
+    const allLogged = (console.log as jest.Mock).mock.calls
+      .map((c) => c[0])
+      .join('\n');
+    // >3 unique target names collapses to bare count with no target names
+    expect(allLogged).toMatch(/and \d+ transitive tasks/m);
+    expect(allLogged).not.toMatch(/and \d+ build,/);
+  });
+
+  it('should filter dependsOn entries pointing at non-existent targets via task graph', async () => {
+    setGraph(
+      new GraphBuilder()
+        .addProjectConfiguration(
+          {
+            root: 'apps/my-app',
+            name: 'my-app',
+            targets: {
+              build: {
+                executor: '@nx/web:build',
+                dependsOn: ['^does-not-exist'],
+              },
+            },
+          },
+          'app'
+        )
+        .addProjectConfiguration(
+          {
+            root: 'libs/lib-a',
+            name: 'lib-a',
+            targets: { build: { executor: '@nx/js:tsc' } },
+          },
+          'lib'
+        )
+        .addDependency('my-app', 'lib-a')
+        .build()
+    );
+
+    await showTargetInfoHandler({ target: 'my-app:build', json: true });
+
+    const parsed = JSON.parse((console.log as jest.Mock).mock.calls[0][0]);
+    expect(parsed.dependsOn).toBeUndefined();
+    expect(parsed.transitiveTasks).toBeUndefined();
+  });
+
   it('should expand self-reference dependsOn to same project taskId', async () => {
     setGraph(
       new GraphBuilder()

--- a/packages/nx/src/command-line/show/show-target/info.ts
+++ b/packages/nx/src/command-line/show/show-target/info.ts
@@ -3,7 +3,11 @@ import type { ProjectGraph } from '../../../config/project-graph';
 import type { InputDefinition } from '../../../config/workspace-json-project-json';
 import type { ConfigurationSourceMaps } from '../../../project-graph/utils/project-configuration/source-maps';
 import { getNamedInputs } from '../../../hasher/task-hasher';
-import { getDependencyConfigs } from '../../../tasks-runner/utils';
+import { createTaskGraph } from '../../../tasks-runner/create-task-graph';
+import {
+  createTaskId,
+  getDependencyConfigs,
+} from '../../../tasks-runner/utils';
 import type { ShowTargetBaseOptions } from '../command-object';
 import {
   resolveTarget,
@@ -57,12 +61,13 @@ function resolveTargetInfoData(t: ResolvedTarget) {
       .map(([name, config]) => [name, config.dependsOn])
   );
 
-  const depConfigs = getDependencyConfigs(
-    { project: projectName, target: targetName },
-    extraTargetDeps,
-    graph,
-    [...allTargetNames]
-  );
+  const depConfigs =
+    getDependencyConfigs(
+      { project: projectName, target: targetName },
+      extraTargetDeps,
+      graph,
+      [...allTargetNames]
+    ) ?? [];
 
   // Determine the hoisted command value and which option key it came from
   let command: string | undefined;
@@ -84,18 +89,15 @@ function resolveTargetInfoData(t: ResolvedTarget) {
     commandSourceKey = 'options.script';
   }
 
-  const dependsOn: string[] = [];
-  const depSourceIndices: number[] = [];
-  if (depConfigs && depConfigs.length > 0) {
-    for (let i = 0; i < depConfigs.length; i++) {
-      const dep = depConfigs[i];
-      const projects = resolveDependencyProjects(dep, projectName, graph);
-      for (const p of projects) {
-        dependsOn.push(`${p}:${dep.target}`);
-        depSourceIndices.push(i);
-      }
-    }
-  }
+  const { dependsOn, depSourceIndices, transitiveTasks } =
+    resolveTaskGraphDependencies(
+      graph,
+      extraTargetDeps,
+      projectName,
+      targetName,
+      configuration,
+      depConfigs
+    );
 
   const configurations = Object.keys(targetConfig.configurations ?? {});
   const targetSourceMap = extractTargetSourceMap(
@@ -115,6 +117,7 @@ function resolveTargetInfoData(t: ResolvedTarget) {
     ...(dependsOn.length > 0
       ? { dependsOn, _depSources: depSourceIndices }
       : {}),
+    ...(transitiveTasks.length > 0 ? { transitiveTasks } : {}),
     parallelism: targetConfig.parallelism ?? true,
     continuous: targetConfig.continuous ?? false,
     cache: targetConfig.cache ?? false,
@@ -164,6 +167,130 @@ function resolveDependencyProjects(
       .map((edge) => edge.target);
   }
   return [projectName];
+}
+
+/**
+ * Builds a task graph rooted at the requested target and returns:
+ *   - `dependsOn`: direct task dependencies of the root, with real
+ *     project/target resolution applied.
+ *   - `depSourceIndices`: for each direct dep, the index of the original
+ *     depConfig it corresponds to (for source-map hints), or -1 if unknown.
+ *   - `transitiveTasks`: task IDs reachable through the direct deps (not
+ *     the root, not direct deps).
+ *
+ * If `createTaskGraph` throws (e.g. circular dependencies), falls back to
+ * the `depConfig`-based resolution so the output still shows the configured
+ * list rather than silently collapsing to empty.
+ */
+function resolveTaskGraphDependencies(
+  graph: ProjectGraph,
+  extraTargetDeps: Record<string, any>,
+  projectName: string,
+  targetName: string,
+  configuration: string | undefined,
+  depConfigs: { target: string; dependencies?: boolean; projects?: string[] }[]
+): {
+  dependsOn: string[];
+  depSourceIndices: number[];
+  transitiveTasks: string[];
+} {
+  try {
+    const taskGraph = createTaskGraph(
+      graph,
+      extraTargetDeps,
+      [projectName],
+      [targetName],
+      configuration,
+      {}
+    );
+
+    const rootId = createTaskId(projectName, targetName, configuration);
+    const directDeps = taskGraph.dependencies[rootId] ?? [];
+    const directDepSet = new Set<string>(directDeps);
+
+    const depSourceIndices = directDeps.map((depTaskId) => {
+      const task = taskGraph.tasks[depTaskId];
+      if (!task) return -1;
+      return findDepConfigIndex(task.target, depConfigs, projectName, graph);
+    });
+
+    // `Object.keys(dependencies)` gives the set of real (non-dummy) tasks
+    // in the graph — `filterDummyTasks` (called inside `createTaskGraph`)
+    // removes dummy entries from `dependencies` but leaves them in `tasks`.
+    const transitiveTasks = Object.keys(taskGraph.dependencies).filter(
+      (id) => id !== rootId && !directDepSet.has(id)
+    );
+
+    return { dependsOn: directDeps, depSourceIndices, transitiveTasks };
+  } catch {
+    return {
+      ...resolveDependsOnFromConfigs(depConfigs, projectName, graph),
+      transitiveTasks: [],
+    };
+  }
+}
+
+function resolveDependsOnFromConfigs(
+  depConfigs: { target: string; dependencies?: boolean; projects?: string[] }[],
+  projectName: string,
+  graph: ProjectGraph
+): { dependsOn: string[]; depSourceIndices: number[] } {
+  const dependsOn: string[] = [];
+  const depSourceIndices: number[] = [];
+  for (let i = 0; i < depConfigs.length; i++) {
+    const dep = depConfigs[i];
+    const projects = resolveDependencyProjects(dep, projectName, graph);
+    for (const p of projects) {
+      dependsOn.push(`${p}:${dep.target}`);
+      depSourceIndices.push(i);
+    }
+  }
+  return { dependsOn, depSourceIndices };
+}
+
+/**
+ * Builds the summary line shown beneath the direct `Depends On` list.
+ *
+ * Up to 3 unique target names: list them (`and 5 build, compile transitive tasks`).
+ * Beyond that: collapse to the count alone (`and 12 transitive tasks`).
+ */
+function formatTransitiveSummary(taskIds: string[]): string {
+  const count = taskIds.length;
+  const plural = count === 1 ? 'task' : 'tasks';
+  const targetNames = uniqueTargetNames(taskIds);
+  if (targetNames.length === 0 || targetNames.length > 3) {
+    return `and ${count} transitive ${plural}`;
+  }
+  return `and ${count} ${targetNames.join(', ')} transitive ${plural}`;
+}
+
+function uniqueTargetNames(taskIds: string[]): string[] {
+  const set = new Set<string>();
+  for (const id of taskIds) {
+    // task ids are `project:target` or `project:target:config`
+    const parts = id.split(':');
+    if (parts.length >= 2) set.add(parts[1]);
+  }
+  return [...set].sort();
+}
+
+function findDepConfigIndex(
+  taskTarget: { project: string; target: string },
+  depConfigs: {
+    target: string;
+    dependencies?: boolean;
+    projects?: string[];
+  }[],
+  rootProject: string,
+  graph: ProjectGraph
+): number {
+  for (let i = 0; i < depConfigs.length; i++) {
+    const dep = depConfigs[i];
+    if (dep.target !== taskTarget.target) continue;
+    const resolved = resolveDependencyProjects(dep, rootProject, graph);
+    if (resolved.includes(taskTarget.project)) return i;
+  }
+  return -1;
 }
 
 /**
@@ -288,11 +415,15 @@ function renderTargetInfo(data: TargetInfoData, args: ShowTargetBaseOptions) {
   if (data.dependsOn && data.dependsOn.length > 0) {
     console.log(`${c.bold('Depends On')}:`);
     for (let i = 0; i < data.dependsOn.length; i++) {
+      const srcIdx = data._depSources?.[i];
       const hint =
-        data._depSources?.[i] !== undefined
-          ? sourceHint(`dependsOn.${data._depSources[i]}`, 'dependsOn')
-          : '';
+        srcIdx !== undefined && srcIdx >= 0
+          ? sourceHint(`dependsOn.${srcIdx}`, 'dependsOn')
+          : sourceHint('dependsOn');
       console.log(`  ${data.dependsOn[i]}${hint}`);
+    }
+    if (data.transitiveTasks && data.transitiveTasks.length > 0) {
+      console.log(`  ${c.dim(formatTransitiveSummary(data.transitiveTasks))}`);
     }
   }
 


### PR DESCRIPTION
## Current Behavior

- During project graph normalization, dependsOn entries whose target doesn't exist are left in place, which means downstream consumers have to re-validate against the real target set every time.
- `nx show target` resolves the `Depends On` list using a heuristic on raw `dependsOn` configs. That heuristic doesn't fully match what `createTaskGraph` would schedule — e.g. a `{ projects: ['lib-a'] }` entry is listed even if `lib-a` doesn't actually have the referenced target, and there's no indication of what transitively runs when the target is scheduled.

## Expected Behavior

### 1. Normalize-project-nodes drops broken same-project dependsOn entries

A new `normalizeTargetsDependsOn` pass runs inside `normalizeProjectNodes` after target defaults have been merged. It filters:

- Bare-string entries (e.g. `"prebuild"`) when the referenced target doesn't exist on the same project.
- Object entries with no `projects`, `projects: 'self'`, or `projects: '{self}'` when the referenced target doesn't exist on the same project.

Cross-project entries are intentionally left alone — `"^target"`, `{ target: 'X', dependencies: true }`, and `{ projects: [...] }` need the real project graph (and in some cases the dep edges) to validate, so they're resolved later during task graph creation.

### 2. `nx show target` is task-graph-driven

`showTargetInfoHandler` now builds a task graph rooted at the requested target via `createTaskGraph`. The `Depends On` list reads direct task dependencies off the graph, giving the same filtering and resolution behavior as `nx run`:

- Non-existent targets disappear from the list.
- `^target` expands to real dependency-project task IDs.
- `{ projects: [...] }` entries drop projects that don't actually have the target.

A new `transientTasks` field on the JSON output surfaces everything that runs transitively. The text renderer shows a summary line beneath `Depends On`:

```
Depends On:
  lib-a:build
  and 5 build, compile transient tasks
```

With >3 unique target names, the summary collapses to a bare count (`and 12 transient tasks`) to stay scannable. Source-map hints for `--verbose` are preserved — each direct dep task ID is matched back to its originating `depConfig` entry.

## Related Issue(s)

None — proactive correctness + observability improvement.