### PR TITLE
chore(repo): use mise exec when running commands in cloned repos

### DIFF
--- a/tools/update-repos/src/update-repo.ts
+++ b/tools/update-repos/src/update-repo.ts
@@ -53,10 +53,13 @@ async function execWithOutput(
   if (description) {
     log(`🔄 ${description}`);
   }
-  log(`📝 Running: ${command}`);
+  const finalCommand = command.startsWith('mise ')
+    ? command
+    : `mise exec -- ${command}`;
+  log(`📝 Running: ${finalCommand}`);
 
   return new Promise((resolve, reject) => {
-    const child = spawn('bash', ['-c', command], {
+    const child = spawn('bash', ['-c', finalCommand], {
       cwd,
       stdio: ['inherit', 'pipe', 'pipe'],
     });


### PR DESCRIPTION
## Current Behavior

`update-repos` spawns child processes to run `pnpm install`, `nx migrate`, etc. inside each cloned target repo. The child inherits the launching shell's `PATH`, which mise activation populated with hardcoded version-specific install paths (e.g. `/.../installs/node/24.11.0/bin`). Mise activation is a shell hook on `cd` — it does not re-fire when a child process changes its own `cwd`. As a result, every cloned repo's commands run against the outer shell's pinned tool versions rather than the versions in the cloned repo's own `mise.toml`.

## Expected Behavior

Each cloned repo's commands honor the tool versions pinned in that repo's `mise.toml`.

`execWithOutput` now prefixes every spawned command with `mise exec --` (except commands that already start with `mise`, so `mise trust` / `mise install` aren't wrapped in themselves). `mise exec` re-reads `mise.toml` from the `cwd` at invocation time and activates the correct tool versions for that repo.

## Related Issue(s)

Fixes #