### PR TITLE
fix(core): make nx version lookup bundle-safe

### DIFF
--- a/packages/nx/src/utils/versions.ts
+++ b/packages/nx/src/utils/versions.ts
@@ -1,5 +1,1 @@
-import { extname } from 'path';
-
-const isTS = extname(__filename) === '.ts';
-const pathToPackageJson = isTS ? '../../package.json' : '../../../package.json';
-export const nxVersion = require(pathToPackageJson).version;
+export const nxVersion = require('nx/package.json').version;


### PR DESCRIPTION
## Current Behavior

Nx reads its own version through a package.json path derived from __filename. When Nx internals are bundled into another tool, that relative path can point outside the original package layout.

## Expected Behavior

Nx resolves its version through the exported nx/package.json self-reference, so bundlers can resolve it statically and the runtime no longer depends on the source/dist file layout.

## Related Issue(s)

N/A