### PR TITLE
docs(pnpm): standardize 'pnpm' capitalization across documentation and source

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -26,14 +26,14 @@ eval "$(mise activate bash)"
 echo "⚙️ Configuring mise activation in shell..."
 echo 'eval "$(~/.local/bin/mise activate bash)"' >> ~/.bashrc
 
-# Prevent corepack from prompting user before downloading PNPM 
+# Prevent corepack from prompting user before downloading pnpm
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
-# Enable corepack 
-corepack enable 
+# Enable corepack
+corepack enable
 
-# Install the PNPM version defined in the root package.json
-echo "⚙️ Installing required PNPM version..."
+# Install the pnpm version defined in the root package.json
+echo "⚙️ Installing required pnpm version..."
 corepack prepare --activate
 
 # Install NPM dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -191,7 +191,7 @@ jobs:
                 echo Node: \$(node -v)
                 echo NPM: \$(npm -v)
 
-                # Install PNPM
+                # Install pnpm
                 npm i -g pnpm@${PNPM_VERSION} --force
                 pnpm --version
 
@@ -288,7 +288,7 @@ jobs:
                 echo Node: \$(node -v)
                 echo NPM: \$(npm -v)
 
-                # Install PNPM
+                # Install pnpm
                 npm i -g pnpm@${PNPM_VERSION} --force
                 pnpm --version
 

