### PR TITLE
fix(js): add npm workspace support to prune-lockfile executor

### DIFF
--- a/e2e/js/src/js-executor-prune-lockfile.test.ts
+++ b/e2e/js/src/js-executor-prune-lockfile.test.ts
@@ -63,4 +63,61 @@ describe('js:prune-lockfile executor', () => {
       });
     }
   );
+
+  describe('package manager npm (plain semver workspace dependency)', () => {
+    let scope: string;
+
+    beforeAll(() => {
+      scope = newProject({
+        packages: ['@nx/node', '@nx/js'],
+        preset: 'ts',
+        packageManager: 'npm',
+      });
+    });
+    afterAll(() => {
+      cleanupProject();
+    });
+
+    // npm workspaces reference sibling packages with plain semver (e.g. "*" or
+    // "0.0.1") rather than a `workspace:`/`file:`/`link:` protocol prefix. The
+    // executor must still recognize these as workspace modules and rewrite
+    // them to point at `workspace_modules`. Regression test for #33523.
+    it('should rewrite dependency to workspace_modules when version is plain semver', () => {
+      const nodeapp = uniq('nodeapp');
+      const nodelib = uniq('nodelib');
+
+      runCLI(
+        `generate @nx/node:app ${nodeapp} --linter=eslint --unitTestRunner=jest`
+      );
+      runCLI(
+        `generate @nx/js:lib ${nodelib} --bundler=tsc --linter=eslint --unitTestRunner=jest`
+      );
+
+      updateJson(`${nodeapp}/package.json`, (json) => {
+        json.dependencies = {
+          ...json.dependencies,
+          [`@${scope}/${nodelib}`]: '*',
+        };
+        json.nx.targets['prune-lockfile'] = {
+          executor: '@nx/js:prune-lockfile',
+          options: {
+            buildTarget: 'build',
+          },
+        };
+        return json;
+      });
+      runCommand(`npm install`);
+
+      runCLI(`build ${nodeapp}`);
+      runCLI(`prune-lockfile ${nodeapp}`);
+
+      checkFilesExist(`${nodeapp}/dist/package-lock.json`);
+      const prunedPackageJson = JSON.parse(
+        readFile(`${nodeapp}/dist/package.json`)
+      );
+      expect(prunedPackageJson.dependencies[`@${scope}/${nodelib}`]).toBe(
+        `file:./workspace_modules/@${scope}/${nodelib}`
+      );
+    });
+  });
 });

--- a/packages/js/src/executors/prune-lockfile/prune-lockfile.ts
+++ b/packages/js/src/executors/prune-lockfile/prune-lockfile.ts
@@ -16,6 +16,8 @@ import {
   getLockFileName,
   createLockFile,
 } from 'nx/src/plugins/js/lock-file/lock-file';
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { getWorkspacePackagesFromGraph } from 'nx/src/plugins/js/utils/get-workspace-packages-from-graph';
 import { type PruneLockfileOptions } from './schema';
 
 export default async function pruneLockfileExecutor(
@@ -59,13 +61,16 @@ function createPrunedLockfile(packageJson: PackageJson, graph: ProjectGraph) {
   const lockfileName = getLockFileName(packageManager);
   const lockFile = createLockFile(packageJson, graph, packageManager);
 
+  const workspacePackages = getWorkspacePackagesFromGraph(graph);
+
   for (const [pkgName, pkgVersion] of Object.entries(
     packageJson.dependencies ?? {}
   )) {
     if (
       pkgVersion.startsWith('workspace:') ||
       pkgVersion.startsWith('file:') ||
-      pkgVersion.startsWith('link:')
+      pkgVersion.startsWith('link:') ||
+      workspacePackages.has(pkgName)
     ) {
       packageJson.dependencies[pkgName] = `file:./workspace_modules/${pkgName}`;
     }


### PR DESCRIPTION
## Current Behavior

The `@nx/js:prune-lockfile` executor only identifies workspace module dependencies when the `package.json` version string starts with `workspace:`, `file:`, or `link:`. npm workspaces reference sibling packages using plain semver (e.g. `"@repo/schemas": "0.0.1"` or `"@repo/schemas": "*"`), so those dependencies are never rewritten to point at `workspace_modules/` and pruning fails for npm-based workspaces.

## Expected Behavior

Workspace module dependencies are correctly identified and rewritten to `file:./workspace_modules/<pkg>` regardless of package manager, including npm with plain-semver versions.

The fix pulls the set of workspace packages from the project graph via `getWorkspacePackagesFromGraph` and treats any dependency whose name matches a workspace package as a workspace module, in addition to the existing protocol-prefix checks.

A regression e2e test covers the npm plain-semver case (`"*"`): it asserts the pruned `package.json` has its dependency rewritten to `file:./workspace_modules/@scope/nodelib`. The existing npm test case used `file:../<lib>` which matched the `file:` prefix check and would've passed even without the fix, so it didn't actually cover the reported scenario.

## Related Issue(s)

Fixes #33523