### PR TITLE
chore(core): remove debug tmp writes from new generator spec

### DIFF
--- a/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.spec.ts
@@ -7,9 +7,7 @@ import {
 } from '@nx/devkit';
 import { createTree } from '@nx/devkit/testing';
 import Ajv from 'ajv';
-import { mkdirSync, writeFileSync } from 'fs';
 import * as nxSchema from 'nx/schemas/nx-schema.json';
-import { join } from 'path';
 import { Preset } from '../utils/presets';
 import { generateWorkspaceFiles } from './generate-workspace-files';
 
@@ -95,12 +93,6 @@ describe('@nx/workspace:generateWorkspaceFiles', () => {
               workspaces: true,
             });
             await formatFiles(tree);
-            const dir = join(__dirname, 'tmp', `${preset}-${nxCloud}`);
-            mkdirSync(dir, { recursive: true });
-            writeFileSync(
-              join(dir, 'README.md'),
-              tree.read('proj/README.md', 'utf-8')
-            );
             expect(tree.read('proj/README.md', 'utf-8')).toMatchSnapshot();
           }
         );


### PR DESCRIPTION
The generate-workspace-files spec wrote each rendered README to `__dirname/tmp/<preset>-<nxCloud>/README.md` via raw fs, landing inside the source tree and triggering Nx sandbox violations during `nx test workspace`. The toMatchSnapshot assertion that followed was always the real check; the filesystem writes were leftover debug scaffolding from the bulk README regeneration in #27038.

Also drops the now-unused `fs` and `path` imports.