### PR TITLE
fix(core): surface ./nx --version stderr and force devDeps install

### DIFF
--- a/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
@@ -65,7 +65,17 @@ export function generateDotNxSetup(version?: string) {
   flushChanges(host.root, changes);
   // Ensure that the dot-nx installation is available.
   // This is needed when using a global nx with dot-nx, otherwise running any nx command using global command will fail due to missing modules.
-  execSync('./nx --version', { stdio: 'ignore', windowsHide: true });
+  // Pipe stderr so failures surface in telemetry instead of bare "Command failed: ./nx --version".
+  try {
+    execSync('./nx --version', {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+  } catch (e) {
+    if ((e as any)?.stderr) process.stderr.write((e as any).stderr);
+    throw e;
+  }
 }
 
 export function normalizeVersionForNxJson(pkg: string, version: string) {

--- a/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/nxw.ts
@@ -89,7 +89,8 @@ function performInstallation(
   );
 
   try {
-    cp.execSync('npm i', {
+    // --include=dev forces install even if consumer env sets NODE_ENV=production / omit=dev.
+    cp.execSync('npm i --include=dev', {
       cwd: path.dirname(installationPath),
       stdio: 'inherit',
       windowsHide: true,


### PR DESCRIPTION
## Current Behavior

`nx init` (non-JS path) verifies the dot-nx wrapper by running `./nx --version` with `stdio: 'ignore'`. Failures bubble as bare "Command failed: ./nx --version" with no stderr — telemetry can't tell what broke. Inside the wrapper, `nxw.js` writes `nx` as a `devDependency` and runs plain `npm i`. Under `NODE_ENV=production` / `omit=dev` the install exits 0 without installing nx, then the next `require()` throws `MODULE_NOT_FOUND` — invisible silent failure.

## Expected Behavior

`./nx --version` pipes stderr (mirrors `runInstall` in init/utils.ts) so the real error reaches `recordInitError`'s `readErrorStderr` and lands in commandStats. `nxw.js` runs `npm i --include=dev` so the install is resilient to consumer env.

## Related Issue(s)

Fixes NXC-4262