### PR TITLE
fix(js): reference vitest.config in eslint dep-checks for vitest libs

### DIFF
--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -507,7 +507,7 @@ describe('lib', () => {
       }
     );
 
-    it('should ignore rollup and vite config files when bundler=rollup and unitTestRunner=vitest', async () => {
+    it('should ignore rollup and vitest config files when bundler=rollup and unitTestRunner=vitest', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
         directory: 'my-lib',
@@ -526,7 +526,7 @@ describe('lib', () => {
               ignoredFiles: [
                 '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
                 '{projectRoot}/rollup.config.{js,ts,mjs,mts,cjs,cts}',
-                '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+                '{projectRoot}/vitest.config.{js,ts,mjs,mts}',
               ],
             },
           ],
@@ -534,7 +534,7 @@ describe('lib', () => {
       });
     });
 
-    it('should ignore esbuild and vite config files when bundler=esbuild and unitTestRunner=vitest', async () => {
+    it('should ignore esbuild and vitest config files when bundler=esbuild and unitTestRunner=vitest', async () => {
       await libraryGenerator(tree, {
         ...defaultOptions,
         directory: 'my-lib',
@@ -553,7 +553,7 @@ describe('lib', () => {
               ignoredFiles: [
                 '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
                 '{projectRoot}/esbuild.config.{js,ts,mjs,mts}',
-                '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+                '{projectRoot}/vitest.config.{js,ts,mjs,mts}',
               ],
             },
           ],

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -481,7 +481,14 @@ export async function addLint(
           ignoredFiles.add('{projectRoot}/esbuild.config.{js,ts,mjs,mts}');
         }
         if (options.unitTestRunner === 'vitest') {
-          ignoredFiles.add('{projectRoot}/vite.config.{js,ts,mjs,mts}');
+          // When bundler is 'vite', vite.config holds both build and test config
+          // (added above). Otherwise, @nx/vitest:configuration generates a
+          // dedicated vitest.config file for non-framework JS libraries.
+          ignoredFiles.add(
+            options.bundler === 'vite'
+              ? '{projectRoot}/vite.config.{js,ts,mjs,mts}'
+              : '{projectRoot}/vitest.config.{js,ts,mjs,mts}'
+          );
         }
 
         if (ignoredFiles.size) {


### PR DESCRIPTION
## Current Behavior

When generating an `@nx/js` library with `--unitTestRunner=vitest` and `--linter=eslint` (and a non-vite bundler such as `tsc`/`swc`/`rollup`/`esbuild`/`none`), the generated eslint config adds `{projectRoot}/vite.config.{js,ts,mjs,mts}` to the `@nx/dependency-checks` `ignoredFiles` list — but the file actually generated is `vitest.config.mts`, so the ignore pattern never matches.

## Expected Behavior

The eslint config references `{projectRoot}/vitest.config.{js,ts,mjs,mts}` whenever `@nx/vitest:configuration` produces a dedicated vitest config (i.e. bundler is not `vite`). When bundler is `vite`, the existing `vite.config.{...}` ignore is still correct since the same file holds both build and test config.

Since #33670 (Nx 22.2), `@nx/vitest:configuration` calls `shouldUseVitestConfig()` and emits `vitest.config.mts` for non-framework JS libraries with no existing `vite.config`. The eslint ignore pattern in `packages/js/src/generators/library/library.ts` was never updated to match.

## Related Issue(s)

Fixes #35450