--- a/astro-docs/src/content/docs/extending-nx/create-install-package.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/create-install-package.mdoc
@@ -122,7 +122,7 @@ By running
 npx nx local-registry
 ```
 
-...a local instance of [Verdaccio](https://verdaccio.org/) will be launched at http://localhost:4873 and the NPM, Yarn and PNPM registries will be configured to point to it. This means that you can safely publish, without hitting npm, and test as if you were an end user of your package.
+...a local instance of [Verdaccio](https://verdaccio.org/) will be launched at http://localhost:4873 and the NPM, Yarn and pnpm registries will be configured to point to it. This means that you can safely publish, without hitting npm, and test as if you were an end user of your package.
 
 {% aside type="note" title="Registry Cleanup & Reset" %}
 Note, after terminating the terminal window where the `nx local-registry` command is running (e.g. using `CTRL+c` or `CMD+c`) the registry will be stopped, previously installed packages will be cleaned up and the npm/yarn/pnpm registries will be restored to their original state, pointing to the real NPM servers again.

--- a/astro-docs/src/content/docs/extending-nx/local-generators.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/local-generators.mdoc
@@ -10,8 +10,8 @@ Nx provides tooling around creating, and running custom generators from within y
 
 {% youtube
 src="https://www.youtube.com/embed/myqfGDWC2go"
-title="Scaffold new Pkgs in a PNPM Workspaces Monorepo"
-caption="Demoes how to use Nx generators in a PNPM workspace to automate the creation of libraries"
+title="Scaffold new Pkgs in a pnpm Workspaces Monorepo"
+caption="Demoes how to use Nx generators in a pnpm workspace to automate the creation of libraries"
 /%}
 
 ## Creating a generator

--- a/astro-docs/src/content/docs/features/generate-code.mdoc
+++ b/astro-docs/src/content/docs/features/generate-code.mdoc
@@ -73,4 +73,4 @@ export default async function (tree: Tree, schema: any) {
 
 To help build generators, Nx provides the `@nx/devkit` package containing utilities and helpers. Learn more about creating your own generators on [our docs page](/docs/extending-nx/local-generators) or watch the video below:
 
-{% youtube src="https://www.youtube.com/embed/myqfGDWC2go" title="Scaffold new Pkgs in a PNPM Workspaces Monorepo" caption="Demonstrates how to use Nx generators in a PNPM workspace to automate the creation of libraries" /%}
+{% youtube src="https://www.youtube.com/embed/myqfGDWC2go" title="Scaffold new Pkgs in a pnpm Workspaces Monorepo" caption="Demonstrates how to use Nx generators in a pnpm workspace to automate the creation of libraries" /%}

--- a/astro-docs/src/content/docs/getting-started/start-with-existing-project.mdoc
+++ b/astro-docs/src/content/docs/getting-started/start-with-existing-project.mdoc
@@ -7,7 +7,7 @@ sidebar:
 filter: 'type:Guides'
 ---
 
-{% course_video src="https://youtu.be/3hW53b1IJ84" courseTitle="From PNPM Workspaces to Distributed CI" courseUrl="https://nx.dev/courses/pnpm-nx-next/lessons-01-nx-init" /%}
+{% course_video src="https://youtu.be/3hW53b1IJ84" courseTitle="From pnpm Workspaces to Distributed CI" courseUrl="https://nx.dev/courses/pnpm-nx-next/lessons-01-nx-init" /%}
 
 Nx is designed for incremental adoption. Start with task running and [caching](/docs/features/cache-task-results), then add [plugins](/docs/technologies), [CI integrations](/docs/guides/nx-cloud/setup-ci), or other capabilities as your needs grow.
 

--- a/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-existing-project.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-existing-project.mdoc
@@ -405,6 +405,6 @@ For more information about how Nx can improve your CI pipeline, check out our [C
 
 {% linkcard title="Cache Task Results" description="Learn more about how caching works" href="/docs/features/cache-task-results" /%}
 
-{% linkcard title="Adding Nx to NPM/Yarn/PNPM Workspace" description="Learn more about how to add Nx to an existing monorepo" href="/docs/guides/adopting-nx/adding-to-monorepo" /%}
+{% linkcard title="Adding Nx to NPM/Yarn/pnpm Workspace" description="Learn more about how to add Nx to an existing monorepo" href="/docs/guides/adopting-nx/adding-to-monorepo" /%}
 
 {% /cardgrid %}

--- a/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-monorepo.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-monorepo.mdoc
@@ -1,10 +1,10 @@
 ---
-title: Adding Nx to NPM/Yarn/PNPM Workspace
-description: Learn how to integrate Nx into an existing NPM, Yarn, or PNPM workspace monorepo to gain task scheduling, caching, and improved CI performance.
+title: Adding Nx to NPM/Yarn/pnpm Workspace
+description: Learn how to integrate Nx into an existing NPM, Yarn, or pnpm workspace monorepo to gain task scheduling, caching, and improved CI performance.
 filter: 'type:Guides'
 weight: 2
 sidebar:
-  label: NPM/Yarn/PNPM workspaces
+  label: NPM/Yarn/pnpm workspaces
 ---
 
 {% aside type="note" title="Migrating from Lerna?" %}
@@ -14,7 +14,7 @@ on [https://lerna.js.org/upgrade](https://lerna.js.org/upgrade).
 {% /aside %}
 
 Nx has first-class support for [monorepos](/docs/getting-started/tutorials/crafting-your-workspace). If you have
-an existing NPM/Yarn or PNPM-based monorepo setup, you can easily add Nx to get
+an existing NPM/Yarn or pnpm-based monorepo setup, you can easily add Nx to get
 
 - fast [task scheduling](/docs/features/run-tasks)
 - high-performance task [caching](/docs/features/cache-task-results)
@@ -23,7 +23,7 @@ an existing NPM/Yarn or PNPM-based monorepo setup, you can easily add Nx to get
 This is a low-impact operation because all that needs to be done is to install the `nx` package at the root level and
 add an `nx.json` for configuring caching and task pipelines.
 
-{% course_video src="https://youtu.be/3hW53b1IJ84" courseTitle="From PNPM Workspaces to Distributed CI" courseUrl="https://nx.dev/courses/pnpm-nx-next/lessons-01-nx-init" /%}
+{% course_video src="https://youtu.be/3hW53b1IJ84" courseTitle="From pnpm Workspaces to Distributed CI" courseUrl="https://nx.dev/courses/pnpm-nx-next/lessons-01-nx-init" /%}
 
 ## Installing Nx
 
@@ -305,8 +305,8 @@ For example, use Nx to run your builds:
 npx nx run-many -t build
 ```
 
