### PR TITLE
fix(core): consider virtual trees in multiGlobWithWorkspaceContext

### DIFF
--- a/packages/nx/src/utils/workspace-context.spec.ts
+++ b/packages/nx/src/utils/workspace-context.spec.ts
@@ -1,0 +1,78 @@
+const mockGlob = jest.fn();
+const mockMultiGlob = jest.fn();
+const mockDaemonGlob = jest.fn();
+const mockDaemonMultiGlob = jest.fn();
+const mockEnabled = jest.fn();
+const mockIsOnDaemon = jest.fn();
+
+jest.mock('../native', () => ({
+  WorkspaceContext: jest.fn().mockImplementation(() => ({
+    glob: mockGlob,
+    multiGlob: mockMultiGlob,
+    workspaceRoot: '/virtual',
+  })),
+  getMainWorktreeRoot: jest.fn().mockReturnValue('/virtual'),
+}));
+
+jest.mock('./cache-directory', () => ({
+  workspaceDataDirectoryForWorkspace: jest.fn().mockReturnValue('/virtual/.nx'),
+}));
+
+jest.mock('../daemon/client/client', () => ({
+  daemonClient: {
+    enabled: () => mockEnabled(),
+    glob: (...args: unknown[]) => mockDaemonGlob(...args),
+    multiGlob: (...args: unknown[]) => mockDaemonMultiGlob(...args),
+  },
+}));
+
+jest.mock('../daemon/is-on-daemon', () => ({
+  isOnDaemon: () => mockIsOnDaemon(),
+}));
+
+import {
+  globWithWorkspaceContext,
+  multiGlobWithWorkspaceContext,
+  resetWorkspaceContext,
+} from './workspace-context';
+
+describe('workspace-context /virtual short-circuit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetWorkspaceContext();
+    // Simulate the problematic case: daemon is enabled and we are NOT
+    // running on the daemon (i.e. a generator test in a host process).
+    mockEnabled.mockReturnValue(true);
+    mockIsOnDaemon.mockReturnValue(false);
+    mockGlob.mockReturnValue(['virtual-glob-result']);
+    mockMultiGlob.mockReturnValue([['virtual-multiglob-result']]);
+  });
+
+  it('globWithWorkspaceContext bypasses the daemon when workspaceRoot is /virtual', async () => {
+    const result = await globWithWorkspaceContext('/virtual', ['**/*.ts']);
+
+    expect(mockDaemonGlob).not.toHaveBeenCalled();
+    expect(mockGlob).toHaveBeenCalledWith(['**/*.ts'], undefined);
+    expect(result).toEqual(['virtual-glob-result']);
+  });
+
+  it('multiGlobWithWorkspaceContext bypasses the daemon when workspaceRoot is /virtual', async () => {
+    const result = await multiGlobWithWorkspaceContext('/virtual', ['**/*.ts']);
+
+    expect(mockDaemonMultiGlob).not.toHaveBeenCalled();
+    expect(mockMultiGlob).toHaveBeenCalledWith(['**/*.ts'], undefined);
+    expect(result).toEqual([['virtual-multiglob-result']]);
+  });
+
+  it('multiGlobWithWorkspaceContext routes to the daemon for a real workspace root', async () => {
+    mockDaemonMultiGlob.mockResolvedValueOnce([['daemon-result']]);
+
+    const result = await multiGlobWithWorkspaceContext('/some/real/root', [
+      '**/*.ts',
+    ]);
+
+    expect(mockMultiGlob).not.toHaveBeenCalled();
+    expect(mockDaemonMultiGlob).toHaveBeenCalledWith(['**/*.ts'], undefined);
+    expect(result).toEqual([['daemon-result']]);
+  });
+});

--- a/packages/nx/src/utils/workspace-context.ts
+++ b/packages/nx/src/utils/workspace-context.ts
@@ -69,7 +69,7 @@ export async function multiGlobWithWorkspaceContext(
   globs: string[],
   exclude?: string[]
 ) {
-  if (isOnDaemon() || !daemonClient.enabled()) {
+  if (workspaceRoot === '/virtual' || isOnDaemon() || !daemonClient.enabled()) {
     ensureContextAvailable(workspaceRoot);
     return workspaceContext.multiGlob(globs, exclude);
   }


### PR DESCRIPTION
## Current Behavior

`multiGlobWithWorkspaceContext` in `packages/nx/src/utils/workspace-context.ts` is missing the `workspaceRoot === '/virtual'` short-circuit that its sibling `globWithWorkspaceContext` already has (added in #31805).

When the Nx daemon is running and a generator test uses `createTreeWithEmptyWorkspace` (which sets the root to the `/virtual` sentinel), `multiGlobWithWorkspaceContext` forwards to the daemon attached to the real workspace, gets back real paths, and then plugins (e.g. project-graph-inferring plugins) ENOENT trying to read those paths at `/virtual/<path>`.

This silently breaks generator test suites for any workspace that has project-graph-inferring plugins (which is most modern Nx workspaces).

## Expected Behavior

`multiGlobWithWorkspaceContext` should bypass the daemon when called with `workspaceRoot === '/virtual'`, just like `globWithWorkspaceContext` does. Generator tests run against the in-memory virtual tree without any daemon round-trip.

## Related Issue(s)

Fixes #35373

Related: #32588 reported the same symptom via `@nx/cypress` in Sept 2025 and was auto-closed stale; this PR addresses the root cause.

The original `globWithWorkspaceContext` `/virtual` guard was added in #31805 — this PR mirrors it on the multi-glob path.
