### PR TITLE
fix(bundling): include tsconfig solution input for rollup

### DIFF
--- a/packages/rollup/src/generators/configuration/configuration.legacy.spec.ts
+++ b/packages/rollup/src/generators/configuration/configuration.legacy.spec.ts
@@ -46,6 +46,22 @@ describe('configurationGenerator', () => {
       name: '@proj/mypkg',
       version: '0.0.1',
     });
+
+    expect(
+      readJson(tree, 'nx.json').targetDefaults['@nx/rollup:rollup']
+    ).toEqual({
+      cache: true,
+      dependsOn: ['^build'],
+      inputs: [
+        'default',
+        '^default',
+        {
+          json: '{workspaceRoot}/tsconfig.json',
+          fields: ['extends', 'files', 'include'],
+        },
+      ],
+    });
+    expect(project.targets.build.inputs).toBeUndefined();
   });
 
   it('should respect existing package.json file', async () => {

--- a/packages/rollup/src/generators/configuration/configuration.ts
+++ b/packages/rollup/src/generators/configuration/configuration.ts
@@ -19,6 +19,7 @@ import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript'
 import {
   getDefinedCustomConditionName,
   isUsingTsSolutionSetup,
+  TS_SOLUTION_SETUP_TSCONFIG_INPUT,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { dirname, join, relative } from 'node:path/posix';
 import { mergeTargetConfigurations } from 'nx/src/devkit-internals';
@@ -215,7 +216,9 @@ function addBuildTarget(
   options: RollupProjectSchema,
   isTsSolutionSetup: boolean
 ) {
-  addBuildTargetDefaults(tree, '@nx/rollup:rollup', options.buildTarget);
+  addBuildTargetDefaults(tree, '@nx/rollup:rollup', options.buildTarget, [
+    TS_SOLUTION_SETUP_TSCONFIG_INPUT,
+  ]);
   const project = readProjectConfiguration(tree, options.project);
   const prevBuildOptions = project.targets?.[options.buildTarget]?.options;
 

--- a/packages/rollup/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/rollup/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -23,6 +23,14 @@ exports[`@nx/rollup/plugin non-root project should create nodes 1`] = `
                     "rollup",
                   ],
                 },
+                {
+                  "fields": [
+                    "extends",
+                    "files",
+                    "include",
+                  ],
+                  "json": "{workspaceRoot}/tsconfig.json",
+                },
               ],
               "metadata": {
                 "description": "Run Rollup",
@@ -89,6 +97,14 @@ exports[`@nx/rollup/plugin non-root project should create nodes 2`] = `
                   "externalDependencies": [
                     "rollup",
                   ],
+                },
+                {
+                  "fields": [
+                    "extends",
+                    "files",
+                    "include",
+                  ],
+                  "json": "{workspaceRoot}/tsconfig.json",
                 },
               ],
               "metadata": {
@@ -157,6 +173,14 @@ exports[`@nx/rollup/plugin root project should create nodes 1`] = `
                     "rollup",
                   ],
                 },
+                {
+                  "fields": [
+                    "extends",
+                    "files",
+                    "include",
+                  ],
+                  "json": "{workspaceRoot}/tsconfig.json",
+                },
               ],
               "metadata": {
                 "description": "Run Rollup",
@@ -222,6 +246,14 @@ exports[`@nx/rollup/plugin root project should create nodes 2`] = `
                   "externalDependencies": [
                     "rollup",
                   ],
+                },
+                {
+                  "fields": [
+                    "extends",
+                    "files",
+                    "include",
+                  ],
+                  "json": "{workspaceRoot}/tsconfig.json",
                 },
               ],
               "metadata": {

--- a/packages/rollup/src/plugins/plugin.spec.ts
+++ b/packages/rollup/src/plugins/plugin.spec.ts
@@ -20,6 +20,7 @@ jest.mock('@nx/devkit', () => ({
 
 // Mock isUsingTsSolutionSetup to ensure consistent test environment
 jest.mock('@nx/js/src/utils/typescript/ts-solution-setup', () => ({
+  ...jest.requireActual('@nx/js/src/utils/typescript/ts-solution-setup'),
   isUsingTsSolutionSetup: jest.fn(() => false),
 }));
 
@@ -27,6 +28,19 @@ describe('@nx/rollup/plugin', () => {
   let createNodesFunction = createNodesV2[1];
   let context: CreateNodesContextV2;
   let cwd = process.cwd();
+  let originalCacheProjectGraph = process.env.NX_CACHE_PROJECT_GRAPH;
+
+  beforeEach(() => {
+    process.env.NX_CACHE_PROJECT_GRAPH = 'false';
+  });
+
+  afterEach(() => {
+    if (originalCacheProjectGraph !== undefined) {
+      process.env.NX_CACHE_PROJECT_GRAPH = originalCacheProjectGraph;
+    } else {
+      delete process.env.NX_CACHE_PROJECT_GRAPH;
+    }
+  });
 
   describe.each(['js', 'ts'])('root project', (extname) => {
     const tempFs = new TempFs('test');

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -1,6 +1,6 @@
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { basename, dirname, join } from 'path';
-import { existsSync, readdirSync } from 'fs';
+import { readdirSync } from 'fs';
 import {
   type CreateDependencies,
   CreateNodesContextV2,
@@ -18,13 +18,22 @@ import { getLockFileName } from '@nx/js';
 import { getNamedInputs } from '@nx/devkit/src/utils/get-named-inputs';
 import { type RollupOptions } from 'rollup';
 import { hashObject } from 'nx/src/hasher/file-hasher';
-import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import {
+  isUsingTsSolutionSetup,
+  TS_SOLUTION_SETUP_TSCONFIG_INPUT,
+} from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { addBuildAndWatchDepsTargets } from '@nx/js/src/plugins/typescript/util';
 
 function readTargetsCache(
   cachePath: string
 ): Record<string, Record<string, TargetConfiguration>> {
-  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
+  try {
+    return process.env.NX_CACHE_PROJECT_GRAPH !== 'false'
+      ? readJsonFile(cachePath)
+      : {};
+  } catch {
+    return {};
+  }
 }
 
 function writeTargetsToCache(
@@ -191,6 +200,7 @@ async function buildRollupTarget(
         ? ['production', '^production']
         : ['default', '^default']),
       { externalDependencies: ['rollup'] },
+      TS_SOLUTION_SETUP_TSCONFIG_INPUT,
     ],
     outputs,
     metadata: {


### PR DESCRIPTION
## Current Behavior

Rollup build target defaults and inferred Rollup build targets do not include the root `tsconfig.json` fields that TypeScript solution setup detection reads. Changes to `extends`, `files`, or `include` in `{workspaceRoot}/tsconfig.json` can therefore cause Rollup tasks to miss cache invalidation.

## Expected Behavior

Rollup target defaults and inferred Rollup build targets include `{workspaceRoot}/tsconfig.json` fields `extends`, `files`, and `include` as task inputs.