### PR TITLE
fix(core): allow --target/-t and -p flags for nx run with colon targets

### DIFF
--- a/packages/nx/src/command-line/run/command-object.spec.ts
+++ b/packages/nx/src/command-line/run/command-object.spec.ts
@@ -10,6 +10,24 @@ describe('run-one command setup', () => {
     compareArgs(infixOptions, runOptions);
   });
 
+  describe('flag-based invocation', () => {
+    it.each([
+      ['short form: -p / -t', ['run', '-p', 'myapp', '-t', 'test:unit']],
+      [
+        'long form: --project / --target',
+        ['run', '--project', 'myapp', '--target', 'test:unit'],
+      ],
+      [
+        'equals form: --project= / --target=',
+        ['run', '--project=myapp', '--target=test:unit'],
+      ],
+    ])('parses %s when target contains a colon', (_label, argv) => {
+      const parsed = getParsedRunArgs(argv);
+      expect(parsed.project).toEqual('myapp');
+      expect(parsed.target).toEqual('test:unit');
+    });
+  });
+
   it.each(['--array=1,2,3', '--array=1 2 3', '--array=1 --array=2 --array=3'])(
     'should read arrays (%s)',
     (args) => {
@@ -71,8 +89,12 @@ describe('run-one command setup', () => {
 function compareArgs(a: any, b: any) {
   delete a['_'];
   delete b['_'];
-  // delete a['__overrides_unparsed__'];
-  // delete b['__overrides_unparsed__'];
+  // `project`/`target` have `p`/`t` yargs aliases; strip the alias keys
+  // before comparing so the two invocation forms match structurally.
+  delete a['p'];
+  delete b['p'];
+  delete a['t'];
+  delete b['t'];
   if (a['target'] && a['project']) {
     a['project:target:configuration'] = `${a['project']}:${a['target']}`;
     delete a['project'];

--- a/packages/nx/src/command-line/run/run-one.spec.ts
+++ b/packages/nx/src/command-line/run/run-one.spec.ts
@@ -195,6 +195,28 @@ describe('parseRunOneOptions', () => {
     });
   });
 
+  describe('when project:target:configuration is not a string', () => {
+    // yargs may coerce the positional to `true` when the user passes only
+    // flag-based options like `nx run -p my-project -t test:unit`.
+    it('should not crash when the positional is a boolean', () => {
+      const parsedArgs = {
+        'project:target:configuration': true,
+        project: 'my-app',
+        target: 'test:unit',
+      };
+
+      const result = parseRunOneOptions(
+        testCwd,
+        parsedArgs,
+        projectGraph,
+        nxJson
+      );
+
+      expect(result.project).toBe('my-app');
+      expect(result.target).toBe('test:unit');
+    });
+  });
+
   describe('error handling', () => {
     it('should throw error when target is missing', () => {
       const parsedArgs = {

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -175,7 +175,10 @@ export function parseRunOneOptions(
   let target;
   let configuration;
 
-  if (parsedArgs[PROJECT_TARGET_CONFIG]?.lastIndexOf(':') > 0) {
+  if (
+    typeof parsedArgs[PROJECT_TARGET_CONFIG] === 'string' &&
+    parsedArgs[PROJECT_TARGET_CONFIG].lastIndexOf(':') > 0
+  ) {
     // run case
     [project, target, configuration] = splitTarget(
       parsedArgs[PROJECT_TARGET_CONFIG],
@@ -189,7 +192,7 @@ export function parseRunOneOptions(
     }
   } else if (parsedArgs.target) {
     target = parsedArgs.target;
-  } else if (parsedArgs[PROJECT_TARGET_CONFIG]) {
+  } else if (typeof parsedArgs[PROJECT_TARGET_CONFIG] === 'string') {
     // If project:target:configuration exists but has no colon, check if it's a project with run target
     if (
       projectGraph.nodes[parsedArgs[PROJECT_TARGET_CONFIG]]?.data?.targets?.run

--- a/packages/nx/src/command-line/yargs-utils/shared-options.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.ts
@@ -387,6 +387,14 @@ export function withRunOneOptions(yargs: Argv) {
     .option('project', {
       describe: 'Target project.',
       type: 'string',
+      alias: 'p',
+    })
+    .option('target', {
+      describe:
+        'Target to run. Useful when the target name contains a colon, which conflicts with the positional `project:target:configuration` form.',
+      type: 'string',
+      alias: 't',
+      requiresArg: true,
     })
     .option('help', {
       describe: 'Show Help.',


### PR DESCRIPTION
## Current Behavior

`nx run -p my-project -t test:unit` crashes with a `TypeError` instead of running the target:

```
NX   parsedArgs[PROJECT_TARGET_CONFIG]?.lastIndexOf is not a function

TypeError: parsedArgs[PROJECT_TARGET_CONFIG]?.lastIndexOf is not a function
    at parseRunOneOptions (.../nx/src/command-line/run/run-one.js:105:44)
```

Two bugs are combining here:

1. `--target` / `-t` is never registered as a yargs option on the `run` command (`withRunOneOptions` only declares `--project` and `--help`), so the flag silently falls through into the overrides array and the target value is lost.
2. With no positional value provided but flags present, yargs assigns boolean `true` to the `project:target:configuration` positional that the `run [project][:target][:configuration] [_..]` signature declares. `parseRunOneOptions` then calls `.lastIndexOf(':')` on `true` and crashes.

Workaround today is to escape the colon: `nx run my-project:test\:unit`. That works but is non-obvious, and the flag-based form is what most users reach for first.

## Expected Behavior

`nx run -p my-project -t test:unit` runs the `test:unit` target on `my-project`. Escaped and long-form invocations continue to work.

Changes:

- Register `--target` / `-t` as a real yargs option in `withRunOneOptions`, and add `-p` as an alias for `--project`.
- Guard the positional check in `parseRunOneOptions` with `typeof parsedArgs[PROJECT_TARGET_CONFIG] === 'string'` so a non-string value can never crash `.lastIndexOf`.
- Add unit tests for the flag-based invocation (short, long, and `=` forms) and for the boolean-positional guard. Update `compareArgs` in `command-object.spec.ts` to strip the new `p`/`t` alias keys when comparing infix vs. `run` invocations.

Verified end-to-end against a reproduction workspace: `nx run -p my-project -t test:unit` now runs successfully.

## Related Issue(s)

Fixes #35098