### PR TITLE
chore(repo): prune 39 unmaintained community plugins

### DIFF
--- a/.github/workflows/curate-community-plugins.yml
+++ b/.github/workflows/curate-community-plugins.yml
@@ -1,0 +1,43 @@
+name: Curate Community Plugins
+
+on:
+  schedule:
+    # 1st of every month at 9am UTC
+    - cron: '0 9 1 * *'
+  workflow_dispatch: # allow manual trigger
+
+permissions: {}
+
+jobs:
+  curate:
+    if: ${{ github.repository_owner == 'nrwl' }}
+    permissions:
+      contents: write # to push branch
+      pull-requests: write # to create PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
+        with:
+          version: 10.28.2
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Assess and prune community plugins
+        run: pnpm exec tsx scripts/documentation/assess-community-plugins.ts --prune
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/astro-docs/src/content/approved-community-plugins.json
+++ b/astro-docs/src/content/approved-community-plugins.json
@@ -1,18 +1,8 @@
 [
   {
-    "name": "@ahryman40k/nx-vitepress",
-    "description": "Nx plugin add vitepress project to your workspace",
-    "url": "https://github.com/Ahryman40k/nx-vitepress/tree/main/packages/nx-vitepress"
-  },
-  {
     "name": "@klerick/nx-angular-mf",
     "description": "Custom Angular Builder for Microfrontend Architecture",
     "url": "https://github.com/klerick/nx-angular-mf"
-  },
-  {
-    "name": "@nightwatch/nx",
-    "description": "The NightwatchJS plugin allows your workspace to use the power of NightwatchJS for E2E and Component Testing on Desktop and Mobile",
-    "url": "https://github.com/nightwatchjs/nightwatch-plugin-nx/"
   },
   {
     "name": "@nxkit/playwright",
@@ -30,34 +20,9 @@
     "url": "https://github.com/nxkit/nxkit"
   },
   {
-    "name": "nx-plugin-vite",
-    "description": "Nx plugin integrations with Vite.",
-    "url": "https://nx-plugins.netlify.app/"
-  },
-  {
-    "name": "nx-serverless-cdk",
-    "description": "Create CDK applications and construct libraries. Test and debug infrastructure code and AWS Lambda functions locally.",
-    "url": "https://github.com/castleadmin/nx-plugins/tree/main/nx-serverless-cdk/plugin"
-  },
-  {
-    "name": "@ago-dev/nx-aws-cdk-v2",
-    "description": "An nx plugin for the aws-cdk v2.",
-    "url": "https://github.com/adrian-goe/nx-aws-cdk-v2"
-  },
-  {
     "name": "@berenddeboer/nx-aws-cdk",
     "description": "A self-inferring Nx plugin for developing AWS CDK applications. Supports all CDK commands.",
     "url": "https://github.com/berenddeboer/nx-plugins/tree/main/packages/nx-aws-cdk"
-  },
-  {
-    "name": "@nx-iac/aws-cdk",
-    "description": "Empowers your Nx workspace with AWS CDK capabilities ⚡",
-    "url": "https://github.com/joelklint/nx-aws-cdk"
-  },
-  {
-    "name": "@routineless/nx-aws-cdk",
-    "description": "Nx plugin to generate and manage aws cdk app and lambdas.",
-    "url": "https://github.com/KozelAnatoliy/routineless/tree/main/packages/nx-aws-cdk"
   },
   {
     "name": "@berenddeboer/nx-sst",
@@ -80,16 +45,6 @@
     "url": "https://github.com/Phillip9587/nx-stylelint"
   },
   {
-    "name": "@nxext/ionic-react",
-    "description": "An Nx plugin for developing Ionic React applications and libraries",
-    "url": "https://github.com/nxext/nx-extensions-ionic/tree/main/packages/ionic-react"
-  },
-  {
-    "name": "@nxext/ionic-angular",
-    "description": "An Nx plugin for developing Ionic Angular applications and libraries",
-    "url": "https://github.com/nxext/nx-extensions-ionic/tree/main/packages/ionic-angular"
-  },
-  {
     "name": "@nxext/capacitor",
     "description": "An Nx plugin for developing cross-platform applications using Capacitor",
     "url": "https://github.com/nxext/nx-extensions/tree/main/packages/capacitor"
@@ -98,11 +53,6 @@
     "name": "@angular-architects/ddd",
     "description": "Nx plugin for structuring a monorepo with domains and layers",
     "url": "https://github.com/angular-architects/nx-ddd-plugin"
-  },
-  {
-    "name": "@flowaccount/nx-serverless",
-    "description": "Nx plugin for node/angular-universal schematics and deployment builders in an Nx workspace",
-    "url": "https://github.com/flowaccount/nx-plugins"
   },
   {
     "name": "@ns3/nx-serverless",
@@ -120,36 +70,6 @@
     "url": "https://github.com/Bielik20/nx-plugins/tree/master/packages/nx-playwright"
   },
   {
-    "name": "@nx-plus/nuxt",
-    "description": "Nx plugin adding first class support for Nuxt in your Nx workspace.",
-    "url": "https://github.com/ZachJW34/nx-plus/tree/master/libs/nuxt"
-  },
-  {
-    "name": "@nx-plus/vue",
-    "description": "Nx plugin adding first class support for Vue in your Nx workspace.",
-    "url": "https://github.com/ZachJW34/nx-plus/tree/master/libs/vue"
-  },
-  {
-    "name": "@nx-plus/docusaurus",
-    "description": "Nx plugin adding first class support for Docusaurus in your Nx workspace.",
-    "url": "https://github.com/ZachJW34/nx-plus/tree/master/libs/docusaurus"
-  },
-  {
-    "name": "@twittwer/compodoc",
-    "description": "Nx Plugin to integrate the generation of documentation with Compodoc in the Nx workflow",
-    "url": "https://github.com/twittwer/nx-tools/tree/master/libs/compodoc#readme"
-  },
-  {
-    "name": "@enio.ai/nx-install",
-    "description": "nx-install is a plugin for Nx workspaces to quickly setup custom install commands via npm.",
-    "url": "https://github.com/enio-ireland/enio/tree/develop/packages/nx-install#readme"
-  },
-  {
-    "name": "@enio.ai/typedoc",
-    "description": "typedoc is a plugin for Nx workspaces to quickly setup documentation automation on your projects using typedoc.",
-    "url": "https://github.com/enio-ireland/enio/tree/develop/packages/typedoc#readme"
-  },
-  {
     "name": "@nxext/svelte",
     "description": "Nx plugin to use Svelte within nx workspaces",
     "url": "https://github.com/nxext/nx-extensions/tree/master/packages/svelte"
@@ -158,11 +78,6 @@
     "name": "@nxext/stencil",
     "description": "Nx plugin to use StencilJs within nx workspaces",
     "url": "https://github.com/nxext/nx-extensions/tree/master/packages/stencil"
-  },
-  {
-    "name": "@nxext/vue",
-    "description": "Nx plugin to use VueJS 3 within nx workspaces",
-    "url": "https://github.com/nxext/nx-extensions/tree/master/packages/vue"
   },
   {
     "name": "@nxext/solid",
@@ -175,11 +90,6 @@
     "url": "https://github.com/nx-go/nx-go"
   },
   {
-    "name": "@nx-golang/gin",
-    "description": "Nx plugin to use Go-Gin in a Nx workspace",
-    "url": "https://github.com/nx-golang/nx-golang"
-  },
-  {
     "name": "@angular-architects/module-federation",
     "description": "Nx plugin to use webpack module federation",
     "url": "https://github.com/angular-architects/module-federation-plugin"
@@ -190,24 +100,9 @@
     "url": "https://github.com/tinesoft/nxrocks/tree/master/packages/nx-spring-boot"
   },
   {
-    "name": "@trumbitta/nx-plugin-openapi",
-    "description": "OpenAPI Plugin for Nx. Keep your API spec files in libs, and auto-generate sources.",
-    "url": "https://github.com/trumbitta/nx-trumbitta/tree/main/packages/nx-plugin-openapi"
-  },
-  {
-    "name": "@trumbitta/nx-plugin-unused-deps",
-    "description": "Check the dependency graph of your monorepo, looking for unused NPM packages.",
-    "url": "https://github.com/trumbitta/nx-trumbitta/tree/main/packages/nx-plugin-unused-deps"
-  },
-  {
     "name": "@nxrocks/nx-flutter",
     "description": "Nx Plugin adding first class support for Flutter in your Nx workspace",
     "url": "https://github.com/tinesoft/nxrocks/tree/master/packages/nx-flutter"
-  },
-  {
-    "name": "@srleecode/domain",
-    "description": "Nx Plugin for allowing operations to occur at the domain level instead of the default library level",
-    "url": "https://github.com/srlee309/domain"
   },
   {
     "name": "@jscutlery/semver",
@@ -315,44 +210,9 @@
     "url": "https://github.com/nativescript/nx"
   },
   {
-    "name": "@nxtensions/astro",
-    "description": "Nx plugin adding first class support for Astro (https://astro.build).",
-    "url": "https://github.com/nxtensions/nxtensions/tree/main/packages/astro"
-  },
-  {
     "name": "@nxrs/cargo",
     "description": "Nx plugin adding first-class support for Rust applications and libraries.",
     "url": "https://github.com/nxrs/cargo/tree/main/packages/cargo"
-  },
-  {
-    "name": "nx-uvu",
-    "description": "An nx executor for the uvu test library",
-    "url": "https://github.com/jmcdo29/nx-uvu"
-  },
-  {
-    "name": "@ndrsg/nx-http",
-    "description": "Plugin with executors, which can perform http-stuff (e.g. requests, webhooks, file up/downloads, ...)",
-    "url": "https://github.com/ndrsg/nx-ext/tree/main/packages/nx-http"
-  },
-  {
-    "name": "@diogovcs/graphql-mesh",
-    "description": "Nx plugin to add GraphQL Mesh integration to Nx Workspace.",
-    "url": "https://github.com/DiogoVCS/nx-workspace-plugins"
-  },
-  {
-    "name": "@computas/nx-yarn",
-    "description": "A plugin to help make nx with yarn a pleasant experience.",
-    "url": "https://github.com/computas/nx-yarn"
-  },
-  {
-    "name": "@theunderscorer/nx-semantic-release",
-    "description": "Nx plugin for automated releases using semantic-release.",
-    "url": "https://github.com/TheUnderScorer/nx-semantic-release"
-  },
-  {
-    "name": "nx-pwm",
-    "description": "Nx plugin and CLI to help maintain packages, inspired by NX repo tooling",
-    "url": "https://github.com/gioragutt/nx-pwm"
   },
   {
     "name": "@nxrocks/nx-micronaut",
@@ -368,11 +228,6 @@
     "name": "@mands/nx-playwright",
     "description": "The Playwright plugin allows your workspace to use the power of Playwright end-to-end testing using a native runner.",
     "url": "https://github.com/marksandspencer/nx-plugins/tree/main/packages/nx-playwright"
-  },
-  {
-    "name": "@diogovcs/stryker-mutator",
-    "description": "Nx plugin to add Stryker Mutator mutation tests to the Nx Workspace.",
-    "url": "https://github.com/DiogoVCS/nx-workspace-plugins"
   },
   {
     "name": "@spaceribs/nx-web-ext",
@@ -405,24 +260,9 @@
     "url": "https://github.com/cammisuli/monodon/tree/main/packages/rust"
   },
   {
-    "name": "nx-mesh",
-    "description": "GraphQL Mesh support for Nx",
-    "url": "https://github.com/domjtalbot/nx-mesh"
-  },
-  {
     "name": "@nxazure/func",
     "description": "Nx plugin to add Azure Functions support to Nx Workspace.",
     "url": "https://github.com/AlexPshul/nxazure/tree/master/packages/func"
-  },
-  {
-    "name": "@rbnx/webdriverio",
-    "description": "A Nx plugin that adds the WebdriverIO testing framework to a NX workspace.",
-    "url": "https://github.com/Roozenboom/rbnx/tree/main/packages/webdriverio"
-  },
-  {
-    "name": "nx-ngrok",
-    "description": "Ngrok support for Nx",
-    "url": "https://github.com/domjtalbot/nx-ngrok"
   },
   {
     "name": "@nxrocks/nx-ktor",
@@ -430,24 +270,9 @@
     "url": "https://github.com/tinesoft/nxrocks/tree/master/packages/nx-ktor"
   },
   {
-    "name": "nx-size-limit",
-    "description": "Adds size-limit support for Nx (performance budget tool for JavaScript)",
-    "url": "https://github.com/LironHazan/nx-size-limit"
-  },
-  {
-    "name": "@loft-orbital/terraform",
-    "description": "Terraform executors and generators",
-    "url": "https://github.com/loft-orbital/nx-plugins/tree/main/packages/terraform"
-  },
-  {
     "name": "@nxlv/python",
     "description": "Nx plugin designed to extend the Nx features to work with Python projects based on Poetry.",
     "url": "https://github.com/lucasvieirasilva/nx-plugins/tree/main/packages/nx-python"
-  },
-  {
-    "name": "nx-gcp-cache",
-    "description": "Nx plugin to use Google Cloud Storage as distributed remote cache",
-    "url": "https://github.com/davidgarciab/nx-gcp-cache"
   },
   {
     "name": "@jnxplus/nx-gradle",
@@ -480,11 +305,6 @@
     "url": "https://github.com/simondotm/nx-firebase"
   },
   {
-    "name": "@dman926/nx-python-pdm",
-    "description": "Use Python in NX workspaces with PDM",
-    "url": "https://github.com/dman926/nx-python-pdm"
-  },
-  {
     "name": "@gnuechtel/nx-cucumber",
     "description": "Plugin to use Cucumber within Nx workspaces",
     "url": "https://gitlab.com/gnuechtel/open-source/-/tree/main/libs/nx-cucumber"
@@ -493,11 +313,6 @@
     "name": "@analogjs/platform",
     "description": "Official plugin to add Analog to your Nx monorepo.",
     "url": "https://analogjs.org/docs/integrations/nx"
-  },
-  {
-    "name": "@getlarge/nx-heroku",
-    "description": "Plugin to deploy and promote Nx apps on Heroku",
-    "url": "https://github.com/getlarge/nx-heroku"
   },
   {
     "name": "@getlarge/nx-node-sea",
@@ -513,16 +328,6 @@
     "name": "nx-github-pages",
     "description": "A small Nx plugin to make deploying static projects to GitHub Pages easy.",
     "url": "https://github.com/agentender/nx-github-pages"
-  },
-  {
-    "name": "nx-solhint",
-    "description": "Solhint generators and inferred tasks for Nx",
-    "url": "https://github.com/juliangsibecas/nx-solhint"
-  },
-  {
-    "name": "nx-foundry",
-    "description": "Foundry generators and inferred tasks for Nx",
-    "url": "https://github.com/juliangsibecas/nx-foundry"
   },
   {
     "name": "@robby-rabbitman/nx-plus-web-test-runner",

--- a/astro-docs/src/content/docs/extending-nx/publish-plugin.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/publish-plugin.mdoc
@@ -35,9 +35,17 @@ Nx provides a utility (`nx list`) that lists both core and community plugins. Yo
 }
 ```
 
-{% aside type="caution" title="Unmaintained Plugins" %}
-We reserve the right to remove unmaintained plugins from the registry. If the plugins become maintained again, they can be resubmitted to the registry.
-{% /aside %}
+### Ongoing maintenance requirements
+
+An automated check runs once a month and removes plugins that meet any of these criteria:
+
+- The GitHub repository no longer exists or has been archived
+- No npm publish in the last 24 months
+- The declared `@nx/devkit` (or `@nx/workspace`/`nx`) range does not support any of the last three Nx major versions
+
+The 24-month cutoff reflects the Nx release cadence. Nx ships a major version every six months, so a plugin with no publish in two years is four Nx majors behind — past the point where compatibility can be assumed.
+
+If a removed plugin becomes maintained again, you can resubmit it.
 
 Once those criteria are met, you can submit your plugin by following the steps below:
 

--- a/scripts/documentation/assess-community-plugins.ts
+++ b/scripts/documentation/assess-community-plugins.ts
@@ -1,0 +1,553 @@
+/**
+ * Assess the health of approved community plugins.
+ *
+ * For each plugin in `astro-docs/src/content/approved-community-plugins.json`,
+ * fetches:
+ *   - npm: last publish date, monthly downloads, declared Nx peer/dep range
+ *   - GitHub (if listing URL is a github.com URL): stargazers, archived flag,
+ *     repo existence (404 detection)
+ *
+ * Produces a verdict per plugin (healthy / stale / abandoned / incompatible)
+ * plus a written report in `tmp/notes/`.
+ *
+ * Run:
+ *   npx tsx scripts/documentation/assess-community-plugins.ts
+ *
+ * GitHub calls go through the `gh` CLI (so they use your existing `gh auth
+ * login` token). If `gh` is not installed or not authenticated, star counts
+ * and archive/404 checks are skipped.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join, resolve } from 'path';
+import { spawnSync } from 'child_process';
+import * as semver from 'semver';
+
+// ============================================================
+// Tunable thresholds — adjust these to change the verdict rules
+// ============================================================
+const THRESHOLDS = {
+  // "stale" if no publish in this many months
+  staleMonths: 12,
+  // "abandoned" if no publish in this many months, or repo 404/archived.
+  // Rationale: Nx ships a major ~every 6 months, so 24 months ≈ 4 majors
+  // behind — well past the point where compatibility can be assumed.
+  abandonedMonths: 24,
+  // downloads below this count as "low usage" (used for stale verdict)
+  lowMonthlyDownloads: 100,
+  // how many Nx majors back a plugin can be and still count as compatible
+  // e.g. 2 means current, current-1, and current-2 are all accepted
+  nxMajorLookback: 2,
+};
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const PLUGINS_FILE = join(
+  REPO_ROOT,
+  'astro-docs',
+  'src',
+  'content',
+  'approved-community-plugins.json'
+);
+const OUTPUT_DIR = join(REPO_ROOT, 'tmp', 'notes');
+// ============================================================
+
+function readCurrentNxMajor(): number {
+  const pkg = JSON.parse(
+    readFileSync(join(REPO_ROOT, 'package.json'), 'utf-8')
+  );
+  const range: string = pkg.devDependencies?.nx || pkg.dependencies?.nx || '';
+  const match = range.match(/(\d+)/);
+  if (!match)
+    throw new Error(
+      'Could not determine current Nx major from root package.json'
+    );
+  return Number(match[1]);
+}
+
+const CURRENT_NX_MAJOR = readCurrentNxMajor();
+const SUPPORTED_NX_MAJORS = Array.from(
+  { length: THRESHOLDS.nxMajorLookback + 1 },
+  (_, i) => CURRENT_NX_MAJOR - THRESHOLDS.nxMajorLookback + i
+);
+
+interface CommunityPlugin {
+  name: string;
+  description: string;
+  url: string;
+}
+
+interface Assessment {
+  name: string;
+  url: string;
+  description: string;
+  monthlyDownloads: number | null;
+  lastPublishedDate: string | null;
+  monthsSinceLastPublish: number | null;
+  nxVersionRange: string;
+  compatibleNxMajors: number[] | null;
+  githubStars: number | null;
+  githubRepo: string | null;
+  repoStatus: 'ok' | 'archived' | 'not_found' | 'not_github' | 'unchecked';
+  verdict: 'healthy' | 'stale' | 'abandoned' | 'incompatible';
+  reasons: string[];
+}
+
+function assertGhCli(): void {
+  const res = spawnSync('gh', ['--version'], { stdio: 'ignore' });
+  if (res.status !== 0) {
+    throw new Error(
+      '`gh` CLI not found. Install it (https://cli.github.com) and run `gh auth login`.'
+    );
+  }
+}
+assertGhCli();
+
+// Serialize all npm requests through a single queue so concurrent callers
+// (e.g. Promise.all over data+downloads) don't both race past the throttle.
+let npmQueue: Promise<void> = Promise.resolve();
+const NPM_MIN_INTERVAL_MS = 250;
+async function withNpmThrottle<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = npmQueue;
+  let release: () => void;
+  npmQueue = new Promise<void>((r) => (release = r));
+  await prev;
+  try {
+    return await fn();
+  } finally {
+    setTimeout(() => release!(), NPM_MIN_INTERVAL_MS);
+  }
+}
+
+async function npmFetch(url: string, attempt = 0): Promise<Response> {
+  const res = await withNpmThrottle(() => fetch(url));
+  if (res.status === 429 && attempt < 3) {
+    const backoff = 2000 * Math.pow(2, attempt);
+    console.warn(`npm 429 on ${url} — backing off ${backoff}ms`);
+    await new Promise((r) => setTimeout(r, backoff));
+    return npmFetch(url, attempt + 1);
+  }
+  return res;
+}
+
+function monthsBetween(a: Date, b: Date): number {
+  return (b.getTime() - a.getTime()) / (1000 * 60 * 60 * 24 * 30.44);
+}
+
+function parseGithubRepo(url: string): { owner: string; repo: string } | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== 'github.com') return null;
+    const [, owner, repo] = parsed.pathname.split('/');
+    if (!owner || !repo) return null;
+    return { owner, repo: repo.replace(/\.git$/, '') };
+  } catch {
+    return null;
+  }
+}
+
+async function fetchNpmData(name: string): Promise<{
+  lastPublishedDate: Date | null;
+  nxVersionRange: string;
+}> {
+  const res = await npmFetch(`https://registry.npmjs.org/${name}`);
+  if (res.status === 404) {
+    return { lastPublishedDate: null, nxVersionRange: '' };
+  }
+  if (!res.ok) {
+    throw new Error(`npm registry ${res.status} for ${name}`);
+  }
+  const data = (await res.json()) as any;
+  const latest = data['dist-tags']?.latest;
+  const lastPublishedDate = data.time?.[latest]
+    ? new Date(data.time[latest])
+    : null;
+  const version = data.versions?.[latest] ?? {};
+  const nxVersionRange =
+    version.peerDependencies?.['@nx/devkit'] ||
+    version.dependencies?.['@nx/devkit'] ||
+    version.peerDependencies?.['@nx/workspace'] ||
+    version.dependencies?.['@nx/workspace'] ||
+    version.peerDependencies?.nx ||
+    version.dependencies?.nx ||
+    '';
+  return { lastPublishedDate, nxVersionRange };
+}
+
+async function fetchNpmDownloads(name: string): Promise<number | null> {
+  const res = await npmFetch(
+    `https://api.npmjs.org/downloads/point/last-month/${name}`
+  );
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`npm downloads ${res.status} for ${name}`);
+  }
+  const data = (await res.json()) as any;
+  // 404-style body: { error: "package ... not found" } — no downloads field
+  if (typeof data.downloads !== 'number') return null;
+  return data.downloads;
+}
+
+function fetchGithubRepo(
+  owner: string,
+  repo: string
+): { stars: number; archived: boolean; status: 'ok' | 'not_found' } {
+  const res = spawnSync('gh', ['api', `repos/${owner}/${repo}`], {
+    encoding: 'utf-8',
+  });
+  if (res.status !== 0) {
+    const stderr = res.stderr || '';
+    if (/HTTP 404|Not Found/i.test(stderr)) {
+      return { stars: 0, archived: false, status: 'not_found' };
+    }
+    throw new Error(`gh api failed for ${owner}/${repo}: ${stderr.trim()}`);
+  }
+  const data = JSON.parse(res.stdout) as any;
+  return {
+    stars: data.stargazers_count ?? 0,
+    archived: !!data.archived,
+    status: 'ok',
+  };
+}
+
+function supportsMajor(range: string, major: number): boolean {
+  // A plugin "supports" major X if its declared range intersects anywhere
+  // within X.x. This treats exact pins (e.g. "21.6.7") and narrow ranges
+  // as still targeting their major, matching author intent.
+  try {
+    return semver.intersects(range, `${major}.x`, { includePrerelease: true });
+  } catch {
+    return false;
+  }
+}
+
+function checkCompatibleMajors(
+  range: string,
+  majors: number[]
+): number[] | null {
+  if (!range) return null;
+  return majors.filter((m) => supportsMajor(range, m));
+}
+
+function assess(
+  plugin: CommunityPlugin,
+  npm: { lastPublishedDate: Date | null; nxVersionRange: string },
+  downloads: number | null,
+  gh: {
+    stars: number | null;
+    archived: boolean;
+    status: Assessment['repoStatus'];
+  },
+  githubRepo: string | null
+): Assessment {
+  const now = new Date();
+  const monthsSince = npm.lastPublishedDate
+    ? monthsBetween(npm.lastPublishedDate, now)
+    : null;
+  const compatibleMajors = checkCompatibleMajors(
+    npm.nxVersionRange,
+    SUPPORTED_NX_MAJORS
+  );
+  const incompatible =
+    compatibleMajors !== null && compatibleMajors.length === 0;
+
+  const reasons: string[] = [];
+
+  if (gh.status === 'not_found') reasons.push('GitHub repo returns 404');
+  if (gh.archived) reasons.push('GitHub repo is archived');
+  if (monthsSince !== null && monthsSince > THRESHOLDS.abandonedMonths) {
+    reasons.push(
+      `last published ${monthsSince.toFixed(1)} months ago (> ${THRESHOLDS.abandonedMonths})`
+    );
+  } else if (monthsSince !== null && monthsSince > THRESHOLDS.staleMonths) {
+    reasons.push(
+      `last published ${monthsSince.toFixed(1)} months ago (> ${THRESHOLDS.staleMonths})`
+    );
+  }
+  if (downloads !== null && downloads < THRESHOLDS.lowMonthlyDownloads) {
+    reasons.push(
+      `${downloads} monthly downloads (< ${THRESHOLDS.lowMonthlyDownloads})`
+    );
+  }
+  if (incompatible) {
+    reasons.push(
+      `declared Nx range "${npm.nxVersionRange}" does not include Nx ${SUPPORTED_NX_MAJORS.join(' or ')}`
+    );
+  }
+
+  let verdict: Assessment['verdict'];
+  if (
+    gh.status === 'not_found' ||
+    gh.archived ||
+    (monthsSince !== null && monthsSince > THRESHOLDS.abandonedMonths)
+  ) {
+    verdict = 'abandoned';
+  } else if (incompatible) {
+    verdict = 'incompatible';
+  } else if (
+    (monthsSince !== null && monthsSince > THRESHOLDS.staleMonths) ||
+    (downloads !== null && downloads < THRESHOLDS.lowMonthlyDownloads)
+  ) {
+    verdict = 'stale';
+  } else {
+    verdict = 'healthy';
+  }
+
+  return {
+    name: plugin.name,
+    url: plugin.url,
+    description: plugin.description,
+    monthlyDownloads: downloads,
+    lastPublishedDate: npm.lastPublishedDate
+      ? npm.lastPublishedDate.toISOString().slice(0, 10)
+      : null,
+    monthsSinceLastPublish:
+      monthsSince === null ? null : Number(monthsSince.toFixed(1)),
+    nxVersionRange: npm.nxVersionRange,
+    compatibleNxMajors: compatibleMajors,
+    githubStars: gh.stars,
+    githubRepo,
+    repoStatus: gh.status,
+    verdict,
+    reasons,
+  };
+}
+
+function renderMarkdown(assessments: Assessment[]): string {
+  const majorsCol = (majors: number[] | null) =>
+    majors === null ? 'n/a' : majors.length === 0 ? 'none' : majors.join(', ');
+  const bucket = (v: Assessment['verdict']) =>
+    assessments
+      .filter((a) => a.verdict === v)
+      .sort((a, b) => (a.monthlyDownloads ?? -1) - (b.monthlyDownloads ?? -1));
+
+  const lines: string[] = [];
+  lines.push('# Community plugins assessment');
+  lines.push('');
+  lines.push(`Generated: ${new Date().toISOString()}`);
+  lines.push(`Total plugins assessed: ${assessments.length}`);
+  lines.push(
+    `Supported Nx majors (for compat check): ${SUPPORTED_NX_MAJORS.join(', ')}`
+  );
+  lines.push('');
+  lines.push('## Thresholds');
+  lines.push('');
+  lines.push('```');
+  lines.push(JSON.stringify(THRESHOLDS, null, 2));
+  lines.push('```');
+  lines.push('');
+  lines.push('## Summary');
+  lines.push('');
+  lines.push('| Verdict | Count |');
+  lines.push('| --- | ---: |');
+  for (const v of ['healthy', 'stale', 'incompatible', 'abandoned'] as const) {
+    lines.push(`| ${v} | ${bucket(v).length} |`);
+  }
+  lines.push('');
+
+  const section = (title: string, v: Assessment['verdict']) => {
+    const items = bucket(v);
+    lines.push(`## ${title} (${items.length})`);
+    lines.push('');
+    if (items.length === 0) {
+      lines.push('_None._');
+      lines.push('');
+      return;
+    }
+    lines.push(
+      '| Plugin | Downloads/mo | Last publish | Months since | Nx range | Supports | Stars | Repo | Reasons |'
+    );
+    lines.push('| --- | ---: | --- | ---: | --- | --- | ---: | --- | --- |');
+    for (const a of items) {
+      lines.push(
+        `| [${a.name}](${a.url}) | ${a.monthlyDownloads ?? 'n/a'} | ${a.lastPublishedDate ?? 'n/a'} | ${a.monthsSinceLastPublish ?? 'n/a'} | ${a.nxVersionRange || 'n/a'} | ${majorsCol(a.compatibleNxMajors)} | ${a.githubStars ?? 'n/a'} | ${a.repoStatus} | ${a.reasons.join('; ')} |`
+      );
+    }
+    lines.push('');
+  };
+
+  section('Abandoned', 'abandoned');
+  section('Incompatible with current Nx', 'incompatible');
+  section('Stale', 'stale');
+  section('Healthy', 'healthy');
+
+  return lines.join('\n');
+}
+
+async function main() {
+  const allPlugins = JSON.parse(
+    readFileSync(PLUGINS_FILE, 'utf-8')
+  ) as CommunityPlugin[];
+  const limit = process.env.LIMIT
+    ? Number(process.env.LIMIT)
+    : allPlugins.length;
+  const plugins = allPlugins.slice(0, limit);
+
+  console.log(`Assessing ${plugins.length} community plugins`);
+  console.log(
+    `Compat check against Nx majors: ${SUPPORTED_NX_MAJORS.join(', ')}`
+  );
+
+  const assessments: Assessment[] = [];
+  for (let i = 0; i < plugins.length; i++) {
+    const plugin = plugins[i];
+    process.stdout.write(`[${i + 1}/${plugins.length}] ${plugin.name} ... `);
+
+    const [npm, downloads] = await Promise.all([
+      fetchNpmData(plugin.name),
+      fetchNpmDownloads(plugin.name),
+    ]);
+
+    const parsed = parseGithubRepo(plugin.url);
+    let gh: {
+      stars: number | null;
+      archived: boolean;
+      status: Assessment['repoStatus'];
+    } = { stars: null, archived: false, status: 'not_github' };
+
+    if (parsed) {
+      const info = fetchGithubRepo(parsed.owner, parsed.repo);
+      gh = {
+        stars: info.stars,
+        archived: info.archived,
+        status: info.status,
+      };
+    }
+
+    const result = assess(
+      plugin,
+      npm,
+      downloads,
+      gh,
+      parsed ? `${parsed.owner}/${parsed.repo}` : null
+    );
+    assessments.push(result);
+    console.log(result.verdict);
+  }
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const jsonPath = join(OUTPUT_DIR, 'community-plugins-assessment.json');
+  const mdPath = join(OUTPUT_DIR, 'community-plugins-assessment.md');
+  writeFileSync(
+    jsonPath,
+    JSON.stringify(
+      {
+        thresholds: THRESHOLDS,
+        supportedNxMajors: SUPPORTED_NX_MAJORS,
+        assessments,
+      },
+      null,
+      2
+    )
+  );
+  writeFileSync(mdPath, renderMarkdown(assessments));
+
+  console.log('');
+  console.log(`Wrote ${jsonPath}`);
+  console.log(`Wrote ${mdPath}`);
+
+  if (process.argv.includes('--prune')) {
+    await prune(allPlugins, assessments);
+  }
+}
+
+function prune(allPlugins: CommunityPlugin[], assessments: Assessment[]): void {
+  const removeVerdicts = new Set<string>(['abandoned', 'incompatible']);
+  const toRemove = new Set(
+    assessments.filter((a) => removeVerdicts.has(a.verdict)).map((a) => a.name)
+  );
+
+  if (toRemove.size === 0) {
+    console.log('No plugins to remove — all healthy or stale.');
+    return;
+  }
+
+  const kept = allPlugins.filter((p) => !toRemove.has(p.name));
+  const removed = assessments.filter((a) => toRemove.has(a.name));
+
+  console.log(
+    `\nRemoving ${toRemove.size} plugins (${kept.length} remaining):`
+  );
+  for (const a of removed) {
+    console.log(`  - ${a.name} (${a.verdict}: ${a.reasons.join('; ')})`);
+  }
+
+  // Write updated plugins file
+  writeFileSync(PLUGINS_FILE, JSON.stringify(kept, null, 2) + '\n');
+  console.log(`\nUpdated ${PLUGINS_FILE}`);
+
+  // Format with prettier
+  const prettierResult = spawnSync(
+    'npx',
+    ['prettier', '--write', PLUGINS_FILE],
+    { encoding: 'utf-8', cwd: REPO_ROOT }
+  );
+  if (prettierResult.status !== 0) {
+    console.warn('prettier failed:', prettierResult.stderr);
+  }
+
+  // Create branch, commit, push, open PR
+  const branch = `chore/prune-community-plugins-${new Date().toISOString().slice(0, 10)}`;
+  const abandonedList = removed.filter((a) => a.verdict === 'abandoned');
+  const incompatibleList = removed.filter((a) => a.verdict === 'incompatible');
+
+  const prBody = [
+    '## Summary',
+    '',
+    `Removes **${toRemove.size}** community plugins that no longer meet our listing criteria.`,
+    '',
+    '### Removal criteria',
+    '',
+    '- **Abandoned**: GitHub repo is 404, archived, or last published >24 months ago',
+    `- **Incompatible**: declared Nx range does not include Nx ${SUPPORTED_NX_MAJORS.join(', ')}`,
+    '',
+    `### Abandoned (${abandonedList.length})`,
+    '',
+    ...abandonedList.map((a) => `- \`${a.name}\` — ${a.reasons.join('; ')}`),
+    '',
+    `### Incompatible (${incompatibleList.length})`,
+    '',
+    ...incompatibleList.map((a) => `- \`${a.name}\` — ${a.reasons.join('; ')}`),
+    '',
+    `### Kept (${kept.length} plugins remain)`,
+    '',
+    `Generated by \`npx tsx scripts/documentation/assess-community-plugins.ts --prune\``,
+  ].join('\n');
+
+  run('git', ['checkout', '-b', branch]);
+  run('git', ['add', PLUGINS_FILE]);
+  run('git', [
+    'commit',
+    '-m',
+    `chore(repo): prune ${toRemove.size} unmaintained community plugins`,
+  ]);
+  run('git', ['push', '-u', 'origin', branch]);
+
+  const prBodyFile = join(REPO_ROOT, 'tmp', 'prune-pr-body.md');
+  writeFileSync(prBodyFile, prBody);
+  run('gh', [
+    'pr',
+    'create',
+    '--title',
+    `chore(repo): prune ${toRemove.size} unmaintained community plugins`,
+    '--body-file',
+    prBodyFile,
+    '--base',
+    'master',
+  ]);
+}
+
+function run(cmd: string, args: string[]): void {
+  console.log(`$ ${cmd} ${args.join(' ')}`);
+  const res = spawnSync(cmd, args, {
+    encoding: 'utf-8',
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+  });
+  if (res.status !== 0) {
+    throw new Error(`Command failed: ${cmd} ${args.join(' ')}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Removes **39** community plugins that no longer meet our listing criteria.

### Removal criteria

- **Abandoned**: GitHub repo is 404, archived, or last published >24 months ago
- **Incompatible**: declared Nx range does not include Nx 20, 21, 22

### Abandoned (32)

- `@ahryman40k/nx-vitepress` — last published 40.0 months ago (> 24)
- `@nightwatch/nx` — last published 40.6 months ago (> 24); 69 monthly downloads (< 100)
- `nx-plugin-vite` — last published 45.5 months ago (> 24)
- `@ago-dev/nx-aws-cdk-v2` — last published 35.5 months ago (> 24)
- `@nx-iac/aws-cdk` — last published 28.5 months ago (> 24); declared Nx range "17.0.1" does not include Nx 20 or 21 or 22
- `@routineless/nx-aws-cdk` — last published 25.0 months ago (> 24); 20 monthly downloads (< 100); declared Nx range "^18.0.4" does not include Nx 20 or 21 or 22
- `@nxext/ionic-react` — GitHub repo is archived
- `@nxext/ionic-angular` — GitHub repo is archived
- `@nx-plus/nuxt` — last published 45.7 months ago (> 24)
- `@nx-plus/vue` — last published 40.6 months ago (> 24)
- `@nx-plus/docusaurus` — last published 40.6 months ago (> 24)
- `@enio.ai/nx-install` — last published 37.6 months ago (> 24); 14 monthly downloads (< 100)
- `@enio.ai/typedoc` — last published 37.6 months ago (> 24)
- `@nxext/vue` — last published 32.1 months ago (> 24); 17 monthly downloads (< 100); declared Nx range "^16.7.1" does not include Nx 20 or 21 or 22
- `@nx-golang/gin` — last published 39.6 months ago (> 24); 46 monthly downloads (< 100)
- `@trumbitta/nx-plugin-openapi` — last published 43.8 months ago (> 24)
- `@trumbitta/nx-plugin-unused-deps` — last published 43.8 months ago (> 24)
- `@srleecode/domain` — GitHub repo returns 404
- `nx-uvu` — last published 32.5 months ago (> 24); declared Nx range "^16.3.2" does not include Nx 20 or 21 or 22
- `@ndrsg/nx-http` — last published 46.5 months ago (> 24); 23 monthly downloads (< 100)
- `@diogovcs/graphql-mesh` — last published 28.9 months ago (> 24); 79 monthly downloads (< 100)
- `@computas/nx-yarn` — last published 46.8 months ago (> 24); 16 monthly downloads (< 100)
- `@theunderscorer/nx-semantic-release` — GitHub repo is archived; last published 20.2 months ago (> 12); declared Nx range "19.6.0" does not include Nx 20 or 21 or 22
- `nx-pwm` — last published 40.6 months ago (> 24); 26 monthly downloads (< 100); declared Nx range "15.2.4" does not include Nx 20 or 21 or 22
- `@diogovcs/stryker-mutator` — last published 28.9 months ago (> 24)
- `nx-mesh` — GitHub repo is archived; last published 35.9 months ago (> 24)
- `@rbnx/webdriverio` — last published 28.3 months ago (> 24); declared Nx range "^16.0.0" does not include Nx 20 or 21 or 22
- `nx-ngrok` — GitHub repo is archived; last published 36.2 months ago (> 24)
- `nx-size-limit` — last published 32.6 months ago (> 24)
- `@loft-orbital/terraform` — GitHub repo is archived; last published 31.0 months ago (> 24)
- `nx-gcp-cache` — last published 29.7 months ago (> 24)
- `@dman926/nx-python-pdm` — last published 29.0 months ago (> 24); 9 monthly downloads (< 100); declared Nx range "17.1.3" does not include Nx 20 or 21 or 22

### Incompatible (7)

- `nx-serverless-cdk` — last published 20.4 months ago (> 12); declared Nx range "^19.5.7" does not include Nx 20 or 21 or 22
- `@flowaccount/nx-serverless` — last published 12.7 months ago (> 12); declared Nx range "^18.0.4" does not include Nx 20 or 21 or 22
- `@twittwer/compodoc` — last published 18.4 months ago (> 12); declared Nx range "^16.0.0" does not include Nx 20 or 21 or 22
- `@nxtensions/astro` — last published 21.5 months ago (> 12); declared Nx range "^19.0.0" does not include Nx 20 or 21 or 22
- `@getlarge/nx-heroku` — last published 23.7 months ago (> 12); 97 monthly downloads (< 100); declared Nx range "18.0.8" does not include Nx 20 or 21 or 22
- `nx-solhint` — last published 19.0 months ago (> 12); 7 monthly downloads (< 100); declared Nx range "19.8.0" does not include Nx 20 or 21 or 22
- `nx-foundry` — last published 19.0 months ago (> 12); 22 monthly downloads (< 100); declared Nx range "19.6.5" does not include Nx 20 or 21 or 22

### Kept (73 plugins remain)

Generated by `npx tsx scripts/documentation/assess-community-plugins.ts --prune`