### PR TITLE
fix(core): keep continuous children alive when nx:noop orchestrator completes

### DIFF
--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -53,6 +53,7 @@ import { TaskStatus } from './tasks-runner';
 import { Batch, TasksSchedule } from './tasks-schedule';
 import {
   calculateReverseDeps,
+  expandInitiatingTasksThroughNoop,
   getExecutorForTask,
   getPrintableCommandArgsForTask,
   getTargetConfigurationForTask,
@@ -98,7 +99,16 @@ export class TaskOrchestrator {
   );
   private reverseTaskDeps = calculateReverseDeps(this.taskGraph);
 
-  private initializingTaskIds = new Set(this.initiatingTasks.map((t) => t.id));
+  // `nx:noop` initiating tasks exit instantly via the fast-path in
+  // `spawnProcess`. If we treat the noop itself as the keep-alive anchor for
+  // its continuous dependencies, `cleanUpUnneededContinuousTasks` kills those
+  // children the moment the noop finishes. Expand through noops so the
+  // underlying real tasks become the anchors.
+  private initializingTaskIds = expandInitiatingTasksThroughNoop(
+    this.initiatingTasks,
+    this.taskGraph,
+    this.projectGraph
+  );
 
   private processedTasks = new Map<string, Promise<NodeJS.ProcessEnv>>();
 

--- a/packages/nx/src/tasks-runner/utils.spec.ts
+++ b/packages/nx/src/tasks-runner/utils.spec.ts
@@ -1,5 +1,6 @@
 import {
   expandDependencyConfigSyntaxSugar,
+  expandInitiatingTasksThroughNoop,
   expandWildcardTargetConfiguration,
   getDependencyConfigs,
   getOutputsForTargetAndConfiguration,
@@ -8,6 +9,7 @@ import {
   validateOutputs,
 } from './utils';
 import { ProjectGraph, ProjectGraphProjectNode } from '../config/project-graph';
+import { Task, TaskGraph } from '../config/task-graph';
 import { ProjectConfiguration } from '../config/workspace-json-project-json';
 
 describe('utils', () => {
@@ -830,6 +832,184 @@ describe('utils', () => {
         Run \`nx repair\` to fix this."
       `);
     });
+  });
+});
+
+describe('expandInitiatingTasksThroughNoop', () => {
+  function mkTask(id: string): Task {
+    const [project, target] = id.split(':');
+    return {
+      id,
+      target: { project, target },
+      overrides: {},
+      outputs: [],
+      projectRoot: project,
+      parallelism: true,
+    };
+  }
+
+  function mkProjectGraph(
+    targets: Record<string, Record<string, { executor: string }>>
+  ): ProjectGraph {
+    const nodes: ProjectGraph['nodes'] = {};
+    for (const [project, ts] of Object.entries(targets)) {
+      nodes[project] = {
+        name: project,
+        type: 'lib',
+        data: { root: `libs/${project}`, targets: ts as any },
+      };
+    }
+    return { nodes, dependencies: {}, externalNodes: {} };
+  }
+
+  function mkTaskGraph(
+    tasks: string[],
+    dependencies: Record<string, string[]> = {},
+    continuousDependencies: Record<string, string[]> = {}
+  ): TaskGraph {
+    const taskMap: Record<string, Task> = {};
+    for (const t of tasks) taskMap[t] = mkTask(t);
+    const deps: Record<string, string[]> = {};
+    const cdeps: Record<string, string[]> = {};
+    for (const t of tasks) {
+      deps[t] = dependencies[t] ?? [];
+      cdeps[t] = continuousDependencies[t] ?? [];
+    }
+    return {
+      tasks: taskMap,
+      dependencies: deps,
+      continuousDependencies: cdeps,
+      roots: [],
+    };
+  }
+
+  it('returns initiating ids unchanged when none are noop', () => {
+    const projectGraph = mkProjectGraph({
+      app: { build: { executor: 'nx:run-commands' } },
+    });
+    const taskGraph = mkTaskGraph(['app:build']);
+    const result = expandInitiatingTasksThroughNoop(
+      [taskGraph.tasks['app:build']],
+      taskGraph,
+      projectGraph
+    );
+    expect([...result]).toEqual(['app:build']);
+  });
+
+  it('replaces a noop initiating task with its continuous dependencies', () => {
+    const projectGraph = mkProjectGraph({
+      app: {
+        dev: { executor: 'nx:noop' },
+        serve: { executor: 'nx:run-commands' },
+        watch: { executor: 'nx:run-commands' },
+      },
+    });
+    const taskGraph = mkTaskGraph(
+      ['app:dev', 'app:serve', 'app:watch'],
+      {},
+      { 'app:dev': ['app:serve', 'app:watch'] }
+    );
+    const result = expandInitiatingTasksThroughNoop(
+      [taskGraph.tasks['app:dev']],
+      taskGraph,
+      projectGraph
+    );
+    expect([...result].sort()).toEqual(['app:serve', 'app:watch']);
+  });
+
+  it('replaces a noop initiating task with its non-continuous dependencies', () => {
+    const projectGraph = mkProjectGraph({
+      app: {
+        orchestrate: { executor: 'nx:noop' },
+        build: { executor: 'nx:run-commands' },
+      },
+    });
+    const taskGraph = mkTaskGraph(['app:orchestrate', 'app:build'], {
+      'app:orchestrate': ['app:build'],
+    });
+    const result = expandInitiatingTasksThroughNoop(
+      [taskGraph.tasks['app:orchestrate']],
+      taskGraph,
+      projectGraph
+    );
+    expect([...result]).toEqual(['app:build']);
+  });
+
+  it('recursively collapses nested noop orchestrators', () => {
+    const projectGraph = mkProjectGraph({
+      app: {
+        outer: { executor: 'nx:noop' },
+        inner: { executor: 'nx:noop' },
+        serve: { executor: 'nx:run-commands' },
+      },
+    });
+    const taskGraph = mkTaskGraph(
+      ['app:outer', 'app:inner', 'app:serve'],
+      {},
+      {
+        'app:outer': ['app:inner'],
+        'app:inner': ['app:serve'],
+      }
+    );
+    const result = expandInitiatingTasksThroughNoop(
+      [taskGraph.tasks['app:outer']],
+      taskGraph,
+      projectGraph
+    );
+    expect([...result]).toEqual(['app:serve']);
+  });
+
+  it('returns an empty set for a noop with no dependencies', () => {
+    const projectGraph = mkProjectGraph({
+      app: { nothing: { executor: 'nx:noop' } },
+    });
+    const taskGraph = mkTaskGraph(['app:nothing']);
+    const result = expandInitiatingTasksThroughNoop(
+      [taskGraph.tasks['app:nothing']],
+      taskGraph,
+      projectGraph
+    );
+    expect(result.size).toBe(0);
+  });
+
+  it('terminates on cyclic noop dependencies', () => {
+    const projectGraph = mkProjectGraph({
+      app: {
+        a: { executor: 'nx:noop' },
+        b: { executor: 'nx:noop' },
+      },
+    });
+    const taskGraph = mkTaskGraph(['app:a', 'app:b'], {
+      'app:a': ['app:b'],
+      'app:b': ['app:a'],
+    });
+    const result = expandInitiatingTasksThroughNoop(
+      [taskGraph.tasks['app:a']],
+      taskGraph,
+      projectGraph
+    );
+    expect(result.size).toBe(0);
+  });
+
+  it('preserves non-noop initiating tasks alongside expanded noops', () => {
+    const projectGraph = mkProjectGraph({
+      app: {
+        dev: { executor: 'nx:noop' },
+        serve: { executor: 'nx:run-commands' },
+        test: { executor: 'nx:run-commands' },
+      },
+    });
+    const taskGraph = mkTaskGraph(
+      ['app:dev', 'app:serve', 'app:test'],
+      {},
+      { 'app:dev': ['app:serve'] }
+    );
+    const result = expandInitiatingTasksThroughNoop(
+      [taskGraph.tasks['app:dev'], taskGraph.tasks['app:test']],
+      taskGraph,
+      projectGraph
+    );
+    expect([...result].sort()).toEqual(['app:serve', 'app:test']);
   });
 });
 

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -436,6 +436,48 @@ export function getExecutorNameForTask(task: Task, projectGraph: ProjectGraph) {
   return getTargetConfigurationForTask(task, projectGraph)?.executor;
 }
 
