### PR TITLE
fix(misc): resolve pnpm catalog: refs in version lookups

### DIFF
--- a/packages/storybook/src/generators/convert-to-inferred/lib/utils.ts
+++ b/packages/storybook/src/generators/convert-to-inferred/lib/utils.ts
@@ -1,5 +1,9 @@
 import { ast, query } from '@phenomnomnominal/tsquery';
-import { readJson, joinPathFragments, type Tree } from '@nx/devkit';
+import {
+  getDependencyVersionFromPackageJson,
+  joinPathFragments,
+  type Tree,
+} from '@nx/devkit';
 import { AggregatedLog } from '@nx/devkit/src/generators/plugin-migrations/aggregate-log-util';
 import { toProjectRelativePath } from '@nx/devkit/src/generators/plugin-migrations/plugin-migration-utils';
 import { dirname } from 'path/posix';
@@ -173,14 +177,13 @@ export function getInstalledPackageVersion(
   tree: Tree,
   pkgName: string
 ): string | null {
-  const { dependencies, devDependencies } = readJson(tree, 'package.json');
-  const version = dependencies?.[pkgName] ?? devDependencies?.[pkgName];
-
-  return version;
+  // resolves pnpm catalog: refs (and yarn catalog refs)
+  return getDependencyVersionFromPackageJson(tree, pkgName);
 }
 
 export function getInstalledPackageVersionInfo(tree: Tree, pkgName: string) {
   const version = getInstalledPackageVersion(tree, pkgName);
+  const coerced = version ? coerce(version) : null;
 
-  return version ? { major: major(coerce(version)), version } : null;
+  return coerced ? { major: major(coerced), version } : null;
 }

--- a/packages/vite/src/utils/ensure-dependencies.spec.ts
+++ b/packages/vite/src/utils/ensure-dependencies.spec.ts
@@ -1,7 +1,12 @@
 import { addDependenciesToPackageJson, readJson, type Tree } from '@nx/devkit';
+import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { ensureDependencies } from './ensure-dependencies';
-import { nxVersion } from './versions';
+import {
+  nxVersion,
+  vitePluginReactV4Version,
+  vitePluginReactVersion,
+} from './versions';
 
 describe('@nx/vite:init', () => {
   let tree: Tree;
@@ -81,5 +86,70 @@ describe('@nx/vite:init', () => {
     const packageJson = readJson(tree, 'package.json');
 
     expect(packageJson).toMatchSnapshot();
+  });
+
+  it('should default to latest @vitejs/plugin-react when vite range is unparseable', () => {
+    addDependenciesToPackageJson(tree, {}, { vite: 'workspace:*' });
+
+    ensureDependencies(tree, { uiFramework: 'react' });
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.devDependencies['@vitejs/plugin-react']).toEqual(
+      vitePluginReactVersion
+    );
+  });
+
+  describe('with pnpm catalog references', () => {
+    let tempFs: TempFs;
+
+    beforeEach(() => {
+      tempFs = new TempFs('vite-ensure-deps');
+      tree.root = tempFs.tempDir;
+      // force `detectPackageManager` to return `pnpm`
+      tempFs.createFileSync('pnpm-lock.yaml', 'lockfileVersion: 9.0');
+    });
+
+    afterEach(() => {
+      tempFs.cleanup();
+    });
+
+    it('should resolve a named catalog reference when picking @vitejs/plugin-react', () => {
+      addDependenciesToPackageJson(tree, {}, { vite: 'catalog:tooling' });
+      tree.write(
+        'pnpm-workspace.yaml',
+        `catalogs:\n  tooling:\n    vite: "^7.3.2"\n`
+      );
+
+      ensureDependencies(tree, { uiFramework: 'react' });
+
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@vitejs/plugin-react']).toEqual(
+        vitePluginReactV4Version
+      );
+    });
+
+    it('should resolve a default catalog reference when picking @vitejs/plugin-react', () => {
+      addDependenciesToPackageJson(tree, {}, { vite: 'catalog:' });
+      tree.write('pnpm-workspace.yaml', `catalog:\n  vite: "^8.0.0"\n`);
+
+      ensureDependencies(tree, { uiFramework: 'react' });
+
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@vitejs/plugin-react']).toEqual(
+        vitePluginReactVersion
+      );
+    });
+
+    it('should default to latest @vitejs/plugin-react when catalog entry is missing', () => {
+      addDependenciesToPackageJson(tree, {}, { vite: 'catalog:tooling' });
+      tree.write('pnpm-workspace.yaml', `catalogs:\n  tooling: {}\n`);
+
+      ensureDependencies(tree, { uiFramework: 'react' });
+
+      const packageJson = readJson(tree, 'package.json');
+      expect(packageJson.devDependencies['@vitejs/plugin-react']).toEqual(
+        vitePluginReactVersion
+      );
+    });
   });
 });

