### PR TITLE
fix(js): strip glob from inferred outputs before resolving as path

### DIFF
--- a/packages/js/src/executors/copy-workspace-modules/copy-workspace-modules.ts
+++ b/packages/js/src/executors/copy-workspace-modules/copy-workspace-modules.ts
@@ -19,6 +19,7 @@ import { dirname, join, relative, sep } from 'path';
 import { lstatSync } from 'fs';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { getWorkspacePackagesFromGraph } from 'nx/src/plugins/js/utils/get-workspace-packages-from-graph';
+import { stripGlobToBaseDir } from '../../utils/strip-glob-to-base-dir';
 
 export default async function copyWorkspaceModules(
   schema: CopyWorkspaceModulesOptions,
@@ -195,6 +196,7 @@ function getOutputDir(
 }
 
 function normalizeOutputPath(outputPath: string) {
+  outputPath = stripGlobToBaseDir(outputPath);
   if (!outputPath.startsWith(workspaceRoot)) {
     outputPath = join(workspaceRoot, outputPath);
   }

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -25,6 +25,7 @@ import { fileExists } from 'nx/src/utils/fileutils';
 import { interpolate } from 'nx/src/tasks-runner/utils';
 import { detectModuleFormat } from './lib/detect-module-format';
 import { getOutputFileName } from './lib/output-file';
+import { stripGlobToBaseDir } from '../../utils/strip-glob-to-base-dir';
 
 interface ActiveTask {
   id: string;
@@ -487,16 +488,6 @@ function getFileToRun(
   }
 
   return join(context.root, buildOptions.outputPath, outputFileName);
-}
-
-function stripGlobToBaseDir(pathWithGlob: string): string {
-  const globIdx = pathWithGlob.search(/[*?[{(]/);
-  if (globIdx === -1) {
-    return pathWithGlob.replace(/[\\/]+$/, '');
-  }
-  const prefix = pathWithGlob.slice(0, globIdx);
-  const lastSep = Math.max(prefix.lastIndexOf('/'), prefix.lastIndexOf('\\'));
-  return lastSep === -1 ? '' : prefix.slice(0, lastSep);
 }
 
 function fileToRunCorrectPath(fileToRun: string): string {

--- a/packages/js/src/executors/prune-lockfile/prune-lockfile.ts
+++ b/packages/js/src/executors/prune-lockfile/prune-lockfile.ts
@@ -19,6 +19,7 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { getWorkspacePackagesFromGraph } from 'nx/src/plugins/js/utils/get-workspace-packages-from-graph';
 import { type PruneLockfileOptions } from './schema';
+import { stripGlobToBaseDir } from '../../utils/strip-glob-to-base-dir';
 
 export default async function pruneLockfileExecutor(
   schema: PruneLockfileOptions,
@@ -138,6 +139,7 @@ function getOutputDir(schema: PruneLockfileOptions, context: ExecutorContext) {
 }
 
 function normalizeOutputPath(outputPath: string) {
+  outputPath = stripGlobToBaseDir(outputPath);
   if (!outputPath.startsWith(workspaceRoot)) {
     outputPath = join(workspaceRoot, outputPath);
   }

--- a/packages/js/src/utils/buildable-libs-utils.ts
+++ b/packages/js/src/utils/buildable-libs-utils.ts
@@ -17,6 +17,7 @@ import { output } from 'nx/src/utils/output';
 import { dirname, isAbsolute, join, relative, extname, resolve } from 'path';
 import type * as ts from 'typescript';
 import { readTsConfigPaths, resolvePathsBaseUrl } from './typescript/ts-config';
+import { stripGlobToBaseDir } from './strip-glob-to-base-dir';
 import { randomUUID } from 'crypto';
 import {
   isProjectGraphExternalNode,
@@ -569,7 +570,7 @@ export function updateBuildableProjectPackageJsonDependencies(
     node
   );
 
-  const packageJsonPath = `${outputs[0]}/package.json`;
+  const packageJsonPath = `${stripGlobToBaseDir(outputs[0])}/package.json`;
   let packageJson;
   let workspacePackageJson;
   try {
@@ -610,7 +611,11 @@ export function updateBuildableProjectPackageJsonDependencies(
             entry.node
           );
 
-          const depPackageJsonPath = join(root, outputs[0], 'package.json');
+          const depPackageJsonPath = join(
+            root,
+            stripGlobToBaseDir(outputs[0]),
+            'package.json'
+          );
           depVersion = readJsonFile(depPackageJsonPath).version;
 
           packageJson[typeOfDependency][packageName] = depVersion;

--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -28,6 +28,7 @@ import type { PackageJson } from 'nx/src/utils/package-json';
 import { readFileMapCache } from 'nx/src/project-graph/nx-deps-cache';
 
 import { getRelativeDirectoryToProjectRoot } from '../get-main-file-dir';
+import { stripGlobToBaseDir } from '../strip-glob-to-base-dir';
 
 export type SupportedFormat = 'cjs' | 'esm';
 
@@ -208,7 +209,11 @@ function addMissingDependencies(
           entry.node
         );
 
-        const depPackageJsonPath = join(root, outputs[0], 'package.json');
+        const depPackageJsonPath = join(
+          root,
+          stripGlobToBaseDir(outputs[0]),
+          'package.json'
+        );
 
         if (existsSync(depPackageJsonPath)) {
           const version = readJsonFile(depPackageJsonPath).version;

--- a/packages/js/src/utils/strip-glob-to-base-dir.spec.ts
+++ b/packages/js/src/utils/strip-glob-to-base-dir.spec.ts
@@ -1,0 +1,54 @@
+import { stripGlobToBaseDir } from './strip-glob-to-base-dir';
+
+describe('stripGlobToBaseDir', () => {
+  it('should return the input unchanged when there is no glob', () => {
+    expect(stripGlobToBaseDir('apps/foo/dist')).toBe('apps/foo/dist');
+    expect(stripGlobToBaseDir('/abs/path/dist')).toBe('/abs/path/dist');
+  });
+
+  it('should trim trailing separators when there is no glob', () => {
+    expect(stripGlobToBaseDir('apps/foo/dist/')).toBe('apps/foo/dist');
+    expect(stripGlobToBaseDir('apps/foo/dist///')).toBe('apps/foo/dist');
+    expect(stripGlobToBaseDir('apps\\foo\\dist\\')).toBe('apps\\foo\\dist');
+  });
+
+  it('should strip the glob portion back to the last path separator', () => {
+    expect(stripGlobToBaseDir('apps/foo/dist/**/*.js')).toBe('apps/foo/dist');
+    expect(
+      stripGlobToBaseDir(
+        'apps/foo/dist/**/*.{js,cjs,mjs,jsx,d.ts,d.cts,d.mts}{,.map}'
+      )
+    ).toBe('apps/foo/dist');
+  });
+
+  it('should handle absolute paths with globs', () => {
+    expect(
+      stripGlobToBaseDir('/home/runner/work/apps/foo/dist/**/*.{js,d.ts}')
+    ).toBe('/home/runner/work/apps/foo/dist');
+  });
+
+  it('should handle Windows-style separators', () => {
+    expect(stripGlobToBaseDir('apps\\foo\\dist\\**\\*.js')).toBe(
+      'apps\\foo\\dist'
+    );
+  });
+
+  it('should strip back to the last separator before the first glob char', () => {
+    // Glob char in the middle of a segment: strip that segment too.
+    expect(stripGlobToBaseDir('apps/foo/dist/sub*dir/file.js')).toBe(
+      'apps/foo/dist'
+    );
+  });
+
+  it('should recognize the full set of glob meta characters', () => {
+    expect(stripGlobToBaseDir('apps/foo/?.js')).toBe('apps/foo');
+    expect(stripGlobToBaseDir('apps/foo/[abc].js')).toBe('apps/foo');
+    expect(stripGlobToBaseDir('apps/foo/{a,b}.js')).toBe('apps/foo');
+    expect(stripGlobToBaseDir('apps/foo/(a|b).js')).toBe('apps/foo');
+  });
+
+  it('should return an empty string when the glob has no preceding separator', () => {
+    expect(stripGlobToBaseDir('**/*.js')).toBe('');
+    expect(stripGlobToBaseDir('*.js')).toBe('');
+  });
+});

--- a/packages/js/src/utils/strip-glob-to-base-dir.ts
+++ b/packages/js/src/utils/strip-glob-to-base-dir.ts
@@ -1,0 +1,13 @@
+// `outputs` entries on inferred targets (e.g. from `@nx/js/typescript`) are
+// cache-match patterns and may contain globs. Strip the glob portion back to
+// the last path separator to recover the base output directory. Returns the
+// input with trailing separators stripped when there is no glob.
+export function stripGlobToBaseDir(pathWithGlob: string): string {
+  const globIdx = pathWithGlob.search(/[*?[{(]/);
+  if (globIdx === -1) {
+    return pathWithGlob.replace(/[\\/]+$/, '');
+  }
+  const prefix = pathWithGlob.slice(0, globIdx);
+  const lastSep = Math.max(prefix.lastIndexOf('/'), prefix.lastIndexOf('\\'));
+  return lastSep === -1 ? '' : prefix.slice(0, lastSep);
+}

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -14,6 +14,7 @@ import { join, resolve } from 'path';
 import { readModulePackageJson } from 'nx/src/utils/package-json';
 import { daemonClient } from 'nx/src/daemon/client/client';
 import { interpolate } from 'nx/src/tasks-runner/utils';
+import { stripGlobToBaseDir } from '@nx/js/src/utils/strip-glob-to-base-dir';
 const detectPort = require('detect-port');
 
 // platform specific command name
@@ -100,11 +101,13 @@ function getBuildTargetOutputPath(options: Schema, context: ExecutorContext) {
       const project = context.projectGraph.nodes[context.projectName];
       const buildTarget = project.data.targets[target.target];
       outputPath = buildTarget.outputs?.[0];
-      if (outputPath)
+      if (outputPath) {
         outputPath = interpolate(outputPath, {
           projectName: project.data.name,
           projectRoot: project.data.root,
         });
+        outputPath = stripGlobToBaseDir(outputPath);
+      }
     }
   } catch (e) {
     throw new Error(`Invalid buildTarget: ${options.buildTarget}`);


### PR DESCRIPTION
## Current Behavior

When a project's build target is inferred via the `@nx/js/typescript` plugin, its `outputs[0]` is a glob pattern (e.g. `{projectRoot}/dist/**/*.{js,cjs,mjs,jsx,d.ts,d.cts,d.mts}{,.map}`). Several executors and utilities pass that value directly to filesystem APIs:

- `@nx/js:prune-lockfile` and `@nx/js:copy-workspace-modules` crash with `ENOENT: no such file or directory, lstat '.../dist/**/*.{js,...}'` because `lstatSync` is called on the literal glob.
- `@nx/web:file-server` returns the glob as the static-serve directory.
- `update-package-json` and `buildable-libs-utils` silently skip dependent-lib version resolution when `outputs[0]` is a glob (`existsSync` returns false / try-catch swallows).

## Expected Behavior

The glob portion is stripped back to the last path separator before the value is used as a filesystem path, recovering the base output directory (e.g. `apps/foo/dist`). Behavior is unchanged for non-glob output paths.

The `stripGlobToBaseDir` helper that already existed locally in `@nx/js:node` is extracted to `packages/js/src/utils/strip-glob-to-base-dir.ts` and reused by all affected sites. Unit tests cover the helper's contract.

## Related Issue(s)

Fixes #35452