-But instead keep using NPM/Yarn/PNPM workspace commands for your tests and other scripts. Here's an example of using
-PNPM commands to run tests across packages
+But instead keep using NPM/Yarn/pnpm workspace commands for your tests and other scripts. Here's an example of using
+pnpm commands to run tests across packages
 
 ```shell
 pnpm run -r test

--- a/astro-docs/src/content/docs/guides/Nx Cloud/optimize-your-ttg.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/optimize-your-ttg.mdoc
@@ -77,7 +77,7 @@ Once feedback and context switching are handled, compress the compute side.
 **Cache hit rate is low**
 
 - Ensure tasks are cacheable and deterministic. Define `outputs` and configure `inputs`/`namedInputs` correctly. See: [Configure Inputs](/docs/guides/tasks--caching/configure-inputs), [Configure Outputs](/docs/guides/tasks--caching/configure-outputs), [Inputs Reference](/docs/reference/inputs)
-- Standardize Node/PNPM versions across dev and CI; avoid environment variables that unintentionally affect inputs.
+- Standardize Node/pnpm versions across dev and CI; avoid environment variables that unintentionally affect inputs.
 - Use [Remote caching (Nx Replay)](/docs/features/ci-features/remote-cache) to share results between CI and dev machines.
 
 **Agents are idle, or queue time is high**

--- a/astro-docs/src/content/docs/guides/Nx Cloud/setup-ci.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/setup-ci.mdoc
@@ -14,7 +14,7 @@ nx connect
 
 Each platform has specific configurations and optimizations that help you build and test only what is affected, retrieve previous successful builds, and optimize CI performance.
 
-{% course_video src="https://www.youtube.com/watch?v=8mqHXYIl_qI" courseTitle="From PNPM Workspaces to Distributed CI" courseUrl="https://nx.dev/courses/pnpm-nx-next/lessons-06-nx-cloud-setup" /%}
+{% course_video src="https://www.youtube.com/watch?v=8mqHXYIl_qI" courseTitle="From pnpm Workspaces to Distributed CI" courseUrl="https://nx.dev/courses/pnpm-nx-next/lessons-06-nx-cloud-setup" /%}
 
 ## CI configuration
 

--- a/astro-docs/src/content/docs/reference/Nx Cloud/launch-template-examples.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/launch-template-examples.mdoc
@@ -498,7 +498,7 @@ launch-templates:
           echo "Node: $(node -v)"
           echo "NPM: $(npm -v)"
           echo "Yarn: $(yarn -v)"
-          echo "PNPM: $(pnpm -v)"
+          echo "pnpm: $(pnpm -v)"
           echo "Golang: $(go version)"
           echo "Java: $(javac --version)"
           # add any other toolchain you want

--- a/astro-docs/src/content/docs/reference/Nx Cloud/release-notes.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/release-notes.mdoc
@@ -370,11 +370,11 @@ To enable it, you need to set this env variable on the nx-api deployment:
 - node modules caching fixes on Nx Agents
   - previously, we were always recommending caching the `node_modules` folder itself in your Nx Agents yaml configs
   - this does not work with `npm ci`, as it always deletes the local `node_modules` folder before starting the installation. Instead, NPM recommends caching the `$HOME/.npm` directory.
-  - Yarn and PNPM also have their own dedicated folders they recommend for caching
+  - Yarn and pnpm also have their own dedicated folders they recommend for caching
   - Part of this release, we now fixed caching folders in the `$HOME` directory, so all the below options should work:
     - `~/.npm`
     - `~/.cache/yarn`
-    - `.pnpm-store` (note PNPM on Nx Agents does not store its cache folder in the \$HOME dir)
+    - `.pnpm-store` (note pnpm on Nx Agents does not store its cache folder in the \$HOME dir)
   - Please refer to the [custom launch templates docs](/docs/reference/nx-cloud/launch-templates#full-example) for how you can setup your caching under these new recommendations
 - Nx Agents `$HOME` directory mounting
   - previously, when your Nx Agents pods were starting up, we were mounting as a k8s volume just the folder in which you checkout your repo: `$HOME/workspace`

--- a/astro-docs/src/content/docs/technologies/angular/Guides/dynamic-module-federation-with-angular.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/Guides/dynamic-module-federation-with-angular.mdoc
@@ -116,7 +116,7 @@ The terminal examples will show `nx` being run as if it is installed globally. I
 
 - NPM: `npx nx ...`
 - Yarn: `yarn nx ...`
-- PNPM: `pnpm nx ...`
+- pnpm: `pnpm nx ...`
 
 {% /aside %}
 

--- a/nx-dev/nx-dev/courses-content/explore-nx/lessons/01-why-nx.md
+++ b/nx-dev/nx-dev/courses-content/explore-nx/lessons/01-why-nx.md
@@ -10,7 +10,7 @@ This video gives you a birds-eye view of Nx in ~10 minutes. It covers topics suc
 - Nx Architecture
 - Add Nx to an arbitrary project
 - Why would adding Nx be useful?
-- Nx in a PNPM monorepo
+- Nx in a pnpm monorepo
 - Why use Nx Plugins
 - Setting up a new Nx Integrated Monorepo
 - Abstracting low-level configs

--- a/nx-dev/nx-dev/courses-content/pnpm-nx-next/course.md
+++ b/nx-dev/nx-dev/courses-content/pnpm-nx-next/course.md
@@ -1,12 +1,12 @@
 ---
-title: 'From PNPM Workspaces to Distributed CI'
-description: 'Learn how to transform a PNPM workspace monorepo into a high-performance distributed CI setup using Nx.'
+title: 'From pnpm Workspaces to Distributed CI'
+description: 'Learn how to transform a pnpm workspace monorepo into a high-performance distributed CI setup using Nx.'
 authors: [Juri Strumpflohner]
 repository: 'https://github.com/nrwl/nx-course-pnpm-nx'
 order: 2
 ---
 
-In this course, we'll walk through a step-by-step guide using the Tasker application as our example. Tasker is a task management app built with Next.js, structured as a PNPM workspace monorepo. The monorepo contains the Next.js application which is modularized into packages that handle data access via Prisma to a local DB, UI components, and more.
+In this course, we'll walk through a step-by-step guide using the Tasker application as our example. Tasker is a task management app built with Next.js, structured as a pnpm workspace monorepo. The monorepo contains the Next.js application which is modularized into packages that handle data access via Prisma to a local DB, UI components, and more.
 
 Throughout the course, we'll take incremental steps to enhance the monorepo:
 

--- a/nx-dev/nx-dev/courses-content/pnpm-nx-next/lessons/00-overview.md
+++ b/nx-dev/nx-dev/courses-content/pnpm-nx-next/lessons/00-overview.md
@@ -4,7 +4,7 @@ videoUrl: 'https://youtu.be/VJ1v5dktwwI'
 duration: '1:01'
 ---
 
-In this course, we'll walk through a step-by-step guide using the Tasker application as our example. Tasker is a task management app built with Next.js, structured as a PNPM workspace monorepo. The monorepo contains the Next.js application which is modularized into packages that handle data access via Prisma to a local DB, UI components, and more.
+In this course, we'll walk through a step-by-step guide using the Tasker application as our example. Tasker is a task management app built with Next.js, structured as a pnpm workspace monorepo. The monorepo contains the Next.js application which is modularized into packages that handle data access via Prisma to a local DB, UI components, and more.
 
 Throughout the course, we'll take incremental steps to enhance the monorepo:
 

--- a/nx-dev/nx-dev/courses-content/pnpm-nx-next/lessons/01-nx-init.md
+++ b/nx-dev/nx-dev/courses-content/pnpm-nx-next/lessons/01-nx-init.md
@@ -4,13 +4,13 @@ videoUrl: 'https://youtu.be/3hW53b1IJ84'
 duration: '3:42'
 ---
 
-In this lesson, we'll explore how to add Nx to our existing PNPM workspace. You can either add just the `nx` package to your `package.json` and then create a `nx.json` [configuration file](/docs/reference/nx-json), or simply run:
+In this lesson, we'll explore how to add Nx to our existing pnpm workspace. You can either add just the `nx` package to your `package.json` and then create a `nx.json` [configuration file](/docs/reference/nx-json), or simply run:
 
 ```shell
 nx init
 ```
 
-This process will analyze your repository and ask you a couple of questions to properly set up Nx while maintaining your existing PNPM workspace structure.
+This process will analyze your repository and ask you a couple of questions to properly set up Nx while maintaining your existing pnpm workspace structure.
 
 ## Relevant Links
 

--- a/nx-dev/nx-dev/courses-content/pnpm-nx-next/lessons/02-run-tasks.md
+++ b/nx-dev/nx-dev/courses-content/pnpm-nx-next/lessons/02-run-tasks.md
@@ -4,7 +4,7 @@ videoUrl: 'https://youtu.be/CJLRkzRrcjg'
 duration: '1:56'
 ---
 
-In this lesson, you'll learn how to use Nx to run your PNPM workspace's `package.json` scripts. So rather than running:
+In this lesson, you'll learn how to use Nx to run your pnpm workspace's `package.json` scripts. So rather than running:
 
 ```shell
 pnpm --filter @tasker/web build

