### PR TITLE
fix(js): rewrite workspace refs in all dep types during lockfile pruning

### DIFF
--- a/packages/js/src/executors/prune-lockfile/prune-lockfile.ts
+++ b/packages/js/src/executors/prune-lockfile/prune-lockfile.ts
@@ -63,16 +63,24 @@ function createPrunedLockfile(packageJson: PackageJson, graph: ProjectGraph) {
 
   const workspacePackages = getWorkspacePackagesFromGraph(graph);
 
-  for (const [pkgName, pkgVersion] of Object.entries(
-    packageJson.dependencies ?? {}
-  )) {
-    if (
-      pkgVersion.startsWith('workspace:') ||
-      pkgVersion.startsWith('file:') ||
-      pkgVersion.startsWith('link:') ||
-      workspacePackages.has(pkgName)
-    ) {
-      packageJson.dependencies[pkgName] = `file:./workspace_modules/${pkgName}`;
+  for (const depType of [
+    'dependencies',
+    'devDependencies',
+    'optionalDependencies',
+    'peerDependencies',
+  ] as const) {
+    for (const [pkgName, pkgVersion] of Object.entries(
+      packageJson[depType] ?? {}
+    )) {
+      if (
+        pkgVersion.startsWith('workspace:') ||
+        pkgVersion.startsWith('file:') ||
+        pkgVersion.startsWith('link:') ||
+        workspacePackages.has(pkgName)
+      ) {
+        packageJson[depType][pkgName] =
+          `file:./workspace_modules/${pkgName}`;
+      }
     }
   }
 

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -785,9 +785,11 @@ function mapRootSnapshot(
           for (const [importerPath, importerSnapshot] of Object.entries(
             rootImporters
           )) {
+            // Search all dep sections in the importer, not just dependencies
             const workspaceDep =
-              importerSnapshot.dependencies &&
-              importerSnapshot.dependencies[packageName];
+              importerSnapshot.dependencies?.[packageName] ||
+              importerSnapshot.devDependencies?.[packageName] ||
+              importerSnapshot.optionalDependencies?.[packageName];
             if (workspaceDep) {
               const workspaceDepImporterPath = workspaceDep.replace(
                 'link:',
@@ -800,8 +802,11 @@ function mapRootSnapshot(
               importers[packageName] = importerKeyForPackage;
               snapshot.specifiers[packageName] =
                 `file:./workspace_modules/${packageName}`;
-              snapshot.dependencies = snapshot.dependencies || {};
-              snapshot.dependencies[packageName] =
+              // Write to the same section as in the original package.json
+              const section =
+                depType === 'peerDependencies' ? 'dependencies' : depType;
+              snapshot[section] = snapshot[section] || {};
+              snapshot[section][packageName] =
                 `link:./workspace_modules/${packageName}`;
               break;
             }


### PR DESCRIPTION
## Current Behavior

The `@nx/js:prune-lockfile` executor only rewrites `workspace:*` references to `file:./workspace_modules/<pkg>` in `packageJson.dependencies`. Workspace packages listed in `devDependencies`, `optionalDependencies`, or `peerDependencies` are silently skipped.

Similarly, the pnpm lockfile pruner (`mapRootSnapshot`) only searches `importerSnapshot.dependencies` when looking up workspace packages, so workspace deps in other sections produce no entry in the pruned lockfile.

This causes `pnpm install --frozen-lockfile` to fail with `ERR_PNPM_OUTDATED_LOCKFILE` because the lockfile specifiers don't match the `package.json`.

## Expected Behavior

The pruned lockfile and rewritten `package.json` correctly handle workspace packages in all dependency sections (`dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`), and `pnpm install --frozen-lockfile` succeeds.

### Changes

**Bug 1 fix** (`packages/js/src/executors/prune-lockfile/prune-lockfile.ts`):
- Iterate all four dependency types (`dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`) instead of only `dependencies` when rewriting workspace/file/link references in the output `package.json`.

**Bug 2 fix** (`packages/nx/src/plugins/js/lock-file/pnpm-parser.ts`):
- Search `importerSnapshot.dependencies`, `devDependencies`, and `optionalDependencies` when looking up workspace packages in the root lockfile importer snapshot.
- Write the pruned entry to the matching dep section (instead of always writing to `dependencies`), so pnpm doesn't report specifiers "moved" between sections.

## Related Issue(s)

Fixes #35425