### PR TITLE
chore(repo): fix typecheck failures across e2e and eslint-rules

### DIFF
--- a/e2e/nx/tsconfig.spec.json
+++ b/e2e/nx/tsconfig.spec.json
@@ -4,16 +4,5 @@
     "module": "commonjs",
     "types": ["jest", "node"]
   },
-  "include": [
-    "**/*.test.ts",
-    "**/*.spec.ts",
-    "**/*.spec.tsx",
-    "**/*.test.tsx",
-    "**/*.spec.js",
-    "**/*.test.js",
-    "**/*.spec.jsx",
-    "**/*.test.jsx",
-    "**/*.d.ts",
-    "jest.config.ts"
-  ]
+  "include": ["src/**/*.ts", "**/*.d.ts", "jest.config.ts"]
 }

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -244,6 +244,9 @@
       "src/utils/catalog": [
         "dist/src/utils/catalog/index.d.ts"
       ],
+      "src/internal-testing-utils/*": [
+        "src/internal-testing-utils/*.ts"
+      ],
       "src/*.js": [
         "dist/src/*.d.ts"
       ],
@@ -411,6 +414,10 @@
     "./src/native/*.mjs": {
       "@nx/nx-source": "./src/native/*.mjs",
       "default": "./dist/src/native/*.mjs"
+    },
+    "./src/internal-testing-utils/*": {
+      "types": "./src/internal-testing-utils/*.ts",
+      "default": "./src/internal-testing-utils/*.ts"
     },
     "./src/*.js": {
       "@nx/nx-source": "./src/*.ts",

--- a/tools/eslint-rules/rules/valid-schema-description.ts
+++ b/tools/eslint-rules/rules/valid-schema-description.ts
@@ -1,5 +1,5 @@
 import { ESLintUtils } from '@typescript-eslint/utils';
-import type { AST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser' with { 'resolution-mode': 'import' };
 
 // NOTE: The rule will be available in ESLint configs as "@nx/workspace/valid-schema-description"
 export const RULE_NAME = 'valid-schema-description';


### PR DESCRIPTION
## Current Behavior

Four `typecheck` tasks fail on master:

- `eslint-rules:typecheck` — TS1541 in `tools/eslint-rules/rules/valid-schema-description.ts`. The type-only import of `jsonc-eslint-parser` (an ESM-only module) needs a `resolution-mode` attribute under `module: node16`.
- `e2e-nx:typecheck` — TS6307: `e2e/nx/src/import-utils.ts` is imported by tests but isn't matched by `tsconfig.spec.json`'s `include` list (the file is a helper, not a `*.test.ts`).
- `e2e-angular:typecheck` and `e2e-storybook:typecheck` — TS2307: deep imports into `nx/src/internal-testing-utils/*` (used by `packages/devkit/internal-testing-utils.ts`, `packages/workspace/migrations.spec.ts`, and several `packages/*/src/**/*.spec.ts`) can't be resolved. The catch-all `typesVersions` entry `src/*` redirects these to `dist/src/internal-testing-utils/*.d.ts`, which doesn't exist — the files are excluded from `tsconfig.lib.json` so they're never built into `dist/`.

## Expected Behavior

All `typecheck` tasks pass. Specifically:

- The ESLint rule's type-only import declares `resolution-mode: 'import'`, satisfying TS1541.
- `e2e/nx/tsconfig.spec.json` includes `src/**/*.ts`, picking up helper files alongside tests. The redundant `*.test.ts` / `*.spec.ts` glob variants (no `.tsx`/`.jsx`/`.js` tests in this project, no `.ts` files outside `src/`) collapse into `["src/**/*.ts", "**/*.d.ts", "jest.config.ts"]`.
- `packages/nx/package.json` adds a more-specific entry for `src/internal-testing-utils/*` to both `typesVersions` (so Node10 module resolution finds the source `.ts` files instead of nonexistent built declarations) and `exports` (so the `types-versions-exports-sync` conformance rule stays satisfied). The exports object only needs `types` and `default` — both pointing to the same `.ts` source — since these utilities are workspace-internal: `default` is reached at jest runtime via the resolver's fallback condition list, and `types` covers modern TS resolution. The published `files` list still excludes the source `.ts` files, so external consumers are unaffected.