### PR TITLE
fix(misc): exclude stories and specs from tailwind content scanning

### DIFF
--- a/packages/react/src/generators/setup-tailwind/files/tailwind.config.js__tmpl__
+++ b/packages/react/src/generators/setup-tailwind/files/tailwind.config.js__tmpl__
@@ -6,7 +6,7 @@ module.exports = {
   content: [
     join(
       __dirname,
-      '{src,pages,components,app}/**/*!(*.stories|*.spec).{ts,tsx,html}'
+      '{src,pages,components,app}/**/!(*.stories|*.spec).{ts,tsx,html}'
     ),
     ...createGlobPatternsForDependencies(__dirname),
   ],

--- a/packages/react/tailwind.ts
+++ b/packages/react/tailwind.ts
@@ -7,7 +7,7 @@ import { createGlobPatternsForDependencies as jsGenerateGlobs } from '@nx/js/src
  */
 export function createGlobPatternsForDependencies(
   dirPath: string,
-  fileGlobPattern: string = '/**/*!(*.stories|*.spec).{tsx,ts,jsx,js,html}'
+  fileGlobPattern: string = '/**/!(*.stories|*.spec).{tsx,ts,jsx,js,html}'
 ) {
   try {
     return jsGenerateGlobs(dirPath, fileGlobPattern);

--- a/packages/vue/src/generators/setup-tailwind/files/tailwind.config.js.template
+++ b/packages/vue/src/generators/setup-tailwind/files/tailwind.config.js.template
@@ -7,7 +7,7 @@ module.exports = {
     join(__dirname, 'index.html'),
     join(
       __dirname,
-      'src/**/*!(*.stories|*.spec).{vue,ts,tsx,js,jsx}'
+      'src/**/!(*.stories|*.spec).{vue,ts,tsx,js,jsx}'
     ),
     ...createGlobPatternsForDependencies(__dirname),
   ],

--- a/packages/vue/tailwind.ts
+++ b/packages/vue/tailwind.ts
@@ -7,7 +7,7 @@ import { createGlobPatternsForDependencies as jsGenerateGlobs } from '@nx/js/src
  */
 export function createGlobPatternsForDependencies(
   dirPath: string,
-  fileGlobPattern: string = '/**/*!(*.stories|*.spec).{vue,tsx,ts,jsx,js}'
+  fileGlobPattern: string = '/**/!(*.stories|*.spec).{vue,tsx,ts,jsx,js}'
 ) {
   try {
     return jsGenerateGlobs(dirPath, fileGlobPattern);


### PR DESCRIPTION
## Current Behavior

The default tailwind content glob in `@nx/react/tailwind` and `@nx/vue/tailwind` helpers, plus their `setup-tailwind` generator templates, is meant to skip `*.stories.*` and `*.spec.*` files, but the leading `*` in the `!()` extglob makes the negation a no-op — story and spec classes end up scanned alongside production code.

## Expected Behavior

Stories and specs are excluded from tailwind content scanning, matching the intent of the existing pattern.

## Technical details

The current pattern `*!(*.stories|*.spec).{...}` fails because the leading `*` lets the matcher split the input across `*` and `!()` (e.g., `foo.stories` → `*` = `foo.`, `!()` = `stories`, which doesn't end in `.stories`), so the file matches the glob and gets included. Removing the leading `*` makes `!(*.stories|*.spec)` apply to the full filename portion. Affects:

- `packages/react/tailwind.ts` (helper default)
- `packages/vue/tailwind.ts` (helper default)
- `packages/react/src/generators/setup-tailwind/files/tailwind.config.js__tmpl__`
- `packages/vue/src/generators/setup-tailwind/files/tailwind.config.js.template`