### PR TITLE
chore(linter): declare @nx/jest as optional peer dependency

### DIFF
--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -32,6 +32,7 @@
   "generators": "./generators.json",
   "executors": "./executors.json",
   "peerDependencies": {
+    "@nx/jest": "workspace:*",
     "@zkochan/js-yaml": "0.0.7",
     "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
   },
@@ -46,6 +47,9 @@
     "nx": "workspace:*"
   },
   "peerDependenciesMeta": {
+    "@nx/jest": {
+      "optional": true
+    },
     "@zkochan/js-yaml": {
       "optional": true
     }

--- a/packages/eslint/tsconfig.lib.json
+++ b/packages/eslint/tsconfig.lib.json
@@ -16,13 +16,16 @@
   "include": ["**/*.ts"],
   "references": [
     {
-      "path": "../nx/tsconfig.lib.json"
-    },
-    {
       "path": "../js/tsconfig.lib.json"
     },
     {
       "path": "../devkit/tsconfig.lib.json"
+    },
+    {
+      "path": "../nx/tsconfig.lib.json"
+    },
+    {
+      "path": "../jest/tsconfig.lib.json"
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2736,6 +2736,9 @@ importers:
       '@nx/devkit':
         specifier: workspace:*
         version: link:../devkit
+      '@nx/jest':
+        specifier: workspace:*
+        version: link:../jest
       '@nx/js':
         specifier: workspace:*
         version: link:../js


### PR DESCRIPTION
## Current Behavior

`packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.ts:37` calls `ensurePackage<typeof import('@nx/jest')>('@nx/jest', nxVersion)`. This runtime-optional reference (type-only import plus a string argument) is invisible to Nx's static project-graph analysis, so the graph has no `@nx/eslint → @nx/jest` edge today.

Combined with the custom jest resolver in `scripts/patched-jest-resolver.js` — which maps `@nx/jest` subpaths to workspace source — the `eslint:test` task ends up reading `packages/jest/index.ts` and 19 files under `packages/jest/src/**` at module-load time. Those reads are undeclared inputs and are flagged as sandbox violations by the staging sandbox reports.

## Expected Behavior

Declaring `@nx/jest` as an **optional** `peerDependency` of `@nx/eslint` materializes the missing edge in Nx's project graph (the graph reader in `explicit-package-json-dependencies.ts` walks `peerDependencies` alongside `dependencies`). The inferred test-task input `^production` is transitive, so `packages/jest/**` production source is then covered as declared inputs of `eslint:test` and the 20 violations disappear.

`peerDependenciesMeta.@nx/jest.optional: true` keeps `@nx/jest` off the user's install surface — package managers don't auto-install it and don't warn about missing optional peers. Users who invoke the `workspace-rules-project` generator with jest scaffolding still get `@nx/jest` via the existing `ensurePackage` runtime install path, unchanged.