### PR TITLE
fix(core): exclude hyperfine env vars from daemon env reflection

### DIFF
--- a/packages/nx/src/daemon/client/daemon-environment.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.ts
@@ -111,6 +111,9 @@ const DAEMON_ENV_PREFIX_EXCLUSIONS = [
   'ALACRITTY_',
   'KONSOLE_',
   'TMUX',
+
+  // Benchmarking / profiling tools
+  'HYPERFINE_', // hyperfine sets HYPERFINE_RANDOMIZED_ENVIRONMENT_OFFSET for each iteration
 ];
 
 function isExcludedEnvVar(key: string): boolean {


### PR DESCRIPTION
## Current Behavior
Daemon env reflection sends filtered process.env on first message. Server compares key-by-key; any diff invalidates the project graph cache and forwards env to plugin workers. hyperfine rotates HYPERFINE_RANDOMIZED_ENVIRONMENT_OFFSET per iteration, so every run busts the graph cache and respawns plugin workers (~170ms overhead).

## Expected Behavior
hyperfine env vars do not affect graph construction. Filter them alongside existing editor, terminal, and CI runner prefixes.
