### PR TITLE
chore(core): lock in Nx Cloud prompt A/B winner for init and CNW

### DIFF
--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.spec.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.spec.ts
@@ -104,7 +104,7 @@ describe('ab-testing', () => {
     });
   });
 
-  describe('setupNxCloudV2 prompt variants', () => {
+  describe('setupNxCloudV2 prompt', () => {
     const originalEnv = process.env;
 
     beforeEach(() => {
@@ -116,28 +116,28 @@ describe('ab-testing', () => {
       process.env = originalEnv;
     });
 
-    it.each([
-      { flowVariant: '0', expectedCode: 'connect-to-cloud' },
-      { flowVariant: '1', expectedCode: 'cloud-ab-never-rebuild' },
-      { flowVariant: '2', expectedCode: 'cloud-ab-ci-providers-speed' },
-    ])(
-      'should select $expectedCode for flow variant $flowVariant',
-      ({ flowVariant, expectedCode }) => {
+    it.each(['0', '1', '2'])(
+      'should return the same prompt for flow variant %s',
+      (flowVariant) => {
         jest.resetModules();
         process.env.NX_CNW_FLOW_VARIANT = flowVariant;
         const { PromptMessages: FreshPromptMessages } = require('./ab-testing');
         const pm = new FreshPromptMessages();
-        expect(pm.getPrompt('setupNxCloudV2').code).toBe(expectedCode);
+        expect(pm.getPrompt('setupNxCloudV2').code).toBe(
+          'cloud-ci-providers-speed'
+        );
       }
     );
 
-    it('should select variant 0 for docs generation', () => {
+    it('should return the same prompt for docs generation', () => {
       process.env.NX_GENERATE_DOCS_PROCESS = 'true';
       const { PromptMessages: FreshPromptMessages } = jest.requireActual(
         './ab-testing'
       ) as typeof import('./ab-testing');
       const pm = new FreshPromptMessages();
-      expect(pm.getPrompt('setupNxCloudV2').code).toBe('connect-to-cloud');
+      expect(pm.getPrompt('setupNxCloudV2').code).toBe(
+        'cloud-ci-providers-speed'
+      );
     });
   });
 });

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -205,39 +205,11 @@ const messageOptions: Record<string, MessageData[]> = {
     },
   ],
   /**
-   * Simplified Cloud prompt for template flow
+   * Simplified Cloud prompt for template flow.
    */
   setupNxCloudV2: [
     {
-      code: 'connect-to-cloud',
-      message: 'Enable remote caching to speed up builds with Nx Cloud?',
-      initial: 0,
-      choices: [
-        { value: 'yes', name: 'Yes' },
-        { value: 'skip', name: 'Skip for now' },
-        { value: 'never', name: chalk.dim("No, don't ask again") },
-      ],
-      footer:
-        '\nFree for small teams. 2-minute setup with GitHub — cache locally and in CI: https://nx.dev/nx-cloud',
-      fallback: undefined,
-      completionMessage: 'platform-setup',
-    },
-    {
-      code: 'cloud-ab-never-rebuild',
-      message: 'Never rebuild the same code twice \u2014 enable Nx Cloud?',
-      initial: 0,
-      choices: [
-        { value: 'yes', name: 'Yes' },
-        { value: 'skip', name: 'Skip for now' },
-        { value: 'never', name: chalk.dim("No, don't ask again") },
-      ],
-      footer:
-        '\nFree for small teams. Remote caching for local dev and CI. 2-minute setup: https://nx.dev/nx-cloud',
-      fallback: undefined,
-      completionMessage: 'platform-setup',
-    },
-    {
-      code: 'cloud-ab-ci-providers-speed',
+      code: 'cloud-ci-providers-speed',
       message: 'Speed up GitHub Actions, GitLab CI, and more with Nx Cloud?',
       initial: 0,
       choices: [
@@ -246,7 +218,7 @@ const messageOptions: Record<string, MessageData[]> = {
         { value: 'never', name: chalk.dim("No, don't ask again") },
       ],
       footer:
-        '\nFree remote caching and task distribution. 2-minute setup: https://nx.dev/nx-cloud',
+        '\nFree for small teams. Remote caching and task distribution. 2-minute setup: https://nx.dev/nx-cloud',
       fallback: undefined,
       completionMessage: 'platform-setup',
     },

--- a/packages/nx/src/utils/ab-testing.ts
+++ b/packages/nx/src/utils/ab-testing.ts
@@ -43,8 +43,8 @@ interface MessageData {
 const messageOptions: Record<string, MessageData[]> = {
   setupNxCloud: [
     {
-      code: 'cloud-ab-remote-cache-speed',
-      message: 'Enable remote caching to speed up builds with Nx Cloud?',
+      code: 'cloud-ci-providers-speed',
+      message: 'Speed up GitHub Actions, GitLab CI, and more with Nx Cloud?',
       initial: 0,
       choices: [
         { value: 'yes', name: 'Yes' },
@@ -52,7 +52,7 @@ const messageOptions: Record<string, MessageData[]> = {
         { value: 'never', name: pc.dim("No, don't ask again") },
       ],
       footer:
-        '\nFree for small teams. 2-minute setup with GitHub — cache locally and in CI: https://nx.dev/nx-cloud',
+        '\nFree for small teams. Remote caching and task distribution. 2-minute setup: https://nx.dev/nx-cloud',
     },
   ],
   setupViewLogs: [


### PR DESCRIPTION
## Current Behavior

`create-nx-workspace` randomly serves one of three Nx Cloud prompt copy variants during the template flow; `nx init` pins a baseline copy that predates the test.

A/B results (NXC-4336):

- Variant 0 (baseline): `Enable remote caching to speed up builds with Nx Cloud?` — 15.4% yes / 29.2% never
- Variant 1: `Never rebuild the same code twice — enable Nx Cloud?` — 13.4% yes / 28.4% never
- **Variant 2: `Speed up GitHub Actions, GitLab CI, and more with Nx Cloud?` — 17.8% yes / 22.4% never**

## Expected Behavior

Both `create-nx-workspace` (`setupNxCloudV2`) and `nx init` (`setupNxCloud`) serve the winning variant. Footer is reworded to lead with the free-tier messaging:

> Free for small teams. Remote caching and task distribution. 2-minute setup: https://nx.dev/nx-cloud

The CNW `setupNxCloudV2` array collapses from 3 variants to 1; `PromptMessages.getPrompt` already falls back to index 0 when `flowVariant >= length`, so existing flow-variant plumbing keeps working. Spec updated to assert the locked-in code for all flow variants (0/1/2) and docs generation.

## Related Issue(s)

Fixes NXC-4336