### PR TITLE
docs(misc): fix link to plugin registry from batch mode definition

### DIFF
--- a/astro-docs/src/content/docs/reference/glossary.mdoc
+++ b/astro-docs/src/content/docs/reference/glossary.mdoc
@@ -29,7 +29,7 @@ Atomizer automatically splits tasks on [Nx Agents](#nx-agents), providing you de
 A way to run multiple [tasks](#task) in a single process instead of spawning a separate process for each one.
 Batch mode reduces per-process startup overhead and lets tools like `tsc` and Gradle share state across tasks.
 Enable it by setting `NX_BATCH_MODE=true` or passing `--batch`.
-Not all plugin executors support batch mode, check the specific plugin [technology page](/docs/technologies-tools) to see if it's supported.
+Not all plugin executors support batch mode, check the specific plugin [technology page](/docs/plugin-registry) to see if it's supported.
 
 ### Buildable library
 


### PR DESCRIPTION
PR to fix broken link. The plugin registry is the obvious page to link to from the batch mode definition.

Fixes DOC-491
