### PR TITLE
feat(core): allow combining dependencies: true with projects in dependsOn

### DIFF
--- a/packages/nx/src/config/workspace-json-project-json.ts
+++ b/packages/nx/src/config/workspace-json-project-json.ts
@@ -176,14 +176,18 @@ export interface TargetMetadata {
 
 export interface TargetDependencyConfig {
   /**
-   * A list of projects that have `target`.
-   * Should not be specified together with `dependencies`.
+   * A list of projects (or glob patterns / negations like `"!my-app"`) that have `target`.
+   * When specified together with `dependencies: true`, these patterns are layered on top
+   * of the current project's traced dependencies — positive patterns add extra projects
+   * and negative patterns remove traced dependencies from the resulting set.
    */
   projects?: string[] | string;
 
   /**
    * If true, the target will be executed for each project that this project depends on.
-   * Should not be specified together with `projects`.
+   * May be combined with `projects` to adjust the resulting set. For example,
+   * `{ dependencies: true, projects: "!my-app", target: "build" }` runs `build` on every
+   * dependency except `my-app`.
    */
   dependencies?: boolean;
 

--- a/packages/nx/src/tasks-runner/create-task-graph.spec.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.spec.ts
@@ -2950,6 +2950,165 @@ describe('createTaskGraph', () => {
     ]);
   });
 
