### PR TITLE
fix(linter): only rewrite workspace-package peer deps to workspace:*

### DIFF
--- a/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
@@ -2893,7 +2893,7 @@ describe('Dependency checks (eslint)', () => {
       `);
     });
 
-    it('should use workspace:* for peer dependencies when peerDepsVersionStrategy is workspace', () => {
+    it('should preserve installed version for external peer dependencies when peerDepsVersionStrategy is workspace', () => {
       const packageJson = {
         name: '@mycompany/liba',
         peerDependencies: {},
@@ -2946,13 +2946,84 @@ describe('Dependency checks (eslint)', () => {
         "{
           "name": "@mycompany/liba",
           "peerDependencies": {
-            "external1": "workspace:*"
+            "external1": "~16.1.2"
           }
         }"
       `);
     });
 
-    it('should report version mismatch for peer dependencies when peerDepsVersionStrategy is workspace', () => {
+    it('should use workspace:* for workspace-package peer dependencies when peerDepsVersionStrategy is workspace', () => {
+      const packageJson = {
+        name: '@mycompany/liba',
+        peerDependencies: {},
+      };
+
+      const fileSys = {
+        './libs/liba/package.json': JSON.stringify(packageJson, null, 2),
+        './libs/liba/src/index.ts': '',
+        './libs/libb/package.json': JSON.stringify(
+          { name: '@mycompany/libb', version: '0.0.1' },
+          null,
+          2
+        ),
+        './package.json': JSON.stringify(rootPackageJson, null, 2),
+      };
+      vol.fromJSON(fileSys, '/root');
+
+      const failures = runRule(
+        { peerDepsVersionStrategy: 'workspace' },
+        `/root/libs/liba/package.json`,
+        JSON.stringify(packageJson, null, 2),
+        {
+          nodes: {
+            liba: {
+              name: 'liba',
+              type: 'lib',
+              data: {
+                root: 'libs/liba',
+                targets: { build: {} },
+              },
+            },
+            libb: {
+              name: 'libb',
+              type: 'lib',
+              data: {
+                root: 'libs/libb',
+                metadata: { js: { packageName: '@mycompany/libb' } },
+                targets: { build: {} },
+              },
+            },
+          },
+          externalNodes,
+          dependencies: {
+            liba: [{ source: 'liba', target: 'libb', type: 'static' }],
+          },
+        },
+        {
+          liba: [createFile(`libs/liba/src/main.ts`, ['libb'])],
+          libb: [createFile(`libs/libb/src/index.ts`)],
+        }
+      );
+
+      expect(failures.length).toEqual(1);
+
+      const content = JSON.stringify(packageJson, null, 2);
+      const result =
+        content.slice(0, failures[0].fix.range[0]) +
+        failures[0].fix.text +
+        content.slice(failures[0].fix.range[1]);
+
+      expect(result).toMatchInlineSnapshot(`
+        "{
+          "name": "@mycompany/liba",
+          "peerDependencies": {
+            "@mycompany/libb": "workspace:*"
+          }
+        }"
+      `);
+    });
+
+    it('should NOT rewrite external peer dependency ranges to workspace:* when peerDepsVersionStrategy is workspace', () => {
       const packageJson = {
         name: '@mycompany/liba',
         peerDependencies: {
@@ -2994,12 +3065,71 @@ describe('Dependency checks (eslint)', () => {
         }
       );
 
-      expect(failures.length).toEqual(1);
-      expect(failures[0].message).toMatchInlineSnapshot(
-        `"The version specifier does not contain the installed version of "external1" package: workspace:*."`
+      // external1 is already pinned to the installed version, so no failure
+      // — and crucially, the rule must not try to rewrite it to workspace:*
+      expect(failures.length).toEqual(0);
+    });
+
+    it('should rewrite workspace-package peer dependency ranges to workspace:* when peerDepsVersionStrategy is workspace', () => {
+      const packageJson = {
+        name: '@mycompany/liba',
+        peerDependencies: {
+          '@mycompany/libb': '^1.0.0',
+        },
+      };
+
+      const fileSys = {
+        './libs/liba/package.json': JSON.stringify(packageJson, null, 2),
+        './libs/liba/src/index.ts': '',
+        './libs/libb/package.json': JSON.stringify(
+          { name: '@mycompany/libb', version: '0.0.1' },
+          null,
+          2
+        ),
+        './package.json': JSON.stringify(rootPackageJson, null, 2),
+      };
+      vol.fromJSON(fileSys, '/root');
+
+      const failures = runRule(
+        { peerDepsVersionStrategy: 'workspace' },
+        `/root/libs/liba/package.json`,
+        JSON.stringify(packageJson, null, 2),
+        {
+          nodes: {
+            liba: {
+              name: 'liba',
+              type: 'lib',
+              data: {
+                root: 'libs/liba',
+                targets: { build: {} },
+              },
+            },
+            libb: {
+              name: 'libb',
+              type: 'lib',
+              data: {
+                root: 'libs/libb',
+                metadata: { js: { packageName: '@mycompany/libb' } },
+                targets: { build: {} },
+              },
+            },
+          },
+          externalNodes,
+          dependencies: {
+            liba: [{ source: 'liba', target: 'libb', type: 'static' }],
+          },
+        },
+        {
+          liba: [createFile(`libs/liba/src/main.ts`, ['libb'])],
+          libb: [createFile(`libs/libb/src/index.ts`)],
+        }
       );
 
-      // Apply fix
+      expect(failures.length).toEqual(1);
+      expect(failures[0].message).toMatchInlineSnapshot(
+        `"The version specifier does not contain the installed version of "@mycompany/libb" package: workspace:*."`
+      );
+
       const content = JSON.stringify(packageJson, null, 2);
       const result =
         content.slice(0, failures[0].fix.range[0]) +
@@ -3010,7 +3140,7 @@ describe('Dependency checks (eslint)', () => {
         "{
           "name": "@mycompany/liba",
           "peerDependencies": {
-            "external1": "workspace:*"
+            "@mycompany/libb": "workspace:*"
           }
         }"
       `);
@@ -3280,7 +3410,7 @@ describe('Dependency checks (eslint)', () => {
       `);
     });
 
-    it('should use workspace:* for all peer dependencies when peerDepsVersionStrategy is workspace', () => {
+    it('should use workspace:* for workspace-package peer dependencies but keep installed ranges for external packages when peerDepsVersionStrategy is workspace', () => {
       const packageJson = {
         name: '@mycompany/liba',
         peerDependencies: {},
@@ -3319,6 +3449,7 @@ describe('Dependency checks (eslint)', () => {
               type: 'lib',
               data: {
                 root: 'libs/libb',
+                metadata: { js: { packageName: '@mycompany/libb' } },
                 targets: {
                   build: {},
                 },
@@ -3349,11 +3480,12 @@ describe('Dependency checks (eslint)', () => {
         failures[0].fix.text +
         content.slice(failures[0].fix.range[1]);
 
-      // Both workspace packages and external packages should use workspace:*
-      // for version synchronization in integrated monorepos
+      // Only the workspace package gets workspace:*; the external npm package
+      // keeps its installed range so pnpm install doesn't fail with
+      // ERR_PNPM_WORKSPACE_PKG_NOT_FOUND (#35318).
       const resultObj = JSON.parse(result);
       expect(resultObj.peerDependencies['@mycompany/libb']).toBe('workspace:*');
-      expect(resultObj.peerDependencies.external1).toBe('workspace:*');
+      expect(resultObj.peerDependencies.external1).toBe('~16.1.2');
     });
 
     it('should report version mismatch for workspace packages when peerDepsVersionStrategy is workspace', () => {
@@ -3397,6 +3529,7 @@ describe('Dependency checks (eslint)', () => {
               type: 'lib',
               data: {
                 root: 'libs/libb',
+                metadata: { js: { packageName: '@mycompany/libb' } },
                 targets: {
                   build: {},
                 },

--- a/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
@@ -2989,7 +2989,12 @@ describe('Dependency checks (eslint)', () => {
               type: 'lib',
               data: {
                 root: 'libs/libb',
-                metadata: { js: { packageName: '@mycompany/libb' } },
+                metadata: {
+                  js: {
+                    packageName: '@mycompany/libb',
+                    isInPackageManagerWorkspaces: true,
+                  },
+                },
                 targets: { build: {} },
               },
             },
@@ -3109,7 +3114,12 @@ describe('Dependency checks (eslint)', () => {
               type: 'lib',
               data: {
                 root: 'libs/libb',
-                metadata: { js: { packageName: '@mycompany/libb' } },
+                metadata: {
+                  js: {
+                    packageName: '@mycompany/libb',
+                    isInPackageManagerWorkspaces: true,
+                  },
+                },
                 targets: { build: {} },
               },
             },
@@ -3449,7 +3459,12 @@ describe('Dependency checks (eslint)', () => {
               type: 'lib',
               data: {
                 root: 'libs/libb',
-                metadata: { js: { packageName: '@mycompany/libb' } },
+                metadata: {
+                  js: {
+                    packageName: '@mycompany/libb',
+                    isInPackageManagerWorkspaces: true,
+                  },
+                },
                 targets: {
                   build: {},
                 },
@@ -3529,7 +3544,12 @@ describe('Dependency checks (eslint)', () => {
               type: 'lib',
               data: {
                 root: 'libs/libb',
-                metadata: { js: { packageName: '@mycompany/libb' } },
+                metadata: {
+                  js: {
+                    packageName: '@mycompany/libb',
+                    isInPackageManagerWorkspaces: true,
+                  },
+                },
                 targets: {
                   build: {},
                 },
@@ -3565,6 +3585,75 @@ describe('Dependency checks (eslint)', () => {
           }
         }"
       `);
+    });
+
+    it('should NOT rewrite to workspace:* for workspace projects not in package manager workspaces', () => {
+      // A workspace project consumed via TS path mappings but not registered
+      // in pnpm-workspace.yaml / package.json "workspaces" cannot be resolved
+      // as workspace:*, so the rule must leave its peer dep range alone.
+      const packageJson = {
+        name: '@mycompany/liba',
+        peerDependencies: {
+          '@mycompany/libb': '^1.0.0',
+        },
+      };
+
+      const fileSys = {
+        './libs/liba/package.json': JSON.stringify(packageJson, null, 2),
+        './libs/liba/src/index.ts': '',
+        './libs/libb/package.json': JSON.stringify(
+          { name: '@mycompany/libb', version: '0.0.1' },
+          null,
+          2
+        ),
+        './package.json': JSON.stringify(rootPackageJson, null, 2),
+      };
+      vol.fromJSON(fileSys, '/root');
+
+      const failures = runRule(
+        { peerDepsVersionStrategy: 'workspace' },
+        `/root/libs/liba/package.json`,
+        JSON.stringify(packageJson, null, 2),
+        {
+          nodes: {
+            liba: {
+              name: 'liba',
+              type: 'lib',
+              data: {
+                root: 'libs/liba',
+                targets: { build: {} },
+              },
+            },
+            libb: {
+              name: 'libb',
+              type: 'lib',
+              data: {
+                root: 'libs/libb',
+                metadata: {
+                  js: {
+                    packageName: '@mycompany/libb',
+                    isInPackageManagerWorkspaces: false,
+                  },
+                },
+                targets: { build: {} },
+              },
+            },
+          },
+          externalNodes,
+          dependencies: {
+            liba: [{ source: 'liba', target: 'libb', type: 'static' }],
+          },
+        },
+        {
+          liba: [createFile(`libs/liba/src/main.ts`, ['libb'])],
+          libb: [createFile(`libs/libb/src/index.ts`)],
+        }
+      );
+
+      // The package range stays as-is — no workspace:* rewrite.
+      expect(failures.some((f) => f.message?.includes('workspace:*'))).toBe(
+        false
+      );
     });
   });
 });

--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -170,14 +170,16 @@ export default ESLintUtils.RuleCreator(
     );
     const expectedDependencyNames = Object.keys(npmDependencies);
 
-    // Package names published by workspace projects. Used to decide whether
-    // `peerDepsVersionStrategy: 'workspace'` should rewrite a peer dep range
-    // to `workspace:*` — only workspace packages should get that treatment;
-    // external npm packages (react, axios, …) must keep their real ranges.
+    // Packages eligible for `workspace:*` rewrites under
+    // `peerDepsVersionStrategy: 'workspace'`. Must be both a workspace project
+    // and registered in the package manager's workspaces — otherwise
+    // `workspace:*` won't resolve at install time.
     const workspacePackageNames = new Set<string>();
     for (const node of Object.values(projectGraph.nodes)) {
-      const name = node.data?.metadata?.js?.packageName;
-      if (name) workspacePackageNames.add(name);
+      const js = node.data?.metadata?.js;
+      if (js?.packageName && js.isInPackageManagerWorkspaces) {
+        workspacePackageNames.add(js.packageName);
+      }
     }
 
     const packageJson = JSON.parse(context.sourceCode.getText());

--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -170,6 +170,16 @@ export default ESLintUtils.RuleCreator(
     );
     const expectedDependencyNames = Object.keys(npmDependencies);
 
+    // Package names published by workspace projects. Used to decide whether
+    // `peerDepsVersionStrategy: 'workspace'` should rewrite a peer dep range
+    // to `workspace:*` — only workspace packages should get that treatment;
+    // external npm packages (react, axios, …) must keep their real ranges.
+    const workspacePackageNames = new Set<string>();
+    for (const node of Object.values(projectGraph.nodes)) {
+      const name = node.data?.metadata?.js?.packageName;
+      if (name) workspacePackageNames.add(name);
+    }
+
     const packageJson = JSON.parse(context.sourceCode.getText());
     const projPackageJsonDeps = getProductionDependencies(packageJson);
 
@@ -296,7 +306,8 @@ export default ESLintUtils.RuleCreator(
             missingDeps.forEach((d) => {
               if (
                 dependencySection === 'peerDependencies' &&
-                peerDepsVersionStrategy === 'workspace'
+                peerDepsVersionStrategy === 'workspace' &&
+                workspacePackageNames.has(d)
               ) {
                 projPackageJsonDeps[d] = WORKSPACE_VERSION_WILDCARD;
               } else {
@@ -368,7 +379,8 @@ export default ESLintUtils.RuleCreator(
       if (
         dependencySection === 'peerDependencies' &&
         peerDepsVersionStrategy === 'workspace' &&
-        !packageRange.startsWith('workspace:')
+        !packageRange.startsWith('workspace:') &&
+        workspacePackageNames.has(packageName)
       ) {
         context.report({
           node: node as any,


### PR DESCRIPTION
## Current Behavior

The `@nx/eslint-plugin/dependency-checks` rule's `peerDepsVersionStrategy: 'workspace'` option unconditionally rewrote **every** peer dependency to `workspace:*`, including external npm packages like `react`, `axios`, etc. Running `pnpm install` (or any equivalent) on the resulting `package.json` failed with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND` because those packages do not exist in the workspace. `eslint --fix` was therefore actively breaking working workspaces that enabled the strategy.

Two fix branches in `packages/eslint-plugin/src/rules/dependency-checks.ts` had the bug:

- The `missingDependencies` fix (around L299), which inserted new peer entries at `workspace:*`.
- The version-mismatch fix (around L370-382), which rewrote any non-`workspace:*` range to `workspace:*`.

## Expected Behavior

`peerDepsVersionStrategy: 'workspace'` should only produce `workspace:*` ranges for peer dependencies that are **workspace-published packages**. External npm packages must retain the normal installed-version logic so the resulting `package.json` is installable.

This PR:

- Builds a `workspacePackageNames` `Set<string>` once from `projectGraph.nodes[*].data.metadata.js.packageName`.
- Gates both `peerDepsVersionStrategy === 'workspace'` branches on `workspacePackageNames.has(packageName)`. Workspace packages continue to get `workspace:*`; external packages fall through to the existing installed-version / catalog / root-package-json resolution.

Three existing tests in `dependency-checks.spec.ts` that encoded the buggy behavior (asserting `workspace:*` for external packages) were updated to reflect the correct behavior. Two new focused tests were added to pin down each case explicitly (workspace package → `workspace:*`; external package → installed range preserved).

## Related Issue(s)

Fixes #35318

Follow-up to #33417, which introduced `peerDepsVersionStrategy`.
