### PR TITLE
fix(detox): generate valid JSON in .detoxrc for non-expo apps

### DIFF
--- a/packages/detox/src/generators/application/files/app/.detoxrc.json.template
+++ b/packages/detox/src/generators/application/files/app/.detoxrc.json.template
@@ -35,14 +35,12 @@
       "type": "android.apk",
       "build": "cd <%= offsetFromRoot %><%= appRoot %>/android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release",
       "binaryPath": "<%= offsetFromRoot %><%= appRoot %>/android/app/build/outputs/apk/release/app-release.apk"
-    },
-<% if (framework === 'expo') { %>
+    }<% if (framework === 'expo') { %>,
     "android.local": {
       "type": "android.apk",
       "build": "<%= exec %> nx run <%= appFileName %>:build --platform android --profile preview --wait --local --no-interactive --output=<%= offsetFromRoot %><%= appRoot %>/dist/<%= appExpoName %>.apk",
       "binaryPath": "<%= offsetFromRoot %><%= appRoot %>/dist/<%= appExpoName %>.apk"
-    },
-<% } %>
+    }<% } %>
   },
   "devices": {
     "simulator": {
@@ -80,12 +78,10 @@
     "android.emu.debug": {
       "device": "emulator",
       "app": "android.debug"
-    },
-<% if (framework === 'expo') { %>
+    }<% if (framework === 'expo') { %>,
     "android.emu.local": {
       "device": "emulator",
       "app": "android.local"
-    },
-<% } %>
+    }<% } %>
   }
 }


### PR DESCRIPTION
## Current Behavior

The detox application generator's `.detoxrc.json` template ends each of the `apps` and `configurations` blocks with an EJS-conditional expo-only entry, e.g.:

```
    "android.release": { ... },
<% if (framework === 'expo') { %>
    "android.local": { ... },
<% } %>
  },
```

When `framework !== 'expo'` (i.e. a react-native app), the conditional content is stripped but the trailing comma after `"android.release"` remains. The generated `.detoxrc.json` therefore contains a trailing comma before the closing `}` of both `apps` and `configurations`, which is invalid JSON.

This goes unnoticed by the runtime config loader (Detox uses a lenient parser), but `e2e/detox/src/detox.test.ts` calls `updateJson('${appName}-e2e/.detoxrc.json', ...)` from `@nx/e2e-utils`, which uses strict `JSON.parse` and crashes:

```
SyntaxError: Expected double-quoted property name in JSON at position 1528 (line 34 column 3)
    at JSON.parse (<anonymous>)
    at updateFile (../utils/file-utils.ts:35:7)
    at updateJson (../utils/file-utils.ts:80:3)
```

The macOS CI job that runs `e2e-detox` is gated on react-native projects being affected, so the failure has been latent on master and only surfaces when an unrelated PR causes the detox/react-native graph to be considered affected.

## Expected Behavior

The generated `.detoxrc.json` is valid JSON for both `react-native` and `expo` frameworks.

The fix moves the comma inside the EJS conditional so it is only emitted alongside the following expo entry. Verified by rendering the template with both framework values and parsing the output with `JSON.parse`:

```
react-native: PARSES OK
expo: PARSES OK
```

## Related Issue(s)

N/A