+/**
+ * Expand a set of initiating task IDs by walking through any `nx:noop` tasks
+ * and replacing them with their direct dependencies + continuous dependencies.
+ * Non-noop tasks are kept as-is; cycles are safe.
+ *
+ * An `nx:noop` executor returns immediately, so if it is the only thing
+ * anchoring a continuous child, the child gets killed by
+ * `cleanUpUnneededContinuousTasks` the moment the noop completes. Treating the
+ * noop's dependencies as the real anchors preserves the intended orchestration.
+ */
+export function expandInitiatingTasksThroughNoop(
+  initiatingTasks: Task[],
+  taskGraph: TaskGraph,
+  projectGraph: ProjectGraph
+): Set<string> {
+  const expanded = new Set<string>();
+  const visited = new Set<string>();
+  const queue: string[] = initiatingTasks.map((t) => t.id);
+
+  while (queue.length > 0) {
+    const taskId = queue.shift()!;
+    if (visited.has(taskId)) continue;
+    visited.add(taskId);
+
+    const task = taskGraph.tasks[taskId];
+    if (!task) continue;
+
+    if (getExecutorNameForTask(task, projectGraph) === 'nx:noop') {
+      for (const dep of taskGraph.dependencies[taskId] ?? []) {
+        queue.push(dep);
+      }
+      for (const dep of taskGraph.continuousDependencies[taskId] ?? []) {
+        queue.push(dep);
+      }
+    } else {
+      expanded.add(taskId);
+    }
+  }
+
+  return expanded;
+}
+
 export function getExecutorForTask(
   task: Task,
   projects: Record<string, ProjectConfiguration>


### PR DESCRIPTION
## Current Behavior

A target with `executor: nx:noop` and `dependsOn` pointing at continuous tasks is unusable as a top-level orchestrator.

Given a config like:

```jsonc
"dev": {
  "executor": "nx:noop",
  "dependsOn": ["serve", "watch-css"]
}
```

where `serve` and `watch-css` are continuous, running `nx run app:dev`:

1. `serve` and `watch-css` start and become ready.
2. The `nx:noop` fast-path (`task-orchestrator.ts:1128`) exits `dev` instantly with success.
3. `cleanUpUnneededContinuousTasks` (`task-orchestrator.ts:1785-1809`) runs on every completion. Its predicate keeps a continuous task alive only if it's in `initializingTaskIds` *and still incomplete*, OR it's a `continuousDependencies` entry of some incomplete task.
4. The only initiating task (`dev`) just completed, and the continuous children aren't directly in `initializingTaskIds` — they're only deps of the now-complete noop.
5. Both continuous children get `SIGKILL`'d immediately.

## Expected Behavior

Running a top-level `nx:noop` orchestrator should keep its continuous `dependsOn` children alive. The orchestrator process stays running until the continuous children exit (e.g. user Ctrl+C), matching the ergonomics of `nx run-many -t serve,watch-css`.

## Fix

Expand `initializingTaskIds` inside the orchestrator through `nx:noop` tasks when seeding the keep-alive anchor set. The real tasks beneath a noop become the anchors so they survive the noop's instant completion.

- New helper `expandInitiatingTasksThroughNoop` in `packages/nx/src/tasks-runner/utils.ts`: BFS that drops any `nx:noop` from the anchor set and enqueues its `dependencies` + `continuousDependencies`, recursing through nested noops; cycle-safe via a `visited` set.
- Wire it into `TaskOrchestrator.initializingTaskIds` at `task-orchestrator.ts:101`.
- The public `initiatingTasks` array is left untouched, so TUI output (`tui-summary-life-cycle.ts`), atomized `e2e-ci` coordinator semantics, hashing, and caching are unchanged. For atomized chunk patterns the expansion has no visible effect because children aren't continuous.

## Related Issue(s)

Fixes #