### PR TITLE
chore(testing): resolve @nx/dotnet to source in jest tests

### DIFF
--- a/scripts/patched-jest-resolver.js
+++ b/scripts/patched-jest-resolver.js
@@ -51,6 +51,7 @@ module.exports = function (modulePath, options) {
     '@nx/vite',
     '@nx/jest',
     '@nx/docker',
+    '@nx/dotnet',
     '@nx/js',
     '@nx/next',
     '@nx/storybook',


### PR DESCRIPTION
## Current Behavior

Running `nx test dotnet` resolves `@nx/dotnet/*` specifiers to compiled `dist/*.js` files instead of TypeScript source.

`scripts/patched-jest-resolver.js` maintains a `workspacePackages` allowlist of `@nx/*` packages that should route to their TS source during tests. `@nx/dotnet` is missing from that list, so the resolver falls through to `enhanced-resolve`, which honors `packages/dotnet/package.json#exports` — and those entries all point at `./dist/*.js`.

Every other `@nx/*` plugin in the repo is on the allowlist, so this is specific to `@nx/dotnet`.

## Expected Behavior

`nx test dotnet` resolves `@nx/dotnet/*` imports to TypeScript source files under `packages/dotnet/src/` like every other workspace package, so tests exercise the current source and don't require a prior build.

## Related Issue(s)

<!-- None; internal dev loop fix surfaced while running the dotnet test suite. -->