### PR TITLE
chore(repo): resolve sandbox violations on graph-client:build-client task

### DIFF
--- a/.nx/workflows/sandboxing-config.yaml
+++ b/.nx/workflows/sandboxing-config.yaml
@@ -19,3 +19,12 @@ task-exclusions:
       - '**'
     exclude-writes:
       - '**'
+  # Webpack snapshots context dirs registered by postcss-loader via tailwind's
+  # dir-dependency emission, so it hashes stories/specs siblings of declared
+  # content even though they never enter the bundle and are intentionally
+  # excluded from inputs.
+  - project: graph-client
+    target: build-client
+    exclude-reads:
+      - '**/*.stories.{js,jsx,ts,tsx,mdx}'
+      - '**/*.{spec,test}.{js,jsx,ts,tsx}'

--- a/graph/client/tailwind.config.js
+++ b/graph/client/tailwind.config.js
@@ -6,7 +6,7 @@ const path = require('node:path');
 // nx-ignore-next-line
 const { workspaceRoot } = require('@nx/devkit');
 
-const glob = '**/*.{js,ts,jsx,tsx,html}';
+const glob = '**/!(*.stories|*.spec).{js,ts,jsx,tsx,html}';
 
 module.exports = {
   content: [

--- a/graph/migrate/tailwind.config.js
+++ b/graph/migrate/tailwind.config.js
@@ -1,6 +1,6 @@
 const { join } = require('path');
 
-const glob = '**/*!(*.stories|*.spec).{ts,tsx,html}';
+const glob = '**/!(*.stories|*.spec).{ts,tsx,html}';
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {

--- a/graph/ui-code-block/tailwind.config.js
+++ b/graph/ui-code-block/tailwind.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const glob = '**/*.{js,ts,jsx,tsx,html}';
+const glob = '**/!(*.stories|*.spec).{js,ts,jsx,tsx,html}';
 
 module.exports = {
   content: [

--- a/graph/ui-project-details/tailwind.config.js
+++ b/graph/ui-project-details/tailwind.config.js
@@ -6,7 +6,7 @@ const path = require('node:path');
 // nx-ignore-next-line
 const { workspaceRoot } = require('@nx/devkit');
 
-const glob = '**/*.{js,ts,jsx,tsx,html}';
+const glob = '**/!(*.stories|*.spec).{js,ts,jsx,tsx,html}';
 
 module.exports = {
   content: [

--- a/graph/ui-render-config/tailwind.config.js
+++ b/graph/ui-render-config/tailwind.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-const glob = '**/*.{js,ts,jsx,tsx,html}';
+const glob = '**/!(*.stories|*.spec).{js,ts,jsx,tsx,html}';
 
 module.exports = {
   content: [

--- a/nx-dev/nx-dev/tailwind.config.js
+++ b/nx-dev/nx-dev/tailwind.config.js
@@ -9,9 +9,9 @@ module.exports = {
   mode: 'jit',
   darkMode: 'class',
   content: [
-    path.join(__dirname, '{pages,app}/**/*.{js,ts,jsx,tsx}'),
-    '../ui-*/src/**/*.{js,ts,jsx,tsx}',
-    '../feature-*/src/**/*.{js,ts,jsx,tsx}',
+    path.join(__dirname, '{pages,app}/**/!(*.stories|*.spec).{js,ts,jsx,tsx}'),
+    '../ui-*/src/**/!(*.stories|*.spec).{js,ts,jsx,tsx}',
+    '../feature-*/src/**/!(*.stories|*.spec).{js,ts,jsx,tsx}',
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Current Behavior

`graph-client:build-client` triggers 21 sandbox-read violations on staging. Webpack snapshots context dirs registered by postcss-loader via tailwind's `dir-dependency` emission, so it hashes `*.stories.*` and `*.spec.*` siblings of declared content (in graph-client and its workspace deps) even though those files never enter the bundle and are intentionally excluded from inputs.

The reads are structural to how postcss-loader translates tailwind's `dir-dependency` into webpack's `addContextDependency(dir)` — webpack snapshots and hashes the entire directory regardless of which entries the glob actually matches. They happen with **any** tailwind content glob that resolves to a directory, not because of the specific patterns used.

Separately, this repo's tailwind configs use broad globs (or the buggy `*!(...)` extglob form) that scan stories and specs alongside production code — a correctness issue independent of the sandbox violations.

## Expected Behavior

The sandbox report comes back clean for `graph-client:build-client`. Tailwind content scanning excludes stories and specs.

## Validation

This run shows all violations are gone (except the one for the root `tsconfig.json` file, which will be addressed by [a separate PR](https://github.com/nrwl/nx/pull/35477)): https://staging.nx.app/runs/0W9AQdqnyQ/task/graph-client%3Abuild-client%3Arelease?batchId=635272b4-2d1b-4b5b-89df-ebac5e1f04a8

## Changes

- Add a `graph-client:build-client` task exclusion in `.nx/workflows/sandboxing-config.yaml` for the stories/specs reads. **This is what resolves the sandbox violations.** The files remain on disk but aren't correctness-relevant: they're excluded from inputs by the `production` named-input set, never enter the bundle, and only exist in the snapshot because webpack hashes the parent dir.
- Fix tailwind content globs in `graph/{client,migrate,ui-code-block,ui-project-details,ui-render-config}/tailwind.config.js` and `nx-dev/nx-dev/tailwind.config.js` to actually exclude `*.stories.*` and `*.spec.*`. **This is independent of the sandbox fix** — the file reads still happen at the OS level; this just stops tailwind from scanning the content of those files when computing classes for the production CSS.