+  it('should filter dependencies when dependsOn combines dependencies: true with a projects filter', () => {
+    const graph: ProjectGraph = {
+      nodes: {
+        app1: {
+          name: 'app1',
+          type: 'app',
+          data: {
+            root: 'app1-root',
+            targets: {
+              build: {
+                executor: 'nx:run-commands',
+                dependsOn: [
+                  { target: 'build', dependencies: true, projects: '!lib1' },
+                ],
+              },
+            },
+          },
+        },
+        lib1: {
+          name: 'lib1',
+          type: 'lib',
+          data: {
+            root: 'lib1-root',
+            targets: {
+              build: { executor: 'nx:run-commands' },
+            },
+          },
+        },
+        lib2: {
+          name: 'lib2',
+          type: 'lib',
+          data: {
+            root: 'lib2-root',
+            targets: {
+              build: { executor: 'nx:run-commands' },
+            },
+          },
+        },
+        lib3: {
+          name: 'lib3',
+          type: 'lib',
+          data: {
+            root: 'lib3-root',
+            targets: {
+              build: { executor: 'nx:run-commands' },
+            },
+          },
+        },
+        otherApp: {
+          name: 'otherApp',
+          type: 'app',
+          data: {
+            root: 'other-root',
+            targets: {
+              build: { executor: 'nx:run-commands' },
+            },
+          },
+        },
+      },
+      dependencies: {
+        app1: [
+          { source: 'app1', target: 'lib1', type: 'static' },
+          { source: 'app1', target: 'lib2', type: 'static' },
+          { source: 'app1', target: 'lib3', type: 'static' },
+        ],
+        lib1: [],
+        lib2: [],
+        lib3: [],
+        otherApp: [],
+      },
+    };
+    const taskGraph = createTaskGraph(graph, {}, ['app1'], ['build'], null, {});
+    expect(taskGraph.tasks).toHaveProperty('app1:build');
+    expect(taskGraph.tasks).toHaveProperty('lib2:build');
+    expect(taskGraph.tasks).toHaveProperty('lib3:build');
+    // lib1 is filtered out even though it is a dependency
+    expect(taskGraph.tasks).not.toHaveProperty('lib1:build');
+    // otherApp is not a dependency so it is not included
+    expect(taskGraph.tasks).not.toHaveProperty('otherApp:build');
+    expect(taskGraph.dependencies['app1:build'].sort()).toEqual([
+      'lib2:build',
+      'lib3:build',
+    ]);
+  });
+
+  it('should add non-dependency projects when dependsOn combines dependencies: true with a positive projects pattern', () => {
+    const graph: ProjectGraph = {
+      nodes: {
+        app1: {
+          name: 'app1',
+          type: 'app',
+          data: {
+            root: 'app1-root',
+            targets: {
+              build: {
+                executor: 'nx:run-commands',
+                dependsOn: [
+                  {
+                    target: 'build',
+                    dependencies: true,
+                    projects: ['shared-util'],
+                  },
+                ],
+              },
+            },
+          },
+        },
+        lib1: {
+          name: 'lib1',
+          type: 'lib',
+          data: {
+            root: 'lib1-root',
+            targets: {
+              build: { executor: 'nx:run-commands' },
+            },
+          },
+        },
+        'shared-util': {
+          name: 'shared-util',
+          type: 'lib',
+          data: {
+            root: 'shared-util-root',
+            targets: {
+              build: { executor: 'nx:run-commands' },
+            },
+          },
+        },
+        unrelated: {
+          name: 'unrelated',
+          type: 'lib',
+          data: {
+            root: 'unrelated-root',
+            targets: {
+              build: { executor: 'nx:run-commands' },
+            },
+          },
+        },
+      },
+      dependencies: {
+        app1: [{ source: 'app1', target: 'lib1', type: 'static' }],
+        lib1: [],
+        'shared-util': [],
+        unrelated: [],
+      },
+    };
+    const taskGraph = createTaskGraph(graph, {}, ['app1'], ['build'], null, {});
+    expect(taskGraph.tasks).toHaveProperty('app1:build');
+    // Actual dep — still present.
+    expect(taskGraph.tasks).toHaveProperty('lib1:build');
+    // Added via the `projects` pattern even though it is not a dep of app1.
+    expect(taskGraph.tasks).toHaveProperty('shared-util:build');
+    // Not listed and not a dep — skipped.
+    expect(taskGraph.tasks).not.toHaveProperty('unrelated:build');
+    expect(taskGraph.dependencies['app1:build'].sort()).toEqual([
+      'lib1:build',
+      'shared-util:build',
+    ]);
+  });
+
   it('should handle multiple dependsOn task groups', () => {
     const taskGraph = createTaskGraph(
       {

--- a/packages/nx/src/tasks-runner/create-task-graph.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.ts
@@ -14,6 +14,7 @@ import { TargetDefaults, TargetDependencies } from '../config/nx-json';
 import { output } from '../utils/output';
 import { TargetDependencyConfig } from '../config/workspace-json-project-json';
 import { findCycles } from './task-graph-utils';
+import { findMatchingProjects } from '../utils/find-matching-projects';
 
 const DUMMY_TASK_TARGET = '__nx_dummy_task__';
 
@@ -153,17 +154,17 @@ export class ProcessTasks {
         task,
         this.projectGraph
       );
-      if (dependencyConfig.projects) {
-        this.processTasksForMultipleProjects(
+      if (dependencyConfig.dependencies) {
+        this.processTasksForDependencies(
+          projectUsedToDeriveDependencies,
           dependencyConfig,
           configuration,
           task,
           taskOverrides,
           overrides
         );
-      } else if (dependencyConfig.dependencies) {
-        this.processTasksForDependencies(
-          projectUsedToDeriveDependencies,
+      } else if (dependencyConfig.projects) {
+        this.processTasksForMultipleProjects(
           dependencyConfig,
           configuration,
           task,
@@ -277,14 +278,30 @@ export class ProcessTasks {
       return;
     }
 
+    const actualDepNames: string[] = [];
     for (const dep of this.projectGraph.dependencies[
       projectUsedToDeriveDependencies
     ]) {
+      // Skip external dependencies — they have no project graph node.
+      if (this.projectGraph.nodes[dep.target]) {
+        actualDepNames.push(dep.target);
+      }
+    }
+
+    const actualDeps = new Set(actualDepNames);
+    const targetProjectNames =
+      dependencyConfig.projects && dependencyConfig.projects.length
+        ? findMatchingProjects(
+            [...actualDepNames, ...dependencyConfig.projects],
+            this.projectGraph.nodes
+          )
+        : actualDepNames;
+
+    for (const projectName of targetProjectNames) {
       const depProject = this.projectGraph.nodes[
-        dep.target
+        projectName
       ] as ProjectGraphProjectNode;
 
-      // this is to handle external dependencies
       if (!depProject) continue;
 
       if (projectHasTarget(depProject, dependencyConfig.target)) {
@@ -330,8 +347,10 @@ export class ProcessTasks {
             overrides
           );
         }
-      } else {
-        // Create a dummy task for task.target.project... which simulates if depProject had dependencyConfig.target
+      } else if (actualDeps.has(projectName)) {
+        // Create a dummy task for task.target.project... which simulates if depProject had dependencyConfig.target.
+        // Only emitted for actual graph dependencies, so we can walk further to find the target transitively.
+        // Projects pulled in solely by a `projects` filter don't get a dummy — no transitive walk is expected.
         const dummyId = createTaskId(
           depProject.name,
           task.target.project +

--- a/packages/nx/src/tasks-runner/utils.spec.ts
+++ b/packages/nx/src/tasks-runner/utils.spec.ts
@@ -539,6 +539,55 @@ describe('utils', () => {
       ]);
     });
 
+    it('should keep both dependencies: true and the raw projects patterns when combined', () => {
+      const result = getDependencyConfigs(
+        { project: 'app', target: 'build' },
+        {},
+        {
+          dependencies: {},
+          nodes: {
+            app: {
+              name: 'app',
+              type: 'app',
+              data: {
+                root: 'apps/app',
+                targets: {
+                  build: {
+                    dependsOn: [
+                      {
+                        target: 'build',
+                        dependencies: true,
+                        projects: '!lib1',
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+            lib1: {
+              name: 'lib1',
+              type: 'lib',
+              data: { root: 'libs/lib1', targets: { build: {} } },
+            },
+            lib2: {
+              name: 'lib2',
+              type: 'lib',
+              data: { root: 'libs/lib2', targets: { build: {} } },
+            },
+          },
+        },
+        ['build']
+      );
+      // Patterns stay raw — they are applied to traced deps at task-graph build time.
+      expect(result).toEqual([
+        {
+          target: 'build',
+          dependencies: true,
+          projects: ['!lib1'],
+        },
+      ]);
+    });
+
     it('should support wildcards with dependencies', () => {
       const result = getDependencyConfigs(
         { project: 'project', target: 'build' },

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -76,11 +76,15 @@ export function normalizeDependencyConfigProjects(
   const noStringConfig =
     normalizeTargetDependencyWithStringProjects(dependencyConfig);
 
-  if (noStringConfig.projects) {
+  if (noStringConfig.projects && !noStringConfig.dependencies) {
     dependencyConfig.projects = findMatchingProjects(
       noStringConfig.projects,
       graph.nodes
     );
+  } else if (noStringConfig.projects) {
+    // `dependencies: true` + `projects` is a filter applied against the traced
+    // dependencies at task-graph build time, so keep the raw patterns here.
+    dependencyConfig.projects = noStringConfig.projects;
   } else if (!noStringConfig.dependencies) {
     dependencyConfig.projects = [currentProject];
   }


### PR DESCRIPTION
## Current Behavior

In a `dependsOn` entry, the `projects` field and `dependencies: true` are mutually exclusive in practice:

- When `dependencies: true` is set, `projects` is effectively ignored — the target runs on every traced project graph dependency.
- When only `projects` is set, it is pre-resolved at normalization time via `findMatchingProjects` against the full workspace and used as a standalone list.

There is no way to say "run this target on all of my dependencies **except** `my-app`", or "run this target on all of my dependencies **plus** `shared-util`".

## Expected Behavior

`projects` patterns can be combined with `dependencies: true` and are layered on top of the traced dependencies:

- Positive patterns (including globs) **add** projects to the resulting set, even if they are not graph dependencies of the current project.
- Negative patterns (e.g. `"!my-app"`) **remove** traced dependencies from the resulting set.

Examples:

```jsonc
// Run build on every dependency except my-app
{ "dependencies": true, "projects": "!my-app", "target": "build" }

// Run build on every dependency plus shared-util
{ "dependencies": true, "projects": ["shared-util"], "target": "build" }
```

### Implementation notes

- `normalizeDependencyConfigProjects` now keeps raw patterns when `dependencies: true` is also set, so they reach the task graph builder.
- `processTasksForDependencies` computes the effective set via `findMatchingProjects([...tracedDeps, ...patterns], nodes)`, leveraging its existing left-to-right pattern application (positives add, `!` removes).
- Dummy-task transitive walking (used when a dep does not define the target) is preserved only for actual project-graph dependencies, not for projects pulled in solely by positive patterns.
- `TargetDependencyConfig` JSDoc updated to document the combined semantic.

## Related Issue(s)

N/A