### PR TITLE
feat(js): support nx.sync.ignoredDependencies in typescript-sync

### DIFF
--- a/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
@@ -482,6 +482,40 @@ describe('syncGenerator()', () => {
       `);
     });
 
+    it('should skip dependencies listed in `nx.sync.ignoredDependencies` and prune existing references for them', async () => {
+      // b depends on both a and c, but its tsconfig opts out of c via
+      // ignoredDependencies. The reference to c should not be added (and an
+      // existing stale one should be pruned).
+      addProject('c');
+      projectGraph.dependencies['b'].push({
+        type: 'static',
+        source: 'b',
+        target: 'c',
+      });
+      writeJson(tree, 'packages/b/tsconfig.json', {
+        compilerOptions: {
+          composite: true,
+        },
+        references: [{ path: '../c' }],
+        nx: {
+          sync: {
+            ignoredDependencies: ['c'],
+          },
+        },
+      });
+
+      await syncGenerator(tree);
+
+      expect(readJson(tree, 'packages/b/tsconfig.json').references)
+        .toMatchInlineSnapshot(`
+        [
+          {
+            "path": "../a",
+          },
+        ]
+      `);
+    });
+
     it('should not prune stale project references from projects included in `nx.sync.ignoredReferences`', async () => {
       writeJson(tree, 'packages/b/tsconfig.json', {
         compilerOptions: {

--- a/packages/js/src/generators/typescript-sync/typescript-sync.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.ts
@@ -28,6 +28,7 @@ interface Tsconfig {
   nx?: {
     sync?: {
       ignoredReferences?: string[];
+      ignoredDependencies?: string[];
     };
   };
 }
@@ -392,6 +393,9 @@ function updateTsConfigReferences(
   );
   const tsConfig = parseJson<Tsconfig>(stringifiedJsonContents);
   const ignoredReferences = new Set(tsConfig.nx?.sync?.ignoredReferences ?? []);
+  const ignoredDependencies = new Set(
+    tsConfig.nx?.sync?.ignoredDependencies ?? []
+  );
 
   // We have at least one dependency so we can safely set it to an empty array if not already set
   const references = [];
@@ -448,6 +452,12 @@ function updateTsConfigReferences(
   }
 
   for (const dep of dependencies) {
+    if (ignoredDependencies.has(dep.name)) {
+      // The user has explicitly opted out of this dependency edge, typically
+      // to break a circular project reference graph that the project graph
+      // intentionally allows.
+      continue;
+    }
     // Ensure the project reference for the target is set if we can find the
     // relevant tsconfig file
     let referencePath: string;


### PR DESCRIPTION
## Current Behavior

`@nx/js:typescript-sync` always materializes every project-graph edge of a project as a TypeScript project reference in the corresponding runtime tsconfig. The existing `nx.sync.ignoredReferences` opt-out keeps user-authored reference paths from being pruned, but there is no way to tell the generator "don't add a reference for this dependency in the first place."

That becomes a problem when the project graph contains intentional cycles — for example when `@nx/workspace` declares its lazy-loaded plugin peers (`@nx/js`, `@nx/angular`, etc.) as optional peers, and those same plugins depend back on `@nx/workspace`. Materializing both edges as TS project references produces `TS6202: Project references may not form a circular graph`. The only workaround today is `implicitDependencies: ["!name", …]` in `project.json`, which removes the edge from the project graph entirely and hides it from every other consumer (dependency tooling, graph visualizations, supply-chain audits).

## Expected Behavior

Tsconfig files now accept an `nx.sync.ignoredDependencies: string[]` field (sibling of the existing `nx.sync.ignoredReferences`). When the sync generator processes that tsconfig, any project-graph dependency whose project name is in the set is skipped — no new reference is added for it, and any existing reference for that dependency is pruned as stale.

This lets a workspace keep real, cyclic project-graph edges (so the package.json peer relationships stay visible) while opting the affected tsconfig out of materializing the cycle into project references. The task graph is kept acyclic separately via explicit `dependsOn` entries.