### PR TITLE
chore(misc): a/b testing init Cloud prompt

### DIFF
--- a/packages/nx/src/utils/ab-testing.ts
+++ b/packages/nx/src/utils/ab-testing.ts
@@ -54,6 +54,18 @@ const messageOptions: Record<string, MessageData[]> = {
       footer:
         '\nFree for small teams. Remote caching and task distribution. 2-minute setup: https://nx.dev/nx-cloud',
     },
+    {
+      code: 'cloud-self-healing-remote-cache',
+      message: `Would you like to enable AI-powered Self-Healing CI and Remote Caching?`,
+      initial: 0,
+      choices: [
+        { value: 'yes', name: 'Yes' },
+        { value: 'skip', name: 'Skip for now' },
+        { value: 'never', name: pc.dim("No, don't ask again") },
+      ],
+      footer: '\nLearn about it at https://nx.dev/nx-cloud',
+      hint: `\n(it's free and can be disabled any time)`,
+    },
   ],
   setupViewLogs: [
     {


### PR DESCRIPTION
Do A/B test against the previous messaging from March that seems to have higher success rate.

NXC-4363