### PR TITLE
fix(core): start TUI event reader synchronously in enter() to prevent stdin race

### DIFF
--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -477,11 +477,10 @@ impl AppLifeCycle {
         let mut tui_mode = initial_mode;
 
         // Spawn unified async task (identical for both modes!)
+        // The TUI event reader is already running — enter() called start()
+        // synchronously so EventStream::new() ran before any stdin bytes had
+        // a chance to leak into the read buffer.
         spawn(async move {
-            // Start the TUI event loop. This must happen inside the async block
-            // because start() uses tokio::spawn() which requires a runtime context.
-            tui.start();
-
             // Set up console messenger (identical for both modes)
             {
                 let connection = NxConsoleMessageConnection::new(&workspace_root).await;

--- a/packages/nx/src/native/tui/tui.rs
+++ b/packages/nx/src/native/tui/tui.rs
@@ -207,7 +207,13 @@ impl Tui {
         let _cancellation_token = self.cancellation_token.clone();
         let _event_tx = self.event_tx.clone();
         debug!("start(): spawning new event task");
-        self.task = Some(tokio::spawn(async move {
+        // Use napi's bindgen_prelude::spawn so this works from any thread
+        // (e.g. the JS main thread that calls __init), not only from inside a
+        // Tokio runtime context. This lets enter() couple raw-mode entry with
+        // EventStream creation synchronously, closing a race where bytes
+        // queued in stdin (OSC color-query replies, leftover prompt input)
+        // get parsed as keypresses.
+        self.task = Some(napi::bindgen_prelude::spawn(async move {
             debug!("Event task spawned - inside async block");
             debug!("Event task: creating EventStream");
             let mut reader = crossterm::event::EventStream::new();
@@ -372,10 +378,15 @@ impl Tui {
             }
         }
 
-        // NOTE: start() is NOT called here. It must be called from within a
-        // Tokio runtime context (e.g., inside napi's spawn() block) because it
-        // uses tokio::spawn() internally. The caller is responsible for calling
-        // start() after entering the runtime.
+        // Start the event reader synchronously so the EventStream exists
+        // before we return to the caller. Otherwise any bytes that arrive on
+        // stdin between enable_raw_mode() and EventStream::new() (e.g. tail
+        // bytes of an OSC 11 color-scheme reply, or leftover input from an
+        // interactive prompt that ran just before the TUI) get read as
+        // keypresses once the reader finally starts — which manifested as a
+        // bogus filter being pre-applied on TUI boot.
+        self.start();
+
         Ok(())
     }
 


### PR DESCRIPTION
Since the napi v2→v3 migration (#34619) moved Tui::start() out of enter() and
into an async block, there is a window between enable_raw_mode() and
EventStream::new() during which bytes can sit in the kernel tty buffer and
later be parsed as keypresses by the reader. Two known sources:

1. Tail bytes of the OSC 11 color-scheme reply that terminal-colorsaurus
   doesn't fully consume (the reply contains '/' separators, e.g.
   `\x1b]11;rgb:RRRR/GGGG/BBBB\x07`, which trigger filter mode and feed
   hex digits as filter text).
2. Leftover input from the analytics prompt (#34144, new in v22.6) that
   uses enquirer/raw-mode and may not drain stdin completely.

Either path manifests as the TUI booting with a bogus filter pre-applied
that hides every task.

start() was moved out because tokio::spawn requires a Tokio runtime context,
and the sync __init NAPI method runs on the JS main thread without one.
Switching the inner spawn to napi::bindgen_prelude::spawn (which uses napi's
static runtime and works from any thread — already used elsewhere for the
same reason) lets enter() call start() synchronously again, so EventStream
exists before enter() returns and consumes those bytes itself.

https://claude.ai/code/session_01RwrzRzTCZ7k8Uzw2xux6kM