### PR TITLE
fix(core): don't spread plugin name into set constructor

### DIFF
--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -320,7 +320,7 @@ async function updateProjectGraphWithPlugins(
 
   let spinner: DelayedSpinner;
   const inProgressPlugins = new Set<string>(
-    ...createDependencyPlugins.map((plugin) => plugin.name)
+    createDependencyPlugins.map((plugin) => plugin.name)
   );
 
   function getSpinnerText() {
@@ -438,7 +438,7 @@ export async function applyProjectMetadata(
   );
 
   const inProgressPlugins = new Set<string>(
-    ...createMetadataPlugins.map((p) => p.name)
+    createMetadataPlugins.map((p) => p.name)
   );
 
   function getSpinnerText() {

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -16,6 +16,7 @@ import { assertWorkspaceValidity } from '../utils/assert-workspace-validity';
 import { DelayedSpinner } from '../utils/delayed-spinner';
 import { readJsonFile } from '../utils/fileutils';
 import { PackageJson } from '../utils/package-json';
+import { formatPluginProgressText } from '../utils/plugin-progress-text';
 import { ProgressTopics } from '../utils/progress-topics';
 import { workspaceRoot } from '../utils/workspace-root';
 import {
@@ -323,22 +324,13 @@ async function updateProjectGraphWithPlugins(
     createDependencyPlugins.map((plugin) => plugin.name)
   );
 
-  function getSpinnerText() {
-    if (!spinner || inProgressPlugins.size === 0) {
-      return '';
-    }
-
-    if (inProgressPlugins.size === 1) {
-      return `Creating project graph dependencies with ${
-        inProgressPlugins.values().next().value
-      }`;
-    } else {
-      return [
-        `Creating project graph dependencies with ${inProgressPlugins.size} plugins`,
-        ...Array.from(inProgressPlugins).map((p) => `  - ${p}`),
-      ].join('\n');
-    }
-  }
+  const getSpinnerText = () =>
+    spinner
+      ? formatPluginProgressText(
+          'Creating project graph dependencies',
+          inProgressPlugins
+        )
+      : '';
 
   spinner = new DelayedSpinner(getSpinnerText(), {
     progressTopic: ProgressTopics.GraphConstruction,
@@ -441,22 +433,10 @@ export async function applyProjectMetadata(
     createMetadataPlugins.map((p) => p.name)
   );
 
-  function getSpinnerText() {
-    if (!spinner || inProgressPlugins.size === 0) {
-      return '';
-    }
-
-    if (inProgressPlugins.size === 1) {
-      return `Creating project metadata with ${
-        inProgressPlugins.values().next().value
-      }`;
-    } else {
-      return [
-        `Creating project metadata with ${inProgressPlugins.size} plugins`,
-        ...Array.from(inProgressPlugins).map((p) => `  - ${p}`),
-      ].join('\n');
-    }
-  }
+  const getSpinnerText = () =>
+    spinner
+      ? formatPluginProgressText('Creating project metadata', inProgressPlugins)
+      : '';
 
   spinner = createMetadataPlugins.length
     ? new DelayedSpinner(getSpinnerText(), {

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -12,6 +12,7 @@ import { minimatch } from 'minimatch';
 import { performance } from 'perf_hooks';
 
 import { DelayedSpinner } from '../../utils/delayed-spinner';
+import { formatPluginProgressText } from '../../utils/plugin-progress-text';
 import { ProgressTopics } from '../../utils/progress-topics';
 import {
   AggregateCreateNodesError,
@@ -84,22 +85,13 @@ export async function createProjectConfigurationsWithPlugins(
   let spinner: DelayedSpinner;
   const inProgressPlugins = new Set<string>();
 
-  function getSpinnerText() {
-    if (!spinner || inProgressPlugins.size === 0) {
-      return '';
-    }
-
-    if (inProgressPlugins.size === 1) {
-      return `Creating project graph nodes with ${
-        inProgressPlugins.values().next().value
-      }`;
-    } else {
-      return [
-        `Creating project graph nodes with ${inProgressPlugins.size} plugins`,
-        ...Array.from(inProgressPlugins).map((p) => `  - ${p}`),
-      ].join('\n');
-    }
-  }
+  const getSpinnerText = () =>
+    spinner
+      ? formatPluginProgressText(
+          'Creating project graph nodes',
+          inProgressPlugins
+        )
+      : '';
 
   const createNodesPlugins = plugins.filter(
     (plugin) => plugin.createNodes?.[0]

--- a/packages/nx/src/utils/plugin-progress-text.spec.ts
+++ b/packages/nx/src/utils/plugin-progress-text.spec.ts
@@ -1,0 +1,72 @@
+import { formatPluginProgressText } from './plugin-progress-text';
+
+describe('formatPluginProgressText', () => {
+  it('returns an empty string when no plugins are in progress', () => {
+    expect(
+      formatPluginProgressText('Creating project metadata', new Set())
+    ).toBe('');
+  });
+
+  it('returns a single-line message when exactly one plugin is in progress', () => {
+    const inProgress = new Set(['@nx/rust']);
+    expect(
+      formatPluginProgressText(
+        'Creating project graph dependencies',
+        inProgress
+      )
+    ).toBe('Creating project graph dependencies with @nx/rust');
+  });
+
+  it('returns a multi-line message listing each plugin when multiple are in progress', () => {
+    const inProgress = new Set(['@nx/rust', '@nx/js', '@nx/eslint']);
+    expect(
+      formatPluginProgressText(
+        'Creating project graph dependencies',
+        inProgress
+      )
+    ).toBe(
+      [
+        'Creating project graph dependencies with 3 plugins',
+        '  - @nx/rust',
+        '  - @nx/js',
+        '  - @nx/eslint',
+      ].join('\n')
+    );
+  });
+
+  it('preserves each plugin name as a whole entry, not per-character', () => {
+    // Regression: `new Set(...array)` spreads into the Set constructor,
+    // which takes a single iterable — for a string that means iterating
+    // character-by-character. The formatter must surface full plugin names.
+    const inProgress = new Set(['@nx/rust']);
+    const output = formatPluginProgressText(
+      'Creating project graph dependencies',
+      inProgress
+    );
+    expect(output).toContain('@nx/rust');
+    expect(output).not.toMatch(/^\s*- @$/m);
+    expect(output).not.toMatch(/^\s*- r$/m);
+  });
+
+  it('does not mutate the provided set', () => {
+    const inProgress = new Set(['@nx/rust', '@nx/js']);
+    formatPluginProgressText('Creating project metadata', inProgress);
+    expect(inProgress.size).toBe(2);
+  });
+
+  it('reflects the current set contents across successive calls', () => {
+    const inProgress = new Set(['@nx/rust', '@nx/js']);
+    const before = formatPluginProgressText(
+      'Creating project metadata',
+      inProgress
+    );
+    inProgress.delete('@nx/rust');
+    const after = formatPluginProgressText(
+      'Creating project metadata',
+      inProgress
+    );
+
+    expect(before).toContain('2 plugins');
+    expect(after).toBe('Creating project metadata with @nx/js');
+  });
+});

--- a/packages/nx/src/utils/plugin-progress-text.ts
+++ b/packages/nx/src/utils/plugin-progress-text.ts
@@ -1,0 +1,17 @@
+export function formatPluginProgressText(
+  action: string,
+  inProgressPlugins: ReadonlySet<string>
+): string {
+  if (inProgressPlugins.size === 0) {
+    return '';
+  }
+
+  if (inProgressPlugins.size === 1) {
+    return `${action} with ${inProgressPlugins.values().next().value}`;
+  }
+
+  return [
+    `${action} with ${inProgressPlugins.size} plugins`,
+    ...Array.from(inProgressPlugins, (p) => `  - ${p}`),
+  ].join('\n');
+}


### PR DESCRIPTION
This pull request contains a small fix in the `build-project-graph.ts` file to correct the way `Set` is initialized for tracking in-progress plugins. The change removes the unnecessary spread operator when creating the `Set` from plugin names.

* Fixed `inProgressPlugins` initialization in both `updateProjectGraphWithPlugins` and `applyProjectMetadata` functions by removing the spread operator, ensuring plugin names are correctly added to the `Set`. [[1]](diffhunk://#diff-14bd07dde50d74ec748f1bce0f9d8cf05504e36c83928d1ad077dcff088b6822L323-R323) [[2]](diffhunk://#diff-14bd07dde50d74ec748f1bce0f9d8cf05504e36c83928d1ad077dcff088b6822L441-R441)