--- a/packages/vite/src/utils/ensure-dependencies.ts
+++ b/packages/vite/src/utils/ensure-dependencies.ts
@@ -1,6 +1,7 @@
 import {
   addDependenciesToPackageJson,
   detectPackageManager,
+  getDependencyVersionFromPackageJson,
   logger,
   type GeneratorCallback,
   type Tree,
@@ -52,10 +53,11 @@ export function ensureDependencies(
     if (schema.compiler === 'swc') {
       devDependencies['@vitejs/plugin-react-swc'] = vitePluginReactSwcVersion;
     } else {
-      // @vitejs/plugin-react v6 requires Vite 8+, use v4 for older versions
-      const pkgJson = JSON.parse(host.read('package.json', 'utf-8'));
-      const viteRange = pkgJson?.devDependencies?.['vite'];
-      const viteMajor = viteRange ? major(coerce(viteRange)) : null;
+      // @vitejs/plugin-react v6 requires Vite 8+, use v4 for older versions.
+      // getDependencyVersionFromPackageJson resolves pnpm catalog: refs.
+      const viteRange = getDependencyVersionFromPackageJson(host, 'vite');
+      const coerced = viteRange ? coerce(viteRange) : null;
+      const viteMajor = coerced ? major(coerced) : null;
       devDependencies['@vitejs/plugin-react'] =
         viteMajor !== null && viteMajor < 8
           ? vitePluginReactV4Version

--- a/packages/vitest/src/utils/ensure-dependencies.ts
+++ b/packages/vitest/src/utils/ensure-dependencies.ts
@@ -1,6 +1,7 @@
 import {
   addDependenciesToPackageJson,
   detectPackageManager,
+  getDependencyVersionFromPackageJson,
   logger,
   type GeneratorCallback,
   type Tree,
@@ -57,10 +58,11 @@ export async function ensureDependencies(
     if (schema.compiler === 'swc') {
       devDependencies['@vitejs/plugin-react-swc'] = vitePluginReactSwcVersion;
     } else {
-      // @vitejs/plugin-react v6 requires Vite 8+, use v4 for older versions
-      const pkgJson = JSON.parse(tree.read('package.json', 'utf-8'));
-      const viteRange = pkgJson?.devDependencies?.['vite'];
-      const viteMajor = viteRange ? major(coerce(viteRange)) : null;
+      // @vitejs/plugin-react v6 requires Vite 8+, use v4 for older versions.
+      // getDependencyVersionFromPackageJson resolves pnpm catalog: refs.
+      const viteRange = getDependencyVersionFromPackageJson(tree, 'vite');
+      const coerced = viteRange ? coerce(viteRange) : null;
+      const viteMajor = coerced ? major(coerced) : null;
       devDependencies['@vitejs/plugin-react'] =
         viteMajor !== null && viteMajor < 8
           ? vitePluginReactV4Version


### PR DESCRIPTION
## Current Behavior

`@nx/react:application` (and any path that calls `@nx/vite` or `@nx/vitest` `ensureDependencies`) crashes when the root `package.json` declares `vite` via a pnpm catalog alias such as `"vite": "catalog:"` or `"vite": "catalog:tooling"`:

```
NX   Invalid version. Must be a string. Got type "object".
TypeError ... at new SemVer ... at major ... at ensureDependencies
```

`@nx/storybook`'s `convert-to-inferred` migration is broken in the same way: `getInstalledPackageVersion` reads dependencies straight from `package.json` with no catalog resolution, so a literal `catalog:` value reaches `coerce` and throws via `major(null)` in `getInstalledPackageVersionInfo`.

## Expected Behavior

- pnpm catalog aliases in `package.json` are resolved through `pnpm-workspace.yaml` (default and named catalogs) before semver parsing.
- When the resolved/raw range is not coercible (missing catalog entry, missing `pnpm-workspace.yaml`, `workspace:*`, `link:`, `file:`, `git:`), the code falls back to the existing default rather than throwing.
- Existing v4-vs-v6 `@vitejs/plugin-react` selection for plain semver ranges is preserved.

## Changes

- `@nx/vite` / `@nx/vitest`: `ensureDependencies` now reads `vite` via `getDependencyVersionFromPackageJson` (catalog-aware) and null-guards the `coerce` result.
- `@nx/storybook`: `getInstalledPackageVersion` now uses `getDependencyVersionFromPackageJson`, and `getInstalledPackageVersionInfo` null-guards `coerce`.
- Tests added in `packages/vite/src/utils/ensure-dependencies.spec.ts` for named catalog, default catalog, missing catalog entry, and unparseable ranges (`workspace:*`).

## Related Issue(s)

Fixes #35453