### PR TITLE
chore(repo): short-circuit isUsingTsSolutionSetup in unit tests

### DIFF
--- a/packages/rollup/src/plugins/with-nx/normalize-options.spec.ts
+++ b/packages/rollup/src/plugins/with-nx/normalize-options.spec.ts
@@ -5,6 +5,15 @@ jest.mock('@nx/js', () => ({
   createEntryPoints: (x: string) => x,
 }));
 
+// This spec simulates a non-TS-solution workspace via `workspaceRoot: '/tmp'`
+// (where tsconfig.base.json doesn't exist). The global mock in
+// `scripts/unit-test-setup.js` short-circuits `isUsingTsSolutionSetup()` before
+// any fs read, so we override it here to explicitly express the intent.
+jest.mock('@nx/js/src/utils/typescript/ts-solution-setup', () => ({
+  ...jest.requireActual('@nx/js/src/utils/typescript/ts-solution-setup'),
+  isUsingTsSolutionSetup: jest.fn(() => false),
+}));
+
 jest.mock('@nx/devkit', () => ({
   ...jest.requireActual('@nx/devkit'),
   workspaceRoot: '/tmp',

--- a/packages/vite/src/plugins/plugin-vitest.spec.ts
+++ b/packages/vite/src/plugins/plugin-vitest.spec.ts
@@ -59,6 +59,15 @@ jest.mock('vite', () => ({
   }),
 }));
 
+// This spec simulates a non-TS-solution workspace via the `node:fs` mock above
+// (`existsSync` returns false for `tsconfig.base.json`). The global mock in
+// `scripts/unit-test-setup.js` short-circuits `isUsingTsSolutionSetup()` before
+// any fs read, so we override it here to explicitly express the intent.
+jest.mock('@nx/js/src/utils/typescript/ts-solution-setup', () => ({
+  ...jest.requireActual('@nx/js/src/utils/typescript/ts-solution-setup'),
+  isUsingTsSolutionSetup: jest.fn(() => false),
+}));
+
 jest.mock('../utils/executor-utils', () => ({
   loadViteDynamicImport: jest.fn().mockResolvedValue({
     resolveConfig: jest.fn().mockResolvedValue({

--- a/scripts/unit-test-setup.js
+++ b/scripts/unit-test-setup.js
@@ -39,4 +39,38 @@ module.exports = () => {
      */
     ensurePackage: jest.fn((pkg) => jest.requireActual(pkg)),
   }));
+
+  /**
+   * `isUsingTsSolutionSetup()` falls back to `new FsTree(workspaceRoot, false)`
+   * when called without a tree, which reads the real repo's `tsconfig.json` /
+   * `tsconfig.base.json`. That surfaces as a sandbox violation for tests that
+   * indirectly invoke it (cypress-preset, playwright-preset, plugin
+   * `createNodesV2`, executor `normalize`, etc.).
+   *
+   * Unit tests should never touch the real workspace FS, so when the function
+   * is called without a tree, short-circuit to `true`. `true` matches the
+   * de-facto behavior of hitting the real FS (the Nx repo is a TS solution
+   * workspace), preserving every test's existing expectations without
+   * reading from disk. Calls that pass an explicit (virtual) tree still run
+   * the real implementation.
+   *
+   * There are two copies of the function — one in `@nx/js` and one in
+   * `@nx/workspace` — both need to be mocked.
+   */
+  const mockIsUsingTsSolutionSetup = (specifier) => {
+    jest.doMock(specifier, () => {
+      const actual = jest.requireActual(specifier);
+      return {
+        __esModule: true,
+        ...actual,
+        isUsingTsSolutionSetup: jest.fn((tree) =>
+          tree ? actual.isUsingTsSolutionSetup(tree) : true
+        ),
+      };
+    });
+  };
+  mockIsUsingTsSolutionSetup('@nx/js/src/utils/typescript/ts-solution-setup');
+  mockIsUsingTsSolutionSetup(
+    '@nx/workspace/src/utilities/typescript/ts-solution-setup'
+  );
 };


### PR DESCRIPTION
## Current Behavior

`isUsingTsSolutionSetup()` (in both `@nx/js` and `@nx/workspace`) falls back to `new FsTree(workspaceRoot, false)` when called without a tree, reading the real repo's `tsconfig.json` / `tsconfig.base.json`. Many unit tests indirectly invoke it (cypress-preset, playwright-preset, plugin `createNodesV2`, executor `normalize`, etc.), which surfaces as sandbox violations across ~13 test targets (angular, rspack, vite, rollup, webpack, react, next, js, cypress, remix, workspace, nest, node).

## Expected Behavior

Unit tests should never touch the real workspace FS. A global mock in `scripts/unit-test-setup.js` short-circuits `isUsingTsSolutionSetup()` when called without a tree, returning `true` to match the de-facto behavior of hitting the real FS (the Nx repo is a TS solution workspace) and preserve every test's existing expectations. Calls that pass an explicit (virtual) tree still run the real implementation.

Two specs that deliberately simulate a non-TS-solution workspace (via `node:fs` / `workspaceRoot` mocks) add a per-file override returning `false` to keep expressing that intent:

- `packages/vite/src/plugins/plugin-vitest.spec.ts`
- `packages/rollup/src/plugins/with-nx/normalize-options.spec.ts`