### PR TITLE
chore(repo): include native dts header in build-native inputs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -28,6 +28,7 @@
     "native": [
       "{projectRoot}/**/*.rs",
       "{projectRoot}/**/Cargo.*",
+      "{projectRoot}/src/native/dts-header.d.ts",
       "{workspaceRoot}/Cargo.toml",
       "{workspaceRoot}/Cargo.lock",
       "{workspaceRoot}/clippy.toml",


### PR DESCRIPTION
The `dts-header.d.ts` file added in #35251 is consumed by napi via the `dtsHeaderFile` config in packages/nx/package.json, but the `native` named input in nx.json only globbed `*.rs` and Cargo files. Changes to the header would not invalidate `build-native` (or the related `build-native-wasm`, `format-native`, `lint-native` targets that share the same input), producing stale `index.d.ts` outputs from cache.