### PR TITLE
fix(bundling): declare tsconfig.json as input for esbuild targets

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -87,6 +87,18 @@
       "inputs": ["production", "^production"],
       "cache": true
     },
+    "@nx/esbuild:esbuild": {
+      "cache": true,
+      "dependsOn": ["^build", "typecheck", "build-base"],
+      "inputs": [
+        "production",
+        "^production",
+        {
+          "json": "{workspaceRoot}/tsconfig.json",
+          "fields": ["extends", "files", "include"]
+        }
+      ]
+    },
     "build-native": { "inputs": ["native"], "cache": true },
     "build-base": {
       "dependsOn": ["^build-base", "build-native", "copy-assets"],

--- a/packages/devkit/src/generators/target-defaults-utils.spec.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.spec.ts
@@ -12,8 +12,90 @@ jest.mock(
 import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
 import { readNxJson, updateNxJson, type Tree } from 'nx/src/devkit-exports';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
-import { addE2eCiTargetDefaults } from './target-defaults-utils';
+import {
+  addBuildTargetDefaults,
+  addE2eCiTargetDefaults,
+} from './target-defaults-utils';
 describe('target-defaults-utils', () => {
+  describe('addBuildTargetDefaults', () => {
+    let tree: Tree;
+
+    beforeEach(() => {
+      tree = createTreeWithEmptyWorkspace();
+    });
+
+    it('should set executor-keyed target defaults with default inputs', () => {
+      addBuildTargetDefaults(tree, '@nx/example:build');
+
+      const nxJson = readNxJson(tree);
+      expect(nxJson.targetDefaults['@nx/example:build']).toEqual({
+        cache: true,
+        dependsOn: ['^build'],
+        inputs: ['default', '^default'],
+      });
+    });
+
+    it('should use production named inputs when available', () => {
+      const nxJson = readNxJson(tree);
+      nxJson.namedInputs = {
+        default: ['{projectRoot}/**/*'],
+        production: ['default'],
+      };
+      updateNxJson(tree, nxJson);
+
+      addBuildTargetDefaults(tree, '@nx/example:build');
+
+      expect(
+        readNxJson(tree).targetDefaults['@nx/example:build'].inputs
+      ).toEqual(['production', '^production']);
+    });
+
+    it('should honor a custom build target name in dependsOn', () => {
+      addBuildTargetDefaults(tree, '@nx/example:build', 'compile');
+
+      expect(
+        readNxJson(tree).targetDefaults['@nx/example:build'].dependsOn
+      ).toEqual(['^compile']);
+    });
+
+    it('should append extra inputs after the default/production inputs', () => {
+      addBuildTargetDefaults(tree, '@nx/example:build', 'build', [
+        {
+          json: '{workspaceRoot}/tsconfig.json',
+          fields: ['extends', 'files', 'include'],
+        },
+      ]);
+
+      expect(
+        readNxJson(tree).targetDefaults['@nx/example:build'].inputs
+      ).toEqual([
+        'default',
+        '^default',
+        {
+          json: '{workspaceRoot}/tsconfig.json',
+          fields: ['extends', 'files', 'include'],
+        },
+      ]);
+    });
+
+    it('should not overwrite existing target defaults for the executor', () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        '@nx/example:build': { cache: true, inputs: ['custom'] },
+      };
+      updateNxJson(tree, nxJson);
+
+      addBuildTargetDefaults(tree, '@nx/example:build', 'build', [
+        { json: '{workspaceRoot}/tsconfig.json', fields: ['extends'] },
+      ]);
+
+      expect(readNxJson(tree).targetDefaults['@nx/example:build']).toEqual({
+        cache: true,
+        inputs: ['custom'],
+      });
+    });
+  });
+
   describe('addE2eCiTargetDefaults', () => {
     let tree: Tree;
     let tempFs: TempFs;

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -1,6 +1,7 @@
 import {
   type CreateNodesV2,
   type PluginConfiguration,
+  type TargetConfiguration,
   type Tree,
   readNxJson,
   updateNxJson,
@@ -10,17 +11,20 @@ import { findMatchingConfigFiles } from 'nx/src/devkit-internals';
 export function addBuildTargetDefaults(
   tree: Tree,
   executorName: string,
-  buildTargetName = 'build'
+  buildTargetName = 'build',
+  extraInputs: TargetConfiguration['inputs'] = []
 ): void {
   const nxJson = readNxJson(tree);
   nxJson.targetDefaults ??= {};
   nxJson.targetDefaults[executorName] ??= {
     cache: true,
     dependsOn: [`^${buildTargetName}`],
-    inputs:
-      nxJson.namedInputs && 'production' in nxJson.namedInputs
+    inputs: [
+      ...(nxJson.namedInputs && 'production' in nxJson.namedInputs
         ? ['production', '^production']
-        : ['default', '^default'],
+        : ['default', '^default']),
+      ...extraInputs,
+    ],
   };
   updateNxJson(tree, nxJson);
 }

--- a/packages/esbuild/src/generators/configuration/configuration.spec.ts
+++ b/packages/esbuild/src/generators/configuration/configuration.spec.ts
@@ -1,6 +1,7 @@
 import type { Tree } from '@nx/devkit';
 import {
   addProjectConfiguration,
+  readJson,
   readProjectConfiguration,
   writeJson,
 } from '@nx/devkit';
@@ -59,6 +60,89 @@ describe('configurationGenerator', () => {
       outputFileName: 'main.js',
       outputPath: 'dist/mypkg',
       tsConfig: `tsconfig.app.json`,
+    });
+  });
+
+  it('should set @nx/esbuild:esbuild target defaults with the tsconfig field-scoped input', async () => {
+    addProjectConfiguration(tree, 'mypkg', {
+      root: 'mypkg',
+    });
+    tree.write('mypkg/src/main.ts', 'console.log("main");');
+    writeJson(tree, 'mypkg/tsconfig.app.json', {});
+
+    await configurationGenerator(tree, {
+      project: 'mypkg',
+    });
+
+    const nxJson = readJson(tree, 'nx.json');
+    expect(nxJson.targetDefaults['@nx/esbuild:esbuild']).toEqual({
+      cache: true,
+      dependsOn: ['^build'],
+      inputs: [
+        'default',
+        '^default',
+        {
+          json: '{workspaceRoot}/tsconfig.json',
+          fields: ['extends', 'files', 'include'],
+        },
+      ],
+    });
+    expect(
+      readProjectConfiguration(tree, 'mypkg').targets.build.inputs
+    ).toBeUndefined();
+  });
+
+  it('should use production named inputs when defined', async () => {
+    writeJson(tree, 'nx.json', {
+      namedInputs: {
+        default: ['{projectRoot}/**/*'],
+        production: ['default'],
+      },
+    });
+    addProjectConfiguration(tree, 'mypkg', {
+      root: 'mypkg',
+    });
+    tree.write('mypkg/src/main.ts', 'console.log("main");');
+    writeJson(tree, 'mypkg/tsconfig.app.json', {});
+
+    await configurationGenerator(tree, {
+      project: 'mypkg',
+    });
+
+    const nxJson = readJson(tree, 'nx.json');
+    expect(nxJson.targetDefaults['@nx/esbuild:esbuild'].inputs).toEqual([
+      'production',
+      '^production',
+      {
+        json: '{workspaceRoot}/tsconfig.json',
+        fields: ['extends', 'files', 'include'],
+      },
+    ]);
+  });
+
+  it('should not override existing @nx/esbuild:esbuild target defaults', async () => {
+    writeJson(tree, 'nx.json', {
+      targetDefaults: {
+        '@nx/esbuild:esbuild': {
+          cache: true,
+          inputs: ['custom-input'],
+        },
+      },
+    });
+    addProjectConfiguration(tree, 'mypkg', {
+      root: 'mypkg',
+    });
+    tree.write('mypkg/src/main.ts', 'console.log("main");');
+    writeJson(tree, 'mypkg/tsconfig.app.json', {});
+
+    await configurationGenerator(tree, {
+      project: 'mypkg',
+    });
+
+    const nxJson = readJson(tree, 'nx.json');
+    expect(nxJson.targetDefaults['@nx/esbuild:esbuild']).toEqual({
+      cache: true,
+      inputs: ['custom-input'],
     });
   });
 });

--- a/packages/esbuild/src/generators/configuration/configuration.ts
+++ b/packages/esbuild/src/generators/configuration/configuration.ts
@@ -56,7 +56,12 @@ function addBuildTarget(
   options: EsBuildProjectSchema,
   isTsSolutionSetup: boolean
 ) {
-  addBuildTargetDefaults(tree, '@nx/esbuild:esbuild', options.buildTarget);
+  addBuildTargetDefaults(tree, '@nx/esbuild:esbuild', options.buildTarget, [
+    {
+      json: '{workspaceRoot}/tsconfig.json',
+      fields: ['extends', 'files', 'include'],
+    },
+  ]);
   const project = readProjectConfiguration(tree, options.project);
 
   const prevBuildOptions = project.targets?.[options.buildTarget]?.options;


### PR DESCRIPTION
## Current Behavior

The `@nx/esbuild:esbuild` executor calls `isUsingTsSolutionSetup` at task runtime, which reads `extends`, `files`, and `include` from the workspace-root `tsconfig.json`. Targets using the executor do not declare those fields as inputs, so cache hashes do not reflect changes to them and builds can hit stale cache entries after a `tsconfig.json` edit.

## Expected Behavior

Targets using the `@nx/esbuild:esbuild` executor include a field-scoped `{workspaceRoot}/tsconfig.json` input covering exactly the fields the executor reads, so hashes change when those fields change and remain unaffected by unrelated edits.

- `addBuildTargetDefaults` gains an optional `extraInputs` parameter so plugin generators can extend the default/production inputs when seeding executor-keyed target defaults. Existing call sites are unchanged.
- The `@nx/esbuild:configuration` generator uses that parameter to add a field-scoped `{workspaceRoot}/tsconfig.json` input (fields: `extends`, `files`, `include`) to the `@nx/esbuild:esbuild` target defaults it seeds.
- This repo's `nx.json` gains the same executor-keyed target defaults so `tools-documentation-create-embeddings` (the only esbuild target in the repo) inherits the fix. `dependsOn` mirrors the existing `build` target-name default to preserve the inferred `typecheck` and `build-base` dependencies.