### PR TITLE
chore(repo): stop update-package-json spec from writing to disk

### DIFF
--- a/packages/rollup/src/plugins/package-json/update-package-json.spec.ts
+++ b/packages/rollup/src/plugins/package-json/update-package-json.spec.ts
@@ -3,6 +3,21 @@ import * as utils from 'nx/src/utils/fileutils';
 import { PackageJson } from 'nx/src/utils/package-json';
 
 describe('updatePackageJson', () => {
+  let writeFileSyncSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // Use require to get the real fs module object (esModuleInterop's __importStar
+    // would create a copy, and spies on the copy wouldn't affect the callsite).
+    const fs = require('fs');
+    writeFileSyncSpy = jest
+      .spyOn(fs, 'writeFileSync')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    writeFileSyncSpy.mockRestore();
+  });
+
   const commonOptions = {
     outputPath: 'dist/index.js',
     tsConfig: './tsconfig.json',
@@ -16,7 +31,9 @@ describe('updatePackageJson', () => {
 
   describe('generateExportsField: true', () => {
     it('should support ESM', () => {
-      const spy = jest.spyOn(utils, 'writeJsonFile');
+      const spy = jest
+        .spyOn(utils, 'writeJsonFile')
+        .mockImplementation(() => undefined);
 
       updatePackageJson(
         {
@@ -45,7 +62,9 @@ describe('updatePackageJson', () => {
     });
 
     it('should support CJS', () => {
-      const spy = jest.spyOn(utils, 'writeJsonFile');
+      const spy = jest
+        .spyOn(utils, 'writeJsonFile')
+        .mockImplementation(() => undefined);
 
       updatePackageJson(
         {
@@ -70,7 +89,9 @@ describe('updatePackageJson', () => {
     });
 
     it('should support ESM + CJS', () => {
-      const spy = jest.spyOn(utils, 'writeJsonFile');
+      const spy = jest
+        .spyOn(utils, 'writeJsonFile')
+        .mockImplementation(() => undefined);
 
       updatePackageJson(
         {
@@ -100,7 +121,9 @@ describe('updatePackageJson', () => {
     });
 
     it('should support custom exports field', () => {
-      const spy = jest.spyOn(utils, 'writeJsonFile');
+      const spy = jest
+        .spyOn(utils, 'writeJsonFile')
+        .mockImplementation(() => undefined);
 
       updatePackageJson(
         {
@@ -142,7 +165,9 @@ describe('updatePackageJson', () => {
 
   describe('generateExportsField: false', () => {
     it('should support ESM', () => {
-      const spy = jest.spyOn(utils, 'writeJsonFile');
+      const spy = jest
+        .spyOn(utils, 'writeJsonFile')
+        .mockImplementation(() => undefined);
 
       updatePackageJson(
         {
@@ -163,7 +188,9 @@ describe('updatePackageJson', () => {
     });
 
     it('should support CJS', () => {
-      const spy = jest.spyOn(utils, 'writeJsonFile');
+      const spy = jest
+        .spyOn(utils, 'writeJsonFile')
+        .mockImplementation(() => undefined);
 
       updatePackageJson(
         {
@@ -183,7 +210,9 @@ describe('updatePackageJson', () => {
     });
 
     it('should support ESM + CJS', () => {
-      const spy = jest.spyOn(utils, 'writeJsonFile');
+      const spy = jest
+        .spyOn(utils, 'writeJsonFile')
+        .mockImplementation(() => undefined);
 
       updatePackageJson(
         {
@@ -203,7 +232,9 @@ describe('updatePackageJson', () => {
     });
 
     it('should support custom exports field', () => {
-      const spy = jest.spyOn(utils, 'writeJsonFile');
+      const spy = jest
+        .spyOn(utils, 'writeJsonFile')
+        .mockImplementation(() => undefined);
 
       updatePackageJson(
         {
@@ -233,7 +264,9 @@ describe('updatePackageJson', () => {
 
   describe('skipTypeField', () => {
     it('should not include type field if skipTypeField is true', () => {
-      const spy = jest.spyOn(utils, 'writeJsonFile');
+      const spy = jest
+        .spyOn(utils, 'writeJsonFile')
+        .mockImplementation(() => undefined);
 
       updatePackageJson(
         {
@@ -261,7 +294,9 @@ describe('updatePackageJson', () => {
     });
 
     it('should include type field if skipTypeField is undefined', () => {
-      const spy = jest.spyOn(utils, 'writeJsonFile');
+      const spy = jest
+        .spyOn(utils, 'writeJsonFile')
+        .mockImplementation(() => undefined);
 
       updatePackageJson(
         {
@@ -289,7 +324,9 @@ describe('updatePackageJson', () => {
     });
 
     it('should include type field if skipTypeField is false', () => {
-      const spy = jest.spyOn(utils, 'writeJsonFile');
+      const spy = jest
+        .spyOn(utils, 'writeJsonFile')
+        .mockImplementation(() => undefined);
 
       updatePackageJson(
         {


### PR DESCRIPTION
## Current Behavior

Running `nx run rollup:test` produces three unexpected writes to the workspace root that are not declared as outputs:

- `dist/index.js/index.cjs.default.js`
- `dist/index.js/index.cjs.mjs`
- `dist/index.js/package.json`

These show up as sandbox violations because the spec file at `packages/rollup/src/plugins/package-json/update-package-json.spec.ts` is, in reality, writing to the filesystem during test runs:

1. `jest.spyOn(utils, 'writeJsonFile')` is used without `.mockImplementation(...)`. `spyOn` wraps the function to record calls but does not replace its behavior, so the real `writeJsonFile` runs and writes `package.json`.
2. `update-package-json.ts` also calls `fs.writeFileSync` directly (for the `.cjs.mjs` / `.cjs.default.js` CJS-interop shims), which the spec never mocked at all.

Every run pollutes the workspace root with a `dist/index.js/` directory.

## Expected Behavior

Tests verify call arguments via the spies without touching the real filesystem. No `dist/index.js/` directory is created, and the three sandbox violations for `rollup:test` go away.

- All 11 `writeJsonFile` spies now use `.mockImplementation(() => undefined)`.
- A `beforeEach` / `afterEach` adds a `jest.spyOn(fs, 'writeFileSync').mockImplementation(() => undefined)` using `require('fs')` so the spy lands on the real fs module (using `import * as fs from 'fs'` would go through `esModuleInterop`'s `__importStar` copy and miss the call site in `update-package-json.ts`).
- Assertions continue to work — `toHaveBeenCalledWith(...)` tracks calls on spies with or without a mock implementation.

Verified: `nx test rollup --testPathPatterns=update-package-json.spec` → 11/11 passing, and no `dist/index.js/` is created during the run.

## Related Issue(s)

N/A — caught via the sandbox-violation report for `rollup:test`.