### PR TITLE
chore(nx-dev): declare next:build manifests as sitemap inputs

### DIFF
--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -27,6 +27,9 @@
         "production",
         "{projectRoot}/next-sitemap.config.js",
         "{projectRoot}/scripts/patch-sitemap-index.mjs",
+        {
+          "dependentTasksOutputFiles": "**/.next/{build-manifest,export-marker,prerender-manifest,routes-manifest}.json"
+        },
         { "env": "NX_DEV_URL" },
         { "env": "NEXT_PUBLIC_NO_INDEX" }
       ],


### PR DESCRIPTION
## Current Behavior

The `nx-dev:sitemap` task invokes `next-sitemap`, whose `ManifestParser` reads four manifests from the `nx-dev:next:build` output (`build-manifest.json`, `export-marker.json`, `prerender-manifest.json`, `routes-manifest.json` under `.next/`). None of these are declared as inputs on `sitemap`, so the reads show up as sandbox violations and the sitemap cache key doesn't change when those manifests change.

## Expected Behavior

The four manifests are declared inputs via a single `dependentTasksOutputFiles` entry, narrowly scoped to `**/.next/{build-manifest,export-marker,prerender-manifest,routes-manifest}.json` so unrelated `.next/` artifacts don't invalidate the sitemap cache. `nx show target inputs nx-dev:sitemap --check` confirms all four paths resolve as declared inputs.