### PR TITLE
fix(core): prevent spinner flicker when sync applying

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -312,9 +312,6 @@ export class DaemonClient {
     // If the graph takes a while to load, we want to show a spinner.
     spinner = new DelayedSpinner(
       'Calculating the project graph on the Nx Daemon'
-    ).scheduleMessageUpdate(
-      'Calculating the project graph on the Nx Daemon is taking longer than expected. Re-run with NX_DAEMON=false to see more details.',
-      { ciDelay: 60_000, delay: 30_000 }
     );
     this.currentSpinner = spinner;
     try {

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -2,7 +2,6 @@ import { prompt } from 'enquirer';
 import { join } from 'node:path';
 import { stripVTControlCharacters } from 'node:util';
 
-const ora = require('ora');
 import type { Observable } from 'rxjs';
 import {
   NxJsonConfiguration,
@@ -13,6 +12,7 @@ import { ProjectGraph, ProjectGraphProjectNode } from '../config/project-graph';
 import { Task, TaskGraph } from '../config/task-graph';
 import { TargetDependencyConfig } from '../config/workspace-json-project-json';
 import { daemonClient } from '../daemon/client/client';
+import { globalSpinner } from '../utils/spinner';
 import { createTaskHasher } from '../hasher/create-task-hasher';
 import {
   getTaskDetails,
@@ -755,8 +755,7 @@ async function ensureWorkspaceIsInSyncAndGetGraphs(
     (await promptForApplyingSyncGeneratorChanges());
 
   if (applyChanges) {
-    const spinner = ora('Syncing the workspace...');
-    spinner.start();
+    const spinner = globalSpinner.start('Syncing the workspace...');
 
     // Flush sync generator changes to disk
     const flushResult = await flushSyncGeneratorChanges(results);


### PR DESCRIPTION
## Current Behavior
When sync changes are being auto-applied the spinner flickers a bit

## Expected Behavior
No flicker

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
