### PR TITLE
chore(repo): resolve sandbox violations on graph typecheck tasks

### DIFF
--- a/graph/client/project.json
+++ b/graph/client/project.json
@@ -48,7 +48,12 @@
       "defaultConfiguration": "release"
     },
     "typecheck": {
-      "dependsOn": ["^typecheck", "nx:build-native"]
+      "dependsOn": ["^typecheck", "nx:build-native"],
+      "inputs": [
+        "...",
+        "{workspaceRoot}/packages/devkit/tsconfig.lib.json",
+        "{workspaceRoot}/packages/nx/tsconfig.lib.json"
+      ]
     },
     "serve-base": {
       "configurations": {

--- a/graph/migrate/project.json
+++ b/graph/migrate/project.json
@@ -7,7 +7,12 @@
   "// targets": "to see all targets run: nx show project graph-migrate --web",
   "targets": {
     "typecheck": {
-      "dependsOn": ["^typecheck", "nx:build-native"]
+      "dependsOn": ["^typecheck", "nx:build-native"],
+      "inputs": [
+        "...",
+        "{workspaceRoot}/packages/devkit/tsconfig.lib.json",
+        "{workspaceRoot}/packages/nx/tsconfig.lib.json"
+      ]
     }
   }
 }

--- a/graph/project-details/project.json
+++ b/graph/project-details/project.json
@@ -4,5 +4,13 @@
   "sourceRoot": "graph/project-details/src",
   "projectType": "library",
   "tags": [],
-  "targets": {}
+  "targets": {
+    "typecheck": {
+      "inputs": [
+        "...",
+        "{workspaceRoot}/packages/devkit/tsconfig.lib.json",
+        "{workspaceRoot}/packages/nx/tsconfig.lib.json"
+      ]
+    }
+  }
 }

--- a/graph/ui-project-details/project.json
+++ b/graph/ui-project-details/project.json
@@ -43,7 +43,16 @@
       }
     },
     "typecheck": {
-      "dependsOn": ["^typecheck", "nx:build-native"]
+      "dependsOn": [
+        "^typecheck",
+        "nx:build-native",
+        { "projects": ["devkit"], "target": "build-base" }
+      ],
+      "inputs": [
+        "...",
+        "{workspaceRoot}/packages/devkit/tsconfig.lib.json",
+        "{workspaceRoot}/packages/nx/tsconfig.lib.json"
+      ]
     }
   },
   "implicitDependencies": ["!devkit"]

--- a/graph/ui-project-details/tsconfig.lib.json
+++ b/graph/ui-project-details/tsconfig.lib.json
@@ -21,8 +21,7 @@
     "**/*.stories.js",
     "**/*.stories.jsx",
     "**/*.stories.tsx",
-    "node_modules",
-    "../../packages/nx/**/*"
+    "node_modules"
   ],
   "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"],
   "files": [
@@ -44,6 +43,14 @@
     },
     {
       "path": "../ui-code-block/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/devkit/tsconfig.lib.json"
     }
-  ]
+  ],
+  "nx": {
+    "sync": {
+      "ignoredReferences": ["../../packages/devkit/tsconfig.lib.json"]
+    }
+  }
 }

--- a/nx.json
+++ b/nx.json
@@ -190,7 +190,7 @@
     },
     {
       "plugin": "@nx/js/typescript",
-      "include": ["e2e/**/*"],
+      "include": ["e2e/**/*", "nx-dev/ui-fence/**/*"],
       "options": { "typecheck": true, "build": false }
     },
     {


### PR DESCRIPTION
## Current Behavior

Four `typecheck` tasks in the Nx repo — `graph-client`, `graph-migrate`, `graph-project-details`, `graph-ui-project-details` — trigger sandbox violations on staging. tsc reads files from `packages/devkit`, `packages/nx`, and `nx-dev/ui-fence` that are not declared as inputs, and rebuilds `nx-dev/ui-fence` inside the consumer's sandbox, producing cross-project writes that cascade down the graph chain.

## Expected Behavior

The four graph typecheck tasks have all required cross-project tsconfigs declared as inputs and their cross-project source/output reads covered by task-level dependencies. tsc no longer rebuilds `nx-dev/ui-fence` inside consumer sandboxes. Sandbox runs come back clean.

## Changes

Three independent causes, addressed together.

1. **`nx-dev/ui-fence` had no upstream `typecheck` task.** Its `.d.ts`/`tsbuildinfo` outputs weren't being materialized, so consumers rebuilt it inside their own sandboxes — causing cross-project writes that cascaded down the graph chain. Added `nx-dev/ui-fence/**` to the existing `@nx/js/typescript` plugin block in `nx.json`. ui-fence now has its own task, its outputs flow through `dependentTasksOutputFiles`, and the cascading writes disappear.

2. **`graph-ui-project-details` declares `implicitDependencies: ["!devkit"]`** to break a project graph cycle, which removes devkit (and transitively nx) from its nx project graph. The plugin's `^{projectRoot}/...` patterns walk the project graph, so they never reach `packages/devkit/tsconfig.lib.json` or `packages/nx/tsconfig.lib.json` — even though tsc walks into them via tsconfig project references. Addressed by:
   - Adding `packages/devkit/tsconfig.lib.json` as an explicit project reference in `graph/ui-project-details/tsconfig.lib.json` (with `nx.sync.ignoredReferences` to keep typescript-sync from stripping it).
   - Adding a task-level `dependsOn` on `devkit:build-base` so the task graph actually has devkit producing outputs.
   - Declaring `{workspaceRoot}/packages/devkit/tsconfig.lib.json` and `{workspaceRoot}/packages/nx/tsconfig.lib.json` as explicit inputs on the four graph projects' typecheck overrides.

3. **`nx-dev/ui-fence/tsconfig.lib.json` extends `./tsconfig.json`** — previously the plugin emitted `^{projectRoot}/tsconfig.lib.json` only, so the extended `tsconfig.json` was an undeclared read. Resolved by #35457, which makes the plugin walk `extends` chains in external project references — no per-project workaround needed here.

The four `project.json` overrides use `"..."` spread tokens for `inputs` to inherit the plugin-inferred input set rather than redeclaring it, keeping the diff minimal and the intent ("plugin defaults plus these specific cross-graph-cut tsconfigs") clear.