### PR TITLE
chore(repo): remove polygraph plugin entry from claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,7 +41,6 @@
     }
   },
   "enabledPlugins": {
-    "nx@nx-claude-plugins": true,
-    "polygraph@nx-claude-plugins": true
+    "nx@nx-claude-plugins": true
   }
 }


### PR DESCRIPTION
## Current Behavior

`.claude/settings.json` enables `polygraph@nx-claude-plugins`, but the `nx-claude-plugins` marketplace only ships the `nx` plugin. The `polygraph` plugin lives in the separate `polygraph-plugins` marketplace, which is not declared in `extraKnownMarketplaces` either — so the entry refers to a plugin+marketplace pair that doesn't exist. Every contributor picks up the broken id when they pull the repo.

The bad id was introduced in #34790, which moved to the new plugin but left the marketplace name pointing at the old one.

## Expected Behavior

Polygraph is now installed globally via the session-start opt-in prompt, so the repo-level `enabledPlugins` entry is no longer needed. Remove it entirely rather than pointing it at a marketplace the settings file doesn't declare.