### PR TITLE
chore(nx-dev): declare sitemap on build and deploy-build outputs

### DIFF
--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -16,10 +16,7 @@
         { "externalDependencies": ["next"] },
         { "dependentTasksOutputFiles": "**/*.d.ts", "transitive": true }
       ],
-      "outputs": [
-        "{workspaceRoot}/nx-dev/nx-dev/.next",
-        "{workspaceRoot}/nx-dev/nx-dev/public/sitemap*.xml"
-      ]
+      "outputs": ["{workspaceRoot}/nx-dev/nx-dev/.next"]
     },
     "sitemap": {
       "dependsOn": ["nx-dev:next:build"],
@@ -44,11 +41,11 @@
     },
     "build": {
       "dependsOn": ["sitemap", "copy-redirects"],
-      "outputs": ["{projectRoot}/.next"]
+      "outputs": ["{projectRoot}/.next", "{projectRoot}/public/sitemap*.xml"]
     },
     "deploy-build": {
       "dependsOn": ["build"],
-      "outputs": ["{projectRoot}/.next"]
+      "outputs": ["{projectRoot}/.next", "{projectRoot}/public/sitemap*.xml"]
     },
     "serve": {
       "command": "nx dev nx-dev"


### PR DESCRIPTION
## Current Behavior

`nx-dev:build` is a no-op aggregator over `sitemap` and `copy-redirects` but only declares `{projectRoot}/.next` as its output. Tasks that depend on `nx-dev:build` and use `dependentTasksOutputFiles` — e.g. `astro-docs:validate-links`, which reads `nx-dev/nx-dev/public/sitemap-0.xml` to cross-check links — never pick up the sitemap as a declared input. Under sandboxing this surfaces as an unexpected read, and it also means the sitemap doesn't participate in the consumer's input hash.

Separately, `nx-dev:next:build` lists `public/sitemap*.xml` as an output even though `next build` never writes sitemaps (the `sitemap` target does). At best the glob captures nothing; at worst, on a re-run it snapshots stale files from a previous build into `next:build`'s cache.

## Expected Behavior

`nx-dev:build` and `nx-dev:deploy-build` declare `{projectRoot}/public/sitemap*.xml` alongside `{projectRoot}/.next`, matching what their dependsOn chain actually produces. This mirrors the existing `nx:noop` atomizer pattern used by `@nx/playwright` and `@nx/cypress`, where the rollup target declares the superset of outputs its children produce.

`nx:next:build` no longer claims an output it doesn't write.

Verified: `nx show target inputs astro-docs:validate-links --check nx-dev/nx-dev/public/sitemap-0.xml nx-dev/nx-dev/public/sitemap.xml` now reports both as inputs.