### PR TITLE
fix(nextjs): add semver to required packages in update-package-json

### DIFF
--- a/packages/next/src/executors/build/lib/update-package-json.ts
+++ b/packages/next/src/executors/build/lib/update-package-json.ts
@@ -17,6 +17,7 @@ export function updatePackageJson(
   // These are always required for a production Next.js app to run.
   // sharp is for next/image https://nextjs.org/docs/messages/sharp-missing-in-production
   // critters is required for experimental optimizing CSS
+  // semver is required by .nx-helpers/with-nx.js at runtime
   const requiredPackages = [
     'react',
     'react-dom',
@@ -24,6 +25,7 @@ export function updatePackageJson(
     'typescript',
     'sharp',
     'critters',
+    'semver',
   ];
   for (const pkg of requiredPackages) {
     const externalNode = context.projectGraph.externalNodes[`npm:${pkg}`];


### PR DESCRIPTION
## Current Behavior
When using @nx/next:build with Yarn PnP, the generated .nx-helpers/with-nx.js requires semver at runtime, but semver is not included in the generated package.json. This causes the application to fail when starting in a deployed environment with the error: "Required package: semver, Required by: /app/.nx-helpers/with-nx.js"

## Expected Behavior
The generated package.json should include semver as a dependency so that .nx-helpers/with-nx.js can resolve it at runtime in all package manager environments, including Yarn PnP.

## Related Issue(s)
Fixes #34095