### PR TITLE
fix(core): wait for stdio drain before capturing task output

### DIFF
--- a/packages/nx/src/tasks-runner/running-tasks/node-child-process.spec.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/node-child-process.spec.ts
@@ -1,0 +1,56 @@
+import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
+import type { ChildProcess } from 'child_process';
+import { NodeChildProcessWithNonDirectOutput } from './node-child-process';
+
+function makeMockChildProcess(): ChildProcess {
+  const proc = new EventEmitter() as EventEmitter & Partial<ChildProcess>;
+  proc.stdout = new PassThrough() as any;
+  proc.stderr = new PassThrough() as any;
+  return proc as ChildProcess;
+}
+
+describe('NodeChildProcessWithNonDirectOutput', () => {
+  it('captures late stdout that arrives after the child exits (#35302)', async () => {
+    const proc = makeMockChildProcess();
+    const wrapped = new NodeChildProcessWithNonDirectOutput(proc, {
+      streamOutput: false,
+      prefix: 'test',
+    });
+
+    const exitSpy = jest.fn();
+    wrapped.onExit(exitSpy);
+
+    // Simulate the race reported in #35302: 'exit' fires synchronously,
+    // then stdout 'data' arrives on a subsequent tick, then 'close' fires
+    // after stdio has drained. Before the fix the exit handler listened
+    // for 'exit', joined chunks early, and dropped the late output.
+    proc.emit('exit', 0, null);
+    proc.stdout!.emit('data', Buffer.from('late-output'));
+    proc.emit('close', 0, null);
+
+    // Allow any microtasks to settle.
+    await Promise.resolve();
+
+    const { terminalOutput } = await wrapped.getResults();
+    expect(terminalOutput).toContain('late-output');
+    expect(exitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures output that arrives before the child closes', async () => {
+    const proc = makeMockChildProcess();
+    const wrapped = new NodeChildProcessWithNonDirectOutput(proc, {
+      streamOutput: false,
+      prefix: 'test',
+    });
+
+    proc.stdout!.emit('data', Buffer.from('hello'));
+    proc.stderr!.emit('data', Buffer.from('world'));
+    proc.emit('close', 0, null);
+
+    const { code, terminalOutput } = await wrapped.getResults();
+    expect(code).toBe(0);
+    expect(terminalOutput).toContain('hello');
+    expect(terminalOutput).toContain('world');
+  });
+});

--- a/packages/nx/src/tasks-runner/running-tasks/node-child-process.ts
+++ b/packages/nx/src/tasks-runner/running-tasks/node-child-process.ts
@@ -45,7 +45,8 @@ export class NodeChildProcessWithNonDirectOutput implements RunningTask {
       }
     }
 
-    this.childProcess.on('exit', (code, signal) => {
+    // 'close' (not 'exit') ensures stdio has drained before we join chunks (#35302).
+    this.childProcess.on('close', (code, signal) => {
       if (code === null) code = signalToCode(signal);
       this.exitCode = code;
       // Join once and cache before notifying exit callbacks


### PR DESCRIPTION
## Current Behavior

`NodeChildProcessWithNonDirectOutput` in `packages/nx/src/tasks-runner/running-tasks/node-child-process.ts:48` listens for the child process `'exit'` event. In that listener it joins `terminalOutputChunks` into a single string and clears the buffer before notifying `exitCallbacks`.

The child process `'exit'` event fires when the child exits, but its stdout/stderr streams may still have buffered `'data'` events pending on Node's event queue. When a task writes output and exits on the same tick (e.g. `echo X && exit 0`), the `'exit'` listener can run *before* the final `'data'` callback lands in `terminalOutputChunks`. The result: the late chunk is pushed into a new (now-empty) array that nobody reads, and the joined output that reaches `exitCallbacks` is missing its tail. The effect is visible as missing stdout when running many tasks at once (#35302).

## Expected Behavior

Switch the listener from `'exit'` to `'close'`. Per Node.js docs, `'close'` fires only after the child has exited **and** its stdio streams have closed — so every `'data'` event has been delivered by then. The listener body is otherwise unchanged (`(code, signal)` is still the argument shape).

No callers of `exitCallbacks` are timing-sensitive: they only read `code` and `terminalOutput`. The slight delay from waiting for stdio drain is precisely what we want here.

Added a regression test that simulates the race (`'exit'` fires, then stdout `'data'` arrives, then `'close'` fires) and asserts the late output is captured in the joined `terminalOutput`.

## Related Issue(s)

Fixes #35302