--- a/nx-dev/nx-dev/courses-content/pnpm-nx-next/lessons/13-outro.md
+++ b/nx-dev/nx-dev/courses-content/pnpm-nx-next/lessons/13-outro.md
@@ -4,4 +4,4 @@ videoUrl: 'https://youtu.be/a_pfLrvf88E'
 duration: '0:39'
 ---
 
-Thank you for completing this course on optimizing your PNPM workspace with Nx. You've learned how to implement and configure Nx, set up efficient caching, optimize CI processes, and improve e2e test execution times.
+Thank you for completing this course on optimizing your pnpm workspace with Nx. You've learned how to implement and configure Nx, set up efficient caching, optimize CI processes, and improve e2e test execution times.

--- a/nx-dev/ui-markdoc/src/lib/tags/personas.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/personas.component.tsx
@@ -113,7 +113,7 @@ const typeMap: Record<
           fill="currentColor"
           className="h-6 w-6"
         >
-          {/*PNPM*/}
+          {/*pnpm*/}
           <path d="M0 0v7.5h7.5V0zm8.25 0v7.5h7.498V0zm8.25 0v7.5H24V0zM8.25 8.25v7.5h7.498v-7.5zm8.25 0v7.5H24v-7.5zM0 16.5V24h7.5v-7.5zm8.25 0V24h7.498v-7.5zm8.25 0V24H24v-7.5z" />
         </svg>
       </div>

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -263,7 +263,7 @@ export async function determinePackageManager(
           choices: [
             { name: 'npm', message: 'NPM' },
             { name: 'yarn', message: 'Yarn' },
-            { name: 'pnpm', message: 'PNPM' },
+            { name: 'pnpm', message: 'pnpm' },
             { name: 'bun', message: 'Bun' },
           ],
         },

