### PR TITLE
fix(core): restore top-level schemas/ in published nx package

### DIFF
--- a/packages/nx/assets.json
+++ b/packages/nx/assets.json
@@ -15,7 +15,6 @@
     { "glob": "src/native/wasi-worker-browser.mjs" },
     { "glob": "src/native/wasi-worker.mjs" },
     { "glob": "src/native/*.{node,wasm}", "includeIgnoredFiles": true },
-    { "glob": "schemas/*.json" },
     { "glob": "native-packages/*/package.json" },
     {
       "glob": "index.d.ts",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -14,9 +14,9 @@
     "dist/plugins",
     "dist/presets",
     "dist/release",
-    "dist/schemas",
     "dist/src",
     "dist/tasks-runners",
+    "schemas",
     "migrations.json",
     "executors.json",
     "generators.json"
@@ -284,8 +284,8 @@
     "./generators": "./generators.json",
     "./executors.json": "./executors.json",
     "./executors": "./executors.json",
-    "./schemas/*": "./dist/schemas/*.json",
-    "./schemas/*.json": "./dist/schemas/*.json",
+    "./schemas/*": "./schemas/*.json",
+    "./schemas/*.json": "./schemas/*.json",
     "./presets/*": {
       "@nx/nx-source": "./presets/*.json",
       "default": "./dist/presets/*.json"


### PR DESCRIPTION
## Current Behavior

In 22.7.0-rc.1, `$schema` references in `nx.json` and `project.json` no longer resolve in VS Code / JetBrains / any editor that reads `$schema` as a filesystem path.

Root cause — two commits combined:

1. #34111 moved schemas from `packages/nx/schemas/` to `packages/nx/dist/schemas/`.
2. #35109 introduced a `files` allowlist that shipped only `dist/`, dropping the legacy top-level `schemas/` from the published npm tarball.

Node subpath `exports` (`"./schemas/*": "./dist/schemas/*.json"`) do **not** redirect filesystem paths — editors bypass Node resolution entirely. So the regression affected both existing workspaces upgrading from 22.6.x (with `$schema` already in their configs) and fresh installs (since `nx init`, `create-nx-workspace`, and the project-configuration generator all write `./node_modules/nx/schemas/...`).

## Expected Behavior

`schemas/*.json` ship at the root of the published `nx` package again, so `./node_modules/nx/schemas/nx-schema.json` (and the project/workspace variants) resolve on disk — no migration required, no changes to the paths generators write.

Schemas are static JSON assets, not build artifacts — they're now published from source, not copied through `dist/`:

- `packages/nx/package.json` `files`: `"dist/schemas"` → `"schemas"`.
- `packages/nx/package.json` `exports`: `./schemas/*` and `./schemas/*.json` both map to `./schemas/*.json`.
- `packages/nx/assets.json`: dropped the `schemas/*.json` → `dist/` copy step.

Verified via `npm pack --dry-run` — tarball now contains `schemas/nx-schema.json`, `schemas/project-schema.json`, `schemas/workspace-schema.json` at root, with no `dist/schemas/` entries.

## Related Issue(s)

Fixes #35411