### PR TITLE
fix(node): include tsconfig input in node-app esbuild scaffold

### DIFF
--- a/packages/esbuild/src/generators/configuration/configuration.ts
+++ b/packages/esbuild/src/generators/configuration/configuration.ts
@@ -15,6 +15,7 @@ import {
   getDefinedCustomConditionName,
   getProjectSourceRoot,
   isUsingTsSolutionSetup,
+  TS_SOLUTION_SETUP_TSCONFIG_INPUT,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { basename, dirname, join } from 'node:path/posix';
 import { mergeTargetConfigurations } from 'nx/src/devkit-internals';
@@ -57,10 +58,7 @@ function addBuildTarget(
   isTsSolutionSetup: boolean
 ) {
   addBuildTargetDefaults(tree, '@nx/esbuild:esbuild', options.buildTarget, [
-    {
-      json: '{workspaceRoot}/tsconfig.json',
-      fields: ['extends', 'files', 'include'],
-    },
+    TS_SOLUTION_SETUP_TSCONFIG_INPUT,
   ]);
   const project = readProjectConfiguration(tree, options.project);
 

--- a/packages/js/src/utils/typescript/ts-solution-setup.ts
+++ b/packages/js/src/utils/typescript/ts-solution-setup.ts
@@ -19,6 +19,12 @@ import {
   isUsingPackageManagerWorkspaces,
 } from '../package-manager-workspaces';
 import { getNeededCompilerOptionOverrides } from './configuration';
+import type { JsonInput } from 'nx/src/native';
+
+export const TS_SOLUTION_SETUP_TSCONFIG_INPUT: JsonInput = {
+  json: '{workspaceRoot}/tsconfig.json',
+  fields: ['extends', 'files', 'include'],
+};
 
 export function isUsingTypeScriptPlugin(tree: Tree): boolean {
   const nxJson = readNxJson(tree);

--- a/packages/node/src/generators/application/lib/create-project.ts
+++ b/packages/node/src/generators/application/lib/create-project.ts
@@ -6,6 +6,7 @@ import {
   writeJson,
 } from '@nx/devkit';
 import { addBuildTargetDefaults } from '@nx/devkit/src/generators/target-defaults-utils';
+import { TS_SOLUTION_SETUP_TSCONFIG_INPUT } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import type { PackageJson } from 'nx/src/utils/package-json';
 import { hasWebpackPlugin } from '../../../utils/has-webpack-plugin';
 import { NormalizedSchema } from './normalized-schema';
@@ -31,7 +32,9 @@ export function addProject(
   };
 
   if (options.bundler === 'esbuild') {
-    addBuildTargetDefaults(tree, '@nx/esbuild:esbuild');
+    addBuildTargetDefaults(tree, '@nx/esbuild:esbuild', 'build', [
+      TS_SOLUTION_SETUP_TSCONFIG_INPUT,
+    ]);
     project.targets.build = getEsBuildConfig(tree, project, options);
   } else if (options.bundler === 'webpack') {
     if (!hasWebpackPlugin(tree) && options.addPlugin === false) {


### PR DESCRIPTION
## Current Behavior

The node app generator with `bundler=esbuild` does not include the field-scoped `tsconfig.json` input needed for proper cache hashing. This means builds may return stale cached results when the workspace's `tsconfig.json` is edited (e.g., changing `extends`, `files`, or `include` fields).

## Expected Behavior

The node app generator now includes `TS_SOLUTION_SETUP_TSCONFIG_INPUT` as an input for `@nx/esbuild:esbuild` targets, ensuring cache hashes properly reflect changes to the workspace root `tsconfig.json`.

Additionally, exports `TS_SOLUTION_SETUP_TSCONFIG_INPUT` from `@nx/js` so other Nx packages can reuse this constant for their own executors and plugins.