### PR TITLE
chore(module-federation): re-enable webpack module federation e2e suites

### DIFF
--- a/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
@@ -15,10 +15,7 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
-// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('React Module Federation - Webpack Basic - Host Remote Generation', () => {
+describe('React Module Federation - Webpack Basic - Host Remote Generation', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts
@@ -14,10 +14,7 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
-// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('React Module Federation - Webpack Basic - Playwright', () => {
+describe('React Module Federation - Webpack Basic - Playwright', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/core-webpack-name-and-root.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-name-and-root.test.ts
@@ -10,10 +10,7 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
-// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('React Module Federation - Webpack Name and Root Format', () => {
+describe('React Module Federation - Webpack Name and Root Format', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/core-webpack-query-params.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-query-params.test.ts
@@ -5,10 +5,7 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
-// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('React Module Federation - Webpack Query Params', () => {
+describe('React Module Federation - Webpack Query Params', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/core-webpack-ssr.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-ssr.test.ts
@@ -15,10 +15,7 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
-// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('React Module Federation - Webpack SSR', () => {
+describe('React Module Federation - Webpack SSR', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
+++ b/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
@@ -14,10 +14,7 @@ import {
 } from '@nx/e2e-utils';
 import { runCLI } from './utils';
 
-// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
-// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('Dynamic Module Federation', () => {
+describe('Dynamic Module Federation', () => {
   beforeAll(() => {
     newProject({ packages: ['@nx/react'] });
   });

--- a/e2e/react/src/module-federation/federate-module.webpack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.webpack.test.ts
@@ -10,10 +10,7 @@ import {
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 
-// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
-// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('Federate Module', () => {
+describe('Federate Module', () => {
   let proj: string;
 
   beforeAll(() => {

--- a/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
@@ -12,10 +12,7 @@ import {
 import { stripIndents } from 'nx/src/utils/strip-indents';
 import { readPort, runCLI } from './utils';
 
-// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
-// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('Independent Deployability', () => {
+describe('Independent Deployability', () => {
   let proj: string;
   beforeAll(() => {
     process.env.NX_ADD_PLUGINS = 'false';

--- a/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
@@ -11,10 +11,7 @@ import {
 import { readPort, runCLI } from './utils';
 import { stripIndents } from 'nx/src/utils/strip-indents';
 
-// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
-// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('React Rspack Module Federation Misc - Convert To Rspack', () => {
+describe('React Rspack Module Federation Misc - Convert To Rspack', () => {
   beforeAll(() => {
     process.env.NX_ADD_PLUGINS = 'false';
     newProject({ packages: ['@nx/react', '@nx/rspack'] });

--- a/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
@@ -11,10 +11,7 @@ import {
 import { readPort, runCLI } from './utils';
 import { stripIndents } from 'nx/src/utils/strip-indents';
 
-// TODO: re-enable when @module-federation/enhanced supports webpack 5.106.0+
-// webpack 5.106.0 removed lib/util/create-schema-validation.js which @module-federation/enhanced@2.3.1 depends on
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('React Rspack Module Federation Misc - Interoperability', () => {
+describe('React Rspack Module Federation Misc - Interoperability', () => {
   beforeEach(() => {
     process.env.NX_ADD_PLUGINS = 'false';
     newProject({ packages: ['@nx/react'] });


### PR DESCRIPTION
## Current Behavior

The React module federation e2e suites that exercise webpack generation paths were temporarily disabled in #35214 because webpack 5.106.0 removed `lib/util/create-schema-validation.js`, which `@module-federation/enhanced@2.3.1` still depended on. Ten suites were skipped:

- `core-webpack-basic-host-remote-generation.test.ts`
- `core-webpack-basic-playwright.test.ts`
- `core-webpack-name-and-root.test.ts`
- `core-webpack-query-params.test.ts`
- `core-webpack-ssr.test.ts`
- `dynamic-federation.webpack.test.ts`
- `federate-module.webpack.test.ts`
- `independent-deployability.webpack.test.ts`
- `misc-rspack-convert-to-rspack.test.ts`
- `misc-rspack-interoperability.test.ts`

## Expected Behavior

`@module-federation/enhanced` has since been bumped to `2.3.3` in this repo, so the webpack 5.106.0 incompatibility should be resolved upstream. Re-enable the suites and let CI confirm they pass.

## Related Issue(s)

NXC-4220