### PR TITLE
docs(nextjs): clarify Vercel root directory and document NEXT_PUBLIC_ cache issue

### DIFF
--- a/astro-docs/src/content/docs/technologies/react/Guides/deploy-nextjs-to-vercel.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/Guides/deploy-nextjs-to-vercel.mdoc
@@ -12,7 +12,7 @@ Your Next.js application should already be ready for deployment to Vercel.
 
 ### New Vercel project
 
-1. If you are "importing" your Nx workspace's repository for the first time, make sure you do _not_ choose a root directory as part of the repo selection process (therefore leaving it to be the root of the full repo/workspace)
+1. If you are "importing" your Nx workspace's repository for the first time, make sure you leave the **Root Directory** field **empty**. Do not set it to `./` or any subdirectory. Vercel will use the full repository root, which is required for Nx to work correctly.
 2. Ensure the Next.js "Framework Preset" is selected
 3. Expand the "Build and Output Settings" and toggle the override switch for the build command. For example, for an application named `tuskdesk` the value will look like this:
 
@@ -37,6 +37,45 @@ If you have an existing project on Vercel then the exact same guidance applies a
 When everything is updated appropriately, for our `tuskdesk` example we would see the following in our "General" settings UI:
 
 ![Existing Vercel Project](../../../../../assets/guides/next/next-deploy-vercel-2.png)
+
+## Handling `NEXT_PUBLIC_` environment variables with Nx cache
+
+Next.js bakes `NEXT_PUBLIC_*` environment variables into the static bundle at **build time**. If Nx (or Nx Cloud) has a cached build from a previous run, for example from your local development environment, it will restore that cached output rather than running `next build` again. This means the cached bundle may contain development values for your `NEXT_PUBLIC_*` variables even when Vercel has the correct production values configured.
+
+The proper solution is to include your `NEXT_PUBLIC_*` environment variables in the `inputs` of your build target. This tells Nx to treat a change in those variable values as a cache miss, ensuring a fresh build is triggered whenever they differ.
+
+In your application's `project.json`, extend the build target inputs:
+
+```json
+{
+  "targets": {
+    "build": {
+      "inputs": [
+        "default",
+        "^production",
+        { "env": "NEXT_PUBLIC_API_URL" },
+        { "env": "NEXT_PUBLIC_SUPABASE_URL" }
+      ]
+    }
+  }
+}
+```
+
+Add one `{ "env": "VARIABLE_NAME" }` entry for each `NEXT_PUBLIC_*` variable your application uses. When the value of any listed variable differs from the cached build, Nx will invalidate the cache and rebuild.
+
+{% aside type="note" title="Preserving plugin-inferred inputs" %}
+The `@nx/next` plugin automatically infers certain inputs for Next.js build targets. When you override the `inputs` array, make sure to include `"default"` and `"^production"` so those defaults are preserved. If you are unsure what inputs your build target currently has, run `nx show project <app-name>` to inspect the effective configuration.
+{% /aside %}
+
+If you need a quick workaround before configuring inputs, you can pass `--skip-nx-cache` to bypass the cache entirely:
+
+```shell
+npx nx build tuskdesk --prod --skip-nx-cache
+```
+
+Note that this disables all Nx caching for that run, eliminating the performance benefit. The `inputs` approach above is preferred for ongoing deployments.
+
+See [Nx Inputs documentation](/reference/inputs#environment-variables) for more details.
 
 ## Skipping build if the application is not affected
 

--- a/astro-docs/src/content/docs/technologies/react/Guides/deploy-nextjs-to-vercel.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/Guides/deploy-nextjs-to-vercel.mdoc
@@ -75,7 +75,7 @@ npx nx build tuskdesk --prod --skip-nx-cache
 
 Note that this disables all Nx caching for that run, eliminating the performance benefit. The `inputs` approach above is preferred for ongoing deployments.
 
-See [Nx Inputs documentation](/reference/inputs#environment-variables) for more details.
+See [Nx Inputs documentation](/docs/reference/inputs#environment-variables) for more details.
 
 ## Skipping build if the application is not affected
 


### PR DESCRIPTION
Someone got confused because the build is restoring from cache when the env var the app uses is different from prod vs local. We should mention that env vars need to be added as inputs.

Fixes #33331