### PR TITLE
fix(core): skip execSync pm version check when devEngines present

### DIFF
--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -116,6 +116,18 @@ export interface PackageJson {
   'nx-migrations'?: string | NxMigrationsConfiguration;
   'ng-update'?: string | NxMigrationsConfiguration;
   packageManager?: string;
+  // https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines
+  devEngines?: {
+    packageManager?: {
+      name?: string;
+      version?: string;
+      onFail?: 'ignore' | 'warn' | 'error' | 'download';
+    };
+    runtime?: Record<string, unknown>;
+    cpu?: Record<string, unknown>;
+    libc?: Record<string, unknown>;
+    os?: Record<string, unknown>;
+  };
   description?: string;
   keywords?: string[];
 }

--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -329,6 +329,46 @@ describe('package-manager', () => {
         .mockReturnValueOnce({ packageManager: 'npm@6.32.4' });
       expect(() => getPackageManagerVersion('yarn')).toThrow();
     });
+
+    it('should prefer packageManager field over execSync to avoid spawn cost', () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValueOnce(true);
+      const execSyncSpy = jest
+        .spyOn(childProcess, 'execSync')
+        .mockImplementation(() => '99.99.99');
+      jest
+        .spyOn(fileUtils, 'readJsonFile')
+        .mockReturnValueOnce({ packageManager: 'pnpm@10.33.0' });
+      expect(getPackageManagerVersion('pnpm')).toEqual('10.33.0');
+      expect(execSyncSpy).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to devEngines.packageManager when packageManager field is missing', () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValueOnce(true);
+      const execSyncSpy = jest
+        .spyOn(childProcess, 'execSync')
+        .mockImplementation(() => '99.99.99');
+      jest.spyOn(fileUtils, 'readJsonFile').mockReturnValueOnce({
+        devEngines: {
+          packageManager: { name: 'pnpm', version: '10.33.0' },
+        },
+      });
+      expect(getPackageManagerVersion('pnpm')).toEqual('10.33.0');
+      expect(execSyncSpy).not.toHaveBeenCalled();
+    });
+
+    it('should fall through to execSync when devEngines.packageManager version is a range', () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValueOnce(true);
+      const execSyncSpy = jest
+        .spyOn(childProcess, 'execSync')
+        .mockImplementation(() => '10.33.0');
+      jest.spyOn(fileUtils, 'readJsonFile').mockReturnValueOnce({
+        devEngines: {
+          packageManager: { name: 'pnpm', version: '^10.0.0' },
+        },
+      });
+      expect(getPackageManagerVersion('pnpm')).toEqual('10.33.0');
+      expect(execSyncSpy).toHaveBeenCalled();
+    });
   });
 
   describe('isWorkspacesEnabled', () => {

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -285,14 +285,25 @@ export function getPackageManagerVersion(
   cwd = process.cwd()
 ): string {
   let version: string;
+  // Resolve the version from package.json fields first to skip the ~170ms
+  // `execSync('<pm> --version')` spawn on every cold Nx invocation. Match
+  // Corepack's resolution order: top-level `packageManager` then
+  // `devEngines.packageManager` (npm 11+).
   if (existsSync(join(cwd, 'package.json'))) {
-    const packageManagerEntry = readJsonFile<PackageJson>(
-      join(cwd, 'package.json')
-    )?.packageManager;
+    const pkgJson = readJsonFile<PackageJson>(join(cwd, 'package.json'));
     version = parseVersionFromPackageManagerField(
       packageManager,
-      packageManagerEntry
+      pkgJson?.packageManager
     );
+    if (!version) {
+      const dev = pkgJson?.devEngines?.packageManager;
+      if (dev?.name && dev?.version) {
+        version = parseVersionFromPackageManagerField(
+          packageManager,
+          `${dev.name}@${dev.version}`
+        );
+      }
+    }
   }
   if (!version) {
     try {


### PR DESCRIPTION
## Current Behavior

`getPackageManagerVersion` already reads the top-level `packageManager` field, but workspaces that pin the package manager only via npm 11's `devEngines.packageManager` fall through to `execSync('<pm> --version')`, costing ~170 ms per cold Nx process. See NXC-4354 for measurements.

## Expected Behavior

Match Corepack's resolution order:

1. Top-level `packageManager` field (existing behavior)
2. `devEngines.packageManager` field (npm 11+) — **new**
3. `execSync('<pm> --version')` fallback

Range versions (e.g. `^10.0.0`) in `devEngines.packageManager.version` fall through to `execSync` since they can't resolve to a concrete version. Exact versions use the fast path. `package.json` is now read once per call instead of potentially twice.

## Related Issue(s)

Fixes NXC-4354