--- a/packages/devkit/src/utils/catalog/pnpm-manager.ts
+++ b/packages/devkit/src/utils/catalog/pnpm-manager.ts
@@ -13,7 +13,7 @@ import type {
 const PNPM_WORKSPACE_FILENAME = 'pnpm-workspace.yaml';
 
 /**
- * PNPM-specific catalog manager implementation
+ * pnpm-specific catalog manager implementation
  */
 export class PnpmCatalogManager implements CatalogManager {
   readonly name = 'pnpm';

--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -35,7 +35,7 @@ const NON_SEMVER_TAGS = {
 /**
  * Get the resolved version of a dependency from package.json.
  *
- * Retrieves a package version and automatically resolves PNPM catalog references
+ * Retrieves a package version and automatically resolves pnpm catalog references
  * (e.g., "catalog:default") to their actual version strings. By default, searches
  * `dependencies` first, then falls back to `devDependencies`.
  *

--- a/packages/expo/plugins/metro-resolver.ts
+++ b/packages/expo/plugins/metro-resolver.ts
@@ -163,7 +163,7 @@ function pnpmResolver(
     if (debug)
       console.log(
         pc.cyan(
-          `[Nx] Unable to resolve with default PNPM resolver: ${realModuleName}`
+          `[Nx] Unable to resolve with default pnpm resolver: ${realModuleName}`
         )
       );
   }

--- a/packages/nx/src/command-line/exec/exec.ts
+++ b/packages/nx/src/command-line/exec/exec.ts
@@ -67,7 +67,7 @@ async function runScriptAsNxTarget(
   argv: string[],
   nxArgs: NxArgs
 ) {
-  // NPM, Yarn, and PNPM set this to the name of the currently executing script. Lets use it if we can.
+  // NPM, Yarn, and pnpm set this to the name of the currently executing script. Lets use it if we can.
   const targetName = process.env.npm_lifecycle_event;
   if (targetName) {
     const defaultPorject = getDefaultProject(projectGraph);

--- a/packages/nx/src/command-line/import/import.ts
+++ b/packages/nx/src/command-line/import/import.ts
@@ -776,7 +776,7 @@ async function handleMissingWorkspacesEntry(
                   `See: https://bun.sh/docs/install/workspaces`,
                 ]
               : [
-                  `We recommend enabling PNPM workspaces to install dependencies for the imported project.`,
+                  `We recommend enabling pnpm workspaces to install dependencies for the imported project.`,
                   `Add the following entry to to pnpm-workspace.yaml and run "${pmc.install}":`,
                   pc.bold(`packages:\n  - '${pkgPath}'`),
                   `See: https://pnpm.io/workspaces`,

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -493,7 +493,7 @@ async function runInit(
       learnMoreLink: 'https://nx.dev/getting-started/adding-to-existing',
       appendLines: _isMonorepo
         ? [
-            `- Read a detailed guide about adding Nx to NPM/YARN/PNPM workspaces: https://nx.dev/recipes/adopting-nx/adding-to-monorepos`,
+            `- Read a detailed guide about adding Nx to npm/yarn/pnpm workspaces: https://nx.dev/recipes/adopting-nx/adding-to-monorepos`,
             `- Learn how Nx helps manage your TypeScript monorepo: https://nx.dev/features/maintain-ts-monorepos`,
           ]
         : [],

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -2340,7 +2340,7 @@ snapshots:
         'test-lockfile-hash-exact-over-range'
       );
 
-      // Should prioritize exact version patch over range patch per PNPM's priority order
+      // Should prioritize exact version patch over range patch per pnpm's priority order
       expect(externalNodes['npm:vitest']).toMatchObject({
         type: 'npm',
         name: 'npm:vitest',

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -171,7 +171,7 @@ function isAliasVersion(depVersion: string) {
 
 /**
  * Finds the appropriate patch hash for a package based on its name and version.
- * Follows PNPM's priority order (https://pnpm.io/settings#patcheddependencies):
+ * Follows pnpm's priority order (https://pnpm.io/settings#patcheddependencies):
  * 1. Exact version match (e.g., "vitest@3.2.4") - highest priority
  * 2. Version range match (e.g., "vitest@^3.0.0")
  * 3. Name-only match (e.g., "vitest") - lowest priority
@@ -305,7 +305,7 @@ function getNodes(
     // Parse the base version (without peer dependency info, etc.)
     const baseVersion = parseBaseVersion(versionFromKey, isV5);
 
-    // Find the appropriate patch hash using PNPM's priority order:
+    // Find the appropriate patch hash using pnpm's priority order:
     // 1. Exact version match, 2. Version range match, 3. Name-only match
     const patchHash = findPatchHash(
       patchEntriesByPackage,

--- a/packages/nx/src/utils/catalog/pnpm-manager.ts
+++ b/packages/nx/src/utils/catalog/pnpm-manager.ts
@@ -14,7 +14,7 @@ import type {
 const PNPM_WORKSPACE_FILENAME = 'pnpm-workspace.yaml';
 
 /**
- * PNPM-specific catalog manager implementation
+ * pnpm-specific catalog manager implementation
  */
 export class PnpmCatalogManager implements CatalogManager {
   readonly name = 'pnpm';

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -474,7 +474,7 @@ export async function installPackageToTmpAsync(
 /**
  * Get the resolved version of a dependency from package.json.
  *
- * Retrieves a package version and automatically resolves PNPM catalog references
+ * Retrieves a package version and automatically resolves pnpm catalog references
  * (e.g., "catalog:default") to their actual version strings. By default, searches
  * `dependencies` first, then falls back to `devDependencies`.
  *

--- a/packages/react-native/plugins/metro-resolver.ts
+++ b/packages/react-native/plugins/metro-resolver.ts
@@ -156,7 +156,7 @@ function pnpmResolver(
     if (debug)
       console.log(
         pc.cyan(
-          `[Nx] Unable to resolve with default PNPM resolver: ${realModuleName}`
+          `[Nx] Unable to resolve with default pnpm resolver: ${realModuleName}`
         )
       );
   }

--- a/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
+++ b/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
@@ -1276,7 +1276,7 @@ jobs:
           AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
 
       - script: npm install --prefix=$HOME/.local -g pnpm@8
-        displayName: Install PNPM
+        displayName: Install pnpm
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -1343,7 +1343,7 @@ jobs:
           AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
 
       - script: npm install --prefix=$HOME/.local -g pnpm@8
-        displayName: Install PNPM
+        displayName: Install pnpm
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -1484,7 +1484,7 @@ jobs:
       - checkout
 
       - run:
-          name: Install PNPM
+          name: Install pnpm
           command: npm install --prefix=$HOME/.local -g pnpm@8
 
       # This enables task distribution via Nx Cloud
@@ -1529,7 +1529,7 @@ jobs:
       - checkout
 
       - run:
-          name: Install PNPM
+          name: Install pnpm
           command: npm install --prefix=$HOME/.local -g pnpm@8
 
       # This enables task distribution via Nx Cloud
@@ -3510,7 +3510,7 @@ jobs:
           AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
 
       - script: npm install --prefix=$HOME/.local -g pnpm@8
-        displayName: Install PNPM
+        displayName: Install pnpm
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -3577,7 +3577,7 @@ jobs:
           AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
 
       - script: npm install --prefix=$HOME/.local -g pnpm@8
-        displayName: Install PNPM
+        displayName: Install pnpm
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -3720,7 +3720,7 @@ jobs:
       - checkout
 
       - run:
-          name: Install PNPM
+          name: Install pnpm
           command: npm install --prefix=$HOME/.local -g pnpm@8
 
       # This enables task distribution via Nx Cloud
@@ -3765,7 +3765,7 @@ jobs:
       - checkout
 
       - run:
-          name: Install PNPM
+          name: Install pnpm
           command: npm install --prefix=$HOME/.local -g pnpm@8
 
       # This enables task distribution via Nx Cloud

--- a/packages/workspace/src/generators/ci-workflow/files/azure/azure-pipelines.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/azure/azure-pipelines.yml__tmpl__
@@ -44,7 +44,7 @@ jobs:
 
       <% if(packageManager == 'pnpm'){ %>
       - script: npm install --prefix=$HOME/.local -g pnpm@8
-        displayName: Install PNPM
+        displayName: Install pnpm
 
       <% } %>
       <% if(packageManager == 'bun'){ %>

--- a/packages/workspace/src/generators/ci-workflow/files/circleci/.circleci/config.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/circleci/.circleci/config.yml__tmpl__
@@ -11,7 +11,7 @@ jobs:
       - checkout
       <% if(packageManager == 'pnpm'){ %>
       - run:
-          name: Install PNPM
+          name: Install pnpm
           command: npm install --prefix=$HOME/.local -g pnpm@8
       <% } %>
       <% if(packageManager == 'bun'){ %>

--- a/scripts/patched-jest-resolver.js
+++ b/scripts/patched-jest-resolver.js
@@ -116,7 +116,7 @@ module.exports = function (modulePath, options) {
     }
 
     // Find workspace root - avoid filesystem lookups inside node_modules
-    // For PNPM workspaces, we know the structure: workspace/packages/packageName
+    // For pnpm workspaces, we know the structure: workspace/packages/packageName
     let workspaceRoot = options.rootDir;
 
     // If we're in a packages subdirectory, go up two levels to workspace root


### PR DESCRIPTION
## Current Behavior

`PNPM` appears throughout the Nx documentation and in some source-level user-facing strings (prompts, log messages). The pnpm project itself consistently uses lowercase `pnpm` in all of its own documentation.

## Expected Behavior

All references to pnpm use lowercase `pnpm` to match the official casing used by the pnpm project.

## Related Issue(s)

Fixes #34483