### PR TITLE
fix(nx-dev): remove broken header links (podcast)

### DIFF
--- a/astro-docs/src/components/layout/Header.astro
+++ b/astro-docs/src/components/layout/Header.astro
@@ -31,8 +31,18 @@ const currentVersion = versions.find((v) => v.current);
 <div class="flex items-center justify-between h-full gap-4">
   <div class="flex items-center gap-2 flex-shrink-0">
     <a href={import.meta.env.SITE} class="flex items-center no-underline">
-      <Image src={nxLogoDark} alt="Nx" class="h-12 w-auto dark:hidden" loading="eager" />
-      <Image src={nxLogoLight} alt="Nx" class="h-12 w-auto hidden dark:block" loading="eager" />
+      <Image
+        src={nxLogoDark}
+        alt="Nx"
+        class="h-12 w-auto dark:hidden"
+        loading="eager"
+      />
+      <Image
+        src={nxLogoLight}
+        alt="Nx"
+        class="h-12 w-auto hidden dark:block"
+        loading="eager"
+      />
     </a>
     <a
       id="header-docs-home-link"
@@ -124,29 +134,6 @@ const currentVersion = versions.find((v) => v.current);
             >
               Learn
             </h5>
-            <a
-              href={`${nxDevUrl}/podcast`}
-              class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60"
-            >
-              <svg
-                class="w-5 h-5 text-slate-400 dark:text-slate-500"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke-width="1.5"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M12 18.75a6 6 0 0 0 6-6v-1.5m-6 7.5a6 6 0 0 1-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 0 1-3-3V4.5a3 3 0 1 1 6 0v8.25a3 3 0 0 1-3 3Z"
-                ></path>
-              </svg>
-              <span
-                class="text-sm font-medium text-slate-900 dark:text-slate-200"
-                >Podcasts</span
-              >
-            </a>
             <a
               href={`${nxDevUrl}/webinar`}
               class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60"
@@ -260,75 +247,6 @@ const currentVersion = versions.find((v) => v.current);
               <span
                 class="text-sm font-medium text-slate-900 dark:text-slate-200"
                 >Discord</span
-              >
-            </a>
-            <a
-              href={`${nxDevUrl}/resources-library?filterBy=book`}
-              class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60"
-            >
-              <svg
-                class="w-5 h-5 text-slate-400 dark:text-slate-500"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke-width="1.5"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"
-                ></path>
-              </svg>
-              <span
-                class="text-sm font-medium text-slate-900 dark:text-slate-200"
-                >Books</span
-              >
-            </a>
-            <a
-              href={`${nxDevUrl}/resources-library?filterBy=case-study`}
-              class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60"
-            >
-              <svg
-                class="w-5 h-5 text-slate-400 dark:text-slate-500"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke-width="1.5"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
-                ></path>
-              </svg>
-              <span
-                class="text-sm font-medium text-slate-900 dark:text-slate-200"
-                >Case Studies</span
-              >
-            </a>
-            <a
-              href={`${nxDevUrl}/resources-library?filterBy=whitepaper`}
-              class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60"
-            >
-              <svg
-                class="w-5 h-5 text-slate-400 dark:text-slate-500"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke-width="1.5"
-                stroke="currentColor"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
-                ></path>
-              </svg>
-              <span
-                class="text-sm font-medium text-slate-900 dark:text-slate-200"
-                >Whitepapers</span
               >
             </a>
           </div>

--- a/astro-docs/src/components/layout/Header.astro
+++ b/astro-docs/src/components/layout/Header.astro
@@ -135,7 +135,7 @@ const currentVersion = versions.find((v) => v.current);
               Learn
             </h5>
             <a
-              href={`${nxDevUrl}/webinar`}
+              href={`${nxDevUrl}/webinars`}
               class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60"
             >
               <svg
@@ -247,6 +247,75 @@ const currentVersion = versions.find((v) => v.current);
               <span
                 class="text-sm font-medium text-slate-900 dark:text-slate-200"
                 >Discord</span
+              >
+            </a>
+            <a
+              href={`${nxDevUrl}/resources?filterBy=book`}
+              class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60"
+            >
+              <svg
+                class="w-5 h-5 text-slate-400 dark:text-slate-500"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"
+                ></path>
+              </svg>
+              <span
+                class="text-sm font-medium text-slate-900 dark:text-slate-200"
+                >Books</span
+              >
+            </a>
+            <a
+              href={`${nxDevUrl}/resources?filterBy=case-study`}
+              class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60"
+            >
+              <svg
+                class="w-5 h-5 text-slate-400 dark:text-slate-500"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+                ></path>
+              </svg>
+              <span
+                class="text-sm font-medium text-slate-900 dark:text-slate-200"
+                >Case Studies</span
+              >
+            </a>
+            <a
+              href={`${nxDevUrl}/resources?filterBy=whitepaper`}
+              class="flex items-center gap-3 px-2 py-2 rounded-md no-underline hover:bg-slate-50 transition-colors dark:hover:bg-slate-800/60"
+            >
+              <svg
+                class="w-5 h-5 text-slate-400 dark:text-slate-500"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+                ></path>
+              </svg>
+              <span
+                class="text-sm font-medium text-slate-900 dark:text-slate-200"
+                >Whitepapers</span
               >
             </a>
           </div>


### PR DESCRIPTION
## Current Behavior

The Resources dropdown in the astro-docs header contained links returning 404 on nx.dev:

- `/podcast`
- `/resources-library?*` -> `/resources?...`

Additionally, `/webinar` redirected to `/webinars` (canonical).

## Expected Behavior

- Podcasts entry removed (page no longer exists).
- Books / Case Studies / Whitepapers repointed to the new `/resources?filterBy=...` URLs.
- Webinars points directly to `/webinars` (no redirect).

All 12 Resources dropdown links verified returning 200. Books link clicked through from the local astro-docs dropdown and confirmed to load the Resources Library page.