### PR TITLE
chore(misc): ignore generated banner.json in astro-docs lint

### DIFF
--- a/astro-docs/eslint.config.mjs
+++ b/astro-docs/eslint.config.mjs
@@ -18,6 +18,7 @@ export default [
       '.netlify/',
       'test-output/',
       'playwright-report/',
+      'src/content/banner.json',
     ],
   },
 ];


### PR DESCRIPTION
## Current Behavior

The project's eslint config ignores common generated directories (`dist/`, `.astro/`, `.netlify/`, ...) but not `astro-docs/src/content/banner.json`. That file is a build artifact produced at prebuild time by `astro-docs:prebuild-banner` (fetches banner config from a remote URL and writes it to disk) and is `.gitignore`d. The root eslint config registers `jsonc-eslint-parser` for `**/*.json`, so `eslint .` walks into this generated file and parses it — wasted work, and its content is irrelevant to lint correctness.

As a side effect, the undeclared read also shows up as a sandbox violation for `astro-docs:lint` because Nx's `{projectRoot}/**/*` input expansion (correctly) excludes gitignored files.

## Expected Behavior

`astro-docs/eslint.config.mjs` excludes the generated banner file alongside the other build-artifact paths it already ignores, so eslint no longer reads it. The sandbox violation disappears as a consequence.