### PR TITLE
chore(misc): richer telemetry for init and connect commands

### DIFF
--- a/packages/nx/src/command-line/init/command-object.ts
+++ b/packages/nx/src/command-line/init/command-object.ts
@@ -92,7 +92,9 @@ export const yargsInitCommand: CommandModule = {
       // `stdio: 'pipe'`) so telemetry gets the real cause.
       const stderr = readErrorStderr(error).trim();
       const telemetryMessage = (
-        stderr ? `${errorMessage} | stderr: ${stderr.slice(-250)}` : errorMessage
+        stderr
+          ? `${errorMessage} | stderr: ${stderr.slice(-250)}`
+          : errorMessage
       ).slice(0, 500);
       // Structured code for bucketing. Prefer Node's `e.code` (set on
       // syscall failures); fall back to E-codes/ERR_* extracted from full

--- a/packages/nx/src/command-line/init/command-object.ts
+++ b/packages/nx/src/command-line/init/command-object.ts
@@ -12,6 +12,11 @@ import { recordStat } from '../../utils/ab-testing';
 import { nxVersion } from '../../utils/versions';
 import { isCI } from '../../utils/is-ci';
 import { detectPackageManager } from '../../utils/package-manager';
+import {
+  extractErrorName,
+  readErrorStderr,
+  toErrorString,
+} from './implementation/utils';
 
 export const yargsInitCommand: CommandModule = {
   command: 'init',
@@ -81,9 +86,18 @@ export const yargsInitCommand: CommandModule = {
       }
       process.exit(0);
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
+      const errorMessage = toErrorString(error);
       const errorCode = determineErrorCode(error);
+      // Append stderr tail (present when child-process errors ran with
+      // `stdio: 'pipe'`) so telemetry gets the real cause.
+      const stderr = readErrorStderr(error).trim();
+      const telemetryMessage = (
+        stderr ? `${errorMessage} | stderr: ${stderr.slice(-250)}` : errorMessage
+      ).slice(0, 500);
+      // Structured code for bucketing. Prefer Node's `e.code` (set on
+      // syscall failures); fall back to E-codes/ERR_* extracted from full
+      // stderr (npm/pnpm/yarn); then `error.name`.
+      const errorName = extractErrorName(error, stderr);
 
       await recordStat({
         command: 'init',
@@ -92,8 +106,13 @@ export const yargsInitCommand: CommandModule = {
         meta: {
           type: 'error',
           errorCode,
-          errorMessage: errorMessage.substring(0, 250),
+          errorName,
+          errorMessage: telemetryMessage,
           aiAgent,
+          isCI: isCI(),
+          nodeVersion: process.versions.node,
+          os: process.platform,
+          packageManager: detectPackageManager(),
         },
       });
 

--- a/packages/nx/src/command-line/init/command-object.ts
+++ b/packages/nx/src/command-line/init/command-object.ts
@@ -1,22 +1,6 @@
 import { Argv, CommandModule } from 'yargs';
 import { handleImport } from '../../utils/handle-import';
 import { parseCSV } from '../yargs-utils/shared-options';
-import { isAiAgent } from '../../native';
-import {
-  writeAiOutput,
-  buildErrorResult,
-  writeErrorLog,
-  determineErrorCode,
-} from './utils/ai-output';
-import { recordStat } from '../../utils/ab-testing';
-import { nxVersion } from '../../utils/versions';
-import { isCI } from '../../utils/is-ci';
-import { detectPackageManager } from '../../utils/package-manager';
-import {
-  extractErrorName,
-  readErrorStderr,
-  toErrorString,
-} from './implementation/utils';
 
 export const yargsInitCommand: CommandModule = {
   command: 'init',
@@ -47,88 +31,14 @@ export const yargsInitCommand: CommandModule = {
       throw error;
     });
 
-    const aiAgent = isAiAgent();
-
-    recordStat({
-      command: 'init',
-      nxVersion,
-      useCloud: false,
-      meta: {
-        type: 'start',
-        nodeVersion: process.versions.node,
-        os: process.platform,
-        packageManager: detectPackageManager(),
-        aiAgent,
-        isCI: isCI(),
-      },
-    });
-
-    try {
-      const useV2 = await isInitV2();
-      if (useV2) {
-        // v2 records its own complete event with richer context
-        await require('./init-v2').initHandler(args);
-      } else {
-        await require('./init-v1').initHandler(args);
-        await recordStat({
-          command: 'init',
-          nxVersion,
-          useCloud: false,
-          meta: {
-            type: 'complete',
-            nodeVersion: process.versions.node,
-            os: process.platform,
-            packageManager: detectPackageManager(),
-            aiAgent,
-            isCI: isCI(),
-          },
-        });
-      }
-      process.exit(0);
-    } catch (error) {
-      const errorMessage = toErrorString(error);
-      const errorCode = determineErrorCode(error);
-      // Append stderr tail (present when child-process errors ran with
-      // `stdio: 'pipe'`) so telemetry gets the real cause.
-      const stderr = readErrorStderr(error).trim();
-      const telemetryMessage = (
-        stderr
-          ? `${errorMessage} | stderr: ${stderr.slice(-250)}`
-          : errorMessage
-      ).slice(0, 500);
-      // Structured code for bucketing. Prefer Node's `e.code` (set on
-      // syscall failures); fall back to E-codes/ERR_* extracted from full
-      // stderr (npm/pnpm/yarn); then `error.name`.
-      const errorName = extractErrorName(error, stderr);
-
-      await recordStat({
-        command: 'init',
-        nxVersion,
-        useCloud: false,
-        meta: {
-          type: 'error',
-          errorCode,
-          errorName,
-          errorMessage: telemetryMessage,
-          aiAgent,
-          isCI: isCI(),
-          nodeVersion: process.versions.node,
-          os: process.platform,
-          packageManager: detectPackageManager(),
-        },
-      });
-
-      // Output structured error for AI agents
-      if (aiAgent) {
-        const errorLogPath = writeErrorLog(error);
-        writeAiOutput(buildErrorResult(errorMessage, errorCode, errorLogPath));
-      } else {
-        // Ensure the cursor is always restored just in case the user has bailed during interactive prompts
-        // Skip for AI agents to avoid corrupting NDJSON output
-        process.stdout.write('\x1b[?25h');
-      }
-      process.exit(1);
+    const useV2 = await isInitV2();
+    if (useV2) {
+      await require('./init-v2').initHandler(args);
+    } else {
+      // v1 path retained for `NX_ADD_PLUGINS=false`; slated for removal.
+      await require('./init-v1').initHandler(args);
     }
+    process.exit(0);
   },
 };
 

--- a/packages/nx/src/command-line/init/configure-plugins.ts
+++ b/packages/nx/src/command-line/init/configure-plugins.ts
@@ -41,7 +41,6 @@ export function installPluginPackages(
       nxJson.installation.plugins[plugin] = nxVersion;
     }
     writeJsonFile(join(repoRoot, 'nx.json'), nxJson);
-    // Invoke the nx wrapper to install plugins; pipe stderr for telemetry.
     try {
       runNxSync('--version', { stdio: 'pipe' });
     } catch (e) {

--- a/packages/nx/src/command-line/init/configure-plugins.ts
+++ b/packages/nx/src/command-line/init/configure-plugins.ts
@@ -41,8 +41,13 @@ export function installPluginPackages(
       nxJson.installation.plugins[plugin] = nxVersion;
     }
     writeJsonFile(join(repoRoot, 'nx.json'), nxJson);
-    // Invoking nx wrapper to install plugins.
-    runNxSync('--version', { stdio: 'ignore' });
+    // Invoke the nx wrapper to install plugins; pipe stderr for telemetry.
+    try {
+      runNxSync('--version', { stdio: 'pipe' });
+    } catch (e) {
+      if ((e as any)?.stderr) process.stderr.write((e as any).stderr);
+      throw e;
+    }
   }
 }
 

--- a/packages/nx/src/command-line/init/implementation/utils.spec.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.spec.ts
@@ -328,7 +328,9 @@ describe('utils', () => {
 
   describe('extractErrorName', () => {
     it('prefers Node e.code when set', () => {
-      expect(extractErrorName({ code: 'EACCES' }, 'stderr E404')).toBe('EACCES');
+      expect(extractErrorName({ code: 'EACCES' }, 'stderr E404')).toBe(
+        'EACCES'
+      );
     });
 
     it.each([

--- a/packages/nx/src/command-line/init/implementation/utils.spec.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.spec.ts
@@ -3,7 +3,12 @@ jest.mock('./deduce-default-base', () => ({
 }));
 
 import { NxJsonConfiguration } from '../../../config/nx-json';
-import { createNxJsonFromTurboJson } from './utils';
+import {
+  createNxJsonFromTurboJson,
+  extractErrorName,
+  readErrorStderr,
+  toErrorString,
+} from './utils';
 
 describe('utils', () => {
   describe('createNxJsonFromTurboJson', () => {
@@ -264,6 +269,84 @@ describe('utils', () => {
       },
     ])('$description', ({ turbo, nx }) => {
       expect(createNxJsonFromTurboJson(turbo)).toEqual(nx);
+    });
+  });
+
+  describe('toErrorString', () => {
+    it('returns error.message when present', () => {
+      expect(toErrorString(new Error('boom'))).toBe('boom');
+    });
+
+    it('returns "Error" for bare new Error() instead of empty string', () => {
+      expect(toErrorString(new Error())).toBe('Error');
+    });
+
+    it('returns "Unknown error" for null/undefined', () => {
+      expect(toErrorString(null)).toBe('Unknown error');
+      expect(toErrorString(undefined)).toBe('Unknown error');
+    });
+
+    it('coerces primitive throws', () => {
+      expect(toErrorString('str')).toBe('str');
+      expect(toErrorString(42)).toBe('42');
+    });
+
+    it('includes own-property code when message is empty', () => {
+      const e = new Error('') as Error & { code?: string };
+      e.code = 'E404';
+      expect(toErrorString(e)).toContain('E404');
+    });
+
+    it('serializes plain objects', () => {
+      expect(toErrorString({ foo: 'bar' })).toBe('{"foo":"bar"}');
+    });
+
+    it('falls through to toString() for unserializable objects', () => {
+      const circular: any = {};
+      circular.self = circular;
+      expect(toErrorString(circular)).toBe('[object Object]');
+    });
+  });
+
+  describe('readErrorStderr', () => {
+    it('returns string stderr as-is', () => {
+      expect(readErrorStderr({ stderr: 'hello' })).toBe('hello');
+    });
+
+    it('decodes Buffer stderr to utf8', () => {
+      expect(readErrorStderr({ stderr: Buffer.from('boom', 'utf8') })).toBe(
+        'boom'
+      );
+    });
+
+    it('returns "" when stderr is absent or nullish', () => {
+      expect(readErrorStderr({})).toBe('');
+      expect(readErrorStderr(null)).toBe('');
+      expect(readErrorStderr({ stderr: null })).toBe('');
+    });
+  });
+
+  describe('extractErrorName', () => {
+    it('prefers Node e.code when set', () => {
+      expect(extractErrorName({ code: 'EACCES' }, 'stderr E404')).toBe('EACCES');
+    });
+
+    it.each([
+      ['npm error code E404', 'E404'],
+      ['npm error code ERESOLVE', 'ERESOLVE'],
+      ['npm error code EINTEGRITY sha512 failure', 'EINTEGRITY'],
+      ['ERR_PNPM_PEER_DEP_ISSUES Unmet peer deps', 'ERR_PNPM_PEER_DEP_ISSUES'],
+    ])('extracts %s as %s', (stderr, expected) => {
+      expect(extractErrorName({}, stderr)).toBe(expected);
+    });
+
+    it('falls back to error.name for plain Errors', () => {
+      expect(extractErrorName(new TypeError('x'), '')).toBe('TypeError');
+    });
+
+    it('returns typeof for non-Error throws', () => {
+      expect(extractErrorName('str', '')).toBe('string');
+      expect(extractErrorName(42, '')).toBe('number');
     });
   });
 });

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -229,11 +229,73 @@ export function runInstall(
   repoRoot: string,
   pmc: PackageManagerCommands = getPackageManagerCommand()
 ) {
-  execSync(pmc.install, {
-    stdio: ['ignore', 'ignore', 'inherit'],
-    cwd: repoRoot,
-    windowsHide: true,
-  });
+  try {
+    // stderr piped so the error carries it for telemetry.
+    execSync(pmc.install, {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      encoding: 'utf8',
+      cwd: repoRoot,
+      windowsHide: true,
+    });
+  } catch (e) {
+    if ((e as any)?.stderr) process.stderr.write((e as any).stderr);
+    throw e;
+  }
+}
+
+/**
+ * Coerce any thrown value into a non-empty telemetry string. The naive
+ * `error.message || String(error)` yields "" for bare `new Error()`.
+ */
+export function toErrorString(error: unknown): string {
+  if (error == null) return 'Unknown error';
+  if (error instanceof Error) {
+    if (error.message) return error.message;
+    if (error.name && error.name !== 'Error') return error.name;
+    // Drop `stack` — large and contains absolute paths (PII).
+    const keys = Object.getOwnPropertyNames(error).filter((k) => k !== 'stack');
+    const serialized = safeJsonStringify(error, keys);
+    if (serialized && serialized !== '{}') return serialized;
+    return error.name || 'Error';
+  }
+  if (typeof error === 'object') {
+    const serialized = safeJsonStringify(error);
+    if (serialized && serialized !== '{}') return serialized;
+    return Object.prototype.toString.call(error);
+  }
+  return String(error);
+}
+
+/** Read `.stderr` off a thrown child-process error; supports string or Buffer. */
+export function readErrorStderr(error: unknown): string {
+  const raw = (error as any)?.stderr;
+  if (typeof raw === 'string') return raw;
+  if (raw && typeof (raw as Buffer).toString === 'function') {
+    return (raw as Buffer).toString('utf8');
+  }
+  return '';
+}
+
+/**
+ * Pick a structured name for telemetry bucketing: Node `e.code`,
+ * else an `E…`/`ERR_…` token from stderr (E404, ERESOLVE, EINTEGRITY,
+ * ERR_PNPM_*, ...), else `error.name`.
+ */
+export function extractErrorName(error: unknown, stderr: string): string {
+  const nodeCode = (error as any)?.code;
+  if (typeof nodeCode === 'string') return nodeCode;
+  const m = stderr.match(/\b(E[A-Z0-9_]{2,}|ERR_[A-Z0-9_]+)\b/);
+  if (m) return m[1];
+  if (error instanceof Error) return error.name;
+  return typeof error;
+}
+
+function safeJsonStringify(value: unknown, replacer?: string[]): string {
+  try {
+    return JSON.stringify(value, replacer);
+  } catch {
+    return '';
+  }
 }
 
 export async function initCloud(

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -230,7 +230,6 @@ export function runInstall(
   pmc: PackageManagerCommands = getPackageManagerCommand()
 ) {
   try {
-    // stderr piped so the error carries it for telemetry.
     execSync(pmc.install, {
       stdio: ['ignore', 'ignore', 'pipe'],
       encoding: 'utf8',
@@ -266,7 +265,6 @@ export function toErrorString(error: unknown): string {
   return String(error);
 }
 
-/** Read `.stderr` off a thrown child-process error; supports string or Buffer. */
 export function readErrorStderr(error: unknown): string {
   const raw = (error as any)?.stderr;
   if (typeof raw === 'string') return raw;
@@ -276,11 +274,6 @@ export function readErrorStderr(error: unknown): string {
   return '';
 }
 
-/**
- * Pick a structured name for telemetry bucketing: Node `e.code`,
- * else an `E…`/`ERR_…` token from stderr (E404, ERESOLVE, EINTEGRITY,
- * ERR_PNPM_*, ...), else `error.name`.
- */
 export function extractErrorName(error: unknown, stderr: string): string {
   const nodeCode = (error as any)?.code;
   if (typeof nodeCode === 'string') return nodeCode;

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -23,10 +23,13 @@ import { addNxToAngularCliRepo } from './implementation/angular';
 import { generateDotNxSetup } from './implementation/dot-nx/add-nx-scripts';
 import {
   createNxJsonFile,
+  extractErrorName,
   initCloud,
   isMonorepo,
   printFinalMessage,
+  readErrorStderr,
   setNeverConnectToCloud,
+  toErrorString,
   updateGitIgnore,
 } from './implementation/utils';
 import { ensurePackageHasProvenance } from '../../utils/provenance';
@@ -64,32 +67,100 @@ export async function initHandler(
   options: InitArgs,
   inner = false
 ): Promise<void> {
-  // Use environment variable to force local execution
-  if (process.env.NX_USE_LOCAL === 'true' || inner) {
-    return await initHandlerImpl(options);
-  }
-
-  let cleanup: () => void | undefined;
-  try {
-    await ensurePackageHasProvenance('nx', 'latest');
-    const packageInstallResults = installPackageToTmp('nx', 'latest');
-    cleanup = packageInstallResults.cleanup;
-
-    let modulePath = require.resolve('nx/src/command-line/init/init-v2.js', {
-      paths: [packageInstallResults.tempDir],
+  // Only the outermost CLI invocation records start/error telemetry. When
+  // the downloaded-latest nx re-invokes us with `inner=true` its own outer
+  // wrapper already recorded these events.
+  const selfRecord = !inner;
+  const aiAgent = isAiAgent();
+  const baseMeta = {
+    nodeVersion: process.versions.node,
+    os: process.platform,
+    packageManager: detectPackageManager(),
+    aiAgent,
+    isCI: isCI(),
+  };
+  if (selfRecord) {
+    recordStat({
+      command: 'init',
+      nxVersion,
+      useCloud: false,
+      meta: { type: 'start', ...baseMeta },
     });
-
-    const module = await handleImport(modulePath);
-    const result = await module.initHandler(options, true);
-    cleanup();
-    return result;
-  } catch (error) {
-    if (cleanup) {
-      cleanup();
-    }
-    // Fall back to local implementation
-    return initHandlerImpl(options);
   }
+
+  try {
+    if (process.env.NX_USE_LOCAL === 'true' || inner) {
+      return await initHandlerImpl(options);
+    }
+
+    let cleanup: () => void | undefined;
+    try {
+      await ensurePackageHasProvenance('nx', 'latest');
+      const packageInstallResults = installPackageToTmp('nx', 'latest');
+      cleanup = packageInstallResults.cleanup;
+
+      let modulePath = require.resolve('nx/src/command-line/init/init-v2.js', {
+        paths: [packageInstallResults.tempDir],
+      });
+
+      const module = await handleImport(modulePath);
+      const result = await module.initHandler(options, true);
+      cleanup();
+      return result;
+    } catch {
+      if (cleanup) cleanup();
+      // Fall back to local implementation
+      return await initHandlerImpl(options);
+    }
+  } catch (error) {
+    if (selfRecord) {
+      await recordInitError(error, aiAgent, baseMeta);
+      // recordInitError terminates the process on the CLI path; the throw
+      // below is unreachable in practice but kept for type-level safety.
+    }
+    throw error;
+  }
+}
+
+async function recordInitError(
+  error: unknown,
+  aiAgent: boolean,
+  baseMeta: Record<string, string | boolean>
+): Promise<void> {
+  const errorMessage = toErrorString(error);
+  const errorCode = determineErrorCode(error);
+  // Append stderr tail (attached when child-process errors ran with
+  // `stdio: 'pipe'`) so telemetry carries the real cause.
+  const stderr = readErrorStderr(error).trim();
+  const telemetryMessage = (
+    stderr ? `${errorMessage} | stderr: ${stderr.slice(-250)}` : errorMessage
+  ).slice(0, 500);
+  // Structured code for bucketing. Prefer Node's `e.code`; fall back to
+  // E-code/ERR_* tokens extracted from stderr; then `error.name`.
+  const errorName = extractErrorName(error, stderr);
+
+  await recordStat({
+    command: 'init',
+    nxVersion,
+    useCloud: false,
+    meta: {
+      type: 'error',
+      errorCode,
+      errorName,
+      errorMessage: telemetryMessage,
+      ...baseMeta,
+    },
+  });
+
+  if (aiAgent) {
+    const errorLogPath = writeErrorLog(error);
+    writeAiOutput(buildErrorResult(errorMessage, errorCode, errorLogPath));
+  } else {
+    // Restore the cursor in case the user bailed during an interactive
+    // prompt. Skip for AI agents — it would corrupt NDJSON output.
+    process.stdout.write('\x1b[?25h');
+  }
+  process.exit(1);
 }
 
 async function initHandlerImpl(options: InitArgs): Promise<void> {

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -67,76 +67,44 @@ export async function initHandler(
   options: InitArgs,
   inner = false
 ): Promise<void> {
-  // Only the outermost CLI invocation records start/error telemetry. When
-  // the downloaded-latest nx re-invokes us with `inner=true` its own outer
-  // wrapper already recorded these events.
-  const selfRecord = !inner;
-  const aiAgent = isAiAgent();
-  const baseMeta = {
-    nodeVersion: process.versions.node,
-    os: process.platform,
-    packageManager: detectPackageManager(),
-    aiAgent,
-    isCI: isCI(),
-  };
-  if (selfRecord) {
-    recordStat({
-      command: 'init',
-      nxVersion,
-      useCloud: false,
-      meta: { type: 'start', ...baseMeta },
-    });
+  // Use environment variable to force local execution
+  if (process.env.NX_USE_LOCAL === 'true' || inner) {
+    return await initHandlerImpl(options);
   }
 
+  let cleanup: () => void | undefined;
   try {
-    if (process.env.NX_USE_LOCAL === 'true' || inner) {
-      return await initHandlerImpl(options);
-    }
+    await ensurePackageHasProvenance('nx', 'latest');
+    const packageInstallResults = installPackageToTmp('nx', 'latest');
+    cleanup = packageInstallResults.cleanup;
 
-    let cleanup: () => void | undefined;
-    try {
-      await ensurePackageHasProvenance('nx', 'latest');
-      const packageInstallResults = installPackageToTmp('nx', 'latest');
-      cleanup = packageInstallResults.cleanup;
+    let modulePath = require.resolve('nx/src/command-line/init/init-v2.js', {
+      paths: [packageInstallResults.tempDir],
+    });
 
-      let modulePath = require.resolve('nx/src/command-line/init/init-v2.js', {
-        paths: [packageInstallResults.tempDir],
-      });
-
-      const module = await handleImport(modulePath);
-      const result = await module.initHandler(options, true);
-      cleanup();
-      return result;
-    } catch {
-      if (cleanup) cleanup();
-      // Fall back to local implementation
-      return await initHandlerImpl(options);
-    }
+    const module = await handleImport(modulePath);
+    const result = await module.initHandler(options, true);
+    cleanup();
+    return result;
   } catch (error) {
-    if (selfRecord) {
-      await recordInitError(error, aiAgent, baseMeta);
-      // recordInitError terminates the process on the CLI path; the throw
-      // below is unreachable in practice but kept for type-level safety.
+    if (cleanup) {
+      cleanup();
     }
-    throw error;
+    // Fall back to local implementation
+    return initHandlerImpl(options);
   }
 }
 
 async function recordInitError(
   error: unknown,
-  aiAgent: boolean,
   baseMeta: Record<string, string | boolean>
 ): Promise<void> {
   const errorMessage = toErrorString(error);
   const errorCode = determineErrorCode(error);
-  // Append stderr tail (attached when child-process errors ran with
-  // `stdio: 'pipe'`) so telemetry carries the real cause.
   const stderr = readErrorStderr(error).trim();
   const telemetryMessage = (
     stderr ? `${errorMessage} | stderr: ${stderr.slice(-250)}` : errorMessage
   ).slice(0, 500);
-  // Structured code for bucketing. Prefer Node's `e.code`; fall back to
-  // E-code/ERR_* tokens extracted from stderr; then `error.name`.
   const errorName = extractErrorName(error, stderr);
 
   await recordStat({
@@ -152,7 +120,7 @@ async function recordInitError(
     },
   });
 
-  if (aiAgent) {
+  if (baseMeta.aiAgent) {
     const errorLogPath = writeErrorLog(error);
     writeAiOutput(buildErrorResult(errorMessage, errorCode, errorLogPath));
   } else {
@@ -165,6 +133,31 @@ async function recordInitError(
 
 async function initHandlerImpl(options: InitArgs): Promise<void> {
   process.env.NX_RUNNING_NX_INIT = 'true';
+  const baseMeta = {
+    nodeVersion: process.versions.node,
+    os: process.platform,
+    packageManager: detectPackageManager(),
+    aiAgent: isAiAgent(),
+    isCI: isCI(),
+  };
+  recordStat({
+    command: 'init',
+    nxVersion,
+    useCloud: false,
+    meta: { type: 'start', ...baseMeta },
+  });
+
+  try {
+    return await runInit(options, baseMeta);
+  } catch (error) {
+    await recordInitError(error, baseMeta);
+  }
+}
+
+async function runInit(
+  options: InitArgs,
+  baseMeta: Record<string, string | boolean>
+): Promise<void> {
   const version =
     process.env.NX_VERSION ?? (prerelease(nxVersion) ? nxVersion : 'latest');
   if (process.env.NX_VERSION) {

--- a/packages/nx/src/command-line/nx-cloud/connect/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/connect/command-object.ts
@@ -1,7 +1,6 @@
 import { Argv, CommandModule } from 'yargs';
 import { handleImport } from '../../../utils/handle-import';
 import { linkToNxDevAndExamples } from '../../yargs-utils/documentation';
-import { nxVersion } from '../../../utils/versions';
 import { withVerbose } from '../../yargs-utils/shared-options';
 
 export const yargsConnectCommand: CommandModule = {
@@ -15,13 +14,6 @@ export const yargsConnectCommand: CommandModule = {
     await (
       await handleImport('./connect-to-nx-cloud.js', __dirname)
     ).connectToNxCloudCommand({ ...args, checkRemote });
-    await (
-      await handleImport('../../../utils/ab-testing.js', __dirname)
-    ).recordStat({
-      command: 'connect',
-      nxVersion,
-      useCloud: true,
-    });
     process.exit(0);
   },
 };

--- a/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
@@ -83,9 +83,7 @@ export async function connectToNxCloudCommand(
   options: { generateToken?: boolean; checkRemote?: boolean },
   command?: string
 ): Promise<boolean> {
-  // Prompt-based callers (init, generate-driven flows) record their own
-  // telemetry via `connectExistingRepoToNxCloudPrompt` / `connectToNxCloudWithPrompt`.
-  // Only self-record when invoked directly from the `nx connect` CLI.
+  // `connectToNxCloudWithPrompt` (called from `migrate`) records its own stat; skip here to avoid double-counting.
   const selfRecord = !command;
   const baseMeta = {
     nodeVersion: process.versions.node,

--- a/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
@@ -83,6 +83,68 @@ export async function connectToNxCloudCommand(
   options: { generateToken?: boolean; checkRemote?: boolean },
   command?: string
 ): Promise<boolean> {
+  // Prompt-based callers (init, generate-driven flows) record their own
+  // telemetry via `connectExistingRepoToNxCloudPrompt` / `connectToNxCloudWithPrompt`.
+  // Only self-record when invoked directly from the `nx connect` CLI.
+  const selfRecord = !command;
+  const baseMeta = {
+    nodeVersion: process.versions.node,
+    os: process.platform,
+    packageManager: detectPackageManager(),
+    aiAgent: isAiAgent(),
+    isCI: isCI(),
+  };
+  if (selfRecord) {
+    await recordStat({
+      command: 'connect',
+      nxVersion,
+      useCloud: true,
+      meta: { type: 'start', ...baseMeta },
+    });
+  }
+  try {
+    const result = await runConnectToNxCloud(options, command);
+    if (selfRecord) {
+      await recordStat({
+        command: 'connect',
+        nxVersion,
+        useCloud: result,
+        meta: { type: 'complete', ...baseMeta },
+      });
+    }
+    return result;
+  } catch (error) {
+    if (selfRecord) {
+      const message =
+        (error instanceof Error && error.message) ||
+        String(error ?? 'Unknown error');
+      const errorName =
+        typeof (error as any)?.code === 'string'
+          ? ((error as any).code as string)
+          : error instanceof Error
+            ? error.name
+            : typeof error;
+      await recordStat({
+        command: 'connect',
+        nxVersion,
+        useCloud: false,
+        meta: {
+          type: 'error',
+          errorCode: 'UNKNOWN',
+          errorName,
+          errorMessage: message.slice(0, 500),
+          ...baseMeta,
+        },
+      });
+    }
+    throw error;
+  }
+}
+
+async function runConnectToNxCloud(
+  options: { generateToken?: boolean; checkRemote?: boolean },
+  command?: string
+): Promise<boolean> {
   const nxJson = readNxJson();
 
   const installationSource = process.env.NX_CONSOLE


### PR DESCRIPTION
## Current Behavior

`nx init` error telemetry is largely opaque: ~22% of starts land in a bare `Command failed: npm install` bucket, and ~5% record an empty `errorMessage`. We can't tell what's actually going wrong. `nx connect` has no start/error events at all — failures (missing remote, auth, network) go untracked.

## Expected Behavior

Telemetry-only change. Child-process calls in init pipe stderr so the captured output reaches the error payload; error events now include `errorName` (from Node `e.code` or an extracted `E…`/`ERR_…` token like `E404`, `ERESOLVE`, `EINTEGRITY`, `ERR_PNPM_*`) and the same env context (`nodeVersion`, `os`, `packageManager`, `isCI`, `aiAgent`) as start events. `toErrorString` fixes the empty-message bucket. `nx connect` gains proper start/complete/error events.

No behavioral fixes — once the enriched data comes in we'll prioritize real fixes by actual failure distribution.

## Related Issue(s)

Fixes NXC-4262