### PR TITLE
fix(maven): skip attached artifacts that fail to materialize in batch record

### DIFF
--- a/packages/maven/shared/src/main/kotlin/dev/nx/maven/shared/BuildStateRecorder.kt
+++ b/packages/maven/shared/src/main/kotlin/dev/nx/maven/shared/BuildStateRecorder.kt
@@ -169,22 +169,32 @@ object BuildStateRecorder {
 
     private fun captureAttachedArtifacts(project: MavenProject, basedir: File): List<ArtifactInfo> {
         return project.attachedArtifacts.mapNotNull { artifact: Artifact ->
+            // In Maven 4, accessing artifact.file may invoke TransformedArtifact.getFile(),
+            // which lazily materializes the file (e.g. touching mtime on the consumer POM).
+            // That can throw if the target dir was just cleaned. Treat a throw the same as
+            // a missing file: log and skip.
+            val file = try {
+                artifact.file
+            } catch (e: Exception) {
+                log.debug("Skipping attached artifact ${artifact.groupId}:${artifact.artifactId}:${artifact.version} — file not available: ${e.message}")
+                return@mapNotNull null
+            }
             when {
-                artifact.file == null -> {
+                file == null -> {
                     log.debug("Attached artifact has no file: ${artifact.groupId}:${artifact.artifactId}:${artifact.version}")
                     null
                 }
-                !artifact.file.exists() -> {
-                    log.debug("Attached artifact file does not exist: ${artifact.file.absolutePath}")
+                !file.exists() -> {
+                    log.debug("Attached artifact file does not exist: ${file.absolutePath}")
                     null
                 }
                 // Skip temporary files (consumer POMs with random hash names)
-                artifact.file.name.startsWith("consumer-") && artifact.file.name.matches(Regex("consumer-\\d+\\.pom")) -> {
-                    log.debug("Skipping temporary consumer POM: ${artifact.file.name}")
+                file.name.startsWith("consumer-") && file.name.matches(Regex("consumer-\\d+\\.pom")) -> {
+                    log.debug("Skipping temporary consumer POM: ${file.name}")
                     null
                 }
                 else -> ArtifactInfo(
-                    file = toRelativePathCached(artifact.file.absolutePath, basedir),
+                    file = toRelativePathCached(file.absolutePath, basedir),
                     type = artifact.type,
                     classifier = artifact.classifier,
                     groupId = artifact.groupId,


### PR DESCRIPTION
## Current Behavior

Running `nx run-many -t clean` (or any target that wipes `target/` before `record` runs) in batch mode against a Maven 4 project fails with:

```
Caused by: java.nio.file.NoSuchFileException: .../target/consumer-<hash>.pom
    at java.nio.file.Files.setLastModifiedTime(...)
    at org.apache.maven.internal.transformation.impl.TransformedArtifact.mayUpdate(...)
    at org.apache.maven.internal.transformation.impl.TransformedArtifact.getFile(...)
    at dev.nx.maven.shared.BuildStateRecorder.captureAttachedArtifacts(BuildStateRecorder.kt:173)
```

In Maven 4, the consumer POM is exposed as a `TransformedArtifact`. Reading `Artifact.file` invokes `getFile()`, which lazily materializes the file by touching its `lastModifiedTime`. After `clean` deletes `target/`, that touch throws and propagates out of `BuildStateRecorder.captureAttachedArtifacts`, failing the `record` mojo and the entire build. The existing `consumer-<hash>.pom` filter is dead code on this path because the throw happens at the property access, before the filter runs.

## Expected Behavior

`record` is a best-effort metadata recorder. When an attached artifact's file cannot be resolved — null, missing on disk, or a `TransformedArtifact` whose materialization throws — we skip that artifact and continue, the same way the existing null/exists/consumer-POM guards do. The build succeeds.

The fix resolves `artifact.file` once with `try/catch`, logs the failure at `debug`, and returns `null` from the mapper. Subsequent `null`/`exists`/consumer-POM checks run against the local. Behavior is unchanged when `getFile()` succeeds.

Verified locally with `nx run e2e-maven:e2e-ci--src/maven-batch-v4.test.ts` — the previously-failing `should clean multiple projects with run-many in batch mode` test now passes (no more `NoSuchFileException`).

## Related Issue(s)

None.
