### PR TITLE
fix(js): include npm alias targets in pruned lockfile

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -539,9 +539,18 @@ function getDependencies(
                 findVersion(versionRange, name, isV5),
                 isV5
               );
-              const target =
+              let target =
                 ctx.externalNodes[`npm:${name}@${version}`] ||
                 ctx.externalNodes[`npm:${name}`];
+              // For npm aliases (e.g. "auth0-legacy": "auth0@4.37.0"),
+              // the alias name won't match any node. Fall back to
+              // looking up the raw versionRange as a package reference.
+              if (!target && name !== versionRange) {
+                const rawVersion = parseBaseVersion(versionRange, isV5);
+                target =
+                  ctx.externalNodes[`npm:${rawVersion}`] ||
+                  ctx.externalNodes[`npm:${versionRange}`];
+              }
               if (target) {
                 const dep: RawProjectGraphDependency = {
                   source: node.name,

--- a/packages/nx/src/plugins/js/lock-file/project-graph-pruning.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/project-graph-pruning.spec.ts
@@ -271,6 +271,145 @@ describe('project-graph-pruning', () => {
       expect(result.externalNodes?.['npm:blurhash@2.0.5']).toBeDefined();
     });
 
+    it('should traverse real package node behind npm alias', () => {
+      // Setup: auth0@5.5.0 depends on auth0-legacy (alias for auth0@4.37.0)
+      // auth0@4.37.0 depends on jose. The pruned graph must include all three.
+      const aliasGraph: ProjectGraph = {
+        nodes: {},
+        dependencies: {
+          'npm:auth0': [
+            {
+              source: 'npm:auth0',
+              target: 'npm:auth0-legacy',
+              type: 'static',
+            },
+          ],
+          'npm:auth0-legacy': [],
+          'npm:auth0@4.37.0': [
+            {
+              source: 'npm:auth0@4.37.0',
+              target: 'npm:jose',
+              type: 'static',
+            },
+          ],
+          'npm:jose': [],
+        },
+        externalNodes: {
+          'npm:auth0': {
+            type: 'npm',
+            name: 'npm:auth0',
+            data: {
+              packageName: 'auth0',
+              version: '5.5.0',
+            },
+          },
+          'npm:auth0-legacy': {
+            type: 'npm',
+            name: 'npm:auth0-legacy',
+            data: {
+              packageName: 'auth0-legacy',
+              version: 'npm:auth0@4.37.0',
+            },
+          },
+          'npm:auth0@4.37.0': {
+            type: 'npm',
+            name: 'npm:auth0@4.37.0',
+            data: {
+              packageName: 'auth0',
+              version: '4.37.0',
+            },
+          },
+          'npm:jose': {
+            type: 'npm',
+            name: 'npm:jose',
+            data: {
+              packageName: 'jose',
+              version: '4.15.9',
+            },
+          },
+        },
+      };
+
+      const aliasBuilder = new ProjectGraphBuilder();
+      addNodesAndDependencies(
+        aliasGraph,
+        { auth0: '5.5.0' },
+        new Map(),
+        aliasBuilder
+      );
+
+      const result = aliasBuilder.getUpdatedProjectGraph();
+      // The alias node itself should be included
+      expect(result.externalNodes?.['npm:auth0-legacy']).toBeDefined();
+      // The real package behind the alias must also be included
+      expect(result.externalNodes?.['npm:auth0@4.37.0']).toBeDefined();
+      // Transitive deps of the real package must be included
+      expect(result.externalNodes?.['npm:jose']).toBeDefined();
+    });
+
+    it('should traverse real scoped package node behind npm alias', () => {
+      // Setup: pkg depends on my-alias (alias for @scope/real@1.0.0)
+      // @scope/real@1.0.0 depends on some-dep
+      const aliasGraph: ProjectGraph = {
+        nodes: {},
+        dependencies: {
+          'npm:pkg': [
+            {
+              source: 'npm:pkg',
+              target: 'npm:my-alias',
+              type: 'static',
+            },
+          ],
+          'npm:my-alias': [],
+          'npm:@scope/real@1.0.0': [
+            {
+              source: 'npm:@scope/real@1.0.0',
+              target: 'npm:some-dep',
+              type: 'static',
+            },
+          ],
+          'npm:some-dep': [],
+        },
+        externalNodes: {
+          'npm:pkg': {
+            type: 'npm',
+            name: 'npm:pkg',
+            data: { packageName: 'pkg', version: '2.0.0' },
+          },
+          'npm:my-alias': {
+            type: 'npm',
+            name: 'npm:my-alias',
+            data: {
+              packageName: 'my-alias',
+              version: 'npm:@scope/real@1.0.0',
+            },
+          },
+          'npm:@scope/real@1.0.0': {
+            type: 'npm',
+            name: 'npm:@scope/real@1.0.0',
+            data: { packageName: '@scope/real', version: '1.0.0' },
+          },
+          'npm:some-dep': {
+            type: 'npm',
+            name: 'npm:some-dep',
+            data: { packageName: 'some-dep', version: '3.0.0' },
+          },
+        },
+      };
+
+      const aliasBuilder = new ProjectGraphBuilder();
+      addNodesAndDependencies(
+        aliasGraph,
+        { pkg: '2.0.0' },
+        new Map(),
+        aliasBuilder
+      );
+
+      const result = aliasBuilder.getUpdatedProjectGraph();
+      expect(result.externalNodes?.['npm:@scope/real@1.0.0']).toBeDefined();
+      expect(result.externalNodes?.['npm:some-dep']).toBeDefined();
+    });
+
     it('should handle versioned external nodes', () => {
       const packageJsonDeps = {
         lodash: '4.17.20',

--- a/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
+++ b/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
@@ -178,6 +178,21 @@ function traverseNode(
     return;
   }
   builder.addExternalNode(node);
+
+  // If this is an alias node (version starts with "npm:"), also traverse the
+  // real underlying package node. For example, an alias node "npm:auth0-legacy"
+  // with version "npm:auth0@4.37.0" must pull in the real "npm:auth0@4.37.0"
+  // node and its transitive dependencies.
+  if (node.data.version.startsWith('npm:')) {
+    const aliasTarget = node.data.version.slice('npm:'.length); // e.g. "auth0@4.37.0" or "@scope/pkg@1.0.0"
+    const realNode =
+      graph.externalNodes[`npm:${aliasTarget}`] ||
+      graph.externalNodes[`npm:${extractPackageName(aliasTarget)}`];
+    if (realNode) {
+      traverseNode(graph, builder, realNode);
+    }
+  }
+
   graph.dependencies[node.name]?.forEach((dep) => {
     const depNode = graph.externalNodes[dep.target];
     traverseNode(graph, builder, depNode);
@@ -285,6 +300,15 @@ function switchNodeToHoisted(
     builder.addStaticDependency(source, node.name);
     invBuilder.addStaticDependency(node.name, source);
   });
+}
+
+// Extract the package name from an "alias target" string like "auth0@4.37.0"
+// or "@scope/pkg@1.0.0". Returns "auth0" or "@scope/pkg".
+function extractPackageName(aliasTarget: string): string {
+  const versionSep = aliasTarget.startsWith('@')
+    ? aliasTarget.indexOf('@', 1)
+    : aliasTarget.indexOf('@');
+  return versionSep === -1 ? aliasTarget : aliasTarget.slice(0, versionSep);
 }
 
 // BFS to find the shortest path to a dependency specified in package.json


### PR DESCRIPTION
## Current Behavior                                                                                                                        
                                                                                                                                            
  When a pnpm lockfile contains npm aliases (e.g. auth0-legacy: auth0@4.37.0 as a dependency of auth0@5.5.0), the @nx/js:prune-lockfile  executor produces a pruned lockfile that is missing the real package snapshot for the alias target.                                       
   
  This causes pnpm install --frozen-lockfile to fail with:                                                                                  
                                                                                                                                          
  ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for 'auth0@4.37.0' in pnpm-lock.yaml                                      
                                                                                                                                            
  The root cause is in two places:                                                                                                          
                                                                                                                                            
  1. getDependencies in pnpm-parser.ts: when building the project graph dependency edges from the lockfile, the alias name (e.g. auth0-legacy) is used to look up the target node (npm:auth0-legacy@... or npm:auth0-legacy). Since no node exists with the alias name, the dependency edge is silently dropped, leaving auth0@4.37.0 unreachable in the graph.                                                      
  2. traverseNode in project-graph-pruning.ts: even if an alias node existed in the graph, the traversal never followed through to the real underlying package node to include it and its transitive dependencies.                                                                    
  
##  Expected Behavior                                                                                                                         
                                                                                                                                          
  The pruned lockfile should include all npm alias targets and their transitive dependencies. pnpm install --frozen-lockfile should succeed without errors when the project uses packages that declare npm alias dependencies.
                                                                                                                                            
##  Related Issue(s)                                                                                                                        
                                                   
  Fixes #35205