### PR TITLE
chore(testing): stub plugin imports in devkit specs to avoid cross-project reads

### DIFF
--- a/packages/devkit/src/generators/e2e-web-server-info-utils.spec.ts
+++ b/packages/devkit/src/generators/e2e-web-server-info-utils.spec.ts
@@ -1,3 +1,18 @@
+// Stub out the real @nx/vite/plugin so findPluginForConfigFile's dynamic
+// `await import('@nx/vite/plugin')` doesn't pull @nx/vite and @nx/js source
+// into this test. Only the createNodesV2 glob is consumed, and the include/
+// exclude assertions depend on the nxJson registration, not the real plugin.
+jest.mock(
+  '@nx/vite/plugin',
+  () => ({
+    createNodesV2: [
+      '**/{vite,vitest}.config.{js,ts,mjs,mts,cjs,cts}',
+      jest.fn(),
+    ],
+  }),
+  { virtual: true }
+);
+
 import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
 import { type Tree, readNxJson, updateNxJson } from 'nx/src/devkit-exports';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';

--- a/packages/devkit/src/generators/target-defaults-utils.spec.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.spec.ts
@@ -1,3 +1,14 @@
+// Stub out @nx/cypress/plugin so the dynamic `await import('@nx/cypress/plugin')`
+// in addE2eCiTargetDefaults doesn't pull real plugin code (which transitively
+// imports @nx/js source and inflates sandbox inputs).
+jest.mock(
+  '@nx/cypress/plugin',
+  () => ({
+    createNodesV2: ['**/cypress.config.{js,ts,mjs,cjs}', jest.fn()],
+  }),
+  { virtual: true }
+);
+
 import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
 import { readNxJson, updateNxJson, type Tree } from 'nx/src/devkit-exports';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';

--- a/packages/devkit/src/utils/find-plugin-for-config-file.spec.ts
+++ b/packages/devkit/src/utils/find-plugin-for-config-file.spec.ts
@@ -1,3 +1,15 @@
+// Stub out @nx/cypress/plugin so findPluginForConfigFile's dynamic
+// `await import('@nx/cypress/plugin')` (fired when include/exclude is present)
+// doesn't pull real plugin code, which transitively imports @nx/js source and
+// inflates sandbox inputs.
+jest.mock(
+  '@nx/cypress/plugin',
+  () => ({
+    createNodesV2: ['**/cypress.config.{js,ts,mjs,cjs}', jest.fn()],
+  }),
+  { virtual: true }
+);
+
 import { type Tree, readNxJson, updateNxJson } from 'nx/src/devkit-exports';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';


### PR DESCRIPTION
## Current Behavior

Three devkit specs exercise helpers that do `await import('@nx/<plugin>/plugin')` at runtime (`findPluginForConfigFile` when a registration has `include`/`exclude`, and `addE2eCiTargetDefaults` unconditionally for every e2e plugin registration). Combined with the custom jest resolver in `scripts/patched-jest-resolver.js` — which maps `@nx/<pkg>` subpaths to workspace source — the dynamic imports pull the real plugin source plus everything transitively re-exported by `@nx/js` and `@nx/vite` into the jest process.

Concretely, `devkit:test` ends up reading ~49 files across `packages/js/src/**` and `packages/vite/**` that are not declared (and cannot be declared without creating a project-graph cycle since `@nx/js` and `@nx/vite` both depend on `@nx/devkit`). The sandbox flags all 49 as undeclared-read violations.

## Expected Behavior

None of these specs aim to validate the real plugin's behavior. They exercise devkit's own logic — how a registration is matched to a config file, how target defaults are written into `nx.json`, and how e2e web server info is resolved from a registered plugin — treating `@nx/<plugin>/plugin` as an opaque reference. The plugin's `createNodesV2[0]` glob is used by the devkit helpers only as a pattern pre-filter against conventional config filenames (`vite.config.ts`, `cypress.config.ts`); what the real plugin does beyond that is outside the scope of these tests.

Stubbing the three plugin modules with `jest.mock(..., { virtual: true })` that exposes just the real plugin's glob pattern:

- Preserves the minimal contract the devkit helpers rely on (the module resolves, and its glob matches the conventional config filenames used in the tests).
- Drops the incidental loading of the real plugin and its entire transitive graph — removing all 49 reported sandbox violations.
- Eliminates an accidental coupling to the pinned `@nx/cypress` version currently pulled from `node_modules`, which also transitively requires `@nx/js` workspace source via the custom resolver.

Changes are test-only; no production code is touched.