### PR TITLE
fix(core): use require for global to local Nx handoff so Windows drive paths work

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -146,9 +146,9 @@ async function main() {
       warnIfUsingOutdatedGlobalInstall(GLOBAL_NX_VERSION, LOCAL_NX_VERSION);
       if (localNx.includes('.nx')) {
         const nxWrapperPath = localNx.replace(/\.nx.*/, '.nx/') + 'nxw.js';
-        await import(nxWrapperPath);
+        require(nxWrapperPath);
       } else {
-        await import(localNx);
+        require(localNx);
       }
     }
   }


### PR DESCRIPTION
## Current Behavior

After updating to Nx **22.7.0**, the Nx CLI fails on **Windows** when running most commands inside a workspace (e.g. `nx report`, `nx build`, `nx test`):

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader.
On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'
    at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:195:11)
    ...
```

The error references the workspace's drive letter (`d:`, `c:`, etc.), reproduces under both pnpm and yarn, and affects every Windows user whose workspace lives on a drive-letter path. `nx --version` works (it returns before the failing code path), and so does running outside a workspace. Reverting global Nx to 22.6.5 works around it.

## Expected Behavior

Nx commands work on Windows regardless of which drive the workspace lives on.

## Related Issue(s)

Fixes #35461

---

## Explanation of the change

In #35326 (shipped in 22.7.0), the global → local Nx handoff in `packages/nx/bin/nx.ts` was changed from `require(localNx)` to `await import(localNx)`. `localNx` is a runtime-resolved absolute filesystem path, e.g. `D:\monorepo\node_modules\nx\bin\nx.js`.

Node's ESM loader URL-parses dynamic-`import()` specifiers:

- On POSIX, an absolute path leads with `/`, and Node's path fast-path converts it to `file://` for you, so `await import('/abs/path.js')` happens to work.
- On Windows, `D:\...` matches the WHATWG URL grammar for a scheme, so the loader resolves it as a URL with protocol `d:`, then the scheme allow-list (`file:` / `data:` / `node:`) rejects it — producing the `ERR_UNSUPPORTED_ESM_URL_SCHEME` error above.

This patch reverts those two lines back to `require()`. Both targets (`nx/bin/nx.js` and `.nx/nxw.js`) are CommonJS, and `require` accepts absolute paths uniformly across platforms — no `pathToFileURL` shim needed.

### No perf regression vs #35326

#35326's stated goal was to stop eagerly loading heavy modules (daemon client, perf-logging, init-local, dotenv, analytics-prompt) at the top of `bin/nx.ts` so that `nx --version` and other fast paths don't pay for what they don't use. **That win came from moving static top-level `import` declarations into lazy call-site loads inside `main()` — not from picking `import()` over `require()`.**

The two reverted lines were already lazy in the previous code (called inside `main()`), so the previous switch to `await import(...)` bought no laziness. They're also the only two call sites in the file that take a runtime absolute filesystem path; every other lazy load in `main()` uses bare or relative specifiers and is unaffected by this change.

If anything, `require()` is marginally faster than `await import()` for these targets — it skips the Promise wrapper, namespace object, and microtask hop, and the targets are CJS so there is no ESM-only capability being given up.
