### PR TITLE
fix(core): fall back to workspace project lookup when require resolves a hoisted copy

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -1232,6 +1232,56 @@ describe('TargetProjectLocator', () => {
     });
   });
 
+  describe('findProjectFromImport workspace fallback', () => {
+    it('should fall back to findImportInWorkspaceProjects when require resolves into node_modules', () => {
+      // Scenario: workspace package `@org/pkg1` is imported from a file in
+      // another workspace project that does NOT declare `@org/pkg1` as a
+      // dependency. In pnpm layouts, Node's resolver can walk up and find a
+      // hoisted copy of the package in `node_modules/.pnpm/...`, causing
+      // `resolveImportWithRequire` to return a path under `node_modules/`.
+      // The edge to `pkg1` would previously be dropped; it should now be
+      // recovered via the workspace-metadata fallback.
+      const projects: Record<string, ProjectGraphProjectNode> = {
+        pkg1: {
+          name: 'pkg1',
+          type: 'lib',
+          data: {
+            root: 'pkg1',
+            metadata: {
+              js: {
+                packageName: '@org/pkg1',
+                packageExports: 'dist/index.js',
+                isInPackageManagerWorkspaces: true,
+              },
+            },
+          },
+        },
+        consumer: {
+          name: 'consumer',
+          type: 'lib',
+          data: { root: 'consumer' },
+        },
+      };
+
+      const locator = new TargetProjectLocator(projects, {}, new Map());
+
+      // Force the require-resolution step to return a node_modules path,
+      // emulating a hoisted pnpm copy.
+      jest
+        .spyOn(locator as any, 'resolveImportWithRequire')
+        .mockReturnValue(
+          'node_modules/.pnpm/@org+pkg1@1.0.0/node_modules/@org/pkg1/dist/index.js'
+        );
+
+      const result = locator.findProjectFromImport(
+        '@org/pkg1',
+        'consumer/src/index.ts'
+      );
+
+      expect(result).toEqual('pkg1');
+    });
+  });
+
   describe('findImportInWorkspaceProjects', () => {
     it.each`
       exports                                                      | importPath

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -165,11 +165,15 @@ export class TargetProjectLocator {
         filePath
       );
 
-      return this.findProjectOfResolvedModule(resolvedModule);
+      const resolvedProject = this.findProjectOfResolvedModule(resolvedModule);
+      if (resolvedProject) {
+        return resolvedProject;
+      }
     } catch {}
 
     // fall back to see if it's a locally linked workspace project where the
-    // output might not exist yet
+    // output might not exist yet (e.g. the import resolved into node_modules
+    // via a hoisted copy instead of the workspace symlink)
     const localProject = this.findImportInWorkspaceProjects(importExpr);
     if (localProject) {
       return localProject;


### PR DESCRIPTION
## Current Behavior

`TargetProjectLocator.findProjectFromImport` returns `undefined` whenever `resolveImportWithRequire` succeeds but the resolved path lives under `node_modules/` — it never reaches the `findImportInWorkspaceProjects` fallback.

In pnpm workspaces, this drops edges between workspace projects whenever the consumer imports a workspace package it doesn't declare as a dependency. `require.resolve` walks up through `node_modules` and lands on the hoisted external copy in `.pnpm/` (e.g. `node_modules/.pnpm/@nx+jest@.../node_modules/@nx/jest/index.js`) instead of the workspace symlink. `findProjectOfResolvedModule` sees `node_modules/` in the path, returns `undefined`, and the edge is silently lost.

Concrete example in this repo: `packages/eslint/src/generators/workspace-rules-project/workspace-rules-project.ts` calls `ensurePackage<typeof import('@nx/jest')>('@nx/jest', nxVersion)`. The Rust import locator correctly captures `@nx/jest` as a static import, but the edge `@nx/eslint -> @nx/jest` never materializes in the project graph. #35377 worked around this by declaring `@nx/jest` as an optional peer dependency so the edge would be picked up via `explicit-package-json-dependencies` instead.

## Expected Behavior

When `findProjectOfResolvedModule` can't map the resolved path to a workspace project, fall through to `findImportInWorkspaceProjects` — the workspace-package-metadata lookup that already handles "locally linked workspace project where the output might not exist yet." It correctly maps the import expression (e.g. `@nx/jest`) to the corresponding workspace project via `entryPointsToProjectMap`.

After this fix, on this repo:
- `eslint -> jest (static)` materializes without needing the peer-dep workaround
- `@nx/nx-source -> eslint-rules (static)` is recovered (root `eslint.config.mjs` imports from `./tools/eslint-rules`)
- No edges removed

Added a regression test that stubs `resolveImportWithRequire` to return a `node_modules/.pnpm/...` path and asserts the workspace fallback resolves to the correct project. Verified it fails against the pre-fix code.

## Related Issue(s)

<!-- No open issue; this is a follow-up to the workaround in #35377 -->
