### PR TITLE
feat(vite): add compiler option to vite plugin for tsgo support

### DIFF
--- a/packages/vite/src/plugins/plugin.spec.ts
+++ b/packages/vite/src/plugins/plugin.spec.ts
@@ -217,6 +217,76 @@ describe('@nx/vite/plugin', () => {
       ).toEqual(['@nx/js:typescript-sync']);
     });
 
+    it('should use tsgo for typecheck when compiler option is tsgo', async () => {
+      tempFs.createFileSync('tsconfig.json', '');
+
+      const nodes = await createNodesFunction(
+        ['vite.config.ts'],
+        {
+          buildTargetName: 'build',
+          serveTargetName: 'serve',
+          previewTargetName: 'preview',
+          testTargetName: 'test',
+          serveStaticTargetName: 'serve-static',
+          compiler: 'tsgo',
+        },
+        context
+      );
+
+      const typecheck = nodes[0][1].projects['.'].targets.typecheck;
+      expect(typecheck.command).toEqual(`tsgo --noEmit -p tsconfig.json`);
+      expect(typecheck.inputs).toContainEqual({
+        externalDependencies: ['@typescript/native-preview'],
+      });
+    });
+
+    it('should use tsgo with --build flag when compiler is tsgo and using TS solution setup', async () => {
+      (isUsingTsSolutionSetup as jest.Mock).mockReturnValue(true);
+      tempFs.createFileSync('tsconfig.json', '');
+
+      const nodes = await createNodesFunction(
+        ['vite.config.ts'],
+        {
+          buildTargetName: 'build',
+          serveTargetName: 'serve',
+          previewTargetName: 'preview',
+          testTargetName: 'test',
+          serveStaticTargetName: 'serve-static',
+          compiler: 'tsgo',
+        },
+        context
+      );
+
+      const typecheck = nodes[0][1].projects['.'].targets.typecheck;
+      expect(typecheck.command).toEqual(`tsgo --build --emitDeclarationOnly`);
+      expect(typecheck.inputs).toContainEqual({
+        externalDependencies: ['@typescript/native-preview'],
+      });
+    });
+
+    it('should use vue-tsc when compiler option is vue-tsc (for non-detected Vue setups)', async () => {
+      tempFs.createFileSync('tsconfig.json', '');
+
+      const nodes = await createNodesFunction(
+        ['vite.config.ts'],
+        {
+          buildTargetName: 'build',
+          serveTargetName: 'serve',
+          previewTargetName: 'preview',
+          testTargetName: 'test',
+          serveStaticTargetName: 'serve-static',
+          compiler: 'vue-tsc',
+        },
+        context
+      );
+
+      const typecheck = nodes[0][1].projects['.'].targets.typecheck;
+      expect(typecheck.command).toEqual(`vue-tsc --noEmit -p tsconfig.json`);
+      expect(typecheck.inputs).toContainEqual({
+        externalDependencies: ['vue-tsc', 'typescript'],
+      });
+    });
+
     it('should infer the sync generator when using TS solution setup', async () => {
       (isUsingTsSolutionSetup as jest.Mock).mockReturnValue(true);
       tempFs.createFileSync('tsconfig.json', '');

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -423,7 +423,9 @@ async function buildViteTargets(
     const hasVuePlugin = viteBuildConfig.plugins?.some(
       (p) => p.name === 'vite:vue'
     );
-    const typeCheckCommand = hasVuePlugin ? 'vue-tsc' : (options.compiler ?? 'tsc');
+    const typeCheckCommand = hasVuePlugin
+      ? 'vue-tsc'
+      : (options.compiler ?? 'tsc');
 
     targets[options.typecheckTargetName] = {
       cache: true,

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -42,10 +42,12 @@ export interface VitePluginOptions {
   serveStaticTargetName?: string;
   typecheckTargetName?: string;
   /**
-   * The compiler to use for type-checking. Defaults to `tsc`.
-   * Set to `tsgo` to use the TypeScript Go compiler (`@typescript/native-preview`).
+   * The compiler to use for type-checking. When unset, defaults to `vue-tsc`
+   * for Vue projects (detected via the `vite:vue` plugin) and `tsc` otherwise.
+   * Set to `tsgo` to use the TypeScript Go compiler (`@typescript/native-preview`),
+   * or `vue-tsc` to force Vue-aware type-checking when auto-detection misses your setup.
    */
-  compiler?: string;
+  compiler?: 'tsc' | 'tsgo' | 'vue-tsc';
   watchDepsTargetName?: string;
   buildDepsTargetName?: string;
 
@@ -423,9 +425,17 @@ async function buildViteTargets(
     const hasVuePlugin = viteBuildConfig.plugins?.some(
       (p) => p.name === 'vite:vue'
     );
-    const typeCheckCommand = hasVuePlugin
-      ? 'vue-tsc'
-      : (options.compiler ?? 'tsc');
+    // Explicit `compiler` option wins over inference so users can override
+    // when their setup isn't detected (e.g. custom/non-standard Vue plugin).
+    const resolvedCompiler =
+      options.compiler ?? (hasVuePlugin ? 'vue-tsc' : 'tsc');
+    const typeCheckCommand = resolvedCompiler;
+    const typeCheckExternalDeps =
+      resolvedCompiler === 'tsgo'
+        ? ['@typescript/native-preview']
+        : resolvedCompiler === 'vue-tsc'
+          ? ['vue-tsc', 'typescript']
+          : ['typescript'];
 
     targets[options.typecheckTargetName] = {
       cache: true,
@@ -433,11 +443,7 @@ async function buildViteTargets(
         ...('production' in namedInputs
           ? ['production', '^production']
           : ['default', '^default']),
-        {
-          externalDependencies: hasVuePlugin
-            ? ['vue-tsc', 'typescript']
-            : ['typescript'],
-        },
+        { externalDependencies: typeCheckExternalDeps },
       ],
       command: isUsingTsSolutionSetup
         ? `${typeCheckCommand} --build --emitDeclarationOnly`
@@ -739,7 +745,6 @@ function normalizeOptions(options: VitePluginOptions): VitePluginOptions {
   options.testTargetName ??= 'test';
   options.serveStaticTargetName ??= 'serve-static';
   options.typecheckTargetName ??= 'typecheck';
-  options.compiler ??= 'tsc';
   return options;
 }
 

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -41,6 +41,11 @@ export interface VitePluginOptions {
   previewTargetName?: string;
   serveStaticTargetName?: string;
   typecheckTargetName?: string;
+  /**
+   * The compiler to use for type-checking. Defaults to `tsc`.
+   * Set to `tsgo` to use the TypeScript Go compiler (`@typescript/native-preview`).
+   */
+  compiler?: string;
   watchDepsTargetName?: string;
   buildDepsTargetName?: string;
 
@@ -418,7 +423,7 @@ async function buildViteTargets(
     const hasVuePlugin = viteBuildConfig.plugins?.some(
       (p) => p.name === 'vite:vue'
     );
-    const typeCheckCommand = hasVuePlugin ? 'vue-tsc' : 'tsc';
+    const typeCheckCommand = hasVuePlugin ? 'vue-tsc' : (options.compiler ?? 'tsc');
 
     targets[options.typecheckTargetName] = {
       cache: true,
@@ -732,6 +737,7 @@ function normalizeOptions(options: VitePluginOptions): VitePluginOptions {
   options.testTargetName ??= 'test';
   options.serveStaticTargetName ??= 'serve-static';
   options.typecheckTargetName ??= 'typecheck';
+  options.compiler ??= 'tsc';
   return options;
 }
 


### PR DESCRIPTION
## Description

Adds a `compiler` option to the `@nx/vite` plugin, mirroring the same option already in `@nx/js` (added in #33821).

This lets users specify an alternative TypeScript compiler for the inferred `typecheck` target — specifically `tsgo` from `@typescript/native-preview` (TypeScript 7 Go compiler).

## Problem

`@nx/vite` hardcodes `'tsc'` for typecheck while `@nx/js` already supports a configurable `compiler` option. Users who want `tsgo` have to patch `@nx/vite` manually.

## Solution

3 lines in `packages/vite/src/plugins/plugin.ts`:

1. Add `compiler?: string` to `VitePluginOptions` (with JSDoc)
2. `options.compiler ?? 'tsc'` instead of hardcoded `'tsc'` (Vue projects still use `vue-tsc`)
3. `options.compiler ??= 'tsc'` in `normalizeOptions`

## Usage

```json
// nx.json
{
  "plugins": [
    {
      "plugin": "@nx/vite/plugin",
      "options": {
        "compiler": "tsgo"
      }
    }
  ]
}
```

## Benchmarks (large monorepo, ~400 projects)

| Project | `tsc` | `tsgo` | Speedup |
|---|---|---|---|
| `dashboard-web` | 2.33s | 0.43s | **5.4×** |
| `market-react` | 11.57s | 3.64s | **3.2×** |

On CI: total typecheck CPU dropped **2.7×**, allowing us to eliminate worker sharding entirely.

Currently working around this with a pnpm patch on `@nx/vite` — happy to remove it once this lands.

## Prior art

- #33821 — same `compiler` option added to `@nx/js`
- #35047 / #35167 — Nx team experimented with tsgo internally