### PR TITLE
docs(misc): note sandboxing rolling out to other Nx Cloud plans on June 1

### DIFF
--- a/astro-docs/src/content/docs/features/CI Features/sandboxing.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/sandboxing.mdoc
@@ -18,8 +18,7 @@ implications on [caching](/docs/features/cache-task-results) correctness, from f
 serving stale results to missing output files after a cache restore.
 
 {% aside type="note" title="Enterprise Feature" %}
-Sandboxing is available on the [Nx Enterprise plan](https://nx.dev/enterprise).
-[Reach out to learn more](https://nx.dev/enterprise).
+Sandboxing is currently available on the [Nx Enterprise plan](https://nx.dev/enterprise). We're working on rolling it out to other Nx Cloud plans starting June 1st. If you'd like to use it sooner, [reach out to learn more](https://nx.dev/enterprise).
 {% /aside %}
 
 {% aside type="caution" title="Nx 22.6+ Required" %}


### PR DESCRIPTION
## Current Behavior

The Task Sandboxing docs callout states sandboxing is only available on the Nx Enterprise plan, with no mention of plans to expand availability.

## Expected Behavior

Callout clarifies sandboxing is currently Enterprise-only but will roll out to other Nx Cloud plans starting June 1st. Users interested sooner can still reach out via the existing contact link.

## Related Issue(s)

N/A