### PR TITLE
fix(js): include extended tsconfigs from project references in typecheck inputs

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -2088,6 +2088,51 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         );
       });
 
+      it('should collect tsconfig paths from `extends` chains in external project references', async () => {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+          'libs/my-lib/tsconfig.json': JSON.stringify({
+            include: ['src/**/*.ts'],
+            references: [
+              { path: './tsconfig.lib.json' },
+              { path: '../other-lib/tsconfig.lib.json' },
+            ],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            include: ['src/**/*.ts'],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/my-lib/package.json': `{}`,
+          'libs/other-lib/tsconfig.json': JSON.stringify({
+            references: [{ path: './tsconfig.lib.json' }],
+          }),
+          // tsconfig.lib.json in the external dep extends a same-project
+          // tsconfig.shared.json — tsc reads it via the extends chain, so it
+          // must be emitted as an input pattern.
+          'libs/other-lib/tsconfig.lib.json': JSON.stringify({
+            extends: './tsconfig.shared.json',
+            include: ['src/**/*.ts'],
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/other-lib/tsconfig.shared.json': JSON.stringify({
+            compilerOptions: { strict: true },
+          }),
+          'libs/other-lib/package.json': `{}`,
+        });
+        const result = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          {}
+        );
+        const myLibTargets = result.projects['libs/my-lib']?.targets;
+        expect(myLibTargets.typecheck.inputs).toContain(
+          '^{projectRoot}/tsconfig.lib.json'
+        );
+        expect(myLibTargets.typecheck.inputs).toContain(
+          '^{projectRoot}/tsconfig.shared.json'
+        );
+      });
+
       it('should normalize and add directories in `include` from internal project references', async () => {
         configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -1222,9 +1222,9 @@ function resolveShallowExternalProjectReferences(
 
 /**
  * Collects unique tsconfig paths (relative to their project root) from the
- * project reference chain and returns them as `^{projectRoot}/...` input
- * patterns. We only need to discover the full set of distinct relative paths
- * from the reference chain.
+ * project reference chain — including any `extends` chains within those refs —
+ * and returns them as `^{projectRoot}/...` input patterns. We only need to
+ * discover the full set of distinct relative paths.
  */
 function getExternalProjectReferenceTsconfigPatterns(
   tsConfig: ParsedTsconfigData,
@@ -1282,7 +1282,47 @@ function getExternalProjectReferenceTsconfigPatterns(
 
     const wsRelPath = posixRelative(workspaceRoot, configPath);
     const tsConfigData = tsConfigCacheData[wsRelPath]?.data;
-    if (!tsConfigData?.projectReferences?.length) {
+    if (!tsConfigData) {
+      continue;
+    }
+
+    // Walk `extends` chains for the visited tsconfig. tsc reads extended
+    // configs while resolving project references, so the rel paths must be
+    // emitted as inputs. Workspace-root files (no owning project) are skipped
+    // — those are covered by the local project's own extends walk.
+    if (tsConfigData.extendedConfigFiles?.length) {
+      for (const extended of tsConfigData.extendedConfigFiles) {
+        if (!extended.filePath || visited.has(extended.filePath)) {
+          continue;
+        }
+        const extendedWsRelPath = posixRelative(
+          workspaceRoot,
+          extended.filePath
+        );
+        if (!tsConfigCacheData[extendedWsRelPath]) {
+          continue;
+        }
+        const extendedContext = getConfigContext(
+          extended.filePath,
+          workspaceRoot,
+          cache
+        );
+        if (
+          extendedContext.project.root &&
+          extendedContext.project.root !== '.'
+        ) {
+          uniqueRelPaths.add(
+            posixRelative(extendedContext.project.absolute, extended.filePath)
+          );
+          worklist.push({
+            configPath: extended.filePath,
+            ownerProject: extendedContext.project,
+          });
+        }
+      }
+    }
+
+    if (!tsConfigData.projectReferences?.length) {
       continue;
     }
 


### PR DESCRIPTION
## Current Behavior

The `@nx/js/typescript` plugin walks the project reference chain to collect tsconfig paths as inputs for the inferred `typecheck` target, but does not follow `extends` chains on those referenced tsconfigs. When `tsc --build` walks into an external project reference whose `tsconfig.lib.json` extends a sibling tsconfig (e.g. `./tsconfig.json`), that extended file is read at compile time but is not declared as an input — causing sandbox violations and incorrect cache keys for the consumer's `typecheck` task.

## Expected Behavior

The plugin walks `extends` chains for every tsconfig visited during the reference chain traversal, emitting `^{projectRoot}/...` patterns for the extended files alongside the existing reference-chain patterns. Tasks consuming external project references with `extends` chains now correctly declare the full set of tsconfig files tsc reads.

## Changes

`getExternalProjectReferenceTsconfigPatterns` now walks `extends` for each tsconfig visited during the worklist traversal. The walk:

- Reuses the same `visited` set as the reference-chain walk (no redundant work).
- Reuses the cached parsed tsconfig data (`tsConfigCacheData`) and `getConfigContext` cache (no extra parsing).
- Pushes extended files onto the same worklist so extends-of-extends and references-from-extends are covered transitively.
- Skips workspace-root files (no owning project) — those are already covered by the local project's existing extends walk.

Patterns emit in the same `^{projectRoot}/relPath` form as the rest of the function, so the existing transitive resolution through the project graph applies unchanged.

A focused unit test pins the new behavior: a project with an external ref whose `tsconfig.lib.json` extends a same-project `tsconfig.shared.json` correctly emits `^{projectRoot}/tsconfig.shared.json` as an input.