### PR TITLE
feat(core)!: rename CreateNodes V2 types to canonical OG names

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@module-federation/runtime": "2.3.3",
     "@module-federation/enhanced": "catalog:",
     "@module-federation/sdk": "^2.1.0",
-    "@monodon/rust": "2.3.0",
+    "@monodon/rust": "3.0.0",
     "@napi-rs/cli": "3.5.1",
     "@napi-rs/wasm-runtime": "0.2.4",
     "@nestjs/cli": "^10.0.2",

--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -10,7 +10,7 @@ import {
   readNxJson,
   type Tree,
 } from '@nx/devkit';
-import { createNodesV2 } from '../../plugins/plugin';
+import { createNodes } from '../../plugins/plugin';
 import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { assertNotUsingTsSolutionSetup } from '../utils/validations';
 import {
@@ -40,7 +40,7 @@ export async function angularInitGenerator(
       tree,
       await createProjectGraphAsync(),
       '@nx/angular/plugin',
-      createNodesV2,
+      createNodes,
       {
         targetNamePrefix: ['', 'angular:', 'angular-'],
       },

--- a/packages/angular/src/plugins/plugin.spec.ts
+++ b/packages/angular/src/plugins/plugin.spec.ts
@@ -1,6 +1,6 @@
-import type { CreateNodesContextV2 } from '@nx/devkit';
+import type { CreateNodesContext } from '@nx/devkit';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
-import { createNodesV2, type AngularProjectConfiguration } from './plugin';
+import { createNodes, type AngularProjectConfiguration } from './plugin';
 import { loadVite } from './utils/vitest';
 
 jest.mock('nx/src/utils/cache-directory', () => ({
@@ -14,8 +14,8 @@ jest.mock('./utils/vitest', () => ({
 }));
 
 describe('@nx/angular/plugin', () => {
-  let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let createNodesFunction = createNodes[1];
+  let context: CreateNodesContext;
   let tempFs: TempFs;
   let cwd: string;
 

--- a/packages/angular/src/plugins/plugin.ts
+++ b/packages/angular/src/plugins/plugin.ts
@@ -5,11 +5,11 @@ import {
 } from '@nx/devkit/internal';
 import {
   AggregateCreateNodesError,
-  type CreateNodesContextV2,
+  type CreateNodesContext,
   createNodesFromFiles,
   type CreateNodesResult,
   CreateNodesResultV2,
-  type CreateNodesV2,
+  type CreateNodes,
   detectPackageManager,
   getPackageManagerCommand,
   type ProjectConfiguration,
@@ -84,7 +84,7 @@ const knownExecutors = {
   ]),
 };
 
-export const createNodesV2: CreateNodesV2<AngularPluginOptions> = [
+export const createNodes: CreateNodes<AngularPluginOptions> = [
   '**/angular.json',
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
@@ -147,10 +147,15 @@ export const createNodesV2: CreateNodesV2<AngularPluginOptions> = [
   },
 ];
 
+/**
+ * @deprecated Use {@link createNodes} instead. This will be removed in Nx 24.
+ */
+export const createNodesV2 = createNodes;
+
 async function createNodesInternal(
   configFilePath: string,
   options: {} | undefined,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   projectsCache: PluginCache<AngularProjects>,
   pmc: ReturnType<typeof getPackageManagerCommand>,
   hash: string
@@ -177,7 +182,7 @@ async function buildAngularProjects(
   configFilePath: string,
   options: AngularPluginOptions,
   angularWorkspaceRoot: string,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ): Promise<AngularProjects> {
   const projects: Record<string, AngularProjects[string] & { root: string }> =
@@ -343,7 +348,7 @@ function updateAppShellTarget(
   projects: AngularProjects,
   angularJson: AngularJson,
   angularWorkspaceRoot: string,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): void {
   // it must exist since we collected it when processing it
   const target = projects[projectName].targets[targetName];
@@ -392,7 +397,7 @@ async function updateBuildTarget(
   targetName: string,
   target: TargetConfiguration,
   angularTarget: AngularTargetConfiguration,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   angularWorkspaceRoot: string,
   projectRoot: string,
   namedInputs: ReturnType<typeof getNamedInputs>
@@ -451,7 +456,7 @@ async function updateTestTarget(
   projectName: string,
   target: TargetConfiguration,
   angularTarget: AngularTargetConfiguration,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   angularWorkspaceRoot: string,
   projectRoot: string,
   namedInputs: ReturnType<typeof getNamedInputs>,
@@ -496,7 +501,7 @@ async function updateTestTarget(
 function updateServerTarget(
   target: TargetConfiguration,
   angularTarget: AngularTargetConfiguration,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   angularWorkspaceRoot: string,
   projectRoot: string,
   namedInputs: ReturnType<typeof getNamedInputs>
@@ -566,7 +571,7 @@ async function getNgPackagrOutputs(
   target: AngularTargetConfiguration,
   angularWorkspaceRoot: string,
   projectRoot: string,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<string[]> {
   let ngPackageJsonPath = join(
     context.workspaceRoot,
@@ -631,7 +636,7 @@ function getKarmaTargetOutputs(
   target: AngularTargetConfiguration,
   angularWorkspaceRoot: string,
   projectRoot: string,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): string[] {
   const defaultOutput = posix.join(
     '{workspaceRoot}',
@@ -700,7 +705,7 @@ async function getVitestTargetOutputs(
   target: AngularTargetConfiguration,
   angularWorkspaceRoot: string,
   projectRoot: string,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<string[]> {
   // https://github.com/angular/angular-cli/blob/d9cd609c5d13fe492b1f31973d9be518f8529387/packages/angular/build/src/builders/unit-test/runners/vitest/plugins.ts#L365
   const defaultOutput = posix.join(
@@ -984,7 +989,7 @@ interface AngularEntry {
 
 async function filterAngularConfigs(
   configFiles: readonly string[],
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<{
   entries: AngularEntry[];
   preErrors: Array<[string, Error]>;

--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContextV2 } from '@nx/devkit';
+import { CreateNodesContext } from '@nx/devkit';
 import { defineConfig } from 'cypress';
 
 import { createNodesV2 } from './plugin';
@@ -9,7 +9,7 @@ import { nxE2EPreset } from '../../plugins/cypress-preset';
 
 describe('@nx/cypress/plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
   let tempFs: TempFs;
   let cwd = process.cwd();
   let originalCacheProjectGraph: string | undefined;

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -5,10 +5,10 @@ import {
 } from '@nx/devkit/internal';
 import {
   AggregateCreateNodesError,
-  type CreateNodesContextV2,
+  type CreateNodesContext,
   createNodesFromFiles,
-  CreateNodesResultV2,
-  type CreateNodesV2,
+  CreateNodesResultArray,
+  type CreateNodes,
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
@@ -46,7 +46,7 @@ const defaultPatterns = {
   },
 };
 
-export const createNodes: CreateNodesV2<CypressPluginOptions> = [
+export const createNodes: CreateNodes<CypressPluginOptions> = [
   cypressConfigGlob,
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
@@ -73,7 +73,7 @@ export const createNodes: CreateNodesV2<CypressPluginOptions> = [
         entries.map(() => [lockFileName])
       );
 
-      let results: CreateNodesResultV2 = [];
+      let results: CreateNodesResultArray = [];
       let nodeErrors: Array<[string | null, Error]> = [];
       try {
         results = await createNodesFromFiles(
@@ -115,7 +115,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFilePath: string,
   options: CypressPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   pluginCache: PluginCache<CypressTargets>,
   pmc: ReturnType<typeof getPackageManagerCommand>,
   projectHash: string
@@ -319,7 +319,7 @@ async function buildCypressTargets(
   configFilePath: string,
   projectRoot: string,
   options: CypressPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ): Promise<CypressTargets> {
   const cypressConfig = await loadConfigFile(
@@ -769,7 +769,7 @@ interface CypressEntry {
 
 async function filterCypressConfigs(
   configFiles: readonly string[],
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<{
   entries: CypressEntry[];
   preErrors: Array<[string, Error]>;

--- a/packages/detox/src/plugins/plugin.ts
+++ b/packages/detox/src/plugins/plugin.ts
@@ -4,10 +4,10 @@ import {
   PluginCache,
 } from '@nx/devkit/internal';
 import {
-  CreateNodesContextV2,
+  CreateNodesContext,
   createNodesFromFiles,
   CreateNodesResult,
-  CreateNodesV2,
+  CreateNodes,
   detectPackageManager,
   getPackageManagerCommand,
   NxJsonConfiguration,
@@ -29,7 +29,7 @@ export interface DetoxPluginOptions {
 
 type DetoxTargets = Record<string, TargetConfiguration<DetoxPluginOptions>>;
 
-export const createNodes: CreateNodesV2<DetoxPluginOptions> = [
+export const createNodes: CreateNodes<DetoxPluginOptions> = [
   '**/{detox.config,.detoxrc}.{json,js}',
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
@@ -74,7 +74,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFile: string,
   options: DetoxPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   targetsCache: PluginCache<DetoxTargets>,
   pmc: ReturnType<typeof getPackageManagerCommand>,
   hash: string
@@ -100,7 +100,7 @@ async function createNodesInternal(
 function buildDetoxTargets(
   projectRoot: string,
   options: DetoxPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ) {
   const namedInputs = getNamedInputs(projectRoot, context);

--- a/packages/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator.ts
+++ b/packages/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator.ts
@@ -10,7 +10,7 @@ import {
   readProjectConfiguration,
   updateNxJson,
   updateProjectConfiguration,
-  type CreateNodesV2,
+  type CreateNodes,
   type ExpandedPluginConfiguration,
   type NxJsonConfiguration,
   type ProjectGraph,
@@ -63,8 +63,8 @@ class ExecutorToPluginMigrator<T> {
   #nxJson: NxJsonConfiguration;
   #targetDefaultsForExecutor: Partial<TargetConfiguration>;
   #targetAndProjectsToMigrate: Map<string, Set<string>>;
-  #createNodes?: CreateNodesV2<T>;
-  #createNodesV2?: CreateNodesV2<T>;
+  #createNodes?: CreateNodes<T>;
+  #createNodesV2?: CreateNodes<T>;
   #createNodesResultsForTargets: Map<string, ConfigurationResult>;
   #skippedProjects: Set<string>;
 
@@ -75,8 +75,8 @@ class ExecutorToPluginMigrator<T> {
     pluginPath: string,
     pluginOptionsBuilder: PluginOptionsBuilder<T>,
     postTargetTransformer: PostTargetTransformer,
-    createNodes?: CreateNodesV2<T>,
-    createNodesV2?: CreateNodesV2<T>,
+    createNodes?: CreateNodes<T>,
+    createNodesV2?: CreateNodes<T>,
     specificProjectToMigrate?: string,
     filters?: {
       skipProjectFilter?: SkipProjectFilter;
@@ -374,7 +374,7 @@ export async function migrateProjectExecutorsToPlugin<T>(
   tree: Tree,
   projectGraph: ProjectGraph,
   pluginPath: string,
-  createNodesV2: CreateNodesV2<T>,
+  createNodesV2: CreateNodes<T>,
   defaultPluginOptions: T,
   migrations: Array<{
     executors: string[];
@@ -405,7 +405,7 @@ export async function migrateProjectExecutorsToPluginV1<T>(
   tree: Tree,
   projectGraph: ProjectGraph,
   pluginPath: string,
-  createNodes: CreateNodesV2<T>,
+  createNodes: CreateNodes<T>,
   defaultPluginOptions: T,
   migrations: Array<{
     executors: string[];
@@ -434,8 +434,8 @@ async function migrateProjects<T>(
   tree: Tree,
   projectGraph: ProjectGraph,
   pluginPath: string,
-  createNodes: CreateNodesV2<T>,
-  createNodesV2: CreateNodesV2<T>,
+  createNodes: CreateNodes<T>,
+  createNodesV2: CreateNodes<T>,
   defaultPluginOptions: T,
   migrations: Array<{
     executors: string[];
@@ -515,8 +515,8 @@ async function addPluginRegistrations<T>(
   tree: Tree,
   projects: Map<string, Record<string, string>>,
   pluginPath: string,
-  createNodes: CreateNodesV2 | undefined,
-  createNodesV2: CreateNodesV2 | undefined,
+  createNodes: CreateNodes | undefined,
+  createNodesV2: CreateNodes | undefined,
   defaultPluginOptions: T,
   projectGraph: ProjectGraph,
   spinner: typeof globalSpinner
@@ -630,8 +630,8 @@ async function getCreateNodesResultsForPlugin(
   tree: Tree,
   pluginConfiguration: ExpandedPluginConfiguration,
   pluginPath: string,
-  createNodes: CreateNodesV2 | undefined,
-  createNodesV2: CreateNodesV2 | undefined,
+  createNodes: CreateNodes | undefined,
+  createNodesV2: CreateNodes | undefined,
   nxJson: NxJsonConfiguration
 ): Promise<ConfigurationResult> {
   let projectConfigs: ConfigurationResult;

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -1,5 +1,5 @@
 import {
-  type CreateNodesV2,
+  type CreateNodes,
   type NxJsonConfiguration,
   type PluginConfiguration,
   type ProjectConfiguration,
@@ -289,11 +289,11 @@ export async function addE2eCiTargetDefaults(
   }
 
   const resolvedE2ePlugin: {
-    createNodes?: CreateNodesV2;
-    createNodesV2?: CreateNodesV2;
+    createNodes?: CreateNodes;
+    createNodesV2?: CreateNodes;
   } = await import(e2ePlugin);
   const e2ePluginGlob =
-    resolvedE2ePlugin.createNodesV2?.[0] ?? resolvedE2ePlugin.createNodes?.[0];
+    resolvedE2ePlugin.createNodes?.[0] ?? resolvedE2ePlugin.createNodesV2?.[0];
   // The e2e config file must be one this plugin actually processes (its path
   // matches the plugin's createNodes glob) before the registration's
   // include/exclude filters are applied.

--- a/packages/devkit/src/utils/add-plugin.spec.ts
+++ b/packages/devkit/src/utils/add-plugin.spec.ts
@@ -2,7 +2,7 @@ import { createTreeWithEmptyWorkspace } from 'nx/src/generators/testing-utils/cr
 import type { Tree } from 'nx/src/generators/tree';
 import { readJson, writeJson } from 'nx/src/generators/utils/json';
 import type { PackageJson } from 'nx/src/utils/package-json';
-import { CreateNodesV2 } from 'nx/src/project-graph/plugins';
+import { CreateNodes } from 'nx/src/project-graph/plugins';
 import { ProjectGraph } from 'nx/src/devkit-exports';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 
@@ -10,7 +10,7 @@ import { addPlugin, generateCombinations } from './add-plugin';
 
 describe('addPlugin', () => {
   let tree: Tree;
-  let createNodes: CreateNodesV2<{ targetName: string }>;
+  let createNodes: CreateNodes<{ targetName: string }>;
   let graph: ProjectGraph;
   let fs: TempFs;
 

--- a/packages/devkit/src/utils/add-plugin.ts
+++ b/packages/devkit/src/utils/add-plugin.ts
@@ -4,7 +4,7 @@ import type { ConfigurationResult } from 'nx/src/project-graph/utils/project-con
 import yargs from 'yargs-parser';
 
 import {
-  CreateNodesV2,
+  CreateNodes,
   ProjectConfiguration,
   ProjectGraph,
   readJson,
@@ -28,7 +28,7 @@ export async function addPlugin<PluginOptions>(
   tree: Tree,
   graph: ProjectGraph,
   pluginName: string,
-  createNodesTuple: CreateNodesV2<PluginOptions>,
+  createNodesTuple: CreateNodes<PluginOptions>,
   options: Partial<
     Record<keyof PluginOptions, PluginOptions[keyof PluginOptions][]>
   >,
@@ -42,7 +42,7 @@ export async function addPlugin<PluginOptions>(
       new LoadedNxPlugin(
         {
           name: pluginName,
-          createNodesV2: createNodesTuple,
+          createNodes: createNodesTuple,
         },
         {
           plugin: pluginName,
@@ -63,7 +63,7 @@ export async function addPluginV1<PluginOptions>(
   tree: Tree,
   graph: ProjectGraph,
   pluginName: string,
-  createNodesTuple: CreateNodesV2<PluginOptions>,
+  createNodesTuple: CreateNodes<PluginOptions>,
   options: Partial<
     Record<keyof PluginOptions, PluginOptions[keyof PluginOptions][]>
   >,

--- a/packages/devkit/src/utils/calculate-hash-for-create-nodes.ts
+++ b/packages/devkit/src/utils/calculate-hash-for-create-nodes.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { CreateNodesContextV2, hashArray } from 'nx/src/devkit-exports';
+import { CreateNodesContext, hashArray } from 'nx/src/devkit-exports';
 
 import {
   hashMultiGlobWithWorkspaceContext,
@@ -15,7 +15,7 @@ import {
 export async function calculateHashForCreateNodes(
   projectRoot: string,
   options: object,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   additionalGlobs: string[] = []
 ): Promise<string> {
   return hashArray([
@@ -30,7 +30,7 @@ export async function calculateHashForCreateNodes(
 export async function calculateHashesForCreateNodes(
   projectRoots: string[],
   options: object,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   additionalGlobs: string[][] = []
 ): Promise<string[]> {
   if (projectRoots.length === 0) {

--- a/packages/devkit/src/utils/find-plugin-for-config-file.ts
+++ b/packages/devkit/src/utils/find-plugin-for-config-file.ts
@@ -2,7 +2,7 @@ import {
   type Tree,
   type PluginConfiguration,
   readNxJson,
-  CreateNodesV2,
+  CreateNodes,
 } from 'nx/src/devkit-exports';
 import { findMatchingConfigFiles } from 'nx/src/devkit-internals';
 import { minimatch } from 'minimatch';
@@ -31,11 +31,11 @@ export async function findPluginForConfigFile(
 
     if (plugin.include || plugin.exclude) {
       const resolvedPlugin: {
-        createNodes?: CreateNodesV2;
-        createNodesV2?: CreateNodesV2;
+        createNodes?: CreateNodes;
+        createNodesV2?: CreateNodes;
       } = await import(pluginName);
       const pluginGlob =
-        resolvedPlugin.createNodesV2?.[0] ?? resolvedPlugin.createNodes?.[0];
+        resolvedPlugin.createNodes?.[0] ?? resolvedPlugin.createNodesV2?.[0];
       // The file must be one this plugin actually processes (its path matches
       // the plugin's createNodes glob) before the registration's include/exclude
       // filters are applied.

--- a/packages/devkit/src/utils/get-named-inputs.ts
+++ b/packages/devkit/src/utils/get-named-inputs.ts
@@ -5,7 +5,7 @@ import type { PackageJson } from 'nx/src/utils/package-json';
 import type { InputDefinition } from 'nx/src/config/workspace-json-project-json';
 
 import {
-  CreateNodesContextV2,
+  CreateNodesContext,
   ProjectConfiguration,
   readJsonFile,
 } from 'nx/src/devkit-exports';
@@ -15,7 +15,7 @@ import {
  */
 export function getNamedInputs(
   directory: string,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): { [inputName: string]: (string | InputDefinition)[] } {
   const projectJsonPath = join(directory, 'project.json');
   const projectJson: ProjectConfiguration = existsSync(projectJsonPath)

--- a/packages/devkit/src/utils/replace-project-configuration-with-plugin.spec.ts
+++ b/packages/devkit/src/utils/replace-project-configuration-with-plugin.spec.ts
@@ -1,6 +1,6 @@
 import {
   addProjectConfiguration,
-  CreateNodesV2,
+  CreateNodes,
   readProjectConfiguration,
   Tree,
 } from 'nx/src/devkit-exports';
@@ -10,7 +10,7 @@ import { replaceProjectConfigurationsWithPlugin } from './replace-project-config
 
 describe('replaceProjectConfigurationsWithPlugin', () => {
   let tree: Tree;
-  let createNodes: CreateNodesV2;
+  let createNodes: CreateNodes;
 
   beforeEach(async () => {
     tree = createTreeWithEmptyWorkspace();

--- a/packages/devkit/src/utils/replace-project-configuration-with-plugin.ts
+++ b/packages/devkit/src/utils/replace-project-configuration-with-plugin.ts
@@ -1,5 +1,5 @@
 import {
-  CreateNodesV2,
+  CreateNodes,
   glob,
   ProjectConfiguration,
   readNxJson,
@@ -15,7 +15,7 @@ export async function replaceProjectConfigurationsWithPlugin<T = unknown>(
   tree: Tree,
   rootMappings: Map<string, string>,
   pluginPath: string,
-  createNodes: CreateNodesV2<T>,
+  createNodes: CreateNodes<T>,
   pluginOptions: T
 ): Promise<void> {
   const nxJson = readNxJson(tree);

--- a/packages/docker/index.ts
+++ b/packages/docker/index.ts
@@ -1,1 +1,5 @@
-export { createNodesV2, DockerPluginOptions } from './src/plugins/plugin';
+export {
+  createNodes,
+  createNodesV2,
+  DockerPluginOptions,
+} from './src/plugins/plugin';

--- a/packages/docker/src/generators/init/init.ts
+++ b/packages/docker/src/generators/init/init.ts
@@ -11,7 +11,7 @@ import {
   updateNxJson,
 } from '@nx/devkit';
 import { InitGeneratorSchema } from './schema';
-import { createNodesV2 } from '../../plugins/plugin';
+import { createNodes } from '../../plugins/plugin';
 import { nxVersion } from '../../utils/versions';
 
 export function updateDependencies(tree: Tree, schema: InitGeneratorSchema) {

--- a/packages/docker/src/plugins/plugin.spec.ts
+++ b/packages/docker/src/plugins/plugin.spec.ts
@@ -1,6 +1,6 @@
-import { CreateNodesContextV2, workspaceRoot } from '@nx/devkit';
+import { CreateNodesContext, workspaceRoot } from '@nx/devkit';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
-import { createNodesV2, getProjectNameFromPath } from './plugin';
+import { createNodes, getProjectNameFromPath } from './plugin';
 import * as gitUtils from 'nx/src/utils/git-utils';
 
 jest.mock('nx/src/utils/cache-directory', () => ({
@@ -22,8 +22,8 @@ expect.addSnapshotSerializer({
 });
 
 describe('@nx/docker', () => {
-  let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let createNodesFunction = createNodes[1];
+  let context: CreateNodesContext;
   let tempFs: TempFs;
   let cwd: string;
 

--- a/packages/docker/src/plugins/plugin.ts
+++ b/packages/docker/src/plugins/plugin.ts
@@ -4,12 +4,12 @@ import {
   PluginCache,
 } from '@nx/devkit/internal';
 import {
-  type CreateNodesV2,
+  type CreateNodes,
   type ProjectConfiguration,
   type TargetConfiguration,
   createNodesFromFiles,
   readJsonFile,
-  CreateNodesContextV2,
+  CreateNodesContext,
   workspaceRoot,
 } from '@nx/devkit';
 import { hashObject } from 'nx/src/hasher/file-hasher';
@@ -56,7 +56,7 @@ type DockerTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
 
 const dockerfileGlob = '**/Dockerfile';
 
-export const createNodesV2: CreateNodesV2<DockerPluginOptions> = [
+export const createNodes: CreateNodes<DockerPluginOptions> = [
   dockerfileGlob,
   async (configFilePaths, options, context) => {
     const optionsHash = hashObject(options);
@@ -93,11 +93,16 @@ export const createNodesV2: CreateNodesV2<DockerPluginOptions> = [
   },
 ];
 
+/**
+ * @deprecated Use {@link createNodes} instead. This will be removed in Nx 24.
+ */
+export const createNodesV2 = createNodes;
+
 async function createNodesInternal(
   configFilePath: string,
   hash: string,
   normalizedOptions: NormalizedDockerPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   targetsCache: PluginCache<DockerTargets>
 ) {
   const projectRoot = dirname(configFilePath);
@@ -126,7 +131,7 @@ function interpolateDockerTargetOptions(
   options: DockerTargetOptions,
   projectRoot: string,
   imageRef: string,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): DockerTargetOptions {
   const commitSha = getLatestCommitSha();
   const projectName = getProjectName(projectRoot, context.workspaceRoot);
@@ -246,7 +251,7 @@ function buildTargetConfigurations(
 async function createDockerTargets(
   projectRoot: string,
   options: NormalizedDockerPluginOptions,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ) {
   const imageRef = getProjectNameFromPath(projectRoot, workspaceRoot);
 

--- a/packages/dotnet/src/plugins/create-nodes.ts
+++ b/packages/dotnet/src/plugins/create-nodes.ts
@@ -1,5 +1,5 @@
 import {
-  CreateNodesV2,
+  CreateNodes,
   logger,
   ProjectConfiguration,
   TargetConfiguration,
@@ -175,7 +175,7 @@ function mergeUserTargetConfigurations(
   };
 }
 
-export const createNodesV2: CreateNodesV2<DotNetPluginOptions> = [
+export const createNodes: CreateNodes<DotNetPluginOptions> = [
   dotnetProjectGlob,
   async (configFilePaths, options, context) => {
     // Analyze all projects - the C# analyzer builds the complete Nx structure
@@ -253,3 +253,8 @@ export const createNodesV2: CreateNodesV2<DotNetPluginOptions> = [
     }
   },
 ];
+
+/**
+ * @deprecated Use {@link createNodes} instead. This will be removed in Nx 24.
+ */
+export const createNodesV2 = createNodes;

--- a/packages/dotnet/src/plugins/plugin.ts
+++ b/packages/dotnet/src/plugins/plugin.ts
@@ -1,11 +1,11 @@
-import { createNodesV2, type DotNetPluginOptions } from './create-nodes';
+import { createNodes, type DotNetPluginOptions } from './create-nodes';
 import { createDependencies } from './create-dependencies';
 import { NxPlugin } from '@nx/devkit';
 
 const regularPlugin: NxPlugin<DotNetPluginOptions> = {
   name: '@nx/dotnet',
-  createNodes: createNodesV2,
-  createNodesV2,
+  createNodes,
+  createNodesV2: createNodes,
   createDependencies,
 };
 

--- a/packages/eslint/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/eslint/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -12,7 +12,7 @@ import {
 } from '@nx/devkit';
 import { basename, dirname, relative } from 'node:path/posix';
 import { interpolate } from 'nx/src/tasks-runner/utils';
-import { createNodesV2, type EslintPluginOptions } from '../../plugins/plugin';
+import { createNodes, type EslintPluginOptions } from '../../plugins/plugin';
 import { assertSupportedEslintVersion } from '../../utils/assert-supported-eslint-version';
 import { ESLINT_CONFIG_FILENAMES } from '../../utils/config-file';
 import { targetOptionsToCliMap } from './lib/target-options-map';
@@ -32,7 +32,7 @@ export async function convertToInferred(tree: Tree, options: Schema) {
       tree,
       projectGraph,
       '@nx/eslint/plugin',
-      createNodesV2,
+      createNodes,
       { targetName: 'lint' },
       [
         {

--- a/packages/eslint/src/generators/init/init.ts
+++ b/packages/eslint/src/generators/init/init.ts
@@ -21,7 +21,7 @@ import {
   determineEslintConfigFormat,
   findEslintFile,
 } from '../utils/eslint-file';
-import { createNodesV2 } from '../../plugins/plugin';
+import { createNodes } from '../../plugins/plugin';
 import { hasEslintPlugin } from '../utils/plugin';
 import { extname } from 'path';
 
@@ -132,7 +132,7 @@ export async function initEsLint(
       tree,
       graph,
       '@nx/eslint/plugin',
-      createNodesV2,
+      createNodes,
       {
         targetName: lintTargetNames,
       },
@@ -155,7 +155,7 @@ export async function initEsLint(
       tree,
       graph,
       '@nx/eslint/plugin',
-      createNodesV2,
+      createNodes,
       {
         targetName: lintTargetNames,
       },

--- a/packages/eslint/src/plugins/plugin.spec.ts
+++ b/packages/eslint/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContextV2 } from '@nx/devkit';
+import { CreateNodesContext } from '@nx/devkit';
 import { minimatch } from 'minimatch';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { createNodesV2, EslintPluginOptions } from './plugin';
@@ -20,7 +20,7 @@ jest.mock('../utils/resolve-eslint-class', () => ({
 }));
 
 describe('@nx/eslint/plugin', () => {
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
   let tempFs: TempFs;
   let configFiles: string[] = [];
 
@@ -1149,7 +1149,7 @@ describe('@nx/eslint/plugin', () => {
   }
 
   async function invokeCreateNodesOnMatchingFiles(
-    context: CreateNodesContextV2,
+    context: CreateNodesContext,
     options?: EslintPluginOptions
   ) {
     const aggregateProjects: Record<string, any> = {};

--- a/packages/eslint/src/plugins/plugin.ts
+++ b/packages/eslint/src/plugins/plugin.ts
@@ -3,10 +3,10 @@ import {
   PluginCache,
 } from '@nx/devkit/internal';
 import {
-  CreateNodesContextV2,
+  CreateNodesContext,
   createNodesFromFiles,
   CreateNodesResult,
-  CreateNodesV2,
+  CreateNodes,
   detectPackageManager,
   getPackageManagerCommand,
   TargetConfiguration,
@@ -62,7 +62,7 @@ const internalCreateNodesV2 = async (
   ESLint: typeof ESLintType,
   configFilePath: string,
   options: EslintPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   projectRootsByEslintRoots: Map<string, string[]>,
   lintableFilesPerProjectRoot: Map<string, string[]>,
   tsconfigChainsByProjectRoot: Map<string, string[]>,
@@ -155,7 +155,7 @@ const internalCreateNodesV2 = async (
   };
 };
 
-export const createNodes: CreateNodesV2<EslintPluginOptions> = [
+export const createNodes: CreateNodes<EslintPluginOptions> = [
   ESLINT_CONFIG_GLOB_V2,
   async (configFiles, options, context) => {
     options = normalizeOptions(options);
@@ -363,7 +363,7 @@ function collectTsconfigChainsByProjectRoot(
 async function collectLintableFilesByProjectRoot(
   projectRoots: string[],
   options: EslintPluginOptions,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<Map<string, string[]>> {
   const lintableFilesPerProjectRoot = new Map<string, string[]>();
 
@@ -409,7 +409,7 @@ function getProjectUsingESLintConfig(
   projectRoot: string,
   eslintVersion: string,
   options: EslintPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>,
   tsconfigChainOutsideProjectRoot: string[]
 ): CreateNodesResult['projects'][string] | null {

--- a/packages/expo/plugins/plugin.ts
+++ b/packages/expo/plugins/plugin.ts
@@ -6,11 +6,11 @@ import {
 } from '@nx/devkit/internal';
 import {
   AggregateCreateNodesError,
-  CreateNodesContextV2,
+  CreateNodesContext,
   createNodesFromFiles,
   CreateNodesResult,
   CreateNodesResultV2,
-  CreateNodesV2,
+  CreateNodes,
   detectPackageManager,
   getPackageManagerCommand,
   NxJsonConfiguration,
@@ -40,7 +40,7 @@ export interface ExpoPluginOptions {
 
 type ExpoTargets = Record<string, TargetConfiguration<ExpoPluginOptions>>;
 
-export const createNodes: CreateNodesV2<ExpoPluginOptions> = [
+export const createNodes: CreateNodes<ExpoPluginOptions> = [
   '**/app.{json,config.js,config.ts}',
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
@@ -106,7 +106,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFile: string,
   options: ExpoPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   targetsCache: PluginCache<ExpoTargets>,
   pmc: ReturnType<typeof getPackageManagerCommand>,
   hash: string
@@ -132,7 +132,7 @@ async function createNodesInternal(
 function buildExpoTargets(
   projectRoot: string,
   options: ExpoPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ) {
   const namedInputs = getNamedInputs(projectRoot, context);
@@ -193,7 +193,7 @@ function buildExpoTargets(
 
 function getAppConfig(
   configFilePath: string,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<any> {
   const resolvedPath = join(context.workspaceRoot, configFilePath);
 
@@ -202,7 +202,7 @@ function getAppConfig(
 
 async function filterExpoConfigs(
   configFiles: readonly string[],
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<{
   entries: Array<{ configFile: string; projectRoot: string }>;
   preErrors: Array<[string, Error]>;

--- a/packages/gradle/plugin-v1.spec.ts
+++ b/packages/gradle/plugin-v1.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContextV2 } from '@nx/devkit';
+import { CreateNodesContext } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { createNodesV2 } from './plugin-v1';
 import { type GradleReport } from './src/plugin-v1/utils/get-gradle-report';
@@ -14,7 +14,7 @@ jest.mock('./src/plugin-v1/utils/get-gradle-report', () => {
 
 describe('@nx/gradle/plugin-v1', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
   let tempFs: TempFs;
 
   beforeEach(async () => {

--- a/packages/gradle/plugin.spec.ts
+++ b/packages/gradle/plugin.spec.ts
@@ -1,6 +1,6 @@
-import { CreateNodesContextV2, readJsonFile } from '@nx/devkit';
+import { CreateNodesContext, readJsonFile } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
-import { createNodesV2 } from './plugin';
+import { createNodes } from './plugin';
 import { type ProjectGraphReport } from './src/plugin/utils/get-project-graph-from-gradle-plugin';
 import { join } from 'path';
 
@@ -16,8 +16,8 @@ jest.mock('./src/plugin/utils/get-project-graph-from-gradle-plugin', () => {
 });
 
 describe('@nx/gradle/plugin', () => {
-  let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let createNodesFunction = createNodes[1];
+  let context: CreateNodesContext;
   let tempFs: TempFs;
 
   beforeEach(async () => {

--- a/packages/gradle/plugin.ts
+++ b/packages/gradle/plugin.ts
@@ -1,9 +1,12 @@
 import { createDependencies as _createDependencies } from './src/plugin/dependencies';
-import { createNodesV2 as _createNodesV2 } from './src/plugin/nodes';
+import { createNodes as _createNodes } from './src/plugin/nodes';
 
 const isDisabled = process.env.NX_GRADLE_DISABLE === 'true';
 
 export const name = isDisabled ? '@nx/gradle [disabled]' : '@nx/gradle';
-export const createNodesV2 = isDisabled ? undefined : _createNodesV2;
-export const createNodes = createNodesV2;
+export const createNodes = isDisabled ? undefined : _createNodes;
+/**
+ * @deprecated Use {@link createNodes} instead. This will be removed in Nx 24.
+ */
+export const createNodesV2 = createNodes;
 export const createDependencies = isDisabled ? undefined : _createDependencies;

--- a/packages/gradle/src/plugin-v1/nodes.spec.ts
+++ b/packages/gradle/src/plugin-v1/nodes.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContextV2 } from '@nx/devkit';
+import { CreateNodesContext } from '@nx/devkit';
 
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { type GradleReport } from './utils/get-gradle-report';
@@ -16,7 +16,7 @@ import { createNodesV2 } from './nodes';
 
 describe('@nx/gradle/plugin-v1/nodes', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
   let tempFs: TempFs;
   let cwd: string;
 

--- a/packages/gradle/src/plugin-v1/nodes.ts
+++ b/packages/gradle/src/plugin-v1/nodes.ts
@@ -1,7 +1,7 @@
 import { calculateHashesForCreateNodes } from '@nx/devkit/internal';
 import {
-  CreateNodesV2,
-  CreateNodesContextV2,
+  CreateNodes,
+  CreateNodesContext,
   ProjectConfiguration,
   TargetConfiguration,
   createNodesFromFiles,
@@ -60,7 +60,7 @@ type GradleTargets = Record<string, Partial<ProjectConfiguration>>;
  * @deprecated The `@nx/gradle/plugin-v1` entry is deprecated and will be removed in Nx 24.
  * Switch to the default `@nx/gradle` plugin.
  */
-export const createNodesV2: CreateNodesV2<GradlePluginOptions> = [
+export const createNodesV2: CreateNodes<GradlePluginOptions> = [
   gradleConfigAndTestGlob,
   async (files, options, context) => {
     const { buildFiles, projectRoots, gradlewFiles, testFiles } =
@@ -118,7 +118,7 @@ export const makeCreateNodesForGradleConfigFile =
   async (
     gradleFilePath,
     options: GradlePluginOptions | undefined,
-    context: CreateNodesContextV2,
+    context: CreateNodesContext,
     idx?: number
   ) => {
     const projectRoot = dirname(gradleFilePath);
@@ -179,7 +179,7 @@ async function createGradleProject(
   gradleReport: GradleReport,
   gradleFilePath: string,
   options: GradlePluginOptions | undefined,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   testFiles = []
 ) {
   try {
@@ -255,7 +255,7 @@ async function createGradleProject(
 async function createGradleTargets(
   tasks: GradleTask[],
   options: GradlePluginOptions | undefined,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   outputDirs: Map<string, string>,
   gradleProject: string,
   gradleBuildFilePath: string,
@@ -331,7 +331,7 @@ async function createGradleTargets(
 }
 
 function createInputsMap(
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Record<string, TargetConfiguration['inputs']> {
   const namedInputs = context.nxJsonConfiguration.namedInputs;
   return {

--- a/packages/gradle/src/plugin/nodes.spec.ts
+++ b/packages/gradle/src/plugin/nodes.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContextV2, readJsonFile } from '@nx/devkit';
+import { CreateNodesContext, readJsonFile } from '@nx/devkit';
 import { join } from 'path';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { type ProjectGraphReport } from './utils/get-project-graph-from-gradle-plugin';
@@ -14,11 +14,11 @@ jest.mock('./utils/get-project-graph-from-gradle-plugin', () => {
   };
 });
 
-import { createNodesV2 } from './nodes';
+import { createNodes } from './nodes';
 
 describe('@nx/gradle/plugin/nodes', () => {
-  let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let createNodesFunction = createNodes[1];
+  let context: CreateNodesContext;
   let tempFs: TempFs;
   let cwd: string;
 

--- a/packages/gradle/src/plugin/nodes.ts
+++ b/packages/gradle/src/plugin/nodes.ts
@@ -1,7 +1,7 @@
 import { calculateHashesForCreateNodes } from '@nx/devkit/internal';
 import {
-  CreateNodesV2,
-  CreateNodesContextV2,
+  CreateNodes,
+  CreateNodesContext,
   ProjectConfiguration,
   workspaceRoot,
   ProjectGraphExternalNode,
@@ -105,7 +105,7 @@ function extractNxConfigOnly(
   return result;
 }
 
-export const createNodesV2: CreateNodesV2<GradlePluginOptions> = [
+export const createNodes: CreateNodes<GradlePluginOptions> = [
   gradleConfigAndTestGlob,
   async (files, options, context) => {
     const { buildFiles: buildFilesFromSplitConfigFiles, gradlewFiles } =
@@ -201,6 +201,11 @@ export const createNodesV2: CreateNodesV2<GradlePluginOptions> = [
   },
 ];
 
+/**
+ * @deprecated Use {@link createNodes} instead. This will be removed in Nx 24.
+ */
+export const createNodesV2 = createNodes;
+
 export const makeCreateNodesForGradleConfigFile =
   (
     projects: Record<string, Partial<ProjectConfiguration>>,
@@ -211,7 +216,7 @@ export const makeCreateNodesForGradleConfigFile =
   async (
     gradleFilePath,
     options: GradlePluginOptions | undefined,
-    context: CreateNodesContextV2,
+    context: CreateNodesContext,
     idx?: number
   ) => {
     const projectRoot = dirname(gradleFilePath);

--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContextV2 } from '@nx/devkit';
+import { CreateNodesContext } from '@nx/devkit';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { join } from 'path';
 import { createNodesV2 } from './plugin';
@@ -10,7 +10,7 @@ jest.mock('nx/src/utils/cache-directory', () => ({
 
 describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
   let tempFs: TempFs;
   let cwd: string;
 
@@ -939,7 +939,7 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
 
 describe('@nx/jest/plugin config file inputs', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
   let tempFs: TempFs;
   let cwd: string;
 
@@ -1681,7 +1681,7 @@ describe('@nx/jest/plugin config file inputs', () => {
   });
 });
 
-function mockJestConfig(config: any, context: CreateNodesContextV2) {
+function mockJestConfig(config: any, context: CreateNodesContext) {
   jest.mock(join(context.workspaceRoot, 'proj/jest.config.js'), () => config, {
     virtual: true,
   });

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -6,9 +6,9 @@ import {
   PluginCache,
 } from '@nx/devkit/internal';
 import {
-  CreateNodesContextV2,
+  CreateNodesContext,
   createNodesFromFiles,
-  CreateNodesV2,
+  CreateNodes,
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
@@ -78,7 +78,7 @@ type JestTargets = Awaited<ReturnType<typeof buildJestTargets>>;
 
 const jestConfigGlob = '**/jest.config.{cjs,mjs,js,cts,mts,ts}';
 
-export const createNodes: CreateNodesV2<JestPluginOptions> = [
+export const createNodes: CreateNodes<JestPluginOptions> = [
   jestConfigGlob,
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
@@ -247,7 +247,7 @@ function checkIfConfigFileShouldBeProject(
   configFilePath: string,
   projectRoot: string,
   isInPackageManagerWorkspaces: (path: string) => boolean,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): boolean {
   // Do not create a project if package.json and project.json isn't there.
   const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));
@@ -288,7 +288,7 @@ async function buildJestTargets(
   configFilePath: string,
   projectRoot: string,
   options: JestPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   presetCache: Record<string, unknown>,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ): Promise<Pick<ProjectConfiguration, 'targets' | 'metadata'>> {
@@ -905,7 +905,7 @@ function getOutputs(
   projectRoot: string,
   coverageDirectory: string | undefined,
   outputFile: string | undefined,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): string[] {
   function getOutput(path: string): string {
     const relativePath = relative(
@@ -982,7 +982,7 @@ async function getTestPaths(
   projectRoot: string,
   rawConfig: any,
   rootDir: string,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   presetCache: Record<string, unknown>
 ): Promise<{ specs: string[]; testMatch: string[] }> {
   const testMatch = await getJestOption<string[]>(

--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { detectPackageManager, type CreateNodesContextV2 } from '@nx/devkit';
+import { detectPackageManager, type CreateNodesContext } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import picomatch = require('picomatch');
 import { mkdirSync, rmSync } from 'node:fs';
@@ -13,7 +13,7 @@ jest.mock('nx/src/utils/cache-directory', () => ({
 }));
 
 describe(`Plugin: ${PLUGIN_NAME}`, () => {
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
   let cwd = process.cwd();
   let tempFs: TempFs;
   let originalCacheProjectGraph: string | undefined;
@@ -7024,7 +7024,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
 
 async function applyFilesToTempFsAndContext(
   tempFs: TempFs,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   fileSys: Record<string, string>
 ): Promise<string[]> {
   await tempFs.createFiles(fileSys);
@@ -7037,7 +7037,7 @@ async function applyFilesToTempFsAndContext(
 
 async function invokeCreateNodesOnMatchingFiles(
   configFiles: string[],
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   pluginOptions: TscPluginOptions
 ) {
   const aggregateProjects: Record<string, any> = {};

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -8,8 +8,8 @@ import {
   readJsonFile,
   writeJsonFile,
   type CreateDependencies,
-  type CreateNodesContextV2,
-  type CreateNodesV2,
+  type CreateNodesContext,
+  type CreateNodes,
   type NxJsonConfiguration,
   type ProjectConfiguration,
   type TargetConfiguration,
@@ -257,7 +257,7 @@ export const PLUGIN_NAME = '@nx/js/typescript';
 
 const tsConfigGlob = '**/tsconfig*.json';
 
-export const createNodesV2: CreateNodesV2<TscPluginOptions> = [
+export const createNodesV2: CreateNodes<TscPluginOptions> = [
   tsConfigGlob,
   async (configFilePaths, options, context) => {
     const optionsHash = hashObject(options);
@@ -360,7 +360,7 @@ async function resolveValidConfigFilesAndHashes(
   configFilePaths: readonly string[],
   options: NormalizedPluginOptions,
   optionsHash: string,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   cache: InvocationCache,
   lockFileName: string
 ): Promise<{
@@ -526,7 +526,7 @@ function checkIfConfigFileShouldBeProject(
 function buildTscTargets(
   config: ConfigContext,
   options: NormalizedPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   configFiles: readonly string[],
   cache: InvocationCache,
   pmc: ReturnType<typeof getPackageManagerCommand>

--- a/packages/maven/src/plugins/nodes.ts
+++ b/packages/maven/src/plugins/nodes.ts
@@ -1,4 +1,4 @@
-import { CreateNodesResultV2, CreateNodesV2, hashArray } from '@nx/devkit';
+import { CreateNodesResultArray, CreateNodes, hashArray } from '@nx/devkit';
 import { calculateHashesForCreateNodes } from '@nx/devkit/internal';
 import { dirname, relative } from 'path';
 import { DEFAULT_OPTIONS, MavenPluginOptions } from './types';
@@ -14,9 +14,9 @@ import { hashObject } from 'nx/src/devkit-internals';
 /**
  * Maven plugin that analyzes Maven projects and returns configurations
  */
-export const createNodes: CreateNodesV2<MavenPluginOptions> = [
+export const createNodes: CreateNodes<MavenPluginOptions> = [
   '**/pom.xml',
-  async (configFiles, options, context): Promise<CreateNodesResultV2> => {
+  async (configFiles, options, context): Promise<CreateNodesResultArray> => {
     const opts: MavenPluginOptions = {
       ...DEFAULT_OPTIONS,
       ...options,

--- a/packages/maven/src/plugins/types.ts
+++ b/packages/maven/src/plugins/types.ts
@@ -1,4 +1,4 @@
-import type { CreateNodesResultV2 } from '@nx/devkit';
+import type { CreateNodesResultArray } from '@nx/devkit';
 import type { RawProjectGraphDependency } from 'nx/src/project-graph/project-graph-builder';
 
 export interface MavenPluginOptions {
@@ -12,7 +12,7 @@ export const DEFAULT_OPTIONS: MavenPluginOptions = {};
 // TypeScript only needs the final Nx format using official @nx/devkit types
 
 export interface MavenAnalysisData {
-  createNodesResults: CreateNodesResultV2;
+  createNodesResults: CreateNodesResultArray;
   createDependenciesResults: RawProjectGraphDependency[];
   generatedAt?: number;
   workspaceRoot?: string;

--- a/packages/next/src/plugins/plugin.spec.ts
+++ b/packages/next/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContextV2 } from '@nx/devkit';
+import { CreateNodesContext } from '@nx/devkit';
 import type { NextConfig } from 'next';
 
 import { createNodesV2 } from './plugin';
@@ -6,7 +6,7 @@ import { TempFs } from '@nx/devkit/internal-testing-utils';
 
 describe('@nx/next/plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
 
   describe('root projects', () => {
     let tempFs: TempFs;

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -7,10 +7,10 @@ import {
 import {
   AggregateCreateNodesError,
   CreateDependencies,
-  CreateNodesContextV2,
+  CreateNodesContext,
   createNodesFromFiles,
   CreateNodesResultV2,
-  CreateNodesV2,
+  CreateNodes,
   detectPackageManager,
   getPackageManagerCommand,
   NxJsonConfiguration,
@@ -49,7 +49,7 @@ export const createDependencies: CreateDependencies = () => {
   return [];
 };
 
-export const createNodes: CreateNodesV2<NextPluginOptions> = [
+export const createNodes: CreateNodes<NextPluginOptions> = [
   nextConfigBlob,
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
@@ -117,7 +117,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFilePath: string,
   options: NextPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   targetsCache: PluginCache<NextTargets>,
   isTsSolutionSetup: boolean,
   pmc: ReturnType<typeof getPackageManagerCommand>,
@@ -153,7 +153,7 @@ async function buildNextTargets(
   nextConfigPath: string,
   projectRoot: string,
   options: NextPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   isTsSolutionSetup: boolean,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ) {
@@ -276,7 +276,7 @@ async function getOutputs(projectRoot, nextConfig) {
 
 function getNextConfig(
   configFilePath: string,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<any> {
   const resolvedPath = join(context.workspaceRoot, configFilePath);
 
@@ -290,7 +290,7 @@ interface NextEntry {
 
 async function filterNextConfigs(
   configFiles: readonly string[],
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<{
   entries: NextEntry[];
   preErrors: Array<[string, Error]>;

--- a/packages/nuxt/src/plugins/plugin.spec.ts
+++ b/packages/nuxt/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContextV2 } from '@nx/devkit';
+import { CreateNodesContext } from '@nx/devkit';
 import { createNodes } from './plugin';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 
@@ -20,7 +20,7 @@ jest.mock('../utils/executor-utils', () => ({
 }));
 describe('@nx/nuxt/plugin', () => {
   let createNodesFunction = createNodes[1];
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
 
   describe('root project', () => {
     let tempFs: TempFs;

--- a/packages/nuxt/src/plugins/plugin.ts
+++ b/packages/nuxt/src/plugins/plugin.ts
@@ -7,10 +7,10 @@ import {
 import {
   AggregateCreateNodesError,
   CreateDependencies,
-  CreateNodesContextV2,
+  CreateNodesContext,
   createNodesFromFiles,
   CreateNodesResultV2,
-  CreateNodesV2,
+  CreateNodes,
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
@@ -38,7 +38,7 @@ export interface NuxtPluginOptions {
   watchDepsTargetName?: string;
 }
 
-export const createNodes: CreateNodesV2<NuxtPluginOptions> = [
+export const createNodes: CreateNodes<NuxtPluginOptions> = [
   '**/nuxt.config.{js,ts,mjs,mts,cjs,cts}',
   async (files, options, context) => {
     const packageManager = detectPackageManager(context.workspaceRoot);
@@ -97,7 +97,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFilePath: string,
   options: NuxtPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>,
   hash: string
 ) {
@@ -123,7 +123,7 @@ async function buildNuxtTargets(
   configFilePath: string,
   projectRoot: string,
   options: NuxtPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ) {
   const nuxtConfig: {
@@ -249,7 +249,7 @@ function buildStaticTarget(
 
 async function getInfoFromNuxtConfig(
   configFilePath: string,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   projectRoot: string
 ): Promise<{
   buildDir: string;
@@ -324,7 +324,7 @@ interface NuxtEntry {
 
 async function filterNuxtConfigs(
   configFiles: readonly string[],
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<{
   entries: NuxtEntry[];
   preErrors: Array<[string, Error]>;

--- a/packages/nx/plugins/package-json.ts
+++ b/packages/nx/plugins/package-json.ts
@@ -1,4 +1,4 @@
-import { createNodesFromFiles, NxPluginV2 } from '../src/project-graph/plugins';
+import { createNodesFromFiles, NxPlugin } from '../src/project-graph/plugins';
 import { workspaceRoot } from '../src/utils/workspace-root';
 import {
   buildPackageJsonWorkspacesMatcher,
@@ -32,9 +32,9 @@ function writeCache() {
   }
 }
 
-const plugin: NxPluginV2 = {
+const plugin: NxPlugin = {
   name: 'nx-all-package-jsons-plugin',
-  createNodesV2: [
+  createNodes: [
     '*/**/package.json',
     (configFiles, options, context) => {
       const cache = readPackageJsonConfigurationCache();

--- a/packages/nx/src/adapter/angular-json.ts
+++ b/packages/nx/src/adapter/angular-json.ts
@@ -1,12 +1,12 @@
 import { existsSync } from 'fs';
 import * as path from 'path';
-import { readJsonFile } from '../utils/fileutils';
 import { ProjectsConfigurations } from '../config/workspace-json-project-json';
-import { CreateNodesV2, NxPluginV2 } from '../project-graph/plugins';
+import { CreateNodes, NxPlugin } from '../project-graph/plugins';
+import { readJsonFile } from '../utils/fileutils';
 
 export const NX_ANGULAR_JSON_PLUGIN_NAME = 'nx-angular-json-plugin';
 
-const createNodes: CreateNodesV2 = [
+const createNodes: CreateNodes = [
   'angular.json',
   (f, _, ctx) => [
     [
@@ -18,10 +18,9 @@ const createNodes: CreateNodesV2 = [
   ],
 ];
 
-export const NxAngularJsonPlugin: NxPluginV2 = {
+export const NxAngularJsonPlugin: NxPlugin = {
   name: NX_ANGULAR_JSON_PLUGIN_NAME,
   createNodes,
-  createNodesV2: createNodes,
 };
 
 export default NxAngularJsonPlugin;

--- a/packages/nx/src/devkit-exports.ts
+++ b/packages/nx/src/devkit-exports.ts
@@ -6,61 +6,44 @@
 /**
  * @category Tree
  */
-export type { Tree, FileChange } from './generators/tree';
+export type { FileChange, Tree } from './generators/tree';
 
 /**
  * @category Workspace
  */
 export type {
-  WorkspaceJsonConfiguration,
-  ProjectsConfigurations,
-  TargetDependencyConfig,
-  TargetConfiguration,
   ProjectConfiguration,
+  ProjectsConfigurations,
   ProjectType,
+  TargetConfiguration,
+  TargetDependencyConfig,
   Workspace,
+  WorkspaceJsonConfiguration,
 } from './config/workspace-json-project-json';
 
 /**
  * @category Workspace
  */
 export type {
-  Generator,
-  Migration,
-  MigrationReturnObject,
-  GeneratorCallback,
-  PromiseExecutor,
   AsyncIteratorExecutor,
+  CustomHasher,
   Executor,
   ExecutorContext,
-  TaskGraphExecutor,
-  GeneratorsJson,
   ExecutorsJson,
-  MigrationsJson,
-  CustomHasher,
+  Generator,
+  GeneratorCallback,
+  GeneratorsJson,
   HasherContext,
+  Migration,
+  MigrationReturnObject,
+  MigrationsJson,
+  PromiseExecutor,
+  TaskGraphExecutor,
 } from './config/misc-interfaces';
 
 export { workspaceLayout } from './config/configuration';
 
-export type {
-  NxPlugin,
-  NxPluginV2,
-  CreateNodesResult,
-  CreateNodesContextV2,
-  CreateNodesFunctionV2,
-  CreateNodesResultV2,
-  CreateNodesV2,
-  CreateDependencies,
-  CreateDependenciesContext,
-  CreateMetadata,
-  CreateMetadataContext,
-  ProjectsMetadata,
-  PreTasksExecution,
-  PreTasksExecutionContext,
-  PostTasksExecution,
-  PostTasksExecutionContext,
-} from './project-graph/plugins';
+export type * from './project-graph/plugins/public-api';
 
 export {
   AggregateCreateNodesError,
@@ -83,15 +66,15 @@ export type { TaskResult, TaskResults } from './tasks-runner/life-cycle';
  * @category Workspace
  */
 export type {
+  ExpandedPluginConfiguration,
   ImplicitDependencyEntry,
   ImplicitJsonSubsetDependency,
+  NxAffectedConfig,
   NxJsonConfiguration,
   PluginConfiguration,
-  ExpandedPluginConfiguration,
   TargetDefaults,
   TargetDefaultEntry,
   TargetDefaultsRecord,
-  NxAffectedConfig,
 } from './config/nx-json';
 
 /**
@@ -113,8 +96,8 @@ export type { PackageManager } from './utils/package-manager';
  * @category Package Manager
  */
 export {
-  getPackageManagerCommand,
   detectPackageManager,
+  getPackageManagerCommand,
   getPackageManagerVersion,
   isWorkspacesEnabled,
 } from './utils/package-manager';
@@ -133,10 +116,10 @@ export { runExecutor } from './command-line/run/run';
  */
 export {
   addProjectConfiguration,
+  getProjects,
   readProjectConfiguration,
   removeProjectConfiguration,
   updateProjectConfiguration,
-  getProjects,
 } from './generators/utils/project-configuration';
 
 /**
@@ -156,13 +139,13 @@ export {
  * @category Project Graph
  */
 export type {
-  ProjectFileMap,
-  FileMap,
   FileData,
+  FileMap,
+  ProjectFileMap,
   ProjectGraph,
   ProjectGraphDependency,
-  ProjectGraphProjectNode,
   ProjectGraphExternalNode,
+  ProjectGraphProjectNode,
 } from './config/project-graph';
 
 export type { GraphJson } from './command-line/graph/graph';
@@ -176,9 +159,9 @@ export { DependencyType } from './config/project-graph';
  * @category Project Graph
  */
 export {
-  RawProjectGraphDependency,
   DynamicDependency,
   ImplicitDependency,
+  RawProjectGraphDependency,
   StaticDependency,
   validateDependency,
 } from './project-graph/project-graph-builder';
@@ -186,7 +169,7 @@ export {
 /**
  * @category Generators
  */
-export { readJson, writeJson, updateJson } from './generators/utils/json';
+export { readJson, updateJson, writeJson } from './generators/utils/json';
 
 /**
  * @category Utils
@@ -248,8 +231,8 @@ export {
 /**
  * @category Utils
  */
-export { Hash, TaskHasher, Hasher } from './hasher/task-hasher';
 export { hashArray } from './hasher/file-hasher';
+export { Hash, Hasher, TaskHasher } from './hasher/task-hasher';
 
 /**
  * @category Utils

--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -9,17 +9,17 @@ import { hashArray } from '../../hasher/file-hasher';
 import {
   CreateDependencies,
   CreateDependenciesContext,
-  CreateNodesContextV2,
+  CreateNodes,
+  CreateNodesContext,
   createNodesFromFiles,
-  CreateNodesV2,
 } from '../../project-graph/plugins';
 import { RawProjectGraphDependency } from '../../project-graph/project-graph-builder';
 import { workspaceDataDirectory } from '../../utils/cache-directory';
 import { combineGlobPatterns } from '../../utils/globs';
-import { detectPackageManager } from '../../utils/package-manager';
-import { nxVersion } from '../../utils/versions';
 import { logger } from '../../utils/logger';
+import { detectPackageManager } from '../../utils/package-manager';
 import { safeWriteFileCache } from '../../utils/plugin-cache-utils';
+import { nxVersion } from '../../utils/versions';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { readBunLockFile } from './lock-file/bun-parser';
 import {
@@ -38,18 +38,14 @@ export const name = 'nx/js/dependencies-and-lockfile';
 let cachedExternalNodes: ProjectGraph['externalNodes'] | undefined;
 let cachedKeyMap: Map<string, any> | undefined;
 
-export const createNodesV2: CreateNodesV2 = [
+export const createNodes: CreateNodes = [
   combineGlobPatterns(LOCKFILES),
   (files, _, context) => {
     return createNodesFromFiles(internalCreateNodes, files, _, context);
   },
 ];
 
-function internalCreateNodes(
-  lockFile: string,
-  _,
-  context: CreateNodesContextV2
-) {
+function internalCreateNodes(lockFile: string, _, context: CreateNodesContext) {
   const pluginConfig = jsPluginConfig(context.nxJsonConfiguration);
   if (!pluginConfig.analyzeLockfile) {
     return {};

--- a/packages/nx/src/plugins/js/lock-file/lock-file.ts
+++ b/packages/nx/src/plugins/js/lock-file/lock-file.ts
@@ -13,7 +13,7 @@ import {
 } from '../../../config/project-graph';
 import {
   CreateDependenciesContext,
-  CreateNodesContextV2,
+  CreateNodesContext,
 } from '../../../project-graph/plugins';
 import { RawProjectGraphDependency } from '../../../project-graph/project-graph-builder';
 import { readJsonFile } from '../../../utils/fileutils';
@@ -83,7 +83,7 @@ export function getLockFileNodes(
   packageManager: PackageManager,
   contents: string,
   lockFileHash: string,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): {
   nodes: Record<string, ProjectGraphExternalNode>;
   keyMap: Map<string, any>;

--- a/packages/nx/src/plugins/package-json/create-nodes.spec.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.spec.ts
@@ -2,7 +2,7 @@ import '../../internal-testing-utils/mock-fs';
 
 import { join } from 'node:path';
 import { vol } from 'memfs';
-import { createNodeFromPackageJson, createNodesV2 } from './create-nodes';
+import { createNodeFromPackageJson, createNodes } from './create-nodes';
 import { workspaceDataDirectory } from '../../utils/cache-directory';
 import { PluginCache } from '../../utils/plugin-cache-utils';
 
@@ -284,16 +284,12 @@ describe('nx package.json workspaces plugin', () => {
 
       // No matching project based on the package.json "workspace" config
       expect(
-        await createNodesV2[1](['package.json'], undefined, context)
+        await createNodes[1](['package.json'], undefined, context)
       ).toMatchInlineSnapshot(`[]`);
 
       // Matching project based on the package.json "workspace" config
       expect(
-        await createNodesV2[1](
-          ['packages/vite/package.json'],
-          undefined,
-          context
-        )
+        await createNodes[1](['packages/vite/package.json'], undefined, context)
       ).toMatchInlineSnapshot(`
         [
           [
@@ -335,12 +331,12 @@ describe('nx package.json workspaces plugin', () => {
 
       // No matching project based on the package.json "workspace" config
       expect(
-        await createNodesV2[1](['packages/fs/package.json'], undefined, context)
+        await createNodes[1](['packages/fs/package.json'], undefined, context)
       ).toMatchInlineSnapshot(`[]`);
 
       // No matching project based on the package.json "workspace" config
       expect(
-        await createNodesV2[1](
+        await createNodes[1](
           ['packages/orm-browser-example/package.json'],
           undefined,
           context
@@ -349,7 +345,7 @@ describe('nx package.json workspaces plugin', () => {
 
       // No matching project based on the package.json "workspace" config
       expect(
-        await createNodesV2[1](
+        await createNodes[1](
           ['packages/framework-examples/package.json'],
           undefined,
           context
@@ -387,16 +383,12 @@ describe('nx package.json workspaces plugin', () => {
 
       // No matching project based on the pnpm-workspace.yaml "packages" config
       expect(
-        await createNodesV2[1](['package.json'], undefined, context)
+        await createNodes[1](['package.json'], undefined, context)
       ).toMatchInlineSnapshot(`[]`);
 
       // Matching project based on the pnpm-workspace.yaml "packages" config
       expect(
-        await createNodesV2[1](
-          ['packages/vite/package.json'],
-          undefined,
-          context
-        )
+        await createNodes[1](['packages/vite/package.json'], undefined, context)
       ).toMatchInlineSnapshot(`
         [
           [
@@ -438,12 +430,12 @@ describe('nx package.json workspaces plugin', () => {
 
       // No matching project based on the pnpm-workspace.yaml "packages" config
       expect(
-        await createNodesV2[1](['packages/fs/package.json'], undefined, context)
+        await createNodes[1](['packages/fs/package.json'], undefined, context)
       ).toMatchInlineSnapshot(`[]`);
 
       // No matching project based on the pnpm-workspace.yaml "packages" config
       expect(
-        await createNodesV2[1](
+        await createNodes[1](
           ['packages/orm-browser-example/package.json'],
           undefined,
           context
@@ -452,7 +444,7 @@ describe('nx package.json workspaces plugin', () => {
 
       // No matching project based on the pnpm-workspace.yaml "packages" config
       expect(
-        await createNodesV2[1](
+        await createNodes[1](
           ['packages/framework-examples/package.json'],
           undefined,
           context
@@ -487,16 +479,12 @@ describe('nx package.json workspaces plugin', () => {
 
       // No matching project based on the lerna.json "packages" config
       expect(
-        await createNodesV2[1](['package.json'], undefined, context)
+        await createNodes[1](['package.json'], undefined, context)
       ).toMatchInlineSnapshot(`[]`);
 
       // Matching project based on the lerna.json "packages" config
       expect(
-        await createNodesV2[1](
-          ['packages/vite/package.json'],
-          undefined,
-          context
-        )
+        await createNodes[1](['packages/vite/package.json'], undefined, context)
       ).toMatchInlineSnapshot(`
         [
           [
@@ -538,12 +526,12 @@ describe('nx package.json workspaces plugin', () => {
 
       // No matching project based on the lerna.json "packages" config
       expect(
-        await createNodesV2[1](['packages/fs/package.json'], undefined, context)
+        await createNodes[1](['packages/fs/package.json'], undefined, context)
       ).toMatchInlineSnapshot(`[]`);
 
       // No matching project based on the lerna.json "packages" config
       expect(
-        await createNodesV2[1](
+        await createNodes[1](
           ['packages/orm-browser-example/package.json'],
           undefined,
           context
@@ -552,7 +540,7 @@ describe('nx package.json workspaces plugin', () => {
 
       // No matching project based on the lerna.json "packages" config
       expect(
-        await createNodesV2[1](
+        await createNodes[1](
           ['packages/framework-examples/package.json'],
           undefined,
           context
@@ -580,7 +568,7 @@ describe('nx package.json workspaces plugin', () => {
       );
 
       expect(
-        await createNodesV2[1](['packages/a/package.json'], undefined, context)
+        await createNodes[1](['packages/a/package.json'], undefined, context)
       ).toMatchInlineSnapshot(`
         [
           [
@@ -664,7 +652,7 @@ describe('nx package.json workspaces plugin', () => {
       );
 
       expect(
-        await createNodesV2[1](['packages/a/package.json'], undefined, context)
+        await createNodes[1](['packages/a/package.json'], undefined, context)
       ).toMatchInlineSnapshot(`
         [
           [
@@ -755,7 +743,7 @@ describe('nx package.json workspaces plugin', () => {
       );
 
       expect(
-        await createNodesV2[1](['packages/a/package.json'], undefined, context)
+        await createNodes[1](['packages/a/package.json'], undefined, context)
       ).toMatchInlineSnapshot(`
         [
           [
@@ -940,7 +928,7 @@ describe('nx package.json workspaces plugin', () => {
     );
 
     expect(
-      await createNodesV2[1](
+      await createNodes[1](
         [
           'package.json',
           'packages/lib-a/package.json',

--- a/packages/nx/src/plugins/package-json/create-nodes.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.ts
@@ -22,10 +22,7 @@ import {
 } from '../../utils/package-manager';
 import { joinPathFragments } from '../../utils/path';
 import { nxVersion } from '../../utils/versions';
-import {
-  createNodesFromFiles,
-  CreateNodesV2,
-} from '../../project-graph/plugins';
+import { createNodesFromFiles, CreateNodes } from '../../project-graph/plugins';
 import { basename } from 'path';
 import { hashObject } from '../../hasher/file-hasher';
 import {
@@ -40,7 +37,7 @@ const globPatterns = combineGlobPatterns(
   '**/project.json'
 );
 
-export const createNodesV2: CreateNodesV2 = [
+export const createNodes: CreateNodes = [
   globPatterns,
   (configFiles, _, context) => {
     const { packageJsons, projectJsonRoots } = splitConfigFiles(configFiles);

--- a/packages/nx/src/plugins/project-json/build-nodes/project-json.spec.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/project-json.spec.ts
@@ -3,11 +3,11 @@ import * as memfs from 'memfs';
 import '../../../internal-testing-utils/mock-fs';
 
 import { ProjectJsonProjectsPlugin } from './project-json';
-import { CreateNodesContextV2 } from '../../../project-graph/plugins';
-const { createNodesV2 } = ProjectJsonProjectsPlugin;
+import { CreateNodesContext } from '../../../project-graph/plugins';
+const createNodes = ProjectJsonProjectsPlugin.createNodes!;
 
 describe('nx project.json plugin', () => {
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
   beforeEach(() => {
     context = {
       nxJsonConfiguration: {},
@@ -36,7 +36,7 @@ describe('nx project.json plugin', () => {
     );
 
     expect(
-      await createNodesV2[1](
+      await createNodes[1](
         ['project.json', 'packages/lib-a/project.json'],
         undefined,
         context

--- a/packages/nx/src/plugins/project-json/build-nodes/project-json.ts
+++ b/packages/nx/src/plugins/project-json/build-nodes/project-json.ts
@@ -2,14 +2,11 @@ import { dirname, join } from 'node:path';
 
 import { ProjectConfiguration } from '../../../config/workspace-json-project-json';
 import { readJsonFile } from '../../../utils/fileutils';
-import {
-  createNodesFromFiles,
-  NxPluginV2,
-} from '../../../project-graph/plugins';
+import { createNodesFromFiles, NxPlugin } from '../../../project-graph/plugins';
 
-export const ProjectJsonProjectsPlugin: NxPluginV2 = {
+export const ProjectJsonProjectsPlugin: NxPlugin = {
   name: 'nx/core/project-json',
-  createNodesV2: [
+  createNodes: [
     '{project.json,**/project.json}',
     (configFiles, _, context) => {
       return createNodesFromFiles(

--- a/packages/nx/src/project-graph/error-types.ts
+++ b/packages/nx/src/project-graph/error-types.ts
@@ -1,8 +1,8 @@
+import { ProjectGraph } from '../config/project-graph';
+import { ProjectConfiguration } from '../config/workspace-json-project-json';
+import { CreateNodesFunction } from './plugins/public-api';
 import { ConfigurationResult } from './utils/project-configuration-utils';
 import type { ConfigurationSourceMaps } from './utils/project-configuration/source-maps';
-import { ProjectConfiguration } from '../config/workspace-json-project-json';
-import { ProjectGraph } from '../config/project-graph';
-import { CreateNodesFunctionV2 } from './plugins/public-api';
 
 export type ProjectGraphErrorTypes =
   | AggregateCreateNodesError
@@ -291,7 +291,7 @@ export class AggregateCreateNodesError extends Error {
    */
   constructor(
     public readonly errors: Array<[file: string | null, error: Error]>,
-    public readonly partialResults: Awaited<ReturnType<CreateNodesFunctionV2>>
+    public readonly partialResults: Awaited<ReturnType<CreateNodesFunction>>
   ) {
     super('Failed to create nodes');
     this.name = this.constructor.name;

--- a/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
@@ -20,7 +20,7 @@ import { LoadedNxPlugin } from '../loaded-nx-plugin';
 import type {
   CreateDependenciesContext,
   CreateMetadataContext,
-  CreateNodesContextV2,
+  CreateNodesContext,
   CreateNodesResult,
   PostTasksExecutionContext,
   PreTasksExecutionContext,
@@ -74,7 +74,7 @@ export class IsolatedPlugin implements LoadedNxPlugin {
     filePattern: string,
     fn: (
       matchedFiles: string[],
-      context: CreateNodesContextV2
+      context: CreateNodesContext
     ) => Promise<
       Array<readonly [plugin: string, file: string, result: CreateNodesResult]>
     >,

--- a/packages/nx/src/project-graph/plugins/isolation/messaging.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/messaging.ts
@@ -8,7 +8,7 @@ import type { LoadedNxPlugin } from '../loaded-nx-plugin';
 import type {
   CreateDependenciesContext,
   CreateMetadataContext,
-  CreateNodesContextV2,
+  CreateNodesContext,
   PostTasksExecutionContext,
   PreTasksExecutionContext,
 } from '../public-api';
@@ -63,7 +63,7 @@ type PluginMessageDefs = DefineMessages<{
   createNodes: {
     payload: {
       configFiles: string[];
-      context: CreateNodesContextV2;
+      context: CreateNodesContext;
     };
     result:
       | {

--- a/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
@@ -9,9 +9,9 @@ import type { RawProjectGraphDependency } from '../project-graph-builder';
 import type {
   CreateDependenciesContext,
   CreateMetadataContext,
-  CreateNodesContextV2,
+  CreateNodesContext,
   CreateNodesResult,
-  NxPluginV2,
+  NxPlugin,
   PostTasksExecutionContext,
   PreTasksExecutionContext,
   ProjectsMetadata,
@@ -32,7 +32,7 @@ export class LoadedNxPlugin {
     // the result's context.
     fn: (
       matchedFiles: string[],
-      context: CreateNodesContextV2
+      context: CreateNodesContext
     ) => Promise<
       Array<readonly [plugin: string, file: string, result: CreateNodesResult]>
     >,
@@ -74,7 +74,7 @@ export class LoadedNxPlugin {
   setWorkerEnv?(env: Record<string, string>): Promise<void>;
 
   constructor(
-    plugin: NxPluginV2,
+    plugin: NxPlugin,
     pluginDefinition: PluginConfiguration,
     public readonly index?: number
   ) {
@@ -85,12 +85,15 @@ export class LoadedNxPlugin {
       this.exclude = pluginDefinition.exclude;
     }
 
-    const createNodesV2Impl = plugin.createNodesV2 ?? plugin.createNodes;
-    if (createNodesV2Impl) {
+    // Fall back to `createNodesV2` for plugins authored against the old name.
+    const createNodesImpl =
+      plugin.createNodes ??
+      (plugin as { createNodesV2?: NxPlugin['createNodes'] }).createNodesV2;
+    if (createNodesImpl) {
       this.createNodes = [
-        createNodesV2Impl[0],
+        createNodesImpl[0],
         async (configFiles, context) => {
-          const result = await createNodesV2Impl[1](
+          const result = await createNodesImpl[1](
             configFiles,
             this.options,
             context

--- a/packages/nx/src/project-graph/plugins/public-api.ts
+++ b/packages/nx/src/project-graph/plugins/public-api.ts
@@ -10,23 +10,38 @@ import type {
 import type { ProjectConfiguration } from '../../config/workspace-json-project-json';
 
 import type { NxJsonConfiguration } from '../../config/nx-json';
-import type { RawProjectGraphDependency } from '../project-graph-builder';
 import type { TaskResults } from '../../tasks-runner/life-cycle';
+import type { RawProjectGraphDependency } from '../project-graph-builder';
 
-export interface CreateNodesContextV2 {
+export interface CreateNodesContext {
   readonly nxJsonConfiguration: NxJsonConfiguration;
   readonly workspaceRoot: string;
 }
 
-export type CreateNodesResultV2 = Array<
+/**
+ * @deprecated This will be removed in Nx 24. See {@link CreateNodesContext}
+ */
+export type CreateNodesContextV2 = CreateNodesContext;
+
+export type CreateNodesResultArray = Array<
   readonly [configFileSource: string, result: CreateNodesResult]
 >;
 
-export type CreateNodesFunctionV2<T = unknown> = (
+/**
+ * @deprecated This will be removed in Nx 24. See {@link CreateNodesResultArray}
+ */
+export type CreateNodesResultV2 = CreateNodesResultArray;
+
+export type CreateNodesFunction<T = unknown> = (
   projectConfigurationFiles: readonly string[],
   options: T | undefined,
-  context: CreateNodesContextV2
-) => CreateNodesResultV2 | Promise<CreateNodesResultV2>;
+  context: CreateNodesContext
+) => CreateNodesResultArray | Promise<CreateNodesResultArray>;
+
+/**
+ * @deprecated see {@link CreateNodesFunction}
+ */
+export type CreateNodesFunctionV2<T = unknown> = CreateNodesFunction<T>;
 
 export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
@@ -43,13 +58,17 @@ export interface CreateNodesResult {
 }
 
 /**
- * A pair of file patterns and {@link CreateNodesFunctionV2}
- * In Nx 21 {@link CreateNodes} will be replaced with this type. In Nx 22, this type will be removed.
+ * A pair of file patterns and {@link CreateNodesFunction}
  */
-export type CreateNodesV2<T = unknown> = readonly [
+export type CreateNodes<T = unknown> = readonly [
   projectFilePattern: string,
-  createNodesFunction: CreateNodesFunctionV2<T>,
+  createNodesFunction: CreateNodesFunction<T>,
 ];
+
+/**
+ * @deprecated - use {@link CreateNodes} instead
+ */
+export type CreateNodesV2<T = unknown> = CreateNodes<T>;
 
 /**
  * Context for {@link CreateDependencies}
@@ -111,20 +130,22 @@ export type CreateMetadata<T = unknown> = (
 /**
  * A plugin which enhances the behavior of Nx
  */
-export type NxPluginV2<TOptions = unknown> = {
+export type NxPlugin<TOptions = unknown> = {
   name: string;
 
   /**
    * Provides a file pattern and function that retrieves configuration info from
    * those files. e.g. { '**\/*.csproj': buildProjectsFromCsProjFile }
    */
-  createNodes?: CreateNodesV2<TOptions>;
+  createNodes?: CreateNodes<TOptions>;
 
   /**
    * Provides a file pattern and function that retrieves configuration info from
    * those files. e.g. { '**\/*.csproj': buildProjectsFromCsProjFiles }
+   *
+   * @deprecated Prefer `createNodes` for new plugins
    */
-  createNodesV2?: CreateNodesV2<TOptions>;
+  createNodesV2?: CreateNodes<TOptions>;
 
   /**
    * Provides a function to analyze files to create dependencies for the {@link ProjectGraph}
@@ -171,7 +192,10 @@ export type PostTasksExecution<TOptions = unknown> = (
   options: TOptions | undefined,
   context: PostTasksExecutionContext
 ) => void | Promise<void>;
+
 /**
  * A plugin which enhances the behavior of Nx
+ *
+ * @deprecated See {@link NxPlugin}
  */
-export type NxPlugin<TOptions = unknown> = NxPluginV2<TOptions>;
+export type NxPluginV2<TOptions = unknown> = NxPlugin<TOptions>;

--- a/packages/nx/src/project-graph/plugins/utils.ts
+++ b/packages/nx/src/project-graph/plugins/utils.ts
@@ -1,15 +1,15 @@
-import { CreateNodesContextV2, CreateNodesResult } from './public-api';
+import { CreateNodesContext, CreateNodesResult } from './public-api';
 import { AggregateCreateNodesError } from '../error-types';
 export async function createNodesFromFiles<T = unknown>(
   createNodes: (
     projectConfigurationFile: string,
     options: T | undefined,
-    context: CreateNodesContextV2 & { configFiles: readonly string[] },
+    context: CreateNodesContext & { configFiles: readonly string[] },
     idx: number
   ) => CreateNodesResult | Promise<CreateNodesResult>,
   configFiles: readonly string[],
   options: T,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ) {
   // Settle each file in parallel but capture per-input outcomes so the
   // returned arrays preserve `configFiles` order. Pushing into shared

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -4,7 +4,7 @@ import {
 } from '../../config/workspace-json-project-json';
 import { dirname } from 'path';
 import { isProjectConfigurationsError } from '../error-types';
-import { createNodesFromFiles, NxPluginV2 } from '../plugins';
+import { createNodesFromFiles, NxPlugin } from '../plugins';
 import { LoadedNxPlugin } from '../plugins/loaded-nx-plugin';
 import {
   createProjectConfigurationsWithPlugins,
@@ -1247,9 +1247,9 @@ describe('project-configuration-utils', () => {
 
   describe('createProjectConfigurations', () => {
     /* A fake plugin that sets `fake-lib` tag to libs. */
-    const fakeTagPlugin: NxPluginV2 = {
+    const fakeTagPlugin: NxPlugin = {
       name: 'fake-tag-plugin',
-      createNodesV2: [
+      createNodes: [
         'libs/*/project.json',
         (vitestConfigPaths) =>
           createNodesFromFiles(
@@ -1272,9 +1272,9 @@ describe('project-configuration-utils', () => {
       ],
     };
 
-    const fakeTargetsPlugin: NxPluginV2 = {
+    const fakeTargetsPlugin: NxPlugin = {
       name: 'fake-targets-plugin',
-      createNodesV2: [
+      createNodes: [
         'libs/*/project.json',
         (projectJsonPaths) =>
           createNodesFromFiles(
@@ -1303,9 +1303,9 @@ describe('project-configuration-utils', () => {
       ],
     };
 
-    const sameNamePlugin: NxPluginV2 = {
+    const sameNamePlugin: NxPlugin = {
       name: 'same-name-plugin',
-      createNodesV2: [
+      createNodes: [
         'libs/*/project.json',
         (projectJsonPaths) =>
           createNodesFromFiles(
@@ -1529,9 +1529,9 @@ describe('project-configuration-utils', () => {
     });
 
     it('should provide helpful error if project has task containing cache and continuous', async () => {
-      const invalidCachePlugin: NxPluginV2 = {
+      const invalidCachePlugin: NxPlugin = {
         name: 'invalid-cache-plugin',
-        createNodesV2: [
+        createNodes: [
           'libs/*/project.json',
           (projectJsonPaths) => {
             const results = [];
@@ -1657,9 +1657,9 @@ describe('project-configuration-utils', () => {
     });
 
     it('should include project and target context in error message when plugin returns invalid {workspaceRoot} token', async () => {
-      const invalidTokenPlugin: NxPluginV2 = {
+      const invalidTokenPlugin: NxPlugin = {
         name: 'invalid-token-plugin',
-        createNodesV2: [
+        createNodes: [
           'libs/*/project.json',
           (projectJsonPaths) =>
             createNodesFromFiles(
@@ -1712,9 +1712,9 @@ describe('project-configuration-utils', () => {
     });
 
     it('should include nx.json context in error message when target defaults have invalid {workspaceRoot} token', async () => {
-      const simplePlugin: NxPluginV2 = {
+      const simplePlugin: NxPlugin = {
         name: 'simple-plugin',
-        createNodesV2: [
+        createNodes: [
           'libs/*/project.json',
           (projectJsonPaths) =>
             createNodesFromFiles(

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
@@ -7,9 +7,9 @@ import { LoadedNxPlugin } from '../plugins/loaded-nx-plugin';
 import { dirname, join } from 'path';
 import { readFile } from 'fs/promises';
 import {
-  CreateNodesContextV2,
+  CreateNodesContext,
   createNodesFromFiles,
-  CreateNodesResultV2,
+  CreateNodesResultArray,
 } from '../plugins';
 
 describe('retrieve-workspace-files', () => {
@@ -140,13 +140,13 @@ function createTestPlugin(name: string, pattern: string): LoadedNxPlugin {
   return new LoadedNxPlugin(
     {
       name,
-      createNodesV2: [
+      createNodes: [
         pattern,
         async (
-          projectFiles: string[],
+          projectFiles: readonly string[],
           _,
-          context: CreateNodesContextV2
-        ): Promise<CreateNodesResultV2> => {
+          context: CreateNodesContext
+        ): Promise<CreateNodesResultArray> => {
           return await createNodesFromFiles(
             async (configFile, options, context) => {
               const fullPath = join(context.workspaceRoot, configFile);

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContextV2 } from '@nx/devkit';
+import { CreateNodesContext } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import * as jsUtils from '@nx/js';
 import { PlaywrightTestConfig } from '@playwright/test';
@@ -7,7 +7,7 @@ import { createNodesV2 } from './plugin';
 
 describe('@nx/playwright/plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
   let tempFs: TempFs;
   let cwd = process.cwd();
   let originalCacheProjectGraph: string | undefined;

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -6,9 +6,9 @@ import {
 import {
   AggregateCreateNodesError,
   createNodesFromFiles,
-  type CreateNodesContextV2,
+  type CreateNodesContext,
   CreateNodesResultV2,
-  type CreateNodesV2,
+  type CreateNodes,
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
@@ -43,7 +43,7 @@ interface NormalizedOptions {
 type PlaywrightTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
 
 const playwrightConfigGlob = '**/playwright.config.{js,ts,cjs,cts,mjs,mts}';
-export const createNodes: CreateNodesV2<PlaywrightPluginOptions> = [
+export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
   playwrightConfigGlob,
   async (configFilePaths, options, context) => {
     const optionsHash = hashObject(options);
@@ -113,7 +113,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFilePath: string,
   normalizedOptions: NormalizedOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   pluginCache: PluginCache<PlaywrightTargets>,
   pmc: ReturnType<typeof getPackageManagerCommand>,
   externalTsconfigInputs: string[],
@@ -151,7 +151,7 @@ async function buildPlaywrightTargets(
   configFilePath: string,
   projectRoot: string,
   options: NormalizedOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>,
   externalTsconfigInputs: string[]
 ): Promise<PlaywrightTargets> {
@@ -392,7 +392,7 @@ async function buildPlaywrightTargets(
 }
 
 async function getAllTestFiles(opts: {
-  context: CreateNodesContextV2;
+  context: CreateNodesContext;
   path: string;
   config: PlaywrightTestConfig;
 }) {
@@ -651,7 +651,7 @@ interface PlaywrightEntry {
 
 async function filterPlaywrightConfigs(
   configFilePaths: readonly string[],
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<{
   entries: PlaywrightEntry[];
   preErrors: Array<[string, Error]>;

--- a/packages/react-native/plugins/plugin.ts
+++ b/packages/react-native/plugins/plugin.ts
@@ -6,11 +6,11 @@ import {
 } from '@nx/devkit/internal';
 import {
   AggregateCreateNodesError,
-  CreateNodesContextV2,
+  CreateNodesContext,
   createNodesFromFiles,
   CreateNodesResult,
   CreateNodesResultV2,
-  CreateNodesV2,
+  CreateNodes,
   detectPackageManager,
   joinPathFragments,
   NxJsonConfiguration,
@@ -40,7 +40,7 @@ type ReactNativeTargets = Record<
   TargetConfiguration<ReactNativePluginOptions>
 >;
 
-export const createNodes: CreateNodesV2<ReactNativePluginOptions> = [
+export const createNodes: CreateNodes<ReactNativePluginOptions> = [
   '**/app.{json,config.js,config.ts}',
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
@@ -108,7 +108,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFile: string,
   options: ReactNativePluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   targetsCache: PluginCache<ReactNativeTargets>,
   hash: string
 ): Promise<CreateNodesResult> {
@@ -133,7 +133,7 @@ async function createNodesInternal(
 function buildReactNativeTargets(
   projectRoot: string,
   options: ReactNativePluginOptions,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ) {
   const namedInputs = getNamedInputs(projectRoot, context);
 
@@ -194,7 +194,7 @@ function buildReactNativeTargets(
 
 function getAppConfig(
   configFilePath: string,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<any> {
   const resolvedPath = join(context.workspaceRoot, configFilePath);
 
@@ -203,7 +203,7 @@ function getAppConfig(
 
 async function filterReactNativeConfigs(
   configFiles: readonly string[],
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<{
   entries: Array<{ configFile: string; projectRoot: string }>;
   preErrors: Array<[string, Error]>;

--- a/packages/react/router-plugin.ts
+++ b/packages/react/router-plugin.ts
@@ -1,4 +1,5 @@
 export {
+  createNodes,
   createNodesV2,
   ReactRouterPluginOptions,
 } from './src/plugins/router-plugin';

--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -12,7 +12,7 @@ import {
 import { nxVersion } from '../../utils/versions';
 import { InitSchema } from './schema';
 import { getReactDependenciesVersionsToInstall } from '../../utils/version-utils';
-import { createNodesV2 } from '../../plugins/router-plugin';
+import { createNodes } from '../../plugins/router-plugin';
 
 export async function reactInitGenerator(tree: Tree, schema: InitSchema) {
   const tasks: GeneratorCallback[] = [];
@@ -46,7 +46,7 @@ export async function reactInitGenerator(tree: Tree, schema: InitSchema) {
       tree,
       await createProjectGraphAsync(),
       '@nx/react/router-plugin',
-      createNodesV2,
+      createNodes,
       {
         buildTargetName: ['build', 'react-router:build', 'react-router-build'],
         devTargetName: ['dev', 'react-router:dev', 'react-router-dev'],

--- a/packages/react/src/plugins/router-plugin.spec.ts
+++ b/packages/react/src/plugins/router-plugin.spec.ts
@@ -1,5 +1,5 @@
-import { type CreateNodesContextV2 } from '@nx/devkit';
-import { createNodesV2 } from './router-plugin';
+import { type CreateNodesContext } from '@nx/devkit';
+import { createNodes } from './router-plugin';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { isUsingTsSolutionSetup } from '@nx/js/internal';
 import { join } from 'path';
@@ -15,8 +15,8 @@ jest.mock('@nx/js/internal', () => ({
 }));
 
 describe('@nx/react/react-router-plugin', () => {
-  let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let createNodesFunction = createNodes[1];
+  let context: CreateNodesContext;
   let tempFs: TempFs;
   let cwd: string;
 
@@ -86,7 +86,7 @@ describe('@nx/react/react-router-plugin', () => {
     });
   });
 
-  function mockConfig(path: string, config, context: CreateNodesContextV2) {
+  function mockConfig(path: string, config, context: CreateNodesContext) {
     jest.mock(join(context.workspaceRoot, path), () => config, {
       virtual: true,
     });

--- a/packages/react/src/plugins/router-plugin.ts
+++ b/packages/react/src/plugins/router-plugin.ts
@@ -6,8 +6,8 @@ import {
   PluginCache,
 } from '@nx/devkit/internal';
 import {
-  type CreateNodesV2,
-  type CreateNodesContextV2,
+  type CreateNodes,
+  type CreateNodesContext,
   detectPackageManager,
   type TargetConfiguration,
   createNodesFromFiles,
@@ -42,7 +42,7 @@ type ReactRouterTargets = Pick<
 const pmCommand = getPackageManagerCommand();
 const reactRouterConfigBlob = '**/react-router.config.{ts,js,cjs,cts,mjs,mts}';
 
-export const createNodesV2: CreateNodesV2<ReactRouterPluginOptions> = [
+export const createNodes: CreateNodes<ReactRouterPluginOptions> = [
   reactRouterConfigBlob,
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
@@ -135,11 +135,16 @@ export const createNodesV2: CreateNodesV2<ReactRouterPluginOptions> = [
   },
 ];
 
+/**
+ * @deprecated Use {@link createNodes} instead. This will be removed in Nx 24.
+ */
+export const createNodesV2 = createNodes;
+
 async function buildReactRouterTargets(
   configFilePath: string,
   projectRoot: string,
   options: ReactRouterPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   siblingFiles: string[],
   isUsingTsSolutionSetup: boolean
 ): Promise<ReactRouterTargets> {
@@ -351,7 +356,7 @@ function normalizeOptions(options: ReactRouterPluginOptions) {
 
 function checkIfConfigFileShouldBeProject(
   projectRoot: string,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): boolean {
   // Do not create a project if package.json and project.json isn't there.
   const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));

--- a/packages/remix/src/plugins/plugin.spec.ts
+++ b/packages/remix/src/plugins/plugin.spec.ts
@@ -1,5 +1,5 @@
 import {
-  type CreateNodesContextV2,
+  type CreateNodesContext,
   detectPackageManager,
   joinPathFragments,
 } from '@nx/devkit';
@@ -22,7 +22,7 @@ jest.mock('@nx/js/internal', () => ({
 
 describe('@nx/remix/plugin', () => {
   let createNodesFunction = createNodes[1];
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
   let cwd = process.cwd();
 
   beforeEach(() => {

--- a/packages/remix/src/plugins/plugin.ts
+++ b/packages/remix/src/plugins/plugin.ts
@@ -9,10 +9,10 @@ import { hashObject } from 'nx/src/hasher/file-hasher';
 import {
   AggregateCreateNodesError,
   type CreateDependencies,
-  type CreateNodesContextV2,
+  type CreateNodesContext,
   createNodesFromFiles,
   CreateNodesResultV2,
-  CreateNodesV2,
+  CreateNodes,
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
@@ -50,7 +50,7 @@ export const createDependencies: CreateDependencies = () => {
 
 const remixConfigGlob = '**/{remix,vite}.config.{js,cjs,mjs,ts,cts,mts}';
 
-export const createNodes: CreateNodesV2<RemixPluginOptions> = [
+export const createNodes: CreateNodes<RemixPluginOptions> = [
   remixConfigGlob,
   async (configFilePaths, options, context) => {
     const optionsHash = hashObject(options);
@@ -120,7 +120,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFilePath: string,
   options: RemixPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   targetsCache: PluginCache<RemixTargets>,
   isUsingTsSolutionSetup: boolean,
   pmc: ReturnType<typeof getPackageManagerCommand>,
@@ -165,7 +165,7 @@ async function buildRemixTargets(
   configFilePath: string,
   projectRoot: string,
   options: RemixPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   siblingFiles: string[],
   remixCompiler: RemixCompiler,
   isUsingTsSolutionSetup: boolean,
@@ -479,7 +479,7 @@ interface RemixEntry {
 
 async function filterRemixConfigs(
   configFilePaths: readonly string[],
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<{
   entries: RemixEntry[];
   preErrors: Array<[string, Error]>;

--- a/packages/rollup/src/plugins/plugin.spec.ts
+++ b/packages/rollup/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { type CreateNodesContextV2 } from '@nx/devkit';
+import { type CreateNodesContext } from '@nx/devkit';
 import { createNodesV2 } from './plugin';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 
@@ -26,7 +26,7 @@ jest.mock('@nx/js/internal', () => ({
 
 describe('@nx/rollup/plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
   let cwd = process.cwd();
   let originalCacheProjectGraph = process.env.NX_CACHE_PROJECT_GRAPH;
 

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -9,10 +9,10 @@ import { readdirSync } from 'fs';
 import {
   AggregateCreateNodesError,
   type CreateDependencies,
-  CreateNodesContextV2,
+  CreateNodesContext,
   createNodesFromFiles,
   CreateNodesResultV2,
-  CreateNodesV2,
+  CreateNodes,
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
@@ -43,7 +43,7 @@ type RollupTargets = Record<string, TargetConfiguration>;
 
 const rollupConfigGlob = '**/rollup.config.{js,cjs,mjs,ts,cts,mts}';
 
-export const createNodes: CreateNodesV2<RollupPluginOptions> = [
+export const createNodes: CreateNodes<RollupPluginOptions> = [
   rollupConfigGlob,
   async (configFilePaths, options, context) => {
     const normalizedOptions = normalizeOptions(options);
@@ -114,7 +114,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFilePath: string,
   options: Required<RollupPluginOptions>,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   targetsCache: PluginCache<RollupTargets>,
   isTsSolutionSetup: boolean,
   pmc: ReturnType<typeof getPackageManagerCommand>,
@@ -150,7 +150,7 @@ async function buildRollupTarget(
   configFilePath: string,
   projectRoot: string,
   options: RollupPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   isTsSolutionSetup: boolean,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ): Promise<Record<string, TargetConfiguration>> {
@@ -281,7 +281,7 @@ interface RollupEntry {
 
 async function filterRollupConfigs(
   configFiles: readonly string[],
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<{
   entries: RollupEntry[];
   preErrors: Array<[string, Error]>;

--- a/packages/rsbuild/index.ts
+++ b/packages/rsbuild/index.ts
@@ -1,1 +1,5 @@
-export { createNodesV2, RsbuildPluginOptions } from './src/plugins/plugin';
+export {
+  createNodes,
+  createNodesV2,
+  RsbuildPluginOptions,
+} from './src/plugins/plugin';

--- a/packages/rsbuild/src/generators/init/init.ts
+++ b/packages/rsbuild/src/generators/init/init.ts
@@ -9,7 +9,7 @@ import {
   runTasksInSerial,
 } from '@nx/devkit';
 import { InitGeneratorSchema } from './schema';
-import { createNodesV2 } from '../../plugins/plugin';
+import { createNodes } from '../../plugins/plugin';
 import { nxVersion } from '../../utils/versions';
 import { getRsbuildVersionsForInstalledMajor } from '../../utils/version-utils';
 import { assertSupportedRsbuildVersion } from '../../utils/assert-supported-rsbuild-version';
@@ -50,7 +50,7 @@ export async function initGeneratorInternal(
       tree,
       await createProjectGraphAsync(),
       '@nx/rsbuild',
-      createNodesV2,
+      createNodes,
       {
         buildTargetName: ['build', 'rsbuild:build', 'rsbuild-build'],
         devTargetName: ['dev', 'rsbuild:dev', 'rsbuild-dev'],

--- a/packages/rsbuild/src/plugins/plugin.spec.ts
+++ b/packages/rsbuild/src/plugins/plugin.spec.ts
@@ -1,7 +1,7 @@
-import { type CreateNodesContextV2 } from '@nx/devkit';
+import { type CreateNodesContext } from '@nx/devkit';
 import { isUsingTsSolutionSetup } from '@nx/js/internal';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
-import { createNodesV2 } from './plugin';
+import { createNodes } from './plugin';
 
 jest.mock('@rsbuild/core', () => ({
   ...jest.requireActual('@rsbuild/core'),
@@ -17,8 +17,8 @@ jest.mock('@nx/js/internal', () => ({
 }));
 
 describe('@nx/rsbuild', () => {
-  let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let createNodesFunction = createNodes[1];
+  let context: CreateNodesContext;
   let tempFs: TempFs;
 
   beforeEach(() => {

--- a/packages/rsbuild/src/plugins/plugin.ts
+++ b/packages/rsbuild/src/plugins/plugin.ts
@@ -8,8 +8,8 @@ import {
   CreateNodesResultV2,
   type ProjectConfiguration,
   type TargetConfiguration,
-  CreateNodesV2,
-  CreateNodesContextV2,
+  CreateNodes,
+  CreateNodesContext,
   createNodesFromFiles,
   joinPathFragments,
   getPackageManagerCommand,
@@ -40,7 +40,7 @@ type RsbuildTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
 
 const rsbuildConfigGlob = '**/rsbuild.config.{js,ts,mjs,mts,cjs,cts}';
 
-export const createNodesV2: CreateNodesV2<RsbuildPluginOptions> = [
+export const createNodes: CreateNodes<RsbuildPluginOptions> = [
   rsbuildConfigGlob,
   async (configFilePaths, options, context) => {
     const optionsHash = hashObject(options);
@@ -107,10 +107,15 @@ export const createNodesV2: CreateNodesV2<RsbuildPluginOptions> = [
   },
 ];
 
+/**
+ * @deprecated Use {@link createNodes} instead. This will be removed in Nx 24.
+ */
+export const createNodesV2 = createNodes;
+
 async function createNodesInternal(
   configFilePath: string,
   normalizedOptions: RsbuildPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   targetsCache: PluginCache<RsbuildTargets>,
   isUsingTsSolutionSetup: boolean,
   pmc: ReturnType<typeof getPackageManagerCommand>,
@@ -153,7 +158,7 @@ async function createRsbuildTargets(
   options: RsbuildPluginOptions,
   tsConfigFiles: string[],
   isUsingTsSolutionSetup: boolean,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ): Promise<RsbuildTargets> {
   const absoluteConfigFilePath = joinPathFragments(
@@ -341,7 +346,7 @@ interface RsbuildEntry {
 
 async function filterRsbuildConfigs(
   configFiles: readonly string[],
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<{
   entries: RsbuildEntry[];
   preErrors: Array<[string, Error]>;

--- a/packages/rspack/plugin.ts
+++ b/packages/rspack/plugin.ts
@@ -1,2 +1,6 @@
-export { createDependencies, createNodesV2 } from './src/plugins/plugin';
+export {
+  createDependencies,
+  createNodes,
+  createNodesV2,
+} from './src/plugins/plugin';
 export type { RspackPluginOptions } from './src/plugins/plugin';

--- a/packages/rspack/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/rspack/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -13,7 +13,7 @@ import {
 } from '@nx/devkit';
 import { ast, query } from '@phenomnomnominal/tsquery';
 import * as ts from 'typescript';
-import { createNodesV2, type RspackPluginOptions } from '../../plugins/plugin';
+import { createNodes, type RspackPluginOptions } from '../../plugins/plugin';
 import { rspackCoreVersion } from '../../utils/versions';
 import {
   buildPostTargetTransformerFactory,
@@ -45,7 +45,7 @@ export async function convertToInferred(tree: Tree, options: Schema) {
       tree,
       projectGraph,
       '@nx/rspack/plugin',
-      createNodesV2,
+      createNodes,
       {
         buildTargetName: 'build',
         previewTargetName: 'preview',

--- a/packages/rspack/src/generators/init/init.ts
+++ b/packages/rspack/src/generators/init/init.ts
@@ -9,7 +9,7 @@ import {
   Tree,
 } from '@nx/devkit';
 import { initGenerator } from '@nx/js';
-import { createNodesV2 } from '../../../plugin';
+import { createNodes } from '../../../plugin';
 import {
   lessLoaderVersion,
   reactRefreshVersion,
@@ -39,7 +39,7 @@ export async function rspackInitGenerator(
       tree,
       await createProjectGraphAsync(),
       '@nx/rspack/plugin',
-      createNodesV2,
+      createNodes,
       {
         buildTargetName: [
           'build',

--- a/packages/rspack/src/plugins/plugin.spec.ts
+++ b/packages/rspack/src/plugins/plugin.spec.ts
@@ -1,7 +1,7 @@
-import { type CreateNodesContextV2 } from '@nx/devkit';
+import { type CreateNodesContext } from '@nx/devkit';
 import { isUsingTsSolutionSetup } from '@nx/js/internal';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
-import { createNodesV2 } from './plugin';
+import { createNodes } from './plugin';
 
 jest.mock('@nx/js/internal', () => ({
   ...jest.requireActual('@nx/js/internal'),
@@ -9,8 +9,8 @@ jest.mock('@nx/js/internal', () => ({
 }));
 
 describe('@nx/rspack', () => {
-  let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let createNodesFunction = createNodes[1];
+  let context: CreateNodesContext;
   let tempFs: TempFs;
   let originalCacheProjectGraph = process.env.NX_CACHE_PROJECT_GRAPH;
 

--- a/packages/rspack/src/plugins/plugin.ts
+++ b/packages/rspack/src/plugins/plugin.ts
@@ -1,9 +1,9 @@
 import { getNamedInputs, PluginCache } from '@nx/devkit/internal';
 import {
   CreateDependencies,
-  CreateNodesContextV2,
+  CreateNodesContext,
   createNodesFromFiles,
-  CreateNodesV2,
+  CreateNodes,
   detectPackageManager,
   ProjectConfiguration,
   readJsonFile,
@@ -38,7 +38,7 @@ export const createDependencies: CreateDependencies = () => {
 
 const rspackConfigGlob = '**/rspack.config.{js,ts,mjs,mts,cjs,cts}';
 
-export const createNodesV2: CreateNodesV2<RspackPluginOptions> = [
+export const createNodes: CreateNodes<RspackPluginOptions> = [
   rspackConfigGlob,
   async (configFilePaths, options, context) => {
     const optionsHash = hashObject(options);
@@ -73,10 +73,15 @@ export const createNodesV2: CreateNodesV2<RspackPluginOptions> = [
   },
 ];
 
+/**
+ * @deprecated Use {@link createNodes} instead. This will be removed in Nx 24.
+ */
+export const createNodesV2 = createNodes;
+
 async function createNodesInternal(
   configFilePath: string,
   options: RspackPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   targetsCache: PluginCache<RspackTargets>,
   isTsSolutionSetup: boolean,
   pmc: ReturnType<typeof getPackageManagerCommand>,
@@ -145,7 +150,7 @@ async function createRspackTargets(
   configFilePath: string,
   projectRoot: string,
   options: RspackPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   isTsSolutionSetup: boolean,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ): Promise<RspackTargets> {

--- a/packages/storybook/src/plugins/plugin.spec.ts
+++ b/packages/storybook/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContextV2 } from '@nx/devkit';
+import { CreateNodesContext } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import type { StorybookConfig } from 'storybook/internal/types';
 import { join } from 'node:path';
@@ -6,7 +6,7 @@ import { createNodesV2 } from './plugin';
 
 describe('@nx/storybook/plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
   let tempFs: TempFs;
 
   beforeEach(async () => {

--- a/packages/storybook/src/plugins/plugin.ts
+++ b/packages/storybook/src/plugins/plugin.ts
@@ -7,10 +7,10 @@ import {
 import {
   AggregateCreateNodesError,
   CreateDependencies,
-  CreateNodesContextV2,
+  CreateNodesContext,
   createNodesFromFiles,
   CreateNodesResultV2,
-  CreateNodesV2,
+  CreateNodes,
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
@@ -46,7 +46,7 @@ export const createDependencies: CreateDependencies = () => {
 
 const storybookConfigGlob = '**/.storybook/main.{js,ts,mjs,mts,cjs,cts}';
 
-export const createNodes: CreateNodesV2<StorybookPluginOptions> = [
+export const createNodes: CreateNodes<StorybookPluginOptions> = [
   storybookConfigGlob,
   async (configFilePaths, options, context) => {
     const normalizedOptions = normalizeOptions(options);
@@ -129,7 +129,7 @@ function getProjectRootFromConfigPath(configFilePath: string): string {
 async function createNodesInternal(
   configFilePath: string,
   options: Required<StorybookPluginOptions>,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   targetsCache: PluginCache<StorybookTargets>,
   pmc: ReturnType<typeof getPackageManagerCommand>,
   projectRoot: string,
@@ -167,7 +167,7 @@ async function buildStorybookTargets(
   configFilePath: string,
   projectRoot: string,
   options: StorybookPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   projectName: string,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ) {
@@ -348,7 +348,7 @@ function serveStaticTarget(
 
 async function getStorybookFramework(
   configFilePath: string,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<string | undefined> {
   const resolvedPath = join(context.workspaceRoot, configFilePath);
   const mainTsJs = readFileSync(resolvedPath, 'utf-8');
@@ -405,7 +405,7 @@ function parseFrameworkName(mainTsJs: string) {
 
 async function getStorybookFullyResolvedFramework(
   configFilePath: string,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<string> {
   const resolvedPath = join(context.workspaceRoot, configFilePath);
   const { framework } = await loadConfigFile<StorybookConfig>(resolvedPath);
@@ -431,7 +431,7 @@ interface StorybookEntry {
 
 async function filterStorybookConfigs(
   configFiles: readonly string[],
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<{
   entries: StorybookEntry[];
   preErrors: Array<[string, Error]>;

--- a/packages/vite/src/plugins/plugin.spec.ts
+++ b/packages/vite/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContextV2 } from '@nx/devkit';
+import { CreateNodesContext } from '@nx/devkit';
 import { createNodesV2 } from './plugin';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { loadViteDynamicImport } from '../utils/executor-utils';
@@ -17,7 +17,7 @@ jest.mock('@nx/js/internal', () => ({
 
 describe('@nx/vite/plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
 
   beforeEach(() => {
     (isUsingTsSolutionSetup as jest.Mock).mockReturnValue(false);

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -5,9 +5,9 @@ import {
 } from '@nx/devkit/internal';
 import {
   CreateDependencies,
-  CreateNodesContextV2,
+  CreateNodesContext,
   createNodesFromFiles,
-  CreateNodesV2,
+  CreateNodes,
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
@@ -64,7 +64,7 @@ export const createDependencies: CreateDependencies = () => {
 
 const viteConfigGlob = '**/vite.config.{js,ts,mjs,mts,cjs,cts}';
 
-export const createNodes: CreateNodesV2<VitePluginOptions> = [
+export const createNodes: CreateNodes<VitePluginOptions> = [
   viteConfigGlob,
   async (configFilePaths, options, context) => {
     const optionsHash = hashObject(options);
@@ -188,7 +188,7 @@ async function buildViteTargets(
   tsConfigFiles: string[],
   hasReactRouterConfig: boolean,
   isUsingTsSolutionSetup: boolean,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>,
   tsconfigInputs: string[]
 ): Promise<ViteTargets> {
@@ -656,7 +656,7 @@ function collectTsconfigInputsByProjectRoot(
 
 function checkIfConfigFileShouldBeProject(
   projectRoot: string,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): boolean {
   // Do not create a project if package.json and project.json isn't there.
   const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));

--- a/packages/vitest/src/plugins/plugin-vitest.spec.ts
+++ b/packages/vitest/src/plugins/plugin-vitest.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContextV2 } from '@nx/devkit';
+import { CreateNodesContext } from '@nx/devkit';
 import { createNodesV2 } from './plugin';
 import { loadViteDynamicImport } from '../utils/executor-utils';
 
@@ -70,7 +70,7 @@ jest.mock('../utils/executor-utils', () => ({
 
 describe('@nx/vitest', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
 
   describe('root project', () => {
     beforeEach(async () => {

--- a/packages/vitest/src/plugins/plugin.ts
+++ b/packages/vitest/src/plugins/plugin.ts
@@ -5,9 +5,9 @@ import {
 } from '@nx/devkit/internal';
 import {
   CreateDependencies,
-  CreateNodesContextV2,
+  CreateNodesContext,
   createNodesFromFiles,
-  CreateNodesV2,
+  CreateNodes,
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
@@ -59,7 +59,7 @@ export const createDependencies: CreateDependencies = () => {
 
 const vitestConfigGlob = '**/{vite,vitest}.config.{js,ts,mjs,mts,cjs,cts}';
 
-export const createNodes: CreateNodesV2<VitestPluginOptions> = [
+export const createNodes: CreateNodes<VitestPluginOptions> = [
   vitestConfigGlob,
   async (configFilePaths, options, context) => {
     const pmc = getPackageManagerCommand(
@@ -163,7 +163,7 @@ async function buildVitestTargets(
   configFilePath: string,
   projectRoot: string,
   options: VitestPluginOptions,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>,
   tsconfigInputs: string[]
 ): Promise<VitestTargets> {
@@ -556,7 +556,7 @@ function collectTsconfigInputsByProjectRoot(
 
 function checkIfConfigFileShouldBeProject(
   projectRoot: string,
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): boolean {
   // Do not create a project if package.json and project.json isn't there.
   const siblingFiles = readdirSync(join(context.workspaceRoot, projectRoot));

--- a/packages/webpack/src/plugins/plugin.spec.ts
+++ b/packages/webpack/src/plugins/plugin.spec.ts
@@ -12,14 +12,14 @@ jest.mock('@nx/js/internal', () => ({
   isUsingTsSolutionSetup: jest.fn(() => false),
 }));
 
-import { CreateNodesContextV2 } from '@nx/devkit';
+import { CreateNodesContext } from '@nx/devkit';
 import { createNodesV2 } from './plugin';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { join } from 'path';
 
 describe('@nx/webpack/plugin', () => {
   let createNodesFunction = createNodesV2[1];
-  let context: CreateNodesContextV2;
+  let context: CreateNodesContext;
   let tempFs: TempFs;
   let originalCacheProjectGraph = process.env.NX_CACHE_PROJECT_GRAPH;
 

--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -6,11 +6,11 @@ import {
 import {
   AggregateCreateNodesError,
   CreateDependencies,
-  CreateNodesContextV2,
+  CreateNodesContext,
   createNodesFromFiles,
   CreateNodesResult,
   CreateNodesResultV2,
-  CreateNodesV2,
+  CreateNodes,
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
@@ -50,7 +50,7 @@ export const createDependencies: CreateDependencies = () => {
 
 const webpackConfigGlob = '**/webpack.config.{js,ts,mjs,cjs}';
 
-export const createNodes: CreateNodesV2<WebpackPluginOptions> = [
+export const createNodes: CreateNodes<WebpackPluginOptions> = [
   webpackConfigGlob,
   async (configFilePaths, options, context) => {
     const optionsHash = hashObject(options);
@@ -121,7 +121,7 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFilePath: string,
   options: Required<WebpackPluginOptions>,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   targetsCache: PluginCache<WebpackTargets>,
   isTsSolutionSetup: boolean,
   pmc: ReturnType<typeof getPackageManagerCommand>,
@@ -160,7 +160,7 @@ async function createWebpackTargets(
   configFilePath: string,
   projectRoot: string,
   options: Required<WebpackPluginOptions>,
-  context: CreateNodesContextV2,
+  context: CreateNodesContext,
   isTsSolutionSetup: boolean,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ): Promise<WebpackTargets> {
@@ -344,7 +344,7 @@ interface WebpackEntry {
 
 async function filterWebpackConfigs(
   configFiles: readonly string[],
-  context: CreateNodesContextV2
+  context: CreateNodesContext
 ): Promise<{
   entries: WebpackEntry[];
   preErrors: Array<[string, Error]>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,8 +601,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       '@monodon/rust':
-        specifier: 2.3.0
-        version: 2.3.0(@napi-rs/cli@3.5.1(@emnapi/runtime@1.7.1)(@types/node@24.12.2)(node-addon-api@7.1.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
+        specifier: 3.0.0
+        version: 3.0.0(@napi-rs/cli@3.5.1(@emnapi/runtime@1.7.1)(@types/node@24.12.2)(node-addon-api@7.1.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
       '@napi-rs/cli':
         specifier: 3.5.1
         version: 3.5.1(@emnapi/runtime@1.7.1)(@types/node@24.12.2)(node-addon-api@7.1.1)
@@ -2402,7 +2402,7 @@ importers:
         version: 2.3.0
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 21.2.0(34548aaea574a8d49ef3ef8d9bfa54b4)
+        version: 21.2.0(de19134c5273622bd3ce91befcb71b51)
       '@angular/localize':
         specifier: catalog:angular-supported-versions
         version: 21.2.0(@angular/compiler-cli@21.2.0(@angular/compiler@21.2.0)(typescript@5.9.2))(@angular/compiler@21.2.0)
@@ -2508,7 +2508,7 @@ importers:
     dependencies:
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 21.2.0(34548aaea574a8d49ef3ef8d9bfa54b4)
+        version: 21.2.0(de19134c5273622bd3ce91befcb71b51)
       '@angular/compiler-cli':
         specifier: catalog:angular-supported-versions
         version: 21.2.0(@angular/compiler@21.2.0)(typescript@5.9.2)
@@ -8238,8 +8238,8 @@ packages:
   '@module-federation/webpack-bundler-runtime@2.3.3':
     resolution: {integrity: sha512-W+P6ZF9J3gwnQuoF07YV0OiR1D6sI/uErUu4+c3QXxka3orANUHujkddNSsDxL1obAGoJa7Da99crZKf7u2j/w==}
 
-  '@monodon/rust@2.3.0':
-    resolution: {integrity: sha512-iMnMnO/UF84Cod+J0DHaSTJLTlxT5eWXuTFeFlge5AeKNlzhnfCa733M2LiZjD9WVfIGK5yy4go63S3bshB0mg==}
+  '@monodon/rust@3.0.0':
+    resolution: {integrity: sha512-c55j09hU9ar2EFbklh6aRz3ex8nMHazR2XkjscKZmYFsBYl8Ag/CpzbJ4MhopxBW2EhryWyv7m6ZEEnOWLYw6Q==}
     peerDependencies:
       '@napi-rs/cli': ^3.0.0-alpha.55
 
@@ -9378,11 +9378,6 @@ packages:
     peerDependenciesMeta:
       cypress:
         optional: true
-
-  '@nx/devkit@20.8.2':
-    resolution: {integrity: sha512-rr9p2/tZDQivIpuBUpZaFBK6bZ+b5SAjZk75V4tbCUqGW3+5OPuVvBPm+X+7PYwUF6rwSpewxkjWNeGskfCe+Q==}
-    peerDependencies:
-      nx: '>= 19 <= 21'
 
   '@nx/devkit@22.6.5':
     resolution: {integrity: sha512-9kvAI+kk2pfEXLqS8OyjI9XvWmp+Gdn7jPfxDAz8BOqxMyPy3p5hYl+jc4TIsLOWunAFl8azqrcYsHzEpaWCIA==}
@@ -25337,64 +25332,6 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.9.2
 
-  '@angular/build@21.2.0(34548aaea574a8d49ef3ef8d9bfa54b4)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2102.0(chokidar@3.6.0)
-      '@angular/compiler': 21.2.0
-      '@angular/compiler-cli': 21.2.0(@angular/compiler@21.2.0)(typescript@5.9.2)
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@inquirer/confirm': 5.1.21(@types/node@24.12.2)
-      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
-      beasties: 0.4.1
-      browserslist: 4.28.1
-      esbuild: 0.27.3
-      https-proxy-agent: 7.0.6
-      istanbul-lib-instrument: 6.0.3
-      jsonc-parser: 3.3.1
-      listr2: 9.0.5
-      magic-string: 0.30.21
-      mrmime: 2.0.1
-      parse5-html-rewriting-stream: 8.0.0
-      picomatch: 4.0.3
-      piscina: 5.1.4
-      rolldown: 1.0.0-rc.4
-      sass: 1.97.3
-      semver: 7.7.4
-      source-map-support: 0.5.21
-      tinyglobby: 0.2.15
-      tslib: 2.8.1
-      typescript: 5.9.2
-      undici: 7.22.0
-      vite: 7.3.1(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
-      watchpack: 2.5.1
-    optionalDependencies:
-      '@angular/core': 21.2.0(@angular/compiler@21.2.0)(rxjs@7.8.2)(zone.js@0.16.0)
-      '@angular/localize': 21.2.0(@angular/compiler-cli@21.2.0(@angular/compiler@21.2.0)(typescript@5.9.2))(@angular/compiler@21.2.0)
-      '@angular/platform-browser': 21.2.0(@angular/common@21.2.0(@angular/core@21.2.0(@angular/compiler@21.2.0)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.2.0(@angular/compiler@21.2.0)(rxjs@7.8.2)(zone.js@0.16.0))
-      '@angular/platform-server': 21.2.0(@angular/common@21.2.0(@angular/core@21.2.0(@angular/compiler@21.2.0)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/compiler@21.2.0)(@angular/core@21.2.0(@angular/compiler@21.2.0)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.2.0(@angular/common@21.2.0(@angular/core@21.2.0(@angular/compiler@21.2.0)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.2.0(@angular/compiler@21.2.0)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
-      '@angular/ssr': 21.2.0(04a10a167fdb5b9e93e7071d2f6d2277)
-      less: 4.5.1
-      lmdb: 3.5.1
-      ng-packagr: 21.2.0(@angular/compiler-cli@21.2.0(@angular/compiler@21.2.0)(typescript@5.9.2))(tailwindcss@4.1.11)(tslib@2.8.1)(typescript@5.9.2)
-      postcss: 8.5.8
-      tailwindcss: 4.1.11
-      vitest: 4.1.2(@types/node@24.12.2)(jsdom@26.1.0)(vite@8.0.0(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.5.1)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - '@types/node'
-      - chokidar
-      - jiti
-      - lightningcss
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   '@angular/build@21.2.0(a8859e04184b94f7a58c470e139e255e)':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -29618,11 +29555,11 @@ snapshots:
     transitivePeerDependencies:
       - node-fetch
 
-  '@monodon/rust@2.3.0(@napi-rs/cli@3.5.1(@emnapi/runtime@1.7.1)(@types/node@24.12.2)(node-addon-api@7.1.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))':
+  '@monodon/rust@3.0.0(@napi-rs/cli@3.5.1(@emnapi/runtime@1.7.1)(@types/node@24.12.2)(node-addon-api@7.1.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))':
     dependencies:
       '@ltd/j-toml': 1.38.0
       '@napi-rs/cli': 3.5.1(@emnapi/runtime@1.7.1)(@types/node@24.12.2)(node-addon-api@7.1.1)
-      '@nx/devkit': 20.8.2(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
+      '@nx/devkit': 22.6.5(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
       chalk: 4.1.2
       npm-run-path: 4.0.1
       semver: 7.5.4
@@ -31282,18 +31219,6 @@ snapshots:
       - supports-color
       - typescript
       - verdaccio
-
-  '@nx/devkit@20.8.2(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))':
-    dependencies:
-      ejs: 3.1.10
-      enquirer: 2.3.6
-      ignore: 5.3.2
-      minimatch: 10.2.5
-      nx: 23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18))
-      semver: 7.7.4
-      tmp: 0.2.6
-      tslib: 2.8.1
-      yargs-parser: 21.1.1
 
   '@nx/devkit@22.6.5(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))':
     dependencies:


### PR DESCRIPTION
## Current Behavior

The canonical plugin API types are suffixed with `V2` (`CreateNodesV2`, `CreateNodesContextV2`, `CreateNodesFunctionV2`, `CreateNodesResultV2`, `NxPluginV2`), left over from when the V1 signatures existed. V1 was removed in Nx 22 (#32951), freeing up the un-suffixed identifiers but leaving the V2 names as the public API.

## Expected Behavior

The un-suffixed names (`CreateNodes`, `CreateNodesContext`, `CreateNodesFunction`, `NxPlugin`, plus a new `CreateNodesResultArray`) become the canonical public types. The `V2` identifiers remain as `@deprecated` type aliases so plugin code authored against them keeps compiling. The plugin loader still checks both `plugin.createNodes` and `plugin.createNodesV2` property names at runtime, so third-party plugins that export under either name continue to load.

### Rename map

| Old (now `@deprecated` alias) | New canonical         |
|-------------------------------|-----------------------|
| `CreateNodesV2<T>`            | `CreateNodes<T>`      |
| `CreateNodesContextV2`        | `CreateNodesContext`  |
| `CreateNodesResultV2`         | `CreateNodesResultArray` |
| `CreateNodesFunctionV2<T>`    | `CreateNodesFunction<T>` |
| `NxPluginV2<T>`               | `NxPlugin<T>`         |

### Changes

- `packages/nx` internals (plugin loader, isolation worker, utils, lock-file, package/project.json plugins, specs) switched to canonical types.
- `packages/devkit` utilities (`addPlugin`, `findPluginForConfigFile`, `targetDefaultsUtils`, `calculateHashForCreateNodes`, `replaceProjectConfigurationsWithPlugin`, `getNamedInputs`, `executor-to-plugin-migrator`, etc.) migrated to canonical types. `addPlugin` now registers plugin objects with `createNodes:` as the canonical key.
- 50 first-party plugin packages updated to canonical type names. Seven packages whose only primary export was `createNodesV2` now export `createNodes` as the primary value, with `createNodesV2 = createNodes` preserved as a backward-compat alias for older Nx consumers.

## Related Issue(s)

N/A