### PR TITLE
fix(docker): respect skipDefaultTag in run target command

### DIFF
--- a/packages/docker/src/plugins/plugin.spec.ts
+++ b/packages/docker/src/plugins/plugin.spec.ts
@@ -1223,6 +1223,61 @@ describe('@nx/docker', () => {
         '--tag apps-api'
       );
     });
+
+    it('should omit imageRef from run target command when skipDefaultTag is true', async () => {
+      await tempFs.createFiles({
+        'proj/Dockerfile': 'FROM node:18',
+        'proj/project.json': '{}',
+      });
+
+      const results = await createNodesFunction(
+        ['proj/Dockerfile'],
+        {
+          buildTarget: {
+            name: 'build',
+            skipDefaultTag: true,
+          },
+        },
+        context
+      );
+
+      const targets = results[0][1].projects['proj'].targets;
+      expect(targets['docker:run'].command).toBe('docker run {args}');
+    });
+
+    it('should include imageRef in run target command when skipDefaultTag is false or undefined', async () => {
+      await tempFs.createFiles({
+        'proj/Dockerfile': 'FROM node:18',
+        'proj/project.json': '{}',
+      });
+
+      const resultsFalse = await createNodesFunction(
+        ['proj/Dockerfile'],
+        {
+          buildTarget: {
+            name: 'build',
+            skipDefaultTag: false,
+          },
+        },
+        context
+      );
+      expect(
+        resultsFalse[0][1].projects['proj'].targets['docker:run'].command
+      ).toBe('docker run {args} proj');
+
+      const resultsUndefined = await createNodesFunction(
+        ['proj/Dockerfile'],
+        {
+          buildTarget: {
+            name: 'build',
+          },
+        },
+        context
+      );
+      expect(
+        resultsUndefined[0][1].projects['proj'].targets['docker:run'].command
+      ).toBe('docker run {args} proj');
+    });
   });
 
   describe('target configurations', () => {

--- a/packages/docker/src/plugins/plugin.ts
+++ b/packages/docker/src/plugins/plugin.ts
@@ -336,7 +336,9 @@ async function createDockerTargets(
 
   targets[interpolatedRunTarget.name] = {
     dependsOn: [interpolatedBuildTarget.name],
-    command: `docker run {args} ${imageRef}`,
+    command: interpolatedBuildTarget.skipDefaultTag
+      ? `docker run {args}`
+      : `docker run {args} ${imageRef}`,
     options: runOptions,
     ...(runConfigurations && { configurations: runConfigurations }),
     inputs: [


### PR DESCRIPTION
## Current Behavior

When `buildTarget.skipDefaultTag` is `true` in the `@nx/docker` plugin configuration, the plugin still hardcodes the default `${imageRef}` into the generated `docker:run` target command:

```ts
// packages/docker/src/plugins/plugin.ts (before this PR)
command: `docker run {args} ${imageRef}`,
```

But when `skipDefaultTag: true`, the build target intentionally does _not_ create the `${imageRef}` tag (see the matching handling at `plugin.ts:202-207`). The run target then tries to run an image tag that was never built, so `docker run` either fails outright or — if the tag happens to match something in Docker's index — interprets the trailing `imageRef` as an in-container command, producing confusing output.

## Expected Behavior

When `skipDefaultTag: true`, the generated `docker:run` command should omit the `${imageRef}` suffix so users can pass the correct image reference through `{args}` (typically a custom tag they set via `--tag custom:ref` on the build). When `skipDefaultTag` is `false` or unset, the existing behavior is preserved and `${imageRef}` is still appended.

New behavior:

```ts
command: interpolatedBuildTarget.skipDefaultTag
  ? `docker run {args}`
  : `docker run {args} ${imageRef}`,
```

Symmetric unit tests are added under the existing `describe('skipDefaultTag', ...)` block in `plugin.spec.ts` covering both the `true` and `false`/`undefined` cases against `targets['docker:run'].command`.

## Related Issue(s)

Fixes #34230
