### PR TITLE
chore(misc): declare lazy-loaded @nx/* packages as optional peers for storybook, web, vitest, and vue

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -47,7 +47,13 @@
     "storybook": "9.0.6"
   },
   "peerDependencies": {
+    "@nx/web": "workspace:*",
     "storybook": ">=7.0.0 <11.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@nx/web": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/storybook/tsconfig.lib.json
+++ b/packages/storybook/tsconfig.lib.json
@@ -30,6 +30,9 @@
     },
     {
       "path": "../devkit/tsconfig.lib.json"
+    },
+    {
+      "path": "../web/tsconfig.lib.json"
     }
   ]
 }

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -59,10 +59,14 @@
     "@phenomnomnominal/tsquery": "catalog:typescript"
   },
   "peerDependencies": {
+    "@nx/eslint": "workspace:*",
     "vitest": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0",
     "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {
+    "@nx/eslint": {
+      "optional": true
+    },
     "vitest": {
       "optional": true
     },

--- a/packages/vitest/tsconfig.lib.json
+++ b/packages/vitest/tsconfig.lib.json
@@ -15,6 +15,9 @@
     },
     {
       "path": "../nx/tsconfig.lib.json"
+    },
+    {
+      "path": "../eslint/tsconfig.lib.json"
     }
   ]
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -46,5 +46,24 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {}
+  "peerDependencies": {
+    "@nx/cypress": "workspace:*",
+    "@nx/playwright": "workspace:*",
+    "@nx/rsbuild": "workspace:*",
+    "@nx/storybook": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@nx/cypress": {
+      "optional": true
+    },
+    "@nx/playwright": {
+      "optional": true
+    },
+    "@nx/rsbuild": {
+      "optional": true
+    },
+    "@nx/storybook": {
+      "optional": true
+    }
+  }
 }

--- a/packages/vue/tsconfig.lib.json
+++ b/packages/vue/tsconfig.lib.json
@@ -28,6 +28,18 @@
     },
     {
       "path": "../nx/tsconfig.lib.json"
+    },
+    {
+      "path": "../storybook/tsconfig.lib.json"
+    },
+    {
+      "path": "../rsbuild/tsconfig.lib.json"
+    },
+    {
+      "path": "../playwright/tsconfig.lib.json"
+    },
+    {
+      "path": "../cypress/tsconfig.lib.json"
     }
   ]
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,6 +43,34 @@
     "nx": "workspace:*",
     "@nx/vitest": "workspace:*"
   },
+  "peerDependencies": {
+    "@nx/cypress": "workspace:*",
+    "@nx/eslint": "workspace:*",
+    "@nx/jest": "workspace:*",
+    "@nx/playwright": "workspace:*",
+    "@nx/vite": "workspace:*",
+    "@nx/webpack": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@nx/cypress": {
+      "optional": true
+    },
+    "@nx/eslint": {
+      "optional": true
+    },
+    "@nx/jest": {
+      "optional": true
+    },
+    "@nx/playwright": {
+      "optional": true
+    },
+    "@nx/vite": {
+      "optional": true
+    },
+    "@nx/webpack": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/web/tsconfig.lib.json
+++ b/packages/web/tsconfig.lib.json
@@ -16,16 +16,34 @@
   "include": ["**/*.ts"],
   "references": [
     {
-      "path": "../vitest/tsconfig.lib.json"
-    },
-    {
       "path": "../js/tsconfig.lib.json"
     },
     {
       "path": "../devkit/tsconfig.lib.json"
     },
     {
+      "path": "../vitest/tsconfig.lib.json"
+    },
+    {
       "path": "../nx/tsconfig.lib.json"
+    },
+    {
+      "path": "../webpack/tsconfig.lib.json"
+    },
+    {
+      "path": "../vite/tsconfig.lib.json"
+    },
+    {
+      "path": "../playwright/tsconfig.lib.json"
+    },
+    {
+      "path": "../jest/tsconfig.lib.json"
+    },
+    {
+      "path": "../eslint/tsconfig.lib.json"
+    },
+    {
+      "path": "../cypress/tsconfig.lib.json"
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3835,6 +3835,9 @@ importers:
       '@nx/js':
         specifier: workspace:*
         version: link:../js
+      '@nx/web':
+        specifier: workspace:*
+        version: link:../web
       '@phenomnomnominal/tsquery':
         specifier: catalog:typescript
         version: 6.1.4(typescript@5.9.2)
@@ -3900,6 +3903,9 @@ importers:
       '@nx/devkit':
         specifier: workspace:*
         version: link:../devkit
+      '@nx/eslint':
+        specifier: workspace:*
+        version: link:../eslint
       '@nx/js':
         specifier: workspace:*
         version: link:../js
@@ -3925,6 +3931,9 @@ importers:
 
   packages/vue:
     dependencies:
+      '@nx/cypress':
+        specifier: workspace:*
+        version: link:../cypress
       '@nx/devkit':
         specifier: workspace:*
         version: link:../devkit
@@ -3934,6 +3943,15 @@ importers:
       '@nx/js':
         specifier: workspace:*
         version: link:../js
+      '@nx/playwright':
+        specifier: workspace:*
+        version: link:../playwright
+      '@nx/rsbuild':
+        specifier: workspace:*
+        version: link:../rsbuild
+      '@nx/storybook':
+        specifier: workspace:*
+        version: link:../storybook
       '@nx/vite':
         specifier: workspace:*
         version: link:../vite
@@ -3959,12 +3977,30 @@ importers:
 
   packages/web:
     dependencies:
+      '@nx/cypress':
+        specifier: workspace:*
+        version: link:../cypress
       '@nx/devkit':
         specifier: workspace:*
         version: link:../devkit
+      '@nx/eslint':
+        specifier: workspace:*
+        version: link:../eslint
+      '@nx/jest':
+        specifier: workspace:*
+        version: link:../jest
       '@nx/js':
         specifier: workspace:*
         version: link:../js
+      '@nx/playwright':
+        specifier: workspace:*
+        version: link:../playwright
+      '@nx/vite':
+        specifier: workspace:*
+        version: link:../vite
+      '@nx/webpack':
+        specifier: workspace:*
+        version: link:../webpack
       detect-port:
         specifier: ^1.5.1
         version: 1.6.1


### PR DESCRIPTION
## Current Behavior

Several `ensurePackage('@nx/X', nxVersion)` and `ensurePackage<typeof import('@nx/X')>(...)` references are invisible to Nx's project-graph source analysis, so the corresponding workspace edges are missing today:

- `packages/storybook/src/generators/configuration/lib/util-functions.ts` lazy-loads `@nx/web`
- `packages/web/src/generators/application/application.ts` lazy-loads `@nx/cypress`, `@nx/eslint`, `@nx/jest`, `@nx/playwright`, `@nx/vite`, `@nx/webpack`
- `packages/vitest/src/utils/ignore-vitest-temp-files.ts` lazy-loads `@nx/eslint`
- `packages/vue/src/**` lazy-loads `@nx/cypress`, `@nx/playwright`, `@nx/rsbuild`, `@nx/storybook`

This means tasks in those packages read files from their lazy-loaded dependencies at module-load time without declaring them as inputs — the motivation behind the sandbox-violation work in #35377.

## Expected Behavior

Declares each lazy-loaded package as an optional `peerDependency` with `peerDependenciesMeta.*.optional: true`. `explicit-package-json-dependencies` walks `peerDependencies` alongside `dependencies`, materializing the edges in the graph. `optional: true` keeps them off the user's install surface — package managers don't auto-install optional peers and don't warn when they're missing.

`@nx/vitest` is already declared as a `devDependency` of `@nx/web`, so the `web → vitest` edge is already present; no change needed there.

Follows the pattern established in #35377 (`@nx/eslint → @nx/jest`).

### Scope

Narrower subset of #35392, scoped to `@nx/storybook`, `@nx/web`, `@nx/vitest`, and `@nx/vue`. Those four close the most commonly hit transitive lazy-load chains (`storybook → web → jest`, `vue → storybook → web → jest`, `web → vitest → eslint`, etc.) without needing the `implicitDependencies: ["!name", ...]` cycle negations that `@nx/workspace` and `@nx/js` require in #35392.

Note: `@nx/vitest` is not covered by #35392 at all, so this PR adds at least one edge that isn't in the broader PR.

### Verification

- Regenerated project graph locally — all new edges appear as `static` type:
  - `storybook → web`
  - `web → {cypress, eslint, jest, playwright, vite, webpack}`
  - `vitest → eslint`
  - `vue → {cypress, playwright, rsbuild, storybook}`
- Full cycle scan: **0 cycles introduced**.
- `nx prepush` passes cleanly.

## Related Issue(s)

<!-- No open issue; follow-up to #35377 and narrower alternative to #35392 -->